### PR TITLE
[MoE Refactor] Refactor FusedMoEQuantConfig into pre/post-weight loading types.

### DIFF
--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -488,8 +488,7 @@ def _two_sided_data_worker(rank, world_size):
     from vllm.distributed.parallel_state import get_dp_group
     from vllm.forward_context import get_forward_context
     from vllm.model_executor.layers.fused_moe.config import (
-        FusedMoEQuantConfig,
-        FusedMoEQuantDesc,
+        FUSED_MOE_UNQUANTIZED_CONFIG,
     )
     from vllm.model_executor.layers.fused_moe.prepare_finalize.flashinfer_nvlink_two_sided import (  # noqa: E501
         flashinfer_alltoall_combine,
@@ -538,13 +537,8 @@ def _two_sided_data_worker(rank, world_size):
     )
 
     # Unquantized config: quant_dtype=None means moe_kernel_quantize_input is a no-op
-    no_quant = FusedMoEQuantDesc()
-    quant_config = FusedMoEQuantConfig(
-        _a1=no_quant,
-        _a2=no_quant,
-        _w1=no_quant,
-        _w2=no_quant,
-    )
+    quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
+
     assert quant_config.quant_dtype is None  # sanity: no quantization
 
     with _make_forward_context(rank, world_size, tokens_per_rank):

--- a/tests/kernels/moe/test_deepgemm.py
+++ b/tests/kernels/moe/test_deepgemm.py
@@ -21,9 +21,8 @@ from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
 )
 from vllm.model_executor.layers.fused_moe.config import (
-    FusedMoEQuantConfig,
-    FusedMoEQuantDesc,
     fp8_w8a8_moe_quant_config,
+    mxfp4_fp8_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 from vllm.model_executor.layers.fused_moe.triton_deep_gemm_moe import (
@@ -296,15 +295,11 @@ def run_single_fp4_case(m, n, k, topk, num_experts):
     from vllm.model_executor.layers.quantization.utils.quant_utils import (
         GroupShape,
     )
-    from vllm.platforms import current_platform
 
-    _fp8_dtype = current_platform.fp8_dtype()
-    _block_shape = GroupShape(128, 128)
-    quant_config = FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(_fp8_dtype, _block_shape, None, None, None, None),
-        _a2=FusedMoEQuantDesc(_fp8_dtype, _block_shape, None, None, None, None),
-        _w1=FusedMoEQuantDesc("mxfp4", None, w1_s, None, None, None),
-        _w2=FusedMoEQuantDesc("mxfp4", None, w2_s, None, None, None),
+    quant_config = mxfp4_fp8_moe_quant_config(
+        block_shape=GroupShape(128, 128),
+        w1_scale=w1_s,
+        w2_scale=w2_s,
     )
     moe_config = make_dummy_moe_config()
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -228,7 +228,110 @@ class FusedMoEWeightDesc:
 
 
 @dataclass
-class FusedMoEQuantConfig:
+class FusedMoERuntimeQuantConfig:
+    _a1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _a2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _w1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _w2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+
+    @property
+    def a1_scale(self) -> torch.Tensor | None:
+        assert self._a1_w.scale is None or isinstance(self._a1_w.scale, torch.Tensor)
+        return self._a1_w.scale
+
+    @property
+    def a1_gscale(self) -> torch.Tensor | None:
+        return self._a1_w.alpha_or_gscale
+
+    # Activation properties
+    @property
+    def is_scale_swizzled(self) -> bool:
+        return self._a1_w.is_scale_swizzled
+
+    @property
+    def gemm1_alpha(self) -> float | None:
+        return self._a1_w.gemm_alpha
+
+    @property
+    def gemm1_beta(self) -> float | None:
+        return self._a1_w.gemm_beta
+
+    @property
+    def gemm1_clamp_limit(self) -> float | None:
+        return self._a1_w.gemm_clamp_limit
+
+    @property
+    def a2_scale(self) -> torch.Tensor | None:
+        assert self._a2_w.scale is None or isinstance(self._a2_w.scale, torch.Tensor)
+        return self._a2_w.scale
+
+    @property
+    def a2_gscale(self) -> torch.Tensor | None:
+        return self._a2_w.alpha_or_gscale
+
+    @property
+    def w1_scale(self) -> torch.Tensor | None:
+        assert self._w1_w.scale is None or isinstance(self._w1_w.scale, torch.Tensor)
+        return self._w1_w.scale
+
+    @property
+    def w1_zp(self) -> torch.Tensor | None:
+        return self._w1_w.zp
+
+    @property
+    def w1_bias(self) -> torch.Tensor | None:
+        return self._w1_w.bias
+
+    @property
+    def w1_precision(self) -> "PrecisionConfig | None":
+        assert self._w1_w.scale is None or isinstance(self._w1_w.scale, PrecisionConfig)
+        return self._w1_w.scale
+
+    @property
+    def g1_alphas(self) -> torch.Tensor | None:
+        return self._w1_w.alpha_or_gscale
+
+    @property
+    def w2_scale(self) -> torch.Tensor | None:
+        assert self._w2_w.scale is None or isinstance(self._w2_w.scale, torch.Tensor)
+        return self._w2_w.scale
+
+    @property
+    def w2_zp(self) -> torch.Tensor | None:
+        return self._w2_w.zp
+
+    @property
+    def w2_bias(self) -> torch.Tensor | None:
+        return self._w2_w.bias
+
+    @property
+    def w2_precision(self) -> "PrecisionConfig | None":
+        assert self._w2_w.scale is None or isinstance(self._w2_w.scale, PrecisionConfig)
+        return self._w2_w.scale
+
+    @property
+    def g2_alphas(self) -> torch.Tensor | None:
+        return self._w2_w.alpha_or_gscale
+
+    # TODO(bnell): get rid of the need for setters.
+    # This are needed because of the order in which the quant config
+    # and process_weights_after_loading are called. The runtime quant
+    # config should be created post-process_weights_after_loading.
+    def set_w1_scale(self, scale: torch.Tensor | None):
+        self._w1_w.scale = scale
+
+    def set_w1_bias(self, bias: torch.Tensor | None):
+        self._w1_w.bias = bias
+
+    def set_w2_scale(self, scale: torch.Tensor | None):
+        self._w2_w.scale = scale
+
+    def set_w2_bias(self, bias: torch.Tensor | None):
+        self._w2_w.bias = bias
+
+
+@dataclass
+class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
     """
     The FusedMoEQuantConfig contains all the quantization parameters for
     a single FusedMoEMethodBase operation.  It consists of four
@@ -262,16 +365,10 @@ class FusedMoEQuantConfig:
       so that only the required quantization parameters are used/stored.
     """
 
-    # TODO(bnell) make sure a1_scales/a2_scales don't interfere with chunking
     _a1: FusedMoEQuantDesc = FusedMoEQuantDesc()
     _a2: FusedMoEQuantDesc = FusedMoEQuantDesc()
     _w1: FusedMoEQuantDesc = FusedMoEQuantDesc()
     _w2: FusedMoEQuantDesc = FusedMoEQuantDesc()
-
-    _a1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
-    _a2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
-    _w1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
-    _w2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
 
     mx_alignment: int = 0
     ocp_mx_scheme: str | None = None
@@ -435,11 +532,9 @@ class FusedMoEQuantConfig:
     def w2_group_shape(self) -> GroupShape | None:
         return self._w2.shape
 
-    # TODO(bnell): get rid of the need to do this
     def set_w2_scale(self, scale: torch.Tensor | None):
         self._w2_w.scale = scale
 
-    # TODO(bnell): get rid of the need to do this
     def set_w2_bias(self, bias: torch.Tensor | None):
         self._w2_w.bias = bias
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -269,7 +269,7 @@ class _FusedMoEQuantDesc:
 
 
 @dataclass
-class _FusedMoEWeightDesc:
+class _FusedMoERuntimeQuantDesc:
     """
     A quantization descriptor for fused MoE ops. This class can describe
     either activations or weights.
@@ -302,10 +302,10 @@ class _FusedMoEWeightDesc:
 
 @dataclass
 class FusedMoERuntimeQuantConfig:
-    _a1_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
-    _a2_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
-    _w1_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
-    _w2_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
+    _a1_w: _FusedMoERuntimeQuantDesc = field(default_factory=_FusedMoERuntimeQuantDesc)
+    _a2_w: _FusedMoERuntimeQuantDesc = field(default_factory=_FusedMoERuntimeQuantDesc)
+    _w1_w: _FusedMoERuntimeQuantDesc = field(default_factory=_FusedMoERuntimeQuantDesc)
+    _w2_w: _FusedMoERuntimeQuantDesc = field(default_factory=_FusedMoERuntimeQuantDesc)
 
     @property
     def a1_scale(self) -> torch.Tensor | None:
@@ -412,7 +412,7 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
     removed in the future when the classes are fully separated) and adds
     four _FusedMoEQuantDescs (_a1, _a2, _w1, _w2) that describe the
     quantization dtype and group shape for each activation and weight.
-    The inherited FusedMoEWeightDescs (_a1_w, _a2_w, _w1_w, _w2_w) contain
+    The inherited FusedMoERuntimeQuantDescs (_a1_w, _a2_w, _w1_w, _w2_w) contain
     the runtime quantization parameters (scales, zero points, biases, etc.).
 
     Each FusedMoEMethodBase must implement a get_fused_moe_quant_config
@@ -796,7 +796,7 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
             _a2=_FusedMoEQuantDesc(quant_dtype, a_shape),
             _w1=_FusedMoEQuantDesc(weight_dtype, w_shape),
             _w2=_FusedMoEQuantDesc(weight_dtype, w_shape),
-            _a1_w=_FusedMoEWeightDesc(
+            _a1_w=_FusedMoERuntimeQuantDesc(
                 scale=a1_scale,
                 alpha_or_gscale=a1_gscale,
                 is_scale_swizzled=is_scale_swizzled,
@@ -804,11 +804,11 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
                 gemm_beta=gemm1_beta,
                 gemm_clamp_limit=gemm1_clamp_limit,
             ),
-            _a2_w=_FusedMoEWeightDesc(scale=a2_scale, alpha_or_gscale=a2_gscale),
-            _w1_w=_FusedMoEWeightDesc(
+            _a2_w=_FusedMoERuntimeQuantDesc(scale=a2_scale, alpha_or_gscale=a2_gscale),
+            _w1_w=_FusedMoERuntimeQuantDesc(
                 scale=w1_scale, alpha_or_gscale=g1_alphas, zp=w1_zp, bias=w1_bias
             ),
-            _w2_w=_FusedMoEWeightDesc(
+            _w2_w=_FusedMoERuntimeQuantDesc(
                 scale=w2_scale, alpha_or_gscale=g2_alphas, zp=w2_zp, bias=w2_bias
             ),
         )
@@ -913,8 +913,8 @@ def gptq_marlin_moe_quant_config(
         _a2=_FusedMoEQuantDesc(dtype=None, shape=a_shape),
         _w1=_FusedMoEQuantDesc(weight_dtype, w_shape),
         _w2=_FusedMoEQuantDesc(weight_dtype, w_shape),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
     )
 
 
@@ -935,13 +935,13 @@ def mxfp4_w4a16_moe_quant_config(
         _a2=_FusedMoEQuantDesc(),
         _w1=_FusedMoEQuantDesc("mxfp4"),
         _w2=_FusedMoEQuantDesc("mxfp4"),
-        _a1_w=_FusedMoEWeightDesc(
+        _a1_w=_FusedMoERuntimeQuantDesc(
             gemm_alpha=gemm1_alpha,
             gemm_beta=gemm1_beta,
             gemm_clamp_limit=gemm1_clamp_limit,
         ),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, bias=w2_bias),
     )
 
 
@@ -967,14 +967,14 @@ def mxfp4_mxfp8_moe_quant_config(
         _a2=_FusedMoEQuantDesc("mxfp8"),
         _w1=_FusedMoEQuantDesc("mxfp4"),
         _w2=_FusedMoEQuantDesc("mxfp4"),
-        _a1_w=_FusedMoEWeightDesc(
+        _a1_w=_FusedMoERuntimeQuantDesc(
             gemm_alpha=gemm1_alpha,
             gemm_beta=gemm1_beta,
             gemm_clamp_limit=gemm1_clamp_limit,
             is_scale_swizzled=is_scale_swizzled,
         ),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, bias=w2_bias),
         mx_alignment=mx_alignment,
     )
 
@@ -1001,14 +1001,14 @@ def mxfp4_fp8_moe_quant_config(
         _a2=_FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
         _w1=_FusedMoEQuantDesc("mxfp4"),
         _w2=_FusedMoEQuantDesc("mxfp4"),
-        _a1_w=_FusedMoEWeightDesc(
+        _a1_w=_FusedMoERuntimeQuantDesc(
             gemm_alpha=gemm1_alpha,
             gemm_beta=gemm1_beta,
             gemm_clamp_limit=gemm1_clamp_limit,
             is_scale_swizzled=is_scale_swizzled,
         ),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, bias=w2_bias),
         mx_alignment=mx_alignment,
     )
 
@@ -1030,10 +1030,10 @@ def mxfp4_w4a8_moe_quant_config(
         _a2=_FusedMoEQuantDesc("fp8"),
         _w1=_FusedMoEQuantDesc("mxfp4"),
         _w2=_FusedMoEQuantDesc("mxfp4"),
-        _a1_w=_FusedMoEWeightDesc(scale=a1_scale),
-        _a2_w=_FusedMoEWeightDesc(scale=a2_scale),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _a1_w=_FusedMoERuntimeQuantDesc(scale=a1_scale),
+        _a2_w=_FusedMoERuntimeQuantDesc(scale=a2_scale),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, bias=w2_bias),
     )
 
 
@@ -1158,8 +1158,8 @@ def int4_w4a16_moe_quant_config(
         _a2=_FusedMoEQuantDesc(shape=group_shape),
         _w1=_FusedMoEQuantDesc("int4", group_shape),
         _w2=_FusedMoEQuantDesc("int4", group_shape),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, zp=w1_zp),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, zp=w2_zp),
     )
 
 
@@ -1175,8 +1175,8 @@ def fp8_w8a16_moe_quant_config(
     return FusedMoEQuantConfig(
         _w1=_FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
         _w2=_FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale),
     )
 
 
@@ -1196,8 +1196,8 @@ def int8_w8a16_moe_quant_config(
         _a2=_FusedMoEQuantDesc(shape=group_shape),
         _w1=_FusedMoEQuantDesc(torch.int8, group_shape),
         _w2=_FusedMoEQuantDesc(torch.int8, group_shape),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, zp=w1_zp),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, zp=w2_zp),
     )
 
 
@@ -1259,8 +1259,8 @@ def awq_marlin_moe_quant_config(
         _a2=_FusedMoEQuantDesc(dtype=None, shape=a_shape),
         _w1=_FusedMoEQuantDesc(weight_dtype, shape=w_shape),
         _w2=_FusedMoEQuantDesc(weight_dtype, shape=w_shape),
-        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
+        _w1_w=_FusedMoERuntimeQuantDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
     )
 
 
@@ -1272,8 +1272,8 @@ def biased_moe_quant_config(
     Construct a quant config for unquantized activations with biases.
     """
     return FusedMoEQuantConfig(
-        _w1_w=_FusedMoEWeightDesc(bias=w1_bias),
-        _w2_w=_FusedMoEWeightDesc(bias=w2_bias),
+        _w1_w=_FusedMoERuntimeQuantDesc(bias=w1_bias),
+        _w2_w=_FusedMoERuntimeQuantDesc(bias=w2_bias),
     )
 
 
@@ -1306,14 +1306,14 @@ def humming_moe_quant_config(
         shape=weight_group_shape,
     )
 
-    w1_weight_desc = _FusedMoEWeightDesc(
+    w1_weight_desc = _FusedMoERuntimeQuantDesc(
         scale=w13_scale,
         alpha_or_gscale=w13_gscale,
         zp=w13_zp,
         bias=w13_bias,
     )
 
-    w2_weight_desc = _FusedMoEWeightDesc(
+    w2_weight_desc = _FusedMoERuntimeQuantDesc(
         scale=w2_scale,
         alpha_or_gscale=w2_gscale,
         zp=w2_zp,

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -173,10 +173,13 @@ def get_routing_method_type(
 
 
 @dataclass
-class FusedMoEQuantDesc:
+class _FusedMoEQuantDesc:
     """
     A quantization descriptor for fused MoE ops. This class can describe
     either activations or weights.
+
+    Note: this class is very similar to QuantKey. We should consider consolidating
+    these two classes.
     """
 
     # The quantized type of this parameters.  None means unquantized or
@@ -196,12 +199,12 @@ class FusedMoEQuantDesc:
     @staticmethod
     def make(
         quant_key: QuantKey | None, shape: GroupShape | None
-    ) -> "FusedMoEQuantDesc":
+    ) -> "_FusedMoEQuantDesc":
         """
-        Construct a FusedMoEQuantDesc from an optional QuantKey.
+        Construct a _FusedMoEQuantDesc from an optional QuantKey.
 
         Maps the QuantKey dtype and scale descriptor to the appropriate
-        FusedMoEQuantDesc dtype (which can be a torch.dtype or a string
+        _FusedMoEQuantDesc dtype (which can be a torch.dtype or a string
         for special types like "nvfp4", "mxfp4", "int4") and group shape.
 
         Unquantized dtypes (fp16, bf16, fp32) or quant_key is None are mapped to None.
@@ -209,7 +212,7 @@ class FusedMoEQuantDesc:
         from vllm.scalar_type import scalar_types
 
         if quant_key is None:
-            return FusedMoEQuantDesc(None, shape=shape)
+            return _FusedMoEQuantDesc(None, shape=shape)
 
         assert shape is None
 
@@ -258,14 +261,15 @@ class FusedMoEQuantDesc:
             dtype_result = torch.int8
         else:
             raise ValueError(
-                f"Unable to map QuantKey dtype {quant_dtype} to FusedMoEQuantDesc dtype"
+                f"Unable to map QuantKey dtype {quant_dtype} to "
+                "_FusedMoEQuantDesc dtype"
             )
 
-        return FusedMoEQuantDesc(dtype=dtype_result, shape=group_shape)
+        return _FusedMoEQuantDesc(dtype=dtype_result, shape=group_shape)
 
 
 @dataclass
-class FusedMoEWeightDesc:
+class _FusedMoEWeightDesc:
     """
     A quantization descriptor for fused MoE ops. This class can describe
     either activations or weights.
@@ -298,10 +302,10 @@ class FusedMoEWeightDesc:
 
 @dataclass
 class FusedMoERuntimeQuantConfig:
-    _a1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
-    _a2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
-    _w1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
-    _w2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _a1_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
+    _a2_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
+    _w1_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
+    _w2_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
 
     @property
     def a1_scale(self) -> torch.Tensor | None:
@@ -406,7 +410,7 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
     a single FusedMoEMethodBase operation.  It currently inherits from
     FusedMoERuntimeQuantConfig (this inheritance is temporary and will be
     removed in the future when the classes are fully separated) and adds
-    four FusedMoEQuantDescs (_a1, _a2, _w1, _w2) that describe the
+    four _FusedMoEQuantDescs (_a1, _a2, _w1, _w2) that describe the
     quantization dtype and group shape for each activation and weight.
     The inherited FusedMoEWeightDescs (_a1_w, _a2_w, _w1_w, _w2_w) contain
     the runtime quantization parameters (scales, zero points, biases, etc.).
@@ -434,15 +438,15 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
 
     Other notes:
     - PrecisionConfigs are specific to GPT OSS Triton.
-    - As a follow up it would probably make sense to subclass FusedMoEQuantDesc
+    - As a follow up it would probably make sense to subclass _FusedMoEQuantDesc
       or FusedMoEQuantConfig for particular FusedMoEMethodBase subclasses
       so that only the required quantization parameters are used/stored.
     """
 
-    _a1: FusedMoEQuantDesc = FusedMoEQuantDesc()
-    _a2: FusedMoEQuantDesc = FusedMoEQuantDesc()
-    _w1: FusedMoEQuantDesc = FusedMoEQuantDesc()
-    _w2: FusedMoEQuantDesc = FusedMoEQuantDesc()
+    _a1: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
+    _a2: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
+    _w1: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
+    _w2: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
 
     mx_alignment: int = 0
     ocp_mx_scheme: str | None = None
@@ -788,11 +792,11 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
             quant_dtype, per_act_token_quant, per_out_ch_quant, block_shape
         )
         quant_config = FusedMoEQuantConfig(
-            _a1=FusedMoEQuantDesc(quant_dtype, a_shape),
-            _a2=FusedMoEQuantDesc(quant_dtype, a_shape),
-            _w1=FusedMoEQuantDesc(weight_dtype, w_shape),
-            _w2=FusedMoEQuantDesc(weight_dtype, w_shape),
-            _a1_w=FusedMoEWeightDesc(
+            _a1=_FusedMoEQuantDesc(quant_dtype, a_shape),
+            _a2=_FusedMoEQuantDesc(quant_dtype, a_shape),
+            _w1=_FusedMoEQuantDesc(weight_dtype, w_shape),
+            _w2=_FusedMoEQuantDesc(weight_dtype, w_shape),
+            _a1_w=_FusedMoEWeightDesc(
                 scale=a1_scale,
                 alpha_or_gscale=a1_gscale,
                 is_scale_swizzled=is_scale_swizzled,
@@ -800,11 +804,11 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
                 gemm_beta=gemm1_beta,
                 gemm_clamp_limit=gemm1_clamp_limit,
             ),
-            _a2_w=FusedMoEWeightDesc(scale=a2_scale, alpha_or_gscale=a2_gscale),
-            _w1_w=FusedMoEWeightDesc(
+            _a2_w=_FusedMoEWeightDesc(scale=a2_scale, alpha_or_gscale=a2_gscale),
+            _w1_w=_FusedMoEWeightDesc(
                 scale=w1_scale, alpha_or_gscale=g1_alphas, zp=w1_zp, bias=w1_bias
             ),
-            _w2_w=FusedMoEWeightDesc(
+            _w2_w=_FusedMoEWeightDesc(
                 scale=w2_scale, alpha_or_gscale=g2_alphas, zp=w2_zp, bias=w2_bias
             ),
         )
@@ -905,12 +909,12 @@ def gptq_marlin_moe_quant_config(
         raise ValueError(f"Unsupported weight_bits: {weight_bits}")
 
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(dtype=None, shape=a_shape),
-        _a2=FusedMoEQuantDesc(dtype=None, shape=a_shape),
-        _w1=FusedMoEQuantDesc(weight_dtype, w_shape),
-        _w2=FusedMoEQuantDesc(weight_dtype, w_shape),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
+        _a1=_FusedMoEQuantDesc(dtype=None, shape=a_shape),
+        _a2=_FusedMoEQuantDesc(dtype=None, shape=a_shape),
+        _w1=_FusedMoEQuantDesc(weight_dtype, w_shape),
+        _w2=_FusedMoEQuantDesc(weight_dtype, w_shape),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
     )
 
 
@@ -927,17 +931,17 @@ def mxfp4_w4a16_moe_quant_config(
     Construct a quant config for unquantized activations and mxfp4 weights.
     """
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(),
-        _a2=FusedMoEQuantDesc(),
-        _w1=FusedMoEQuantDesc("mxfp4"),
-        _w2=FusedMoEQuantDesc("mxfp4"),
-        _a1_w=FusedMoEWeightDesc(
+        _a1=_FusedMoEQuantDesc(),
+        _a2=_FusedMoEQuantDesc(),
+        _w1=_FusedMoEQuantDesc("mxfp4"),
+        _w2=_FusedMoEQuantDesc("mxfp4"),
+        _a1_w=_FusedMoEWeightDesc(
             gemm_alpha=gemm1_alpha,
             gemm_beta=gemm1_beta,
             gemm_clamp_limit=gemm1_clamp_limit,
         ),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
     )
 
 
@@ -959,18 +963,18 @@ def mxfp4_mxfp8_moe_quant_config(
     Construct a quant config for mxfp4 activations and mxfp4 weights.
     """
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc("mxfp8"),
-        _a2=FusedMoEQuantDesc("mxfp8"),
-        _w1=FusedMoEQuantDesc("mxfp4"),
-        _w2=FusedMoEQuantDesc("mxfp4"),
-        _a1_w=FusedMoEWeightDesc(
+        _a1=_FusedMoEQuantDesc("mxfp8"),
+        _a2=_FusedMoEQuantDesc("mxfp8"),
+        _w1=_FusedMoEQuantDesc("mxfp4"),
+        _w2=_FusedMoEQuantDesc("mxfp4"),
+        _a1_w=_FusedMoEWeightDesc(
             gemm_alpha=gemm1_alpha,
             gemm_beta=gemm1_beta,
             gemm_clamp_limit=gemm1_clamp_limit,
             is_scale_swizzled=is_scale_swizzled,
         ),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
         mx_alignment=mx_alignment,
     )
 
@@ -993,18 +997,18 @@ def mxfp4_fp8_moe_quant_config(
     Construct a quant config for mxfp4 activations and mxfp4 weights.
     """
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
-        _a2=FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
-        _w1=FusedMoEQuantDesc("mxfp4"),
-        _w2=FusedMoEQuantDesc("mxfp4"),
-        _a1_w=FusedMoEWeightDesc(
+        _a1=_FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
+        _a2=_FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
+        _w1=_FusedMoEQuantDesc("mxfp4"),
+        _w2=_FusedMoEQuantDesc("mxfp4"),
+        _a1_w=_FusedMoEWeightDesc(
             gemm_alpha=gemm1_alpha,
             gemm_beta=gemm1_beta,
             gemm_clamp_limit=gemm1_clamp_limit,
             is_scale_swizzled=is_scale_swizzled,
         ),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
         mx_alignment=mx_alignment,
     )
 
@@ -1022,14 +1026,14 @@ def mxfp4_w4a8_moe_quant_config(
     Construct a quant config for fp8 activations and mxfp4 weights.
     """
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc("fp8"),
-        _a2=FusedMoEQuantDesc("fp8"),
-        _w1=FusedMoEQuantDesc("mxfp4"),
-        _w2=FusedMoEQuantDesc("mxfp4"),
-        _a1_w=FusedMoEWeightDesc(scale=a1_scale),
-        _a2_w=FusedMoEWeightDesc(scale=a2_scale),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        _a1=_FusedMoEQuantDesc("fp8"),
+        _a2=_FusedMoEQuantDesc("fp8"),
+        _w1=_FusedMoEQuantDesc("mxfp4"),
+        _w2=_FusedMoEQuantDesc("mxfp4"),
+        _a1_w=_FusedMoEWeightDesc(scale=a1_scale),
+        _a2_w=_FusedMoEWeightDesc(scale=a2_scale),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
     )
 
 
@@ -1150,12 +1154,12 @@ def int4_w4a16_moe_quant_config(
     """
     group_shape = GroupShape(*block_shape) if block_shape is not None else None
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(shape=group_shape),
-        _a2=FusedMoEQuantDesc(shape=group_shape),
-        _w1=FusedMoEQuantDesc("int4", group_shape),
-        _w2=FusedMoEQuantDesc("int4", group_shape),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
+        _a1=_FusedMoEQuantDesc(shape=group_shape),
+        _a2=_FusedMoEQuantDesc(shape=group_shape),
+        _w1=_FusedMoEQuantDesc("int4", group_shape),
+        _w2=_FusedMoEQuantDesc("int4", group_shape),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
     )
 
 
@@ -1169,10 +1173,10 @@ def fp8_w8a16_moe_quant_config(
     """
     group_shape = GroupShape(*block_shape) if block_shape is not None else None
     return FusedMoEQuantConfig(
-        _w1=FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
-        _w2=FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale),
+        _w1=_FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
+        _w2=_FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale),
     )
 
 
@@ -1188,12 +1192,12 @@ def int8_w8a16_moe_quant_config(
     """
     group_shape = GroupShape(*block_shape) if block_shape is not None else None
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(shape=group_shape),
-        _a2=FusedMoEQuantDesc(shape=group_shape),
-        _w1=FusedMoEQuantDesc(torch.int8, group_shape),
-        _w2=FusedMoEQuantDesc(torch.int8, group_shape),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
+        _a1=_FusedMoEQuantDesc(shape=group_shape),
+        _a2=_FusedMoEQuantDesc(shape=group_shape),
+        _w1=_FusedMoEQuantDesc(torch.int8, group_shape),
+        _w2=_FusedMoEQuantDesc(torch.int8, group_shape),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
     )
 
 
@@ -1251,12 +1255,12 @@ def awq_marlin_moe_quant_config(
         raise ValueError(f"Unsupported weight_bits: {weight_bits}")
 
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(dtype=None, shape=a_shape),
-        _a2=FusedMoEQuantDesc(dtype=None, shape=a_shape),
-        _w1=FusedMoEQuantDesc(weight_dtype, shape=w_shape),
-        _w2=FusedMoEQuantDesc(weight_dtype, shape=w_shape),
-        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
+        _a1=_FusedMoEQuantDesc(dtype=None, shape=a_shape),
+        _a2=_FusedMoEQuantDesc(dtype=None, shape=a_shape),
+        _w1=_FusedMoEQuantDesc(weight_dtype, shape=w_shape),
+        _w2=_FusedMoEQuantDesc(weight_dtype, shape=w_shape),
+        _w1_w=_FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
     )
 
 
@@ -1268,8 +1272,8 @@ def biased_moe_quant_config(
     Construct a quant config for unquantized activations with biases.
     """
     return FusedMoEQuantConfig(
-        _w1_w=FusedMoEWeightDesc(bias=w1_bias),
-        _w2_w=FusedMoEWeightDesc(bias=w2_bias),
+        _w1_w=_FusedMoEWeightDesc(bias=w1_bias),
+        _w2_w=_FusedMoEWeightDesc(bias=w2_bias),
     )
 
 
@@ -1287,29 +1291,29 @@ def humming_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
 ) -> FusedMoEQuantConfig:
     if q_dtype is None:
-        a_quant_desc = FusedMoEQuantDesc(dtype=None)
+        a_quant_desc = _FusedMoEQuantDesc(dtype=None)
     else:
         shape = GroupShape(row=1, col=-1)
-        a_quant_desc = FusedMoEQuantDesc(dtype=q_dtype, shape=shape)
+        a_quant_desc = _FusedMoEQuantDesc(dtype=q_dtype, shape=shape)
 
-    w1_quant_desc = FusedMoEQuantDesc(
+    w1_quant_desc = _FusedMoEQuantDesc(
         dtype=weight_dtype,
         shape=weight_group_shape,
     )
 
-    w2_quant_desc = FusedMoEQuantDesc(
+    w2_quant_desc = _FusedMoEQuantDesc(
         dtype=weight_dtype,
         shape=weight_group_shape,
     )
 
-    w1_weight_desc = FusedMoEWeightDesc(
+    w1_weight_desc = _FusedMoEWeightDesc(
         scale=w13_scale,
         alpha_or_gscale=w13_gscale,
         zp=w13_zp,
         bias=w13_bias,
     )
 
-    w2_weight_desc = FusedMoEWeightDesc(
+    w2_weight_desc = _FusedMoEWeightDesc(
         scale=w2_scale,
         alpha_or_gscale=w2_gscale,
         zp=w2_zp,

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -15,7 +15,10 @@ from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_DTYPES,
     OCP_MX_Scheme,
 )
-from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    QuantKey,
+)
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_triton_kernels
 from vllm.utils.math_utils import cdiv
@@ -187,13 +190,25 @@ class FusedMoEQuantDesc:
     #               (i.e. per-token-per-group)
     shape: GroupShape | None = None
 
+    @staticmethod
+    def make(quant_key: QuantKey) -> "FusedMoEQuantDesc":
+        raise NotImplementedError
+
+
+@dataclass
+class FusedMoEWeightDesc:
+    """
+    A quantization descriptor for fused MoE ops. This class can describe
+    either activations or weights.
+    """
+
     # Quantization scales.
     # TODO(bnell): maybe put PrecisionConfigs in subclass of QuantDesc?
     scale: Union[torch.Tensor, "PrecisionConfig", None] = None
 
     # Quantization alphas or gscales, used for nvfp4 types.
     # W4A8 FP8: used for per-channel scales
-    # TODO(bnell): put some of these in subclasses
+    # TODO: overlap with gemm_alpha/beta?
     alpha_or_gscale: torch.Tensor | None = None
 
     # Zero points for int4/int8 types
@@ -202,9 +217,16 @@ class FusedMoEQuantDesc:
     # Biases for GPT triton MoE
     bias: torch.Tensor | None = None
 
+    is_scale_swizzled: bool = True
 
-# TODO(bnell): have subclasses for specific moe methods?
-# e.g. for specific arguments bias, precision, etc.
+    # MXFP4-specific TRTLLM parameters for SwiGLU activation clamping.
+    # These correspond to gemm1_alpha, gemm1_beta, gemm1_clamp_limit
+    # in TrtLlmMxfp4ExpertsBase.
+    gemm_alpha: float | None = None
+    gemm_beta: float | None = None
+    gemm_clamp_limit: float | None = None
+
+
 @dataclass
 class FusedMoEQuantConfig:
     """
@@ -241,25 +263,35 @@ class FusedMoEQuantConfig:
     """
 
     # TODO(bnell) make sure a1_scales/a2_scales don't interfere with chunking
-    _a1: FusedMoEQuantDesc
-    _a2: FusedMoEQuantDesc
-    _w1: FusedMoEQuantDesc
-    _w2: FusedMoEQuantDesc
-    is_scale_swizzled: bool = True
+    _a1: FusedMoEQuantDesc = FusedMoEQuantDesc()
+    _a2: FusedMoEQuantDesc = FusedMoEQuantDesc()
+    _w1: FusedMoEQuantDesc = FusedMoEQuantDesc()
+    _w2: FusedMoEQuantDesc = FusedMoEQuantDesc()
 
-    # MXFP4-specific TRTLLM parameters for SwiGLU activation clamping.
-    # These correspond to gemm1_alpha, gemm1_beta, gemm1_clamp_limit
-    # in TrtLlmMxfp4ExpertsBase.
-    gemm1_alpha: float | None = None
-    gemm1_beta: float | None = None
-    gemm1_clamp_limit: float | None = None
+    _a1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _a2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _w1_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
+    _w2_w: FusedMoEWeightDesc = FusedMoEWeightDesc()
 
     mx_alignment: int = 0
+    ocp_mx_scheme: str | None = None
 
     def __post_init__(self):
         assert not self.per_act_token_quant or self.block_shape is None, (
             "illegal quantization"
         )
+
+        if isinstance(self.quant_dtype, str) or isinstance(
+            self.weight_quant_dtype, str
+        ):
+            ocp_mx_scheme = OCP_MX_Scheme.from_quant_dtype(
+                self.quant_dtype, self.weight_quant_dtype
+            )
+
+            if ocp_mx_scheme is not None:
+                ocp_mx_scheme = ocp_mx_scheme.value
+
+            self.ocp_mx_scheme = ocp_mx_scheme
 
     #
     # Convenience accessors for various properties.
@@ -310,65 +342,106 @@ class FusedMoEQuantConfig:
 
     @property
     def a1_scale(self) -> torch.Tensor | None:
-        assert self._a1.scale is None or isinstance(self._a1.scale, torch.Tensor)
-        return self._a1.scale
+        assert self._a1_w.scale is None or isinstance(self._a1_w.scale, torch.Tensor)
+        return self._a1_w.scale
 
     @property
     def a1_gscale(self) -> torch.Tensor | None:
-        return self._a1.alpha_or_gscale
+        return self._a1_w.alpha_or_gscale
+
+    # Activation properties
+    @property
+    def is_scale_swizzled(self) -> bool:
+        return self._a1_w.is_scale_swizzled
+
+    @property
+    def gemm1_alpha(self) -> float | None:
+        return self._a1_w.gemm_alpha
+
+    @property
+    def gemm1_beta(self) -> float | None:
+        return self._a1_w.gemm_beta
+
+    @property
+    def gemm1_clamp_limit(self) -> float | None:
+        return self._a1_w.gemm_clamp_limit
 
     @property
     def a2_scale(self) -> torch.Tensor | None:
-        assert self._a2.scale is None or isinstance(self._a2.scale, torch.Tensor)
-        return self._a2.scale
+        assert self._a2_w.scale is None or isinstance(self._a2_w.scale, torch.Tensor)
+        return self._a2_w.scale
 
     @property
     def a2_gscale(self) -> torch.Tensor | None:
-        return self._a2.alpha_or_gscale
+        return self._a2_w.alpha_or_gscale
 
     @property
     def w1_scale(self) -> torch.Tensor | None:
-        assert self._w1.scale is None or isinstance(self._w1.scale, torch.Tensor)
-        return self._w1.scale
+        assert self._w1_w.scale is None or isinstance(self._w1_w.scale, torch.Tensor)
+        return self._w1_w.scale
 
     @property
     def w1_zp(self) -> torch.Tensor | None:
-        return self._w1.zp
+        return self._w1_w.zp
 
     @property
     def w1_bias(self) -> torch.Tensor | None:
-        return self._w1.bias
+        return self._w1_w.bias
 
     @property
     def w1_precision(self) -> "PrecisionConfig | None":
-        assert self._w1.scale is None or isinstance(self._w1.scale, PrecisionConfig)
-        return self._w1.scale
+        assert self._w1_w.scale is None or isinstance(self._w1_w.scale, PrecisionConfig)
+        return self._w1_w.scale
 
     @property
     def g1_alphas(self) -> torch.Tensor | None:
-        return self._w1.alpha_or_gscale
+        return self._w1_w.alpha_or_gscale
+
+    @property
+    def w1_group_shape(self) -> GroupShape | None:
+        return self._w1.shape
+
+    # TODO(bnell): get rid of the need to do this
+    def set_w1_scale(self, scale: torch.Tensor | None):
+        self._w1_w.scale = scale
+
+    # TODO(bnell): get rid of the need to do this
+    def set_w1_bias(self, bias: torch.Tensor | None):
+        self._w1_w.bias = bias
 
     @property
     def w2_scale(self) -> torch.Tensor | None:
-        assert self._w2.scale is None or isinstance(self._w2.scale, torch.Tensor)
-        return self._w2.scale
+        assert self._w2_w.scale is None or isinstance(self._w2_w.scale, torch.Tensor)
+        return self._w2_w.scale
 
     @property
     def w2_zp(self) -> torch.Tensor | None:
-        return self._w2.zp
+        return self._w2_w.zp
 
     @property
     def w2_bias(self) -> torch.Tensor | None:
-        return self._w2.bias
+        return self._w2_w.bias
 
     @property
     def w2_precision(self) -> "PrecisionConfig | None":
-        assert self._w2.scale is None or isinstance(self._w2.scale, PrecisionConfig)
-        return self._w2.scale
+        assert self._w2_w.scale is None or isinstance(self._w2_w.scale, PrecisionConfig)
+        return self._w2_w.scale
 
     @property
     def g2_alphas(self) -> torch.Tensor | None:
-        return self._w2.alpha_or_gscale
+        return self._w2_w.alpha_or_gscale
+
+    @property
+    def w2_group_shape(self) -> GroupShape | None:
+        return self._w2.shape
+
+    # TODO(bnell): get rid of the need to do this
+    def set_w2_scale(self, scale: torch.Tensor | None):
+        self._w2_w.scale = scale
+
+    # TODO(bnell): get rid of the need to do this
+    def set_w2_bias(self, bias: torch.Tensor | None):
+        self._w2_w.bias = bias
 
     @property
     def use_fp8_w8a8(self) -> bool:
@@ -393,25 +466,6 @@ class FusedMoEQuantConfig:
     @property
     def use_nvfp4_w4a16(self) -> bool:
         return self._a1.dtype is None and self._w1.dtype == "nvfp4"
-
-    @property
-    def ocp_mx_scheme(self) -> str | None:
-        if not hasattr(self, "_ocp_mx_scheme"):
-            if (self._a1.dtype is not None and not isinstance(self._a1.dtype, str)) or (
-                self._w1.dtype is not None and not isinstance(self._w1.dtype, str)
-            ):
-                self._ocp_mx_scheme = None
-            else:
-                ocp_mx_scheme = OCP_MX_Scheme.from_quant_dtype(
-                    self._a1.dtype, self._w1.dtype
-                )
-
-                if ocp_mx_scheme is not None:
-                    ocp_mx_scheme = ocp_mx_scheme.value
-
-                self._ocp_mx_scheme = ocp_mx_scheme
-
-        return self._ocp_mx_scheme
 
     @property
     def use_mxfp4_w4a16(self) -> bool:
@@ -565,18 +619,25 @@ class FusedMoEQuantConfig:
             quant_dtype, per_act_token_quant, per_out_ch_quant, block_shape
         )
         quant_config = FusedMoEQuantConfig(
-            _a1=FusedMoEQuantDesc(quant_dtype, a_shape, a1_scale, a1_gscale),
-            _a2=FusedMoEQuantDesc(quant_dtype, a_shape, a2_scale, a2_gscale),
-            _w1=FusedMoEQuantDesc(
-                weight_dtype, w_shape, w1_scale, g1_alphas, w1_zp, w1_bias
+            _a1=FusedMoEQuantDesc(quant_dtype, a_shape),
+            _a2=FusedMoEQuantDesc(quant_dtype, a_shape),
+            _w1=FusedMoEQuantDesc(weight_dtype, w_shape),
+            _w2=FusedMoEQuantDesc(weight_dtype, w_shape),
+            _a1_w=FusedMoEWeightDesc(
+                scale=a1_scale,
+                alpha_or_gscale=a1_gscale,
+                is_scale_swizzled=is_scale_swizzled,
+                gemm_alpha=gemm1_alpha,
+                gemm_beta=gemm1_beta,
+                gemm_clamp_limit=gemm1_clamp_limit,
             ),
-            _w2=FusedMoEQuantDesc(
-                weight_dtype, w_shape, w2_scale, g2_alphas, w2_zp, w2_bias
+            _a2_w=FusedMoEWeightDesc(scale=a2_scale, alpha_or_gscale=a2_gscale),
+            _w1_w=FusedMoEWeightDesc(
+                scale=w1_scale, alpha_or_gscale=g1_alphas, zp=w1_zp, bias=w1_bias
             ),
-            is_scale_swizzled=is_scale_swizzled,
-            gemm1_alpha=gemm1_alpha,
-            gemm1_beta=gemm1_beta,
-            gemm1_clamp_limit=gemm1_clamp_limit,
+            _w2_w=FusedMoEWeightDesc(
+                scale=w2_scale, alpha_or_gscale=g2_alphas, zp=w2_zp, bias=w2_bias
+            ),
         )
         assert quant_config.per_act_token_quant == per_act_token_quant
         assert quant_config.per_out_ch_quant == per_out_ch_quant
@@ -677,8 +738,10 @@ def gptq_marlin_moe_quant_config(
     return FusedMoEQuantConfig(
         _a1=FusedMoEQuantDesc(dtype=None, shape=a_shape),
         _a2=FusedMoEQuantDesc(dtype=None, shape=a_shape),
-        _w1=FusedMoEQuantDesc(weight_dtype, w_shape, w1_scale, None, w1_zp, w1_bias),
-        _w2=FusedMoEQuantDesc(weight_dtype, w_shape, w2_scale, None, w2_zp, w2_bias),
+        _w1=FusedMoEQuantDesc(weight_dtype, w_shape),
+        _w2=FusedMoEQuantDesc(weight_dtype, w_shape),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
     )
 
 
@@ -697,11 +760,15 @@ def mxfp4_w4a16_moe_quant_config(
     return FusedMoEQuantConfig(
         _a1=FusedMoEQuantDesc(),
         _a2=FusedMoEQuantDesc(),
-        _w1=FusedMoEQuantDesc("mxfp4", None, w1_scale, None, None, w1_bias),
-        _w2=FusedMoEQuantDesc("mxfp4", None, w2_scale, None, None, w2_bias),
-        gemm1_alpha=gemm1_alpha,
-        gemm1_beta=gemm1_beta,
-        gemm1_clamp_limit=gemm1_clamp_limit,
+        _w1=FusedMoEQuantDesc("mxfp4"),
+        _w2=FusedMoEQuantDesc("mxfp4"),
+        _a1_w=FusedMoEWeightDesc(
+            gemm_alpha=gemm1_alpha,
+            gemm_beta=gemm1_beta,
+            gemm_clamp_limit=gemm1_clamp_limit,
+        ),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
     )
 
 
@@ -725,13 +792,51 @@ def mxfp4_mxfp8_moe_quant_config(
     return FusedMoEQuantConfig(
         _a1=FusedMoEQuantDesc("mxfp8"),
         _a2=FusedMoEQuantDesc("mxfp8"),
-        _w1=FusedMoEQuantDesc("mxfp4", None, w1_scale, None, None, w1_bias),
-        _w2=FusedMoEQuantDesc("mxfp4", None, w2_scale, None, None, w2_bias),
-        gemm1_alpha=gemm1_alpha,
-        gemm1_beta=gemm1_beta,
-        gemm1_clamp_limit=gemm1_clamp_limit,
+        _w1=FusedMoEQuantDesc("mxfp4"),
+        _w2=FusedMoEQuantDesc("mxfp4"),
+        _a1_w=FusedMoEWeightDesc(
+            gemm_alpha=gemm1_alpha,
+            gemm_beta=gemm1_beta,
+            gemm_clamp_limit=gemm1_clamp_limit,
+            is_scale_swizzled=is_scale_swizzled,
+        ),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
         mx_alignment=mx_alignment,
-        is_scale_swizzled=is_scale_swizzled,
+    )
+
+
+def mxfp4_fp8_moe_quant_config(
+    w1_scale: Union[torch.Tensor, "PrecisionConfig"],
+    w2_scale: Union[torch.Tensor, "PrecisionConfig"],
+    a1_scale: torch.Tensor | None = None,
+    a2_scale: torch.Tensor | None = None,
+    w1_bias: torch.Tensor | None = None,
+    w2_bias: torch.Tensor | None = None,
+    block_shape: GroupShape | None = None,
+    gemm1_alpha: float | None = None,
+    gemm1_beta: float | None = None,
+    gemm1_clamp_limit: float | None = None,
+    mx_alignment: int = 0,
+    is_scale_swizzled: bool = False,
+) -> FusedMoEQuantConfig:
+    """
+    Construct a quant config for mxfp4 activations and mxfp4 weights.
+    """
+    return FusedMoEQuantConfig(
+        _a1=FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
+        _a2=FusedMoEQuantDesc(current_platform.fp8_dtype(), block_shape),
+        _w1=FusedMoEQuantDesc("mxfp4"),
+        _w2=FusedMoEQuantDesc("mxfp4"),
+        _a1_w=FusedMoEWeightDesc(
+            gemm_alpha=gemm1_alpha,
+            gemm_beta=gemm1_beta,
+            gemm_clamp_limit=gemm1_clamp_limit,
+            is_scale_swizzled=is_scale_swizzled,
+        ),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
+        mx_alignment=mx_alignment,
     )
 
 
@@ -748,10 +853,14 @@ def mxfp4_w4a8_moe_quant_config(
     Construct a quant config for fp8 activations and mxfp4 weights.
     """
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc("fp8", None, a1_scale, None, None, None),
-        _a2=FusedMoEQuantDesc("fp8", None, a2_scale, None, None, None),
-        _w1=FusedMoEQuantDesc("mxfp4", None, w1_scale, None, None, w1_bias),
-        _w2=FusedMoEQuantDesc("mxfp4", None, w2_scale, None, None, w2_bias),
+        _a1=FusedMoEQuantDesc("fp8"),
+        _a2=FusedMoEQuantDesc("fp8"),
+        _w1=FusedMoEQuantDesc("mxfp4"),
+        _w2=FusedMoEQuantDesc("mxfp4"),
+        _a1_w=FusedMoEWeightDesc(scale=a1_scale),
+        _a2_w=FusedMoEWeightDesc(scale=a2_scale),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, bias=w2_bias),
     )
 
 
@@ -874,8 +983,10 @@ def int4_w4a16_moe_quant_config(
     return FusedMoEQuantConfig(
         _a1=FusedMoEQuantDesc(shape=group_shape),
         _a2=FusedMoEQuantDesc(shape=group_shape),
-        _w1=FusedMoEQuantDesc("int4", group_shape, w1_scale, None, w1_zp),
-        _w2=FusedMoEQuantDesc("int4", group_shape, w2_scale, None, w2_zp),
+        _w1=FusedMoEQuantDesc("int4", group_shape),
+        _w2=FusedMoEQuantDesc("int4", group_shape),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
     )
 
 
@@ -889,14 +1000,10 @@ def fp8_w8a16_moe_quant_config(
     """
     group_shape = GroupShape(*block_shape) if block_shape is not None else None
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(),
-        _a2=FusedMoEQuantDesc(),
-        _w1=FusedMoEQuantDesc(
-            current_platform.fp8_dtype(), group_shape, w1_scale, None, None
-        ),
-        _w2=FusedMoEQuantDesc(
-            current_platform.fp8_dtype(), group_shape, w2_scale, None, None
-        ),
+        _w1=FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
+        _w2=FusedMoEQuantDesc(current_platform.fp8_dtype(), group_shape),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale),
     )
 
 
@@ -914,8 +1021,10 @@ def int8_w8a16_moe_quant_config(
     return FusedMoEQuantConfig(
         _a1=FusedMoEQuantDesc(shape=group_shape),
         _a2=FusedMoEQuantDesc(shape=group_shape),
-        _w1=FusedMoEQuantDesc(torch.int8, group_shape, w1_scale, None, w1_zp),
-        _w2=FusedMoEQuantDesc(torch.int8, group_shape, w2_scale, None, w2_zp),
+        _w1=FusedMoEQuantDesc(torch.int8, group_shape),
+        _w2=FusedMoEQuantDesc(torch.int8, group_shape),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp),
     )
 
 
@@ -975,8 +1084,10 @@ def awq_marlin_moe_quant_config(
     return FusedMoEQuantConfig(
         _a1=FusedMoEQuantDesc(dtype=None, shape=a_shape),
         _a2=FusedMoEQuantDesc(dtype=None, shape=a_shape),
-        _w1=FusedMoEQuantDesc(weight_dtype, w_shape, w1_scale, None, w1_zp, w1_bias),
-        _w2=FusedMoEQuantDesc(weight_dtype, w_shape, w2_scale, None, w2_zp, w2_bias),
+        _w1=FusedMoEQuantDesc(weight_dtype, shape=w_shape),
+        _w2=FusedMoEQuantDesc(weight_dtype, shape=w_shape),
+        _w1_w=FusedMoEWeightDesc(scale=w1_scale, zp=w1_zp, bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(scale=w2_scale, zp=w2_zp, bias=w2_bias),
     )
 
 
@@ -988,10 +1099,61 @@ def biased_moe_quant_config(
     Construct a quant config for unquantized activations with biases.
     """
     return FusedMoEQuantConfig(
-        _a1=FusedMoEQuantDesc(),
-        _a2=FusedMoEQuantDesc(),
-        _w1=FusedMoEQuantDesc(bias=w1_bias),
-        _w2=FusedMoEQuantDesc(bias=w2_bias),
+        _w1_w=FusedMoEWeightDesc(bias=w1_bias),
+        _w2_w=FusedMoEWeightDesc(bias=w2_bias),
+    )
+
+
+def humming_moe_quant_config(
+    q_dtype: torch.dtype | str | None,
+    weight_dtype: torch.dtype | str | None,
+    weight_group_shape: GroupShape | None = None,
+    w13_scale: torch.Tensor | None = None,
+    w13_gscale: torch.Tensor | None = None,
+    w13_zp: torch.Tensor | None = None,
+    w13_bias: torch.Tensor | None = None,
+    w2_scale: torch.Tensor | None = None,
+    w2_gscale: torch.Tensor | None = None,
+    w2_zp: torch.Tensor | None = None,
+    w2_bias: torch.Tensor | None = None,
+) -> FusedMoEQuantConfig:
+    if q_dtype is None:
+        a_quant_desc = FusedMoEQuantDesc(dtype=None)
+    else:
+        shape = GroupShape(row=1, col=-1)
+        a_quant_desc = FusedMoEQuantDesc(dtype=q_dtype, shape=shape)
+
+    w1_quant_desc = FusedMoEQuantDesc(
+        dtype=weight_dtype,
+        shape=weight_group_shape,
+    )
+
+    w2_quant_desc = FusedMoEQuantDesc(
+        dtype=weight_dtype,
+        shape=weight_group_shape,
+    )
+
+    w1_weight_desc = FusedMoEWeightDesc(
+        scale=w13_scale,
+        alpha_or_gscale=w13_gscale,
+        zp=w13_zp,
+        bias=w13_bias,
+    )
+
+    w2_weight_desc = FusedMoEWeightDesc(
+        scale=w2_scale,
+        alpha_or_gscale=w2_gscale,
+        zp=w2_zp,
+        bias=w2_bias,
+    )
+
+    return FusedMoEQuantConfig(
+        _a1=a_quant_desc,
+        _a2=a_quant_desc,
+        _w1=w1_quant_desc,
+        _w2=w2_quant_desc,
+        _w1_w=w1_weight_desc,
+        _w2_w=w2_weight_desc,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -16,6 +16,9 @@ from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_Scheme,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    FP4_DTYPE,
+    FP8_DTYPE,
+    MXFP_SCALE_DTYPE,
     GroupShape,
     QuantKey,
 )
@@ -191,8 +194,74 @@ class FusedMoEQuantDesc:
     shape: GroupShape | None = None
 
     @staticmethod
-    def make(quant_key: QuantKey) -> "FusedMoEQuantDesc":
-        raise NotImplementedError
+    def make(
+        quant_key: QuantKey | None, shape: GroupShape | None
+    ) -> "FusedMoEQuantDesc":
+        """
+        Construct a FusedMoEQuantDesc from an optional QuantKey.
+
+        Maps the QuantKey dtype and scale descriptor to the appropriate
+        FusedMoEQuantDesc dtype (which can be a torch.dtype or a string
+        for special types like "nvfp4", "mxfp4", "int4") and group shape.
+
+        Unquantized dtypes (fp16, bf16, fp32) or quant_key is None are mapped to None.
+        """
+        from vllm.scalar_type import scalar_types
+
+        if quant_key is None:
+            return FusedMoEQuantDesc(None, shape=shape)
+
+        assert shape is None
+
+        # Extract group shape from scale descriptor
+        group_shape = quant_key.scale.group_shape
+
+        # Determine the dtype mapping
+        quant_dtype = quant_key.dtype
+        scale_dtype = quant_key.scale.dtype
+        has_scale2 = quant_key.scale2 is not None
+
+        # Map special cases to string dtypes
+        dtype_result: torch.dtype | str | None
+
+        # Unquantized types (fp16, bf16, fp32) -> None
+        if quant_dtype in (torch.float16, torch.bfloat16, torch.float32):
+            dtype_result = None
+        # NVFP4: FP4_DTYPE with scale2 present and FP8 scale
+        elif quant_dtype == FP4_DTYPE and has_scale2:
+            dtype_result = "nvfp4"
+        # MXFP4/MXFP6/MXFP8: scale dtype is MXFP_SCALE_DTYPE (uint8)
+        elif scale_dtype == MXFP_SCALE_DTYPE:
+            if quant_dtype == FP4_DTYPE:
+                dtype_result = "mxfp4"
+            elif quant_dtype == FP8_DTYPE:
+                # MX FP8 formats - check group shape to distinguish
+                # Standard MXFP8 uses 32-element groups
+                dtype_result = "mxfp8"
+            else:
+                raise ValueError(
+                    f"Unsupported MXFP dtype: {quant_dtype} with scale dtype "
+                    f"{scale_dtype}"
+                )
+        # INT4: INT4_DTYPE scalar type
+        elif quant_dtype == scalar_types.uint4b8:
+            dtype_result = "int4"
+        # INT8: INT8_DTYPE scalar type
+        elif quant_dtype == scalar_types.uint8b128:
+            # Map to torch.int8 for standard int8 quantization
+            dtype_result = torch.int8
+        # FP8 quantization
+        elif quant_dtype == FP8_DTYPE:
+            dtype_result = quant_dtype
+        # torch.int8 (for non-scalar-type int8)
+        elif quant_dtype == torch.int8:
+            dtype_result = torch.int8
+        else:
+            raise ValueError(
+                f"Unable to map QuantKey dtype {quant_dtype} to FusedMoEQuantDesc dtype"
+            )
+
+        return FusedMoEQuantDesc(dtype=dtype_result, shape=group_shape)
 
 
 @dataclass
@@ -334,8 +403,13 @@ class FusedMoERuntimeQuantConfig:
 class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
     """
     The FusedMoEQuantConfig contains all the quantization parameters for
-    a single FusedMoEMethodBase operation.  It consists of four
-    FusedMoEQuantDescs, one for each activation and set of weights.
+    a single FusedMoEMethodBase operation.  It currently inherits from
+    FusedMoERuntimeQuantConfig (this inheritance is temporary and will be
+    removed in the future when the classes are fully separated) and adds
+    four FusedMoEQuantDescs (_a1, _a2, _w1, _w2) that describe the
+    quantization dtype and group shape for each activation and weight.
+    The inherited FusedMoEWeightDescs (_a1_w, _a2_w, _w1_w, _w2_w) contain
+    the runtime quantization parameters (scales, zero points, biases, etc.).
 
     Each FusedMoEMethodBase must implement a get_fused_moe_quant_config
     method to construct a FusedMoEQuantConfig for use with that class.

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Union
 
@@ -302,10 +302,10 @@ class _FusedMoEWeightDesc:
 
 @dataclass
 class FusedMoERuntimeQuantConfig:
-    _a1_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
-    _a2_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
-    _w1_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
-    _w2_w: _FusedMoEWeightDesc = _FusedMoEWeightDesc()
+    _a1_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
+    _a2_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
+    _w1_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
+    _w2_w: _FusedMoEWeightDesc = field(default_factory=_FusedMoEWeightDesc)
 
     @property
     def a1_scale(self) -> torch.Tensor | None:
@@ -443,10 +443,10 @@ class FusedMoEQuantConfig(FusedMoERuntimeQuantConfig):
       so that only the required quantization parameters are used/stored.
     """
 
-    _a1: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
-    _a2: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
-    _w1: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
-    _w2: _FusedMoEQuantDesc = _FusedMoEQuantDesc()
+    _a1: _FusedMoEQuantDesc = field(default_factory=_FusedMoEQuantDesc)
+    _a2: _FusedMoEQuantDesc = field(default_factory=_FusedMoEQuantDesc)
+    _w1: _FusedMoEQuantDesc = field(default_factory=_FusedMoEQuantDesc)
+    _w2: _FusedMoEQuantDesc = field(default_factory=_FusedMoEQuantDesc)
 
     mx_alignment: int = 0
     ocp_mx_scheme: str | None = None

--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -152,8 +152,11 @@ class CPUExpertsFp8(mk.FusedMoEExpertsMonolithic):
             list(self.quant_config.block_shape)
             if self.quant_config.block_shape
             else (
-                [self.quant_config._w1.shape.row, self.quant_config._w1.shape.col]
-                if self.quant_config._w1.shape is not None
+                [
+                    self.quant_config.w1_group_shape.row,
+                    self.quant_config.w1_group_shape.col,
+                ]
+                if self.quant_config.w1_group_shape is not None
                 else None
             )
         )

--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -60,8 +60,9 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
         self.w1_scale_val = self.quant_config.w1_scale
         self.w2_scale_val = self.quant_config.w2_scale
 
-        self.quant_config._w1.scale = None
-        self.quant_config._w2.scale = None
+        # TODO(bnell): get rid of the need to do this
+        self.quant_config.set_w1_scale(None)
+        self.quant_config.set_w2_scale(None)
 
         self.quantization_emulation = True
 

--- a/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
@@ -63,8 +63,9 @@ class OCP_MXQuantizationEmulationTritonExperts(TritonExperts):
         self.w1_scale_val = self.quant_config.w1_scale
         self.w2_scale_val = self.quant_config.w2_scale
 
-        self.quant_config._w1.scale = None
-        self.quant_config._w2.scale = None
+        # TODO(bnell): get rid of the need to do this
+        self.quant_config.set_w1_scale(None)
+        self.quant_config.set_w2_scale(None)
 
         self.quantization_emulation = True
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -17,8 +17,8 @@ from vllm.model_executor.layers.fused_moe.all2all_utils import (
 )
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
-    FusedMoEQuantDesc,
     RoutingMethodType,
+    mxfp4_fp8_moe_quant_config,
     mxfp4_mxfp8_moe_quant_config,
     mxfp4_w4a8_moe_quant_config,
     mxfp4_w4a16_moe_quant_config,
@@ -1387,13 +1387,13 @@ def make_mxfp4_moe_quant_config(
 
         # DeepGEMM FP4 uses FP8 per-token-group activation quantization
         # with block 128, matching the FP8 DeepGEMM path.
-        _fp8_dtype = current_platform.fp8_dtype()
         _block_shape = GroupShape(128, 128)
-        return FusedMoEQuantConfig(
-            _a1=FusedMoEQuantDesc(_fp8_dtype, _block_shape, None, None, None, None),
-            _a2=FusedMoEQuantDesc(_fp8_dtype, _block_shape, None, None, None, None),
-            _w1=FusedMoEQuantDesc("mxfp4", None, w1_scale, None, None, w1_bias),
-            _w2=FusedMoEQuantDesc("mxfp4", None, w2_scale, None, None, w2_bias),
+        return mxfp4_fp8_moe_quant_config(
+            block_shape=_block_shape,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
             gemm1_alpha=gemm1_alpha,
             gemm1_beta=gemm1_beta,
             gemm1_clamp_limit=swiglu_limit,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -865,9 +865,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w13_bias = getattr(layer, "w13_bias", None)
             w2_bias = getattr(layer, "w2_bias", None)
             if w13_bias is not None:
-                quant_config._w1.bias = w13_bias
+                quant_config.set_w1_bias(w13_bias)
             if w2_bias is not None:
-                quant_config._w2.bias = w2_bias
+                quant_config.set_w2_bias(w2_bias)
 
         return quant_config
 

--- a/vllm/model_executor/layers/quantization/online/moe_base.py
+++ b/vllm/model_executor/layers/quantization/online/moe_base.py
@@ -108,7 +108,7 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
             w13_bias = getattr(layer, "w13_bias", None)
             w2_bias = getattr(layer, "w2_bias", None)
             if w13_bias is not None:
-                quant_config.set_w1_bias(w2_bias)
+                quant_config.set_w1_bias(w13_bias)
             if w2_bias is not None:
                 quant_config.set_w2_bias(w2_bias)
 

--- a/vllm/model_executor/layers/quantization/online/moe_base.py
+++ b/vllm/model_executor/layers/quantization/online/moe_base.py
@@ -108,9 +108,9 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
             w13_bias = getattr(layer, "w13_bias", None)
             w2_bias = getattr(layer, "w2_bias", None)
             if w13_bias is not None:
-                quant_config._w1.bias = w13_bias
+                quant_config.set_w1_bias(w2_bias)
             if w2_bias is not None:
-                quant_config._w2.bias = w2_bias
+                quant_config.set_w2_bias(w2_bias)
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -9,8 +9,7 @@ from humming.schema import BaseWeightSchema
 
 from vllm import envs
 from vllm.model_executor.layers.fused_moe.config import (
-    FusedMoEQuantConfig,
-    FusedMoEQuantDesc,
+    humming_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.linear import LinearBase
@@ -168,12 +167,10 @@ def get_humming_moe_quant_config(layer: FusedMoE):
     input_schema = layer.input_schemas["w13"]
     weight_schema = layer.weight_schemas["w13"]
 
-    a_dtype = input_schema.a_dtype
-    if a_dtype is None or a_dtype.num_bits == 16:
-        a_quant_desc = FusedMoEQuantDesc(dtype=None)
+    if input_schema.a_dtype is None or input_schema.a_dtype.num_bits == 16:
+        q_dtype = None
     else:
-        shape = GroupShape(row=1, col=-1)
-        a_quant_desc = FusedMoEQuantDesc(dtype=str(a_dtype), shape=shape)
+        q_dtype = str(input_schema.a_dtype)
 
     weight_scale_group_size = weight_schema.weight_scale_group_size
     weight_scale_group_size_n = weight_schema.weight_scale_group_size_n
@@ -188,27 +185,16 @@ def get_humming_moe_quant_config(layer: FusedMoE):
     else:
         weight_group_shape = GroupShape(row=weight_scale_group_size, col=1)
 
-    w1_quant_desc = FusedMoEQuantDesc(
-        dtype=str(weight_schema.b_dtype),
-        shape=weight_group_shape,
-        scale=getattr(layer, "w13_weight_scale", None),
-        alpha_or_gscale=getattr(layer, "w13_global_scale", None),
-        zp=getattr(layer, "w13_zero_point", None),
-        bias=getattr(layer, "w13_bias", None),
-    )
-
-    w2_quant_desc = FusedMoEQuantDesc(
-        dtype=str(weight_schema.b_dtype),
-        shape=weight_group_shape,
-        scale=getattr(layer, "w2_weight_scale", None),
-        alpha_or_gscale=getattr(layer, "w2_global_scale", None),
-        zp=getattr(layer, "w2_zero_point", None),
-        bias=getattr(layer, "w2_bias", None),
-    )
-
-    return FusedMoEQuantConfig(
-        _a1=a_quant_desc,
-        _a2=a_quant_desc,
-        _w1=w1_quant_desc,
-        _w2=w2_quant_desc,
+    return humming_moe_quant_config(
+        q_dtype=q_dtype,
+        weight_dtype=str(weight_schema.b_dtype),
+        weight_group_shape=weight_group_shape,
+        w13_scale=getattr(layer, "w13_weight_scale", None),
+        w13_gscale=getattr(layer, "w13_global_scale", None),
+        w13_zp=getattr(layer, "w13_zero_point", None),
+        w13_bias=getattr(layer, "w13_bias", None),
+        w2_scale=getattr(layer, "w2_weight_scale", None),
+        w2_gscale=getattr(layer, "w2_global_scale", None),
+        w2_zp=getattr(layer, "w2_zero_point", None),
+        w2_bias=getattr(layer, "w2_bias", None),
     )


### PR DESCRIPTION
## Purpose

Internally split `FusedMoEQuantConfig` into data that can be known pre-weight loading (`FusedMoEQuantDesc`) and post-weight loading (`FusedMoEWeightDesc`).  The dividing line is more or less any `Tensor`s or values that must be loaded and only finalized after `weight_loading`/`process_weights_after_loading` are called. 

The ultimate goal is to allow construction of MKs in quant_method `__init__` time and pass in the rest (`FusedMoEWeightDesc`s) at runtime.

cc @yzong-rh , @robertgshaw2-redhat 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

