### PR TITLE
Support routed-experts replay with prefix caching

### DIFF
--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -365,13 +365,10 @@ async def test_dp_pause_keep_race_staggered_engines():
         async def staggered_pause_keep(method: str, *args) -> Any:
             if method != "pause_scheduler" or not args or args[0] != "keep":
                 return await original_call_utility(method, *args)
-            # Fire pause(keep) to engine 0 (don't await — with DP
-            # two-phase pause, consensus requires all ranks).
-            pause_0 = asyncio.create_task(
-                client._call_utility_async(method, *args, engine=client.core_engines[0])
+            # Send pause(keep) to engine 0 first
+            await client._call_utility_async(
+                method, *args, engine=client.core_engines[0]
             )
-            # Let the event loop send the message to engine 0.
-            await asyncio.sleep(0.5)
             # In the middle: send two requests (race window)
             sp = SamplingParams(max_tokens=5, ignore_eos=True)
 
@@ -387,13 +384,11 @@ async def test_dp_pause_keep_race_staggered_engines():
             t2 = asyncio.create_task(consume_gen("race-2"))
             mid_pause_tasks.extend([t1, t2])
             await asyncio.sleep(3)
-            # Fire pause(keep) to engine 1, then await both so
-            # consensus can be reached.
-            pause_1 = asyncio.create_task(
-                client._call_utility_async(method, *args, engine=client.core_engines[1])
+            # Then send pause(keep) to engine 1
+            result = await client._call_utility_async(
+                method, *args, engine=client.core_engines[1]
             )
-            results = await asyncio.gather(pause_0, pause_1)
-            return results[0]
+            return result
 
         client.call_utility_async = staggered_pause_keep
 
@@ -403,113 +398,3 @@ async def test_dp_pause_keep_race_staggered_engines():
         assert not await engine.is_paused()
         # Let the two requests we sent mid-pause complete
         await asyncio.gather(*mid_pause_tasks)
-
-
-@pytest.mark.asyncio
-async def test_dp_pause_barrier_request_deadlock():
-    """
-    Test that start_dp_wave is ignored while paused.
-
-    Sequence:
-      1. Pause all engines (PAUSED_ALL).
-      2. Send barrier to engine 0 only — blocks in dist.barrier(dp_group).
-      3. Send a request routed to engine 1.
-      4. Wait for any (buggy) START_DP_WAVE propagation.
-      5. Send barrier to engine 1 — completes in fixed code, deadlocks
-         in buggy code because engine 1 is stuck in EP all-to-all.
-    """
-    if DP_SIZE != 2:
-        pytest.skip("requires DP_SIZE=2")
-
-    with ExitStack() as after:
-        engine_args = _get_dp_pause_engine_args(expert_parallel=True)
-        engine = AsyncLLM.from_engine_args(engine_args)
-        after.callback(engine.shutdown)
-
-        client = engine.engine_core
-
-        # Cache get_supported_tasks so that generate() won't need to
-        # send a utility call to all engines (which would hang once
-        # engine 0 is blocked in the barrier).
-        await engine.get_supported_tasks()
-
-        # Pause all engines normally — no staggering.
-        await engine.pause_generation(mode="keep")
-        assert await engine.is_paused()
-
-        original_call_utility = client.call_utility_async
-        mid_barrier_tasks: list[asyncio.Task] = []
-
-        async def staggered_barrier(method: str, *args) -> Any:
-            if method != "barrier":
-                return await original_call_utility(method, *args)
-
-            # Send barrier to engine 0 only — it blocks in
-            # dist.barrier(dp_group) waiting for engine 1.
-            barrier_0 = asyncio.create_task(
-                client._call_utility_async(method, *args, engine=client.core_engines[0])
-            )
-            await asyncio.sleep(1)
-
-            # While engine 0 is blocked, send a request routed
-            # specifically to engine 1.
-            sp = SamplingParams(max_tokens=5, ignore_eos=True)
-
-            engine_1 = client.core_engines[1]
-            original_get_engine = client.get_core_engine_for_request
-
-            def route_to_engine_1(req):
-                client.reqs_in_flight[req.request_id] = engine_1
-                return engine_1
-
-            client.get_core_engine_for_request = route_to_engine_1
-
-            async def consume_gen(req_id: str) -> None:
-                async for _ in engine.generate(
-                    request_id=req_id,
-                    prompt=DP_PAUSE_PROMPT,
-                    sampling_params=sp,
-                ):
-                    pass
-
-            t1 = asyncio.create_task(consume_gen("race-1"))
-            mid_barrier_tasks.append(t1)
-
-            # Yield so generate() preprocessing completes and
-            # add_request_async is called (which, in buggy code,
-            # would send FIRST_REQ and wake engine 1).
-            for _ in range(200):
-                await asyncio.sleep(0)
-
-            client.get_core_engine_for_request = original_get_engine
-
-            # Wait for any START_DP_WAVE to propagate and for
-            # engine 1 to potentially enter execute_dummy_batch.
-            await asyncio.sleep(5)
-
-            # Now send barrier to engine 1.  In buggy code engine 1
-            # is stuck in execute_dummy_batch (EP all-to-all) while
-            # engine 0 is stuck in dist.barrier(dp_group) — deadlock.
-            result = await client._call_utility_async(
-                method, *args, engine=client.core_engines[1]
-            )
-            await barrier_0
-            return result
-
-        client.call_utility_async = staggered_barrier
-
-        # Drive the staggered barrier.  Old code deadlocks here.
-        try:
-            await asyncio.wait_for(client.call_utility_async("barrier"), timeout=30)
-        except asyncio.TimeoutError:
-            for t in mid_barrier_tasks:
-                t.cancel()
-            pytest.fail(
-                "Staggered barrier deadlocked — FIRST_REQ sent while "
-                "paused caused collective-op mismatch between engines"
-            )
-
-        await engine.resume_generation()
-        assert not await engine.is_paused()
-        # Let the two requests we sent mid-barrier complete.
-        await asyncio.gather(*mid_barrier_tasks)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -219,6 +219,9 @@ class ModelConfig:
     flexibility."""
     enable_return_routed_experts: bool = False
     """Whether to return routed experts."""
+    routed_experts_replay_max_blocks: int = Field(default=4096, ge=1)
+    """Maximum number of KV-cache-sized routing blocks to keep in the
+    routed-experts replay LRU cache."""
     max_logprobs: int = 20
     """Maximum number of log probabilities to return when `logprobs` is
     specified in `SamplingParams`. The default value comes the default for the

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -666,33 +666,6 @@ class ParallelConfig:
         return aggregated_has_unfinished
 
     @staticmethod
-    def sync_dp_state(
-        dp_group: ProcessGroup, has_unfinished: bool, pending_pause: bool
-    ) -> tuple[bool, bool]:
-        """Combined all-reduce for DP state synchronization.
-
-        Uses a single SUM all-reduce on a 2-element tensor:
-          [0] = 1 if this rank has unfinished work, else 0.
-                SUM > 0 ≡ logical OR across ranks → any rank has work.
-          [1] = 1 if this rank has a pending pause request, else 0.
-                SUM == dp_size ≡ all ranks reached pause consensus.
-
-        has_unfinished_global is true if any rank has unfinished work,
-        or if some ranks are waiting for a pause consensus.
-
-        Returns:
-            (has_unfinished_global, pause_consensus)
-        """
-        tensor = torch.tensor(
-            [int(has_unfinished), int(pending_pause)], dtype=torch.int32, device="cpu"
-        )
-        torch.distributed.all_reduce(tensor, op=ReduceOp.SUM, group=dp_group)
-        dp_size = dp_group.size()
-        pause_count = tensor[1].item()
-        has_unfinished_global = tensor[0].item() > 0 or pause_count % dp_size != 0
-        return has_unfinished_global, pause_count == dp_size
-
-    @staticmethod
     def sync_kv_cache_memory_size(dp_group: ProcessGroup, kv_cache_memory: int) -> int:
         if kv_cache_memory == -1:
             kv_cache_memory = torch.iinfo(torch.int64).max

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1839,6 +1839,7 @@ class VllmConfig:
             f"quantization_config={self.model_config.quantization_config}, "  # noqa
             f"enforce_eager={self.model_config.enforce_eager}, "
             f"enable_return_routed_experts={self.model_config.enable_return_routed_experts}, "  # noqa
+            f"routed_experts_replay_max_blocks={self.model_config.routed_experts_replay_max_blocks}, "  # noqa
             f"kv_cache_dtype={self.cache_config.cache_dtype}, "
             f"device_config={self.device_config.device}, "
             f"structured_outputs_config={self.structured_outputs_config!r}, "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -414,6 +414,9 @@ class EngineArgs:
 
     model: str = ModelConfig.model
     enable_return_routed_experts: bool = ModelConfig.enable_return_routed_experts
+    routed_experts_replay_max_blocks: int = (
+        ModelConfig.routed_experts_replay_max_blocks
+    )
     model_weights: str = ModelConfig.model_weights
     served_model_name: str | list[str] | None = ModelConfig.served_model_name
     tokenizer: str | None = ModelConfig.tokenizer
@@ -793,6 +796,10 @@ class EngineArgs:
         model_group.add_argument(
             "--enable-return-routed-experts",
             **model_kwargs["enable_return_routed_experts"],
+        )
+        model_group.add_argument(
+            "--routed-experts-replay-max-blocks",
+            **model_kwargs["routed_experts_replay_max_blocks"],
         )
         model_group.add_argument("--max-logprobs", **model_kwargs["max_logprobs"])
         model_group.add_argument("--logprobs-mode", **model_kwargs["logprobs_mode"])
@@ -1532,6 +1539,9 @@ class EngineArgs:
             allow_deprecated_quantization=self.allow_deprecated_quantization,
             enforce_eager=self.enforce_eager,
             enable_return_routed_experts=self.enable_return_routed_experts,
+            routed_experts_replay_max_blocks=(
+                self.routed_experts_replay_max_blocks
+            ),
             max_logprobs=self.max_logprobs,
             logprobs_mode=self.logprobs_mode,
             disable_sliding_window=self.disable_sliding_window,

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import contextlib
 import logging
 from abc import ABC, abstractmethod
+from collections import OrderedDict
+from collections.abc import Sequence
 
 import numpy as np
 import torch
@@ -48,6 +50,7 @@ def _capture_routing_op_fake(
 
 
 _MB = 1024 * 1024
+_MAX_ROUTED_EXPERT_BLOCK_CACHE_BLOCKS = 4096
 
 
 class _RoutedExpertsDeviceCache:
@@ -125,8 +128,9 @@ class _RoutedExpertsHostCache:
         required_len = max_pos + 1
 
         if req_id not in self._req_buffers:
-            buf = np.zeros(
+            buf = np.full(
                 (required_len, self.num_hidden_layers, self.num_experts_per_tok),
+                -1,
                 dtype=self.DTYPE,
             )
             self._req_buffers[req_id] = buf
@@ -138,8 +142,9 @@ class _RoutedExpertsHostCache:
             return buf
 
         new_len = min(max(required_len, buf.shape[0] * 2), self.max_model_len)
-        new_buf = np.zeros(
+        new_buf = np.full(
             (new_len, self.num_hidden_layers, self.num_experts_per_tok),
+            -1,
             dtype=self.DTYPE,
         )
         new_buf[: buf.shape[0]] = buf
@@ -172,6 +177,38 @@ class _RoutedExpertsHostCache:
         )
 
 
+class _RoutedExpertsBlockCache:
+    """Content-addressed routing cache for prefix-cache block reuse."""
+
+    def __init__(self, max_blocks: int) -> None:
+        self.max_blocks = max(1, max_blocks)
+        self._blocks: OrderedDict[bytes, np.ndarray] = OrderedDict()
+
+    def get(self, block_hash: bytes) -> np.ndarray | None:
+        key = bytes(block_hash)
+        block = self._blocks.get(key)
+        if block is not None:
+            self._blocks.move_to_end(key)
+        return block
+
+    def put(self, block_hash: bytes, routed_experts: np.ndarray) -> list[bytes]:
+        key = bytes(block_hash)
+        if key in self._blocks:
+            self._blocks.move_to_end(key)
+        self._blocks[key] = routed_experts.copy()
+        evicted: list[bytes] = []
+        while len(self._blocks) > self.max_blocks:
+            evicted_key, _ = self._blocks.popitem(last=False)
+            evicted.append(evicted_key)
+        return evicted
+
+    def clear(self) -> None:
+        self._blocks.clear()
+
+    def __len__(self) -> int:
+        return len(self._blocks)
+
+
 class RoutedExpertsCapturer(ABC):
     @staticmethod
     def create(
@@ -181,6 +218,7 @@ class RoutedExpertsCapturer(ABC):
         max_num_batched_tokens: int,
         max_model_len: int,
         device: str,
+        block_size: int = 0,
         shared_host_cache: _RoutedExpertsHostCache | None = None,
         skip_host_cache: bool = False,
     ):
@@ -191,6 +229,7 @@ class RoutedExpertsCapturer(ABC):
                 num_fused_shared_experts=num_fused_shared_experts,
                 max_model_len=max_model_len,
                 device=device,
+                block_size=block_size,
                 shared_host_cache=shared_host_cache,
                 skip_host_cache=skip_host_cache,
             )
@@ -209,7 +248,29 @@ class RoutedExpertsCapturer(ABC):
         self,
         positions: torch.Tensor,
         num_scheduled_tokens: dict[str, int],
+        block_hashes: dict[str, Sequence[bytes]] | None = None,
+        block_size: int = 0,
     ):
+        raise NotImplementedError
+
+    def hydrate_cached_prefix(
+        self,
+        req_id: str,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+        block_size: int,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_num_available_prefix_tokens(
+        self,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+        block_size: int,
+    ) -> int:
+        raise NotImplementedError
+
+    def take_routing_replay_block_hash_updates(self) -> tuple[list[bytes], list[bytes]]:
         raise NotImplementedError
 
     def finalize_pending_copy(self):
@@ -229,6 +290,7 @@ def _count_moe_layers(hf_config) -> int:
     - Nemotron-style: an explicit ``layers_block_type`` list with "moe" entries.
     - Qwen3MoE / DeepSeek-style sparse: ``decoder_sparse_step > 1`` with optional
       ``mlp_only_layers`` exclusions.
+    - GLM / DeepSeek-style prefix-dense stacks via ``first_k_dense_replace``.
     - Default: every layer is MoE except those listed in ``mlp_only_layers``.
     """
     layers_block_type = getattr(hf_config, "layers_block_type", None)
@@ -236,6 +298,14 @@ def _count_moe_layers(hf_config) -> int:
         return layers_block_type.count("moe")
     n = hf_config.num_hidden_layers
     mlp_only = getattr(hf_config, "mlp_only_layers", None) or []
+    first_k_dense = getattr(hf_config, "first_k_dense_replace", None)
+    moe_layer_freq = getattr(hf_config, "moe_layer_freq", 1) or 1
+    if first_k_dense is not None:
+        return sum(
+            1
+            for i in range(n)
+            if i >= first_k_dense and i % moe_layer_freq == 0 and i not in mlp_only
+        )
     step = getattr(hf_config, "decoder_sparse_step", 1) or 1
     if step > 1:
         return sum(1 for i in range(n) if (i + 1) % step == 0 and i not in mlp_only)
@@ -264,6 +334,7 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         num_fused_shared_experts: int,
         max_model_len: int,
         device: str,
+        block_size: int = 0,
         shared_host_cache: _RoutedExpertsHostCache | None = None,
         skip_host_cache: bool = False,
     ):
@@ -272,6 +343,7 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         self.num_experts_per_tok = model_config.hf_text_config.num_experts_per_tok
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_model_len = max_model_len
+        self.block_size = block_size
         self._skip_host_cache = skip_host_cache
 
         if skip_host_cache:
@@ -299,9 +371,21 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         self._has_pending_copy = False
         self._pending_positions: np.ndarray | None = None
         self._pending_num_scheduled: dict[str, int] | None = None
+        self._pending_block_hashes: dict[str, Sequence[bytes]] | None = None
+        self._pending_block_size = block_size
         self._pending_total_tokens: int = 0
+        self._added_routing_replay_block_hashes: list[bytes] = []
+        self._removed_routing_replay_block_hashes: list[bytes] = []
 
         if not skip_host_cache:
+            max_blocks = 1
+            if block_size > 0:
+                max_blocks = max_num_batched_tokens * (
+                    (max_model_len + block_size - 1) // block_size
+                )
+                max_blocks = min(max_blocks, _MAX_ROUTED_EXPERT_BLOCK_CACHE_BLOCKS)
+            self.block_cache = _RoutedExpertsBlockCache(max_blocks=max_blocks)
+
             # Same (L, N, K) layout as device_cache.buffer.
             self._pinned_staging = torch.zeros(
                 (
@@ -322,11 +406,13 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
             pinned_mb = self._pinned_staging.nbytes / _MB
             logger.info(
                 "Routing experts pinned staging buffer allocated. "
-                "shape=%s, size=%.2f MB",
+                "shape=%s, size=%.2f MB, block_cache_max_blocks=%s",
                 tuple(self._pinned_staging.shape),
                 pinned_mb,
+                self.block_cache.max_blocks,
             )
         else:
+            self.block_cache = None
             self._pinned_staging = None
             self._device_staging = None
             self._copy_stream = None
@@ -348,6 +434,8 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         self,
         positions: torch.Tensor,
         num_scheduled_tokens: dict[str, int],
+        block_hashes: dict[str, Sequence[bytes]] | None = None,
+        block_size: int = 0,
     ):
         if self.host_cache is None:
             return
@@ -383,12 +471,116 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         # 3. Save metadata for deferred scatter.
         self._pending_positions = positions.numpy().copy()
         self._pending_num_scheduled = num_scheduled_tokens
+        self._pending_block_hashes = block_hashes
+        self._pending_block_size = block_size or self.block_size
         self._pending_total_tokens = total_tokens
         self._has_pending_copy = True
 
     # ------------------------------------------------------------------
     # Optimized scatter into pre-allocated host-cache buffers
     # ------------------------------------------------------------------
+
+    def hydrate_cached_prefix(
+        self,
+        req_id: str,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+        block_size: int,
+    ) -> None:
+        if self.host_cache is None or self.block_cache is None:
+            return
+        if num_cached_tokens <= 0 or block_size <= 0:
+            return
+
+        num_blocks = min(num_cached_tokens // block_size, len(block_hashes))
+        if num_blocks <= 0:
+            return
+
+        max_pos = num_blocks * block_size - 1
+        buf = self.host_cache.get_or_grow_buffer(req_id, max_pos)
+        hydrated_max_pos = -1
+        for block_idx in range(num_blocks):
+            cached_block = self.block_cache.get(block_hashes[block_idx])
+            if cached_block is None:
+                continue
+            if cached_block.shape != (
+                block_size,
+                self.num_hidden_layers,
+                self.num_experts_per_tok,
+            ):
+                continue
+            start = block_idx * block_size
+            end = start + block_size
+            buf[start:end] = cached_block
+            hydrated_max_pos = max(hydrated_max_pos, end - 1)
+
+        if hydrated_max_pos >= 0:
+            self.host_cache.update_filled_len(req_id, hydrated_max_pos)
+
+    def get_num_available_prefix_tokens(
+        self,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+        block_size: int,
+    ) -> int:
+        if self.block_cache is None:
+            return 0
+        self.finalize_pending_copy()
+        if num_cached_tokens <= 0 or block_size <= 0:
+            return 0
+
+        num_blocks = min(num_cached_tokens // block_size, len(block_hashes))
+        if num_blocks <= 0:
+            return 0
+
+        expected_shape = (
+            block_size,
+            self.num_hidden_layers,
+            self.num_experts_per_tok,
+        )
+        for block_idx in range(num_blocks):
+            cached_block = self.block_cache.get(block_hashes[block_idx])
+            if cached_block is None or cached_block.shape != expected_shape:
+                return block_idx * block_size
+        return num_blocks * block_size
+
+    def _publish_complete_blocks(
+        self,
+        req_id: str,
+        buf: np.ndarray,
+        positions: np.ndarray,
+    ) -> None:
+        if self.block_cache is None or self._pending_block_hashes is None:
+            return
+        block_size = self._pending_block_size
+        if block_size <= 0 or positions.size == 0:
+            return
+
+        block_hashes = self._pending_block_hashes.get(req_id)
+        if not block_hashes:
+            return
+
+        # A block can become hashable one scheduler step after its routing
+        # rows are filled when the block is completed by a sampled token.
+        first_block = max(int(positions.min()) // block_size - 1, 0)
+        last_block = min(int(positions.max()) // block_size + 1, len(block_hashes))
+        for block_idx in range(first_block, last_block):
+            start = block_idx * block_size
+            end = start + block_size
+            if end > buf.shape[0]:
+                continue
+            block = buf[start:end]
+            if block.shape[0] != block_size or np.any(block < 0) or not np.any(block):
+                continue
+            rows = block.reshape(-1, block.shape[-1])
+            if rows.shape[-1] > 1:
+                sorted_rows = np.sort(rows, axis=-1)
+                if np.any(np.diff(sorted_rows, axis=-1) == 0):
+                    continue
+            block_hash = bytes(block_hashes[block_idx])
+            evicted_hashes = self.block_cache.put(block_hash, block)
+            self._added_routing_replay_block_hashes.append(block_hash)
+            self._removed_routing_replay_block_hashes.extend(evicted_hashes)
 
     def _scatter_to_host(self):
         """Scatter D2H data into per-request host cache buffers.
@@ -419,6 +611,9 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
                 buf = host_cache.get_or_grow_buffer(req_id, pos_val)
                 buf[pos_val] = host_values[offset]
                 host_cache.update_filled_len(req_id, pos_val)
+                self._publish_complete_blocks(
+                    req_id, buf, positions_np[offset : offset + 1]
+                )
             else:
                 pos = positions_np[offset : offset + n_tokens]
                 max_pos = int(pos[-1]) if n_tokens > 0 else 0
@@ -427,11 +622,13 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
                 buf = host_cache.get_or_grow_buffer(req_id, max_pos)
                 buf[pos] = host_values[offset : offset + n_tokens]
                 host_cache.update_filled_len(req_id, max_pos)
+                self._publish_complete_blocks(req_id, buf, pos)
 
             offset += n_tokens
 
         self._pending_positions = None
         self._pending_num_scheduled = None
+        self._pending_block_hashes = None
         self._pending_total_tokens = 0
 
     # ------------------------------------------------------------------
@@ -476,6 +673,13 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
     def get_device_cache(self):
         return self.device_cache
 
+    def take_routing_replay_block_hash_updates(self) -> tuple[list[bytes], list[bytes]]:
+        added = self._added_routing_replay_block_hashes
+        removed = self._removed_routing_replay_block_hashes
+        self._added_routing_replay_block_hashes = []
+        self._removed_routing_replay_block_hashes = []
+        return added, removed
+
 
 class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
     def __init__(self):
@@ -487,8 +691,34 @@ class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
     def get_routed_experts(self, req_id: str, seqlen=None, free_slot=True):
         return None
 
-    def sync_fwd_experts_buffer_DtoH(self, positions, num_scheduled_tokens):
+    def sync_fwd_experts_buffer_DtoH(
+        self,
+        positions,
+        num_scheduled_tokens,
+        block_hashes=None,
+        block_size: int = 0,
+    ):
         pass
+
+    def hydrate_cached_prefix(
+        self,
+        req_id: str,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+        block_size: int,
+    ) -> None:
+        pass
+
+    def get_num_available_prefix_tokens(
+        self,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+        block_size: int,
+    ) -> int:
+        return 0
+
+    def take_routing_replay_block_hash_updates(self) -> tuple[list[bytes], list[bytes]]:
+        return [], []
 
     def finalize_pending_copy(self):
         pass
@@ -638,6 +868,8 @@ def issue_routing_d2h_copy(
     num_scheduled_tokens: dict[str, int],
     positions: torch.Tensor,
     positions_cpu: torch.Tensor,
+    requests: dict | None = None,
+    block_size: int = 0,
 ) -> None:
     """Issue async D2H copy of routed experts after the forward pass.
 
@@ -657,9 +889,18 @@ def issue_routing_d2h_copy(
     }
     n = sum(ordered.values())
     positions_cpu[:n].copy_(positions[:n])
+    block_hashes = None
+    if requests is not None:
+        block_hashes = {
+            req_id: requests[req_id].block_hashes
+            for req_id in ordered
+            if req_id in requests
+        }
     capturer.sync_fwd_experts_buffer_DtoH(
         positions=positions_cpu[:n],
         num_scheduled_tokens=ordered,
+        block_hashes=block_hashes,
+        block_size=block_size,
     )
 
 
@@ -728,6 +969,7 @@ def init_routed_experts_capturer_with_shared_cache(
     max_num_batched_tokens: int,
     max_model_len: int,
     device: str,
+    block_size: int = 0,
     rank: int = 0,
     world_size: int = 1,
 ) -> RoutedExpertsCapturer:
@@ -750,6 +992,7 @@ def init_routed_experts_capturer_with_shared_cache(
             max_num_batched_tokens=max_num_batched_tokens,
             max_model_len=max_model_len,
             device=device,
+            block_size=block_size,
             skip_host_cache=True,
         )
         set_global_experts_capturer(capturer)
@@ -762,6 +1005,7 @@ def init_routed_experts_capturer_with_shared_cache(
         max_num_batched_tokens=max_num_batched_tokens,
         max_model_len=max_model_len,
         device=device,
+        block_size=block_size,
         skip_host_cache=False,
     )
     set_global_experts_capturer(capturer)

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -50,7 +50,6 @@ def _capture_routing_op_fake(
 
 
 _MB = 1024 * 1024
-_MAX_ROUTED_EXPERT_BLOCK_CACHE_BLOCKS = 4096
 
 
 class _RoutedExpertsDeviceCache:
@@ -383,7 +382,10 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
                 max_blocks = max_num_batched_tokens * (
                     (max_model_len + block_size - 1) // block_size
                 )
-                max_blocks = min(max_blocks, _MAX_ROUTED_EXPERT_BLOCK_CACHE_BLOCKS)
+                max_blocks = min(
+                    max_blocks,
+                    model_config.routed_experts_replay_max_blocks,
+                )
             self.block_cache = _RoutedExpertsBlockCache(max_blocks=max_blocks)
 
             # Same (L, N, K) layout as device_cache.buffer.

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -42,6 +42,8 @@ class NewRequestData:
 
     # Only used for v2 model runner.
     prefill_token_ids: list[int] | None = None
+    # Prefix-cache block hashes for the request's full token blocks.
+    block_hashes: list[bytes] = field(default_factory=list)
 
     @classmethod
     def from_request(
@@ -62,6 +64,7 @@ class NewRequestData:
             prompt_embeds=request.prompt_embeds,
             prompt_is_token_ids=request.prompt_is_token_ids,
             prefill_token_ids=prefill_token_ids,
+            block_hashes=list(request.block_hashes),
         )
 
     def __repr__(self) -> str:
@@ -77,6 +80,7 @@ class NewRequestData:
             f"sampling_params={self.sampling_params},"
             f"block_ids={self.block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
+            f"num_block_hashes={len(self.block_hashes)},"
             f"lora_request={self.lora_request},"
             f"prompt_embeds_shape={prompt_embeds_shape}"
             ")"
@@ -102,6 +106,7 @@ class NewRequestData:
             f"sampling_params={self.sampling_params},"
             f"block_ids={self.block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
+            f"num_block_hashes={len(self.block_hashes)},"
             f"lora_request={self.lora_request},"
             f"prompt_embeds_shape={prompt_embeds_shape}"
             ")"
@@ -124,6 +129,8 @@ class CachedRequestData:
     new_block_ids: list[tuple[list[int], ...] | None]
     num_computed_tokens: list[int]
     num_output_tokens: list[int]
+    # Full prefix-cache block-hash chain per request, aligned with req_ids.
+    block_hashes: list[list[bytes]] = field(default_factory=list)
 
     # Version of dataclass repr with token IDs obfuscated.
     def anon_repr(self) -> str:
@@ -131,6 +138,7 @@ class CachedRequestData:
         all_token_ids_lens = {
             req_id: len(toks) for req_id, toks in self.all_token_ids.items()
         }
+        block_hashes_lens = [len(hashes) for hashes in self.block_hashes]
         return (
             f"CachedRequestData("
             f"req_ids={self.req_ids},"
@@ -139,7 +147,8 @@ class CachedRequestData:
             f"all_token_ids_lens={all_token_ids_lens},"
             f"new_block_ids={self.new_block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
-            f"num_output_tokens={self.num_output_tokens}"
+            f"num_output_tokens={self.num_output_tokens},"
+            f"block_hashes_lens={block_hashes_lens}"
             f")"
         )
 
@@ -174,6 +183,7 @@ class CachedRequestData:
             new_block_ids=[],
             num_computed_tokens=[],
             num_output_tokens=[],
+            block_hashes=[],
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import replace
 from typing import Any
 
@@ -146,8 +147,18 @@ class Scheduler(SchedulerInterface):
         assert num_gpu_blocks is not None and num_gpu_blocks > 0
 
         self.block_size = block_size
+        self.hash_block_size = (
+            hash_block_size if hash_block_size is not None else block_size
+        )
         self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         self.pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self._routing_replay_block_alignment = self.block_size
+        for kv_cache_group in self.kv_cache_config.kv_cache_groups:
+            self._routing_replay_block_alignment = math.lcm(
+                self._routing_replay_block_alignment,
+                kv_cache_group.kv_cache_spec.block_size,
+            )
+        self._routing_replay_block_hashes: set[bytes] = set()
 
         # req_id -> Request
         self.requests: dict[str, Request] = {}
@@ -255,6 +266,17 @@ class Scheduler(SchedulerInterface):
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
 
+        if (
+            self.vllm_config.model_config.enable_return_routed_experts
+            and self.cache_config.enable_prefix_caching
+        ):
+            logger.warning_once(
+                "enable_return_routed_experts is enabled with prefix caching. "
+                "Prefix-cache hits will be clipped to the longest prefix whose "
+                "routed-expert replay blocks are available; clipped tokens are "
+                "recomputed."
+            )
+
         self._pause_state: PauseState = PauseState.UNPAUSED
 
     def _mamba_block_aligned_split(
@@ -306,6 +328,110 @@ class Scheduler(SchedulerInterface):
                 # prefill the last few tokens
                 pass
         return num_new_tokens
+
+    def _clip_kv_cache_blocks_to_num_tokens(
+        self,
+        blocks: KVCacheBlocks,
+        num_tokens: int,
+    ) -> KVCacheBlocks:
+        if num_tokens <= 0:
+            return self.kv_cache_manager.empty_kv_cache_blocks
+
+        clipped_groups = []
+        for group_blocks, kv_cache_group in zip(
+            blocks.blocks, self.kv_cache_config.kv_cache_groups
+        ):
+            group_block_size = kv_cache_group.kv_cache_spec.block_size
+            num_group_blocks = num_tokens // group_block_size
+            clipped_groups.append(list(group_blocks)[:num_group_blocks])
+        return self.kv_cache_manager.create_kv_cache_blocks(tuple(clipped_groups))
+
+    def _get_num_available_routing_replay_prefix_tokens(
+        self,
+        block_hashes: Sequence[bytes],
+        num_cached_tokens: int,
+    ) -> int:
+        block_size = self.hash_block_size
+        if num_cached_tokens <= 0 or block_size <= 0:
+            return 0
+
+        num_blocks = min(num_cached_tokens // block_size, len(block_hashes))
+        for block_idx in range(num_blocks):
+            if bytes(block_hashes[block_idx]) not in self._routing_replay_block_hashes:
+                return block_idx * block_size
+        return num_blocks * block_size
+
+    def _clip_prefix_cache_hit_for_routing_replay(
+        self,
+        request: Request,
+        new_computed_blocks: KVCacheBlocks,
+        num_new_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+        load_kv_async: bool,
+    ) -> tuple[KVCacheBlocks, int, int, bool]:
+        initial_num_computed_tokens = (
+            num_new_local_computed_tokens + num_external_computed_tokens
+        )
+        if (
+            not self.vllm_config.model_config.enable_return_routed_experts
+            or initial_num_computed_tokens <= 0
+        ):
+            return (
+                new_computed_blocks,
+                num_new_local_computed_tokens,
+                num_external_computed_tokens,
+                load_kv_async,
+            )
+
+        replay_tokens = self._get_num_available_routing_replay_prefix_tokens(
+            block_hashes=request.block_hashes,
+            num_cached_tokens=initial_num_computed_tokens,
+        )
+        final_num_computed_tokens = min(initial_num_computed_tokens, replay_tokens)
+        alignment = self._routing_replay_block_alignment
+        final_num_computed_tokens = (
+            final_num_computed_tokens // alignment * alignment
+        )
+
+        if final_num_computed_tokens >= initial_num_computed_tokens:
+            return (
+                new_computed_blocks,
+                num_new_local_computed_tokens,
+                num_external_computed_tokens,
+                load_kv_async,
+            )
+
+        final_local_computed_tokens = min(
+            num_new_local_computed_tokens,
+            final_num_computed_tokens,
+        )
+        final_external_computed_tokens = max(
+            0,
+            final_num_computed_tokens - final_local_computed_tokens,
+        )
+        if final_local_computed_tokens < num_new_local_computed_tokens:
+            new_computed_blocks = self._clip_kv_cache_blocks_to_num_tokens(
+                new_computed_blocks,
+                final_local_computed_tokens,
+            )
+        if final_external_computed_tokens == 0:
+            load_kv_async = False
+
+        logger.warning(
+            "Clipping prefix-cache hit for routed-expert replay: req_id=%s "
+            "initial_num_computed_tokens=%d final_num_computed_tokens=%d "
+            "delta=%d",
+            request.request_id,
+            initial_num_computed_tokens,
+            final_num_computed_tokens,
+            initial_num_computed_tokens - final_num_computed_tokens,
+        )
+        return (
+            new_computed_blocks,
+            final_local_computed_tokens,
+            final_external_computed_tokens,
+            load_kv_async,
+        )
 
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:
@@ -593,6 +719,25 @@ class Scheduler(SchedulerInterface):
 
                         num_external_computed_tokens = ext_tokens
 
+                        connector_prefix_cache_queries = (
+                            request.num_tokens - num_new_local_computed_tokens
+                        )
+                        connector_prefix_cache_hits = num_external_computed_tokens
+
+                    (
+                        new_computed_blocks,
+                        num_new_local_computed_tokens,
+                        num_external_computed_tokens,
+                        load_kv_async,
+                    ) = self._clip_prefix_cache_hit_for_routing_replay(
+                        request,
+                        new_computed_blocks,
+                        num_new_local_computed_tokens,
+                        num_external_computed_tokens,
+                        load_kv_async,
+                    )
+                    request.num_external_computed_tokens = num_external_computed_tokens
+                    if self.connector is not None:
                         connector_prefix_cache_queries = (
                             request.num_tokens - num_new_local_computed_tokens
                         )
@@ -1012,6 +1157,7 @@ class Scheduler(SchedulerInterface):
         all_token_ids: dict[str, list[int]] = {}
         num_computed_tokens: list[int] = []
         num_output_tokens: list[int] = []
+        block_hashes: list[list[bytes]] = []
         resumed_req_ids = set()
 
         num_running_reqs = len(running_reqs)
@@ -1047,6 +1193,7 @@ class Scheduler(SchedulerInterface):
             num_output_tokens.append(
                 req.num_output_tokens + req.num_output_placeholders
             )
+            block_hashes.append(list(req.block_hashes))
 
         return CachedRequestData(
             req_ids=req_ids,
@@ -1056,6 +1203,7 @@ class Scheduler(SchedulerInterface):
             new_block_ids=new_block_ids,
             num_computed_tokens=num_computed_tokens,
             num_output_tokens=num_output_tokens,
+            block_hashes=block_hashes,
         )
 
     def _try_schedule_encoder_inputs(
@@ -1258,6 +1406,11 @@ class Scheduler(SchedulerInterface):
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
+        if self.vllm_config.model_config.enable_return_routed_experts:
+            for block_hash in model_runner_output.routing_replay_removed_block_hashes:
+                self._routing_replay_block_hashes.discard(bytes(block_hash))
+            for block_hash in model_runner_output.routing_replay_added_block_hashes:
+                self._routing_replay_block_hashes.add(bytes(block_hash))
 
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
@@ -1825,6 +1978,8 @@ class Scheduler(SchedulerInterface):
             self.prev_step_scheduled_req_ids.clear()
 
         reset_successful = self.kv_cache_manager.reset_prefix_cache()
+        if reset_successful:
+            self._routing_replay_block_hashes.clear()
         if reset_running_requests and not reset_successful:
             raise RuntimeError(
                 "Failed to reset KV cache even when all the running requests are "

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -361,6 +361,11 @@ class Scheduler(SchedulerInterface):
                 return block_idx * block_size
         return num_blocks * block_size
 
+    @staticmethod
+    def _is_remote_prefill_decode_request(request: Request) -> bool:
+        params = request.kv_transfer_params
+        return bool(params and params.get("do_remote_prefill"))
+
     def _clip_prefix_cache_hit_for_routing_replay(
         self,
         request: Request,
@@ -376,6 +381,14 @@ class Scheduler(SchedulerInterface):
             not self.vllm_config.model_config.enable_return_routed_experts
             or initial_num_computed_tokens <= 0
         ):
+            return (
+                new_computed_blocks,
+                num_new_local_computed_tokens,
+                num_external_computed_tokens,
+                load_kv_async,
+            )
+
+        if self._is_remote_prefill_decode_request(request):
             return (
                 new_computed_blocks,
                 num_new_local_computed_tokens,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1575,8 +1575,7 @@ class EngineCoreProc(EngineCore):
 
         pause_state = PauseState.PAUSED_ALL if mode == "keep" else PauseState.PAUSED_NEW
         self.scheduler.set_pause_state(pause_state)
-
-        if self._pause_complete():
+        if not self.has_work():
             if clear_cache:
                 self._reset_caches()
             return None
@@ -1584,13 +1583,6 @@ class EngineCoreProc(EngineCore):
         future = Future[Any]()
         self._idle_state_callbacks.append(partial(engine_idle_callback, future=future))
         return future
-
-    def _pause_complete(self) -> bool:
-        """Returns True if the pause has fully completed and the caller can
-        return ``None`` synchronously; False if the pause is still pending
-        and the caller should register an idle-state callback to finish it.
-        """
-        return not self.has_work()
 
     def _send_finish_outputs_to_client(
         self, req_ids: list[str], client_index: int, finish_reason: FinishReason
@@ -1647,14 +1639,6 @@ class DPEngineCoreProc(EngineCoreProc):
         self.current_wave = 0
         self.last_counts = (0, 0)
 
-        # Two-phase pause protocol state. When pending_pause is True, the
-        # engine keeps stepping (dummy batches) while waiting for all DP
-        # ranks to also set pending_pause. Once all ranks agree via
-        # all-reduce, ignore_start_dp_wave is set so that stale
-        # START_DP_WAVE messages cannot re-wake the engines.
-        self.pending_pause = False
-        self.ignore_start_dp_wave = False
-
         from vllm.distributed.elastic_ep.elastic_state import ElasticEPScalingState
 
         self.eep_scaling_state: ElasticEPScalingState | None = None
@@ -1684,7 +1668,6 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         self.dp_rank = dp_rank
-        self.dp_size = dp_size
         dp_group, dp_store = parallel_config.stateless_init_dp_group(return_store=True)
         self.dp_group, self.dp_store = dp_group, dp_store
 
@@ -1692,24 +1675,6 @@ class DPEngineCoreProc(EngineCoreProc):
         super().shutdown()
         if dp_group := getattr(self, "dp_group", None):
             stateless_destroy_torch_distributed_process_group(dp_group)
-
-    def _pause_complete(self) -> bool:
-        """Two-phase DP-aware pause.
-
-        Phase 1: Set local pause state and ``pending_pause`` flag. If the
-        engines are idle, kick-start them by setting ``engines_running`` to
-        True so ranks enter the stepping loop and reach the all-reduce
-        consensus checkpoint in ``_has_global_unfinished_reqs``.
-
-        Phase 2 (in ``_has_global_unfinished_reqs``): Once the all-reduce
-        confirms that **all** ranks have ``pending_pause`` set, collectively
-        stop stepping and set ``ignore_start_dp_wave`` so that stale
-        ``START_DP_WAVE`` messages cannot re-wake any engine.
-        """
-        self.pending_pause = True
-        self.engines_running = True
-
-        return False
 
     def add_request(self, request: Request, request_wave: int = 0):
         super().add_request(request, request_wave)
@@ -1720,60 +1685,36 @@ class DPEngineCoreProc(EngineCoreProc):
                 not self.engines_running
                 and self.scheduler.pause_state == PauseState.UNPAUSED
             ):
+                self.engines_running = True
                 # Request received for an already-completed wave, notify
                 # front-end that we need to start the next one.
-                self.engines_running = True
                 self.output_queue.put_nowait(
                     (-1, EngineCoreOutputs(start_wave=self.current_wave))
                 )
 
     def resume_scheduler(self):
-        if self.pending_pause or (self.engines_running and self.ignore_start_dp_wave):
-            raise RuntimeError(
-                "resume_scheduler called while pause is still in "
-                "flight. Wait for the pause future to resolve before "
-                "resuming."
-            )
-        if self.engines_running:
-            logger.debug("Resume called while engines are not paused, ignoring.")
-            return
-
         super().resume_scheduler()
-        self.ignore_start_dp_wave = False
-
-        # Barrier: wait for all DP ranks to have resumed (and cleared
-        # ignore_start_dp_wave) before any rank starts stepping. Uses
-        # the existing all-reduce which is safe because engines are
-        # stopped.
-        has_global_unfinished = ParallelConfig.has_unfinished_dp(
-            self.dp_group, self.scheduler.has_unfinished_requests()
-        )
-
-        if has_global_unfinished:
-            self.engines_running = True
-
-    def barrier(self):
-        """Blocking barrier on the DP process group (test-only utility)."""
-        import torch.distributed as dist
-
-        dist.barrier(group=self.dp_group)
+        if (
+            self.has_coordinator
+            and not self.engines_running
+            and self.scheduler.has_unfinished_requests()
+        ):
+            # Wake up other DP engines.
+            self.output_queue.put_nowait(
+                (-1, EngineCoreOutputs(start_wave=self.current_wave))
+            )
 
     def _handle_client_request(
         self, request_type: EngineCoreRequestType, request: Any
     ) -> None:
         if request_type == EngineCoreRequestType.START_DP_WAVE:
-            if self.ignore_start_dp_wave:
-                return
             new_wave, exclude_eng_index = request
             if exclude_eng_index != self.engine_index and (
                 new_wave >= self.current_wave
             ):
                 self.current_wave = new_wave
                 if not self.engines_running:
-                    logger.debug(
-                        "EngineCore starting idle loop for wave %d.",
-                        new_wave,
-                    )
+                    logger.debug("EngineCore starting idle loop for wave %d.", new_wave)
                     self.engines_running = True
         else:
             super()._handle_client_request(request_type, request)
@@ -1853,18 +1794,7 @@ class DPEngineCoreProc(EngineCoreProc):
         if self.step_counter % 32 != 0:
             return True
 
-        has_unfinished, pause_consensus = ParallelConfig.sync_dp_state(
-            self.dp_group,
-            has_unfinished=local_unfinished,
-            pending_pause=self.pending_pause,
-        )
-
-        if pause_consensus:
-            self.ignore_start_dp_wave = True
-            self.pending_pause = False
-            logger.debug("DP pause consensus reached, ignoring START_DP_WAVE.")
-
-        return has_unfinished
+        return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
 
     def reinitialize_distributed(
         self, reconfig_request: ReconfigureDistributedRequest

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -151,6 +151,7 @@ class RequestState:
         top_p: float | None = None,
         n: int | None = None,
         temperature: float | None = None,
+        return_completion_routed_experts_only: bool = False,
         stream_input: bool = False,
     ):
         self.request_id = request_id
@@ -172,6 +173,9 @@ class RequestState:
         self.top_p = top_p
         self.n = n
         self.temperature = temperature
+        self.return_completion_routed_experts_only = (
+            return_completion_routed_experts_only
+        )
         self.is_prefilling = True
         self.queue = queue
         self.num_cached_tokens = 0
@@ -246,6 +250,18 @@ class RequestState:
             output_kind = request.pooling_params.output_kind
 
         assert request.external_req_id is not None
+        return_completion_routed_experts_only = False
+        if (
+            request.sampling_params is not None
+            and request.sampling_params.extra_args is not None
+        ):
+            kv_transfer_params = request.sampling_params.extra_args.get(
+                "kv_transfer_params"
+            )
+            return_completion_routed_experts_only = bool(
+                kv_transfer_params and kv_transfer_params.get("do_remote_prefill")
+            )
+
         return cls(
             request_id=request.request_id,
             external_req_id=request.external_req_id,
@@ -262,6 +278,9 @@ class RequestState:
             top_p=top_p,
             n=n,
             temperature=temperature,
+            return_completion_routed_experts_only=(
+                return_completion_routed_experts_only
+            ),
             arrival_time=request.arrival_time,
             queue=queue,
             log_stats=log_stats,
@@ -332,6 +351,8 @@ class RequestState:
             prompt_routed_experts, gen_routed_experts = split_routed_experts(
                 routed_experts, prompt_len, num_gen
             )
+            if self.return_completion_routed_experts_only:
+                prompt_routed_experts = None
 
         output = self._new_completion_output(
             new_token_ids, finish_reason, stop_reason, gen_routed_experts

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -201,6 +201,10 @@ class ModelRunnerOutput:
     # req_id -> routed experts ndarray of shape (seq_len, num_moe_layers, top_k)
     routed_experts_dict: dict[str, np.ndarray] | None = None
 
+    # Block-hash deltas for routed-expert replay data cached by the model runner.
+    routing_replay_added_block_hashes: list[bytes] = field(default_factory=list)
+    routing_replay_removed_block_hashes: list[bytes] = field(default_factory=list)
+
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -39,6 +39,7 @@ class CachedRequestState:
     generator: torch.Generator | None
 
     block_ids: tuple[list[int], ...]
+    block_hashes: list[bytes]
     num_computed_tokens: int
     output_token_ids: list[int]
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1053,6 +1053,20 @@ class GPUModelRunner(
         if hasattr(self, "_kv_block_zeroer"):
             self._kv_block_zeroer.zero_block_ids(block_ids)
 
+    def _hydrate_cached_routed_experts(
+        self,
+        req_state: CachedRequestState,
+        num_cached_tokens: int,
+    ) -> None:
+        if not self.routed_experts_initialized or num_cached_tokens <= 0:
+            return
+        get_global_experts_capturer().hydrate_cached_prefix(
+            req_id=req_state.req_id,
+            block_hashes=req_state.block_hashes,
+            num_cached_tokens=num_cached_tokens,
+            block_size=self.cache_config.block_size,
+        )
+
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:
         """Initialize attributes from torch.cuda.get_device_properties"""
@@ -1149,6 +1163,9 @@ class GPUModelRunner(
             if req_id in self.requests:
                 # For streaming case only.
                 req_state = self._update_streaming_request(req_id, new_req_data)
+                self._hydrate_cached_routed_experts(
+                    req_state, new_req_data.num_computed_tokens
+                )
                 reqs_to_add.append(req_state)
                 continue
 
@@ -1183,11 +1200,15 @@ class GPUModelRunner(
                 pooling_params=pooling_params,
                 generator=generator,
                 block_ids=new_req_data.block_ids,
+                block_hashes=list(new_req_data.block_hashes),
                 num_computed_tokens=new_req_data.num_computed_tokens,
                 output_token_ids=[],
                 lora_request=new_req_data.lora_request,
             )
             self.requests[req_id] = req_state
+            self._hydrate_cached_routed_experts(
+                req_state, new_req_data.num_computed_tokens
+            )
             self.late_interaction_runner.register_request(req_id, pooling_params)
 
             if sampling_params and sampling_params.prompt_logprobs is not None:
@@ -1285,6 +1306,10 @@ class GPUModelRunner(
 
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens
+            if i < len(req_data.block_hashes):
+                req_state.block_hashes = list(req_data.block_hashes[i])
+            if resumed_from_preemption:
+                self._hydrate_cached_routed_experts(req_state, num_computed_tokens)
 
             if not is_last_rank:
                 if not req_data.new_token_ids:
@@ -1512,6 +1537,7 @@ class GPUModelRunner(
         req_state.pooling_params = new_req_data.pooling_params
         self.late_interaction_runner.register_request(req_id, req_state.pooling_params)
         req_state.block_ids = new_req_data.block_ids
+        req_state.block_hashes = list(new_req_data.block_hashes)
         req_state.num_computed_tokens = new_req_data.num_computed_tokens
         req_state.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
             req_state.prompt_token_ids, req_state.prompt_embeds
@@ -4382,6 +4408,8 @@ class GPUModelRunner(
                 num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                 positions=self.positions,
                 positions_cpu=self._positions_cpu,
+                requests=self.requests,
+                block_size=self.cache_config.block_size,
             )
 
         if propose_drafts_after_bookkeeping:
@@ -4404,7 +4432,10 @@ class GPUModelRunner(
 
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
             routed_experts_dict = None
+            routing_replay_added_block_hashes: list[bytes] = []
+            routing_replay_removed_block_hashes: list[bytes] = []
             if self.routed_experts_initialized:
+                capturer = get_global_experts_capturer()
                 routed_experts_dict = extract_routed_experts_for_current_batch(
                     req_ids=req_ids_output_copy,
                     requests=self.requests,
@@ -4412,6 +4443,10 @@ class GPUModelRunner(
                     num_tokens_no_spec=self.input_batch.num_tokens_no_spec,
                     max_model_len=self.max_model_len,
                 )
+                (
+                    routing_replay_added_block_hashes,
+                    routing_replay_removed_block_hashes,
+                ) = capturer.take_routing_replay_block_hash_updates()
 
             output = ModelRunnerOutput(
                 req_ids=req_ids_output_copy,
@@ -4426,6 +4461,12 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts_dict=routed_experts_dict,
+                routing_replay_added_block_hashes=(
+                    routing_replay_added_block_hashes
+                ),
+                routing_replay_removed_block_hashes=(
+                    routing_replay_removed_block_hashes
+                ),
             )
 
         if not self.use_async_scheduling:
@@ -7009,6 +7050,7 @@ class GPUModelRunner(
             max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
             max_model_len=self.max_model_len,
             device=self.device,
+            block_size=self.cache_config.block_size,
             rank=tp_group.rank_in_group,
             world_size=tp_group.world_size,
         )


### PR DESCRIPTION
## Purpose
- add routed-experts replay for prefix-cache hits by storing routing blocks keyed by KV block hash
- clip prefix-cache hits to available routed-expert replay blocks when routed experts are requested
- avoid replay-prefill work on P/D decode requests that already use external KV cache
- expose --routed-experts-replay-max-blocks to tune replay LRU size
- revert the two-phase DP pause protocol from #39366 for Prime RL NCCL transfer compatibility

## Test Plan
- GLM 5.1 FP8 DPEP16 raw vLLM smoke with use_deep_gemm=true returned valid prompt/completion routed experts
- Prime RL GLM 5.1 P/D R3 run reached training steps with low mismatch KL after router replay
- Prime RL Qwen3-30B-A3B Wordle multi-turn R3 run reached step 0 with Mismatch KL 0.0009

## Test Result
- Verified routed-experts cache initialized with configurable block cache size in vLLM logs
- Verified P/D decode path does not clip/re-prefill routed experts on decode workers
- Verified trainer consumed routed experts without layer-count/indexing failures

Note: this PR intentionally includes the #39366 revert needed by the current Prime RL pause/resume path.