### PR TITLE
Fix/full attention ghost block race

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
     VLLM_MAIN_CUDA_VERSION: str = "13.0"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
+    VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT: bool = False
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -526,6 +527,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
+    # When True, enable the FullAttentionManager same-step ghost-block defer
+    # (PR #42359). Off by default. Only takes effect when speculative decoding
+    # is enabled — see `vllm/v1/core/single_type_kv_cache_manager.py`.
+    "VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT": lambda: bool(
+        int(os.getenv("VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT", "0"))
+    ),
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs
     "MAX_JOBS": lambda: os.getenv("MAX_JOBS", None),

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -73,6 +73,10 @@ class KVCacheCoordinator(ABC):
                 kv_cache_group_id=i,
                 dcp_world_size=dcp_world_size,
                 pcp_world_size=pcp_world_size,
+                # Forward spec-decode bit so FullAttentionManager can combine
+                # it with VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT to decide
+                # whether to defer same-step ghost-block hits (PR #42359).
+                use_eagle=use_eagle,
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -473,6 +473,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
         num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
     ) -> int:
         if (
             len(new_computed_blocks) > 0
@@ -487,6 +488,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         return super().get_num_blocks_to_allocate(
             request_id, num_tokens, new_computed_blocks,
             total_computed_tokens, num_tokens_main_model,
+            apply_admission_cap=apply_admission_cap,
         )
 
     @classmethod

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -444,6 +444,51 @@ class SingleTypeKVCacheManager(ABC):
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Track block hashes committed to the cache in the current scheduling
+        # step so we can defer requests that would otherwise read KV blocks
+        # that the GPU has not yet written (same-step ghost block race).
+        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        num_cached_before = self.num_cached_block.get(request.request_id, 0)
+        super().cache_blocks(request, num_tokens)
+        num_cached_after = self.num_cached_block.get(request.request_id, 0)
+        for block in self.req_to_blocks[request.request_id][
+            num_cached_before:num_cached_after
+        ]:
+            if block.is_null or block.block_hash is None:
+                continue
+            self.cached_blocks_this_step.add(block.block_hash)
+
+    def new_step_starts(self) -> None:
+        self.cached_blocks_this_step.clear()
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+    ) -> int:
+        if (
+            len(new_computed_blocks) > 0
+            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
+        ):
+            # A block at the tail of the prefix hit was committed by another
+            # request in the current scheduling step; the GPU has not written
+            # its KV yet. Return an impossible block count so the scheduler
+            # skips this request and retries in the next step (same pattern
+            # used by MambaManager, see PR #29387).
+            return self.block_pool.num_gpu_blocks + 1
+        return super().get_num_blocks_to_allocate(
+            request_id, num_tokens, new_computed_blocks,
+            total_computed_tokens, num_tokens_main_model,
+        )
+
     @classmethod
     def find_longest_cache_hit(
         cls,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -444,7 +444,6 @@ class SingleTypeKVCacheManager(ABC):
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Track block hashes committed to the cache in the current scheduling
@@ -486,8 +485,11 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             # used by MambaManager, see PR #29387).
             return self.block_pool.num_gpu_blocks + 1
         return super().get_num_blocks_to_allocate(
-            request_id, num_tokens, new_computed_blocks,
-            total_computed_tokens, num_tokens_main_model,
+            request_id,
+            num_tokens,
+            new_computed_blocks,
+            total_computed_tokens,
+            num_tokens_main_model,
             apply_admission_cap=apply_admission_cap,
         )
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -42,6 +42,7 @@ class SingleTypeKVCacheManager(ABC):
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
         max_admission_blocks_per_request: int | None = None,
+        use_eagle: bool = False,
     ) -> None:
         """
         Initializes the SingleTypeKVCacheManager.
@@ -55,6 +56,12 @@ class SingleTypeKVCacheManager(ABC):
                 chunked-local); `None` (the default) means no cap, which is
                 correct for full-attention-style specs that hold every
                 block until the request finishes.
+            use_eagle: True iff speculative decoding is enabled at engine init
+                (forwarded from KVCacheCoordinator). Combined with the env var
+                VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT to gate the same-step
+                ghost-block defer. Subclasses may override
+                `_ghost_block_guard_enabled` directly (MambaManager does so to
+                keep its always-on guard from PR #29387).
         """
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -80,6 +87,20 @@ class SingleTypeKVCacheManager(ABC):
 
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
+
+        # Same-step ghost-block defer guard (PR #42359 / #29387).
+        # When enabled, `cache_blocks` records full blocks committed during the
+        # current scheduling step and `get_num_blocks_to_allocate` defers any
+        # request whose prefix-hit tail is one of those blocks (because the
+        # GPU has not written its KV yet). Default policy: gated on env var
+        # AND `use_eagle`. MambaManager overrides this to True (always-on) in
+        # its own `__init__` after calling super().
+        from vllm import envs
+
+        self._ghost_block_guard_enabled: bool = (
+            envs.VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT and use_eagle
+        )
+        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -115,6 +136,18 @@ class SingleTypeKVCacheManager(ABC):
         Returns:
             The number of blocks to allocate.
         """
+
+        # Same-step ghost-block defer guard.
+        # If the prefix-hit tail is a block another request committed earlier
+        # in this scheduling step, its KV is not yet written on the GPU.
+        # Returning an impossible block count makes allocate_slots return None,
+        # so the scheduler defers this request to the next step.
+        if (
+            self._ghost_block_guard_enabled
+            and len(new_computed_blocks) > 0
+            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
+        ):
+            return self.block_pool.num_gpu_blocks + 1
 
         num_required_blocks = cdiv(num_tokens, self.block_size)
         if apply_admission_cap and self._max_admission_blocks_per_request is not None:
@@ -300,6 +333,17 @@ class SingleTypeKVCacheManager(ABC):
 
         self.num_cached_block[request.request_id] = num_full_blocks
 
+        # Same-step ghost-block defer guard: record full blocks committed
+        # this step so subsequent requests in the same step can be deferred
+        # (see `get_num_blocks_to_allocate`).
+        if self._ghost_block_guard_enabled:
+            for block in self.req_to_blocks[request.request_id][
+                num_cached_blocks:num_full_blocks
+            ]:
+                if block.is_null or block.block_hash is None:
+                    continue
+                self.cached_blocks_this_step.add(block.block_hash)
+
     def free(self, request_id: str) -> None:
         """
         Free the blocks for the request.
@@ -439,60 +483,13 @@ class SingleTypeKVCacheManager(ABC):
         return 0
 
     def new_step_starts(self) -> None:
-        # do nothing by default
-        return None
+        # Same-step ghost-block defer guard: clear the per-step tracking set.
+        # No-op when the guard is disabled.
+        if self._ghost_block_guard_enabled:
+            self.cached_blocks_this_step.clear()
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        # Track block hashes committed to the cache in the current scheduling
-        # step so we can defer requests that would otherwise read KV blocks
-        # that the GPU has not yet written (same-step ghost block race).
-        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
-
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
-        num_cached_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens)
-        num_cached_after = self.num_cached_block.get(request.request_id, 0)
-        for block in self.req_to_blocks[request.request_id][
-            num_cached_before:num_cached_after
-        ]:
-            if block.is_null or block.block_hash is None:
-                continue
-            self.cached_blocks_this_step.add(block.block_hash)
-
-    def new_step_starts(self) -> None:
-        self.cached_blocks_this_step.clear()
-
-    def get_num_blocks_to_allocate(
-        self,
-        request_id: str,
-        num_tokens: int,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        total_computed_tokens: int,
-        num_tokens_main_model: int,
-        apply_admission_cap: bool = False,
-    ) -> int:
-        if (
-            len(new_computed_blocks) > 0
-            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
-        ):
-            # A block at the tail of the prefix hit was committed by another
-            # request in the current scheduling step; the GPU has not written
-            # its KV yet. Return an impossible block count so the scheduler
-            # skips this request and retries in the next step (same pattern
-            # used by MambaManager, see PR #29387).
-            return self.block_pool.num_gpu_blocks + 1
-        return super().get_num_blocks_to_allocate(
-            request_id,
-            num_tokens,
-            new_computed_blocks,
-            total_computed_tokens,
-            num_tokens_main_model,
-            apply_admission_cap=apply_admission_cap,
-        )
-
     @classmethod
     def find_longest_cache_hit(
         cls,
@@ -845,7 +842,10 @@ class MambaManager(SingleTypeKVCacheManager):
         self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
     ) -> None:
         super().__init__(kv_cache_spec, block_pool, **kwargs)
-        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
+        # Mamba's state-space K/V cannot tolerate same-step prefix-cache hits
+        # on not-yet-written blocks regardless of speculative decoding (see
+        # PR #29387). Override the base-class env-gated default with always-on.
+        self._ghost_block_guard_enabled = True
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
         if self.mamba_cache_mode == "align":
@@ -949,15 +949,9 @@ class MambaManager(SingleTypeKVCacheManager):
         apply_admission_cap: bool = False,
     ) -> int:
         assert isinstance(self.kv_cache_spec, MambaSpec)
-        if (
-            len(new_computed_blocks) > 0
-            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
-        ):
-            # Mamba can't rely on blocks generated by other requests in the current step
-            # To put it in the next step, we return num_gpu_blocks + 1 so
-            # that kv_cache_manager will think there is no enough blocks to allocate now
-            # and don't schedule it in the current step.
-            return self.block_pool.num_gpu_blocks + 1
+        # NOTE: same-step ghost-block defer is handled in the base class.
+        # MambaManager.__init__ sets `_ghost_block_guard_enabled = True`,
+        # so the base early-returns before this method body runs.
         if self.mamba_cache_mode != "align":
             # Allocate extra `num_speculative_blocks` blocks for
             # speculative decoding (MTP/EAGLE) with linear attention.
@@ -1098,22 +1092,6 @@ class MambaManager(SingleTypeKVCacheManager):
         """
         return num_computed_tokens - 1
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
-        num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens)
-        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
-        if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
-                if block.is_null:
-                    continue
-                assert block.block_hash is not None
-                self.cached_blocks_this_step.add(block.block_hash)
-
-    def new_step_starts(self) -> None:
-        self.cached_blocks_this_step.clear()
-
 
 class CrossAttentionManager(SingleTypeKVCacheManager):
     """Manager for cross-attention KV cache in encoder-decoder models."""
@@ -1205,6 +1183,7 @@ def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
     max_num_batched_tokens: int,
     max_model_len: int,
+    use_eagle: bool = False,
     **kwargs,
 ) -> SingleTypeKVCacheManager:
     manager_class = spec_manager_map[type(kv_cache_spec)]
@@ -1218,5 +1197,10 @@ def get_manager_for_kv_cache_spec(
                 max_model_len=max_model_len,
             )
         )
+    # `use_eagle` is accepted by the base SingleTypeKVCacheManager and gates
+    # the same-step ghost-block defer in combination with the env var
+    # VLLM_ALLOW_SPEC_DEC_SAME_STEP_PREFIX_HIT (PR #42359). MambaManager
+    # overrides the gate to always-on in its own __init__ (PR #29387).
+    kwargs["use_eagle"] = use_eagle
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager


### PR DESCRIPTION
## Purpose

`FullAttentionManager.cache_blocks()` commits prefix block hashes to the shared `BlockPool` hash table **before** the GPU forward pass writes the KV values.
In the same scheduling step, `get_computed_blocks()` calls `find_longest_cache_hit` for a newly-admitted request and finds those uncommitted blocks as cache hits — the request skips re-prefilling that suffix and attends over zero/stale KV.
`MambaManager` already guards against this with `cached_blocks_this_step` (PR #29387). `FullAttentionManager` had no equivalent guard.

This PR mirrors `MambaManager` exactly:
- `__init__`: add `cached_blocks_this_step: set[BlockHashWithGroupId]`
- `cache_blocks()`: record newly committed block hashes each step
- `new_step_starts()`: clear the set each scheduling step
- `get_num_blocks_to_allocate()`: return `num_gpu_blocks + 1` when the tail of the prefix hit chain is a ghost block, causing the scheduler to defer the request to the next step (when the GPU write is complete)

Ghost blocks always form a contiguous suffix of the hit chain (prefix hash chaining guarantees this), so checking the last block suffices. The deferral is exactly one step — by the next scheduling cycle the GPU has written the KV and the cache hit is legitimate.

"Possible" fix to #41838.

## Test Plan

Serve GPT-OSS-120B on 2xH200 [openai/gpt-oss-120b](https://huggingface.co/openai/gpt-oss-120b) and [nvidia/gpt-oss-120b-Eagle3-v3](https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v3)

```
vllm serve /trt_llm_ci/data/llm-models/gpt_oss/gpt-oss-120b \
--max-num-seqs 16 \
--max-num-batched-tokens 4096 \
--max-model-len 65536 \
--host 0.0.0.0 \
--port 8001 \
--tensor-parallel-size 2 \
--gpu-memory-utilization 0.9 \
--trust-remote-code \
--async-scheduling \
--enable-prefix-caching \
--max-cudagraph-capture-size 1024 \
--stream-interval 20 \
--speculative-config '{"model":"/trt_llm_ci/data/llm-models/gpt_oss/gpt-oss-120b-Eagle3","num_speculative_tokens":3,"method":"eagle3"}' \
--compilation-config '{"use_inductor_graph_partition":1,"pass_config":{"enable_qk_norm_rope_fusion":true,"eliminate_noops":true,"fuse_allreduce_rms":true}}' \
  2>&1 | tee out.log &
```

Then run send the same request 4 times with concurrency=4. The request has 31408 tokens after tokenized.

## Test Result

Before, the req[1-3] is computed with the same prefill step as req[0]'s last block, causing referring to not-yet-computed "ghost" KV block.
<img width="2253" height="271" alt="Image" src="https://github.com/user-attachments/assets/6bae0b01-b77a-40d5-8039-7f191f136133" />

After, req[1-3] is computed **After** the req[0] prefill request is completed, dragging 1 step but necessary for correct computation.
<img width="2855" height="261" alt="Image" src="https://github.com/user-attachments/assets/7714395d-5588-435e-993a-9484568667f8" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

