### PR TITLE
[PD] Bump NIXL connector dependency to 1.x

### DIFF
--- a/.buildkite/ci_config.yaml
+++ b/.buildkite/ci_config.yaml
@@ -8,6 +8,7 @@ run_all_patterns:
   - "CMakeLists.txt"
   - "requirements/common.txt"
   - "requirements/cuda.txt"
+  - "requirements/kv_connectors.txt"
   - "requirements/build/cuda.txt"
   - "requirements/test/cuda.txt"
   - "setup.py"

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,5 +1,3 @@
 lmcache >= 0.3.9
-nixl[cu13] >= 0.7.1, <= 0.10.1 # Required for disaggregated prefill
-nixl-cu12 >= 0.7.1, <= 0.10.1
-nixl-cu13 >= 0.7.1, <= 0.10.1
+nixl >= 1.1.0 # Required for disaggregated prefill
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
## Summary

Update the NIXL KV connector dependency from CUDA-runtime-specific bounds to the simplified NIXL meta package requirement `nixl >= 1.1.0`.

NIXL 1.1.0 now publishes meta-package metadata that depends on both CUDA runtime wheels and chooses the correct backend at runtime based on the torch CUDA version.

Also add `requirements/kv_connectors.txt` to the Buildkite `run_all_patterns` list so future KV connector dependency changes trigger full CI.

## Duplicate check

This overlaps with #39797, but it is not the same patch:

- #39797 is stale/conflicting and targeted `<=1.0.0`.
- This PR is rebased on current `main` and starts at `1.1.0` instead of including the problematic `1.0.x` wheels.
- This PR uses the simplified `nixl >= 1.1.0` form instead of selecting CUDA-specific wheels in vLLM.

## Notes

The #39797 discussion called out that NIXL 1.0.x packaging can pull both CUDA runtime wheels. #39851 then showed `nixl-cu12==1.0.1` breaking CUDA 13 CI because it shipped `nixl_ep` compiled against `libcudart.so.12`. This PR therefore does not allow `1.0.1`; it targets the NIXL 1.1.0 line where the packaging simplification from ai-dynamo/nixl#1574 has landed.

The 1.1.0 PyPI metadata for `nixl` now requires both `nixl-cu12==1.1.0` and `nixl-cu13==1.1.0`, so vLLM no longer needs to list the CUDA backend wheels directly.

## Testing

- `git diff --check`
- `uv pip install --python /tmp/vllm-nixl-check --dry-run --no-cache --index-url https://pypi.org/simple 'nixl>=1.1.0'`
- Commit hooks run by `git commit`

Runtime NIXL smoke testing was not run in this local environment; the Buildkite full CI run should cover the representative CUDA environment.

## AI assistance

AI assistance was used to prepare this change.
