### PR TITLE
[Frontend] Add HyperCLOVAX-SEED-Think reasoning and tool parsers

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -21,6 +21,7 @@ vLLM currently supports the following reasoning models:
 | [GLM-4.5 series](https://huggingface.co/collections/zai-org/glm-45-687c621d34bda8c9e4bf503b) | `glm45` | `json`, `regex` | ✅ |
 | [Holo2 series](https://huggingface.co/collections/Hcompany/holo2) | `holo2` | `json`, `regex` | ✅ |
 | [Hunyuan A13B series](https://huggingface.co/collections/tencent/hunyuan-a13b-685ec38e5b46321e3ea7c4be) | `hunyuan_a13b` | `json`, `regex` | ✅ |
+| [HyperCLOVAX-SEED-Think](https://huggingface.co/naver-hyperclovax/HyperCLOVAX-SEED-Think-32B) | `hyperclovax_seed_think` | `json`, `regex` | ✅ |
 | [IBM Granite 3.2 language models](https://huggingface.co/collections/ibm-granite/granite-32-language-models-67b3bc8c13508f6d064cff9a) | `granite` | ❌ | ❌ |
 | [MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) | `minimax_m2_append_think` | `json`, `regex` | ✅ |
 | [Qwen3 series](https://huggingface.co/collections/Qwen/qwen3-67dd247413f0e2e4f653967f) | `qwen3` | `json`, `regex` | ✅ |
@@ -31,6 +32,7 @@ vLLM currently supports the following reasoning models:
     The reasoning feature for the Qwen3 series is enabled by default. To disable it, you must pass `enable_thinking=False` in your `chat_template_kwargs`.
     DeepSeek-V3.1 tool calling is supported in non-thinking mode.
     Holo2 reasoning is enabled by default. To disable it, you must also pass `thinking=False` in your `chat_template_kwargs`.
+    HyperCLOVAX-SEED-Think reasoning is controlled via `thinking` in `chat_template_kwargs` (default `False`). With `thinking=True` the model emits `[reasoning]</think>\n\n[content]`; with `thinking=False` the chat_template embeds `</think>` in the prompt and the model output is content-only.
 
 ## Quickstart
 

--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -369,6 +369,18 @@ Flags:
 * For non-reasoning: `--tool-call-parser hunyuan_a13b`
 * For reasoning: `--tool-call-parser hunyuan_a13b --reasoning-parser hunyuan_a13b`
 
+### HyperCLOVAX-SEED-Think Models (`hyperclovax_seed_think`)
+
+Supported models:
+
+* [`naver-hyperclovax/HyperCLOVAX-SEED-Think-32B`](https://huggingface.co/naver-hyperclovax/HyperCLOVAX-SEED-Think-32B)
+
+Tool calls are emitted in the model's native XML format
+(`<tool_call>name\n<arg_key>k</arg_key>\n<arg_value>v</arg_value>...</tool_call>`),
+with a JSON-list fallback for `tool_choice="required"` and named tool_choice.
+
+Flags: `--tool-call-parser hyperclovax_seed_think --reasoning-parser hyperclovax_seed_think --enable-auto-tool-choice`
+
 ### Cohere Command A Reasoning (`cohere_command3`)
 
 Supported models:

--- a/tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py
+++ b/tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py
@@ -30,10 +30,8 @@ def mock_tokenizer():
         "</think>": THINK_END_ID,
         "<|im_end|>": IM_END_ID,
     }
-    tokenizer.encode.side_effect = (
-        lambda text, add_special_tokens=True: [THINK_END_ID]
-        if text == "</think>"
-        else []
+    tokenizer.encode.side_effect = lambda text, add_special_tokens=True: (
+        [THINK_END_ID] if text == "</think>" else []
     )
     # `run_reasoning_extraction_streaming` in tests/reasoning/utils.py calls
     # `tokenizer.tokenize(delta)` to derive `token_delta`. The parser's
@@ -67,9 +65,7 @@ def test_reasoning_end_str_property(mock_tokenizer):
     "thinking,expected_no_reasoning_content",
     [(True, False), (False, True), (None, True)],
 )
-def test_thinking_flag_capture(
-    mock_tokenizer, thinking, expected_no_reasoning_content
-):
+def test_thinking_flag_capture(mock_tokenizer, thinking, expected_no_reasoning_content):
     """`thinking` from chat_template_kwargs flips no_reasoning_content."""
     kwargs = {}
     if thinking is not None:
@@ -121,13 +117,11 @@ class TestExtractReasoning:
         assert content is None
 
     def test_no_think_end_thinking_false_treats_all_as_content(self, mock_tokenizer):
-        """thinking=false: </think> is already in the prompt; model output is content."""
+        """thinking=false: </think> is in the prompt; output is content."""
         parser = HyperCLOVAXSeedThinkReasoningParser(
             mock_tokenizer, chat_template_kwargs={"thinking": False}
         )
-        reasoning, content = parser.extract_reasoning(
-            "direct answer", self._request()
-        )
+        reasoning, content = parser.extract_reasoning("direct answer", self._request())
         assert reasoning is None
         assert content == "direct answer"
 
@@ -203,9 +197,7 @@ class TestStreamingExtraction:
         parser = HyperCLOVAXSeedThinkReasoningParser(
             mock_tokenizer, chat_template_kwargs={"thinking": True}
         )
-        reasoning, content = run_reasoning_extraction(
-            parser, deltas, streaming=True
-        )
+        reasoning, content = run_reasoning_extraction(parser, deltas, streaming=True)
         assert reasoning == expected_reasoning
         assert content == expected_content
 

--- a/tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py
+++ b/tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py
@@ -267,6 +267,15 @@ class TestTokenIdHelpers:
         # Suffix matches the encoded </think> sequence.
         assert parser.is_reasoning_end([1, 2, THINK_END_ID]) is True
 
+    def test_is_reasoning_end_when_think_end_in_middle(self, mock_tokenizer):
+        """Structured decoding requires detecting the marker anywhere in the
+        sequence, not only at the tail (regression test for #42366 review)."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        # </think> followed by additional content tokens — still ended.
+        assert parser.is_reasoning_end([1, 2, THINK_END_ID, 3, 4, 5]) is True
+
     def test_is_reasoning_end_no_think_end_thinking_true(self, mock_tokenizer):
         parser = HyperCLOVAXSeedThinkReasoningParser(
             mock_tokenizer, chat_template_kwargs={"thinking": True}

--- a/tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py
+++ b/tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the HyperCLOVAX-SEED-Think reasoning parser."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.reasoning.utils import run_reasoning_extraction
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.reasoning import ReasoningParserManager
+from vllm.reasoning.hyperclovax_seed_think_reasoning_parser import (
+    HyperCLOVAXSeedThinkReasoningParser,
+)
+
+PARSER_NAME = "hyperclovax_seed_think"
+
+# Token IDs used by the mock tokenizer. The parser only needs:
+#   - tokenizer.encode("</think>", add_special_tokens=False) -> list[int]
+#   - tokenizer.get_vocab() -> dict[str, int]  (accessed lazily via .vocab)
+THINK_END_ID = 9001
+IM_END_ID = 9002
+
+
+@pytest.fixture
+def mock_tokenizer():
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {
+        "</think>": THINK_END_ID,
+        "<|im_end|>": IM_END_ID,
+    }
+    tokenizer.encode.side_effect = (
+        lambda text, add_special_tokens=True: [THINK_END_ID]
+        if text == "</think>"
+        else []
+    )
+    # `run_reasoning_extraction_streaming` in tests/reasoning/utils.py calls
+    # `tokenizer.tokenize(delta)` to derive `token_delta`. The parser's
+    # streaming path is text-driven, so any iterable works.
+    tokenizer.tokenize.return_value = []
+    return tokenizer
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_parser_is_registered():
+    """The lazy-loading table must expose `hyperclovax_seed_think`."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(PARSER_NAME)
+    assert parser_cls is HyperCLOVAXSeedThinkReasoningParser
+
+
+def test_reasoning_end_str_property(mock_tokenizer):
+    parser = HyperCLOVAXSeedThinkReasoningParser(mock_tokenizer)
+    assert parser.reasoning_end_str == "</think>"
+
+
+# ---------------------------------------------------------------------------
+# Constructor / mode capture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "thinking,expected_no_reasoning_content",
+    [(True, False), (False, True), (None, True)],
+)
+def test_thinking_flag_capture(
+    mock_tokenizer, thinking, expected_no_reasoning_content
+):
+    """`thinking` from chat_template_kwargs flips no_reasoning_content."""
+    kwargs = {}
+    if thinking is not None:
+        kwargs["chat_template_kwargs"] = {"thinking": thinking}
+    parser = HyperCLOVAXSeedThinkReasoningParser(mock_tokenizer, **kwargs)
+    assert parser.thinking is bool(thinking)
+    assert parser.no_reasoning_content is expected_no_reasoning_content
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming extract_reasoning
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReasoning:
+    def _request(self):
+        return ChatCompletionRequest(model="test-model", messages=[])
+
+    def test_with_think_end_splits(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        reasoning, content = parser.extract_reasoning(
+            "step by step</think>\n\nfinal answer", self._request()
+        )
+        assert reasoning == "step by step"
+        assert content == "final answer"
+
+    def test_with_think_end_strips_leading_newlines(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        # `\n\n` between </think> and content is stripped via lstrip("\n").
+        reasoning, content = parser.extract_reasoning(
+            "reasoning</think>\n\n\nfinal", self._request()
+        )
+        assert reasoning == "reasoning"
+        assert content == "final"
+
+    def test_no_think_end_thinking_true_treats_all_as_reasoning(self, mock_tokenizer):
+        """thinking=true + no </think> → truncated mid-reasoning."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        reasoning, content = parser.extract_reasoning(
+            "thinking aloud, never closed", self._request()
+        )
+        assert reasoning == "thinking aloud, never closed"
+        assert content is None
+
+    def test_no_think_end_thinking_false_treats_all_as_content(self, mock_tokenizer):
+        """thinking=false: </think> is already in the prompt; model output is content."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+        reasoning, content = parser.extract_reasoning(
+            "direct answer", self._request()
+        )
+        assert reasoning is None
+        assert content == "direct answer"
+
+    def test_empty_reasoning_segment_becomes_none(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        reasoning, content = parser.extract_reasoning(
+            "</think>only content", self._request()
+        )
+        assert reasoning is None
+        assert content == "only content"
+
+    def test_empty_content_segment_becomes_none(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        reasoning, content = parser.extract_reasoning(
+            "reasoning only</think>", self._request()
+        )
+        assert reasoning == "reasoning only"
+        assert content is None
+
+    def test_stops_at_first_think_end(self, mock_tokenizer):
+        """str.partition is used → stops at the first </think>."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        reasoning, content = parser.extract_reasoning(
+            "first</think>middle</think>last", self._request()
+        )
+        assert reasoning == "first"
+        assert content == "middle</think>last"
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingExtraction:
+    @pytest.mark.parametrize(
+        "deltas,expected_reasoning,expected_content",
+        [
+            (
+                ["step ", "by ", "step", "</think>", "\n\nanswer"],
+                "step by step",
+                "answer",
+            ),
+            (
+                ["thinking", "</think>", "\n\nfinal", " answer"],
+                "thinking",
+                "final answer",
+            ),
+            (
+                # </think> arrives split across two deltas; the partial-prefix
+                # guard must hold the buffer until the close-tag completes.
+                ["reason", "</thi", "nk>", "\n\nanswer"],
+                "reason",
+                "answer",
+            ),
+            (
+                # No </think> ever; everything stays as reasoning.
+                ["never ", "closes ", "reasoning"],
+                "never closes reasoning",
+                None,
+            ),
+        ],
+    )
+    def test_thinking_true_streaming_paths(
+        self, mock_tokenizer, deltas, expected_reasoning, expected_content
+    ):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        reasoning, content = run_reasoning_extraction(
+            parser, deltas, streaming=True
+        )
+        assert reasoning == expected_reasoning
+        assert content == expected_content
+
+    def test_thinking_false_streams_as_content_only(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+        reasoning, content = run_reasoning_extraction(
+            parser, ["plain ", "content ", "only"], streaming=True
+        )
+        assert reasoning is None
+        assert content == "plain content only"
+
+    def test_streaming_empty_initial_delta_returns_none(self, mock_tokenizer):
+        """No emission when there's nothing yet (current_text empty)."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        result = parser.extract_reasoning_streaming(
+            previous_text="",
+            current_text="",
+            delta_text="",
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+        )
+        assert result is None
+
+    def test_streaming_close_in_single_delta(self, mock_tokenizer):
+        """A delta containing both `</think>` and the start of content should
+        emit a single DeltaMessage carrying the reasoning prefix as
+        ``reasoning`` and the post-marker content as ``content``."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        delta = parser.extract_reasoning_streaming(
+            previous_text="",
+            current_text="reason</think>\n\ntail",
+            delta_text="reason</think>\n\ntail",
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+        )
+        assert isinstance(delta, DeltaMessage)
+        assert delta.reasoning == "reason"
+        assert delta.content == "tail"
+
+
+# ---------------------------------------------------------------------------
+# is_reasoning_end / extract_content_ids
+# ---------------------------------------------------------------------------
+
+
+class TestTokenIdHelpers:
+    def test_is_reasoning_end_when_think_end_at_tail(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        # Suffix matches the encoded </think> sequence.
+        assert parser.is_reasoning_end([1, 2, THINK_END_ID]) is True
+
+    def test_is_reasoning_end_no_think_end_thinking_true(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        assert parser.is_reasoning_end([1, 2, 3]) is False
+
+    def test_is_reasoning_end_thinking_false_short_input(self, mock_tokenizer):
+        """thinking=false starts with no_reasoning_content=True, so a single
+        token (no </think> needed) should already report end."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+        assert parser.is_reasoning_end([42]) is True
+
+    def test_is_reasoning_end_im_end_short_input(self, mock_tokenizer):
+        """Single token list containing <|im_end|> should signal end."""
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        assert parser.is_reasoning_end([IM_END_ID]) is True
+
+    def test_extract_content_ids_returns_post_think_end(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        # [reasoning_tok, reasoning_tok, </think>, content_tok, content_tok]
+        ids = [1, 2, THINK_END_ID, 4, 5]
+        assert parser.extract_content_ids(ids) == [4, 5]
+
+    def test_extract_content_ids_think_end_at_tail_returns_empty(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        # Per the parser's docstring: trailing </think> with no content yet → [].
+        assert parser.extract_content_ids([1, 2, THINK_END_ID]) == []
+
+    def test_extract_content_ids_no_think_end_returns_empty(self, mock_tokenizer):
+        parser = HyperCLOVAXSeedThinkReasoningParser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        assert parser.extract_content_ids([1, 2, 3, 4]) == []

--- a/tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
+++ b/tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
@@ -390,3 +390,21 @@ class TestStreamingJSON:
         )
         # Buffer is not yet parseable → no tool_call emission.
         assert _collect_streaming_tool_calls(results) == []
+
+    def test_split_think_end_across_deltas_does_not_leak(
+        self, tool_parser, mock_request
+    ):
+        """Standalone usage: when `</think>` straddles deltas, the partial tail
+        must not be emitted as content (regression test for #42366 review)."""
+        deltas = [
+            "</thi",
+            "nk>",
+            '[{"name": "get_current_weather", "parameters": {"location": "Seoul"}}]',
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        content = _collect_streaming_content(results)
+        assert "</thi" not in content
+        assert "nk>" not in content
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 1
+        assert tc[0]["name"] == "get_current_weather"

--- a/tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
+++ b/tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
@@ -99,9 +99,9 @@ class TestExtractToolCallsXML:
         out = (
             "<tool_call>get_current_weather\n"
             "<arg_key>location</arg_key>\n"
-            "<arg_value>\"Seoul\"</arg_value>\n"
+            '<arg_value>"Seoul"</arg_value>\n'
             "<arg_key>unit</arg_key>\n"
-            "<arg_value>\"celsius\"</arg_value>\n"
+            '<arg_value>"celsius"</arg_value>\n'
             "</tool_call>"
         )
         r = tool_parser.extract_tool_calls(out, request=mock_request)
@@ -132,7 +132,7 @@ class TestExtractToolCallsXML:
         out = (
             "I'll check that for you.<tool_call>get_current_weather\n"
             "<arg_key>location</arg_key>\n"
-            "<arg_value>\"Seoul\"</arg_value>\n"
+            '<arg_value>"Seoul"</arg_value>\n'
             "</tool_call>"
         )
         r = tool_parser.extract_tool_calls(out, request=mock_request)
@@ -145,7 +145,7 @@ class TestExtractToolCallsXML:
             "thinking aloud</think>\n\nokay, calling:"
             "<tool_call>get_current_weather\n"
             "<arg_key>location</arg_key>\n"
-            "<arg_value>\"Seoul\"</arg_value>\n"
+            '<arg_value>"Seoul"</arg_value>\n'
             "</tool_call>"
         )
         r = tool_parser.extract_tool_calls(out, request=mock_request)
@@ -156,11 +156,11 @@ class TestExtractToolCallsXML:
         out = (
             "<tool_call>get_current_weather\n"
             "<arg_key>location</arg_key>\n"
-            "<arg_value>\"Seoul\"</arg_value>\n"
+            '<arg_value>"Seoul"</arg_value>\n'
             "</tool_call>\n"
             "<tool_call>get_current_weather\n"
             "<arg_key>location</arg_key>\n"
-            "<arg_value>\"Busan\"</arg_value>\n"
+            '<arg_value>"Busan"</arg_value>\n'
             "</tool_call>"
         )
         r = tool_parser.extract_tool_calls(out, request=mock_request)
@@ -169,9 +169,7 @@ class TestExtractToolCallsXML:
         assert json.loads(r.tool_calls[0].function.arguments)["location"] == "Seoul"
         assert json.loads(r.tool_calls[1].function.arguments)["location"] == "Busan"
 
-    def test_malformed_tool_call_falls_back_to_content(
-        self, tool_parser, mock_request
-    ):
+    def test_malformed_tool_call_falls_back_to_content(self, tool_parser, mock_request):
         """<tool_call> marker present but body has no parseable function name."""
         out = "<tool_call>\n</tool_call>"
         r = tool_parser.extract_tool_calls(out, request=mock_request)
@@ -191,9 +189,7 @@ class TestExtractToolCallsJSON:
         r = tool_parser.extract_tool_calls(out, request=mock_request)
         assert r.tools_called is True
         assert r.tool_calls[0].function.name == "get_current_weather"
-        assert json.loads(r.tool_calls[0].function.arguments) == {
-            "location": "Seoul"
-        }
+        assert json.loads(r.tool_calls[0].function.arguments) == {"location": "Seoul"}
         assert r.content is None
 
     def test_json_single_object_payload(self, tool_parser, mock_request):
@@ -202,18 +198,14 @@ class TestExtractToolCallsJSON:
         r = tool_parser.extract_tool_calls(out, request=mock_request)
         assert r.tools_called is True
         assert len(r.tool_calls) == 1
-        assert json.loads(r.tool_calls[0].function.arguments) == {
-            "location": "Busan"
-        }
+        assert json.loads(r.tool_calls[0].function.arguments) == {"location": "Busan"}
 
     def test_json_with_arguments_key(self, tool_parser, mock_request):
         """Accepts `arguments` as an alias for `parameters`."""
         out = '[{"name": "get_current_weather", "arguments": {"location": "Seoul"}}]'
         r = tool_parser.extract_tool_calls(out, request=mock_request)
         assert r.tools_called is True
-        assert json.loads(r.tool_calls[0].function.arguments) == {
-            "location": "Seoul"
-        }
+        assert json.loads(r.tool_calls[0].function.arguments) == {"location": "Seoul"}
 
     def test_json_after_think_end(self, tool_parser, mock_request):
         """JSON payload preceded by reasoning + </think>."""
@@ -298,7 +290,7 @@ class TestStreamingXML:
             "<tool_call>",
             "get_current_weather\n",
             "<arg_key>location</arg_key>\n",
-            "<arg_value>\"Seoul\"</arg_value>\n",
+            '<arg_value>"Seoul"</arg_value>\n',
             "</tool_call>",
         ]
         results = _simulate_streaming(tool_parser, deltas, mock_request)
@@ -311,7 +303,7 @@ class TestStreamingXML:
         deltas = [
             "Let me check.",
             "<tool_call>get_current_weather\n",
-            "<arg_key>location</arg_key>\n<arg_value>\"Seoul\"</arg_value>\n",
+            '<arg_key>location</arg_key>\n<arg_value>"Seoul"</arg_value>\n',
             "</tool_call>",
         ]
         results = _simulate_streaming(tool_parser, deltas, mock_request)
@@ -322,10 +314,10 @@ class TestStreamingXML:
     def test_multiple_tool_calls(self, tool_parser, mock_request):
         deltas = [
             "<tool_call>get_current_weather\n"
-            "<arg_key>location</arg_key>\n<arg_value>\"Seoul\"</arg_value>\n"
+            '<arg_key>location</arg_key>\n<arg_value>"Seoul"</arg_value>\n'
             "</tool_call>\n"
             "<tool_call>get_current_weather\n"
-            "<arg_key>location</arg_key>\n<arg_value>\"Busan\"</arg_value>\n"
+            '<arg_key>location</arg_key>\n<arg_value>"Busan"</arg_value>\n'
             "</tool_call>",
         ]
         results = _simulate_streaming(tool_parser, deltas, mock_request)
@@ -340,7 +332,7 @@ class TestStreamingXML:
         deltas = [
             "<tool_",
             "call>get_current_weather\n",
-            "<arg_key>location</arg_key>\n<arg_value>\"Seoul\"</arg_value>\n",
+            '<arg_key>location</arg_key>\n<arg_value>"Seoul"</arg_value>\n',
             "</tool_call>",
         ]
         results = _simulate_streaming(tool_parser, deltas, mock_request)

--- a/tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
+++ b/tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+"""Unit tests for the HyperCLOVAX-SEED-Think tool call parser."""
+
+import json
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.tool_parsers.abstract_tool_parser import ToolParserManager
+from vllm.tool_parsers.hyperclovax_seed_think_tool_parser import (
+    HyperCLOVAXSeedThinkToolParser,
+)
+
+PARSER_NAME = "hyperclovax_seed_think"
+
+
+@pytest.fixture
+def mock_tokenizer():
+    tokenizer = MagicMock()
+    # The parser only touches `self.vocab` (via `tokenizer.get_vocab()`) once it
+    # needs token IDs for streaming bookkeeping; otherwise it's text-driven.
+    tokenizer.get_vocab.return_value = {
+        "<tool_call>": 1000,
+        "</tool_call>": 1001,
+        "<arg_key>": 1002,
+        "</arg_key>": 1003,
+        "<arg_value>": 1004,
+        "</arg_value>": 1005,
+        "</think>": 1006,
+        "<|im_end|>": 1007,
+    }
+    return tokenizer
+
+
+@pytest.fixture
+def tool_parser(mock_tokenizer):
+    return HyperCLOVAXSeedThinkToolParser(mock_tokenizer)
+
+
+@pytest.fixture
+def mock_request() -> ChatCompletionRequest:
+    request = Mock(spec=ChatCompletionRequest)
+    request.tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="get_current_weather",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                        "unit": {"type": "string"},
+                    },
+                    "required": ["location"],
+                },
+            ),
+        ),
+    ]
+    request.tool_choice = "auto"
+    return request
+
+
+# ---------------------------------------------------------------------------
+# Registration / class invariants
+# ---------------------------------------------------------------------------
+
+
+def test_parser_is_registered():
+    parser_cls = ToolParserManager.get_tool_parser(PARSER_NAME)
+    assert parser_cls is HyperCLOVAXSeedThinkToolParser
+
+
+def test_supports_required_and_named_is_false():
+    """All tool_choice modes must route through this parser."""
+    assert HyperCLOVAXSeedThinkToolParser.supports_required_and_named is False
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming: XML <tool_call> format
+# ---------------------------------------------------------------------------
+
+
+class TestExtractToolCallsXML:
+    def test_no_tool_call(self, tool_parser, mock_request):
+        out = "Just a regular response."
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is False
+        assert r.tool_calls == []
+        assert r.content == out
+
+    def test_single_tool_call(self, tool_parser, mock_request):
+        out = (
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>\"Seoul\"</arg_value>\n"
+            "<arg_key>unit</arg_key>\n"
+            "<arg_value>\"celsius\"</arg_value>\n"
+            "</tool_call>"
+        )
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert len(r.tool_calls) == 1
+        assert r.tool_calls[0].type == "function"
+        assert r.tool_calls[0].function.name == "get_current_weather"
+        assert json.loads(r.tool_calls[0].function.arguments) == {
+            "location": "Seoul",
+            "unit": "celsius",
+        }
+        assert r.content is None
+
+    def test_arg_value_falls_back_to_raw_string(self, tool_parser, mock_request):
+        """Non-JSON arg_value bodies are kept as raw strings."""
+        out = (
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>Seoul</arg_value>\n"
+            "</tool_call>"
+        )
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert json.loads(r.tool_calls[0].function.arguments) == {
+            "location": "Seoul",
+        }
+
+    def test_content_before_tool_call_is_preserved(self, tool_parser, mock_request):
+        out = (
+            "I'll check that for you.<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>\"Seoul\"</arg_value>\n"
+            "</tool_call>"
+        )
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert r.content == "I'll check that for you."
+
+    def test_reasoning_prefix_stripped_from_content(self, tool_parser, mock_request):
+        """Content before <tool_call> after </think> wins over pre-</think> text."""
+        out = (
+            "thinking aloud</think>\n\nokay, calling:"
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>\"Seoul\"</arg_value>\n"
+            "</tool_call>"
+        )
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert r.content == "okay, calling:"
+
+    def test_multiple_tool_calls(self, tool_parser, mock_request):
+        out = (
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>\"Seoul\"</arg_value>\n"
+            "</tool_call>\n"
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n"
+            "<arg_value>\"Busan\"</arg_value>\n"
+            "</tool_call>"
+        )
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert len(r.tool_calls) == 2
+        assert json.loads(r.tool_calls[0].function.arguments)["location"] == "Seoul"
+        assert json.loads(r.tool_calls[1].function.arguments)["location"] == "Busan"
+
+    def test_malformed_tool_call_falls_back_to_content(
+        self, tool_parser, mock_request
+    ):
+        """<tool_call> marker present but body has no parseable function name."""
+        out = "<tool_call>\n</tool_call>"
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        # Empty name → no valid tool_calls → fallback to content.
+        assert r.tools_called is False
+        assert r.content == out
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming: JSON list fallback (tool_choice=required path)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractToolCallsJSON:
+    def test_json_list_payload(self, tool_parser, mock_request):
+        out = '[{"name": "get_current_weather", "parameters": {"location": "Seoul"}}]'
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert r.tool_calls[0].function.name == "get_current_weather"
+        assert json.loads(r.tool_calls[0].function.arguments) == {
+            "location": "Seoul"
+        }
+        assert r.content is None
+
+    def test_json_single_object_payload(self, tool_parser, mock_request):
+        """A single JSON object (not wrapped in a list) is treated as one call."""
+        out = '{"name": "get_current_weather", "parameters": {"location": "Busan"}}'
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert len(r.tool_calls) == 1
+        assert json.loads(r.tool_calls[0].function.arguments) == {
+            "location": "Busan"
+        }
+
+    def test_json_with_arguments_key(self, tool_parser, mock_request):
+        """Accepts `arguments` as an alias for `parameters`."""
+        out = '[{"name": "get_current_weather", "arguments": {"location": "Seoul"}}]'
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert json.loads(r.tool_calls[0].function.arguments) == {
+            "location": "Seoul"
+        }
+
+    def test_json_after_think_end(self, tool_parser, mock_request):
+        """JSON payload preceded by reasoning + </think>."""
+        out = (
+            "thinking</think>\n\n"
+            '[{"name": "get_current_weather", "parameters": {"location": "Seoul"}}]'
+        )
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is True
+        assert r.tool_calls[0].function.name == "get_current_weather"
+
+    def test_invalid_json_falls_back_to_content(self, tool_parser, mock_request):
+        out = "[not, valid, json"
+        r = tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called is False
+        assert r.content == out
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+def _simulate_streaming(
+    parser: HyperCLOVAXSeedThinkToolParser,
+    deltas: list[str],
+    request: ChatCompletionRequest,
+) -> list[DeltaMessage | None]:
+    results: list[DeltaMessage | None] = []
+    previous_text = ""
+    previous_token_ids: list[int] = []
+    vocab = parser.vocab
+    for delta_text in deltas:
+        current_text = previous_text + delta_text
+        delta_token_ids = [tid for tok, tid in vocab.items() if tok in delta_text]
+        current_token_ids = previous_token_ids + delta_token_ids
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=previous_token_ids,
+            current_token_ids=current_token_ids,
+            delta_token_ids=delta_token_ids,
+            request=request,
+        )
+        results.append(result)
+        previous_text = current_text
+        previous_token_ids = current_token_ids
+    return results
+
+
+def _collect_streaming_tool_calls(
+    results: list[DeltaMessage | None],
+) -> list[dict]:
+    tool_calls: dict[int, dict] = {}
+    for result in results:
+        if result is None or not result.tool_calls:
+            continue
+        for tc in result.tool_calls:
+            idx = tc.index
+            entry = tool_calls.setdefault(idx, {"name": "", "arguments": ""})
+            if tc.function.name:
+                entry["name"] += tc.function.name
+            if tc.function.arguments:
+                entry["arguments"] += tc.function.arguments
+    return [tool_calls[i] for i in sorted(tool_calls.keys())]
+
+
+def _collect_streaming_content(results: list[DeltaMessage | None]) -> str:
+    return "".join(r.content for r in results if r is not None and r.content)
+
+
+class TestStreamingXML:
+    def test_plain_content_only(self, tool_parser, mock_request):
+        deltas = ["Just ", "plain ", "text."]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        assert _collect_streaming_content(results) == "Just plain text."
+        assert _collect_streaming_tool_calls(results) == []
+
+    def test_single_tool_call_chunked(self, tool_parser, mock_request):
+        deltas = [
+            "<tool_call>",
+            "get_current_weather\n",
+            "<arg_key>location</arg_key>\n",
+            "<arg_value>\"Seoul\"</arg_value>\n",
+            "</tool_call>",
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 1
+        assert tc[0]["name"] == "get_current_weather"
+        assert json.loads(tc[0]["arguments"]) == {"location": "Seoul"}
+
+    def test_content_then_tool_call(self, tool_parser, mock_request):
+        deltas = [
+            "Let me check.",
+            "<tool_call>get_current_weather\n",
+            "<arg_key>location</arg_key>\n<arg_value>\"Seoul\"</arg_value>\n",
+            "</tool_call>",
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        assert _collect_streaming_content(results) == "Let me check."
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 1 and tc[0]["name"] == "get_current_weather"
+
+    def test_multiple_tool_calls(self, tool_parser, mock_request):
+        deltas = [
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n<arg_value>\"Seoul\"</arg_value>\n"
+            "</tool_call>\n"
+            "<tool_call>get_current_weather\n"
+            "<arg_key>location</arg_key>\n<arg_value>\"Busan\"</arg_value>\n"
+            "</tool_call>",
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 2
+        assert json.loads(tc[0]["arguments"]) == {"location": "Seoul"}
+        assert json.loads(tc[1]["arguments"]) == {"location": "Busan"}
+
+    def test_split_open_tag_across_delta(self, tool_parser, mock_request):
+        """`<tool_call>` itself may straddle deltas — the partial-prefix guard
+        must hold any tail that could complete an open tag."""
+        deltas = [
+            "<tool_",
+            "call>get_current_weather\n",
+            "<arg_key>location</arg_key>\n<arg_value>\"Seoul\"</arg_value>\n",
+            "</tool_call>",
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 1 and tc[0]["name"] == "get_current_weather"
+        # The "<tool_" prefix must NOT have leaked into content.
+        assert "<tool_" not in _collect_streaming_content(results)
+
+    def test_im_end_marker_stripped_from_content(self, tool_parser, mock_request):
+        """`<|im_end|>` is an EOS marker that should never reach the user."""
+        deltas = ["answer<|im_end|>"]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        assert _collect_streaming_content(results) == "answer"
+
+
+class TestStreamingJSON:
+    def test_json_list_emitted_in_one_message(self, tool_parser, mock_request):
+        """JSON list payload (tool_choice=required path)."""
+        deltas = [
+            '[{"name": "get_current_weather", ',
+            '"parameters": {"location": "Seoul"}}]',
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 1
+        assert tc[0]["name"] == "get_current_weather"
+        assert json.loads(tc[0]["arguments"]) == {"location": "Seoul"}
+
+    def test_json_after_think_end(self, tool_parser, mock_request):
+        """`</think>` in the buffer should not block the JSON path."""
+        deltas = [
+            "</think>",
+            "\n\n",
+            '[{"name": "get_current_weather", "parameters": {"location": "Busan"}}]',
+        ]
+        results = _simulate_streaming(tool_parser, deltas, mock_request)
+        tc = _collect_streaming_tool_calls(results)
+        assert len(tc) == 1
+        assert json.loads(tc[0]["arguments"]) == {"location": "Busan"}
+
+    def test_json_partial_payload_holds(self, tool_parser, mock_request):
+        """Incomplete JSON must not be emitted yet."""
+        results = _simulate_streaming(
+            tool_parser,
+            ['[{"name": "get_current_weather", "parameters": '],
+            mock_request,
+        )
+        # Buffer is not yet parseable → no tool_call emission.
+        assert _collect_streaming_tool_calls(results) == []

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -76,6 +76,10 @@ _REASONING_PARSERS_TO_REGISTER = {
         "hy_v3_reasoning_parser",
         "HYV3ReasoningParser",
     ),
+    "hyperclovax_seed_think": (
+        "hyperclovax_seed_think_reasoning_parser",
+        "HyperCLOVAXSeedThinkReasoningParser",
+    ),
     "kimi_k2": (
         "kimi_k2_reasoning_parser",
         "KimiK2ReasoningParser",

--- a/vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py
+++ b/vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py
@@ -12,7 +12,6 @@ callback (which does not receive the request) knows which mode to apply.
 """
 
 from collections.abc import Sequence
-from typing import Optional, Union
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
@@ -25,6 +24,7 @@ IM_END = "<|im_end|>"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _partial_prefix_len(text: str, target: str) -> int:
     """Length of the longest prefix of ``target`` matching the suffix of ``text``.
@@ -43,6 +43,7 @@ def _partial_prefix_len(text: str, target: str) -> int:
 # ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------
+
 
 class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
     """Reasoning parser for the HyperCLOVAX-SEED-Think model.
@@ -87,7 +88,7 @@ class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None]:
         # Authoritative signal: presence of </think> in the output.
         reasoning, sep, content = model_output.partition(THINK_END)
         if sep:
@@ -112,7 +113,7 @@ class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
         previous_token_ids: Sequence[int],
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
-    ) -> Union[DeltaMessage, None]:
+    ) -> DeltaMessage | None:
         if not current_text:
             return None
 
@@ -167,7 +168,7 @@ class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
         if n == 0 or len(input_ids) < n:
             return False
         return any(
-            input_ids[i:i + n] == self.think_end_tokens
+            input_ids[i : i + n] == self.think_end_tokens
             for i in range(len(input_ids) - n + 1)
         )
 
@@ -183,8 +184,6 @@ class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
         # (no trailing content yet) returns an empty list.
         upper = len(input_ids) - n
         for i in range(upper):
-            if input_ids[i:i + n] == self.think_end_tokens:
-                return list(input_ids[i + n:])
+            if input_ids[i : i + n] == self.think_end_tokens:
+                return list(input_ids[i + n :])
         return []
-
-

--- a/vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py
+++ b/vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py
@@ -155,11 +155,20 @@ class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
     # ------------------------------------------------------------------
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        if len(input_ids) > 1:
-            n = len(self.think_end_tokens)
-            return n > 0 and len(input_ids) >= n and input_ids[-n:] == self.think_end_tokens
-        return self.no_reasoning_content or (
+        # Structured decoding asks "has reasoning ended at any point so far?",
+        # so we must accept the end marker anywhere in the sequence, not only
+        # at the tail. Short-circuit on the no-reasoning case and on the
+        # explicit <|im_end|> stop token first.
+        if self.no_reasoning_content or (
             self.end_token_id is not None and self.end_token_id in input_ids
+        ):
+            return True
+        n = len(self.think_end_tokens)
+        if n == 0 or len(input_ids) < n:
+            return False
+        return any(
+            input_ids[i:i + n] == self.think_end_tokens
+            for i in range(len(input_ids) - n + 1)
         )
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:

--- a/vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py
+++ b/vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py
@@ -1,0 +1,181 @@
+"""HyperCLOVAX-SEED-Think reasoning parser for vLLM.
+
+The chat_template's generation prompt depends on the ``thinking`` flag:
+  thinking=true  → '<|im_start|>assistant\\n<think>\\n'
+                   → model output: [reasoning]</think>\\n\\n[content]
+  thinking=false → '<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n'
+                   → model output: [content]   (no </think> in output)
+
+vLLM instantiates this parser per request, passing ``chat_template_kwargs``
+to ``__init__``. We capture ``thinking`` at init time so that the streaming
+callback (which does not receive the request) knows which mode to apply.
+"""
+
+from collections.abc import Sequence
+from typing import Optional, Union
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.reasoning import ReasoningParser
+
+THINK_END = "</think>"
+IM_END = "<|im_end|>"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _partial_prefix_len(text: str, target: str) -> int:
+    """Length of the longest prefix of ``target`` matching the suffix of ``text``.
+
+    Used to detect protocol tokens split across delta boundaries. The exact-
+    match case (full ``target`` as a suffix) is excluded; callers should check
+    that separately with ``in`` or ``find``.
+    """
+    max_len = min(len(text), len(target) - 1)
+    for ln in range(max_len, 0, -1):
+        if text[-ln:] == target[:ln]:
+            return ln
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+class HyperCLOVAXSeedThinkReasoningParser(ReasoningParser):
+    """Reasoning parser for the HyperCLOVAX-SEED-Think model.
+
+    Only a single boundary token (``</think>``) is tracked, so we use
+    ``str.partition`` directly rather than the multi-string mixin pattern
+    used by other HyperCLOVAX parsers.
+    """
+
+    # Reasoning block delimiter (used by guided-decoding integrations).
+    @property
+    def reasoning_end_str(self) -> str | None:
+        return THINK_END
+
+    def __init__(self, tokenizer, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+
+        # Per-request init: capture the mode from chat_template_kwargs so the
+        # streaming callback (which doesn't receive the request) knows what to do.
+        chat_template_kwargs = kwargs.get("chat_template_kwargs") or {}
+        self.thinking: bool = bool(chat_template_kwargs.get("thinking", False))
+
+        # When thinking=false the model output has no </think>; start in content mode.
+        self.no_reasoning_content: bool = not self.thinking
+
+        # add_special_tokens=False avoids a leading BOS in the comparison sequence.
+        self.think_end_tokens: list[int] = tokenizer.encode(
+            THINK_END, add_special_tokens=False
+        )
+        self.end_token_id = self.vocab.get(IM_END)
+
+        self.buffer_string: str = ""
+        # After </think> transitions us into content mode we want to drop the
+        # `</think>\n\n` separator the chat_template inserts, so the very next
+        # content delta lstrips leading newlines. Mirrors the lstrip in
+        # ``extract_reasoning`` for the non-streaming path.
+        self._strip_pending_newlines: bool = False
+
+    # ------------------------------------------------------------------
+    # Non-streaming
+    # ------------------------------------------------------------------
+
+    def extract_reasoning(
+        self, model_output: str, request: ChatCompletionRequest
+    ) -> tuple[Optional[str], Optional[str]]:
+        # Authoritative signal: presence of </think> in the output.
+        reasoning, sep, content = model_output.partition(THINK_END)
+        if sep:
+            return reasoning.strip("\n") or None, content.lstrip("\n") or None
+
+        # </think> absent and thinking=true: truncated mid-reasoning → all reasoning.
+        if self.thinking:
+            return model_output, None
+
+        # Otherwise: treat as plain content (matches the chat_template else branch).
+        return None, model_output
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> Union[DeltaMessage, None]:
+        if not current_text:
+            return None
+
+        if self.no_reasoning_content:
+            if self._strip_pending_newlines:
+                delta_text = delta_text.lstrip("\n")
+                if not delta_text:
+                    return None
+                self._strip_pending_newlines = False
+            return DeltaMessage(content=delta_text)
+
+        self.buffer_string += delta_text
+
+        # </think> seen → end reasoning, switch to content mode.
+        reasoning_part, sep, content_part = self.buffer_string.partition(THINK_END)
+        if sep:
+            self.no_reasoning_content = True
+            self.buffer_string = ""
+            content = content_part.lstrip("\n") or None
+            # If the closing delta carried only `</think>` (no trailing content
+            # yet), defer the lstrip to the next content delta.
+            if content is None:
+                self._strip_pending_newlines = True
+            reasoning = reasoning_part or None
+            if reasoning is None and content is None:
+                return None
+            return DeltaMessage(reasoning=reasoning, content=content)
+
+        # </think> may straddle deltas; hold the buffer if its tail is a partial.
+        if _partial_prefix_len(self.buffer_string, THINK_END) > 0:
+            return None
+
+        # Safe to emit as reasoning_content.
+        emit = self.buffer_string
+        self.buffer_string = ""
+        return DeltaMessage(reasoning=emit)
+
+    # ------------------------------------------------------------------
+    # Structured output helpers
+    # ------------------------------------------------------------------
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        if len(input_ids) > 1:
+            n = len(self.think_end_tokens)
+            return n > 0 and len(input_ids) >= n and input_ids[-n:] == self.think_end_tokens
+        return self.no_reasoning_content or (
+            self.end_token_id is not None and self.end_token_id in input_ids
+        )
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        # Locate the </think> sequence and return everything after it. The
+        # original basic_parsers reference uses ``end_token_id`` to denote the
+        # reasoning-end token, which is ``</think>`` for this model — not
+        # ``<|im_end|>``.
+        n = len(self.think_end_tokens)
+        if n == 0:
+            return []
+        # Skip the very last position so that an end-marker at the boundary
+        # (no trailing content yet) returns an empty list.
+        upper = len(input_ids) - n
+        for i in range(upper):
+            if input_ids[i:i + n] == self.think_end_tokens:
+                return list(input_ids[i + n:])
+        return []
+
+

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -86,6 +86,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "hy_v3_tool_parser",
         "HYV3ToolParser",
     ),
+    "hyperclovax_seed_think": (
+        "hyperclovax_seed_think_tool_parser",
+        "HyperCLOVAXSeedThinkToolParser",
+    ),
     "internlm": (
         "internlm2_tool_parser",
         "Internlm2ToolParser",

--- a/vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py
+++ b/vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py
@@ -258,7 +258,15 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
                 self.cursor = idx + len(THINK_END)
                 while self.cursor < len(self.buffer_string) and self.buffer_string[self.cursor] == "\n":
                     self.cursor += 1
-            self.reasoning_ended = True
+                self.reasoning_ended = True
+            elif _partial_prefix_len(self.buffer_string, THINK_END) > 0:
+                # ``</think>`` may straddle deltas; hold the buffer until the
+                # tag completes so we don't leak its tail as content.
+                return None
+            else:
+                # No </think> in the buffer and no partial match — production
+                # path (reasoning parser already stripped it) or thinking=false.
+                self.reasoning_ended = True
 
         # JSON list fallback for ``tool_choice="required"`` / named when the
         # structured-output schema forces the model into a JSON payload

--- a/vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py
+++ b/vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py
@@ -33,12 +33,15 @@ Streaming policy:
 import json
 import re
 from collections.abc import Sequence
-from typing import Union
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import (
-    DeltaFunctionCall, DeltaMessage, DeltaToolCall,
-    ExtractedToolCallInformation, FunctionCall, ToolCall,
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
 )
 from vllm.logger import init_logger
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
@@ -63,6 +66,7 @@ _ARG_PAIR_RE = re.compile(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _partial_prefix_len(text: str, target: str) -> int:
     """Length of the longest prefix of ``target`` matching the suffix of ``text``.
@@ -118,6 +122,7 @@ def _parse_tool_call_block(block: str) -> ToolCall | None:
 # Parser
 # ---------------------------------------------------------------------------
 
+
 class HyperCLOVAXSeedThinkToolParser(ToolParser):
     """Tool call parser for the HyperCLOVAX-SEED-Think model.
 
@@ -161,7 +166,8 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
         if TOOL_CALL_OPEN in model_output:
             try:
                 tool_calls = [
-                    tc for block in _TOOL_CALL_RE.findall(model_output)
+                    tc
+                    for block in _TOOL_CALL_RE.findall(model_output)
                     if (tc := _parse_tool_call_block(block)) is not None
                 ]
                 if not tool_calls:
@@ -244,7 +250,7 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
-    ) -> Union[DeltaMessage, None]:
+    ) -> DeltaMessage | None:
         self.buffer_string += delta_text
 
         # vLLM's parse_delta only routes here after the reasoning phase is
@@ -256,7 +262,10 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
             idx = self.buffer_string.find(THINK_END)
             if idx != -1:
                 self.cursor = idx + len(THINK_END)
-                while self.cursor < len(self.buffer_string) and self.buffer_string[self.cursor] == "\n":
+                while (
+                    self.cursor < len(self.buffer_string)
+                    and self.buffer_string[self.cursor] == "\n"
+                ):
                     self.cursor += 1
                 self.reasoning_ended = True
             elif _partial_prefix_len(self.buffer_string, THINK_END) > 0:
@@ -273,7 +282,7 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
         # (``[{"name": ..., "parameters": {...}}]``). We only need to handle
         # this path here because, with ``supports_required_and_named=False``,
         # all tool_choice modes route through this parser.
-        unprocessed = self.buffer_string[self.cursor:].lstrip()
+        unprocessed = self.buffer_string[self.cursor :].lstrip()
         if not self.json_tool_emitted and unprocessed.startswith(("[", "{")):
             return self._emit_json_tool_calls()
 
@@ -283,20 +292,22 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
     # Internal
     # ------------------------------------------------------------------
 
-    def _emit_next(self) -> Union[DeltaMessage, None]:
-        """Drain processable content / tool_calls from the buffer into one DeltaMessage."""
+    def _emit_next(self) -> DeltaMessage | None:
+        """Drain processable content / tool_calls into one DeltaMessage."""
         content_parts: list[str] = []
         tool_call_deltas: list[DeltaToolCall] = []
 
         while self.cursor < len(self.buffer_string):
-            unprocessed = self.buffer_string[self.cursor:]
+            unprocessed = self.buffer_string[self.cursor :]
             open_idx = unprocessed.find(TOOL_CALL_OPEN)
 
             # Case A: no <tool_call> in remaining → stream as content.
             if open_idx == -1:
                 # Hold any tail that is a partial of <tool_call> or <|im_end|>
                 # to avoid leaking a split protocol token across delta boundaries.
-                partial_len = _partial_prefix_len_any(unprocessed, [TOOL_CALL_OPEN, IM_END])
+                partial_len = _partial_prefix_len_any(
+                    unprocessed, [TOOL_CALL_OPEN, IM_END]
+                )
                 safe_end = len(unprocessed) - partial_len
                 if safe_end <= 0:
                     break
@@ -322,7 +333,7 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
             if close_idx == -1:
                 break
 
-            block = unprocessed[len(TOOL_CALL_OPEN):close_idx]
+            block = unprocessed[len(TOOL_CALL_OPEN) : close_idx]
             self.cursor += close_idx + len(TOOL_CALL_CLOSE)
 
             tc = _parse_tool_call_block(block)
@@ -330,10 +341,12 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
                 continue
 
             self.current_tool_id += 1
-            self.prev_tool_call_arr.append({
-                "name": tc.function.name,
-                "arguments": tc.function.arguments,
-            })
+            self.prev_tool_call_arr.append(
+                {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                }
+            )
             self.streamed_args_for_tool.append(tc.function.arguments)
 
             tool_call_deltas.append(
@@ -360,14 +373,14 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
             kwargs["tool_calls"] = tool_call_deltas
         return DeltaMessage(**kwargs)
 
-    def _emit_json_tool_calls(self) -> Union[DeltaMessage, None]:
+    def _emit_json_tool_calls(self) -> DeltaMessage | None:
         """Emit tool_calls parsed from a JSON list payload.
 
         Called when the buffered output looks like a JSON object/array rather
         than the XML ``<tool_call>`` format. Waits for a fully parseable
         payload and then emits all tool_calls in one ``DeltaMessage``.
         """
-        payload = self.buffer_string[self.cursor:].lstrip()
+        payload = self.buffer_string[self.cursor :].lstrip()
         try:
             parsed = json.loads(payload)
         except ValueError:
@@ -388,8 +401,10 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
             args_obj = item.get("parameters")
             if args_obj is None:
                 args_obj = item.get("arguments", {})
-            args_str = args_obj if isinstance(args_obj, str) else json.dumps(
-                args_obj, ensure_ascii=False
+            args_str = (
+                args_obj
+                if isinstance(args_obj, str)
+                else json.dumps(args_obj, ensure_ascii=False)
             )
 
             self.current_tool_id += 1
@@ -402,7 +417,8 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
                     type="function",
                     id=f"hyperclovax_seed_think_tool_{self.current_tool_id}",
                     function=DeltaFunctionCall(
-                        name=name, arguments=args_str,
+                        name=name,
+                        arguments=args_str,
                     ).model_dump(exclude_none=True),
                 )
             )
@@ -413,5 +429,3 @@ class HyperCLOVAXSeedThinkToolParser(ToolParser):
         self.json_tool_emitted = True
         self.cursor = len(self.buffer_string)
         return DeltaMessage(tool_calls=tool_call_deltas)
-
-

--- a/vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py
+++ b/vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py
@@ -1,0 +1,409 @@
+"""HyperCLOVAX-SEED-Think tool call parser for vLLM.
+
+Tool call output format (as specified in the chat_template's system prompt):
+
+    <tool_call>{function-name}
+    <arg_key>{k1}</arg_key>
+    <arg_value>{v1}</arg_value>
+    ...
+    </tool_call>
+
+Multiple ``<tool_call>`` blocks may appear consecutively, separated by ``\\n``.
+
+Full output with thinking=true:
+    [reasoning]</think>\\n\\n[content?]<tool_call>...</tool_call>...<|im_end|>
+With thinking=false the prompt embeds ``</think>`` so the output omits it:
+    [content?]<tool_call>...</tool_call>...<|im_end|>
+
+For ``tool_choice="required"`` and named tool_choice, vLLM injects a JSON
+list schema via ``StructuredOutputsParams``. When the schema actually
+engages (thinking=true case, after ``</think>``) the model produces
+``[{"name": ..., "parameters": {...}}]`` instead of the XML form. We accept
+both formats; see ``_emit_json_tool_calls`` for the streaming JSON path.
+
+Streaming policy:
+  vLLM's ``parse_delta`` already routes the reasoning phase through the
+  reasoning parser, so we only receive post-``</think>`` deltas. Text
+  outside ``<tool_call>`` blocks is emitted as ``content`` and complete
+  ``<tool_call>...</tool_call>`` blocks as ``tool_calls``. Multiple
+  complete blocks observed in a single delta are bundled into one
+  ``DeltaMessage`` to avoid losing them when the stream ends.
+"""
+
+import json
+import re
+from collections.abc import Sequence
+from typing import Union
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall, DeltaMessage, DeltaToolCall,
+    ExtractedToolCallInformation, FunctionCall, ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+logger = init_logger(__name__)
+
+TOOL_CALL_OPEN = "<tool_call>"
+TOOL_CALL_CLOSE = "</tool_call>"
+THINK_END = "</think>"
+IM_END = "<|im_end|>"
+
+_TOOL_CALL_RE = re.compile(
+    re.escape(TOOL_CALL_OPEN) + r"(.*?)" + re.escape(TOOL_CALL_CLOSE),
+    re.DOTALL,
+)
+_ARG_PAIR_RE = re.compile(
+    r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>",
+    re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _partial_prefix_len(text: str, target: str) -> int:
+    """Length of the longest prefix of ``target`` matching the suffix of ``text``.
+
+    Used to detect protocol tokens split across delta boundaries. The exact-
+    match case (full ``target`` as a suffix) is excluded; callers should check
+    that separately with ``in`` or ``find``.
+    """
+    max_len = min(len(text), len(target) - 1)
+    for ln in range(max_len, 0, -1):
+        if text[-ln:] == target[:ln]:
+            return ln
+    return 0
+
+
+def _partial_prefix_len_any(text: str, targets: list[str]) -> int:
+    """Maximum partial-prefix length of ``text`` against any of ``targets``."""
+    return max((_partial_prefix_len(text, t) for t in targets), default=0)
+
+
+def _parse_tool_call_block(block: str) -> ToolCall | None:
+    """Parse the body of a ``<tool_call>...</tool_call>`` block into a ToolCall.
+
+    The chat_template's system prompt teaches the model to emit arguments as
+    ``<arg_key>{k}</arg_key>\\n<arg_value>{v}</arg_value>`` pairs. Each value
+    is JSON-loaded when possible (numbers/bool/null/list/dict) and falls back
+    to the raw string otherwise.
+    """
+    name, _, rest = block.strip().partition("\n")
+    name = name.strip()
+    if not name:
+        return None
+
+    arguments: dict = {}
+    for k, v in _ARG_PAIR_RE.findall(rest):
+        k = k.strip()
+        v = v.strip()
+        try:
+            arguments[k] = json.loads(v)
+        except ValueError:
+            arguments[k] = v
+
+    return ToolCall(
+        type="function",
+        function=FunctionCall(
+            name=name,
+            arguments=json.dumps(arguments, ensure_ascii=False),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+class HyperCLOVAXSeedThinkToolParser(ToolParser):
+    """Tool call parser for the HyperCLOVAX-SEED-Think model.
+
+    Parses ``<tool_call>...</tool_call>`` blocks (or the alternate
+    ``<arguments>`` body) from the model output. Streaming uses a cursor over
+    the accumulated buffer to handle multi-block and split-delta cases.
+    """
+
+    # HyperCLOVAX-SEED-Think emits tool calls in the XML
+    # ``<tool_call>...</tool_call>`` format defined in its chat_template. For
+    # ``tool_choice="required"`` or named tool_choice, vLLM normally enforces
+    # a JSON list schema via ``StructuredOutputsParams`` and uses its built-in
+    # JSON extractor. With ``thinking=true`` the schema kicks in after
+    # ``</think>`` and the model emits JSON; with ``thinking=false`` the
+    # ``</think>`` is already in the prompt so the schema never engages and
+    # the model produces natural XML. To handle both consistently, we set
+    # ``supports_required_and_named = False`` so that all tool_choice modes
+    # route through this parser, which then accepts either the XML format or
+    # the JSON list fallback.
+    supports_required_and_named: bool = False
+
+    def __init__(self, tokenizer, tools=None):
+        super().__init__(tokenizer, tools)
+
+        # Streaming state
+        self.buffer_string: str = ""
+        self.cursor: int = 0
+        self.reasoning_ended: bool = False
+        self.json_tool_emitted: bool = False
+
+    # ------------------------------------------------------------------
+    # Non-streaming
+    # ------------------------------------------------------------------
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        # Primary: XML ``<tool_call>...</tool_call>`` format from the chat_template.
+        if TOOL_CALL_OPEN in model_output:
+            try:
+                tool_calls = [
+                    tc for block in _TOOL_CALL_RE.findall(model_output)
+                    if (tc := _parse_tool_call_block(block)) is not None
+                ]
+                if not tool_calls:
+                    raise ValueError("no valid tool calls parsed")
+
+                # Text before the first <tool_call> → content. Use ``</think>``
+                # presence directly; more robust than relying on the
+                # chat_template_kwargs flag.
+                before_tool, _, _ = model_output.partition(TOOL_CALL_OPEN)
+                _, sep, after_think = before_tool.partition(THINK_END)
+                content = (after_think if sep else before_tool).strip() or None
+
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=content,
+                )
+            except Exception:
+                logger.exception("Error extracting XML tool call.")
+                return ExtractedToolCallInformation(
+                    tools_called=False, tool_calls=[], content=model_output
+                )
+
+        # Fallback: JSON list ``[{"name": ..., "parameters": {...}}]`` —
+        # produced when vLLM's ``required``/named-tool path forces the model
+        # into a JSON schema via ``StructuredOutputsParams``. Strip any
+        # leading reasoning so we can locate the JSON payload.
+        _, sep, post_think = model_output.partition(THINK_END)
+        candidate = (post_think if sep else model_output).strip()
+        if candidate.startswith("[") or candidate.startswith("{"):
+            try:
+                parsed = json.loads(candidate)
+                if isinstance(parsed, dict):
+                    parsed = [parsed]
+                if isinstance(parsed, list) and parsed:
+                    tool_calls = []
+                    for item in parsed:
+                        if not isinstance(item, dict):
+                            continue
+                        name = item.get("name") or item.get("function", {}).get("name")
+                        if not name:
+                            continue
+                        # ``parameters`` (Function schema) or ``arguments``
+                        args_obj = item.get("parameters")
+                        if args_obj is None:
+                            args_obj = item.get("arguments", {})
+                        if isinstance(args_obj, str):
+                            args_str = args_obj
+                        else:
+                            args_str = json.dumps(args_obj, ensure_ascii=False)
+                        tool_calls.append(
+                            ToolCall(
+                                type="function",
+                                function=FunctionCall(name=name, arguments=args_str),
+                            )
+                        )
+                    if tool_calls:
+                        return ExtractedToolCallInformation(
+                            tools_called=True,
+                            tool_calls=tool_calls,
+                            content=None,
+                        )
+            except (ValueError, TypeError):
+                pass
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> Union[DeltaMessage, None]:
+        self.buffer_string += delta_text
+
+        # vLLM's parse_delta only routes here after the reasoning phase is
+        # over (it strips ``</think>`` and earlier tokens before invoking us).
+        # If our buffer still happens to contain ``</think>`` — e.g. when this
+        # parser is exercised standalone — advance past it; otherwise this is
+        # a no-op.
+        if not self.reasoning_ended:
+            idx = self.buffer_string.find(THINK_END)
+            if idx != -1:
+                self.cursor = idx + len(THINK_END)
+                while self.cursor < len(self.buffer_string) and self.buffer_string[self.cursor] == "\n":
+                    self.cursor += 1
+            self.reasoning_ended = True
+
+        # JSON list fallback for ``tool_choice="required"`` / named when the
+        # structured-output schema forces the model into a JSON payload
+        # (``[{"name": ..., "parameters": {...}}]``). We only need to handle
+        # this path here because, with ``supports_required_and_named=False``,
+        # all tool_choice modes route through this parser.
+        unprocessed = self.buffer_string[self.cursor:].lstrip()
+        if not self.json_tool_emitted and unprocessed.startswith(("[", "{")):
+            return self._emit_json_tool_calls()
+
+        return self._emit_next()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _emit_next(self) -> Union[DeltaMessage, None]:
+        """Drain processable content / tool_calls from the buffer into one DeltaMessage."""
+        content_parts: list[str] = []
+        tool_call_deltas: list[DeltaToolCall] = []
+
+        while self.cursor < len(self.buffer_string):
+            unprocessed = self.buffer_string[self.cursor:]
+            open_idx = unprocessed.find(TOOL_CALL_OPEN)
+
+            # Case A: no <tool_call> in remaining → stream as content.
+            if open_idx == -1:
+                # Hold any tail that is a partial of <tool_call> or <|im_end|>
+                # to avoid leaking a split protocol token across delta boundaries.
+                partial_len = _partial_prefix_len_any(unprocessed, [TOOL_CALL_OPEN, IM_END])
+                safe_end = len(unprocessed) - partial_len
+                if safe_end <= 0:
+                    break
+                chunk = unprocessed[:safe_end].replace(IM_END, "")
+                self.cursor += safe_end
+                if chunk:
+                    content_parts.append(chunk)
+                if partial_len > 0:
+                    break
+                continue
+
+            # Case B: text precedes the next <tool_call> → emit as content first.
+            if open_idx > 0:
+                pre = unprocessed[:open_idx].replace(IM_END, "")
+                self.cursor += open_idx
+                # Whitespace-only segments between tool_calls are separators; drop them.
+                if pre.strip():
+                    content_parts.append(pre)
+                continue
+
+            # Case C: cursor sits at <tool_call> — wait for </tool_call>.
+            close_idx = unprocessed.find(TOOL_CALL_CLOSE, len(TOOL_CALL_OPEN))
+            if close_idx == -1:
+                break
+
+            block = unprocessed[len(TOOL_CALL_OPEN):close_idx]
+            self.cursor += close_idx + len(TOOL_CALL_CLOSE)
+
+            tc = _parse_tool_call_block(block)
+            if tc is None:
+                continue
+
+            self.current_tool_id += 1
+            self.prev_tool_call_arr.append({
+                "name": tc.function.name,
+                "arguments": tc.function.arguments,
+            })
+            self.streamed_args_for_tool.append(tc.function.arguments)
+
+            tool_call_deltas.append(
+                DeltaToolCall(
+                    index=self.current_tool_id,
+                    type="function",
+                    id=f"hyperclovax_seed_think_tool_{self.current_tool_id}",
+                    function=DeltaFunctionCall(
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+
+        if not content_parts and not tool_call_deltas:
+            return None
+
+        # ``DeltaMessage.tool_calls`` rejects ``None`` (must be a list), so only
+        # set the field when we actually have tool_call deltas to emit.
+        kwargs: dict = {}
+        if content_parts:
+            kwargs["content"] = "".join(content_parts)
+        if tool_call_deltas:
+            kwargs["tool_calls"] = tool_call_deltas
+        return DeltaMessage(**kwargs)
+
+    def _emit_json_tool_calls(self) -> Union[DeltaMessage, None]:
+        """Emit tool_calls parsed from a JSON list payload.
+
+        Called when the buffered output looks like a JSON object/array rather
+        than the XML ``<tool_call>`` format. Waits for a fully parseable
+        payload and then emits all tool_calls in one ``DeltaMessage``.
+        """
+        payload = self.buffer_string[self.cursor:].lstrip()
+        try:
+            parsed = json.loads(payload)
+        except ValueError:
+            return None  # not yet complete; wait for more
+
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+        if not isinstance(parsed, list) or not parsed:
+            return None
+
+        tool_call_deltas: list[DeltaToolCall] = []
+        for item in parsed:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name") or (item.get("function") or {}).get("name")
+            if not name:
+                continue
+            args_obj = item.get("parameters")
+            if args_obj is None:
+                args_obj = item.get("arguments", {})
+            args_str = args_obj if isinstance(args_obj, str) else json.dumps(
+                args_obj, ensure_ascii=False
+            )
+
+            self.current_tool_id += 1
+            self.prev_tool_call_arr.append({"name": name, "arguments": args_str})
+            self.streamed_args_for_tool.append(args_str)
+
+            tool_call_deltas.append(
+                DeltaToolCall(
+                    index=self.current_tool_id,
+                    type="function",
+                    id=f"hyperclovax_seed_think_tool_{self.current_tool_id}",
+                    function=DeltaFunctionCall(
+                        name=name, arguments=args_str,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+
+        if not tool_call_deltas:
+            return None
+
+        self.json_tool_emitted = True
+        self.cursor = len(self.buffer_string)
+        return DeltaMessage(tool_calls=tool_call_deltas)
+
+


### PR DESCRIPTION
## Summary

Adds reasoning + tool parsers for the **`naver-hyperclovax/HyperCLOVAX-SEED-Think-32B`** model, targeting the model's actual published chat template (`</think>` boundary + XML `<tool_call>` format).

Two new parser modules, each registered via the existing lazy-loading tables
(`_REASONING_PARSERS_TO_REGISTER` / `_TOOL_PARSERS_TO_REGISTER`).

## Files

- `vllm/reasoning/hyperclovax_seed_think_reasoning_parser.py` (new, ~180 lines)
- `vllm/tool_parsers/hyperclovax_seed_think_tool_parser.py` (new, ~410 lines)
- `vllm/reasoning/__init__.py` (+4 lines, lazy table entry)
- `vllm/tool_parsers/__init__.py` (+4 lines, lazy table entry)
- `tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py` (new, 26 unit tests)
- `tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py` (new, 23 unit tests)

## Model output formats

### Reasoning (chat_template controlled by `chat_template_kwargs.thinking`)
- `thinking=true` → generation prompt ends with `<think>\n`; model emits
  `[reasoning]</think>\n\n[content]`.
- `thinking=false` → prompt already contains `<think>\n\n</think>\n\n`;
  model emits `[content]` directly.

### Tool calls (per chat_template's system prompt)
```
<tool_call>{function-name}
<arg_key>{k1}</arg_key>
<arg_value>{v1}</arg_value>
...
</tool_call>
```

For `tool_choice="required"` / named tool_choice, vLLM's default
`adjust_request` injects a JSON list schema. With `thinking=true` the
schema engages after `</think>` and the model outputs
`[{"name": ..., "parameters": {...}}]` instead of the XML form. The tool
parser accepts both formats; non-streaming via `extract_tool_calls`,
streaming via `_emit_json_tool_calls`.

## Why `supports_required_and_named = False`

Mirrors the GLM / Qwen3Coder pattern for XML-emitting tool models:
- vLLM's built-in `extract_required_tool_call_streaming` /
  `TypeAdapter(list[FunctionDefinition])` validators reject the XML
  output produced when the structured-output schema fails to engage
  (`thinking=false + required` case).
- Routing through this parser allows accepting either XML or JSON list
  formats uniformly.

## Test plan

End-to-end validation against the 32B checkpoint covers a 12-case matrix
(reasoning × 2 stream modes × 2 thinking modes, then tool calling × 2
stream × 2 thinking × 2 tool_choice modes):

```bash
# Server (single GPU)
vllm serve naver-hyperclovax/HyperCLOVAX-SEED-Think-32B \
  --reasoning-parser hyperclovax_seed_think \
  --tool-call-parser hyperclovax_seed_think \
  --enable-auto-tool-choice \
  --port 8765

# Client: 12-case matrix runner
python3 run_tests.py   # produces R1-R4.json + T1-T8.json + summary.xlsx
```

## Test results — 12/12 PASS

| Case | thinking | stream | tool_choice | Result |
|------|----------|--------|-------------|--------|
| R1 | true  | true  | —        | PASS |
| R2 | true  | false | —        | PASS |
| R3 | false | true  | —        | PASS |
| R4 | false | false | —        | PASS |
| T1 | true  | true  | auto     | PASS |
| T2 | true  | true  | required | PASS |
| T3 | true  | false | auto     | PASS |
| T4 | true  | false | required | PASS |
| T5 | false | true  | auto     | PASS |
| T6 | false | true  | required | PASS |
| T7 | false | false | auto     | PASS |
| T8 | false | false | required | PASS |

All `tool_call` cases produce a valid JSON `arguments` payload containing
the required `location` field.

### Unit tests (49 cases, all pass)

```bash
.venv/bin/python -m pytest \
    tests/reasoning/test_hyperclovax_seed_think_reasoning_parser.py \
    tests/tool_parsers/test_hyperclovax_seed_think_tool_parser.py
# 49 passed
```

The unit tests use `unittest.mock.MagicMock` tokenizers (no HF model
download), covering: registration, `thinking` flag capture, non-streaming
extraction edge cases, partial-tag streaming guards, JSON-list fallback
streaming, `is_reasoning_end` / `extract_content_ids` token-id helpers,
and the `<|im_end|>` strip + `<tool_call>`-straddling-deltas cases.

## Usage

```bash
vllm serve naver-hyperclovax/HyperCLOVAX-SEED-Think-32B \
  --reasoning-parser hyperclovax_seed_think \
  --tool-call-parser hyperclovax_seed_think \
  --enable-auto-tool-choice
```

Request body example:
```json
{
  "model": "...",
  "messages": [...],
  "tools": [...],
  "tool_choice": "auto",
  "chat_template_kwargs": {"thinking": true},
  "stream": true
}
```

## Test plan checklist

- [x] Reasoning split with `thinking=true` (streaming + non-streaming)
- [x] All-content path with `thinking=false` (streaming + non-streaming)
- [x] XML tool_call extraction (`<tool_call>...</tool_call>`)
- [x] JSON list tool_call fallback (`[{"name":...,"parameters":{...}}]`)
- [x] `tool_choice="required"` for both thinking modes
- [x] Content + tool_call mixed output
- [x] Multi-tool_call output (covered by parser logic, not hit in this matrix)

## AI assistance disclosure (per AGENTS.md §1)

This PR was authored with assistance from Anthropic Claude (Claude Code).
The human submitter (@ugiugi0823) has reviewed every changed line and
executed the full 12-case end-to-end matrix against the 32B checkpoint
locally. Design and parser-behavior decisions (dual XML/JSON path,
`supports_required_and_named=False`, the `chat_template_kwargs.thinking`
handling) were made after empirical inspection of the raw token outputs
of the model under each combination — not inferred from training-time
priors.

Duplicate-work check (per AGENTS.md §1): no overlapping open PRs at the time of this revision.

