### PR TITLE
fix: MoE model using shared routed experts crashes on AMD GPUs

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/aiter_shared_routed_fused_moe_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/aiter_shared_routed_fused_moe_router.py
@@ -73,7 +73,7 @@ class AiterSharedRoutedFusedMoERouter(BaseRouter):
             "Number of tokens mismatch"
         )
 
-        from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+        from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
             aiter_topK_meta_data,
         )
 
@@ -127,7 +127,7 @@ class AiterSharedRoutedFusedMoERouter(BaseRouter):
         )
 
         if aiter_topK_meta_data is not None:
-            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+            from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
                 inject_shared_expert_weights,
             )
 


### PR DESCRIPTION

stale import crashes every ROCm+AITER MoE model at startup

## Purpose

Issue: 
Loading a MoE model (e.g., DeepSeek-V2/V3, Mixtral) on a ROCm platform with AITER fused MoE enabled, when the shared routed expert  path is activated.
ModuleNotFoundError at model load time — the import vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe fails because that module  no longer exists, crashing model initialization with no workaround.


Root Cause: 
PR #41979 reorganized fused_moe/ by moving expert implementations into an experts/ subdirectory and renaming rocm_aiter_fused_moe.py →  experts/rocm_aiter_moe.py, 
but missed two lazy imports in router/aiter_shared_routed_fused_moe_router.py that still reference the old path.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

