### PR TITLE
[Misc] Warn when CUDA PTX arch flags are ignored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # CMAKE_CUDA_FLAGS so that they are not applied globally.
   #
   clear_cuda_arches(CUDA_ARCH_FLAGS)
+  warn_if_ptx_arch_requested("${CUDA_ARCH_FLAGS}")
   extract_unique_cuda_archs_ascending(CUDA_ARCHS "${CUDA_ARCH_FLAGS}")
   message(STATUS "CUDA target architectures: ${CUDA_ARCHS}")
   # Filter the target architectures by the supported supported archs

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -201,6 +201,25 @@ macro(clear_cuda_arches CUDA_ARCH_FLAGS)
 endmacro()
 
 #
+# Warn when a caller requested PTX code generation through global CUDA arch
+# flags. vLLM removes those flags and reapplies per-source gencode flags, so the
+# user's global PTX request will not be preserved.
+#
+function(warn_if_ptx_arch_requested CUDA_ARCH_FLAGS)
+  foreach(_ARCH_FLAG ${CUDA_ARCH_FLAGS})
+    if(_ARCH_FLAG MATCHES "code=.*compute_[0-9]+[af]?")
+      message(WARNING
+        "PTX code generation requested in CUDA architecture flags "
+        "(${_ARCH_FLAG}), but vLLM does not preserve global PTX requests "
+        "when normalizing per-source CUDA architectures. Remove '+PTX' from "
+        "TORCH_CUDA_ARCH_LIST or rely on vLLM's built-in per-kernel PTX "
+        "selection.")
+      return()
+    endif()
+  endforeach()
+endfunction()
+
+#
 # Extract unique CUDA architectures from a list of compute capabilities codes in 
 # the form `<major><minor>[<letter>]`, convert them to the form sort 
 # `<major>.<minor>`, dedupes them and then sorts them in ascending order and 


### PR DESCRIPTION
## Purpose

Addresses one item from #9129: warn when PTX code generation is requested via CUDA architecture flags but vLLM normalizes those global flags into per-source CUDA architecture settings.

Users can request PTX through `TORCH_CUDA_ARCH_LIST` values such as `8.0+PTX`. vLLM strips the Torch-provided global `-gencode` flags and rebuilds per-source gencode flags, so the global PTX request is not preserved. This PR surfaces that behavior during CMake configuration instead of silently dropping the request.

## Changes

- Add `warn_if_ptx_arch_requested()` in `cmake/utils.cmake`.
- Call it after `clear_cuda_arches()` captures and removes global CUDA arch flags.
- Detect both direct `code=compute_XX` and bracketed forms such as `code=[sm_90a,compute_90a]`.

## Testing

- `git diff --check HEAD~1..HEAD`
- Local regex smoke test for SASS-only and PTX-containing gencode flags
- `cmake -P` script validation with CMake 4.3.2:
  - no warning for `-gencode arch=compute_80,code=sm_80`
  - warning for `-gencode arch=compute_80,code=compute_80`
  - warning for `-gencode arch=compute_90a,code=[sm_90a,compute_90a]`

## AI assistance disclosure

This PR was prepared with AI assistance. I reviewed the changed lines and validation results before opening the PR.
