### PR TITLE
[Misc] Log FlashInfer runtime JIT compilation

### DIFF
--- a/tests/test_flashinfer_utils.py
+++ b/tests/test_flashinfer_utils.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import vllm.utils.flashinfer as flashinfer_utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_flashinfer_jit_cache():
+    flashinfer_utils._may_need_flashinfer_jit_compile.cache_clear()
+    yield
+    flashinfer_utils._may_need_flashinfer_jit_compile.cache_clear()
+
+
+def test_lazy_wrapper_logs_when_flashinfer_may_jit_compile(monkeypatch):
+    op = Mock(return_value="result")
+    info_once = Mock()
+
+    monkeypatch.setattr(flashinfer_utils, "has_flashinfer", lambda: True)
+    monkeypatch.setattr(flashinfer_utils, "has_flashinfer_cubin", lambda: False)
+    monkeypatch.setattr(flashinfer_utils.shutil, "which", lambda cmd: "/usr/bin/nvcc")
+    monkeypatch.setattr(
+        flashinfer_utils,
+        "_get_submodule",
+        lambda module_name: SimpleNamespace(op=op),
+    )
+    monkeypatch.setattr(flashinfer_utils.logger, "info_once", info_once)
+
+    wrapper = flashinfer_utils._lazy_import_wrapper("flashinfer.test", "op")
+
+    assert wrapper() == "result"
+    op.assert_called_once_with()
+    info_once.assert_called_once_with(flashinfer_utils._FLASHINFER_JIT_COMPILE_MESSAGE)
+
+
+@pytest.mark.parametrize(
+    ("has_cubin", "nvcc_path"),
+    [
+        (True, "/usr/bin/nvcc"),
+        (False, None),
+    ],
+)
+def test_flashinfer_jit_log_skipped_when_compile_is_unlikely(
+    has_cubin, nvcc_path, monkeypatch
+):
+    info_once = Mock()
+
+    monkeypatch.setattr(flashinfer_utils, "has_flashinfer_cubin", lambda: has_cubin)
+    monkeypatch.setattr(flashinfer_utils.shutil, "which", lambda cmd: nvcc_path)
+    monkeypatch.setattr(flashinfer_utils.logger, "info_once", info_once)
+
+    flashinfer_utils._log_flashinfer_jit_compile_once()
+
+    info_once.assert_not_called()

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -30,6 +30,11 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "FLASHINFER_CUBINS_REPOSITORY",
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",  # noqa: E501
 )
+_FLASHINFER_JIT_COMPILE_MESSAGE = (
+    "FlashInfer is running without precompiled cubins (flashinfer-cubin). "
+    "FlashInfer may JIT-compile kernels on first use, which can take "
+    "several minutes; subsequent runs should reuse the cache."
+)
 
 
 @functools.cache
@@ -60,6 +65,16 @@ def has_flashinfer() -> bool:
         )
         return False
     return True
+
+
+@functools.cache
+def _may_need_flashinfer_jit_compile() -> bool:
+    return not has_flashinfer_cubin() and shutil.which("nvcc") is not None
+
+
+def _log_flashinfer_jit_compile_once() -> None:
+    if _may_need_flashinfer_jit_compile():
+        logger.info_once(_FLASHINFER_JIT_COMPILE_MESSAGE)
 
 
 def _missing(*_: Any, **__: Any) -> NoReturn:
@@ -96,6 +111,7 @@ def _lazy_import_wrapper(
         impl = _get_impl()
         if impl is None:
             return fallback_fn(*args, **kwargs)
+        _log_flashinfer_jit_compile_once()
         return impl(*args, **kwargs)
 
     return wrapper
@@ -447,6 +463,7 @@ if has_flashinfer():
             k_pe: The rope part of k (shared), shape [num_tokens, 1, rope_dim].
                   This is broadcast to all heads.
         """
+        _log_flashinfer_jit_compile_once()
         from flashinfer.concat_ops import concat_mla_k
 
         concat_mla_k(k, k_nope, k_pe)
@@ -481,6 +498,7 @@ if has_flashinfer():
         use_8x4_sf_layout: bool,
         backend: str,
     ) -> torch.Tensor:
+        _log_flashinfer_jit_compile_once()
         from flashinfer import mm_fp4 as flashinfer_mm_fp4_
 
         return flashinfer_mm_fp4_(
@@ -523,6 +541,7 @@ if has_flashinfer():
         dtype: torch.dtype,
         backend: str,
     ) -> torch.Tensor:
+        _log_flashinfer_jit_compile_once()
         from flashinfer import bmm_fp8 as bmm_fp8_
 
         return bmm_fp8_(A, B, A_scale, B_scale, dtype, None, backend)
@@ -550,6 +569,7 @@ if has_flashinfer():
     def flashinfer_nvfp4_quantize(
         a: torch.Tensor, a_global_sf: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        _log_flashinfer_jit_compile_once()
         from flashinfer import SfLayout
         from flashinfer import nvfp4_quantize as nvfp4_quantize_
 
@@ -588,6 +608,7 @@ if has_flashinfer():
         out_dtype: torch.dtype,
         backend: str = "cutlass",
     ) -> torch.Tensor:
+        _log_flashinfer_jit_compile_once()
         from flashinfer import mm_mxfp8 as mm_mxfp8_
 
         return mm_mxfp8_(
@@ -709,6 +730,7 @@ def flashinfer_scaled_fp4_mm_out(
         if block_scale_b.dtype != torch.uint8:
             block_scale_b = block_scale_b.view(torch.uint8)
 
+    _log_flashinfer_jit_compile_once()
     from flashinfer import mm_fp4 as flashinfer_mm_fp4_
 
     flashinfer_mm_fp4_(
@@ -772,6 +794,7 @@ def flashinfer_scaled_fp8_mm_out(
     assert out.device.type == "cuda"
     assert a.is_contiguous()
 
+    _log_flashinfer_jit_compile_once()
     from flashinfer import bmm_fp8 as bmm_fp8_
 
     bmm_fp8_(


### PR DESCRIPTION
Fixes #38246.

Adds a one-time INFO log before vLLM calls FlashInfer kernels in environments that can fall back to runtime JIT compilation. This specifically covers the case where `flashinfer-cubin` is not installed but `nvcc` is available, so a first FlashInfer call may compile kernels and appear to hang for several minutes.

The notice is centralized in `vllm.utils.flashinfer` and reused by the lazy FlashInfer wrappers plus direct FlashInfer helper paths. It stays silent when precompiled cubins are available or when FlashInfer cannot JIT because `nvcc` is missing.

Validation:
- `git diff --check`
- `uvx pre-commit run --hook-stage manual --files vllm/utils/flashinfer.py tests/test_flashinfer_utils.py`
- Focused Python smoke test for the JIT logging branches using a no-project `uv` environment
