### PR TITLE
Fix AttributeError in Gemma3n forward() when inputs_embeds is None during profiling

### DIFF
--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -726,7 +726,9 @@ class Gemma3nForConditionalGeneration(
         # select a chunk of pre-allocated PLEs. During normal execution,
         # `embed_input_ids` is called before forward, hence this slice
         # will contain PLEs computed from the actual input_ids.
-        per_layer_inputs = self.per_layer_embeddings[: inputs_embeds.shape[0]]
+        seq_len = (inputs_embeds.shape[0]
+                   if inputs_embeds is not None else input_ids.shape[0])
+        per_layer_inputs = self.per_layer_embeddings[:seq_len]
 
         hidden_states = self.language_model.model(
             input_ids,

--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -726,9 +726,7 @@ class Gemma3nForConditionalGeneration(
         # select a chunk of pre-allocated PLEs. During normal execution,
         # `embed_input_ids` is called before forward, hence this slice
         # will contain PLEs computed from the actual input_ids.
-        seq_len = (inputs_embeds.shape[0]
-                   if inputs_embeds is not None else input_ids.shape[0])
-        per_layer_inputs = self.per_layer_embeddings[:seq_len]
+        per_layer_inputs = self.per_layer_embeddings[:positions.shape[0]]
 
         hidden_states = self.language_model.model(
             input_ids,


### PR DESCRIPTION
## Problem                                                                                                                                                                                                   
                                                                                                                                                                                                               
  During vLLM's memory profiling pass, `Gemma3nForConditionalGeneration.forward()` sets `inputs_embeds = None` when `intermediate_tensors is not None` (line ~721). The code then unconditionally accesses     
  `inputs_embeds.shape[0]`, raising:                                                                                                                                                                           
                                                                                                                                                                                                               
  AttributeError: 'NoneType' object has no attribute 'shape'
                                                            
  This prevents any Gemma3n model from loading under vLLM.

  ## Root Cause                                                                                                                                                                                                
   
  `GPUModelRunner` passes non-None `intermediate_tensors` during the profiling pass, triggering the branch that sets `inputs_embeds = None`. The existing comment at this location already documents this      
  intent:         
                                                                                                                                                                                                               
  > *"During profiling, `embed_input_ids` is not called, hence we don't have input_ids to compute PLEs."*                                                                                                      
   
  But the shape lookup immediately below was never guarded against this case.                                                                                                                                  
                  
  ## Fix                                                                                                                                                                                                       
                  
  ```python                                                                                                                                                                                                    
  # Before
  per_layer_inputs = self.per_layer_embeddings[: inputs_embeds.shape[0]]                                                                                                                                       
                                                                                                                                                                                                               
  # After
  seq_len = (inputs_embeds.shape[0]                                                                                                                                                                            
             if inputs_embeds is not None else input_ids.shape[0])                                                                                                                                             
  per_layer_inputs = self.per_layer_embeddings[:seq_len]
                                                                                                                                                                                                               
  Testing                                                                                                                                                                                                      
   
  Tested on vLLM v0.20.0 with google/gemma-3n-E2B-it under enforce_eager=True on NVIDIA Blackwell (SM120). Model loads and runs correctly after this fix.                                                      
                  
  Checklist                                                                                                                                                                                                    
                  
  - Not a duplicate: searched open PRs and issues for gemma3n profiling inputs_embeds — no existing fix found.                                                                                                 
  - ruff check passed on the modified file.
  - AI assistance used: yes (Claude).

