### PR TITLE
[XPU] Slice GDN attention inputs to num_actual_tokens

### DIFF
--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -121,6 +121,18 @@ def _gdn_attention_core_xpu_impl(
         self.conv1d.weight.size(0), self.conv1d.weight.size(2)
     )
 
+    # Under PIECEWISE cudagraph capture the model runner pads inputs to the
+    # captured size; metadata's `num_actual_tokens` stays unpadded, and the
+    # SYCL kernel asserts `core_attn_out.size(0) == num_actual_tokens`.
+    # Slice to the actual count, mirroring the CUDA path in gdn_linear_attn.py.
+    # Slicing dim 0 of contiguous tensors yields contiguous views that share
+    # storage with the originals, so the op's `mutates_args` contract holds.
+    num_actual_tokens = attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
+    core_attn_out = core_attn_out[:num_actual_tokens]
+    z = z[:num_actual_tokens]
+    projected_states_qkvz = projected_states_qkvz[:num_actual_tokens]
+    projected_states_ba = projected_states_ba[:num_actual_tokens]
+
     torch.ops._xpu_C.gdn_attention(
         core_attn_out,
         z,


### PR DESCRIPTION
## Purpose

Follow-up to #39466. That PR moved the SYCL `gdn_attention` call into a new `gdn_attention_core_xpu` custom op in `vllm/_xpu_ops.py` and added it to `splitting_ops` so torch.compile / cudagraph could capture around the eager-fallback boundary, making GDN + torch.compile **runnable** on XPU. The wrapper, however, passes `core_attn_out`, `z`, `projected_states_qkvz`, and `projected_states_ba` through unchanged.

Under PIECEWISE cudagraph capture the model runner pads forward inputs to the captured cudagraph size (e.g. 1, 4) while `attn_metadata.num_actual_tokens` stays at the real (unpadded) count. The SYCL kernel asserts `core_attn_out.size(0) == num_actual_tokens` (in `csrc/xpu/gdn_attn/gdn_attn_interface.cpp`) and aborts whenever the real decode batch is smaller than the captured size — e.g. 3 concurrent decodes hitting the size-4 cudagraph:

```
RuntimeError: Expected core_attn_out.size(0) == num_actual_tokens to be true
```

raised from `vllm/_xpu_ops.py` inside the `gdn_attention_core_xpu` custom op.

The CUDA path already slices the equivalent inputs to `num_actual_tokens` before its kernel call in `gdn_linear_attn.py`. This PR mirrors that slice inside the `_gdn_attention_core_xpu_impl` wrapper added by #39466. Slicing dim 0 of the contiguous buffers yields contiguous views that share storage with the originals, so the op's `mutates_args` contract still holds and padded slots stay at their `torch.zeros` init.

Related to vllm-project/vllm-xpu-kernels#320. (Using "Related to" rather than "Closes": a proper kernel-side fix that relaxes the assert is what that issue's *Proposed kernel-side fix* section asks for and is still independently desirable. This PR makes the trap unreachable from upstream vLLM but doesn't relax the contract.)

## Test Plan

Repro on a hybrid GDN model (Qwen3-Next or Qwen3.6-MoE family) with torch.compile + cudagraph + smaller-than-captured decode batches:

```
VLLM_XPU_ENABLE_XPU_GRAPH=1 \
vllm serve <gdn-model> \
  --enforce-eager false \
  --compilation-config '{"cudagraph_capture_sizes":[1,4]}'
```

Then drive 3 concurrent decode streams so they hit the size-4 captured graph with a real batch of 3. Before this patch the call aborts with the `RuntimeError` above; after this patch the call completes and continues to stream.

## Test Result

Verified on Qwen3.6-35B-A3B-GPTQ-Int4 + `turboquant_k3v4_nc` with `--compilation-config '{"cudagraph_capture_sizes":[1,2,4,8]}'`:

- Single-stream throughput: ~20 tok/s (eager) → **65.76 tok/s** with torch.compile + cudagraph enabled.
- 4-concurrent stress: previously crashing `batch=3 padded to 4` case fired 3,570 times with zero errors. Aggregate ~216.7 tok/s.

cc @yuwenzho @jikunshang — follow-up to #39466 closing the gap reported in vllm-project/vllm-xpu-kernels#320.