### PR TITLE
fix: return None from get_pkg_version on non-Linux platforms

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -301,7 +301,8 @@ def get_xpu_runtime_version():
 
 
 def get_pkg_version(run_lambda, pkg):
-    assert get_platform() == "linux"
+    if get_platform() != "linux":
+        return None
 
     if pkg == "vllm_xpu_kernels":
         rc, out, _ = run_lambda("pip show vllm-xpu-kernels")


### PR DESCRIPTION


## Purpose

\`collect_env.py\` crashes on macOS and Windows because \`get_pkg_version()\` hard-asserts \`get_platform() == \"linux\"\`, but it is called unconditionally from \`get_env_info()\` via the Intel XPU helpers (\`get_intel_graphics_compiler_version\`, \`get_level_zero_loader_version\`, etc.).

Replace the assert with an early \`return None\` so the XPU fields surface as \`None\` on non-Linux platforms instead of aborting the entire environment report.

Fixes #41906

## Test Plan

\`\`\`
python -c \"
import vllm.collect_env as ce
ce.get_platform = lambda: 'darwin'
assert ce.get_pkg_version(lambda c: (0,'',''), 'igc') is None
ce.get_platform = lambda: 'win32'
assert ce.get_pkg_version(lambda c: (0,'',''), 'igc') is None
print('OK')
\"
\`\`\`

## Test Result

\`OK\` on macOS arm64. Running \`python collect_env.py\` on macOS now completes successfully instead of raising \`AssertionError\`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as \"Fix some issue (link existing issues this PR will resolve)\".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating \`supported_models.md\` and \`examples\` for a new model.
</details>