### PR TITLE
[UT][XPU] fix test_parallel_sampling due to global random state

### DIFF
--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -79,10 +79,11 @@ def _get_test_sampling_params(
     structured_outputs: bool = False,
 ) -> tuple[list[SamplingParams], list[int]]:
     """Generate random sampling params for a batch."""
+    rng = random.Random(seed)
 
     def get_mostly_n_gt1() -> int:
         r"""Mostly n \in [2,20], ~1/3 n=1"""
-        x = random.randint(0, 28)
+        x = rng.randint(0, 28)
         if x < 10:
             return 1
         else:


### PR DESCRIPTION



## Purpose

Problem: `_get_test_sampling_params` uses the global random module. When run together with other test files in the same pytest session, the global random state is polluted, causing the generated n values to be larger than expected and increasing the probability of duplicate completions.

Fix: Replace the global random with a local random.Random(seed) instance to ensure `n_list` is deterministic regardless of test execution order.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

