### PR TITLE
[CI] Migrate all gpu_1_queue jobs to h200_18gb MIG

### DIFF
--- a/.buildkite/test_areas/cuda.yaml
+++ b/.buildkite/test_areas/cuda.yaml
@@ -20,6 +20,7 @@ steps:
 - label: Cudagraph
   key: cudagraph
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
   - tests/v1/cudagraph
   - vllm/v1/cudagraph_dispatcher.py

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -30,6 +30,7 @@ steps:
 - label: Engine (1 GPU)
   key: engine-1-gpu
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
     - vllm/v1/engine/
     - tests/v1/engine/
@@ -50,6 +51,7 @@ steps:
 - label: e2e Core (1 GPU)
   key: e2e-core-1-gpu
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
     - vllm/v1/
     - tests/v1/e2e/general/

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -6,6 +6,7 @@ steps:
   key: entrypoints-unit-tests
   timeout_in_minutes: 10
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/entrypoints
   - tests/entrypoints/
@@ -17,6 +18,7 @@ steps:
   key: entrypoints-integration-llm
   timeout_in_minutes: 40
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/llm
@@ -36,6 +38,7 @@ steps:
   key: entrypoints-integration-api-server-openai-part-1
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/openai
@@ -48,6 +51,7 @@ steps:
   key: entrypoints-integration-api-server-openai-part-2
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/openai
@@ -73,6 +77,7 @@ steps:
   key: entrypoints-integration-api-server-2
   timeout_in_minutes: 130
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/rpc
@@ -88,6 +93,7 @@ steps:
   key: entrypoints-integration-speech_to_text
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/speech_to_text
@@ -99,6 +105,7 @@ steps:
   key: entrypoints-integration-pooling
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/pooling
@@ -110,6 +117,7 @@ steps:
   key: entrypoints-integration-responses-api
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/openai/responses

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -17,6 +17,7 @@ steps:
 - label: Kernels Core Operation Test
   key: kernels-core-operation-test
   timeout_in_minutes: 75
+  device: h200_18gb
   source_file_dependencies:
   - csrc/
   - tests/kernels/core
@@ -41,6 +42,7 @@ steps:
 - label: Kernels Attention Test %N
   key: kernels-attention-test
   timeout_in_minutes: 35
+  device: h200_18gb
   source_file_dependencies:
   - csrc/attention/
   - vllm/v1/attention
@@ -55,6 +57,7 @@ steps:
 - label: Kernels Quantization Test %N
   key: kernels-quantization-test
   timeout_in_minutes: 90
+  device: h200_18gb
   source_file_dependencies:
   - csrc/quantization/
   - vllm/model_executor/layers/quantization
@@ -66,6 +69,7 @@ steps:
 - label: Kernels MoE Test %N
   key: kernels-moe-test
   timeout_in_minutes: 25
+  device: h200_18gb
   source_file_dependencies:
   - csrc/quantization/cutlass_w8a8/moe/
   - csrc/moe/
@@ -82,6 +86,7 @@ steps:
 - label: Kernels Mamba Test
   key: kernels-mamba-test
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - csrc/mamba/
   - tests/kernels/mamba
@@ -91,6 +96,7 @@ steps:
 
 - label: Kernels KDA Test
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/layers/fla/ops/kda.py
   - vllm/model_executor/layers/fla/ops/chunk_delta_h.py

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -5,6 +5,7 @@ steps:
 - label: LM Eval Small Models
   key: lm-eval-small-models
   timeout_in_minutes: 75
+  device: h200_18gb
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
@@ -114,6 +115,7 @@ steps:
 - label: LM Eval TurboQuant KV Cache
   key: lm-eval-turboquant-kv-cache
   timeout_in_minutes: 75
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/layers/quantization/turboquant/
   - vllm/v1/attention/backends/turboquant_attn.py
@@ -152,6 +154,7 @@ steps:
 
 - label: MRCR Eval Small Models
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
   - tests/evals/mrcr/
   commands:

--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -5,6 +5,7 @@ steps:
 - label: LoRA %N
   key: lora
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
   - vllm/lora
   - tests/lora

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -5,6 +5,7 @@ steps:
 - label: V1 Spec Decode
   key: v1-spec-decode
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
     - vllm/config/
     - vllm/distributed/
@@ -58,6 +59,7 @@ steps:
 - label: V1 Core + KV + Metrics
   key: v1-core-kv-metrics
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
     - vllm/config/
     - vllm/distributed/
@@ -153,6 +155,7 @@ steps:
   key: examples
   timeout_in_minutes: 45
   working_dir: "/vllm-workspace/examples"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/entrypoints
   - vllm/multimodal
@@ -212,6 +215,7 @@ steps:
   depends_on: ~
   optional: true
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
   - tests/standalone_tests/python_only_compile.sh
   - setup.py
@@ -221,6 +225,7 @@ steps:
 - label: Async Engine, Inputs, Utils, Worker
   key: async-engine-inputs-utils-worker
   timeout_in_minutes: 50
+  device: h200_18gb
   source_file_dependencies:
   - vllm/assets/
   - vllm/config/
@@ -338,9 +343,8 @@ steps:
 - label: Acceptance Length Test (Large Models) # optional
   key: acceptance-length-test-large-models
   timeout_in_minutes: 25
-  gpu: h100
+  device: h200_18gb
   optional: true
-  num_gpus: 1
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/v1/spec_decode/

--- a/.buildkite/test_areas/model_executor.yaml
+++ b/.buildkite/test_areas/model_executor.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Model Executor
   key: model-executor
   timeout_in_minutes: 35
+  device: h200_18gb
   source_file_dependencies:
   - vllm/engine/arg_utils.py
   - vllm/config/model.py

--- a/.buildkite/test_areas/model_runner_v2.yaml
+++ b/.buildkite/test_areas/model_runner_v2.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Model Runner V2 Core Tests
   key: model-runner-v2-core-tests
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/v1/worker/gpu/
   - vllm/v1/worker/gpu_worker.py
@@ -29,6 +30,7 @@ steps:
   key: model-runner-v2-examples
   timeout_in_minutes: 45
   working_dir: "/vllm-workspace/examples"
+  device: h200_18gb
   source_file_dependencies:
     - vllm/v1/worker/gpu/
     - vllm/v1/core/sched/
@@ -102,6 +104,7 @@ steps:
   key: model-runner-v2-spec-decode
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/tests"
+  device: h200_18gb
   source_file_dependencies:
   - vllm/v1/worker/gpu/
   - vllm/v1/worker/gpu_worker.py

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -6,6 +6,7 @@ steps:
   key: basic-models-tests-initialization
   timeout_in_minutes: 45
   torch_nightly: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/test_initialization.py
@@ -19,6 +20,7 @@ steps:
 - label: Basic Models Tests (Extra Initialization) %N
   key: basic-models-tests-extra-initialization
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/models/
   - tests/models/test_initialization.py
@@ -35,6 +37,7 @@ steps:
 - label: Basic Models Tests (Other)
   key: basic-models-tests-other
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/test_terratorch.py
@@ -61,6 +64,7 @@ steps:
   working_dir: "/vllm-workspace/"
   optional: true
   soft_fail: true
+  device: h200_18gb
   commands:
     - pip install --upgrade git+https://github.com/huggingface/transformers
     - pytest -v -s tests/models/test_initialization.py
@@ -77,6 +81,7 @@ steps:
   working_dir: "/vllm-workspace/"
   optional: true
   soft_fail: true
+  device: h200_18gb
   commands:
     - pip install transformers==4.57.5
     - pytest -v -s tests/models/test_initialization.py

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Language Models Tests (Standard)
   key: language-models-tests-standard
   timeout_in_minutes: 25
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/language
@@ -18,6 +19,7 @@ steps:
 - label: Language Models Tests (Extra Standard) %N
   key: language-models-tests-extra-standard
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/models/
   - tests/models/language/pooling/test_embedding.py
@@ -35,6 +37,7 @@ steps:
 - label: Language Models Tests (Hybrid) %N
   key: language-models-tests-hybrid
   timeout_in_minutes: 75
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/language/generation
@@ -60,6 +63,7 @@ steps:
 - label: Language Models Test (Extended Generation) # 80min
   key: language-models-test-extended-generation
   timeout_in_minutes: 110
+  device: h200_18gb
   optional: true
   source_file_dependencies:
   - vllm/
@@ -85,6 +89,7 @@ steps:
 - label: Language Models Test (Extended Pooling)  # 36min
   key: language-models-test-extended-pooling
   timeout_in_minutes: 50
+  device: h200_18gb
   optional: true
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -40,6 +40,7 @@ steps:
 - label: "Multi-Modal Models (Standard) 3: llava + qwen2_vl"
   key: multi-modal-models-standard-3-llava-qwen2-vl
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -56,6 +57,7 @@ steps:
 - label: "Multi-Modal Models (Standard) 4: other + whisper"
   key: multi-modal-models-standard-4-other-whisper
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -94,6 +96,7 @@ steps:
 - label: Multi-Modal Accuracy Eval (Small Models) # 50min
   key: multi-modal-accuracy-eval-small-models
   timeout_in_minutes: 70
+  device: h200_18gb
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   source_file_dependencies:
   - vllm/multimodal/
@@ -105,6 +108,7 @@ steps:
 - label: Multi-Modal Models (Extended Generation 1)
   key: multi-modal-models-extended-generation-1
   optional: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal/generation
@@ -122,6 +126,7 @@ steps:
 - label: Multi-Modal Models (Extended Generation 2)
   key: multi-modal-models-extended-generation-2
   optional: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal/generation
@@ -132,6 +137,7 @@ steps:
 - label: Multi-Modal Models (Extended Generation 3)
   key: multi-modal-models-extended-generation-3
   optional: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal/generation

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -5,6 +5,7 @@ steps:
 - label: PyTorch Compilation Unit Tests
   key: pytorch-compilation-unit-tests
   timeout_in_minutes: 10
+  device: h200_18gb
   source_file_dependencies:
     - vllm/__init__.py
     - vllm/_aiter_ops.py
@@ -78,6 +79,7 @@ steps:
 - label: PyTorch Compilation Passes Unit Tests
   key: pytorch-compilation-passes-unit-tests
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
     - vllm/__init__.py
     - vllm/_aiter_ops.py
@@ -110,6 +112,7 @@ steps:
 - label: PyTorch Fullgraph Smoke Test
   key: pytorch-fullgraph-smoke-test
   timeout_in_minutes: 35
+  device: h200_18gb
   source_file_dependencies:
   - vllm/__init__.py
   - vllm/_aiter_ops.py

--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Quantization
   key: quantization
   timeout_in_minutes: 90
+  device: h200_18gb
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
@@ -42,6 +43,7 @@ steps:
 - label: Quantized Models Test
   key: quantized-models-test
   timeout_in_minutes: 60
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/layers/quantization
   - tests/models/quantization

--- a/.buildkite/test_areas/samplers.yaml
+++ b/.buildkite/test_areas/samplers.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Samplers Test
   key: samplers-test
   timeout_in_minutes: 75
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/layers
   - vllm/sampling_metadata.py


### PR DESCRIPTION
## Summary
- Move all test steps that were falling through to `gpu_1_queue` (L4 instances) to explicitly use `device: h200_18gb` (H200 18GB MIG partition)
- This covers 53 steps across 15 test area files including kernels, entrypoints, models, pytorch compilation, quantization, lora, samplers, and more
- Also fixed one step (`Acceptance Length Test`) that used non-standard `gpu:`/`num_gpus:` fields instead of `device:`

## Test plan
- [ ] Launch CI build with `NOAUTO=1` and unblock all affected jobs
- [ ] Monitor for failures and investigate root causes
- [ ] Verify all migrated jobs pass on h200_18gb MIG

🤖 Generated with [Claude Code](https://claude.com/claude-code)