### PR TITLE
[Bugfix] Fix MooncakeConnectorWorker cleanup crash on partial init

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -15,6 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     KVConnectorRole,
     MooncakeConnector,
     MooncakeConnectorMetadata,
+    MooncakeConnectorWorker,
     MooncakeXferMetadata,
     MooncakeXferResponse,
     MooncakeXferResponseStatus,
@@ -832,3 +833,36 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
 
         prefill_worker.sender_loop = origin_sender_loop
         prefill_worker.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for partial-init cleanup (issue #42385)
+# ---------------------------------------------------------------------------
+
+
+def test_mooncake_worker_shutdown_partial_init_safe():
+    """shutdown() on a bare uninitialized instance must not raise."""
+    worker = object.__new__(MooncakeConnectorWorker)
+    # No __init__ called – none of the normal attributes exist.
+    worker.shutdown()  # should return silently
+
+
+def test_mooncake_worker_missing_engine_preserves_original_error(capsys):
+    """When TransferEngine is unavailable __init__ raises RuntimeError and
+    the subsequent __del__ must not produce an AttributeError."""
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+        ".mooncake_connector.TransferEngine",
+        None,
+    ):
+        import gc
+
+        with pytest.raises(RuntimeError, match="Mooncake is not available"):
+            MooncakeConnectorWorker(
+                vllm_config=MagicMock(),
+                engine_id="test-engine",
+            )
+        gc.collect()  # trigger __del__ on any lingering instance
+
+    captured = capsys.readouterr()
+    assert "AttributeError" not in captured.err

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
+import contextlib
 import logging
 import threading
 import time
@@ -732,6 +733,7 @@ class MooncakeConnectorWorker:
         engine_id: str,
         kv_cache_config: "KVCacheConfig | None" = None,
     ):
+        self._shutdown_done = False
         if TransferEngine is None:
             logger.error("Mooncake is not available")
             raise RuntimeError("Mooncake is not available")
@@ -891,21 +893,34 @@ class MooncakeConnectorWorker:
             self.block_size = kernel_block_size
 
     def __del__(self):
-        self.shutdown()
+        with contextlib.suppress(Exception):
+            self.shutdown()
 
     def shutdown(self):
         """Cleanup background threads on destruction."""
-        self.async_zmq_ctx.term()
-        if not self.is_kv_consumer:
-            self._sender_executor.shutdown(wait=False)
-            if self.sender_loop.is_running():
+        if getattr(self, "_shutdown_done", False):
+            return
+        self._shutdown_done = True
+        if getattr(self, "async_zmq_ctx", None) is not None:
+            self.async_zmq_ctx.term()
+        if not getattr(self, "is_kv_consumer", True):
+            if getattr(self, "_sender_executor", None) is not None:
+                self._sender_executor.shutdown(wait=False)
+            if (
+                getattr(self, "sender_loop", None) is not None
+                and self.sender_loop.is_running()
+            ):
                 self.sender_loop.call_soon_threadsafe(self.sender_loop.stop)
                 self._sender_listener_t.join()
             if should_launch_bootstrap_server(self.vllm_config) and hasattr(
                 self, "bootstrap_server"
             ):
                 self.bootstrap_server.shutdown()
-        if not self.is_kv_producer and self.receiver_loop.is_running():
+        if (
+            not getattr(self, "is_kv_producer", True)
+            and getattr(self, "receiver_loop", None) is not None
+            and self.receiver_loop.is_running()
+        ):
             self.receiver_loop.call_soon_threadsafe(self.receiver_loop.stop)
             self._mooncake_receiver_t.join()
 


### PR DESCRIPTION
Fixes #42385

### Problem
When the Mooncake TransferEngine isn't available, `MooncakeConnectorWorker.__init__` raises a RuntimeError early, before any of the worker resources get initialized. The destructor was calling `shutdown()` anyway, which tried to access `self.async_zmq_ctx` and other attributes that were never set. This secondary AttributeError would completely bury the original "Mooncake is not available" error in the logs, making debugging unnecessarily painful.

### Solution
Made `shutdown()` defensive by:
- Adding a `_shutdown_done` flag to make it idempotent
- Using `getattr()` with defaults before touching any resource
- Wrapping `__del__` with `contextlib.suppress(Exception)` so cleanup errors can't escape

Now if init fails, you actually see the real error instead of a cascade of AttributeErrors.

### Tests
Added two regression tests:
1. Directly calling `shutdown()` on a bare uninitialized instance (should return silently)
2. Full missing-TransferEngine scenario that confirms no AttributeError shows up in stderr
<img width="669" height="255" alt="image" src="https://github.com/user-attachments/assets/f697f916-c1e1-4141-8481-3af4f50e534b" />

All 13 mooncake tests pass.