### PR TITLE
[ROCm] Run AITER RMSNorm pad fusion before AR RMS fusion

### DIFF
--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -143,6 +143,11 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
                 if self.pass_config.fuse_gemm_comms:
                     self.passes += [AsyncTPPass(config)]
 
+            if self.pass_config.fuse_act_padding and rocm_aiter_ops.is_enabled():
+                # Run the more specific RMSNorm+router-pad fusion before
+                # AR+RMS, since both consume fused_add_rms_norm.
+                self.passes += [RocmAiterTritonAddRMSNormPadFusionPass(config)]
+
             if self.pass_config.fuse_allreduce_rms:
                 if rocm_aiter_ops.is_enabled():
                     self.passes += [RocmAiterAllReduceFusionPass(config)]
@@ -163,9 +168,6 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
                 self.passes += [ActivationQuantFusionPass(config)]
                 if rocm_aiter_ops.is_enabled():
                     self.passes += [RocmAiterSiluMulFp8GroupQuantFusionPass(config)]
-
-            if self.pass_config.fuse_act_padding and rocm_aiter_ops.is_enabled():
-                self.passes += [RocmAiterTritonAddRMSNormPadFusionPass(config)]
 
             if self.pass_config.fuse_mla_dual_rms_norm and rocm_aiter_ops.is_enabled():
                 self.passes += [MLADualRMSNormFusionPass(config)]


### PR DESCRIPTION
## Purpose

Reorder `RocmAiterTritonAddRMSNormPadFusionPass` to run before `RocmAiterAllReduceFusionPass` in `pass_manager.py`. Both passes match `fused_add_rms_norm`, but the pad-fusion pattern is a strict superset (`fused_add_rms_norm` → router GEMM → pad). Today AR+RMS fusion runs first and claims the shared node, starving pad-fusion on layers where its wider pattern would otherwise match (typical of GPT-OSS-style MoE).  Running pad-fusion first lets it claim its full subgraph; AR+RMS still runs afterward on every layer without a downstream router pad. No flag or kernel changes.

## Test Plan

ROCm MI355X serving validation with `openai/gpt-oss-120b`, TP=2, AITER unified attention, fp8 KV cache.

- Validate fusion firing via post-grad debug dumps (`VLLM_DEBUG_DUMP_PATH`), comparing how often each pass claims `fused_add_rms_norm` before vs after.
- Compare median TPOT and output throughput before vs after on the same serving recipe (`vllm bench serve`, random ISL=1000 / OSL=100, concurrency=32, n=5).
- Sanity-check accuracy with `lm-eval` gsm8k 5-shot.

## Test Result

### Before PR

Pass order: AR+RMS fusion runs first (`post_grad.1.rocm_aiter_allreduce_fusion_pass`), pad fusion runs later (`post_grad.5` / `post_grad.6`). On the serving compile shapes, AR+RMS claims all 74 `fused_add_rms_norm` nodes and produces 111 `allreduce_rmsnorm` ops; pad fusion enters those graphs with nothing left to match and fires 0 times. Pad fusion only fires on the warmup-style graph (108 ops there), so total kernel-level pad coverage stays low.

Fusion claim counts across all `__compiled_fn_1.kernel_*.py` (per rank, TP=2):

| Pass | Claims |
|---|---:|
| `RocmAiterTritonAddRMSNormPadFusionPass` | 72 |
| `RocmAiterAllReduceFusionPass` | 150 |

Final post-grad graph (per compile shape):

| Compile shape | `add_rmsnorm_pad` | `allreduce_rmsnorm` |
|---|---:|---:|
| `AFTER_POST_GRAD.0.py` | 0 | 111 |
| `AFTER_POST_GRAD.1.py` | 0 | 111 |
| `AFTER_POST_GRAD.2.py` | 108 | 0 |

Performance (n=5, apples-to-apples, conc=32):

| Metric | Value |
|---|---:|
| Median TPOT | 8.76 ms |
| Output token throughput | 3169 ± 38 tok/s |

### After PR

First checked for accuracy hit but there was none!

Accuracy (gsm8k, 5-shot):

| Filter | Metric | Value | Stderr |
|---|---|---:|---:|
| flexible-extract | exact_match | 0.9007 | ± 0.0082 |
| strict-match     | exact_match | 0.2722 | ± 0.0123 |

Pass order: pad fusion runs first (`post_grad.1.RocmAiterTritonAddRMSNormPadFusionPass`) and AR+RMS fusion runs after (`post_grad.2.rocm_aiter_allreduce_fusion_pass`). On the serving compile shapes, pad fusion claims its router-pad subgraphs and AR+RMS only fires on the residual boundary layers.

Per-pass evidence (single rank, serving compile shape): pad fusion enters with 74 `fused_add_rms_norm` nodes and produces 108 `add_rmsnorm_pad` ops, leaving 36 unclaimed; AR+RMS then fuses 3 of those 36 leftovers into `allreduce_rmsnorm` ops.

Fusion claim counts across all `__compiled_fn_1.kernel_*.py` (per rank, TP=2):

| Pass | Claims |
|---|---:|
| `RocmAiterTritonAddRMSNormPadFusionPass` | 216 |
| `RocmAiterAllReduceFusionPass` | 6 |

Final post-grad graph (per compile shape):

| Compile shape | `add_rmsnorm_pad` | `allreduce_rmsnorm` |
|---|---:|---:|
| `AFTER_POST_GRAD.0.py` | 108 | 3 |
| `AFTER_POST_GRAD.1.py` | 108 | 3 |
| `AFTER_POST_GRAD.2.py` | 108 | 0 |



Performance (n=5, apples-to-apples, conc=32):

| Metric | Value |
|---|---:|
| Median TPOT | 8.28 ms |
| Output token throughput | 3405 ± 26 tok/s |

<details>
<summary>Bench command (run 5×)</summary>

```bash
for i in 1 2 3 4 5; do
  echo "=== run $i ==="
  vllm bench serve \
    --backend vllm \
    --dataset-name random \
    --ignore-eos \
    --host localhost \
    --port 8022 \
    --model openai/gpt-oss-120b \
    --ready-check-timeout-sec 6000 \
    --percentile-metrics ttft,tpot,itl,e2el \
    --random-input-len 1000 \
    --random-output-len 100 \
    --max-concurrency 32 \
    --seed 10 \
    --num-prompts 3072 \
    --num-warmups 64
done
```
</details>


### Delta

| Metric | Δ |
|---|---:|
| Median TPOT | **-5.5%** |
| Output token throughput | **+7.4%** |