### PR TITLE
[Bugfix] Allow compact structured output with auto backend

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ from vllm.config import (
     PoolerConfig,
     SchedulerConfig,
     SpeculativeConfig,
+    StructuredOutputsConfig,
     VllmConfig,
     update_config,
 )
@@ -35,6 +36,16 @@ from vllm.config.vllm import (
 from vllm.platforms import current_platform
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_structured_outputs_disable_any_whitespace_allows_auto_backend():
+    config = StructuredOutputsConfig(
+        backend="auto",
+        disable_any_whitespace=True,
+    )
+
+    assert config.backend == "auto"
+    assert config.disable_any_whitespace
 
 
 def test_compile_config_repr_succeeds():

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -61,10 +61,14 @@ class StructuredOutputsConfig:
 
     @model_validator(mode="after")
     def _validate_structured_output_config(self) -> Self:
-        if self.disable_any_whitespace and self.backend not in ("xgrammar", "guidance"):
+        if self.disable_any_whitespace and self.backend not in (
+            "auto",
+            "xgrammar",
+            "guidance",
+        ):
             raise ValueError(
                 "disable_any_whitespace is only supported for "
-                "xgrammar and guidance backends."
+                "auto, xgrammar, and guidance backends."
             )
         if self.disable_additional_properties and self.backend != "guidance":
             raise ValueError(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -910,6 +910,15 @@ class SamplingParams(
             # Remember that this backend was set automatically
             self.structured_outputs._backend_was_auto = True
 
+        if (
+            structured_outputs_config.disable_any_whitespace
+            or self.structured_outputs.disable_any_whitespace
+        ) and self.structured_outputs._backend not in ("xgrammar", "guidance"):
+            raise ValueError(
+                "disable_any_whitespace is only supported for "
+                "xgrammar and guidance backends."
+            )
+
         # Run post-init validation. This is also important to ensure subsequent
         # roundtrip serialization/deserialization won't fail.
         self.structured_outputs.__post_init__()


### PR DESCRIPTION
## Purpose

Fixes #42110.

`disable_any_whitespace=true` is the existing workaround for Gemma 4 structured-output whitespace loops, but the config validator rejected it with the default `backend=auto`. This lets `auto` accept the option and validates support after `auto` resolves to the concrete backend.

## Test Plan

- `python -m ruff format vllm\config\structured_outputs.py vllm\sampling_params.py tests\test_config.py`
- `python -m ruff check vllm\config\structured_outputs.py vllm\sampling_params.py tests\test_config.py`
- `python -m py_compile vllm\config\structured_outputs.py vllm\sampling_params.py tests\test_config.py`
- `python -m pytest -q tests\test_config.py::test_structured_outputs_disable_any_whitespace_allows_auto_backend`

## Test Result

- ruff format/check: passed
- py_compile: passed
- direct config smoke test: passed
- pytest could not start in this Windows environment because vLLM test conftest imports `uvloop`, which is unavailable on Windows (`ModuleNotFoundError: No module named 'uvloop'`).
- pre-commit hook installation could not complete because `actionlint` Go dependencies timed out while downloading from `proxy.golang.org`; changed-file ruff/py_compile/diff-check were run instead.

## Notes

AI-assisted change. Scoped to structured-output config validation; no model-specific defaults are changed.