### PR TITLE
[Bugfix][Frontend] Preserve stopped streaming tool content

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -79,6 +79,10 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _is_request_stop(output: CompletionOutput) -> bool:
+    return output.finish_reason == "stop" and isinstance(output.stop_reason, str)
+
+
 class OpenAIServingChat(OpenAIServing):
     def __init__(
         self,
@@ -444,6 +448,7 @@ class OpenAIServingChat(OpenAIServing):
 
         # Always track previous_texts for comprehensive output logging
         previous_texts = [""] * num_choices
+        content_streamed_lens = [0] * num_choices
 
         # Only one of these will be used, thus previous_texts and
         # all_previous_token_ids will not be used twice in the same iteration.
@@ -760,7 +765,19 @@ class OpenAIServingChat(OpenAIServing):
                             and not request.return_token_ids
                         ):
                             continue
-                        delta_message = DeltaMessage()
+                        if (
+                            tool_choice_auto
+                            and _is_request_stop(output)
+                            and not tools_streamed[i]
+                        ):
+                            delta_message = DeltaMessage(
+                                content=current_text[content_streamed_lens[i] :]
+                            )
+                        else:
+                            delta_message = DeltaMessage()
+
+                    if tool_choice_auto and delta_message.content:
+                        content_streamed_lens[i] += len(delta_message.content)
 
                     # Log streaming delta if output logging is enabled
                     if self.enable_log_outputs and self.request_logger:
@@ -816,6 +833,7 @@ class OpenAIServingChat(OpenAIServing):
                         # only happens if we are NOT using structured outputs
                         index = 0
                         auto_tools_called = False
+                        stopped_by_request_stop = _is_request_stop(output)
                         if tool_parser:
                             auto_tools_called = len(tool_parser.prev_tool_call_arr) > 0
                             index = (
@@ -882,7 +900,7 @@ class OpenAIServingChat(OpenAIServing):
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
                         if (
-                            auto_tools_called
+                            (auto_tools_called and not stopped_by_request_stop)
                             or (tools_streamed[i] and not tool_choice_function_name)
                             or (self.use_harmony and harmony_tools_streamed[i])
                         ):


### PR DESCRIPTION
## Purpose

Fixes #42210.

When streaming auto tool parsing is interrupted by a user-provided stop string before the partial JSON can be parsed as a tool call, vLLM currently emits an empty final delta and can report `finish_reason=tool_calls`. This preserves the buffered partial text as assistant content and keeps the final finish reason as `stop` for request stop strings.

## Test Plan

- `python -m ruff format vllm\entrypoints\openai\chat_completion\serving.py`
- `python -m ruff check vllm\entrypoints\openai\chat_completion\serving.py`
- `python -m py_compile vllm\entrypoints\openai\chat_completion\serving.py`
- Local import smoke test for the helper was attempted.

## Test Result

- ruff format/check: passed
- py_compile: passed
- pytest/import smoke tests could not start in this Windows environment because importing vLLM's serving stack reaches `uvloop`, which is unavailable on Windows (`ModuleNotFoundError: No module named 'uvloop'`).
- pre-commit hook installation could not complete because `actionlint` Go dependencies timed out while downloading from `proxy.golang.org`; changed-file ruff/py_compile/diff-check were run instead.

## Notes

AI-assisted change. The fix is limited to the streaming Chat Completions auto-tool path and only applies when the generation stopped because of a string stop reason.