### PR TITLE
[ROCm] Fix #36180:  OOB Q-load in `paged_attention_ll4mi_QKV_mfma4_kernel`

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -1046,15 +1046,27 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
         q + query_start_off * q_stride + wg_start_head_idx * HEAD_SIZE;
     const _B16x8* q_ptrh8 = reinterpret_cast<const _B16x8*>(q_ptr);
     const int qhead_elemh8 = laneid / 4;
+    // The pre-existing layout assumed HEAD_SIZE/8 == WARP_SIZE/4 (i.e.
+    // HEAD_SIZE=128), so qhead_elemh8 spans [0, 16). For HEAD_SIZE=64 only the
+    // lower half maps to in-head chunks; lanes with qhead_elemh8 >=
+    // chunks_per_head don't broadcast into the QK mfma output, so zero their
+    // Qlocal to avoid loading past the head. See #36180.
+    constexpr int chunks_per_head = HEAD_SIZE / 8;
+    const bool valid_chunk = qhead_elemh8 < chunks_per_head;
 
     for (int h = 0; h < QHLOOP - 1; h++) {
       const int qhead_idx = h * 4 + lane4id;
-      Qlocal[h] = q_ptrh8[qhead_idx * HEAD_SIZE / 8 + qhead_elemh8];
+      if (valid_chunk) {
+        Qlocal[h] = q_ptrh8[qhead_idx * chunks_per_head + qhead_elemh8];
+      } else {
+        Qlocal[h].xy[0] = {0};
+        Qlocal[h].xy[1] = {0};
+      }
     }
     const int final_qhead_idx = 4 * (QHLOOP - 1) + lane4id;
-    if (final_qhead_idx < GQA_RATIO) {
+    if (final_qhead_idx < GQA_RATIO && valid_chunk) {
       Qlocal[QHLOOP - 1] =
-          q_ptrh8[final_qhead_idx * HEAD_SIZE / 8 + qhead_elemh8];
+          q_ptrh8[final_qhead_idx * chunks_per_head + qhead_elemh8];
     } else {
       Qlocal[QHLOOP - 1].xy[0] = {0};
       Qlocal[QHLOOP - 1].xy[1] = {0};


### PR DESCRIPTION


## Purpose

Fixes #36180.

The gfx9 mfma4 variant of `paged_attention_ll4mi_QKV_mfma4_kernel` reads past the per-head Q allocation under specific shape conditions. The crash surfaces as `hipErrorIllegalAddress` during FULL cudagraph capture when running `vllm serve meta-llama/Llama-3.2-1B-Instruct --attention-backend ROCM_ATTN`, dying at the size-256 capture entry before `Application startup complete`.

Background: this OOB has been latent in the mfma4 path since it was written. It became user-visible after #36025 switched the default ROCm backend to `ROCM_ATTN` when testing with Llama-3.2-1B and crash was filed as #36180.

## Root cause

The Q-load section of the mfma4 kernel (`q_ptrh8[...]` block in `csrc/rocm/attention.cu`) can produce per-lane addresses that fall past the workgroup's heads on gfx9 for certain head/chunk geometries. Under the failing config, that read crosses the end of the query tensor at `num_seqs=256` because the allocation lands exactly on a 1 MiB power-of-2 boundary with no caching-allocator slack; at non-power-of-2 sizes the OOB lands in slack memory and the kernel silently reads garbage instead of faulting.

## Fix

Introduce a per-lane predicate `valid_chunk = qhead_elemh8 < chunks_per_head` (where `chunks_per_head = HEAD_SIZE / 8`) and guard both Q-load sites the loop over `QHLOOP - 1` heads and the trailing tail-head load on it. Lanes with an in-range chunk index perform the existing load, with the per-head stride rewritten in terms of `chunks_per_head` for clarity; lanes outside the valid range take a no-load branch that zeroes the lane's local Q register instead of dereferencing past the head.

The change was exercised against the models listed in the Test plan; the kernel produces correct output on all of them and the previously-faulting case no longer crashes.

## Test plan

The `hipErrorIllegalAddress` from #36180 **no longer reproduces.** Server reaches `Application startup complete` and serves inferences cleanly.

Verification (run for each model under test):

```bash
# Start the server
vllm serve <model> --attention-backend ROCM_ATTN

# In a separate shell, sample inference test to validate output
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "meta-llama/Llama-3.2-1B-Instruct",
        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": "what is global warming?"}
        ]
    }'
```
## Test Result
Tested and verified on **AMD Instinct MI300X (gfx942)**, in a dockerized container setup.

- `meta-llama/Llama-3.2-1B-Instruct` (the model in #36180)
- `meta-llama/Llama-3.2-3B-Instruct`
- `meta-llama/Llama-3.1-70B-Instruct`

All three start up and serve inferences with `--attention-backend ROCM_ATTN`. Unit tests covering this path are also planned as a follow-up.



---

**AI-assistance:** this fix was developed with assistance from Claude. The author reviewed every line, ran the reproducer, and stands behind the change.


<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
</details>
