### PR TITLE
[Perf] Add VLLM_TRITON_FORCE_FIRST_CONFIG to skip Triton autotuning

### DIFF
--- a/tests/test_force_first_config.py
+++ b/tests/test_force_first_config.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Targeted unit tests for VLLM_TRITON_FORCE_FIRST_CONFIG.
+
+These tests exercise only the patched `Autotuner.run` logic installed by
+`vllm.triton_utils.force_first_config.install`. The wrapped kernel is a
+plain callable so the tests run on CPU-only hosts (no GPU, no actual
+kernel launch) as long as the `triton` package is importable.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.triton_utils import HAS_TRITON, triton
+
+if not HAS_TRITON:
+    pytest.skip("triton not available", allow_module_level=True)
+
+from vllm.triton_utils import force_first_config  # noqa: E402
+
+OutOfResources = triton.runtime.errors.OutOfResources
+
+
+@pytest.fixture
+def patched_autotuner(monkeypatch: pytest.MonkeyPatch):
+    """Install the first-valid-config patch and restore after.
+
+    The env-var gate lives in vllm.env_override; install() itself does not
+    read the environment, so the test calls it directly.
+    """
+    Autotuner = triton.runtime.autotuner.Autotuner
+    original_run = Autotuner.run
+    # Reset the once-only guard so install() re-runs for each test.
+    monkeypatch.setattr(force_first_config, "_installed", False)
+    force_first_config.install()
+    yield Autotuner
+    Autotuner.run = original_run
+
+
+def _make_fake_self(configs, fn):
+    """Minimal stand-in for an Autotuner instance."""
+    return SimpleNamespace(
+        configs=configs,
+        keys=[],
+        arg_names=[],
+        base_fn=fn,
+        fn=fn,
+        best_config=None,
+    )
+
+
+def test_skips_invalid_first_config_and_caches_second(patched_autotuner):
+    bad = triton.Config({"BLOCK": 1024})
+    good = triton.Config({"BLOCK": 64})
+    calls = []
+
+    def fake_fn(*args, **kwargs):
+        calls.append(kwargs["BLOCK"])
+        if kwargs["BLOCK"] == 1024:
+            raise OutOfResources(required=99999, limit=1, name="shared memory")
+        return "ok"
+
+    fake_self = _make_fake_self([bad, good], fake_fn)
+
+    # First call: walks past the invalid config, picks the second.
+    assert patched_autotuner.run(fake_self) == "ok"
+    assert calls == [1024, 64]
+    assert fake_self.best_config is good
+
+    # Second call: cached index is reused, invalid config is NOT retried.
+    calls.clear()
+    assert patched_autotuner.run(fake_self) == "ok"
+    assert calls == [64]
+
+
+def test_empty_configs_falls_back_to_direct_call(patched_autotuner):
+    def fake_fn(*args, **kwargs):
+        return "direct"
+
+    fake_self = _make_fake_self([], fake_fn)
+    assert patched_autotuner.run(fake_self) == "direct"
+
+
+def test_all_configs_invalid_raises_runtime_error(patched_autotuner):
+    cfgs = [triton.Config({"BLOCK": 1024}), triton.Config({"BLOCK": 2048})]
+
+    def always_oor(*args, **kwargs):
+        raise OutOfResources(required=99999, limit=1, name="shared memory")
+
+    fake_self = _make_fake_self(cfgs, always_oor)
+    with pytest.raises(RuntimeError, match="[Nn]o valid config"):
+        patched_autotuner.run(fake_self)

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -856,3 +856,20 @@ def _patch_inductor_fallback_allow_list() -> None:
 
 
 _patch_inductor_fallback_allow_list()
+
+# ============================================================
+# Triton Autotuner determinism
+# ============================================================
+# Replace the Autotuner.run so it always pick the first running configuration.
+# Useful to eliminate autotune variability leading to non determinism.
+# The logic lives in vllm.triton_utils.force_first_config and it is gated on
+# VLLM_TRITON_FORCE_FIRST_CONFIG so it is opt-in.
+if os.environ.get("VLLM_TRITON_FORCE_FIRST_CONFIG", "0").strip().lower() in (
+    "1",
+    "true",
+):
+    from vllm.triton_utils.force_first_config import (
+        install as _install_force_first_config,
+    )
+
+    _install_force_first_config()

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -862,8 +862,6 @@ _patch_inductor_fallback_allow_list()
 # ============================================================
 # Replace the Autotuner.run so it always pick the first running configuration.
 # Useful to eliminate autotune variability leading to non determinism.
-# The logic lives in vllm.triton_utils.force_first_config and it is gated on
-# VLLM_TRITON_FORCE_FIRST_CONFIG so it is opt-in.
 if os.environ.get("VLLM_TRITON_FORCE_FIRST_CONFIG", "0").strip().lower() in (
     "1",
     "true",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -108,6 +108,7 @@ if TYPE_CHECKING:
     VLLM_USE_MEGA_AOT_ARTIFACT: bool = False
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_FASTSAFETENSORS_QUEUE_SIZE: int = 0
+    VLLM_TRITON_FORCE_FIRST_CONFIG: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
@@ -1072,6 +1073,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will use Triton implementations of AWQ.
     "VLLM_USE_TRITON_AWQ": lambda: bool(int(os.getenv("VLLM_USE_TRITON_AWQ", "0"))),
+    # If set, monkey-patch triton.runtime.autotuner.Autotuner.run to skip
+    # benchmarking and select the first valid config (walking past invalid
+    # ones). Used to eliminate autotuning variability when measuring kernel
+    # performance and applied before running any kernel (in vllm/env_override.py)
+    "VLLM_TRITON_FORCE_FIRST_CONFIG": lambda: (
+        os.environ.get("VLLM_TRITON_FORCE_FIRST_CONFIG", "0").strip().lower()
+        in ("1", "true")
+    ),
     # If set, allow loading or unloading lora adapters in runtime,
     "VLLM_ALLOW_RUNTIME_LORA_UPDATING": lambda: (
         os.environ.get("VLLM_ALLOW_RUNTIME_LORA_UPDATING", "0").strip().lower()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1076,7 +1076,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, monkey-patch triton.runtime.autotuner.Autotuner.run to skip
     # benchmarking and select the first valid config (walking past invalid
     # ones). Used to eliminate autotuning variability when measuring kernel
-    # performance and applied before running any kernel (in vllm/env_override.py)
+    # performance and applied before running any kernel.
     "VLLM_TRITON_FORCE_FIRST_CONFIG": lambda: (
         os.environ.get("VLLM_TRITON_FORCE_FIRST_CONFIG", "0").strip().lower()
         in ("1", "true")

--- a/vllm/triton_utils/force_first_config.py
+++ b/vllm/triton_utils/force_first_config.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Skip Triton autotuning under VLLM_TRITON_FORCE_FIRST_CONFIG.
+
+When the env var is set, ``triton.runtime.autotuner.Autotuner.run`` is
+replaced so that, instead of benchmarking every candidate config, it
+walks them in declaration order and uses the first one that does not
+raise ``OutOfResources`` / ``CompileTimeAssertionFailure`` /
+``PTXASError``. The picked index is cached per ``(autotuner, key)`` so
+subsequent calls stay deterministic.
+
+Used to eliminate autotuning variability when measuring kernel
+performance.
+"""
+
+from vllm.logger import init_logger
+from vllm.triton_utils.importing import HAS_TRITON
+
+logger = init_logger(__name__)
+
+_installed: bool = False
+
+
+def is_installed() -> bool:
+    """Return whether the first-valid-config patch is currently installed."""
+    return _installed
+
+
+def install() -> None:
+    """Install the Autotuner.run replacement.
+
+    No-op if Triton is unavailable or the patch is already installed.
+    Callers must use it once before any kernel is launched.
+    """
+    global _installed
+    if _installed:
+        return
+    if not HAS_TRITON:
+        return
+
+    import importlib
+
+    autotuner_mod = importlib.import_module("triton.runtime.autotuner")
+    Autotuner = autotuner_mod.Autotuner
+    from triton.compiler.errors import CompileTimeAssertionFailure
+    from triton.runtime.errors import OutOfResources, PTXASError
+
+    _invalid_config_errors = (OutOfResources, CompileTimeAssertionFailure, PTXASError)
+    _picked_cache: dict[tuple, int] = {}
+    seen_kernels: set[str] = set()
+
+    def _run_first_valid_config(self, *args, **kwargs):
+        if not self.configs:
+            return self.fn(*args, **kwargs)
+
+        key_vals = tuple(kwargs[name] for name in self.keys if name in kwargs)
+        cache_key = (id(self), key_vals)
+        kernel_name = getattr(self.base_fn, "__name__", repr(self.fn))
+
+        cached_idx = _picked_cache.get(cache_key)
+        candidate_indices = (
+            [cached_idx] if cached_idx is not None else list(range(len(self.configs)))
+        )
+
+        last_exc: Exception | None = None
+        for idx in candidate_indices:
+            config = self.configs[idx]
+            if config.pre_hook is not None:
+                full_nargs = {
+                    **dict(zip(self.arg_names, args)),
+                    **kwargs,
+                    **config.all_kwargs(),
+                }
+                config.pre_hook(full_nargs)
+            # Prefer self.fn.run(...) — the kernel-launch entrypoint for both
+            # JITFunction and Heuristics. Calling JITFunction(...) directly
+            # raises "Cannot call @triton.jit'd outside of the scope of a
+            # kernel". Fall back to plain call only if .run is missing.
+            launch = getattr(self.fn, "run", self.fn)
+            try:
+                result = launch(*args, **kwargs, **config.all_kwargs())
+            except _invalid_config_errors as e:
+                last_exc = e
+                continue
+
+            if cached_idx is None:
+                _picked_cache[cache_key] = idx
+                self.best_config = config
+                if kernel_name not in seen_kernels:
+                    seen_kernels.add(kernel_name)
+                    logger.info(
+                        "[triton-autotune-disabled] kernel=%s configs=%d "
+                        "picked_index=%d picked=%s",
+                        kernel_name,
+                        len(self.configs),
+                        idx,
+                        config,
+                    )
+            return result
+
+        raise RuntimeError(
+            f"No valid config for kernel "
+            f"{kernel_name} key={key_vals} (tried {len(self.configs)} configs)"
+        ) from last_exc
+
+    Autotuner.run = _run_first_valid_config
+    _installed = True

--- a/vllm/triton_utils/force_first_config.py
+++ b/vllm/triton_utils/force_first_config.py
@@ -16,11 +16,7 @@ def is_installed() -> bool:
 
 
 def install() -> None:
-    """Install the Autotuner.run replacement.
-
-    No-op if Triton is unavailable or the patch is already installed.
-    Callers must use it once before any kernel is launched.
-    """
+    """Install the Autotuner.run replacement."""
     global _installed
     if _installed:
         return

--- a/vllm/triton_utils/force_first_config.py
+++ b/vllm/triton_utils/force_first_config.py
@@ -1,17 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Skip Triton autotuning under VLLM_TRITON_FORCE_FIRST_CONFIG.
-
-When the env var is set, ``triton.runtime.autotuner.Autotuner.run`` is
-replaced so that, instead of benchmarking every candidate config, it
-walks them in declaration order and uses the first one that does not
-raise ``OutOfResources`` / ``CompileTimeAssertionFailure`` /
-``PTXASError``. The picked index is cached per ``(autotuner, key)`` so
-subsequent calls stay deterministic.
-
-Used to eliminate autotuning variability when measuring kernel
-performance.
-"""
+"""Skip Triton autotuning under VLLM_TRITON_FORCE_FIRST_CONFIG."""
 
 from vllm.logger import init_logger
 from vllm.triton_utils.importing import HAS_TRITON


### PR DESCRIPTION
## Purpose

Triton's `@triton.autotune` benchmarks every candidate config on the first launch per `key`, then caches the winner. Three things make this painful when debugging or measuring:

1. **Autotune is timing-driven, so its winner is non-deterministic.** Run-to-run jitter can promote a different (BLOCK_M, num_warps, ...) tuple each time, and a different tuple reduces partial sums in a different order — so identical inputs produce numerically different outputs across runs.

2. **Cached results bleed across investigations.** Triton's autotune cache is persisted on disk, so "just rerun it" doesn't reset state. Editing every kernel's `configs=[...]` list to pin a value, or wiping caches between runs, is fragile and error-prone (plus third-party libs ship their own autotuned kernels we don't own).
3. **No visibility into what was picked.** If autotuning chose a different config on a particular GPU/run, you only find out by digging.

This PR adds a **debug-only** knob, `VLLM_TRITON_FORCE_FIRST_CONFIG`, that short-circuits autotune at runtime by walking the candidate configs in declaration order and using the first one that compiles+launches without `OutOfResources` / `CompileTimeAssertionFailure` / `PTXASError`. The picked index is cached per `(autotuner, key)` so subsequent calls stay deterministic and cheap. One INFO line per unique kernel is logged so you can see exactly which config ran.

**Default off — no behavior change unless explicitly enabled.**

### Sample output

With `VLLM_TRITON_FORCE_FIRST_CONFIG=1`:

```
[force_first_config.py:91] [triton-autotune-disabled] kernel=chunk_scaled_dot_kkt_fwd_kernel configs=27 picked_index=0 picked=BK: 32, num_warps: 2, num_ctas: 1, num_stages: 2, maxnreg: None
[force_first_config.py:91] [triton-autotune-disabled] kernel=chunk_gated_delta_rule_fwd_kernel_h_blockdim64 configs=12 picked_index=0 picked=BV: 32, num_warps: 2, num_ctas: 1, num_stages: 2, maxnreg: None
[force_first_config.py:91] [triton-autotune-disabled] kernel=chunk_fwd_kernel_o configs=24 picked_index=0 picked=BK: 64, BV: 64, num_warps: 2, num_ctas: 1, num_stages: 2, maxnreg: None
```

## Relationship to #34648

#34648 (`VLLM_TRITON_AUTOTUNE`) targets the same root cause but with a different mechanism and a different default behavior. Summary of differences:

| | #34648 | This PR |
|---|---|---|
| Default | **Disables** autotune by default (changes vLLM behavior) | **Off** — pure opt-in debug knob |
| Patch site | `triton.autotune` (the **decorator**) — passes `configs[:1]` | `Autotuner.run` (the **runtime method**) |
| Reaches autotuners already constructed at import time (e.g. in `fla`, `flashinfer`) | Only if `disable_autotune_globally()` runs before those modules are imported (import-order dependent) | Yes — patches the class method, takes effect on next launch |
| Bad-config handling | Crashes if `configs[0]` OOMs or fails to compile on the target GPU | Walks past invalid configs, picks first **valid** one |
| Per-kernel visibility | None | One INFO line per unique kernel (count + picked config) |
| Batch-invariance integration | Auto-enabled under `VLLM_BATCH_INVARIANT=1` | None (independent debug knob) |

The two have different purposes: #34648 is a user-facing toggle intended to make determinism the default; this PR is a runtime-level patch intended for debugging and perf measurement, with no default behavior change. The runtime-method approach is what allowed it to intercept third-party autotuners we don't decorate ourselves.

## How this was used to debug #40172

While preparing #40172 (fused Triton kernel for GPU-side Mamba state postprocessing in hybrid models, now merged), we observed (under MTP) a different number of accepted tokens across runs that didn't correlate with code changes (see https://github.com/vllm-project/vllm/pull/40172#issuecomment-4430777524) . Re-running the same configuration produced different number of accepted tokens, particularly in the GDN prefill path.

Setting `VLLM_TRITON_FORCE_FIRST_CONFIG=1` for both baseline and patched runs eliminated that noise.

This is the workflow that motivated the patch: a one-line env-var flip that makes Triton autotune behave deterministically *for everything in the process*, without needing to know in advance which kernels are involved or owning the code that decorates them.

## Test Plan

Unit tests covering the patched `Autotuner.run` logic with a fake autotuner instance (CPU-only, no GPU required as long as `triton` is importable):

```bash
.venv/bin/python -m pytest tests/test_force_first_config.py -vvv
```

The tests cover:
- skip-invalid-`configs[0]` and pick the next valid config
- per-`(autotuner, key)` caching: invalid config is not retried on
  subsequent calls
- empty `configs` falls back to direct call
- all-invalid raises `RuntimeError` with the original `OutOfResources`
  chained as `__cause__`

End-to-end smoke test: `vllm serve` on a GDN-using model with the env var set, confirming the per-kernel INFO lines appear and the server serves requests:

```bash
VLLM_TRITON_FORCE_FIRST_CONFIG=1 vllm serve "Qwen/Qwen3.5-9B" \
    --port 8007 -tp 1 -pp 1 -dp 1 \
    --language-model-only \
    --gdn-prefill-backend=triton \
    --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'
```

## Test Result

```
tests/test_force_first_config.py::test_skips_invalid_first_config_and_caches_second PASSED
tests/test_force_first_config.py::test_empty_configs_falls_back_to_direct_call PASSED
tests/test_force_first_config.py::test_all_configs_invalid_raises_runtime_error PASSED

3 passed
```

Pre-commit hooks (`ruff-check`, `ruff-format`, `mypy-3.12`, SPDX, typos) pass on the changed files.

## Duplicate-work check (per AGENTS.md)

- `gh pr list --search "triton autotune in:title,body"` — only related open
  PR is #34648, addressed above; #43047 (shmem-aware autotune pruner) is
  orthogonal (config pruning for low-shmem GPUs, not determinism).
- `gh pr list --search "VLLM_TRITON in:title,body"` — no other matches.
.
