### PR TITLE
Reject ramp-up-start-rps=0 for linear strategy in vllm bench serve

### DIFF
--- a/tests/benchmarks/test_ramp_up_validation.py
+++ b/tests/benchmarks/test_ramp_up_validation.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ramp-up argument validation in `vllm bench serve`.
+
+The `--ramp-up-strategy linear` path used to crash at runtime when
+`--ramp-up-start-rps 0` was passed: `_get_current_request_rate` returns
+`0.0` at `progress=0`, which then fails the `current_request_rate > 0.0`
+assertion and would otherwise hit a `ZeroDivisionError` in the gamma
+delay computation. The exponential path already validated this, but the
+linear path did not. These tests pin down both the runtime symptom and
+the validation that prevents it.
+"""
+
+import argparse
+import asyncio
+
+import pytest
+
+from vllm.benchmarks.datasets import SampleRequest
+from vllm.benchmarks.serve import (
+    _get_current_request_rate,
+    get_request,
+    main_async,
+)
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    """Build a minimal argparse.Namespace for `main_async` validation paths.
+
+    Only fields that the early validation in `main_async` reads need to be
+    populated; the rest can stay as defaults that the test never reaches.
+    """
+    defaults: dict = {
+        "seed": 0,
+        "plot_timeline": False,
+        "timeline_itl_thresholds": "25,50",
+        "ramp_up_strategy": None,
+        "ramp_up_start_rps": None,
+        "ramp_up_end_rps": None,
+        "request_rate": float("inf"),
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_linear_ramp_up_with_zero_start_rps_is_rejected() -> None:
+    """Linear ramp-up with start_rps=0 must be rejected up front.
+
+    Without validation, the first request would receive rate=0 from
+    `_get_current_request_rate`, which then fails the `> 0` assertion
+    inside `get_request`. Reject at the CLI boundary instead.
+    """
+    args = _make_args(
+        ramp_up_strategy="linear",
+        ramp_up_start_rps=0,
+        ramp_up_end_rps=10,
+    )
+    with pytest.raises(ValueError, match="start RPS must be greater than 0"):
+        asyncio.run(main_async(args))
+
+
+def test_exponential_ramp_up_with_zero_start_rps_is_rejected() -> None:
+    """Exponential ramp-up with start_rps=0 must still be rejected.
+
+    Regression guard for the existing validation, which previously
+    lived in its own branch and is now unified with the linear path.
+    """
+    args = _make_args(
+        ramp_up_strategy="exponential",
+        ramp_up_start_rps=0,
+        ramp_up_end_rps=10,
+    )
+    with pytest.raises(ValueError, match="start RPS must be greater than 0"):
+        asyncio.run(main_async(args))
+
+
+def test_linear_ramp_up_first_request_rate_with_zero_start_is_zero() -> None:
+    """Document the underlying broken behaviour at idx=0.
+
+    `_get_current_request_rate` returns `start_rps` at `progress=0` for
+    linear ramp. With `start=0`, the first request's rate is exactly 0,
+    which is the value that breaks downstream invariants.
+    """
+    rate = _get_current_request_rate(
+        ramp_up_strategy="linear",
+        ramp_up_start_rps=0,
+        ramp_up_end_rps=10,
+        request_index=0,
+        total_requests=5,
+        request_rate=float("inf"),
+    )
+    assert rate == 0.0
+
+
+def test_get_request_rejects_zero_rate_from_linear_ramp_up() -> None:
+    """`get_request` must surface the zero-rate first-request case.
+
+    Even if validation is bypassed (e.g. programmatic callers), the
+    runtime assertion in `get_request` must still trip rather than
+    sleep forever or divide by zero.
+    """
+    reqs = [
+        SampleRequest(prompt=f"p{i}", prompt_len=1, expected_output_len=1)
+        for i in range(3)
+    ]
+
+    async def _drive() -> None:
+        gen = get_request(
+            input_requests=reqs,
+            request_rate=float("inf"),
+            ramp_up_strategy="linear",
+            ramp_up_start_rps=0,
+            ramp_up_end_rps=10,
+        )
+        async for _ in gen:
+            pass
+
+    with pytest.raises(AssertionError, match="non-positive request rate"):
+        asyncio.run(_drive())

--- a/tests/benchmarks/test_ramp_up_validation.py
+++ b/tests/benchmarks/test_ramp_up_validation.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+
+import pytest
+
+from vllm.benchmarks.serve import add_cli_args, main_async
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+@pytest.mark.parametrize("strategy", ["linear", "exponential"])
+def test_zero_ramp_up_start_rps_is_rejected(strategy: str) -> None:
+    parser = FlexibleArgumentParser()
+    add_cli_args(parser)
+    args = parser.parse_args(
+        [
+            "--ramp-up-strategy",
+            strategy,
+            "--ramp-up-start-rps",
+            "0",
+            "--ramp-up-end-rps",
+            "10",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="^--ramp-up-start-rps must be > 0$"):
+        asyncio.run(main_async(args))

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1669,8 +1669,13 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
             raise ValueError("Ramp-up start and end RPS must be non-negative")
         if args.ramp_up_start_rps > args.ramp_up_end_rps:
             raise ValueError("Ramp-up start RPS must be less than end RPS")
-        if args.ramp_up_strategy == "exponential" and args.ramp_up_start_rps == 0:
-            raise ValueError("For exponential ramp-up, the start RPS cannot be 0.")
+        # Both linear and exponential ramp-up break when start RPS is 0:
+        # linear yields rate=0 at progress=0 (fails the `rate > 0` assertion
+        # in `get_request` and would otherwise hit a ZeroDivisionError in the
+        # gamma delay computation); exponential divides by start RPS to
+        # compute the ratio.
+        if args.ramp_up_start_rps == 0:
+            raise ValueError("Ramp-up start RPS must be greater than 0.")
 
     label = args.label
 

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1998,8 +1998,8 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
             raise ValueError("Ramp-up start and end RPS must be non-negative")
         if args.ramp_up_start_rps > args.ramp_up_end_rps:
             raise ValueError("Ramp-up start RPS must be less than end RPS")
-        if args.ramp_up_strategy == "exponential" and args.ramp_up_start_rps == 0:
-            raise ValueError("For exponential ramp-up, the start RPS cannot be 0.")
+        if args.ramp_up_start_rps == 0:
+            raise ValueError("--ramp-up-start-rps must be > 0")
 
     label = args.label
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`vllm bench serve --ramp-up-strategy linear --ramp-up-start-rps 0 --ramp-up-end-rps 10` reaches request generation and crashes:

```text
AssertionError: Obtained non-positive request rate 0.0.
```

Reject zero at the existing ramp-up argument check, before contacting the server. Both linear and exponential strategies now return the same flag-specific error:

```text
ValueError: --ramp-up-start-rps must be > 0
```

No other open PR addresses zero ramp-up start RPS, and current `main` still has the exponential-only guard.

## Test Plan

```bash
.venv/bin/python -m pytest tests/benchmarks/test_ramp_up_validation.py -v
.venv/bin/python -m vllm.entrypoints.cli.main bench serve \
  --ramp-up-strategy linear --ramp-up-start-rps 0 --ramp-up-end-rps 10
.venv/bin/pre-commit run --files \
  vllm/benchmarks/serve.py tests/benchmarks/test_ramp_up_validation.py
```

## Test Result

The focused validation test failed for both strategies on current `main`. With this change:

```text
test_zero_ramp_up_start_rps_is_rejected[linear] PASSED
test_zero_ramp_up_start_rps_is_rejected[exponential] PASSED
2 passed, 14 warnings in 0.55s
```

<details>
<summary>CLI and pre-fix failure output</summary>

```text
# current main, direct request generator
File "vllm/benchmarks/serve.py", line 452, in get_request
  assert current_request_rate > 0.0, (
AssertionError: Obtained non-positive request rate 0.0.
exit_code=1

# this branch, full CLI argument path
File "vllm/benchmarks/serve.py", line 2002, in main_async
  raise ValueError("--ramp-up-start-rps must be > 0")
ValueError: --ramp-up-start-rps must be > 0
exit_code=1
```

</details>

Touched-file pre-commit hooks passed, including ruff, mypy, SPDX, and repository checks.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and user-visible failure are included above.
- [x] The test commands are included above.
- [x] The before and after results are included above.
- [x] No documentation update is needed; this rejects an invalid value earlier.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
