### PR TITLE
[Quantization][ModelOpt] W4A16 NVFP4 fused MoE + --override-activation-dtype flag

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -7,6 +7,7 @@ Run `pytest tests/quantization/test_modelopt.py`.
 
 import os
 from typing import NoReturn
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -285,3 +286,117 @@ def test_modelopt_nvfp4_config_dispatches_w4a16_method():
     assert config.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod
     assert config.LinearMethodCls is not ModelOptNvFp4LinearMethod
     assert config.quant_method == "W4A16_NVFP4"
+
+
+@pytest.mark.parametrize(
+    "quant_method, override, expected_use_a16, act_key_is_none",
+    [
+        ("NVFP4", "auto", False, False),  # W4A4 default
+        ("W4A16_NVFP4", "auto", True, True),  # native W4A16 ckpt
+        ("NVFP4", "bfloat16", True, True),  # W4A4 + override flag
+    ],
+)
+def test_modelopt_nvfp4_moe_dispatches_to_marlin_when_w4a16(
+    quant_method,
+    override,
+    expected_use_a16,
+    act_key_is_none,
+):
+    """``ModelOptNvFp4FusedMoE``: when the ckpt's ``quant_method`` is
+    ``W4A16_NVFP4`` OR ``--override-activation-dtype`` is set, the MoE
+    class must pass ``activation_key=None`` to
+    ``select_nvfp4_moe_backend``. That filters out every W4A4 backend
+    (their ``_supports_quant_scheme`` requires
+    ``(kNvfp4Static, kNvfp4Dynamic)`` exactly); Marlin survives because
+    it only checks ``weight_key``. A regression here would mean a W4A16
+    ckpt silently went to the cutlass W4A4 path.
+    """
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4Config,
+        ModelOptNvFp4FusedMoE,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kNvfp4Dynamic,
+        kNvfp4Static,
+    )
+
+    config = ModelOptNvFp4Config(
+        quant_method=quant_method,
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        group_size=16,
+        override_activation_dtype=override,
+    )
+
+    mock_select = MagicMock(return_value=(MagicMock(), MagicMock()))
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.select_nvfp4_moe_backend",
+            mock_select,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt."
+            "is_global_sf_supported_for_nvfp4_backend",
+            return_value=False,
+        ),
+    ):
+        moe = ModelOptNvFp4FusedMoE(config, MagicMock())
+
+    assert moe.use_a16 is expected_use_a16
+    _, kwargs = mock_select.call_args
+    assert kwargs["weight_key"] is kNvfp4Static
+    if act_key_is_none:
+        assert kwargs["activation_key"] is None
+    else:
+        assert kwargs["activation_key"] is kNvfp4Dynamic
+
+
+@pytest.mark.parametrize(
+    "quant_algo, override, expected_method_name",
+    [
+        ("NVFP4", None, "ModelOptNvFp4LinearMethod"),  # W4A4 default
+        ("W4A16_NVFP4", None, "ModelOptNvFp4W4A16LinearMethod"),  # native W4A16
+        (
+            "NVFP4",
+            "bfloat16",
+            "ModelOptNvFp4W4A16LinearMethod",
+        ),  # flag flips W4A4 → W4A16
+        (
+            "W4A16_NVFP4",
+            "float16",
+            "ModelOptNvFp4W4A16LinearMethod",
+        ),  # override is a no-op
+    ],
+)
+def test_modelopt_nvfp4_override_activation_dtype_pipeline(
+    quant_algo,
+    override,
+    expected_method_name,
+):
+    """End-to-end ``--override-activation-dtype`` pipeline: an
+    ``hf_quant_config`` dict (optionally carrying the engine-injected
+    ``__override_activation_dtype__`` private key) flows through
+    ``ModelOptQuantConfigBase.from_config`` → kwarg propagation →
+    ``ModelOptNvFp4Config.__init__``, and ends up selecting the correct
+    ``LinearMethodCls``. A regression here would mean
+    ``--override-activation-dtype=bfloat16`` silently no-op'd against a
+    W4A4 ckpt.
+    """
+    from vllm.model_executor.layers.quantization import modelopt as m
+
+    hf_quant_config = {
+        "quantization": {
+            "quant_algo": quant_algo,
+            "kv_cache_quant_algo": None,
+            "group_size": 16,
+            "exclude_modules": [],
+        }
+    }
+    if override is not None:
+        hf_quant_config["__override_activation_dtype__"] = override
+
+    config = m.ModelOptNvFp4Config.from_config(hf_quant_config)
+
+    assert config.LinearMethodCls is getattr(m, expected_method_name)
+    assert config.override_activation_dtype == (override or "auto")

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -210,6 +210,13 @@ class ModelConfig:
     """Arguments for online quantization.
     Auto-created when `quantization` equals to one of the string values of
     the `OnlineQuantScheme` enum."""
+    override_activation_dtype: Literal["auto", "bfloat16", "float16"] = "auto"
+    """Engine-level override for the activation dtype the quantization
+    config would otherwise pick. Mirrors ``override_attention_dtype``.
+    ``"auto"`` is the default (behavior unchanged). ``"bfloat16"`` /
+    ``"float16"`` are currently honored by ModelOpt NVFP4: a W4A4 NVFP4
+    ckpt is routed through the W4A16 LinearMethod and Marlin MoE backend
+    regardless of the on-disk ``quant_algo``. """
     allow_deprecated_quantization: bool = False
     """Whether to allow deprecated quantization methods."""
     enforce_eager: bool = False

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -528,6 +528,9 @@ class EngineArgs:
     tokenizer_revision: str | None = ModelConfig.tokenizer_revision
     quantization: QuantizationMethods | str | None = ModelConfig.quantization
     quantization_config: "dict[str, Any] | OnlineQuantizationConfigArgs | None" = None
+    override_activation_dtype: Literal["auto", "bfloat16", "float16"] = (
+        ModelConfig.override_activation_dtype
+    )
     allow_deprecated_quantization: bool = ModelConfig.allow_deprecated_quantization
     enforce_eager: bool = ModelConfig.enforce_eager
     disable_custom_all_reduce: bool = ParallelConfig.disable_custom_all_reduce
@@ -785,6 +788,10 @@ class EngineArgs:
         )
         model_group.add_argument("--max-model-len", **model_kwargs["max_model_len"])
         model_group.add_argument("--quantization", "-q", **model_kwargs["quantization"])
+        model_group.add_argument(
+            "--override-activation-dtype",
+            **model_kwargs["override_activation_dtype"],
+        )
         model_group.add_argument(
             "--allow-deprecated-quantization",
             **model_kwargs["allow_deprecated_quantization"],
@@ -1529,6 +1536,7 @@ class EngineArgs:
             max_model_len=self.max_model_len,
             quantization=self.quantization,
             quantization_config=self.quantization_config,
+            override_activation_dtype=self.override_activation_dtype,
             allow_deprecated_quantization=self.allow_deprecated_quantization,
             enforce_eager=self.enforce_eager,
             enable_return_routed_experts=self.enable_return_routed_experts,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -272,6 +272,7 @@ class ModelOptQuantConfigBase(QuantizationConfig):
         exclude_modules: list[str],
         original_config: dict[str, Any],
         group_size: int | None,
+        **kwargs: Any,
     ) -> "ModelOptQuantConfigBase":
         raise NotImplementedError("Please implement this function in sub classes")
 
@@ -355,12 +356,22 @@ class ModelOptQuantConfigBase(QuantizationConfig):
                 "`hf_quant_config.json` file for your model's "
                 "quant configuration."
             )
+        # Engine-level overrides flow in via private dict keys injected
+        # by weight_utils._maybe_inject_engine_overrides. Read them here
+        # once and propagate to every subclass's _from_config via kwargs.
+        # Subclasses that honor a knob name the kwarg in their signature
+        # (e.g. ModelOptNvFp4Config); others absorb-and-discard via
+        # **kwargs. The keys stay in original_config (no pop) — matches
+        # the total_num_heads precedent in compressed_tensors.
+        override_activation_dtype = config.get("__override_activation_dtype__", "auto")
+
         return cls._from_config(
             quant_method=quant_method,
             kv_cache_quant_method=kv_cache_quant_method,
             exclude_modules=exclude_modules,
             group_size=group_size,
             original_config=config,
+            override_activation_dtype=override_activation_dtype,
         )
 
 
@@ -1013,6 +1024,7 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         kv_cache_quant_algo: str | None = None,
         exclude_modules: list[str] | None = None,
         group_size: int = 16,
+        override_activation_dtype: str = "auto",
     ) -> None:
         if exclude_modules is None:
             exclude_modules = []
@@ -1030,10 +1042,30 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
             self.group_size = group_size
             self.kv_cache_quant_algo = kv_cache_quant_algo
 
-        # Select LinearMethod implementation based on quant_algo (FP8 pattern).
-        # NVFP4         -> W4A4: cutlass NVFP4 GEMM with input quantization
-        # W4A16_NVFP4   -> W4A16: FP4 Marlin GEMM with bf16/fp16 activations
-        if quant_method == "NVFP4":
+        # Engine-level --override-activation-dtype (orthogonal to
+        # --quantization). When set to bfloat16/float16, behave as if
+        # quant_algo were W4A16_NVFP4 regardless of what's on disk.
+        # ModelOptNvFp4FusedMoE.__init__ reads this same field to decide
+        # whether to force the Marlin MoE backend.
+        self.override_activation_dtype = override_activation_dtype
+        force_w4a16 = override_activation_dtype in ("bfloat16", "float16")
+
+        # LinearMethod selection: override > on-disk per-algo.
+        # NVFP4        -> W4A4: cutlass NVFP4 GEMM with input quantization
+        # W4A16_NVFP4  -> W4A16: FP4 Marlin GEMM with bf16/fp16 activations
+        if force_w4a16:
+            self.LinearMethodCls = ModelOptNvFp4W4A16LinearMethod
+            if quant_method != "W4A16_NVFP4":
+                logger.info(
+                    "ModelOpt NVFP4 W4A16 override active "
+                    "(override_activation_dtype=%s): loading a %s "
+                    "checkpoint via the W4A16 LinearMethod and Marlin "
+                    "MoE backend. Per-tensor input_scale tensors will "
+                    "be ignored.",
+                    override_activation_dtype,
+                    quant_method,
+                )
+        elif quant_method == "NVFP4":
             self.LinearMethodCls = ModelOptNvFp4LinearMethod
         elif quant_method == "W4A16_NVFP4":
             self.LinearMethodCls = ModelOptNvFp4W4A16LinearMethod
@@ -1098,6 +1130,7 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
             kv_cache_quant_method,
             exclude_modules,
             group_size,
+            override_activation_dtype=kwargs.get("override_activation_dtype", "auto"),
         )
 
 
@@ -1393,13 +1426,17 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
     ) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
-        # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. With
-        # activation_key=None every W4A4 backend's _supports_quant_scheme
-        # rejects itself (they all require (kNvfp4Static, kNvfp4Dynamic)
-        # exactly); only Marlin survives. Marlin's MoE path drops
-        # activation scales in convert_to_nvfp4_moe_kernel_format, so no
-        # other change is needed.
-        self.use_a16 = quant_config.quant_method == "W4A16_NVFP4"
+        # W4A16 mode fires on either a W4A16_NVFP4 on-disk ckpt OR an
+        # engine-level --override-activation-dtype=bfloat16/float16 flag.
+        # With activation_key=None every W4A4 backend's
+        # _supports_quant_scheme rejects itself (they all require
+        # (kNvfp4Static, kNvfp4Dynamic) exactly); only Marlin survives.
+        # Marlin's MoE path drops activation scales in
+        # convert_to_nvfp4_moe_kernel_format, so no other change is needed.
+        self.use_a16 = (
+            quant_config.quant_method == "W4A16_NVFP4"
+            or quant_config.override_activation_dtype in ("bfloat16", "float16")
+        )
         self.nvfp4_backend, self.experts_cls = select_nvfp4_moe_backend(
             config=self.moe,
             weight_key=kNvfp4Static,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1393,11 +1393,17 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
     ) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
-        # Select experts implementation.
+        # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. With
+        # activation_key=None every W4A4 backend's _supports_quant_scheme
+        # rejects itself (they all require (kNvfp4Static, kNvfp4Dynamic)
+        # exactly); only Marlin survives. Marlin's MoE path drops
+        # activation scales in convert_to_nvfp4_moe_kernel_format, so no
+        # other change is needed.
+        self.use_a16 = quant_config.quant_method == "W4A16_NVFP4"
         self.nvfp4_backend, self.experts_cls = select_nvfp4_moe_backend(
             config=self.moe,
             weight_key=kNvfp4Static,
-            activation_key=kNvfp4Dynamic,
+            activation_key=None if self.use_a16 else kNvfp4Dynamic,
         )
 
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -259,6 +259,17 @@ def convert_bin_to_safetensor_file(
             raise RuntimeError(f"The output tensors do not match for key {k}")
 
 
+def _maybe_inject_engine_overrides(
+    config: dict[str, Any], model_config: "ModelConfig"
+) -> dict[str, Any]:
+    """Inject engine-level quantization overrides into the parsed
+    quant-config dict so they're visible to quant_cls.from_config."""
+    override_act_dtype = getattr(model_config, "override_activation_dtype", "auto")
+    if override_act_dtype != "auto":
+        config["__override_activation_dtype__"] = override_act_dtype
+    return config
+
+
 # TODO(woosuk): Move this to other place.
 def get_quant_config(
     model_config: ModelConfig, load_config: LoadConfig
@@ -317,7 +328,9 @@ def get_quant_config(
         ):
             pass  # fall through to file-based loading below
         else:
-            return quant_cls.from_config(hf_quant_config)
+            return quant_cls.from_config(
+                _maybe_inject_engine_overrides(hf_quant_config, model_config)
+            )
 
     # if hf_quant_config is None, we will try to get config from
     # hf_overrides
@@ -427,7 +440,9 @@ def get_quant_config(
             config["adapter_name_or_path"] = model_config.model
         elif model_config.quantization in ("modelopt", "modelopt_mixed"):
             if config.get("producer", {}).get("name") == "modelopt":
-                return quant_cls.from_config(config)
+                return quant_cls.from_config(
+                    _maybe_inject_engine_overrides(config, model_config)
+                )
             else:
                 raise ValueError(
                     f"Unsupported quantization config"


### PR DESCRIPTION
## Summary

Adds ModelOpt NVFP4 W4A16 support for the fused-MoE path and an engine-level `--override-activation-dtype` flag that lets a user load a W4A4 NVFP4 checkpoint via the W4A16 path without editing the checkpoint's JSON.

Follow-up to #41769 (phase-1, merged), which added `ModelOptNvFp4W4A16LinearMethod` for dense Linear. This PR completes W4A16 NVFP4 support across the model: MoE + a user-facing override.

**Tested**: 7 unit tests + end-to-end smoke on `nvidia/Qwen3.6-35B-A3B-NVFP4` (Qwen3.5-MoE-VL hybrid), with the flag (Marlin path) and without (FlashInferCutlass W4A4 path, regression check). See Test plan.

## What's in this PR

Three commits, each scoped to one logical change:

### 1. `[Quantization][ModelOpt] Add W4A16 NVFP4 support to fused MoE` 

Extends `ModelOptNvFp4FusedMoE.__init__` to honor `W4A16_NVFP4` on-disk checkpoints. When `quant_config.quant_method == "W4A16_NVFP4"`, the MoE class passes `activation_key=None` to `select_nvfp4_moe_backend`. 
Every W4A4 backend's `_supports_quant_scheme` requires `(kNvfp4Static, kNvfp4Dynamic)` exactly, so they all reject themselves; Marlin's `_supports_quant_scheme` (`fused_marlin_moe.py:607`) only checks `weight_key`, so it accepts. Marlin's MoE prep already nulls activation scales in `convert_to_nvfp4_moe_kernel_format` (`oracle/nvfp4.py:362-363`) and routes through `nvfp4_w4a16_moe_quant_config` (`oracle/nvfp4.py:433`) — no other change needed.

### 2. `[Quantization][ModelOpt] Add --override-activation-dtype CLI flag` *(4 files, +80/−8)*

Adds an engine-level dtype override that mirrors the existing `--override-attention-dtype` precedent (`vllm/config/model.py:315`). When set to `bfloat16` or `float16`, a W4A4 NVFP4 checkpoint is routed through the W4A16 LinearMethod and Marlin MoE backend regardless of the on-disk `quant_algo`.

Pipeline:
- `ModelConfig.override_activation_dtype: Literal["auto", "bfloat16", "float16"]` (inline at field site so `get_kwargs(ModelConfig)` auto-derives argparse `choices=`).
- `weight_utils._maybe_inject_engine_overrides()` injects a `__override_activation_dtype__` private key into `hf_quant_config` at the two ModelOpt code paths. Inject-and-leave, matching the `total_num_heads` precedent at `compressed_tensors.py:250-251`.
- `ModelOptQuantConfigBase.from_config` reads the key once, propagates as a kwarg to every subclass's `_from_config`. `ModelOptNvFp4Config` pulls it via `kwargs.get(...)`; the other three ModelOpt Configs absorb-and-discard via their existing `**kwargs: Any`.
- `ModelOptNvFp4FusedMoE`'s `use_a16` extends to OR on `quant_config.override_activation_dtype in ("bfloat16", "float16")`.

### 3. `[Quantization][ModelOpt] Add unit tests` *(+99 LOC in `tests/quantization/test_modelopt.py`)*

Two parametrized tests, 7 effective cases:

## Why a new flag rather than `--hf-overrides`?

`--hf-overrides` is the natural alternative for "patch the on-disk quant config." It has three paths to the quant parser and **none** are usable here:

1. Path A (`--hf-overrides '{"quantization_config": {...}}'`) — `ModelConfig._apply_dict_overrides` at `vllm/config/model.py:454` does **wholesale replace** on plain dict attributes. To change one field, the user has to type the entire `quantization_config` block verbatim.
2. Path B (`hf_overrides.quantization_config_file`) and Path C (`hf_overrides.quantization_config_dict_json`) at `weight_utils.py:338,354` are both gated by `if hf_quant_config is None` — unreachable when the ckpt already carries an on-disk quant config.

`--override-activation-dtype` is one token, semantically specific, and mirrors the existing single-subsystem override pattern. Full design + alternatives discussion in commit-2's added comments + the PR diff.

## Test plan

### Done

#### Unit tests — 7/7 pass on CPU, no GPU / no ckpt needed

```bash
pytest tests/quantization/test_modelopt.py::test_modelopt_nvfp4_moe_dispatches_to_marlin_when_w4a16 \
       tests/quantization/test_modelopt.py::test_modelopt_nvfp4_override_activation_dtype_pipeline -v
# 7 passed in 2.07s
```

#### End-to-end smoke — `nvidia/Qwen3.6-35B-A3B-NVFP4`

Qwen3.5-MoE-VL hybrid (gated-delta linear attention + conv1d + experts, ~35B). One GPU, eager mode.

**With override (`LLM(override_activation_dtype="bfloat16", ...)`)** — exercises this PR's new path:

```
WARNING modelopt.py:1036  Detected ModelOpt NVFP4 checkpoint (quant_algo=NVFP4)
INFO    modelopt.py:1060  ModelOpt NVFP4 W4A16 override active (override_activation_dtype=bfloat16):
                          loading a NVFP4 checkpoint via the W4A16 LinearMethod and Marlin MoE backend.
INFO    nvfp4.py:282      Using 'MARLIN' NvFp4 MoE backend out of potential backends:
                          ['FLASHINFER_TRTLLM', 'FLASHINFER_CUTEDSL', 'FLASHINFER_CUTEDSL_BATCHED',
                           'FLASHINFER_CUTLASS', 'VLLM_CUTLASS', 'MARLIN', 'EMULATION'].
Model loading took 20.54 GiB memory and 34.06 seconds
...
=== prompt:     'The capital of France is'
=== completion: ' Paris.\n\n<think>\n\n</think>\n\nThat is correct. Paris is the capital and'
=== prompt:     'Q: What is 2 + 2? A:'
=== completion: '\n\n<think>\n\n</think>\n\n4'
```

The three log signals together prove the full pipeline wired up: on-disk `quant_algo=NVFP4` (no JSON edit), override INFO line fires, MoE oracle picks Marlin (only backend that accepts `activation_key=None`).

**Without the flag — regression check** (same ckpt, plain `LLM(...)`):

```
WARNING modelopt.py:1023  Detected ModelOpt NVFP4 checkpoint (quant_algo=NVFP4)
INFO    nvfp4.py:282      Using 'FLASHINFER_CUTLASS' NvFp4 MoE backend ...
=== prompt:     'The capital of France is'
=== completion: ' Paris.\n\n<think>\n\n</think>\n\nThat is correct. Paris is the capital and'
```

W4A4 path stays intact; the override INFO log does not fire; FlashInferCutlass NVFP4 MoE backend selected; coherent generation. Confirms zero behavioral drift when the flag is unset.

## Duplicate-work check

- Builds on #41769 (merged, phase-1 dense Linear W4A16).
- #41566 (open) is **not** a duplicate: it targets MXFP4/MXFP8 on gpt-oss via a `QuantSpec(weight, activation)` rework of `OnlineQuantScheme`; this PR targets NVFP4 on ModelOpt via a new `ModelConfig.override_activation_dtype` field. Different quant method, different mechanism, no file overlap.
- No other open PRs match `modelopt nvfp4 moe w4a16` or `override-activation-dtype`.