### PR TITLE
fused_moe: add VLLM_TRITON_USE_TD tensor-descriptor path

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -53,6 +53,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import quantize_weights
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
+from vllm.triton_utils import tl
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 
@@ -289,6 +290,7 @@ def run_moe_test(
 @pytest.mark.parametrize("ep_size", EP_SIZE)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("padding", [True, False])
+@pytest.mark.parametrize("use_td", [False, True])
 def test_fused_moe(
     m: int,
     n: int,
@@ -298,9 +300,13 @@ def test_fused_moe(
     ep_size: int,
     dtype: torch.dtype,
     padding: bool,
+    use_td: bool,
     monkeypatch,
     workspace_init,
 ):
+    if use_td and not hasattr(tl, "make_tensor_descriptor"):
+        pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
     set_random_seed(7)
 
     #

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -60,6 +60,8 @@ from vllm.triton_utils import tl
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def iterative_moe(
     hidden_states: torch.Tensor,
@@ -326,17 +328,17 @@ def test_fused_moe(
     # Setup test data
     #
 
-    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
-    w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
-    w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
+    a = torch.randn((m, k), device=DEVICE_TYPE, dtype=dtype) / 10
+    w1 = torch.randn((e, 2 * n, k), device=DEVICE_TYPE, dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device=DEVICE_TYPE, dtype=dtype) / 10
 
-    score = torch.randn((m, e), device="cuda", dtype=dtype)
+    score = torch.randn((m, e), device=DEVICE_TYPE, dtype=dtype)
 
     if ep_size > 1:
         local_e = e // ep_size
-        e_ids = torch.randint(0, e, (local_e,), device="cuda", dtype=torch.int32)
-        e_map = torch.full((e,), -1, device="cuda", dtype=torch.int32)
-        e_map[e_ids] = torch.arange(local_e, device="cuda", dtype=torch.int32)
+        e_ids = torch.randint(0, e, (local_e,), device=DEVICE_TYPE, dtype=torch.int32)
+        e_map = torch.full((e,), -1, device=DEVICE_TYPE, dtype=torch.int32)
+        e_map[e_ids] = torch.arange(local_e, device=DEVICE_TYPE, dtype=torch.int32)
         w1 = w1[e_ids]
         w2 = w2[e_ids]
     else:

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -36,6 +36,9 @@ from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     batched_fused_marlin_moe,
     fused_marlin_moe,
 )
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_use_td_hw_supported,
+)
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_permute_bias,
 )
@@ -306,6 +309,12 @@ def test_fused_moe(
 ):
     if use_td and not hasattr(tl, "make_tensor_descriptor"):
         pytest.skip("Triton < 3.6 lacks tl.make_tensor_descriptor")
+    if use_td and not moe_use_td_hw_supported():
+        pytest.skip(
+            "tensor_descriptor.gather requires XPU or NVIDIA Blackwell "
+            "(sm100+); lowers to tile::gather4 (tcgen05/TMEM), which ptxas "
+            "rejects on Hopper (sm90) and earlier"
+        )
     monkeypatch.setenv("VLLM_TRITON_USE_TD", "1" if use_td else "0")
     set_random_seed(7)
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -842,6 +842,19 @@ def invoke_fused_moe_triton_kernel(
     BLOCK_SIZE_K = config.pop("BLOCK_SIZE_K")
     if block_shape is not None:
         BLOCK_SIZE_K = min(BLOCK_SIZE_K, min(block_shape[0], block_shape[1]))
+    if use_td and A.size(1) % BLOCK_SIZE_K != 0:
+        # TD gather/load feeding tl.dot with a non-block-aligned K
+        # miscompiles (~74% of output elements wrong) on real HW;
+        # this is a compiler-codegen issue, not a Python-maskable
+        # boundary gap. Fall back to the pointer-arith path.
+        logger.warning_once(
+            "Disabling VLLM_TRITON_USE_TD for this MoE launch: K=%d is not "
+            "a multiple of BLOCK_SIZE_K=%d, which triggers a known "
+            "Triton tensor-descriptor + tl.dot miscompilation.",
+            A.size(1),
+            BLOCK_SIZE_K,
+        )
+        use_td = False
     fused_moe_kernel[grid](
         A,
         B,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -791,7 +791,9 @@ def invoke_fused_moe_triton_kernel(
     else:
         SWAP_AB = False
 
-    is_quantized = use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
+    # Quantized weights always carry a B_scale (see the asserts below); key off
+    # that rather than enumerating quant flags, which misses w8a16-fp8/nvfp4/etc.
+    is_quantized = B_scale is not None
     warn_if_moe_use_td_ineffective("TRITON", is_quantized=is_quantized)
 
     # TD path is unvalidated under quantization; fall back to the pointer path.

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -28,6 +28,8 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
 from vllm.model_executor.layers.fused_moe.utils import (
     enable_swap_ab,
     moe_kernel_quantize_input,
+    resolve_moe_use_td,
+    warn_if_moe_use_td_ineffective,
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -347,6 +349,8 @@ def fused_moe_kernel(
     per_channel_quant: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     SWAP_AB: tl.constexpr,
+    # Tensor-descriptor path for the A gather and B load in the K-loop.
+    USE_TD: tl.constexpr = False,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -436,7 +440,23 @@ def fused_moe_kernel(
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    if SWAP_AB:
+    if USE_TD:
+        # ``tt.descriptor_gather`` requires block_shape[0] == 1 and i32 idx.
+        m_td = num_valid_tokens // top_k
+        a_desc = tl.make_tensor_descriptor(
+            base=a_ptr,
+            shape=(m_td, K),
+            strides=(stride_am, stride_ak),
+            block_shape=(1, BLOCK_SIZE_K),
+        )
+        b_desc = tl.make_tensor_descriptor(
+            base=b_ptr + off_experts * stride_be,
+            shape=(N, K),
+            strides=(stride_bn, stride_bk),
+            block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_K),
+        )
+        gather_idx = (offs_token // top_k).to(tl.int32)
+    elif SWAP_AB:
         a_ptrs = a_ptr + (
             offs_k[:, None] * stride_ak + offs_token[None, :] // top_k * stride_am
         )
@@ -454,7 +474,6 @@ def fused_moe_kernel(
             + off_experts * stride_be
             + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
         )
-
     if use_int8_w8a16:
         b_scale_ptrs = (
             b_scale_ptr + off_experts * stride_bse + offs_bn[None, :] * stride_bsn
@@ -498,18 +517,21 @@ def fused_moe_kernel(
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         # Load the next block of A and B, generate a mask by checking the
         # K dimension.
-        if SWAP_AB:
+        if USE_TD:
+            a = a_desc.gather(gather_idx, k * BLOCK_SIZE_K)
+            b = b_desc.load([pid_n * BLOCK_SIZE_N, k * BLOCK_SIZE_K]).T
+        elif SWAP_AB:
             a_mask = (offs_k[:, None] < K - k * BLOCK_SIZE_K) & token_mask[None, :]
             b_mask = offs_k[None, :] < K - k * BLOCK_SIZE_K
+            a = tl.load(a_ptrs, mask=a_mask, other=0.0)
+            b = tl.load(b_ptrs, mask=b_mask, other=0.0)
         else:
-            a_mask = token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K)
-            b_mask = offs_k[:, None] < K - k * BLOCK_SIZE_K
-        a = tl.load(
-            a_ptrs,
-            mask=a_mask,
-            other=0.0,
-        )
-        b = tl.load(b_ptrs, mask=b_mask, other=0.0)
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                other=0.0,
+            )
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
         # We accumulate along the K dimension.
         if use_int8_w8a16:
             accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
@@ -536,9 +558,10 @@ def fused_moe_kernel(
                     accumulator += tl.dot(a, b)
         else:
             accumulator += tl.dot(a, b)
-        # Advance the ptrs to the next K block.
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
+        if not USE_TD:
+            # Advance the ptrs to the next K block.
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
 
     if SWAP_AB:
         accumulator = tl.trans(accumulator, (1, 0))
@@ -765,6 +788,13 @@ def invoke_fused_moe_triton_kernel(
     else:
         SWAP_AB = False
 
+    warn_if_moe_use_td_ineffective(
+        "TRITON",
+        is_quantized=(
+            use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
+        ),
+    )
+
     if use_fp8_w8a8 or use_int8_w8a8:
         assert B_scale is not None
         assert block_shape is None or triton.cdiv(
@@ -847,6 +877,7 @@ def invoke_fused_moe_triton_kernel(
         HAS_BIAS=HAS_BIAS,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         SWAP_AB=SWAP_AB,
+        USE_TD=resolve_moe_use_td(),
         **config,
     )
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -33,6 +33,7 @@ from vllm.model_executor.layers.fused_moe.utils import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.platform_utils import get_device_name_as_file_name
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -440,6 +441,8 @@ def fused_moe_kernel(
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
+    # TD gather and the SWAP_AB accumulator layout are mutually exclusive.
+    tl.static_assert(not (USE_TD and SWAP_AB))
     if USE_TD:
         # ``tt.descriptor_gather`` requires block_shape[0] == 1 and i32 idx.
         m_td = num_valid_tokens // top_k
@@ -788,12 +791,16 @@ def invoke_fused_moe_triton_kernel(
     else:
         SWAP_AB = False
 
-    warn_if_moe_use_td_ineffective(
-        "TRITON",
-        is_quantized=(
-            use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
-        ),
-    )
+    is_quantized = use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
+    warn_if_moe_use_td_ineffective("TRITON", is_quantized=is_quantized)
+
+    # TD path is unvalidated under quantization; fall back to the pointer path.
+    use_td = resolve_moe_use_td() and not is_quantized
+    if use_td:
+        # The TD path builds a tensor descriptor inside the kernel, which
+        # requires a PyTorch-backed scratch allocator to be registered
+        # (Triton raises "no allocator was set" otherwise on CUDA).
+        set_triton_allocator(A.device)
 
     if use_fp8_w8a8 or use_int8_w8a8:
         assert B_scale is not None
@@ -877,7 +884,7 @@ def invoke_fused_moe_triton_kernel(
         HAS_BIAS=HAS_BIAS,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         SWAP_AB=SWAP_AB,
-        USE_TD=resolve_moe_use_td(),
+        USE_TD=use_td,
         **config,
     )
 

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -362,6 +362,13 @@ def make_unquantized_moe_kernel(
     experts_cls: type[mk.FusedMoEExperts],
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
 ) -> mk.FusedMoEKernel:
+    from vllm.model_executor.layers.fused_moe.utils import (
+        warn_if_moe_use_td_ineffective,
+    )
+
+    # Warn against the selected backend, not each probed candidate.
+    warn_if_moe_use_td_ineffective(backend.value, is_quantized=False)
+
     # Create Prepare/Finalize
     is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
     prepare_finalize = maybe_make_prepare_finalize(

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn.functional as F
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
@@ -585,3 +586,54 @@ def enable_swap_ab(BLOCK_SIZE_M: int, BLOCK_SIZE_N: int) -> bool:
         and BLOCK_SIZE_M < 64
         and BLOCK_SIZE_N >= 64
     )
+
+
+def resolve_moe_use_td() -> bool:
+    """Tri-state resolver for ``VLLM_TRITON_USE_TD`` (auto-on for XPU)."""
+    override = envs.VLLM_TRITON_USE_TD
+    if override is None:
+        return current_platform.is_xpu()
+    return override
+
+
+_warned_moe_use_td_ineffective = False
+
+
+def warn_if_moe_use_td_ineffective(
+    active_backend: str, is_quantized: bool = False
+) -> None:
+    """One-shot warning when ``VLLM_TRITON_USE_TD`` is set but ignored.
+
+    Fires when the user set the env explicitly and either (a) the active
+    MoE backend is not Triton-family, or (b) the model is quantized (the
+    TD path falls back to the pointer path under any quantization).
+    """
+    global _warned_moe_use_td_ineffective
+    if _warned_moe_use_td_ineffective:
+        return
+    if envs.VLLM_TRITON_USE_TD is None:
+        return
+    is_triton = "TRITON" in active_backend.upper()
+    if is_triton and not is_quantized:
+        return
+    import logging
+
+    logger = logging.getLogger("vllm")
+    if not is_triton:
+        reason = (
+            f"the active MoE backend is {active_backend!r}; pass "
+            "`--moe-backend triton` (or `triton_unfused` / `batched_triton`) "
+            "to enable the tensor-descriptor path"
+        )
+    else:
+        reason = (
+            "the model uses quantized MoE weights; the TD path is "
+            "currently restricted to non-quantized weights and falls "
+            "back to the pointer path"
+        )
+    logger.warning(
+        "VLLM_TRITON_USE_TD is set to %s but %s.",
+        envs.VLLM_TRITON_USE_TD,
+        reason,
+    )
+    _warned_moe_use_td_ineffective = True

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
@@ -39,6 +40,8 @@ from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+
+logger = init_logger(__name__)
 
 
 @triton.jit
@@ -605,25 +608,22 @@ def warn_if_moe_use_td_ineffective(
     """One-shot warning when ``VLLM_TRITON_USE_TD`` is set but ignored.
 
     Fires when the user set the env explicitly and either (a) the active
-    MoE backend is not Triton-family, or (b) the model is quantized (the
-    TD path falls back to the pointer path under any quantization).
+    MoE backend is not the fused Triton kernel, or (b) the model is
+    quantized (the TD path falls back to the pointer path under any
+    quantization).
     """
     global _warned_moe_use_td_ineffective
     if _warned_moe_use_td_ineffective:
         return
     if envs.VLLM_TRITON_USE_TD is None:
         return
-    is_triton = "TRITON" in active_backend.upper()
+    is_triton = active_backend.upper() == "TRITON"
     if is_triton and not is_quantized:
         return
-    import logging
-
-    logger = logging.getLogger("vllm")
     if not is_triton:
         reason = (
             f"the active MoE backend is {active_backend!r}; pass "
-            "`--moe-backend triton` (or `triton_unfused` / `batched_triton`) "
-            "to enable the tensor-descriptor path"
+            "`--moe-backend triton` to enable the tensor-descriptor path"
         )
     else:
         reason = (

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -591,8 +591,37 @@ def enable_swap_ab(BLOCK_SIZE_M: int, BLOCK_SIZE_N: int) -> bool:
     )
 
 
+def moe_use_td_hw_supported() -> bool:
+    """Whether the current device can run the TD (gather) path of
+    ``fused_moe_kernel`` (ignores the ``VLLM_TRITON_USE_TD`` override).
+
+    The A-load uses ``tensor_descriptor.gather``, which lowers to the PTX
+    ``tile::gather4`` instruction. That instruction is part of the
+    ``tcgen05``/Tensor Memory (TMEM) family introduced with Blackwell and has
+    no Hopper (sm90) equivalent -- ptxas rejects it there ("Feature
+    '.tile::gather4 ...' requires .target sm_100 or higher"). Unlike
+    ``scatter4``, ``gather4`` is supported across the whole sm100+ range
+    including consumer Blackwell (sm120/sm121): see triton-lang/triton#8498,
+    which enables ``gather4`` on sm120/sm121 while leaving ``scatter4``
+    unsupported there. So this gates on a blanket ``has_device_capability(100)``
+    rather than the sm100 *family* check used for the scatter store path.
+    """
+    if current_platform.is_xpu():
+        return True
+    if current_platform.is_cuda():
+        return current_platform.has_device_capability(100)
+    return False
+
+
 def resolve_moe_use_td() -> bool:
-    """Tri-state resolver for ``VLLM_TRITON_USE_TD`` (auto-on for XPU)."""
+    """Tri-state resolver for ``VLLM_TRITON_USE_TD``.
+
+    Unset auto-selects the TD path on XPU only, mirroring the attention
+    dispatcher in ``triton_attn.py``. ``1``/``0`` force it on/off regardless
+    of hardware; forcing ``1`` where it cannot compile (see
+    ``moe_use_td_hw_supported``) fails at ptxas. Blackwell CUDA (sm100+) can
+    compile it but is opt-in only, pending validation.
+    """
     override = envs.VLLM_TRITON_USE_TD
     if override is None:
         return current_platform.is_xpu()


### PR DESCRIPTION
Working on perf optimizations for the Triton MoE kernels. Adds an opt-in `VLLM_TRITON_USE_TD` env var that switches the fused MoE kernel onto a tensor-descriptor based load/store path, mirroring `VLLM_TRITON_ATTN_USE_TD` (PR #40327). Auto-on for XPU; off by default on CUDA/ROCm (opt-in on Blackwell). The changes in this PR are scoped to the fused MoE kernel (`fused_moe_kernel`) only.

The env var name follows the single-flag design proposed in the TD adoption strategy RFC (#42545): one `VLLM_TRITON_USE_TD` switch gates the tensor-descriptor path across Triton kernels. Note the auto-select policy is per-subsystem: with the env unset, both the attention dispatcher (`triton_attn.py`) and this MoE path auto-enable on XPU only. Blackwell CUDA can run the path but must opt in explicitly (see below). This PR renames the previously-proposed `VLLM_TRITON_MOE_USE_TD` to the general form for consistency with the RFC.

## Quantization

The TD gather branch is validated for non-quantized (bf16) weights only. Under any quantization (fp8 w8a8, int8 w8a8, int8 w8a16, int4 w4a16) the launch site falls back to the pointer path — `use_td = resolve_moe_use_td() and not is_quantized` — so quantized MoE is byte-identical to `main`. When `VLLM_TRITON_USE_TD` is set explicitly but ineffective (non-Triton backend, or quantized weights), a one-shot warning fires against the *selected* MoE backend.

Extending the TD path to quantized MoE is a known gap and is being addressed as a separate follow-up under the same RFC (#42545); that PR is almost ready for publication.

## Hardware gating (CUDA)

The A gather uses `tensor_descriptor.gather`, which lowers to the PTX `tile::gather4` instruction (part of the `tcgen05`/Tensor Memory family introduced with Blackwell). `ptxas` rejects it on Hopper (sm90) and earlier — `Feature '.tile::gather4 ...' requires .target sm_100 or higher`. `moe_use_td_hw_supported()` reports whether a device can *compile* the path: `True` on XPU, `has_device_capability(100)` on CUDA (gather4 spans the whole sm100+ range incl. consumer Blackwell sm120/121, unlike `scatter4` — see triton-lang/triton#8498), `False` otherwise.

Auto-select does not follow compile-capability: with the env unset the path is XPU-only. Blackwell CUDA can compile it but is opt-in (`VLLM_TRITON_USE_TD=1`) pending its own accuracy/perf validation — it currently has none, and this PR deliberately does not enable it by default. An explicit `VLLM_TRITON_USE_TD=1` on hardware that cannot compile the path still forces it (useful for A/B), so the parametrized test carries a matching hardware skip-guard, and the launch registers the Triton scratch allocator (`make_tensor_descriptor` needs it on CUDA). A `tl.static_assert` enforces that `USE_TD` and `SWAP_AB` are never both enabled.

## Testing / CI coverage

`test_fused_moe` is parametrized over `use_td`. The `use_td=True` cell skips on any device that cannot compile the TD path (Hopper/Ampere, and Triton < 3.6) — i.e. it does not execute on the default upstream kernel-CI fleet. The TD branch is exercised only on XPU / Blackwell CI, so the validation below was run by hand on the target hardware.
[pr-42436-multiplatform-validation.zip](https://github.com/user-attachments/files/30166388/pr-42436-multiplatform-validation.zip)


## Results - multi-platform production-readiness validation (2026-07-17/18)

Extended the validation above to a full unit → accuracy → E2E-perf → quantized-smoke → kernel-level pass on one card each of Intel Arc Pro B70 (XPU), NVIDIA H200 (Hopper, sm90), NVIDIA B200 (Blackwell, sm100). Pinned commit: `92a58914f9ee6a39bc884c278a2fc6367aea7c3a`.

Full methodology, kernel-level benchmark results, dispatch-log verification of the TD auto-select resolver on every platform, hardware-gate verification on H200, quantization no-op verification, an unresolved B70 host-to-host perf disagreement, and a data-correctness correction applied to some `sharegpt` numbers below (documented in the report itself), are in the attached campaign report (`TRITONXPU-181_production_readiness_campaign_2026-07-18.md`). Full raw logs attached per-platform (`b70/`, `h200/`, `b200/`).

Summary: correctness (K-alignment guard fix, TD/pointer parity, quantization no-op fallback, hardware-gate enforcement on Hopper) is well-evidenced across all 3 platforms via dispatch-log-level verification, not just output matching. Perf is shape/platform-dependent with no universal TD win — reported honestly below, not as a performance pitch.

Variant naming used below: `default` = no `--moe-backend` flag, no `VLLM_TRITON_USE_TD` (platform's true native default — SYCL on B70, FlashInfer TRTLLM on B200, Triton on H200 per vLLM's own Hopper-specific backend priority); `td0`/`td1` = `--moe-backend triton` with `VLLM_TRITON_USE_TD=0`/`=1`.

### Accuracy — GSM8K, full 1319-question test set, 5-shot, greedy decode (temperature=0.0), seed=42

| Platform | td0 (pointer) | td1 (TD) | Δ |
|---|---:|---:|---:|
| B70 | 46.85% | 46.85% | 0.00pp (bit-identical) |
| H200 | 48.60% | N/A (TD uncompilable on sm90) | — |
| B200 | 48.07% | 48.07% | 0.00pp (bit-identical) |

TD does not change accuracy anywhere it runs — bit-identical to the pointer path token-for-token
on both B70 and B200 (confirms the K-alignment correctness fix). Raw per-platform results below.

<details>
<summary>B70</summary>

```json
--- sycl (default) ---
{
  "accuracy": 0.47763457164518575,
  "invalid_rate": 0.001516300227445034,
  "latency": 43.434272416867316,
  "questions_per_second": 30.367724071458788,
  "total_output_tokens": 178930,
  "tokens_per_second": 4119.5578984883405,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": null,
  "vllm_triton_use_td_env": null,
  "seed": 42
}

--- td0 ---
{
  "accuracy": 0.46853677028051555,
  "invalid_rate": 0.002274450341167551,
  "latency": 103.7776588909328,
  "questions_per_second": 12.70986466736766,
  "total_output_tokens": 179153,
  "tokens_per_second": 1726.3156821477774,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": "triton",
  "vllm_triton_use_td_env": "0",
  "seed": 42
}

--- td1 ---
{
  "accuracy": 0.46853677028051555,
  "invalid_rate": 0.002274450341167551,
  "latency": 74.65302416798659,
  "questions_per_second": 17.66840680200637,
  "total_output_tokens": 179153,
  "tokens_per_second": 2399.8090097042054,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": "triton",
  "vllm_triton_use_td_env": "1",
  "seed": 42
}
```
</details>

<details>
<summary>H200</summary>

```json
--- default (= td0, dispatch-confirmed identical Triton code path) ---
{
  "accuracy": 0.48597422289613346,
  "invalid_rate": 0.0,
  "latency": 9.003313882742077,
  "questions_per_second": 146.5016123150292,
  "total_output_tokens": 179112,
  "tokens_per_second": 19894.00817662586,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": null,
  "vllm_triton_use_td_env": null,
  "seed": 42
}

--- td0 ---
{
  "accuracy": 0.48597422289613346,
  "invalid_rate": 0.0,
  "latency": 10.623563874978572,
  "questions_per_second": 124.15795824474773,
  "total_output_tokens": 179112,
  "tokens_per_second": 16859.878860601406,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": "triton",
  "vllm_triton_use_td_env": "0",
  "seed": 42
}
```
(No `td1` row: TD cannot compile on Hopper/sm90 — `ptxas` rejects `tile::gather4` as requiring sm_100+. Attempted and captured as an expected-failure artifact, see the attached logs.)
</details>

<details>
<summary>B200</summary>

```json
--- default (FlashInfer TRTLLM, real distinct backend) ---
{
  "accuracy": 0.4836997725549659,
  "invalid_rate": 0.000758150113722517,
  "latency": 10.077878876123577,
  "questions_per_second": 130.8807156955382,
  "total_output_tokens": 178460,
  "tokens_per_second": 17708.09137454568,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": null,
  "vllm_triton_use_td_env": null,
  "seed": 42
}

--- td0 ---
{
  "accuracy": 0.4806671721000758,
  "invalid_rate": 0.002274450341167551,
  "latency": 8.92053499398753,
  "questions_per_second": 147.8610869066721,
  "total_output_tokens": 179372,
  "tokens_per_second": 20107.762608509165,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": "triton",
  "vllm_triton_use_td_env": "0",
  "seed": 42
}

--- td1 ---
{
  "accuracy": 0.4806671721000758,
  "invalid_rate": 0.002274450341167551,
  "latency": 9.130568650085479,
  "questions_per_second": 144.45978673931242,
  "total_output_tokens": 179372,
  "tokens_per_second": 19645.21673010155,
  "num_questions": 1319,
  "num_shots": 5,
  "max_tokens": 256,
  "moe_backend_arg": "triton",
  "vllm_triton_use_td_env": "1",
  "seed": 42
}
```
</details>

`td0`/`td1` are bit-identical on both B70 and B200 (confirms the K-alignment fix preserves output correctness under TD). Full accuracy methodology caveat (N=1 has a ~1-2pp run-to-run noise floor on this class of backend) is in the attached report §5.

### Perf — `vllm bench sweep serve`, N=3 per (variant, dataset), median reported, seed=42, `--no-enable-prefix-caching`

Datasets: `sharegpt` (500 prompts, concurrency 64), `prefill_heavy` (random, in=2048/out=512, concurrency 32), `decode_heavy` (random, in=512/out=2048, concurrency 8). Model: `ibm-granite/granite-3.0-3b-a800m-instruct` (bf16).

**td0 vs td1, mean output tok/s over N=3 runs** (mean used here instead of median — with only 3
samples per cell, one dataset's median flips sign depending on which single run is treated as
the outlier; mean is more stable for this specific comparison. Raw per-run values are below,
unchanged, so this is fully reproducible from the same numbers):

| Platform | Dataset | td0 (pointer) | td1 (TD) | Δ |
|---|---|---:|---:|---:|
| B70 | sharegpt | 719.5 | 762.6 | **+6.0%** |
| B70 | prefill_heavy | 420.1 | 417.6 | -0.6% |
| B70 | decode_heavy | 134.0 | 133.3 | -0.5% |
| B200 | sharegpt | 8181.1 | 8057.0 | -1.5% |
| B200 | prefill_heavy | 6264.2 | 6094.0 | -2.7% |
| B200 | decode_heavy | 2228.7 | 2144.7 | -3.8% |

B70: a real throughput gain on `sharegpt` (mixed realistic prompt/response lengths, BMG's most
representative workload), flat on the two synthetic datasets. B200: small negative deltas on
prefill/decode-heavy, consistent with this hardware's already-documented TD-neutral-to-slightly-
regressive pattern — this PR does not enable TD by default on CUDA, and this data supports that
choice.

<details>
<summary>B70</summary>

```json
{
  "sycl (default)": {
    "sharegpt": [982.13, 994.13, 1065.42],
    "prefill_heavy": [640.0, 638.36, 633.31],
    "decode_heavy": [158.47, 158.87, 159.72]
  },
  "td0": {
    "sharegpt": [599.93, 774.98, 783.72],
    "prefill_heavy": [418.45, 421.03, 420.96],
    "decode_heavy": [133.91, 134.13, 133.88]
  },
  "td1": {
    "sharegpt": [685.9, 768.48, 833.28],
    "prefill_heavy": [418.19, 419.06, 415.58],
    "decode_heavy": [133.4, 133.4, 133.14]
  }
}
```
Medians: sycl sharegpt=994.1, prefill_heavy=638.4, decode_heavy=158.9 | td0 sharegpt=775.0, prefill_heavy=421.0, decode_heavy=133.9 | td1 sharegpt=768.5, prefill_heavy=418.2, decode_heavy=133.4 tok/s.
</details>

<details>
<summary>H200</summary>

```json
{
  "default": {
    "sharegpt": [8003.47, 7249.66, 7635.22],
    "prefill_heavy": [5049.66, 4989.72, 4961.28],
    "decode_heavy": [2007.62, 1979.14, 1977.29]
  },
  "td0": {
    "sharegpt": [7266.54, 7919.86, 7713.62],
    "prefill_heavy": [5140.22, 5040.31, 5046.53],
    "decode_heavy": [2009.16, 1969.85, 2007.99]
  }
}
```
Medians: default sharegpt=7635.2, prefill_heavy=4989.7, decode_heavy=1979.1 | td0 sharegpt=7713.6, prefill_heavy=5046.5, decode_heavy=2008.0 tok/s. No `td1` (uncompilable on sm90).
</details>

<details>
<summary>B200</summary>

```json
{
  "default (env-unset, still --moe-backend triton, kept for reference)": {
    "sharegpt": [7351.53, 8372.63, 8720.87],
    "prefill_heavy": [6207.44, 6315.79, 6205.99],
    "decode_heavy": [2187.75, 2230.64, 2213.36]
  },
  "default_native (true no-flag default, FlashInfer TRTLLM)": {
    "sharegpt": [9115.8, 9278.24, 9218.8],
    "prefill_heavy": [7542.21, 7465.44, 7468.28],
    "decode_heavy": [2981.51, 2979.89, 2979.25]
  },
  "td0": {
    "sharegpt": [7803.92, 7989.08, 8750.16],
    "prefill_heavy": [6224.09, 6285.98, 6282.4],
    "decode_heavy": [2242.47, 2216.71, 2226.98]
  },
  "td1": {
    "sharegpt": [7640.3, 7953.87, 8576.79],
    "prefill_heavy": [6092.19, 6106.03, 6083.66],
    "decode_heavy": [2139.16, 2157.93, 2137.13]
  }
}
```
Medians: `default_native` (FlashInfer, true platform default) sharegpt=9218.8, prefill_heavy=7468.3, decode_heavy=2979.9 | td0 sharegpt=7989.1, prefill_heavy=6282.4, decode_heavy=2227.0 | td1 sharegpt=7953.9, prefill_heavy=6092.2, decode_heavy=2139.2 tok/s. Collected with `--no-enable-flashinfer-autotune` (see attached report §4.5 for an unrelated FlashInfer autotuner crash found and root-caused during this measurement — not a PR#42436 issue).
</details>

### Attachments

[pr-42436-multiplatform-validation.zip](https://github.com/user-attachments/files/30166403/pr-42436-multiplatform-validation.zip)

Attached as a single zip (`pr-42436-multiplatform-validation.zip`) containing:

- `TRITONXPU-181_production_readiness_campaign_2026-07-18.md` — full campaign report.
- Per-platform raw logs (`b70/`, `h200/`, `b200/`), each split into `accuracy/`, `perf/`, `quant_smoke/`, `kernel_bench/`, `result_json/` — every command's full stdout/stderr/meta.json, no empty directories.



