### PR TITLE
[Misc] Fix mypy error in parser_manager type narrowing

### DIFF
--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -158,7 +158,7 @@ class ParserManager:
 
             if isinstance(name, str):
                 names = [name]
-            elif is_list_of(name, str):
+            elif name is not None and is_list_of(name, str):
                 names = name
             else:
                 names = [class_name]


### PR DESCRIPTION
## Summary

Fixes a mypy `[assignment]` error in `vllm/parser/parser_manager.py:162`.

vllm/parser/parser_manager.py:162: error: Incompatible types in assignment (expression has type “list[str] | None”, variable has type “list[str]”)  [assignment]


## Root cause

mypy does not narrow closure variables through `TypeIs` predicates. Inside the `_decorator` closure, `name` is a free variable captured from `register_module`'s parameters, and although `is_list_of` returns `TypeIs[list[T]]`, mypy is conservative about narrowing free variables and keeps `name` as `list[str] | None`.

`isinstance` narrowing happens to work in the same code because mypy treats it specially, but `TypeIs` is not given the same treatment in closures.

## Fix

Add an explicit `name is not None` check before `is_list_of`. mypy handles `is not None` narrowing inside closures reliably, which then lets `is_list_of` run as the runtime element-type check.

This matches the pattern already in use at `vllm/tool_parsers/abstract_tool_parser.py:319`:

```python
elif name is not None and is_list_of(name, str):

Verification

$ pre-commit run mypy-local --all-files 2>&1 | grep "parser_manager"
# (no output — error is gone)

```

## Notes
	•	One-line change.
	•	No behavior change at runtime: name is not None is implied by is_list_of returning True, since is_list_of rejects None via isinstance(value, list).
	•	No new imports.