### PR TITLE
[Bugfix] Abort request on ValueError/VLLMValidationError in generate() and encode()

### DIFF
--- a/tests/v1/engine/test_async_llm_error_handling.py
+++ b/tests/v1/engine/test_async_llm_error_handling.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for ValueError/VLLMValidationError abort behaviour in AsyncLLM.
+
+These tests verify that when a ValueError (or its subclass VLLMValidationError)
+is raised *after* add_request() has already returned a queue — meaning the
+request is live in both the OutputProcessor and EngineCore scheduler — the
+generate() and encode() methods call abort() to clean up that state.
+
+Prior to the fix, the ``except ValueError`` handlers in both methods did not
+call abort(), unlike every other exception handler.  This left requests
+permanently stranded in the scheduler, eventually exhausting the KV cache and
+deadlocking all subsequent requests.
+
+No CUDA / real model is required; all engine internals are mocked.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vllm.exceptions import VLLMValidationError
+from vllm.v1.engine.async_llm import AsyncLLM
+
+
+def _make_engine() -> AsyncLLM:
+    """Return an AsyncLLM instance with all internals mocked out."""
+    engine = object.__new__(AsyncLLM)
+    engine.log_requests = False
+    # output_handler is checked only inside add_request/_run_output_handler,
+    # both of which are mocked below, so the value here doesn't matter.
+    engine.output_handler = MagicMock()
+    return engine
+
+
+def _make_queue(request_id: str, side_effect: Exception) -> MagicMock:
+    """Return a mock RequestOutputCollector whose get() raises side_effect."""
+    q = MagicMock()
+    q.request_id = request_id
+    q.get_nowait.return_value = None
+    q.get = AsyncMock(side_effect=side_effect)
+    q.close = MagicMock()
+    return q
+
+
+# ---------------------------------------------------------------------------
+# generate() tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_aborts_on_valuerror_after_queue_created():
+    """
+    If a plain ValueError propagates into the generate() loop via the queue
+    (e.g. from output_handler.propagate_error), abort() must be called so the
+    scheduler doesn't retain a zombie request.
+    """
+    engine = _make_engine()
+    mock_queue = _make_queue("req-1", ValueError("test error"))
+
+    engine.add_request = AsyncMock(return_value=mock_queue)
+    engine.abort = AsyncMock()
+
+    with pytest.raises(ValueError, match="test error"):
+        async for _ in engine.generate(
+            prompt={"prompt_token_ids": [1, 2, 3]},
+            sampling_params=MagicMock(),
+            request_id="req-1",
+        ):
+            pass
+
+    engine.abort.assert_called_once_with("req-1", internal=True)
+
+
+@pytest.mark.asyncio
+async def test_generate_aborts_on_vllm_validation_error_after_queue_created():
+    """
+    VLLMValidationError is a ValueError subclass. If it is raised after the
+    request is already in the scheduler (add_request succeeded), generate()
+    must still abort the request.
+    """
+    engine = _make_engine()
+    error = VLLMValidationError(
+        "max_tokens must be at least 1, got 0.",
+        parameter="max_tokens",
+        value=0,
+    )
+    mock_queue = _make_queue("req-2", error)
+
+    engine.add_request = AsyncMock(return_value=mock_queue)
+    engine.abort = AsyncMock()
+
+    with pytest.raises(VLLMValidationError):
+        async for _ in engine.generate(
+            prompt={"prompt_token_ids": [1, 2, 3]},
+            sampling_params=MagicMock(),
+            request_id="req-2",
+        ):
+            pass
+
+    engine.abort.assert_called_once_with("req-2", internal=True)
+
+
+@pytest.mark.asyncio
+async def test_generate_no_abort_when_add_request_raises():
+    """
+    When the ValueError comes from add_request() itself (before the queue is
+    created), q is None and abort() must NOT be called — there is nothing to
+    clean up.
+    """
+    engine = _make_engine()
+    engine.add_request = AsyncMock(
+        side_effect=ValueError("prompt too long")
+    )
+    engine.abort = AsyncMock()
+
+    with pytest.raises(ValueError, match="prompt too long"):
+        async for _ in engine.generate(
+            prompt={"prompt_token_ids": [1, 2, 3]},
+            sampling_params=MagicMock(),
+            request_id="req-3",
+        ):
+            pass
+
+    engine.abort.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# encode() tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_encode_aborts_on_valuerror_after_queue_created():
+    """Same invariant as generate(), but for encode()."""
+    engine = _make_engine()
+    mock_queue = _make_queue("req-4", ValueError("test error"))
+
+    engine.add_request = AsyncMock(return_value=mock_queue)
+    engine.abort = AsyncMock()
+
+    with pytest.raises(ValueError, match="test error"):
+        async for _ in engine.encode(
+            prompt={"prompt_token_ids": [1, 2, 3]},
+            pooling_params=MagicMock(),
+            request_id="req-4",
+        ):
+            pass
+
+    engine.abort.assert_called_once_with("req-4", internal=True)
+
+
+@pytest.mark.asyncio
+async def test_encode_no_abort_when_add_request_raises():
+    """When add_request() itself raises, abort() must NOT be called."""
+    engine = _make_engine()
+    engine.add_request = AsyncMock(
+        side_effect=ValueError("unsupported pooling task")
+    )
+    engine.abort = AsyncMock()
+
+    with pytest.raises(ValueError, match="unsupported pooling task"):
+        async for _ in engine.encode(
+            prompt={"prompt_token_ids": [1, 2, 3]},
+            pooling_params=MagicMock(),
+            request_id="req-5",
+        ):
+            pass
+
+    engine.abort.assert_not_called()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -603,6 +603,8 @@ class AsyncLLM(EngineClient):
 
         # Request validation error.
         except ValueError as e:
+            if q is not None:
+                await self.abort(q.request_id, internal=True)
             if self.log_requests:
                 logger.info("Request %s failed (bad request): %s.", request_id, e)
             raise
@@ -866,6 +868,8 @@ class AsyncLLM(EngineClient):
 
         # Request validation error.
         except ValueError:
+            if q is not None:
+                await self.abort(q.request_id, internal=True)
             if self.log_requests:
                 logger.info("Request %s failed (bad request).", request_id)
             raise


### PR DESCRIPTION
## Summary

Fixes #42381.

The `except ValueError` handlers in `AsyncLLM.generate()` and `AsyncLLM.encode()` were the only exception handlers in those methods that did not call `abort()` when `q is not None`. This left requests permanently stranded in the scheduler when a `ValueError` or `VLLMValidationError` was raised after `add_request()` had already succeeded, eventually exhausting KV cache blocks and deadlocking the engine. This PR makes the `ValueError` path consistent with every other exception handler.

No existing PR addresses this fix (searched `42381 in:body` and `ValueError abort generate scheduler` before opening).

### Root cause

Every exception handler in `generate()` and `encode()` calls `await self.abort(q.request_id, internal=True)` when `q is not None` — except the `ValueError` handler:

```python
# Before — missing abort()
except ValueError as e:
    if self.log_requests:
        logger.info("Request %s failed (bad request): %s.", request_id, e)
    raise
```

The most direct path to trigger this is `output_processor.propagate_error(e)`: when the `output_handler` task encounters any exception, it puts it directly into each active request's `RequestOutputCollector` queue. On the next `await q.get()` the exception is re-raised in `generate()`. If that exception is a `ValueError`, it escapes the unguarded handler and the scheduler retains a zombie request that permanently holds KV cache blocks.

### Fix

Add `if q is not None: await self.abort(q.request_id, internal=True)` to both `ValueError` handlers:

```python
# After
except ValueError as e:
    if q is not None:
        await self.abort(q.request_id, internal=True)
    if self.log_requests:
        logger.info("Request %s failed (bad request): %s.", request_id, e)
    raise
```

**No change in the common case:** when `ValueError` is raised inside `process_inputs()` (before the queue is created), `q` remains `None` and `abort()` is correctly skipped — same behaviour as before.

### Tests

5 new unit tests in `tests/v1/engine/test_async_llm_error_handling.py` (no GPU required — all engine internals are mocked):

| Test | What it verifies |
|---|---|
| `test_generate_aborts_on_valuerror_after_queue_created` | `abort()` called when `ValueError` propagates via queue in `generate()` |
| `test_generate_aborts_on_vllm_validation_error_after_queue_created` | Same for `VLLMValidationError` subclass |
| `test_generate_no_abort_when_add_request_raises` | `abort()` NOT called when `ValueError` comes from `add_request()` itself (`q` is `None`) |
| `test_encode_aborts_on_valuerror_after_queue_created` | Same abort fix verified for `encode()` |
| `test_encode_no_abort_when_add_request_raises` | Same no-abort-on-early-error verified for `encode()` |

Test run on RunPod L4 (Python 3.11, vLLM installed from pip, CUDA 12.4):
```
pytest tests/v1/engine/test_async_llm_error_handling.py -v
5 passed, 2 warnings in 4.71s
```

---

> AI assistance disclosure: this PR was developed with the assistance of Claude (Anthropic). Per vLLM contributing guidelines, `Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>` is included in the commit trailer.
