### PR TITLE
[Model Runner V2][Bug Fix][DSV4] Ensure lazy attention state initializations happen during cudagraph capture

### DIFF
--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -216,7 +216,6 @@ class CudaGraphManager:
                 for desc in descs:
                     # Prepare inputs and get forward function
                     forward_fn, attn_state = create_forward_fn(desc)
-                    captured_attn_states[desc] = attn_state
 
                     # Warmup
                     forward_fn(CUDAGraphMode.NONE)
@@ -226,8 +225,15 @@ class CudaGraphManager:
                         "CG Capture: mode=%s, batch_desc=%s", desc.cg_mode.name, desc
                     )
                     if desc.cg_mode == CUDAGraphMode.PIECEWISE:
+                        captured_attn_states[desc] = attn_state
                         forward_fn(CUDAGraphMode.PIECEWISE)
                     else:
+                        # Capture with fresh attention state. The warmup
+                        # attention state is discarded because some backends
+                        # (e.g. FlashMLA) perform lazy initializations that
+                        # must be captured in the graph.
+                        forward_fn, attn_state = create_forward_fn(desc)
+                        captured_attn_states[desc] = attn_state
                         assert desc not in self.graphs, (
                             f"Graph already captured for {desc}"
                         )


### PR DESCRIPTION
# Context
DeepSeek V4 Flash with full CUDA graph capture in Model Runner V2 produces corrupted output (gibberish or repetition loops). The root cause is that `CudaGraphManager.capture()` runs a warmup forward pass before the actual graph capture, and both passes share the same `FlashMLASchedMeta `objects.

FlashMLA's C++ decode kernel (`sparse_decode_fwd` / `dense_decode_fwd`) has a conditional initialization path: if `tile_scheduler_metadata` is `None`, it allocates the tensor and runs `run_get_decoding_sched_meta_kernel` to compute a work-partitioning plan across SMs based on the current `topk_length` values. If `tile_scheduler_metadata` is already populated, it skips planning and reuses the existing plan.

During MRV2's capture flow:
1. Warmup (eager, not recorded) -`FlashMLASchedMeta` starts with `tile_scheduler_metadata=None`. The C++ kernel allocates the tensor and runs the planning kernel with dummy `topk_length` values. The metadata is now populated.
2. Capture (inside `torch.cuda.graph()`) - The same FlashMLASchedMeta objects are reused. The C++ kernel sees the already-populated metadata, takes the reuse branch, and skips the planning kernel. Only the attention and combine kernels are recorded into the graph.
3. Replay - The planning kernel never re-executes. The attention kernels run with a stale plan derived from dummy warmup values, producing incorrect work partitioning and corrupted output.

MRV1 is unaffected because `CUDAGraphWrapper` goes directly into capture with no warmup. The planning kernel sees `tile_scheduler_metadata=None` during capture, so it gets recorded into the graph and re-executes on every replay with current `topk_length` values read from persistent buffers updated before each replay.

# Fix
Call `create_forward_fn` separately for warmup and capture. The warmup uses a throwaway `forward_fn` and `attn_state`, and the capture gets a fresh `attn_state` with fresh `FlashMLASchedMeta` objects (`tile_scheduler_metadata=None`). This ensures the C++ kernel takes the allocation+planning path during capture, so r`un_get_decoding_sched_meta_kernel` is recorded into the graph and re-executes on every replay with current inputs.

While specifically intended to fix the issue for DSV4, it protects any attention backend that performs lazy initialization gated behind a first-call check.

# Accuracy Benchmarks
**Server Command**
```
export VLLM_USE_FLASHINFER_MOE_FP8=0
export FLASHINFER_DISABLE_VERSION_CHECK=1
export VLLM_USE_V2_MODEL_RUNNER=1

MODEL_CKPT="deepseek-ai/DeepSeek-V4-Flash"

vllm serve $MODEL_CKPT \
    -dp 4 -ep \
    --port 8003 \
    --block-size 256 \
    --kv-cache-dtype fp8 \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --moe-backend deep_gemm_mega_moe \
    --no-enable-prefix-caching \
    --kernel-config.enable_flashinfer_autotune=False
```

# Before
```
✓ gsm8k done  flexible-extract=0.1691, strict-match=0.1562, duration:53.1s
✓ aime25 done  exact_match=0.0000, duration:89.9s
```
# After
```
✓ gsm8k done  flexible-extract=0.9538, strict-match=0.9545, duration:33.0s
✓ aime25 done  exact_match=0.9417, duration:1901.8s
```
The gsm8k and aime25 scores are now at expected levels for Model Runner V2.

# Manual Test
## Requests
**Sourdough Guide**
```
curl -s http://localhost:8003/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-ai/DeepSeek-V4-Flash",
    "messages": [{"role": "user", "content": "Write a detailed step-by-step guide on how to make sourdough bread from scratch, including starter preparation."}],
    "max_tokens": 1024,
    "temperature": 0.6
  }' | jq -r '.choices[0].message.content'
```
**Count to 100**
```
curl -s http://localhost:8003/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-ai/DeepSeek-V4-Flash",
    "messages": [{"role": "user", "content": "Count to 100."}],
    "max_tokens": 512,
    "temperature": 0
  }' | jq -r '.choices[0].message.content'
```

## EP = 4
**Server Command**
```
export VLLM_USE_FLASHINFER_MOE_FP8=0
export FLASHINFER_DISABLE_VERSION_CHECK=1
export VLLM_USE_V2_MODEL_RUNNER=1

MODEL_CKPT="deepseek-ai/DeepSeek-V4-Flash"

vllm serve $MODEL_CKPT \
    -dp 4 -ep \
    --port 8003 \
    --block-size 256 \
    --kv-cache-dtype fp8 \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --moe-backend deep_gemm_mega_moe \
    --no-enable-prefix-caching \
    --kernel-config.enable_flashinfer_autotune=False
```

### Before
**Sourdough Guide**
```
This is a comprehensive, step-by-step guide to making sourdough bread from scratch. It covers everything from creating your own starter to baking a beautiful loaf. Sourdough requires patience, but the reward

 but the reward, a bit the first, but rewards you are, but rewards you cannot be a bit, but the "s a " ( **.

** Step  Note: the **.

---

---

**.

---

---

---

**.

---

---

---

---

** ****.

---

.

---

---

**---

---

---

---

** starter.

** the

The patience patience is baking---

---

** a**

---

 your

---

*---

*---

* it's your

---

*

---

*

---

---

**---

*---

##---

#####s##---

---

##---

---

---

---

---

##---

##---

#####---

###---

#######---

########The##aura#############它##<##<###############<### dátummal那也是它它**#####******###**#####**最大的###1**<****butnvhogsoyistyouiRewevenbutbutbutbutbutbutbutbutthepooltforustip1be1berewardabelereward**Rewstbbez(fuelbewithfuelpoolb11是poolstorele它](/🥙【1(11---fuel最大的----(1而非( _【（（——（<（1(_---- ~~(（【----<1}}}（(((<(**<**<<1**<----<<( ** ** ** _ ** ( ** _ **")).(")). _")). **")). _")). _##### _")).")) _"))."))"))."))")).~"))"))~~~
```

**Count to 100**
```
1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
```

### After
```
**Sourdough Guide**
This is a comprehensive, step-by-step guide to making sourdough bread from scratch. It is broken into two main phases: **Phase 1: Creating & Maintaining Your Starter** (takes 5-7 days) and **Phase 2: Baking the Loaf** (takes about 24-30 hours).

---

### Phase 1: The Sourdough Starter (The "Mother")

A starter is a living culture of wild yeast and bacteria. You are creating an ecosystem that will leaven your bread. This process requires patience.

**Ingredients:**
- **Whole Wheat or Rye Flour:** 100g (for the initial kick-start; these have more wild yeast)
- **Unbleached All-Purpose Flour:** As needed for feedings
- **Filtered or Non-Chlorinated Water:** Chlorine kills the good bacteria.

**Equipment:**
- A clean glass jar (pint or quart size)
- A kitchen scale (highly recommended for accuracy)
- A wooden spoon or chopstick
- A rubber band or marker
- A clean cloth or paper towel (optional, for covering)

#### Day 1: The Beginning
1.  **Combine:** In your jar, mix **100g whole wheat/rye flour** and **100g lukewarm water** (about 75-80°F/24-27°C).
2.  **Stir:** Mix vigorously until no dry flour remains. It should look like a thick, pasty batter.
3.  **Mark:** Use a rubber band to mark the height of the starter on the jar.
4.  **Cover:** Loosely cover with a lid (don't screw it tight) or a cloth. Place it in a warm spot (70-75°F/21-24°C is ideal). Avoid drafts.
5.  **Wait:** Let it sit for 24 hours. You may see tiny bubbles by the end. Don't worry if you don't.

#### Day 2-3: The First Feedings
- **Check:** You might see a layer of grayish liquid on top (called "hooch"). This is a sign of hunger. If you see mold (fuzzy, colored spots), discard and start over.
- **Discard & Feed:** Discard **half** of the starter (about 100g). Add **50g all-purpose flour** + **50g lukewarm water**. Stir well, mark the height, and re-cover.
- **Repeat:** Do this feeding **once every 24 hours** for days 2 and 3. You should see more bubbles and a slight increase in volume (maybe 20-30%).

#### Day 4-5: The Pick-Up
- **Increase Feeding:** The starter should now be bubbly and smell pleasantly sour/yogurt-like. Switch to feeding **every 12 hours** (morning and night).
- **Ratio:** Use a 1:1:1 ratio. For example: **20g starter** + **20g flour** + **20g water**. (This is called "scaling down" to manage waste).
- **Observation:** After 4-6 hours, it should double in volume (reaching the rubber band mark). This is called "peak."

#### Day 6-7: The Float Test (Readiness)
- **The Test:** Your starter is ready when it reliably doubles in volume within 4-6 hours of feeding, and a small spoonful floats in a cup of room-temperature water.
- **The Smell:** It should smell fruity, tangy, and yeasty—not like nail polish remover (acetone) or cheese.
- **Maintenance:** Once ready, you can keep it on the counter (feed daily) or in the fridge (feed weekly). For baking, always feed it 8-12 hours before you plan to use it.

---

### Phase 2: Baking the Sourdough Loaf

This recipe makes one large (900g-1kg) loaf. The key is time and gentle handling.

**Ingredients for the Dough:**
- **Active Starter:** 100g (fed 8-12 hours prior, bubbly and passed the float test)
- **Water:** 350g (lukewarm, 80-85°F/27-29°C)
- **Bread Flour:** 500g (high protein, 12-14%)
- **Salt:** 10g (fine sea salt or kosher salt)

**Equipment:**
- Large mixing bowl
- Bench scraper
- Kitchen scale
- Banneton (proofing basket) or a colander lined with a floured tea towel
- Dutch oven (heavy pot with lid) or baking stone + steam pan
- Parchment paper
- Lame or sharp knife (for scoring)
- Cooling rack

#### Day 1 (Evening): Mix & Autolyse
```

**Count to 100**
```
1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
91, 92, 93, 94, 95, 96, 97, 98, 99, 100.
```

## TP = 4
**Server Command**
```
export VLLM_USE_FLASHINFER_MOE_FP8=0
export FLASHINFER_DISABLE_VERSION_CHECK=1
export VLLM_USE_V2_MODEL_RUNNER=1

MODEL_CKPT="deepseek-ai/DeepSeek-V4-Flash"

vllm serve $MODEL_CKPT \
    -tp 4 \
    --port 8003 \
    --block-size 256 \
    --kv-cache-dtype fp8 \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --moe-backend deep_gemm \
    --no-enable-prefix-caching \
    --kernel-config.enable_flashinfer_autotune=False
```

### Before
**Sourdough Guide**
```
This is a comprehensive, step-by-step guide to making sourdough bread from scratch. It covers everything from creating your own starter to baking a beautiful loaf. Sourdough baking is a process of patience-test of patience *process of patience-driven process, a ** * **process, **slow process of patience-driven process driven by feel, rewarding, rewarding process.

** Step  **process, ** This process that combines a beautiful, detailed, ** Step  **** Step  **** **** Step **** starting with a from your art from a

This requiring baking baking baking *a**a * *art of art *skill _* science based

** *a—**—**
```

**Count to 100**
```
1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, , 20, 20, 20, , 100, 20, 10, 20, 21, 21, 21, 21, 21, 21, 21, 21,
```

### After
**Sourdough Guide**
```
This is a comprehensive, step-by-step guide to making sourdough bread from scratch. It is broken into two main phases: **Phase 1: Creating and Maintaining Your Starter** (takes 5-7 days) and **Phase 2: Baking the Loaf** (takes about 24-30 hours).

---

### Phase 1: The Sourdough Starter (The "Mother")

A starter is a living culture of wild yeast and bacteria. You are essentially creating a mini-ecosystem.

**What you need:**
- **Unbleached, all-purpose flour** (or whole wheat/rye for a faster start)
- **Water** (filtered or non-chlorinated tap water is best; chlorine kills the good bacteria)
- **A clean glass jar** (a 16-24 oz mason jar works perfectly)
- **A fork or spoon**
- **A kitchen scale** (highly recommended for accuracy)

**Day 1 (Morning):**
1.  **Combine:** In your clean jar, mix **50g flour** and **50g water** (room temperature).
2.  **Mix:** Stir vigorously until no dry flour remains. It will look like a thick paste.
3.  **Cover:** Loosely cover the jar with a lid (don't screw it on tight) or a cloth and rubber band. The starter needs to breathe but not dry out.
4.  **Rest:** Place the jar in a warm spot (ideally 70-75°F / 21-24°C). A countertop away from drafts is fine.

**Days 2, 3, & 4 (Daily Feedings):**
You will repeat this process every 24 hours.
1.  **Discard:** Remove and discard *half* of the starter (about 50g). Do not skip this step; it prevents the culture from becoming too acidic.
2.  **Feed:** Add **50g fresh flour** and **50g fresh water** to the remaining starter in the jar.
3.  **Mix:** Stir well to incorporate air.
4.  **Cover & Rest:** Re-cover and return to the warm spot.

**What you'll see:**
- **Day 1-2:** Little to no activity. You might see a few small bubbles. It may smell a bit like wet flour or even a little "cheesy" (this is normal as bad bacteria die off).
- **Day 3-4:** More bubbles. The volume should start to increase noticeably. The smell will shift to a more pleasant, slightly sour, yogurt-like aroma.

**Day 5-7 (The "Maturity" Test):**
Your starter is ready to bake with when it passes the **"Float Test."**
1.  **Feed as usual** in the morning.
2.  **Check 6-12 hours later.** It should have doubled or tripled in volume (see photo example below).
3.  **The Float Test:** Gently drop a small spoonful of the starter into a glass of room-temperature water. **If it floats, it's ready!** If it sinks, it needs more time and feedings. Continue the daily feedings until it floats.

*Note: A healthy starter is bubbly, smells pleasantly sour (like yogurt or ripe fruit), and has a domed top.*

**Maintenance (After it's ready):**
- **If baking daily:** Keep it on the counter and feed it once a day (1:1:1 ratio by weight – starter:flour:water).
- **If baking weekly:** Store it in the fridge. Feed it once a week. Before baking, take it out, feed it, and let it sit at room temperature for 8-12 hours to become active again.

---

### Phase 2: Baking the Sourdough Loaf

**Total Time:** ~24-30 hours (mostly hands-off fermentation)

**Ingredients (for one large loaf):**
- **Active Starter:** 100g (must be bubbly and pass the float test)
- **Water:** 350g (room temperature, filtered)
- **Bread Flour:** 500g (high protein, like King Arthur or Bob's Red Mill)
- **Salt:** 10g (fine sea salt or table salt)

**Equipment:**
- Large mixing bowl
- Dutch oven (or heavy oven-safe pot with a lid)
- Bench scraper (or a plastic dough scraper)
- Banneton (proofing basket) or a large bowl lined with a floured kitchen towel
- Parchment paper
- Sharp knife or razor blade (for scoring)
- Kitchen scale

---

### Step-by-Step Baking Process

**Day 1 (Evening): The "Levain" Build & Autolyse**

**Step 1: Feed Your Starter (2-3 hours before mixing)**
- Take your mature starter out of the fridge (if
```
**Count to 100**
```
1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
91, 92, 93, 94, 95, 96, 97, 98, 99, 100.
```

# Sanity Check Benchmarks
## Llama-3-8B + EAGLE

### Concurrency = 1

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 3.01 | 3.01 | +0.0% |
| Output token throughput (tok/s) | 385.17 | 385.22 | +0.0% |
| Total token throughput (tok/s) | 637.94 | 638.02 | +0.0% |
| Mean TTFT (ms) | 16.18 | 16.92 | +4.6% |
| Median TTFT (ms) | 16.28 | 16.99 | +4.4% |
| P90 TTFT (ms) | 16.68 | 17.79 | +6.7% |
| Mean TPOT (ms) | 2.49 | 2.48 | -0.4% |
| Median TPOT (ms) | 2.53 | 2.53 | +0.0% |
| P90 TPOT (ms) | 3.00 | 2.99 | -0.3% |
| Mean ITL (ms) | 4.77 | 4.76 | -0.2% |
| Median ITL (ms) | 4.88 | 4.87 | -0.2% |
| P90 ITL (ms) | 4.94 | 4.93 | -0.2% |
| Mean E2EL (ms) | 332.29 | 332.25 | -0.0% |
| Median E2EL (ms) | 337.56 | 337.32 | -0.1% |
| P90 E2EL (ms) | 396.31 | 396.07 | -0.1% |
| Acceptance rate (%) | 31.80 | 31.80 | +0.00pp |
| Acceptance length | 1.95 | 1.95 | +0.0% |

### Concurrency = 16

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 37.80 | 37.62 | -0.5% |
| Output token throughput (tok/s) | 4838.84 | 4814.96 | -0.5% |
| Total token throughput (tok/s) | 7400.49 | 7363.97 | -0.5% |
| Mean TTFT (ms) | 30.81 | 29.14 | -5.4% |
| Median TTFT (ms) | 28.02 | 27.56 | -1.6% |
| P90 TTFT (ms) | 43.33 | 39.93 | -7.8% |
| Mean TPOT (ms) | 2.98 | 2.97 | -0.3% |
| Median TPOT (ms) | 2.94 | 2.91 | -1.0% |
| P90 TPOT (ms) | 3.73 | 3.69 | -1.1% |
| Mean ITL (ms) | 5.76 | 5.73 | -0.5% |
| Median ITL (ms) | 4.89 | 4.89 | +0.0% |
| P90 ITL (ms) | 14.70 | 14.57 | -0.9% |
| Mean E2EL (ms) | 409.82 | 406.90 | -0.7% |
| Median E2EL (ms) | 402.20 | 400.72 | -0.4% |
| P90 E2EL (ms) | 507.28 | 497.79 | -1.9% |
| Acceptance rate (%) | 32.40 | 32.29 | -0.11pp |
| Acceptance length | 1.97 | 1.97 | +0.0% |

### Concurrency = 64

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 91.85 | 92.99 | +1.2% |
| Output token throughput (tok/s) | 11757.39 | 11902.86 | +1.2% |
| Total token throughput (tok/s) | 17870.89 | 18092.00 | +1.2% |
| Mean TTFT (ms) | 51.50 | 51.49 | -0.0% |
| Median TTFT (ms) | 42.93 | 42.23 | -1.6% |
| P90 TTFT (ms) | 76.10 | 94.48 | +24.2% |
| Mean TPOT (ms) | 4.91 | 4.83 | -1.6% |
| Median TPOT (ms) | 4.96 | 4.84 | -2.4% |
| P90 TPOT (ms) | 6.09 | 6.03 | -1.0% |
| Mean ITL (ms) | 9.32 | 9.13 | -2.0% |
| Median ITL (ms) | 6.94 | 6.93 | -0.1% |
| P90 ITL (ms) | 17.24 | 17.10 | -0.8% |
| Mean E2EL (ms) | 675.48 | 664.48 | -1.6% |
| Median E2EL (ms) | 677.80 | 663.48 | -2.1% |
| P90 E2EL (ms) | 825.72 | 821.97 | -0.5% |
| Acceptance rate (%) | 31.22 | 31.03 | -0.19pp |
| Acceptance length | 1.94 | 1.93 | -0.5% |

---

## Qwen3-8B + EAGLE3

### Concurrency = 1

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 3.37 | 3.43 | +1.8% |
| Output token throughput (tok/s) | 431.66 | 439.04 | +1.7% |
| Total token throughput (tok/s) | 765.86 | 778.96 | +1.7% |
| Mean TTFT (ms) | 18.87 | 17.31 | -8.3% |
| Median TTFT (ms) | 18.32 | 17.46 | -4.7% |
| P90 TTFT (ms) | 20.89 | 17.93 | -14.2% |
| Mean TPOT (ms) | 2.19 | 2.16 | -1.4% |
| Median TPOT (ms) | 2.18 | 2.17 | -0.5% |
| P90 TPOT (ms) | 2.38 | 2.35 | -1.3% |
| Mean ITL (ms) | 4.86 | 4.80 | -1.2% |
| Median ITL (ms) | 4.97 | 4.92 | -1.0% |
| P90 ITL (ms) | 5.21 | 5.09 | -2.3% |
| Mean E2EL (ms) | 296.49 | 291.51 | -1.7% |
| Median E2EL (ms) | 296.24 | 293.73 | -0.8% |
| P90 E2EL (ms) | 322.54 | 315.19 | -2.3% |
| Acceptance rate (%) | 42.78 | 42.78 | +0.00pp |
| Acceptance length | 2.28 | 2.28 | +0.0% |

### Concurrency = 16

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 39.51 | 41.54 | +5.1% |
| Output token throughput (tok/s) | 5057.17 | 5316.64 | +5.1% |
| Total token throughput (tok/s) | 7822.56 | 8223.93 | +5.1% |
| Mean TTFT (ms) | 37.31 | 35.56 | -4.7% |
| Median TTFT (ms) | 32.92 | 30.53 | -7.3% |
| P90 TTFT (ms) | 55.26 | 48.29 | -12.6% |
| Mean TPOT (ms) | 2.75 | 2.63 | -4.4% |
| Median TPOT (ms) | 2.77 | 2.62 | -5.4% |
| P90 TPOT (ms) | 3.20 | 3.10 | -3.1% |
| Mean ITL (ms) | 6.12 | 5.83 | -4.7% |
| Median ITL (ms) | 4.84 | 4.83 | -0.2% |
| P90 ITL (ms) | 16.14 | 14.92 | -7.6% |
| Mean E2EL (ms) | 385.94 | 369.24 | -4.3% |
| Median E2EL (ms) | 386.75 | 365.57 | -5.5% |
| P90 E2EL (ms) | 448.50 | 425.64 | -5.1% |
| Acceptance rate (%) | 42.77 | 42.52 | -0.25pp |
| Acceptance length | 2.28 | 2.28 | +0.0% |

### Concurrency = 64

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 84.97 | 87.41 | +2.9% |
| Output token throughput (tok/s) | 10876.00 | 11188.78 | +2.9% |
| Total token throughput (tok/s) | 16683.49 | 17163.28 | +2.9% |
| Mean TTFT (ms) | 71.38 | 71.96 | +0.8% |
| Median TTFT (ms) | 71.38 | 70.40 | -1.4% |
| P90 TTFT (ms) | 122.54 | 119.07 | -2.8% |
| Mean TPOT (ms) | 5.20 | 5.04 | -3.1% |
| Median TPOT (ms) | 5.29 | 5.09 | -3.8% |
| P90 TPOT (ms) | 6.52 | 6.28 | -3.7% |
| Mean ITL (ms) | 11.50 | 11.12 | -3.3% |
| Median ITL (ms) | 6.88 | 6.76 | -1.7% |
| P90 ITL (ms) | 18.47 | 17.66 | -4.4% |
| Mean E2EL (ms) | 732.41 | 712.15 | -2.8% |
| Median E2EL (ms) | 746.67 | 718.81 | -3.7% |
| P90 E2EL (ms) | 893.65 | 871.84 | -2.4% |
| Acceptance rate (%) | 42.11 | 42.03 | -0.08pp |
| Acceptance length | 2.26 | 2.26 | +0.0% |

---

## DeepSeek-V3.2-NVFP4 + MTP

### Concurrency = 1

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 0.84 | 0.91 | +8.3% |
| Output token throughput (tok/s) | 108.04 | 116.27 | +7.6% |
| Total token throughput (tok/s) | 178.61 | 192.20 | +7.6% |
| Mean TTFT (ms) | 305.36 | 244.82 | -19.8% |
| Median TTFT (ms) | 299.80 | 240.26 | -19.9% |
| P90 TTFT (ms) | 335.06 | 254.87 | -23.9% |
| Mean TPOT (ms) | 6.92 | 6.74 | -2.6% |
| Median TPOT (ms) | 6.93 | 6.74 | -2.7% |
| P90 TPOT (ms) | 7.51 | 7.32 | -2.5% |
| Mean ITL (ms) | 11.93 | 11.62 | -2.6% |
| Median ITL (ms) | 12.00 | 11.69 | -2.6% |
| P90 ITL (ms) | 12.24 | 11.82 | -3.4% |
| Mean E2EL (ms) | 1184.66 | 1100.88 | -7.1% |
| Median E2EL (ms) | 1185.53 | 1107.29 | -6.6% |
| P90 E2EL (ms) | 1256.24 | 1171.11 | -6.8% |
| Acceptance rate (%) | 75.52 | 75.52 | +0.00pp |
| Acceptance length | 1.76 | 1.76 | +0.0% |

### Concurrency = 16

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 3.27 | 3.64 | +11.3% |
| Output token throughput (tok/s) | 418.95 | 466.55 | +11.4% |
| Total token throughput (tok/s) | 638.97 | 711.59 | +11.4% |
| Mean TTFT (ms) | 588.80 | 564.02 | -4.2% |
| Median TTFT (ms) | 587.59 | 466.55 | -20.6% |
| P90 TTFT (ms) | 904.74 | 1069.33 | +18.2% |
| Mean TPOT (ms) | 33.47 | 29.76 | -11.1% |
| Median TPOT (ms) | 33.18 | 29.41 | -11.4% |
| P90 TPOT (ms) | 43.83 | 40.99 | -6.5% |
| Mean ITL (ms) | 58.04 | 51.68 | -11.0% |
| Median ITL (ms) | 21.05 | 21.05 | +0.0% |
| P90 ITL (ms) | 266.85 | 205.34 | -23.1% |
| Mean E2EL (ms) | 4839.09 | 4344.16 | -10.2% |
| Median E2EL (ms) | 4816.00 | 4195.25 | -12.9% |
| P90 E2EL (ms) | 6061.81 | 5908.11 | -2.5% |
| Acceptance rate (%) | 76.33 | 76.74 | +0.41pp |
| Acceptance length | 1.76 | 1.77 | +0.6% |

### Concurrency = 64

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Request throughput (req/s) | 6.10 | 7.51 | +23.1% |
| Output token throughput (tok/s) | 780.35 | 960.66 | +23.1% |
| Total token throughput (tok/s) | 1182.39 | 1455.61 | +23.1% |
| Mean TTFT (ms) | 800.74 | 685.36 | -14.4% |
| Median TTFT (ms) | 893.56 | 720.66 | -19.3% |
| P90 TTFT (ms) | 952.53 | 981.55 | +3.0% |
| Mean TPOT (ms) | 75.74 | 61.24 | -19.1% |
| Median TPOT (ms) | 81.49 | 63.81 | -21.7% |
| P90 TPOT (ms) | 102.87 | 83.89 | -18.5% |
| Mean ITL (ms) | 131.33 | 106.42 | -19.0% |
| Median ITL (ms) | 30.46 | 29.85 | -2.0% |
| P90 ITL (ms) | 303.91 | 245.09 | -19.4% |
| Mean E2EL (ms) | 10420.12 | 8462.54 | -18.8% |
| Median E2EL (ms) | 11111.12 | 8741.48 | -21.3% |
| P90 E2EL (ms) | 13833.20 | 11409.04 | -17.5% |
| Acceptance rate (%) | 76.33 | 76.78 | +0.45pp |
| Acceptance length | 1.76 | 1.77 | +0.6% |

No significant regressions observed for any of these models, as expected.
