### PR TITLE
[CI] Migrate 6 verified jobs from gpu_1_queue to h200_18gb MIG

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -91,6 +91,7 @@ steps:
 
 - label: Kernels KDA Test
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/layers/fla/ops/kda.py
   - vllm/model_executor/layers/fla/ops/chunk_delta_h.py

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -114,6 +114,7 @@ steps:
 - label: LM Eval TurboQuant KV Cache
   key: lm-eval-turboquant-kv-cache
   timeout_in_minutes: 75
+  device: h200_18gb
   source_file_dependencies:
   - vllm/model_executor/layers/quantization/turboquant/
   - vllm/v1/attention/backends/turboquant_attn.py

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -339,8 +339,9 @@ steps:
 - label: Acceptance Length Test (Large Models) # optional
   key: acceptance-length-test-large-models
   timeout_in_minutes: 25
-  device: h200_18gb
+  gpu: h100
   optional: true
+  num_gpus: 1
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/v1/spec_decode/

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -212,6 +212,7 @@ steps:
   depends_on: ~
   optional: true
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
   - tests/standalone_tests/python_only_compile.sh
   - setup.py
@@ -338,9 +339,8 @@ steps:
 - label: Acceptance Length Test (Large Models) # optional
   key: acceptance-length-test-large-models
   timeout_in_minutes: 25
-  gpu: h100
+  device: h200_18gb
   optional: true
-  num_gpus: 1
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/v1/spec_decode/

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Basic Models Tests (Initialization)
   key: basic-models-tests-initialization
   timeout_in_minutes: 45
+  device: h200_18gb
   torch_nightly: true
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Language Models Tests (Standard)
   key: language-models-tests-standard
   timeout_in_minutes: 25
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/language


### PR DESCRIPTION
## Summary
- Move 6 CI jobs that were validated on H200 18GB MIG (build [#65789](https://buildkite.com/vllm/ci/builds/65789)) from `gpu_1_queue` (L4) to `device: h200_18gb`
- These are the jobs that passed cleanly (all shards) — the remaining ~47 jobs fail due to PyTorch's `CUDACachingAllocator` NVML assertion on MIG partitions
- Also fixes `Acceptance Length Test` which used non-standard `gpu:`/`num_gpus:` fields

## Migrated jobs
| Job | File | Notes |
|-----|------|-------|
| Kernels KDA Test | kernels.yaml | Pure kernel test, no engine init |
| LM Eval TurboQuant KV Cache | lm_eval.yaml | Pre-quantized model path |
| Acceptance Length Test (Large Models) | misc.yaml | Also fixed `gpu:` → `device:` |
| Python-only Installation | misc.yaml | No GPU, install-only check |
| Basic Models Tests (Initialization) | models_basic.yaml | Lightweight init test |
| Language Models Tests (Standard) | models_language.yaml | Core model tests |

## Why not all jobs?
53 of 65 jobs failed on MIG due to `RuntimeError: NVML_SUCCESS == r INTERNAL ASSERT FAILED at "/pytorch/c10/cuda/CUDACachingAllocator.cpp":1165`. PyTorch's CUDA memory allocator makes NVML calls that are restricted on MIG partitions. Jobs with parallelism shards where some shards failed (LoRA, Hybrid, Extra Init) were also excluded.

Full analysis: https://github.com/vllm-project/vllm/pull/42401#issuecomment-4433355882

## Test plan
- [x] All 6 jobs validated on h200_18gb MIG in build #65789
- [ ] CI run on this PR to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)