### PR TITLE
Only disable hybrid_kv_cache_manager if KV connector does not support it

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1316,6 +1316,11 @@ class VllmConfig:
                     "the `reasoning_start_str` and `reasoning_end_str`."
                 )
 
+        # Handle the KV connector configs before evaluating HMA rules so that
+        # features like KV offloading (which populate kv_transfer_config
+        # automatically) are accounted for in the SupportsHMA check below.
+        self._post_init_kv_transfer_config()
+
         # Hybrid KV cache manager (HMA) runtime rules:
         # - Explicit enable (--no-disable-kv-cache-manager): error if runtime
         #   disables it
@@ -1352,7 +1357,10 @@ class VllmConfig:
 
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
-            if self.kv_transfer_config is not None:
+            if (
+                self.kv_transfer_config is not None
+                and self.kv_transfer_config.kv_connector is not None
+            ):
                 # Only auto-disable HMA when the configured connector does not
                 # advertise SupportsHMA. HMA-capable connectors (e.g.
                 # NixlConnector) should keep HMA on so hybrid models like
@@ -1365,16 +1373,10 @@ class VllmConfig:
                     supports_hma,
                 )
 
-                try:
-                    connector_cls = KVConnectorFactory.get_connector_class(
-                        self.kv_transfer_config
-                    )
-                    connector_supports_hma = supports_hma(connector_cls)
-                except Exception:
-                    # If the connector class can't be resolved at config-time
-                    # (e.g. external module not yet importable), fall back to
-                    # the conservative default of disabling HMA.
-                    connector_supports_hma = False
+                connector_cls = KVConnectorFactory.get_connector_class(
+                    self.kv_transfer_config
+                )
+                connector_supports_hma = supports_hma(connector_cls)
 
                 if not connector_supports_hma:
                     need_disable_hybrid_kv_cache_manager = True
@@ -1431,8 +1433,6 @@ class VllmConfig:
             if "-quant_fp8" not in custom_ops:
                 custom_ops.append("+quant_fp8")
 
-        # Handle the KV connector configs
-        self._post_init_kv_transfer_config()
         self._verify_kv_transfer_compat()
 
         # Log the custom passes that are enabled

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1383,14 +1383,13 @@ class VllmConfig:
                     logger.warning(
                         "Turning off hybrid kv cache manager because "
                         "`--kv-transfer-config` is set with a connector that "
-                        "does not implement SupportsHMA. This will reduce the "
-                        "performance of vLLM on LLMs with sliding window "
-                        "attention or Mamba attention. If you are a developer "
-                        "of kv connector, please consider supporting hybrid "
-                        "kv cache manager for your connector by making sure "
-                        "your connector is a subclass of `SupportsHMA` "
-                        "defined in kv_connector/v1/base.py. To force-disable "
-                        "HMA, pass --disable-hybrid-kv-cache-manager."
+                        "does not implement `SupportsHMA`. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window attention "
+                        "or Mamba attention. If you are a developer of kv connector"
+                        ", please consider supporting hybrid kv cache manager for "
+                        "your connector by making sure your connector is a subclass"
+                        " of `SupportsHMA` defined in kv_connector/v1/base.py and"
+                        " use --no-disable-hybrid-kv-cache-manager to start vLLM."
                     )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1316,9 +1316,7 @@ class VllmConfig:
                     "the `reasoning_start_str` and `reasoning_end_str`."
                 )
 
-        # Handle the KV connector configs before evaluating HMA rules so that
-        # features like KV offloading (which populate kv_transfer_config
-        # automatically) are accounted for in the SupportsHMA check below.
+        # Populate KV connector config before evaluating HMA rules
         self._post_init_kv_transfer_config()
 
         # Hybrid KV cache manager (HMA) runtime rules:
@@ -1356,16 +1354,12 @@ class VllmConfig:
                 need_disable_hybrid_kv_cache_manager = True
 
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
-            # Default to disable HMA, but only if the user didn't express a preference.
             if (
                 self.kv_transfer_config is not None
                 and self.kv_transfer_config.kv_connector is not None
             ):
-                # Only auto-disable HMA when the configured connector does not
-                # advertise SupportsHMA. HMA-capable connectors (e.g.
-                # NixlConnector) should keep HMA on so hybrid models like
-                # DeepSeek V4 don't have their SWA/chunked-local layers
-                # promoted to full attention during KV-cache profiling.
+                # Disable HMA if the configured connector does not
+                # implement SupportsHMA.
                 from vllm.distributed.kv_transfer.kv_connector.factory import (
                     KVConnectorFactory,
                 )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1353,18 +1353,43 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                # Only auto-disable HMA when the configured connector does not
+                # advertise SupportsHMA. HMA-capable connectors (e.g.
+                # NixlConnector) should keep HMA on so hybrid models like
+                # DeepSeek V4 don't have their SWA/chunked-local layers
+                # promoted to full attention during KV-cache profiling.
+                from vllm.distributed.kv_transfer.kv_connector.factory import (
+                    KVConnectorFactory,
                 )
+                from vllm.distributed.kv_transfer.kv_connector.v1 import (
+                    supports_hma,
+                )
+
+                try:
+                    connector_cls = KVConnectorFactory.get_connector_class(
+                        self.kv_transfer_config
+                    )
+                    connector_supports_hma = supports_hma(connector_cls)
+                except Exception:
+                    # If the connector class can't be resolved at config-time
+                    # (e.g. external module not yet importable), fall back to
+                    # the conservative default of disabling HMA.
+                    connector_supports_hma = False
+
+                if not connector_supports_hma:
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set with a connector that "
+                        "does not implement SupportsHMA. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window "
+                        "attention or Mamba attention. If you are a developer "
+                        "of kv connector, please consider supporting hybrid "
+                        "kv cache manager for your connector by making sure "
+                        "your connector is a subclass of `SupportsHMA` "
+                        "defined in kv_connector/v1/base.py. To force-disable "
+                        "HMA, pass --disable-hybrid-kv-cache-manager."
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )


### PR DESCRIPTION
## Purpose
Currently `need_disable_hybrid_kv_cache_manager` is set True as long as `kv_transfer_config is not None`, despite the KV connector supports it. This PR checks `supports_hma` to determine whether to disable.

The motivation is running into the following error with setting `--kv-transfer-config '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'` on dsv4:
```
Traceback (most recent call last):
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     output = func(*args, **kwargs)
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     return func(*args, **kwargs)
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/worker/gpu_worker.py", line 405, in determine_available_memory
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     return func(*args, **kwargs)
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/worker/gpu_model_runner.py", line 6008, in profile_cudagraph_memory
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     self._init_minimal_kv_cache_for_profiling()
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/worker/gpu_model_runner.py", line 5938, in _init_minimal_kv_cache_for_profiling
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     self.initialize_kv_cache(minimal_config, is_profiling=True)
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/worker/gpu_model_runner.py", line 6900, in initialize_kv_cache
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     kv_caches = self.initialize_kv_cache_tensors(
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/worker/gpu_model_runner.py", line 6814, in initialize_kv_cache_tensors
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     kv_cache_raw_tensors = self._allocate_kv_cache_tensors(kv_cache_config)
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]   File "/vllm/vllm/v1/worker/gpu_model_runner.py", line 6595, in _allocate_kv_cache_tensors
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]     tensor = torch.zeros(
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962]              ^^^^^^^^^^^^
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962] torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 GiB. GPU 5 has a total capacity of 267.69 GiB of which 1.86 GiB is free. Including non-PyTorch memory, this process has 265.82 GiB memory in use. Of the allocated memory 260.79 GiB is allocated by PyTorch, and 439.02 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)
(Worker_TP5 pid=2930321) ERROR 05-12 09:31:16 [multiproc_executor.py:962] 
```

Applying the PR, the error is gone.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

