### PR TITLE
[Bug][Structured Outputs] Fix bug that leads to unconstrained generations with structural tags

### DIFF
--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -10,6 +10,7 @@ import pytest
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 
 
 class MockReasoner:
@@ -213,6 +214,32 @@ class TestReasoningStructuredOutput:
             is True
         )
         assert result is False
+
+    def test_should_advance_reasoning_just_ended_with_spec_decode_structural_tag(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """When reasoning ends this step, advance immediately for structural
+        tags with speculative decoding."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.STRUCTURAL_TAG,
+            "{}",
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.return_value = True
+        structured_req.reasoner = reasoner
+
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is True
 
     def test_should_advance_reasoning_already_ended(
         self,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -15,6 +15,7 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
+    StructuredOutputOptions,
 )
 from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
@@ -353,6 +354,17 @@ class StructuredOutputManager:
             # Reasoning just ended, so we shouldn't advance til
             # next pass
             structured_req.reasoning_ended = True
+
+            # Only treat reasoning_ended as allowing FSM advance for speculative
+            # decoding with structural-tag constraints; other paths keep prior
+            # streaming gating without this shortcut.
+            if (
+                structured_req.reasoning_ended
+                and self.vllm_config.speculative_config is not None
+                and structured_req.structured_output_key[0]
+                == StructuredOutputOptions.STRUCTURAL_TAG
+            ):
+                return True
 
         return False
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -359,8 +359,7 @@ class StructuredOutputManager:
             # decoding with structural-tag constraints; other paths keep prior
             # streaming gating without this shortcut.
             if (
-                structured_req.reasoning_ended
-                and self.vllm_config.speculative_config is not None
+                self.vllm_config.speculative_config is not None
                 and structured_req.structured_output_key[0]
                 == StructuredOutputOptions.STRUCTURAL_TAG
             ):

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -351,13 +351,15 @@ class StructuredOutputManager:
         if reasoner.is_reasoning_end_streaming(
             all_token_ids, itertools.islice(all_token_ids, start, None)
         ):
-            # Reasoning just ended, so we shouldn't advance til
-            # next pass
             structured_req.reasoning_ended = True
 
-            # Only treat reasoning_ended as allowing FSM advance for speculative
-            # decoding with structural-tag constraints; other paths keep prior
-            # streaming gating without this shortcut.
+            # Reasoning just ended this step. Defer FSM advance until the next
+            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
+            # advancing on the closing boundary token can accept tokens that still
+            # belong to the reasoning stream. Structural tags are the only safe
+            # same-step exception: they model phased output (e.g. thinking tag ->
+            # answer tag), and speculative decoding must run grammar.validate_tokens
+            # on draft tokens produced immediately after that transition.
             if (
                 self.vllm_config.speculative_config is not None
                 and structured_req.structured_output_key[0]


### PR DESCRIPTION
With structural tags, a reasoning parser, and speculative decoding, we sometimes get logits that are not grammar-masked (allow-all bitmask), which leads to unconstrained token generation when we expect guided decoding.

What goes wrong

- [reasoning_ended](https://github.com/vllm-project/vllm/blob/379f0ec369d300d6fb45983882f1a4d548065d73/vllm/v1/structured_output/__init__.py#L355) (which gates both should_fill_bitmask and [should_advance](https://github.com/vllm-project/vllm/blob/379f0ec369d300d6fb45983882f1a4d548065d73/vllm/v1/structured_output/__init__.py#L321)) is updated only after a decode step finishes—when should_advance runs during update_from_output.

- While should_advance is false (still treating the stream as “reasoning”), the scheduler does not call grammar.accept_tokens(...) on the new token IDs. The grammar matcher therefore does not advance through prefix / trigger / begin states for those tokens.

- Speculative decoding can commit many token IDs in one step. Those IDs can include trigger (and following) text which are necessary for the FSM advancement. 

- On the next step, the matcher is still at an earlier state while the trigger tags are now a part of the input ids. The next accept_tokens calls then see tokens that do not match the trigger tags (since the accept_tokens are called on the accepted output tokens) , so structured decoding is not enabled in the following calls as well.