### PR TITLE
[CI] Fix `test_async_scheduling.py` flakiness

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -429,7 +429,7 @@ def _logprobs_match(
         and lps_a.keys() == lps_b.keys()
         and all(
             a.decoded_token == b.decoded_token
-            and a.rank == b.rank
+            and a.rank == pytest.approx(b.rank, rel=0.005)
             and a.logprob == pytest.approx(b.logprob, rel=rel_tol, abs=abs_tol)
             for a, b in ((lps_a[x], lps_b[x]) for x in lps_a)
         )


### PR DESCRIPTION
This has become super flakey recently, e.g. https://buildkite.com/vllm/ci/builds/65896/canvas?sid=019e1d8a-5417-4923-8772-6383caefd793&tab=output

I think this started after https://github.com/vllm-project/vllm/pull/41411.

It looks like because we are now comparing prompt logprobs, ranks can be much larger and the difference between their logprob values much smaller, in some cases meaning the order changes and so the ranks can be off by one or two.

Adding tolerance to the rank comparison will hopefully resolve this.

