### PR TITLE
Expose KV offload cache usage metric 

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OFFLOAD_CACHE_USAGE_KEY,
     OffloadingConnectorStats,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
@@ -149,3 +152,41 @@ def test_reset():
     # After reset, stats should be empty
     assert offload_connector_stats.is_empty()
     assert len(offload_connector_stats.data) == 0
+
+
+def test_reduce_offload_usage_uses_max():
+    stats = OffloadingConnectorStats()
+    stats.record_offload_usage(0.2)
+    stats.record_offload_usage(0.7)
+    stats.record_offload_usage(0.4)
+
+    reduced = stats.reduce()
+
+    assert reduced[OFFLOAD_CACHE_USAGE_KEY] == 0.7
+
+
+def test_aggregate_merges_offload_usage_samples():
+    stats1 = OffloadingConnectorStats()
+    stats1.record_offload_usage(0.1)
+    stats1.record_offload_usage(0.3)
+
+    stats2 = OffloadingConnectorStats()
+    stats2.record_offload_usage(0.8)
+
+    merged = stats1.aggregate(stats2)
+
+    assert merged is stats1
+    assert stats1.data[OFFLOAD_CACHE_USAGE_KEY] == [0.1, 0.3, 0.8]
+
+
+def test_scheduler_get_kv_connector_stats_includes_offload_usage():
+    connector = OffloadingConnector.__new__(OffloadingConnector)
+    connector.connector_worker = None
+    connector.connector_scheduler = SimpleNamespace(
+        manager=SimpleNamespace(offload_cache_usage_fraction=lambda: 0.42)
+    )
+
+    stats = connector.get_kv_connector_stats()
+
+    assert isinstance(stats, OffloadingConnectorStats)
+    assert stats.data[OFFLOAD_CACHE_USAGE_KEY] == [0.42]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -14,6 +14,11 @@ PromMetricT = TypeVar("PromMetricT", bound=PromMetric)
 
 logger = init_logger(__name__)
 
+# Key used in KVConnectorStats.data to carry offload-store utilization samples
+# (list[float], 0.0-1.0). Stored alongside transfer-op metrics so it flows
+# through the same aggregation pipeline without extra API surface.
+OFFLOAD_CACHE_USAGE_KEY = "offload_cache_usage_perc"
+
 
 @dataclass
 class KVConnectorStats:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    OFFLOAD_CACHE_USAGE_KEY,
     KVConnectorPromMetrics,
     KVConnectorStats,
     PromMetric,
@@ -30,13 +31,13 @@ class OffloadingConnectorStats(KVConnectorStats):
             self.reset()
 
     def reset(self):
-        self.data: dict[str, list[OffloadingOperationMetrics]] = {}
+        self.data: dict[str, list] = {}
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
         if not other.is_empty():
             for k, v in other.data.items():
                 if k not in self.data:
-                    self.data[k] = v
+                    self.data[k] = list(v)
                 else:
                     accumulator = self.data[k]
                     assert isinstance(accumulator, list)
@@ -51,16 +52,19 @@ class OffloadingConnectorStats(KVConnectorStats):
         stats for the last time interval.
         """
         return_dict: dict[str, int | float] = {}
-        for transfer_type, ops_list in self.data.items():
-            assert isinstance(ops_list, list)
+        for stat_key, samples in self.data.items():
+            assert isinstance(samples, list)
+            if stat_key == OFFLOAD_CACHE_USAGE_KEY:
+                return_dict[OFFLOAD_CACHE_USAGE_KEY] = max(samples) if samples else 0.0
+                continue
             total_bytes = 0
             total_time = 0.0
-            for op in ops_list:
+            for op in samples:
                 assert isinstance(op, dict)
                 total_bytes += op["op_size"]
                 total_time += op["op_time"]
-            return_dict[f"{transfer_type}_total_bytes"] = total_bytes
-            return_dict[f"{transfer_type}_total_time"] = total_time
+            return_dict[f"{stat_key}_total_bytes"] = total_bytes
+            return_dict[f"{stat_key}_total_time"] = total_time
         return return_dict
 
     def is_empty(self) -> bool:
@@ -74,6 +78,12 @@ class OffloadingConnectorStats(KVConnectorStats):
             self.data[transfer_type_key].append(op)
         else:
             self.data[transfer_type_key] = [op]
+
+    def record_offload_usage(self, usage_fraction: float) -> None:
+        usage_fraction = max(0.0, min(1.0, usage_fraction))
+        bucket = self.data.setdefault(OFFLOAD_CACHE_USAGE_KEY, [])
+        assert isinstance(bucket, list)
+        bucket.append(usage_fraction)
 
 
 class OffloadPromMetrics(KVConnectorPromMetrics):
@@ -130,6 +140,10 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         """
 
         for transfer_type, ops in transfer_stats_data.items():
+            # Non-transfer entries (e.g. CPU KV usage samples) are handled by
+            # the scheduler; skip them here.
+            if transfer_type == OFFLOAD_CACHE_USAGE_KEY:
+                continue
             # Cache:
             if (engine_idx, transfer_type) not in self.histogram_transfer_size:
                 self.histogram_transfer_size[(engine_idx, transfer_type)] = (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -175,9 +175,15 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
         return "HND"
 
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
-        if self.connector_worker is None:
-            return None  # We only emit stats from the worker-side
-        return self.connector_worker.get_kv_connector_stats()
+        if self.connector_worker is not None:
+            return self.connector_worker.get_kv_connector_stats()
+        if self.connector_scheduler is not None:
+            usage = self.connector_scheduler.manager.offload_cache_usage_fraction()
+            if usage is not None:
+                stats = OffloadingConnectorStats()
+                stats.record_offload_usage(usage)
+                return stats
+        return None
 
     @classmethod
     def build_kv_connector_stats(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -23,7 +23,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    OFFLOAD_CACHE_USAGE_KEY,
+    KVConnectorStats,
+)
 from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
@@ -1268,10 +1271,14 @@ class Scheduler(SchedulerInterface):
         kv_connector_stats: KVConnectorStats | None = (
             kv_connector_output.kv_connector_stats if kv_connector_output else None
         )
-        if kv_connector_stats and self.connector:
+        if self.connector:
             kv_stats = self.connector.get_kv_connector_stats()
             if kv_stats:
-                kv_connector_stats = kv_connector_stats.aggregate(kv_stats)
+                kv_connector_stats = (
+                    kv_connector_stats.aggregate(kv_stats)
+                    if kv_connector_stats
+                    else kv_stats
+                )
 
         failed_kv_load_req_ids = None
         if kv_connector_output and kv_connector_output.invalid_block_ids:
@@ -1883,6 +1890,11 @@ class Scheduler(SchedulerInterface):
             else []
         )
         spec_stats = spec_decoding_stats
+        kv_offload_cache_usage = 0.0
+        if kv_connector_stats:
+            kv_offload_samples = kv_connector_stats.data.get(OFFLOAD_CACHE_USAGE_KEY)
+            if kv_offload_samples:
+                kv_offload_cache_usage = float(max(kv_offload_samples))
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
@@ -1891,6 +1903,7 @@ class Scheduler(SchedulerInterface):
             num_waiting_reqs=len(self.waiting),
             num_skipped_waiting_reqs=len(self.skipped_waiting),
             kv_cache_usage=self.kv_cache_manager.usage,
+            kv_offload_cache_usage=kv_offload_cache_usage,
             prefix_cache_stats=prefix_cache_stats,
             connector_prefix_cache_stats=connector_prefix_cache_stats,
             kv_cache_eviction_events=eviction_events,

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -219,6 +219,14 @@ class OffloadingManager(ABC):
         """
         return ()
 
+    def offload_cache_usage_fraction(self) -> float | None:
+        """
+        Return the fraction of the offload store's block pool currently in use
+        (0.0 = empty, 1.0 = full), or None if this manager does not expose
+        utilization (e.g. an unbounded remote-storage backend).
+        """
+        return None
+
     def shutdown(self) -> None:
         """Shutdown the manager and release any resources."""
         return

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -223,6 +223,12 @@ class CPUOffloadingManager(OffloadingManager):
                 )
             )
 
+    def offload_cache_usage_fraction(self) -> float | None:
+        if self._num_blocks == 0:
+            return 0.0
+        in_use = self._num_blocks - self._get_num_free_blocks()
+        return in_use / self._num_blocks
+
     def take_events(self) -> Iterable[OffloadingEvent]:
         if self.events is not None:
             yield from self.events

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -526,6 +526,19 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_kv_cache_usage, per_engine_labelvalues
         )
 
+        gauge_kv_offload_cache_usage = self._gauge_cls(
+            name="vllm:kv_offload_cache_usage_perc",
+            documentation=(
+                "KV offload store usage. 1 means 100 percent of the "
+                "connector offload block pool is in use. 0 when no offload."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_kv_offload_cache_usage = create_metric_per_engine(
+            gauge_kv_offload_cache_usage, per_engine_labelvalues
+        )
+
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             counter_corrupted_requests = self._counter_cls(
                 name="vllm:corrupted_requests",
@@ -1079,6 +1092,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.gauge_kv_offload_cache_usage[engine_idx].set(
+                scheduler_stats.kv_offload_cache_usage
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -181,6 +181,8 @@ class SchedulerStats:
     current_wave: int = 0
 
     kv_cache_usage: float = 0.0
+    # Fraction of the offload store's block pool in use (0.0-1.0); 0 when no offload.
+    kv_offload_cache_usage: float = 0.0
 
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
     connector_prefix_cache_stats: PrefixCacheStats | None = None


### PR DESCRIPTION
## Purpose
Expose KV cache usage metric for offloading KV connectors.

Adds a new Prometheus gauge, vllm:kv_offload_cache_usage_perc, to report offload-store block pool utilization (0.0 to 1.0; 0.0 when offload is not configured or utilization is unavailable).

KV offload usage is read from the OffloadingConnector scheduler-side path, while most existing connector metrics are emitted from the worker side. This difference necessitated the following changes:

 - Added offload_cache_usage_fraction() to OffloadingManager and implemented it in CPUOffloadingManager.
 - Emitted offload-usage samples from the scheduler-side OffloadingConnector via KVConnectorStats.
 - Extended SchedulerStats with kv_offload_cache_usage and propagated it to metrics logging

## Test Plan
vllm serve command : 
```
vllm serve  RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8   --tensor-parallel-size 2 --kv-transfer-config  '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"block_size": 64, "cpu_bytes_to_use": 160000000000}}' --port 9010  --gpu-memory-utilization 0.40
```

query metrics like : 
```
watch -n1 "curl -s http://localhost:9010/metrics | grep -E '^vllm:(kv_cache_usage_perc|kv_offload_cache_usage_perc)\{'"
```

## Test Result
watch KV cache usage grow like 
```
vllm:kv_cache_usage_perc{engine="0",model_name="RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8"} 0.1615432750596425
vllm:kv_offload_cache_usage_perc{engine="0",model_name="RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8"} 1.0
```
