### PR TITLE
[BugFix][CPU][Spec Decode] Fix Eagle implementation on CPU backend

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -308,6 +308,10 @@ def apply_top_k_top_p(
     if p is None and k is None:
         return logits
 
+    # Keep CPU logits on the PyTorch path to avoid invoking Triton kernels.
+    if logits.device.type == "cpu":
+        return apply_top_k_top_p_pytorch(logits, k, p, allow_cpu_sync=True)
+
     if HAS_TRITON and logits.shape[0] >= 8:
         return apply_top_k_top_p_triton(logits, k, p)
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -309,7 +309,7 @@ def apply_top_k_top_p(
         return logits
 
     # Keep CPU logits on the PyTorch path to avoid invoking Triton kernels.
-    if logits.device.type == "cpu":
+    if current_platform.is_cpu():
         return apply_top_k_top_p_pytorch(logits, k, p, allow_cpu_sync=True)
 
     if HAS_TRITON and logits.shape[0] >= 8:

--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -111,6 +111,8 @@ class CPUModelRunner(GPUModelRunner):
             logger.info_once("Loading drafter model...")
             self.drafter.load_model(self.model)
 
+        self._setup_aux_hidden_state_outputs()
+
     def get_model(self) -> nn.Module:
         return self.model
 

--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -111,7 +111,7 @@ class CPUModelRunner(GPUModelRunner):
             logger.info_once("Loading drafter model...")
             self.drafter.load_model(self.model)
 
-        self._setup_aux_hidden_state_outputs()
+        self._setup_eagle3_aux_hidden_state_outputs()
 
     def get_model(self) -> nn.Module:
         return self.model

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4911,27 +4911,7 @@ class GPUModelRunner(
                         )
                         eplb_models += 1
 
-                if self.use_aux_hidden_state_outputs:
-                    if not supports_eagle3(self.get_model()):
-                        raise RuntimeError(
-                            "Model does not support EAGLE3 interface but "
-                            "aux_hidden_state_outputs was requested"
-                        )
-
-                    # Try to get auxiliary layers from speculative config,
-                    # otherwise use model's default layers
-                    aux_layers = self._get_eagle3_aux_layers_from_config()
-                    if aux_layers:
-                        logger.info(
-                            "Using auxiliary layers from speculative config: %s",
-                            aux_layers,
-                        )
-                    else:
-                        aux_layers = (
-                            self.model.get_eagle3_default_aux_hidden_state_layers()
-                        )
-
-                    self.model.set_aux_hidden_state_layers(aux_layers)
+                self._setup_aux_hidden_state_outputs()
 
                 if (
                     is_mixture_of_experts(self.model)
@@ -5027,6 +5007,27 @@ class GPUModelRunner(
                 )
 
         get_offloader().post_init()
+
+    def _setup_aux_hidden_state_outputs(self) -> None:
+        if not self.use_aux_hidden_state_outputs:
+            return
+
+        if not supports_eagle3(self.get_model()):
+            raise RuntimeError(
+                "Model does not support EAGLE3 interface but "
+                "aux_hidden_state_outputs was requested"
+            )
+        # Try to get auxiliary layers from speculative config,
+        # otherwise use model's default layers
+        aux_layers = self._get_eagle3_aux_layers_from_config()
+        if aux_layers:
+            logger.info(
+                "Using auxiliary layers from speculative config: %s", aux_layers
+            )
+        else:
+            aux_layers = self.model.get_eagle3_default_aux_hidden_state_layers()
+
+        self.model.set_aux_hidden_state_layers(aux_layers)
 
     def _get_eagle3_aux_layers_from_config(self) -> tuple[int, ...] | None:
         """Extract Eagle3 auxiliary layer indices from speculative config.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4911,7 +4911,7 @@ class GPUModelRunner(
                         )
                         eplb_models += 1
 
-                self._setup_aux_hidden_state_outputs()
+                self._setup_eagle3_aux_hidden_state_outputs()
 
                 if (
                     is_mixture_of_experts(self.model)
@@ -5008,7 +5008,7 @@ class GPUModelRunner(
 
         get_offloader().post_init()
 
-    def _setup_aux_hidden_state_outputs(self) -> None:
+    def _setup_eagle3_aux_hidden_state_outputs(self) -> None:
         if not self.use_aux_hidden_state_outputs:
             return
 


### PR DESCRIPTION



## Purpose
Currently Eagle doesn't work on CPU backend:


## Test Plan
Server:

```bash
vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --dtype bfloat16 \
  --no-enable-prefix-caching \
  --trust-remote-code \
  --speculative-config '{"method": "eagle3", "model": "RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3", "num_speculative_tokens": 2}'
```

Benchmark:

```bash
vllm bench serve \
  --dataset-name hf \
  --dataset-path philschmid/mt-bench \
  --max-concurrency 1 \
  --num-prompts 20 \
  --hf-output-len 128 \
  --model meta-llama/Llama-3.1-8B-Instruct
```

## Test Result
Without the fix the server fails to start:
```sh
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962] WorkerProc hit an exception.
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962] Traceback (most recent call last):
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     output = func(*args, **kwargs)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/cpu_worker.py", line 154, in determine_available_memory
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     self.model_runner.warming_up_model()
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     return func(*args, **kwargs)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/cpu_model_runner.py", line 122, in warming_up_model
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     self.profile_run()
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/gpu_model_runner.py", line 5954, in profile_run
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     hidden_states, last_hidden_states = self._dummy_run(
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]                                         ^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/miniforge3/envs/vllm-cpu/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     return func(*args, **kwargs)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/gpu_model_runner.py", line 5631, in _dummy_run
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     hidden_states, _ = outputs
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     ^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962] ValueError: too many values to unpack (expected 2)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962] Traceback (most recent call last):
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/executor/multiproc_executor.py", line 957, in worker_busy_loop
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     output = func(*args, **kwargs)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]              ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/cpu_worker.py", line 154, in determine_available_memory
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     self.model_runner.warming_up_model()
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     return func(*args, **kwargs)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/cpu_model_runner.py", line 122, in warming_up_model
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     self.profile_run()
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/gpu_model_runner.py", line 5954, in profile_run
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     hidden_states, last_hidden_states = self._dummy_run(
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]                                         ^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/miniforge3/envs/vllm-cpu/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     return func(*args, **kwargs)
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]   File "/home/sdp/sd-cpu/vllm/vllm/v1/worker/gpu_model_runner.py", line 5631, in _dummy_run
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     hidden_states, _ = outputs
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962]     ^^^^^^^^^^^^^^^^
(Worker pid=2020223) ERROR 05-12 15:55:50 [multiproc_executor.py:962] ValueError: too many values to unpack (expected 2)
```

With the fix the server starts and we are able to benchmark
```sh
============ Serving Benchmark Result ============
Successful requests:                     20
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  87.39
Total input tokens:                      1734
Total generated tokens:                  2560
Request throughput (req/s):              0.23
Output token throughput (tok/s):         29.29
Peak output token throughput (tok/s):    15.00
Peak concurrent requests:                2.00
Total token throughput (tok/s):          49.14
---------------Time to First Token----------------
Mean TTFT (ms):                          149.51
Median TTFT (ms):                        155.83
P99 TTFT (ms):                           188.41
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.23
Median TPOT (ms):                        32.76
P99 TPOT (ms):                           40.17
---------------Inter-token Latency----------------
Mean ITL (ms):                           68.17
Median ITL (ms):                         67.84
P99 ITL (ms):                            75.29
---------------Speculative Decoding---------------
Acceptance rate (%):                     53.43
Acceptance length:                       2.07
Drafts:                                  1238
Draft tokens:                            2476
Accepted tokens:                         1323
Per-position acceptance (%):
  Position 0:                            65.02
  Position 1:                            41.84
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

