### PR TITLE
[CI] Use uv with Python 3.12 for PyPI wheel upload

### DIFF
--- a/.buildkite/scripts/upload-release-wheels-pypi.sh
+++ b/.buildkite/scripts/upload-release-wheels-pypi.sh
@@ -41,7 +41,7 @@ set -x # avoid printing secrets above
 
 # install uv if not already available
 if ! command -v uv &> /dev/null; then
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  curl -LsSf https://astral.sh/uv/install.sh | UV_VERSION=0.11.14 sh
   export PATH="$HOME/.local/bin:$PATH"
 fi
 

--- a/.buildkite/scripts/upload-release-wheels-pypi.sh
+++ b/.buildkite/scripts/upload-release-wheels-pypi.sh
@@ -39,11 +39,17 @@ fi
 
 set -x # avoid printing secrets above
 
-# install twine and sdist build prerequisites from pypi
-python3 -m venv /tmp/vllm-release-env
+# install uv if not already available
+if ! command -v uv &> /dev/null; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# install twine and sdist build prerequisites using uv with Python 3.12
+uv venv --python 3.12 /tmp/vllm-release-env
 source /tmp/vllm-release-env/bin/activate
-pip install twine
-pip install -r requirements/build/cuda.txt
+uv pip install twine
+uv pip install -r requirements/build/cuda.txt
 python3 -m twine --version
 
 # copy release wheels to local directory


### PR DESCRIPTION
## Summary

- Fixes the "Upload release wheels to PyPI" step failing because the build agent uses system Python 3.9, which cannot install `torch==2.11.0` (requires Python >= 3.10)
- Replaces `python3 -m venv` + bare `pip` with `uv venv --python 3.12` + `uv pip install`, ensuring a compatible Python version is always used regardless of the agent's system Python
- Installs `uv` on-the-fly if not already present on the agent

## Context

Build [#1398](https://buildkite.com/vllm/release-v2/builds/1398#019e0933-ce1f-423c-951d-2d604e582f2c) failed with:
```
ERROR: Could not find a version that satisfies the requirement torch==2.11.0
ERROR: No matching distribution found for torch==2.11.0
```

`torch 2.11.0` exists on PyPI but only ships wheels for Python >= 3.10. The agent's system Python is 3.9 (EOL Oct 2025), so pip finds no compatible distribution.

## Test plan

- [ ] Re-run the release-v2 pipeline build #1398 after merging and verify the "Upload release wheels to PyPI" step passes
- [ ] Verify `uv venv --python 3.12` correctly provisions the venv and `torch==2.11.0` installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)