### PR TITLE
enable split_group for pytorch process group creation

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
     VLLM_USE_RAY_V2_EXECUTOR_BACKEND: bool = False
-    VLLM_DISTRIBUTED_USE_SPLIT_GROUP: bool = False
+    VLLM_DISTRIBUTED_USE_SPLIT_GROUP: bool = True
     VLLM_XLA_USE_SPMD: bool = False
     VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn"] = "fork"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
@@ -883,7 +883,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # and ``init_distributed_environment`` initializes the default PG with
     # mixed ``cpu:gloo,cuda:nccl`` backend + eager ``device_id`` binding.
     "VLLM_DISTRIBUTED_USE_SPLIT_GROUP": lambda: bool(
-        int(os.getenv("VLLM_DISTRIBUTED_USE_SPLIT_GROUP", "0"))
+        int(os.getenv("VLLM_DISTRIBUTED_USE_SPLIT_GROUP", "1"))
     ),
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work


### PR DESCRIPTION

Summary:
A follow up on #41980 to enable the usage of `split_group` API by default

---

Signed-off-by: Tushar Jain <tushar00jain@users.noreply.github.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/vllm-project/vllm/pull/42471).
* #42565
* __->__ #42471