### PR TITLE
[Frontend] Add --spec-method/--spec-model/--spec-tokens CLI aliases

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1419,23 +1419,11 @@ class EngineArgs:
         vllm_group.add_argument(
             "--speculative-config", "-sc", **vllm_kwargs["speculative_config"]
         )
+        speculative_kwargs = get_kwargs(SpeculativeConfig)
+        vllm_group.add_argument("--spec-method", **speculative_kwargs["method"])
+        vllm_group.add_argument("--spec-model", **speculative_kwargs["model"])
         vllm_group.add_argument(
-            "--spec-method",
-            type=str,
-            default=None,
-            help="Top-level alias for speculative_config['method'].",
-        )
-        vllm_group.add_argument(
-            "--spec-model",
-            type=str,
-            default=None,
-            help="Top-level alias for speculative_config['model'].",
-        )
-        vllm_group.add_argument(
-            "--spec-tokens",
-            type=int,
-            default=None,
-            help="Top-level alias for speculative_config['num_speculative_tokens'].",
+            "--spec-tokens", **speculative_kwargs["num_speculative_tokens"]
         )
         vllm_group.add_argument(
             "--kv-transfer-config", **vllm_kwargs["kv_transfer_config"]
@@ -1635,29 +1623,23 @@ class EngineArgs:
         """Initializes and returns a SpeculativeConfig object based on
         `speculative_config`.
         """
-        spec_aliases = {
-            flag: (key, value)
-            for flag, key, value in (
-                ("--spec-method", "method", self.spec_method),
-                ("--spec-model", "model", self.spec_model),
-                ("--spec-tokens", "num_speculative_tokens", self.spec_tokens),
-            )
-            if value is not None
-        }
-
-        if self.speculative_config is None:
-            if not spec_aliases:
-                return None
-            self.speculative_config = {}
-
-        for flag, (key, value) in spec_aliases.items():
-            existing = self.speculative_config.get(key, value)
-            if existing != value:
+        for flag, key, value in (
+            ("--spec-method", "method", self.spec_method),
+            ("--spec-model", "model", self.spec_model),
+            ("--spec-tokens", "num_speculative_tokens", self.spec_tokens),
+        ):
+            if value is None:
+                continue
+            if self.speculative_config is None:
+                self.speculative_config = {}
+            if key in self.speculative_config:
                 raise ValueError(
-                    f"Conflicting speculative config: {flag}={value!r} and "
-                    f"--speculative-config['{key}']={existing!r}."
+                    f"{flag} and --speculative-config['{key}'] are mutually exclusive"
                 )
             self.speculative_config[key] = value
+
+        if self.speculative_config is None:
+            return None
 
         # Note(Shangming): These parameters are not obtained from the cli arg
         # '--speculative-config' and must be passed in when creating the engine

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -599,6 +599,9 @@ class EngineArgs:
     reasoning_parser_plugin: str | None = None
 
     speculative_config: dict[str, Any] | None = None
+    spec_method: str | None = None
+    spec_model: str | None = None
+    spec_tokens: int | None = None
 
     show_hidden_metrics_for_version: str | None = (
         ObservabilityConfig.show_hidden_metrics_for_version
@@ -1417,6 +1420,24 @@ class EngineArgs:
             "--speculative-config", "-sc", **vllm_kwargs["speculative_config"]
         )
         vllm_group.add_argument(
+            "--spec-method",
+            type=str,
+            default=None,
+            help="Top-level alias for speculative_config['method'].",
+        )
+        vllm_group.add_argument(
+            "--spec-model",
+            type=str,
+            default=None,
+            help="Top-level alias for speculative_config['model'].",
+        )
+        vllm_group.add_argument(
+            "--spec-tokens",
+            type=int,
+            default=None,
+            help="Top-level alias for speculative_config['num_speculative_tokens'].",
+        )
+        vllm_group.add_argument(
             "--kv-transfer-config", **vllm_kwargs["kv_transfer_config"]
         )
         vllm_group.add_argument("--kv-events-config", **vllm_kwargs["kv_events_config"])
@@ -1614,8 +1635,29 @@ class EngineArgs:
         """Initializes and returns a SpeculativeConfig object based on
         `speculative_config`.
         """
+        spec_aliases = {
+            "--spec-method": ("method", self.spec_method),
+            "--spec-model": ("model", self.spec_model),
+            "--spec-tokens": ("num_speculative_tokens", self.spec_tokens),
+        }
+        spec_aliases = {
+            flag: (key, value)
+            for flag, (key, value) in spec_aliases.items()
+            if value is not None
+        }
+
         if self.speculative_config is None:
-            return None
+            if not spec_aliases:
+                return None
+            self.speculative_config = {}
+
+        for flag, (key, value) in spec_aliases.items():
+            if key in self.speculative_config:
+                raise ValueError(
+                    f"Conflicting speculative config: {flag} and "
+                    f"--speculative-config both set '{key}'."
+                )
+            self.speculative_config[key] = value
 
         # Note(Shangming): These parameters are not obtained from the cli arg
         # '--speculative-config' and must be passed in when creating the engine

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1636,13 +1636,12 @@ class EngineArgs:
         `speculative_config`.
         """
         spec_aliases = {
-            "--spec-method": ("method", self.spec_method),
-            "--spec-model": ("model", self.spec_model),
-            "--spec-tokens": ("num_speculative_tokens", self.spec_tokens),
-        }
-        spec_aliases = {
             flag: (key, value)
-            for flag, (key, value) in spec_aliases.items()
+            for flag, key, value in (
+                ("--spec-method", "method", self.spec_method),
+                ("--spec-model", "model", self.spec_model),
+                ("--spec-tokens", "num_speculative_tokens", self.spec_tokens),
+            )
             if value is not None
         }
 
@@ -1652,10 +1651,11 @@ class EngineArgs:
             self.speculative_config = {}
 
         for flag, (key, value) in spec_aliases.items():
-            if key in self.speculative_config:
+            existing = self.speculative_config.get(key, value)
+            if existing != value:
                 raise ValueError(
-                    f"Conflicting speculative config: {flag} and "
-                    f"--speculative-config both set '{key}'."
+                    f"Conflicting speculative config: {flag}={value!r} and "
+                    f"--speculative-config['{key}']={existing!r}."
                 )
             self.speculative_config[key] = value
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -202,6 +202,10 @@ class LLM:
             dictionary or an AttentionConfig instance. If a dictionary, it will
             be converted to an AttentionConfig. Allows specifying the attention
             backend and other attention-related settings.
+        spec_method: Top-level alias for `speculative_config["method"]`.
+        spec_model: Top-level alias for `speculative_config["model"]`.
+        spec_tokens: Top-level alias for
+            `speculative_config["num_speculative_tokens"]`.
         **kwargs: Arguments for [`EngineArgs`][vllm.EngineArgs].
 
     Note:
@@ -252,6 +256,9 @@ class LLM:
         | OnlineQuantizationConfigArgs
         | None = None,
         logits_processors: list[str | type[LogitsProcessor]] | None = None,
+        spec_method: str | None = None,
+        spec_model: str | None = None,
+        spec_tokens: int | None = None,
         **kwargs: Any,
     ) -> None:
         """LLM constructor."""
@@ -373,6 +380,9 @@ class LLM:
             compilation_config=compilation_config_instance,
             quantization_config=quantization_config,
             logits_processors=logits_processors,
+            spec_method=spec_method,
+            spec_model=spec_model,
+            spec_tokens=spec_tokens,
             **kwargs,
         )
 


### PR DESCRIPTION
Top-level CLI aliases for the most-used `speculative_config` fields: `--spec-method`, `--spec-model`, `--spec-tokens`. Same mutually-exclusive pattern as `--attention-backend` vs `--attention-config`. Also exposed as named `LLM(...)` kwargs.

AI assistance (Claude) was used; I reviewed every changed line. No existing PR for this — checked.