### PR TITLE
refactor(compilation): format dumped graph code headers as comments

### DIFF
--- a/tests/compile/passes/test_format_graph_code.py
+++ b/tests/compile/passes/test_format_graph_code.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch.fx._utils import lazy_format_graph_code as original_lazy_format_graph_code
+from torch._logging._internal import LazyString
+
+from vllm.compilation.passes.vllm_inductor_pass import format_graph_code
+
+
+def _create_simple_graphmodule() -> torch.fx.GraphModule:
+    """Create a simple GraphModule for testing."""
+
+    class SimpleModel(torch.nn.Module):
+        def forward(self, x):
+            x = x + 1
+            x = x.reshape(-1, 128)
+            y = torch.sum(x, dim=-1)
+            return torch.sigmoid(y)
+
+    model = SimpleModel()
+    return torch.fx.symbolic_trace(model)
+
+
+class TestFormatGraphCodeIsLazy:
+    """Tests for lazy evaluation behavior."""
+
+    def test_returns_lazystring(self):
+        """Verify format_graph_code returns a LazyString."""
+        gm = _create_simple_graphmodule()
+        result = format_graph_code("test", gm)
+        assert isinstance(result, LazyString), (
+            f"Expected LazyString return type, got {type(result)}"
+        )
+
+    def test_same_return_type_as_original(self):
+        """Verify format_graph_code returns the same type as the original."""
+        gm = _create_simple_graphmodule()
+        original_result = original_lazy_format_graph_code("test", gm)
+        new_result = format_graph_code("test", gm)
+        assert type(original_result) == type(new_result), (
+            f"Return types differ: original={type(original_result)}, "
+            f"new={type(new_result)}"
+        )
+
+
+class TestFormatGraphCodeValidPython:
+    """Tests for valid Python code output."""
+
+    def test_formatted_output_compiles(self):
+        """Verify formatted output is valid Python code."""
+        gm = _create_simple_graphmodule()
+        formatted = str(format_graph_code("test", gm))
+
+        # Should compile without raising SyntaxError
+        compile(formatted, "<string>", "exec")
+
+    def test_original_output_invalid_python(self):
+        """Verify original output is NOT valid Python code.
+
+        This ensures our formatting actually solves the problem,
+        rather than the original output already being valid Python.
+        """
+        gm = _create_simple_graphmodule()
+        original_output = str(original_lazy_format_graph_code("test", gm))
+
+        # Original version should contain header lines (non-Python syntax)
+        assert "=====" in original_output, (
+            "Expected header lines in original output"
+        )
+
+        # Original version should fail to compile
+        with pytest.raises(SyntaxError):
+            compile(original_output, "<string>", "exec")
+
+    def test_header_lines_become_comments(self):
+        """Verify title lines like '==== title ====' become comments."""
+        gm = _create_simple_graphmodule()
+        formatted = str(format_graph_code("test", gm))
+
+        # No bare '=====' lines should remain (they should be comments)
+        for line in formatted.split("\n"):
+            stripped = line.strip()
+            if "=====" in stripped and not stripped.startswith("#"):
+                pytest.fail(
+                    f"Header line not converted to comment: {stripped}"
+                )
+
+    def test_traced_graph_becomes_comment(self):
+        """Verify 'TRACED GRAPH' header becomes a comment."""
+        gm = _create_simple_graphmodule()
+        formatted = str(format_graph_code("test", gm))
+
+        # "TRACED GRAPH" should only appear as a comment
+        for line in formatted.split("\n"):
+            if "TRACED GRAPH" in line:
+                assert line.strip().startswith("#"), (
+                    f"'TRACED GRAPH' not converted to comment: {line}"
+                )
+
+    def test_eval_with_key_becomes_comment(self):
+        """Verify '<eval_with_key>...' lines become comments."""
+        gm = _create_simple_graphmodule()
+        formatted = str(format_graph_code("test", gm))
+
+        # "<eval_with_key>" should only appear as a comment
+        for line in formatted.split("\n"):
+            if "<eval_with_key>" in line:
+                assert line.strip().startswith("#"), (
+                    f"'<eval_with_key>' not converted to comment: {line}"
+                )

--- a/vllm/compilation/passes/vllm_inductor_pass.py
+++ b/vllm/compilation/passes/vllm_inductor_pass.py
@@ -40,9 +40,6 @@ def _format_graph_code_content(result: str) -> str:
         # Source: <eval_with_key>.107 from /path/to/file.py:123
         class MyClass...
 
-    The key insight is that the <eval_with_key> line may contain Python code
-    (like a class definition) after the metadata, which must be preserved.
-
     Args:
         result: The raw output from lazy_format_graph_code.
 
@@ -50,9 +47,10 @@ def _format_graph_code_content(result: str) -> str:
         The formatted content with headers converted to comments.
     """
     title_pattern = re.compile(r'^\s*={2,}\s*(.+?)\s*={2,}\s*$')
-    # Match <eval_with_key> lines, capturing metadata and optional code after
+    # Match <eval_with_key> lines, capturing metadata and optional code after.
+    # We use a non-greedy match for metadata up to the function name.
     eval_with_key_pattern = re.compile(
-        r'^(\s*<eval_with_key>\S+\s+from\s+\S+\s+in\s+\S+)\s+(class\s+.*)'
+        r'^(\s*<eval_with_key>.*? in \S+)(?:\s+(.*))?$'
     )
 
     lines = result.split('\n')
@@ -61,25 +59,19 @@ def _format_graph_code_content(result: str) -> str:
     for line in lines:
         if line.strip() == 'TRACED GRAPH':
             formatted_lines.append('# TRACED GRAPH')
-        elif title_pattern.match(line):
-            match = title_pattern.match(line)
-            if match:
-                title = match.group(1).strip()
-                formatted_lines.append(f'# {title}')
-            else:
-                formatted_lines.append(line)
+        elif (match := title_pattern.match(line)):
+            formatted_lines.append(f'# {match.group(1).strip()}')
+        elif (eval_match := eval_with_key_pattern.match(line)):
+            metadata = eval_match.group(1).strip()
+            code = eval_match.group(2)
+            formatted_lines.append(f'# Source: {metadata}')
+            if code and code.strip():
+                formatted_lines.append(code.strip())
+        elif re.match(r'^\s*<eval_with_key>', line):
+            # Fallback: entire line is metadata if no code found
+            formatted_lines.append(f'# Source: {line.strip()}')
         else:
-            eval_match = eval_with_key_pattern.match(line)
-            if eval_match:
-                metadata = eval_match.group(1).strip()
-                code = eval_match.group(2)
-                formatted_lines.append(f'# Source: {metadata}')
-                formatted_lines.append(code)
-            elif re.match(r'^\s*<eval_with_key>', line):
-                # Fallback: entire line is metadata if no code found
-                formatted_lines.append(f'# Source: {line.strip()}')
-            else:
-                formatted_lines.append(line)
+            formatted_lines.append(line)
 
     return '\n'.join(formatted_lines)
 

--- a/vllm/compilation/passes/vllm_inductor_pass.py
+++ b/vllm/compilation/passes/vllm_inductor_pass.py
@@ -15,6 +15,7 @@ import torch._inductor.pattern_matcher as pm
 from torch import fx
 from torch._dynamo.utils import lazy_format_graph_code
 from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
+from torch._logging._internal import LazyString
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -23,6 +24,91 @@ from .fx_utils import is_func
 from .inductor_pass import InductorPass, enable_fake_mode
 
 logger = init_logger(__name__)
+
+
+def _format_graph_code_content(result: str) -> str:
+    """Convert non-Python header lines in lazy_format_graph_code output to comments.
+
+    This transforms lines like:
+        TRACED GRAPH
+        ===== post_grad.0.NoOpEliminationPass.after =====
+        <eval_with_key>.107 from /path/to/file.py:123 in forward class MyClass...
+
+    Into Python comments:
+        # TRACED GRAPH
+        # post_grad.0.NoOpEliminationPass.after
+        # Source: <eval_with_key>.107 from /path/to/file.py:123
+        class MyClass...
+
+    The key insight is that the <eval_with_key> line may contain Python code
+    (like a class definition) after the metadata, which must be preserved.
+
+    Args:
+        result: The raw output from lazy_format_graph_code.
+
+    Returns:
+        The formatted content with headers converted to comments.
+    """
+    title_pattern = re.compile(r'^\s*={2,}\s*(.+?)\s*={2,}\s*$')
+    # Match <eval_with_key> lines, capturing metadata and optional code after
+    eval_with_key_pattern = re.compile(
+        r'^(\s*<eval_with_key>\S+\s+from\s+\S+\s+in\s+\S+)\s+(class\s+.*)'
+    )
+
+    lines = result.split('\n')
+    formatted_lines = []
+
+    for line in lines:
+        if line.strip() == 'TRACED GRAPH':
+            formatted_lines.append('# TRACED GRAPH')
+        elif title_pattern.match(line):
+            match = title_pattern.match(line)
+            if match:
+                title = match.group(1).strip()
+                formatted_lines.append(f'# {title}')
+            else:
+                formatted_lines.append(line)
+        else:
+            eval_match = eval_with_key_pattern.match(line)
+            if eval_match:
+                metadata = eval_match.group(1).strip()
+                code = eval_match.group(2)
+                formatted_lines.append(f'# Source: {metadata}')
+                formatted_lines.append(code)
+            elif re.match(r'^\s*<eval_with_key>', line):
+                # Fallback: entire line is metadata if no code found
+                formatted_lines.append(f'# Source: {line.strip()}')
+            else:
+                formatted_lines.append(line)
+
+    return '\n'.join(formatted_lines)
+
+
+def format_graph_code(
+    name: str, gm: fx.GraphModule, tabsize: int = 4
+) -> LazyString:
+    """Wrapper around lazy_format_graph_code with cleaner output.
+
+    This function provides the same interface as lazy_format_graph_code,
+    but additionally converts non-Python header lines (like '===== title ====='
+    and '<eval_with_key>.xxx from /path/to/file') to Python comments for
+    better readability of dumped graph code.
+
+    The formatting is applied lazily - the actual string transformation only
+    happens when the result is converted to a string (e.g., when written to
+    file or printed), preserving the lazy evaluation behavior of PyTorch's
+    original lazy_format_graph_code.
+
+    Args:
+        name: Name to include in the graph dump.
+        gm: The GraphModule to format.
+        tabsize: Indentation size (default: 4).
+
+    Returns:
+        A LazyString that applies formatting on str() conversion.
+    """
+    result = lazy_format_graph_code(name, gm, tabsize)
+    return LazyString(lambda: _format_graph_code_content(str(result)))
 
 
 @dataclass


### PR DESCRIPTION
Introduce a wrapper around torch.lazy_format_graph_code that converts non-Python header lines (e.g., TRACED GRAPH, section dividers, and eval_with_key metadata) into Python comments. This significantly improves the readability of exported graph modules while preserving lazy string evaluation to maintain performance during compilation.


Todo
- [ ] wait other PR and replace the use of torch.lazy_format_graph_code

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

