### PR TITLE
[Bugfix] Fix Qwen3-ASR transcription streaming postprocessing

### DIFF
--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
@@ -11,7 +11,7 @@ Integration-style tests exercise ``OpenAIServingTranscription`` streaming and
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,7 +32,10 @@ from vllm.entrypoints.speech_to_text.transcription.protocol import Transcription
 from vllm.entrypoints.speech_to_text.transcription.serving import (
     OpenAIServingTranscription,
 )
-from vllm.model_executor.models.interfaces import SupportsTranscription
+from vllm.model_executor.models.interfaces import (
+    StreamingTranscriptionPostProcessor,
+    SupportsTranscription,
+)
 from vllm.model_executor.models.qwen3_asr import Qwen3ASRForConditionalGeneration
 from vllm.outputs import CompletionOutput, RequestOutput
 
@@ -60,18 +63,60 @@ def test_asr_inter_chunk_separator_matches_protocol(language, expected_sep):
 
 
 def test_qwen3_asr_stream_processor_passes_plain_text_without_prefix():
-    post_process_delta = Qwen3ASRForConditionalGeneration.get_streaming_post_processor()
+    post_processor = (
+        Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()()
+    )
 
-    assert post_process_delta("Hello", False) == "Hello"
-    assert post_process_delta(" world", True) == " world"
+    assert post_processor.process_delta("Hello", False) == "Hello"
+    assert post_processor.process_delta(" world", True) == " world"
 
 
 def test_qwen3_asr_stream_processor_buffers_prefix_with_leading_space():
-    post_process_delta = Qwen3ASRForConditionalGeneration.get_streaming_post_processor()
+    post_processor = (
+        Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()()
+    )
 
-    assert post_process_delta(" language Eng", False) == ""
-    assert post_process_delta("lish<asr", False) == ""
-    assert post_process_delta("_text>Hello", True) == "Hello"
+    assert post_processor.process_delta(" language Eng", False) == ""
+    assert post_processor.process_delta("lish<asr", False) == ""
+    assert post_processor.process_delta("_text>Hello", True) == "Hello"
+
+
+def test_qwen3_asr_stream_processor_keeps_independent_state():
+    processor_cls = Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()
+    first_processor = processor_cls()
+    second_processor = processor_cls()
+
+    assert first_processor.process_delta(" language Eng", False) == ""
+    assert second_processor.process_delta("plain text", True) == "plain text"
+    assert first_processor.process_delta("lish<asr_text>Hello", True) == "Hello"
+
+
+def test_qwen3_asr_stream_processor_emits_finished_incomplete_prefix():
+    post_processor = (
+        Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()()
+    )
+
+    assert (
+        post_processor.process_delta(" language English", True) == " language English"
+    )
+
+
+def test_qwen3_asr_stream_processor_stops_buffering_long_plain_prefix():
+    post_processor = (
+        Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()()
+    )
+    text = " language " + ("x" * 50)
+
+    assert post_processor.process_delta(text, False) == text
+
+
+def test_qwen3_asr_stream_processor_stops_buffering_prefix_with_newline():
+    post_processor = (
+        Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()()
+    )
+    text = " language English\nhello"
+
+    assert post_processor.process_delta(text, False) == text
 
 
 def test_joined_chunks_english_has_space_between():
@@ -107,8 +152,10 @@ class _StubTranscriptionModel:
         return text
 
     @classmethod
-    def get_streaming_post_processor(cls) -> Callable[[str, bool], str]:
-        return lambda text_delta, finished: text_delta
+    def get_streaming_post_processor_cls(
+        cls,
+    ) -> type[StreamingTranscriptionPostProcessor]:
+        return StreamingTranscriptionPostProcessor
 
 
 def _request_output(text: str, finish_reason: str | None = "stop") -> RequestOutput:
@@ -161,6 +208,9 @@ async def test_transcription_stream_generator_english_inserts_space_between_chun
     serving = OpenAIServingTranscription.__new__(OpenAIServingTranscription)
     serving.enable_force_include_usage = False
     serving.model_cls = _StubTranscriptionModel
+    serving.streaming_post_processor_cls = (
+        _StubTranscriptionModel.get_streaming_post_processor_cls()
+    )
     serving.task_type = "transcribe"
     request = SimpleNamespace(
         model="stub-model",
@@ -198,6 +248,9 @@ async def test_transcription_stream_generator_chinese_no_space_between_chunks():
     serving = OpenAIServingTranscription.__new__(OpenAIServingTranscription)
     serving.enable_force_include_usage = False
     serving.model_cls = _StubTranscriptionModel
+    serving.streaming_post_processor_cls = (
+        _StubTranscriptionModel.get_streaming_post_processor_cls()
+    )
     serving.task_type = "transcribe"
     request = SimpleNamespace(
         model="stub-model",
@@ -232,11 +285,15 @@ async def test_transcription_stream_generator_strips_qwen3_asr_prefix_per_chunk(
         yield _request_output("")
 
     async def gen_world() -> AsyncGenerator[RequestOutput, None]:
-        yield _request_output("language English<asr_text>world")
+        yield _request_output(" language Eng", finish_reason=None)
+        yield _request_output("lish<asr_text>world")
 
     serving = OpenAIServingTranscription.__new__(OpenAIServingTranscription)
     serving.enable_force_include_usage = False
     serving.model_cls = Qwen3ASRForConditionalGeneration
+    serving.streaming_post_processor_cls = (
+        Qwen3ASRForConditionalGeneration.get_streaming_post_processor_cls()
+    )
     serving.task_type = "transcribe"
     request = SimpleNamespace(
         model="stub-qwen3-asr",

--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
@@ -11,7 +11,7 @@ Integration-style tests exercise ``OpenAIServingTranscription`` streaming and
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -33,6 +33,7 @@ from vllm.entrypoints.speech_to_text.transcription.serving import (
     OpenAIServingTranscription,
 )
 from vllm.model_executor.models.interfaces import SupportsTranscription
+from vllm.model_executor.models.qwen3_asr import Qwen3ASRForConditionalGeneration
 from vllm.outputs import CompletionOutput, RequestOutput
 
 # --- Unit: helper + protocol -------------------------------------------------
@@ -56,6 +57,21 @@ def test_default_no_space_languages_includes_zh_and_ja():
 def test_asr_inter_chunk_separator_matches_protocol(language, expected_sep):
     sep = asr_inter_chunk_separator(language, SupportsTranscription.no_space_languages)
     assert sep == expected_sep
+
+
+def test_qwen3_asr_stream_processor_passes_plain_text_without_prefix():
+    post_process_delta = Qwen3ASRForConditionalGeneration.get_streaming_post_processor()
+
+    assert post_process_delta("Hello", False) == "Hello"
+    assert post_process_delta(" world", True) == " world"
+
+
+def test_qwen3_asr_stream_processor_buffers_prefix_with_leading_space():
+    post_process_delta = Qwen3ASRForConditionalGeneration.get_streaming_post_processor()
+
+    assert post_process_delta(" language Eng", False) == ""
+    assert post_process_delta("lish<asr", False) == ""
+    assert post_process_delta("_text>Hello", True) == "Hello"
 
 
 def test_joined_chunks_english_has_space_between():
@@ -90,8 +106,12 @@ class _StubTranscriptionModel:
     def post_process_output(cls, text: str) -> str:
         return text
 
+    @classmethod
+    def get_streaming_post_processor(cls) -> Callable[[str, bool], str]:
+        return lambda text_delta, finished: text_delta
 
-def _request_output(text: str) -> RequestOutput:
+
+def _request_output(text: str, finish_reason: str | None = "stop") -> RequestOutput:
     return RequestOutput(
         request_id="rid",
         prompt=None,
@@ -104,7 +124,7 @@ def _request_output(text: str) -> RequestOutput:
                 token_ids=(1, 2, 3),
                 cumulative_logprob=None,
                 logprobs=None,
-                finish_reason="stop",
+                finish_reason=finish_reason,
             )
         ],
         finished=True,
@@ -201,6 +221,44 @@ async def test_transcription_stream_generator_chinese_no_space_between_chunks():
         out_lines.append(line)
     combined = "".join(_sse_delta_contents("".join(out_lines)))
     assert combined == "你好世界"
+
+
+@pytest.mark.asyncio
+async def test_transcription_stream_generator_strips_qwen3_asr_prefix_per_chunk():
+    async def gen_hello() -> AsyncGenerator[RequestOutput, None]:
+        yield _request_output("language Eng", finish_reason=None)
+        yield _request_output("lish<asr", finish_reason=None)
+        yield _request_output("_text>Hello", finish_reason=None)
+        yield _request_output("")
+
+    async def gen_world() -> AsyncGenerator[RequestOutput, None]:
+        yield _request_output("language English<asr_text>world")
+
+    serving = OpenAIServingTranscription.__new__(OpenAIServingTranscription)
+    serving.enable_force_include_usage = False
+    serving.model_cls = Qwen3ASRForConditionalGeneration
+    serving.task_type = "transcribe"
+    request = SimpleNamespace(
+        model="stub-qwen3-asr",
+        stream_include_usage=False,
+        stream_continuous_usage_stats=False,
+    )
+
+    out_lines: list[str] = []
+    agen = OpenAIServingTranscription.transcription_stream_generator(
+        serving,
+        request=request,
+        result_generator=[gen_hello(), gen_world()],
+        request_id="test-qwen3-asr",
+        request_metadata=RequestResponseMetadata(request_id="test-qwen3-asr"),
+        audio_duration_s=1.0,
+        separator=" ",
+    )
+    async for line in agen:
+        out_lines.append(line)
+
+    combined = "".join(_sse_delta_contents("".join(out_lines)))
+    assert combined == "Hello world"
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -114,6 +114,9 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         self.asr_config = self.model_cls.get_speech_to_text_config(
             self.model_config, task_type
         )
+        self.streaming_post_processor_cls = (
+            self.model_cls.get_streaming_post_processor_cls()
+        )
 
         self.enable_force_include_usage = enable_force_include_usage
 
@@ -692,7 +695,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         try:
             for result_generator in list_result_generator:
                 beginning_of_chunk = True
-                post_process_delta = self.model_cls.get_streaming_post_processor()
+                post_processor = self.streaming_post_processor_cls()
                 async for res in result_generator:
                     # On first result.
                     if res.prompt_token_ids is not None:
@@ -710,7 +713,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                     assert len(res.outputs) == 1
                     output = res.outputs[0]
 
-                    output_text = post_process_delta(
+                    output_text = post_processor.process_delta(
                         output.text, output.finish_reason is not None
                     )
 

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -692,6 +692,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         try:
             for result_generator in list_result_generator:
                 beginning_of_chunk = True
+                post_process_delta = self.model_cls.get_streaming_post_processor()
                 async for res in result_generator:
                     # On first result.
                     if res.prompt_token_ids is not None:
@@ -709,19 +710,24 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                     assert len(res.outputs) == 1
                     output = res.outputs[0]
 
+                    output_text = post_process_delta(
+                        output.text, output.finish_reason is not None
+                    )
+
                     # dont add separator to the first chunk
                     if (
                         result_generator is not list_result_generator[0]
                         and beginning_of_chunk
+                        and output_text
                     ):
-                        output.text = separator + output.text
+                        output_text = separator + output_text
                         beginning_of_chunk = False
 
-                    # TODO: For models that output structured formats (e.g.,
-                    # Qwen3-ASR with "language X<asr_text>" prefix), streaming
-                    # would need buffering to strip the prefix properly since
-                    # deltas may split the tag across chunks.
-                    delta_message = DeltaMessage(content=output.text)
+                    if output.finish_reason is None and not output_text:
+                        completion_tokens += len(output.token_ids)
+                        continue
+
+                    delta_message = DeltaMessage(content=output_text)
                     completion_tokens += len(output.token_ids)
 
                     if output.finish_reason is None:

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -70,6 +70,13 @@ The output embeddings must be one of the following formats:
 """
 
 
+class StreamingTranscriptionPostProcessor:
+    """Stateful streaming post-processor for transcription deltas."""
+
+    def process_delta(self, text_delta: str, finished: bool) -> str:
+        return text_delta
+
+
 def _require_is_multimodal(is_multimodal: Tensor | None) -> Tensor:
     """
     A helper function to be used in the context of
@@ -1199,15 +1206,17 @@ class SupportsTranscription(Protocol):
         return text
 
     @classmethod
-    def get_streaming_post_processor(cls) -> Callable[[str, bool], str]:
+    def get_streaming_post_processor_cls(
+        cls,
+    ) -> type[StreamingTranscriptionPostProcessor]:
         """
-        Return a stateful post-processor for streaming output deltas.
+        Return a stateful post-processor class for streaming output deltas.
 
-        The callable receives the next decoded text delta and whether the
+        Each instance receives the next decoded text delta and whether the
         request output is final. It returns the cleaned delta that should be
         sent to the client.
         """
-        return lambda text_delta, finished: text_delta
+        return StreamingTranscriptionPostProcessor
 
     @classmethod
     def get_language_detection_prompt(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1199,6 +1199,17 @@ class SupportsTranscription(Protocol):
         return text
 
     @classmethod
+    def get_streaming_post_processor(cls) -> Callable[[str, bool], str]:
+        """
+        Return a stateful post-processor for streaming output deltas.
+
+        The callable receives the next decoded text delta and whether the
+        request output is final. It returns the cleaned delta that should be
+        sent to the client.
+        """
+        return lambda text_delta, finished: text_delta
+
+    @classmethod
     def get_language_detection_prompt(
         cls,
         audio: np.ndarray,

--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -22,7 +22,7 @@
 # limitations under the License.
 """Inference-only Qwen3-ASR model."""
 
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import regex as re
@@ -38,6 +38,7 @@ from vllm.inputs import ModalityData, MultiModalDataDict, PromptType, TokensProm
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
+    StreamingTranscriptionPostProcessor,
     SupportsLoRA,
     SupportsMRoPE,
     SupportsMultiModal,
@@ -94,6 +95,52 @@ _ASR_TEXT_TAG = "<asr_text>"
 # User-supplied `prompt` / `response_prefix` must not inject extra ChatML turns.
 _CHATML_LIKE_TOKEN = re.compile(r"<\|[^|]+\|>")
 _LANGUAGE_PREFIX = "language "
+_MAX_STREAMING_PREFIX_CHARS = 50
+
+
+def _post_process_qwen3_asr_output(text: str) -> str:
+    if not text or _ASR_TEXT_TAG not in text:
+        return text
+
+    _, text_part = text.rsplit(_ASR_TEXT_TAG, 1)
+    return text_part
+
+
+class Qwen3ASRStreamingPostProcessor(StreamingTranscriptionPostProcessor):
+    def __init__(self) -> None:
+        self.raw_text = ""
+        self.emitted_text = ""
+        self.is_structured_output: bool | None = None
+
+    def process_delta(self, text_delta: str, finished: bool) -> str:
+        self.raw_text += text_delta
+
+        if self.is_structured_output is None:
+            text_without_leading_space = self.raw_text.lstrip()
+            maybe_structured_output = (
+                text_without_leading_space == ""
+                or _LANGUAGE_PREFIX.startswith(text_without_leading_space)
+                or (
+                    text_without_leading_space.startswith(_LANGUAGE_PREFIX)
+                    and len(text_without_leading_space) < _MAX_STREAMING_PREFIX_CHARS
+                    and "\n" not in text_without_leading_space
+                )
+            )
+            if maybe_structured_output and _ASR_TEXT_TAG not in self.raw_text:
+                if not finished:
+                    return ""
+                self.is_structured_output = False
+            else:
+                self.is_structured_output = _ASR_TEXT_TAG in self.raw_text
+
+        processed_text = (
+            _post_process_qwen3_asr_output(self.raw_text)
+            if self.is_structured_output
+            else self.raw_text
+        )
+        new_text = processed_text[len(self.emitted_text) :]
+        self.emitted_text = processed_text
+        return new_text
 
 
 def _sanitize_transcription_user_text(text: str) -> str:
@@ -633,46 +680,10 @@ class Qwen3ASRForConditionalGeneration(
         The model outputs in format: "language {lang}<asr_text>{transcription}"
         This method strips the language prefix and asr_text tags.
         """
-        if not text:
-            return ""
-
-        if _ASR_TEXT_TAG not in text:
-            return text
-
-        # Split on <asr_text> tag and take the transcription part
-        _, text_part = text.rsplit(_ASR_TEXT_TAG, 1)
-        return text_part
+        return _post_process_qwen3_asr_output(text)
 
     @classmethod
-    def get_streaming_post_processor(cls) -> Callable[[str, bool], str]:
-        raw_text = ""
-        emitted_text = ""
-        is_structured_output: bool | None = None
-
-        def post_process_delta(text_delta: str, finished: bool) -> str:
-            nonlocal raw_text, emitted_text, is_structured_output
-
-            raw_text += text_delta
-
-            if is_structured_output is None:
-                text_without_leading_space = raw_text.lstrip()
-                maybe_structured_output = (
-                    text_without_leading_space == ""
-                    or _LANGUAGE_PREFIX.startswith(text_without_leading_space)
-                    or text_without_leading_space.startswith(_LANGUAGE_PREFIX)
-                )
-                if maybe_structured_output and _ASR_TEXT_TAG not in raw_text:
-                    if not finished:
-                        return ""
-                    is_structured_output = False
-                else:
-                    is_structured_output = _ASR_TEXT_TAG in raw_text
-
-            processed_text = (
-                cls.post_process_output(raw_text) if is_structured_output else raw_text
-            )
-            new_text = processed_text[len(emitted_text) :]
-            emitted_text = processed_text
-            return new_text
-
-        return post_process_delta
+    def get_streaming_post_processor_cls(
+        cls,
+    ) -> type[StreamingTranscriptionPostProcessor]:
+        return Qwen3ASRStreamingPostProcessor

--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -22,7 +22,7 @@
 # limitations under the License.
 """Inference-only Qwen3-ASR model."""
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
 
 import regex as re
@@ -93,6 +93,7 @@ logger = init_logger(__name__)
 _ASR_TEXT_TAG = "<asr_text>"
 # User-supplied `prompt` / `response_prefix` must not inject extra ChatML turns.
 _CHATML_LIKE_TOKEN = re.compile(r"<\|[^|]+\|>")
+_LANGUAGE_PREFIX = "language "
 
 
 def _sanitize_transcription_user_text(text: str) -> str:
@@ -641,3 +642,37 @@ class Qwen3ASRForConditionalGeneration(
         # Split on <asr_text> tag and take the transcription part
         _, text_part = text.rsplit(_ASR_TEXT_TAG, 1)
         return text_part
+
+    @classmethod
+    def get_streaming_post_processor(cls) -> Callable[[str, bool], str]:
+        raw_text = ""
+        emitted_text = ""
+        is_structured_output: bool | None = None
+
+        def post_process_delta(text_delta: str, finished: bool) -> str:
+            nonlocal raw_text, emitted_text, is_structured_output
+
+            raw_text += text_delta
+
+            if is_structured_output is None:
+                text_without_leading_space = raw_text.lstrip()
+                maybe_structured_output = (
+                    text_without_leading_space == ""
+                    or _LANGUAGE_PREFIX.startswith(text_without_leading_space)
+                    or text_without_leading_space.startswith(_LANGUAGE_PREFIX)
+                )
+                if maybe_structured_output and _ASR_TEXT_TAG not in raw_text:
+                    if not finished:
+                        return ""
+                    is_structured_output = False
+                else:
+                    is_structured_output = _ASR_TEXT_TAG in raw_text
+
+            processed_text = (
+                cls.post_process_output(raw_text) if is_structured_output else raw_text
+            )
+            new_text = processed_text[len(emitted_text) :]
+            emitted_text = processed_text
+            return new_text
+
+        return post_process_delta


### PR DESCRIPTION
Fix Qwen3-ASR transcription streaming leaking raw ASR prefixes.

Related to #35767.

### Why this is not a duplicate

I checked the related open PRs and issues before opening this:

- `gh issue view 35767 --repo vllm-project/vllm --comments`
  - Confirmed #35767 discusses the broader Qwen3-ASR realtime/raw-format leak problem and links adjacent work.
- `gh pr list --repo vllm-project/vllm --state open --search "35767 in:body"`
  - Found #35894 and #36018.
  - #35894 targets the realtime Qwen3-ASR streaming path.
  - #36018 adds a `response_prefix` parameter for audio transcription/translation endpoints.
- `gh pr list --repo vllm-project/vllm --state open --search "speech_to_text post_process_output streaming"`
  - No open PRs found.
- `gh pr list --repo vllm-project/vllm --state open --search "Qwen3-ASR audio transcriptions streaming asr_text prefix"`
  - Found #35894 and #36018, both adjacent but not the same scope.

This PR is scoped to the REST `/v1/audio/transcriptions` streaming path in `speech_to_text`, where `RequestOutputKind.DELTA` chunks were sent without model-specific post-processing. It does not implement realtime SDK-style streaming or add new request parameters.

### What changed

- Added a default `SupportsTranscription.get_streaming_post_processor_cls()` hook.
  - Default behavior returns a no-op `StreamingTranscriptionPostProcessor`, so existing transcription models keep their current streaming behavior.
- Added a stateful Qwen3-ASR streaming post-processor.
  - Buffers `language ...<asr_text>` when the prefix/tag is split across streaming deltas, including leading whitespace before the prefix.
  - Emits only the cleaned transcription text after `<asr_text>`.
  - Passes through normal text immediately when the output does not look like the Qwen3-ASR structured prefix.
  - Keeps mutable parsing state per generated audio chunk.
- Updated the speech-to-text streaming generator to instantiate the model-specific streaming post-processor per audio chunk before emitting SSE deltas.
- Moved inter-chunk separators to apply to the first non-empty cleaned delta, rather than raw model text.
- Added regression coverage for split Qwen3-ASR prefix/tag streaming, leading-whitespace prefix buffering, independent processor state, incomplete prefixes, and plain text passthrough.
- Rebasing preserved the upstream Qwen3-ASR prompt sanitization helper; it remains input-side only and is not applied to model output deltas.

### Tests

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/speech_to_text/transcription/test_qwen3_asr_sanitize_prompt.py \
  tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py \
  -q
```

Result:

```text
35 passed, 17 warnings
```

```bash
.venv/bin/pre-commit run --files \
  vllm/model_executor/models/interfaces.py \
  vllm/model_executor/models/qwen3_asr.py \
  vllm/entrypoints/speech_to_text/base/serving.py \
  tests/entrypoints/speech_to_text/transcription/test_qwen3_asr_sanitize_prompt.py \
  tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
```

Result:

```text
Passed
```

```bash
git diff --check
```

Result: passed.

### AI assistance

This PR was prepared with AI assistance. I reviewed the changed code and ran the tests listed above.