### PR TITLE
[Bugfix] Per-choice reasoning_parser in Mistral grammar streaming

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2131,3 +2131,156 @@ class TestCreateRemainingArgsDelta:
         assert tc.type == "function"
         assert tc.function.name is None
         assert tc.function.arguments == '{"data": "value"}'
+
+
+@pytest.mark.asyncio
+async def test_mistral_grammar_path_uses_per_choice_reasoning_parser():
+    """In the Mistral-grammar streaming branch with n>=2, each choice must
+    receive its own reasoning_parser; otherwise stateful methods called
+    inside ``extract_maybe_reasoning_and_tool_streaming`` bleed across
+    choices.
+    """
+    from vllm.tool_parsers.mistral_tool_parser import (
+        MistralStreamingResult,
+        MistralToolParser,
+    )
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    openai_serving_render = _build_serving_render(mock_engine, models.registry)
+
+    serving_chat = OpenAIServingChat(
+        mock_engine,
+        models,
+        response_role="assistant",
+        openai_serving_render=openai_serving_render,
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+    )
+
+    # Track every reasoning_parser instance that the Mistral-grammar branch
+    # forwards into ``extract_maybe_reasoning_and_tool_streaming``.
+    captured_reasoning_parser_ids: list[int] = []
+
+    def make_mock_parser(*args, **kwargs):
+        per_choice_reasoning_parser = MagicMock()
+
+        tool_parser_mock = MagicMock(spec=MistralToolParser)
+
+        def fake_extract(
+            *,
+            reasoning_parser,
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            output_token_ids,
+            reasoning_ended,
+            prompt_is_reasoning_end,
+            request,
+        ):
+            captured_reasoning_parser_ids.append(id(reasoning_parser))
+            return MistralStreamingResult(
+                delta_message=None,
+                reasoning_ended=True,
+                tools_called=False,
+                current_text=current_text,
+                current_token_ids=list(current_token_ids),
+            )
+
+        tool_parser_mock.extract_maybe_reasoning_and_tool_streaming = fake_extract
+
+        parser_mock = MagicMock()
+        parser_mock.tool_parser = tool_parser_mock
+        parser_mock.reasoning_parser = per_choice_reasoning_parser
+        return parser_mock
+
+    serving_chat.parser_cls = make_mock_parser
+
+    num_choices = 2
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "hi"}],
+        n=num_choices,
+        stream=True,
+    )
+    # Force the Mistral-grammar streaming branch without having to
+    # construct a real MistralToolParser (which requires a Mistral
+    # tokenizer with [TOOL_CALLS] in its vocab).
+    request._grammar_from_tool_parser = True
+
+    async def result_generator():
+        # One delta per choice, then a finishing chunk.
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="hi",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=i,
+                    text="x",
+                    token_ids=[10],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                )
+                for i in range(num_choices)
+            ],
+            finished=False,
+        )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="hi",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=i,
+                    text="",
+                    token_ids=[],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                )
+                for i in range(num_choices)
+            ],
+            finished=True,
+        )
+
+    tokenizer = get_tokenizer(MODEL_NAME)
+
+    async for _ in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        pass
+
+    # With the bug, every call would see the single shared external
+    # ``reasoning_parser`` -> only one unique id.  With the fix, each
+    # choice owns its parser -> at least num_choices unique ids.
+    assert len(captured_reasoning_parser_ids) >= num_choices, (
+        "Mistral-grammar streaming branch was not exercised: "
+        f"only {len(captured_reasoning_parser_ids)} call(s) recorded"
+    )
+    assert len(set(captured_reasoning_parser_ids)) >= num_choices, (
+        "All Mistral-grammar calls received the SAME reasoning_parser "
+        "instance (shared-reference bug). Expected one instance per choice."
+    )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -694,9 +694,12 @@ class OpenAIServingChat(OpenAIServing):
                         assert tool_parser is not None
                         assert isinstance(tool_parser, MistralToolParser)
                         assert reasoning_end_arr is not None
+                        assert parser is not None
                         output_token_ids = as_list(output.token_ids)
+                        # Per-choice reasoning_parser: the outer one is shared
+                        # across choices and would leak state when n >= 2.
                         result = tool_parser.extract_maybe_reasoning_and_tool_streaming(
-                            reasoning_parser=reasoning_parser,
+                            reasoning_parser=parser.reasoning_parser,
                             previous_text=previous_text,
                             current_text=current_text,
                             delta_text=delta_text,


### PR DESCRIPTION
## Purpose

Fix the last remaining shared-reference bug in
`chat_completion_stream_generator` when `n >= 2`: the **Mistral-grammar
streaming branch** still forwards a single shared `reasoning_parser`
instance to `MistralToolParser.extract_maybe_reasoning_and_tool_streaming`,
which calls stateful methods on it (`extract_reasoning_streaming`,
`is_reasoning_end_streaming`). With `n >= 2`, streaming state (e.g.
`buffer`, `state` on `Olmo3ReasoningParser`; `buffered_text`,
`current_state` on `HunyuanA13BReasoningParser`) leaks from choice 0
into choice 1+.

History / why this isn't a duplicate:

- #38158 fixed `[parser] * num_choices` aliasing for the tool parser and
  `all_previous_token_ids`.
- The DelegatingParser refactor (#39446) made each per-choice
  `parser._reasoning_parser` an independent instance for the regular
  streaming path, so most reasoning extraction is already isolated.
- But the Mistral-grammar branch (`serving.py:689-707`) still uses the
  externally-passed `reasoning_parser` that
  `_create_chat_completion` creates once and shares across choices.

This PR forwards `parser.reasoning_parser` (the per-choice instance
already constructed by the per-choice `DelegatingParser`) instead.
`_WrappedParser.__init__` and `MinimaxM2Parser.__init__` both create a
fresh `reasoning_parser_cls(tokenizer, **kwargs)` per parser instance,
so this is a drop-in replacement of equivalent type with independent
state.

Other call sites of the external `reasoning_parser`
(`is_reasoning_end(res.prompt_token_ids)` at line 603, `extract_reasoning`
in `chat_completion_full_generator` at line 1120) are stateless and
unchanged.

## Test Plan

Regression test added in
`tests/entrypoints/openai/chat_completion/test_serving_chat.py`:

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_mistral_grammar_path_uses_per_choice_reasoning_parser \
  -v
```

The test:

- Patches `serving_chat.parser_cls` with a factory that returns mock
  parsers, each carrying its own `reasoning_parser` and a
  `MagicMock(spec=MistralToolParser)` whose
  `extract_maybe_reasoning_and_tool_streaming` records the forwarded
  `reasoning_parser` instance.
- Drives `chat_completion_stream_generator` with `n=2` and
  `request._grammar_from_tool_parser=True` to exercise the
  Mistral-grammar branch without needing a real Mistral tokenizer.
- Asserts at least `num_choices` distinct
  `id(reasoning_parser)` values are observed.

The existing `test_streaming_n_gt1_independent_tool_parsers` (added in
#38158) is also re-run as a sanity check.

## Test Result

```
tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_mistral_grammar_path_uses_per_choice_reasoning_parser PASSED
tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_n_gt1_independent_tool_parsers PASSED
======================== 2 passed in 6.45s ========================
```

Verified that reverting the one-line fix in `serving.py` makes the new
test fail with:

```
AssertionError: All Mistral-grammar calls received the SAME
reasoning_parser instance (shared-reference bug). Expected one
instance per choice.
assert 1 >= 2
```

so the test is a genuine regression test.

`pre-commit run --files <changed files>` passes (ruff, ruff-format,
typos, mypy-3.10, SPDX, etc).

## Notes

- Supersedes #38526. That PR predates #38158 and the DelegatingParser
  refactor; after those, the only remaining buggy call site is the one
  this PR fixes.
- AI assistance was used (Claude). The submitting human reviewed every
  changed line and ran the test commands above locally.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
