### PR TITLE
[CI] Re-enable Nemotron Parse parity test and switch testing to nemotron-parse v1.2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -785,10 +785,15 @@ class HfRunner:
         audios: PromptAudioInput | None = None,
         videos: PromptVideoInput | None = None,
         use_cache: bool = True,
+        tokenization_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> list[TokensTextLogprobs]:
         all_inputs = self.get_inputs(
-            prompts, images=images, videos=videos, audios=audios
+            prompts,
+            images=images,
+            videos=videos,
+            audios=audios,
+            tokenization_kwargs=tokenization_kwargs,
         )
 
         all_logprobs: list[list[dict[int, float]]] = []

--- a/tests/models/multimodal/generation/test_nemotron_parse.py
+++ b/tests/models/multimodal/generation/test_nemotron_parse.py
@@ -14,7 +14,9 @@ from vllm.tokenizers import TokenizerLike
 from ....conftest import HfRunner, PromptImageInput, VllmRunner
 
 IMAGE = ImageAsset("paper-11").pil_image_ext(ext="png").convert("RGB")
-PROMPT = "</s><s><predict_bbox><predict_classes><output_markdown>"
+PROMPT = (
+    "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"
+)
 
 
 class DummyLogprobs(dict[int, Logprob]):
@@ -85,7 +87,7 @@ def run_test(
                 max_tokens,
                 num_logprobs=num_logprobs,
                 images=images,
-                use_cache=False,  # HF Nemotron Parse crashes here without this
+                tokenization_kwargs={"add_special_tokens": False},
             )
             for prompts, images in inputs
         ]
@@ -103,11 +105,7 @@ def run_test(
         )
 
 
-@pytest.mark.skip(
-    reason="Model's custom MBart decoder has head count mismatch with "
-    "transformers v5's GQA-aware cross-attention (8 vs 16 heads)"
-)
-@pytest.mark.parametrize("model", ["nvidia/NVIDIA-Nemotron-Parse-v1.1"])
+@pytest.mark.parametrize("model", ["nvidia/NVIDIA-Nemotron-Parse-v1.2"])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("num_logprobs", [5])
 def test_models(

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1379,7 +1379,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         "CohereLabs/cohere-transcribe-03-2026", trust_remote_code=True
     ),
     "NemotronParseForConditionalGeneration": _HfExamplesInfo(
-        "nvidia/NVIDIA-Nemotron-Parse-v1.1", trust_remote_code=True
+        "nvidia/NVIDIA-Nemotron-Parse-v1.2", trust_remote_code=True
     ),
     "WhisperForConditionalGeneration": _HfExamplesInfo(
         "openai/whisper-large-v3-turbo",


### PR DESCRIPTION

## Purpose
Fixes #38740 
Re-enables tests for the nemotron-parse model. Switches the model under test tests, since the Nemotron-Parse-v1.2 includes fixes that unblock vLLM: https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2/discussions/6 

The PROMPT constant is also updated to v1.2's documented four-token format (adds <predict_no_text_in_pic>) per the v1.2 model card.

Also fix two pre-existing bugs in the test that were hidden before:
1. The PROMPT explicitly carries the decoder control prefix `</s><s>`..., but HfRunner.get_inputs invokes the model's processor (NemotronParseProcessor) with the tokenizer's default add_special_tokens=True, which silently wraps the prompt into `<s></s><s>...</s>`.
2. use_cache=False was a v1.1-era HF crash workaround. It is not needed anymore.

Difference from PR #38748: that PR makes vLLM compatible with v1.1's broken-on-Transformers-v5 config (modifies
vllm/model_executor/models/nemotron_parse.py) but does not re-enable the test.

## Test Plan

    .venv/bin/python -m pytest \
        tests/models/multimodal/generation/test_nemotron_parse.py \
        -v -s --tb=short

## Test Result

    => 1 passed in 110.08s

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
