### PR TITLE
[Perf] Skip repeated sampling params validation for streaming input

### DIFF
--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -8,10 +8,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vllm.engine.protocol import StreamingInput
+from vllm.inputs import TokensPrompt
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.output_processor import RequestOutputCollector
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 @pytest.fixture
@@ -104,6 +108,106 @@ def make_output(request_id: str, finished: bool) -> RequestOutput:
         outputs=[],
         finished=finished,
     )
+
+
+def make_engine_core_request(
+    request_id: str,
+    sampling_params: SamplingParams,
+) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=[1],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def make_streaming_llm() -> AsyncLLM:
+    llm = MagicMock(spec=AsyncLLM)
+    llm.get_supported_tasks = AsyncMock(return_value=("generate",))
+    llm.input_processor = MagicMock()
+
+    def process_inputs(*_args, **kwargs):
+        return make_engine_core_request(
+            kwargs["request_id"],
+            kwargs["params"],
+        )
+
+    llm.input_processor.process_inputs.side_effect = process_inputs
+    llm.input_processor.assign_request_id.side_effect = lambda request: setattr(
+        request, "request_id", f"{request.request_id}-internal"
+    )
+    llm.model_config = MagicMock()
+    llm.model_config.is_encoder_decoder = False
+    llm._add_request = AsyncMock()
+    llm._run_output_handler = MagicMock()
+    llm.log_requests = False
+    llm._validate_streaming_input_sampling_params = (
+        AsyncLLM._validate_streaming_input_sampling_params
+    )
+    llm._add_streaming_input_request = AsyncLLM._add_streaming_input_request.__get__(
+        llm,
+        AsyncLLM,
+    )
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_streaming_input_reused_sampling_params_skip_validation():
+    sampling_params = SamplingParams(max_tokens=10)
+    llm = make_streaming_llm()
+
+    async def input_generator() -> AsyncGenerator[StreamingInput, None]:
+        yield StreamingInput(prompt=TokensPrompt(prompt_token_ids=[1]))
+        yield StreamingInput(prompt=TokensPrompt(prompt_token_ids=[2]))
+
+    queue = await llm._add_streaming_input_request(
+        "test",
+        input_generator(),
+        sampling_params,
+    )
+    task = queue._input_stream_task
+    assert task is not None
+    await task
+
+    validate_params = [
+        call.kwargs.get("validate_params", True)
+        for call in llm.input_processor.process_inputs.call_args_list
+    ]
+    assert validate_params == [True, False, False]
+
+
+@pytest.mark.asyncio
+async def test_streaming_input_per_chunk_sampling_params_validate():
+    sampling_params = SamplingParams(max_tokens=10)
+    chunk_params = SamplingParams(max_tokens=5)
+    llm = make_streaming_llm()
+
+    async def input_generator() -> AsyncGenerator[StreamingInput, None]:
+        yield StreamingInput(
+            prompt=TokensPrompt(prompt_token_ids=[1]),
+            sampling_params=chunk_params,
+        )
+
+    queue = await llm._add_streaming_input_request(
+        "test",
+        input_generator(),
+        sampling_params,
+    )
+    task = queue._input_stream_task
+    assert task is not None
+    await task
+
+    validate_params = [
+        call.kwargs.get("validate_params", True)
+        for call in llm.input_processor.process_inputs.call_args_list
+    ]
+    assert validate_params == [True, True]
 
 
 @pytest.mark.asyncio

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -460,16 +460,18 @@ class AsyncLLM(EngineClient):
             try:
                 async for input_chunk in input_stream:
                     sp = input_chunk.sampling_params
-                    if sp:
+                    if sp is not None:
                         self._validate_streaming_input_sampling_params(sp)
+                        validate_params = True
                     else:
                         sp = sampling_params
-                    # TODO(nick): Avoid re-validating reused sampling parameters
+                        validate_params = False
                     req = self.input_processor.process_inputs(
                         request_id=internal_req_id,
                         prompt=input_chunk.prompt,
                         params=sp,
                         resumable=True,
+                        validate_params=validate_params,
                         **inputs,  # type: ignore[arg-type]
                     )
                     req.external_req_id = request_id

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -244,8 +244,10 @@ class InputProcessor:
         priority: int = 0,
         data_parallel_rank: int | None = None,
         resumable: bool = False,
+        validate_params: bool = True,
     ) -> EngineCoreRequest:
-        self._validate_params(params, supported_tasks)
+        if validate_params:
+            self._validate_params(params, supported_tasks)
         self._validate_lora(lora_request)
 
         parallel_config = self.vllm_config.parallel_config


### PR DESCRIPTION
## Summary

- avoid re-running full `SamplingParams`/`PoolingParams` validation for streaming input chunks that reuse the request-level sampling params
- keep validation enabled for explicit per-chunk `sampling_params`, so changed chunk-level parameters are still checked before being sent to engine core
- add focused async streaming tests covering both reused request-level params and explicit per-chunk params

## Why this is useful

Streaming input sessions can submit many small chunks while reusing the same request-level `SamplingParams`. The request-level params are already validated when `_add_streaming_input_request()` creates the final sentinel request. Re-validating those same params for every chunk repeats work in the frontend hot path, including logprob/logit-bias/logits-processor/structured-output checks inside `SamplingParams.verify()`.

This change only skips validation for chunks that omit `StreamingInput.sampling_params` and therefore reuse the already-validated request-level params. Explicit per-chunk params continue to validate normally.

## Duplicate-work check

I checked open PRs before opening this:

- `Avoid re-validating reused sampling parameters`: no open PRs
- `streaming SamplingParams validation`: no open PRs
- `validate_params process_inputs`: no open PRs
- `streaming input sampling params`: returned #42433, #37843, #35904; these cover EC transfer params, streaming `max_tokens` session updates, and structured output/reasoning, not repeated params validation
- `streaming input validation`: returned related streaming/realtime PRs such as #34793, but those fix empty-stream/realtime error behavior rather than skipping repeated params validation

No linked issue; this addresses the existing TODO in `vllm/v1/engine/async_llm.py`.

## Tests

- `uvx ruff check vllm/v1/engine/async_llm.py vllm/v1/engine/input_processor.py tests/v1/streaming_input/test_async_llm_streaming.py`
- `uvx ruff format --check vllm/v1/engine/async_llm.py vllm/v1/engine/input_processor.py tests/v1/streaming_input/test_async_llm_streaming.py`
- `python -m pytest tests/v1/streaming_input/test_async_llm_streaming.py -q`

## AI assistance

Used OpenAI Codex to inspect the streaming input path, implement the small patch, run duplicate-work searches, and execute the targeted tests.
