### PR TITLE
[Model] MiniMax-M2.5: match HF reference router gate dtype

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -117,7 +117,12 @@ class MiniMaxM2MoE(nn.Module):
             config.hidden_size,
             config.num_local_experts,
             bias=False,
-            params_dtype=torch.float32,
+            # Match HF reference (transformers/.../modeling_minimax_m2.py:
+            # `self.gate = nn.Linear(...)`): the gate runs in the model dtype
+            # (BF16/FP16). The FP32 sigmoid + bias-add + topk math is
+            # performed inside the expert-selection kernel (e.g.
+            # aiter::grouped_topk_kernel on ROCm; _C.topk_sigmoid on CUDA)
+            # which upcasts router_logits to FP32 internally before sigmoid.
             quant_config=None,
             prefix=f"{prefix}.gate",
         )
@@ -131,8 +136,8 @@ class MiniMaxM2MoE(nn.Module):
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
-        # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states.to(torch.float32))
+        # router_logits: (num_tokens, n_experts) in model dtype.
+        router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )


### PR DESCRIPTION
## Purpose

`MiniMaxM2MoE` currently forces the router gate to FP32 and casts `hidden_states` to FP32 before the gate matmul. The upstream HuggingFace reference for MiniMax-M2.5 runs the gate in the model dtype and only performs sigmoid, bias-add, and top-k routing math in FP32.

This PR removes the vLLM-side FP32 gate override so the model matches the HF reference while preserving FP32 routing precision inside the expert-selection kernel.

This affects both NVIDIA and AMD GPUs:

- On ROCm/AITER, `aiter::grouped_topk_kernel` upcasts router logits to FP32
  internally before sigmoid, bias-add, and top-k.
- On CUDA, `_C.topk_sigmoid` performs the same FP32 routing math internally.

The `e_score_correction_bias` path is unchanged: vLLM still loads it as FP32
via `MiniMaxM2MoE.ebias_weight_loader`.

## Test Plan

Performance validation performed on MI355X / ROCm with MiniMax-M2.5, TP=4:

    vllm serve MiniMaxAI/MiniMax-M2.5 \
      --tensor_parallel_size 4 \
      --attention-backend ROCM_AITER_UNIFIED_ATTN \
      --kv-cache-dtype fp8 \
      --block_size 64 \
      --max-num-seqs 512 \
      --max-num-batched-tokens 32768 \
      --no_enable_prefix_caching \
      --performance-mode throughput \
      --async_scheduling \
      --trust_remote_code

    vllm bench serve \
      --backend vllm \
      --dataset_name random \
      --ignore_eos \
      --model MiniMaxAI/MiniMax-M2.5 \
      --random_input_len 1000 \
      --random_output_len 100 \
      --percentile_metrics ttft,tpot,itl,e2el \
      --num_prompts 64 \
      --num_warmups 32
      
  LM-Eval test
  To-do!

## Test Result


Perf-only A/B was run on MI355X / ROCm with MiniMax-M2.5, TP=4. The comparison
is against the same branch plus fix from #42409 ; only this PR's router-gate dtype change differs between arms.

| `--max-concurrency` | Median TPOT baseline | Median TPOT patched | Delta TPOT | Throughput baseline | Throughput patched | Delta throughput |
|---:|---:|---:|---:|---:|---:|---:|
| 16 | 14.74 ± 0.37 ms | 14.64 ± 0.56 ms | -0.70% | 9,506 tok/s | 9,902 tok/s | +4.16% |
| 32 | 16.71 ± 0.66 ms | 15.97 ± 0.18 ms | -4.39% | 15,659 tok/s | 16,240 tok/s | +3.71% |
| 64 | 22.16 ± 0.13 ms | 21.55 ± 0.06 ms | -2.74% | 23,533 tok/s | 24,013 tok/s | +2.04% |
| 128 | 21.90 ± 0.17 ms | 21.14 ± 0.16 ms | -3.46% | 24,083 tok/s | 25,614 tok/s | +6.36% |

TPOT and throughput both improved at every tested concurrency.

No documentation update is needed; this is an implementation fix for the
existing MiniMax-M2/MiniMax-M2.5 model path.
