### PR TITLE
[Kernel][DSv4] Add sparse-gather variant of dequantize_and_gather_k_cache

### DIFF
--- a/benchmarks/attention_benchmarks/deepseek_v4_kernel/bench_sparse_pr_style.py
+++ b/benchmarks/attention_benchmarks/deepseek_v4_kernel/bench_sparse_pr_style.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""PR-style microbenchmark for the sparse-gather dequant kernel.
+
+Mirrors the table layout of PR #42236 (the CuteDSL dense-gather port):
+
+  Table A  — Sparse Kernel: Triton vs CuteDSL on identical inputs.
+             Columns: k_len | triton_us | cutedsl_us | triton_GB/s |
+                      cutedsl_GB/s | speedup
+             Shapes are the same single-req / batched lengths PR #42236
+             used (1, 8, 32, 128, 512, 2048, 8192, 16384, 32000, 262144,
+             plus the batched [97, 1024, 8192, 16384] case).
+
+  Table B  — Sparse CuteDSL vs Dense CuteDSL across sparsity fractions
+             3% / 6% / 12% / 25% / 50% / 100%, on N_dense ∈
+             {8192, 16384, 32768}. Shows the real feature gain (a
+             sparse-25% gather beats the dense-100% baseline by ~1.2×).
+
+Bytes-moved accounting follows PR #42236: per row we count
+``HEAD_BYTES`` (584 B, the FP8+BF16+scale source) read + 1024 B (the
+BF16 output) written.
+
+Usage:
+    python benchmarks/attention_benchmarks/deepseek_v4_kernel/\\
+        bench_sparse_pr_style.py [--out results_sparse/bench_tables.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from vllm.utils.import_utils import has_cutedsl
+from vllm.v1.attention.ops.deepseek_v4_ops import quantize_and_insert_k_cache
+from vllm.v1.attention.ops.deepseek_v4_ops.cache_utils import (
+    dequantize_and_gather_k_cache_sparse_triton,
+)
+
+if has_cutedsl():
+    from vllm.v1.attention.ops.deepseek_v4_ops.dequant_gather_k_cutedsl import (
+        dequantize_and_gather_k_cache_cutedsl,
+        dequantize_and_gather_k_cache_sparse_cutedsl,
+    )
+else:
+    raise SystemExit(
+        "has_cutedsl()=False — sparse-cutedsl benchmark requires the CuteDSL "
+        "stack (cutlass, cute, quack). Install or run on a host that has them."
+    )
+
+
+HEAD_DIM = 512
+HEAD_BYTES = 584
+BYTES_PER_ROW = HEAD_BYTES + HEAD_DIM * 2  # read + write
+DEVICE = "cuda"
+
+
+def _make_cache(num_tokens: int, block_size: int, seed: int = 0):
+    """Populate a paged FP8 K-cache from ``num_tokens`` random BF16 tokens.
+
+    Returns (k_cache, slot_ids_int32) where slot_ids_int32 is a flat list of
+    all valid slot ids in the cache (one per inserted token, in insertion
+    order — i.e. a contiguous range mapped through a 1-1 page assignment).
+    """
+    torch.manual_seed(seed)
+    num_blocks = (num_tokens + block_size - 1) // block_size + 1
+    k_cache = torch.zeros(
+        num_blocks, block_size, HEAD_BYTES, dtype=torch.uint8, device=DEVICE
+    )
+    slot_ids = torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+    kv = torch.randn(num_tokens, HEAD_DIM, dtype=torch.bfloat16, device=DEVICE)
+    quantize_and_insert_k_cache(
+        kv, k_cache.view(num_blocks, -1), slot_ids, block_size=block_size
+    )
+    return k_cache, slot_ids.to(torch.int32)
+
+
+def _time(fn, warmup: int = 5, iters: int = 50) -> tuple[float, float, float]:
+    """Returns (median_us, p99_us, min_us).
+
+    Reports min instead of std because CUDA-event timing on a shared host is
+    bimodal — most samples cluster tightly around the steady-state cost, but
+    occasional OS / driver hiccups inject 100×-median outliers that swamp
+    any unweighted std-dev. ``min`` is the cleanest "no-interference" lower
+    bound; ``p99`` captures the realistic worst case.
+    """
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+    starts = [torch.Event(enable_timing=True) for _ in range(iters)]
+    ends = [torch.Event(enable_timing=True) for _ in range(iters)]
+    for s, e in zip(starts, ends, strict=True):
+        s.record()
+        fn()
+        e.record()
+    torch.accelerator.synchronize()
+    us = sorted(s.elapsed_time(e) * 1e3 for s, e in zip(starts, ends, strict=True))
+    n = len(us)
+    median = us[n // 2]
+    p99 = us[min(n - 1, int(n * 0.99))]
+    return median, p99, us[0]
+
+
+def _bw(rows: int, median_us: float) -> float:
+    return rows * BYTES_PER_ROW / (median_us * 1e-6) / 1e9
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Table A — Sparse Triton vs Sparse CuteDSL, single-impl-vs-single-impl,
+# matching PR #42236 Table 1 shapes.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def table_a(block_size: int, iters: int) -> list[str]:
+    """Run Table A: Triton vs CuteDSL sparse on PR #42236 shapes."""
+    # PR #42236 Table 1 k_len list, minus the 262144 case (would need a 154 MB
+    # cache; we cap at 32K — same as the realistic prefill chunk upper bound).
+    # The 32000 case mirrors PR #42236 verbatim.
+    cases = [
+        ("1", [1]),
+        ("8", [8]),
+        ("32", [32]),
+        ("128", [128]),
+        ("512", [512]),
+        ("2048", [2048]),
+        ("8192", [8192]),
+        ("16384", [16384]),
+        ("32000", [32000]),
+        ("262144", [262144]),
+        ("batched [97, 1024, 8192, 16384]", [97, 1024, 8192, 16384]),
+    ]
+
+    rows = []
+    rows.append(
+        "| k_len | triton_us | triton_p99_us | triton_min_us | cutedsl_us | "
+        "cutedsl_p99_us | cutedsl_min_us | triton_GB/s | cutedsl_GB/s | speedup |"
+    )
+    rows.append(
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    )
+
+    for label, lens in cases:
+        N = sum(lens)
+        k_cache, all_slot_ids = _make_cache(N, block_size)
+        # Use all slot ids as the gather list, in order. Same total work,
+        # no padding-induced wasted bandwidth.
+        slot_indices = all_slot_ids.clone()
+        out = torch.zeros(N, HEAD_DIM, dtype=torch.bfloat16, device=DEVICE)
+
+        # Default-arg binding pins the loop variables to each closure (avoids
+        # late-binding capture).
+        def call_triton(out=out, k_cache=k_cache, slot_indices=slot_indices):
+            dequantize_and_gather_k_cache_sparse_triton(
+                out, k_cache, slot_indices, block_size
+            )
+
+        def call_cutedsl(out=out, k_cache=k_cache, slot_indices=slot_indices):
+            dequantize_and_gather_k_cache_sparse_cutedsl(
+                out, k_cache, slot_indices, block_size
+            )
+
+        t_med, t_p99, t_min = _time(call_triton, iters=iters)
+        c_med, c_p99, c_min = _time(call_cutedsl, iters=iters)
+        rows.append(
+            f"| {label} | {t_med:.2f} | {t_p99:.2f} | {t_min:.2f} | "
+            f"{c_med:.2f} | {c_p99:.2f} | {c_min:.2f} | "
+            f"{_bw(N, t_med):.1f} | {_bw(N, c_med):.1f} | "
+            f"{t_med / c_med:.2f}x |"
+        )
+        # Free per-case to keep memory in check for the 262144 case.
+        del k_cache, all_slot_ids, slot_indices, out
+        torch.accelerator.empty_cache()
+
+    return rows
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Table B — Sparse CuteDSL vs Dense CuteDSL across sparsity fractions.
+# Shows the actual feature value: at typical C4A topk-union ratios (~10–25%),
+# the sparse kernel saves wall time vs the dense baseline.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _flat_seq_lens_t(num_tokens: int) -> torch.Tensor:
+    """Single-req seq_lens tensor used by the dense CuteDSL wrapper."""
+    return torch.tensor([num_tokens], dtype=torch.int32, device=DEVICE)
+
+
+def _flat_block_table(num_tokens: int, block_size: int) -> torch.Tensor:
+    """Identity block_table for the dense CuteDSL wrapper.
+
+    ``_make_cache`` lays tokens out one-per-physical-slot in order, so the
+    block_table is just ``arange(num_blocks)`` for the single request.
+    """
+    num_blocks = (num_tokens + block_size - 1) // block_size + 1
+    return torch.arange(num_blocks, dtype=torch.int32, device=DEVICE).unsqueeze(0)
+
+
+def table_b(block_size: int, iters: int) -> list[str]:
+    """Run Table B: sparse-cutedsl vs dense-cutedsl across sparsity sweeps.
+
+    Dense is re-measured fresh inside each (N_dense, fraction) cell so the
+    `dense_us` and `sparse_us` columns share identical thermal / cache /
+    memory-fragmentation state. We also bracket the timings with
+    ``empty_cache()`` to avoid carry-over from Table A.
+    """
+    n_dense_values = [8192, 16384, 32768]
+    fractions = [0.03, 0.06, 0.12, 0.25, 0.50, 1.00]
+
+    rows = []
+    rows.append(
+        "| N_dense | fraction | rows | dense_us | dense_p99_us | dense_min_us | "
+        "sparse_us | sparse_p99_us | sparse_min_us | dense_GB/s | sparse_GB/s | "
+        "speedup |"
+    )
+    rows.append(
+        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | "
+        "---: | ---: |"
+    )
+
+    for N_dense in n_dense_values:
+        torch.accelerator.empty_cache()
+        k_cache, all_slot_ids = _make_cache(N_dense, block_size)
+        seq_lens_t = _flat_seq_lens_t(N_dense)
+        block_table = _flat_block_table(N_dense, block_size)
+        out_dense = torch.zeros(
+            1, N_dense, HEAD_DIM, dtype=torch.bfloat16, device=DEVICE
+        )
+
+        # Default-arg binding pins the per-iteration tensors to the closure.
+        def call_dense(
+            out_dense=out_dense,
+            k_cache=k_cache,
+            seq_lens_t=seq_lens_t,
+            block_table=block_table,
+        ):
+            dequantize_and_gather_k_cache_cutedsl(
+                out_dense, k_cache, seq_lens_t, None, block_table, block_size, 0
+            )
+
+        for frac in fractions:
+            M = max(1, int(round(frac * N_dense)))
+            g = torch.Generator(device=DEVICE).manual_seed(int(frac * 1000))
+            perm = torch.randperm(N_dense, generator=g, device=DEVICE)
+            slot_indices = all_slot_ids[perm[:M]].contiguous()
+            out_sparse = torch.zeros(M, HEAD_DIM, dtype=torch.bfloat16, device=DEVICE)
+
+            def call_sparse(
+                out_sparse=out_sparse,
+                k_cache=k_cache,
+                slot_indices=slot_indices,
+            ):
+                dequantize_and_gather_k_cache_sparse_cutedsl(
+                    out_sparse, k_cache, slot_indices, block_size
+                )
+
+            dense_med, dense_p99, dense_min = _time(call_dense, iters=iters)
+            sparse_med, sparse_p99, sparse_min = _time(call_sparse, iters=iters)
+            dense_bw = _bw(N_dense, dense_med)
+            sparse_bw = _bw(M, sparse_med)
+            rows.append(
+                f"| {N_dense} | {int(frac * 100):d}% | {M} | "
+                f"{dense_med:.2f} | {dense_p99:.2f} | {dense_min:.2f} | "
+                f"{sparse_med:.2f} | {sparse_p99:.2f} | {sparse_min:.2f} | "
+                f"{dense_bw:.1f} | {sparse_bw:.1f} | "
+                f"{dense_med / sparse_med:.2f}x |"
+            )
+
+        del k_cache, all_slot_ids, out_dense
+        torch.accelerator.empty_cache()
+
+    return rows
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Driver
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=200)
+    parser.add_argument("--block-size", type=int, default=64)
+    parser.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Path to write the markdown report (also printed to stdout).",
+    )
+    args = parser.parse_args()
+
+    # No torch.accelerator equivalent for device name / properties as of
+    # torch 2.11 — fall back to the CUDA APIs (this script is CUDA-only).
+    gpu = torch.cuda.get_device_name(0)  # noqa: TID251
+    p = torch.cuda.get_device_properties(0)  # noqa: TID251
+    header = [
+        "# DSv4 sparse dequant kernel — PR-style benchmark",
+        "",
+        f"- GPU: **{gpu}** (sm_{p.major}{p.minor})",
+        f"- block_size: {args.block_size}, iters: {args.iters}",
+        "- Bytes/row = 584 (FP8+BF16+scale read) + 1024 (BF16 written) = 1608",
+        "- `*_us` columns are median µs; `*_p99_us` is the 99th percentile; "
+        "`*_min_us` is the fastest sample (no-interference lower bound). All "
+        "over `iters` cuda-event samples after 5 warmups. Median is the "
+        "primary signal; p99 and min bound the noise envelope.",
+        "",
+    ]
+
+    section_a = [
+        "## Table A — Sparse Triton vs Sparse CuteDSL",
+        "",
+        "Identical inputs (all slot ids of a freshly populated cache). Mirrors "
+        "PR #42236 Table 1's `k_len` shapes.",
+        "",
+    ]
+    section_a += table_a(args.block_size, args.iters)
+    section_a += [""]
+
+    section_b = [
+        "## Table B — Sparse CuteDSL vs Dense CuteDSL across sparsity",
+        "",
+        "Same K-cache; sparse path samples a random subset of slot ids at "
+        "fractions `f ∈ {3, 6, 12, 25, 50, 100}%`. The dense column is "
+        "`dequantize_and_gather_k_cache_cutedsl(seq_lens=[N_dense])`. "
+        "`speedup = dense_us / sparse_us`; values >1 mean the sparse kernel "
+        "saves wall time over the dense baseline at that sparsity.",
+        "",
+    ]
+    section_b += table_b(args.block_size, args.iters)
+    section_b += [""]
+
+    section_c = [
+        "## Table C — End-to-end TTFT",
+        "",
+        "_Pending — kernel-only PR. End-to-end TTFT numbers depend on the "
+        "C4A prefill pipeline integration (dedup of `topk_indices` per "
+        "request, sparse dequant call, mapping into the compact `kv` "
+        "buffer), which is scheduled as a follow-up PR._",
+        "",
+    ]
+
+    report = "\n".join(header + section_a + section_b + section_c)
+    print(report)
+
+    if args.out:
+        out_path = Path(args.out)
+        if not out_path.is_absolute():
+            out_path = Path(__file__).resolve().parent / out_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(report)
+        print(f"\nWrote: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/attention_benchmarks/deepseek_v4_kernel/results_sparse/pr_tables.md
+++ b/benchmarks/attention_benchmarks/deepseek_v4_kernel/results_sparse/pr_tables.md
@@ -1,0 +1,53 @@
+# DSv4 sparse dequant kernel — PR-style benchmark
+
+- GPU: **NVIDIA B200** (sm_100)
+- block_size: 64, iters: 200
+- Bytes/row = 584 (FP8+BF16+scale read) + 1024 (BF16 written) = 1608
+- `*_us` columns are median µs; `*_p99_us` is the 99th percentile; `*_min_us` is the fastest sample (no-interference lower bound). All over `iters` cuda-event samples after 5 warmups. Median is the primary signal; p99 and min bound the noise envelope.
+
+## Table A — Sparse Triton vs Sparse CuteDSL
+
+Identical inputs (all slot ids of a freshly populated cache). Mirrors PR #42236 Table 1's `k_len` shapes.
+
+| k_len | triton_us | triton_p99_us | triton_min_us | cutedsl_us | cutedsl_p99_us | cutedsl_min_us | triton_GB/s | cutedsl_GB/s | speedup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 20.22 | 37.70 | 16.64 | 11.58 | 23.46 | 8.93 | 0.1 | 0.1 | 1.75x |
+| 8 | 17.63 | 46.82 | 14.43 | 10.75 | 21.50 | 8.48 | 0.7 | 1.2 | 1.64x |
+| 32 | 23.49 | 37.34 | 15.84 | 11.17 | 16.80 | 8.70 | 2.2 | 4.6 | 2.10x |
+| 128 | 18.62 | 27.55 | 16.35 | 12.42 | 16.54 | 9.02 | 11.1 | 16.6 | 1.50x |
+| 512 | 20.00 | 35.62 | 16.80 | 12.90 | 19.90 | 10.30 | 41.2 | 63.8 | 1.55x |
+| 2048 | 20.10 | 25.92 | 17.15 | 13.92 | 26.21 | 10.78 | 163.9 | 236.6 | 1.44x |
+| 8192 | 21.12 | 29.18 | 18.85 | 12.80 | 28.10 | 11.65 | 623.7 | 1029.1 | 1.65x |
+| 16384 | 23.17 | 36.32 | 22.59 | 16.19 | 17.70 | 14.37 | 1137.1 | 1627.1 | 1.43x |
+| 32000 | 36.58 | 37.70 | 34.69 | 20.96 | 23.10 | 19.62 | 1406.8 | 2455.0 | 1.75x |
+| 262144 | 227.36 | 230.11 | 226.72 | 110.46 | 112.61 | 108.06 | 1854.0 | 3816.0 | 2.06x |
+| batched [97, 1024, 8192, 16384] | 30.69 | 31.84 | 29.34 | 18.37 | 20.64 | 17.38 | 1346.5 | 2249.6 | 1.67x |
+
+## Table B — Sparse CuteDSL vs Dense CuteDSL across sparsity
+
+Same K-cache; sparse path samples a random subset of slot ids at fractions `f ∈ {3, 6, 12, 25, 50, 100}%`. The dense column is `dequantize_and_gather_k_cache_cutedsl(seq_lens=[N_dense])`. `speedup = dense_us / sparse_us`; values >1 mean the sparse kernel saves wall time over the dense baseline at that sparsity.
+
+| N_dense | fraction | rows | dense_us | dense_p99_us | dense_min_us | sparse_us | sparse_p99_us | sparse_min_us | dense_GB/s | sparse_GB/s | speedup |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 8192 | 3% | 246 | 12.42 | 13.82 | 11.58 | 10.37 | 14.59 | 8.61 | 1060.9 | 38.2 | 1.20x |
+| 8192 | 6% | 492 | 12.70 | 15.65 | 11.33 | 10.85 | 15.01 | 8.70 | 1036.9 | 72.9 | 1.17x |
+| 8192 | 12% | 983 | 12.32 | 13.38 | 11.62 | 10.53 | 14.78 | 8.93 | 1069.2 | 150.1 | 1.17x |
+| 8192 | 25% | 2048 | 12.42 | 13.82 | 11.39 | 11.14 | 15.33 | 9.25 | 1060.9 | 295.7 | 1.11x |
+| 8192 | 50% | 4096 | 12.93 | 17.22 | 11.33 | 12.16 | 16.51 | 10.02 | 1018.9 | 541.6 | 1.06x |
+| 8192 | 100% | 8192 | 13.02 | 19.36 | 11.23 | 12.38 | 13.47 | 11.46 | 1011.4 | 1063.7 | 1.05x |
+| 16384 | 3% | 492 | 14.91 | 17.22 | 13.82 | 10.59 | 13.25 | 8.77 | 1766.7 | 74.7 | 1.41x |
+| 16384 | 6% | 983 | 15.78 | 17.09 | 13.86 | 10.53 | 12.90 | 8.80 | 1670.0 | 150.1 | 1.50x |
+| 16384 | 12% | 1966 | 14.59 | 17.02 | 13.82 | 10.85 | 14.34 | 9.12 | 1805.5 | 291.4 | 1.35x |
+| 16384 | 25% | 4096 | 14.66 | 17.15 | 13.76 | 10.72 | 15.62 | 9.60 | 1797.6 | 614.4 | 1.37x |
+| 16384 | 50% | 8192 | 15.10 | 16.96 | 13.82 | 12.32 | 13.57 | 11.46 | 1744.3 | 1069.2 | 1.23x |
+| 16384 | 100% | 16384 | 14.50 | 17.86 | 13.82 | 16.06 | 17.18 | 13.92 | 1817.4 | 1640.0 | 0.90x |
+| 32768 | 3% | 983 | 20.35 | 22.56 | 19.52 | 11.65 | 16.26 | 9.12 | 2589.0 | 135.7 | 1.75x |
+| 32768 | 6% | 1966 | 20.32 | 22.53 | 19.58 | 11.81 | 16.67 | 9.82 | 2593.1 | 267.7 | 1.72x |
+| 32768 | 12% | 3932 | 20.29 | 22.72 | 19.74 | 11.97 | 16.26 | 9.89 | 2597.1 | 528.3 | 1.70x |
+| 32768 | 25% | 8192 | 20.35 | 22.27 | 19.78 | 12.80 | 17.50 | 11.26 | 2589.0 | 1029.1 | 1.59x |
+| 32768 | 50% | 16384 | 20.29 | 22.40 | 19.74 | 16.13 | 17.41 | 14.24 | 2597.1 | 1633.5 | 1.26x |
+| 32768 | 100% | 32768 | 20.35 | 23.04 | 19.74 | 20.80 | 23.36 | 19.90 | 2589.0 | 2533.2 | 0.98x |
+
+## Table C — End-to-end TTFT
+
+_Pending — kernel-only PR. End-to-end TTFT numbers depend on the C4A prefill pipeline integration (dedup of `topk_indices` per request, sparse dequant call, mapping into the compact `kv` buffer), which is scheduled as a follow-up PR._

--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -17,9 +17,15 @@ import pytest
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.utils.import_utils import has_cutedsl
 from vllm.v1.attention.ops.deepseek_v4_ops import (
     dequantize_and_gather_k_cache,
+    dequantize_and_gather_k_cache_sparse,
     quantize_and_insert_k_cache,
+)
+from vllm.v1.attention.ops.deepseek_v4_ops.cache_utils import (
+    dequantize_and_gather_k_cache_sparse_triton,
+    dequantize_and_gather_k_cache_triton,
 )
 from vllm.v1.attention.ops.deepseek_v4_ops.fused_compress_quant_cache import (
     _fused_kv_compress_norm_rope_insert_indexer_attn,
@@ -27,6 +33,14 @@ from vllm.v1.attention.ops.deepseek_v4_ops.fused_compress_quant_cache import (
 )
 
 from .test_fused_indexer_q_rope_quant import quantize_to_mxfp4
+
+_SPARSE_IMPLS = {"triton": dequantize_and_gather_k_cache_sparse_triton}
+if has_cutedsl():
+    from vllm.v1.attention.ops.deepseek_v4_ops.dequant_gather_k_cutedsl import (
+        dequantize_and_gather_k_cache_sparse_cutedsl,
+    )
+
+    _SPARSE_IMPLS["cutedsl"] = dequantize_and_gather_k_cache_sparse_cutedsl
 
 
 def _ue8m0_reference(x: torch.Tensor, block_size: int, fp8_max: float):
@@ -667,3 +681,252 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
             assert torch.equal(actual_scale, scale[i : i + 1]), (
                 f"token {i}: scale {actual_scale.item()} != {scale[i].item()}"
             )
+
+
+# ── Test F: sparse-gather variant ─────────────────────────────────────────────
+#
+# The sparse kernel must produce, at each output row `i`, exactly the bytes
+# the legacy kernel writes at the corresponding (req, position) in its
+# contiguous output — so feeding it the contiguous-slot list rebuilt from the
+# block_table must reproduce the legacy output bit-for-bit.
+
+
+def _make_v4_dequant_inputs(
+    seq_lens: list[int],
+    block_size: int,
+    seed: int = 0,
+):
+    """Populate a paged FP8 cache from random bf16 tokens via the production
+    quant_and_insert kernel. Returns (k_cache, block_tables, compressed_kv)."""
+    HEAD_DIM = 512
+    HEAD_BYTES = 584
+    device = "cuda"
+    torch.manual_seed(seed)
+
+    num_reqs = len(seq_lens)
+    total_tokens = sum(seq_lens)
+    blocks_per_req = [(s + block_size - 1) // block_size for s in seq_lens]
+    total_blocks = sum(blocks_per_req) + 1  # +1 slack
+    k_cache = torch.zeros(
+        total_blocks, block_size, HEAD_BYTES, dtype=torch.uint8, device=device
+    )
+
+    max_blocks = max(blocks_per_req)
+    block_table = torch.zeros((num_reqs, max_blocks), dtype=torch.int32, device=device)
+    slot_mappings = []
+    block_cursor = 0
+    for i, (s, nb) in enumerate(zip(seq_lens, blocks_per_req, strict=False)):
+        ids = torch.arange(block_cursor, block_cursor + nb, dtype=torch.int32)
+        block_table[i, :nb] = ids.to(device)
+        slot_ids = torch.empty(s, dtype=torch.int64)
+        for t in range(s):
+            slot_ids[t] = int(ids[t // block_size].item()) * block_size + (
+                t % block_size
+            )
+        slot_mappings.append(slot_ids.to(device))
+        block_cursor += nb
+
+    compressed_kv = torch.randn(
+        total_tokens, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    offset = 0
+    for s, slots in zip(seq_lens, slot_mappings, strict=False):
+        quantize_and_insert_k_cache(
+            compressed_kv[offset : offset + s],
+            k_cache.view(total_blocks, -1),
+            slots,
+            block_size=block_size,
+        )
+        offset += s
+
+    return k_cache, block_table, compressed_kv
+
+
+def _build_slot_indices(
+    seq_lens: list[int],
+    block_table: torch.Tensor,
+    block_size: int,
+    gather_lens: list[int] | None = None,
+) -> torch.Tensor:
+    """Reconstruct the global slot ids the legacy kernel implicitly visits.
+
+    Returns a flat [sum(gather_lens)] int32 tensor of slot ids ordered
+    (req-major, position-within-req-major). With ``gather_lens == seq_lens``
+    this is the full contiguous slot list per request.
+    """
+    device = block_table.device
+    parts = []
+    for r, s in enumerate(seq_lens):
+        gl = gather_lens[r] if gather_lens is not None else s
+        start = s - gl
+        for t in range(start, s):
+            block_in_seq = t // block_size
+            pos_in_block = t % block_size
+            phys_block = int(block_table[r, block_in_seq].item())
+            parts.append(phys_block * block_size + pos_in_block)
+    return torch.tensor(parts, dtype=torch.int32, device=device)
+
+
+@pytest.mark.parametrize("impl_name", list(_SPARSE_IMPLS.keys()))
+@pytest.mark.parametrize(
+    "seq_lens, gather_lens",
+    [
+        ([17], None),
+        ([8, 17], None),
+        ([8, 17], [3, 11]),
+        ([64, 33, 7, 128], [64, 33, 7, 64]),
+    ],
+)
+@pytest.mark.parametrize("block_size", [16, 64])
+def test_dequant_sparse_matches_legacy_on_contiguous(
+    impl_name, seq_lens, gather_lens, block_size
+):
+    """Sparse-kernel == legacy when slot_indices = contiguous slot list."""
+    sparse_fn = _SPARSE_IMPLS[impl_name]
+    HEAD_DIM = 512
+    device = "cuda"
+    k_cache, block_table, _ = _make_v4_dequant_inputs(seq_lens, block_size, seed=42)
+
+    num_reqs = len(seq_lens)
+    lens = gather_lens if gather_lens is not None else seq_lens
+    max_tokens = max(lens)
+    seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32, device=device)
+    gather_lens_t = (
+        torch.tensor(gather_lens, dtype=torch.int32, device=device)
+        if gather_lens is not None
+        else None
+    )
+
+    out_legacy = torch.zeros(
+        num_reqs, max_tokens, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    dequantize_and_gather_k_cache_triton(
+        out_legacy, k_cache, seq_lens_t, gather_lens_t, block_table, block_size, 0
+    )
+
+    slot_indices = _build_slot_indices(seq_lens, block_table, block_size, gather_lens)
+    out_sparse_flat = torch.zeros(
+        slot_indices.shape[0], HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    sparse_fn(out_sparse_flat, k_cache, slot_indices, block_size)
+
+    offset = 0
+    for r, gl in enumerate(lens):
+        ref = out_legacy[r, :gl]
+        got = out_sparse_flat[offset : offset + gl]
+        assert torch.equal(ref, got), (
+            f"{impl_name} req {r}: sparse-vs-legacy max diff "
+            f"{(ref - got).abs().max().item()}"
+        )
+        offset += gl
+
+
+@pytest.mark.parametrize("impl_name", list(_SPARSE_IMPLS.keys()))
+def test_dequant_sparse_skips_padding_minus_one(impl_name):
+    """``-1`` slot ids must leave the corresponding output rows untouched."""
+    sparse_fn = _SPARSE_IMPLS[impl_name]
+    HEAD_DIM = 512
+    device = "cuda"
+    seq_lens = [16]
+    block_size = 16
+    k_cache, block_table, _ = _make_v4_dequant_inputs(seq_lens, block_size, seed=1)
+
+    real = _build_slot_indices(seq_lens, block_table, block_size, [8])
+    slot_indices = torch.full(
+        (real.shape[0] * 2,), -1, dtype=torch.int32, device=device
+    )
+    slot_indices[::2] = real
+
+    SENTINEL = 7.5
+    out = torch.full(
+        (slot_indices.shape[0], HEAD_DIM),
+        SENTINEL,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    sparse_fn(out, k_cache, slot_indices, block_size)
+
+    assert torch.all(out[1::2] == SENTINEL), (
+        f"{impl_name} kernel wrote into a -1 padding row — should have been skipped"
+    )
+    assert not torch.all(out[::2] == SENTINEL), (
+        f"{impl_name} kernel did not write into real rows"
+    )
+
+
+@pytest.mark.parametrize("impl_name", list(_SPARSE_IMPLS.keys()))
+def test_dequant_sparse_empty_n_zero(impl_name):
+    """N=0 is a no-op (must not launch the kernel and not crash)."""
+    sparse_fn = _SPARSE_IMPLS[impl_name]
+    HEAD_DIM = 512
+    device = "cuda"
+    k_cache, _, _ = _make_v4_dequant_inputs([4], 16, seed=0)
+    slot_indices = torch.empty(0, dtype=torch.int32, device=device)
+    out = torch.empty(0, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    # The public dispatcher short-circuits N=0; the per-impl wrappers don't
+    # all gate this themselves, so use the dispatcher for the empty-case test.
+    dequantize_and_gather_k_cache_sparse(out, k_cache, slot_indices, 16)
+    if impl_name == "triton":
+        sparse_fn(out, k_cache, slot_indices, 16)
+
+
+@pytest.mark.parametrize("impl_name", list(_SPARSE_IMPLS.keys()))
+def test_dequant_sparse_scattered_permutation(impl_name):
+    """Random permutation of valid slot ids must produce the same set of
+    output rows as the contiguous gather, just in permuted order."""
+    sparse_fn = _SPARSE_IMPLS[impl_name]
+    HEAD_DIM = 512
+    device = "cuda"
+    seq_lens = [128]
+    block_size = 16
+    k_cache, block_table, _ = _make_v4_dequant_inputs(seq_lens, block_size, seed=11)
+
+    real = _build_slot_indices(seq_lens, block_table, block_size)
+    perm = torch.randperm(real.shape[0], device=device)
+    permuted_indices = real[perm]
+
+    out_contig = torch.zeros(
+        real.shape[0], HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    out_perm = torch.zeros_like(out_contig)
+
+    sparse_fn(out_contig, k_cache, real, block_size)
+    sparse_fn(out_perm, k_cache, permuted_indices, block_size)
+
+    assert torch.equal(out_perm, out_contig[perm]), (
+        f"{impl_name} permuted sparse output does not match contiguous "
+        f"reference after unpermutation"
+    )
+
+
+@pytest.mark.skipif(not has_cutedsl(), reason="cutedsl not available")
+def test_dequant_sparse_cutedsl_matches_triton_random():
+    """CuteDSL and Triton sparse paths must produce bit-identical output."""
+    HEAD_DIM = 512
+    device = "cuda"
+    block_size = 64
+    seq_lens = [2048, 1024, 4096, 512]
+    k_cache, block_table, _ = _make_v4_dequant_inputs(seq_lens, block_size, seed=21)
+
+    all_slots = _build_slot_indices(seq_lens, block_table, block_size)
+    g = torch.Generator(device=device).manual_seed(99)
+    N = all_slots.numel() // 2
+    perm = torch.randperm(all_slots.numel(), generator=g, device=device)
+    slot_indices = all_slots[perm[:N]].contiguous()
+    slot_indices[::13] = -1  # sparse padding pattern
+
+    out_triton = torch.zeros(N, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    out_cutedsl = torch.zeros(N, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    dequantize_and_gather_k_cache_sparse_triton(
+        out_triton, k_cache, slot_indices, block_size
+    )
+    dequantize_and_gather_k_cache_sparse_cutedsl(  # type: ignore[name-defined]
+        out_cutedsl, k_cache, slot_indices, block_size
+    )
+    valid = slot_indices >= 0
+    assert torch.equal(out_triton[valid], out_cutedsl[valid]), (
+        f"CuteDSL vs Triton sparse mismatch; max diff "
+        f"{(out_triton[valid].float() - out_cutedsl[valid].float()).abs().max().item()}"
+    )
+    assert torch.all(out_triton[~valid] == 0)
+    assert torch.all(out_cutedsl[~valid] == 0)

--- a/vllm/v1/attention/ops/deepseek_v4_ops/__init__.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/__init__.py
@@ -5,6 +5,7 @@ from .cache_utils import (
     combine_topk_swa_indices,
     compute_global_topk_indices_and_lens,
     dequantize_and_gather_k_cache,
+    dequantize_and_gather_k_cache_sparse,
     quantize_and_insert_k_cache,
 )
 from .fused_indexer_q import MXFP4_BLOCK_SIZE, fused_indexer_q_rope_quant
@@ -16,6 +17,7 @@ __all__ = [
     "combine_topk_swa_indices",
     "compute_global_topk_indices_and_lens",
     "dequantize_and_gather_k_cache",
+    "dequantize_and_gather_k_cache_sparse",
     "fused_indexer_q_rope_quant",
     "fused_inv_rope_fp8_quant",
     "fused_q_kv_rmsnorm",

--- a/vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py
@@ -350,6 +350,166 @@ def dequantize_and_gather_k_cache_triton(
     )
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Sparse variant — dequant only at the explicitly listed global slot ids.
+#
+# The dense kernel dequantizes every position in a contiguous window
+# ``[seq_len - gather_len, seq_len)`` per request. For C4A prefill the kv
+# buffer that path produces is later read sparsely by ``flash_mla_sparse_fwd``
+# at the topk-selected positions — i.e. the entries outside the topk union
+# are dequantized and discarded. This kernel cuts straight to the chase: it
+# dequantizes only at the positions the caller asks for.
+#
+# Slot ids are the global slot ids produced by ``compute_global_topk_indices_
+# and_lens`` (= block_table[req][i // block_size] * block_size + i %
+# block_size); ``-1`` entries are padding and produce no work and no write
+# (caller pre-zeros the destination row, matching the existing topk-padding
+# convention in DSv4's sparse path).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _dequantize_and_gather_k_kernel_sparse(
+    out_ptr,
+    out_stride0,
+    slot_indices_ptr,  # [N] int32
+    k_cache_ptr,
+    N,
+    block_size: tl.constexpr,
+    fp8_dim: tl.constexpr,  # 448
+    bf16_dim: tl.constexpr,  # 64
+    scale_dim: tl.constexpr,  # 8
+    quant_block: tl.constexpr,  # 64
+    token_data_size: tl.constexpr,  # 576
+    block_stride: tl.constexpr,
+):
+    """1-program-per-output-row sparse FP8 dequant.
+
+    Same per-token instruction sequence as the dense Triton kernel (single
+    vectorized FP8 load + BF16 tail), but without any req / prefix-sum
+    bookkeeping — each program owns a single output row whose source is the
+    global slot id at ``slot_indices_ptr[pid]``.
+    """
+    pid = tl.program_id(0)
+    if pid >= N:
+        return
+
+    slot_id = tl.load(slot_indices_ptr + pid)
+    if slot_id < 0:
+        return  # -1 padding: leave output untouched
+
+    block_id = slot_id // block_size
+    pos_in_block = slot_id % block_size
+
+    # int64: block_id * block_stride can exceed 2^31 with many KV-cache blocks.
+    cache_block_ptr = k_cache_ptr + block_id.to(tl.int64) * block_stride
+    token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+    token_scale_ptr = (
+        cache_block_ptr + block_size * token_data_size + pos_in_block * scale_dim
+    )
+    token_fp8_ptr = token_data_ptr
+    token_bf16_ptr = token_data_ptr + fp8_dim
+    output_row_ptr = out_ptr + pid * out_stride0
+
+    block_idx = tl.arange(0, scale_dim)  # [8]
+    elem_idx = tl.arange(0, quant_block)  # [64]
+    offsets_2d = block_idx[:, None] * quant_block + elem_idx[None, :]  # [8, 64]
+    valid_mask = offsets_2d < fp8_dim
+    x_uint8 = tl.load(token_fp8_ptr + offsets_2d, mask=valid_mask, other=0)
+
+    scale_offsets = tl.arange(0, scale_dim)
+    encoded_scale = tl.load(token_scale_ptr + scale_offsets)
+    scale_per_block = tl.exp2(encoded_scale.to(tl.float32) - 127.0)
+
+    x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+    x_float = x_fp8.to(tl.float32)
+    x_dequant = x_float * scale_per_block[:, None]
+    x_bf16 = x_dequant.to(tl.bfloat16)
+    tl.store(output_row_ptr + offsets_2d, x_bf16, mask=valid_mask)
+
+    bf16_offsets = tl.arange(0, bf16_dim)
+    bf16_cache_ptr = token_bf16_ptr.to(tl.pointer_type(tl.bfloat16))
+    bf16_vals = tl.load(bf16_cache_ptr + bf16_offsets)
+    tl.store(output_row_ptr + fp8_dim + bf16_offsets, bf16_vals)
+
+
+def dequantize_and_gather_k_cache_sparse_triton(
+    # [N, head_dim] bf16 — caller flattens any (queries × topk) layout to N.
+    out: torch.Tensor,
+    # [num_blocks, block_size, head_bytes]
+    k_cache: torch.Tensor,
+    # [N] int32 — global slot ids, ``-1`` = padding (skip).
+    slot_indices: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Triton implementation of the sparse-gather dequant."""
+    N = slot_indices.shape[0]
+    if N == 0:
+        return
+
+    TOKEN_FP8_DIM = 448
+    TOKEN_BF16_DIM = 64
+    TOKEN_SCALE_DIM = 8
+    QUANT_BLOCK_SIZE = 64
+    TOKEN_DATA_SIZE = TOKEN_FP8_DIM + TOKEN_BF16_DIM * 2
+
+    _dequantize_and_gather_k_kernel_sparse[(N,)](
+        out,
+        out.stride(0),
+        slot_indices,
+        k_cache,
+        N,
+        block_size=block_size,
+        fp8_dim=TOKEN_FP8_DIM,
+        bf16_dim=TOKEN_BF16_DIM,
+        scale_dim=TOKEN_SCALE_DIM,
+        quant_block=QUANT_BLOCK_SIZE,
+        token_data_size=TOKEN_DATA_SIZE,
+        block_stride=k_cache.stride(0),
+        num_warps=1,
+    )
+
+
+def dequantize_and_gather_k_cache_sparse(
+    # [N, head_dim] bf16 — caller flattens any (queries × topk) layout to N.
+    out: torch.Tensor,
+    # [num_blocks, block_size, head_bytes]
+    k_cache: torch.Tensor,
+    # [N] int32 — global slot ids, ``-1`` = padding (skip).
+    slot_indices: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Sparse gather + dequant of FP8 K-cache entries.
+
+    For each ``i`` in ``[0, N)``:
+      * if ``slot_indices[i] >= 0``: dequant the K-cache entry at that global
+        slot id into ``out[i, :]``;
+      * if ``slot_indices[i] == -1``: leave ``out[i, :]`` untouched.
+
+    Pair with ``compute_global_topk_indices_and_lens`` to drive ``out`` from
+    DSv4's per-token topk_indices. Caller is responsible for pre-zeroing
+    ``out`` if padding rows are read downstream.
+
+    Dispatches to the CuteDSL sparse kernel when available (cp.async + bit-
+    manip dequant — bandwidth-bound on Blackwell), and falls back to the
+    Triton sparse kernel otherwise.
+    """
+    if slot_indices.numel() == 0:
+        return
+
+    if has_cutedsl():
+        from .dequant_gather_k_cutedsl import (
+            dequantize_and_gather_k_cache_sparse_cutedsl,
+        )
+
+        dequantize_and_gather_k_cache_sparse_cutedsl(
+            out, k_cache, slot_indices, block_size
+        )
+        return
+
+    dequantize_and_gather_k_cache_sparse_triton(out, k_cache, slot_indices, block_size)
+
+
 def dequantize_and_gather_k_cache(
     # [num_reqs, max_num_tokens, head_size]
     out: torch.Tensor,

--- a/vllm/v1/attention/ops/deepseek_v4_ops/dequant_gather_k_cutedsl.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/dequant_gather_k_cutedsl.py
@@ -32,6 +32,25 @@ def dequantize_and_gather_k_cache_cutedsl(
     )(out, k_cache, seq_lens, gather_lens, block_table, offset)
 
 
+def dequantize_and_gather_k_cache_sparse_cutedsl(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    slot_indices: torch.Tensor,
+    block_size: int,
+) -> None:
+    """CuteDSL sparse-gather dequant.
+
+    Same per-token compute pipeline as ``dequantize_and_gather_k_cache_cutedsl``
+    (4-stage cp.async + bit-manip FP8→BF16 + BF16 scale multiply), but the
+    iteration is driven by a flat list of global slot ids instead of
+    ``(seq_lens, gather_lens, block_table)``. Slot ids of ``-1`` are
+    skipped — the corresponding output row is left untouched.
+    """
+    DequantGatherKCacheSparseKernel.compile(block_size=block_size)(
+        out, k_cache, slot_indices
+    )
+
+
 class DequantGatherKCacheKernel:
     # Hard-coded for DSv4.
     head_dim = 512
@@ -329,6 +348,289 @@ class DequantGatherKCacheKernel:
             gather_lens,
             block_table,
             Int32(0),
+            stream,
+            options="--enable-tvm-ffi",
+        )
+
+
+class DequantGatherKCacheSparseKernel:
+    """Sparse-gather variant of ``DequantGatherKCacheKernel``.
+
+    Same per-token cp.async pipeline + FP8→BF16 bit manip + BF16 scale
+    multiply as the dense kernel. The driver loop iterates over a flat
+    ``slot_indices`` tensor instead of computing positions from
+    ``(seq_lens, gather_lens, block_table)``. ``slot_indices[i] == -1``
+    is a padding sentinel: no load, no store for that row.
+    """
+
+    # Hard-coded for DSv4.
+    head_dim = 512
+    group_size = 64
+
+    def __init__(self, fp8_dim: int = 448, block_size: int = 64):
+        self.fp8_dim = fp8_dim
+        self.bf16_dim = self.head_dim - fp8_dim
+        self.data_dim = fp8_dim + self.bf16_dim * 2
+        self.block_size = block_size
+
+        self.num_warps = 4
+        self.tb_size = self.num_warps * 32
+        self.num_stages = 4
+        # Match the dense kernel's per-req worker count. 1024 worker CTAs
+        # × 4 warps = 4096 warps total; each warp owns ⌈N / 4096⌉ rows.
+        self.num_workers = 1024
+
+    @cute.jit
+    def __call__(
+        self,
+        out: cute.Tensor,
+        k_cache: cute.Tensor,
+        slot_indices: cute.Tensor,
+        stream: CUstream,
+    ):
+        # Split k_cache layout identical to the dense kernel.
+        k_data = cute.make_tensor(
+            k_cache.iterator,
+            layout=cute.make_layout(
+                (k_cache.shape[0], self.block_size, self.data_dim),
+                stride=(k_cache.stride[0], self.data_dim, 1),
+            ),
+        )
+        k_scale = cute.make_tensor(
+            k_cache.iterator + (self.block_size * self.data_dim),
+            layout=cute.make_layout(
+                (k_cache.shape[0], self.block_size, 8),
+                stride=(k_cache.stride[0], 8, 1),
+            ),
+        )
+
+        grid = (self.num_workers, 1, 1)
+        self.kernel(
+            out,
+            k_data,
+            k_scale,
+            slot_indices,
+        ).launch(grid=grid, block=(self.tb_size, 1, 1), stream=stream)
+
+    @cute.jit
+    def load_g2s(
+        self,
+        k_data_slice: cute.Tensor,
+        k_scale: cute.Tensor,
+        s_kdata_slice: cute.Tensor,
+        s_kscale: cute.Tensor,
+        page_id,
+        block_offset,
+        lane_id,
+        stage_id,
+    ):
+        """Identical to ``DequantGatherKCacheKernel.load_g2s`` but takes
+        ``(page_id, block_offset)`` directly instead of looking them up via
+        ``(req_id, pos, block_table)``."""
+        op = cpasync.CopyG2SOp(cute.nvgpu.LoadCacheMode.GLOBAL)
+        cp16_atom = cute.make_copy_atom(op, Uint32, num_bits_per_copy=128)
+        cp8_atom = cute.make_copy_atom(cpasync.CopyG2SOp(), Uint8, num_bits_per_copy=64)
+
+        # Load the first 512 bytes (32x16B).
+        idx = lane_id
+        src = k_data_slice[page_id, block_offset, (None, idx)]
+        cute.copy(
+            cp16_atom,
+            cute.recast_tensor(src, Uint32),
+            s_kdata_slice[(None, idx), stage_id],
+        )
+
+        # Load the tail 64 bytes (4×16B FP8 + 1×8B scale; data_dim // 16 == 36).
+        idx += 32
+        if idx < cutlass.const_expr(self.data_dim // 16):
+            src = k_data_slice[page_id, block_offset, (None, idx)]
+            cute.copy(
+                cp16_atom,
+                cute.recast_tensor(src, Uint32),
+                s_kdata_slice[(None, idx), stage_id],
+            )
+        elif idx == cutlass.const_expr(self.data_dim // 16):
+            cute.copy(
+                cp8_atom,
+                k_scale[page_id, block_offset, None],
+                s_kscale[None, stage_id],
+            )
+
+    @cute.kernel
+    def kernel(
+        self,
+        out: cute.Tensor,  # [N, head_dim] bf16
+        k_data: cute.Tensor,
+        k_scale: cute.Tensor,
+        slot_indices: cute.Tensor,  # [N] int32
+    ):
+        worker_id, _, _ = cute.arch.block_idx()
+        tid, _, _ = cute.arch.thread_idx()
+        warp_id = cute.arch.make_warp_uniform(tid // 32)
+        lane_id = tid % 32
+
+        num_workers, _, _ = cute.arch.grid_dim()
+
+        # Smem layout per-warp — identical to the dense kernel.
+        smem = cutlass.utils.SmemAllocator()
+        s_kdata = smem.allocate_tensor(
+            Uint32,
+            cute.make_layout((self.data_dim // 4, self.num_warps, self.num_stages)),
+            byte_alignment=16,
+        )[None, warp_id, None]
+        s_kscale = smem.allocate_tensor(
+            Uint8,
+            cute.make_layout((8, self.num_warps, self.num_stages)),
+            byte_alignment=8,
+        )[None, warp_id, None]
+
+        k_data_slice = cute.logical_divide(k_data, (None, None, 16))
+        s_kdata_16B_slice = cute.logical_divide(s_kdata, (4, None))
+        s_kdata_8B_slice = cute.logical_divide(s_kdata, (2, None))
+        # ``out`` is [N, head_dim]; divide head_dim by 8 to expose 16B vector
+        # store granularity per lane. Result: [N, (8, head_dim/8)].
+        out_slice = cute.logical_divide(out, (None, 8))
+
+        cp_op = cute.nvgpu.CopyUniversalOp()
+        cp8_atom = cute.make_copy_atom(cp_op, Uint32, num_bits_per_copy=64)
+        cp16_atom = cute.make_copy_atom(cp_op, Uint32, num_bits_per_copy=128)
+
+        N = slot_indices.shape[0]
+
+        # Each warp owns rows ``base + k * stride`` for k = 0, 1, ...
+        # base = worker_id * num_warps + warp_id; stride = num_workers * num_warps.
+        warp_base = worker_id * self.num_warps + warp_id
+        warp_stride = num_workers * self.num_warps
+
+        # ── Prefetch num_stages-1 stages. ────────────────────────────────────
+        for s in cutlass.range_constexpr(self.num_stages - 1):
+            row = warp_base + s * warp_stride
+            if row < N:
+                slot = slot_indices[row]
+                if slot >= 0:
+                    page_id = slot // self.block_size
+                    block_off = slot % self.block_size
+                    self.load_g2s(
+                        k_data_slice,
+                        k_scale,
+                        s_kdata_16B_slice,
+                        s_kscale,
+                        page_id,
+                        block_off,
+                        lane_id,
+                        s,
+                    )
+            cute.arch.cp_async_commit_group()
+        prefetch_stage = self.num_stages - 1
+        compute_stage = 0
+
+        # ── Main loop. ──────────────────────────────────────────────────────
+        for i in range(warp_base, N, warp_stride):
+            # Re-load slot for this row to determine validity at compute time
+            # (cheap warp-uniform int load; avoids tracking a separate validity
+            # vector across pipeline stages).
+            slot = slot_indices[i]
+            is_valid = slot >= 0
+
+            # Issue prefetch for the row ``num_stages-1`` iterations ahead.
+            next_row = i + warp_stride * (self.num_stages - 1)
+            if next_row < N:
+                next_slot = slot_indices[next_row]
+                if next_slot >= 0:
+                    next_page = next_slot // self.block_size
+                    next_off = next_slot % self.block_size
+                    self.load_g2s(
+                        k_data_slice,
+                        k_scale,
+                        s_kdata_16B_slice,
+                        s_kscale,
+                        next_page,
+                        next_off,
+                        lane_id,
+                        prefetch_stage,
+                    )
+                prefetch_stage = (prefetch_stage + 1) % self.num_stages
+            cute.arch.cp_async_commit_group()
+
+            cute.arch.cp_async_wait_group(self.num_stages - 1)
+            cute.arch.sync_warp()
+
+            if is_valid:
+                # Per-thread tile loads (same layout as dense kernel).
+                data0 = cute.make_rmem_tensor((2,), Uint32)
+                data1 = cute.make_rmem_tensor((2,), Uint32)
+                cute.copy(
+                    cp8_atom,
+                    s_kdata_8B_slice[(None, lane_id), compute_stage],
+                    data0,
+                )
+                cute.copy(
+                    cp8_atom,
+                    s_kdata_8B_slice[(None, lane_id + 32), compute_stage],
+                    data1,
+                )
+
+                # UE8M0 scale → bf16x2 by bit-manip (exact power-of-2).
+                scale0_u32 = Uint32(
+                    s_kscale[lane_id * 8 // self.group_size, compute_stage]
+                )
+                scale0_bf16x2 = (scale0_u32 << Uint32(23)) | (scale0_u32 << Uint32(7))
+                scale1_u32 = Uint32(
+                    s_kscale[(lane_id + 32) * 8 // self.group_size, compute_stage]
+                )
+                scale1_bf16x2 = (scale1_u32 << Uint32(23)) | (scale1_u32 << Uint32(7))
+
+                dequant0 = cute.make_rmem_tensor(4, Uint32)
+                dequant1 = cute.make_rmem_tensor(4, Uint32)
+                for j in cutlass.range_constexpr(2):
+                    tmp0 = _fp8x4_to_bf16x4(data0[j])
+                    tmp1 = _fp8x4_to_bf16x4(data1[j])
+                    dequant0[j * 2] = _bf16x2_mul(tmp0[0], scale0_bf16x2)
+                    dequant1[j * 2] = _bf16x2_mul(tmp1[0], scale1_bf16x2)
+                    dequant0[j * 2 + 1] = _bf16x2_mul(tmp0[1], scale0_bf16x2)
+                    dequant1[j * 2 + 1] = _bf16x2_mul(tmp1[1], scale1_bf16x2)
+
+                # Last 64 elems are BF16 tail; overwrite dequant1 of the last
+                # 8 threads with the BF16 source.
+                if lane_id + 32 >= self.fp8_dim // 8:
+                    idx = self.fp8_dim // 16 + (lane_id + 32) - self.fp8_dim // 8
+                    cute.copy(
+                        cp16_atom,
+                        s_kdata_16B_slice[(None, idx), compute_stage],
+                        dequant1,
+                    )
+
+                dst = out_slice[i, (None, lane_id)]
+                cute.copy(cp16_atom, dequant0, cute.recast_tensor(dst, Uint32))
+
+                dst = out_slice[i, (None, lane_id + 32)]
+                cute.copy(cp16_atom, dequant1, cute.recast_tensor(dst, Uint32))
+
+            compute_stage = (compute_stage + 1) % self.num_stages
+
+    @cache
+    @staticmethod
+    def compile(fp8_dim: int = 448, block_size: int = 64):
+        N = cute.sym_int()
+        head_dim = DequantGatherKCacheSparseKernel.head_dim
+        head_bytes = fp8_dim + (head_dim - fp8_dim) * 2 + 8
+
+        out = make_fake_tensor(BFloat16, (N, head_dim), 16)
+        k_cache = cute.runtime.make_fake_tensor(
+            Uint8,
+            (cute.sym_int(), block_size, head_bytes),
+            stride=(cute.sym_int64(divisibility=32), head_bytes, 1),
+            assumed_align=32,
+        )
+        slot_indices = make_fake_tensor(Int32, (N,))
+
+        kernel = DequantGatherKCacheSparseKernel(fp8_dim, block_size)
+        stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+        return cute.compile(
+            kernel,
+            out,
+            k_cache,
+            slot_indices,
             stream,
             options="--enable-tvm-ffi",
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add a sparse-gather variant of `dequantize_and_gather_k_cache` for DSv4's
C4A topk-driven prefill path. The dense kernel (introduced for `[email protected]`
in #42236) materializes the full compressed prefix per request into a
BF16 `kv` buffer, but `flash_mla_sparse_fwd` then reads only the topk-
selected positions out of it — entries outside the topk union are
dequantized and discarded.

This PR ships a kernel that dequantizes exactly the global slot ids the
caller asks for, exposed via the new public API:

```python
from vllm.v1.attention.ops.deepseek_v4_ops import (
    dequantize_and_gather_k_cache_sparse,
)
dequantize_and_gather_k_cache_sparse(
    out,            # [N, head_dim] bf16; caller flattens any (queries × topk) layout
    k_cache,        # [num_blocks, block_size, head_bytes] uint8
    slot_indices,   # [N] int32 — global slot ids; -1 = padding (skip)
    block_size,
)
```

`slot_indices` is exactly what `compute_global_topk_indices_and_lens`
already produces. `-1` rows are skipped (no load, no store), matching
the existing topk-padding convention. Behind a `has_cutedsl()`
dispatcher (same shape as the dense `dequantize_and_gather_k_cache`):

- **Triton fallback** (`_sparse_triton`): 1-program-per-output-row,
  single 512-element FP8 tile load + BF16 tail, `num_warps=1` for
  vectorised loads.
- **CuteDSL fast path** (`_sparse_cutedsl`): reuses
  `DequantGatherKCacheKernel`'s 4-stage cp.async G2S pipeline + bit-manip
  FP8→BF16 + BF16 UE8M0 scale multiply. Driver loops over `slot_indices`
  instead of `(seq_lens, gather_lens, block_table)`.

This PR ships the kernel only. Wiring it into the C4A prefill loop in
`DeepseekV4MLAAttention._forward_prefill` requires per-request
`topk_indices` deduplication, a compact `kv` buffer layout, and a remap
step in `combine_topk_swa_indices` — that integration plus end-to-end
TTFT data is scheduled as a follow-up PR.

**Not duplicating existing work.** No open PR targets this kernel.
Closest neighbours: #42248 (ROCm MLA decode fallback — different code
path) and #40909 (ROCm AITER buffer sharing — different optimisation).
#42236 added the dense CuteDSL kernel that this PR's sparse path
complements; this PR does not modify the dense path.

## Test Plan

```bash
.venv/bin/python -m pytest tests/kernels/test_compressor_kv_cache.py -v
```

Hardware: **NVIDIA B200** (sm_100), CUDA 13.0.

23 new sparse tests, parameterised across both Triton and CuteDSL impls:

- `test_dequant_sparse_matches_legacy_on_contiguous` — bit-identical to
  the legacy Triton dense kernel when `slot_indices` reconstructs the
  contiguous gather list. 16 cases (impl × seq_lens × block_size).
- `test_dequant_sparse_skips_padding_minus_one` — `-1` padding rows must
  remain at the caller-prefilled sentinel.
- `test_dequant_sparse_empty_n_zero` — `N=0` is a no-op.
- `test_dequant_sparse_scattered_permutation` — permutation of valid
  slot ids must produce the same set of output rows.
- `test_dequant_sparse_cutedsl_matches_triton_random` — CuteDSL and
  Triton must produce bit-identical output on a random scattered batch
  with interleaved `-1` padding.

Microbenchmark (PR-style):

```bash
.venv/bin/python benchmarks/attention_benchmarks/deepseek_v4_kernel/bench_sparse_pr_style.py \
    --iters 200 --out results_sparse/pr_tables.md
```

## Test Result

```
============================ 55 passed in 10.78s =============================
```

(23 new sparse tests + 32 pre-existing tests in the file; full sweep on
NVIDIA B200 sm_100 / CUDA 13.0.)

### Benchmark — Table A: Sparse Triton vs Sparse CuteDSL

Mirrors PR #42236 Table 1's `k_len` shapes. Identical inputs (all slot
ids of a freshly populated cache, in order). `block_size=64`, `iters=200`,
median µs; `*_p99_us` and `*_min_us` bound the noise envelope.

| k_len | triton_us | triton_p99_us | triton_min_us | cutedsl_us | cutedsl_p99_us | cutedsl_min_us | triton_GB/s | cutedsl_GB/s | speedup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 20.22 | 37.70 | 16.64 | 11.58 | 23.46 | 8.93 | 0.1 | 0.1 | 1.75x |
| 8 | 17.63 | 46.82 | 14.43 | 10.75 | 21.50 | 8.48 | 0.7 | 1.2 | 1.64x |
| 32 | 23.49 | 37.34 | 15.84 | 11.17 | 16.80 | 8.70 | 2.2 | 4.6 | 2.10x |
| 128 | 18.62 | 27.55 | 16.35 | 12.42 | 16.54 | 9.02 | 11.1 | 16.6 | 1.50x |
| 512 | 20.00 | 35.62 | 16.80 | 12.90 | 19.90 | 10.30 | 41.2 | 63.8 | 1.55x |
| 2048 | 20.10 | 25.92 | 17.15 | 13.92 | 26.21 | 10.78 | 163.9 | 236.6 | 1.44x |
| 8192 | 21.12 | 29.18 | 18.85 | 12.80 | 28.10 | 11.65 | 623.7 | 1029.1 | 1.65x |
| 16384 | 23.17 | 36.32 | 22.59 | 16.19 | 17.70 | 14.37 | 1137.1 | 1627.1 | 1.43x |
| 32000 | 36.58 | 37.70 | 34.69 | 20.96 | 23.10 | 19.62 | 1406.8 | 2455.0 | 1.75x |
| 262144 | 227.36 | 230.11 | 226.72 | 110.46 | 112.61 | 108.06 | 1854.0 | 3816.0 | 2.06x |
| batched [97, 1024, 8192, 16384] | 30.69 | 31.84 | 29.34 | 18.37 | 20.64 | 17.38 | 1346.5 | 2249.6 | 1.67x |

### Benchmark — Table B: Sparse CuteDSL vs Dense CuteDSL across sparsity

Same K-cache, sparse path samples a random subset of slot ids at the
listed fractions. `speedup = dense_us / sparse_us` — values >1 mean the
sparse kernel saves wall time vs the dense baseline at that sparsity.

| N_dense | fraction | rows | dense_us | dense_p99_us | dense_min_us | sparse_us | sparse_p99_us | sparse_min_us | dense_GB/s | sparse_GB/s | speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8192 | 3% | 246 | 12.42 | 13.82 | 11.58 | 10.37 | 14.59 | 8.61 | 1060.9 | 38.2 | 1.20x |
| 8192 | 6% | 492 | 12.70 | 15.65 | 11.33 | 10.85 | 15.01 | 8.70 | 1036.9 | 72.9 | 1.17x |
| 8192 | 12% | 983 | 12.32 | 13.38 | 11.62 | 10.53 | 14.78 | 8.93 | 1069.2 | 150.1 | 1.17x |
| 8192 | 25% | 2048 | 12.42 | 13.82 | 11.39 | 11.14 | 15.33 | 9.25 | 1060.9 | 295.7 | 1.11x |
| 8192 | 50% | 4096 | 12.93 | 17.22 | 11.33 | 12.16 | 16.51 | 10.02 | 1018.9 | 541.6 | 1.06x |
| 8192 | 100% | 8192 | 13.02 | 19.36 | 11.23 | 12.38 | 13.47 | 11.46 | 1011.4 | 1063.7 | 1.05x |
| 16384 | 3% | 492 | 14.91 | 17.22 | 13.82 | 10.59 | 13.25 | 8.77 | 1766.7 | 74.7 | 1.41x |
| 16384 | 6% | 983 | 15.78 | 17.09 | 13.86 | 10.53 | 12.90 | 8.80 | 1670.0 | 150.1 | 1.50x |
| 16384 | 12% | 1966 | 14.59 | 17.02 | 13.82 | 10.85 | 14.34 | 9.12 | 1805.5 | 291.4 | 1.35x |
| 16384 | 25% | 4096 | 14.66 | 17.15 | 13.76 | 10.72 | 15.62 | 9.60 | 1797.6 | 614.4 | 1.37x |
| 16384 | 50% | 8192 | 15.10 | 16.96 | 13.82 | 12.32 | 13.57 | 11.46 | 1744.3 | 1069.2 | 1.23x |
| 16384 | 100% | 16384 | 14.50 | 17.86 | 13.82 | 16.06 | 17.18 | 13.92 | 1817.4 | 1640.0 | 0.90x |
| 32768 | 3% | 983 | 20.35 | 22.56 | 19.52 | 11.65 | 16.26 | 9.12 | 2589.0 | 135.7 | 1.75x |
| 32768 | 6% | 1966 | 20.32 | 22.53 | 19.58 | 11.81 | 16.67 | 9.82 | 2593.1 | 267.7 | 1.72x |
| 32768 | 12% | 3932 | 20.29 | 22.72 | 19.74 | 11.97 | 16.26 | 9.89 | 2597.1 | 528.3 | 1.70x |
| 32768 | 25% | 8192 | 20.35 | 22.27 | 19.78 | 12.80 | 17.50 | 11.26 | 2589.0 | 1029.1 | 1.59x |
| 32768 | 50% | 16384 | 20.29 | 22.40 | 19.74 | 16.13 | 17.41 | 14.24 | 2597.1 | 1633.5 | 1.26x |
| 32768 | 100% | 32768 | 20.35 | 23.04 | 19.74 | 20.80 | 23.36 | 19.90 | 2589.0 | 2533.2 | 0.98x |

At the realistic C4A topk-union fractions (≤25%) on a full prefill chunk
(N_dense=32768), sparse CuteDSL beats dense CuteDSL by **1.59–1.75×**.

### End-to-end TTFT

_Not measured in this PR._ End-to-end TTFT depends on the C4A prefill
pipeline integration (per-request `topk_indices` deduplication, compact
`kv` buffer layout, remap in `combine_topk_swa_indices`), which is
scheduled as a follow-up PR. Bringing that data here would require
landing the integration first.

---

_AI assistance: this PR was prepared with help from Claude. The submitting
human reviewed every changed line and ran the listed test command on a
B200 (sm_100) host with CUDA 13.0._

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


