### PR TITLE
[kv_offload] Add req_id to ReqContext for per-request tracking

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -627,7 +627,7 @@ def _make_scheduler_with_lookup(
     return scheduler
 
 
-_EMPTY_REQ_CTX = ReqContext()
+_EMPTY_REQ_CTX = ReqContext(req_id="")
 
 
 class TestMaximalPrefixLookup:

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -19,9 +19,11 @@ from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.policies.arc import ARCCachePolicy
 
 
-def make_req_context(kv_transfer_params: dict | None = None) -> ReqContext:
+def make_req_context(
+    req_id: str = "", kv_transfer_params: dict | None = None
+) -> ReqContext:
     """Create a ReqContext as production code would, from a request's params."""
-    return ReqContext(kv_transfer_params=kv_transfer_params)
+    return ReqContext(req_id=req_id, kv_transfer_params=kv_transfer_params)
 
 
 _EMPTY_REQ_CTX = make_req_context()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -138,7 +138,10 @@ class RequestOffloadState:
         self.group_states = tuple(
             RequestGroupState() for _ in self.config.kv_group_configs
         )
-        self.req_context = ReqContext(kv_transfer_params=self.req.kv_transfer_params)
+        self.req_context = ReqContext(
+            req_id=self.req.request_id,
+            kv_transfer_params=self.req.kv_transfer_params,
+        )
 
     def update_offload_keys(self) -> None:
         for group_config, group_state in zip(

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -46,6 +46,7 @@ def get_offload_group_idx(key: OffloadKey) -> int:
 
 @dataclass
 class ReqContext:
+    req_id: str
     kv_transfer_params: dict[str, Any] | None = None
 
 


### PR DESCRIPTION


## Purpose
Adds a `req_id: str` field to `ReqContext`, making per-request identity available to all `OffloadingManager` API calls without changing interface signatures.

Relates to the tactical task in #33689:
```
 Add request ID to RequestContext (to allow handling of infinite loop (per-requst) of get_num_new_matched_tokens returning None)
```

## Test Plan
```
pytest \
	tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py \
	tests/v1/kv_offload/cpu/test_manager.py
```

## Test Result
```
53 passed
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

