### PR TITLE
[Fix]  Weight loading for qwen3_5 using runai_streamer

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -262,8 +262,8 @@ class Qwen3_5Model(Qwen3NextModel):
                 param,
                 curr_expert_weight,
                 name,
-                shard_id,
-                expert_id,
+                shard_id=shard_id,
+                expert_id=expert_id,
                 return_success=True,
             )
             if success:


### PR DESCRIPTION

## Purpose
Fixes an `AssertionError: Expecting expert_id argument` crash during model loading when serving unquantized Qwen3.5 MoE models (e.g., `Qwen/Qwen3.5-397B-A17B` or `Qwen/Qwen3.5-122B-A10B`) on multi-host TPU setups with `--load-format=runai_streamer`.

### Root Cause Analysis (RCA)
The issue is caused by an argument-passing mismatch between the upstream vLLM model definition for Qwen3.5 and custom weight loader hooks. In `vllm/model_executor/models/qwen3_5.py`, `load_fused_expert_weights` invoked `weight_loader` by passing `shard_id` and `expert_id` purely as positional arguments:

```python
            success = weight_loader(
                param,
                curr_expert_weight,
                name,
                shard_id,
                expert_id,
                return_success=True,
            )
```

However, downstream hooks (such as `maybe_process_weights` in TPU inference weight loaders) explicitly extract these values from keyword arguments (`kwargs`):

```python
        expert_id = kwargs.get('expert_id')
        shard_id = kwargs.get('shard_id')
        assert expert_id is not None, "Expecting expert_id argument"
```

Because the arguments were passed positionally, `kwargs.get('expert_id')` evaluated to `None`, triggering an engine crash during initialization. This PR explicitly passes `shard_id=shard_id` and `expert_id=expert_id` as keyword arguments to ensure compatibility across weight loader hook implementations safely.

## Test Plan
- Deploy a multi-host TPU v6e (16 chips) cluster using Kubernetes LeaderWorkerSet configurations to serve unquantized Qwen3.5 MoE checkpoints using `--load-format=runai_streamer`.
- Reference test configurations used for reproduction:

```containers:
        - name: vllm-leader
          image: vllm/vllm-tpu:nightly-20260429-7fd569e-75a7cf2
          env:
          - name: HUGGING_FACE_HUB_TOKEN
            valueFrom:
              secretKeyRef:
                name: hf-secret
                key: hf_api_token
          - name: USE_MOE_EP_KERNEL
            value: "0"
          - name: TPU_MULTIHOST_BACKEND
            value: ray
          - name: JAX_PLATFORMS
            value: ""
          - name: MODEL_IMPL_TYPE
            value: "vllm"
          command: ["/bin/bash", "-c"]
          args:
          - |
            
            export MODEL_IMPL_TYPE="vllm"
            export USE_MOE_EP_KERNEL="0"
            export RAY_memory_monitor_refresh_ms=0
            export RAY_memory_usage_threshold=1.0
            export RUNAI_STREAMER_MEMORY_LIMIT=0
            export VLLM_ENGINE_READY_TIMEOUT_S=6000

            bash /workspace/vllm/examples/online_serving/multi-node-serving.sh leader --ray_cluster_size=$(LWS_GROUP_SIZE);
            python3 -m vllm.entrypoints.openai.api_server \
            --host=0.0.0.0 \
            --port=8000 \
            --tensor-parallel-size=16 \
            --max-model-len=131072 \
            --kv-cache-dtype=fp8 \
            --gpu-memory-utilization=0.95 \
            --no-enable-prefix-caching \
            --max-num-batched-tokens=512 \
            --max-num-seqs=16 \
            --language-model-only \
            --enable-auto-tool-choice \
            --model=<gcs_bucket> \
            --served-model-name=Qwen/Qwen3.5-122B-A10B \
            --load-format=runai_streamer \
            --async-scheduling \
            --tool-call-parser=qwen3_coder \
            --reasoning-parser=qwen3 \
            --limit-mm-per-prompt '{"image": 0, "video": 0}' \
            --enable-expert-parallel
```

This patch fixed the error 
```
 # 1. Patch the vLLM bug dynamically and safely via Python
            python3 -c "
            import re
            path = '/vllm/model_executor/models/qwen3_5.py'
            with open(path, 'r') as f: code = f.read()
            
            # Use regex to exclusively target the bad weight_loader call
            code = re.sub(
                r'name,\s+shard_id,\s+expert_id,\s+return_success=True',
                r'name,\n                shard_id=shard_id,\n                expert_id=expert_id,\n                return_success=True',
                code
            )
            
            with open(path, 'w') as f: f.write(code)
            "
```

## Test Result
- **Before**: Engine initialization fails immediately during weight streaming with:
  ```text
  File "/workspace/tpu_inference/tpu_inference/layers/vllm/quantization/unquantized.py", line 308, in maybe_process_weights
  assert expert_id is not None, Expecting expert_id argument 
  AssertionError: Expecting expert_id argument 




- **After**: Model weights load correctly without assertion errors, allowing multi-host serving to start cleanly.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

