### PR TITLE
[BugFix] Set mamba_block_size to max_model_len for KV consumers in align mode

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -396,6 +396,16 @@ class MambaModelConfig(VerifyAndUpdateConfig):
             # to the block size as the basic granularity for prefix caching.
             if cache_config.mamba_block_size is None:
                 cache_config.mamba_block_size = cache_config.block_size
+            # For KV consumers in P/D disaggregated inference with "align"
+            # mode, Mamba states are NOT transferred via the KV connector.
+            # Set mamba_block_size to max_model_len so that the Mamba layer
+            # does not participate in prefix-caching block alignment.
+            if (
+                cache_config.mamba_cache_mode == "align"
+                and vllm_config.kv_transfer_config is not None
+                and vllm_config.kv_transfer_config.is_kv_consumer
+            ):
+                cache_config.mamba_block_size = model_config.max_model_len
         else:
             if cache_config.mamba_cache_mode != "none":
                 cache_config.mamba_cache_mode = "none"


### PR DESCRIPTION
### What this PR does / why we need it?

When running P/D disaggregated inference on hybrid attention/Mamba models (e.g. Jamba), the KV consumer side uses prefix caching in `align` mode. However, Mamba states are **not** transferred via the KV connector — only FullAttention KV cache is transferred.

Currently, `MambaModelConfig.verify_and_update_config` sets `mamba_block_size = block_size` when prefix caching is enabled, which causes the Mamba layer to participate in prefix-caching block alignment on the consumer side. This is incorrect because the consumer never receives Mamba states.

This PR adds a check: when `mamba_cache_mode == "align"` and the current instance is a KV consumer (`kv_transfer_config.is_kv_consumer`), set `mamba_block_size = max_model_len` so the Mamba layer does not participate in prefix-caching block alignment.

### Does this PR introduce _any_ user-facing change?

No. This only affects internal block-size alignment for KV consumer nodes in P/D disaggregated serving with hybrid Mamba models.

### How was this patch tested?

- [ ] Existing CI passes
- [ ] Manual verification on P/D disaggregated serving with Jamba model

Co-authored-by: Claude