### PR TITLE
[Bugfix][V1] Drop stale outputs after runtime request id reuse

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -285,6 +285,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.recompute_kv_load_failures = False
     scheduler.make_stats = Mock(return_value=None)
     scheduler.max_model_len = 128
+    scheduler._inflight_request_snapshots = {}
 
     def free_request(req, delay_free_blocks=False):
         scheduler.finished_req_ids.add(req.request_id)
@@ -319,3 +320,47 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     assert request.status == RequestStatus.FINISHED_ERROR
     assert request.request_id not in scheduler.requests
     assert not scheduler.running
+
+
+def test_async_runtime_id_reuse_after_cancel_no_underflow():
+    """Reuse of a runtime request id between schedule() and update_from_output()
+    must not underflow num_output_placeholders on the new request.
+
+    Sequence:
+      1. add request_a with id "late_req2", schedule it (queues an async batch).
+      2. cancel request_a (removes it from scheduler.requests).
+      3. add request_b reusing the same id "late_req2".
+      4. drain the *old* scheduler_output for request_a.
+
+    Without the identity check, step 4 looks up self.requests["late_req2"],
+    finds request_b, and decrements its num_output_placeholders (which is 0)
+    by len(new_token_ids), tripping `assert num_output_placeholders >= 0`.
+    """
+    scheduler = create_scheduler(async_scheduling=True)
+
+    request_a = create_requests(num_requests=1, req_ids=["late_req2"])[0]
+    scheduler.add_request(request_a)
+    sched_output_a = scheduler.schedule()
+    assert sched_output_a.num_scheduled_tokens.get("late_req2", 0) > 0
+    placeholders_at_schedule = request_a.num_output_placeholders
+    assert placeholders_at_schedule >= 1
+
+    # Cancel request_a before its output has been drained.
+    scheduler.finish_requests("late_req2", RequestStatus.FINISHED_ABORTED)
+    assert "late_req2" not in scheduler.requests
+
+    # New request reusing the same runtime request id.
+    request_b = create_requests(num_requests=1, req_ids=["late_req2"])[0]
+    scheduler.add_request(request_b)
+    assert scheduler.requests["late_req2"] is request_b
+    assert request_b.num_output_placeholders == 0
+    assert request_b.num_output_tokens == 0
+
+    # Drain the OLD batch. Stale output must not touch request_b.
+    model_runner_output = _make_model_runner_output(sched_output_a)
+    scheduler.update_from_output(sched_output_a, model_runner_output)
+
+    assert request_b.num_output_placeholders == 0
+    assert request_b.num_output_tokens == 0
+    assert request_b.status != RequestStatus.FINISHED_ABORTED
+

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2548,6 +2548,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.recompute_kv_load_failures = False
     scheduler.make_stats = Mock(return_value=None)
     scheduler.max_model_len = 128
+    scheduler._inflight_request_snapshots = {}
 
     def free_request(req: Request, delay_free_blocks: bool = False):
         scheduler.finished_req_ids.add(req.request_id)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -170,6 +170,16 @@ class Scheduler(SchedulerInterface):
         # This is flushed at the end of each scheduling step.
         self.finished_req_ids: set[str] = set()
 
+        # Snapshot of Request *object identity* per in-flight SchedulerOutput.
+        # Keyed by id(scheduler_output). Used in update_from_output to detect
+        # runtime request id reuse: if a request is cancelled and a new one is
+        # submitted with the same id between schedule() and drain(),
+        # self.requests[req_id] resolves to the new request. Comparing identity
+        # against the snapshot lets us drop stale outputs instead of corrupting
+        # the new request's accounting (e.g. num_output_placeholders underflow
+        # in async scheduling).
+        self._inflight_request_snapshots: dict[int, dict[str, Request]] = {}
+
         # Counter for requests waiting for streaming input. Used to calculate
         # number of unfinished requests
         self.num_waiting_for_streaming_input: int = 0
@@ -938,8 +948,14 @@ class Scheduler(SchedulerInterface):
         # 3. If some tokens (e.g. spec tokens) are rejected later, the number of
         #    computed tokens will be adjusted in update_from_output.
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        # Capture request *identity* at schedule time so update_from_output can
+        # tell whether self.requests[req_id] still refers to the same Request
+        # that was scheduled (vs. a new request that reused the id after a
+        # cancel + resubmit).
+        request_snapshot: dict[str, Request] = {}
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
+            request_snapshot[req_id] = request
             request.num_computed_tokens += num_scheduled_token
             request.is_prefill_chunk = request.num_computed_tokens < (
                 request.num_tokens + request.num_output_placeholders
@@ -947,6 +963,7 @@ class Scheduler(SchedulerInterface):
             scheduler_output.has_structured_output_requests |= (
                 request.use_structured_output and not request.is_prefill_chunk
             )
+        self._inflight_request_snapshots[id(scheduler_output)] = request_snapshot
 
         # Clear the finished request IDs.
         # NOTE: We shouldn't do self.finished_req_ids.clear() here because
@@ -1281,6 +1298,14 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens,
             )
 
+        # Pop the per-batch identity snapshot recorded in _update_after_schedule.
+        # Always pop (even when None) so id() reuse cannot resurrect a stale
+        # entry on a future scheduler_output that happens to land at the same
+        # memory address.
+        request_snapshot = self._inflight_request_snapshots.pop(
+            id(scheduler_output), None
+        )
+
         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
         # the below loop can be a performance bottleneck. We should do our best
         # to avoid expensive operations inside the loop.
@@ -1300,6 +1325,18 @@ class Scheduler(SchedulerInterface):
                 # cache transfer in KV connector), the aborted request will not
                 # be set to None (in order to finish async KV transfer).
                 # In this case, we use is_finished() to check.
+                continue
+            # Detect runtime request id reuse: if the request scheduled in this
+            # batch was cancelled and a new request reusing the same id was
+            # added before this drain, self.requests[req_id] now points to a
+            # different Request object that never participated in this batch.
+            # Applying the stale output to the new request would corrupt its
+            # accounting (in async scheduling this triggers
+            # `assert request.num_output_placeholders >= 0`).
+            if (
+                request_snapshot is not None
+                and request_snapshot.get(req_id) is not request
+            ):
                 continue
 
             req_index = model_runner_output.req_id_to_index[req_id]


### PR DESCRIPTION
## Summary

Fixes #42492.

In v1 async scheduling, an async batch produced by `Scheduler.schedule()`
can be drained later by `Scheduler.update_from_output()`. The drain
loop looks up each request via `self.requests.get(req_id)` — a name-keyed
lookup. If the request is cancelled and a new request is submitted
reusing the same runtime request id between the two calls, that lookup
resolves to the new request, and the old batch's output is applied to
it. This decrements `num_output_placeholders` on a request that never
participated in the old batch, underflowing past zero and tripping
`assert request.num_output_placeholders >= 0` in
`async_scheduler.py:53`.

The bug is frontend-legal: the API server and tests both allow id reuse
after cancellation. The reproducer in the issue confirms the assertion
crash.

## Root cause

`request_id` is a name. Across `cancel + resubmit`, the name is reused
but the underlying `Request` object identity changes. The scheduler's
async accounting (`num_output_placeholders`, spec rejection refunds,
encoder-input frees, etc.) is tied to the specific Request object that
was scheduled, so a name-only lookup at drain time can bind the output
to the wrong object.

## Fix

Snapshot per-batch Request object *identity* at schedule time and use
it to gate the drain loop:

1. `Scheduler.__init__`: add `self._inflight_request_snapshots: dict[int, dict[str, Request]] = {}`.
2. `Scheduler._update_after_schedule`: build a `req_id -> Request`
   mapping in the existing per-request loop and store it under
   `id(scheduler_output)`.
3. `Scheduler.update_from_output`: pop the snapshot at entry (always —
   so `id()` reuse cannot resurrect a stale entry), and in the per-req
   drain loop, after the existing `is_finished()` early-continue, skip
   any req where `request_snapshot[req_id] is not request`.

The snapshot is bounded by the live SchedulerOutputs (≤ `batch_queue_size`
in PP mode, ≤ 1 otherwise) and has no IPC implications — `id()` is only
used in the scheduler process, where each `SchedulerOutput` Python
object is held alive by the caller (`EngineCore.step` /
`step_with_batch_queue`'s `batch_queue`) until `update_from_output` runs.
The happy path is unaffected: `request_snapshot[req_id] is request`
holds whenever the id has not been reused.

`AsyncScheduler` does not override `update_from_output` and chains
`super()` in `_update_after_schedule`, so the fix in the base class
covers both schedulers without subclass changes.

## Tests

- New regression test `test_async_runtime_id_reuse_after_cancel_no_underflow`
  in `tests/v1/core/test_async_scheduler.py` (CPU-only,
  `pytest.mark.cpu_test`). It schedules `request_a` with id `late_req2`,
  cancels it, submits `request_b` reusing `late_req2`, then drains the
  old `scheduler_output`. Without the fix, the assertion fires; with the
  fix, `request_b.num_output_placeholders == 0` and `request_b` is
  untouched.
- Two existing tests
  (`test_abort_request_when_structured_output_fsm_cannot_advance` in
  both `test_scheduler.py` and `test_async_scheduler.py`) construct a
  `Scheduler` via `object.__new__` and bypass `__init__`. Each gets a
  one-line `scheduler._inflight_request_snapshots = {}` in its manual
  setup so the new attribute is present.

```
$ pytest tests/v1/core/test_scheduler.py tests/v1/core/test_async_scheduler.py -m cpu_test
================ 106 passed, 17 warnings in 176.58s (0:02:56) =================
```

I also verified the new test fails on `main` and passes on this branch
by reverting only the `scheduler.py` hunk.

## Incidental finding (disclosure, not in this PR)

While auditing the scheduler for other places that look up a request
by `request_id` after a cross-step delay, I noticed the same
identity-vs-name shape in `Scheduler._update_from_kv_xfer_finished`
(the KV connector `finished_recving` / `finished_sending` path):
a stale `finished_sending` for a reused id would reach
`_free_blocks(self.requests[req_id])` and free the *new* request's
blocks. It is not reproduced by #42492 (the traceback there is purely
the placeholder underflow), and the KV transfer path drains a different
output structure with no back-pointer to the originating
`SchedulerOutput`, so the per-`SchedulerOutput` snapshot mechanism used
here does not transplant to it directly (a request-local or
per-transfer identity token would be the natural fit). Flagging it here
so it is not forgotten; happy to file a separate issue and/or follow-up
PR if maintainers want it tracked, but keeping this PR focused on the
one reproducer in #42492.

## Duplicate-work check

```
$ gh pr list --repo vllm-project/vllm --state open --search "42492 in:body"
(none)
$ gh pr list --repo vllm-project/vllm --state open --search "num_output_placeholders"
(no matching PR addresses runtime id reuse / cancel+resubmit)
```

#35759 (AsyncScheduler streaming-input / chunked-prefill crash) and
#38624 (preempt path async tokens) both touch async scheduler accounting
but address different code paths.
