### PR TITLE
Revert "[PD] Bump NIXL connector dependency to 1.x" (#42364)

### DIFF
--- a/.buildkite/ci_config.yaml
+++ b/.buildkite/ci_config.yaml
@@ -8,7 +8,6 @@ run_all_patterns:
   - "CMakeLists.txt"
   - "requirements/common.txt"
   - "requirements/cuda.txt"
-  - "requirements/kv_connectors.txt"
   - "requirements/build/cuda.txt"
   - "requirements/test/cuda.txt"
   - "setup.py"

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,3 +1,5 @@
 lmcache >= 0.3.9
-nixl >= 1.1.0 # Required for disaggregated prefill
+nixl[cu13] >= 0.7.1, <= 0.10.1 # Required for disaggregated prefill
+nixl-cu12 >= 0.7.1, <= 0.10.1
+nixl-cu13 >= 0.7.1, <= 0.10.1
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
## Revert of #42364

This reverts commit 07534b8782757b069652f56d2d32f8fb8256adfc (merge commit for PR #42364).

**Original PR:** https://github.com/vllm-project/vllm/pull/42364
**Failure count:** 1 new failure linked to this PR
**Build:** https://buildkite.com/vllm/ci/builds/65989

### Failed test
- **Hybrid SSM NixlConnector PD accuracy tests (4 GPUs)** — Accuracy regression: measured 0.766 vs expected 0.8 (tolerance 0.03)

### Root cause
The NIXL dependency bump from CUDA-specific bounds to `nixl >= 1.1.0` appears to have caused an accuracy regression in the Hybrid SSM NixlConnector PD accuracy test.

---
*Auto-generated by CI failure analyzer*