### PR TITLE
[Kernel] Fuse MRoPE cos/sin gather into the Triton kernel for multimodal inputs

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -187,6 +187,149 @@ def triton_mrope(
     return q, k
 
 
+@triton.jit
+def _triton_mrope_forward_fused(
+    q_ptr,
+    k_ptr,
+    cos_sin_cache_ptr,
+    positions_ptr,
+    q_stride,
+    k_stride,
+    positions_stride,
+    n_qh: tl.constexpr,
+    n_kh: tl.constexpr,
+    hd: tl.constexpr,
+    rd: tl.constexpr,
+    pad_n_qh: tl.constexpr,
+    pad_n_kh: tl.constexpr,
+    pad_hd: tl.constexpr,
+    mrope_section_t: tl.constexpr,
+    mrope_section_h: tl.constexpr,
+    mrope_section_w: tl.constexpr,
+    is_interleaved: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    q_ptr = q_ptr + pid * q_stride
+    k_ptr = k_ptr + pid * k_stride
+
+    half_rd = rd // 2
+    t = tl.load(positions_ptr + 0 * positions_stride + pid)
+    h = tl.load(positions_ptr + 1 * positions_stride + pid)
+    w = tl.load(positions_ptr + 2 * positions_stride + pid)
+
+    t_cos = cos_sin_cache_ptr + t * rd
+    h_cos = cos_sin_cache_ptr + h * rd
+    w_cos = cos_sin_cache_ptr + w * rd
+    t_sin = t_cos + half_rd
+    h_sin = h_cos + half_rd
+    w_sin = w_cos + half_rd
+
+    cos_offsets = tl.arange(0, pad_hd // 2)
+    if is_interleaved:
+        h_mask = ((cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section_h)
+        w_mask = ((cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section_w)
+        t_mask = ~(h_mask | w_mask)
+    else:
+        t_end = mrope_section_t
+        h_end = t_end + mrope_section_h
+        t_mask = cos_offsets < mrope_section_t
+        h_mask = (t_end <= cos_offsets) & (cos_offsets < h_end)
+        w_mask = (h_end <= cos_offsets) & (cos_offsets < half_rd)
+
+    t_cos_row = tl.load(t_cos + cos_offsets, mask=t_mask, other=0)
+    h_cos_row = tl.load(h_cos + cos_offsets, mask=h_mask, other=0)
+    w_cos_row = tl.load(w_cos + cos_offsets, mask=w_mask, other=0)
+    t_sin_row = tl.load(t_sin + cos_offsets, mask=t_mask, other=0)
+    h_sin_row = tl.load(h_sin + cos_offsets, mask=h_mask, other=0)
+    w_sin_row = tl.load(w_sin + cos_offsets, mask=w_mask, other=0)
+
+    cos_row = t_cos_row + h_cos_row + w_cos_row
+    sin_row = t_sin_row + h_sin_row + w_sin_row
+
+    first_half_q_offsets = (
+        tl.arange(0, pad_n_qh)[:, None] * hd + tl.arange(0, pad_hd // 2)[None, :]
+    )
+    first_half_k_offsets = (
+        tl.arange(0, pad_n_kh)[:, None] * hd + tl.arange(0, pad_hd // 2)[None, :]
+    )
+    first_q_mask = (tl.arange(0, pad_n_qh)[:, None] < n_qh) & (
+        tl.arange(0, pad_hd // 2)[None, :] < rd // 2
+    )
+    first_k_mask = (tl.arange(0, pad_n_kh)[:, None] < n_kh) & (
+        tl.arange(0, pad_hd // 2)[None, :] < rd // 2
+    )
+
+    q_tile_1 = tl.load(q_ptr + first_half_q_offsets, mask=first_q_mask, other=0).to(
+        sin_row.dtype
+    )
+    k_tile_1 = tl.load(k_ptr + first_half_k_offsets, mask=first_k_mask, other=0).to(
+        sin_row.dtype
+    )
+
+    second_half_q_offsets = first_half_q_offsets + (rd // 2)
+    second_half_k_offsets = first_half_k_offsets + (rd // 2)
+
+    q_tile_2 = tl.load(q_ptr + second_half_q_offsets, mask=first_q_mask, other=0).to(
+        sin_row.dtype
+    )
+    k_tile_2 = tl.load(k_ptr + second_half_k_offsets, mask=first_k_mask, other=0).to(
+        sin_row.dtype
+    )
+
+    new_q_tile_1 = q_tile_1 * cos_row - q_tile_2 * sin_row
+    tl.store(q_ptr + first_half_q_offsets, new_q_tile_1, mask=first_q_mask)
+    new_q_tile_2 = q_tile_2 * cos_row + q_tile_1 * sin_row
+    tl.store(q_ptr + second_half_q_offsets, new_q_tile_2, mask=first_q_mask)
+
+    new_k_tile_1 = k_tile_1 * cos_row - k_tile_2 * sin_row
+    tl.store(k_ptr + first_half_k_offsets, new_k_tile_1, mask=first_k_mask)
+    new_k_tile_2 = k_tile_2 * cos_row + k_tile_1 * sin_row
+    tl.store(k_ptr + second_half_k_offsets, new_k_tile_2, mask=first_k_mask)
+
+
+def triton_mrope_fused(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    mrope_section: list[int],
+    head_size: int,
+    rotary_dim: int,
+    mrope_interleaved: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    n_row = q.shape[0]
+    n_q_head = q.shape[1] // head_size
+    n_kv_head = k.shape[1] // head_size
+    pad_hd = triton.next_power_of_2(head_size)
+    pad_n_q_head = triton.next_power_of_2(n_q_head)
+    pad_n_kv_head = triton.next_power_of_2(n_kv_head)
+
+    q = q.contiguous()
+    k = k.contiguous()
+
+    _triton_mrope_forward_fused[(n_row,)](
+        q,
+        k,
+        cos_sin_cache,
+        positions,
+        q.stride(0),
+        k.stride(0),
+        positions.stride(0),
+        n_q_head,
+        n_kv_head,
+        head_size,
+        rotary_dim,
+        pad_n_q_head,
+        pad_n_kv_head,
+        pad_hd,
+        mrope_section[0],
+        mrope_section[1],
+        mrope_section[2],
+        mrope_interleaved,
+    )
+    return q, k
+
+
 def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
     """Apply interleaved MRoPE to 3D rotary embeddings.
     Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
@@ -332,19 +475,17 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
         assert key is not None
 
         cos_sin_cache = self._match_cos_sin_cache_dtype(query)
-        num_tokens = positions.shape[-1]
-        cos_sin = cos_sin_cache[positions]
-        cos, sin = cos_sin.chunk(2, dim=-1)
         query_shape = query.shape
         key_shape = key.shape
+
         if positions.ndim == 2:
             assert self.mrope_section
 
-            q, k = triton_mrope(
+            q, k = triton_mrope_fused(
                 query,
                 key,
-                cos,
-                sin,
+                cos_sin_cache,
+                positions,
                 self.mrope_section,
                 self.head_size,
                 self.rotary_dim,
@@ -352,6 +493,10 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
             )
 
             return q.reshape(query_shape), k.reshape(key_shape)
+
+        num_tokens = positions.shape[-1]
+        cos_sin = cos_sin_cache[positions]
+        cos, sin = cos_sin.chunk(2, dim=-1)
 
         query = query.view(num_tokens, -1, self.head_size)
         query_rot = query[..., : self.rotary_dim]


### PR DESCRIPTION
### Purpose

For multimodal models (Qwen2-VL, Qwen2.5-VL, etc.), MRoPE applies rotary embeddings using per-token 3D position ids. The current implementation first gathers cos/sin values from the embedding table via `torch.index_select` / `gather`, producing intermediate buffers, then applies the rotary transform in a separate kernel. Two kernel launches plus the intermediate allocation show up on the critical path — about 350 us per call on H100.

This patch folds the gather into the Triton rotary kernel itself: the kernel reads position ids directly, indexes into the cos/sin tables inline, and applies the rotation in one pass. No intermediate buffer, one kernel launch instead of two.

### Test Plan

Correctness:
```bash
pytest tests/kernels/test_mrope.py -v
```
Compares fused kernel output against the reference torch implementation across typical Qwen2-VL / Qwen2.5-VL configs (varying num_tokens, head_dim, 3D position shapes). Max atol/rtol = 1e-3 for bf16.

Performance:
```bash
python benchmarks/kernels/benchmark_mrope.py \
  --model-name Qwen/Qwen2.5-VL-7B-Instruct \
  --num-tokens 1024 4096 \
  --dtype bfloat16 \
  --warmup-iter 10 --benchmark-iter 100
```
Measures torch (gather + rotate) vs triton (fused) median latency. No model weights needed for the kernel-level benchmark — only shape params are extracted from the config.

### Test Result

```
Correctness: all configs PASSED (bf16, fp16)

Kernel latency (Qwen2.5-VL-7B, 4096 tokens, bf16, H100):
  torch (gather + rotate):  ~350 us
  triton (fused):            ~58 us
  speedup:                   ~6x
```

The saving is per-layer per-forward — it adds up for deep models and long-context / video inputs where MRoPE is called repeatedly.
