### PR TITLE
SiluAndMulWithClamp rework for vLLM IR

### DIFF
--- a/tests/ir/test_compile.py
+++ b/tests/ir/test_compile.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+import torch._dynamo
+
+import vllm.ir.op
+from vllm.ir.op import IrOpImplCompiledWrapper
+
+
+# Create a simple IR op for testing
+@vllm.ir.register_op
+def _test_add_mul(
+    x_a: torch.Tensor, x_b: torch.Tensor, scale: float = 2.0
+) -> torch.Tensor:
+    """Simple op: (a + b) * scale"""
+    return (x_a + x_b) * scale
+
+
+@pytest.fixture(autouse=True)
+def clear_compile_wrapper():
+    """Clear the compile wrapper before every test."""
+    _test_add_mul.impls["native"].compile_clear()
+
+
+def test_compile_context_manager_semantics():
+    """Test that compile=True in set_priority produces correct results"""
+    a = torch.randn(4, 5)
+    b = torch.randn(4, 5)
+    scale = 3.0
+
+    # Without compilation
+    with _test_add_mul.set_priority(["native"], compile=False):
+        assert not isinstance(_test_add_mul.dispatch(a, b), IrOpImplCompiledWrapper)
+        out_no_compile = _test_add_mul(a, b, scale)
+
+    # With compilation
+    with _test_add_mul.set_priority(["native"], compile=True):
+        assert isinstance(_test_add_mul.dispatch(a, b), IrOpImplCompiledWrapper)
+        out_compile = _test_add_mul(a, b, scale)
+
+    # Both should produce the same result
+    torch.testing.assert_close(out_no_compile, out_compile)
+    torch.testing.assert_close(out_compile, (a + b) * scale)
+
+
+def test_no_recompile():
+    """Test that dynamic shape is marked correctly and no recompilation happens."""
+    torch._dynamo.reset()
+
+    a = torch.randn(4, 5)
+    b = torch.randn(4, 5)
+    scale = 3.0
+
+    # Without compilation
+    with _test_add_mul.set_priority(["native"], compile=True):
+        out1 = _test_add_mul(a, b, scale)
+
+    torch.testing.assert_close(out1, (a + b) * scale)
+
+    a = torch.randn(10, 5)
+    b = torch.randn(10, 5)
+
+    with (
+        torch.compiler.set_stance("fail_on_recompile"),
+        _test_add_mul.set_priority(["native"], compile=True),
+    ):
+        out2 = _test_add_mul(a, b, scale)
+
+    torch.testing.assert_close(out2, (a + b) * scale)
+
+
+def test_compile_inside_custom_op():
+    """Test that compiled impl works when called inside a custom op"""
+
+    # Create a custom op that calls our IR op internally
+    @torch.library.custom_op("mylib::wrapped_add_mul", mutates_args=())
+    def wrapped_add_mul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return _test_add_mul(a, b, scale=3.0)
+
+    # Use compile=True to optimize even though this custom op is opaque
+
+    @wrapped_add_mul.register_fake
+    def _(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    # Test the wrapped op
+    a = torch.randn(4, 5)
+    b = torch.randn(4, 5)
+
+    assert _test_add_mul.impls["native"]._compiled_wrapper is None
+    with _test_add_mul.set_priority(["native"], compile=True):
+        result = wrapped_add_mul(a, b)
+
+    torch.testing.assert_close(result, (a + b) * 3.0)
+    assert _test_add_mul.impls["native"]._compiled_wrapper is not None
+
+
+def test_compile_with_custom_impl():
+    """Test that compile=True works with custom implementations"""
+
+    @_test_add_mul.register_impl("optimized", compiled=True)
+    def optimized_impl(
+        x_a: torch.Tensor, x_b: torch.Tensor, scale: float = 2.0
+    ) -> torch.Tensor:
+        # Alternative implementation
+        return torch.mul(torch.add(x_a, x_b), scale) + 4
+
+    a = torch.randn(3, 3)
+    b = torch.randn(3, 3)
+
+    # Use the custom implementation with compile=True
+    with _test_add_mul.set_priority(["optimized"], compile=True):
+        result = _test_add_mul(a, b, scale=1.5)
+
+    torch.testing.assert_close(result, (a + b) * 1.5 + 4)
+
+
+def test_nested_priority_contexts():
+    """Test that nested set_priority contexts work correctly with compile"""
+    a = torch.randn(4, 5)
+    b = torch.randn(4, 5)
+
+    # Outer context with compile=False
+    with _test_add_mul.set_priority(["native"], compile=False):
+        assert not isinstance(_test_add_mul.dispatch(a, b), IrOpImplCompiledWrapper)
+        out1 = _test_add_mul(a, b)
+
+        # Inner context with compile=True
+        with _test_add_mul.set_priority(["native"], compile=True):
+            assert isinstance(_test_add_mul.dispatch(a, b), IrOpImplCompiledWrapper)
+            out2 = _test_add_mul(a, b)
+
+        # Back to compile=False
+        assert not isinstance(_test_add_mul.dispatch(a, b), IrOpImplCompiledWrapper)
+        out3 = _test_add_mul(a, b)
+
+    # All should produce the same result
+    torch.testing.assert_close(out1, out2)
+    torch.testing.assert_close(out2, out3)
+
+
+def test_compiled_flag():
+    """Test that compiled flag controls whether impl can be compiled"""
+    # Native impl should have compiled=True
+    assert _test_add_mul.impls["native"].compiled is True
+    assert _test_add_mul.impls["native"].uncompiled_impl_fn is not None
+
+    # Register impl without compiled flag (defaults to False)
+    @_test_add_mul.register_impl("no_compile")
+    def no_compile_impl(
+        x_a: torch.Tensor, x_b: torch.Tensor, scale: float = 2.0
+    ) -> torch.Tensor:
+        return (x_a + x_b) * scale
+
+    assert _test_add_mul.impls["no_compile"].compiled is False
+
+    a = torch.randn(4, 5)
+    b = torch.randn(4, 5)
+
+    # compile=True with no_compile impl should NOT compile it
+    with _test_add_mul.set_priority(["no_compile"], compile=True):
+        # Should use the original impl, not compiled wrapper
+        assert not isinstance(_test_add_mul.dispatch(a, b), IrOpImplCompiledWrapper)
+        out = _test_add_mul(a, b)
+
+    torch.testing.assert_close(out, (a + b) * 2.0)

--- a/tests/kernels/ir/test_activation.py
+++ b/tests/kernels/ir/test_activation.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+import vllm.kernels  # noqa: F401
+from tests.kernels.allclose_default import get_default_rtol
+from vllm import ir
+from vllm.platforms import current_platform
+
+SWIGLU_LIMITS = [3.0, 7.0, 15.0]
+
+
+def silu_and_mul_with_clamp_inputs(
+    n_tokens: int, d: int, dtype: torch.dtype, swiglu_limit: float
+):
+    # Scale the input so that clamping is actually exercised.
+    x = torch.randn(n_tokens, 2 * d, dtype=dtype) * swiglu_limit * 2
+    return (x, swiglu_limit)
+
+
+silu_and_mul_with_clamp_native = ir.ops.silu_and_mul_with_clamp.impls["native"].impl_fn
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+def test_silu_and_mul_with_clamp_registration():
+    expected = {
+        "native": True,
+        "vllm_c": current_platform.is_cuda_alike(),
+        "xpu_kernels": current_platform.is_xpu(),  # if registered
+    }
+    actual = {
+        provider: impl.supported
+        for provider, impl in ir.ops.silu_and_mul_with_clamp.impls.items()
+    }
+    assert actual == expected
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("n_tokens", [1, 8, 17])
+@pytest.mark.parametrize("d", [16, 4096, 8192])
+@pytest.mark.parametrize("swiglu_limit", SWIGLU_LIMITS)
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+class TestSiluAndMulWithClamp:
+    @classmethod
+    def setup_class(cls):
+        torch.set_default_device(current_platform.device_type)
+
+    def test_native_semantics(self, dtype, n_tokens, d, swiglu_limit):
+        x, limit = silu_and_mul_with_clamp_inputs(n_tokens, d, dtype, swiglu_limit)
+        out = silu_and_mul_with_clamp_native(x, limit)
+        assert out.shape == x.shape[:-1] + (d,)
+        assert out.dtype == x.dtype
+
+        # Verify clamping is actually being applied: the clamped output must
+        # differ from the unclamped SiluAndMul output when inputs are large.
+        from vllm.model_executor.layers.activation import SiluAndMul
+
+        unclamped = SiluAndMul.forward_native(x)
+        assert not torch.equal(out.float(), unclamped.float()), (
+            "Input was not large enough to exercise the clamp; increase scale"
+        )
+
+        # Gate clamping semantics: gate=large_val clamped to limit, up=1.0.
+        x_gate = torch.tensor(
+            [[limit * 20.0, 1.0]],
+            dtype=torch.float32,
+            device=current_platform.device_type,
+        )
+        out_gate = silu_and_mul_with_clamp_native(x_gate, limit)
+        expected_gate = torch.nn.functional.silu(
+            torch.tensor(limit, dtype=torch.float32)
+        ).item()
+        torch.testing.assert_close(
+            out_gate,
+            torch.tensor(
+                [[expected_gate]],
+                dtype=torch.float32,
+                device=current_platform.device_type,
+            ),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+        # Up clamping semantics: up >> limit gets clamped to limit.
+        x_up = torch.tensor(
+            [[1.0, limit * 20.0]],
+            dtype=torch.float32,
+            device=current_platform.device_type,
+        )
+        out_up = silu_and_mul_with_clamp_native(x_up, limit)
+        silu_1 = torch.nn.functional.silu(torch.tensor(1.0)).item()
+        torch.testing.assert_close(
+            out_up,
+            torch.tensor(
+                [[silu_1 * limit]],
+                dtype=torch.float32,
+                device=current_platform.device_type,
+            ),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+    @pytest.mark.parametrize("provider", ["vllm_c", "xpu_kernels"])
+    def test_impls(self, dtype, n_tokens, d, swiglu_limit, provider):
+        impl = ir.ops.silu_and_mul_with_clamp.impls[provider]
+        if not impl.supported:
+            pytest.skip(f"{provider} not supported")
+        x, limit = silu_and_mul_with_clamp_inputs(n_tokens, d, dtype, swiglu_limit)
+        out_impl = impl.impl_fn(x, limit)
+        out_native = silu_and_mul_with_clamp_native(x, limit)
+        torch.testing.assert_close(
+            out_impl, out_native, rtol=get_default_rtol(out_impl), atol=1e-3
+        )
+        with ir.ops.silu_and_mul_with_clamp.set_priority([provider, "native"]):
+            out_dispatched = ir.ops.silu_and_mul_with_clamp(x, limit)
+        torch.testing.assert_close(out_dispatched, out_impl, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("compile", [False, True])
+    def test_native_impl_compile(self, dtype, n_tokens, d, swiglu_limit, compile):
+        impl = ir.ops.silu_and_mul_with_clamp.impls["native"]
+        assert impl.supported, "native implementation must be supported!"
+        x, limit = silu_and_mul_with_clamp_inputs(n_tokens, d, dtype, swiglu_limit)
+        out_impl = impl.impl_fn(x, limit)
+        out_native = silu_and_mul_with_clamp_native(x, limit)
+        torch.testing.assert_close(
+            out_impl, out_native, rtol=get_default_rtol(out_impl), atol=1e-3
+        )
+        with ir.ops.silu_and_mul_with_clamp.set_priority(["native"], compile=compile):
+            out_dispatched = ir.ops.silu_and_mul_with_clamp(x, limit)
+
+            if compile:
+                assert isinstance(
+                    ir.ops.silu_and_mul_with_clamp.dispatch(x, limit),
+                    ir.op.IrOpImplCompiledWrapper,
+                ), (
+                    "When `set_priority` with compile=True, the implementation is "
+                    "expected to be wrapped with compile."
+                )
+        torch.testing.assert_close(out_dispatched, out_impl, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("provider", ["vllm_c", "xpu_kernels", "native"])
+    def test_torch_opcheck(self, dtype, n_tokens, d, swiglu_limit, provider):
+        if not ir.ops.silu_and_mul_with_clamp.impls[provider].supported:
+            pytest.skip(f"{provider} not supported")
+        x, limit = silu_and_mul_with_clamp_inputs(n_tokens, d, dtype, swiglu_limit)
+        with ir.ops.silu_and_mul_with_clamp.set_priority([provider, "native"]):
+            torch.library.opcheck(torch.ops.vllm_ir.silu_and_mul_with_clamp, (x, limit))

--- a/tests/kernels/ir/test_activation.py
+++ b/tests/kernels/ir/test_activation.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 import vllm.kernels  # noqa: F401
-from tests.kernels.allclose_default import get_default_rtol
+from tests.kernels.allclose_default import get_default_atol, get_default_rtol
 from vllm import ir
 from vllm.platforms import current_platform
 
@@ -68,43 +68,44 @@ class TestSiluAndMulWithClamp:
         )
 
         # Gate clamping semantics: gate=large_val clamped to limit, up=1.0.
+        # Exercise each parametrized dtype — bf16/fp16 must also satisfy the
+        # clamp identity, with dtype-appropriate tolerances.
         x_gate = torch.tensor(
             [[limit * 20.0, 1.0]],
-            dtype=torch.float32,
+            dtype=dtype,
             device=current_platform.device_type,
         )
         out_gate = silu_and_mul_with_clamp_native(x_gate, limit)
-        expected_gate = torch.nn.functional.silu(
-            torch.tensor(limit, dtype=torch.float32)
-        ).item()
+        expected_gate = torch.tensor(
+            [[torch.nn.functional.silu(torch.tensor(limit)).item()]],
+            dtype=dtype,
+            device=current_platform.device_type,
+        )
         torch.testing.assert_close(
             out_gate,
-            torch.tensor(
-                [[expected_gate]],
-                dtype=torch.float32,
-                device=current_platform.device_type,
-            ),
-            atol=1e-3,
-            rtol=1e-3,
+            expected_gate,
+            atol=get_default_atol(out_gate),
+            rtol=get_default_rtol(out_gate),
         )
 
         # Up clamping semantics: up >> limit gets clamped to limit.
         x_up = torch.tensor(
             [[1.0, limit * 20.0]],
-            dtype=torch.float32,
+            dtype=dtype,
             device=current_platform.device_type,
         )
         out_up = silu_and_mul_with_clamp_native(x_up, limit)
         silu_1 = torch.nn.functional.silu(torch.tensor(1.0)).item()
+        expected_up = torch.tensor(
+            [[silu_1 * limit]],
+            dtype=dtype,
+            device=current_platform.device_type,
+        )
         torch.testing.assert_close(
             out_up,
-            torch.tensor(
-                [[silu_1 * limit]],
-                dtype=torch.float32,
-                device=current_platform.device_type,
-            ),
-            atol=1e-3,
-            rtol=1e-3,
+            expected_up,
+            atol=get_default_atol(out_up),
+            rtol=get_default_rtol(out_up),
         )
 
     @pytest.mark.parametrize("provider", ["vllm_c", "xpu_kernels"])

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -34,6 +34,9 @@ class IrOpPriorityConfig:
     fused_add_rms_norm: list[str] = Field(default_factory=list)
     """Priority list for vllm.ir.ops.fused_add_rms_norm"""
 
+    silu_and_mul_with_clamp: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.silu_and_mul_with_clamp"""
+
     def compute_hash(self) -> str:
         """
         Produces a hash unique to the pass configuration.

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -5,6 +5,7 @@ import inspect
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar, Literal, overload
+from typing import Any, ClassVar, Protocol, overload
 
 import torch
 from torch.library import Library, infer_schema
@@ -114,6 +115,35 @@ def register_op(
     return decorator
 
 
+class CallableOpImpl(Protocol):
+    """
+    Protocol for callable op implementations.
+
+    Both IrOpImpl and IrOpImplCompiledWrapper implement this protocol,
+    allowing them to be used interchangeably in priority lists.
+    """
+
+    impl_fn: Callable
+    """The implementation function to call."""
+
+    uncompiled_impl_fn: Callable
+    """The uncompiled version of the implementation function."""
+
+    supported: bool
+    """Is this implementation supported? Asserted during dispatch"""
+
+    provider: str
+    """Implementation provider"""
+
+    def supports_args(self, *args, **kwargs) -> bool:
+        """Check if this implementation supports the given args."""
+        ...
+
+    def func_impl_fn(self, *args, **kwargs) -> Any:
+        """Call impl_fn with functional semantics (copying for inplace impls)."""
+        ...
+
+
 class IrOp:
     registry: ClassVar[dict[str, "IrOp"]] = {}
 
@@ -146,14 +176,14 @@ class IrOp:
             ]
 
         self.name = name
-        self.impls: dict[str, IrOpImpl] = {}
         self.activations = activations
         self.activation_indices = [
             i
             for i, p in enumerate(self._py_signature.parameters.values())
             if p.name in activations
         ]
-        self._priority_impls: list[IrOpImpl] = []
+        self.impls: dict[str, IrOpImpl] = {}
+        self._priority_impls: list[CallableOpImpl] = []
         self._schema_str = infer_schema(native_impl, mutates_args=[])
         self._input_generator: InputGenerator | None = None
         self._tolerance_overrides: ToleranceSpec = {}
@@ -166,6 +196,8 @@ class IrOp:
             # always supported
             supported=True,
             supports_args=None,
+            # Native can be compiled
+            compiled=True,
         )
 
         # By default, fake routes directly to native,
@@ -206,13 +238,15 @@ class IrOp:
         supported: bool = True,
         supports_args: Callable[..., bool] | None = None,
         inplace: bool = False,
+        compiled: bool = False,
     ):
         """
         Register an implementation for this custom op.
         :param provider: The name of the provider, must be unique.
         :param supported: Static support check, use this to check platform support.
         :param supports_args: Dynamic arg support check, used for types and shapes.
-        :param inplace: Does this op reuse activation input memory for outputs
+        :param inplace: Does this impl reuse activation input memory for outputs
+        :param compiled: Does this impl get compiled if set_priority(..., compile=True)
         :return: A decorator that registers the implementation.
 
         The decorated function must have the same semantics and signature as
@@ -227,6 +261,9 @@ class IrOp:
         compatible with the implementation.
         For custom enablement logic, set op impl priority.
 
+        If compiled is True, that means that eager-mode dispatch will dispatch to a
+        torch.compile-decorated version of this implementation (with
+
         Example:
         ```python
         @my_op.register_impl("my_provider", supported=torch.cuda.is_available())
@@ -239,7 +276,7 @@ class IrOp:
         )
 
         def _register_impl(f: Callable):
-            impl = IrOpImpl(self, provider, f, supported, supports_args, inplace)
+            impl = IrOpImpl(self, provider, f, supported, supports_args, inplace, compiled)
             self.impls[provider] = impl
 
             if self.get_priority():
@@ -276,10 +313,10 @@ class IrOp:
         bound_args.apply_defaults()
         return bound_args.args
 
-    def dispatch(self, *args, **kwargs) -> "IrOpImpl":
+    def dispatch(self, *args, **kwargs) -> CallableOpImpl:
         """
         Dispatch to the appropriate implementation based on current priority
-        and argument support checks. Returns the selected IrOpImpl.
+        and argument support checks. Returns the selected CallableOpImpl.
 
         THIS FUNCTION IS ON THE HOT PATH (OP DISPATCH), MUST BE FAST.
         """
@@ -328,23 +365,31 @@ class IrOp:
         return [p.provider for p in self._priority_impls]
 
     @contextlib.contextmanager
-    def set_priority(self, priority: list[str]):
+    def set_priority(self, priority: list[str], *, compile: bool = False):
         """
         Context manager to set the dispatch priority for implementations for this op.
+
+        :param priority: List of provider names in priority order
+        :param compile: Wrap implementations with torch.compile for better performance
+                       when called inside opaque custom ops.
         """
         assert all(p in self.impls for p in priority), (
             "All providers in priority must be registered implementations."
         )
 
-        def filter_priority_impls(p_list: list[str]) -> list[IrOpImpl]:
-            filtered_impls = []
+        # If compile=True and impl allows compilation, use compiled wrapper
+        def maybe_compile(impl: IrOpImpl) -> CallableOpImpl:
+            return impl.compile() if compile and impl.compiled else impl
+
+        def filter_priority_impls(p_list: list[str]) -> list[CallableOpImpl]:
+            filtered_impls: list[CallableOpImpl] = []
             for p in p_list:
                 impl = self.impls[p]
                 if not impl.supported:
                     # Skip unsupported implementations
                     continue
 
-                filtered_impls.append(impl)
+                filtered_impls.append(maybe_compile(impl))
 
                 # If all args are supported, skip other implementations
                 if impl.supports_all_args:
@@ -356,7 +401,7 @@ class IrOp:
                 "explicitly add 'native' to the end of the priority list",
                 self.name,
             )
-            filtered_impls.append(self.impls["native"])
+            filtered_impls.append(maybe_compile(self.impls["native"]))
             return filtered_impls
 
         # Temporarily set priority
@@ -364,9 +409,10 @@ class IrOp:
         try:
             self._priority_impls = filter_priority_impls(priority)
             logger.debug(
-                "Priority for vllm.ir.%s set to %s",
+                "Priority for vllm.ir.%s set to %s%s",
                 self.name,
                 lazy(lambda: [p.provider for p in self._priority_impls]),
+                " (compiled)" if compile else "",
             )
             yield
         finally:
@@ -477,6 +523,7 @@ class IrOpImpl:
         supported: bool,
         supports_args: Callable[..., bool] | None,
         inplace: bool = False,
+        compiled: bool = False,
     ):
         assert provider not in op.impls, (
             f"Implementation for provider {provider} already registered."
@@ -544,9 +591,12 @@ class IrOpImpl:
         self.op = op
         self.provider = provider
         self.impl_fn = impl_fn
+        self.uncompiled_impl_fn = impl_fn  # Always the uncompiled version
         self.supported = supported
         self._supports_args = supports_args
         self.inplace = inplace
+        self.compiled = compiled  # Whether this impl can be compiled
+        self._compiled_wrapper: IrOpImplCompiledWrapper | None = None
 
     @property
     def supports_all_args(self) -> bool:
@@ -558,6 +608,30 @@ class IrOpImpl:
             return True
 
         return self._supports_args(*args, **kwargs)
+
+    def compile(self) -> "IrOpImplCompiledWrapper":
+        """
+        Get a compiled wrapper for this implementation.
+
+        This helps when the IR op is either called inside an opaque torch custom op and
+        hence invisible to model-level compilation, or outside any compilation context.
+        By pre-compiling the implementation, we can still get performance benefits even
+        when the op is not compiled externally.
+
+        The wrapper also marks activation tensors with dynamic batch dimensions
+        using torch._dynamo.mark_dynamic(t, 0) to ensure proper dynamic shapes.
+
+        The compiled wrapper is cached, so multiple calls return the same wrapper.
+
+        :return: Compiled wrapper following the CallableOpImpl protocol
+        """
+        if self._compiled_wrapper is None:
+            self._compiled_wrapper = IrOpImplCompiledWrapper(self)
+        return self._compiled_wrapper
+
+    def compile_clear(self):
+        """Clear the cached compile wrapper for the implementation."""
+        self._compiled_wrapper = None
 
     @weak_cache
     def uuid(self):
@@ -587,3 +661,46 @@ class IrOpImpl:
             new_args[i] = args[i].clone()
 
         return self.impl_fn(*new_args, **kwargs)
+
+
+class IrOpImplCompiledWrapper:
+    """
+    Wrapper for IrOpImpl that provides a torch.compile-wrapped implementation.
+
+    This wrapper implements CallableOpImpl protocol so it can be used in
+    priority lists, but wraps the implementation with torch.compile and
+    marks dynamic dimensions on activations.
+    """
+
+    def __init__(self, base_impl: IrOpImpl, **compile_kwargs):
+        self.base_impl = base_impl
+        self.supported = base_impl.supported
+        self.provider = f"{base_impl.provider} (compiled)"
+        self.activation_indices = base_impl.op.activation_indices
+        self.uncompiled_impl_fn = base_impl.impl_fn
+
+        # Compile the implementation
+        self.compiled_impl_fn = torch.compile(base_impl.impl_fn, **compile_kwargs)
+
+        # Create impl_fn that marks dynamic dims and calls compiled implementation
+        def impl_fn(*args, **kwargs) -> Any:
+            # Mark batch dimension (dim 0) as dynamic for activation inputs
+            for idx in self.activation_indices:
+                if idx < len(args) and isinstance(args[idx], torch.Tensor):
+                    torch._dynamo.mark_dynamic(args[idx], 0)
+
+            return self.compiled_impl_fn(*args, **kwargs)
+
+        self.impl_fn = impl_fn
+
+    def supports_args(self, *args, **kwargs) -> bool:
+        return self.base_impl.supports_args(*args, **kwargs)
+
+    def func_impl_fn(self, *args, **kwargs) -> Any:
+        """
+        Call impl_fn with functional semantics.
+
+        TODO: Implement compiled version that handles inplace impls correctly.
+        For now, delegate to the base implementation's func_impl_fn.
+        """
+        return self.base_impl.func_impl_fn(*args, **kwargs)

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -4,8 +4,7 @@ import contextlib
 import inspect
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, ClassVar, Literal, overload
-from typing import Any, ClassVar, Protocol, overload
+from typing import Any, ClassVar, Literal, Protocol, overload
 
 import torch
 from torch.library import Library, infer_schema
@@ -276,7 +275,9 @@ class IrOp:
         )
 
         def _register_impl(f: Callable):
-            impl = IrOpImpl(self, provider, f, supported, supports_args, inplace, compiled)
+            impl = IrOpImpl(
+                self, provider, f, supported, supports_args, inplace, compiled
+            )
             self.impls[provider] = impl
 
             if self.get_priority():

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -4,7 +4,8 @@ import contextlib
 import inspect
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, ClassVar, Literal, Protocol, overload
+from typing import Any, ClassVar, Literal, overload
+from typing import Any, ClassVar, Protocol, overload
 
 import torch
 from torch.library import Library, infer_schema
@@ -275,9 +276,7 @@ class IrOp:
         )
 
         def _register_impl(f: Callable):
-            impl = IrOpImpl(
-                self, provider, f, supported, supports_args, inplace, compiled
-            )
+            impl = IrOpImpl(self, provider, f, supported, supports_args, inplace, compiled)
             self.impls[provider] = impl
 
             if self.get_priority():

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .activation import silu_and_mul_with_clamp
 from .layernorm import fused_add_rms_norm, rms_norm
 
-__all__ = ["rms_norm", "fused_add_rms_norm"]
+__all__ = ["rms_norm", "fused_add_rms_norm", "silu_and_mul_with_clamp"]

--- a/vllm/ir/ops/activation.py
+++ b/vllm/ir/ops/activation.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def silu_and_mul_with_clamp(x: Tensor, swiglu_limit: float) -> Tensor:
+    """SwiGLU activation with input clamping (used by some MoE shared experts).
+
+    Computes:
+        gate = clamp(x[..., :d], max=swiglu_limit)
+        up   = clamp(x[..., d:], min=-swiglu_limit, max=swiglu_limit)
+        out  = silu(gate) * up
+    where d = x.shape[-1] // 2.
+    """
+    d = x.shape[-1] // 2
+    gate = torch.clamp(x[..., :d], max=swiglu_limit)
+    up = torch.clamp(x[..., d:], min=-swiglu_limit, max=swiglu_limit)
+    return F.silu(gate) * up

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -61,3 +61,12 @@ def fused_add_rms_norm(
     assert variance_size is None
     torch.ops._C.fused_add_rms_norm(x, x_residual, weight, epsilon)
     return x, x_residual
+
+
+@ir.ops.silu_and_mul_with_clamp.register_impl("vllm_c", supported=CUDA_ALIKE)
+def silu_and_mul_with_clamp(x: Tensor, swiglu_limit: float) -> Tensor:
+    d = x.shape[-1] // 2
+    output_shape = x.shape[:-1] + (d,)
+    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    torch.ops._C.silu_and_mul_with_clamp(out, x, swiglu_limit)
+    return out

--- a/vllm/kernels/xpu_ops.py
+++ b/vllm/kernels/xpu_ops.py
@@ -64,3 +64,14 @@ def fused_add_rms_norm(
     assert variance_size is None
     torch.ops._C.fused_add_rms_norm(x, x_residual, weight, epsilon)
     return x, x_residual
+
+
+@ir.ops.silu_and_mul_with_clamp.register_impl(
+    "xpu_kernels", supported=XPU_KERNELS_SUPPORTED
+)
+def silu_and_mul_with_clamp(x: Tensor, swiglu_limit: float) -> Tensor:
+    d = x.shape[-1] // 2
+    output_shape = x.shape[:-1] + (d,)
+    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    torch.ops._C.silu_and_mul_with_clamp(out, x, swiglu_limit)
+    return out

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -8,6 +8,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+# Import kernels to trigger IR impl registration
+import vllm.kernels  # noqa: F401
+from vllm import ir
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -169,26 +172,14 @@ class SiluAndMulWithClamp(CustomOp):
     def __init__(self, swiglu_limit: float, *, compile_native: bool = True):
         super().__init__(compile_native=compile_native)
         self.swiglu_limit = float(swiglu_limit)
-        if current_platform.is_cuda_alike() or current_platform.is_xpu():
-            self.op = torch.ops._C.silu_and_mul_with_clamp
-        elif current_platform.is_cpu():
+        if current_platform.is_cpu():
             self._forward_method = self.forward_native
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        gate = torch.clamp(x[..., :d], max=self.swiglu_limit)
-        up = torch.clamp(x[..., d:], min=-self.swiglu_limit, max=self.swiglu_limit)
-        return F.silu(gate) * up
+        return ir.ops.silu_and_mul_with_clamp(x, self.swiglu_limit)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        self.op(out, x, self.swiglu_limit)
-        return out
-
-    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
-        return self.forward_cuda(x)
+        return ir.ops.silu_and_mul_with_clamp(x, self.swiglu_limit)
 
 
 # --8<-- [start:mul_and_silu]

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -181,6 +181,9 @@ class SiluAndMulWithClamp(CustomOp):
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
         return ir.ops.silu_and_mul_with_clamp(x, self.swiglu_limit)
 
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        return ir.ops.silu_and_mul_with_clamp(x, self.swiglu_limit)
+
 
 # --8<-- [start:mul_and_silu]
 @CustomOp.register("mul_and_silu")


### PR DESCRIPTION



## Purpose

This PR rewrites the `forward_*` methods in `SiluAndMulWithClamp` with a call to new `vllm.ir.ops.silu_and_mul_with_clamp`. This is part to resolve the issue https://github.com/vllm-project/vllm/issues/40406

## Test Plan

Specific tests for the new vLLM IR have been added. In addition, I checked correctness and latency for the `deepseek-ai/DeepSeek-V4-Flash` model.

## Test Result

I ran `lm_eval` tests on 4xH100s

```
vllm serve --model deepseek-ai/DeepSeek-V4-Flash --tensor-parallel-size 4 --quantization fp8 --max-model-len 4096 --gpu-memory-utilization 0.7 --enforce-eager --kv-cache-dtype fp8 --block-size 256 --enable-expert-parallel --tokenizer-mode deepseek_v4

lm_eval --model local-completions --model_args pretrained=deepseek-ai/DeepSeek-V4-Flash,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=50,max_retries=3 --tasks gsm8k --num_fewshot 5 --batch_size auto
```

**main:**                                                                                                    
                                                                                                               
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9560|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9568|±  |0.0056|           
                                                                                                               
  **branch:**                                                                                           
                                                                                                               
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9530|±  |0.0058|


In addition, I ran some latency experiments on 4xH100s:
```
vllm bench latency --model deepseek-ai/DeepSeek-V4-Flash --tensor-parallel-size 4 --quantization fp8 --max-model-len 4096 --gpu-memory-utilization 0.7 --enforce-eager --kv-cache-dtype fp8 --block-size 256 --enable-expert-parallel --tokenizer-mode deepseek_v4
```

| Metric | Latency/s (main) | Stderr (main) | Latency/s (branch) | Stderr (branch) |
|--------|------------------:|--------------:|--------------------:|----------------:|
| Avg    |         13.341037 |      0.144069 |           13.915080 |        0.239610 |
| p10    |         13.203982 |      0.149102 |           13.690670 |        0.414609 |
| p25    |         13.278748 |      0.165272 |           13.790511 |        0.379956 |
| p50    |         13.343506 |      0.157119 |           13.946527 |        0.177370 |
| p75    |         13.401830 |      0.126252 |           14.037564 |        0.152943 |
| p90    |         13.441323 |      0.112400 |           14.098922 |        0.126524 |
| p99    |         13.658659 |      0.150968 |           14.156002 |        0.144399 |

**NOTE:** The latency benchmark for this model was a bit noisy, but I don't think there is any substantial difference between the vLLM IR and the original implementation.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

