### PR TITLE
Remove verifier model type check in speculative config

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -971,35 +971,6 @@ class SpeculativeConfig:
                 self.draft_parallel_config
             )
 
-        aux_hidden_states_supported = [
-            "llama",
-            "qwen",
-            "minicpm",
-            "gpt_oss",
-            "hunyuan_vl",
-            "hunyuan_v1_dense",
-            "afmoe",
-            "nemotron_h",
-            "deepseek_v2",
-            "deepseek_v3",
-            "kimi_k2",
-            "kimi_k25",
-            "minimax_m2",
-            "gemma4",
-            "laguna",
-        ]
-        if (
-            self.method in ("eagle3", "extract_hidden_states", "dflash")
-            and self.target_model_config
-            and not any(
-                supported_model in self.target_model_config.hf_text_config.model_type
-                for supported_model in aux_hidden_states_supported
-            )
-        ):
-            raise ValueError(
-                f"{self.method} is only supported for {aux_hidden_states_supported}"
-                f" models. Got {self.target_model_config.hf_text_config.model_type=}"
-            )
         self.verify_equal_vocab_size_if_draft_model()
         return self
 


### PR DESCRIPTION



## Purpose

We currently have this check when setting up the speculative config which limits aux_hidden_states usage to models in this hardcoded list. 

The real requirement for support aux_hidden_states is that the model definition extends the `SupportsEagle3` interface. There are already checks for this in [gpu_model_runner.py::load_model](https://github.com/vllm-project/vllm/blob/7a9cc5e7f0cd8b06da9fc7503a442d86cad097d2/vllm/v1/worker/gpu_model_runner.py#L4915) and [eagle3_utils.py::set_eagle3_aux_hidden_state_layers](https://github.com/vllm-project/vllm/blob/7a9cc5e7f0cd8b06da9fc7503a442d86cad097d2/vllm/v1/worker/gpu/spec_decode/eagle/eagle3_utils.py#L18). This pr just removes the check in the speculative config, so that we instead fallback to the more comprehensive checks in gpu_model_runner. 

The other motivation for this change is that it enables the transformers backend's eagle3 support to work. Currently all models running on the transformers backend should extend `SupportsEagle3` but unless the model_type is specifically included in this list vllm will not run it.

## Test Plan

Manually tested.
Temporarily commented out the qwen3 `SupportsEagle3` logic and confirmed that an error is raised by the gpu_model_runner when serving a Qwen3-8B Eagle3 speculator. Then also confirmed that the same model could be served with `--model-impl transformers`.

## Test Result

See above. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

