### PR TITLE
[Attention] Eagerly allocate FlashInfer workspace buffers

### DIFF
--- a/vllm/v1/attention/backends/mla/prefill/flashinfer.py
+++ b/vllm/v1/attention/backends/mla/prefill/flashinfer.py
@@ -77,6 +77,13 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         self._prefill_main: BatchPrefillWithRaggedKVCacheWrapper | None = None
         self._prefill_chunks: list[BatchPrefillWithRaggedKVCacheWrapper] = []
         self._global_hyperparameters: PerLayerParameters | None = None
+        self._get_workspace_buffer()
+
+    def _get_workspace_buffer(self) -> torch.Tensor:
+        (workspace_buffer,) = current_workspace_manager().get_simultaneous(
+            ((envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,), torch.uint8),
+        )
+        return workspace_buffer
 
     def _ensure_chunks(
         self,
@@ -123,9 +130,7 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         global_hyperparameters = self._resolve_global_hyperparameters()
         qo_indptr = prefill_metadata.query_start_loc
         has_context = prefill_metadata.chunked_context is not None
-        (workspace_buffer,) = current_workspace_manager().get_simultaneous(
-            ((envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,), torch.uint8),
-        )
+        workspace_buffer = self._get_workspace_buffer()
 
         if self._prefill_main is None:
             self._prefill_main = BatchPrefillWithRaggedKVCacheWrapper(

--- a/vllm/v1/attention/backends/mla/prefill/flashinfer.py
+++ b/vllm/v1/attention/backends/mla/prefill/flashinfer.py
@@ -77,13 +77,9 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         self._prefill_main: BatchPrefillWithRaggedKVCacheWrapper | None = None
         self._prefill_chunks: list[BatchPrefillWithRaggedKVCacheWrapper] = []
         self._global_hyperparameters: PerLayerParameters | None = None
-        self._get_workspace_buffer()
-
-    def _get_workspace_buffer(self) -> torch.Tensor:
-        (workspace_buffer,) = current_workspace_manager().get_simultaneous(
+        (self._workspace_buffer,) = current_workspace_manager().get_simultaneous(
             ((envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,), torch.uint8),
         )
-        return workspace_buffer
 
     def _ensure_chunks(
         self,
@@ -130,19 +126,17 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         global_hyperparameters = self._resolve_global_hyperparameters()
         qo_indptr = prefill_metadata.query_start_loc
         has_context = prefill_metadata.chunked_context is not None
-        workspace_buffer = self._get_workspace_buffer()
-
         if self._prefill_main is None:
             self._prefill_main = BatchPrefillWithRaggedKVCacheWrapper(
-                workspace_buffer, "NHD", backend="cutlass"
+                self._workspace_buffer, "NHD", backend="cutlass"
             )
-            self._ensure_chunks(_DEFAULT_NUM_CHUNKS, workspace_buffer)
+            self._ensure_chunks(_DEFAULT_NUM_CHUNKS, self._workspace_buffer)
 
         if has_context:
             chunked_context = prefill_metadata.chunked_context
             assert chunked_context is not None
             num_chunks = chunked_context.cu_seq_lens.shape[0]
-            self._ensure_chunks(num_chunks, workspace_buffer)
+            self._ensure_chunks(num_chunks, self._workspace_buffer)
 
         num_qo_heads = self.num_heads
         num_kv_heads = num_qo_heads

--- a/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
+++ b/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
@@ -61,16 +61,12 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             v_head_dim=v_head_dim,
             vllm_config=vllm_config,
         )
-        self._get_workspace_buffer()
-
-    def _get_workspace_buffer(self) -> torch.Tensor:
-        (workspace_buffer,) = current_workspace_manager().get_simultaneous(
+        (self._workspace_buffer,) = current_workspace_manager().get_simultaneous(
             (
                 (envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,),
                 torch.uint8,
             ),
         )
-        return workspace_buffer
 
     def prepare_metadata(
         self,
@@ -90,7 +86,6 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         from flashinfer.prefill import trtllm_ragged_attention_deepseek
 
-        workspace_buffer = self._get_workspace_buffer()
         out = torch.empty(
             q.shape[0],
             q.shape[1],
@@ -103,7 +98,7 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             query=q,
             key=k,
             value=v,
-            workspace_buffer=workspace_buffer,
+            workspace_buffer=self._workspace_buffer,
             seq_lens=self._query_seq_lens,
             max_q_len=self._prefill_metadata.max_query_len,
             max_kv_len=self._prefill_metadata.max_query_len,
@@ -136,7 +131,6 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
 
         assert self._prefill_metadata.chunked_context is not None
         assert self._prefill_metadata.chunked_context.seq_lens[chunk_idx] is not None
-        workspace_buffer = self._get_workspace_buffer()
 
         out = torch.empty(
             q.shape[0],
@@ -150,7 +144,7 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             query=q,
             key=k,
             value=v,
-            workspace_buffer=workspace_buffer,
+            workspace_buffer=self._workspace_buffer,
             seq_lens=self._prefill_metadata.chunked_context.seq_lens[chunk_idx],
             max_q_len=self._prefill_metadata.max_query_len,
             max_kv_len=self._prefill_metadata.chunked_context.max_seq_lens[chunk_idx],

--- a/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
+++ b/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
@@ -61,6 +61,7 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             v_head_dim=v_head_dim,
             vllm_config=vllm_config,
         )
+        self._get_workspace_buffer()
 
     def _get_workspace_buffer(self) -> torch.Tensor:
         (workspace_buffer,) = current_workspace_manager().get_simultaneous(


### PR DESCRIPTION

Alternative to https://github.com/vllm-project/vllm/pull/42112

## Purpose
Eagerly allocate the FlashInfer workspace buffers so that we don't hit the workspace growth error. Workspace is now owned by the `Backend` object.

## Test Plan
```
vllm serve moonshotai/Kimi-K2.6 \
  --trust-remote-code \
  --tensor-parallel-size 4 \
  --attention-config.mla_prefill_backend TRTLLM_RAGGED \
  --tool-call-parser kimi_k2 \
  --enable-auto-tool-choice \
  --reasoning-parser kimi_k2 \
  --speculative-config '{"model": "lightseekorg/kimi-k2.6-eagle3-mla", "method": "eagle3", "num_speculative_tokens": 3}'
```

```
curl -s http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "moonshotai/Kimi-K2.6",
      "messages": [{"role": "user", "content": "Hello, how are you?"}],
      "max_tokens": 64
    }'
```

## Test Result
main:

Crashes on request with the following error:
```
Workspace is locked but allocation from 'trtllm_ragged.py:66:_get_workspace_buffer' requires 394.00 MB, current size is 0.00 MB. Workspace growth is not allowed after locking.
```

PR:
Runs successfully

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

