### PR TITLE
[PD] Fix broken NIXL EP installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -845,9 +845,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
                 libcublas-dev-${CUDA_VERSION_DASH} \
                 libcusolver-dev-${CUDA_VERSION_DASH}"; \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        if [ "$CUDA_MAJOR" -ge 13 ]; then \
-            uv pip install --system nixl-cu13; \
-        fi; \
         uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
             # if the above fails, install from source
             apt-get update -y && \
@@ -857,6 +854,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \
         ); \
+        # Force-reinstall the matching CUDA wheel so the correct nixl_ep_cpp.so is installed.
+        uv pip install --system --force-reinstall --no-deps nixl-cu${CUDA_MAJOR}; \
     fi
 
 ENV VLLM_USAGE_SOURCE production-docker-image


### PR DESCRIPTION
## Purpose

Fix broken NIXL EP installation reported in https://github.com/vllm-project/vllm/issues/42525

There is a name conflict for one of the binaries in nixl-cu12 and nixl-cu13 packages. Depending on the installation order, sometimes the right one wins, sometimes the wrong one.

Short-term fix: force reinstall the correct package

Long-term fix: We will fix this upstream in the next nixl version.

Failing symptoms (before this fix):

```sh
docker run --gpus all --rm -it --entrypoint bash vllm/vllm-openai:nightly -c '
  echo "=== Check CUDA version ==="
  python3 -c "import torch; print(f\"torch CUDA: {torch.version.cuda}\")"
  echo "=== Check nixl_ep linkage ==="
  SITE=$(python3 -c "import site; print(site.getsitepackages()[0])")
  ldd $SITE/nixl_ep/nixl_ep_cpp*.so 2>&1 | grep cudart
  echo "=== Test imports ==="
  python3 -c "import nixl; print(\"nixl: OK\")"
  python3 -c "import nixl_ep; print(\"nixl_ep: OK\")"
  python3 -c "import vllm; print(\"vllm: OK\")"
'
=== Check CUDA version ===
torch CUDA: 13.0
=== Check nixl_ep linkage ===
        libcudart.so.12 => not found
=== Test imports ===
nixl: OK
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.12/dist-packages/nixl_ep/__init__.py", line 23, in <module>
    from . import nixl_ep_cpp as _nixl_ep_cpp
ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
vllm: OK
```

## Test Plan

- Test fix manually in built image
- Test full image rebuild

## Test Result

- Test fix manually in built image: works
- Test full image rebuild:

CUDA 13 image works:
```sh
docker run --gpus all --rm -it --entrypoint bash vllm-openai:nixl-fix-test -c '
  echo "=== Check CUDA version ==="
  python3 -c "import torch; print(f\"torch CUDA: {torch.version.cuda}\")"

  echo "=== Check nixl_ep linkage ==="
  SITE=$(python3 -c "import site; print(site.getsitepackages()[0])")
  ldd $SITE/nixl_ep/nixl_ep_cpp*.so 2>&1 | grep cudart

  echo "=== Test imports ==="
  python3 -c "import nixl; print(\"nixl: OK\")"
  python3 -c "import nixl_ep; print(\"nixl_ep: OK\")"
  python3 -c "import vllm; print(\"vllm: OK\")"
'
=== Check CUDA version ===
torch CUDA: 13.0
=== Check nixl_ep linkage ===
        libcudart.so.13 => /usr/local/cuda/lib64/libcudart.so.13 (0x00007ffff1200000)
=== Test imports ===
nixl: OK
nixl_ep: OK
vllm: OK
```

CUDA 12 image works:
```sh
docker run --gpus all --rm -it --entrypoint bash vllm-openai:nixl-fix-test-cu12 -c '
  echo "=== Check CUDA version ==="
  python3 -c "import torch; print(f\"torch CUDA: {torch.version.cuda}\")"

  echo "=== Check nixl_ep linkage ==="
  SITE=$(python3 -c "import site; print(site.getsitepackages()[0])")
  ldd $SITE/nixl_ep/nixl_ep_cpp*.so 2>&1 | grep cudart

  echo "=== Test imports ==="
  python3 -c "import nixl; print(\"nixl: OK\")"
  python3 -c "import nixl_ep; print(\"nixl_ep: OK\")"
  python3 -c "import vllm; print(\"vllm: OK\")"
'
=== Check CUDA version ===
torch CUDA: 12.9
=== Check nixl_ep linkage ===
        libcudart.so.12 => /usr/local/cuda/lib64/libcudart.so.12 (0x00007ffff0e00000)
=== Test imports ===
nixl: OK
nixl_ep: OK
vllm: OK
```