### PR TITLE
[PD][Core] Fix Mamba prefix cache with PD

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,9 +14,14 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    MambaManager,
     SlidingWindowManager,
 )
-from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, SlidingWindowSpec
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -480,4 +485,284 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"num_tokens={num_tokens}: predictor returned {predicted} "
             f"but allocator pulled {len(new_blocks)}"
         )
-        total_computed = num_tokens
+
+
+## Mamba prefix caching with PD
+
+
+def _make_mamba_align_manager(block_size, block_pool):
+    spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,), (1,)),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    return MambaManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        max_admission_blocks_per_request=10**9,
+    )
+
+
+class _FakeRequest:
+    """Minimal stand-in for vllm.v1.request.Request used by cache_blocks."""
+
+    def __init__(self, request_id, block_hashes):
+        self.request_id = request_id
+        self.block_hashes = block_hashes
+
+
+def test_mamba_align_num_cached_block_excludes_null_blocks_pd():
+    """PD path: all tokens are external, no local prefix hit.
+
+    allocate_new_computed_blocks must set num_cached_block to 0
+    (not to the number of null padding blocks), otherwise cache_blocks()
+    will early-return and never hash the real state block.
+    """
+    block_size = 128
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = _make_mamba_align_manager(block_size, block_pool)
+
+    request_id = "req_pd"
+    num_external = 400
+
+    manager.allocate_new_computed_blocks(
+        request_id,
+        new_computed_blocks=[],
+        num_local_computed_tokens=0,
+        num_external_computed_tokens=num_external,
+    )
+
+    # get_num_skipped_tokens(400)=399 → num_skipped_blocks=3
+    # req_blocks = [null, null, null, fresh]
+    req_blocks = manager.req_to_blocks[request_id]
+    assert len(req_blocks) == 4
+    assert all(req_blocks[i].is_null for i in range(3))
+    assert not req_blocks[3].is_null
+
+    # The fix: num_cached_block must be 0, not 3.
+    assert manager.num_cached_block[request_id] == 0
+
+
+def test_mamba_align_num_cached_block_with_local_prefix_hit():
+    """PD path with a partial local prefix cache hit.
+
+    If 2 computed blocks come from a local prefix hit and 1 is skipped,
+    num_cached_block should be 2 (all original computed blocks).
+    """
+    block_size = 128
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = _make_mamba_align_manager(block_size, block_pool)
+
+    # Simulate 2 local prefix-hit blocks.
+    cached_block_0 = block_pool.blocks[10]
+    cached_block_0.block_hash = make_block_hash_with_group_id(BlockHash(b"h0"), 0)
+    cached_block_1 = block_pool.blocks[11]
+    cached_block_1.block_hash = make_block_hash_with_group_id(BlockHash(b"h1"), 0)
+
+    request_id = "req_partial"
+    # 256 tokens → get_num_skipped_tokens(256)=255 → num_skipped_blocks=1
+    # new_computed_blocks[1:] = [cached_block_1] survives.
+    manager.allocate_new_computed_blocks(
+        request_id,
+        new_computed_blocks=[cached_block_0, cached_block_1],
+        num_local_computed_tokens=2 * block_size,
+        num_external_computed_tokens=0,
+    )
+
+    req_blocks = manager.req_to_blocks[request_id]
+    # [null, cached_block_1]
+    assert len(req_blocks) == 2
+    assert req_blocks[0].is_null
+    assert req_blocks[1] is cached_block_1
+
+    # num_cached_block = len(original new_computed_blocks) = 2
+    assert manager.num_cached_block[request_id] == 2
+
+
+def test_mamba_align_cache_blocks_registers_null_hashes():
+    """After cache_blocks(), null-block-position hashes must be in the
+    hash map so that find_longest_cache_hit can discover them.
+    """
+    block_size = 128
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = _make_mamba_align_manager(block_size, block_pool)
+
+    request_id = "req_nullhash"
+    num_external = 400  # 3 full blocks + 16-token partial
+
+    manager.allocate_new_computed_blocks(
+        request_id,
+        new_computed_blocks=[],
+        num_local_computed_tokens=0,
+        num_external_computed_tokens=num_external,
+    )
+
+    # Build a fake request whose block_hashes cover at least num_full_blocks.
+    num_full_blocks = num_external // block_size  # 3
+    block_hashes = [BlockHash(f"h{i}".encode()) for i in range(num_full_blocks + 1)]
+    fake_req = _FakeRequest(request_id, block_hashes)
+
+    # cache_blocks with num_tokens covering the 3 full blocks.
+    manager.cache_blocks(fake_req, num_full_blocks * block_size)
+
+    # All 3 null-block hashes should now be discoverable in the hash map.
+    for i in range(num_full_blocks):
+        key = make_block_hash_with_group_id(block_hashes[i], 0)
+        cached = block_pool.cached_block_hash_to_block.get_one_block(key)
+        assert cached is not None, f"hash[{i}] not found after cache_blocks"
+        assert cached.is_null, f"hash[{i}] should map to null_block"
+
+
+def test_mamba_align_cache_blocks_does_not_early_return_pd():
+    """End-to-end: cache_blocks must NOT early-return when all blocks are
+    null (the original bug).  After cache_blocks, num_cached_block should
+    advance so subsequent calls with more tokens can cache the state block.
+    """
+    block_size = 128
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = _make_mamba_align_manager(block_size, block_pool)
+
+    request_id = "req_noreturn"
+    num_external = 400
+    num_full_blocks = num_external // block_size  # 3
+
+    manager.allocate_new_computed_blocks(
+        request_id,
+        new_computed_blocks=[],
+        num_local_computed_tokens=0,
+        num_external_computed_tokens=num_external,
+    )
+
+    block_hashes = [BlockHash(f"h{i}".encode()) for i in range(num_full_blocks + 1)]
+    fake_req = _FakeRequest(request_id, block_hashes)
+
+    # First call — should process blocks 0..2 (all null) and advance.
+    manager.cache_blocks(fake_req, num_full_blocks * block_size)
+    assert manager.num_cached_block[request_id] == num_full_blocks
+
+    # Second call with more tokens — block 3 (the real state block) gets cached.
+    manager.cache_blocks(fake_req, (num_full_blocks + 1) * block_size)
+    assert manager.num_cached_block[request_id] == num_full_blocks + 1
+
+    # The real block should now be hashed (non-null).
+    state_block = manager.req_to_blocks[request_id][num_full_blocks]
+    assert not state_block.is_null
+    assert state_block.block_hash is not None
+
+
+def test_mamba_align_find_longest_cache_hit_after_pd_caching():
+    """Full round-trip: after caching a PD request's blocks,
+    a second request with the same prefix should get a cache hit.
+    """
+    block_size = 128
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = _make_mamba_align_manager(block_size, block_pool)
+    spec = manager.kv_cache_spec
+
+    request_id = "req_roundtrip"
+    num_tokens = 3 * block_size  # 384 — exactly block-aligned
+    num_full_blocks = num_tokens // block_size  # 3
+
+    # --- First request (PD): allocate + cache ---
+    manager.allocate_new_computed_blocks(
+        request_id,
+        new_computed_blocks=[],
+        num_local_computed_tokens=0,
+        num_external_computed_tokens=num_tokens,
+    )
+
+    block_hashes = [BlockHash(f"h{i}".encode()) for i in range(num_full_blocks + 1)]
+    fake_req = _FakeRequest(request_id, block_hashes)
+
+    # Cache the full blocks (null positions registered by MambaManager).
+    manager.cache_blocks(fake_req, num_full_blocks * block_size)
+
+    # Simulate decode advancing to fill block 3, then cache it too.
+    # allocate_new_blocks would normally do this; we add a fresh block manually.
+    req_blocks = manager.req_to_blocks[request_id]
+    if len(req_blocks) <= num_full_blocks:
+        fresh = block_pool.get_new_blocks(1)[0]
+        req_blocks.append(fresh)
+    manager.cache_blocks(fake_req, (num_full_blocks + 1) * block_size)
+
+    # --- Second request: find_longest_cache_hit ---
+    hit = MambaManager.find_longest_cache_hit(
+        block_hashes=block_hashes,
+        max_length=num_tokens,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        use_eagle=False,
+        alignment_tokens=block_size,
+    )
+
+    # Mamba searches right-to-left. With 384 tokens → max_num_blocks=3,
+    # it checks block_hashes[2]. The null-block hash was registered,
+    # so this should be a hit of length 3 blocks.
+    hit_blocks = hit[0]
+    assert len(hit_blocks) == num_full_blocks, (
+        f"Expected hit length {num_full_blocks}, got {len(hit_blocks)}"
+    )
+
+
+def test_mamba_align_swa_unchanged_by_num_cached_block_fix():
+    """Verify the num_cached_block fix does not change SWA behavior.
+
+    For SWA, new_computed_blocks from find_longest_cache_hit includes
+    null padding.  len(new_computed_blocks) before skipping should equal
+    len(req_blocks) — same as the old len(req_blocks) code.
+    """
+    block_size = 2
+    sliding_window = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=sliding_window,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    # Simulate SWA find_longest_cache_hit returning [NULL, NULL, B7, B8]
+    # for 4-block prefix with 2-block sliding window.
+    computed_blocks = [
+        block_pool.null_block,
+        block_pool.null_block,
+        block_pool.blocks[7],
+        block_pool.blocks[8],
+    ]
+    # Mark the real blocks as having hashes (as they would from a cache hit).
+    block_pool.blocks[7].block_hash = make_block_hash_with_group_id(BlockHash(b"b7"), 0)
+    block_pool.blocks[8].block_hash = make_block_hash_with_group_id(BlockHash(b"b8"), 0)
+
+    num_local_computed_tokens = 4 * block_size  # 8 tokens
+    manager.allocate_new_computed_blocks(
+        "swa_req",
+        new_computed_blocks=computed_blocks,
+        num_local_computed_tokens=num_local_computed_tokens,
+        num_external_computed_tokens=0,
+    )
+
+    # SWA: get_num_skipped_tokens(8) = max(0, 8-4+1) = 5 → num_skipped_blocks=2
+    # new_computed_blocks[2:] = [B7, B8]
+    # req_blocks = [null, null, B7, B8]
+    # num_cached_block should be 4 (= len(original computed_blocks))
+    # which is the same as len(req_blocks) — matching old behavior.
+    assert manager.num_cached_block["swa_req"] == 4
+    assert len(manager.req_to_blocks["swa_req"]) == 4

--- a/tests/v1/kv_connector/unit/conftest.py
+++ b/tests/v1/kv_connector/unit/conftest.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import gc
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def clean_gpu_memory_between_tests():
+    """Free GPU memory before and after each test that uses a real GPU.
+
+    Call gc.collect() + empty_cache() before the test so that allocations
+    from previous tests (in the same session) don't prevent this test from
+    reserving the memory it needs.  Repeat after the test so that the next
+    test starts with a clean slate.
+    """
+    gc.collect()
+    if torch.accelerator.is_available():
+        torch.accelerator.empty_cache()
+    yield
+    gc.collect()
+    if torch.accelerator.is_available():
+        torch.accelerator.empty_cache()

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -277,6 +277,83 @@ def test_apply_prefix_caching_mamba_hybrid(
 @pytest.mark.cpu_test
 @pytest.mark.parametrize(
     "local_physical_per_logical,remote_physical_per_logical,"
+    "local_block_ids,remote_block_ids,"
+    "expected_local,expected_remote",
+    [
+        # SSM prefix caching: remote has 3 placeholder + 1 real block,
+        # local has only the 1 real block. FA blocks are equal (no trim).
+        pytest.param(
+            10,
+            10,
+            [list(range(10)), [42]],
+            [list(range(10)), [40, 41, 42, 43]],
+            [list(range(10)), [42]],
+            [list(range(10)), [43]],
+            id="ssm_prefix_trim_only",
+        ),
+        # FA partial prefix cache hit with homogeneous TP: local has 4 FA
+        # blocks (prefix cached), remote has full 10. SSM equal (no trim).
+        pytest.param(
+            10,
+            10,
+            [list(range(6, 10)), [42]],
+            [list(range(10)), [42]],
+            [list(range(6, 10)), [42]],
+            [list(range(6, 10)), [42]],
+            id="fa_prefix_hit_homo_tp",
+        ),
+        # Both: FA partial prefix hit + SSM placeholder trim.
+        # local FA=[6..9] (4 blocks, prefix cached), remote FA=[0..9]
+        # local SSM=[99], remote SSM=[10, 20, 99] (2 placeholders + real)
+        pytest.param(
+            10,
+            10,
+            [[6, 7, 8, 9], [99]],
+            [list(range(10)), [10, 20, 99]],
+            [[6, 7, 8, 9], [99]],
+            [[6, 7, 8, 9], [99]],
+            id="fa_prefix_hit_and_ssm_trim",
+        ),
+    ],
+)
+def test_apply_prefix_caching_ssm_prefix_cache_hit(
+    local_physical_per_logical,
+    remote_physical_per_logical,
+    local_block_ids,
+    remote_block_ids,
+    expected_local,
+    expected_remote,
+):
+    """_apply_prefix_caching end-trims SSM remote blocks to match the single
+    local block (placeholders dropped) and end-trims FA remote blocks on
+    partial prefix cache hits when physical_per_logical matches.
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = True
+    worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
+    worker._group_spec_types = (FullAttentionSpec, MambaSpec)
+    worker.kv_cache_config = make_kv_cache_config(block_size=16, mamba_enabled=True)
+
+    aligned_local, aligned_remote = worker._apply_prefix_caching(
+        local_block_ids, remote_block_ids, remote_physical_per_logical
+    )
+
+    assert aligned_local == expected_local, (
+        f"Expected local {expected_local}, got {aligned_local}"
+    )
+    assert aligned_remote == expected_remote, (
+        f"Expected remote {expected_remote}, got {aligned_remote}"
+    )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "local_physical_per_logical,remote_physical_per_logical,"
     "remote_fa_blocks,local_fa_blocks,ssm_blocks,"
     "correct_remote_fa,correct_local_fa",
     [

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -2348,9 +2348,17 @@ class NixlConnectorWorker:
                     and num_local_blocks < num_remote_blocks
                 ):
                     # NOTE (NickLucche): With prefix caching on SSM, (remote) blocks
-                    # prior to the last one are placeholders (null blocks). We only
-                    # care about the last one, which maintains the full state in-place.
+                    # prior to the last one are placeholders (null blocks). Mind that
+                    # this doesn't really impact transfer, as we only still care about
+                    # the last "block", the full in-place state.
                     assert num_local_blocks == 1, "SSM can only have one local block"
+                    remote_block_ids[i] = remote_group[-num_local_blocks:]
+                elif (
+                    self._physical_blocks_per_logical_kv_block
+                    == remote_physical_per_logical
+                    and num_local_blocks < num_remote_blocks
+                ):
+                    # Partial prefix cache hit for FA group.
                     remote_block_ids[i] = remote_group[-num_local_blocks:]
                 else:
                     max_padding = max(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -2343,8 +2343,15 @@ class NixlConnectorWorker:
             for i, remote_group in enumerate(remote_block_ids):
                 num_local_blocks = len(local_block_ids[i])
                 num_remote_blocks = len(remote_group)
-                if _is_ssm_spec(self._group_spec_types[i]):
-                    assert num_local_blocks == num_remote_blocks
+                if (
+                    _is_ssm_spec(self._group_spec_types[i])
+                    and num_local_blocks < num_remote_blocks
+                ):
+                    # NOTE (NickLucche): With prefix caching on SSM, (remote) blocks
+                    # prior to the last one are placeholders (null blocks). We only
+                    # care about the last one, which maintains the full state in-place.
+                    assert num_local_blocks == 1, "SSM can only have one local block"
+                    remote_block_ids[i] = remote_group[-num_local_blocks:]
                 else:
                     max_padding = max(
                         self._physical_blocks_per_logical_kv_block,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -262,9 +262,6 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        assert num_external_computed_tokens == 0, (
-            "External KV connector is not verified yet"
-        )
         num_computed_tokens = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
@@ -666,7 +663,8 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                if self.need_mamba_block_aligned_split:
+                # Skip block alignment when setting up async receive (no local work).
+                if self.need_mamba_block_aligned_split and not load_kv_async:
                     num_new_tokens = self._mamba_block_aligned_split(
                         request,
                         num_new_tokens,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -9,8 +9,10 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
+    BlockHashListWithBlockSize,
     BlockHashWithGroupId,
     KVCacheBlock,
+    make_block_hash_with_group_id,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
@@ -203,6 +205,8 @@ class SingleTypeKVCacheManager(ABC):
         )
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
+        # Capture before slicing: only real prefix-hit blocks count as cached.
+        num_computed_blocks = len(new_computed_blocks)
         if num_skipped_blocks > 0:
             # It is possible that all new computed blocks are skipped when
             # num_skipped_blocks > len(new_computed_blocks).
@@ -225,10 +229,10 @@ class SingleTypeKVCacheManager(ABC):
         req_blocks.extend([self._null_block] * num_skipped_blocks)
         # Add the remaining computed blocks.
         req_blocks.extend(new_computed_blocks)
-        # All cached hits (including skipped nulls) are already cached; mark
-        # them so cache_blocks() will not try to re-cache blocks that already
-        # have a block_hash set.
-        self.num_cached_block[request_id] = len(req_blocks)
+        # Only count actual prefix-hit blocks as cached. Null blocks from
+        # Mamba align-mode or SWA skipping must NOT be counted here —
+        # otherwise cache_blocks() will early-return before hashing them.
+        self.num_cached_block[request_id] = num_computed_blocks
 
         if num_external_computed_tokens > 0:
             # Allocate new blocks for external computed tokens.
@@ -1054,13 +1058,36 @@ class MambaManager(SingleTypeKVCacheManager):
         super().cache_blocks(request, num_tokens)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
-                if block.is_null:
+            # Resolve block hashes at this manager's block_size granularity.
+            if self.block_size == self.block_pool.hash_block_size:
+                block_hashes: BlockHashList = request.block_hashes
+            else:
+                block_hashes = BlockHashListWithBlockSize(
+                    request.block_hashes,
+                    self.block_pool.hash_block_size,
+                    self.block_size,
+                )
+            req_blocks = self.req_to_blocks[request.request_id]
+            for i in range(num_cached_blocks_before, num_cached_blocks_after):
+                blk = req_blocks[i]
+                if blk.is_null:
+                    # Register hash -> null_block so find_longest_cache_hit
+                    # can discover these positions. Mamba state is cumulative:
+                    # only the last block holds data, but earlier positions
+                    # must be in the hash map for the right-to-left search to
+                    # identify the hit length. The null_block singleton's
+                    # block_hash stays None, so these entries won't be evicted
+                    # via _maybe_evict_cached_block; they are cleared on
+                    # reset_prefix_cache().
+                    block_hash_with_gid = make_block_hash_with_group_id(
+                        block_hashes[i], self.kv_cache_group_id
+                    )
+                    self.block_pool.cached_block_hash_to_block.insert(
+                        block_hash_with_gid, blk
+                    )
                     continue
-                assert block.block_hash is not None
-                self.cached_blocks_this_step.add(block.block_hash)
+                assert blk.block_hash is not None
+                self.cached_blocks_this_step.add(blk.block_hash)
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -205,7 +205,6 @@ class SingleTypeKVCacheManager(ABC):
         )
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
-        # Capture before slicing: only real prefix-hit blocks count as cached.
         num_computed_blocks = len(new_computed_blocks)
         if num_skipped_blocks > 0:
             # It is possible that all new computed blocks are skipped when
@@ -229,9 +228,7 @@ class SingleTypeKVCacheManager(ABC):
         req_blocks.extend([self._null_block] * num_skipped_blocks)
         # Add the remaining computed blocks.
         req_blocks.extend(new_computed_blocks)
-        # Only count actual prefix-hit blocks as cached. Null blocks from
-        # Mamba align-mode or SWA skipping must NOT be counted here —
-        # otherwise cache_blocks() will early-return before hashing them.
+        # Count real prefix-hit blocks before skipping.
         self.num_cached_block[request_id] = num_computed_blocks
 
         if num_external_computed_tokens > 0:
@@ -1058,7 +1055,6 @@ class MambaManager(SingleTypeKVCacheManager):
         super().cache_blocks(request, num_tokens)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if num_cached_blocks_after > num_cached_blocks_before:
-            # Resolve block hashes at this manager's block_size granularity.
             if self.block_size == self.block_pool.hash_block_size:
                 block_hashes: BlockHashList = request.block_hashes
             else:
@@ -1071,14 +1067,9 @@ class MambaManager(SingleTypeKVCacheManager):
             for i in range(num_cached_blocks_before, num_cached_blocks_after):
                 blk = req_blocks[i]
                 if blk.is_null:
-                    # Register hash -> null_block so find_longest_cache_hit
-                    # can discover these positions. Mamba state is cumulative:
-                    # only the last block holds data, but earlier positions
-                    # must be in the hash map for the right-to-left search to
-                    # identify the hit length. The null_block singleton's
-                    # block_hash stays None, so these entries won't be evicted
-                    # via _maybe_evict_cached_block; they are cleared on
-                    # reset_prefix_cache().
+                    # find_longest_cache_hit searches right-to-left through hashes.
+                    # When null-block positions are not in the hash map, the search
+                    # misses and hit_length drops to 0 (mamba caching specific).
                     block_hash_with_gid = make_block_hash_with_group_id(
                         block_hashes[i], self.kv_cache_group_id
                     )


### PR DESCRIPTION
Fix 0% prefix cache hit rate with Mamba in PD disaggregation (all/align).
Based on https://github.com/vllm-project/vllm/pull/42554, real diff here https://github.com/NickLucche/vllm/compare/mamba-prefix-caching-pd...NickLucche:vllm:pd-fix-apc

## Bug

  Mamba prefix cache reports 0% hit rate on the Decode side in PD disaggregation.

  **This is PD-specific.** In standalone mode, `allocate_new_computed_blocks` is
  skipped entirely (`num_external_computed_tokens = 0`), and null blocks only
  appear later during RUNNING via `remove_skipped_blocks`, by which time the real
  blocks are already hashed.

  In PD mode, `allocate_new_computed_blocks` runs with
  `num_external_computed_tokens > 0`, which pads `req_blocks` with null blocks
  via Mamba's `get_num_skipped_tokens(N) = N-1`. The old code then set:

  ```python
  self.num_cached_block[request_id] = len(req_blocks)  # counts nulls!

  When _update_waiting_for_remote_kv later called cache_blocks(), it found
  num_cached_block >= num_full_blocks and early-returned — nothing was ever
  hashed into the block pool, so every subsequent find_longest_cache_hit missed.

  allocate_new_computed_blocks (400 tokens, block_size=128):
    get_num_skipped_tokens(400) = 399 → num_skipped_blocks = 3
    req_blocks = [null, null, null, fresh]
    num_cached_block = 3                  ← BUG: counts nulls

  cache_blocks(400):
    num_full_blocks = 400 // 128 = 3
    3 >= 3 → EARLY RETURN → nothing hashed → 0% hit rate
```

## Fix

  Two changes, both in single_type_kv_cache_manager.py:

  1. **Don't count null blocks in num_cached_block**

  Capture len(new_computed_blocks) before the skip-slicing that strips
  leading blocks. This counts only real prefix-hit blocks, not null padding:

```python
  num_computed_blocks = len(new_computed_blocks)   # before slicing
  # ... slicing, padding, etc ...
  self.num_cached_block[request_id] = num_computed_blocks
```

  This is a no-op for FullAttention (no skipping) and SWA (the null padding in
  new_computed_blocks from find_longest_cache_hit exactly equals
  num_skipped_blocks, so the count is unchanged).

  2. **Register null-block hashes in MambaManager.cache_blocks**

  With fix 1, cache_blocks() no longer early-returns — it iterates the null
  blocks. But BlockPool.cache_full_blocks skips them (blk.is_null → continue),
  so their hashes never enter the hash map.

  Mamba's find_longest_cache_hit searches right-to-left through block hashes.
  If null-block positions aren't in the hash map, the search misses and
  hit_length drops to 0, dragging the HMA coordinator's overall hit to 0.

   MambaManager.cache_blocks now registers hash → null_block entries for null positions.

## Reproducer (PD disaggregation)

```bash
# D
 VLLM_NIXL_SIDE_CHANNEL_PORT=$(just port 5558) VLLM_SSM_CONV_STATE_LAYOUT=DS 
vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 --port $(just port 8200) --enforce-eager --tensor-parallel-size 1 --gpu-memory-utilization 0.9 --trust-remote-code --max-model-len 131072 --block-size 128 --enable-prefix-caching --no-disable-hybrid-kv-cache-manager --mamba-cache-mode align --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

# P
VLLM_NIXL_SIDE_CHANNEL_PORT=$(just port 5557) vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 --port $(just port 8100)  --gpu-memory-utilization 0.9 --trust-remote-code --enforce-eager --max-model-len 131072 --block-size 128 --enable-prefix-caching --no-disable-hybrid-kv-cache-manager --mamba-cache-mode align --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

# proxy
python vllm//tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --port $(just port 8192) --prefiller-port $(just port 8100) --decoder-port $(just port 8200)

# Send same request twice and observe D-side logs:

# D
(APIServer pid=2777847) INFO 05-13 18:03:41 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, **Prefix cache hit rate: 0.0%,** External prefix cache hit rate: 100.0%

```

## Test with

```bash
  pytest tests/v1/core/test_single_type_kv_cache_manager.py -k "mamba_align" -v
  pytest tests/v1/kv_connector/unit/test_nixl_connector_hma.py -k "ssm_prefix" -v
```


## Benchmark

A simple scenario, PD TP1, H100, Nemotron3-Nano, ~8k/1k:
```
vllm bench serve --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \
  --dataset-name prefix_repetition --num-prompts 1000 \
  --base-url http://localhost:55483 --ignore-eos --max-concurrency 100 \
  --prefix-repetition-prefix-len 6000 --prefix-repetition-suffix-len 2000 \
  --prefix-repetition-num-prefixes 100 --prefix-repetition-output-len 1000

# --no-enable-prefix-caching
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Maximum request concurrency:             100
Benchmark duration (s):                  539.67
Total input tokens:                      8000031
Total generated tokens:                  1000000
Request throughput (req/s):              1.85
Output token throughput (tok/s):         1852.97
Peak output token throughput (tok/s):    2100.00
Peak concurrent requests:                106.00
Total token throughput (tok/s):          16676.77
---------------Time to First Token----------------
Mean TTFT (ms):                          1632.73
Median TTFT (ms):                        579.53
P99 TTFT (ms):                           18875.09
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.70
Median TPOT (ms):                        52.04
P99 TPOT (ms):                           52.53
---------------Inter-token Latency----------------
Mean ITL (ms):                           51.70
Median ITL (ms):                         51.92
P99 ITL (ms):                            60.07
==================================================

# --enable-prefix-caching --mamba-cache-mode align
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Maximum request concurrency:             100
Benchmark duration (s):                  533.51
Total input tokens:                      8000031
Total generated tokens:                  1000000
Request throughput (req/s):              1.87
Output token throughput (tok/s):         1874.39
Peak output token throughput (tok/s):    2100.00
Peak concurrent requests:                112.00
Total token throughput (tok/s):          16869.59
---------------Time to First Token----------------
Mean TTFT (ms):                          1458.54
Median TTFT (ms):                        508.13
P99 TTFT (ms):                           16325.75
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.35
Median TPOT (ms):                        51.32
P99 TPOT (ms):                           53.01
---------------Inter-token Latency----------------
Mean ITL (ms):                           51.35
Median ITL (ms):                         51.49
P99 ITL (ms):                            61.80
==================================================
```