### PR TITLE
[MM] Pad Qwen2_5_VisionMLP weights to use CUTLASS kernels

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -26,6 +26,7 @@
 # limitations under the License.
 """Inference-only Qwen2.5-VL model compatible with HuggingFace weights."""
 
+import itertools
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from functools import lru_cache, partial
 from typing import Annotated, Any, Literal, TypeAlias
@@ -63,12 +64,12 @@ from vllm.model_executor.layers.attention import MMEncoderAttention
 from vllm.model_executor.layers.conv import Conv3dLayer
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
-    LinearBase,
+    WEIGHT_LOADER_V2_SUPPORTED,
     ColumnParallelLinear,
+    LinearBase,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
-    WEIGHT_LOADER_V2_SUPPORTED,
     adjust_bitsandbytes_4bit_shard,
     adjust_block_scale_shard,
     adjust_marlin_shard,
@@ -310,14 +311,20 @@ class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
                     "Shard id with multiple indices is not supported "
                     "for BNB quantization with TP yet."
                 )
+            shard_ids = (
+                loaded_shard_id
+                if isinstance(loaded_shard_id, tuple)
+                else range(len(output_sizes))
+            )
             shard_offsets: list[tuple[int, int, int]] = []
-            for i, output_size in enumerate(output_sizes):
-                shard_offsets.append((i, current_shard_offset, output_size))
+            for i, shard_id in enumerate(shard_ids):
+                output_size = output_sizes[i]
+                shard_offsets.append((shard_id, current_shard_offset, output_size))
                 current_shard_offset += output_size
             packed_dim = getattr(param, "packed_dim", None)
             for shard_id, shard_offset, shard_size in shard_offsets:
                 if packed_dim == output_dim:
-                    packed_factor = getattr(param, "packed_factor")
+                    packed_factor = param.packed_factor
                     shard_size = shard_size // packed_factor
                     shard_offset = shard_offset // packed_factor
                     shard_size, shard_offset = adjust_marlin_shard(
@@ -325,9 +332,7 @@ class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
                     )
 
                 if use_bitsandbytes_4bit:
-                    index = list(
-                        itertools.accumulate([0] + self.loaded_output_sizes)
-                    )
+                    index = list(itertools.accumulate([0] + self.loaded_output_sizes))
                     orig_offsets = {
                         str(i): (index[i], size)
                         for i, size in enumerate(self.loaded_output_sizes)
@@ -367,7 +372,7 @@ class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
 
             packed_dim = getattr(param, "packed_dim", None)
             if packed_dim == output_dim:
-                packed_factor = getattr(param, "packed_factor")
+                packed_factor = param.packed_factor
                 shard_size = shard_size // packed_factor
                 shard_offset = shard_offset // packed_factor
                 loaded_shard_size = loaded_shard_size // packed_factor
@@ -384,9 +389,7 @@ class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
             is_sharded_weight = is_sharded_weight or use_bitsandbytes_4bit
 
             if use_bitsandbytes_4bit:
-                index = list(
-                    itertools.accumulate([0] + self.loaded_output_sizes)
-                )
+                index = list(itertools.accumulate([0] + self.loaded_output_sizes))
                 orig_offsets = {
                     str(i): (index[i], size)
                     for i, size in enumerate(self.loaded_output_sizes)
@@ -424,12 +427,14 @@ class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
         param: BasevLLMParameter,
         loaded_weight: torch.Tensor,
         output_sizes: list[int] | None = None,
+        shard_ids: tuple[int, ...] | range | None = None,
     ):
         current_shard_offset = 0
         shard_offsets: list[tuple[int, int, int]] = []
         output_sizes = output_sizes or self.loaded_output_sizes
-        for i, output_size in enumerate(output_sizes):
-            shard_offsets.append((i, current_shard_offset, output_size))
+        shard_ids = shard_ids or range(len(output_sizes))
+        for shard_id, output_size in zip(shard_ids, output_sizes):
+            shard_offsets.append((shard_id, current_shard_offset, output_size))
             current_shard_offset += output_size
 
         for shard_id, shard_offset, shard_size in shard_offsets:
@@ -481,7 +486,10 @@ class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
                     for size in (output_sizes or self.loaded_output_sizes)
                 ]
             self._load_fused_module_from_checkpoint(
-                param, loaded_weight, output_sizes=output_sizes
+                param,
+                loaded_weight,
+                output_sizes=output_sizes,
+                shard_ids=loaded_shard_id,
             )
             return
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -26,17 +26,16 @@
 # limitations under the License.
 """Inference-only Qwen2.5-VL model compatible with HuggingFace weights."""
 
-import itertools
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from functools import lru_cache, partial
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias, cast
 
 import einops
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.parameter import Parameter, UninitializedParameter
+from torch.nn.parameter import Parameter
 from transformers import BatchFeature
 from transformers.models.qwen2_5_vl import Qwen2_5_VLProcessor
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
@@ -50,12 +49,8 @@ from vllm.compilation.decorators import (
 )
 from vllm.config import VllmConfig
 from vllm.distributed import (
-    divide,
-    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     parallel_state,
-    split_tensor_along_last_dim,
-    tensor_model_parallel_all_reduce,
 )
 from vllm.distributed import utils as dist_utils
 from vllm.logger import init_logger
@@ -64,16 +59,10 @@ from vllm.model_executor.layers.attention import MMEncoderAttention
 from vllm.model_executor.layers.conv import Conv3dLayer
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
-    WEIGHT_LOADER_V2_SUPPORTED,
     ColumnParallelLinear,
-    LinearBase,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
-    adjust_bitsandbytes_4bit_shard,
-    adjust_block_scale_shard,
-    adjust_marlin_shard,
-    adjust_scalar_to_fused_array,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
@@ -82,15 +71,6 @@ from vllm.model_executor.layers.rotary_embedding.common import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
-from vllm.model_executor.parameter import (
-    BasevLLMParameter,
-    BlockQuantScaleParameter,
-    PackedColumnParameter,
-    PackedvLLMParameter,
-    PerTensorScaleParameter,
-    RowvLLMParameter,
-)
-from vllm.model_executor.utils import set_weight_attrs
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.evs import (
     compute_mrope_for_media,
@@ -144,595 +124,109 @@ from .vision import (
 
 logger = init_logger(__name__)
 
-# === Weight Padding Linear Layers === #
-# These classes are modified from the original Linear layers in
-# vllm/model_executor/layers/linear.py to pad the weight to the target shape
-# for using CUTLASS kernels instead of the slow Triton kernels.
+# === Vision FP8 Weight Padding === #
+
+_Qwen2_5_VLPaddedLinear: TypeAlias = MergedColumnParallelLinear | RowParallelLinear
 
 
 def _round_up_to_multiple(value: int, multiple: int) -> int:
     return ((value + multiple - 1) // multiple) * multiple
 
 
-def _pad_tensor_to_shape(tensor: torch.Tensor, shape: torch.Size) -> torch.Tensor:
-    if tensor.shape == shape:
-        return tensor
-
-    assert tensor.ndim == len(shape), (
-        f"Cannot pad tensor of shape {tensor.shape} to {shape}"
+def _is_fp8(quant_config) -> bool:
+    return (
+        quant_config is not None
+        and getattr(quant_config, "quant_method", None) == "fp8"
     )
-    pad: list[int] = []
-    for tensor_size, target_size in reversed(tuple(zip(tensor.shape, shape))):
-        assert tensor_size <= target_size, (
-            f"Cannot pad tensor dimension {tensor_size} to smaller "
-            f"target dimension {target_size}"
-        )
-        pad.extend([0, target_size - tensor_size])
-    return F.pad(tensor, pad)
 
 
-class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
-    def __init__(
-        self,
-        input_size: int,
-        output_sizes: list[int],
-        bias: bool = True,
-        gather_output: bool = False,
-        skip_bias_add: bool = False,
-        params_dtype: torch.dtype | None = None,
-        quant_config: QuantizationConfig | None = None,
-        prefix: str = "",
-        *,
-        return_bias: bool = True,
-        disable_tp: bool = False,
-        loaded_input_size: int | None = None,
-        loaded_output_sizes: list[int] | None = None,
+def _pad_weight_per_shard(
+    layer: _Qwen2_5_VLPaddedLinear,
+    *,
+    per_shard_output_pad: int,
+    input_pad: int,
+) -> None:
+    """Zero-pad ``layer.weight`` and ``layer.weight_scale`` in place.
+    Output padding is applied PER OUTPUT SHARD (so merged gate/up are padded
+    independently; concatenating naively would shift the up shard). Input
+    padding is applied along the per-rank input dim. This runs after FP8
+    processing, where non-Marlin kernels store the weight as [input, output].
+    """
+    if per_shard_output_pad == 0 and input_pad == 0:
+        return
+    weight = cast(Parameter, layer.weight)
+    w = weight.data
+    num_shards = len(layer.output_partition_sizes)
+    per_shard_out = layer.output_size_per_partition // num_shards
+    if w.shape == (
+        layer.input_size_per_partition,
+        layer.output_size_per_partition,
     ):
-        self.output_sizes = output_sizes
-        self.loaded_input_size = loaded_input_size or input_size
-        self.loaded_output_sizes = loaded_output_sizes or output_sizes
-        assert self.loaded_input_size <= input_size
-        assert len(self.loaded_output_sizes) == len(self.output_sizes)
-        assert all(
-            loaded_output_size <= output_size
-            for loaded_output_size, output_size in zip(
-                self.loaded_output_sizes, self.output_sizes
-            )
+        shards = w.split(per_shard_out, dim=1)
+        shards = [F.pad(s, (0, per_shard_output_pad, 0, input_pad)) for s in shards]
+        padded_weight = torch.cat(shards, dim=1)
+    else:
+        assert w.shape == (
+            layer.output_size_per_partition,
+            layer.input_size_per_partition,
+        ), (
+            f"Unexpected weight shape {w.shape} for "
+            f"input_size_per_partition={layer.input_size_per_partition}, "
+            f"output_size_per_partition={layer.output_size_per_partition}"
         )
-        if (
-            self.loaded_input_size != input_size
-            or self.loaded_output_sizes != self.output_sizes
-        ):
-            logger.warning(
-                "Layer %s pads weight from input_size=%s, output_sizes=%s "
-                "to input_size=%s, output_sizes=%s",
-                prefix,
-                self.loaded_input_size,
-                self.loaded_output_sizes,
-                input_size,
-                self.output_sizes,
-            )
-        self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
-
-        assert all(output_size % self.tp_size == 0 for output_size in output_sizes)
-        ColumnParallelLinear.__init__(
-            self,
-            input_size=input_size,
-            output_size=sum(output_sizes),
-            bias=bias,
-            gather_output=gather_output,
-            skip_bias_add=skip_bias_add,
-            params_dtype=params_dtype,
-            quant_config=quant_config,
-            prefix=prefix,
-            return_bias=return_bias,
-            disable_tp=disable_tp,
-        )
-
-    def _get_output_shard_info(self, shard_id: int) -> tuple[int, int, int, int]:
-        physical_shard_offset = sum(self.output_sizes[:shard_id])
-        physical_shard_size = self.output_sizes[shard_id]
-        loaded_shard_offset = sum(self.loaded_output_sizes[:shard_id])
-        loaded_shard_size = self.loaded_output_sizes[shard_id]
-        return (
-            physical_shard_offset,
-            physical_shard_size,
-            loaded_shard_offset,
-            loaded_shard_size,
-        )
-
-    def weight_loader(
-        self,
-        param: Parameter,
-        loaded_weight: torch.Tensor,
-        loaded_shard_id: tuple[int, ...] | int | None = None,
-    ):
-        self.validate_shard_id(loaded_shard_id)
-        is_gguf_weight = getattr(param, "is_gguf_weight", False)
-        is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
-        if isinstance(loaded_shard_id, tuple) and (
-            is_gguf_weight or is_gguf_weight_type
-        ):
-            raise NotImplementedError(
-                "Shard id with multiple indices is not supported for GGUF."
-            )
-        if is_gguf_weight_type:
-            if loaded_shard_id is not None:
-                param.data[loaded_shard_id].copy_(loaded_weight)
-                param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
-            else:
-                param.shard_weight_type = {
-                    i: loaded_weight.item() for i, _ in enumerate(self.output_sizes)
-                }
-            return
-
-        if is_gguf_weight:
-            output_dim = getattr(param, "output_dim", None)
-            shard_size = loaded_weight.size(output_dim) // self.tp_size
-            start_idx = self.tp_rank * shard_size
-
-            if loaded_shard_id is not None:
-                loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
-                param.shard_id.append(loaded_shard_id)
-                param.shard_id_map[loaded_shard_id] = len(param.data_container)
-                param.data_container.append(loaded_weight)
-                return
-
-        param_data = param.data
-        output_dim = getattr(param, "output_dim", None)
-        needs_scalar_to_array = getattr(param, "needs_scalar_to_array", False)
-
-        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
-            if output_dim is None:
-                if needs_scalar_to_array:
-                    param_data, loaded_weight = adjust_scalar_to_fused_array(
-                        param_data, loaded_weight, 0
-                    )
-
-                loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
-                assert param_data.shape == loaded_weight.shape
-                param_data.copy_(loaded_weight)
-                return
-
-            output_sizes = (
-                self.loaded_output_sizes[loaded_shard_id[0] : loaded_shard_id[-1] + 1]
-                if loaded_shard_id is not None
-                else self.loaded_output_sizes
-            )
-            current_shard_offset = 0
-            use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
-            if (
-                use_bitsandbytes_4bit
-                and isinstance(loaded_shard_id, tuple)
-                and self.tp_size > 1
-            ):
-                raise NotImplementedError(
-                    "Shard id with multiple indices is not supported "
-                    "for BNB quantization with TP yet."
-                )
-            shard_ids = (
-                loaded_shard_id
-                if isinstance(loaded_shard_id, tuple)
-                else range(len(output_sizes))
-            )
-            shard_offsets: list[tuple[int, int, int]] = []
-            for i, shard_id in enumerate(shard_ids):
-                output_size = output_sizes[i]
-                shard_offsets.append((shard_id, current_shard_offset, output_size))
-                current_shard_offset += output_size
-            packed_dim = getattr(param, "packed_dim", None)
-            for shard_id, shard_offset, shard_size in shard_offsets:
-                if packed_dim == output_dim:
-                    packed_factor = param.packed_factor
-                    shard_size = shard_size // packed_factor
-                    shard_offset = shard_offset // packed_factor
-                    shard_size, shard_offset = adjust_marlin_shard(
-                        param, shard_size, shard_offset
-                    )
-
-                if use_bitsandbytes_4bit:
-                    index = list(itertools.accumulate([0] + self.loaded_output_sizes))
-                    orig_offsets = {
-                        str(i): (index[i], size)
-                        for i, size in enumerate(self.loaded_output_sizes)
-                    }
-                    orig_offsets["total"] = (sum(self.loaded_output_sizes), 0)
-                    shard_size, shard_offset = adjust_bitsandbytes_4bit_shard(
-                        param, orig_offsets, str(shard_id)
-                    )
-
-                loaded_weight_shard = loaded_weight.narrow(
-                    output_dim, shard_offset, shard_size
-                )
-                self.weight_loader(param, loaded_weight_shard, shard_id)
-            return
-
-        assert loaded_shard_id < len(self.output_sizes)
-        if output_dim is not None:
-            (
-                shard_offset,
-                shard_size,
-                loaded_shard_offset,
-                loaded_shard_size,
-            ) = self._get_output_shard_info(loaded_shard_id)
-            shard_offset //= self.tp_size
-            shard_size //= self.tp_size
-            loaded_shard_offset //= self.tp_size
-            loaded_shard_size //= self.tp_size
-
-            if isinstance(param, BlockQuantScaleParameter):
-                weight_block_size = getattr(self, "weight_block_size", None)
-                shard_size, shard_offset = adjust_block_scale_shard(
-                    weight_block_size, shard_size, shard_offset
-                )
-                loaded_shard_size, loaded_shard_offset = adjust_block_scale_shard(
-                    weight_block_size, loaded_shard_size, loaded_shard_offset
-                )
-
-            packed_dim = getattr(param, "packed_dim", None)
-            if packed_dim == output_dim:
-                packed_factor = param.packed_factor
-                shard_size = shard_size // packed_factor
-                shard_offset = shard_offset // packed_factor
-                loaded_shard_size = loaded_shard_size // packed_factor
-                loaded_shard_offset = loaded_shard_offset // packed_factor
-                shard_size, shard_offset = adjust_marlin_shard(
-                    param, shard_size, shard_offset
-                )
-                loaded_shard_size, loaded_shard_offset = adjust_marlin_shard(
-                    param, loaded_shard_size, loaded_shard_offset
-                )
-
-            use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
-            is_sharded_weight = getattr(param, "is_sharded_weight", False)
-            is_sharded_weight = is_sharded_weight or use_bitsandbytes_4bit
-
-            if use_bitsandbytes_4bit:
-                index = list(itertools.accumulate([0] + self.loaded_output_sizes))
-                orig_offsets = {
-                    str(i): (index[i], size)
-                    for i, size in enumerate(self.loaded_output_sizes)
-                }
-                orig_offsets["total"] = (sum(self.loaded_output_sizes), 0)
-                loaded_shard_size, loaded_shard_offset = adjust_bitsandbytes_4bit_shard(
-                    param, orig_offsets, str(loaded_shard_id)
-                )
-            param_data = param_data.narrow(output_dim, shard_offset, shard_size)
-            start_idx = self.tp_rank * loaded_shard_size
-            if not is_sharded_weight:
-                loaded_weight = loaded_weight.narrow(
-                    output_dim, start_idx, loaded_shard_size
-                )
-        elif needs_scalar_to_array:
-            param_data, loaded_weight = adjust_scalar_to_fused_array(
-                param_data, loaded_weight, loaded_shard_id
-            )
-
+        shards = w.split(per_shard_out, dim=0)
+        shards = [F.pad(s, (0, input_pad, 0, per_shard_output_pad)) for s in shards]
+        padded_weight = torch.cat(shards, dim=0)
+    layer.weight = Parameter(padded_weight, requires_grad=False)
+    new_per_shard = per_shard_out + per_shard_output_pad
+    layer.output_partition_sizes = [new_per_shard] * num_shards
+    layer.output_size_per_partition = new_per_shard * num_shards
+    layer.input_size_per_partition += input_pad
+    if hasattr(layer, "logical_widths"):
+        layer.logical_widths = layer.output_partition_sizes
+    if hasattr(layer, "input_size"):
+        if isinstance(layer, RowParallelLinear):
+            layer.input_size += input_pad * layer.tp_size
         else:
-            ignore_warning = getattr(param, "ignore_warning", False)
-            if not ignore_warning:
-                logger.warning(
-                    "Loading a weight without `output_dim` attribute in "
-                    "WeightPaddingMergedColumnParallelLinear, assume the weight is "
-                    "the same for all partitions."
-                )
-
-        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
-        assert param_data.shape == loaded_weight.shape
-        param_data.copy_(loaded_weight)
-
-    def _load_fused_module_from_checkpoint(
-        self,
-        param: BasevLLMParameter,
-        loaded_weight: torch.Tensor,
-        output_sizes: list[int] | None = None,
-        shard_ids: tuple[int, ...] | range | None = None,
-    ):
-        current_shard_offset = 0
-        shard_offsets: list[tuple[int, int, int]] = []
-        output_sizes = output_sizes or self.loaded_output_sizes
-        shard_ids = shard_ids or range(len(output_sizes))
-        for shard_id, output_size in zip(shard_ids, output_sizes):
-            shard_offsets.append((shard_id, current_shard_offset, output_size))
-            current_shard_offset += output_size
-
-        for shard_id, shard_offset, shard_size in shard_offsets:
-            if (
-                isinstance(param, (PackedColumnParameter, PackedvLLMParameter))
-                and param.packed_dim == param.output_dim
-            ):
-                shard_size, shard_offset = param.adjust_shard_indexes_for_packing(
-                    shard_size=shard_size, shard_offset=shard_offset
-                )
-
-            loaded_weight_shard = loaded_weight.narrow(
-                param.output_dim, shard_offset, shard_size
-            )
-            self.weight_loader_v2(param, loaded_weight_shard, shard_id)
-
-    def weight_loader_v2(
-        self,
-        param: BasevLLMParameter,
-        loaded_weight: torch.Tensor,
-        loaded_shard_id: tuple[int, ...] | int | None = None,
-    ):
-        self.validate_shard_id(loaded_shard_id)
-        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
-            if isinstance(param, PerTensorScaleParameter):
-                if isinstance(loaded_shard_id, tuple):
-                    for idx in loaded_shard_id:
-                        param.load_merged_column_weight(
-                            loaded_weight=loaded_weight, shard_id=idx
-                        )
-                else:
-                    for idx in range(param.data.shape[0]):
-                        param.load_merged_column_weight(
-                            loaded_weight=loaded_weight, shard_id=idx
-                        )
-                return
-            elif type(param) in (RowvLLMParameter, BasevLLMParameter):
-                param.load_merged_column_weight(loaded_weight=loaded_weight)
-                return
-            output_sizes = (
-                [self.loaded_output_sizes[idx] for idx in loaded_shard_id]
-                if loaded_shard_id
-                else None
-            )
-            if isinstance(param, BlockQuantScaleParameter):
-                weight_block_size = getattr(self, "weight_block_size", None)
-                output_sizes = [
-                    adjust_block_scale_shard(weight_block_size, size, 0)[0]
-                    for size in (output_sizes or self.loaded_output_sizes)
-                ]
-            self._load_fused_module_from_checkpoint(
-                param,
-                loaded_weight,
-                output_sizes=output_sizes,
-                shard_ids=loaded_shard_id,
-            )
-            return
-
-        assert loaded_shard_id < len(self.output_sizes)
-
-        if isinstance(param, PerTensorScaleParameter):
-            param.load_merged_column_weight(
-                loaded_weight=loaded_weight,
-                shard_id=loaded_shard_id,
-                tp_rank=self.tp_rank,
-            )
-            return
-
-        output_dim = getattr(param, "output_dim", None)
-        if output_dim is None:
-            param.load_merged_column_weight(
-                loaded_weight=loaded_weight,
-                shard_id=loaded_shard_id,
-                tp_rank=self.tp_rank,
-            )
-            return
-
-        (
-            shard_offset,
-            shard_size,
-            loaded_shard_offset,
-            loaded_shard_size,
-        ) = self._get_output_shard_info(loaded_shard_id)
-        shard_offset //= self.tp_size
-        shard_size //= self.tp_size
-        loaded_shard_offset //= self.tp_size
-        loaded_shard_size //= self.tp_size
-
-        if isinstance(param, BlockQuantScaleParameter):
-            weight_block_size = getattr(self, "weight_block_size", None)
-            shard_size, shard_offset = adjust_block_scale_shard(
-                weight_block_size, shard_size, shard_offset
-            )
-            loaded_shard_size, loaded_shard_offset = adjust_block_scale_shard(
-                weight_block_size, loaded_shard_size, loaded_shard_offset
-            )
-
-        param_data = param.data.narrow(output_dim, shard_offset, shard_size)
-        loaded_weight = loaded_weight.narrow(
-            output_dim,
-            self.tp_rank * loaded_shard_size,
-            loaded_shard_size,
-        )
-        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
-        assert param_data.shape == loaded_weight.shape
-        param_data.copy_(loaded_weight)
-
-
-class WeightPaddingRowParallelLinear(RowParallelLinear):
-    def __init__(
-        self,
-        input_size: int,
-        output_size: int,
-        bias: bool = True,
-        input_is_parallel: bool = True,
-        skip_bias_add: bool = False,
-        params_dtype: torch.dtype | None = None,
-        reduce_results: bool = True,
-        quant_config: QuantizationConfig | None = None,
-        prefix: str = "",
-        *,
-        return_bias: bool = True,
-        disable_tp: bool = False,
-    ):
-        self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
-        self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.logical_input_size_per_partition = divide(input_size, self.tp_size)
-        self.logical_output_size_per_partition = output_size
-        self.input_size_per_partition = _round_up_to_multiple(
-            self.logical_input_size_per_partition, 16
-        )
-        self.output_size_per_partition = _round_up_to_multiple(
-            self.logical_output_size_per_partition, 16
-        )
-        self.output_partition_sizes = [self.output_size_per_partition]
-
-        logical_weight_shape = (
-            self.logical_input_size_per_partition,
-            self.logical_output_size_per_partition,
-        )
-        padded_weight_shape = (
-            self.input_size_per_partition,
-            self.output_size_per_partition,
-        )
-        if logical_weight_shape != padded_weight_shape:
-            logger.warning(
-                "Layer %s pads weight from %s to %s",
-                prefix,
-                logical_weight_shape,
-                padded_weight_shape,
-            )
-
-        LinearBase.__init__(
-            self,
-            input_size,
-            output_size,
-            bias,
-            skip_bias_add,
-            params_dtype,
-            quant_config,
-            prefix,
-            return_bias=return_bias,
-            disable_tp=disable_tp,
-        )
-
-        self.input_is_parallel = input_is_parallel
-        self.reduce_results = reduce_results
-
-        assert self.quant_method is not None
-        self.quant_method.create_weights(
-            layer=self,
-            input_size_per_partition=self.input_size_per_partition,
-            output_partition_sizes=self.output_partition_sizes,
-            input_size=self.input_size_per_partition * self.tp_size,
-            output_size=self.output_size_per_partition,
-            params_dtype=self.params_dtype,
-            weight_loader=(
-                self.weight_loader_v2
-                if self.quant_method.__class__.__name__ in WEIGHT_LOADER_V2_SUPPORTED
-                else self.weight_loader
-            ),
-        )
-        if not reduce_results and (bias and not skip_bias_add):
-            raise ValueError(
-                "When not reduce the results, adding bias to the "
-                "results can lead to incorrect results"
-            )
-
-        if bias:
-            self.bias = Parameter(torch.empty(self.output_size, dtype=params_dtype))
-            set_weight_attrs(
-                self.bias,
-                {
-                    "output_dim": 0,
-                    "weight_loader": self.weight_loader,
-                },
-            )
+            layer.input_size += input_pad
+    if hasattr(layer, "output_size"):
+        if isinstance(layer, ColumnParallelLinear):
+            layer.output_size += per_shard_output_pad * num_shards * layer.tp_size
         else:
-            self.register_parameter("bias", None)
-        self.update_param_tp_status()
+            layer.output_size += per_shard_output_pad
+    # Pad per-channel weight_scale along the output dim with 1.0 (safe because
+    # the corresponding weight rows are exactly zero).
+    ws = getattr(layer, "weight_scale", None)
+    if isinstance(ws, torch.nn.Parameter) and ws.dim() >= 1 and ws.shape[0] > 1:
+        ws_shards = ws.data.split(per_shard_out, dim=0)
+        ws_shards = [F.pad(s, (0, per_shard_output_pad), value=1.0) for s in ws_shards]
+        layer.weight_scale = Parameter(torch.cat(ws_shards, dim=0), requires_grad=False)
 
-    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        input_dim = getattr(param, "input_dim", None)
-        use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
-        is_sharded_weight = getattr(param, "is_sharded_weight", False)
-        is_sharded_weight = is_sharded_weight or use_bitsandbytes_4bit
 
-        is_gguf_weight = getattr(param, "is_gguf_weight", False)
-        is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
-        if is_gguf_weight_type:
-            param.weight_type = loaded_weight.item()
+def _install_post_pad_hook(
+    layer: _Qwen2_5_VLPaddedLinear,
+    *,
+    per_shard_output_pad: int,
+    input_pad: int,
+) -> None:
+    """Wrap layer.quant_method.process_weights_after_loading so it pads after
+    the quant method finishes (e.g. after FP8 quantization)."""
+    qm = layer.quant_method
+    original = qm.process_weights_after_loading
 
-        if is_gguf_weight and isinstance(param, UninitializedParameter):
-            weight_shape = list(loaded_weight.shape)
-            if input_dim:
-                weight_shape[input_dim] = weight_shape[input_dim] // self.tp_size
-            param.materialize(tuple(weight_shape), dtype=loaded_weight.dtype)
-
-        param_data = param.data
-        if input_dim is not None and not is_sharded_weight:
-            shard_size = loaded_weight.shape[input_dim] // self.tp_size
-            start_idx = self.tp_rank * shard_size
-            loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
-
-        if len(loaded_weight.shape) == 0:
-            loaded_weight = loaded_weight.reshape(1)
-
-        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
-        assert param_data.shape == loaded_weight.shape
-        param_data.copy_(loaded_weight)
-
-    def weight_loader_v2(self, param: BasevLLMParameter, loaded_weight: torch.Tensor):
-        if len(loaded_weight.shape) == 0:
-            assert loaded_weight.numel() == 1
-            loaded_weight = loaded_weight.reshape(1)
-
-        input_dim = getattr(param, "input_dim", None)
-        if input_dim is not None:
-            shard_size = loaded_weight.shape[input_dim] // self.tp_size
-            start_idx = self.tp_rank * shard_size
-            loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
-
-        param_data = param.data
-        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
-        assert param_data.shape == loaded_weight.shape
-        param_data.copy_(loaded_weight)
-
-    def forward(
-        self,
-        input_,
-    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
-        if self.input_is_parallel:
-            input_parallel = input_
-        else:
-            split_input = split_tensor_along_last_dim(
-                input_, num_partitions=self.tp_size
-            )
-            input_parallel = split_input[self.tp_rank].contiguous()
-
-        assert self.quant_method is not None
-        if input_parallel.shape[-1] < self.input_size_per_partition:
-            input_parallel = F.pad(
-                input_parallel,
-                (0, self.input_size_per_partition - input_parallel.shape[-1]),
-            )
-
-        bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
-        apply_bias = (
-            None
-            if bias_ is not None
-            and self.output_size_per_partition != self.logical_output_size_per_partition
-            else bias_
+    def wrapped(module: nn.Module) -> None:
+        original(module)
+        if getattr(module, "_qwen2_5_vl_fp8_weight_padded", False):
+            return
+        padded_module = cast(_Qwen2_5_VLPaddedLinear, module)
+        _pad_weight_per_shard(
+            padded_module,
+            per_shard_output_pad=per_shard_output_pad,
+            input_pad=input_pad,
         )
-        output_parallel = self.quant_method.apply(self, input_parallel, apply_bias)
-        if output_parallel.shape[-1] > self.logical_output_size_per_partition:
-            output_parallel = output_parallel[
-                ..., : self.logical_output_size_per_partition
-            ].contiguous()
-        if bias_ is not None and apply_bias is None:
-            output_parallel = output_parallel + bias_
+        module._qwen2_5_vl_fp8_weight_padded = True
 
-        if self.reduce_results and self.tp_size > 1:
-            output = tensor_model_parallel_all_reduce(output_parallel)
-        else:
-            output = output_parallel
-
-        if not self.return_bias:
-            return output
-        output_bias = self.bias if self.skip_bias_add else None
-        return output, output_bias
-
-    def extra_repr(self) -> str:
-        s = f"in_features={self.logical_input_size_per_partition}"
-        s += f", output_features={self.output_size}"
-        s += f", bias={self.bias is not None}"
-        s += f", tp_size={self.tp_size}"
-        s += f", reduce_results={self.reduce_results}"
-        return s
+    qm.process_weights_after_loading = wrapped  # type: ignore[method-assign]
 
 
 # === Vision Inputs === #
@@ -898,51 +392,54 @@ class Qwen2_5_VisionMLP(nn.Module):
     ):
         super().__init__()
         use_data_parallel = is_vit_use_data_parallel()
+        tp_size = 1 if use_data_parallel else get_tensor_model_parallel_world_size()
         self.in_features = in_features
-        self.padded_in_features = _round_up_to_multiple(in_features, 16)
         self.hidden_features = hidden_features
-        self.padded_hidden_features = _round_up_to_multiple(hidden_features, 16)
-        if (
-            self.in_features != self.padded_in_features
-            or self.hidden_features != self.padded_hidden_features
-        ):
-            logger.warning(
-                "Layer %s pads MLP features from in_features=%s, "
-                "hidden_features=%s to in_features=%s, hidden_features=%s",
-                prefix,
-                self.in_features,
-                self.hidden_features,
-                self.padded_in_features,
-                self.padded_hidden_features,
-            )
-        self.gate_up_proj = WeightPaddingMergedColumnParallelLinear(
-            input_size=self.padded_in_features,
-            output_sizes=[self.padded_hidden_features] * 2,  # [gate_proj, up_proj]
-            loaded_input_size=in_features,
-            loaded_output_sizes=[hidden_features] * 2,
+        # Layers are constructed with the ORIGINAL sizes; base loader runs
+        # unchanged, divide() still asserts hidden_features % tp_size == 0.
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=in_features,
+            output_sizes=[hidden_features] * 2,
             bias=bias,
             quant_config=quant_config,
             prefix=f"{prefix}.gate_up_proj",
             disable_tp=use_data_parallel,
         )
-
-        self.down_proj = WeightPaddingRowParallelLinear(
-            self.padded_hidden_features,
-            self.padded_in_features,
+        self.down_proj = RowParallelLinear(
+            hidden_features,
+            in_features,
             bias=bias,
             quant_config=quant_config,
             prefix=f"{prefix}.down_proj",
             disable_tp=use_data_parallel,
         )
         self.act_fn = act_fn
+        # Pad targets: each per-rank dimension touched by a CUTLASS GEMM must
+        # be a multiple of 16. Pad input/output independently per shard.
+        self.padded_in_features = _round_up_to_multiple(in_features, 16)
+        per_shard_hidden = hidden_features // tp_size
+        padded_per_shard_hidden = _round_up_to_multiple(per_shard_hidden, 16)
+        self.padded_hidden_per_shard = padded_per_shard_hidden
+        self.use_fp8_weight_padding = _is_fp8(quant_config)
+        if self.use_fp8_weight_padding:
+            _install_post_pad_hook(
+                self.gate_up_proj,
+                per_shard_output_pad=padded_per_shard_hidden - per_shard_hidden,
+                input_pad=self.padded_in_features - in_features,
+            )
+            _install_post_pad_hook(
+                self.down_proj,
+                per_shard_output_pad=self.padded_in_features - in_features,
+                input_pad=padded_per_shard_hidden - per_shard_hidden,
+            )
 
     def forward(self, x: torch.Tensor):
-        if x.shape[-1] < self.padded_in_features:
+        if self.use_fp8_weight_padding and x.shape[-1] < self.padded_in_features:
             x = F.pad(x, (0, self.padded_in_features - x.shape[-1]))
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
         x_down, _ = self.down_proj(x)
-        if x_down.shape[-1] > self.in_features:
+        if self.use_fp8_weight_padding and x_down.shape[-1] > self.in_features:
             x_down = x_down[..., : self.in_features]
         return x_down
 
@@ -983,7 +480,7 @@ class Qwen2_5_VisionAttention(nn.Module):
             disable_tp=use_data_parallel,
         )
 
-        self.proj = WeightPaddingRowParallelLinear(
+        self.proj = RowParallelLinear(
             input_size=projection_size,
             output_size=embed_dim,
             quant_config=quant_config,
@@ -1194,7 +691,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
                 disable_tp=use_data_parallel,
             ),
             nn.GELU(),
-            WeightPaddingRowParallelLinear(
+            RowParallelLinear(
                 self.hidden_size,
                 d_model,
                 bias=True,

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -35,6 +35,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn.parameter import Parameter, UninitializedParameter
 from transformers import BatchFeature
 from transformers.models.qwen2_5_vl import Qwen2_5_VLProcessor
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
@@ -47,7 +48,14 @@ from vllm.compilation.decorators import (
     support_torch_compile,
 )
 from vllm.config import VllmConfig
-from vllm.distributed import parallel_state
+from vllm.distributed import (
+    divide,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    parallel_state,
+    split_tensor_along_last_dim,
+    tensor_model_parallel_all_reduce,
+)
 from vllm.distributed import utils as dist_utils
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import get_act_and_mul_fn
@@ -55,10 +63,16 @@ from vllm.model_executor.layers.attention import MMEncoderAttention
 from vllm.model_executor.layers.conv import Conv3dLayer
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
+    LinearBase,
     ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
+    WEIGHT_LOADER_V2_SUPPORTED,
+    adjust_bitsandbytes_4bit_shard,
+    adjust_block_scale_shard,
+    adjust_marlin_shard,
+    adjust_scalar_to_fused_array,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
@@ -67,6 +81,15 @@ from vllm.model_executor.layers.rotary_embedding.common import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
+from vllm.model_executor.parameter import (
+    BasevLLMParameter,
+    BlockQuantScaleParameter,
+    PackedColumnParameter,
+    PackedvLLMParameter,
+    PerTensorScaleParameter,
+    RowvLLMParameter,
+)
+from vllm.model_executor.utils import set_weight_attrs
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.evs import (
     compute_mrope_for_media,
@@ -119,6 +142,590 @@ from .vision import (
 )
 
 logger = init_logger(__name__)
+
+# === Weight Padding Linear Layers === #
+# These classes are modified from the original Linear layers in
+# vllm/model_executor/layers/linear.py to pad the weight to the target shape
+# for using CUTLASS kernels instead of the slow Triton kernels.
+
+
+def _round_up_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _pad_tensor_to_shape(tensor: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    if tensor.shape == shape:
+        return tensor
+
+    assert tensor.ndim == len(shape), (
+        f"Cannot pad tensor of shape {tensor.shape} to {shape}"
+    )
+    pad: list[int] = []
+    for tensor_size, target_size in reversed(tuple(zip(tensor.shape, shape))):
+        assert tensor_size <= target_size, (
+            f"Cannot pad tensor dimension {tensor_size} to smaller "
+            f"target dimension {target_size}"
+        )
+        pad.extend([0, target_size - tensor_size])
+    return F.pad(tensor, pad)
+
+
+class WeightPaddingMergedColumnParallelLinear(MergedColumnParallelLinear):
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        bias: bool = True,
+        gather_output: bool = False,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+        loaded_input_size: int | None = None,
+        loaded_output_sizes: list[int] | None = None,
+    ):
+        self.output_sizes = output_sizes
+        self.loaded_input_size = loaded_input_size or input_size
+        self.loaded_output_sizes = loaded_output_sizes or output_sizes
+        assert self.loaded_input_size <= input_size
+        assert len(self.loaded_output_sizes) == len(self.output_sizes)
+        assert all(
+            loaded_output_size <= output_size
+            for loaded_output_size, output_size in zip(
+                self.loaded_output_sizes, self.output_sizes
+            )
+        )
+        if (
+            self.loaded_input_size != input_size
+            or self.loaded_output_sizes != self.output_sizes
+        ):
+            logger.warning(
+                "Layer %s pads weight from input_size=%s, output_sizes=%s "
+                "to input_size=%s, output_sizes=%s",
+                prefix,
+                self.loaded_input_size,
+                self.loaded_output_sizes,
+                input_size,
+                self.output_sizes,
+            )
+        self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
+        self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+
+        assert all(output_size % self.tp_size == 0 for output_size in output_sizes)
+        ColumnParallelLinear.__init__(
+            self,
+            input_size=input_size,
+            output_size=sum(output_sizes),
+            bias=bias,
+            gather_output=gather_output,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+
+    def _get_output_shard_info(self, shard_id: int) -> tuple[int, int, int, int]:
+        physical_shard_offset = sum(self.output_sizes[:shard_id])
+        physical_shard_size = self.output_sizes[shard_id]
+        loaded_shard_offset = sum(self.loaded_output_sizes[:shard_id])
+        loaded_shard_size = self.loaded_output_sizes[shard_id]
+        return (
+            physical_shard_offset,
+            physical_shard_size,
+            loaded_shard_offset,
+            loaded_shard_size,
+        )
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ):
+        self.validate_shard_id(loaded_shard_id)
+        is_gguf_weight = getattr(param, "is_gguf_weight", False)
+        is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
+        if isinstance(loaded_shard_id, tuple) and (
+            is_gguf_weight or is_gguf_weight_type
+        ):
+            raise NotImplementedError(
+                "Shard id with multiple indices is not supported for GGUF."
+            )
+        if is_gguf_weight_type:
+            if loaded_shard_id is not None:
+                param.data[loaded_shard_id].copy_(loaded_weight)
+                param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
+            else:
+                param.shard_weight_type = {
+                    i: loaded_weight.item() for i, _ in enumerate(self.output_sizes)
+                }
+            return
+
+        if is_gguf_weight:
+            output_dim = getattr(param, "output_dim", None)
+            shard_size = loaded_weight.size(output_dim) // self.tp_size
+            start_idx = self.tp_rank * shard_size
+
+            if loaded_shard_id is not None:
+                loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+                param.shard_id.append(loaded_shard_id)
+                param.shard_id_map[loaded_shard_id] = len(param.data_container)
+                param.data_container.append(loaded_weight)
+                return
+
+        param_data = param.data
+        output_dim = getattr(param, "output_dim", None)
+        needs_scalar_to_array = getattr(param, "needs_scalar_to_array", False)
+
+        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
+            if output_dim is None:
+                if needs_scalar_to_array:
+                    param_data, loaded_weight = adjust_scalar_to_fused_array(
+                        param_data, loaded_weight, 0
+                    )
+
+                loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
+                assert param_data.shape == loaded_weight.shape
+                param_data.copy_(loaded_weight)
+                return
+
+            output_sizes = (
+                self.loaded_output_sizes[loaded_shard_id[0] : loaded_shard_id[-1] + 1]
+                if loaded_shard_id is not None
+                else self.loaded_output_sizes
+            )
+            current_shard_offset = 0
+            use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
+            if (
+                use_bitsandbytes_4bit
+                and isinstance(loaded_shard_id, tuple)
+                and self.tp_size > 1
+            ):
+                raise NotImplementedError(
+                    "Shard id with multiple indices is not supported "
+                    "for BNB quantization with TP yet."
+                )
+            shard_offsets: list[tuple[int, int, int]] = []
+            for i, output_size in enumerate(output_sizes):
+                shard_offsets.append((i, current_shard_offset, output_size))
+                current_shard_offset += output_size
+            packed_dim = getattr(param, "packed_dim", None)
+            for shard_id, shard_offset, shard_size in shard_offsets:
+                if packed_dim == output_dim:
+                    packed_factor = getattr(param, "packed_factor")
+                    shard_size = shard_size // packed_factor
+                    shard_offset = shard_offset // packed_factor
+                    shard_size, shard_offset = adjust_marlin_shard(
+                        param, shard_size, shard_offset
+                    )
+
+                if use_bitsandbytes_4bit:
+                    index = list(
+                        itertools.accumulate([0] + self.loaded_output_sizes)
+                    )
+                    orig_offsets = {
+                        str(i): (index[i], size)
+                        for i, size in enumerate(self.loaded_output_sizes)
+                    }
+                    orig_offsets["total"] = (sum(self.loaded_output_sizes), 0)
+                    shard_size, shard_offset = adjust_bitsandbytes_4bit_shard(
+                        param, orig_offsets, str(shard_id)
+                    )
+
+                loaded_weight_shard = loaded_weight.narrow(
+                    output_dim, shard_offset, shard_size
+                )
+                self.weight_loader(param, loaded_weight_shard, shard_id)
+            return
+
+        assert loaded_shard_id < len(self.output_sizes)
+        if output_dim is not None:
+            (
+                shard_offset,
+                shard_size,
+                loaded_shard_offset,
+                loaded_shard_size,
+            ) = self._get_output_shard_info(loaded_shard_id)
+            shard_offset //= self.tp_size
+            shard_size //= self.tp_size
+            loaded_shard_offset //= self.tp_size
+            loaded_shard_size //= self.tp_size
+
+            if isinstance(param, BlockQuantScaleParameter):
+                weight_block_size = getattr(self, "weight_block_size", None)
+                shard_size, shard_offset = adjust_block_scale_shard(
+                    weight_block_size, shard_size, shard_offset
+                )
+                loaded_shard_size, loaded_shard_offset = adjust_block_scale_shard(
+                    weight_block_size, loaded_shard_size, loaded_shard_offset
+                )
+
+            packed_dim = getattr(param, "packed_dim", None)
+            if packed_dim == output_dim:
+                packed_factor = getattr(param, "packed_factor")
+                shard_size = shard_size // packed_factor
+                shard_offset = shard_offset // packed_factor
+                loaded_shard_size = loaded_shard_size // packed_factor
+                loaded_shard_offset = loaded_shard_offset // packed_factor
+                shard_size, shard_offset = adjust_marlin_shard(
+                    param, shard_size, shard_offset
+                )
+                loaded_shard_size, loaded_shard_offset = adjust_marlin_shard(
+                    param, loaded_shard_size, loaded_shard_offset
+                )
+
+            use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
+            is_sharded_weight = getattr(param, "is_sharded_weight", False)
+            is_sharded_weight = is_sharded_weight or use_bitsandbytes_4bit
+
+            if use_bitsandbytes_4bit:
+                index = list(
+                    itertools.accumulate([0] + self.loaded_output_sizes)
+                )
+                orig_offsets = {
+                    str(i): (index[i], size)
+                    for i, size in enumerate(self.loaded_output_sizes)
+                }
+                orig_offsets["total"] = (sum(self.loaded_output_sizes), 0)
+                loaded_shard_size, loaded_shard_offset = adjust_bitsandbytes_4bit_shard(
+                    param, orig_offsets, str(loaded_shard_id)
+                )
+            param_data = param_data.narrow(output_dim, shard_offset, shard_size)
+            start_idx = self.tp_rank * loaded_shard_size
+            if not is_sharded_weight:
+                loaded_weight = loaded_weight.narrow(
+                    output_dim, start_idx, loaded_shard_size
+                )
+        elif needs_scalar_to_array:
+            param_data, loaded_weight = adjust_scalar_to_fused_array(
+                param_data, loaded_weight, loaded_shard_id
+            )
+
+        else:
+            ignore_warning = getattr(param, "ignore_warning", False)
+            if not ignore_warning:
+                logger.warning(
+                    "Loading a weight without `output_dim` attribute in "
+                    "WeightPaddingMergedColumnParallelLinear, assume the weight is "
+                    "the same for all partitions."
+                )
+
+        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+    def _load_fused_module_from_checkpoint(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        output_sizes: list[int] | None = None,
+    ):
+        current_shard_offset = 0
+        shard_offsets: list[tuple[int, int, int]] = []
+        output_sizes = output_sizes or self.loaded_output_sizes
+        for i, output_size in enumerate(output_sizes):
+            shard_offsets.append((i, current_shard_offset, output_size))
+            current_shard_offset += output_size
+
+        for shard_id, shard_offset, shard_size in shard_offsets:
+            if (
+                isinstance(param, (PackedColumnParameter, PackedvLLMParameter))
+                and param.packed_dim == param.output_dim
+            ):
+                shard_size, shard_offset = param.adjust_shard_indexes_for_packing(
+                    shard_size=shard_size, shard_offset=shard_offset
+                )
+
+            loaded_weight_shard = loaded_weight.narrow(
+                param.output_dim, shard_offset, shard_size
+            )
+            self.weight_loader_v2(param, loaded_weight_shard, shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ):
+        self.validate_shard_id(loaded_shard_id)
+        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
+            if isinstance(param, PerTensorScaleParameter):
+                if isinstance(loaded_shard_id, tuple):
+                    for idx in loaded_shard_id:
+                        param.load_merged_column_weight(
+                            loaded_weight=loaded_weight, shard_id=idx
+                        )
+                else:
+                    for idx in range(param.data.shape[0]):
+                        param.load_merged_column_weight(
+                            loaded_weight=loaded_weight, shard_id=idx
+                        )
+                return
+            elif type(param) in (RowvLLMParameter, BasevLLMParameter):
+                param.load_merged_column_weight(loaded_weight=loaded_weight)
+                return
+            output_sizes = (
+                [self.loaded_output_sizes[idx] for idx in loaded_shard_id]
+                if loaded_shard_id
+                else None
+            )
+            if isinstance(param, BlockQuantScaleParameter):
+                weight_block_size = getattr(self, "weight_block_size", None)
+                output_sizes = [
+                    adjust_block_scale_shard(weight_block_size, size, 0)[0]
+                    for size in (output_sizes or self.loaded_output_sizes)
+                ]
+            self._load_fused_module_from_checkpoint(
+                param, loaded_weight, output_sizes=output_sizes
+            )
+            return
+
+        assert loaded_shard_id < len(self.output_sizes)
+
+        if isinstance(param, PerTensorScaleParameter):
+            param.load_merged_column_weight(
+                loaded_weight=loaded_weight,
+                shard_id=loaded_shard_id,
+                tp_rank=self.tp_rank,
+            )
+            return
+
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            param.load_merged_column_weight(
+                loaded_weight=loaded_weight,
+                shard_id=loaded_shard_id,
+                tp_rank=self.tp_rank,
+            )
+            return
+
+        (
+            shard_offset,
+            shard_size,
+            loaded_shard_offset,
+            loaded_shard_size,
+        ) = self._get_output_shard_info(loaded_shard_id)
+        shard_offset //= self.tp_size
+        shard_size //= self.tp_size
+        loaded_shard_offset //= self.tp_size
+        loaded_shard_size //= self.tp_size
+
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = getattr(self, "weight_block_size", None)
+            shard_size, shard_offset = adjust_block_scale_shard(
+                weight_block_size, shard_size, shard_offset
+            )
+            loaded_shard_size, loaded_shard_offset = adjust_block_scale_shard(
+                weight_block_size, loaded_shard_size, loaded_shard_offset
+            )
+
+        param_data = param.data.narrow(output_dim, shard_offset, shard_size)
+        loaded_weight = loaded_weight.narrow(
+            output_dim,
+            self.tp_rank * loaded_shard_size,
+            loaded_shard_size,
+        )
+        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+
+class WeightPaddingRowParallelLinear(RowParallelLinear):
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        bias: bool = True,
+        input_is_parallel: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        reduce_results: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+        disable_tp: bool = False,
+    ):
+        self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
+        self.logical_input_size_per_partition = divide(input_size, self.tp_size)
+        self.logical_output_size_per_partition = output_size
+        self.input_size_per_partition = _round_up_to_multiple(
+            self.logical_input_size_per_partition, 16
+        )
+        self.output_size_per_partition = _round_up_to_multiple(
+            self.logical_output_size_per_partition, 16
+        )
+        self.output_partition_sizes = [self.output_size_per_partition]
+
+        logical_weight_shape = (
+            self.logical_input_size_per_partition,
+            self.logical_output_size_per_partition,
+        )
+        padded_weight_shape = (
+            self.input_size_per_partition,
+            self.output_size_per_partition,
+        )
+        if logical_weight_shape != padded_weight_shape:
+            logger.warning(
+                "Layer %s pads weight from %s to %s",
+                prefix,
+                logical_weight_shape,
+                padded_weight_shape,
+            )
+
+        LinearBase.__init__(
+            self,
+            input_size,
+            output_size,
+            bias,
+            skip_bias_add,
+            params_dtype,
+            quant_config,
+            prefix,
+            return_bias=return_bias,
+            disable_tp=disable_tp,
+        )
+
+        self.input_is_parallel = input_is_parallel
+        self.reduce_results = reduce_results
+
+        assert self.quant_method is not None
+        self.quant_method.create_weights(
+            layer=self,
+            input_size_per_partition=self.input_size_per_partition,
+            output_partition_sizes=self.output_partition_sizes,
+            input_size=self.input_size_per_partition * self.tp_size,
+            output_size=self.output_size_per_partition,
+            params_dtype=self.params_dtype,
+            weight_loader=(
+                self.weight_loader_v2
+                if self.quant_method.__class__.__name__ in WEIGHT_LOADER_V2_SUPPORTED
+                else self.weight_loader
+            ),
+        )
+        if not reduce_results and (bias and not skip_bias_add):
+            raise ValueError(
+                "When not reduce the results, adding bias to the "
+                "results can lead to incorrect results"
+            )
+
+        if bias:
+            self.bias = Parameter(torch.empty(self.output_size, dtype=params_dtype))
+            set_weight_attrs(
+                self.bias,
+                {
+                    "output_dim": 0,
+                    "weight_loader": self.weight_loader,
+                },
+            )
+        else:
+            self.register_parameter("bias", None)
+        self.update_param_tp_status()
+
+    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+        input_dim = getattr(param, "input_dim", None)
+        use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
+        is_sharded_weight = getattr(param, "is_sharded_weight", False)
+        is_sharded_weight = is_sharded_weight or use_bitsandbytes_4bit
+
+        is_gguf_weight = getattr(param, "is_gguf_weight", False)
+        is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
+        if is_gguf_weight_type:
+            param.weight_type = loaded_weight.item()
+
+        if is_gguf_weight and isinstance(param, UninitializedParameter):
+            weight_shape = list(loaded_weight.shape)
+            if input_dim:
+                weight_shape[input_dim] = weight_shape[input_dim] // self.tp_size
+            param.materialize(tuple(weight_shape), dtype=loaded_weight.dtype)
+
+        param_data = param.data
+        if input_dim is not None and not is_sharded_weight:
+            shard_size = loaded_weight.shape[input_dim] // self.tp_size
+            start_idx = self.tp_rank * shard_size
+            loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
+
+        if len(loaded_weight.shape) == 0:
+            loaded_weight = loaded_weight.reshape(1)
+
+        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+    def weight_loader_v2(self, param: BasevLLMParameter, loaded_weight: torch.Tensor):
+        if len(loaded_weight.shape) == 0:
+            assert loaded_weight.numel() == 1
+            loaded_weight = loaded_weight.reshape(1)
+
+        input_dim = getattr(param, "input_dim", None)
+        if input_dim is not None:
+            shard_size = loaded_weight.shape[input_dim] // self.tp_size
+            start_idx = self.tp_rank * shard_size
+            loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
+
+        param_data = param.data
+        loaded_weight = _pad_tensor_to_shape(loaded_weight, param_data.shape)
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+    def forward(
+        self,
+        input_,
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            split_input = split_tensor_along_last_dim(
+                input_, num_partitions=self.tp_size
+            )
+            input_parallel = split_input[self.tp_rank].contiguous()
+
+        assert self.quant_method is not None
+        if input_parallel.shape[-1] < self.input_size_per_partition:
+            input_parallel = F.pad(
+                input_parallel,
+                (0, self.input_size_per_partition - input_parallel.shape[-1]),
+            )
+
+        bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+        apply_bias = (
+            None
+            if bias_ is not None
+            and self.output_size_per_partition != self.logical_output_size_per_partition
+            else bias_
+        )
+        output_parallel = self.quant_method.apply(self, input_parallel, apply_bias)
+        if output_parallel.shape[-1] > self.logical_output_size_per_partition:
+            output_parallel = output_parallel[
+                ..., : self.logical_output_size_per_partition
+            ].contiguous()
+        if bias_ is not None and apply_bias is None:
+            output_parallel = output_parallel + bias_
+
+        if self.reduce_results and self.tp_size > 1:
+            output = tensor_model_parallel_all_reduce(output_parallel)
+        else:
+            output = output_parallel
+
+        if not self.return_bias:
+            return output
+        output_bias = self.bias if self.skip_bias_add else None
+        return output, output_bias
+
+    def extra_repr(self) -> str:
+        s = f"in_features={self.logical_input_size_per_partition}"
+        s += f", output_features={self.output_size}"
+        s += f", bias={self.bias is not None}"
+        s += f", tp_size={self.tp_size}"
+        s += f", reduce_results={self.reduce_results}"
+        return s
+
 
 # === Vision Inputs === #
 
@@ -283,18 +890,37 @@ class Qwen2_5_VisionMLP(nn.Module):
     ):
         super().__init__()
         use_data_parallel = is_vit_use_data_parallel()
-        self.gate_up_proj = MergedColumnParallelLinear(
-            input_size=in_features,
-            output_sizes=[hidden_features] * 2,  # [gate_proj, up_proj]
+        self.in_features = in_features
+        self.padded_in_features = _round_up_to_multiple(in_features, 16)
+        self.hidden_features = hidden_features
+        self.padded_hidden_features = _round_up_to_multiple(hidden_features, 16)
+        if (
+            self.in_features != self.padded_in_features
+            or self.hidden_features != self.padded_hidden_features
+        ):
+            logger.warning(
+                "Layer %s pads MLP features from in_features=%s, "
+                "hidden_features=%s to in_features=%s, hidden_features=%s",
+                prefix,
+                self.in_features,
+                self.hidden_features,
+                self.padded_in_features,
+                self.padded_hidden_features,
+            )
+        self.gate_up_proj = WeightPaddingMergedColumnParallelLinear(
+            input_size=self.padded_in_features,
+            output_sizes=[self.padded_hidden_features] * 2,  # [gate_proj, up_proj]
+            loaded_input_size=in_features,
+            loaded_output_sizes=[hidden_features] * 2,
             bias=bias,
             quant_config=quant_config,
             prefix=f"{prefix}.gate_up_proj",
             disable_tp=use_data_parallel,
         )
 
-        self.down_proj = RowParallelLinear(
-            hidden_features,
-            in_features,
+        self.down_proj = WeightPaddingRowParallelLinear(
+            self.padded_hidden_features,
+            self.padded_in_features,
             bias=bias,
             quant_config=quant_config,
             prefix=f"{prefix}.down_proj",
@@ -303,9 +929,13 @@ class Qwen2_5_VisionMLP(nn.Module):
         self.act_fn = act_fn
 
     def forward(self, x: torch.Tensor):
+        if x.shape[-1] < self.padded_in_features:
+            x = F.pad(x, (0, self.padded_in_features - x.shape[-1]))
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
         x_down, _ = self.down_proj(x)
+        if x_down.shape[-1] > self.in_features:
+            x_down = x_down[..., : self.in_features]
         return x_down
 
 
@@ -345,7 +975,7 @@ class Qwen2_5_VisionAttention(nn.Module):
             disable_tp=use_data_parallel,
         )
 
-        self.proj = RowParallelLinear(
+        self.proj = WeightPaddingRowParallelLinear(
             input_size=projection_size,
             output_size=embed_dim,
             quant_config=quant_config,
@@ -556,7 +1186,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
                 disable_tp=use_data_parallel,
             ),
             nn.GELU(),
-            RowParallelLinear(
+            WeightPaddingRowParallelLinear(
                 self.hidden_size,
                 d_model,
                 bias=True,


### PR DESCRIPTION


## Purpose

This PR optimizes Qwen2.5-VL FP8 prefill performance by padding the shape of multiple linear layers to multiplies of 16 for using fast CUTLASS kernels instead of falling back to Triton `scaled_mm_kernel`.

Previously, #41868 (partially) solved this issue by padding both input matrices in `CutlassFP8ScaledMMLinearKernel`. This approach has potential side efforts on other models.

This PR targets only the vision MLP layer in Qwen2.5-VL. It zero-pads the up & gate & down projection weight matrices and avoids de-padding gate & up projection outputs and padding for down projection input.

## Test Plan

Launch engine:

```bash
export MM_LIMIT='{"image": 1}'
export COMPILATION_CONFIG='{"compile_mm_encoder": true, "cudagraph_mode": "FULL_AND_PIECEWISE", "max_cudagraph_capture_size": 2048}'
python -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --profiler-config.profiler cuda \
  --no-enable-prefix-caching \
  --max-model-len 32768 \
  --max-num-seqs 1024 \
  --distributed-executor-backend uni \
  --limit-mm-per-prompt "$MM_LIMIT" \
  --compilation-config "$COMPILATION_CONFIG" \
  --max-num-batched-tokens 2048 \
  --quantization fp8
```

Benchmark:

```bash
vllm bench serve \
  --backend openai-chat \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --endpoint /v1/chat/completions \
  --base-url http://127.0.0.1:8000 \
  --profile \
  --metric-percentiles 50,90,99 \
  --dataset-name random-mm \
  --random-mm-base-items-per-request 1 \
  --random-mm-num-mm-items-range-ratio 0 \
  --random-mm-bucket-config "{(512, 512, 1): 1.0}" \
  --random-mm-limit-mm-per-prompt '{"image": 1}' \
  --input-len 512 \
  --output-len 100 \
  --num-warmups 50 \
  --num-prompts 1000 \
  --request-rate 100 
```

## Test Result

On a single B200 GPU, without this PR:

```text
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Request rate configured (RPS):           100.00
Benchmark duration (s):                  14.68
Total input tokens:                      856999
Total generated tokens:                  100000
Request throughput (req/s):              68.13
Output token throughput (tok/s):         6813.09
Peak output token throughput (tok/s):    12305.00
Peak concurrent requests:                587.00
Total token throughput (tok/s):          65201.25
---------------Time to First Token----------------
Mean TTFT (ms):                          2151.64
Median TTFT (ms):                        2115.74
P50 TTFT (ms):                           2115.74
P90 TTFT (ms):                           3851.23
P99 TTFT (ms):                           4219.73
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.92
Median TPOT (ms):                        30.59
P50 TPOT (ms):                           30.59
P90 TPOT (ms):                           31.71
P99 TPOT (ms):                           31.84
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.65
Median ITL (ms):                         29.58
P50 ITL (ms):                            29.58
P90 ITL (ms):                            35.84
P99 ITL (ms):                            45.15
==================================================
```

With this PR:

```text
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Request rate configured (RPS):           100.00
Benchmark duration (s):                  14.58
Total input tokens:                      856999
Total generated tokens:                  100000
Request throughput (req/s):              68.57
Output token throughput (tok/s):         6856.56
Peak output token throughput (tok/s):    11739.00
Peak concurrent requests:                579.00
Total token throughput (tok/s):          65617.16
---------------Time to First Token----------------
Mean TTFT (ms):                          2060.89
Median TTFT (ms):                        2020.54
P50 TTFT (ms):                           2020.54
P90 TTFT (ms):                           3768.02
P99 TTFT (ms):                           4137.64
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.85
Median TPOT (ms):                        30.41
P50 TPOT (ms):                           30.41
P90 TPOT (ms):                           31.37
P99 TPOT (ms):                           31.48
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.57
Median ITL (ms):                         29.63
P50 ITL (ms):                            29.63
P90 ITL (ms):                            35.46
P99 ITL (ms):                            42.74
==================================================
```

5% faster TTFT.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

