### PR TITLE
[Bugfix][V1][TurboQuant] Fix workspace AssertionError on first decode (#42544)

### DIFF
--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for WorkspaceManager.
+
+Focused on the lock semantics that turboquant_attn._decode_attention
+depends on: a locked workspace that is already large enough must still
+hand out tensor views, while a locked workspace that would need to grow
+must return None (via try_get_simultaneous) instead of raising — so the
+caller can fall back to per-call allocation. Repros the failure mode in
+vllm-project/vllm#42544.
+"""
+
+import pytest
+import torch
+
+from vllm.v1.worker.workspace import WorkspaceManager
+
+
+@pytest.fixture
+def manager() -> WorkspaceManager:
+    return WorkspaceManager(device=torch.device("cpu"), num_ubatches=1)
+
+
+def test_get_simultaneous_grows_when_unlocked(manager: WorkspaceManager) -> None:
+    a, b = manager.get_simultaneous(
+        ((16,), torch.float32),
+        ((8,), torch.float32),
+    )
+    assert a.shape == (16,)
+    assert b.shape == (8,)
+    assert a.dtype == torch.float32
+
+
+def test_get_simultaneous_raises_on_locked_undersized(
+    manager: WorkspaceManager,
+) -> None:
+    manager.lock()
+    with pytest.raises(AssertionError, match="Workspace is locked"):
+        manager.get_simultaneous(((1024,), torch.float32))
+
+
+def test_get_simultaneous_succeeds_on_locked_when_fits(
+    manager: WorkspaceManager,
+) -> None:
+    manager.get_simultaneous(((1024,), torch.float32))
+    manager.lock()
+    (t,) = manager.get_simultaneous(((128,), torch.float32))
+    assert t.shape == (128,)
+
+
+def test_try_get_simultaneous_returns_none_when_locked_undersized(
+    manager: WorkspaceManager,
+) -> None:
+    """The failure mode from issue #42544: workspace locked at 0 bytes,
+    decode-time allocation requested. Must not raise."""
+    manager.lock()
+    result = manager.try_get_simultaneous(
+        ((24, 4, 8, 257), torch.float32),
+        ((24, 4, 256), torch.bfloat16),
+        ((24, 4), torch.float32),
+    )
+    assert result is None
+
+
+def test_try_get_simultaneous_returns_views_when_locked_and_fits(
+    manager: WorkspaceManager,
+) -> None:
+    manager.get_simultaneous(
+        ((24, 4, 8, 257), torch.float32),
+        ((24, 4, 256), torch.bfloat16),
+        ((24, 4), torch.float32),
+    )
+    manager.lock()
+    result = manager.try_get_simultaneous(
+        ((24, 4, 8, 257), torch.float32),
+        ((24, 4, 256), torch.bfloat16),
+        ((24, 4), torch.float32),
+    )
+    assert result is not None
+    mid, out, lse = result
+    assert mid.shape == (24, 4, 8, 257)
+    assert out.shape == (24, 4, 256)
+    assert out.dtype == torch.bfloat16
+    assert lse.shape == (24, 4)
+
+
+def test_try_get_simultaneous_grows_when_unlocked(
+    manager: WorkspaceManager,
+) -> None:
+    result = manager.try_get_simultaneous(((1024,), torch.float32))
+    assert result is not None
+    (t,) = result
+    assert t.shape == (1024,)

--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -10,6 +10,8 @@ caller can fall back to per-call allocation. Repros the failure mode in
 vllm-project/vllm#42544.
 """
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
@@ -19,6 +21,11 @@ from vllm.v1.worker.workspace import WorkspaceManager
 @pytest.fixture
 def manager() -> WorkspaceManager:
     return WorkspaceManager(device=torch.device("cpu"), num_ubatches=1)
+
+
+@pytest.fixture
+def dbo_manager() -> WorkspaceManager:
+    return WorkspaceManager(device=torch.device("cpu"), num_ubatches=2)
 
 
 def test_get_simultaneous_grows_when_unlocked(manager: WorkspaceManager) -> None:
@@ -91,3 +98,39 @@ def test_try_get_simultaneous_grows_when_unlocked(
     assert result is not None
     (t,) = result
     assert t.shape == (1024,)
+
+
+def test_reserve_sizes_every_ubatch_slot(dbo_manager: WorkspaceManager) -> None:
+    """In DBO setups, reservation at init must hit every ubatch slot —
+    otherwise lock_workspace() snapshots sibling ubatches at 0 bytes and
+    they hit the slow fallback on every forward."""
+    shapes = (
+        ((24, 4, 8, 257), torch.float32),
+        ((24, 4, 256), torch.bfloat16),
+        ((24, 4), torch.float32),
+    )
+    dbo_manager.reserve(*shapes)
+    dbo_manager.lock()
+    for ubatch_id in range(2):
+        with patch(
+            "vllm.v1.worker.workspace.dbo_current_ubatch_id", return_value=ubatch_id
+        ):
+            result = dbo_manager.try_get_simultaneous(*shapes)
+            assert result is not None, f"ubatch {ubatch_id} fell back to None"
+            mid, out, lse = result
+            assert mid.shape == (24, 4, 8, 257)
+            assert out.shape == (24, 4, 256)
+            assert lse.shape == (24, 4)
+
+
+def test_get_simultaneous_does_not_size_sibling_ubatch(
+    dbo_manager: WorkspaceManager,
+) -> None:
+    """Conversely, get_simultaneous on the active ubatch must NOT
+    proactively size siblings — that would orphan their views mid-run
+    (the DBO leak warned about in _ensure_workspace_size)."""
+    with patch("vllm.v1.worker.workspace.dbo_current_ubatch_id", return_value=0):
+        dbo_manager.get_simultaneous(((1024,), torch.float32))
+    dbo_manager.lock()
+    with patch("vllm.v1.worker.workspace.dbo_current_ubatch_id", return_value=1):
+        assert dbo_manager.try_get_simultaneous(((128,), torch.float32)) is None

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -867,21 +867,31 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
     ) -> torch.Tensor:
         # Acquire shared decode scratch buffers from WorkspaceManager.
         # Layers execute sequentially so one set of buffers is sufficient.
-        # Falls back to kernel-internal allocation if workspace unavailable.
+        # output_buf in query dtype — matches the in-kernel fp16 cast in stage2.
         B = query.shape[0]
         D = self.head_size
         S = self.max_num_kv_splits
         Hq = self.num_heads
         mid_o_buf = output_buf = lse_buf = None
         if is_workspace_manager_initialized():
-            # output_buf in query dtype — matches the in-kernel fp16 cast in stage2.
-            mid_o_buf, output_buf, lse_buf = (
-                current_workspace_manager().get_simultaneous(
-                    ((B, Hq, S, D + 1), torch.float32),
-                    ((B, Hq, D), query.dtype),
-                    ((B, Hq), torch.float32),
-                )
+            bufs = current_workspace_manager().try_get_simultaneous(
+                ((B, Hq, S, D + 1), torch.float32),
+                ((B, Hq, D), query.dtype),
+                ((B, Hq), torch.float32),
             )
+            if bufs is not None:
+                mid_o_buf, output_buf, lse_buf = bufs
+            # else: workspace is locked at a size that cannot fit this decode
+            # shape (e.g. warmup never landed a decode pass on a TQ layer).
+            # Fall through to kernel-internal allocation via torch.empty.
+        if mid_o_buf is None:
+            mid_o_buf = torch.empty(
+                (B, Hq, S, D + 1), dtype=torch.float32, device=query.device
+            )
+            output_buf = torch.empty(
+                (B, Hq, D), dtype=query.dtype, device=query.device
+            )
+            lse_buf = torch.empty((B, Hq), dtype=torch.float32, device=query.device)
 
         result = triton_turboquant_decode_attention(
             query=query,

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -319,7 +319,9 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         )
         max_batch_tokens = scheduler_config.max_num_seqs * (1 + extra_spec_tokens)
         query_dtype = vllm_config.model_config.dtype
-        manager.get_simultaneous(
+        # Reserve across every ubatch slot so DBO setups don't get caught
+        # with sibling ubatches locked at 0 bytes.
+        manager.reserve(
             (
                 (
                     max_batch_tokens,

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -295,6 +295,44 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             vllm_config.attention_config.tq_max_kv_splits_for_cuda_graph
         )
 
+        # Pre-reserve decode scratch buffers so `lock_workspace()` (called
+        # at end of warmup) snapshots a workspace large enough for the
+        # steady-state decode shape. Without this, models whose warmup
+        # path never lands a decode forward through the TQ backend (e.g.
+        # dense + hybrid attention) leave the workspace locked at 0 MB
+        # and the first decode request would fall back to torch.empty
+        # for every layer/forward.
+        self._reserve_decode_workspace(vllm_config)
+
+    def _reserve_decode_workspace(self, vllm_config) -> None:
+        if not is_workspace_manager_initialized():
+            return
+        manager = current_workspace_manager()
+        if manager.is_locked():
+            return
+        scheduler_config = vllm_config.scheduler_config
+        speculative_config = vllm_config.speculative_config
+        extra_spec_tokens = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            else 0
+        )
+        max_batch_tokens = scheduler_config.max_num_seqs * (1 + extra_spec_tokens)
+        query_dtype = vllm_config.model_config.dtype
+        manager.get_simultaneous(
+            (
+                (
+                    max_batch_tokens,
+                    self.num_heads,
+                    self.max_num_kv_splits,
+                    self.head_size + 1,
+                ),
+                torch.float32,
+            ),
+            ((max_batch_tokens, self.num_heads, self.head_size), query_dtype),
+            ((max_batch_tokens, self.num_heads), torch.float32),
+        )
+
     def _flash_attn_varlen(
         self,
         q: torch.Tensor,
@@ -888,9 +926,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             mid_o_buf = torch.empty(
                 (B, Hq, S, D + 1), dtype=torch.float32, device=query.device
             )
-            output_buf = torch.empty(
-                (B, Hq, D), dtype=query.dtype, device=query.device
-            )
+            output_buf = torch.empty((B, Hq, D), dtype=query.dtype, device=query.device)
             lse_buf = torch.empty((B, Hq), dtype=torch.float32, device=query.device)
 
         result = triton_turboquant_decode_attention(

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -100,10 +100,9 @@ class WorkspaceManager:
         Returns:
             List of tensor views into the workspace buffer, one per shape/dtype pair.
         """
-        return self._slice_workspace(
-            self._ensure_workspace_size(self._total_bytes(shapes_and_dtypes)),
-            shapes_and_dtypes,
-        )
+        actual_bytes, offsets, total_bytes = self._compute_layout(shapes_and_dtypes)
+        workspace = self._ensure_workspace_size(total_bytes)
+        return self._slice(workspace, shapes_and_dtypes, actual_bytes, offsets)
 
     def try_get_simultaneous(
         self, *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype]
@@ -117,31 +116,51 @@ class WorkspaceManager:
         still returned normally — only the locked-and-undersized case yields
         None.
         """
-        total_bytes = self._total_bytes(shapes_and_dtypes)
+        actual_bytes, offsets, total_bytes = self._compute_layout(shapes_and_dtypes)
         if self._locked:
             ubatch_id = dbo_current_ubatch_id()
             current = self._current_workspaces[ubatch_id]
             if self._workspace_size_bytes(current) < total_bytes:
                 return None
-            return self._slice_workspace(current, shapes_and_dtypes)
-        return self._slice_workspace(
-            self._ensure_workspace_size(total_bytes), shapes_and_dtypes
-        )
+            return self._slice(current, shapes_and_dtypes, actual_bytes, offsets)
+        workspace = self._ensure_workspace_size(total_bytes)
+        return self._slice(workspace, shapes_and_dtypes, actual_bytes, offsets)
+
+    def reserve(self, *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype]) -> None:
+        """Pre-allocate workspace large enough for these shapes on every
+        ubatch slot.
+
+        Use this at init time (before `lock_workspace()`) so the lock
+        snapshots a workspace large enough for steady-state use on every
+        ubatch — not just the one whose forward happens to be active
+        during reservation. Safe to call repeatedly; idempotent.
+
+        Distinct from `get_simultaneous` which only grows the current
+        ubatch (to avoid orphaning sibling ubatches' outstanding views
+        mid-run).
+        """
+        total_bytes = self._compute_layout(shapes_and_dtypes)[2]
+        for ubatch_id in range(self._num_ubatches):
+            self._ensure_workspace_size(total_bytes, ubatch_id=ubatch_id)
 
     @staticmethod
-    def _total_bytes(
+    def _compute_layout(
         shapes_and_dtypes: tuple[tuple[tuple[int, ...], torch.dtype], ...],
-    ) -> int:
-        return sum(round_up(_compute_bytes(s, d), 256) for s, d in shapes_and_dtypes)
-
-    @staticmethod
-    def _slice_workspace(
-        workspace: torch.Tensor,
-        shapes_and_dtypes: tuple[tuple[tuple[int, ...], torch.dtype], ...],
-    ) -> list[torch.Tensor]:
+    ) -> tuple[list[int], list[int], int]:
+        """Compute byte sizes, aligned offsets, and total bytes in one pass."""
         actual_bytes = [_compute_bytes(s, d) for s, d in shapes_and_dtypes]
         aligned_bytes = [round_up(actual, 256) for actual in actual_bytes]
         offsets = list(accumulate([0] + aligned_bytes[:-1]))
+        total_bytes = sum(aligned_bytes)
+        return actual_bytes, offsets, total_bytes
+
+    @staticmethod
+    def _slice(
+        workspace: torch.Tensor,
+        shapes_and_dtypes: tuple[tuple[tuple[int, ...], torch.dtype], ...],
+        actual_bytes: list[int],
+        offsets: list[int],
+    ) -> list[torch.Tensor]:
         return [
             workspace[offsets[i] : offsets[i] + actual_bytes[i]]
             .view(shapes_and_dtypes[i][1])
@@ -149,16 +168,22 @@ class WorkspaceManager:
             for i in range(len(shapes_and_dtypes))
         ]
 
-    def _ensure_workspace_size(self, required_bytes: int) -> torch.Tensor:
-        """Ensure workspace is allocated and large enough, return current workspace.
+    def _ensure_workspace_size(
+        self, required_bytes: int, ubatch_id: int | None = None
+    ) -> torch.Tensor:
+        """Ensure workspace is allocated and large enough, return that workspace.
 
         Args:
             required_bytes: The number of bytes required.
+            ubatch_id: Which ubatch slot to size. Defaults to the current
+                ubatch (`dbo_current_ubatch_id()`); pass an explicit id
+                from `reserve` to size sibling slots.
 
         Returns:
-            The current workspace tensor.
+            The workspace tensor for the selected ubatch.
         """
-        ubatch_id = dbo_current_ubatch_id()
+        if ubatch_id is None:
+            ubatch_id = dbo_current_ubatch_id()
         current_workspace = self._current_workspaces[ubatch_id]
         current_size = self._workspace_size_bytes(current_workspace)
 

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -100,17 +100,50 @@ class WorkspaceManager:
         Returns:
             List of tensor views into the workspace buffer, one per shape/dtype pair.
         """
+        return self._slice_workspace(
+            self._ensure_workspace_size(self._total_bytes(shapes_and_dtypes)),
+            shapes_and_dtypes,
+        )
+
+    def try_get_simultaneous(
+        self, *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype]
+    ) -> list[torch.Tensor] | None:
+        """Like get_simultaneous, but return None when growth would be needed
+        on a locked workspace instead of raising.
+
+        Callers use this when they have a correct (slower) fallback path and
+        want to opportunistically use pre-allocated workspace whenever it
+        already fits. A locked workspace that is already large enough is
+        still returned normally — only the locked-and-undersized case yields
+        None.
+        """
+        total_bytes = self._total_bytes(shapes_and_dtypes)
+        if self._locked:
+            ubatch_id = dbo_current_ubatch_id()
+            current = self._current_workspaces[ubatch_id]
+            if self._workspace_size_bytes(current) < total_bytes:
+                return None
+            return self._slice_workspace(current, shapes_and_dtypes)
+        return self._slice_workspace(
+            self._ensure_workspace_size(total_bytes), shapes_and_dtypes
+        )
+
+    @staticmethod
+    def _total_bytes(
+        shapes_and_dtypes: tuple[tuple[tuple[int, ...], torch.dtype], ...],
+    ) -> int:
+        return sum(round_up(_compute_bytes(s, d), 256) for s, d in shapes_and_dtypes)
+
+    @staticmethod
+    def _slice_workspace(
+        workspace: torch.Tensor,
+        shapes_and_dtypes: tuple[tuple[tuple[int, ...], torch.dtype], ...],
+    ) -> list[torch.Tensor]:
         actual_bytes = [_compute_bytes(s, d) for s, d in shapes_and_dtypes]
         aligned_bytes = [round_up(actual, 256) for actual in actual_bytes]
-        total_bytes = sum(aligned_bytes)
-
-        # Calculate cumulative offsets using itertools.accumulate
         offsets = list(accumulate([0] + aligned_bytes[:-1]))
-
-        current_workspace = self._ensure_workspace_size(total_bytes)
-
         return [
-            current_workspace[offsets[i] : offsets[i] + actual_bytes[i]]
+            workspace[offsets[i] : offsets[i] + actual_bytes[i]]
             .view(shapes_and_dtypes[i][1])
             .reshape(shapes_and_dtypes[i][0])
             for i in range(len(shapes_and_dtypes))


### PR DESCRIPTION
## Purpose

Fixes #42544.

TurboQuant decode attention asserts on the very first inference request when warmup never lands a decode-shape forward through the TQ backend (dense models with hybrid attention, e.g. `Lorbus/Qwen3.6-27B-int4-AutoRound` where only 16 of 64 layers go through TQ). `lock_workspace()` runs at the end of warmup with the workspace still sized at 0 MB, and \`_decode_attention\` immediately trips:

\`\`\`
AssertionError: Workspace is locked but allocation from 'turboquant_attn.py:879:_decode_attention'
requires 0.76 MB, current size is 0.00 MB. Workspace growth is not allowed after locking.
\`\`\`

The pre-existing guard \`if is_workspace_manager_initialized():\` claimed a fallback but never delivered one — \"locked at 0 MB\" looks initialized and still asserts.

## Approach

Two small commits, smallest blast radius first:

**1. \`WorkspaceManager.try_get_simultaneous\` + \`torch.empty\` fallback in \`_decode_attention\`** — same contract as \`get_simultaneous\` except returns \`None\` (instead of raising) when the workspace is locked at a size smaller than the request. \`_decode_attention\` uses it and falls back to per-call \`torch.empty\` for \`mid_o_buf\` / \`output_buf\` / \`lse_buf\`. The locked-and-fits case still returns the workspace views, so the steady-state hot path is unchanged.

**2. Pre-reserve decode scratch buffers in \`TurboQuantAttentionImpl.__init__\`** — sized from \`max_num_seqs × (1 + num_speculative_tokens)\`, \`num_heads\`, \`max_num_kv_splits\`, \`head_size\`. Because attention impls are constructed after \`init_workspace_manager\` runs in \`GPUModelRunner.__init__\` and before \`lock_workspace()\` at the end of warmup, this guarantees the lock snapshot already covers steady-state decode and the fallback path stays cold.

\`get_simultaneous\` is idempotent across same-size requests, so per-layer init calls collapse to a single workspace grow on the first TQ layer.

## Duplicate-work check

Searched open PRs for \`turboquant workspace\` and reviewed:

- **#42215** (\`[Bugfix][V1][TurboQuant] Warm up decode kernels\`) — closest in spirit but materially different. That PR adds a \`kernel_warmup\` pass that walks attention layers and runs \`_decode_attention\` with synthetic tensors to handle both Triton JIT and workspace pre-allocation. This PR is a smaller defensive fix at the \`_decode_attention\` callsite plus a one-time reservation at backend init — no synthetic-forward pass, no kernel-warmup hook. The two are complementary; if #42215 lands first, the \`try_get_simultaneous\` fallback in this PR still has value as a safety net for any future op that hits the same lock-after-warmup hazard.
- **#40706** (KV memory loss / dedup decode scratch) and **#40798** (share decode scratch across layers) — orthogonal; they reshape the workspace layout but don't address the locked-at-0-MB case.

## Test Plan

\`\`\`
.venv/bin/python -m pytest tests/v1/worker/test_workspace.py -v
ruff check vllm/v1/worker/workspace.py vllm/v1/attention/backends/turboquant_attn.py tests/v1/worker/test_workspace.py
ruff format --check vllm/v1/worker/workspace.py vllm/v1/attention/backends/turboquant_attn.py tests/v1/worker/test_workspace.py
\`\`\`

End-to-end on Intel XPU with the repro from the issue (\`Qwen3.6-27B-int4-AutoRound\`, \`--kv-cache-dtype turboquant_k3v4_nc\`, \`--speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":2}'\`, \`--compilation-config '{\"cudagraph_capture_sizes\":[3,9]}'\`).

## Test Result

\`tests/v1/worker/test_workspace.py\`: 9 assertions pass on CPU.

Ruff check & format-check: clean against the pinned \`0.14.0\`.

End-to-end XPU run pending — opening as a draft so the human submitter can verify on real hardware and against the 35B-A3B model that didn't reproduce the bug. Will mark ready-for-review once those pass.

## AI assistance disclosure

This change was drafted with Claude (Claude Code, Opus 4.7) per the issue author's smallest-blast-radius proposal in #42544. The submitting human will review every changed line and run the e2e tests before marking the PR ready for review.

---

<details>
<summary>Checklist</summary>

- [x] Purpose
- [x] Test plan
- [x] Duplicate-work check
- [x] AI-assistance disclosure
- [ ] End-to-end XPU validation (pending human verification)
</details>