### PR TITLE
ROCm: allow 7168 hidden dim in AITER AR RMS fusion

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1041,7 +1041,7 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
         # `_pool` attribute and skip fusion for unsupported sizes.
         # Ref (old kernel): https://github.com/ROCm/aiter/blob/6a0e7b26ccf33164785531212cc2ec2cde0b9243/csrc/include/custom_all_reduce.cuh#L2590
         aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
-        _AITER_OLD_FUSED_AR_RMS_HIDDEN = (512, 1024, 2048, 4096)
+        _AITER_OLD_FUSED_AR_RMS_HIDDEN = (512, 1024, 2048, 4096, 7168)
         if (
             aiter_ar is not None
             and not hasattr(aiter_ar, "_pool")


### PR DESCRIPTION
This updates the ROCm AITER allreduce+rmsnorm fusion pass hidden-dim allowlist for the legacy AITER launcher path to include 7168.

The runtime AITER fused allreduce+rmsnorm gate already accepts hidden_dim=7168 in `vllm/_aiter_ops.py`, but the graph fusion pass still excluded it for older AITER launchers. This keeps the fusion pass gate consistent with the runtime gate.

Tests: not run; allowlist-only change.