### PR TITLE
[Bugfix] Keep streaming detokenization on HF when tokenizer_mode=fastokens (avoids EngineDeadError on Qwen3)

### DIFF
--- a/tests/v1/engine/test_fastokens_decode_unbundle.py
+++ b/tests/v1/engine/test_fastokens_decode_unbundle.py
@@ -1,13 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for ``_to_hf_tokenizer`` in ``vllm/v1/engine/detokenizer.py``.
+"""Unit tests for ``_to_hf_tokenizer`` in ``vllm/v1/engine/detokenizer.py``."""
 
-The helper exists so ``FastIncrementalDetokenizer`` can keep using HF's
-``DecodeStream`` even when the inner tokenizer is a fastokens shim (or any
-future shim that exposes the same ``to_str()`` JSON-serialization contract).
-We exercise both branches without requiring ``fastokens`` to be installed.
-"""
-
+import pytest
 from tokenizers import Tokenizer
 from transformers import AutoTokenizer
 
@@ -25,21 +20,17 @@ def test_to_hf_tokenizer_passes_real_tokenizer_through():
     assert _to_hf_tokenizer(inner) is inner
 
 
-def test_to_hf_tokenizer_rebuilds_from_to_str_shim():
-    """A shim that only exposes ``to_str()`` is rebuilt into a real Tokenizer."""
+def test_to_hf_tokenizer_rebuilds_from_json_shim():
+    """A shim exposing ``_json`` is rebuilt into a real Tokenizer and cached."""
     json_str = AutoTokenizer.from_pretrained(MODEL)._tokenizer.to_str()
 
     class FakeShim:
-        """Stand-in for ``fastokens._compat._TokenizerShim``.
+        """Stand-in for ``fastokens._compat._TokenizerShim``."""
 
-        The production code only relies on ``to_str()`` returning a tokenizer
-        JSON; any object satisfying that contract should work.
-        """
+        def __init__(self, json_str: str) -> None:
+            self._json = json_str
 
-        def to_str(self) -> str:
-            return json_str
-
-    shim = FakeShim()
+    shim = FakeShim(json_str)
     _rebuilt_hf_tokenizer_cache.clear()
 
     rebuilt = _to_hf_tokenizer(shim)
@@ -49,12 +40,13 @@ def test_to_hf_tokenizer_rebuilds_from_to_str_shim():
     assert _to_hf_tokenizer(shim) is rebuilt
 
 
-def test_to_hf_tokenizer_passes_unknown_object_through():
-    """Objects with no ``to_str`` fall through unchanged — informative error
-    downstream rather than a silent rebuild."""
+def test_to_hf_tokenizer_raises_for_object_without_json():
+    """Objects without a ``_json`` attribute raise ``TypeError`` rather than
+    being silently passed through to ``DecodeStream``, which would surface
+    later as a confusing C-extension error."""
 
     class Mystery:
         pass
 
-    obj = Mystery()
-    assert _to_hf_tokenizer(obj) is obj
+    with pytest.raises(TypeError, match="no ``_json`` attribute"):
+        _to_hf_tokenizer(Mystery())

--- a/tests/v1/engine/test_fastokens_decode_unbundle.py
+++ b/tests/v1/engine/test_fastokens_decode_unbundle.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``_to_hf_tokenizer`` in ``vllm/v1/engine/detokenizer.py``.
+
+The helper exists so ``FastIncrementalDetokenizer`` can keep using HF's
+``DecodeStream`` even when the inner tokenizer is a fastokens shim (or any
+future shim that exposes the same ``to_str()`` JSON-serialization contract).
+We exercise both branches without requiring ``fastokens`` to be installed.
+"""
+
+from tokenizers import Tokenizer
+from transformers import AutoTokenizer
+
+from vllm.v1.engine.detokenizer import (
+    _rebuilt_hf_tokenizer_cache,
+    _to_hf_tokenizer,
+)
+
+MODEL = "hf-internal-testing/llama-tokenizer"
+
+
+def test_to_hf_tokenizer_passes_real_tokenizer_through():
+    """A real ``tokenizers.Tokenizer`` is returned unchanged."""
+    inner = AutoTokenizer.from_pretrained(MODEL)._tokenizer
+    assert _to_hf_tokenizer(inner) is inner
+
+
+def test_to_hf_tokenizer_rebuilds_from_to_str_shim():
+    """A shim that only exposes ``to_str()`` is rebuilt into a real Tokenizer."""
+    json_str = AutoTokenizer.from_pretrained(MODEL)._tokenizer.to_str()
+
+    class FakeShim:
+        """Stand-in for ``fastokens._compat._TokenizerShim``.
+
+        The production code only relies on ``to_str()`` returning a tokenizer
+        JSON; any object satisfying that contract should work.
+        """
+
+        def to_str(self) -> str:
+            return json_str
+
+    shim = FakeShim()
+    _rebuilt_hf_tokenizer_cache.clear()
+
+    rebuilt = _to_hf_tokenizer(shim)
+    assert isinstance(rebuilt, Tokenizer)
+    assert rebuilt.to_str() == json_str
+    # Subsequent calls hit the cache (same instance returned).
+    assert _to_hf_tokenizer(shim) is rebuilt
+
+
+def test_to_hf_tokenizer_passes_unknown_object_through():
+    """Objects with no ``to_str`` fall through unchanged — informative error
+    downstream rather than a silent rebuild."""
+
+    class Mystery:
+        pass
+
+    obj = Mystery()
+    assert _to_hf_tokenizer(obj) is obj

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -57,22 +57,23 @@ _rebuilt_hf_tokenizer_cache: "weakref.WeakKeyDictionary[object, Tokenizer]" = (
 def _to_hf_tokenizer(tokenizer_inner: object) -> Tokenizer:
     """Return a ``tokenizers.Tokenizer`` suitable for HF's ``DecodeStream``.
 
-    Real ``Tokenizer`` instances are returned unchanged. Anything else that
-    exposes a ``to_str()`` returning a tokenizer-JSON string is rebuilt into
-    a real ``Tokenizer`` and cached (e.g. ``fastokens._compat._TokenizerShim``).
-    Other types pass through so downstream errors stay informative.
+    Real ``Tokenizer`` instances are returned unchanged. For
+    ``fastokens._compat._TokenizerShim``, rebuild a ``Tokenizer`` from the
+    shim's ``_json`` — the HF-formatted JSON captured at shim construction
+    time.
     """
     if isinstance(tokenizer_inner, Tokenizer):
         return tokenizer_inner
-    to_str = getattr(tokenizer_inner, "to_str", None)
-    if not callable(to_str):
-        return tokenizer_inner  # type: ignore[return-value]
     cached = _rebuilt_hf_tokenizer_cache.get(tokenizer_inner)
     if cached is not None:
         return cached
-    real_tok = Tokenizer.from_str(to_str())
-    # Non-weak-referenceable shims (rare) just skip the cache write and rebuild
-    # on the next call rather than failing detokenization.
+    json_str = getattr(tokenizer_inner, "_json", None)
+    if not isinstance(json_str, str):
+        raise TypeError(
+            f"Cannot rebuild a tokenizers.Tokenizer from "
+            f"{type(tokenizer_inner).__name__}: no ``_json`` attribute."
+        )
+    real_tok = Tokenizer.from_str(json_str)
     with contextlib.suppress(TypeError):
         _rebuilt_hf_tokenizer_cache[tokenizer_inner] = real_tok
     return real_tok

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -3,9 +3,9 @@
 from abc import ABC, abstractmethod
 
 import tokenizers
-import tokenizers.decoders
 from packaging import version
 from tokenizers import Tokenizer
+from tokenizers.decoders import DecodeStream
 from transformers import PreTrainedTokenizerFast
 
 from vllm.logger import init_logger
@@ -25,6 +25,41 @@ USE_FAST_DETOKENIZER = version.parse(tokenizers.__version__) >= version.parse("0
 
 # Error string from https://github.com/huggingface/tokenizers/blob/909fdde2a4ffedd9295206f705eb612be2a91b12/tokenizers/src/tokenizer/mod.rs#L1042
 INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
+
+
+# When ``tokenizer_mode=fastokens`` is active, ``fastokens.patch_transformers()``
+# replaces ``tokenizers.decoders.DecodeStream`` with a fastokens shim and wraps
+# the HuggingFace tokenizer in a ``_TokenizerShim`` that is not a
+# ``tokenizers.Tokenizer``. The fastokens decoder is strict about unknown token
+# IDs (it raises) while HF returns an empty string, which can crash streaming
+# generation on models whose embedding matrix exceeds ``tokenizer.json``'s
+# declared vocab (see https://github.com/crusoecloud/fastokens/issues/30).
+#
+# Mirror dynamo's encode-only approach: keep streaming detokenization on HF's
+# ``DecodeStream`` regardless of which encode backend is in use. Two pieces:
+# (1) use the locally-bound ``DecodeStream`` import above so fastokens'
+#     module-level patch does not reach this hot path;
+# (2) when the tokenizer is a fastokens shim, rebuild a real
+#     ``tokenizers.Tokenizer`` from the shim's JSON state for HF's
+#     ``DecodeStream.step`` to consume.
+_shim_to_hf_tokenizer: dict[int, Tokenizer] = {}
+
+
+def _to_hf_tokenizer(tokenizer_inner: object) -> Tokenizer:
+    """Return a ``tokenizers.Tokenizer`` for HF's ``DecodeStream``.
+
+    Most code paths already pass a real ``Tokenizer``; this helper exists for
+    the fastokens path where ``tokenizer._tokenizer`` is a ``_TokenizerShim``.
+    """
+    if type(tokenizer_inner).__name__ != "_TokenizerShim":
+        return tokenizer_inner  # type: ignore[return-value]
+    cached = _shim_to_hf_tokenizer.get(id(tokenizer_inner))
+    if cached is not None:
+        return cached
+    json_str = getattr(tokenizer_inner, "_json", None) or tokenizer_inner.to_str()
+    real_tok = Tokenizer.from_str(json_str)
+    _shim_to_hf_tokenizer[id(tokenizer_inner)] = real_tok
+    return real_tok
 
 
 class IncrementalDetokenizer:
@@ -174,13 +209,13 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
         self.request_id = request.request_id
         self.skip_special_tokens = sampling_params.skip_special_tokens
 
-        self.tokenizer: Tokenizer = tokenizer._tokenizer
+        self.tokenizer: Tokenizer = _to_hf_tokenizer(tokenizer._tokenizer)
 
         # Use native prefill to prime the decode stream with prompt tokens.
-        # Look up DecodeStream on the module so backend patches (e.g. the
-        # fastokens shim that replaces ``tokenizers.decoders.DecodeStream``)
-        # are honored regardless of import order.
-        self.stream = tokenizers.decoders.DecodeStream(
+        # Use the locally-bound ``DecodeStream`` (HF's original) so fastokens'
+        # module-level patch of ``tokenizers.decoders.DecodeStream`` does not
+        # reach this hot path. See the comment block above ``_to_hf_tokenizer``.
+        self.stream = DecodeStream(
             ids=request.prompt_token_ids,
             skip_special_tokens=self.skip_special_tokens,
         )
@@ -240,9 +275,7 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
                 " for request %s, resetting decode stream.",
                 self.request_id,
             )
-            self.stream = tokenizers.decoders.DecodeStream(
-                skip_special_tokens=self.skip_special_tokens
-            )
+            self.stream = DecodeStream(skip_special_tokens=self.skip_special_tokens)
             token = self.stream.step(self.tokenizer, next_token_id)
         return token
 

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -35,30 +35,35 @@ INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
 # generation on models whose embedding matrix exceeds ``tokenizer.json``'s
 # declared vocab (see https://github.com/crusoecloud/fastokens/issues/30).
 #
-# Mirror dynamo's encode-only approach: keep streaming detokenization on HF's
+# Take an encode-only approach: keep streaming detokenization on HF's
 # ``DecodeStream`` regardless of which encode backend is in use. Two pieces:
 # (1) use the locally-bound ``DecodeStream`` import above so fastokens'
 #     module-level patch does not reach this hot path;
-# (2) when the tokenizer is a fastokens shim, rebuild a real
-#     ``tokenizers.Tokenizer`` from the shim's JSON state for HF's
-#     ``DecodeStream.step`` to consume.
-_shim_to_hf_tokenizer: dict[int, Tokenizer] = {}
+# (2) when the inner tokenizer isn't a real ``tokenizers.Tokenizer`` (e.g.
+#     fastokens' shim), rebuild a real one from its JSON state for HF's
+#     ``DecodeStream.step`` to consume. We duck-type via ``to_str()`` so this
+#     works for any future shim that exposes the same serialization contract.
+_rebuilt_hf_tokenizer_cache: dict[int, Tokenizer] = {}
 
 
 def _to_hf_tokenizer(tokenizer_inner: object) -> Tokenizer:
-    """Return a ``tokenizers.Tokenizer`` for HF's ``DecodeStream``.
+    """Return a ``tokenizers.Tokenizer`` suitable for HF's ``DecodeStream``.
 
-    Most code paths already pass a real ``Tokenizer``; this helper exists for
-    the fastokens path where ``tokenizer._tokenizer`` is a ``_TokenizerShim``.
+    Real ``Tokenizer`` instances are returned unchanged. Anything else that
+    exposes a ``to_str()`` returning a tokenizer-JSON string is rebuilt into
+    a real ``Tokenizer`` and cached (e.g. ``fastokens._compat._TokenizerShim``).
+    Other types pass through so downstream errors stay informative.
     """
-    if type(tokenizer_inner).__name__ != "_TokenizerShim":
+    if isinstance(tokenizer_inner, Tokenizer):
+        return tokenizer_inner
+    to_str = getattr(tokenizer_inner, "to_str", None)
+    if not callable(to_str):
         return tokenizer_inner  # type: ignore[return-value]
-    cached = _shim_to_hf_tokenizer.get(id(tokenizer_inner))
+    cached = _rebuilt_hf_tokenizer_cache.get(id(tokenizer_inner))
     if cached is not None:
         return cached
-    json_str = getattr(tokenizer_inner, "_json", None) or tokenizer_inner.to_str()
-    real_tok = Tokenizer.from_str(json_str)
-    _shim_to_hf_tokenizer[id(tokenizer_inner)] = real_tok
+    real_tok = Tokenizer.from_str(to_str())
+    _rebuilt_hf_tokenizer_cache[id(tokenizer_inner)] = real_tok
     return real_tok
 
 

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
+import weakref
 from abc import ABC, abstractmethod
 
 import tokenizers
@@ -43,7 +45,13 @@ INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
 #     fastokens' shim), rebuild a real one from its JSON state for HF's
 #     ``DecodeStream.step`` to consume. We duck-type via ``to_str()`` so this
 #     works for any future shim that exposes the same serialization contract.
-_rebuilt_hf_tokenizer_cache: dict[int, Tokenizer] = {}
+# Keyed by the shim object itself (not ``id()``) so a garbage-collected shim
+# can't collide with a later object that happens to reuse the same address,
+# and so cache entries drop automatically instead of leaking for the life of
+# the process.
+_rebuilt_hf_tokenizer_cache: "weakref.WeakKeyDictionary[object, Tokenizer]" = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def _to_hf_tokenizer(tokenizer_inner: object) -> Tokenizer:
@@ -59,11 +67,14 @@ def _to_hf_tokenizer(tokenizer_inner: object) -> Tokenizer:
     to_str = getattr(tokenizer_inner, "to_str", None)
     if not callable(to_str):
         return tokenizer_inner  # type: ignore[return-value]
-    cached = _rebuilt_hf_tokenizer_cache.get(id(tokenizer_inner))
+    cached = _rebuilt_hf_tokenizer_cache.get(tokenizer_inner)
     if cached is not None:
         return cached
     real_tok = Tokenizer.from_str(to_str())
-    _rebuilt_hf_tokenizer_cache[id(tokenizer_inner)] = real_tok
+    # Non-weak-referenceable shims (rare) just skip the cache write and rebuild
+    # on the next call rather than failing detokenization.
+    with contextlib.suppress(TypeError):
+        _rebuilt_hf_tokenizer_cache[tokenizer_inner] = real_tok
     return real_tok
 
 


### PR DESCRIPTION
## What

`fastokens.patch_transformers()` swaps HF's `DecodeStream` for a strict shim
that raises on unknown token IDs; HF returns `""`. Easy repro on
`Qwen/Qwen3-0.6B-FP8` (151,936 embedding rows vs 151,669 declared vocab) with
`ignore_eos=true` → `unknown token ID: 151927` → `EngineDeadError`.

Keep encode on fastokens (TTFT win), route streaming detokenization through HF
— same pattern as [dynamo](https://github.com/ai-dynamo/dynamo/blob/v1.1.0/components/src/dynamo/frontend/frontend_args.py#L576).
Two changes in `vllm/v1/engine/detokenizer.py`:

1. Locally bind `DecodeStream` so fastokens' module-level patch doesn't reach
   this path.
2. For fastokens' `_TokenizerShim`, rebuild a real `tokenizers.Tokenizer` from
   the shim's `_json` attribute (cached in a `WeakKeyDictionary`). `to_str()`
   round-trips through fastokens' Rust serializer and emits enum variants
   HF's crate rejects.

Upstream context: https://github.com/crusoecloud/fastokens/issues/30.

## Why not duplicate

`gh pr list --repo vllm-project/vllm --state open --search "fastokens"` /
`"detokenizer DecodeStream"` — both empty.

## Tests

```
pytest tests/v1/engine/test_fastokens_decode_unbundle.py -v   # 3 passed
```

8× H100 smoke (`Qwen/Qwen3-0.6B-FP8`, `--tokenizer-mode fastokens`, c=64,
10240 reqs): before 10240 errors, after 0 errors. TTFT mean 192 → 102 ms vs
default HF (encode-side win preserved).

## AI assistance

Prepared with Claude. Reviewed every line, ran the tests, defending
end-to-end.
