### PR TITLE
integrate nccl2

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -382,7 +382,7 @@ def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
     torch.accelerator.set_device_index(local_rank)
     if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
         dist.init_process_group(
-            backend="cpu:gloo,cuda:nccl",
+            backend="cpu:gloo,cuda:nccl2",
             device_id=torch.device(f"cuda:{local_rank}"),
         )
     else:

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -85,10 +85,12 @@ def multiple_allreduce_worker_fn():
     device = torch.device(f"cuda:{torch.distributed.get_rank()}")
     if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
         # Eager-init path: parent PG has bound_device_id + a CPU backend,
-        # so split_group is supported.
-        group = torch.distributed.split_group(
-            split_ranks=[[0, 1], [2, 3]], backend="cpu:gloo,cuda:nccl"
-        )
+        # so split_group is supported. Leave ``backend`` unset so the child
+        # inherits the parent's per-device backends verbatim -- naming them
+        # explicitly ("cuda:nccl") breaks as soon as the world is built with a
+        # different device backend (e.g. nccl2), since split_group requires an
+        # exact name match.
+        group = torch.distributed.split_group(split_ranks=[[0, 1], [2, 3]])
     else:
         groups = [
             torch.distributed.new_group(ranks=[0, 1], backend="gloo"),
@@ -348,9 +350,9 @@ def test_pynccl_send_recv():
 def multiple_send_recv_worker_fn():
     device = torch.device(f"cuda:{torch.distributed.get_rank()}")
     if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
-        group = torch.distributed.split_group(
-            split_ranks=[[0, 2], [1, 3]], backend="cpu:gloo,cuda:nccl"
-        )
+        # ``backend`` left unset: inherit the parent PG's per-device backends
+        # (see multiple_allreduce_worker_fn).
+        group = torch.distributed.split_group(split_ranks=[[0, 2], [1, 3]])
     else:
         groups = [
             torch.distributed.new_group(ranks=[0, 2], backend="gloo"),

--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -399,8 +399,10 @@ def qr_variable_input(rank, world_size):
     for i in range(world_size):
         ranks.append(i)
     if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
+        # Must match vLLM's own split_group world init (cpu:gloo,cuda:nccl2);
+        # split_group compares backend names verbatim against the parent PG.
         dist.init_process_group(
-            backend="cpu:gloo,cuda:nccl",
+            backend="cpu:gloo,cuda:nccl2",
             init_method="tcp://127.0.0.1:29500",
             rank=rank,
             world_size=world_size,
@@ -414,9 +416,8 @@ def qr_variable_input(rank, world_size):
             world_size=world_size,
         )
     if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
-        cpu_group = torch.distributed.split_group(
-            split_ranks=[ranks], backend="cpu:gloo,cuda:nccl"
-        )
+        # ``backend`` left unset: inherit the parent PG's per-device backends.
+        cpu_group = torch.distributed.split_group(split_ranks=[ranks])
     else:
         cpu_group = torch.distributed.new_group(ranks, backend="nccl")
 

--- a/tests/distributed/test_split_group.py
+++ b/tests/distributed/test_split_group.py
@@ -6,6 +6,8 @@ These tests verify that:
 1. split_group is used for both device and CPU group creation.
 2. Multiple subgroups work correctly with split_group.
 3. Both GPU and CPU all-reduce work on split groups.
+4. All collective operations work correctly through split groups
+   with both use_device_communicator=True and False modes.
 """
 
 import os
@@ -19,6 +21,8 @@ import torch.distributed
 import vllm.envs as envs
 from vllm.distributed.parallel_state import (
     GroupCoordinator,
+    _use_split_group,
+    get_world_group,
     init_distributed_environment,
 )
 from vllm.utils.system_utils import update_environment_variables
@@ -33,7 +37,7 @@ pytestmark = pytest.mark.skipif(
 mp.set_start_method("spawn", force=True)
 
 
-def distributed_run(fn, world_size):
+def distributed_run(fn, world_size, extra_env: dict[str, str] | None = None):
     number_of_processes = world_size
     processes: list[mp.Process] = []
     for i in range(number_of_processes):
@@ -46,6 +50,8 @@ def distributed_run(fn, world_size):
         env["MASTER_PORT"] = "12346"
         # propagate the opt-in flag to the spawned child workers
         env["VLLM_DISTRIBUTED_USE_SPLIT_GROUP"] = "1"
+        if extra_env:
+            env.update(extra_env)
         p = mp.Process(target=fn, args=(env,))
         processes.append(p)
         p.start()
@@ -67,6 +73,35 @@ def worker_fn_wrapper(fn):
         fn()
 
     return wrapped_fn
+
+
+def _world_device_backend() -> str:
+    """Backend name the world PG was built with.
+
+    ``split_group`` matches backend names verbatim against the parent PG, so a
+    subgroup must request exactly what ``init_distributed_environment`` chose
+    (``nccl2`` on the split_group path). Hardcoding ``"nccl"`` here fails with
+    "Backend mismatch for device 'cuda'".
+    """
+    return str(get_world_group().torch_distributed_backend)
+
+
+def _get_use_device_communicator() -> bool:
+    return os.environ.get("USE_DEVICE_COMMUNICATOR", "False") == "True"
+
+
+def _create_coordinator(
+    use_device_communicator: bool, group_name: str
+) -> GroupCoordinator:
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    return GroupCoordinator(
+        group_ranks=[list(range(world_size))],
+        local_rank=rank,
+        torch_distributed_backend=_world_device_backend(),
+        use_device_communicator=use_device_communicator,
+        group_name=group_name,
+    )
 
 
 def _verify_device_group(coordinator: GroupCoordinator):
@@ -106,7 +141,7 @@ def split_group_basic_worker():
     coordinator = GroupCoordinator(
         group_ranks=group_ranks,
         local_rank=rank,
-        torch_distributed_backend="nccl",
+        torch_distributed_backend=_world_device_backend(),
         use_device_communicator=False,
         group_name="test_split_basic",
     )
@@ -125,6 +160,34 @@ def test_split_group_basic():
 
 
 # ---------------------------------------------------------------------------
+# Test 1b: a gloo world (CPU-only platform, or a device backend torch does not
+# have registered) has no device to split on, on an accelerator host as much as
+# on a CPU-only one, so it must keep the legacy ``new_group`` path instead of
+# being asked for a device-bound parent.
+# ---------------------------------------------------------------------------
+def gloo_world_worker(env):
+    update_environment_variables(env)
+    init_distributed_environment(backend="gloo")
+
+    assert not _use_split_group(), (
+        "a gloo world is not device-bound and cannot be split"
+    )
+    world = get_world_group()
+    tensor = torch.ones(1, dtype=torch.float32)
+    torch.distributed.all_reduce(tensor, group=world.cpu_group)
+    assert tensor.item() == world.world_size
+
+
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="Only an accelerator host exercises the gloo/device-bound mismatch.",
+)
+def test_gloo_world_on_accelerator_host():
+    """A gloo world must initialize on a host where torch sees an accelerator."""
+    distributed_run(gloo_world_worker, 1, extra_env={"MASTER_PORT": "12348"})
+
+
+# ---------------------------------------------------------------------------
 # Test 2: Multiple subgroups with split_group (4 GPUs)
 # ---------------------------------------------------------------------------
 @worker_fn_wrapper
@@ -135,7 +198,7 @@ def split_group_multiple_subgroups_worker():
     coordinator = GroupCoordinator(
         group_ranks=group_ranks,
         local_rank=rank,
-        torch_distributed_backend="nccl",
+        torch_distributed_backend=_world_device_backend(),
         use_device_communicator=False,
         group_name="test_split_multi",
     )
@@ -186,7 +249,7 @@ def split_group_contract_worker():
         GroupCoordinator(
             group_ranks=group_ranks,
             local_rank=rank,
-            torch_distributed_backend="nccl",
+            torch_distributed_backend=_world_device_backend(),
             use_device_communicator=False,
             group_name="test_split_contract",
         )
@@ -231,3 +294,643 @@ def test_split_group_contract_same_split_ranks_on_all_ranks():
     disjoint partitions but is a documented contract violation.
     """
     distributed_run(split_group_contract_worker, 4)
+
+
+# ---------------------------------------------------------------------------
+# CPU Group Tests (Tests 3-5)
+# ---------------------------------------------------------------------------
+@worker_fn_wrapper
+def broadcast_object_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_broadcast_object")
+    obj = {"key": "value", "rank": 0}
+    if coordinator.rank_in_group == 0:
+        result = coordinator.broadcast_object(obj, src=0)
+    else:
+        result = coordinator.broadcast_object(src=0)
+    assert result == obj, (
+        f"broadcast_object failed: expected {obj}, got {result}"
+    )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_broadcast_object(use_device_communicator):
+    """Test broadcast_object through split group."""
+    distributed_run(
+        broadcast_object_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def send_recv_object_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_send_recv_object")
+    obj = {"data": [1, 2, 3]}
+    if coordinator.rank_in_group == 0:
+        coordinator.send_object(obj, dst=1)
+    elif coordinator.rank_in_group == 1:
+        result = coordinator.recv_object(src=0)
+        assert result == obj, (
+            f"recv_object failed: expected {obj}, got {result}"
+        )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_send_recv_object(use_device_communicator):
+    """Test send_object/recv_object through split group."""
+    distributed_run(
+        send_recv_object_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def barrier_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_barrier")
+    coordinator.barrier()
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_barrier(use_device_communicator):
+    """Test barrier through split group."""
+    distributed_run(
+        barrier_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Device Group Tests (Tests 6-10)
+# ---------------------------------------------------------------------------
+@worker_fn_wrapper
+def broadcast_gpu_tensor_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_broadcast_gpu_tensor")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    if coordinator.rank_in_group == 0:
+        tensor = torch.ones(16, dtype=torch.float32, device=device)
+    else:
+        tensor = torch.zeros(16, dtype=torch.float32, device=device)
+    coordinator.broadcast(tensor, src=0)
+    expected = torch.ones(16, dtype=torch.float32, device=device)
+    assert torch.equal(tensor, expected), (
+        f"broadcast GPU tensor failed: expected all 1s, "
+        f"got {tensor.flatten()[:4].tolist()}"
+    )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_broadcast_gpu_tensor(use_device_communicator):
+    """Test broadcast of GPU tensor through split group."""
+    distributed_run(
+        broadcast_gpu_tensor_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def all_reduce_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_all_reduce")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    tensor = torch.ones(16, dtype=torch.float32, device=device)
+    if use_dc:
+        result = coordinator.all_reduce(tensor)
+    else:
+        torch.distributed.all_reduce(tensor, group=coordinator.device_group)
+        result = tensor
+    torch.accelerator.synchronize()
+    expected = float(coordinator.world_size)
+    assert torch.all(result == expected).cpu().item(), (
+        f"all_reduce failed: expected {expected}, "
+        f"got {result.flatten()[:4].tolist()}"
+    )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_all_reduce(use_device_communicator):
+    """Test all_reduce through split group."""
+    distributed_run(
+        all_reduce_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def all_gather_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_all_gather")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    rank_in_group = coordinator.rank_in_group
+    tensor = torch.full((4,), float(rank_in_group), dtype=torch.float32, device=device)
+    if use_dc:
+        result = coordinator.all_gather(tensor, dim=0)
+    else:
+        world_size = coordinator.world_size
+        output = torch.empty(
+            4 * world_size, dtype=torch.float32, device=device
+        )
+        torch.distributed.all_gather_into_tensor(
+            output, tensor, group=coordinator.device_group
+        )
+        result = output
+    torch.accelerator.synchronize()
+    expected = torch.cat(
+        [
+            torch.full((4,), float(r), dtype=torch.float32, device=device)
+            for r in range(coordinator.world_size)
+        ]
+    )
+    assert torch.equal(result, expected), (
+        f"all_gather failed: expected {expected.tolist()}, "
+        f"got {result.tolist()}"
+    )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_all_gather(use_device_communicator):
+    """Test all_gather through split group."""
+    distributed_run(
+        all_gather_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def reduce_scatter_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_reduce_scatter")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    world_size = coordinator.world_size
+    chunk_size = 4
+    tensor = torch.ones(
+        world_size * chunk_size, dtype=torch.float32, device=device
+    )
+    if use_dc:
+        result = coordinator.reduce_scatter(tensor, dim=0)
+    else:
+        output = torch.empty(chunk_size, dtype=torch.float32, device=device)
+        torch.distributed.reduce_scatter_tensor(
+            output, tensor, group=coordinator.device_group
+        )
+        result = output
+    torch.accelerator.synchronize()
+    expected_val = float(world_size)
+    assert torch.all(result == expected_val).cpu().item(), (
+        f"reduce_scatter failed: expected {expected_val}, "
+        f"got {result.tolist()}"
+    )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_reduce_scatter(use_device_communicator):
+    """Test reduce_scatter through split group."""
+    distributed_run(
+        reduce_scatter_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def send_recv_gpu_tensor_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_send_recv_gpu_tensor")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    if coordinator.rank_in_group == 0:
+        tensor = torch.full((16,), 42.0, dtype=torch.float32, device=device)
+        if use_dc:
+            coordinator.send(tensor, dst=1)
+        else:
+            dst_global = coordinator.ranks[1]
+            torch.distributed.send(
+                tensor, dst=dst_global, group=coordinator.device_group
+            )
+    elif coordinator.rank_in_group == 1:
+        if use_dc:
+            result = coordinator.recv(
+                size=torch.Size([16]), dtype=torch.float32, src=0
+            )
+        else:
+            result = torch.empty(16, dtype=torch.float32, device=device)
+            src_global = coordinator.ranks[0]
+            torch.distributed.recv(
+                result, src=src_global, group=coordinator.device_group
+            )
+        torch.accelerator.synchronize()
+        expected = torch.full(
+            (16,), 42.0, dtype=torch.float32, device=device
+        )
+        assert torch.equal(result, expected), (
+            f"send/recv GPU tensor failed: expected {expected.tolist()}, "
+            f"got {result.tolist()}"
+        )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_send_recv_gpu_tensor(use_device_communicator):
+    """Test send/recv of GPU tensor through split group."""
+    distributed_run(
+        send_recv_gpu_tensor_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composite Tests (Tests 11-12)
+# ---------------------------------------------------------------------------
+@worker_fn_wrapper
+def broadcast_tensor_dict_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_broadcast_tensor_dict")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    if coordinator.rank_in_group == 0:
+        tensor_dict = {
+            "gpu_tensor": torch.ones(8, dtype=torch.float32, device=device),
+            "scalar": 42,
+            "text": "hello",
+        }
+        result = coordinator.broadcast_tensor_dict(tensor_dict, src=0)
+    else:
+        result = coordinator.broadcast_tensor_dict(src=0)
+    assert result is not None
+    expected_tensor = torch.ones(8, dtype=torch.float32, device=device)
+    assert torch.equal(result["gpu_tensor"], expected_tensor), (
+        f"broadcast_tensor_dict GPU tensor mismatch: "
+        f"expected {expected_tensor.tolist()}, got {result['gpu_tensor'].tolist()}"
+    )
+    assert result["scalar"] == 42, (
+        f"broadcast_tensor_dict scalar mismatch: expected 42, "
+        f"got {result['scalar']}"
+    )
+    assert result["text"] == "hello", (
+        f"broadcast_tensor_dict text mismatch: expected 'hello', "
+        f"got {result['text']}"
+    )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_broadcast_tensor_dict(use_device_communicator):
+    """Test broadcast_tensor_dict through split group."""
+    distributed_run(
+        broadcast_tensor_dict_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+
+
+@worker_fn_wrapper
+def send_recv_tensor_dict_worker():
+    use_dc = _get_use_device_communicator()
+    coordinator = _create_coordinator(use_dc, "test_send_recv_tensor_dict")
+    local_rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{local_rank}")
+    if coordinator.rank_in_group == 0:
+        tensor_dict = {
+            "gpu_tensor": torch.full(
+                (8,), 99.0, dtype=torch.float32, device=device
+            ),
+            "scalar": 42,
+        }
+        coordinator.send_tensor_dict(tensor_dict, dst=1)
+    elif coordinator.rank_in_group == 1:
+        result = coordinator.recv_tensor_dict(src=0)
+        assert result is not None
+        expected_tensor = torch.full(
+            (8,), 99.0, dtype=torch.float32, device=device
+        )
+        assert torch.equal(result["gpu_tensor"], expected_tensor), (
+            f"recv_tensor_dict GPU tensor mismatch: "
+            f"expected {expected_tensor.tolist()}, "
+            f"got {result['gpu_tensor'].tolist()}"
+        )
+        assert result["scalar"] == 42, (
+            f"recv_tensor_dict scalar mismatch: expected 42, "
+            f"got {result['scalar']}"
+        )
+
+
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+@pytest.mark.parametrize("use_device_communicator", [True, False])
+def test_send_recv_tensor_dict(use_device_communicator):
+    """Test send_tensor_dict/recv_tensor_dict through split group."""
+    distributed_run(
+        send_recv_tensor_dict_worker,
+        2,
+        extra_env={"USE_DEVICE_COMMUNICATOR": str(use_device_communicator)},
+    )
+# ---------------------------------------------------------------------------
+# torchcomms-specific tests: each exercises a c10d code path under
+# TORCH_DISTRIBUTED_USE_TORCHCOMMS=1 to confirm it works end-to-end.
+# ---------------------------------------------------------------------------
+
+try:
+    import flashinfer  # noqa: F401
+
+    _flashinfer_available = True
+except ImportError:
+    _flashinfer_available = False
+
+try:
+    import ninja
+
+    _ninja_bin_dir = ninja.BIN_DIR
+except (ImportError, AttributeError):
+    _ninja_bin_dir = None
+
+
+def torchcomms_worker_fn_wrapper(fn):
+    """Like worker_fn_wrapper but enables torchcomms before distributed init."""
+
+    def wrapped_fn(env):
+        update_environment_variables(env)
+        if env.get("USE_TORCHCOMMS") == "True":
+            import torch.distributed.config as tc_cfg
+
+            tc_cfg.use_torchcomms = True
+        local_rank = os.environ["LOCAL_RANK"]
+        device = torch.device(f"cuda:{local_rank}")
+        torch.accelerator.set_device_index(device)
+        init_distributed_environment()
+        fn()
+
+    return wrapped_fn
+
+
+def distributed_run_with_timeout(
+    fn, world_size, extra_env=None, timeout=60
+):
+    """Run distributed fn with timeout. Returns (hung, exitcodes)."""
+    processes: list[mp.Process] = []
+    for i in range(world_size):
+        env: dict[str, str] = {
+            "RANK": str(i),
+            "LOCAL_RANK": str(i),
+            "WORLD_SIZE": str(world_size),
+            "LOCAL_WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "12347",
+        }
+        if extra_env:
+            env.update(extra_env)
+        p = mp.Process(target=fn, args=(env,))
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join(timeout=timeout)
+
+    hung = any(p.is_alive() for p in processes)
+    exitcodes = []
+    for p in processes:
+        if p.is_alive():
+            p.kill()
+            p.join()
+            exitcodes.append(None)
+        else:
+            exitcodes.append(p.exitcode)
+
+    return hung, exitcodes
+
+
+@torchcomms_worker_fn_wrapper
+def batch_isend_irecv_torchcomms_worker():
+    rank = torch.distributed.get_rank()
+    coordinator = _create_coordinator(False, "test_batch_p2p_tc")
+    device = torch.device(f"cuda:{rank}")
+
+    if rank == 0:
+        send_tensor = torch.ones(16, dtype=torch.float32, device=device)
+        ops = [
+            torch.distributed.P2POp(
+                torch.distributed.isend,
+                send_tensor,
+                1,
+                group=coordinator.device_group,
+            )
+        ]
+    else:
+        recv_tensor = torch.zeros(16, dtype=torch.float32, device=device)
+        ops = [
+            torch.distributed.P2POp(
+                torch.distributed.irecv,
+                recv_tensor,
+                0,
+                group=coordinator.device_group,
+            )
+        ]
+
+    reqs = torch.distributed.batch_isend_irecv(ops)
+    for req in reqs:
+        req.wait()
+    torch.cuda.synchronize()
+
+    if rank == 1:
+        assert torch.all(recv_tensor == 1.0).item(), (
+            f"P2P recv failed: expected all 1s, got {recv_tensor.tolist()}"
+        )
+
+
+@pytest.mark.skip(
+    reason="torchcomms shim removed; vLLM now wires nccl2/nccl-lazy explicitly."
+)
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+def test_batch_isend_irecv_torchcomms():
+    hung, exitcodes = distributed_run_with_timeout(
+        batch_isend_irecv_torchcomms_worker,
+        2,
+        extra_env={"USE_TORCHCOMMS": "True"},
+        timeout=60,
+    )
+    assert not hung, "P2P ops should not hang with batch_isend_irecv"
+    # Exit code -11 (SIGSEGV) is acceptable: torchcomms' NCCL garbage
+    # collector thread can crash during Python interpreter shutdown.
+    assert all(ec in (0, -11) for ec in exitcodes if ec is not None), (
+        f"P2P ops failed with exit codes {exitcodes}"
+    )
+
+
+@torchcomms_worker_fn_wrapper
+def all_gather_into_tensor_torchcomms_worker():
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    coordinator = _create_coordinator(False, "test_ag_into_tensor_tc")
+    device = torch.device(f"cuda:{rank}")
+
+    tensor = torch.full(
+        (16,), float(rank), dtype=torch.float32, device=device
+    )
+    output = torch.empty(
+        world_size * tensor.numel(),
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    torch.distributed.all_gather_into_tensor(
+        output, tensor, group=coordinator.device_group
+    )
+    torch.cuda.synchronize()
+
+    expected = torch.cat(
+        [
+            torch.full((16,), float(r), dtype=torch.float32, device=device)
+            for r in range(world_size)
+        ]
+    )
+    assert torch.equal(output, expected), (
+        f"all_gather_into_tensor failed: expected {expected.tolist()}, "
+        f"got {output.tolist()}"
+    )
+
+
+@pytest.mark.skip(
+    reason="torchcomms shim removed; vLLM now wires nccl2/nccl-lazy explicitly."
+)
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+def test_all_gather_into_tensor_torchcomms():
+    hung, exitcodes = distributed_run_with_timeout(
+        all_gather_into_tensor_torchcomms_worker,
+        2,
+        extra_env={"USE_TORCHCOMMS": "True"},
+        timeout=60,
+    )
+    assert not hung, "all_gather_into_tensor should not hang"
+    assert all(ec in (0, -11) for ec in exitcodes if ec is not None), (
+        f"all_gather_into_tensor failed with exit codes {exitcodes}"
+    )
+
+
+@torchcomms_worker_fn_wrapper
+def destroy_env_torchcomms_worker():
+    from vllm.distributed.parallel_state import (
+        destroy_distributed_environment,
+    )
+
+    coordinator = _create_coordinator(False, "test_destroy_env_tc")
+    rank = torch.distributed.get_rank()
+    device = torch.device(f"cuda:{rank}")
+
+    tensor = torch.ones(16, dtype=torch.float32, device=device)
+    torch.distributed.all_reduce(tensor, group=coordinator.device_group)
+    torch.cuda.synchronize()
+
+    destroy_distributed_environment()
+
+
+@pytest.mark.skip(
+    reason="torchcomms shim removed; vLLM now wires nccl2/nccl-lazy explicitly."
+)
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+def test_destroy_env_torchcomms():
+    hung, exitcodes = distributed_run_with_timeout(
+        destroy_env_torchcomms_worker,
+        2,
+        extra_env={"USE_TORCHCOMMS": "True"},
+        timeout=60,
+    )
+    assert not hung, "destroy_distributed_environment should not hang"
+    assert all(ec in (0, -11) for ec in exitcodes if ec is not None), (
+        f"destroy_distributed_environment failed with exit codes {exitcodes}"
+    )
+
+
+@torchcomms_worker_fn_wrapper
+def flashinfer_backend_resolve_torchcomms_worker():
+    from vllm.distributed.device_communicators.flashinfer_all_reduce import (
+        _resolve_fi_ar_backend,
+    )
+
+    backend = _resolve_fi_ar_backend()
+    assert backend == "mnnvl", (
+        f"Expected mnnvl backend with torchcomms, got {backend}"
+    )
+
+
+@pytest.mark.skip(
+    reason="torchcomms shim removed; vLLM now wires nccl2/nccl-lazy explicitly."
+)
+@pytest.mark.skipif(
+    not _flashinfer_available,
+    reason="flashinfer is not installed.",
+)
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 2,
+    reason="Need at least 2 GPUs to run the test.",
+)
+def test_flashinfer_backend_resolve_torchcomms():
+    """``_resolve_fi_ar_backend`` picks the ``mnnvl`` flashinfer all-reduce
+    backend under torchcomms. The ``trtllm`` backend opens its own TCP
+    socket for IPC buffer exchange that doesn't compose with torchcomms'
+    process-group wrapping; mnnvl is the safe choice."""
+    hung, exitcodes = distributed_run_with_timeout(
+        flashinfer_backend_resolve_torchcomms_worker,
+        2,
+        extra_env={"USE_TORCHCOMMS": "True"},
+        timeout=60,
+    )
+    assert not hung, "Backend resolution should not hang"
+    assert all(ec == 0 for ec in exitcodes if ec is not None), (
+        f"Backend resolution failed with exit codes {exitcodes}"
+    )

--- a/tests/distributed/test_torchrun_example.py
+++ b/tests/distributed/test_torchrun_example.py
@@ -13,14 +13,16 @@ from vllm import LLM, SamplingParams
 from vllm.distributed.parallel_state import get_world_group
 
 # By default, let PyTorch choose the WORLD backend for the current device
-# type (legacy lazy-init path). When VLLM_DISTRIBUTED_USE_SPLIT_GROUP=1,
-# use the explicit eager-init pattern required by `split_group` (mixed
-# cpu:gloo,cuda:nccl backend + device_id binding).
+# type (legacy lazy-init path). When VLLM_DISTRIBUTED_USE_SPLIT_GROUP=1, use
+# the explicit eager-init pattern required by ``split_group`` (mixed
+# cpu:gloo,cuda:nccl2 backend + device_id binding). The device backend must
+# match vLLM's own world init exactly -- split_group compares backend names
+# verbatim against the parent PG.
 if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.accelerator.set_device_index(local_rank)
     dist.init_process_group(
-        backend="cpu:gloo,cuda:nccl",
+        backend="cpu:gloo,cuda:nccl2",
         device_id=torch.device(f"cuda:{local_rank}"),
     )
 else:

--- a/tests/distributed/test_torchrun_example_moe.py
+++ b/tests/distributed/test_torchrun_example_moe.py
@@ -13,14 +13,16 @@ from vllm import LLM, SamplingParams
 from vllm.distributed.parallel_state import get_tp_group, get_world_group
 
 # By default, let PyTorch choose the WORLD backend for the current device
-# type (legacy lazy-init path). When VLLM_DISTRIBUTED_USE_SPLIT_GROUP=1,
-# use the explicit eager-init pattern required by `split_group` (mixed
-# cpu:gloo,cuda:nccl backend + device_id binding).
+# type (legacy lazy-init path). When VLLM_DISTRIBUTED_USE_SPLIT_GROUP=1, use
+# the explicit eager-init pattern required by ``split_group`` (mixed
+# cpu:gloo,cuda:nccl2 backend + device_id binding). The device backend must
+# match vLLM's own world init exactly -- split_group compares backend names
+# verbatim against the parent PG.
 if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.accelerator.set_device_index(local_rank)
     dist.init_process_group(
-        backend="cpu:gloo,cuda:nccl",
+        backend="cpu:gloo,cuda:nccl2",
         device_id=torch.device(f"cuda:{local_rank}"),
     )
 else:

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -9,7 +9,11 @@ import torch
 
 import vllm.envs as envs
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
-from vllm.distributed.utils import StatelessProcessGroup
+from vllm.distributed.utils import (
+    StatelessProcessGroup,
+    stateless_destroy_torch_distributed_process_group,
+    stateless_init_torch_distributed_process_group,
+)
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_open_port
 from vllm.utils.system_utils import update_environment_variables
@@ -43,6 +47,31 @@ def test_cuda_device_count_stateless():
     assert ray.get(actor.get_count.remote()) == 1
     ray.get(actor.set_cuda_visible_devices.remote(""))
     assert ray.get(actor.get_count.remote()) == 0
+
+
+def test_stateless_init_with_elastic_agent_store_env(monkeypatch):
+    """A stateless group owns a private ``host:port``.
+
+    ``torchrun`` exports ``TORCHELASTIC_USE_AGENT_STORE`` into every worker,
+    which makes ``torch.distributed.rendezvous`` hand back a client-only
+    ``TCPStore`` on every rank -- nobody would serve the group's own port and
+    every rank would block until the store timeout (30 minutes for gloo).
+    """
+    monkeypatch.setenv("TORCHELASTIC_USE_AGENT_STORE", "True")
+    pg = stateless_init_torch_distributed_process_group(
+        host="127.0.0.1",
+        port=get_open_port(),
+        rank=0,
+        world_size=1,
+        backend="gloo",
+        group_name="test_elastic_agent_store",
+    )
+    try:
+        tensor = torch.ones(1)
+        pg.allreduce([tensor]).wait()
+        assert tensor.item() == 1
+    finally:
+        stateless_destroy_torch_distributed_process_group(pg)
 
 
 def cpu_worker(rank, WORLD_SIZE, port1, port2):

--- a/tests/kernels/moe/modular_kernel_tools/parallel_utils.py
+++ b/tests/kernels/moe/modular_kernel_tools/parallel_utils.py
@@ -88,8 +88,14 @@ def _worker_parallel_launch(
     rank = node_rank * world_local_size + local_rank
     device = torch.device("cuda", local_rank)
     torch.accelerator.set_device_index(device)
+    # Mirror vLLM's own world init: with VLLM_DISTRIBUTED_USE_SPLIT_GROUP=1
+    # (the default) ``init_distributed_environment`` (called below via
+    # ``_set_vllm_config``) forces every GroupCoordinator onto the parent's
+    # "nccl2" cuda backend, and split_group matches backend names exactly, so
+    # a "cuda:nccl" parent here fails with "Backend mismatch for device 'cuda'".
+    device_backend = "nccl2" if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP else "nccl"
     torch.distributed.init_process_group(
-        backend="cpu:gloo,cuda:nccl",
+        backend=f"cpu:gloo,cuda:{device_backend}",
         init_method=init_method,
         rank=rank,
         world_size=world_size,

--- a/tests/kernels/moe/parallel_utils.py
+++ b/tests/kernels/moe/parallel_utils.py
@@ -15,6 +15,7 @@ from torch.distributed import ProcessGroup
 from torch.multiprocessing import spawn  # pyright: ignore[reportPrivateImportUsage]
 from typing_extensions import ParamSpec
 
+import vllm.envs as envs
 from vllm.utils.import_utils import has_deep_ep
 from vllm.utils.network_utils import get_open_port
 
@@ -54,8 +55,13 @@ def _worker_parallel_launch(
     rank = node_rank * world_local_size + local_rank
     torch.accelerator.set_device_index(local_rank)
     device = torch.device("cuda", local_rank)
+    # Mirror vLLM's own world init: with VLLM_DISTRIBUTED_USE_SPLIT_GROUP=1
+    # (the default) every group is carved off a device_id-bound
+    # ``cpu:gloo,cuda:nccl2`` parent, and split_group matches backend names
+    # exactly. Workers launched from here call split_group directly.
+    device_backend = "nccl2" if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP else "nccl"
     torch.distributed.init_process_group(
-        backend="cpu:gloo,cuda:nccl",
+        backend=f"cpu:gloo,cuda:{device_backend}",
         init_method=init_method,
         rank=rank,
         world_size=world_size,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1334,6 +1334,15 @@ def init_test_distributed_environment(
 
     distributed_init_method = f"tcp://localhost:{distributed_init_port}"
 
+    # Ray-spawned workers don't inherit RANK/WORLD_SIZE/MASTER_*. Set the
+    # standard torchrun envs so any library reading them works (torchcomms
+    # auto rank-size detection, profiling tools, etc.) — no need for a
+    # torchcomms-specific branch.
+    os.environ.setdefault("RANK", str(rank))
+    os.environ.setdefault("WORLD_SIZE", str(pp_size * tp_size))
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", str(distributed_init_port))
+
     if get_current_vllm_config_or_none() is not None:
         # Config already set, use it directly
         init_distributed_environment(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -244,12 +244,51 @@ def _platform_device_type() -> str:
         return "cpu"
 
 
+# Name of the accelerator-side backend used by the ``split_group`` code path.
+# ``split_group`` matches backend names *exactly* against the parent process
+# group, so the world PG and every subgroup carved off it must spell the
+# backend the same way. Keep this the single source of truth.
+_SPLIT_GROUP_DEVICE_BACKEND = "nccl2"
+
+# Point-to-point backend for the pipeline-parallel device group: a lazily
+# initialized per-peer communicator so send/recv to different stages overlap.
+_PP_DEVICE_BACKEND = "nccl-lazy"
+
+
+def _split_group_backend_for_device(device_type: str, backend: str) -> str:
+    """Backend name to use for ``device_type`` on the ``split_group`` path.
+
+    Only CUDA/ROCm has an ``nccl2`` implementation; every other accelerator
+    keeps whatever backend the platform asked for (e.g. ``xccl`` on XPU).
+    """
+    if device_type == "cuda":
+        return _SPLIT_GROUP_DEVICE_BACKEND
+    return backend
+
+
+def _use_split_group() -> bool:
+    """Whether subgroups are carved off the default PG with ``split_group``.
+
+    Requires the opt-in *and* a device-bound default PG: ``split_group``
+    refuses to split a PG without a ``bound_device_id``, which is exactly what
+    a gloo world is (CPU-only platform, or a device backend torch does not have
+    registered -- see ``_init_process_group_for_split_group``). Those setups
+    keep the legacy ``new_group`` path.
+    """
+    if not envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
+        return False
+    if not torch.distributed.is_initialized():
+        return False
+    default_pg = torch.distributed.distributed_c10d._get_default_group()
+    return default_pg.bound_device_id is not None
+
+
 def _device_backend_str(torch_distributed_backend: str | Backend) -> str:
     """Normalize ``torch_distributed_backend`` to the ``"<device>:<backend>"``
     format required by ``split_group``'s ``backend`` argument.
 
-    Accepts either a bare backend name (e.g. ``"nccl"``) or an already-prefixed
-    string (e.g. ``"cuda:nccl"``).
+    Accepts either a bare backend name (e.g. ``"nccl2"``) or an already-prefixed
+    string (e.g. ``"cuda:nccl2"``).
     """
     backend_str = str(torch_distributed_backend)
     if ":" in backend_str:
@@ -285,6 +324,47 @@ def _create_subgroups_split_group(
         group_desc=f"{group_name}:cpu",
         backend=f"cpu:gloo,{device_backend_str}",
     )
+    return self_device_group, self_cpu_group
+
+
+def _create_subgroups_pp_lazy(
+    group_ranks: list[list[int]],
+    group_name: str,
+    rank: int,
+    local_rank: int,
+    torch_distributed_backend: str | Backend,
+) -> tuple[ProcessGroup | None, ProcessGroup]:
+    """Create the pipeline-parallel device + CPU subgroups.
+
+    The device subgroup uses the ``nccl-lazy`` backend so each pipeline-stage
+    peer gets a dedicated lazily-initialized P2P comm/stream, letting send/recv
+    to different stages overlap (unlike split_group's single shared comm). It is
+    created members-only (``use_local_synchronization=True``) over the
+    device_id-bound nccl2 parent, which does not implement the eager new_group
+    split path; every rank belongs to exactly one pipeline group, so it makes a
+    single members-only call.
+
+    The CPU subgroup is created via ``split_group`` (collective over the parent),
+    exactly like TP/DP in ``_create_subgroups_split_group``.
+    """
+    device_backend_str = _device_backend_str(torch_distributed_backend)
+    self_cpu_group = torch.distributed.split_group(
+        split_ranks=group_ranks,
+        group_desc=f"{group_name}:cpu",
+        backend=f"cpu:gloo,{device_backend_str}",
+    )
+    self_device_group = None
+    device_id = torch.device(f"cuda:{local_rank}")
+    for ranks in group_ranks:
+        if rank not in ranks:
+            continue
+        self_device_group = torch.distributed.new_group(
+            ranks,
+            backend=_PP_DEVICE_BACKEND,
+            use_local_synchronization=True,
+            device_id=device_id,
+        )
+        break
     return self_device_group, self_cpu_group
 
 
@@ -396,12 +476,31 @@ class GroupCoordinator:
         self_device_group = None
         self_cpu_group = None
 
-        # VLLM_DISTRIBUTED_USE_SPLIT_GROUP gates the new ``split_group``
-        # codepath. Default (False) preserves the legacy ``new_group`` path.
-        if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
-            self_device_group, self_cpu_group = _create_subgroups_split_group(
-                group_ranks, group_name, torch_distributed_backend
-            )
+        # VLLM_DISTRIBUTED_USE_SPLIT_GROUP gates the ``split_group`` codepath.
+        # Default (True) uses split_group over the eagerly-initialized,
+        # device_id-bound world PG; set it to 0 for the legacy ``new_group``
+        # path. A gloo world is not device-bound and cannot be split, so it
+        # also takes the legacy path.
+        if _use_split_group():
+            # ``nccl-lazy`` only exists for CUDA/ROCm; on other accelerators the
+            # pipeline group falls back to split_group like every other group.
+            # The predicate depends only on the platform and the group name, so
+            # every rank takes the same branch (both helpers are collective).
+            if group_name == "pp" and _platform_device_type() == "cuda":
+                # The pipeline-parallel device group uses per-peer lazy P2P
+                # comms (nccl-lazy) so send/recv to different stages overlap;
+                # every other group, and every cpu group, stays on split_group.
+                self_device_group, self_cpu_group = _create_subgroups_pp_lazy(
+                    group_ranks,
+                    group_name,
+                    self.rank,
+                    local_rank,
+                    torch_distributed_backend,
+                )
+            else:
+                self_device_group, self_cpu_group = _create_subgroups_split_group(
+                    group_ranks, group_name, torch_distributed_backend
+                )
             for ranks in group_ranks:
                 if self.rank in ranks:
                     self.ranks = ranks
@@ -486,16 +585,31 @@ class GroupCoordinator:
     def make_sibling_device_group(self, group_desc: str | None = None) -> ProcessGroup:
         """Create a new device-side ProcessGroup with the same per-rank membership
         as this coordinator's `device_group`, but backed by a distinct communicator.
-        This is a collective call: every world rank must invoke it. Used where we
-        want to issue ops that can run concurrently with ops on `device_group`.
+        This is the pipeline-parallel sibling, so on the split_group path it uses
+        the ``nccl-lazy`` backend (per-peer lazy P2P comms); the legacy path keeps
+        this coordinator's own backend so it stays a faithful stock baseline.
+        Every rank creates only its own group members-only
+        (``use_local_synchronization=True``): the nccl2 parent does not implement
+        the eager new_group split path, and members-only groups use hashed names
+        so ``_world.group_count`` cannot diverge between ranks. Used where we want
+        to issue ops that can run concurrently with ops on `device_group`.
         """
         sibling: ProcessGroup | None = None
+        device_id = torch.device(f"cuda:{self.local_rank}")
+        if _use_split_group() and _platform_device_type() == "cuda":
+            backend = _PP_DEVICE_BACKEND
+        else:
+            backend = str(self.torch_distributed_backend)
         for ranks in self.group_ranks:
-            pg = torch.distributed.new_group(
-                ranks, backend=self.torch_distributed_backend, group_desc=group_desc
+            if self.rank not in ranks:
+                continue
+            sibling = torch.distributed.new_group(
+                ranks,
+                backend=backend,
+                group_desc=group_desc,
+                use_local_synchronization=True,
+                device_id=device_id,
             )
-            if self.rank in ranks:
-                sibling = pg
         assert sibling is not None
         return sibling
 
@@ -1431,14 +1545,16 @@ def _init_process_group_for_split_group(
     local_rank: int,
     timeout: timedelta | None,
 ) -> None:
-    """Initialize the default PG with both CPU (gloo) and device (e.g. nccl)
+    """Initialize the default PG with both CPU (gloo) and device (e.g. nccl2)
     backends and an eager ``device_id`` binding so that subgroups can be
     created via ``split_group`` (which requires the parent communicator to
     be eagerly initialized). Falls back to ``gloo`` on CPU-only systems.
     """
     if torch.accelerator.is_available() and backend != "gloo":
-        init_backend = "cpu:gloo,cuda:nccl"
-        device_id: torch.device | None = torch.device(f"cuda:{local_rank}")
+        device_type = _platform_device_type()
+        device_backend = _split_group_backend_for_device(device_type, backend)
+        init_backend = f"cpu:gloo,{device_type}:{device_backend}"
+        device_id: torch.device | None = torch.device(f"{device_type}:{local_rank}")
     else:
         init_backend = "gloo"
         device_id = None
@@ -1455,7 +1571,7 @@ def _init_process_group_for_split_group(
 def _validate_default_pg_for_split_group() -> None:
     """When an external launcher (e.g. ``torchrun``) initialized the default
     PG, ``GroupCoordinator`` cannot patch in additional backends or change
-    the eager-init behavior — ``split_group`` only selects subsets of an
+    the eager-init behavior -- ``split_group`` only selects subsets of an
     existing parent. Validate that the parent has both ``device_id`` and a
     CPU (gloo) backend, and emit a descriptive error pointing at the exact
     init call to update otherwise.
@@ -1473,7 +1589,7 @@ def _validate_default_pg_for_split_group() -> None:
         raise RuntimeError(
             "External launcher initialized the default process group "
             "without a CPU (gloo) backend. vLLM requires both CPU and "
-            "device backends. Pass backend='cpu:gloo,cuda:nccl' to "
+            "device backends. Pass backend='cpu:gloo,cuda:nccl2' to "
             "torch.distributed.init_process_group()."
         ) from e
 
@@ -1518,7 +1634,7 @@ def init_distributed_environment(
     rank: int = -1,
     distributed_init_method: str = "env://",
     local_rank: int = -1,
-    backend: str = "nccl",
+    backend: str = "nccl2",
     timeout: timedelta | None = None,
 ):
     logger.debug(
@@ -1625,8 +1741,27 @@ def init_distributed_environment(
                     "Elastic EP is not yet supported with multi-node TP/PP"
                 )
 
-    if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP and torch.accelerator.is_available():
+    # ``backend == "gloo"`` means there is no device backend to split on: either
+    # the platform is CPU-only or the requested device backend is not available
+    # (see the fallback above). ``_init_process_group_for_split_group`` opts out
+    # of the device-bound world in that case, so a device-bound parent must not
+    # be required of it either -- the accelerator torch reports is unused.
+    if (
+        envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP
+        and torch.accelerator.is_available()
+        and backend != "gloo"
+    ):
         _validate_default_pg_for_split_group()
+        # The split-group parent PG is device-bound with the "nccl2" backend
+        # (selected in _init_process_group_for_split_group, and required of any
+        # external-launcher parent by the validation above). split_group filters
+        # subgroups by the parent's per-device backend name and requires an
+        # *exact* match, so the GroupCoordinators (world/TP/PP/DP) must request
+        # "nccl2" -- not the platform's plain dist_backend (e.g. "nccl"), which
+        # would raise a "Backend mismatch" error. Only the split-group path is
+        # affected; the legacy new_group path below keeps using the
+        # caller-provided backend unchanged.
+        backend = _split_group_backend_for_device(_platform_device_type(), backend)
 
     # set the local rank
     # local_rank is not available in torch ProcessGroup,
@@ -1719,7 +1854,21 @@ def initialize_model_parallel(
         # Use stateless world group for global information
         world_size = get_world_group().world_size
         rank = get_world_group().rank
-        backend = backend or "nccl"
+        # The elastic-EP world is a StatelessGroupCoordinator, which is not
+        # registered in torch's pg_map, so ``get_backend()`` cannot be used to
+        # recover the backend the way the non-elastic branch below does. Fall
+        # back to the same name ``init_distributed_environment`` picked: under
+        # the split_group path the TP/PP/PCP/DCP GroupCoordinators are carved
+        # off the "cuda:nccl2" default PG and split_group matches backend names
+        # exactly, so requesting plain "nccl" here raises "Backend mismatch".
+        if backend is None:
+            from vllm.platforms import current_platform
+
+            backend = current_platform.dist_backend
+            if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
+                backend = _split_group_backend_for_device(
+                    _platform_device_type(), backend
+                )
         tp_pp_pcp_size = (
             tensor_model_parallel_size
             * pipeline_model_parallel_size

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -26,7 +26,7 @@ from torch.distributed.distributed_c10d import (
     _get_default_timeout,
     _unregister_process_group,
 )
-from torch.distributed.rendezvous import rendezvous
+from torch.distributed.rendezvous import _get_use_libuv_from_query_dict
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -586,10 +586,9 @@ def stateless_init_torch_distributed_process_group(
     always formed with process 1, 2, ..., 8, and the additional communication
     channel is formed with process 9 and 10.
 
-    When *listen_socket* is provided, the rendezvous step
-    is skipped and a ``TCPStore`` server is created directly using the
-    pre-bound socket.  This is useful for eliminating TOCTOU races
-    between port allocation and binding.
+    When *listen_socket* is provided, the ``TCPStore`` server is created from
+    that pre-bound socket instead of binding ``port`` itself.  This is useful
+    for eliminating TOCTOU races between port allocation and binding.
     """
     init_method = get_tcp_uri(host, port)
     backend = Backend(backend)  # it is basically string
@@ -610,8 +609,24 @@ def stateless_init_torch_distributed_process_group(
             multi_tenant=True,
         )
     else:
-        store, rank, world_size = next(
-            rendezvous(init_method, rank, world_size, timeout=timeout)
+        # Create the store directly instead of going through
+        # ``torch.distributed.rendezvous``: when an elastic launcher (e.g.
+        # ``torchrun``) is in play it exports ``TORCHELASTIC_USE_AGENT_STORE``,
+        # and ``rendezvous`` then returns a client-only ``TCPStore`` on *every*
+        # rank, assuming the launcher's agent already serves the store at
+        # ``host:port``. This group owns a private ``host:port`` the agent
+        # knows nothing about, so no rank would start the server and all of
+        # them would block until the store timeout expires.
+        store = create_tcp_store(
+            host,
+            port,
+            world_size=world_size,
+            is_master=rank == 0,
+            timeout=timeout,
+            multi_tenant=True,
+            # no URL query to override it, so this is the USE_LIBUV default
+            # ``rendezvous`` would have resolved from the environment.
+            use_libuv=_get_use_libuv_from_query_dict({}),
         )
     store.set_timeout(timeout)
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
     VLLM_USE_RAY_V2_EXECUTOR_BACKEND: bool = False
-    VLLM_DISTRIBUTED_USE_SPLIT_GROUP: bool = False
+    VLLM_DISTRIBUTED_USE_SPLIT_GROUP: bool = True
     VLLM_XLA_USE_SPMD: bool = False
     VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn"] = "fork"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
@@ -883,7 +883,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # and ``init_distributed_environment`` initializes the default PG with
     # mixed ``cpu:gloo,cuda:nccl`` backend + eager ``device_id`` binding.
     "VLLM_DISTRIBUTED_USE_SPLIT_GROUP": lambda: bool(
-        int(os.getenv("VLLM_DISTRIBUTED_USE_SPLIT_GROUP", "0"))
+        int(os.getenv("VLLM_DISTRIBUTED_USE_SPLIT_GROUP", "1"))
     ),
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -881,7 +881,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # When True, GroupCoordinator constructs its CPU/device subgroups via
     # ``torch.distributed.split_group(backend=...)``
     # and ``init_distributed_environment`` initializes the default PG with
-    # mixed ``cpu:gloo,cuda:nccl`` backend + eager ``device_id`` binding.
+    # mixed ``cpu:gloo,cuda:nccl2`` backend + eager ``device_id`` binding.
+    # The pipeline-parallel device group is the one exception: it is built
+    # with ``new_group(backend="nccl-lazy", use_local_synchronization=True)``
+    # for per-peer lazy P2P comms. Set to 0 for the legacy ``new_group`` path
+    # over a lazily-initialized stock ``nccl`` world.
     "VLLM_DISTRIBUTED_USE_SPLIT_GROUP": lambda: bool(
         int(os.getenv("VLLM_DISTRIBUTED_USE_SPLIT_GROUP", "1"))
     ),

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -26,7 +26,12 @@ from vllm.utils.import_utils import import_pynvml
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from .interface import DeviceCapability, Platform, PlatformEnum
+from .interface import (
+    DeviceCapability,
+    Platform,
+    PlatformEnum,
+    init_nccl_family_stateless_pg,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -475,26 +480,9 @@ class CudaPlatformBase(Platform):
         timeout: timedelta,
     ) -> ProcessGroup:
         assert is_nccl_available()
-        pg: ProcessGroup = ProcessGroup(
-            prefix_store,
-            group_rank,
-            group_size,
+        return init_nccl_family_stateless_pg(
+            backend, prefix_store, group_rank, group_size, timeout
         )
-        from torch.distributed.distributed_c10d import ProcessGroupNCCL
-
-        backend_options = ProcessGroupNCCL.Options()
-        backend_options._timeout = timeout
-
-        backend_class = ProcessGroupNCCL(
-            prefix_store, group_rank, group_size, backend_options
-        )
-        backend_type = ProcessGroup.BackendType.NCCL
-        device = torch.device("cuda")
-        pg._set_default_backend(backend_type)
-        backend_class._set_sequence_number_for_group()
-
-        pg._register_backend(device, backend_type, backend_class)
-        return pg
 
     @classmethod
     def device_count(cls) -> int:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -35,6 +35,70 @@ def in_wsl() -> bool:
     return "microsoft" in " ".join(platform.uname()).lower()
 
 
+def init_nccl_family_stateless_pg(
+    backend: str,
+    prefix_store: "PrefixStore",
+    group_rank: int,
+    group_size: int,
+    timeout: timedelta,
+) -> "ProcessGroup":
+    """Build a stateless (globally unregistered) CUDA ProcessGroup for one of
+    the NCCL-family c10d backends.
+
+    ``backend`` is honored, not assumed: callers select ``"nccl2"`` (the in-tree
+    native port) or ``"nccl-lazy"`` (per-peer lazy P2P comms) as well as the
+    stock ``"nccl"``. Silently building a stock ``ProcessGroupNCCL`` for a
+    requested ``nccl2`` group would put the stateless DP/EP groups on a
+    different backend than the rest of the job.
+
+    A device-qualified spec (``"cuda:nccl2"``) is accepted for convenience.
+    """
+    from torch.distributed import ProcessGroup
+    from torch.distributed.distributed_c10d import ProcessGroupNCCL
+
+    name = str(backend)
+    if ":" in name:
+        name = name.rsplit(":", 1)[1]
+
+    if name in ("nccl2", "nccl-lazy"):
+        from torch.distributed.distributed_c10d import (
+            ProcessGroupNCCL2,
+            ProcessGroupNCCLLazy,
+        )
+
+        backend_options = ProcessGroupNCCL2.Options()
+        backend_options._timeout = timeout
+        # A stateless group is its own world: it is not a subset of any parent,
+        # so there are no global ranks to record.
+        backend_options.global_ranks_in_group = []
+        backend_cls = ProcessGroupNCCL2 if name == "nccl2" else ProcessGroupNCCLLazy
+        backend_class = backend_cls(
+            prefix_store, group_rank, group_size, backend_options
+        )
+        # nccl2 / nccl-lazy register with c10d as CUSTOM backend types
+        # (see Backend.register_backend in torch.distributed.distributed_c10d),
+        # so the ProcessGroup must advertise the same type or lookups by
+        # BackendType miss.
+        backend_type = ProcessGroup.BackendType.CUSTOM
+    elif name in ("nccl", "nccl-legacy"):
+        backend_options = ProcessGroupNCCL.Options()
+        backend_options._timeout = timeout
+        backend_class = ProcessGroupNCCL(
+            prefix_store, group_rank, group_size, backend_options
+        )
+        backend_type = ProcessGroup.BackendType.NCCL
+    else:
+        raise ValueError(
+            f"Unsupported device backend {backend!r} for a stateless CUDA "
+            "process group; expected one of 'nccl', 'nccl2', 'nccl-lazy'."
+        )
+
+    pg: ProcessGroup = ProcessGroup(prefix_store, group_rank, group_size)
+    pg._set_default_backend(backend_type)
+    pg._register_backend(torch.device("cuda"), backend_type, backend_class)
+    return pg
+
+
 class PlatformEnum(enum.Enum):
     """Enumeration of supported hardware platforms."""
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -15,7 +15,12 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from .interface import DeviceCapability, Platform, PlatformEnum
+from .interface import (
+    DeviceCapability,
+    Platform,
+    PlatformEnum,
+    init_nccl_family_stateless_pg,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -865,26 +870,9 @@ class RocmPlatform(Platform):
         timeout: timedelta,
     ) -> ProcessGroup:
         assert is_nccl_available()
-        pg: ProcessGroup = ProcessGroup(
-            prefix_store,
-            group_rank,
-            group_size,
+        return init_nccl_family_stateless_pg(
+            backend, prefix_store, group_rank, group_size, timeout
         )
-        from torch.distributed.distributed_c10d import ProcessGroupNCCL
-
-        backend_options = ProcessGroupNCCL.Options()
-        backend_options._timeout = timeout
-
-        backend_class = ProcessGroupNCCL(
-            prefix_store, group_rank, group_size, backend_options
-        )
-        backend_type = ProcessGroup.BackendType.NCCL
-        device = torch.device("cuda")
-        pg._set_default_backend(backend_type)
-        backend_class._set_sequence_number_for_group()
-
-        pg._register_backend(device, backend_type, backend_class)
-        return pg
 
     @classmethod
     def device_count(cls) -> int:


### PR DESCRIPTION

Route vLLM's process-group creation through the in-tree nccl2 backend.

The world (default) process group is initialized eagerly as a device_id-bound
`cpu:gloo,cuda:nccl2` group. Every collective subgroup (tp/dp/ep/etc.) is
carved off it with `torch.distributed.split_group` (`cuda:nccl2` for the device
group, `cpu:gloo,cuda:nccl2` for the CPU group). The pipeline-parallel group is
the sole exception: its device group and its sibling group use
`new_group(backend="nccl-lazy", use_local_synchronization=True, device_id=...)`
for per-peer lazy point-to-point communicators (so send/recv to different
stages can overlap), while its CPU group is still `split_group`.

nccl2 supports comm-split but not the stock eager-`new_group` no-color-split
path, so every world subset is `split_group` except PP, which needs `nccl-lazy`
for P2P overlap. Gated behind `VLLM_DISTRIBUTED_USE_SPLIT_GROUP` (default on);
the legacy `new_group` path remains as a fallback for non-nccl2 setups.

Test Plan:
Static parse check; the nccl2 split_group + nccl-lazy-PP design is validated
end-to-end by the Megatron pp2_dp2 bit-exact smoke on 4xH100 (world/tp/dp
ProcessGroupNCCL2, pp ProcessGroupNCCLLazy, BIT_EXACT_PASS). vLLM-specific GPU
parity is pending.

```
python -c "import ast; ast.parse(open('vllm/distributed/parallel_state.py').read())"
```

Authored with the assistance of an AI coding assistant.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/vllm-project/vllm/pull/42565).
* __->__ #42565
* #42471