### PR TITLE
[CI] Add NIXL EP import canary

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 # Utility to run integration tests sequentially with varying TP configurations.
 SCRIPT="v1/kv_connector/nixl_integration/run_accuracy_test.sh"
+IMPORT_CANARY="v1/kv_connector/nixl_integration/test_nixl_imports.py"
+
+echo "=== Running NIXL import canary ==="
+python3 -m pytest -s -x "${IMPORT_CANARY}"
 
 # Define test configurations
 tp_configs=(

--- a/tests/v1/kv_connector/nixl_integration/test_nixl_imports.py
+++ b/tests/v1/kv_connector/nixl_integration/test_nixl_imports.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NIXL import canaries for CUDA wheel selection."""
+
+import importlib
+import importlib.metadata as metadata
+import pathlib
+import subprocess
+import sys
+
+import pytest
+import torch
+
+
+def _print_distribution_version(package_name: str) -> None:
+    try:
+        version = metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        version = "not installed"
+    print(f"{package_name}: {version}")
+
+
+@pytest.mark.skipif(torch.version.cuda is None, reason="CUDA NIXL EP canary")
+def test_nixl_and_nixl_ep_imports() -> None:
+    """Verify both core NIXL and the NIXL EP extension import successfully."""
+    print(f"torch cuda: {torch.version.cuda}")
+    for package_name in ("nixl", "nixl-cu12", "nixl-cu13"):
+        _print_distribution_version(package_name)
+
+    nixl = importlib.import_module("nixl")
+    print(f"nixl: {nixl.__file__}")
+
+    # Exercise the core NIXL bindings used by NixlConnector.
+    importlib.import_module("nixl._api")
+    importlib.import_module("nixl._bindings")
+
+    # Exercise the NIXL EP extension used by fused MoE expert parallelism.
+    nixl_ep = importlib.import_module("nixl_ep")
+    print(f"nixl_ep: {nixl_ep.__file__}")
+
+    assert nixl_ep.__file__ is not None
+    extension_dir = pathlib.Path(nixl_ep.__file__).parent
+    extension_files = sorted(extension_dir.glob("nixl_ep_cpp*.so"))
+    assert extension_files, f"No nixl_ep_cpp extension found in {extension_dir}"
+
+    extension_file = extension_files[0]
+    completed = subprocess.run(
+        ["ldd", str(extension_file)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    print(completed.stdout)
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr)
+
+    assert completed.returncode == 0
+    if torch.version.cuda is not None:
+        cuda_major = torch.version.cuda.split(".", maxsplit=1)[0]
+        expected_cudart = f"libcudart.so.{cuda_major}"
+        assert expected_cudart in completed.stdout
+        assert f"{expected_cudart} => not found" not in completed.stdout


### PR DESCRIPTION
## Summary

Add a NIXL import canary to the existing NixlConnector integration sweep. The test imports both the core NIXL bindings used by `NixlConnector` and the `nixl_ep` extension used by fused MoE expert parallelism, then checks that the extension links against the CUDA runtime matching `torch.version.cuda`.

## Why

A CUDA 13 nightly image could install both `nixl-cu12` and `nixl-cu13`, leaving `nixl_ep_cpp` backed by the CUDA 12 wheel. Existing NIXL CI exercised the core KV connector path, but not the `nixl_ep` import path, so the container later failed at DSV4 startup with `ImportError: libcudart.so.12`.

This is not duplicating #42542: that PR fixes the Docker install ordering. This PR only adds regression coverage so the NIXL CI job fails before the expensive accuracy sweep if the EP extension is not importable.

Related to #42525 and #42542.

## Testing

- `uv venv --python 3.12`
- `.venv/bin/python -m py_compile tests/v1/kv_connector/nixl_integration/test_nixl_imports.py`
- `bash -n tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh`
- Commit pre-commit hooks passed, including `ruff check`, `ruff format`, shell lint, SPDX, and signoff checks.
- Mounted the new pytest into `vllm/vllm-openai:nightly@sha256:158ea7bae050faf483b63e027b66ea15c02f9b99642befcb02d0c2aa504ef1f9` on ptyche:
  - before the reinstall fix: failed with `ImportError: libcudart.so.12` and `CANARY_BEFORE_FIXED_TEST_EXIT=1`
  - after `uv pip install --system --force-reinstall --no-deps nixl-cu13`: passed with `libcudart.so.13 => /usr/local/cuda/lib64/libcudart.so.13` and `CANARY_AFTER_FIXED_TEST_EXIT=0`

AI assistance was used to prepare this change; the submitter should review and own the final PR contents.
