### PR TITLE
Fix: gemma4 audio batching crash

### DIFF
--- a/multiaudio.py
+++ b/multiaudio.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import base64
+import concurrent.futures
+import io
+import math
+import struct
+import sys
+import wave
+
+import requests
+
+
+VLLM_URL = "http://127.0.0.1:8000/v1/chat/completions"
+MODEL = "google/gemma-4-E2B-it"
+
+
+def make_wav_base64(duration_s: float, freq_hz: float = 440.0, sample_rate: int = 16000) -> str:
+    """Generate a tiny mono PCM WAV and return base64 text."""
+    n_samples = int(duration_s * sample_rate)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+
+        for i in range(n_samples):
+            t = i / sample_rate
+            sample = int(0.2 * 32767 * math.sin(2.0 * math.pi * freq_hz * t))
+            wav.writeframes(struct.pack("<h", sample))
+
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def send_request(i: int, duration_s: float) -> dict:
+    audio_b64 = make_wav_base64(duration_s, freq_hz=440.0 + i * 70)
+
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Briefly describe the audio. One sentence only.",
+                    },
+                    {
+                        "type": "audio_url",
+                        "audio_url": {
+                            "url": f"data:audio/wav;base64,{audio_b64}",
+                        },
+                    },
+                ],
+            }
+        ],
+        "max_tokens": 32,
+        "temperature": 0.0,
+    }
+
+    r = requests.post(VLLM_URL, json=payload, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
+def main() -> None:
+    # Different durations are important. The bug shows up when batched
+    # audio feature tensors have different sequence lengths.
+    durations = [1.0, 1.3, 1.7, 2.1, 2.6]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(durations)) as ex:
+        futures = [
+            ex.submit(send_request, i, duration)
+            for i, duration in enumerate(durations)
+        ]
+
+        for i, fut in enumerate(futures):
+            result = fut.result()  # Intentionally let exceptions break the script.
+            text = result["choices"][0]["message"]["content"]
+            print(f"[{i}] OK: {text!r}")
+
+    print("PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1243,8 +1243,22 @@ class Gemma4ForConditionalGeneration(
         self,
         audio_input: Gemma4AudioInputs,
     ) -> list[torch.Tensor]:
-        input_features = audio_input["input_features_padded"].squeeze(1)
-        input_features_mask = audio_input["input_features_mask"].squeeze(1)
+        input_features_padded = audio_input["input_features_padded"]
+        input_features_mask = audio_input["input_features_mask"]
+
+        if isinstance(input_features_padded, (list, tuple)):
+            input_features_padded = torch.nn.utils.rnn.pad_sequence(
+                input_features_padded,
+                batch_first=True,
+            )
+            input_features_mask = torch.nn.utils.rnn.pad_sequence(
+                input_features_mask,
+                batch_first=True,
+                padding_value=False,
+            )
+
+        input_features = input_features_padded.squeeze(1)
+        input_features_mask = input_features_mask.squeeze(1)
 
         # Run audio tower — mask uses standard HF convention
         # (True=valid, False=padding).


### PR DESCRIPTION
## Summary

This PR fixes a Gemma4 multimodal audio crash that occurs when multiple audio requests are scheduled together.

When multiple audio requests are scheduled, `input_features_padded` and `input_features_mask` may arrive as Python `list`/`tuple` values rather than already-stacked tensors. The existing Gemma4 audio path assumes tensor inputs and immediately calls `.squeeze(1)`, causing:

```text
AttributeError: 'list' object has no attribute 'squeeze'
```
The fix normalizes list/tuple audio batches by padding them with torch.nn.utils.rnn.pad_sequence(...) before the existing squeeze/encoder path runs.


Test code included here:
[multiaudio.py](https://github.com/user-attachments/files/27733358/multiaudio.py)

vllm server command:
```
vllm serve google/gemma-4-E2B-it  --dtype half --max-model-len 2048 --limit-mm-per-prompt.image 0 --limit-mm-per-prompt.audio 1 --gpu-memory-utilization 0.95
```
Test results before patch:
```
(APIServer pid=2717036) ERROR 05-13 21:43:34 [async_llm.py:704] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=2717036) INFO:     127.0.0.1:36188 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error

...

(EngineCore pid=2717449)     input_features = audio_input["input_features_padded"].squeeze(1)
(EngineCore pid=2717449)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2717449) AttributeError: 'list' object has no attribute 'squeeze'
(APIServer pid=2717036) INFO:     Shutting down
(APIServer pid=2717036) INFO:     Waiting for application shutdown.
(APIServer pid=2717036) INFO:     Application shutdown complete.
(APIServer pid=2717036) INFO:     Finished server process [2717036]
```

Test results After patch:
```python3 testpatch.py
[0] OK: 'The audio features a clear, upbeat musical piece with a driving rhythm.'
[1] OK: 'The audio features a clear, upbeat musical piece with a driving rhythm.'
[2] OK: 'The audio features a brief, high-pitched sound followed by a low, resonant tone.'
[3] OK: 'The audio features a person speaking in a calm and conversational tone.'
[4] OK: 'The audio features a person speaking in a calm and conversational tone.'
PASS
```