### PR TITLE
Add extra request body for multi-turn benchmark

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from enum import Enum
 from http import HTTPStatus
 from statistics import mean
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import aiohttp  # type: ignore
 import numpy as np  # type: ignore
@@ -34,6 +34,7 @@ from transformers import AutoTokenizer  # type: ignore
 
 NUM_TOKENS_FROM_DATASET = 0
 TERM_SIGNAL = None
+RequestBody = dict[str, Any]
 
 
 class ConversationSampling(str, Enum):
@@ -65,6 +66,7 @@ class RequestArgs(NamedTuple):
     limit_min_tokens: int  # Use negative value for no limit
     limit_max_tokens: int  # Use negative value for no limit
     timeout_sec: int
+    extra_request_body: RequestBody
 
 
 class BenchmarkArgs(NamedTuple):
@@ -208,18 +210,53 @@ def nanosec_to_sec(value: float) -> float:
     return value / 1000000000.0
 
 
-async def send_request(
-    session: aiohttp.ClientSession,
+def merge_request_body(base: RequestBody, extra: RequestBody) -> RequestBody:
+    for key, value in extra.items():
+        if isinstance(base.get(key), dict) and isinstance(value, dict):
+            merge_request_body(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_extra_request_body(extra_request_body: str | None) -> RequestBody:
+    if extra_request_body is None:
+        return {}
+
+    try:
+        parsed = json.loads(extra_request_body)
+    except json.JSONDecodeError as err:
+        raise ValueError(f"Invalid --extra-request-body JSON: {err}") from err
+
+    if not isinstance(parsed, dict):
+        raise ValueError("--extra-request-body must be a JSON object")
+
+    return parsed
+
+
+def get_extra_request_body(args: argparse.Namespace) -> RequestBody:
+    extra_request_body: RequestBody = {}
+    if args.disable_thinking:
+        extra_request_body = {
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_effort": "low",
+        }
+
+    return merge_request_body(
+        extra_request_body, parse_extra_request_body(args.extra_request_body)
+    )
+
+
+def build_request_payload(
     messages: list[dict[str, str]],
-    chat_url: str,
     model: str,
-    stream: bool = True,
-    min_tokens: int | None = None,
-    max_tokens: int | None = None,
-    timeout_sec: int = 120,
-    conversation_id: str | None = None,
-) -> ServerResponse:
-    payload = {
+    stream: bool,
+    min_tokens: int | None,
+    max_tokens: int | None,
+    conversation_id: str | None,
+    extra_request_body: RequestBody,
+) -> RequestBody:
+    payload: RequestBody = {
         "model": model,
         "messages": messages,
         "seed": 0,
@@ -238,6 +275,31 @@ async def send_request(
 
     if max_tokens is not None:
         payload["max_tokens"] = max_tokens
+
+    return merge_request_body(payload, extra_request_body)
+
+
+async def send_request(
+    session: aiohttp.ClientSession,
+    messages: list[dict[str, str]],
+    chat_url: str,
+    model: str,
+    stream: bool = True,
+    min_tokens: int | None = None,
+    max_tokens: int | None = None,
+    timeout_sec: int = 120,
+    conversation_id: str | None = None,
+    extra_request_body: RequestBody | None = None,
+) -> ServerResponse:
+    payload = build_request_payload(
+        messages=messages,
+        model=model,
+        stream=stream,
+        min_tokens=min_tokens,
+        max_tokens=max_tokens,
+        conversation_id=conversation_id,
+        extra_request_body=extra_request_body or {},
+    )
 
     headers = {"Content-Type": "application/json"}
 
@@ -424,6 +486,7 @@ async def send_turn(
         max_tokens,
         req_args.timeout_sec,
         conversation_id=conv_id,
+        extra_request_body=req_args.extra_request_body,
     )
 
     if response.valid is False:
@@ -880,6 +943,7 @@ def get_client_config(
         limit_min_tokens=args.limit_min_tokens,
         limit_max_tokens=args.limit_max_tokens,
         timeout_sec=args.request_timeout_sec,
+        extra_request_body=get_extra_request_body(args),
     )
 
     return client_args, req_args
@@ -1435,6 +1499,22 @@ async def main() -> None:
         default=False,
         action="store_true",
         help="Disable stream/streaming mode (set 'stream' to False in the API request)",
+    )
+    parser.add_argument(
+        "--extra-request-body",
+        type=str,
+        default=None,
+        help="Additional JSON object to merge into every chat completion request. "
+        "This can be used for model-specific request fields such as "
+        "chat_template_kwargs or reasoning_effort.",
+    )
+    parser.add_argument(
+        "--disable-thinking",
+        default=False,
+        action="store_true",
+        help="Request reasoning models to minimize or disable their thinking budget "
+        "by adding chat_template_kwargs.enable_thinking=false and "
+        "reasoning_effort=low to every request.",
     )
 
     parser.add_argument(

--- a/tests/benchmarks/test_multi_turn_request_body.py
+++ b/tests/benchmarks/test_multi_turn_request_body.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+REPO_ROOT = Path(__file__).parents[2]
+MULTI_TURN_DIR = REPO_ROOT / "benchmarks" / "multi_turn"
+sys.path.insert(0, str(MULTI_TURN_DIR))
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_serving_multi_turn",
+    MULTI_TURN_DIR / "benchmark_serving_multi_turn.py",
+)
+assert SPEC is not None
+benchmark_serving_multi_turn = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(benchmark_serving_multi_turn)
+
+
+def test_parse_extra_request_body_requires_json_object():
+    with pytest.raises(ValueError, match="JSON object"):
+        benchmark_serving_multi_turn.parse_extra_request_body("[1, 2, 3]")
+
+
+def test_disable_thinking_adds_reasoning_controls():
+    args = argparse.Namespace(disable_thinking=True, extra_request_body=None)
+
+    extra_request_body = benchmark_serving_multi_turn.get_extra_request_body(args)
+
+    assert extra_request_body == {
+        "chat_template_kwargs": {"enable_thinking": False},
+        "reasoning_effort": "low",
+    }
+
+
+def test_extra_request_body_merges_with_disable_thinking_defaults():
+    args = argparse.Namespace(
+        disable_thinking=True,
+        extra_request_body='{"chat_template_kwargs":{"foo":"bar"},"metadata":{"x":1}}',
+    )
+
+    extra_request_body = benchmark_serving_multi_turn.get_extra_request_body(args)
+
+    assert extra_request_body == {
+        "chat_template_kwargs": {
+            "enable_thinking": False,
+            "foo": "bar",
+        },
+        "reasoning_effort": "low",
+        "metadata": {"x": 1},
+    }
+
+
+def test_build_request_payload_merges_extra_request_body():
+    payload = benchmark_serving_multi_turn.build_request_payload(
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        model="Qwen/Qwen3-32B-FP8",
+        stream=True,
+        min_tokens=1,
+        max_tokens=63,
+        conversation_id="conv-1",
+        extra_request_body={
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_effort": "low",
+        },
+    )
+
+    assert payload["model"] == "Qwen/Qwen3-32B-FP8"
+    assert payload["stream"] is True
+    assert payload["stream_options"] == {"include_usage": False}
+    assert payload["min_tokens"] == 1
+    assert payload["max_tokens"] == 63
+    assert payload["conversation_id"] == "conv-1"
+    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+    assert payload["reasoning_effort"] == "low"


### PR DESCRIPTION
Fixes #42548.

## Problem

`benchmark_serving_multi_turn.py` derives per-turn `max_tokens` from the dataset reference answer length by default. For reasoning models such as Qwen3, DeepSeek-R1, and gpt-oss, the reasoning phase can consume that entire budget, so the benchmark records near-empty final answers while still exiting successfully. This makes the reported output length and throughput numbers misleading.

## Change

This PR adds two request-level controls to the multi-turn benchmark:

- `--extra-request-body JSON`: merges a user-provided JSON object into every `/v1/chat/completions` request, so benchmark users can pass model-specific OpenAI-compatible fields without editing the script.
- `--disable-thinking`: convenience shorthand that injects `{"chat_template_kwargs": {"enable_thinking": false}, "reasoning_effort": "low"}` for reasoning-model benchmarks.

The generic passthrough is intentional: different reasoning models use different request fields, and this keeps the benchmark usable without hard-coding every model-specific option.

## Tests

- `pytest tests/benchmarks/test_multi_turn_request_body.py -q`
- `pre-commit run --files benchmarks/multi_turn/benchmark_serving_multi_turn.py tests/benchmarks/test_multi_turn_request_body.py`
- `ssh vast: pytest tests/benchmarks/test_multi_turn_request_body.py -q`