### PR TITLE
[Bugfix] DeepSeek V4 MTP: fix AttributeError in compute_logits when calling hc_head_op

### DIFF
--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -235,7 +235,12 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         hidden_states = hidden_states.view(
             -1, mtp_layer.hc_mult, mtp_layer.config.hidden_size
         )
-        hidden_states = self.hc_head_op(
+        # ``hc_head_op`` is installed on the inner ``DeepSeekV4MultiTokenPredictorLayer``
+        # (see ``__init__`` above), not on this parent module, so accessing
+        # ``self.hc_head_op`` would raise ``AttributeError``. Use the
+        # ``mtp_layer`` we selected — it also owns the matching
+        # ``hc_head_{fn,scale,base}`` and ``hc_eps`` we pass in.
+        hidden_states = mtp_layer.hc_head_op(
             hidden_states,
             mtp_layer.hc_head_fn,
             mtp_layer.hc_head_scale,


### PR DESCRIPTION
## What
`DeepSeekV4MultiTokenPredictor.compute_logits` calls `self.hc_head_op(...)`, but `hc_head_op` is only installed on the inner `DeepSeekV4MultiTokenPredictorLayer`, not on the parent `DeepSeekV4MultiTokenPredictor`. The call raises `AttributeError: 'DeepSeekV4MultiTokenPredictor' object has no attribute 'hc_head_op'` the first time speculative decoding runs.

This was introduced by #41946 (`a8887c208`), which:

1. Added `self.hc_head_op = HCHeadOp()` to `DeepSeekV4MultiTokenPredictorLayer.__init__` (correct location).
2. Rewrote the call inside `DeepSeekV4MultiTokenPredictor.compute_logits` from the now-removed `hc_head` free function to `self.hc_head_op(...)` — but `self` here is the parent module, which never got the attribute installed.

## When does this fire
- DeepSeek-V4-Flash deployment
- `--speculative_config '{"method":"mtp",...}'` (a.k.a. `deepseek_mtp` alias)
- First time the engine tries to produce draft logits

Non-speculative serving is unaffected.

## Fix
Route the call through `mtp_layer.hc_head_op` — the same `mtp_layer` (selected one line above) already owns the matching `hc_head_fn` / `hc_head_scale` / `hc_head_base` / `hc_eps` we pass in. One-line change plus a short comment so future refactors of `HCHeadOp` ownership stay aware that `compute_logits` lives on the parent module.

## Reproduction
```bash
vllm serve deepseek-ai/DeepSeek-V4-Flash \
    --trust-remote-code --tensor-parallel-size 2 \
    --tokenizer-mode deepseek_v4 --reasoning-parser deepseek_v4 \
    --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}'
# Any /v1/chat/completions request → HTTP 500
# Worker log: AttributeError: 'DeepSeekV4MultiTokenPredictor' object has no attribute 'hc_head_op'