### PR TITLE
[Bugfix][V1] Fix TOCTOU race causing intermittent `EADDRINUSE` on multi-API-server DP startup

### DIFF
--- a/tests/entrypoints/test_api_server_process_manager.py
+++ b/tests/entrypoints/test_api_server_process_manager.py
@@ -8,8 +8,14 @@ import time
 from unittest.mock import patch
 
 import pytest
+import zmq
 
-from vllm.v1.utils import APIServerProcessManager, wait_for_completion_or_failure
+from vllm.utils.network_utils import make_zmq_socket, split_zmq_path
+from vllm.v1.utils import (
+    APIServerProcessManager,
+    get_engine_client_zmq_addr,
+    wait_for_completion_or_failure,
+)
 
 # Global variables to control worker behavior
 WORKER_RUNTIME_SECONDS = 0.5
@@ -21,6 +27,39 @@ def mock_run_api_server_worker(listen_address, sock, args, client_config=None):
     print(f"Mock worker started with client_config: {client_config}")
     time.sleep(WORKER_RUNTIME_SECONDS)
     print("Mock worker completed successfully")
+
+
+# Module-level stub for the defer-addresses test. Must be importable by
+# `multiprocessing.spawn` (no closures, no nesting).
+def defer_addresses_stub_worker(listen_address, sock, args, client_config):
+    """Bind the per-child ZMQ ROUTER/PULL with the kernel-assigned port,
+    report the actual endpoints back via the pipe, then exit."""
+    ctx = zmq.Context()
+    try:
+        in_sock = make_zmq_socket(
+            ctx, client_config["input_address"], zmq.ROUTER, bind=True
+        )
+        out_sock = make_zmq_socket(
+            ctx, client_config["output_address"], zmq.PULL, bind=True
+        )
+        try:
+            pipe = client_config["actual_address_pipe"]
+            try:
+                pipe.send(
+                    {
+                        "input_address": in_sock.getsockopt(zmq.LAST_ENDPOINT).decode(),
+                        "output_address": out_sock.getsockopt(
+                            zmq.LAST_ENDPOINT
+                        ).decode(),
+                    }
+                )
+            finally:
+                pipe.close()
+        finally:
+            in_sock.close(linger=0)
+            out_sock.close(linger=0)
+    finally:
+        ctx.term()
 
 
 @pytest.fixture
@@ -268,3 +307,131 @@ def test_external_process_monitoring(api_server_args):
         manager.shutdown()
         mock_coordinator.shutdown()
         time.sleep(0.2)
+
+
+@pytest.mark.timeout(60)
+def test_defer_addresses_end_to_end():
+    """Exercise the deferred-port path: parent emits ``tcp://host:0``
+    placeholders, each spawned child binds with a kernel-picked port and
+    reports the actual endpoints back via its per-child pipe; the manager
+    surfaces them via :py:meth:`gather_actual_addresses`.
+
+    This is intentionally single-host: the rank-0 parent's
+    spawn/bind/report loop is fully local. The cross-node aspect of a
+    multi-node DP deployment only kicks in when remote engines later
+    DEALER-connect to the reported addresses, which is outside this
+    component's scope.
+    """
+    host = "127.0.0.1"
+    num_servers = 4  # mirrors a typical DP_local fan-out
+
+    placeholder_inputs = [
+        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        for _ in range(num_servers)
+    ]
+    placeholder_outputs = [
+        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        for _ in range(num_servers)
+    ]
+    for addr in placeholder_inputs + placeholder_outputs:
+        # defer_port=True must emit a port-0 placeholder for TCP.
+        assert addr == f"tcp://{host}:0", addr
+
+    sock = socket.socket()
+    manager = APIServerProcessManager(
+        listen_address=f"tcp://{host}:0",
+        sock=sock,
+        args="test_args",
+        num_servers=num_servers,
+        input_addresses=placeholder_inputs,
+        output_addresses=placeholder_outputs,
+        target_server_fn=defer_addresses_stub_worker,
+        defer_addresses=True,
+    )
+
+    try:
+        assert len(manager.processes) == num_servers
+        actual_inputs, actual_outputs = manager.gather_actual_addresses(timeout=15.0)
+    finally:
+        manager.shutdown()
+        time.sleep(0.2)
+        sock.close()
+
+    assert len(actual_inputs) == num_servers
+    assert len(actual_outputs) == num_servers
+
+    for addr in actual_inputs + actual_outputs:
+        scheme, parsed_host, port = split_zmq_path(addr)
+        assert scheme == "tcp", addr
+        assert parsed_host == host, addr
+        # Kernel must have replaced the port-0 placeholder.
+        assert port and int(port) > 0, addr
+
+    # All ports are distinct across the 2*num_servers sockets.
+    all_addrs = actual_inputs + actual_outputs
+    assert len(set(all_addrs)) == len(all_addrs), all_addrs
+
+
+@pytest.mark.timeout(30)
+def test_defer_addresses_requires_flag():
+    """``gather_actual_addresses`` must refuse to run when the manager was
+    constructed without ``defer_addresses=True``."""
+    sock = socket.socket()
+    manager = APIServerProcessManager(
+        listen_address="localhost:8000",
+        sock=sock,
+        args="test_args",
+        num_servers=1,
+        input_addresses=["tcp://127.0.0.1:5001"],
+        output_addresses=["tcp://127.0.0.1:6001"],
+        target_server_fn=mock_run_api_server_worker,
+        # defer_addresses defaults to False
+    )
+    try:
+        with pytest.raises(RuntimeError, match="defer_addresses=True"):
+            manager.gather_actual_addresses(timeout=1.0)
+    finally:
+        manager.shutdown()
+        time.sleep(0.2)
+        sock.close()
+
+
+@pytest.mark.timeout(30)
+def test_defer_addresses_child_crash_before_report():
+    """If a deferred-address child exits before sending its endpoints,
+    ``gather_actual_addresses`` must raise a clear ``RuntimeError`` rather
+    than hang or return ``None`` slots."""
+    host = "127.0.0.1"
+    num_servers = 2
+    placeholder_inputs = [
+        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        for _ in range(num_servers)
+    ]
+    placeholder_outputs = [
+        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        for _ in range(num_servers)
+    ]
+
+    sock = socket.socket()
+    manager = APIServerProcessManager(
+        listen_address=f"tcp://{host}:0",
+        sock=sock,
+        args="test_args",
+        num_servers=num_servers,
+        input_addresses=placeholder_inputs,
+        output_addresses=placeholder_outputs,
+        # mock_run_api_server_worker exits quickly without touching the
+        # actual_address_pipe — simulating a child that died before
+        # reporting its ZMQ bind addresses.
+        target_server_fn=mock_run_api_server_worker,
+        defer_addresses=True,
+    )
+    try:
+        # Either error path (sentinel fires first or pipe-EOF on close)
+        # carries the substring "reporting" in its message.
+        with pytest.raises(RuntimeError, match="reporting"):
+            manager.gather_actual_addresses(timeout=10.0)
+    finally:
+        manager.shutdown()
+        time.sleep(0.2)
+        sock.close()

--- a/tests/entrypoints/test_api_server_process_manager.py
+++ b/tests/entrypoints/test_api_server_process_manager.py
@@ -29,11 +29,11 @@ def mock_run_api_server_worker(listen_address, sock, args, client_config=None):
     print("Mock worker completed successfully")
 
 
-# Module-level stub for the defer-addresses test. Must be importable by
-# `multiprocessing.spawn` (no closures, no nesting).
+# Module-level stub for the gather_actual_addresses test. Must be
+# importable by `multiprocessing.spawn` (no closures, no nesting).
 def defer_addresses_stub_worker(listen_address, sock, args, client_config):
-    """Bind the per-child ZMQ ROUTER/PULL with the kernel-assigned port,
-    report the actual endpoints back via the pipe, then exit."""
+    """Bind ROUTER/PULL with a kernel-assigned port, report the actual
+    endpoints back via the pipe, then exit."""
     ctx = zmq.Context()
     try:
         in_sock = make_zmq_socket(
@@ -310,31 +310,22 @@ def test_external_process_monitoring(api_server_args):
 
 
 @pytest.mark.timeout(60)
-def test_defer_addresses_end_to_end():
-    """Exercise the deferred-port path: parent emits ``tcp://host:0``
-    placeholders, each spawned child binds with a kernel-picked port and
-    reports the actual endpoints back via its per-child pipe; the manager
-    surfaces them via :py:meth:`gather_actual_addresses`.
-
-    This is intentionally single-host: the rank-0 parent's
-    spawn/bind/report loop is fully local. The cross-node aspect of a
-    multi-node DP deployment only kicks in when remote engines later
-    DEALER-connect to the reported addresses, which is outside this
-    component's scope.
-    """
+def test_gather_actual_addresses_end_to_end():
+    """Each child binds ROUTER/PULL with a kernel-picked port and reports
+    the bound endpoints back via its per-child pipe; the manager surfaces
+    them via :py:meth:`gather_actual_addresses`."""
     host = "127.0.0.1"
-    num_servers = 4  # mirrors a typical DP_local fan-out
+    num_servers = 4
 
     placeholder_inputs = [
-        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        get_engine_client_zmq_addr(local_only=False, host=host)
         for _ in range(num_servers)
     ]
     placeholder_outputs = [
-        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        get_engine_client_zmq_addr(local_only=False, host=host)
         for _ in range(num_servers)
     ]
     for addr in placeholder_inputs + placeholder_outputs:
-        # defer_port=True must emit a port-0 placeholder for TCP.
         assert addr == f"tcp://{host}:0", addr
 
     sock = socket.socket()
@@ -346,7 +337,6 @@ def test_defer_addresses_end_to_end():
         input_addresses=placeholder_inputs,
         output_addresses=placeholder_outputs,
         target_server_fn=defer_addresses_stub_worker,
-        defer_addresses=True,
     )
 
     try:
@@ -364,51 +354,24 @@ def test_defer_addresses_end_to_end():
         scheme, parsed_host, port = split_zmq_path(addr)
         assert scheme == "tcp", addr
         assert parsed_host == host, addr
-        # Kernel must have replaced the port-0 placeholder.
         assert port and int(port) > 0, addr
 
-    # All ports are distinct across the 2*num_servers sockets.
     all_addrs = actual_inputs + actual_outputs
     assert len(set(all_addrs)) == len(all_addrs), all_addrs
 
 
 @pytest.mark.timeout(30)
-def test_defer_addresses_requires_flag():
-    """``gather_actual_addresses`` must refuse to run when the manager was
-    constructed without ``defer_addresses=True``."""
-    sock = socket.socket()
-    manager = APIServerProcessManager(
-        listen_address="localhost:8000",
-        sock=sock,
-        args="test_args",
-        num_servers=1,
-        input_addresses=["tcp://127.0.0.1:5001"],
-        output_addresses=["tcp://127.0.0.1:6001"],
-        target_server_fn=mock_run_api_server_worker,
-        # defer_addresses defaults to False
-    )
-    try:
-        with pytest.raises(RuntimeError, match="defer_addresses=True"):
-            manager.gather_actual_addresses(timeout=1.0)
-    finally:
-        manager.shutdown()
-        time.sleep(0.2)
-        sock.close()
-
-
-@pytest.mark.timeout(30)
-def test_defer_addresses_child_crash_before_report():
-    """If a deferred-address child exits before sending its endpoints,
-    ``gather_actual_addresses`` must raise a clear ``RuntimeError`` rather
-    than hang or return ``None`` slots."""
+def test_gather_actual_addresses_child_crash_before_report():
+    """A child that exits before sending its endpoints must surface a
+    clear ``RuntimeError`` rather than hang or return ``None`` slots."""
     host = "127.0.0.1"
     num_servers = 2
     placeholder_inputs = [
-        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        get_engine_client_zmq_addr(local_only=False, host=host)
         for _ in range(num_servers)
     ]
     placeholder_outputs = [
-        get_engine_client_zmq_addr(local_only=False, host=host, defer_port=True)
+        get_engine_client_zmq_addr(local_only=False, host=host)
         for _ in range(num_servers)
     ]
 
@@ -420,15 +383,13 @@ def test_defer_addresses_child_crash_before_report():
         num_servers=num_servers,
         input_addresses=placeholder_inputs,
         output_addresses=placeholder_outputs,
-        # mock_run_api_server_worker exits quickly without touching the
-        # actual_address_pipe — simulating a child that died before
-        # reporting its ZMQ bind addresses.
+        # mock_run_api_server_worker exits without touching
+        # ``actual_address_pipe`` — simulates a child that dies before
+        # reporting its bound addresses.
         target_server_fn=mock_run_api_server_worker,
-        defer_addresses=True,
     )
     try:
-        # Either error path (sentinel fires first or pipe-EOF on close)
-        # carries the substring "reporting" in its message.
+        # Sentinel-first vs pipe-EOF-first both produce "reporting".
         with pytest.raises(RuntimeError, match="reporting"):
             manager.gather_actual_addresses(timeout=10.0)
     finally:

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -308,7 +308,16 @@ def run_multi_api_server(args: argparse.Namespace):
 
     from vllm.v1.engine.utils import get_engine_zmq_addresses
 
-    addresses = get_engine_zmq_addresses(vllm_config, num_api_servers)
+    # Defer per-API-server port allocation to the child's actual ``bind()``
+    # call (avoids parent-probe vs child-bind TOCTOU). The Rust front-end
+    # path uses a single externally-launched subprocess that takes the
+    # addresses as CLI args, so the deferred-port handshake doesn't apply
+    # there and we keep the pre-allocated TCP ports.
+    addresses = get_engine_zmq_addresses(
+        vllm_config,
+        num_api_servers,
+        defer_api_server_ports=not rust_frontend_path,
+    )
 
     with launch_core_engines(
         vllm_config, executor_class, log_stats, addresses, num_api_servers
@@ -339,7 +348,15 @@ def run_multi_api_server(args: argparse.Namespace):
                 output_addresses=addresses.outputs,
                 stats_update_address=stats_update_address,
                 tensor_queue=tensor_queue,
+                defer_addresses=True,
             )
+
+            # Collect actual ports the children bound and mutate
+            # ``addresses`` in place; the engine handshake (run on ``with``
+            # exit) ships these to every engine on every DP node.
+            actual_inputs, actual_outputs = api_server_manager.gather_actual_addresses()
+            addresses.inputs = actual_inputs
+            addresses.outputs = actual_outputs
 
     # Wait for API servers.
     try:

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -308,11 +308,11 @@ def run_multi_api_server(args: argparse.Namespace):
 
     from vllm.v1.engine.utils import get_engine_zmq_addresses
 
-    # Defer per-API-server port allocation to the child's actual ``bind()``
-    # call (avoids parent-probe vs child-bind TOCTOU). The Rust front-end
-    # path uses a single externally-launched subprocess that takes the
-    # addresses as CLI args, so the deferred-port handshake doesn't apply
-    # there and we keep the pre-allocated TCP ports.
+    # Per-API-server ports are deferred to each child's actual ``bind()`` call
+    # to avoid the parent-probe vs child-bind TOCTOU race; the Rust front-end
+    # is the one consumer that cannot report a kernel-assigned port back
+    # (addresses are passed as CLI args to an externally-launched subprocess),
+    # so it opts out and keeps pre-allocated TCP ports.
     addresses = get_engine_zmq_addresses(
         vllm_config,
         num_api_servers,

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -308,11 +308,9 @@ def run_multi_api_server(args: argparse.Namespace):
 
     from vllm.v1.engine.utils import get_engine_zmq_addresses
 
-    # Per-API-server ports are deferred to each child's actual ``bind()`` call
-    # to avoid the parent-probe vs child-bind TOCTOU race; the Rust front-end
-    # is the one consumer that cannot report a kernel-assigned port back
-    # (addresses are passed as CLI args to an externally-launched subprocess),
-    # so it opts out and keeps pre-allocated TCP ports.
+    # Per-API-server ports are picked by the kernel at each child's bind()
+    # to avoid parent-probe vs child-bind TOCTOU; Rust front-end opts out
+    # because it has no port-report-back channel.
     addresses = get_engine_zmq_addresses(
         vllm_config,
         num_api_servers,
@@ -348,12 +346,10 @@ def run_multi_api_server(args: argparse.Namespace):
                 output_addresses=addresses.outputs,
                 stats_update_address=stats_update_address,
                 tensor_queue=tensor_queue,
-                defer_addresses=True,
             )
 
-            # Collect actual ports the children bound and mutate
-            # ``addresses`` in place; the engine handshake (run on ``with``
-            # exit) ships these to every engine on every DP node.
+            # Forward each child's bound endpoints to the engine handshake
+            # (runs on ``with`` exit).
             actual_inputs, actual_outputs = api_server_manager.gather_actual_addresses()
             addresses.inputs = actual_inputs
             addresses.outputs = actual_outputs

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -81,7 +81,7 @@ class AsyncLLM(EngineClient):
         start_engine_loop: bool = True,
         stat_loggers: list[StatLoggerFactory] | None = None,
         aggregate_engine_logging: bool = False,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ) -> None:
@@ -209,7 +209,7 @@ class AsyncLLM(EngineClient):
         enable_log_requests: bool = False,
         aggregate_engine_logging: bool = False,
         disable_log_stats: bool = False,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ) -> "AsyncLLM":

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -11,7 +11,7 @@ import zmq
 
 from vllm.config import ParallelConfig
 from vllm.logger import init_logger
-from vllm.utils.network_utils import get_tcp_uri, make_zmq_socket
+from vllm.utils.network_utils import make_zmq_socket
 from vllm.utils.system_utils import get_mp_context, set_process_title
 from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequestType
 from vllm.v1.serial_utils import MsgpackDecoder
@@ -91,16 +91,9 @@ class DPCoordinator:
         if parallel_config.enable_elastic_ep:
             local_only_eng = False
 
-        def bind_address(local_only: bool) -> str:
-            return (
-                get_engine_client_zmq_addr(local_only=True, host=host)
-                if local_only
-                else get_tcp_uri(host, 0)
-            )
-
-        front_publish_address = bind_address(local_only)
-        back_publish_address = bind_address(local_only_eng)
-        back_output_address = bind_address(local_only_eng)
+        front_publish_address = get_engine_client_zmq_addr(local_only, host=host)
+        back_publish_address = get_engine_client_zmq_addr(local_only_eng, host=host)
+        back_output_address = get_engine_client_zmq_addr(local_only_eng, host=host)
 
         context = get_mp_context()
         parent_zmq_addr_pipe, child_zmq_addr_pipe = context.Pipe(duplex=False)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -11,6 +11,7 @@ from collections import defaultdict, deque
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import Future
 from dataclasses import dataclass
+from multiprocessing.connection import Connection
 from multiprocessing.queues import Queue
 from threading import Thread
 from typing import Any, TypeAlias, TypeVar
@@ -518,6 +519,29 @@ class MPClient(EngineCoreClient):
                 self.resources.output_socket = make_zmq_socket(
                     self.ctx, output_address, zmq.PULL
                 )
+
+                # For deferred-port placeholders (tcp://host:0), report the
+                # ZMQ-bound endpoints back so the parent can forward them
+                # to engines (mirrors the DPCoordinator pattern).
+                actual_address_pipe: Connection | None = client_addresses.get(  # type: ignore[assignment]
+                    "actual_address_pipe"
+                )
+                if actual_address_pipe is not None:
+                    try:
+                        actual_input = self.input_socket.getsockopt(
+                            zmq.LAST_ENDPOINT
+                        ).decode()
+                        actual_output = self.resources.output_socket.getsockopt(
+                            zmq.LAST_ENDPOINT
+                        ).decode()
+                        actual_address_pipe.send(
+                            {
+                                "input_address": actual_input,
+                                "output_address": actual_output,
+                            }
+                        )
+                    finally:
+                        actual_address_pipe.close()
             else:
                 # Engines are managed by this client.
                 addresses = get_engine_zmq_addresses(vllm_config)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -109,7 +109,7 @@ class EngineCoreClient(ABC):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ) -> "AsyncMPClient":
@@ -477,7 +477,7 @@ class MPClient(EngineCoreClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
     ):
         self.vllm_config = vllm_config
 
@@ -508,7 +508,7 @@ class MPClient(EngineCoreClient):
                 output_address = client_addresses["output_address"]
                 self.stats_update_address = client_addresses.get("stats_update_address")
                 # Tensor queues passed via client_addresses for multi-API-server case
-                tensor_queue = client_addresses.get("tensor_queue")  # type: ignore[assignment]
+                tensor_queue = client_addresses.get("tensor_queue")
                 self.input_socket = self.resources.input_socket = make_zmq_socket(
                     self.ctx,
                     input_address,
@@ -523,7 +523,7 @@ class MPClient(EngineCoreClient):
                 # For deferred-port placeholders (tcp://host:0), report the
                 # ZMQ-bound endpoints back so the parent can forward them
                 # to engines (mirrors the DPCoordinator pattern).
-                actual_address_pipe: Connection | None = client_addresses.get(  # type: ignore[assignment]
+                actual_address_pipe: Connection | None = client_addresses.get(
                     "actual_address_pipe"
                 )
                 if actual_address_pipe is not None:
@@ -555,6 +555,17 @@ class MPClient(EngineCoreClient):
                 self.resources.output_socket = make_zmq_socket(
                     self.ctx, addresses.outputs[0], zmq.PULL
                 )
+
+                # Replace deferred ``tcp://host:0`` placeholders with the
+                # kernel-assigned endpoints so engines DEALER-connect to the
+                # real ports. No-op for the IPC case (``LAST_ENDPOINT``
+                # returns the same path that was bound).
+                addresses.inputs[0] = self.input_socket.getsockopt(
+                    zmq.LAST_ENDPOINT
+                ).decode()
+                addresses.outputs[0] = self.resources.output_socket.getsockopt(
+                    zmq.LAST_ENDPOINT
+                ).decode()
 
                 with launch_core_engines(
                     vllm_config, executor_class, log_stats, addresses
@@ -917,7 +928,7 @@ class AsyncMPClient(MPClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ):
@@ -1167,7 +1178,7 @@ class DPAsyncMPClient(AsyncMPClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ):
@@ -1347,7 +1358,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -520,9 +520,8 @@ class MPClient(EngineCoreClient):
                     self.ctx, output_address, zmq.PULL
                 )
 
-                # For deferred-port placeholders (tcp://host:0), report the
-                # ZMQ-bound endpoints back so the parent can forward them
-                # to engines (mirrors the DPCoordinator pattern).
+                # Report bound endpoints back so the parent can forward
+                # them to engines (mirrors the DPCoordinator pattern).
                 actual_address_pipe: Connection | None = client_addresses.get(
                     "actual_address_pipe"
                 )
@@ -556,10 +555,8 @@ class MPClient(EngineCoreClient):
                     self.ctx, addresses.outputs[0], zmq.PULL
                 )
 
-                # Replace deferred ``tcp://host:0`` placeholders with the
-                # kernel-assigned endpoints so engines DEALER-connect to the
-                # real ports. No-op for the IPC case (``LAST_ENDPOINT``
-                # returns the same path that was bound).
+                # Resolve ``tcp://host:0`` placeholders to bound endpoints
+                # before engines DEALER-connect. No-op for IPC.
                 addresses.inputs[0] = self.input_socket.getsockopt(
                     zmq.LAST_ENDPOINT
                 ).decode()

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1110,9 +1110,11 @@ def launch_core_engines(
     if parallel_config.enable_elastic_ep:
         handshake_local_only = False
 
-    handshake_address = get_engine_client_zmq_addr(
-        handshake_local_only, host, parallel_config.data_parallel_rpc_port
-    )
+    # Preserve "port=0 means auto-pick" for the handshake address, which
+    # is consumed by engines spawned in this process and so cannot defer
+    # port resolution to bind time.
+    rpc_port = parallel_config.data_parallel_rpc_port or get_open_port()
+    handshake_address = get_engine_client_zmq_addr(handshake_local_only, host, rpc_port)
 
     if local_engines_only and dp_rank > 0:
         assert not handshake_local_only

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -956,15 +956,22 @@ def get_engine_zmq_addresses(
     vllm_config: VllmConfig,
     num_api_servers: int = 1,
     *,
-    defer_api_server_ports: bool = False,
+    defer_api_server_ports: bool = True,
 ) -> EngineZmqAddresses:
     """Allocate ZMQ addresses for engine-client communication.
 
-    ``defer_api_server_ports``: emit TCP placeholders (``tcp://host:0``)
-    for per-API-server input/output addresses; the actual ports are picked
-    by the kernel in each child at bind time and must be reported back via
-    ``APIServerProcessManager.gather_actual_addresses`` before the engine
-    handshake. No-op for the IPC (colocated) case."""
+    ``defer_api_server_ports`` (default ``True``): emit TCP placeholders
+    (``tcp://host:0``) for per-API-server input/output addresses; the actual
+    port is picked by the kernel at bind time and the bound endpoint must be
+    propagated back into ``addresses.inputs`` / ``addresses.outputs`` before
+    the engine handshake (via
+    :py:meth:`APIServerProcessManager.gather_actual_addresses` for the
+    cross-process case, or via ``getsockopt(zmq.LAST_ENDPOINT)`` for the
+    single-process ``MPClient`` case). No-op for the IPC (colocated) case.
+
+    Set this to ``False`` only when the consumer of the addresses cannot
+    report back a kernel-assigned port (e.g. the Rust front-end, which
+    receives ``--input-address`` / ``--output-address`` as CLI args)."""
     parallel_config = vllm_config.parallel_config
     local_engine_count = parallel_config.data_parallel_size_local
     local_start_index = parallel_config.data_parallel_rank_local

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -955,8 +955,16 @@ class CoreEngineActorManager:
 def get_engine_zmq_addresses(
     vllm_config: VllmConfig,
     num_api_servers: int = 1,
+    *,
+    defer_api_server_ports: bool = False,
 ) -> EngineZmqAddresses:
-    """Allocate ZMQ addresses for engine-client communication."""
+    """Allocate ZMQ addresses for engine-client communication.
+
+    ``defer_api_server_ports``: emit TCP placeholders (``tcp://host:0``)
+    for per-API-server input/output addresses; the actual ports are picked
+    by the kernel in each child at bind time and must be reported back via
+    ``APIServerProcessManager.gather_actual_addresses`` before the engine
+    handshake. No-op for the IPC (colocated) case."""
     parallel_config = vllm_config.parallel_config
     local_engine_count = parallel_config.data_parallel_size_local
     local_start_index = parallel_config.data_parallel_rank_local
@@ -980,11 +988,15 @@ def get_engine_zmq_addresses(
 
     return EngineZmqAddresses(
         inputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
+            get_engine_client_zmq_addr(
+                client_local_only, host, defer_port=defer_api_server_ports
+            )
             for _ in range(num_api_servers)
         ],
         outputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
+            get_engine_client_zmq_addr(
+                client_local_only, host, defer_port=defer_api_server_ports
+            )
             for _ in range(num_api_servers)
         ],
     )

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -23,7 +23,12 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils import numa_utils
-from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.utils.network_utils import (
+    get_open_port,
+    get_open_zmq_ipc_path,
+    get_tcp_uri,
+    zmq_socket_ctx,
+)
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.executor import Executor
@@ -960,18 +965,14 @@ def get_engine_zmq_addresses(
 ) -> EngineZmqAddresses:
     """Allocate ZMQ addresses for engine-client communication.
 
-    ``defer_api_server_ports`` (default ``True``): emit TCP placeholders
-    (``tcp://host:0``) for per-API-server input/output addresses; the actual
-    port is picked by the kernel at bind time and the bound endpoint must be
-    propagated back into ``addresses.inputs`` / ``addresses.outputs`` before
-    the engine handshake (via
-    :py:meth:`APIServerProcessManager.gather_actual_addresses` for the
-    cross-process case, or via ``getsockopt(zmq.LAST_ENDPOINT)`` for the
-    single-process ``MPClient`` case). No-op for the IPC (colocated) case.
+    By default each TCP address is a ``tcp://host:0`` placeholder; the
+    consumer (API-server child or single-process ``MPClient``) binds, then
+    recovers the kernel-assigned port via ``getsockopt(zmq.LAST_ENDPOINT)``
+    and writes it back into ``addresses`` before the engine handshake.
 
-    Set this to ``False`` only when the consumer of the addresses cannot
-    report back a kernel-assigned port (e.g. the Rust front-end, which
-    receives ``--input-address`` / ``--output-address`` as CLI args)."""
+    Set ``defer_api_server_ports=False`` only when the consumer cannot
+    report a bound port back (e.g. the Rust front-end). IPC paths are
+    unaffected."""
     parallel_config = vllm_config.parallel_config
     local_engine_count = parallel_config.data_parallel_size_local
     local_start_index = parallel_config.data_parallel_rank_local
@@ -993,19 +994,14 @@ def get_engine_zmq_addresses(
     if parallel_config.enable_elastic_ep:
         client_local_only = False
 
+    def _addr() -> str:
+        if client_local_only:
+            return get_open_zmq_ipc_path()
+        return get_tcp_uri(host, 0 if defer_api_server_ports else get_open_port())
+
     return EngineZmqAddresses(
-        inputs=[
-            get_engine_client_zmq_addr(
-                client_local_only, host, defer_port=defer_api_server_ports
-            )
-            for _ in range(num_api_servers)
-        ],
-        outputs=[
-            get_engine_client_zmq_addr(
-                client_local_only, host, defer_port=defer_api_server_ports
-            )
-            for _ in range(num_api_servers)
-        ],
+        inputs=[_addr() for _ in range(num_api_servers)],
+        outputs=[_addr() for _ in range(num_api_servers)],
     )
 
 

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -144,20 +144,26 @@ class CpuGpuBuffer:
         return self.cpu[:n].copy_(self.gpu[:n], non_blocking=True)
 
 
-def get_engine_client_zmq_addr(local_only: bool, host: str, port: int = 0) -> str:
+def get_engine_client_zmq_addr(
+    local_only: bool,
+    host: str,
+    port: int = 0,
+    *,
+    defer_port: bool = False,
+) -> str:
     """Assign a new ZMQ socket address.
 
-    If local_only is True, participants are colocated and so a unique IPC
-    address will be returned.
+    local_only: return an IPC path.
+    defer_port: return ``tcp://host:0`` for the child to bind atomically
+      (avoids parent-probe vs child-bind TOCTOU; child must report back via
+      ``getsockopt(zmq.LAST_ENDPOINT)``).
+    Otherwise: TCP with ``port`` (or ``get_open_port()`` if 0)."""
 
-    Otherwise, the provided host and port will be used to construct a TCP
-    address (port == 0 means assign an available port)."""
-
-    return (
-        get_open_zmq_ipc_path()
-        if local_only
-        else (get_tcp_uri(host, port or get_open_port()))
-    )
+    if local_only:
+        return get_open_zmq_ipc_path()
+    if defer_port:
+        return get_tcp_uri(host, 0)
+    return get_tcp_uri(host, port or get_open_port())
 
 
 class APIServerProcessManager:
@@ -178,6 +184,7 @@ class APIServerProcessManager:
         target_server_fn: Callable | None = None,
         stats_update_address: str | None = None,
         tensor_queue: Queue | None = None,
+        defer_addresses: bool = False,
     ):
         """Initialize and start API server worker processes.
 
@@ -191,6 +198,10 @@ class APIServerProcessManager:
             output_addresses: Output addresses for each API server
             stats_update_address: Optional stats update address
             tensor_queue: Optional tensor IPC queue for sharing MM tensors
+            defer_addresses: Treat ``input_addresses``/``output_addresses``
+                as placeholders; each child reports its real bound endpoint
+                via a per-child pipe (collected by
+                :py:meth:`gather_actual_addresses`).
         """
         self.listen_address = listen_address
         self.sock = sock
@@ -199,11 +210,14 @@ class APIServerProcessManager:
         # Start API servers
         spawn_context = multiprocessing.get_context("spawn")
         self.processes: list[BaseProcess] = []
+        self._address_pipes: list[connection.Connection] | None = (
+            [] if defer_addresses else None
+        )
 
         for i, in_addr, out_addr in zip(
             range(num_servers), input_addresses, output_addresses
         ):
-            client_config = {
+            client_config: dict[str, Any] = {
                 "input_address": in_addr,
                 "output_address": out_addr,
                 "client_count": num_servers,
@@ -214,6 +228,12 @@ class APIServerProcessManager:
             if tensor_queue is not None:
                 client_config["tensor_queue"] = tensor_queue
 
+            child_send: connection.Connection | None = None
+            if self._address_pipes is not None:
+                parent_recv, child_send = spawn_context.Pipe(duplex=False)
+                self._address_pipes.append(parent_recv)
+                client_config["actual_address_pipe"] = child_send
+
             proc = spawn_context.Process(
                 target=target_server_fn or run_api_server_worker_proc,
                 name=f"ApiServer_{i}",
@@ -222,11 +242,90 @@ class APIServerProcessManager:
             self.processes.append(proc)
             proc.start()
 
+            # Drop parent's write end so reader sees EOF on child death.
+            if child_send is not None:
+                child_send.close()
+
         logger.info("Started %d API server processes", len(self.processes))
 
         # Shutdown only the API server processes on garbage collection
         # The extra processes are managed by their owners
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
+
+    def gather_actual_addresses(
+        self,
+        timeout: float = 60.0,
+    ) -> tuple[list[str], list[str]]:
+        """Return (inputs, outputs) reported by each child, indexed by
+        ``client_index``. Requires ``defer_addresses=True``. Raises
+        ``RuntimeError`` on timeout or premature child exit."""
+        if self._address_pipes is None:
+            raise RuntimeError(
+                "gather_actual_addresses() requires that "
+                "APIServerProcessManager was constructed with "
+                "defer_addresses=True"
+            )
+
+        n = len(self._address_pipes)
+        inputs: list[str | None] = [None] * n
+        outputs: list[str | None] = [None] * n
+        pending: dict[connection.Connection, int] = {
+            pipe: i for i, pipe in enumerate(self._address_pipes)
+        }
+        sentinel_to_idx: dict[Any, int] = {
+            proc.sentinel: i for i, proc in enumerate(self.processes)
+        }
+
+        deadline = time.monotonic() + timeout
+        try:
+            while pending:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    missing = [self.processes[i].name for i in pending.values()]
+                    raise RuntimeError(
+                        f"Timed out after {timeout:.1f}s waiting for "
+                        f"API server(s) to report bound ZMQ addresses: "
+                        f"{missing}"
+                    )
+                waitables: list[Any] = list(pending.keys()) + list(
+                    sentinel_to_idx.keys()
+                )
+                ready = connection.wait(waitables, timeout=remaining)
+                # Drain pipes first: a child that sent its message and
+                # then exited can surface both pipe-readable and sentinel
+                # in the same poll, and we must record the success before
+                # observing the exit.
+                for item in ready:
+                    if isinstance(item, connection.Connection) and item in pending:
+                        idx = pending.pop(item)
+                        try:
+                            msg: dict[str, str] = item.recv()
+                        except EOFError as e:
+                            raise RuntimeError(
+                                f"API server {self.processes[idx].name} "
+                                f"closed its address pipe without "
+                                f"reporting its bound ZMQ addresses"
+                            ) from e
+                        inputs[idx] = msg["input_address"]
+                        outputs[idx] = msg["output_address"]
+                for item in ready:
+                    if item in sentinel_to_idx:
+                        # Pop to avoid re-firing on the same sentinel.
+                        idx = sentinel_to_idx.pop(item)
+                        pipe = self._address_pipes[idx]
+                        if pipe in pending:
+                            proc = self.processes[idx]
+                            raise RuntimeError(
+                                f"API server process {proc.name} exited "
+                                f"(code={proc.exitcode}) before reporting "
+                                f"its bound ZMQ addresses"
+                            )
+        finally:
+            for pipe in pending:
+                with contextlib.suppress(Exception):
+                    pipe.close()
+
+        return inputs, outputs  # type: ignore[return-value]
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown API server processes with configurable timeout"""

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -330,6 +330,12 @@ class APIServerProcessManager:
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown API server processes with configurable timeout"""
+        if self._address_pipes is not None:
+            for pipe in self._address_pipes:
+                with contextlib.suppress(Exception):
+                    pipe.close()
+            self._address_pipes = None
+
         if self._finalizer.detach() is not None:
             shutdown(self.processes, timeout=timeout)
 

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -308,6 +308,7 @@ class APIServerProcessManager:
                             ) from e
                         inputs[idx] = msg["input_address"]
                         outputs[idx] = msg["output_address"]
+                        item.close()
                 for item in ready:
                     if item in sentinel_to_idx:
                         # Pop to avoid re-firing on the same sentinel.

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -29,7 +29,7 @@ from torch.autograd.profiler import record_function
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext, is_usage_stats_enabled, usage_message
-from vllm.utils.network_utils import get_open_port, get_open_zmq_ipc_path, get_tcp_uri
+from vllm.utils.network_utils import get_open_zmq_ipc_path, get_tcp_uri
 from vllm.utils.system_utils import decorate_logs, kill_process_tree, set_process_title
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -148,22 +148,14 @@ def get_engine_client_zmq_addr(
     local_only: bool,
     host: str,
     port: int = 0,
-    *,
-    defer_port: bool = False,
 ) -> str:
-    """Assign a new ZMQ socket address.
+    """Return an IPC path (``local_only=True``) or ``tcp://host:port``.
 
-    local_only: return an IPC path.
-    defer_port: return ``tcp://host:0`` for the child to bind atomically
-      (avoids parent-probe vs child-bind TOCTOU; child must report back via
-      ``getsockopt(zmq.LAST_ENDPOINT)``).
-    Otherwise: TCP with ``port`` (or ``get_open_port()`` if 0)."""
-
+    ``port=0`` lets the kernel assign the port at ``bind()`` time; the
+    caller must recover it via ``getsockopt(zmq.LAST_ENDPOINT)``."""
     if local_only:
         return get_open_zmq_ipc_path()
-    if defer_port:
-        return get_tcp_uri(host, 0)
-    return get_tcp_uri(host, port or get_open_port())
+    return get_tcp_uri(host, port)
 
 
 class APIServerProcessManager:
@@ -184,9 +176,14 @@ class APIServerProcessManager:
         target_server_fn: Callable | None = None,
         stats_update_address: str | None = None,
         tensor_queue: Queue | None = None,
-        defer_addresses: bool = False,
     ):
         """Initialize and start API server worker processes.
+
+        ``input_addresses``/``output_addresses`` may contain
+        ``tcp://host:0`` placeholders; each child must report the actual
+        bound endpoint over its ``actual_address_pipe`` in ``client_config``
+        and the parent collects them via
+        :py:meth:`gather_actual_addresses`.
 
         Args:
             target_server_fn: Override function to call for each API server process
@@ -198,21 +195,14 @@ class APIServerProcessManager:
             output_addresses: Output addresses for each API server
             stats_update_address: Optional stats update address
             tensor_queue: Optional tensor IPC queue for sharing MM tensors
-            defer_addresses: Treat ``input_addresses``/``output_addresses``
-                as placeholders; each child reports its real bound endpoint
-                via a per-child pipe (collected by
-                :py:meth:`gather_actual_addresses`).
         """
         self.listen_address = listen_address
         self.sock = sock
         self.args = args
 
-        # Start API servers
         spawn_context = multiprocessing.get_context("spawn")
         self.processes: list[BaseProcess] = []
-        self._address_pipes: list[connection.Connection] | None = (
-            [] if defer_addresses else None
-        )
+        self._address_pipes: list[connection.Connection] = []
 
         for i, in_addr, out_addr in zip(
             range(num_servers), input_addresses, output_addresses
@@ -228,11 +218,9 @@ class APIServerProcessManager:
             if tensor_queue is not None:
                 client_config["tensor_queue"] = tensor_queue
 
-            child_send: connection.Connection | None = None
-            if self._address_pipes is not None:
-                parent_recv, child_send = spawn_context.Pipe(duplex=False)
-                self._address_pipes.append(parent_recv)
-                client_config["actual_address_pipe"] = child_send
+            parent_recv, child_send = spawn_context.Pipe(duplex=False)
+            self._address_pipes.append(parent_recv)
+            client_config["actual_address_pipe"] = child_send
 
             proc = spawn_context.Process(
                 target=target_server_fn or run_api_server_worker_proc,
@@ -243,8 +231,7 @@ class APIServerProcessManager:
             proc.start()
 
             # Drop parent's write end so reader sees EOF on child death.
-            if child_send is not None:
-                child_send.close()
+            child_send.close()
 
         logger.info("Started %d API server processes", len(self.processes))
 
@@ -257,15 +244,8 @@ class APIServerProcessManager:
         timeout: float = 60.0,
     ) -> tuple[list[str], list[str]]:
         """Return (inputs, outputs) reported by each child, indexed by
-        ``client_index``. Requires ``defer_addresses=True``. Raises
-        ``RuntimeError`` on timeout or premature child exit."""
-        if self._address_pipes is None:
-            raise RuntimeError(
-                "gather_actual_addresses() requires that "
-                "APIServerProcessManager was constructed with "
-                "defer_addresses=True"
-            )
-
+        ``client_index``. Raises ``RuntimeError`` on timeout or premature
+        child exit."""
         n = len(self._address_pipes)
         inputs: list[str | None] = [None] * n
         outputs: list[str | None] = [None] * n
@@ -291,10 +271,9 @@ class APIServerProcessManager:
                     sentinel_to_idx.keys()
                 )
                 ready = connection.wait(waitables, timeout=remaining)
-                # Drain pipes first: a child that sent its message and
-                # then exited can surface both pipe-readable and sentinel
-                # in the same poll, and we must record the success before
-                # observing the exit.
+                # Drain pipes before checking sentinels: a child that sent
+                # its message and then exited can surface both events in
+                # the same poll, and we must record the success first.
                 for item in ready:
                     if isinstance(item, connection.Connection) and item in pending:
                         idx = pending.pop(item)
@@ -311,7 +290,6 @@ class APIServerProcessManager:
                         item.close()
                 for item in ready:
                     if item in sentinel_to_idx:
-                        # Pop to avoid re-firing on the same sentinel.
                         idx = sentinel_to_idx.pop(item)
                         pipe = self._address_pipes[idx]
                         if pipe in pending:
@@ -330,11 +308,10 @@ class APIServerProcessManager:
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown API server processes with configurable timeout"""
-        if self._address_pipes is not None:
-            for pipe in self._address_pipes:
-                with contextlib.suppress(Exception):
-                    pipe.close()
-            self._address_pipes = None
+        for pipe in self._address_pipes:
+            with contextlib.suppress(Exception):
+                pipe.close()
+        self._address_pipes = []
 
         if self._finalizer.detach() is not None:
             shutdown(self.processes, timeout=timeout)


### PR DESCRIPTION
## Problem

Running multi-node DP on 2×(4×GB300) (`data_parallel_size=8`, `data_parallel_size_local=4`, `api_server_count=8`, NVFP4 MoE), **5 of 79 startups failed** with the same error from `ApiServer_0`:

```text
(ApiServer_0 pid=...) zmq.error.ZMQError: Address already in use (addr='tcp://<master>:39381')
...
RuntimeError: Process ApiServer_0 (PID: ...) died with exit code 1
```

## Root cause

The rank-0 parent pre-picks ephemeral TCP ports via `bind(("", 0)) → close()` in `get_open_port()` and only later spawns each API server child, which does the real ZMQ `bind` — typically 5–25 s later after model config and scheduler setup. In that window any other process on the host can claim the freed port. The most likely culprit is vLLM itself: it allocates ~30+ TCP ports in the same startup burst (per-API-server inputs/outputs, DP-master pool, handshake, coordinator, stats), and the kernel can hand the same ephemeral port number back to two different `get_open_port()` calls inside the same parent before either child has had a chance to bind. Stale processes from prior crashed runs amplify the risk (the failing log also shows leaked-semaphore / leaked-shared-memory warnings at shutdown).

## Fix

Apply the same `bind-in-child + report-back-via-Pipe` pattern that `DPCoordinator` already uses. The parent emits `tcp://host:0` placeholders; each `ApiServer_i` binds its ROUTER/PULL with port 0 (kernel atomically picks a free port), reads the bound endpoints via `getsockopt(zmq.LAST_ENDPOINT)`, and reports them to the parent over a per-child `multiprocessing.Pipe`. The parent collects the actual addresses *before* the engine startup handshake propagates them to every engine on every DP node. No protocol changes; opt-in everywhere; IPC paths and the single-client (engines-managed-by-this-client) path are unchanged.

## Tests

### Unit test

`tests/entrypoints/test_api_server_process_manager.py`:

- End-to-end happy path with `defer_addresses=True` — 4 children, kernel-picked ports, addresses gathered and verified distinct & well-formed.
- `gather_actual_addresses()` rejects use without `defer_addresses=True`.
- Child exits before reporting → clear `RuntimeError`, no hang.

### Stress testing

On a common case the bug fires ~1/100 runs (DP=8, DP-local=4, 2 nodes) — too rare for reliable verification.

To make it reproducible I ran each compute node with a small "port squatter" that pre-binds every port in `/proc/sys/net/ipv4/ip_local_port_range` except a small window at the top, leaving `_get_open_port()` only ~100 ports to choose from. Under that pressure the TOCTOU race fires almost every run.

Squatter (started in background on each node before `vllm serve`):

```python
import os, socket, sys, time, signal
free_top = int(sys.argv[1])
with open("/proc/sys/net/ipv4/ip_local_port_range") as f:
    lo, hi = map(int, f.read().split())
squat_hi = hi - free_top + 1
held = []
for p in range(lo, squat_hi):
    try:
        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        s.bind(("0.0.0.0", p)); s.listen(1)
        held.append(s)
    except OSError:
        pass
print(f"[squatter] holding {len(held)} ports", flush=True)
signal.signal(signal.SIGTERM, lambda *a: sys.exit(0))
while True: time.sleep(3600)
```

Driver per node:

```bash
ulimit -n 65535
python3 squatter.py 100 &        # leave only 100 ports free
exec vllm serve <args>
```

Results (same config, 2 nodes, DP=8, DP-local=4, squatter at `free_top=100`):

| build       | passed | failed |
|-------------|--------|--------|
| `main`      | 1      | 27     |
| **this PR** | 50     | 0      |
