### PR TITLE
[Bugfix][Multimodal] PyAV video backend returns keyframes labeled as targets

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import io
 from pathlib import Path
 
+import av
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -362,6 +364,82 @@ def test_pyav_dynamic_backend_loads_frames(
         assert frames.shape[0] > 0
         assert frames.shape[0] == len(metadata["frames_indices"])
         assert metadata["video_backend"] == "pyav_dynamic"
+
+
+def _synthesize_long_gop_video(
+    num_frames: int = 50,
+    fps: int = 30,
+    width: int = 64,
+    height: int = 64,
+) -> bytes:
+    """Encode an H.264 clip with one keyframe and green-channel = frame index.
+
+    The marker lets a test recover which frame the decoder actually returned,
+    independent of any metadata label.
+    """
+    buf = io.BytesIO()
+    with av.open(buf, mode="w", format="mp4") as container:
+        stream = container.add_stream("h264", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        stream.codec_context.gop_size = num_frames
+        stream.codec_context.max_b_frames = 0
+        stream.codec_context.options = {
+            "x264-params": (f"scenecut=0:keyint={num_frames}:min-keyint={num_frames}")
+        }
+        for i in range(num_frames):
+            img = np.zeros((height, width, 3), dtype=np.uint8)
+            img[:, :, 1] = i
+            frame = av.VideoFrame.from_ndarray(img, format="rgb24")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+    return buf.getvalue()
+
+
+def test_pyav_backend_returns_target_frames_not_keyframes():
+    """Regression test: PyAV must decode forward past the seek keyframe.
+
+    container.seek() snaps backward to the nearest keyframe. With a long GOP
+    (here: one keyframe at frame 0), a decoder that does not advance forward
+    to the target PTS collapses every sampled slot onto the keyframe. This
+    test encodes a per-frame marker on the green channel and verifies the
+    returned frames are distinct, ordered, and match the requested indices.
+    """
+    num_frames = 50
+    num_sampled = 4
+    height, width = 64, 64
+
+    video_bytes = _synthesize_long_gop_video(
+        num_frames=num_frames, width=width, height=height
+    )
+
+    loader = VIDEO_LOADER_REGISTRY.load("opencv")
+    frames, metadata = loader.load_bytes(
+        video_bytes, num_frames=num_sampled, backend="pyav"
+    )
+    assert frames.shape == (num_sampled, height, width, 3)
+
+    requested = list(metadata["frames_indices"])
+    assert len(requested) == num_sampled
+
+    actual = [int(f[height // 2, width // 2, 1]) for f in frames]
+
+    assert len(set(actual)) == num_sampled, (
+        f"PyAV returned only {len(set(actual))} distinct frames for "
+        f"{num_sampled} requested indices: markers={actual}, "
+        f"requested={requested}. Keyframe-snap regression."
+    )
+
+    assert actual == sorted(actual), f"Returned frames out of order: markers={actual}"
+
+    for marker, want_idx in zip(actual, requested):
+        assert abs(marker - want_idx) <= 10, (
+            f"Frame mismatch: requested index {want_idx}, "
+            f"got marker {marker} (tolerance ±10)"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import io
 from pathlib import Path
 
-import av
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -15,7 +13,7 @@ from vllm.multimodal.video import (
     VideoLoader,
 )
 
-from .utils import create_video_from_image
+from .utils import create_long_gop_video, create_video_from_image
 
 pytestmark = pytest.mark.cpu_test
 
@@ -366,39 +364,6 @@ def test_pyav_dynamic_backend_loads_frames(
         assert metadata["video_backend"] == "pyav_dynamic"
 
 
-def _synthesize_long_gop_video(
-    num_frames: int = 50,
-    fps: int = 30,
-    width: int = 64,
-    height: int = 64,
-) -> bytes:
-    """Encode an H.264 clip with one keyframe and green-channel = frame index.
-
-    The marker lets a test recover which frame the decoder actually returned,
-    independent of any metadata label.
-    """
-    buf = io.BytesIO()
-    with av.open(buf, mode="w", format="mp4") as container:
-        stream = container.add_stream("h264", rate=fps)
-        stream.width = width
-        stream.height = height
-        stream.pix_fmt = "yuv420p"
-        stream.codec_context.gop_size = num_frames
-        stream.codec_context.max_b_frames = 0
-        stream.codec_context.options = {
-            "x264-params": (f"scenecut=0:keyint={num_frames}:min-keyint={num_frames}")
-        }
-        for i in range(num_frames):
-            img = np.zeros((height, width, 3), dtype=np.uint8)
-            img[:, :, 1] = i
-            frame = av.VideoFrame.from_ndarray(img, format="rgb24")
-            for packet in stream.encode(frame):
-                container.mux(packet)
-        for packet in stream.encode():
-            container.mux(packet)
-    return buf.getvalue()
-
-
 def test_pyav_backend_returns_target_frames_not_keyframes():
     """Regression test: PyAV must decode forward past the seek keyframe.
 
@@ -412,7 +377,7 @@ def test_pyav_backend_returns_target_frames_not_keyframes():
     num_sampled = 4
     height, width = 64, 64
 
-    video_bytes = _synthesize_long_gop_video(
+    video_bytes = create_long_gop_video(
         num_frames=num_frames, width=width, height=height
     )
 

--- a/tests/multimodal/utils.py
+++ b/tests/multimodal/utils.py
@@ -66,6 +66,43 @@ def create_video_from_image(
     return video_path
 
 
+def create_long_gop_video(
+    num_frames: int = 50,
+    fps: int = 30,
+    width: int = 64,
+    height: int = 64,
+) -> bytes:
+    """Encode an H.264 clip with one keyframe and green-channel = frame index.
+
+    The marker lets a test recover which frame the decoder actually returned,
+    independent of any metadata label.
+    """
+    import io
+
+    import av
+
+    buf = io.BytesIO()
+    with av.open(buf, mode="w", format="mp4") as container:
+        stream = container.add_stream("h264", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        stream.codec_context.gop_size = num_frames
+        stream.codec_context.max_b_frames = 0
+        stream.codec_context.options = {
+            "x264-params": (f"scenecut=0:keyint={num_frames}:min-keyint={num_frames}")
+        }
+        for i in range(num_frames):
+            img = np.zeros((height, width, 3), dtype=np.uint8)
+            img[:, :, 1] = i
+            frame = av.VideoFrame.from_ndarray(img, format="rgb24")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+    return buf.getvalue()
+
+
 def cosine_similarity(A: npt.NDArray, B: npt.NDArray, axis: int = -1) -> npt.NDArray:
     """Compute cosine similarity between two vectors."""
     return np.sum(A * B, axis=axis) / (

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -390,7 +390,7 @@ class PyAVVideoBackendMixin:
         fps: float,
         duration: float,
     ) -> tuple[npt.NDArray, list[int]]:
-        """Decode target frames via per-frame seek + keyframe decode."""
+        """Decode target frames via per-frame seek + forward decode to PTS."""
         stream = container.streams.video[0]
         # SLICE parallelizes within a single frame without the
         # one-frame-per-thread latency penalty of FRAME threading.
@@ -402,14 +402,30 @@ class PyAVVideoBackendMixin:
         frame_interval = 1.0 / fps if fps > 0 else 0.1
         max_ts = max(0.0, duration - frame_interval) if duration > 0 else float("inf")
 
+        decoder = None
+        last_pts = None
         for idx in frame_indices:
             ts = min(idx / fps, max_ts) if fps > 0 else 0.0
             pts = int(ts / time_base)
-            container.seek(pts, stream=stream)
-            frame = next(container.decode(video=0), None)
-            if frame is not None:
-                frames_list.append(frame.to_ndarray(format="rgb24"))
+            # seek() snaps backward to a keyframe; reuse the running decoder
+            # while targets advance monotonically to avoid re-decoding the
+            # GOP prefix once per requested frame.
+            if decoder is None or last_pts is None or pts <= last_pts:
+                container.seek(pts, stream=stream)
+                decoder = container.decode(video=0)
+            chosen = None
+            for frame in decoder:
+                if frame.pts is None:
+                    continue
+                chosen = frame
+                last_pts = frame.pts
+                if frame.pts >= pts:
+                    break
+            if chosen is not None:
+                frames_list.append(chosen.to_ndarray(format="rgb24"))
                 valid_indices.append(idx)
+            else:
+                decoder = None
 
         if not frames_list:
             return np.empty((0,), dtype=np.uint8), valid_indices

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -415,11 +415,9 @@ class PyAVVideoBackendMixin:
                 decoder = container.decode(video=0)
             chosen = None
             for frame in decoder:
-                if frame.pts is None:
-                    continue
-                chosen = frame
-                last_pts = frame.pts
-                if frame.pts >= pts:
+                if frame.pts is not None and frame.pts >= pts:
+                    chosen = frame
+                    last_pts = frame.pts
                     break
             if chosen is not None:
                 frames_list.append(chosen.to_ndarray(format="rgb24"))


### PR DESCRIPTION

## Bug

From #39986

`backend="pyav"` returns the keyframe at-or-before each requested target, labeled as the target. `container.seek()` defaults to `backward=True` (snaps to nearest keyframe ≤ pts); the previous loop took the very next decoded frame without advancing to the actual target. Affected workloads: any `media_io_kwargs={"video": {"backend": "pyav"}}` on long-GOP clips.

## Fix

Decode forward until `frame.pts >= pts`. Reuse the open decoder while targets advance monotonically (the `np.linspace` common case). Only re-seek on rewind or stream exhaust, so the GOP prefix isn't re-decoded once per target.

## Test

Synthesised single-keyframe 200-frame H.264 fixture (green channel = frame index) decoded by both backends:

- **Pre-fix pyav:** 8 copies of frame 0 (collapsed onto the lone keyframe).
- **Post-fix pyav:** pixel-identical to opencv across all 8 sampled slots, `mean|Δ| = 0.0`.

Self-contained CPU repro runs in <1s — no model, no dataset, no GPU. Happy to land it as a regression test under `tests/multimodal/` if reviewers want; the existing pyav tests only check shape/dtype/count, never pixel content vs the opencv reference, which is why this slipped through.


<details>
<summary> Minimal Repro</summary>

```python
"""Minimal reproduction of the PyAV-backend keyframe-snap bug.

Synthesises a 200-frame H.264 clip with one keyframe (gop_size=200, no
B-frames) and a known signal: each frame N is a solid color whose green
channel equals N. Decodes 8 uniformly-spaced frames via the actual vLLM
loader (`VideoBackend.load_bytes`) for both backends, then recovers
which frame each backend returned by reading the green channel —
independent of the metadata label the loader claims.

Pre-fix: pyav returns 8 copies of frame 0, all labelled as distinct
target indices. Post-fix: pyav matches opencv pixel-for-pixel.
"""

import io
import sys
import types

# `vllm.platforms.cuda` (loaded by vllm/__init__.py) eagerly imports
# vllm._C_stable_libtorch for op-registration side effects. Some local
# editable builds don't include that .so file, but no code reads
# attributes from it. Stubbing lets us import VideoBackend without a
# full rebuild. Drop this hack if your build already provides the
# extension.
sys.modules.setdefault(
    "vllm._C_stable_libtorch", types.ModuleType("vllm._C_stable_libtorch")
)

import av  # noqa: E402
import numpy as np  # noqa: E402

from vllm.multimodal.video import VideoBackend  # noqa: E402

NUM_FRAMES = 200
FPS = 30
WIDTH, HEIGHT = 64, 64
NUM_SAMPLED = 8


def synthesise_long_gop_video() -> bytes:
    """Encode 200 frames of solid-color (green = frame index) with GOP=200."""
    buf = io.BytesIO()
    container = av.open(buf, mode="w", format="mp4")
    stream = container.add_stream("h264", rate=FPS)
    stream.width = WIDTH
    stream.height = HEIGHT
    stream.pix_fmt = "yuv420p"
    stream.codec_context.gop_size = NUM_FRAMES   # one keyframe, at frame 0
    stream.codec_context.max_b_frames = 0        # PTS == decode order
    stream.codec_context.options = {
        "x264-params": "scenecut=0:keyint=200:min-keyint=200"
    }

    for i in range(NUM_FRAMES):
        img = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
        img[:, :, 1] = i                         # green channel encodes index
        frame = av.VideoFrame.from_ndarray(img, format="rgb24")
        for packet in stream.encode(frame):
            container.mux(packet)
    for packet in stream.encode():
        container.mux(packet)
    container.close()
    return buf.getvalue()


def count_keyframes(data: bytes) -> int:
    with av.open(io.BytesIO(data)) as c:
        s = c.streams.video[0]
        return sum(1 for p in c.demux(s) if p.is_keyframe)


def main() -> None:
    data = synthesise_long_gop_video()
    n_keyframes = count_keyframes(data)
    print(f"Encoded {NUM_FRAMES} frames, {len(data)} bytes, "
          f"{n_keyframes} keyframe(s).")
    assert n_keyframes == 1, (
        f"Test fixture is invalid: expected 1 keyframe, got {n_keyframes}. "
        "The bug is only visible when sampled frames span a long GOP."
    )

    opencv_frames, opencv_meta = VideoBackend.load_bytes(
        data, num_frames=NUM_SAMPLED, backend="opencv"
    )
    pyav_frames, pyav_meta = VideoBackend.load_bytes(
        data, num_frames=NUM_SAMPLED, backend="pyav"
    )

    requested = list(opencv_meta["frames_indices"])
    assert requested == list(pyav_meta["frames_indices"]), (
        f"Backends disagree on metadata indices "
        f"({opencv_meta['frames_indices']} vs {pyav_meta['frames_indices']}) "
        "— separate problem."
    )
    print(f"Both backends report frames_indices: {requested}")

    # Recover the frame each backend ACTUALLY returned by reading the green
    # channel of the centre pixel. Independent of the metadata label.
    opencv_actual = [int(f[HEIGHT // 2, WIDTH // 2, 1]) for f in opencv_frames]
    pyav_actual = [int(f[HEIGHT // 2, WIDTH // 2, 1]) for f in pyav_frames]

    print()
    print(f"{'slot':>4} {'requested':>10} {'opencv got':>11} {'pyav got':>9} "
          f"{'mean|Δ|':>9}")
    print("-" * 50)
    for i, idx in enumerate(requested):
        diff = float(np.mean(np.abs(
            opencv_frames[i].astype(int) - pyav_frames[i].astype(int))))
        print(f"{i:>4} {idx:>10} {opencv_actual[i]:>11} "
              f"{pyav_actual[i]:>9} {diff:>9.2f}")

    print()
    opencv_unique = len(set(opencv_actual))
    pyav_unique = len(set(pyav_actual))
    print(f"opencv returned {opencv_unique} distinct frames")
    print(f"pyav   returned {pyav_unique} distinct frames")
    if opencv_unique == pyav_unique == NUM_SAMPLED:
        print("\nPASS: pyav and opencv agree, all requested frames returned.")
    elif pyav_unique < opencv_unique:
        print(f"\nFAIL: pyav collapsed {NUM_SAMPLED} requested slots onto "
              f"{pyav_unique} distinct frame(s) — keyframe-snap bug present.")
    else:
        print(f"\nFAIL: backends disagree (opencv={opencv_unique}, "
              f"pyav={pyav_unique} distinct frames).")


if __name__ == "__main__":
    main()
```
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
