### PR TITLE
feat(lmcache): add readonly mode for kv cache

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -680,6 +680,19 @@ class LMCacheConnectorV1Impl:
 
         self.force_skip_save = bool(os.environ.get("LMCACHE_FORCE_SKIP_SAVE", False))
 
+        # Readonly flag file path: when this file exists, KV cache writes are
+        # disabled (only reads are allowed). This allows dynamic switching at
+        # runtime without restarting the service.
+        # Usage:
+        #   Enable readonly:  touch /tmp/lmcache_readonly
+        #   Disable readonly: rm /tmp/lmcache_readonly
+        # Alternatively, set env var LMCACHE_READONLY=1 at startup for a
+        # static readonly mode.
+        self._readonly_flag_file = os.environ.get(
+            "LMCACHE_READONLY_FLAG_FILE", "/tmp/lmcache_readonly"
+        )
+        self._static_readonly = bool(os.environ.get("LMCACHE_READONLY", False))
+
         self._requests_priority: dict[str, int] = {}
 
         # TODO(baoloongmao): Internal api server & plugin framework support
@@ -713,6 +726,31 @@ class LMCacheConnectorV1Impl:
             VLLM_VERSION,
             getattr(self.lmcache_engine, "metadata", None),
         )
+
+    def _is_readonly(self) -> bool:
+        """Check whether KV cache is currently in readonly mode.
+
+        Readonly mode prevents any KV cache writes (saves) while still
+        allowing reads (loads). This is useful for scenarios like stress
+        testing where you don't want test traffic to overwrite the existing
+        cached KV data.
+
+        The readonly state is determined by (in priority order):
+        1. Static readonly: ``LMCACHE_READONLY=1`` env var set at startup.
+        2. Dynamic readonly: the flag file (default ``/tmp/lmcache_readonly``)
+           exists on disk. The file path can be customised via the
+           ``LMCACHE_READONLY_FLAG_FILE`` env var.
+
+        Dynamic switching (no service restart required):
+            Enable readonly:  ``touch /tmp/lmcache_readonly``
+            Disable readonly: ``rm /tmp/lmcache_readonly``
+
+        Returns:
+            bool: True if KV cache is in readonly mode, False otherwise.
+        """
+        if self._static_readonly:
+            return True
+        return os.path.exists(self._readonly_flag_file)
 
     def get_inference_info(self) -> dict:
         """Get inference information including vLLM config and related details.
@@ -953,6 +991,10 @@ class LMCacheConnectorV1Impl:
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
             return
+
+        if self._is_readonly():
+            # Don't do save in readonly mode
+            return
         if self._parent._connector_metadata is None:
             logger.warning(
                 "In connector.save_kv_layer, but the connector metadata is None"
@@ -1042,6 +1084,10 @@ class LMCacheConnectorV1Impl:
 
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
+            return
+
+        if self._is_readonly():
+            # Don't do save in readonly mode
             return
 
         if self.use_layerwise:
@@ -1306,7 +1352,16 @@ class LMCacheConnectorV1Impl:
             scheduler_output (SchedulerOutput): the scheduler output object.
         """
 
-        force_skip_save = self.kv_role == "kv_consumer" or self.force_skip_save
+        is_readonly = self._is_readonly()
+        if is_readonly:
+            logger.info(
+                "KV cache is in readonly mode, skipping all KV cache saves. "
+                "To disable readonly mode, remove the flag file: %s",
+                self._readonly_flag_file,
+            )
+        force_skip_save = (
+            self.kv_role == "kv_consumer" or self.force_skip_save or is_readonly
+        )
 
         meta = LMCacheConnectorMetadata()
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import enum
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
@@ -522,9 +523,39 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         self.vllm_block_size = vllm_config.cache_config.block_size
 
+        # Readonly flag file path: when this file exists, KV cache writes
+        # (STORE operations) are disabled while reads (RETRIEVE) still work.
+        # This allows dynamic switching at runtime without restarting.
+        # Usage:
+        #   Enable readonly:  touch /tmp/lmcache_readonly
+        #   Disable readonly: rm /tmp/lmcache_readonly
+        self._readonly_flag_file = os.environ.get(
+            "LMCACHE_READONLY_FLAG_FILE", "/tmp/lmcache_readonly"
+        )
+        self._static_readonly = bool(os.environ.get("LMCACHE_READONLY", False))
+
     @property
     def role(self) -> KVConnectorRole:
         return self._role
+
+    def _is_readonly(self) -> bool:
+        """Check whether KV cache is currently in readonly mode.
+
+        Readonly mode prevents any KV cache writes (STORE operations)
+        while still allowing reads (RETRIEVE). This is useful for
+        scenarios like stress testing where you don't want test traffic
+        to overwrite the existing cached KV data in the shared pool.
+
+        Dynamic switching (no service restart required):
+            Enable readonly:  ``touch /tmp/lmcache_readonly``
+            Disable readonly: ``rm /tmp/lmcache_readonly``
+
+        Returns:
+            bool: True if KV cache is in readonly mode.
+        """
+        if self._static_readonly:
+            return True
+        return os.path.exists(self._readonly_flag_file)
 
     # ==============================
     # Worker-side methods
@@ -637,6 +668,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         This prevents overwrites of paged KV buffer before saving done.
         """
+        # Don't do save in readonly mode
+        if self._is_readonly():
+            return
+
         # In MLA scenario, only the first rank of the pipeline group
         # needs to save the KV cache.
         if (
@@ -1047,6 +1082,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         scheduler_output: SchedulerOutput,
         metadata: LMCacheMPConnectorMetadata,
     ) -> None:
+        is_readonly = self._is_readonly()
         blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
 
         for new_request in scheduler_output.scheduled_new_reqs:
@@ -1054,6 +1090,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
             num_new_tokens = scheduler_output.num_scheduled_tokens[new_request.req_id]
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            # Skip STORE in readonly mode
+            if is_readonly:
+                continue
 
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
                 request_tracker, blocks_per_chunk, self.vllm_block_size
@@ -1066,6 +1106,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         scheduler_output: SchedulerOutput,
         metadata: LMCacheMPConnectorMetadata,
     ) -> None:
+        is_readonly = self._is_readonly()
         blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
@@ -1081,6 +1122,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             # stay consistent with _process_new_requests.
             num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            # Skip STORE in readonly mode
+            if is_readonly:
+                continue
 
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
                 request_tracker, blocks_per_chunk, self.vllm_block_size


### PR DESCRIPTION
This commit introduces a readonly mode for the LMCache KV connector, preventing KV cache writes (STORE operations) during scenarios like stress testing to protect the shared cache pool. The readonly state can be toggled dynamically at runtime using a flag file (default: /tmp/lmcache_readonly), or statically at startup via the LMCACHE_READONLY environment variable. Both single-process and multi-process (MP) connectors are supported.


## Purpose
Add a readonly mode for the LMCache KV connector. 

In production environments where multiple vLLM instances share a centralized KV Cache pool (via LMCache), stress testing or benchmarking traffic can inadvertently overwrite and flush out valuable cached KV data generated by real user traffic. This causes a significant performance drop (cache miss) after the stress test ends.

This PR introduces a mechanism to dynamically toggle a "readonly" mode for LMCache:
- **Dynamic Toggle**: By creating a flag file (default: `/tmp/lmcache_readonly`), vLLM instances will immediately stop sending `STORE` operations to LMCache, while `RETRIEVE` operations continue to work. Removing the file resumes normal read-write behavior. No service restart is required.
- **Static Config**: Can also be enabled at startup via `export LMCACHE_READONLY=1`.
- **Scope**: Supported in both `LMCacheConnectorV1Impl` (single-process) and `LMCacheMPConnector` (multi-process).

*Note: I used AI assistance (Claude) to help write and format this code, as required by the AGENTS.md policy.*

## Test Plan
1. Run `pre-commit run --all-files` to ensure code formatting and linting pass.
2. Start a vLLM instance with LMCache enabled.
3. Send a prompt to generate KV cache (verify cache is stored).
4. Enable readonly mode: `touch /tmp/lmcache_readonly`.
5. Send a new, unique prompt.
6. Verify that the new prompt's KV cache is **not** stored in LMCache (cache miss on subsequent identical requests).
7. Disable readonly mode: `rm /tmp/lmcache_readonly`.
8. Send another new prompt and verify it is stored normally.

## Test Result
- `pre-commit` checks passed successfully.
- Verified locally that when `/tmp/lmcache_readonly` exists, `force_skip_save` is triggered in the scheduler, and `wait_for_save` / `save_kv_layer` bypass the store operations in the worker.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
