### PR TITLE
[Dependency] Remove stale cuDNN frontend upper bound

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -13,9 +13,7 @@ flashinfer-python==0.6.12
 flashinfer-cubin==0.6.12
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
-# Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
-# breaking changes in 1.19.0
-nvidia-cudnn-frontend>=1.13.0,<1.19.0
+nvidia-cudnn-frontend>=1.19.1
 
 # Required for faster safetensors model loading
 fastsafetensors >= 0.3.2


### PR DESCRIPTION
## Summary

Remove the stale upper bound on `nvidia-cudnn-frontend` since the breaking changes in `1.19.0` have been fixed. The constraint is now `>=1.19.1`, which excludes `1.19.0` while letting vLLM pick up newer cuDNN frontend fixes and improvements. This is compatible with FlashInfer's `>=1.13.0` requirement.