### PR TITLE
Revert "[Attention] Sync FA with upstream (#41052)"

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -39,7 +39,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG bce29425653ec0fbc579d329883030e832d15ada
+          GIT_TAG f5bc33cfc02c744d24a2e9d50e6db656de40611c
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
## Summary

Reverts the flash attention upstream sync (commit dcacdf9a88, PR #41052) which causes accuracy regression in the Hybrid SSM NixlConnector PD accuracy test.

- **Failing test:** `tests/v1/kv_connector/nixl_integration/test_accuracy.py::test_accuracy` with `ibm-granite/granite-4.0-h-tiny`
- **Expected accuracy:** 0.80 | **Measured:** 0.7665 (outside ±0.03 tolerance)
- **Failing build:** [Nightly #65989](https://buildkite.com/vllm/ci/builds/65989)

## Bisect evidence

| Build | nixl | Flash Attention | Hybrid SSM Test |
|-------|------|-----------------|-----------------|
| #65912 (daily) | 0.10.1 | old `f5bc33c` | **PASS** |
| #65890 (PR #42364 CI) | 1.1.0 | old `f5bc33c` | **PASS** |
| #65989 (nightly) | 1.1.0 | new `bce2942` | **FAIL** |

The FA sync (#41052) is the only variable that changes between the passing PR build (#65890) and the failing nightly (#65989). Single-instance accuracy is unaffected (~0.787 at both commits), so the regression is specific to the P/D disaggregated path — the new FA likely produces subtly different KV cache values during prefill that cascade when transferred via nixl to the decode node.

The FA sync included 57 upstream commits with changes to `varlen_fwd` argument passing, causal calculation fixes, and fp8 rescale changes.

## Test plan

- CI should re-run the Hybrid SSM NixlConnector PD accuracy test and pass
- All other nixl accuracy tests were unaffected and should remain passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>