### PR TITLE
[Bugfix] Clamp NVFP4 MoE activation scales to prevent NaN from dead experts

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -497,11 +497,15 @@ def make_nvfp4_moe_quant_config(
     # The expert's process_weights_after_loading will fuse activation
     # scales in-place. Since the quant config references the same tensor
     # as the registered parameter, EPLB rearrangement stays in sync.
+    # Clamp scales from below at the smallest normal float32 before inverting.
+    # Some checkpoints (e.g. Qwen3.5-122B) have denormal (~0) input_scale for
+    # dead experts, causing 1/scale = Inf → NaN in the FP4 quantization kernel.
+    _tiny = torch.finfo(torch.float32).tiny
     return nvfp4_moe_quant_config(
         g1_alphas=w13_scale_2,
         g2_alphas=w2_scale_2,
-        a1_gscale=(1.0 / a13_scale),
-        a2_gscale=(1.0 / a2_scale),
+        a1_gscale=(1.0 / a13_scale.clamp(min=_tiny)),
+        a2_gscale=(1.0 / a2_scale.clamp(min=_tiny)),
         w1_scale=w13_scale,
         w2_scale=w2_scale,
         # NOTE(rob): this is a hack until the MoE kernels


### PR DESCRIPTION
## Summary

Some NVFP4 checkpoints (e.g. `txn545/Qwen3.5-122B-A10B-NVFP4`) have near-zero or denormal `float32` activation scales for dead MoE experts. In `make_nvfp4_moe_quant_config()`, these are inverted directly (`1.0 / a13_scale`, `1.0 / a2_scale`), producing `Inf`, which the FP4 quantization kernel propagates as `NaN` — corrupting the entire output batch.

Fix: clamp both activation global scales from below at `torch.finfo(torch.float32).tiny` (~1.18e-38) before inversion. Dead experts contribute zero-weighted outputs regardless of their scale value, so this clamp is numerically safe.

- This is not a duplicate of #31740 (which covers SM12.1 platform support); that PR does not touch `oracle/nvfp4.py`.

## Test plan

- Loaded `txn545/Qwen3.5-122B-A10B-NVFP4` on DGX Spark (SM12.1, CUDA 13.1) with vLLM v0.20.2 + this patch
- Ran multi-turn chat completions — no NaN/Inf in outputs
- Without the patch, outputs contain NaN tokens when dead experts are routed

> AI assistance was used to help identify and describe this fix.