### PR TITLE
[Compile][ROCm][MiniMax-M2] Enable MiniMaxQKNormPass on ROCm via AITER fused_qknorm_allreduce

### DIFF
--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -196,7 +196,10 @@ If these conditions are set, the fusion is enabled automatically for optimizatio
 !!! info
     This is a MiniMax-specific compile pass. It is currently only enabled when all of the following hold:
     the model architecture is `MiniMaxM2ForCausalLM`, tensor parallelism is enabled (`tp_size > 1`),
-    and the CUDA custom op `minimax_allreduce_rms_qk` is available. It is not enabled by default at any
+    and a fused backend is available on the current platform — either the CUDA custom op
+    `minimax_allreduce_rms_qk`, or, on ROCm, AITER's `CustomAllreduce.custom_fused_qknorm_ar`
+    (requires `VLLM_ROCM_USE_AITER=1` and an aiter build that contains
+    [ROCm/aiter#3163](https://github.com/ROCm/aiter/pull/3163)). It is not enabled by default at any
     optimization level.
 
 **What it fuses.** Fuses the MiniMax M2 Q/K normalization path that performs an all-reduce over the
@@ -218,7 +221,8 @@ vllm serve MiniMaxAI/MiniMax-M2.5 \
 
 - Pass: [`vllm/compilation/passes/fusion/minimax_qk_norm_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/minimax_qk_norm_fusion.py)
 - CUDA op: [`csrc/minimax_reduce_rms_kernel.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/minimax_reduce_rms_kernel.cu) (`minimax_allreduce_rms_qk`)
-- Workspace helper: [`vllm/model_executor/layers/mamba/lamport_workspace.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/mamba/lamport_workspace.py)
+- CUDA workspace helper: [`vllm/model_executor/layers/mamba/lamport_workspace.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/mamba/lamport_workspace.py)
+- ROCm op: AITER's `CustomAllreduce.custom_fused_qknorm_ar`, routed via [`rocm_aiter_ops`](https://github.com/vllm-project/vllm/blob/main/vllm/_aiter_ops.py) (no in-tree workspace; aiter manages its own IPC buffers)
 
 ### Sequence Parallelism (`enable_sp`)
 

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -60,6 +60,13 @@ class AiterCustomAllreduceProto(Protocol):
         registered: bool = False,
         use_1stage: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]: ...
+    def custom_fused_qknorm_ar(
+        self,
+        qkv_in: torch.Tensor,
+        q_w: torch.Tensor,
+        k_w: torch.Tensor,
+        eps: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]: ...
     def should_custom_ar(self, inp: torch.Tensor) -> bool: ...
 
 
@@ -1441,6 +1448,11 @@ class rocm_aiter_ops:
     def initialize_aiter_allreduce(
         cls, group: ProcessGroup, device: torch.device
     ) -> None:
+        # Idempotent: subsequent callers (e.g. multiple fusion passes
+        # initialising on the same TP group) re-use the existing instance to
+        # avoid leaking the previous CustomAllreduce's IPC handles.
+        if cls._CUSTOM_ALL_REDUCE is not None:
+            return
         try:
             from aiter.dist.device_communicators.custom_all_reduce import (
                 CustomAllreduce as AiterCustomAllreduce,

--- a/vllm/compilation/passes/fusion/minimax_qk_norm_fusion.py
+++ b/vllm/compilation/passes/fusion/minimax_qk_norm_fusion.py
@@ -26,11 +26,14 @@ is_applicable_for_range: only fires for compile_range.end <= max_decode_tokens
 so that large prefill batches fall through to the original forward_qk (= main).
 """
 
+import contextlib
+
 import torch
 import torch._inductor.pattern_matcher as pm
 import torch.fx as fx
 from torch._inductor.pattern_matcher import PatternMatcherPass
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
 from vllm.distributed import tensor_model_parallel_all_reduce
@@ -39,6 +42,7 @@ from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from ..inductor_pass import enable_fake_mode
@@ -46,10 +50,30 @@ from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
 
 logger = init_logger(__name__)
 
-MAX_TOKEN_NUM = 2048
+# Backend selection for the fused op:
+#   "cuda" -> torch.ops._C.minimax_allreduce_rms_qk (NVIDIA TensorRT-LLM port),
+#            uses an in-tree Lamport workspace.
+#   "rocm" -> AITER's CustomAllreduce.custom_fused_qknorm_ar (ROCm/aiter#3163),
+#            uses AITER's own IPC buffers. Gated on VLLM_ROCM_USE_AITER and
+#            validated against the loaded aiter build at pass init.
+_BACKEND: str | None = None
+if current_platform.is_cuda() and hasattr(
+    torch.ops._C, "minimax_allreduce_rms_qk"
+):
+    _BACKEND = "cuda"
+elif current_platform.is_rocm() and rocm_aiter_ops.is_enabled():
+    _BACKEND = "rocm"
+
+# Largest token count the fused kernel can handle. The CUDA in-tree kernel
+# accepts up to 2048; the AITER ROCm/aiter#3163 kernel is currently capped at
+# `kMaxBlocks = 80` (csrc/include/custom_all_reduce.cuh). The pass uses this
+# as its `is_applicable_for_range` ceiling and as the compile-range endpoint
+# in `vllm/config/vllm.py` so cudagraphs above the ceiling fall through to
+# the unfused `MiniMaxText01RMSNormTP.forward_qk` chain.
+MAX_TOKEN_NUM = 80 if _BACKEND == "rocm" else 2048
 
 _MINIMAX_QK_NORM_FUSED_OP = None
-if hasattr(torch.ops._C, "minimax_allreduce_rms_qk"):
+if _BACKEND is not None:
 
     def _minimax_qk_norm_fused(
         qkv: torch.Tensor,
@@ -62,28 +86,43 @@ if hasattr(torch.ops._C, "minimax_allreduce_rms_qk"):
         eps: float,
         max_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        from vllm.distributed.parallel_state import get_tp_group
-        from vllm.model_executor.layers.mamba.lamport_workspace import (
-            get_allreduce_workspace,
-        )
+        if _BACKEND == "cuda":
+            from vllm.distributed.parallel_state import get_tp_group
+            from vllm.model_executor.layers.mamba.lamport_workspace import (
+                get_allreduce_workspace,
+            )
 
-        workspace = get_allreduce_workspace(
-            rank=rank,
-            world_size=nranks,
-            max_tokens=max_tokens,
-            process_group=get_tp_group().cpu_group,
+            workspace = get_allreduce_workspace(
+                rank=rank,
+                world_size=nranks,
+                max_tokens=max_tokens,
+                process_group=get_tp_group().cpu_group,
+            )
+            return torch.ops._C.minimax_allreduce_rms_qk(
+                qkv,
+                norm_weight_q,
+                norm_weight_k,
+                workspace,
+                q_size,
+                kv_size,
+                rank,
+                nranks,
+                eps,
+            )
+        # ROCm: route through AITER's custom_all_reduce instance, which the
+        # MiniMaxQKNormPass has already initialized for this TP group. Raise
+        # rather than `assert` so the check survives `python -O`; rank, nranks
+        # and max_tokens are unused on this path (workspace lives in aiter).
+        ca = rocm_aiter_ops.get_aiter_allreduce()
+        if ca is None or not hasattr(ca, "custom_fused_qknorm_ar"):
+            raise RuntimeError(
+                "MiniMaxQKNormPass ROCm path requires aiter with "
+                "CustomAllreduce.custom_fused_qknorm_ar (ROCm/aiter#3163)."
+            )
+        q_out, k_out, _v_out = ca.custom_fused_qknorm_ar(
+            qkv, norm_weight_q, norm_weight_k, eps
         )
-        return torch.ops._C.minimax_allreduce_rms_qk(
-            qkv,
-            norm_weight_q,
-            norm_weight_k,
-            workspace,
-            q_size,
-            kv_size,
-            rank,
-            nranks,
-            eps,
-        )
+        return q_out, k_out
 
     def _minimax_qk_norm_fused_fake(
         qkv: torch.Tensor,
@@ -237,7 +276,9 @@ class MiniMaxQKNormPass(VllmPatternMatcherPass):
 
         if _MINIMAX_QK_NORM_FUSED_OP is None:
             logger.warning_once(
-                "minimax_allreduce_rms_qk op not found, MiniMaxQKNormPass disabled."
+                "MiniMaxQKNormPass disabled: no backend available "
+                "(CUDA op `minimax_allreduce_rms_qk` not built, and AITER "
+                "either disabled via VLLM_ROCM_USE_AITER=0 or not installed)."
             )
             return
 
@@ -283,18 +324,56 @@ class MiniMaxQKNormPass(VllmPatternMatcherPass):
         )
 
         tp_rank = get_tensor_model_parallel_rank()
-        # Allocate Lamport workspace first.
         from vllm.distributed.parallel_state import get_tp_group
-        from vllm.model_executor.layers.mamba.lamport_workspace import (
-            get_allreduce_workspace,
-        )
 
-        get_allreduce_workspace(
-            rank=tp_rank,
-            world_size=tp_world,
-            max_tokens=self.max_token_num,
-            process_group=get_tp_group().cpu_group,
-        )
+        if _BACKEND == "cuda":
+            # Allocate the Lamport workspace consumed by
+            # torch.ops._C.minimax_allreduce_rms_qk.
+            from vllm.model_executor.layers.mamba.lamport_workspace import (
+                get_allreduce_workspace,
+            )
+
+            get_allreduce_workspace(
+                rank=tp_rank,
+                world_size=tp_world,
+                max_tokens=self.max_token_num,
+                process_group=get_tp_group().cpu_group,
+            )
+        else:
+            # ROCm: the AITER fused kernel needs a custom-allreduce-backed
+            # device communicator. Honour `disable_custom_all_reduce` and
+            # silently fall back to the unfused path if vLLM didn't set one
+            # up (mirrors RocmAiterAllReduceFusionPass's precedent).
+            device_comm = get_tp_group().device_communicator
+            if device_comm is None or getattr(device_comm, "ca_comm", None) is None:
+                logger.warning_once(
+                    "MiniMaxQKNormPass disabled on ROCm: custom_all_reduce "
+                    "is not available (either disable_custom_all_reduce=True "
+                    "or the device communicator is missing)."
+                )
+                return
+            # Idempotent across passes/layers; the underlying
+            # initialize_aiter_allreduce is a no-op if already constructed.
+            preexisting = rocm_aiter_ops.get_aiter_allreduce() is not None
+            rocm_aiter_ops.initialize_aiter_allreduce(
+                get_tp_group().cpu_group, self.device
+            )
+            # Track whether *we* are the owner of the AITER CustomAllreduce so
+            # __del__ only tears it down when this pass instance constructed
+            # it (avoids ripping the CA out from under a sibling fusion pass).
+            self._owns_aiter_ca = not preexisting
+            ca = rocm_aiter_ops.get_aiter_allreduce()
+            if ca is None or not hasattr(ca, "custom_fused_qknorm_ar"):
+                logger.warning_once(
+                    "MiniMaxQKNormPass disabled on ROCm: aiter "
+                    "CustomAllreduce.custom_fused_qknorm_ar is unavailable "
+                    "(requires aiter built from ROCm/aiter#3163 or later)."
+                )
+                if self._owns_aiter_ca:
+                    with contextlib.suppress(Exception):
+                        rocm_aiter_ops.destroy_aiter_allreduce()
+                    self._owns_aiter_ca = False
+                return
 
         self.patterns: PatternMatcherPass = PatternMatcherPass(
             pass_name="minimax_qk_norm_pass"
@@ -338,3 +417,16 @@ class MiniMaxQKNormPass(VllmPatternMatcherPass):
 
     def uuid(self) -> str:
         return VllmInductorPass.hash_source(self, MiniMaxQKNormPattern)
+
+    def __del__(self) -> None:
+        # Only tear down the AITER CustomAllreduce if *this* pass instance
+        # constructed it; otherwise a sibling pass (e.g.
+        # RocmAiterAllReduceFusionPass) still owns and uses it.
+        if (
+            getattr(self, "disabled", True)
+            or _BACKEND != "rocm"
+            or not getattr(self, "_owns_aiter_ca", False)
+        ):
+            return
+        with contextlib.suppress(Exception):
+            rocm_aiter_ops.destroy_aiter_allreduce()

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -32,6 +32,7 @@ if rocm_aiter_ops.is_enabled():
 if current_platform.is_cuda_alike():
     from .fusion.act_quant_fusion import ActivationQuantFusionPass
     from .fusion.attn_quant_fusion import AttnQuantFusionPass
+    from .fusion.minimax_qk_norm_fusion import MiniMaxQKNormPass
     from .fusion.mla_attn_quant_fusion import MLAAttnQuantFusionPass
     from .fusion.mla_rope_kvcache_cat_fusion import MLARoPEKVCacheCatFusionPass
     from .fusion.qk_norm_rope_fusion import QKNormRoPEFusionPass
@@ -44,7 +45,6 @@ if current_platform.is_cuda_alike():
 if current_platform.is_cuda():
     from .fusion.allreduce_rms_fusion import AllReduceFusionPass
     from .fusion.collective_fusion import AsyncTPPass
-    from .fusion.minimax_qk_norm_fusion import MiniMaxQKNormPass
 
 from .inductor_pass import (
     CustomGraphPass,

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -135,7 +135,10 @@ class PassConfig:
     fuse_allreduce_rms: bool = None  # type: ignore[assignment]
     """Enable flashinfer allreduce fusion."""
     fuse_minimax_qk_norm: bool = None  # type: ignore[assignment]
-    """Enable fused allreduce+RMSNorm for MiniMax QK norm."""
+    """Enable fused allreduce+RMSNorm for MiniMax QK norm. On CUDA uses the
+    in-tree Lamport kernel; on ROCm routes through the AITER fused
+    qknorm+allreduce kernel (requires aiter built from ROCm/aiter#3163 or
+    later and a custom_all_reduce-backed device communicator)."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
     fuse_rope_kvcache_cat_mla: bool = None  # type: ignore[assignment]


### PR DESCRIPTION
> **⚠️ Dependency requirement — not mergeable without AITER version bump**
> This PR requires `aiter` to be bumped to a build that includes the merged kernel [ROCm/aiter#3163](https://github.com/ROCm/aiter/pull/3163) (commit `4df783aa9dcce5c46a8f35ebc89b724d67c9eef0` or any subsequent tag). Without that bump the pass disables itself silently and the model falls back to the unfused path but the perf win cited in **Test Result** is only realized after the bump.

---

## Purpose

Enable the existing `MiniMaxQKNormPass` FX fusion pass currently CUDA-only to also fire on ROCm. The replacement op now dispatches by platform:

- **CUDA** (unchanged): `torch.ops._C.minimax_allreduce_rms_qk` + the in-tree Lamport workspace.
- **ROCm** (new): AITER's `CustomAllreduce.custom_fused_qknorm_ar` from [ROCm/aiter#3163](https://github.com/ROCm/aiter/pull/3163), reusing the AITER `custom_all_reduce` instance that `rocm_aiter_ops` already manages for `fused_allreduce_rms` and friends. AITER's kernel collapses the per-token `(q_var, k_var)` AllReduce (2 fp32 / token) and the rsqrt + per-channel weight into a single graph-capture-safe kernel.

UX matches the CUDA path exactly:

```bash
vllm serve MiniMaxAI/MiniMax-M2.5 \
  --tensor-parallel-size 4 \
  --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
```

No new env var. No model-file changes. Honours `--disable-custom-all-reduce` and `VLLM_ROCM_USE_AITER=0` (the pass disables itself when either is set or when aiter is missing / older than #3163, falling back to the unfused `MiniMaxText01RMSNormTP.forward_qk` chain).

Note on `MAX_TOKEN_NUM`: AITER's `qknorm_allreduce_fusion_kernel_2stage` has a hard cap of `kMaxBlocks = 80` tokens (`csrc/include/custom_all_reduce.cuh`); the pass advertises `MAX_TOKEN_NUM = 80` on ROCm (vs. 2048 on CUDA) so cudagraphs above 80 tokens fall through to the unfused chain and the fused kernel is only used for decode-size batches where it actually wins.

Opening this now to ensure readiness once AITER is bumped and iron out issues with integration

### Why piggy-back on the existing pass instead of a new ROCm-only pass

- One `pass_config` flag, one set of patterns, one place to evolve.
- Reuses the `rocm_aiter_ops.initialize_aiter_allreduce(...)` precedent established by `RocmAiterAllReduceFusionPass`, so the AITER CustomAllreduce instance is shared rather than duplicated.
- CUDA is bit-for-bit unchanged - the `if hasattr(...)` gate is just nested behind an explicit `current_platform.is_cuda()` (defense-in-depth, same semantics).

## Test Plan

### 1. Smoke: pass loads and fires on ROCm

```bash
HIP_VISIBLE_DEVICES=0,1 \
VLLM_ROCM_USE_AITER=1 \
vllm serve MiniMaxAI/MiniMax-M2.5 \
  --tensor-parallel-size 2 \
  --kv-cache-dtype fp8 \
  --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
  --trust-remote-code
```

Expected: server boots without errors; the engine config shows `Enabled custom fusions: ..., minimax_qk_norm, ...` and `compile_ranges_endpoints` begins with `80`; `aiter::CustomAllreduce::dispatchFusedQKNormAllReduce<T>` is invoked from inside the captured graphs.

**Verified locally (TP=2, MiniMax-M2.5, MI355X) with `VLLM_LOGGING_LEVEL=DEBUG`:**

```
INFO  [config/compilation.py:315] Enabled custom fusions: norm_quant, act_quant, allreduce_rms, minimax_qk_norm, mla_dual_rms_norm
DEBUG [minimax_qk_norm_fusion.py:416] MiniMaxQKNormPass replaced 1 patterns       # decode compile-range, TP0
DEBUG [minimax_qk_norm_fusion.py:416] MiniMaxQKNormPass replaced 1 patterns       # decode compile-range, TP1
DEBUG [minimax_qk_norm_fusion.py:416] MiniMaxQKNormPass replaced 1 patterns       # mid compile-range, TP0
DEBUG [minimax_qk_norm_fusion.py:416] MiniMaxQKNormPass replaced 1 patterns       # mid compile-range, TP1
DEBUG [minimax_qk_norm_fusion.py:416] MiniMaxQKNormPass replaced 0 patterns       # prefill compile-range (end > 80), TP0
DEBUG [minimax_qk_norm_fusion.py:416] MiniMaxQKNormPass replaced 0 patterns       # prefill compile-range (end > 80), TP1
```

Pass fires for compile-ranges with `end ≤ 80` (one match per piecewise sub-graph, which is one `forward_qk` because vLLM splits on `unified_attention_with_output`) and correctly returns 0 matches for the prefill range above the kernel cap — confirming both the fusion path and the safe fall-through.

### 2. Fallback paths

| Scenario | Expected |
|---|---|
| `VLLM_ROCM_USE_AITER=0` | Pass disables (`_BACKEND=None`, op not registered). |
| `--disable-custom-all-reduce` | Pass disables (`ca_comm is None` guard fires; any pre-existing AITER CA is left untouched). |
| aiter older than ROCm/aiter#3163 | Pass disables (`hasattr(ca, "custom_fused_qknorm_ar")` is `False`; any CA we constructed is torn down before returning, tracked via `self._owns_aiter_ca`). |
| `tp_size == 1` | Pass disables (existing guard). |

Each is exercised by toggling the relevant flag/env and confirming the `warning_once` message in the server log + that the model still serves requests via the unfused `MiniMaxText01RMSNormTP.forward_qk` path.

### 3. Numerical correctness

The AITER kernel itself is validated against a NumPy reference in [`op_tests/multigpu_tests/test_fused_qknorm_ar.py`](https://github.com/ROCm/aiter/blob/main/op_tests/multigpu_tests/test_fused_qknorm_ar.py) (landed with ROCm/aiter#3163) at TP ∈ {2, 4, 8}, dtype ∈ {fp16, bf16}, and multiple shapes.

End-to-end on this PR:

```bash
lm_eval --model local-completions \
  --model_args "base_url=http://127.0.0.1:8019/v1/completions,model=MiniMaxAI/MiniMax-M2.5,tokenizer=MiniMaxAI/MiniMax-M2.5,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
  --tasks gsm8k --num_fewshot 5 --limit 256
```

with `fuse_minimax_qk_norm` on vs. off (TP=2, MI355X). See **Test Result** below.

### 4. CUDA non-regression

The CUDA path is behaviourally unchanged. The only CUDA-touching line is the new explicit `current_platform.is_cuda()` guard around the `hasattr` check — a no-op on any current CUDA build. Existing `fuse_minimax_qk_norm=true` CUDA serve continues to fire the pass with the same `_C` op and Lamport workspace as before.

## Test Result

Apples-to-apples A/B against the same vLLM + AITER build (PR + ROCm/aiter#3163 applied as overlay; shared compile cache flushed between arms; 3 iterations per cell, 64 prompts × 1000-token input × 100-token output, FP8 KV cache).

### TP=2 (MI355X)

| conc | Baseline median TPOT (ms) | Fused median TPOT (ms) | Δ TPOT | Baseline OTPS (tok/s) | Fused OTPS (tok/s) | Δ OTPS |
|---:|---:|---:|---:|---:|---:|---:|
| 16 | 18.50 | **16.64** | **−10.1 %** | 707  | **778**  | **+10.0 %** |
| 64 | 33.13 | **31.08** | **−6.2 %**  | 1518 | **1607** | **+5.9 %**  |

### TP=4 (MI355X), conc = 16

| Iter | Baseline TPOT (ms) | Fused TPOT (ms) | Δ |
|---:|---:|---:|---:|
| 1 | 15.61 | 13.93 | −10.8 % |
| 2 | 15.46 | 13.96 | −9.7 %  |
| 3 | 15.28 | 13.79 | −9.8 %  |
| **median** | **15.46** | **13.93** | **−9.9 %** |

Output throughput at TP=4 conc=16: 854 → **935 tok/s** (**+9.5 %**).

### Accuracy — lm-eval gsm8k (TP=2, `--limit 256`, 5-shot)

|                    | Baseline           | Fused              | Δ        |
|---|---:|---:|---:|
| flexible-extract   | 0.9492 ± 0.0137    | **0.9375 ± 0.0152** | −0.0117 |
| strict-match       | 0.9453 ± 0.0142    | **0.9297 ± 0.0160** | −0.0156 |


