### PR TITLE
[Quant][Triton] Support modelopt_mixed on SM80/SM86 (Ampere)

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -6,12 +6,207 @@
 # version library first.  Such assumption is critical for some customization.
 from .version import __version__, __version_tuple__  # isort:skip
 
+import functools
+import logging
 import typing
+from typing import Optional
 
 # The environment variables override should be imported before any other
 # modules to ensure that the environment variables are set before any
 # other modules are imported.
 import vllm.env_override  # noqa: F401
+
+
+def _install_triton_fp8e4nv_pre_sm89_patch() -> None:
+    """Install the fp8e4nv pre-SM89 Triton compatibility patch in memory.
+
+    This mirrors the runtime behavior from Triton PR #10292 without rewriting
+    Triton's installed files. vLLM can then compile kernels that pass fp8e4nv
+    pointers opaquely on A100/SM80 and RTX 30xx/SM86, while actual fp8e4nv
+    compute on those GPUs still fails with a clear compile-time error.
+    """
+    from collections.abc import Iterable
+    from typing import Any
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        from triton.backends.nvidia import compiler as nvidia_compiler
+    except Exception:
+        logger.warning(
+            "Could not import Triton NVIDIA compiler; fp8e4nv pointer use "
+            "on SM80/SM86 may fail at Triton compile time.",
+            exc_info=True,
+        )
+        return
+
+    cuda_backend = getattr(nvidia_compiler, "CUDABackend", None)
+    if cuda_backend is None:
+        logger.warning(
+            "Triton NVIDIA compiler has no CUDABackend; fp8e4nv pointer use "
+            "on SM80/SM86 may fail at Triton compile time."
+        )
+        return
+
+    patched_attr = "_vllm_fp8e4nv_pre_sm89_patch"
+
+    def _add_item(items: Any, item: str) -> Any:
+        if item in items:
+            return items
+        if isinstance(items, frozenset):
+            return items | {item}
+        if isinstance(items, set):
+            updated = set(items)
+            updated.add(item)
+            return updated
+        if isinstance(items, tuple):
+            return (*items, item)
+        if isinstance(items, list):
+            return [*items, item]
+        if isinstance(items, Iterable) and not isinstance(items, str):
+            return (*tuple(items), item)
+        return (item,)
+
+    def _set_option(options: Any, name: str, value: Any) -> None:
+        try:
+            setattr(options, name, value)
+        except (AttributeError, TypeError):
+            object.__setattr__(options, name, value)
+
+    def _convert_fp8e4nv_pre_sm89(
+        arg: Any,
+        dst_ty: Any,
+        fp_downcast_rounding: Any = None,
+        _semantic: Any = None,
+    ) -> Any:
+        supported = _semantic.builder.options.supported_fp8_dtypes
+        raise ValueError(
+            "type fp8e4nv not supported in this architecture for compute "
+            "(no native or software conversion below compute capability 89). "
+            f"The supported fp8 dtypes are {supported}. "
+            "Pre-sm89 kernels may pass fp8e4nv pointers opaquely "
+            "(load/store/pass-through) but cannot convert to/from fp8e4nv."
+        )
+
+    current_parse_options = getattr(cuda_backend, "parse_options", None)
+    if current_parse_options is None:
+        logger.warning(
+            "CUDABackend has no parse_options; fp8e4nv pointer use on "
+            "SM80/SM86 may fail at Triton compile time."
+        )
+        return
+
+    if not getattr(current_parse_options, patched_attr, False):
+        original_parse_options = current_parse_options
+
+        @functools.wraps(original_parse_options)
+        def parse_options_with_fp8e4nv_pre_sm89(self, opts) -> Any:
+            options = original_parse_options(self, opts)
+            fp8_dtypes = getattr(options, "supported_fp8_dtypes", ())
+            _set_option(
+                options,
+                "supported_fp8_dtypes",
+                _add_item(fp8_dtypes, "fp8e4nv"),
+            )
+            capability = int(self._parse_arch(options.arch))
+            if capability < 89:
+                deprecated = getattr(options, "deprecated_fp8_dot_operand_dtypes", ())
+                _set_option(
+                    options,
+                    "deprecated_fp8_dot_operand_dtypes",
+                    _add_item(deprecated, "fp8e4nv"),
+                )
+            return options
+
+        setattr(parse_options_with_fp8e4nv_pre_sm89, patched_attr, True)
+        cuda_backend.parse_options = parse_options_with_fp8e4nv_pre_sm89
+
+    current_get_codegen = getattr(cuda_backend, "get_codegen_implementation", None)
+    if current_get_codegen is None:
+        logger.warning(
+            "CUDABackend has no get_codegen_implementation; actual fp8e4nv "
+            "compute on SM80/SM86 may fail with a lower-level Triton error."
+        )
+        return
+
+    if not getattr(current_get_codegen, patched_attr, False):
+        original_get_codegen = current_get_codegen
+
+        @functools.wraps(original_get_codegen)
+        def get_codegen_with_fp8e4nv_pre_sm89(self, options):
+            codegen_fns = original_get_codegen(self, options)
+            capability = int(self._parse_arch(options.arch))
+            if capability < 89:
+                codegen_fns["convert_fp8e4nv_pre_sm89"] = _convert_fp8e4nv_pre_sm89
+            return codegen_fns
+
+        setattr(get_codegen_with_fp8e4nv_pre_sm89, patched_attr, True)
+        cuda_backend.get_codegen_implementation = get_codegen_with_fp8e4nv_pre_sm89
+
+    try:
+        import triton.language as tl
+        from triton.language import semantic as triton_semantic
+        from triton.language.semantic import TensorTy
+    except Exception:
+        logger.warning(
+            "Could not import Triton semantic module; actual fp8e4nv compute "
+            "on SM80/SM86 may fail with a lower-level Triton error.",
+            exc_info=True,
+        )
+        return
+
+    triton_semantic_cls = getattr(triton_semantic, "TritonSemantic", None)
+    if triton_semantic_cls is None:
+        logger.warning(
+            "Triton semantic module has no TritonSemantic class; actual "
+            "fp8e4nv compute on SM80/SM86 may fail with a lower-level "
+            "Triton error."
+        )
+        return
+
+    current_cast = getattr(triton_semantic_cls, "cast", None)
+    if current_cast is None:
+        logger.warning(
+            "TritonSemantic has no cast method; actual fp8e4nv compute on "
+            "SM80/SM86 may fail with a lower-level Triton error."
+        )
+        return
+
+    if not getattr(current_cast, patched_attr, False):
+        original_cast = current_cast
+
+        @functools.wraps(original_cast)
+        def cast_with_fp8e4nv_pre_sm89(
+            self,
+            input: TensorTy,
+            dst_ty: tl.dtype,
+            fp_downcast_rounding: Optional[str] = None,  # noqa: UP045
+        ) -> TensorTy:
+            src_ty = input.type
+            normalized_dst_ty = dst_ty
+            if src_ty.is_block():
+                normalized_dst_ty = src_ty.with_element_ty(dst_ty.scalar)
+            if src_ty != normalized_dst_ty:
+                src_sca_ty = src_ty.scalar
+                dst_sca_ty = normalized_dst_ty.scalar
+                if src_sca_ty.is_fp8e4nv() or dst_sca_ty.is_fp8e4nv():
+                    convert = self.builder.codegen_fns.get("convert_fp8e4nv_pre_sm89")
+                    if convert is not None:
+                        return convert(
+                            input,
+                            normalized_dst_ty,
+                            fp_downcast_rounding,
+                            _semantic=self,
+                        )
+            return original_cast(self, input, dst_ty, fp_downcast_rounding)
+
+        setattr(cast_with_fp8e4nv_pre_sm89, patched_attr, True)
+        triton_semantic_cls.cast = cast_with_fp8e4nv_pre_sm89
+
+    logger.info("Installed in-memory Triton fp8e4nv pre-SM89 patch")
+
+
+_install_triton_fp8e4nv_pre_sm89_patch()
 
 MODULE_ATTRS = {
     "AsyncEngineArgs": ".engine.arg_utils:AsyncEngineArgs",

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -468,6 +468,11 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
+        # Needed by MarlinFP8ScaledMMLinearKernel.process_weights_after_loading:
+        # prepare_fp8_layer_for_marlin() casts weight_scale through
+        # layer.orig_dtype. Other FP8 quant methods set this in their own
+        # create_weights(); ModelOptFp8LinearMethod did not until now.
+        layer.orig_dtype = params_dtype
         weight_dtype = (
             torch.float8_e4m3fn
             if self.quant_config.is_checkpoint_fp8_serialized
@@ -2217,7 +2222,11 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 89
+        # Ampere (SM80 / SM86): NVFP4 routed experts run via Marlin W4A16,
+        # FP8 weight-only layers run via CutlassFP8 W8A16 (with the Triton
+        # fp8e4nv type-name patch applied at vllm import). No SM89 FP8
+        # tensor cores are required for modelopt_mixed using W8A16 for FP8 weights.
+        return 80
 
     @classmethod
     def override_quantization_method(


### PR DESCRIPTION
# Enable ModelOpt mixed precision checkpoints to run on Ampere-generation GPUs

## Summary

`ModelOptMixedPrecisionConfig` currently rejects Ampere GPUs at engine config
validation with "Minimum capability: 89". This PR lowers the gate to 80,
accepting A100 (SM80) and RTX 30-series (SM86), and adds the small support
change that makes the path functional on those cards.

## Motivation

`modelopt_mixed` checkpoints are routinely deployable on Ampere. The per-layer
kernel selection already routes correctly:

- NVFP4 routed-expert weights -> `MarlinNvFp4LinearKernel` (W4A16, supports
  SM75+).
- FP8 weight-only layers -> `CutlassFP8ScaledMMLinearKernel` (W8 weight, BF16
  compute on SM80+).

Three things still blocked Ampere:

1. `ModelOptMixedPrecisionConfig.get_min_capability()` returned 89, so the
   engine rejected the model before any kernel was selected. The 89 floor was
   originally for native FP8 tensor cores, but the layers in `modelopt_mixed`
   do not require them because they can be emulated (e.g., using w8a16, similar to FP4 being emulated using w4a16).
2. Triton's `CUDABackend.parse_options` gated the `fp8e4nv` type name behind
   capability >= 89. vLLM FP8 paths may name `fp8e4nv` in kernel signatures
   even when no `fp8e4nv` arithmetic is emitted, so the type-name gate failed
   before runtime kernel selection.
3. A third issue surfaced once the path was enabled:
`ModelOptFp8LinearMethod.create_weights()` did not set
`layer.orig_dtype = params_dtype`. `MarlinFP8ScaledMMLinearKernel`
`process_weights_after_loading()` casts `weight_scale` through
`layer.orig_dtype`; without the assignment the path raises `AttributeError`.

## Changes

`vllm/model_executor/layers/quantization/modelopt.py`

- `ModelOptMixedPrecisionConfig.get_min_capability()`: 89 -> 80.
- `ModelOptFp8LinearMethod.create_weights()` now sets
  `layer.orig_dtype = params_dtype` so Marlin's `weight_scale` cast works on
  SM80/SM86.

`vllm/__init__.py`

- Installs the Triton `fp8e4nv` compatibility patch in memory during vLLM
  import, before Triton kernels are compiled.
- Does not mutate installed Triton files.
- Wraps `CUDABackend.parse_options` to admit `fp8e4nv` as an opaque pointer
  dtype on Ampere.
- Wraps `CUDABackend.get_codegen_implementation` to register the pre-SM89
  `fp8e4nv` conversion guard.
- Wraps `TritonSemantic.cast` so actual `fp8e4nv` casts below SM89 fail with a
  clean compile-time error instead of reaching lower-level MLIR/LLVM failure
  paths.

`vllm/triton_patches.py`

- Removed. The patch is now in process and does not rewrite Triton source
  files.

## Targets

- A100 (SM80): primary validation target.
- RTX 30-series (SM86): covered by the same capability and Triton type-name
  handling.
- SM89+ (Ada / Hopper / Blackwell): unaffected. Native `fp8e4nv` behavior
  remains available there.

## Test Plan

Run Gemma4 26B NVFP4 on A100/SM80 with explicit BF16 KV cache. This exercises
the public `vllm serve` path, ModelOpt NVFP4 loading, the in-memory Triton
patch, Marlin NVFP4 backend selection, Gemma parser flags, and
OpenAI-compatible chat/tool requests.

This test also needs https://github.com/vllm-project/vllm/pull/43330 and
https://github.com/vllm-project/vllm/pull/43379.

```bash
vllm serve nvidia/Gemma-4-26B-A4B-NVFP4 \
  --served-model-name gemma4-nvfp4-sanity \
  --quantization modelopt \
  --tensor-parallel-size 1 \
  --kv-cache-dtype bfloat16 \
  --tool-call-parser gemma4 \
  --reasoning-parser gemma4 \
  --enable-auto-tool-choice \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-num-batched-tokens 2560 \
  --max-num-seqs 1 \
  --gpu-memory-utilization 0.85
```

## Test Result

Passed on A100/SM80.

```text
Installed in-memory Triton fp8e4nv pre-SM89 patch
Resolved architecture: Gemma4ForConditionalGeneration
quantization=modelopt_fp4
kv_cache_dtype=bfloat16
Using MARLIN NvFp4 MoE backend
server ready
RESPONSE identity: content='vllm-sanity-ok' tool_calls=[]
RESPONSE math: content='42' tool_calls=[]
RESPONSE tool_parser: tool_calls=[{'type': 'function', 'function': {'name': 'get_weather', 'arguments': '{... "city": "Paris" ...}'}}]
PASS vllm_serve_sanity
```

## Notes

The in-memory patch mirrors the intent of the pending Triton change:
`fp8e4nv` may be used opaquely in signatures and pointer
load/store/pass-through on pre-SM89 GPUs, while actual `fp8e4nv` arithmetic
below SM89 is rejected with a clear compile-time error.
