### PR TITLE
[Core] Add MoE pruned experts profile support

### DIFF
--- a/tests/model_executor/test_moe_pruned_experts.py
+++ b/tests/model_executor/test_moe_pruned_experts.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+import torch
+
+from vllm.utils.moe_pruned_experts import (
+    build_pruned_expert_map,
+    load_pruned_experts_profile,
+)
+
+
+def test_load_pruned_experts_profile_groups_pruned_experts_by_layer(tmp_path):
+    profile_path = tmp_path / "pruned_experts.json"
+    profile_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "pruned_experts": [[0, 2], [0, 5], [3, 7]],
+            }
+        )
+    )
+
+    profile = load_pruned_experts_profile(str(profile_path))
+
+    assert profile.pruned_experts_by_layer == {0: frozenset({2, 5}), 3: frozenset({7})}
+
+
+def test_build_pruned_expert_map_compacts_unpruned_experts():
+    expert_map, num_local_experts = build_pruned_expert_map(
+        num_experts=8,
+        pruned_experts=frozenset({2, 5}),
+    )
+
+    assert num_local_experts == 6
+    assert expert_map.dtype == torch.int32
+    assert expert_map.tolist() == [0, 1, -1, 2, 3, -1, 4, 5]
+
+
+def test_build_pruned_expert_map_composes_with_existing_expert_map():
+    base_expert_map = torch.tensor([0, 1, -1, -1, 2, 3], dtype=torch.int32)
+
+    expert_map, num_local_experts = build_pruned_expert_map(
+        num_experts=6,
+        pruned_experts=frozenset({1, 4}),
+        base_expert_map=base_expert_map,
+    )
+
+    assert num_local_experts == 2
+    assert expert_map.tolist() == [0, -1, -1, -1, -1, 1]
+
+
+def test_load_pruned_experts_profile_rejects_invalid_expert_entry(tmp_path):
+    profile_path = tmp_path / "pruned_experts.json"
+    profile_path.write_text(json.dumps({"version": 1, "pruned_experts": [[0]]}))
+
+    with pytest.raises(ValueError, match="layer, expert"):
+        load_pruned_experts_profile(str(profile_path))

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from pydantic import Field, field_validator
@@ -92,6 +93,10 @@ class LoadConfig:
     model_loader_extra_config: dict | TensorizerConfig = Field(default_factory=dict)
     """Extra config for model loader. This will be passed to the model loader
     corresponding to the chosen load_format."""
+    moe_pruned_experts_profile: str | None = None
+    """Path to a JSON profile listing MoE experts to skip loading.
+    Pruned experts are removed from the local expert map so the MoE kernel
+    never selects them.  Their weight tensors are allocated but left unloaded."""
     device: str | None = None
     """Device to which model weights will be loaded, default to
     device_config.device"""
@@ -124,11 +129,25 @@ class LoadConfig:
         excluding anything before input ids/embeddings and after
         the final hidden states.
         """
-        # no factors to consider.
-        # this config will not affect the computation graph.
-        factors: list[Any] = []
+        profile_hash = self._profile_content_hash()
+        factors: list[Any] = [self.moe_pruned_experts_profile, profile_hash]
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
+
+    def _profile_content_hash(self) -> str | None:
+        """Return a hex digest of the pruned-experts profile file contents,
+        cached so repeated ``compute_hash`` calls avoid re-reading disk."""
+        if self.moe_pruned_experts_profile is None:
+            return None
+        if not hasattr(self, "_cached_profile_hash"):
+            path = Path(self.moe_pruned_experts_profile)
+            if not path.is_file():
+                raise ValueError(f"MoE pruned experts profile not found at {path}")
+            self._cached_profile_hash = safe_hash(
+                path.read_bytes(),
+                usedforsecurity=False,
+            ).hexdigest()
+        return self._cached_profile_hash
 
     @field_validator("load_format", mode="after")
     def _lowercase_load_format(cls, load_format: str) -> str:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -598,6 +598,7 @@ class EngineArgs:
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
     num_gpu_blocks_override: int | None = CacheConfig.num_gpu_blocks_override
     model_loader_extra_config: dict = get_field(LoadConfig, "model_loader_extra_config")
+    moe_pruned_experts_profile: str | None = LoadConfig.moe_pruned_experts_profile
     ignore_patterns: str | list[str] = get_field(LoadConfig, "ignore_patterns")
 
     enable_chunked_prefill: bool | None = None
@@ -898,6 +899,10 @@ class EngineArgs:
         )
         load_group.add_argument(
             "--model-loader-extra-config", **load_kwargs["model_loader_extra_config"]
+        )
+        load_group.add_argument(
+            "--moe-pruned-experts-profile",
+            **load_kwargs["moe_pruned_experts_profile"],
         )
         load_group.add_argument("--ignore-patterns", **load_kwargs["ignore_patterns"])
         load_group.add_argument("--use-tqdm-on-load", **load_kwargs["use_tqdm_on_load"])
@@ -1690,6 +1695,7 @@ class EngineArgs:
             safetensors_prefetch_num_threads=self.safetensors_prefetch_num_threads,
             safetensors_prefetch_block_size=self.safetensors_prefetch_block_size,
             model_loader_extra_config=self.model_loader_extra_config,
+            moe_pruned_experts_profile=self.moe_pruned_experts_profile,
             ignore_patterns=self.ignore_patterns,
             use_tqdm_on_load=self.use_tqdm_on_load,
             pt_load_map_location=self.pt_load_map_location,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -103,6 +103,11 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         assert self.moe_kernel is not None
+        if self.disable_expert_map and getattr(layer, "has_pruned_experts", False):
+            raise NotImplementedError(
+                "MoE pruned experts profiles require a MoE backend that supports "
+                "expert_map."
+            )
         return self.moe_kernel.apply(
             hidden_states=x,
             w1=layer.w13_weight,

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import torch
 
+from vllm.config import get_current_vllm_config
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
@@ -24,6 +25,11 @@ from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
 )
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
+)
+from vllm.utils.moe_pruned_experts import (
+    build_pruned_expert_map,
+    extract_moe_layer_index,
+    load_pruned_experts_profile,
 )
 
 if TYPE_CHECKING:
@@ -92,6 +98,11 @@ class RoutedExperts(PluggableLayer):
         self.update_expert_map_info()
 
         self.rocm_aiter_fmoe_enabled = moe_config.rocm_aiter_fmoe_enabled
+
+        # Optionally prune experts before weights are created so the pruned
+        # experts are not allocated. Must run before create_weights() below.
+        self.has_pruned_experts = False
+        self._apply_pruned_experts_profile()
 
         # It would be good to eventually codify these in FusedMoEConfig
         # or some other config.
@@ -238,6 +249,92 @@ class RoutedExperts(PluggableLayer):
             self.register_buffer("expert_physical_to_global", physical_to_global)
             self.register_buffer("expert_local_to_global", local_global)
 
+    def _apply_pruned_experts_profile(self) -> None:
+        profile_path = (
+            get_current_vllm_config().load_config.moe_pruned_experts_profile
+        )
+        if not profile_path:
+            self.has_pruned_experts = False
+            return
+
+        layer_idx = extract_moe_layer_index(self.layer_name)
+        if layer_idx is None:
+            logger.warning(
+                "Skipping MoE pruned experts profile for layer %s because "
+                "its layer index could not be inferred.",
+                self.layer_name,
+            )
+            self.has_pruned_experts = False
+            return
+
+        profile = load_pruned_experts_profile(profile_path)
+        pruned_experts = profile.pruned_experts_by_layer.get(layer_idx)
+        if not pruned_experts:
+            self.has_pruned_experts = False
+            return
+
+        if self.global_num_experts != self.moe_config.num_logical_experts:
+            raise NotImplementedError(
+                "MoE pruned experts profiles do not support redundant experts."
+            )
+        if self.rocm_aiter_fmoe_enabled:
+            raise NotImplementedError(
+                "MoE pruned experts profiles do not support ROCm AITER fused MoE."
+            )
+        invalid_experts = [
+            expert_id
+            for expert_id in pruned_experts
+            if expert_id >= self.global_num_experts
+        ]
+        if invalid_experts:
+            raise ValueError(
+                f"MoE pruned experts profile for layer {layer_idx} contains "
+                f"out-of-range experts {invalid_experts}; this layer has "
+                f"{self.global_num_experts} experts."
+            )
+
+        base_expert_map = (
+            self._expert_map.cpu() if self._expert_map is not None else None
+        )
+        pruned_expert_map, num_local_experts = build_pruned_expert_map(
+            num_experts=self.global_num_experts,
+            pruned_experts=pruned_experts,
+            base_expert_map=base_expert_map,
+        )
+        if num_local_experts == 0:
+            raise ValueError(
+                f"MoE pruned experts profile prunes every local expert in "
+                f"layer {layer_idx}."
+            )
+
+        self.local_num_experts = num_local_experts
+        self.moe_config.num_local_experts = num_local_experts
+        self.register_buffer("_expert_map", pruned_expert_map)
+        self.has_pruned_experts = True
+
+        # Pruning relies on expert_map, so force a backend that supports it.
+        moe_backend = self.moe_config.moe_backend
+        if moe_backend == "auto":
+            logger.info_once(
+                "MoE pruned experts profile requires expert_map support; "
+                "using Triton MoE backend instead of auto selection."
+            )
+            self.moe_config.moe_backend = "triton"
+        elif moe_backend != "triton":
+            raise NotImplementedError(
+                "MoE pruned experts profiles currently require the Triton "
+                f"MoE backend, but got moe_backend={moe_backend!r}."
+            )
+
+        logger.info(
+            "MoE pruned experts layer %d: skipped %d/%d experts, "
+            "local_num_experts=%d",
+            layer_idx,
+            len(pruned_experts),
+            self.global_num_experts,
+            self.local_num_experts,
+        )
+
     def _expert_routing_tables(
         self,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
@@ -266,9 +363,12 @@ class RoutedExperts(PluggableLayer):
 
         # Update local attributes from ExpertMapManager
         self.update_expert_map_info()
+        self._apply_pruned_experts_profile()
 
     def _map_global_expert_id_to_local_expert_id(self, expert_id: int) -> int:
         """Map global expert ID to local expert ID."""
+        if self.has_pruned_experts:
+            return int(self._expert_map[expert_id])
         return self.expert_map_manager.map_global_to_local(expert_id)
 
     #

--- a/vllm/utils/moe_pruned_experts.py
+++ b/vllm/utils/moe_pruned_experts.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+import regex as re
+import torch
+
+
+@dataclass(frozen=True)
+class PrunedExpertsProfile:
+    pruned_experts_by_layer: dict[int, frozenset[int]]
+
+
+@lru_cache(maxsize=8)
+def load_pruned_experts_profile(profile_path: str) -> PrunedExpertsProfile:
+    """Load a profile describing experts whose weights should be skipped.
+
+    The profile uses original logical expert ids. Pruned experts are removed
+    from the local expert map (mapped to -1), so the MoE kernel never selects
+    them.  Their weight tensors are allocated but left unloaded.
+    """
+    path = Path(profile_path)
+    with path.open() as f:
+        profile = json.load(f)
+
+    if profile.get("version") != 1:
+        raise ValueError(
+            "MoE pruned experts profile must contain version 1, "
+            f"got {profile.get('version')!r}."
+        )
+
+    entries = profile.get("pruned_experts")
+    if not isinstance(entries, list):
+        raise ValueError(
+            "MoE pruned experts profile must contain a 'pruned_experts' list."
+        )
+
+    pruned_by_layer: dict[int, set[int]] = {}
+    for entry in entries:
+        if not (
+            isinstance(entry, list | tuple)
+            and len(entry) == 2
+            and all(isinstance(value, int) for value in entry)
+        ):
+            raise ValueError("Each pruned expert entry must be a [layer, expert] pair.")
+        layer_idx, expert_idx = entry
+        if layer_idx < 0 or expert_idx < 0:
+            raise ValueError("Layer and expert ids must be non-negative.")
+        pruned_by_layer.setdefault(layer_idx, set()).add(expert_idx)
+
+    return PrunedExpertsProfile(
+        {
+            layer_idx: frozenset(expert_ids)
+            for layer_idx, expert_ids in pruned_by_layer.items()
+        }
+    )
+
+
+def build_pruned_expert_map(
+    num_experts: int,
+    pruned_experts: frozenset[int],
+    base_expert_map: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, int]:
+    """Build a global-to-local expert map with pruned experts mapped to -1."""
+    expert_map = torch.full((num_experts,), -1, dtype=torch.int32)
+    next_local_expert = 0
+
+    for expert_idx in range(num_experts):
+        if expert_idx in pruned_experts:
+            continue
+        if base_expert_map is not None and int(base_expert_map[expert_idx]) == -1:
+            continue
+        expert_map[expert_idx] = next_local_expert
+        next_local_expert += 1
+
+    return expert_map, next_local_expert
+
+
+def extract_moe_layer_index(prefix: str) -> int | None:
+    """Extract the decoder layer index from a vLLM module prefix."""
+    match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", prefix)
+    if match is None:
+        return None
+    return int(match.group(1))


### PR DESCRIPTION
## Purpose

Add support for skipping specific MoE experts during weight loading via a JSON profile (`--moe-pruned-experts-profile`). Pruned experts are removed from the local expert map (mapped to -1) so the MoE kernel never selects them, while their weight tensors are allocated but left unloaded. This enables deploying MoE models with reduced expert counts without modifying the original checkpoint.

**Motivation:** MoE models like [Qwen3-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B) (128 experts, 8 active per token) can be memory-heavy. Pruning inactive or low-utility experts reduces memory footprint while preserving router behavior for the remaining
experts.

**Limitations:**

- Requires the Triton MoE backend
- Does not support redundant experts
- Does not support ROCm AITER fused MoE

## Test Plan

```bash
# Unit tests for pruned experts utilities
pytest tests/model_executor/test_moe_pruned_experts.py -v

# Linting
pre-commit run --all-files

# E2E inference with Qwen3-30B-A3B and a pruned profile
vllm serve Qwen/Qwen3-30B-A3B \
    --moe-pruned-experts-profile pruned_experts.json
```

## Test Result

| Scenario                    | Memory    | Load Time |
| --------------------------- | --------- | --------- |
| Baseline (no pruning)       | 56.93 GiB  | 103.04s   |
| With pruned experts profile | 46.3 GiB | 53.85s    |

**Unit tests:** 4/4 passed

```
tests/model_executor/test_moe_pruned_experts.py::test_load_pruned_experts_profile_groups_pruned_experts_by_layer PASSED
tests/model_executor/test_moe_pruned_experts.py::test_build_pruned_expert_map_compacts_unpruned_experts PASSED
tests/model_executor/test_moe_pruned_experts.py::test_build_pruned_expert_map_composes_with_existing_expert_map PASSED
tests/model_executor/test_moe_pruned_experts.py::test_load_pruned_experts_profile_rejects_invalid_expert_entry PASSED
```
