### PR TITLE
fix: reject routed experts on dense models

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -934,26 +934,24 @@ def test_vllm_config_defaults_are_none():
                 assert getattr(config.compilation_config, k) is None
 
 
-def _make_return_routed_experts_config(is_moe: bool) -> VllmConfig:
-    config = object.__new__(VllmConfig)
-    config.model_config = SimpleNamespace(
-        enable_return_routed_experts=True,
-        is_moe=is_moe,
-    )
+def _make_return_routed_experts_model_config(is_moe: bool) -> ModelConfig:
+    config = object.__new__(ModelConfig)
+    config.enable_return_routed_experts = True
+    config.model_arch_config = SimpleNamespace(num_experts=1 if is_moe else 0)
     return config
 
 
-def test_validate_return_routed_experts_rejects_dense_models():
-    config = _make_return_routed_experts_config(is_moe=False)
+def test_model_config_rejects_return_routed_experts_for_dense_models():
+    config = _make_return_routed_experts_model_config(is_moe=False)
 
     with pytest.raises(ValueError, match="requires a MoE model"):
-        config._validate_return_routed_experts()
+        config._verify_return_routed_experts()
 
 
-def test_validate_return_routed_experts_allows_moe_models():
-    config = _make_return_routed_experts_config(is_moe=True)
+def test_model_config_allows_return_routed_experts_for_moe_models():
+    config = _make_return_routed_experts_model_config(is_moe=True)
 
-    config._validate_return_routed_experts()
+    config._verify_return_routed_experts()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -934,6 +934,28 @@ def test_vllm_config_defaults_are_none():
                 assert getattr(config.compilation_config, k) is None
 
 
+def _make_return_routed_experts_config(is_moe: bool) -> VllmConfig:
+    config = object.__new__(VllmConfig)
+    config.model_config = SimpleNamespace(
+        enable_return_routed_experts=True,
+        is_moe=is_moe,
+    )
+    return config
+
+
+def test_validate_return_routed_experts_rejects_dense_models():
+    config = _make_return_routed_experts_config(is_moe=False)
+
+    with pytest.raises(ValueError, match="requires a MoE model"):
+        config._validate_return_routed_experts()
+
+
+def test_validate_return_routed_experts_allows_moe_models():
+    config = _make_return_routed_experts_config(is_moe=True)
+
+    config._validate_return_routed_experts()
+
+
 @pytest.mark.parametrize(
     ("model_id", "compilation_config", "optimization_level"),
     [

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -702,6 +702,7 @@ class ModelConfig:
         # Avoid running try_verify_and_update_config multiple times
         self.config_updated = False
         self._try_verify_and_update_model_config()
+        self._verify_return_routed_experts()
         self._verify_quantization()
         self._verify_cuda_graph()
         self._verify_bnb_config()
@@ -1092,6 +1093,13 @@ class ModelConfig:
             raise ValueError(
                 "Number of experts in the model must be greater than 0 "
                 "when expert parallelism is enabled."
+            )
+
+    def _verify_return_routed_experts(self) -> None:
+        if self.enable_return_routed_experts and not self.is_moe:
+            raise ValueError(
+                "--enable-return-routed-experts requires a MoE model. "
+                "Disable it for dense models."
             )
 
     def _try_verify_and_update_model_config(self):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1209,8 +1209,6 @@ class VllmConfig:
             )
         current_platform.check_and_update_config(self)
 
-        self._validate_return_routed_experts()
-
         if envs.VLLM_USE_V2_MODEL_RUNNER:
             self._validate_v2_model_runner()
 
@@ -1927,17 +1925,6 @@ class VllmConfig:
             raise ValueError(
                 "VLLM_USE_V2_MODEL_RUNNER does not yet support: "
                 + ", ".join(unsupported)
-            )
-
-    def _validate_return_routed_experts(self) -> None:
-        if (
-            self.model_config is not None
-            and self.model_config.enable_return_routed_experts
-            and not self.model_config.is_moe
-        ):
-            raise ValueError(
-                "--enable-return-routed-experts requires a MoE model. "
-                "Disable it for dense models."
             )
 
     def validate_block_size(self) -> None:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1209,6 +1209,8 @@ class VllmConfig:
             )
         current_platform.check_and_update_config(self)
 
+        self._validate_return_routed_experts()
+
         if envs.VLLM_USE_V2_MODEL_RUNNER:
             self._validate_v2_model_runner()
 
@@ -1925,6 +1927,17 @@ class VllmConfig:
             raise ValueError(
                 "VLLM_USE_V2_MODEL_RUNNER does not yet support: "
                 + ", ".join(unsupported)
+            )
+
+    def _validate_return_routed_experts(self) -> None:
+        if (
+            self.model_config is not None
+            and self.model_config.enable_return_routed_experts
+            and not self.model_config.is_moe
+        ):
+            raise ValueError(
+                "--enable-return-routed-experts requires a MoE model. "
+                "Disable it for dense models."
             )
 
     def validate_block_size(self) -> None:


### PR DESCRIPTION
﻿## Summary
- reject `--enable-return-routed-experts` early when the selected model is not MoE
- keep MoE models on the existing path
- add focused config tests for dense-model rejection and MoE acceptance

Fixes #42593.

## To verify
- `python -m py_compile vllm\config\vllm.py tests\test_config.py`
- `python -m ruff check vllm\config\vllm.py tests\test_config.py`
- `git diff --check`
- direct config check:
  ```powershell
  @'
  from types import SimpleNamespace
  from vllm.config import VllmConfig

  def make_config(is_moe):
      cfg = object.__new__(VllmConfig)
      cfg.model_config = SimpleNamespace(enable_return_routed_experts=True, is_moe=is_moe)
      return cfg

  try:
      make_config(False)._validate_return_routed_experts()
  except ValueError as exc:
      assert "requires a MoE model" in str(exc)
  else:
      raise AssertionError("dense model was not rejected")

  make_config(True)._validate_return_routed_experts()
  print("ok")
  '@ | python -
  ```

`python -m pytest tests\test_config.py::test_validate_return_routed_experts_rejects_dense_models tests\test_config.py::test_validate_return_routed_experts_allows_moe_models -q --basetemp .tmp\pytest -p no:cacheprovider` could not run to collection on this Windows host because the repository-wide `tests/conftest.py` imports `uvloop`, which is not available on Windows.
