### PR TITLE
[LMCache Connector] skip remote KV lookup when local prefix hit is sufficient

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -274,6 +274,12 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             the number of tokens that can be loaded from the
             external KV cache beyond what is already computed.
         """
+        # Short-circuit in the wrapper so both LMCache adapter paths skip
+        # the remote lookup when the remaining span fits in one local block.
+        block_size = self._vllm_config.cache_config.block_size
+        if num_computed_tokens + block_size >= request.num_tokens:
+            return 0, False
+
         return self._lmcache_engine.get_num_new_matched_tokens(
             request, num_computed_tokens
         ), False

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -615,7 +615,6 @@ class Scheduler(SchedulerInterface):
                         self.kv_cache_manager.get_computed_blocks(request)
                     )
 
-                    # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -615,6 +615,7 @@ class Scheduler(SchedulerInterface):
                         self.kv_cache_manager.get_computed_blocks(request)
                     )
 
+                    # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(


### PR DESCRIPTION
## Summary

This change skips `connector.get_num_new_matched_tokens(...)` when the local prefix cache hit is already sufficient to cover the last full prompt block.

Specifically, if

```python
num_new_local_computed_tokens + self.block_size >= request.num_tokens
```

the scheduler will avoid the remote KV lookup and compute the remaining tokens locally.

## Why

When the local cache hit already reaches the final prompt block boundary, issuing an additional remote KV cache match query is unnecessary.

At that point, any remaining prompt tokens are only in the final partial block and can be computed locally without needing another remote prefix-cache lookup. Avoiding that extra query reduces scheduler overhead and removes redundant remote KV lookup work in a case where the local cache is already sufficient.

## Notes

10000tokens hit TTFT lmcache backend 

```code
[query-8010-hey] TTFT = 0.637770 s ->[query-8010-hey] TTFT = 0.091043 s
```

