### PR TITLE
[Bugfix] Fix macOS CPU platform detection by moving darwin fallback outside try/except

### DIFF
--- a/tests/test_cpu_platform_macos_fallback.py
+++ b/tests/test_cpu_platform_macos_fallback.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for macOS source-checkout platform detection.
+
+When running from a source checkout (no ``pip install``), the call to
+``vllm_version_matches_substr("cpu")`` raises ``PackageNotFoundError``.
+The macOS (darwin) fallback must still be reachable so that
+``cpu_platform_plugin()`` returns ``CpuPlatform`` instead of ``None``
+(which would resolve to ``UnspecifiedPlatform`` with an empty
+``device_type``, crashing any ``torch.device()`` call).
+"""
+
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+from vllm.platforms import cpu_platform_plugin
+
+
+def test_cpu_platform_plugin_macos_source_checkout():
+    """cpu_platform_plugin returns CpuPlatform on macOS even when
+    package metadata is missing (source checkout)."""
+    with (
+        patch(
+            "vllm.platforms.vllm_version_matches_substr",
+            side_effect=PackageNotFoundError("vllm"),
+        ),
+        patch("sys.platform", "darwin"),
+    ):
+        result = cpu_platform_plugin()
+    assert result == "vllm.platforms.cpu.CpuPlatform", (
+        f"Expected CpuPlatform on macOS source checkout, got {result!r}"
+    )
+
+
+def test_cpu_platform_plugin_linux_source_checkout():
+    """cpu_platform_plugin returns None on Linux when package metadata
+    is missing and no GPU is present (not a CPU build)."""
+    with (
+        patch(
+            "vllm.platforms.vllm_version_matches_substr",
+            side_effect=PackageNotFoundError("vllm"),
+        ),
+        patch("sys.platform", "linux"),
+    ):
+        result = cpu_platform_plugin()
+    assert result is None, (
+        f"Expected None on Linux source checkout without CPU build, got {result!r}"
+    )
+
+
+def test_cpu_platform_plugin_installed_cpu_build():
+    """cpu_platform_plugin returns CpuPlatform when the installed
+    package version contains 'cpu'."""
+    with patch(
+        "vllm.platforms.vllm_version_matches_substr",
+        return_value=True,
+    ):
+        result = cpu_platform_plugin()
+    assert result == "vllm.platforms.cpu.CpuPlatform", (
+        f"Expected CpuPlatform for installed CPU build, got {result!r}"
+    )

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -169,16 +169,21 @@ def cpu_platform_plugin() -> str | None:
             logger.debug(
                 "Confirmed CPU platform is available because vLLM is built with CPU."
             )
-        if not is_cpu:
-            import sys
-
-            is_cpu = sys.platform.startswith("darwin")
-            if is_cpu:
-                logger.debug(
-                    "Confirmed CPU platform is available because the machine is MacOS."
-                )
     except Exception as e:
         logger.debug("CPU platform is not available because: %s", str(e))
+
+    # Fallback: on macOS, always use CPU.  This must live outside the
+    # try/except above because vllm_version_matches_substr re-raises
+    # PackageNotFoundError in source checkouts, which would skip any
+    # darwin check placed inside the try block.
+    if not is_cpu:
+        import sys
+
+        is_cpu = sys.platform.startswith("darwin")
+        if is_cpu:
+            logger.debug(
+                "Confirmed CPU platform is available because the machine is macOS."
+            )
 
     if not is_cpu:
         return None


### PR DESCRIPTION
## Fix macOS CPU platform detection by moving darwin fallback outside try/except

Fixes: #42628

### Root Cause

`cpu_platform_plugin()` places the macOS (`darwin`) fallback **inside** the same `try` block as `vllm_version_matches_substr("cpu")`. In source checkouts (no `pip install`), `vllm_version_matches_substr` raises `PackageNotFoundError` (it explicitly [re-raises](https://github.com/vllm-project/vllm/blob/main/vllm/platforms/__init__.py#L32)). The exception jumps to the `except` handler, **skipping** the `sys.platform.startswith("darwin")` check entirely.

Result: `cpu_platform_plugin()` returns `None` → `resolve_current_platform_cls_qualname()` falls through to `UnspecifiedPlatform` → `device_type = ""` → `RuntimeError: Device string must not be empty` on any `torch.device()` call.

### Implementation

Move the `darwin` fallback **outside** the `try/except` block so it executes regardless of whether package metadata is available. This approach was chosen over alternatives (e.g. catching `PackageNotFoundError` separately) because it keeps the intent explicit with a comment explaining *why* the check must live outside the `try`.

This is a 3-line logic change (move code, add explanatory comment). No new dependencies, no API changes.

### Tradeoffs & Limitations

- None. The fix preserves all existing behavior for Linux, GPU, and installed-package paths.
- The `darwin` check was already the intended fallback; this just makes it reachable.
- Confirmed no impact on GPU dispatch paths (CUDA, MPS) — the change only affects the CPU plugin function.

### Testing Performed

- [x] Added 3 regression tests covering: macOS source checkout, Linux source checkout, installed CPU build
- [x] All 3 tests pass locally (`pytest tests/test_cpu_platform_macos_fallback.py -v`)
- [x] Pre-commit hooks pass locally
- [x] Existing `tests/test_zen_cpu_platform_detection.py` still passes
- [x] Tested on: CPU (macOS source checkout)