### PR TITLE
[LoRA] Remove engine-side adapter on runtime unload

### DIFF
--- a/tests/entrypoints/serve/lora/test_serving_models.py
+++ b/tests/entrypoints/serve/lora/test_serving_models.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from http import HTTPStatus
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -35,6 +35,8 @@ async def _async_serving_models_init() -> OpenAIServingModels:
     mock_engine_client.model_config = mock_model_config
     mock_engine_client.input_processor = MagicMock()
     mock_engine_client.renderer = MagicMock()
+    mock_engine_client.add_lora = AsyncMock(return_value=True)
+    mock_engine_client.remove_lora = AsyncMock(return_value=True)
 
     serving_models = OpenAIServingModels(
         engine_client=mock_engine_client,
@@ -104,12 +106,36 @@ async def test_unload_lora_adapter_success():
         lora_name="adapter1", lora_path="/path/to/adapter1"
     )
     response = await serving_models.load_lora_adapter(request)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
     assert len(serving_models.lora_requests) == 1
 
+    lora_int_id = serving_models.lora_requests["adapter1"].lora_int_id
     request = UnloadLoRAAdapterRequest(lora_name="adapter1")
     response = await serving_models.unload_lora_adapter(request)
     assert response == LORA_UNLOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
     assert len(serving_models.lora_requests) == 0
+    serving_models.engine_client.remove_lora.assert_awaited_once_with(lora_int_id)
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_adapter_engine_remove_failed():
+    serving_models = await _async_serving_models_init()
+    request = LoadLoRAAdapterRequest(
+        lora_name="adapter1", lora_path="/path/to/adapter1"
+    )
+    response = await serving_models.load_lora_adapter(request)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+    assert len(serving_models.lora_requests) == 1
+
+    lora_int_id = serving_models.lora_requests["adapter1"].lora_int_id
+    serving_models.engine_client.remove_lora.return_value = False
+    request = UnloadLoRAAdapterRequest(lora_name="adapter1")
+    response = await serving_models.unload_lora_adapter(request)
+    assert isinstance(response, ErrorResponse)
+    assert response.error.type == "InternalServerError"
+    assert response.error.code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert len(serving_models.lora_requests) == 1
+    serving_models.engine_client.remove_lora.assert_awaited_once_with(lora_int_id)
 
 
 @pytest.mark.asyncio

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -181,6 +181,11 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def remove_lora(self, lora_id: int) -> bool:
+        """Remove an already loaded LoRA adapter from the engine."""
+        ...
+
+    @abstractmethod
     async def pause_generation(
         self,
         *,

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -213,6 +213,16 @@ class OpenAIServingModels:
             if error_check_ret is not None:
                 return error_check_ret
 
+            lora_request = self.lora_requests[lora_name]
+            removed = await self.engine_client.remove_lora(lora_request.lora_int_id)
+            if not removed:
+                return create_error_response(
+                    message=f"Failed to remove lora adapter '{lora_name}' from the "
+                    "engine.",
+                    err_type="InternalServerError",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+
             # Safe to delete now since we hold the lock
             del self.lora_requests[lora_name]
             logger.info("Removed LoRA adapter: name '%s'", lora_name)


### PR DESCRIPTION



## Purpose
This PR fixes runtime LoRA unloading so that `/v1/unload_lora_adapter` removes the adapter from the engine in addition to deleting the OpenAI serving-side registry entry.

Previously, `/v1/load_lora_adapter` preloaded the LoRA adapter into the engine via `add_lora`, but `/v1/unload_lora_adapter` only removed the adapter from `OpenAIServingModels.lora_requests`. As a result, the serving layer no longer listed the adapter, while the engine-side LoRA manager could still retain it.

This PR updates the unload path to call `engine_client.remove_lora()` with the registered `lora_int_id` before deleting the serving-side registry entry. If the engine-side removal fails, the API now returns an internal server error and keeps the serving-side state unchanged to avoid silently diverging from the engine state.

Related to #42207.
Fixes #42633
## Test Plan

- Added unit test coverage for runtime LoRA unload behavior in `tests/entrypoints/serve/lora/test_serving_models.py`.
- Verified that `/v1/unload_lora_adapter` calls engine-side `remove_lora` with the registered `lora_int_id`.
- Verified that serving-side LoRA registry state is preserved when engine-side removal fails.

## Test Result

bash .venv-test/bin/python -m pytest tests/entrypoints/serve/lora/test_serving_models.py -q
text 8 passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

