### PR TITLE
[Bugfix][Reasoning] Gemma4 parser: surface reasoning as content on half-open thinking

### DIFF
--- a/vllm/reasoning/gemma4_reasoning_parser.py
+++ b/vllm/reasoning/gemma4_reasoning_parser.py
@@ -114,6 +114,28 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         reasoning, content = super().extract_reasoning(model_output, request)
         if reasoning is not None:
             reasoning = _strip_thought_label(reasoning)
+
+        # Fix E (parser hardening, 2026-05-14): half-open thinking — model
+        # emitted `<|channel>` but never `<channel|>` (max_tokens cap mid-think,
+        # routing/scheduler edge cases, etc.). Base parser sets `content=None`
+        # in this case, which surfaces to downstream as silent-empty content
+        # even though the model produced text. Mirror the reasoning into
+        # content so consumers reading only `content` still see the answer.
+        # The reasoning field is preserved separately for clients that parse
+        # it specifically.
+        #
+        # The `self.end_token not in model_output` guard distinguishes
+        # half-open from closed-with-empty-content. In the latter case
+        # (`<|channel>thought\n…<channel|>` with nothing after the end
+        # token), the base parser also returns `(reasoning, None)` — but
+        # there `content=None` is correct semantics (the model closed its
+        # thinking and intentionally said nothing), so we must NOT mirror.
+        if (
+            content is None
+            and reasoning
+            and self.end_token not in model_output
+        ):
+            content = reasoning
         return reasoning, content
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
# [Bugfix][Reasoning] Gemma4 parser: surface reasoning as content on half-open thinking

## What

When the Gemma4 reasoning parser sees a `<|channel>thought\n…` block that is
**not closed** by `<channel|>` (model hit `max_tokens` mid-think, or another
edge case prevents the close marker from being emitted), the base
`BaseThinkingReasoningParser.extract_reasoning()` returns
`content=None`. The full text is preserved in the `reasoning` field, but any
client reading only `message.content` (e.g. lm-evaluation-harness'
`LocalChatCompletion.parse_generations`) sees a silently empty response.

This 11-line addition mirrors the reasoning text into `content` whenever the
parser hits the half-open case. The `reasoning` field is unchanged, so clients
that parse the channels explicitly continue to work; clients that only read
`content` now receive the model's actual output instead of empty.

```diff
@@ vllm/reasoning/gemma4_reasoning_parser.py @@
         reasoning, content = super().extract_reasoning(model_output, request)
         if reasoning is not None:
             reasoning = _strip_thought_label(reasoning)
+
+        # Half-open thinking — model emitted `<|channel>` but never
+        # `<channel|>` (max_tokens cap mid-think, routing/scheduler edge
+        # cases). Base parser sets `content=None`, which surfaces as silent-
+        # empty content downstream even though the model produced text.
+        # Mirror the reasoning into content so consumers reading only
+        # `content` still see the answer. `reasoning` is preserved.
+        #
+        # The `self.end_token not in model_output` guard distinguishes
+        # half-open from closed-with-empty-content. In the latter case
+        # (`<|channel>thought\n…<channel|>` with nothing after the end
+        # token), the base parser also returns `(reasoning, None)` — but
+        # there `content=None` is correct semantics (the model closed its
+        # thinking and intentionally said nothing), so we must NOT mirror.
+        if (
+            content is None
+            and reasoning
+            and self.end_token not in model_output
+        ):
+            content = reasoning
         return reasoning, content
```

## Why — RCA

Discovered while running canonical Gemma-4-26B-A4B NVFP4A16 evaluation suites
on a single RTX 3090. With `--reasoning-parser gemma4 --enable-thinking` and
`num_concurrent=2`, ~1.5% of responses across gsm8k_100 + HumanEval(+) returned
empty `content` even when the same prompt produced full content in isolated
single-request calls. Three separate vLLM bugs interact here, each with its
own fix in the past 48 hours:

### Bug 1 — Gemma4 MoE routing closure capture (fixed by #42250, 2026-05-13)

`Gemma4MoE.__init__` captured `per_expert_scale = self.per_expert_scale` into
a closure local before defining `routing_function`. Under `torch.func.functional_call`
(used by CUDA graph capture / re-record on batch-shape changes from continuous
batching), parameter substitution does not propagate to closure-captured locals.
The routing function used a stale `per_expert_scale` for affected requests →
wrong experts selected for some sequences in a batch → cascade to silent or
garbage tokens. Fixed upstream by reading `self.per_expert_scale` at call time.

### Bug 2 — routed-experts capture / scheduler refactor (reverted by #42434, 2026-05-14)

#39917 ("Replace routing replay with device cache and async D2H pipeline")
rewrote routed-experts capture and scheduler integration. After production
exposure it was reverted in #42434. Builds released between #39917 and
#42434 are exposed to the same instability.

**Scoping note:** Bugs #42250 and #42434 are already resolved upstream.
This PR addresses **Bug 3 only** — the parser-level defense that prevents
silent-empty content regardless of which (current or future) root cause
produces a half-open thinking emission.

### Bug 3 — this PR

Even with both upstream fixes applied, the parser's silent-content path is a
landmine for the API contract. If any future vLLM change causes the model to
emit `<|channel>` but never `<channel|>` (CUDA graph capture races, KV-cache
corruption, scheduler boundary cases, max_tokens cap mid-think, etc.), the
text is silently dropped from `content`. Surfacing it as content closes this
class of failure permanently — independent of whether a model bug occurred at
all.

The half-open case is also a legitimate model behavior: a Gemma 4 instruct
generation that hits `max_tokens` mid-think emits exactly this pattern. Today
the user receives `content=""` and has no idea the model spent thousands of
tokens producing useful text. With this patch, they get the text.

## Symptoms in the wild

On Gemma-4-26B-A4B (128-expert MoE, top-8 routing) NVFP4A16 with
`vllm==0.1.dev16519+g630492da3`, `num_concurrent=2`:

| bench | n | silent-empty content (raw) | text in `reasoning` field |
|---|---|---|---|
| gsm8k_100 | 100 | 5 | (not captured by lm-eval — dropped) |
| HumanEval-164 | 164 | 1 | (not captured) |
| HumanEval+ (164, separate task) | 164 | 1 | (not captured) |

Total ~1.5% rate, stochastic across runs. **Identical prompts in isolated
single-request calls (sequential, no continuous batching) produce 0/7 silent-
empty** on the same vLLM build, ruling out a model-level regression.

## Verification (in vivo)

With #42250 + #42434 + this PR applied to a single-3090 setup,
`probe_silentempty_canary.py` was run at `num_concurrent=2`, `thinking_token_budget=12288`,
`max_tokens=16384`, `--reasoning-parser gemma4 --enable-thinking`:

| bench | n | silent-empty (both content & reasoning null) | Fix-A reroute (content="" but reasoning populated) | non-empty content | finish stop/length |
|---|---:|---:|---:|---:|---|
| gsm8k_100 | 100 | **0** | **0** | 100 | 100 / 0 |
| HumanEval-164 | 164 | **0** | **0** | 164 | 163 / 1 |

**0 silent-empty events across 264 prompts** under the same `num_concurrent=2`
configuration that produced 5 silent-empty on gsm8k_100 and 1 on HumanEval-164 in
the pre-patch baseline. The 1 length-cap on HE is the real `max_tokens` hit; the
parser's half-open path correctly surfaces the partial reasoning as content
(`Fix-A reroute=0` means lm-eval never had to fall back to the
`reasoning_content` field).

Canary run log: 2026-05-14, vLLM HEAD at this PR (`3e55456ed`) + cherry-picked
#42250 (`d93ba4d32`) + #42434 (`d522283d5`) on Gemma-4-26B-A4B NVFP4A16.

## Reproducer

Standalone single-file probe attached: `probe_silentempty_canary.py`. Requires
a Gemma 4 reasoning model + GPU. Runs gsm8k_100 + HumanEval-164 through vLLM
chat-completions with `num_concurrent=2`, captures both `content` and
`reasoning` per response, reports silent-empty/cure-by-reasoning counts.

## Risk

The change only takes effect in the half-open case. Normal CoT outputs (clean
`<|channel>…<channel|>final` ↔ reasoning + content) are not affected. No-marker
outputs (already short-circuited at the top of `extract_reasoning`) are not
affected.

For consumers that distinguish `reasoning` from `content` to render them
separately, the change duplicates the half-open reasoning text into both
fields — they would render the same text twice. The alternative (silent-empty
content) is strictly worse: the text disappears entirely. Consumers can detect
the duplication by checking `content == reasoning` and skip duplicated render.

## Tests

Adding parser tests for the half-open case (will add in this PR commit):

- Output containing `<|channel>thought\n…answer here` with no `<channel|>` →
  `(reasoning="…answer here", content="…answer here")` (was `content=None`)
- Output containing `<|channel>thought\n` only → `(reasoning="", content=None)`
  (no spurious empty content; matches existing semantics)
- Clean CoT: `<|channel>thought\nthink\n<channel|>final` → unchanged
  `(reasoning="think", content="final")`
- **Closed thinking, empty content (negative test for the guard)**:
  `<|channel>thought\nthink\n<channel|>` → `(reasoning="think", content=None)`.
  Base parser also returns `(reasoning, None)` here (because `content or None`
  on the empty suffix is `None`), but `content=None` is the *correct*
  semantics — the model closed its thinking and chose to say nothing. The
  `self.end_token not in model_output` guard ensures we do not mirror in
  this case. Without the guard, this test would fail.
- No markers: `final` → unchanged `(reasoning=None, content="final")`

## References

- #42250 — Gemma4 MoE routing closure capture fix (2026-05-13)
- #42434 — Revert of #39917 routed-experts capture refactor (2026-05-14)
- Related downstream impact: lm-evaluation-harness'
  `LocalChatCompletion.parse_generations` reads only `content`, so the silent-
  empty path scores correct answers as 0. A downstream fix to fall back to
  `reasoning_content` is a separate workaround.

Signed-off-by: <to be filled>
