### PR TITLE
Revert "[Bugfix] Fix EPLB initialization for VLM wrapper models" (#39805)

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -69,7 +69,6 @@ from vllm.model_executor.model_loader.reload import (
     initialize_layerwise_reload,
 )
 from vllm.model_executor.models.interfaces import (
-    MixtureOfExperts,
     MultiModalEmbeddings,
     SupportsMRoPE,
     SupportsMultiModal,
@@ -486,7 +485,6 @@ class GPUModelRunner(
         self.sampler = Sampler(logprobs_mode=self.model_config.logprobs_mode)
 
         self.eplb_state: EplbState | None = None
-        self._moe_model: MixtureOfExperts | None = None
         # NOTE(yongji): flag to temporarily disable EPLB during scaling up/down
         self.eep_eplb_suppressed = False
         """
@@ -3182,7 +3180,8 @@ class GPUModelRunner(
             return
 
         assert self.eplb_state is not None
-        assert self._moe_model is not None
+        model = self.get_model()
+        assert is_mixture_of_experts(model)
         self.eplb_state.step(
             is_dummy,
             is_profile,
@@ -3194,10 +3193,11 @@ class GPUModelRunner(
         expanded_physical_to_logical: torch.Tensor,
         old_num_physical_experts: int,
     ) -> None:
-        assert self._moe_model is not None
+        model = self.get_model()
+        assert is_mixture_of_experts(model)
 
         self.eplb_state = EplbState.from_mapping(
-            model=self._moe_model,
+            model=model,
             model_config=self.model_config,
             device=self.device,
             parallel_config=self.parallel_config,
@@ -4980,20 +4980,8 @@ class GPUModelRunner(
 
                     self.model.set_aux_hidden_state_layers(aux_layers)
 
-                # Resolve the MoE model, unwrapping VLM wrappers if needed.
-                # VLM models (e.g. KimiK25ForConditionalGeneration) wrap the
-                # actual MoE language model but don't implement
-                # MixtureOfExperts themselves.
-                moe_candidate = self.model
-                if not is_mixture_of_experts(moe_candidate) and isinstance(
-                    moe_candidate, SupportsMultiModal
-                ):
-                    moe_candidate = moe_candidate.get_language_model()
-                if is_mixture_of_experts(moe_candidate):
-                    self._moe_model = moe_candidate
-
                 if (
-                    self._moe_model is not None
+                    is_mixture_of_experts(self.model)
                     and self.parallel_config.enable_eplb
                     and not load_dummy_weights
                 ):
@@ -5003,7 +4991,7 @@ class GPUModelRunner(
                     )
                     assert self.eplb_state is not None
                     self.eplb_state.add_model(
-                        self._moe_model,
+                        self.model,
                         self.model_config,
                     )
                     eplb_models += 1
@@ -5043,7 +5031,7 @@ class GPUModelRunner(
         )  # Temporary hack for dynamic res video w/o support for bs>1 yet
 
         if (
-            self._moe_model is not None
+            is_mixture_of_experts(self.model)
             and self.parallel_config.enable_eplb
             and not load_dummy_weights
             and self.eplb_state is not None


### PR DESCRIPTION
## Revert of #39805

This reverts commit 77e1421a68d625bb45ac1d86023be8e555aefeec (merge commit for PR #39805).

**Original PR:** https://github.com/vllm-project/vllm/pull/39805
**Reason:** PR #39805 introduced a `get_language_model()` call in `gpu_model_runner.py` `load_model()` that raises `NotImplementedError` for `NemotronParseForConditionalGeneration`, which does not implement `_mark_language_model`.

**Linked failures (2 new failures in build [#66189](https://buildkite.com/vllm/ci/builds/66189)):**
- `Basic Models Tests (Extra Initialization) 1` — `test_can_initialize_large_subset[NemotronParseForConditionalGeneration]`
- `Multi-Modal Models (Extended Generation 1)` — `test_models[5-bfloat16-nvidia/NVIDIA-Nemotron-Parse-v1.2]`

**Root cause:** The EPLB initialization path now calls `moe_candidate.get_language_model()` for VLM wrapper models, but `NemotronParseForConditionalGeneration` has not been updated to call `_mark_language_model`, causing engine core initialization to fail.

---
Auto-generated by CI failure analyzer.