### PR TITLE
[Models][Qwen3VL] Fix MM encoder cuda graph input capture

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1923,7 +1923,8 @@ class Qwen3VLForConditionalGeneration(
         )
 
         spatial_merge_size = self.visual.spatial_merge_size
-        per_mm_item_output = token_budget // max_batch_size
+        # Use ceil so captured capacity is never smaller than token_budget.
+        per_mm_item_output = (token_budget + max_batch_size - 1) // max_batch_size
 
         frames_per_item = max_frames_per_batch // max_batch_size
         if frames_per_item > 1:


### PR DESCRIPTION
## Purpose

Using a MM encoder CUDA graph currently fails with for Qwen3VL with:
```
File "/home/ubuntu/vllm/vllm/model_executor/models/qwen3_vl.py", line 371, in forward
        x = x.view(L, -1, self.temporal_patch_size, self.patch_size, self.patch_size)

RuntimeError: cannot reshape tensor of 0 elements into shape [0, -1, 2, 16, 16] because the unspecified dimension size -1 can be any value and is ambiguous
```

Qwen2VL and Qwen2.5VL already use ceil to ensure that the capture capacity is never smaller than the token budget:
https://github.com/vllm-project/vllm/blob/65485604960c3dc2ce9dcb6d7e02e65c5acc3321/vllm/model_executor/models/qwen2_vl.py#L1586-L1587
https://github.com/vllm-project/vllm/blob/65485604960c3dc2ce9dcb6d7e02e65c5acc3321/vllm/model_executor/models/qwen2_5_vl.py#L1727-L1731

This PR is a followup on #35963 and applies the same fix to Qwen3VL. /cc @Isotr0py @b-mu

## Test Plan

```
vllm serve Qwen/Qwen3.6-35B-A3B-FP8 --compilation-config '{"cudagraph_mm_encoder": true}'
```

## Test Result

Server starts up properly