### PR TITLE
[Bugfix] Fix LM detection for Nemotron Parse

### DIFF
--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -207,7 +207,8 @@ class SupportsMultiModal(Protocol):
 
         raise NotImplementedError(
             f"No language model found in {type(self).__name__}! "
-            "You should initialize it via `_mark_language_model`."
+            "You should initialize it via `_mark_language_model`, "
+            "and make sure `embed_input_ids` is implemented."
         )
 
     @contextmanager

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -281,6 +281,9 @@ class MBartDecoderNoPos(nn.Module):
         self.layernorm_embedding = nn.LayerNorm(config.d_model)
         self.layer_norm = nn.LayerNorm(config.d_model)
 
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
     def forward(
         self,
         decoder_input_ids: torch.Tensor | None,


### PR DESCRIPTION



## Purpose

The language model for `NemotronParseForConditionalGeneration` failed to be detected because it was missing `embed_input_ids` implementation, causing model initialization to fail. The issue wasn't caught before because the test had been disabled until https://github.com/vllm-project/vllm/issues/42498.

This PR fixes the issue and updates the error message to remind the developer to implement `embed_input_ids`.

FIX https://buildkite.com/vllm/ci/builds/66189/canvas?jid=019e2513-6e08-4c93-bd60-ab472560db99&tab=output
FIX https://buildkite.com/vllm/ci/builds/66189/canvas?sid=019e2513-6c39-4d2f-8154-2d9245ae55e9&tab=output

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

