### PR TITLE
[Bugfix] Guard EPLB VLM unwrap for models without language_model

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4983,14 +4983,23 @@ class GPUModelRunner(
                 # Resolve the MoE model, unwrapping VLM wrappers if needed.
                 # VLM models (e.g. KimiK25ForConditionalGeneration) wrap the
                 # actual MoE language model but don't implement
-                # MixtureOfExperts themselves.
-                moe_candidate = self.model
-                if not is_mixture_of_experts(moe_candidate) and isinstance(
-                    moe_candidate, SupportsMultiModal
-                ):
-                    moe_candidate = moe_candidate.get_language_model()
-                if is_mixture_of_experts(moe_candidate):
-                    self._moe_model = moe_candidate
+                # MixtureOfExperts themselves. Only attempt the unwrap when
+                # EPLB is enabled, since `get_language_model()` may raise
+                # NotImplementedError for VLMs whose language module does not
+                # expose `embed_input_ids` (e.g. NemotronParse).
+                if self.parallel_config.enable_eplb:
+                    moe_candidate: nn.Module | None = self.model
+                    if not is_mixture_of_experts(moe_candidate) and isinstance(
+                        moe_candidate, SupportsMultiModal
+                    ):
+                        try:
+                            moe_candidate = moe_candidate.get_language_model()
+                        except NotImplementedError:
+                            moe_candidate = None
+                    if moe_candidate is not None and is_mixture_of_experts(
+                        moe_candidate
+                    ):
+                        self._moe_model = moe_candidate
 
                 if (
                     self._moe_model is not None


### PR DESCRIPTION
## Summary

Forward-fix for the regression reported in #42636 (open as a draft revert of #39805).

In #39805 the EPLB initialization path was extended to unwrap VLM wrappers via `moe_candidate.get_language_model()` so wrapper models like `KimiK25ForConditionalGeneration` would register their inner MoE language model with EPLB. That call was made **unconditionally** for any `SupportsMultiModal` model, including non-EPLB loads.

For `NemotronParseForConditionalGeneration`, although it *does* call `_mark_language_model` (`vllm/model_executor/models/nemotron_parse.py:593`), its marked module `MBartDecoderNoPos` does not expose `embed_input_ids`. `SupportsMultiModal.get_language_model()` therefore falls through both the marked-name lookup and the children-fallback in `vllm/model_executor/models/interfaces.py:176-211` and raises `NotImplementedError`, breaking engine-core init for any user loading NemotronParse, even without EPLB.

This PR:
- Gates the MoE-resolution block on `self.parallel_config.enable_eplb`, so non-EPLB loads never call `get_language_model()` — restoring pre-#39805 behavior for all non-EPLB users.
- Defensively wraps the `get_language_model()` call in `try/except NotImplementedError` so EPLB-on configs with a VLM that cannot resolve its language model fall through cleanly instead of crashing during load.

Behavior matrix:

| Scenario | Before | After |
|---|---|---|
| EPLB **off**, NemotronParse (regression in #42636) | `NotImplementedError` | block skipped |
| EPLB **on**, KimiK25 (VLM+MoE) — original #39805 target | unwrap → register | unwrap → register |
| EPLB **on**, DeepSeek-style (plain MoE) | `_moe_model = self.model` | unchanged |
| EPLB **on**, VLM without resolvable LM | `NotImplementedError` | caught, `_moe_model=None`, skipped |

## Test plan

- [x] Verified the two failing tests cited in #42636 do not use EPLB, so they exercise scenario A (EPLB off → block skipped, no `get_language_model()` call):
  - `tests/models/multimodal/generation/test_nemotron_parse.py::test_models[nvidia/NVIDIA-Nemotron-Parse-v1.2]`
  - `tests/models/test_initialization.py::test_can_initialize_large_subset[NemotronParseForConditionalGeneration]`
- [x] `ast.parse` syntax check passes; pre-commit hooks pass locally.
- [ ] CI re-run on these tests (please add `ready` label).

## AI assistance disclosure

Code change drafted with assistance from Claude (Anthropic). The submitter reviewed every changed line and verified correctness against the four scenarios above.