### PR TITLE
[Core] Add KV cache release API

### DIFF
--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -74,6 +74,14 @@ llm.wake_up(tags=["weights"])
 llm.wake_up(tags=["kv_cache"])
 ```
 
+If the model weights should stay resident on GPU, use `release_kv_cache()` instead of `sleep(level=1)`. This releases only KV cache memory, clears the logical KV/prefix cache state, and requires `resume_kv_cache()` before generation resumes. Like the default sleep behavior, `release_kv_cache()` aborts in-flight requests before releasing KV cache.
+
+```python
+llm.release_kv_cache()
+# ... Use the freed KV cache memory, for example during weight synchronization.
+llm.resume_kv_cache()
+```
+
 ### Online Serving
 
 To enable sleep mode in a vLLM server you need to initialize it with the flag `VLLM_SERVER_DEV_MODE=1` and pass `--enable-sleep-mode` to the vLLM server.
@@ -111,6 +119,8 @@ curl -X POST 'http://localhost:8000/wake_up?tags=kv_cache'
 
 - `POST /sleep?level=1` — Put the model to sleep (`level=1`).
 - `POST /wake_up` — Wake up the model. Supports optional `tags` query parameters for partial wake-up (e.g., `?tags=weights`).
+- `POST /release_kv_cache` — Release KV cache memory while keeping model weights resident on GPU. In-flight requests are aborted before KV cache is released.
+- `POST /resume_kv_cache` — Reallocate KV cache memory after `release_kv_cache`.
 - `POST /collective_rpc` — Perform a collective remote procedure call (RPC).
 - `GET /is_sleeping` — Check if the model is sleeping.
 

--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import inspect
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -10,10 +12,26 @@ from vllm import LLM, AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 from vllm.device_allocator.cumem import CuMemAllocator
 from vllm.platforms import current_platform
 from vllm.utils.mem_constants import GiB_bytes
+from vllm.v1.engine.core import EngineCore
 
 from ..utils import create_new_process_for_each_test, requires_fp8
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_release_kv_cache_api_has_no_mode():
+    assert "mode" not in inspect.signature(LLM.release_kv_cache).parameters
+
+
+def test_release_kv_cache_requires_sleep_mode():
+    core = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(enable_sleep_mode=False)
+        )
+    )
+
+    with pytest.raises(ValueError, match="requires enable_sleep_mode=True"):
+        EngineCore.release_kv_cache(core)
 
 
 @create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
@@ -73,6 +91,31 @@ def test_basic_cumem():
     # they can be used together
     output = x + y + z
     assert torch.allclose(output, torch.ones_like(output) * 3)
+
+
+@create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
+def test_release_tags_only_releases_selected_tag():
+    allocator = CuMemAllocator.get_instance()
+
+    with allocator.use_memory_pool(tag="weights"):
+        weight = torch.ones(1024, device=DEVICE_TYPE)
+    with allocator.use_memory_pool(tag="scheduling"):
+        scheduling = torch.ones(1024, device=DEVICE_TYPE) * 3
+    with allocator.use_memory_pool(tag="kv_cache"):
+        kv_cache = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device=DEVICE_TYPE)
+        kv_cache.fill_(7)
+
+    free_bytes = torch.cuda.mem_get_info()[0]
+    allocator.release_tags(("kv_cache",))
+    free_bytes_after_release = torch.cuda.mem_get_info()[0]
+    assert free_bytes_after_release > free_bytes
+
+    assert torch.allclose(weight, torch.ones_like(weight))
+    assert torch.allclose(scheduling, torch.ones_like(scheduling) * 3)
+
+    allocator.wake_up(["kv_cache"])
+    kv_cache.zero_()
+    assert torch.count_nonzero(kv_cache) == 0
 
 
 @create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
@@ -175,6 +218,31 @@ def test_end_to_end(model: str):
 
     # cmp output
     assert output[0].outputs[0].text == output3[0].outputs[0].text
+
+
+@create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
+def test_release_resume_kv_cache():
+    model = "facebook/opt-125m"
+    llm = LLM(model, enable_sleep_mode=True, gpu_memory_utilization=0.3)
+    prompt = "How are you?"
+    sampling_params = SamplingParams(temperature=0, max_tokens=10)
+    output = llm.generate(prompt, sampling_params)
+
+    free_gpu_bytes_before_release = torch.cuda.mem_get_info()[0]
+    llm.release_kv_cache()
+
+    free_gpu_bytes_after_release, _ = torch.cuda.mem_get_info()
+    released_bytes = free_gpu_bytes_after_release - free_gpu_bytes_before_release
+    assert released_bytes > 0
+
+    llm.resume_kv_cache()
+    free_gpu_bytes_after_resume = torch.cuda.mem_get_info()[0]
+    resumed_bytes = free_gpu_bytes_after_release - free_gpu_bytes_after_resume
+    assert resumed_bytes > 0
+
+    output2 = llm.generate(prompt, sampling_params)
+
+    assert output[0].outputs[0].text == output2[0].outputs[0].text
 
 
 @create_new_process_for_each_test()

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -53,6 +53,7 @@ class AllocationData:
     handle: HandleType
     tag: str
     cpu_backup_tensor: torch.Tensor | None = None
+    is_mapped: bool = True
 
 
 def create_and_map(allocation_handle: HandleType) -> None:
@@ -190,6 +191,8 @@ class CuMemAllocator:
         backup_bytes = 0
 
         for ptr, data in self.pointer_to_data.items():
+            if not data.is_mapped:
+                continue
             handle = data.handle
             total_bytes += handle[1]
             if data.tag in offload_tags:
@@ -205,6 +208,7 @@ class CuMemAllocator:
                 libcudart.cudaMemcpy(cpu_ptr, ptr, size_in_bytes)
                 data.cpu_backup_tensor = cpu_backup_tensor
             unmap_and_release(handle)
+            data.is_mapped = False
 
         logger.info(
             "CuMemAllocator: sleep freed %.2f GiB memory in total, of which "
@@ -230,8 +234,11 @@ class CuMemAllocator:
         """
         for ptr, data in self.pointer_to_data.items():
             if tags is None or data.tag in tags:
+                if data.is_mapped:
+                    continue
                 handle = data.handle
                 create_and_map(handle)
+                data.is_mapped = True
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:
@@ -241,6 +248,38 @@ class CuMemAllocator:
                         cpu_ptr = cpu_backup_tensor.data_ptr()
                         libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
                         data.cpu_backup_tensor = None
+
+    def release_tags(self, tags: tuple[str, ...] | str) -> None:
+        """
+        Release GPU memory for allocations with the specified tags only.
+        Unlike sleep(), allocations with other tags are kept mapped.
+
+        :param tags: The tags of the memory allocations to discard.
+        """
+        if isinstance(tags, str):
+            tags = (tags,)
+
+        assert isinstance(tags, tuple)
+
+        total_bytes = 0
+        for data in self.pointer_to_data.values():
+            if data.tag not in tags or not data.is_mapped:
+                continue
+            handle = data.handle
+            total_bytes += handle[1]
+            if data.cpu_backup_tensor is not None:
+                data.cpu_backup_tensor = None
+            unmap_and_release(handle)
+            data.is_mapped = False
+
+        logger.info(
+            "CuMemAllocator: release_tags(%s) freed %.2f GiB memory.",
+            tags,
+            total_bytes / 1024**3,
+        )
+
+        gc.collect()
+        torch.cuda.empty_cache()
 
     @contextmanager
     def use_memory_pool(self, tag: str | None = None):

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -171,6 +171,16 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def release_kv_cache(self) -> None:
+        """Release KV cache memory while keeping other GPU allocations resident"""
+        ...
+
+    @abstractmethod
+    async def resume_kv_cache(self) -> None:
+        """Resume KV cache memory released by release_kv_cache"""
+        ...
+
+    @abstractmethod
     async def is_sleeping(self) -> bool:
         """Check whether the engine is sleeping"""
         ...

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1527,6 +1527,22 @@ class LLM:
         """
         self.llm_engine.wake_up(tags)
 
+    def release_kv_cache(self):
+        """
+        Release KV cache memory while keeping model weights and other GPU
+        allocations resident. Like the default sleep behavior, this aborts
+        in-flight requests before clearing logical cache state and releasing
+        KV cache memory.
+        """
+        self.llm_engine.release_kv_cache()
+
+    def resume_kv_cache(self):
+        """
+        Reallocate KV cache memory released by
+        [release_kv_cache][vllm.LLM.release_kv_cache] and resume generation.
+        """
+        self.llm_engine.resume_kv_cache()
+
     def get_metrics(self) -> list["Metric"]:
         """Return a snapshot of aggregated metrics from Prometheus.
 

--- a/vllm/entrypoints/serve/sleep/api_router.py
+++ b/vllm/entrypoints/serve/sleep/api_router.py
@@ -43,6 +43,18 @@ async def wake_up(raw_request: Request):
     return Response(status_code=200)
 
 
+@router.post("/release_kv_cache")
+async def release_kv_cache(raw_request: Request):
+    await engine_client(raw_request).release_kv_cache()
+    return Response(status_code=200)
+
+
+@router.post("/resume_kv_cache")
+async def resume_kv_cache(raw_request: Request):
+    await engine_client(raw_request).resume_kv_cache()
+    return Response(status_code=200)
+
+
 @router.get("/is_sleeping")
 async def is_sleeping(raw_request: Request):
     is_sleeping = await engine_client(raw_request).is_sleeping()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -938,6 +938,18 @@ class AsyncLLM(EngineClient):
         if self.logger_manager is not None:
             self.logger_manager.record_sleep_state(0, 0)
 
+    async def release_kv_cache(self) -> None:
+        await self.engine_core.release_kv_cache_async()
+
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(1, 0)
+
+    async def resume_kv_cache(self) -> None:
+        await self.engine_core.resume_kv_cache_async()
+
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(0, 0)
+
     async def is_sleeping(self) -> bool:
         return await self.engine_core.is_sleeping_async()
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -747,6 +747,41 @@ class EngineCore:
         # Resume scheduling (applies to all levels)
         self.resume_scheduler()
 
+    def release_kv_cache(self) -> None | Future:
+        """Release KV cache memory while keeping other GPU allocations mapped."""
+
+        if not self.vllm_config.model_config.enable_sleep_mode:
+            raise ValueError(
+                "release_kv_cache() requires enable_sleep_mode=True because "
+                "KV cache memory is only tracked by the sleep-mode allocator "
+                "when sleep mode is enabled."
+            )
+
+        pause_future = self.pause_scheduler(mode="abort", clear_cache=True)
+        if pause_future is None:
+            self.model_executor.release_kv_cache()
+            return None
+
+        future = Future[Any]()
+
+        def pause_complete(f: Future):
+            try:
+                f.result()  # propagate any exception
+                future.set_result(self.model_executor.release_kv_cache())
+            except Exception as e:
+                future.set_exception(e)
+
+        logger.info(
+            "Waiting for in-flight requests to complete before releasing KV cache..."
+        )
+        pause_future.add_done_callback(pause_complete)
+        return future
+
+    def resume_kv_cache(self) -> None:
+        """Reallocate KV cache memory released by release_kv_cache."""
+        self.model_executor.resume_kv_cache()
+        self.resume_scheduler()
+
     def is_sleeping(self) -> bool:
         """Check if engine is sleeping at any level."""
         return self.is_scheduler_paused() or self.model_executor.is_sleeping

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -161,6 +161,12 @@ class EngineCoreClient(ABC):
     def wake_up(self, tags: list[str] | None = None) -> None:
         raise NotImplementedError
 
+    def release_kv_cache(self) -> None:
+        raise NotImplementedError
+
+    def resume_kv_cache(self) -> None:
+        raise NotImplementedError
+
     def is_sleeping(self) -> bool:
         raise NotImplementedError
 
@@ -236,6 +242,12 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
+        raise NotImplementedError
+
+    async def release_kv_cache_async(self) -> None:
+        raise NotImplementedError
+
+    async def resume_kv_cache_async(self) -> None:
         raise NotImplementedError
 
     async def is_sleeping_async(self) -> bool:
@@ -327,6 +339,13 @@ class InprocClient(EngineCoreClient):
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         self.engine_core.wake_up(tags)
+
+    def release_kv_cache(self) -> None:
+        result = self.engine_core.release_kv_cache()
+        assert result is None
+
+    def resume_kv_cache(self) -> None:
+        self.engine_core.resume_kv_cache()
 
     def is_sleeping(self) -> bool:
         return self.engine_core.is_sleeping()
@@ -863,6 +882,12 @@ class SyncMPClient(MPClient):
     def wake_up(self, tags: list[str] | None = None) -> None:
         self.call_utility("wake_up", tags)
 
+    def release_kv_cache(self) -> None:
+        self.call_utility("release_kv_cache")
+
+    def resume_kv_cache(self) -> None:
+        self.call_utility("resume_kv_cache")
+
     def is_sleeping(self) -> bool:
         return self.call_utility("is_sleeping")
 
@@ -1098,6 +1123,12 @@ class AsyncMPClient(MPClient):
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
         await self.call_utility_async("wake_up", tags)
+
+    async def release_kv_cache_async(self) -> None:
+        await self.call_utility_async("release_kv_cache")
+
+    async def resume_kv_cache_async(self) -> None:
+        await self.call_utility_async("resume_kv_cache")
 
     async def is_sleeping_async(self) -> bool:
         return await self.call_utility_async("is_sleeping")

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -361,6 +361,18 @@ class LLMEngine:
         if self.logger_manager is not None:
             self.logger_manager.record_sleep_state(0, 0)
 
+    def release_kv_cache(self):
+        self.engine_core.release_kv_cache()
+
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(1, 0)
+
+    def resume_kv_cache(self):
+        self.engine_core.resume_kv_cache()
+
+        if self.logger_manager is not None:
+            self.logger_manager.record_sleep_state(0, 0)
+
     def is_sleeping(self) -> bool:
         return self.engine_core.is_sleeping()
 

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -359,6 +359,39 @@ class Executor(ABC):
         if not self.sleeping_tags:
             self.is_sleeping = False
 
+    def release_kv_cache(self):
+        if self.is_sleeping:
+            logger.warning("Executor is already sleeping.")
+            return
+        time_before_release = time.perf_counter()
+        self.collective_rpc("release_kv_cache")
+        time_after_release = time.perf_counter()
+        self.sleeping_tags = {"kv_cache"}
+        self.is_sleeping = True
+        logger.info(
+            "It took %.6f seconds to release KV cache.",
+            time_after_release - time_before_release,
+        )
+
+    def resume_kv_cache(self):
+        if not self.is_sleeping:
+            logger.warning("Executor is not sleeping.")
+            return
+        if self.sleeping_tags != {"kv_cache"}:
+            raise ValueError(
+                "resume_kv_cache() can only be used after release_kv_cache(). "
+                f"Current sleeping tags: {self.sleeping_tags}"
+            )
+        time_before_resume = time.perf_counter()
+        self.collective_rpc("resume_kv_cache")
+        time_after_resume = time.perf_counter()
+        self.sleeping_tags.clear()
+        self.is_sleeping = False
+        logger.info(
+            "It took %.6f seconds to resume KV cache.",
+            time_after_resume - time_before_resume,
+        )
+
     def reinitialize_distributed(
         self, reconfig_request: ReconfigureDistributedRequest
     ) -> None:

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -496,14 +496,20 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 "Engine sleep state; awake = 0 means engine is sleeping; "
                 "awake = 1 means engine is awake; "
                 "weights_offloaded = 1 means sleep level 1; "
-                "discard_all = 1 means sleep level 2."
+                "discard_all = 1 means sleep level 2; "
+                "kv_cache_released = 1 means only KV cache memory is released."
             ),
             labelnames=labelnames + ["sleep_state"],
             multiprocess_mode="mostrecent",
         )
 
         self.gauge_engine_sleep_state = {}
-        sleep_state = ["awake", "weights_offloaded", "discard_all"]
+        sleep_state = [
+            "awake",
+            "weights_offloaded",
+            "discard_all",
+            "kv_cache_released",
+        ]
 
         for s in sleep_state:
             self.gauge_engine_sleep_state[s] = {
@@ -1219,16 +1225,22 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         awake = 1
         discard_all = 0
         weights_offloaded = 0
+        kv_cache_released = 0
 
         if sleep == 1:
             awake = 0
-            if level == 1:
+            if level == 0:
+                kv_cache_released = 1
+            elif level == 1:
                 weights_offloaded = 1
             elif level == 2:
                 discard_all = 1
 
         for engine_idx in self.engine_indexes:
             self.gauge_engine_sleep_state["discard_all"][engine_idx].set(discard_all)
+            self.gauge_engine_sleep_state["kv_cache_released"][engine_idx].set(
+                kv_cache_released
+            )
             self.gauge_engine_sleep_state["weights_offloaded"][engine_idx].set(
                 weights_offloaded
             )

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -150,6 +150,14 @@ class CPUWorker(Worker):
         logger.warning("sleep mode is not supported on CPU, ignore it.")
         pass
 
+    def release_kv_cache(self) -> None:
+        logger.warning("release_kv_cache is not supported on CPU, ignore it.")
+        pass
+
+    def resume_kv_cache(self) -> None:
+        logger.warning("resume_kv_cache is not supported on CPU, ignore it.")
+        pass
+
     def determine_available_memory(self) -> int:
         self.model_runner.warming_up_model()
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -198,6 +198,31 @@ class Worker(WorkerBase):
         if tags is None or "kv_cache" in tags:
             self.model_runner.post_kv_cache_wake_up()
 
+    def release_kv_cache(self) -> None:
+        from vllm.device_allocator.cumem import CuMemAllocator
+
+        free_bytes_before_release = torch.cuda.mem_get_info()[0]
+
+        allocator = CuMemAllocator.get_instance()
+        allocator.release_tags(("kv_cache",))
+
+        free_bytes_after_release, total = torch.cuda.mem_get_info()
+        freed_bytes = free_bytes_after_release - free_bytes_before_release
+        used_bytes = total - free_bytes_after_release
+        assert freed_bytes >= 0, "Memory usage increased after releasing KV cache."
+        logger.info(
+            "Released KV cache and freed %s GiB memory, %s GiB memory is still in use.",
+            format_gib(freed_bytes),
+            format_gib(used_bytes),
+        )
+
+    def resume_kv_cache(self) -> None:
+        from vllm.device_allocator.cumem import CuMemAllocator
+
+        allocator = CuMemAllocator.get_instance()
+        allocator.wake_up(["kv_cache"])
+        self.model_runner.post_kv_cache_wake_up()
+
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
         if not self.vllm_config.model_config.enable_sleep_mode:
             return nullcontext()


### PR DESCRIPTION
## Summary

This PR adds a KV-cache-only release/resume path for sleep mode.

`release_kv_cache()` aborts in-flight requests, clears logical cache state, and releases only CuMemAllocator allocations tagged as `kv_cache`. Model weights and other allocator tags, such as `weights`, `scheduling`, and custom tags, remain mapped on GPU. `resume_kv_cache()` reallocates the KV cache and resumes scheduling.

This is intended for RL weight-sync windows where the trainer needs the large KV cache allocation freed temporarily, but moving model weights GPU -> CPU -> GPU via `sleep(level=1)` would add unnecessary latency and CPU memory pressure.

## What Changed

- Added `CuMemAllocator.release_tags()` to release selected allocator tags without touching other mapped allocations.
- Added worker/executor/engine/public APIs:
  - `release_kv_cache()`
  - `resume_kv_cache()`
- Added HTTP endpoints under sleep mode dev endpoints:
  - `POST /release_kv_cache`
  - `POST /resume_kv_cache`
- Added a dedicated Prometheus sleep-state label for KV-only release:
  - `kv_cache_released`
- Added a user-visible error when `release_kv_cache()` is called without
  `enable_sleep_mode=True`, because KV cache memory is not tracked by the
  sleep-mode allocator in that configuration.
- Documented the new KV-only release flow in `docs/features/sleep_mode.md`.
- Added tests for:
  - API signature stability: `release_kv_cache()` has no `mode` argument.
  - `release_kv_cache()` rejects `enable_sleep_mode=False`.
  - Tag-selective allocator release keeps non-KV allocations usable.
  - End-to-end release/resume generation correctness.

## Semantics

`release_kv_cache()` intentionally follows the default `sleep()` control-plane semantics:

- It uses abort behavior for in-flight requests.
- It clears logical prefix/KV-related cache state before physical release.
- It keeps the scheduler paused until `resume_kv_cache()` is called.
- It releases only physical memory associated with the `kv_cache` allocator tag.

It does not preserve in-flight request state and does not recompute KV cache on resume.

`release_kv_cache()` requires `enable_sleep_mode=True`. Without sleep mode, the
KV cache is not allocated under the tagged CuMemAllocator pool, so the API fails
closed instead of pausing the scheduler while freeing no KV memory.

## Why This Is Not Duplicating Existing Work

Duplicate-work checks run before preparing this PR:

```bash
gh api '/search/issues?q=release_kv_cache+repo:vllm-project/vllm+type:pr+state:open'
gh api '/search/issues?q=%22release+kv+cache%22+repo:vllm-project/vllm+type:pr+state:open'
gh pr list --repo vllm-project/vllm --state open --search "sleep KV cache in:body,title"
gh pr list --repo vllm-project/vllm --state open --search "RL KV cache memory in:body,title"
```

No open PR implements the same `release_kv_cache()` / `resume_kv_cache()` API.

Related but not equivalent work:

- #40897 adds sleep level 3, which keeps weights resident but discards non-weight allocations broadly. This PR is narrower: it releases only the `kv_cache` tag and leaves `weights`, `scheduling`, and custom tags untouched.
- #42249 adds recompute partial rollout sleep mode, preserving request/token state and recomputing KV after wake. This PR does not preserve in-flight requests or add recompute behavior.
- #38514 adds context-aware KV-cache retention/eviction priorities. It manages which KV blocks to retain under pressure, not an explicit whole-KV-cache memory release API.
- #41594 fixes KV-related memory cleanup during MRV2 shutdown. This PR is a runtime release/resume API, not shutdown cleanup.
- #37065 serializes GPU VMM sleep/wake operations to avoid races. It is relevant to deployment safety but does not add KV-only release semantics.
- #33195 added sleep level 0 scheduling pause without memory release.
- #11743 introduced the transparent sleep-mode foundation this PR builds on.
- #31943 is RL weight-sync related, but addresses synchronization transport rather than freeing KV cache memory.

Related work in vLLM Ascend and SGLang shows similar RL memory lifecycle pressure, but does not provide this vLLM CUDA `kv_cache` tag-only release primitive.

## Test Plan

```bash
.venv/bin/python -m ruff check \
  vllm/v1/engine/core.py \
  vllm/v1/engine/core_client.py \
  vllm/engine/protocol.py \
  vllm/entrypoints/llm.py \
  vllm/entrypoints/serve/sleep/api_router.py \
  vllm/v1/engine/async_llm.py \
  vllm/v1/engine/llm_engine.py \
  vllm/v1/executor/abstract.py \
  vllm/v1/metrics/loggers.py \
  tests/basic_correctness/test_cumem.py

git diff --check

.venv/bin/python -m pytest \
  tests/basic_correctness/test_cumem.py::test_release_kv_cache_api_has_no_mode \
  tests/basic_correctness/test_cumem.py::test_release_kv_cache_requires_sleep_mode \
  tests/basic_correctness/test_cumem.py::test_release_tags_only_releases_selected_tag \
  -q

PATH="$PWD/.venv/bin:$PATH" VLLM_USE_FLASHINFER_SAMPLER=1 \
  .venv/bin/python -m pytest \
  tests/basic_correctness/test_cumem.py::test_release_resume_kv_cache \
  -v -s
```

## Test Results

- `ruff check`: passed.
- `git diff --check`: passed.
- `test_release_kv_cache_api_has_no_mode`, `test_release_kv_cache_requires_sleep_mode`,
  and `test_release_tags_only_releases_selected_tag`: passed.
- `test_release_resume_kv_cache` with `VLLM_USE_FLASHINFER_SAMPLER=1`: passed.
  - Logs confirmed `Using FlashInfer for top-p & top-k sampling`.
  - Logs showed `CuMemAllocator.release_tags(('kv_cache',))` freed about 40.57 GiB.

## Notes

- This PR intentionally does not implement wait/drain semantics. Callers that need graceful async RL draining should stop or drain requests externally before invoking `release_kv_cache()`.
- This PR does not address VLM encoder-cache illegal-memory concerns; that should be validated and fixed separately with a VLM repro.

## AI Assistance

AI assistance was used to prepare this change and draft this PR description. The human submitter is responsible for reviewing every changed line and rerunning relevant tests before submission.
