### PR TITLE
Add release_kv_cache API

### DIFF
--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -61,7 +61,7 @@ llm.wake_up(tags=["kv_cache"])
 
 During RLHF training, vLLM allows you to selectively wake up only the model weights or the KV cache using the tags argument in wake_up(). This fine-grained control is especially useful when updating model weights: by waking up just the weights (e.g., llm.wake_up(tags=["weights"])), you avoid allocating memory for the KV cache until after the weight update is complete. This approach helps prevent GPU out-of-memory (OOM) errors, particularly with large models, by minimizing peak memory usage during weight synchronization and update operations.
 
-Use `tags=["weights"]` or `tags=["kv_cache"]` to control which resources are restored, useful for RLHF and weight updates. **Note** that `is_sleeping` will report `true` until all components are awake.
+Use `tags=["weights"]` or `tags=["kv_cache"]` to control which resources are restored, useful for RLHF and weight updates. `is_sleeping` will report `true` until all sleeping memory tags are restored. It also reports `true` while scheduling is paused or any tag-based sleep has not been woken up.
 
 ```python
 # Put engine to deep sleep (level=2)
@@ -73,6 +73,18 @@ llm.wake_up(tags=["weights"])
 # wake up KV cache after weights are updated
 llm.wake_up(tags=["kv_cache"])
 ```
+
+If you need direct resource-level control, use `sleep(tags=...)` and `wake_up(tags=...)` with memory tags. Currently supported tags are `"kv_cache"` and `"weights"`. Sleeping `"weights"` discards weight memory; sleeping `"kv_cache"` discards KV cache contents. Sleeping memory is remapped empty on wake-up. Like level-based sleep, tag-based sleep accepts a `mode` argument to control in-flight requests. The default is `mode="abort"`, which aborts in-flight requests before memory is released.
+
+```python
+llm.sleep(tags=["kv_cache"])
+llm.wake_up(tags=["kv_cache"])
+
+llm.sleep(tags=["weights"])
+llm.wake_up(tags=["weights"])
+```
+
+`sleep(level=1/2)` remains the preset form, while `sleep(tags=...)` is the explicit memory-tag form. If `tags` are provided, they take precedence over the level preset. `sleep(level=0)` only pauses scheduling. Sleeping an already sleeping tag or waking up a tag that is not sleeping is a no-op.
 
 ### Online Serving
 
@@ -110,6 +122,7 @@ curl -X POST 'http://localhost:8000/wake_up?tags=kv_cache'
 #### HTTP endpoints
 
 - `POST /sleep?level=1` — Put the model to sleep (`level=1`).
+- `POST /sleep?tags=kv_cache&mode=abort` — Sleep the requested memory tags. Repeat `tags` to sleep multiple resources, for example `?tags=weights&tags=kv_cache`.
 - `POST /wake_up` — Wake up the model. Supports optional `tags` query parameters for partial wake-up (e.g., `?tags=weights`).
 - `POST /collective_rpc` — Perform a collective remote procedure call (RPC).
 - `GET /is_sleeping` — Check if the model is sleeping.

--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -74,7 +74,7 @@ llm.wake_up(tags=["weights"])
 llm.wake_up(tags=["kv_cache"])
 ```
 
-If you need direct resource-level control, use `sleep(tags=...)` and `wake_up(tags=...)` with memory tags. Currently supported tags are `"kv_cache"` and `"weights"`. Sleeping `"weights"` discards weight memory; sleeping `"kv_cache"` discards KV cache contents. Sleeping memory is remapped empty on wake-up. Like level-based sleep, tag-based sleep accepts a `mode` argument to control in-flight requests. The default is `mode="abort"`, which aborts in-flight requests before memory is released.
+If you need direct resource-level control, use `sleep(tags=...)` and `wake_up(tags=...)` with memory tags. Tags identify GPU memory to release; they are not offload directives. Currently supported tags are `"kv_cache"` and `"weights"`. Sleeping `"weights"` releases weight GPU memory; sleeping `"kv_cache"` releases KV cache GPU memory and discards KV cache contents. Sleeping memory is remapped empty on wake-up. Like level-based sleep, tag-based sleep accepts a `mode` argument to control in-flight requests. The default is `mode="abort"`, which aborts in-flight requests before memory is released.
 
 ```python
 llm.sleep(tags=["kv_cache"])
@@ -122,7 +122,7 @@ curl -X POST 'http://localhost:8000/wake_up?tags=kv_cache'
 #### HTTP endpoints
 
 - `POST /sleep?level=1` — Put the model to sleep (`level=1`).
-- `POST /sleep?tags=kv_cache&mode=abort` — Sleep the requested memory tags. Repeat `tags` to sleep multiple resources, for example `?tags=weights&tags=kv_cache`.
+- `POST /sleep?tags=kv_cache&mode=abort` — Release the requested memory tags. Repeat `tags` to release multiple resources, for example `?tags=weights&tags=kv_cache`.
 - `POST /wake_up` — Wake up the model. Supports optional `tags` query parameters for partial wake-up (e.g., `?tags=weights`).
 - `POST /collective_rpc` — Perform a collective remote procedure call (RPC).
 - `GET /is_sleeping` — Check if the model is sleeping.

--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -177,6 +177,43 @@ def test_end_to_end(model: str):
     assert output[0].outputs[0].text == output3[0].outputs[0].text
 
 
+@create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
+def test_sleep_wake_memory_tags():
+    model = "Qwen/Qwen3-0.6B"
+    kv_cache_bytes = 8 * GiB_bytes
+    llm = LLM(
+        model,
+        enable_sleep_mode=True,
+        kv_cache_memory_bytes=kv_cache_bytes,
+    )
+    prompt = "How are you?"
+    sampling_params = SamplingParams(temperature=0, max_tokens=10)
+    output = llm.generate(prompt, sampling_params)
+
+    free_gpu_bytes_before_release = torch.cuda.mem_get_info()[0]
+    llm.sleep(tags=["kv_cache"])
+
+    free_gpu_bytes_after_release, _ = torch.cuda.mem_get_info()
+    released_bytes = free_gpu_bytes_after_release - free_gpu_bytes_before_release
+    assert released_bytes >= kv_cache_bytes * 0.99
+
+    free_gpu_bytes_before_resume = torch.cuda.mem_get_info()[0]
+    llm.wake_up(tags=["kv_cache"])
+    free_gpu_bytes_after_resume = torch.cuda.mem_get_info()[0]
+    resumed_bytes = free_gpu_bytes_before_resume - free_gpu_bytes_after_resume
+    assert resumed_bytes >= kv_cache_bytes * 0.99
+
+    output2 = llm.generate(prompt, sampling_params)
+    assert output[0].outputs[0].text == output2[0].outputs[0].text
+
+    free_gpu_bytes_before_weight_release = torch.cuda.mem_get_info()[0]
+    llm.sleep(tags=["weights"])
+    free_gpu_bytes_after_weight_release = torch.cuda.mem_get_info()[0]
+    assert free_gpu_bytes_after_weight_release > free_gpu_bytes_before_weight_release
+
+    llm.wake_up(tags=["weights"])
+
+
 @create_new_process_for_each_test()
 def test_deep_sleep():
     model = "hmellor/tiny-random-LlamaForCausalLM"

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -53,6 +53,7 @@ class AllocationData:
     handle: HandleType
     tag: str
     cpu_backup_tensor: torch.Tensor | None = None
+    is_mapped: bool = True
 
 
 def create_and_map(allocation_handle: HandleType) -> None:
@@ -174,18 +175,26 @@ class CuMemAllocator:
         )
         return data.handle
 
-    def sleep(self, offload_tags: tuple[str, ...] | str | None = None) -> None:
+    def sleep(
+        self,
+        tags: list[str] | tuple[str, ...] | None = None,
+        offload_tags: tuple[str, ...] | str | None = None,
+    ) -> None:
         """
-        Put the allocator in sleep mode.
-        All data in the memory allocation with the specified tag will be
-        offloaded to CPU memory, and others will be discarded.
+        Put matching allocator tags in sleep mode.
 
-        :param offload_tags: The tags of the memory allocation that will be
-            offloaded. The rest of the memory allocation will be discarded.
+        :param tags: Tags to release. If None, all allocations are released.
+        :param offload_tags: Tags that should be copied to CPU before release.
+            Released tags not listed here are discarded and remapped empty on
+            wake-up.
         """
+        if tags is None:
+            tags = tuple(data.tag for data in self.pointer_to_data.values())
+        if not tags:
+            logger.info("No memory tags to release.")
+            return
+
         if offload_tags is None:
-            # by default, allocated tensors are offloaded
-            # when the allocator sleeps
             offload_tags = (CuMemAllocator.default_tag,)
         elif isinstance(offload_tags, str):
             offload_tags = (offload_tags,)
@@ -196,6 +205,10 @@ class CuMemAllocator:
         backup_bytes = 0
 
         for ptr, data in self.pointer_to_data.items():
+            if not data.is_mapped:
+                continue
+            if data.tag not in tags:
+                continue
             handle = data.handle
             total_bytes += handle[1]
             if data.tag in offload_tags:
@@ -211,22 +224,22 @@ class CuMemAllocator:
                 libcudart.cudaMemcpy(cpu_ptr, ptr, size_in_bytes)
                 data.cpu_backup_tensor = cpu_backup_tensor
             unmap_and_release(handle)
+            data.is_mapped = False
 
         logger.info(
-            "CuMemAllocator: sleep freed %.2f GiB memory in total, of which "
-            "%.2f GiB is backed up in CPU and the rest %.2f GiB is discarded "
-            "directly.",
+            "CuMemAllocator: sleep(%s) freed %.2f GiB memory, "
+            "including %.2f GiB backed up in CPU.",
+            tags,
             total_bytes / 1024**3,
             backup_bytes / 1024**3,
-            (total_bytes - backup_bytes) / 1024**3,
         )
 
         gc.collect()
         torch.cuda.empty_cache()
 
-    def wake_up(self, tags: list[str] | None = None) -> None:
+    def wake_up(self, tags: list[str] | tuple[str, ...] | None = None) -> None:
         """
-        Wake up the allocator from sleep mode.
+        Wake up allocations matching the given tags.
         All data that is previously offloaded will be loaded back to GPU
         memory, and the rest of the data will have empty memory.
 
@@ -234,10 +247,19 @@ class CuMemAllocator:
             back to GPU memory. If None, all memory allocation will be loaded
             back to GPU memory.
         """
+        if tags is None:
+            tags = tuple(data.tag for data in self.pointer_to_data.values())
+        if not tags:
+            logger.info("No memory tags to resume.")
+            return
+
         for ptr, data in self.pointer_to_data.items():
-            if tags is None or data.tag in tags:
+            if data.tag in tags:
+                if data.is_mapped:
+                    continue
                 handle = data.handle
                 create_and_map(handle)
+                data.is_mapped = True
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -161,7 +161,12 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
-    async def sleep(self, level: int = 1, mode: "PauseMode" = "abort") -> None:
+    async def sleep(
+        self,
+        level: int = 1,
+        mode: "PauseMode" = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
         """Sleep the engine"""
         ...
 

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -167,12 +167,12 @@ class EngineClient(ABC):
         mode: "PauseMode" = "abort",
         tags: list[str] | None = None,
     ) -> None:
-        """Sleep the engine"""
+        """Sleep the engine and optionally release tagged GPU memory."""
         ...
 
     @abstractmethod
     async def wake_up(self, tags: list[str] | None = None) -> None:
-        """Wake up the engine"""
+        """Wake up the engine, reallocating sleeping memory tags if provided."""
         ...
 
     @abstractmethod

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -803,7 +803,12 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             reset_running_requests, reset_connector
         )
 
-    def sleep(self, level: int = 1, mode: PauseMode = "abort"):
+    def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ):
         """
         Put the engine to sleep. The engine should not process any requests.
         The caller should guarantee that no requests are being processed
@@ -825,8 +830,11 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                            CPU memory pressure.
             mode: How to handle any existing requests, can be "abort", "wait",
                 or "keep".
+            tags: Optional memory tags to sleep instead of using a level
+                preset. Values must be in `("weights", "kv_cache")`. If tags
+                are provided, they take precedence over the level preset.
         """
-        self.llm_engine.sleep(level=level, mode=mode)
+        self.llm_engine.sleep(level=level, mode=mode, tags=tags)
 
     def wake_up(self, tags: list[str] | None = None):
         """

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -831,8 +831,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             mode: How to handle any existing requests, can be "abort", "wait",
                 or "keep".
             tags: Optional memory tags to sleep instead of using a level
-                preset. Values must be in `("weights", "kv_cache")`. If tags
-                are provided, they take precedence over the level preset.
+                preset. Values must be in `("weights", "kv_cache")`. Tags
+                identify GPU memory to release and do not imply CPU offload.
+                If tags are provided, they take precedence over the level
+                preset.
         """
         self.llm_engine.sleep(level=level, mode=mode, tags=tags)
 

--- a/vllm/entrypoints/serve/dev/sleep/api_router.py
+++ b/vllm/entrypoints/serve/dev/sleep/api_router.py
@@ -23,7 +23,10 @@ async def sleep(raw_request: Request):
     # get POST params
     level = raw_request.query_params.get("level", "1")
     mode = raw_request.query_params.get("mode", "abort")
-    await engine_client(raw_request).sleep(int(level), mode)
+    tags = raw_request.query_params.getlist("tags")
+    if tags == []:
+        tags = None
+    await engine_client(raw_request).sleep(int(level), mode, tags)
     # FIXME: in v0 with frontend multiprocessing, the sleep command
     # is sent but does not finish yet when we return a response.
     return Response(status_code=200)

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -928,13 +928,22 @@ class AsyncLLM(EngineClient):
     async def reset_encoder_cache(self) -> None:
         await self.engine_core.reset_encoder_cache_async()
 
-    async def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
-        if level >= 1:
+    async def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
+        clear_mm_cache = (
+            tags is None and level >= 1 or (tags is not None and "weights" in tags)
+        )
+        if clear_mm_cache:
             await self.renderer.clear_mm_cache_async()
-        await self.engine_core.sleep_async(level, mode)
+        await self.engine_core.sleep_async(level, mode, tags)
 
         if self.logger_manager is not None:
-            self.logger_manager.record_sleep_state(1, level)
+            sleep_level = 0 if tags is not None else level
+            self.logger_manager.record_sleep_state(1, sleep_level)
 
     async def wake_up(self, tags: list[str] | None = None) -> None:
         await self.engine_core.wake_up_async(tags)

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -154,6 +154,7 @@ class AsyncLLM(EngineClient):
 
         # Loggers.
         self.logger_manager: StatLoggerManager | None = None
+        self.sleeping_tags: set[str] = set()
         if self.log_stats:
             self.logger_manager = StatLoggerManager(
                 vllm_config=vllm_config,
@@ -943,13 +944,22 @@ class AsyncLLM(EngineClient):
 
         if self.logger_manager is not None:
             sleep_level = 0 if tags is not None else level
-            self.logger_manager.record_sleep_state(1, sleep_level)
+            if tags is not None:
+                self.sleeping_tags.update(tags)
+            elif level >= 1:
+                self.sleeping_tags.update(("weights", "kv_cache"))
+            self.logger_manager.record_sleep_state(1, sleep_level, self.sleeping_tags)
 
     async def wake_up(self, tags: list[str] | None = None) -> None:
         await self.engine_core.wake_up_async(tags)
 
         if self.logger_manager is not None:
-            self.logger_manager.record_sleep_state(0, 0)
+            if tags is None:
+                self.sleeping_tags.clear()
+            else:
+                self.sleeping_tags.difference_update(tags)
+            sleep = int(bool(self.sleeping_tags))
+            self.logger_manager.record_sleep_state(sleep, 0, self.sleeping_tags)
 
     async def is_sleeping(self) -> bool:
         return await self.engine_core.is_sleeping_async()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -744,13 +744,14 @@ class EngineCore:
                 preset.
         """
 
-        if tags is not None and not tags:
-            return None
         if tags is not None:
+            if not tags:
+                raise ValueError(
+                    "sleep() got tags=[], expected None or non-empty tags."
+                )
             for tag in tags:
                 if tag not in ("weights", "kv_cache"):
-                    logger.warning("Tag %s is not sleepable.", tag)
-                    return None
+                    raise ValueError(f"Tag {tag} is not sleepable.")
 
         # Pause scheduler before sleeping.
         clear_prefix_cache = tags is not None or level >= 1

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -724,7 +724,12 @@ class EngineCore:
         """Return whether the scheduler is in any pause state."""
         return self.scheduler.pause_state != PauseState.UNPAUSED
 
-    def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None | Future:
+    def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None | Future:
         """Put the engine to sleep at the specified level.
 
         Args:
@@ -735,18 +740,28 @@ class EngineCore:
                 - Level 2: Discard all GPU memory.
             mode: Pause mode - how to deal with any existing requests, see
                 documentation of pause_scheduler method.
+            tags: Optional memory tags to sleep instead of using a level
+                preset.
         """
 
+        if tags is not None and not tags:
+            return None
+        if tags is not None:
+            for tag in tags:
+                if tag not in ("weights", "kv_cache"):
+                    logger.warning("Tag %s is not sleepable.", tag)
+                    return None
+
         # Pause scheduler before sleeping.
-        clear_prefix_cache = level >= 1
+        clear_prefix_cache = tags is not None or level >= 1
         pause_future = self.pause_scheduler(mode=mode, clear_cache=clear_prefix_cache)
-        if level < 1:
+        if tags is None and level < 1:
             return pause_future
 
-        # Level 1+: Delegate to executor for GPU memory management
+        # Level 1+ or explicit tags: Delegate to executor for GPU memory management
         model_executor = self.model_executor
         if pause_future is None:
-            model_executor.sleep(level)
+            model_executor.sleep(level, tags=tags)
             return None
 
         future = Future[Any]()
@@ -754,7 +769,7 @@ class EngineCore:
         def pause_complete(f: Future):
             try:
                 f.result()  # propagate any exception
-                future.set_result(model_executor.sleep(level))
+                future.set_result(model_executor.sleep(level, tags=tags))
             except Exception as e:
                 future.set_exception(e)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -741,7 +741,8 @@ class EngineCore:
             mode: Pause mode - how to deal with any existing requests, see
                 documentation of pause_scheduler method.
             tags: Optional memory tags to sleep instead of using a level
-                preset.
+                preset. Tags identify GPU memory to release and do not imply
+                CPU offload.
         """
 
         if tags is not None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -156,7 +156,12 @@ class EngineCoreClient(ABC):
     def reset_encoder_cache(self) -> None:
         raise NotImplementedError
 
-    def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
+    def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
         raise NotImplementedError
 
     def wake_up(self, tags: list[str] | None = None) -> None:
@@ -233,7 +238,12 @@ class EngineCoreClient(ABC):
     async def reset_encoder_cache_async(self) -> None:
         raise NotImplementedError
 
-    async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
+    async def sleep_async(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
         raise NotImplementedError
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
@@ -320,10 +330,15 @@ class InprocClient(EngineCoreClient):
     def reset_encoder_cache(self) -> None:
         self.engine_core.reset_encoder_cache()
 
-    def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
+    def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
         if mode == "wait":
             raise ValueError("'wait' pause mode is not supported in inproc-engine mode")
-        result = self.engine_core.sleep(level, mode)
+        result = self.engine_core.sleep(level, mode, tags)
         assert result is None
 
     def wake_up(self, tags: list[str] | None = None) -> None:
@@ -905,8 +920,13 @@ class SyncMPClient(MPClient):
     def pin_lora(self, lora_id: int) -> bool:
         return self.call_utility("pin_lora", lora_id)
 
-    def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
-        self.call_utility("sleep", level, mode)
+    def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
+        self.call_utility("sleep", level, mode, tags)
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         self.call_utility("wake_up", tags)
@@ -1141,8 +1161,13 @@ class AsyncMPClient(MPClient):
     async def reset_encoder_cache_async(self) -> None:
         await self.call_utility_async("reset_encoder_cache")
 
-    async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
-        await self.call_utility_async("sleep", level, mode)
+    async def sleep_async(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ) -> None:
+        await self.call_utility_async("sleep", level, mode, tags)
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
         await self.call_utility_async("wake_up", tags)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -110,6 +110,7 @@ class LLMEngine:
         )
 
         self.logger_manager: StatLoggerManager | None = None
+        self.sleeping_tags: set[str] = set()
         if self.log_stats:
             self.logger_manager = StatLoggerManager(
                 vllm_config=vllm_config,
@@ -364,13 +365,22 @@ class LLMEngine:
 
         if self.logger_manager is not None:
             sleep_level = 0 if tags is not None else level
-            self.logger_manager.record_sleep_state(1, sleep_level)
+            if tags is not None:
+                self.sleeping_tags.update(tags)
+            elif level >= 1:
+                self.sleeping_tags.update(("weights", "kv_cache"))
+            self.logger_manager.record_sleep_state(1, sleep_level, self.sleeping_tags)
 
     def wake_up(self, tags: list[str] | None = None):
         self.engine_core.wake_up(tags)
 
         if self.logger_manager is not None:
-            self.logger_manager.record_sleep_state(0, 0)
+            if tags is None:
+                self.sleeping_tags.clear()
+            else:
+                self.sleeping_tags.difference_update(tags)
+            sleep = int(bool(self.sleeping_tags))
+            self.logger_manager.record_sleep_state(sleep, 0, self.sleeping_tags)
 
     def is_sleeping(self) -> bool:
         return self.engine_core.is_sleeping()

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -349,13 +349,22 @@ class LLMEngine:
         """
         self.engine_core.reset_encoder_cache()
 
-    def sleep(self, level: int = 1, mode: PauseMode = "abort"):
-        if level >= 1:
+    def sleep(
+        self,
+        level: int = 1,
+        mode: PauseMode = "abort",
+        tags: list[str] | None = None,
+    ):
+        clear_mm_cache = (
+            tags is None and level >= 1 or (tags is not None and "weights" in tags)
+        )
+        if clear_mm_cache:
             self.renderer.clear_mm_cache()
-        self.engine_core.sleep(level, mode)
+        self.engine_core.sleep(level, mode, tags)
 
         if self.logger_manager is not None:
-            self.logger_manager.record_sleep_state(1, level)
+            sleep_level = 0 if tags is not None else level
+            self.logger_manager.record_sleep_state(1, sleep_level)
 
     def wake_up(self, tags: list[str] | None = None):
         self.engine_core.wake_up(tags)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -315,20 +315,34 @@ class Executor(ABC):
         """Reset the encoder cache in each worker to clear cached encoder outputs."""
         self.collective_rpc("reset_encoder_cache")
 
-    def sleep(self, level: int = 1):
-        if self.is_sleeping:
-            logger.warning("Executor is already sleeping.")
+    def sleep(
+        self,
+        level: int = 1,
+        tags: list[str] | None = None,
+    ) -> None:
+        tags_to_sleep = ["weights", "kv_cache"] if tags is None else tags
+        tags_to_sleep = [tag for tag in tags_to_sleep if tag not in self.sleeping_tags]
+        if not tags_to_sleep:
+            logger.info("Memory tags %s are already sleeping.", tags)
             return
         time_before_sleep = time.perf_counter()
-        self.collective_rpc("sleep", kwargs=dict(level=level))
+        self.collective_rpc(
+            "sleep",
+            kwargs=dict(level=level, tags=tags_to_sleep if tags is not None else None),
+        )
         time_after_sleep = time.perf_counter()
-        self.sleeping_tags = {"weights", "kv_cache"}
-        self.is_sleeping = True
+        self.sleeping_tags.update(tags_to_sleep)
+        self.is_sleeping = bool(self.sleeping_tags)
         logger.info(
-            "It took %.6f seconds to fall asleep.", time_after_sleep - time_before_sleep
+            "It took %.6f seconds to sleep memory tags %s.",
+            time_after_sleep - time_before_sleep,
+            tags_to_sleep,
         )
 
-    def wake_up(self, tags: list[str] | None = None):
+    def wake_up(
+        self,
+        tags: list[str] | None = None,
+    ) -> None:
         if not self.is_sleeping:
             logger.warning("Executor is not sleeping.")
             return

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -67,7 +67,12 @@ class StatLoggerBase(ABC):
     def log(self):  # noqa
         pass
 
-    def record_sleep_state(self, is_awake: int, level: int):  # noqa
+    def record_sleep_state(  # noqa
+        self,
+        is_awake: int = 0,
+        level: int = 0,
+        sleeping_tags: set[str] | None = None,
+    ):
         pass
 
 
@@ -509,6 +514,25 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.gauge_engine_sleep_state[s] = {
                 idx: gauge_engine_sleep_state.labels(
                     engine=idx, model_name=model_name, sleep_state=s
+                )
+                for idx in engine_indexes
+            }
+
+        gauge_engine_sleep_tag_state = self._gauge_cls(
+            name="vllm:engine_sleep_tag_state",
+            documentation=(
+                "Engine memory sleep tag state; 1 means the memory tag is "
+                "sleeping/released, 0 means the memory tag is awake/allocated."
+            ),
+            labelnames=labelnames + ["sleep_tag"],
+            multiprocess_mode="mostrecent",
+        )
+
+        self.gauge_engine_sleep_tag_state = {}
+        for tag in ("weights", "kv_cache"):
+            self.gauge_engine_sleep_tag_state[tag] = {
+                idx: gauge_engine_sleep_tag_state.labels(
+                    engine=idx, model_name=model_name, sleep_tag=tag
                 )
                 for idx in engine_indexes
             }
@@ -1216,10 +1240,16 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     finished_request.max_tokens_param
                 )
 
-    def record_sleep_state(self, sleep: int = 0, level: int = 0):
+    def record_sleep_state(
+        self,
+        sleep: int = 0,
+        level: int = 0,
+        sleeping_tags: set[str] | None = None,
+    ):
         awake = 1
         discard_all = 0
         weights_offloaded = 0
+        sleeping_tags = sleeping_tags or set()
 
         if sleep == 1:
             awake = 0
@@ -1234,6 +1264,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 weights_offloaded
             )
             self.gauge_engine_sleep_state["awake"][engine_idx].set(awake)
+            for tag in ("weights", "kv_cache"):
+                self.gauge_engine_sleep_tag_state[tag][engine_idx].set(
+                    int(tag in sleeping_tags)
+                )
 
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
@@ -1347,9 +1381,14 @@ class StatLoggerManager:
                 engine_idx=engine_idx,
             )
 
-    def record_sleep_state(self, sleep: int = 0, level: int = 0):
+    def record_sleep_state(
+        self,
+        sleep: int = 0,
+        level: int = 0,
+        sleeping_tags: set[str] | None = None,
+    ):
         for logger in self.stat_loggers:
-            logger.record_sleep_state(sleep, level)
+            logger.record_sleep_state(sleep, level, sleeping_tags)
 
     def log(self):
         for logger in self.stat_loggers:

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -158,7 +158,11 @@ class CPUWorker(Worker):
         else:
             self.model_runner = CPUModelRunner(self.vllm_config, torch.device("cpu"))
 
-    def sleep(self, level: int = 1) -> None:
+    def sleep(
+        self,
+        level: int = 1,
+        tags: list[str] | None = None,
+    ) -> None:
         logger.warning("sleep mode is not supported on CPU, ignore it.")
         pass
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -158,26 +158,41 @@ class Worker(WorkerBase):
         # pending non-blocking PP send work from the previous iteration
         self._pp_send_work: list[Handle] = []
 
-    def sleep(self, level: int = 1) -> None:
+    def sleep(
+        self,
+        level: int = 1,
+        tags: list[str] | None = None,
+    ) -> None:
+        tags_to_sleep = tags if tags is not None else ["weights", "kv_cache"]
+        if not tags_to_sleep:
+            logger.info("No memory tags to sleep.")
+            return
+
         from vllm.device_allocator.cumem import CuMemAllocator
 
         free_bytes_before_sleep = torch.cuda.mem_get_info()[0]
 
         # Save the buffers before level 2 sleep
-        if level == 2:
+        if tags is None and level == 2:
             model = self.model_runner.model
             self._sleep_saved_buffers = {
                 name: buffer.cpu().clone() for name, buffer in model.named_buffers()
             }
 
         allocator = CuMemAllocator.get_instance()
-        allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
+        allocator.sleep(
+            tags=tags_to_sleep,
+            offload_tags=("weights",) if tags is None and level == 1 else tuple(),
+        )
+
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep
         assert freed_bytes >= 0, "Memory usage increased after sleeping."
         logger.info(
-            "Sleep mode freed %s GiB memory, %s GiB memory is still in use.",
+            "Sleep mode released tags %s and freed %s GiB memory, "
+            "%s GiB memory is still in use.",
+            tags_to_sleep,
             format_gib(freed_bytes),
             format_gib(used_bytes),
         )
@@ -188,8 +203,8 @@ class Worker(WorkerBase):
         allocator = CuMemAllocator.get_instance()
         allocator.wake_up(tags)
 
-        # Restore the buffers after level 2 sleep
-        if len(self._sleep_saved_buffers):
+        wake_up_weights = tags is None or "weights" in tags
+        if len(self._sleep_saved_buffers) and wake_up_weights:
             model = self.model_runner.model
             for name, buffer in model.named_buffers():
                 if name in self._sleep_saved_buffers:


### PR DESCRIPTION



## Purpose
This PR adds a KV-cache-only release/resume API for vLLM sleep mode.

The target use case is RL training / rollout weight-sync windows where an external trainer needs temporary GPU
memory, but model weights should remain resident on GPU. Existing `sleep(level=1)` can release KV cache,
but it also offloads weights to CPU. `reset_prefix_cache()` only clears logical cache state and does not release the underlying KV cache allocation.

This PR introduces a smaller primitive:

- `release_kv_cache()`: clears logical cache state, and releases only CuMemAllocator allocations tagged as `kv_cache`.
- `resume_kv_cache()`: reallocates/remaps KV cache and resumes scheduling.

Model weights, scheduling allocations, and other custom allocator tags remain untouched. The API requires
`enable_sleep_mode=True`, because KV cache memory is only tracked by the tagged CuMemAllocator pool in sleep
mode.

## Test Plan

Run the focused allocator and end-to-end KV cache release/resume tests:

```bash
python -m pytest \
  tests/basic_correctness/test_cumem.py::test_release_tags_only_releases_selected_tag \
  -q

python -m pytest \
  tests/basic_correctness/test_cumem.py::test_release_resume_kv_cache \
  -v -s
```

Verify the serving API with sleep mode enabled:

```
vllm serve facebook/opt-125m \
  --enable-sleep-mode \
  --gpu-memory-utilization 0.3 \
  --port 18000 \
  --host 127.0.0.1 \
  --max-model-len 512

curl http://127.0.0.1:18000/health
curl http://127.0.0.1:18000/is_sleeping
curl -X POST http://127.0.0.1:18000/release_kv_cache
curl http://127.0.0.1:18000/is_sleeping
curl http://127.0.0.1:18000/metrics
curl -X POST http://127.0.0.1:18000/resume_kv_cache
curl http://127.0.0.1:18000/is_sleeping
curl -X POST http://127.0.0.1:18000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"facebook/opt-125m","prompt":"Hello","max_tokens":4,"temperature":0}'
```

## Test Result

```
tests/basic_correctness/test_cumem.py::test_release_tags_only_releases_selected_tag PASSED
tests/basic_correctness/test_cumem.py::test_release_resume_kv_cache PASSED
```

Serving API test passed:
```
GET  /health            -> 200
GET  /is_sleeping       -> {"is_sleeping": false}
POST /release_kv_cache  -> 200
GET  /is_sleeping       -> {"is_sleeping": true}
GET  /metrics           -> kv_cache_released = 1.0
POST /resume_kv_cache   -> 200
GET  /is_sleeping       -> {"is_sleeping": false}
POST /v1/completions    -> 200

Metrics after release_kv_cache:
vllm:engine_sleep_state{sleep_state="awake"} 0.0
vllm:engine_sleep_state{sleep_state="weights_offloaded"} 0.0
vllm:engine_sleep_state{sleep_state="discard_all"} 0.0
vllm:engine_sleep_state{sleep_state="kv_cache_released"} 1.0

Server logs:
Route: /release_kv_cache, Methods: POST
Route: /resume_kv_cache, Methods: POST
CuMemAllocator: release_tags(('kv_cache',)) freed 40.60 GiB memory.
Released KV cache and freed 41.27 GiB memory, 1.09 GiB memory is still in use.
It took 0.033738 seconds to resume KV cache.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

