### PR TITLE
[Bugfix] Fix incorrect chat template format for Qwen3.5

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -363,6 +363,7 @@ def test_resolve_chat_template_kwargs_with_template_name():
         ("microsoft/Phi-3.5-vision-instruct", "string"),
         ("Qwen/Qwen2-VL-2B-Instruct", "openai"),
         ("Qwen/Qwen2.5-VL-3B-Instruct", "openai"),
+        ("Qwen/Qwen3.5-4B", "openai"),
         ("fixie-ai/ultravox-v0_5-llama-3_2-1b", "string"),
         ("Qwen/Qwen2-Audio-7B-Instruct", "openai"),
         ("meta-llama/Llama-Guard-3-1B", "openai"),

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -402,6 +402,7 @@ def _iter_nodes_assign_content_item(root: jinja2.nodes.Node):
     ]
 
     # Search for {%- for content in message['content'] -%} loops
+    # or {%- for item in content -%} loops
     for loop_ast in root.find_all(jinja2.nodes.For):
         loop_iter = loop_ast.iter
         loop_target = loop_ast.target
@@ -411,6 +412,9 @@ def _iter_nodes_assign_content_item(root: jinja2.nodes.Node):
                 assert isinstance(loop_target, jinja2.nodes.Name)
                 yield loop_ast, loop_target.name
                 break
+
+        if isinstance(loop_iter, jinja2.nodes.Name) and loop_iter.name == "content":
+            yield loop_ast, loop_iter.name
 
 
 def _try_extract_ast(chat_template: str) -> jinja2.nodes.Template | None:

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -414,7 +414,8 @@ def _iter_nodes_assign_content_item(root: jinja2.nodes.Node):
                 break
 
         if isinstance(loop_iter, jinja2.nodes.Name) and loop_iter.name == "content":
-            yield loop_ast, loop_iter.name
+            assert isinstance(loop_target, jinja2.nodes.Name)
+            yield loop_ast, loop_target.name
 
 
 def _try_extract_ast(chat_template: str) -> jinja2.nodes.Template | None:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix the chat template content format for Qwen3.5 being detected as `string` instead of `openai`. This caused an extra newline to be inserted between multimodal inputs and text inputs, and also interleaving to not be applied by default (unless you set `--interleave-mm-strings`).

Somehow, no one noticed this before. I only figured this out when debugging a token mismatch issue when trying to run https://github.com/vllm-project/speculators/pull/495 with Qwen3.5

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
