### PR TITLE
Fix ITL accuracy when server batches multiple tokens per SSE chunk

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -310,6 +310,7 @@ async def async_request_openai_chat_completions(
         "stream": True,
         "stream_options": {
             "include_usage": True,
+            "continuous_usage_stats": True,
         },
     }
     _update_payload_common(payload, request_func_input)
@@ -322,6 +323,7 @@ async def async_request_openai_chat_completions(
 
     generated_text = ""
     ttft = 0.0
+    prev_completion_tokens = 0
     st = time.perf_counter()
     output.start_time = st
     most_recent_timestamp = st
@@ -350,14 +352,37 @@ async def async_request_openai_chat_completions(
 
                             if choices := data.get("choices"):
                                 content = choices[0]["delta"].get("content")
+
+                                # Determine token count from continuous
+                                # usage stats. Falls back to 1 if the server
+                                # does not support continuous_usage_stats.
+                                n_tokens = 1
+                                if usage := data.get("usage"):
+                                    completion_tokens = usage.get(
+                                        "completion_tokens", 0
+                                    )
+                                    n_tokens = max(
+                                        1,
+                                        completion_tokens - prev_completion_tokens,
+                                    )
+                                    prev_completion_tokens = completion_tokens
+
                                 # First token
                                 if ttft == 0.0:
                                     ttft = timestamp - st
                                     output.ttft = ttft
+                                    if n_tokens > 1:
+                                        output.itl.extend(
+                                            [0.0] * (n_tokens - 1)
+                                        )
 
                                 # Decoding phase
                                 else:
-                                    output.itl.append(timestamp - most_recent_timestamp)
+                                    time_delta = timestamp - most_recent_timestamp
+                                    per_token_itl = time_delta / n_tokens
+                                    output.itl.extend(
+                                        [per_token_itl] * n_tokens
+                                    )
 
                                 generated_text += content or ""
                             elif usage := data.get("usage"):


### PR DESCRIPTION
## Purpose
When serving backends return multiple tokens in a single streaming chunk (observed on Dynamo-based deployment), the benchmark incorrectly records one ITL entry per chunk rather than per token, inflating ITL metrics. This fix enables `continuous_usage_stats` in the OpenAI chat completions request to determine the actual token count per chunk and distributes the measured time evenly across all tokens, producing accurate per-token ITL values. Servers that do not support this option are unaffected as the code falls back to the original one-token-per-chunk behavior.

## Test Plan

```
vllm bench serve --backend openai-chat --base-url http://$MMD_SERVER_IP \
   --model Qwen/Qwen3-VL-32B-Instruct-FP8 \
   --endpoint /chat/completions \
   --dataset-name random-mm \
   --num-prompts 128 \
   --request-rate 0.4 \
   --max-concurrency 128 \
   --random-input-len 128 \
   --random-output-len 256 \
   --percentile-metrics ttft,tpot,itl,e2el \
   --metric-percentiles 50,90,99 \
   --ignore-eos \
   --random-mm-base-items-per-request 8 --random-mm-num-mm-items-range-ratio 0.0 \
   --random-mm-bucket-config '{(1080, 1920, 1): 1.0}'
```

## Test Result
Before the fix (one ITL entry per SSE chunk, regardless of token count):
```
---------------Inter-token Latency----------------
Mean ITL (ms):                           320.96    
Median ITL (ms):                         55.96     
```

After the fix (ITL distributed across actual tokens in each chunk):
```
---------------Inter-token Latency----------------
Mean ITL (ms):                           262.75    
Median ITL (ms):                         56.20     
```
The median ITL is nearly unchanged (~56 ms), which is expected — the majority of SSE chunks still carry a single token, so their per-token latency is identical under both methods. The mean ITL drops significantly (320 → 263 ms) because chunks that carry multiple tokens were previously recorded as a single inflated ITL entry; the fix now splits that time evenly across the actual number of tokens, removing the upward bias. These corrected values have been independently verified against per-token timing calculated from raw debug output.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

