### PR TITLE
[LoRA][Gemma4] Fix text LoRA weight name mapping

### DIFF
--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -8,6 +8,7 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import parse_fine_tuned_lora_name
 from vllm.model_executor.models.baichuan import BaiChuanBaseForCausalLM
 from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
 from vllm.model_executor.models.utils import WeightsMapper
 
 lora_lst = ["baichuan7B", "baichuan7B-zero", "baichuan7B-zero-regex", "chatglm3-6b"]
@@ -150,4 +151,13 @@ def test_gemma4_moe_lora_weights_mapping():
     assert parse_fine_tuned_lora_name(name, mapper) == (
         "model.layers.9.moe.gate_up_proj",
         False,
+    )
+
+
+def test_gemma4_mm_text_lora_weights_mapping():
+    mapper = Gemma4ForConditionalGeneration.hf_to_vllm_mapper
+    name = "base_model.model.layers.9.self_attn.q_proj.weight.lora_A.weight"
+    assert parse_fine_tuned_lora_name(name, mapper) == (
+        "language_model.model.self_decoder.decoder_layers.9.self_attn.q_proj",
+        True,
     )

--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -53,6 +53,16 @@ def test_parse_fine_tuned_lora_name_valid():
             False,
         ),
         LoRANameParserTestConfig(
+            "base_model.model.model.layers.9.self_attn.q_proj.weight.lora_A.weight",
+            "model.layers.9.self_attn.q_proj",
+            True,
+        ),
+        LoRANameParserTestConfig(
+            "base_model.model.model.layers.9.self_attn.q_proj.weight.lora_B.weight",
+            "model.layers.9.self_attn.q_proj",
+            False,
+        ),
+        LoRANameParserTestConfig(
             "language_model.layers.9.mlp.down_proj.lora_A.weight",
             "language_model.layers.9.mlp.down_proj",
             True,

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -186,7 +186,11 @@ def parse_fine_tuned_lora_name(
 
     parts = name.split(".")
     if parts[-1] == "weight" and (parts[-2] == "lora_A" or parts[-2] == "lora_B"):
-        new_name = ".".join(parts[start_index:-2])
+        # Some PEFT adapters include the base weight suffix in LoRA tensor
+        # names, e.g. q_proj.weight.lora_A.weight.  The target module is still
+        # q_proj, not q_proj.weight.
+        end_index = -3 if len(parts) >= 3 and parts[-3] == "weight" else -2
+        new_name = ".".join(parts[start_index:end_index])
         return new_name, parts[-2] == "lora_A"
 
     if parts[-1] == "lora_embedding_A" or parts[-1] == "lora_embedding_B":

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -938,6 +938,10 @@ class Gemma4ForConditionalGeneration(
             "model.embed_audio.": "embed_audio.",
             "model.embed_vision.": "embed_vision.",
             "model.language_model.": "language_model.model.",
+            # Text LoRA adapters for Gemma4ForConditionalGeneration commonly
+            # store language weights under layers.*. The optimized vLLM text
+            # model exposes those layers under self_decoder.decoder_layers.*.
+            "layers.": "language_model.model.self_decoder.decoder_layers.",
             "model.vision_tower.": "vision_tower.",
             "model.audio_tower.": "audio_tower.",
             "lm_head.": "language_model.lm_head.",

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -938,9 +938,6 @@ class Gemma4ForConditionalGeneration(
             "model.embed_audio.": "embed_audio.",
             "model.embed_vision.": "embed_vision.",
             "model.language_model.": "language_model.model.",
-            # Text LoRA adapters for Gemma4ForConditionalGeneration commonly
-            # store language weights under layers.*. The optimized vLLM text
-            # model exposes those layers under self_decoder.decoder_layers.*.
             "layers.": "language_model.model.self_decoder.decoder_layers.",
             "model.vision_tower.": "vision_tower.",
             "model.audio_tower.": "audio_tower.",


### PR DESCRIPTION
Fixes #41702.

## Summary
- Map Gemma4ForConditionalGeneration text LoRA keys stored under `layers.*` onto vLLM's optimized text decoder path `language_model.model.self_decoder.decoder_layers.*`.
- Keep existing Gemma4 text-only and standard PEFT LoRA key behavior unchanged.
- Tolerate PEFT/extracted adapter tensor names that include the base weight suffix before the LoRA suffix, e.g. `q_proj.weight.lora_A.weight`, by resolving the target module as `q_proj`.

## Why this is backwards compatible
- Existing `q_proj.lora_A.weight` / `q_proj.lora_B.weight` names continue to parse exactly as before.
- The new `.weight.lora_A/B.weight` handling only applies when the component immediately before `lora_A`/`lora_B` is literally `weight`.
- The Gemma4 multimodal `layers.*` prefix mapping is additive and only affects adapter/checkpoint keys that start with `layers.`.

## Test plan
- Targeted parser/mapper assertions in a transient vLLM ROCm container:
  - `q_proj.weight.lora_A.weight` parses to `q_proj`.
  - standard `q_proj.lora_A.weight` still parses to `q_proj`.
  - Gemma4ForConditionalGeneration maps `base_model.model.layers.9.self_attn.q_proj.weight.lora_A.weight` to `language_model.model.self_decoder.decoder_layers.9.self_attn.q_proj`.
- Added unit coverage in `tests/lora/test_utils.py` and `tests/lora/test_lora_checkpoints.py`.
- Locally verified on MI325X ROCm with `google/gemma-4-31B-it` and the original `hotdogs/gemma4-31b-opus-lora` adapter: base and LoRA deterministic chat outputs differ, and first-token `Golden` logprob changed from `-0.25738632678985596` to `-0.1122070699930191`.

Note: Full pytest in this ad-hoc ROCm image is blocked by missing test-environment dependencies/fixtures (`tblib`, `tests.models`) and ROCm pin-memory behavior in unrelated checkpoint tests, so the targeted pure-function assertions were run instead.

Made with [Cursor](https://cursor.com)