### PR TITLE
[Bugfix][NVFP4] Expose batch-invariance for FlashInfer + CUTLASS FP4 MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -693,6 +693,19 @@ class CutlassExpertsFp4(mk.FusedMoEExpertsModular):
         return True
 
     @staticmethod
+    def _supports_batch_invariance() -> bool:
+        # The CUTLASS NVFP4 group GEMM uses weight-static activation scales
+        # (``a1_gscale`` / ``a2_gscale`` are loaded weight attributes, not
+        # derived from the batch) and a fixed per-expert tile, so the kernel
+        # output for a given ``(m_per_expert, n, k)`` is deterministic
+        # regardless of the surrounding batch composition. Declaring this
+        # lets ``VLLM_BATCH_INVARIANT=1`` users pair this MoE kernel with a
+        # batch-invariant attention backend (e.g. FlashInfer with its
+        # batch-invariant planner) and avoid the concurrent same-prompt
+        # repetition described in issue #31856.
+        return True
+
+    @staticmethod
     def _supports_quant_scheme(
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -410,6 +410,19 @@ class FlashInferBackend(AttentionBackend):
         )
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # The FlashInfer metadata builder already wires up batch-invariant
+        # planning when ``envs.VLLM_BATCH_INVARIANT`` is true: fixed
+        # ``decode_fixed_split_size`` / ``prefill_fixed_split_size`` values,
+        # ``disable_split_kv=True``, and a larger workspace buffer
+        # (``FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT``). The base
+        # class default of ``False`` was hiding that capability, which forced
+        # the selector to reject FlashInfer whenever batch invariance was
+        # requested. Declaring it here lets users opt in and avoids the
+        # concurrent same-prompt repetition seen with NVFP4 MoE in #31856.
+        return True
+
+    @classmethod
     def supports_sink(cls) -> bool:
         """FlashInfer supports sinks when TRTLLM attention is available (SM100)."""
         from vllm.utils.flashinfer import (


### PR DESCRIPTION
## Summary

Closes a dead gate that prevented `VLLM_BATCH_INVARIANT=1` from working with the FlashInfer attention + CUTLASS NVFP4 MoE stack, and verifies it as a workaround for the concurrent-same-prompt repetition reported in #31856 on MiniMax-M2-family NVFP4 checkpoints.

## What this PR actually does

Declares `supports_batch_invariance() → True` on two classes that already contain batch-invariant code paths but inherited the base-class `False`, which caused the attention selector / MoE oracle to reject the combination whenever a user set `VLLM_BATCH_INVARIANT=1`:

- **`FlashInferBackend`** — `decode_fixed_split_size`, `prefill_fixed_split_size`, `disable_split_kv`, and `FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT` are already wired up when `envs.VLLM_BATCH_INVARIANT` is true (`vllm/v1/attention/backends/flashinfer.py:560,751`); the gate was the only thing preventing the configuration from being selected.
- **`CutlassExpertsFp4`** — the CUTLASS NVFP4 group GEMM is batch-invariant in practice: `a1_gscale` / `a2_gscale` are loaded weight attributes (not derived from the batch), so the per-expert tile output for a fixed `(m_per_expert, n, k)` is deterministic regardless of surrounding batch composition.

Without either declaration, `VLLM_BATCH_INVARIANT=1` was effectively dead code on the default FlashInfer + CUTLASS NVFP4 MoE stack.

## Why this came up: issue #31856

The reporter saw concurrent same-prompt requests spiral into repetition loops on `lukealonso/MiniMax-M2.1-NVFP4`. We reproduced the same behavior on `nvidia/MiniMax-M2.7-NVFP4` (same model family, same NVFP4 ModelOpt recipe) and bisected the divergence layer-by-layer:

- Decode steps 1–3 are bit-exact identical between concurrency=1 and concurrency=2 runs.
- Step 4 first diverges at **layer 0 `self_attn`** output (`sum_diff ≈ 0.27` on a row of magnitude ~1080); the layer 0 `input_norm` input is still bit-identical. Divergence cascades from there.

Mechanism: FlashInfer attention's split-KV partition is a function of the dynamic batch size, so the attention output for the same query row differs subtly between an `m=1` and an `m=2` batch. (Confirmed by the FA3 author for that kernel family in [Dao-AILab/flash-attention#1897](https://github.com/Dao-AILab/flash-attention/issues/1897): "I don't think it's batch invariant unless you fix the split-KV size.") That tiny difference then propagates through the MoE router, where near-tied top-k expert scores get flipped and the model's downstream trajectory diverges.

## Honest framing

The repetition is **not really a vLLM kernel bug** — it's a sensitivity to numerical noise in this NVFP4 checkpoint family that gets triggered by FlashInfer's m-dependent attention. The MoE quantization (NVFP4 with the standard ModelOpt v0.43.0 recipe on cnn_dailymail + Nemotron-Post-Training calibration) leaves greedy-decoded top-k expert routing decisions near-tied at temperature 0, so any noise source can flip them. Evidence the checkpoint is the load-bearing part:

- **`moe_backend=marlin` on the same model is clean** with no BI involvement. Same FlashInfer attention, same hardware, same concurrent same-prompt pattern — only the MoE quantization differs.
- Per-expert `w2.input_scale` distributions in `nvidia/MiniMax-M2.7-NVFP4` have wide tails (e.g., layer 5: max ≈ 138× the median; layer 60: top 1% at ~15× the median), consistent with thin calibration coverage of 256 experts × 62 layers and no SmoothQuant-style outlier migration.
- Greedy temp-0 decoding with FP4-quantized experts leaves no safety margin against any noise — m-dependent attention reductions, cuBLAS algo picks, NCCL ordering, etc. could all in principle trigger similar drift.

So the recommendation hierarchy for users hitting this:

1. **Use a different MoE backend / quantization for this model.** `moe_backend=marlin` is clean today; FP8 variants of the same model also avoid the issue. Best fix, no perf tax, no env var.
2. **Re-quantize the NVFP4 checkpoint with SmoothQuant + per-channel `w2` + broader calibration corpus (code, math, multilingual).** Removes the underlying sensitivity. Action lives with the checkpoint maintainer.
3. **This PR + `VLLM_BATCH_INVARIANT=1`.** Removes one specific noise source (FlashInfer's m-dependent split-KV) so the canonical repro stops deterministically clean. Costs some decode throughput on long contexts due to the fixed-split planner and 2 GiB workspace. Useful when (1) and (2) aren't options.

The PR is worth landing for its own sake — `VLLM_BATCH_INVARIANT=1` is a documented opt-in for users who need deterministic inference (per #24583 and the [Thinking Machines blog](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/)), and the gate currently rejects a real combination of in-tree backends. Whether it should also auto-enable for detected NVFP4 MoE workers (so users don't have to know about the env var) is a follow-up policy call.

## Scope and limitations

This PR addresses `moe_backend=cutlass` (`CutlassExpertsFp4`). It does **not** address `moe_backend=flashinfer_cutlass` (`FlashInferExperts`, which calls `flashinfer.fused_moe.cutlass_fused_moe`). I empirically tested adding the analogous override there: with `VLLM_BATCH_INVARIANT=1` it produces a deterministic *bad* output (both concurrent reqs bit-exact identical but in a repetition attractor). The underlying FlashInfer MoE kernel has its own m-dependent autotuning that BI's vllm-side hooks don't reach. Declaring `_supports_batch_invariance()=True` there would be misleading, so I left it out. Users on that backend should switch to `moe_backend=cutlass` (this PR) or `moe_backend=marlin`.

This PR also intentionally does **not** auto-enable `VLLM_BATCH_INVARIANT` for NVFP4 MoE workers. That would close the silent-bug gap for users who don't know about the env var but would impose the BI workspace + fixed-split cost on every NVFP4 MoE deployment unconditionally. Reasonable follow-up if reviewers prefer.

## Why this isn't duplicating an existing PR

`gh pr list --repo vllm-project/vllm --state open --search "31856 in:body"` → no open PRs. Keyword searches (`nvfp4 moe repeat`, `batch_invariance flashinfer`, `MiniMax-M2 repetition`) returned only unrelated changes. Issue #31856 itself has root-cause analysis from the reporter but no fix linked.

## Test plan

Repro environment: B200 ×8, `nvidia/MiniMax-M2.7-NVFP4` (sample 4 from a GPQA log).

- [x] Canonical deterministic repro reproduced on `main` baseline: `moe_backend=cutlass` + TP=2 + concurrency=2 + same sample 4 + BF16 KV + `cudagraph_mode=NONE` + `enforce_eager` + TF32=0 → **2/2 bad**, 50× repeat of `"We'll also ensure we do not include any"`. `cutlass_c1` (concurrency=1) and `marlin_c2` are clean; `flashinfer_cutlass_c2` is unreliable across runs.
- [x] With this PR's two `supports_batch_invariance` overrides + `VLLM_BATCH_INVARIANT=1`: same repro → **0/2 bad**, both reqs `finish_reason=stop` at 1274 tokens, with **identical sha256** `224a0faefe6df543a49b35628eddd5393218aecdb03be1de99649f77c63fbae3` across both concurrent requests.
- [x] Empirical check on `flashinfer_cutlass` with the analogous override → still bad under BI=1 (documented in Scope above).
- [x] `pre-commit run ruff-check --files <changed>` → Passed.
- [x] `pre-commit run ruff-format --files <changed>` → Passed.
- [x] `pre-commit run mypy-3.10 --files <changed> --hook-stage manual` → Passed.
- [ ] CI: existing NVFP4 / FlashInfer / MoE tests (will run on CI here).

No regression test added: the canonical repro requires the full MiniMax-M2 NVFP4 model + TP=2 which is impractical for CI. Happy to add a unit test that asserts `FlashInferBackend.supports_batch_invariance() is True` and `CutlassExpertsFp4._supports_batch_invariance() is True` if reviewers want it.

## AI assistance

AI assistance (Claude) was used to bisect the layer-level divergence and design the fix. I (the submitter) understand the change end-to-end, reviewed every line, and ran the verification commands above.
