### PR TITLE
[Bugfix] Align runner_type with explicit --convert to avoid pooler_config crash

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -334,6 +334,36 @@ def test_draft_runner(model_id, expected_runner_type, expected_convert_type):
     assert config.convert_type == expected_convert_type
 
 
+@pytest.mark.parametrize(
+    ("model_id", "convert", "expected_runner_type", "expected_convert_type"),
+    [
+        ("distilbert/distilgpt2", "embed", "pooling", "embed"),
+        ("distilbert/distilgpt2", "classify", "pooling", "classify"),
+    ],
+)
+def test_convert_implies_pooling_runner(
+    model_id, convert, expected_runner_type, expected_convert_type
+):
+    """`--convert embed|classify` on a generative model must promote
+    `--runner` from auto to pooling; otherwise `pooler_config` is never
+    initialized and adapter wrapping later crashes. Regression test for
+    https://github.com/vllm-project/vllm/issues/42480
+    """
+    config = ModelConfig(model_id, convert=convert)
+
+    assert config.runner_type == expected_runner_type
+    assert config.convert_type == expected_convert_type
+    assert config.pooler_config is not None
+
+
+def test_convert_runner_conflict():
+    """An explicit `--runner generate` combined with a pooling converter is
+    a real inconsistency, not a configuration we should silently rewrite.
+    """
+    with pytest.raises(ValueError, match="--convert embed"):
+        ModelConfig("distilbert/distilgpt2", runner="generate", convert="embed")
+
+
 MODEL_IDS_EXPECTED = [
     ("Qwen/Qwen1.5-7B", 32768),
     ("mistralai/Mistral-7B-v0.1", 4096),

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -546,6 +546,29 @@ class ModelConfig:
             architectures, self.runner_type, self.convert
         )
 
+        # Align runner_type with an explicit converter. Each entry in
+        # `_RUNNER_CONVERTS` maps a converter to its target runner (e.g.
+        # `embed`/`classify` -> pooling). If the user passed `--convert` but
+        # left `--runner` on auto, infer the intended runner here; otherwise
+        # `pooler_config` never gets initialized below and adapter wrapping
+        # later crashes on `assert pooler_config is not None`. Inconsistent
+        # explicit pairs fail fast with a clear error.
+        if self.convert_type != "none":
+            target_runner = next(
+                r
+                for r, converts in _RUNNER_CONVERTS.items()
+                if self.convert_type in converts
+            )
+            if target_runner != self.runner_type:
+                if self.runner == "auto":
+                    self.runner_type = target_runner
+                else:
+                    raise ValueError(
+                        f"`--convert {self.convert_type}` is only valid with "
+                        f"`--runner {target_runner}`, but `--runner "
+                        f"{self.runner_type}` was specified."
+                    )
+
         if self.runner_type == "generate" and not is_generative_model:
             generate_converts = _RUNNER_CONVERTS["generate"]
             if self.convert_type not in generate_converts:


### PR DESCRIPTION
## Summary

Fixes #42480.

When `--convert embed|classify` is passed on a causal LM (e.g. `Llama-3.1-8B-Instruct`) with `--runner` left on its `auto` default, `_get_runner_type` resolves to `"generate"` based on the architecture, so `pooler_config` never gets initialized in `ModelConfig.__post_init__`. The CLI accepts the config without complaint, and the engine then crashes deep in adapter init with `AssertionError: pooler_config is not None`.

`_RUNNER_CONVERTS` already maps each converter to its target runner. This PR uses that to align the two: if `--convert` is explicit and `--runner` is auto, promote the runner to the converter's target. If both are set explicitly to inconsistent values (e.g. `--runner generate --convert embed`), raise a clear `ValueError` instead of letting it crash later.

This is option 1 from the issue's "Expected Behavior" section ("vLLM successfully starts with the requested `--convert` mode"). @Jeff-Kazzee suggested option 2 (early reject) on the issue and offered to defer if a different shape was preferred; happy to switch to that if maintainers prefer it.

## Not a duplicate

`gh pr list --repo vllm-project/vllm --state open --search "42480 in:body"` returns no PRs. Adjacent searches (`pooler_config is not None`, `convert classify validation`, `convert embed runner`) also found nothing addressing this issue.

## Test plan

- New `tests/test_config.py::test_convert_implies_pooling_runner`: `ModelConfig("distilbert/distilgpt2", convert="embed"|"classify")` should promote `runner_type` to `"pooling"` and initialize `pooler_config`.
- New `tests/test_config.py::test_convert_runner_conflict`: `runner="generate", convert="embed"` should raise `ValueError`.
- `pre-commit run --files vllm/config/model.py tests/test_config.py` is clean locally (ruff, mypy, typos, SPDX, lazy-imports, forbidden-imports, config-docstring).

```
.venv/bin/python -m pytest tests/test_config.py::test_convert_implies_pooling_runner tests/test_config.py::test_convert_runner_conflict -v
```

I couldn't run pytest on Darwin without a CUDA build of vLLM, so a reviewer on a Linux/CUDA host needs to validate the new cases. They follow the same `ModelConfig(model_id, ...)` pattern as the adjacent `test_auto_runner` / `test_pooling_runner` parametrizations.