### PR TITLE
[Core] Per-layer parallelism policy + TPA-GQA on FlashAttention

### DIFF
--- a/tests/distributed/test_layer_parallel_config.py
+++ b/tests/distributed/test_layer_parallel_config.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the per-layer parallel config resolver.
+
+Tests the public API of ``vllm/distributed/layer_parallel_config.py`` in
+isolation (no torch.distributed needed) — the resolver state is module-level
+and can be initialized directly via ``init_layer_parallel_resolver``.
+
+Integration with ``initialize_model_parallel`` is exercised by existing
+distributed test suites (those require multi-process setup).
+"""
+
+import pytest
+
+from vllm.distributed.layer_parallel_config import (
+    LayerParallelConfig,
+    clear_layer_parallel_resolver,
+    get_layer_parallel_config,
+    init_layer_parallel_resolver,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_resolver():
+    """Reset resolver state before AND after each test for isolation."""
+    clear_layer_parallel_resolver()
+    yield
+    clear_layer_parallel_resolver()
+
+
+# ---------------------------------------------------------------- #
+# Default behavior (resolver uninitialized / TPA disabled)
+# ---------------------------------------------------------------- #
+
+
+def test_default_no_init_returns_all_none():
+    """Without `init_layer_parallel_resolver`, all configs are defaults."""
+    cfg = get_layer_parallel_config(None, "model.layers.0.self_attn.qkv_proj")
+    assert cfg == LayerParallelConfig()
+    assert cfg.tp_size is None
+    assert cfg.tp_rank is None
+
+
+def test_tpa_equals_tp_is_noop():
+    """When attn_tp_size == full_tp_size, every layer returns defaults."""
+    init_layer_parallel_resolver(
+        full_tp_size=4, full_tp_rank=2, attn_tp_size=4, attn_tp_rank=2
+    )
+    cfg_attn = get_layer_parallel_config(None, "model.layers.0.self_attn.qkv_proj")
+    cfg_mlp = get_layer_parallel_config(None, "model.layers.0.mlp.gate_proj")
+    assert cfg_attn == LayerParallelConfig()
+    assert cfg_mlp == LayerParallelConfig()
+
+
+# ---------------------------------------------------------------- #
+# TPA mode (attn_tp_size < full_tp_size)
+# ---------------------------------------------------------------- #
+
+
+def test_tpa_attention_layer_resolves_to_attn_tp():
+    """TPA<TP: attention layers get attn_tp_size / attn_tp_rank."""
+    init_layer_parallel_resolver(
+        full_tp_size=8, full_tp_rank=5, attn_tp_size=2, attn_tp_rank=1
+    )
+    cfg = get_layer_parallel_config(None, "model.layers.0.self_attn.qkv_proj")
+    assert cfg.tp_size == 2
+    assert cfg.tp_rank == 1
+
+
+def test_tpa_non_attention_layer_returns_defaults():
+    """TPA<TP: non-attention layers (MLP, MoE, embedding) keep global TP."""
+    init_layer_parallel_resolver(
+        full_tp_size=8, full_tp_rank=5, attn_tp_size=2, attn_tp_rank=1
+    )
+    cfg = get_layer_parallel_config(None, "model.layers.0.mlp.gate_proj")
+    assert cfg == LayerParallelConfig()
+    cfg = get_layer_parallel_config(None, "model.layers.0.mlp.down_proj")
+    assert cfg == LayerParallelConfig()
+    cfg = get_layer_parallel_config(None, "model.embed_tokens")
+    assert cfg == LayerParallelConfig()
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "model.layers.0.self_attn.qkv_proj",
+        "model.layers.7.self_attn.o_proj",
+        "model.layers.0.attention.q_proj",
+        "model.layers.0.attn.qkv",
+    ],
+)
+def test_attention_prefix_patterns_recognized(prefix):
+    """All known attention-prefix patterns trigger the TPA path."""
+    init_layer_parallel_resolver(
+        full_tp_size=8, full_tp_rank=3, attn_tp_size=4, attn_tp_rank=3
+    )
+    cfg = get_layer_parallel_config(None, prefix)
+    assert cfg.tp_size == 4
+
+
+def test_resolver_idempotent_on_same_prefix():
+    """Multiple calls with the same prefix return identical config."""
+    init_layer_parallel_resolver(
+        full_tp_size=4, full_tp_rank=1, attn_tp_size=2, attn_tp_rank=1
+    )
+    prefix = "model.layers.5.self_attn.qkv_proj"
+    a = get_layer_parallel_config(None, prefix)
+    b = get_layer_parallel_config(None, prefix)
+    assert a == b
+
+
+# ---------------------------------------------------------------- #
+# Validation
+# ---------------------------------------------------------------- #
+
+
+def test_init_rejects_non_divisible_sizes():
+    """attn_tp_size must divide full_tp_size."""
+    with pytest.raises(ValueError, match="divisible"):
+        init_layer_parallel_resolver(
+            full_tp_size=6, full_tp_rank=0, attn_tp_size=4, attn_tp_rank=0
+        )
+
+
+def test_init_rejects_rank_out_of_range():
+    """attn_tp_rank must be in [0, attn_tp_size)."""
+    with pytest.raises(ValueError, match="out of range"):
+        init_layer_parallel_resolver(
+            full_tp_size=4, full_tp_rank=0, attn_tp_size=2, attn_tp_rank=2
+        )
+
+
+# ---------------------------------------------------------------- #
+# Reset / lifecycle
+# ---------------------------------------------------------------- #
+
+
+def test_clear_resets_to_default_behavior():
+    """After clear, the resolver returns defaults again."""
+    init_layer_parallel_resolver(
+        full_tp_size=4, full_tp_rank=1, attn_tp_size=2, attn_tp_rank=1
+    )
+    cfg = get_layer_parallel_config(None, "model.layers.0.self_attn.qkv_proj")
+    assert cfg.tp_size == 2
+
+    clear_layer_parallel_resolver()
+    cfg = get_layer_parallel_config(None, "model.layers.0.self_attn.qkv_proj")
+    assert cfg == LayerParallelConfig()
+
+
+def test_reinit_overwrites_previous_state():
+    """Calling init twice updates the resolver state."""
+    init_layer_parallel_resolver(
+        full_tp_size=4, full_tp_rank=0, attn_tp_size=2, attn_tp_rank=0
+    )
+    init_layer_parallel_resolver(
+        full_tp_size=8, full_tp_rank=3, attn_tp_size=4, attn_tp_rank=3
+    )
+    cfg = get_layer_parallel_config(None, "model.layers.0.self_attn.qkv_proj")
+    assert cfg.tp_size == 4
+    assert cfg.tp_rank == 3
+
+
+# ---------------------------------------------------------------- #
+# Layer parallel config dataclass
+# ---------------------------------------------------------------- #
+
+
+def test_layer_parallel_config_is_frozen():
+    """The config dataclass is immutable to prevent accidental mutation."""
+    cfg = LayerParallelConfig(tp_size=4, tp_rank=2)
+    with pytest.raises((AttributeError, Exception)):
+        cfg.tp_size = 8  # noqa: B018
+
+
+def test_layer_parallel_config_equality():
+    """Configs with the same values compare equal (for caching/test use)."""
+    a = LayerParallelConfig(tp_size=4, tp_rank=2)
+    b = LayerParallelConfig(tp_size=4, tp_rank=2)
+    c = LayerParallelConfig(tp_size=4, tp_rank=3)
+    assert a == b
+    assert a != c

--- a/tests/distributed/test_layer_parallel_config.py
+++ b/tests/distributed/test_layer_parallel_config.py
@@ -101,12 +101,55 @@ def test_attention_prefix_patterns_recognized(prefix):
 def test_resolver_idempotent_on_same_prefix():
     """Multiple calls with the same prefix return identical config."""
     init_layer_parallel_resolver(
-        full_tp_size=4, full_tp_rank=1, attn_tp_size=2, attn_tp_rank=1
+        full_tp_size=4, full_tp_rank=1, attn_tp_size=2, attn_tp_rank=0
     )
     prefix = "model.layers.5.self_attn.qkv_proj"
     a = get_layer_parallel_config(None, prefix)
     b = get_layer_parallel_config(None, prefix)
     assert a == b
+
+
+@pytest.mark.parametrize(
+    "tp_size, tpa_size, expected_attn_rank",
+    [
+        # TP=4 TPA=2 DCP=2: DCP groups {0,1} and {2,3}; attn = tp_rank//2
+        (4, 2, [0, 0, 1, 1]),
+        # TP=8 TPA=4 DCP=2: 4 DCP groups of size 2; attn = tp_rank // 2
+        (8, 4, [0, 0, 1, 1, 2, 2, 3, 3]),
+        # TP=8 TPA=2 DCP=4: DCP groups {0..3} and {4..7}; attn = tp_rank // 4
+        (8, 2, [0, 0, 0, 0, 1, 1, 1, 1]),
+        # TP=8 TPA=1 DCP=8: single DCP group; all ranks attn_rank=0
+        (8, 1, [0, 0, 0, 0, 0, 0, 0, 0]),
+    ],
+)
+def test_attn_tp_rank_matches_dcp_layout(tp_size, tpa_size, expected_attn_rank):
+    """attn_tp_rank derivation must match the DCP-group consecutive layout
+    used in vllm/distributed/parallel_state.py initialize_model_parallel:
+    DCP groups are consecutive chunks of the TP axis, so attn_tp_rank for a
+    given full TP rank is `tp_rank // dcp_size = tp_rank // (TP // TPA)`.
+    Bug guard against `tp_rank % tpa_size` (the wrong mapping).
+    """
+    dcp_size = tp_size // tpa_size
+    for tp_rank in range(tp_size):
+        attn_rank = tp_rank // dcp_size
+        assert attn_rank == expected_attn_rank[tp_rank], (
+            f"tp_size={tp_size}, tpa_size={tpa_size}, tp_rank={tp_rank}: "
+            f"expected attn_rank={expected_attn_rank[tp_rank]}, got {attn_rank}"
+        )
+        # Verify the wrong mapping (`tp_rank % tpa_size`) would have produced
+        # a different value for at least some tp_ranks → if these ever agree
+        # for all tp_ranks, the test stops protecting against the regression.
+        if tpa_size != tp_size and tpa_size > 1:
+            wrong = tp_rank % tpa_size
+            if wrong != attn_rank:
+                break  # at least one ranks differs → test is meaningful
+    else:
+        if tpa_size != tp_size and tpa_size > 1:
+            pytest.fail(
+                f"Expected at least one tp_rank where `tp_rank // dcp_size` "
+                f"differs from `tp_rank % tpa_size` for tp={tp_size} tpa={tpa_size}, "
+                f"but they always agreed — the regression guard is degenerate."
+            )
 
 
 # ---------------------------------------------------------------- #

--- a/tests/distributed/test_qk_norm_tpa_sharding.py
+++ b/tests/distributed/test_qk_norm_tpa_sharding.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for resolver-native qk-norm sharding under TPA.
+
+Exercises ``_resolve_qk_norm_sharding`` — the derivation that lets
+``MiniMaxText01RMSNormTP`` self-configure its weight shard + variance-reduce
+group from the per-layer parallel resolver instead of having the model thread
+``weight_shard_world_size`` / ``weight_shard_rank`` / ``reduce_group`` in by
+hand. No torch.distributed is needed: the resolver state is module-level.
+
+The key correctness property is that the resolver path reproduces, bit for bit,
+the manual computation MiniMax-M2 used before this refactor, across all four
+(q_norm / k_norm) x (TPA on / off) combinations.
+"""
+
+import pytest
+
+from vllm.distributed.layer_parallel_config import (
+    clear_layer_parallel_resolver,
+    init_layer_parallel_resolver,
+)
+from vllm.model_executor.custom_op import op_registry
+from vllm.model_executor.layers.minimax_rms_norm.rms_norm_tp import (
+    MiniMaxText01RMSNormTP,
+    _resolve_qk_norm_sharding,
+)
+
+Q_PREFIX = "model.layers.0.self_attn.q_norm"
+K_PREFIX = "model.layers.0.self_attn.k_norm"
+# A non-attention prefix (e.g. a Mamba/linear-attention output norm) must never
+# pick up the attention-TP policy, even when TPA is active.
+LINEAR_ATTN_PREFIX = "model.layers.0.linear_attn.norm"
+
+
+def test_class_still_registered_as_custom_op():
+    """Guard: the module-level helper must not sit between the
+    ``@CustomOp.register`` decorator and the class (which would leave the class
+    unregistered and crash model init with a missing ``name`` attribute)."""
+    assert MiniMaxText01RMSNormTP.name == "minimax_text01_rmsnorm_tp"
+    assert op_registry["minimax_text01_rmsnorm_tp"] is MiniMaxText01RMSNormTP
+
+
+@pytest.fixture(autouse=True)
+def _reset_resolver():
+    clear_layer_parallel_resolver()
+    yield
+    clear_layer_parallel_resolver()
+
+
+# ---------------------------------------------------------------- #
+# Fallback: no resolver / TPA disabled -> global TP world
+# ---------------------------------------------------------------- #
+
+
+def test_no_resolver_falls_back_to_global_tp():
+    # Resolver uninitialized: any prefix resolves to the passed global TP world.
+    assert _resolve_qk_norm_sharding(Q_PREFIX, 1, 8, 3) == (8, 3, False)
+
+
+def test_tpa_inactive_is_global_tp():
+    # attn_tp == full_tp -> resolver returns no policy -> global TP, no attn group.
+    init_layer_parallel_resolver(
+        full_tp_size=8, full_tp_rank=3, attn_tp_size=8, attn_tp_rank=3
+    )
+    assert _resolve_qk_norm_sharding(Q_PREFIX, 1, 8, 3) == (8, 3, False)
+
+
+def test_tpa_inactive_replicated_k_norm_shards_by_kv_heads():
+    # No TPA, but KV heads (2) < full TP (8) -> replicas = 4. The k_norm weight
+    # still shards by kv-head count (8 // 4 = 2), rank folds by the replica factor.
+    init_layer_parallel_resolver(
+        full_tp_size=8, full_tp_rank=5, attn_tp_size=8, attn_tp_rank=5
+    )
+    world, rank, tpa = _resolve_qk_norm_sharding(K_PREFIX, 4, 8, 5)
+    assert (world, rank, tpa) == (2, 1, False)  # 8//4=2, 5//4=1
+
+
+# ---------------------------------------------------------------- #
+# TPA active: shard/reduce over the attention-TP subgroup
+# ---------------------------------------------------------------- #
+
+
+def test_tpa_active_q_norm():
+    # full_tp=16, attn_tp=4. q_norm has no KV replication (replicas=1).
+    # Under a policy the resolver supplies attn_tp_rank (1), overriding the
+    # passed global rank (9).
+    init_layer_parallel_resolver(
+        full_tp_size=16, full_tp_rank=9, attn_tp_size=4, attn_tp_rank=1
+    )
+    assert _resolve_qk_norm_sharding(Q_PREFIX, 1, 16, 9) == (4, 1, True)
+
+
+def test_tpa_active_k_norm_partitioned():
+    # attn_tp=4, kv_heads=4 -> replicas=1: k_norm partitions like q_norm.
+    init_layer_parallel_resolver(
+        full_tp_size=16, full_tp_rank=9, attn_tp_size=4, attn_tp_rank=2
+    )
+    assert _resolve_qk_norm_sharding(K_PREFIX, 1, 16, 9) == (4, 2, True)
+
+
+def test_tpa_active_k_norm_replicated():
+    # attn_tp=4, kv_heads=2 -> replicas=2: k_norm shards by kv-head count (2),
+    # rank folds (3 // 2 = 1).
+    init_layer_parallel_resolver(
+        full_tp_size=16, full_tp_rank=9, attn_tp_size=4, attn_tp_rank=3
+    )
+    assert _resolve_qk_norm_sharding(K_PREFIX, 2, 16, 9) == (2, 1, True)
+
+
+def test_non_attention_prefix_ignored_under_tpa():
+    # TPA active, but a non-attention prefix must resolve to the global TP world
+    # and must NOT signal the attention-TP reduce group.
+    init_layer_parallel_resolver(
+        full_tp_size=16, full_tp_rank=9, attn_tp_size=4, attn_tp_rank=1
+    )
+    assert _resolve_qk_norm_sharding(LINEAR_ATTN_PREFIX, 1, 16, 9) == (16, 9, False)
+
+
+# ---------------------------------------------------------------- #
+# Parity with the pre-refactor manual computation (the merge-safety net)
+# ---------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("full_tp,attn_tp", [(16, 4), (8, 2), (8, 4), (4, 1)])
+def test_matches_legacy_manual_computation(full_tp, attn_tp):
+    """Resolver path == MiniMax-M2's old explicit weight_shard_* math."""
+    for attn_tp_rank in range(attn_tp):
+        init_layer_parallel_resolver(
+            full_tp_size=full_tp,
+            full_tp_rank=attn_tp_rank,  # exact full rank is irrelevant to the math
+            attn_tp_size=attn_tp,
+            attn_tp_rank=attn_tp_rank,
+        )
+
+        # q_norm — legacy: weight_shard_world_size=attn_tp, rank=attn_tp_rank
+        assert _resolve_qk_norm_sharding(Q_PREFIX, 1, full_tp, attn_tp_rank)[:2] == (
+            attn_tp,
+            attn_tp_rank,
+        )
+
+        # replicated k_norm with 2 KV heads — legacy: replicas = attn_tp // 2,
+        # (weight_shard_world_size=2, weight_shard_rank=attn_tp_rank // replicas)
+        if attn_tp >= 2:
+            replicas = attn_tp // 2
+            legacy_world = 2
+            legacy_rank = attn_tp_rank // replicas
+            assert _resolve_qk_norm_sharding(K_PREFIX, replicas, full_tp, attn_tp_rank)[
+                :2
+            ] == (legacy_world, legacy_rank)
+        clear_layer_parallel_resolver()

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1208,12 +1208,12 @@ class ModelConfig:
         parallel_config: ParallelConfig,
     ) -> None:
         total_num_attention_heads = self.model_arch_config.total_num_attention_heads
-        tensor_parallel_size = parallel_config.tensor_parallel_size
-        if total_num_attention_heads % tensor_parallel_size != 0:
+        attention_tp_size = parallel_config.tpa_size
+        if total_num_attention_heads % attention_tp_size != 0:
             raise ValueError(
                 f"Total number of attention heads ({total_num_attention_heads})"
-                " must be divisible by tensor parallel size "
-                f"({tensor_parallel_size})."
+                " must be divisible by attention tensor parallel size "
+                f"({attention_tp_size})."
             )
 
         if parallel_config.enable_expert_parallel:
@@ -1229,7 +1229,13 @@ class ModelConfig:
             )
 
         decode_context_parallel_size = parallel_config.decode_context_parallel_size
-        if decode_context_parallel_size > 1 and not self.use_mla:
+        if (
+            decode_context_parallel_size > 1
+            and not self.use_mla
+            and parallel_config.tensor_parallel_size_attention is None
+        ):
+            # TPA validates its own TP/DCP relationship in ParallelConfig.
+            tensor_parallel_size = parallel_config.tensor_parallel_size
             total_num_kv_heads = self.get_total_num_kv_heads()
             assert tensor_parallel_size > total_num_kv_heads, (
                 f"tensor parallel size {tensor_parallel_size} must be greater "
@@ -1314,15 +1320,16 @@ class ModelConfig:
             return 1
 
         total_num_kv_heads = self.get_total_num_kv_heads()
+        tensor_parallel_size = parallel_config.tpa_size
         # If tensor parallelism is used, we divide the number of KV heads by
         # the tensor parallel size. We will replicate the KV heads in the
         # case where the number of KV heads is smaller than the tensor
         # parallel size so each GPU has at least one KV head.
-        return max(1, total_num_kv_heads // parallel_config.tensor_parallel_size)
+        return max(1, total_num_kv_heads // tensor_parallel_size)
 
     def get_num_attention_heads(self, parallel_config: ParallelConfig) -> int:
         num_heads = self.model_arch_config.total_num_attention_heads
-        return num_heads // parallel_config.tensor_parallel_size
+        return num_heads // parallel_config.tpa_size
 
     def get_num_experts(self) -> int:
         return self.model_arch_config.num_experts

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -121,6 +121,14 @@ class ParallelConfig:
     """Number of pipeline parallel groups."""
     tensor_parallel_size: int = Field(default=1, ge=1)
     """Number of tensor parallel groups."""
+    tensor_parallel_size_attention: int | None = Field(default=None, gt=0)
+    """Tensor parallel size for attention layers.
+
+    When set smaller than ``tensor_parallel_size``, attention projection
+    weights are sharded by this value while non-attention layers keep the
+    full tensor-parallel width. Unmigrated models continue to use global
+    TP via the resolver's sentinel-fallback path.
+    """
     prefill_context_parallel_size: int = Field(default=1, ge=1)
     """Number of prefill context parallel groups."""
     data_parallel_size: int = Field(default=1, ge=1)
@@ -511,7 +519,39 @@ class ParallelConfig:
                 "dcp_comm_backend='a2a' requires decode_context_parallel_size > 1."
             )
 
+        if self.tensor_parallel_size_attention is not None:
+            tpa = self.tensor_parallel_size_attention
+            tp = self.tensor_parallel_size
+            if tpa > tp:
+                raise ValueError(
+                    f"tensor_parallel_size_attention ({tpa}) cannot exceed "
+                    f"tensor_parallel_size ({tp})."
+                )
+            if tp % tpa != 0:
+                raise ValueError(
+                    f"tensor_parallel_size ({tp}) must be divisible by "
+                    f"tensor_parallel_size_attention ({tpa})."
+                )
+            required_dcp = tp // tpa
+            if required_dcp > 1 and self.decode_context_parallel_size != required_dcp:
+                raise ValueError(
+                    f"When tensor_parallel_size_attention ({tpa}) is smaller than "
+                    f"tensor_parallel_size ({tp}), decode_context_parallel_size "
+                    f"must equal tensor_parallel_size / "
+                    f"tensor_parallel_size_attention (= {required_dcp}), but got "
+                    f"{self.decode_context_parallel_size}."
+                )
+
         return self
+
+    @property
+    def tpa_size(self) -> int:
+        """Return the effective attention tensor-parallel size."""
+        return self.tensor_parallel_size_attention or self.tensor_parallel_size
+
+    @property
+    def tpa_enabled(self) -> bool:
+        return self.tpa_size != self.tensor_parallel_size
 
     @property
     def world_size_across_dp(self) -> int:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2066,6 +2066,7 @@ class VllmConfig:
             f"download_dir={self.load_config.download_dir!r}, "
             f"load_format={self.load_config.load_format}, "
             f"tensor_parallel_size={self.parallel_config.tensor_parallel_size}, "  # noqa
+            f"tensor_parallel_size_attention={self.parallel_config.tensor_parallel_size_attention}, "  # noqa
             f"pipeline_parallel_size={self.parallel_config.pipeline_parallel_size}, "  # noqa
             f"data_parallel_size={self.parallel_config.data_parallel_size}, "  # noqa
             f"decode_context_parallel_size={self.parallel_config.decode_context_parallel_size}, "  # noqa

--- a/vllm/distributed/layer_parallel_config.py
+++ b/vllm/distributed/layer_parallel_config.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-layer parallel configuration resolver.
+
+Returns a ``LayerParallelConfig`` for shared layer code to query at
+construction time. A default config (all fields ``None``) means "fall back
+to the global TP world".
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class LayerParallelConfig:
+    """Resolved per-layer parallel configuration.
+
+    Fields default to ``None``, meaning the layer uses the global TP world.
+
+    Attributes:
+        tp_size: Effective TP world size this layer should shard with.
+        tp_rank: This rank's index within ``tp_size``. Differs from the
+            full TP rank when the attention TP group is smaller than the
+            full TP group; QKV weight loading uses this rank.
+    """
+
+    tp_size: int | None = None
+    tp_rank: int | None = None
+
+
+_ATTENTION_PREFIX_PATTERNS: tuple[str, ...] = (
+    ".self_attn.",
+    ".attention.",
+    ".attn.",
+)
+
+
+@dataclass(frozen=True)
+class _ResolverState:
+    full_tp_size: int
+    full_tp_rank: int
+    attn_tp_size: int
+    attn_tp_rank: int
+
+
+_resolver_state: _ResolverState | None = None
+
+
+def init_layer_parallel_resolver(
+    *,
+    full_tp_size: int,
+    full_tp_rank: int,
+    attn_tp_size: int,
+    attn_tp_rank: int,
+) -> None:
+    """Initialize the resolver with the engine's lowered parallel config.
+
+    Called once from ``initialize_model_parallel`` after the TP and DCP
+    groups are constructed. Subsequent calls reset the state.
+
+    Args:
+        full_tp_size: Full tensor-parallel world size.
+        full_tp_rank: This worker's rank in the full TP group.
+        attn_tp_size: Attention TP size. Must divide ``full_tp_size``.
+        attn_tp_rank: This worker's rank within the attention TP group.
+    """
+    global _resolver_state
+    if full_tp_size % attn_tp_size != 0:
+        raise ValueError(
+            "full_tp_size must be divisible by attn_tp_size: "
+            f"got {full_tp_size=}, {attn_tp_size=}"
+        )
+    if not 0 <= attn_tp_rank < attn_tp_size:
+        raise ValueError(f"attn_tp_rank out of range: {attn_tp_rank=}, {attn_tp_size=}")
+    _resolver_state = _ResolverState(
+        full_tp_size=full_tp_size,
+        full_tp_rank=full_tp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_tp_rank=attn_tp_rank,
+    )
+    if attn_tp_size != full_tp_size:
+        logger.info(
+            "Per-layer parallel resolver initialized: "
+            "full_tp=%d, attn_tp=%d (TPA mode active)",
+            full_tp_size,
+            attn_tp_size,
+        )
+
+
+def clear_layer_parallel_resolver() -> None:
+    """Reset the resolver state. Tests only."""
+    global _resolver_state
+    _resolver_state = None
+
+
+def get_layer_parallel_config(
+    layer: Any,  # noqa: ARG001
+    prefix: str,
+) -> LayerParallelConfig:
+    """Resolve the per-layer parallel config for a layer at this prefix.
+
+    Returns a config with non-``None`` fields when this layer differs from
+    the global TP world (currently: attention layers under TPA). Otherwise
+    callers fall back to ``get_tensor_model_parallel_world_size()`` /
+    ``get_tensor_model_parallel_rank()``.
+    """
+    if _resolver_state is None:
+        return LayerParallelConfig()
+
+    state = _resolver_state
+    if state.attn_tp_size == state.full_tp_size:
+        return LayerParallelConfig()
+
+    if not _is_attention_prefix(prefix):
+        return LayerParallelConfig()
+
+    return LayerParallelConfig(
+        tp_size=state.attn_tp_size,
+        tp_rank=state.attn_tp_rank,
+    )
+
+
+def _is_attention_prefix(prefix: str) -> bool:
+    wrapped = f".{prefix}."
+    return any(p in wrapped for p in _ATTENTION_PREFIX_PATTERNS)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -46,6 +46,7 @@ import vllm.envs as envs
 from vllm.distributed.device_communicators.base_device_communicator import (
     DeviceCommunicatorBase,
 )
+from vllm.distributed.layer_parallel_config import init_layer_parallel_resolver
 from vllm.distributed.utils import (
     StatelessProcessGroup,
     get_cached_tcp_store_client,
@@ -1938,6 +1939,30 @@ def initialize_model_parallel(
                 )
     # If no EP group needed, _EP remains None
     # If no EPLB group needed, _EPLB remains None
+
+    # Per-layer parallel config resolver.
+    full_tp_size = tensor_model_parallel_size
+    full_tp_rank = _TP.rank_in_group
+    attn_tp_size = (
+        getattr(parallel_config, "tensor_parallel_size_attention", 0) or full_tp_size
+    )
+    if attn_tp_size > full_tp_size:
+        raise ValueError(
+            f"tensor_parallel_size_attention ({attn_tp_size}) cannot exceed "
+            f"tensor_model_parallel_size ({full_tp_size})"
+        )
+    if full_tp_size % attn_tp_size != 0:
+        raise ValueError(
+            f"tensor_model_parallel_size ({full_tp_size}) must be divisible "
+            f"by tensor_parallel_size_attention ({attn_tp_size})"
+        )
+    attn_tp_rank = full_tp_rank % attn_tp_size
+    init_layer_parallel_resolver(
+        full_tp_size=full_tp_size,
+        full_tp_rank=full_tp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_tp_rank=attn_tp_rank,
+    )
 
     logger.info_once(
         "rank %s in world size %s is assigned as "

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1371,6 +1371,20 @@ def get_tp_group() -> GroupCoordinator:
     return _TP
 
 
+_TPA_GQA_MODE: bool = False
+
+
+def is_tpa_gqa_mode() -> bool:
+    """Return True iff TPA<TP is active (attention TP smaller than full TP).
+
+    Attention backends consult this to skip the pre-attention DCP
+    Q-all-gather: under TPA<TP the queries are already sized for the
+    attention TP group, and ``dcp_combine`` reduce-scatters heads from
+    H/TPA → H/TP for ``o_proj``.
+    """
+    return _TPA_GQA_MODE
+
+
 _DCP: GroupCoordinator | None = None
 
 
@@ -1961,6 +1975,10 @@ def initialize_model_parallel(
         )
     dcp_size_for_attn = full_tp_size // attn_tp_size
     attn_tp_rank = full_tp_rank // dcp_size_for_attn
+
+    global _TPA_GQA_MODE
+    _TPA_GQA_MODE = attn_tp_size > 1 and attn_tp_size < full_tp_size
+
     init_layer_parallel_resolver(
         full_tp_size=full_tp_size,
         full_tp_rank=full_tp_rank,
@@ -2110,6 +2128,12 @@ def destroy_model_parallel():
     if _EPLB:
         _EPLB.destroy()
     _EPLB = None
+
+    global _TPA_GQA_MODE
+    _TPA_GQA_MODE = False
+    from vllm.distributed.layer_parallel_config import clear_layer_parallel_resolver
+
+    clear_layer_parallel_resolver()
 
 
 def destroy_distributed_environment():

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1941,6 +1941,9 @@ def initialize_model_parallel(
     # If no EPLB group needed, _EPLB remains None
 
     # Per-layer parallel config resolver.
+    # DCP groups are consecutive chunks of the TP axis (see the reshape
+    # above), so this rank's attention TP rank is which DCP group it
+    # belongs to: tp_rank // dcp_size_for_attn.
     full_tp_size = tensor_model_parallel_size
     full_tp_rank = _TP.rank_in_group
     attn_tp_size = (
@@ -1956,7 +1959,8 @@ def initialize_model_parallel(
             f"tensor_model_parallel_size ({full_tp_size}) must be divisible "
             f"by tensor_parallel_size_attention ({attn_tp_size})"
         )
-    attn_tp_rank = full_tp_rank % attn_tp_size
+    dcp_size_for_attn = full_tp_size // attn_tp_size
+    attn_tp_rank = full_tp_rank // dcp_size_for_attn
     init_layer_parallel_resolver(
         full_tp_size=full_tp_size,
         full_tp_rank=full_tp_rank,

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1371,6 +1371,15 @@ def get_tp_group() -> GroupCoordinator:
     return _TP
 
 
+_ATTN_TP: GroupCoordinator | None = None
+
+
+def get_attention_tp_group() -> GroupCoordinator:
+    if _ATTN_TP is not None:
+        return _ATTN_TP
+    return get_tp_group()
+
+
 _TPA_GQA_MODE: bool = False
 
 
@@ -1808,6 +1817,22 @@ def initialize_model_parallel(
         tensor_model_parallel_size,
     )  # noqa
 
+    full_tp_size = tensor_model_parallel_size
+    attn_tp_size = (
+        getattr(parallel_config, "tensor_parallel_size_attention", 0) or full_tp_size
+    )
+    if attn_tp_size > full_tp_size:
+        raise ValueError(
+            f"tensor_parallel_size_attention ({attn_tp_size}) cannot exceed "
+            f"tensor_model_parallel_size ({full_tp_size})"
+        )
+    if full_tp_size % attn_tp_size != 0:
+        raise ValueError(
+            f"tensor_model_parallel_size ({full_tp_size}) must be divisible "
+            f"by tensor_parallel_size_attention ({attn_tp_size})"
+        )
+    dcp_size_for_attn = full_tp_size // attn_tp_size
+
     # Build the tensor model-parallel groups.
     global _TP
     assert _TP is None, "tensor model parallel group is already initialized"
@@ -1824,6 +1849,28 @@ def initialize_model_parallel(
         use_message_queue_broadcaster=True,
         group_name="tp",
     )
+
+    global _ATTN_TP
+    assert _ATTN_TP is None, "attention tensor parallel group is already initialized"
+    if attn_tp_size != full_tp_size:
+        group_ranks_tensor = (
+            local_all_ranks.view(-1, full_tp_size)
+            if enable_elastic_ep
+            else all_ranks.view(-1, full_tp_size)
+        )
+        group_ranks = (
+            group_ranks_tensor.reshape(-1, attn_tp_size, dcp_size_for_attn)
+            .transpose(1, 2)
+            .reshape(-1, attn_tp_size)
+            .unbind(0)
+        )
+        group_ranks = [x.tolist() for x in group_ranks]
+        _ATTN_TP = init_model_parallel_group(
+            group_ranks,
+            get_world_group().local_rank,
+            backend,
+            group_name="attn_tp",
+        )
 
     # Build the DCP model-parallel groups.
     global _DCP
@@ -1958,22 +2005,7 @@ def initialize_model_parallel(
     # DCP groups are consecutive chunks of the TP axis (see the reshape
     # above), so this rank's attention TP rank is which DCP group it
     # belongs to: tp_rank // dcp_size_for_attn.
-    full_tp_size = tensor_model_parallel_size
     full_tp_rank = _TP.rank_in_group
-    attn_tp_size = (
-        getattr(parallel_config, "tensor_parallel_size_attention", 0) or full_tp_size
-    )
-    if attn_tp_size > full_tp_size:
-        raise ValueError(
-            f"tensor_parallel_size_attention ({attn_tp_size}) cannot exceed "
-            f"tensor_model_parallel_size ({full_tp_size})"
-        )
-    if full_tp_size % attn_tp_size != 0:
-        raise ValueError(
-            f"tensor_model_parallel_size ({full_tp_size}) must be divisible "
-            f"by tensor_parallel_size_attention ({attn_tp_size})"
-        )
-    dcp_size_for_attn = full_tp_size // attn_tp_size
     attn_tp_rank = full_tp_rank // dcp_size_for_attn
 
     global _TPA_GQA_MODE
@@ -2093,6 +2125,11 @@ def get_node_count() -> int:
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
+    global _ATTN_TP
+    if _ATTN_TP:
+        _ATTN_TP.destroy()
+    _ATTN_TP = None
+
     global _TP
 
     if _TP:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -471,6 +471,9 @@ class EngineArgs:
     numa_bind_cpus: list[str] | None = ParallelConfig.numa_bind_cpus
     device_ids: list[int | str] | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
+    tensor_parallel_size_attention: int | None = (
+        ParallelConfig.tensor_parallel_size_attention
+    )
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
     dcp_comm_backend: DCPCommBackend = ParallelConfig.dcp_comm_backend
@@ -1009,6 +1012,11 @@ class EngineArgs:
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
+        )
+        parallel_group.add_argument(
+            "--tensor-parallel-size-attention",
+            "-tpa",
+            **parallel_kwargs["tensor_parallel_size_attention"],
         )
         parallel_group.add_argument(
             "--decode-context-parallel-size",
@@ -2089,6 +2097,7 @@ class EngineArgs:
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
+            tensor_parallel_size_attention=self.tensor_parallel_size_attention,
             prefill_context_parallel_size=self.prefill_context_parallel_size,
             data_parallel_size=self.data_parallel_size,
             data_parallel_rank=self.data_parallel_rank or 0,

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -335,6 +335,18 @@ class Attention(nn.Module, AttentionLayerBase):
         self.head_size = head_size
         self.head_size_v = self.head_size if head_size_v is None else head_size_v
         self.num_kv_heads = num_kv_heads
+
+        # Number of heads this attention op writes to its output buffer. Under
+        # TPA-GQA the post-attention DCP combine reduce-scatters heads
+        # (H/attn_tp -> H/full_tp), so the output holds num_heads / dcp_size
+        # heads; otherwise it is num_heads. Resolved once here to keep the
+        # forward / CUDA-graph path free of per-step parallel-state lookups.
+        from vllm.distributed.parallel_state import get_dcp_group, is_tpa_gqa_mode
+
+        if is_tpa_gqa_mode():
+            self.output_num_heads = self.num_heads // get_dcp_group().world_size
+        else:
+            self.output_num_heads = self.num_heads
         self.sliding_window = sliding_window
         self.has_sink = extra_impl_args.get("sinks") is not None
 
@@ -524,29 +536,18 @@ class Attention(nn.Module, AttentionLayerBase):
             # Handle both 2D [num_tokens, hidden] and
             # 3D [num_tokens, heads, head_dim] query
             num_tokens = query.shape[0]
-            # Under TPA-GQA the post-attention DCP combine reduce-scatters
-            # heads, so the output buffer holds num_heads / dcp_size heads.
-            from vllm.distributed.parallel_state import (
-                get_dcp_group,
-                is_tpa_gqa_mode,
+            # self.output_num_heads already accounts for the TPA-GQA DCP combine
+            # (num_heads / dcp_size under TPA; num_heads otherwise).
+            output_shape = torch.Size(
+                (num_tokens, self.output_num_heads * self.head_size_v)
             )
-
-            if is_tpa_gqa_mode():
-                out_num_heads = self.num_heads // get_dcp_group().world_size
-            else:
-                out_num_heads = self.num_heads
-            output_shape = torch.Size((num_tokens, out_num_heads * self.head_size_v))
         output = torch.empty(output_shape, dtype=output_dtype, device=query.device)
         hidden_size = output_shape[-1]
         # Reshape the query, key, and value tensors.
         # NOTE(woosuk): We do this outside the custom op to minimize the
         # CPU overheads from the non-CUDA-graph regions.
         query = query.view(-1, self.num_heads, self.head_size)
-        if is_tpa_gqa_mode():
-            out_view_heads = self.num_heads // get_dcp_group().world_size
-        else:
-            out_view_heads = self.num_heads
-        output = output.view(-1, out_view_heads, self.head_size_v)
+        output = output.view(-1, self.output_num_heads, self.head_size_v)
         if key is not None:
             key = key.view(-1, self.num_kv_heads, self.head_size)
         if value is not None:

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -524,14 +524,29 @@ class Attention(nn.Module, AttentionLayerBase):
             # Handle both 2D [num_tokens, hidden] and
             # 3D [num_tokens, heads, head_dim] query
             num_tokens = query.shape[0]
-            output_shape = torch.Size((num_tokens, self.num_heads * self.head_size_v))
+            # Under TPA-GQA the post-attention DCP combine reduce-scatters
+            # heads, so the output buffer holds num_heads / dcp_size heads.
+            from vllm.distributed.parallel_state import (
+                get_dcp_group,
+                is_tpa_gqa_mode,
+            )
+
+            if is_tpa_gqa_mode():
+                out_num_heads = self.num_heads // get_dcp_group().world_size
+            else:
+                out_num_heads = self.num_heads
+            output_shape = torch.Size((num_tokens, out_num_heads * self.head_size_v))
         output = torch.empty(output_shape, dtype=output_dtype, device=query.device)
         hidden_size = output_shape[-1]
         # Reshape the query, key, and value tensors.
         # NOTE(woosuk): We do this outside the custom op to minimize the
         # CPU overheads from the non-CUDA-graph regions.
         query = query.view(-1, self.num_heads, self.head_size)
-        output = output.view(-1, self.num_heads, self.head_size_v)
+        if is_tpa_gqa_mode():
+            out_view_heads = self.num_heads // get_dcp_group().world_size
+        else:
+            out_view_heads = self.num_heads
+        output = output.view(-1, out_view_heads, self.head_size_v)
         if key is not None:
             key = key.view(-1, self.num_kv_heads, self.head_size)
         if value is not None:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1125,11 +1125,15 @@ class QKVParallelLinear(ColumnParallelLinear):
                 # works correctly while preserving the parameter shape.
                 for idx in range(param.data.shape[0]):
                     param.load_qkv_weight(
-                        loaded_weight=loaded_weight, shard_id=idx, tp_rank=self.tp_rank
+                        loaded_weight=loaded_weight,
+                        shard_id=idx,
+                        tp_rank=self._qkv_tp_rank,
                     )
                 return
             elif type(param) in (RowvLLMParameter, BasevLLMParameter):
-                param.load_qkv_weight(loaded_weight=loaded_weight, tp_rank=self.tp_rank)
+                param.load_qkv_weight(
+                    loaded_weight=loaded_weight, tp_rank=self._qkv_tp_rank
+                )
                 return
             # TODO: @dsikka - move to parameter.py
             self._load_fused_module_from_checkpoint(param, loaded_weight)
@@ -1153,7 +1157,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             shard_id=loaded_shard_id,
             shard_offset=shard_offset,
             shard_size=shard_size,
-            tp_rank=self.tp_rank,
+            tp_rank=self._qkv_tp_rank,
         )
 
     def weight_loader(

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -19,6 +19,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
+from vllm.distributed.layer_parallel_config import get_layer_parallel_config
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.batch_invariant import (
@@ -992,13 +993,26 @@ class QKVParallelLinear(ColumnParallelLinear):
         self.total_num_kv_heads = total_num_kv_heads
         # Divide the weight matrix along the last dimension.
         tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.num_heads = divide(self.total_num_heads, tp_size)
-        if tp_size >= self.total_num_kv_heads:
+        tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        layer_parallel_config = get_layer_parallel_config(self, prefix)
+        attn_tp_size = layer_parallel_config.tp_size or tp_size
+        attn_tp_rank = layer_parallel_config.tp_rank
+        if attn_tp_rank is None:
+            attn_tp_rank = tp_rank
+        if disable_tp:
+            attn_tp_size = 1
+            attn_tp_rank = 0
+
+        self.num_heads = divide(self.total_num_heads, attn_tp_size)
+        if attn_tp_size >= self.total_num_kv_heads:
             self.num_kv_heads = 1
-            self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
+            self.num_kv_head_replicas = divide(attn_tp_size, self.total_num_kv_heads)
         else:
-            self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
+            self.num_kv_heads = divide(self.total_num_kv_heads, attn_tp_size)
             self.num_kv_head_replicas = 1
+        self.num_heads_per_rank = self.num_heads
+        self.num_kv_heads_per_rank = self.num_kv_heads
+        self._qkv_tp_rank = attn_tp_rank
         input_size = self.hidden_size
         self.output_sizes = [
             self.num_heads * self.head_size * tp_size,  # q_proj
@@ -1297,9 +1311,9 @@ class QKVParallelLinear(ColumnParallelLinear):
 
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
             if loaded_shard_id == "q":
-                shard_rank = self.tp_rank
+                shard_rank = self._qkv_tp_rank
             else:
-                shard_rank = self.tp_rank // self.num_kv_head_replicas
+                shard_rank = self._qkv_tp_rank // self.num_kv_head_replicas
             start_idx = shard_rank * shard_size
 
             if not is_sharded_weight:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1060,6 +1060,16 @@ class QKVParallelLinear(ColumnParallelLinear):
         }
         return shard_size_mapping.get(loaded_shard_id)
 
+    def split_qkv(
+        self, qkv: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Split a fused-QKV tensor into ``(q, k, v)`` using this layer's
+        per-rank Q/K/V sizes."""
+        q_size = self.num_heads * self.head_size
+        k_size = self.num_kv_heads * self.head_size
+        v_size = self.num_kv_heads * self.v_head_size
+        return qkv.split([q_size, k_size, v_size], dim=-1)
+
     def _load_fused_module_from_checkpoint(
         self, param: BasevLLMParameter, loaded_weight: torch.Tensor
     ):

--- a/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
 
-from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -19,15 +19,25 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
+if TYPE_CHECKING:
+    from vllm.distributed.parallel_state import GroupCoordinator
+
 # Max number of tokens supported by the Lamport fused allreduce+RMSNorm kernel.
 # Larger batches fall back to the eager allreduce + RMSNorm path.
 MINIMAX_QK_NORM_MAX_TOKEN_NUM = 2048
 
 _MINIMAX_FUSED_AR_RMS_QK = getattr(torch.ops._C, "minimax_allreduce_rms_qk", None)
+_REDUCE_GROUPS: dict[int, "GroupCoordinator"] = {}
 
 
-def _all_reduce_variance(var: torch.Tensor) -> torch.Tensor:
-    """All-reduce a per-token variance tensor across the TP group.
+def _register_reduce_group(group: "GroupCoordinator") -> int:
+    key = id(group)
+    _REDUCE_GROUPS[key] = group
+    return key
+
+
+def _all_reduce_variance(var: torch.Tensor, reduce_group_key: int) -> torch.Tensor:
+    """All-reduce a per-token variance tensor across the configured group.
 
     Variance is accumulated in fp32 for numerical stability. The FlashInfer
     fused all-reduce caches a single global workspace keyed to the model's
@@ -37,7 +47,7 @@ def _all_reduce_variance(var: torch.Tensor) -> torch.Tensor:
     a flattened (1D) view keeps these fp32 reductions on custom all-reduce /
     pynccl, both of which handle fp32 correctly.
     """
-    return tensor_model_parallel_all_reduce(var.flatten()).view_as(var)
+    return _REDUCE_GROUPS[reduce_group_key].all_reduce(var.flatten()).view_as(var)
 
 
 @triton.jit
@@ -130,7 +140,8 @@ def _minimax_qk_norm_tp_eager(
     k_weight: torch.Tensor,
     q_size: int,
     kv_size: int,
-    tp_world: int,
+    reduce_world: int,
+    reduce_group_key: int,
     eps: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Pure-torch reference path used when Triton is unavailable."""
@@ -142,7 +153,7 @@ def _minimax_qk_norm_tp_eager(
     k_var = k.pow(2).mean(dim=-1, keepdim=True)
 
     qk_var = torch.cat([q_var, k_var], dim=-1)
-    qk_var = _all_reduce_variance(qk_var) / tp_world
+    qk_var = _all_reduce_variance(qk_var, reduce_group_key) / reduce_world
     q_var, k_var = qk_var.chunk(2, dim=-1)
     q = q * torch.rsqrt(q_var + eps) * q_weight
     k = k * torch.rsqrt(k_var + eps) * k_weight
@@ -155,8 +166,8 @@ def _minimax_qk_norm_tp_fallback(
     k_weight: torch.Tensor,
     q_size: int,
     kv_size: int,
-    tp_rank: int,
-    tp_world: int,
+    reduce_world: int,
+    reduce_group_key: int,
     eps: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """All-reduce + QK RMSNorm without the Lamport fused kernel.
@@ -169,7 +180,14 @@ def _minimax_qk_norm_tp_fallback(
     """
     if not HAS_TRITON:
         return _minimax_qk_norm_tp_eager(
-            qkv, q_weight, k_weight, q_size, kv_size, tp_world, eps
+            qkv,
+            q_weight,
+            k_weight,
+            q_size,
+            kv_size,
+            reduce_world,
+            reduce_group_key,
+            eps,
         )
 
     num_tokens = qkv.shape[0]
@@ -184,7 +202,7 @@ def _minimax_qk_norm_tp_fallback(
 
     # All-reduce sums the per-shard means; the /tp_world that turns this back
     # into the global mean is folded into the apply kernel's rsqrt below.
-    qk_var = _all_reduce_variance(qk_var)
+    qk_var = _all_reduce_variance(qk_var, reduce_group_key)
 
     q_out = torch.empty(num_tokens, q_size, dtype=qkv.dtype, device=qkv.device)
     k_out = torch.empty(num_tokens, kv_size, dtype=qkv.dtype, device=qkv.device)
@@ -198,7 +216,7 @@ def _minimax_qk_norm_tp_fallback(
         row_stride,
         q_size=q_size,
         kv_size=kv_size,
-        tp_world=tp_world,
+        tp_world=reduce_world,
         eps=eps,
         BLOCK=BLOCK,
     )
@@ -211,8 +229,9 @@ def _minimax_qk_norm_fusion(
     k_weight: torch.Tensor,
     q_size: int,
     kv_size: int,
-    tp_rank: int,
-    tp_world: int,
+    reduce_rank: int,
+    reduce_world: int,
+    reduce_group_key: int,
     eps: float,
     workspace: torch.Tensor | None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -220,7 +239,7 @@ def _minimax_qk_norm_fusion(
     num_tokens = qkv.shape[0]
     if (
         workspace is not None
-        and tp_world > 1
+        and reduce_world > 1
         and num_tokens <= MINIMAX_QK_NORM_MAX_TOKEN_NUM
         and _MINIMAX_FUSED_AR_RMS_QK is not None
     ):
@@ -231,12 +250,12 @@ def _minimax_qk_norm_fusion(
             workspace,
             q_size,
             kv_size,
-            tp_rank,
-            tp_world,
+            reduce_rank,
+            reduce_world,
             eps,
         )
     return _minimax_qk_norm_tp_fallback(
-        qkv, q_weight, k_weight, q_size, kv_size, tp_rank, tp_world, eps
+        qkv, q_weight, k_weight, q_size, kv_size, reduce_world, reduce_group_key, eps
     )
 
 
@@ -246,8 +265,9 @@ def _minimax_qk_norm_fusion_fake(
     k_weight: torch.Tensor,
     q_size: int,
     kv_size: int,
-    tp_rank: int,
-    tp_world: int,
+    reduce_rank: int,
+    reduce_world: int,
+    reduce_group_key: int,
     eps: float,
     workspace: torch.Tensor | None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -276,6 +296,7 @@ class MiniMaxText01RMSNormTP(CustomOp):
         *,
         weight_shard_world_size: int | None = None,
         weight_shard_rank: int | None = None,
+        reduce_group: "GroupCoordinator | None" = None,
     ) -> None:
         super().__init__()
         self.tp_world = get_tensor_model_parallel_world_size()
@@ -284,6 +305,10 @@ class MiniMaxText01RMSNormTP(CustomOp):
         self.weight_shard_rank = (
             self.tp_rank if weight_shard_rank is None else weight_shard_rank
         )
+        self.reduce_group = reduce_group or get_tp_group()
+        self.reduce_world = self.reduce_group.world_size
+        self.reduce_rank = self.reduce_group.rank_in_group
+        self.reduce_group_key = _register_reduce_group(self.reduce_group)
 
         self.weight = nn.Parameter(torch.ones(hidden_size // self.weight_shard_world))
         self.weight.weight_loader = partial(
@@ -294,7 +319,7 @@ class MiniMaxText01RMSNormTP(CustomOp):
         self.variance_epsilon = eps
 
         self.workspace = None
-        if _MINIMAX_FUSED_AR_RMS_QK is not None and self.tp_world > 1:
+        if _MINIMAX_FUSED_AR_RMS_QK is not None and self.reduce_world > 1:
             from .lamport_workspace import (
                 get_allreduce_workspace,
             )
@@ -306,10 +331,10 @@ class MiniMaxText01RMSNormTP(CustomOp):
             # the eager allreduce + RMSNorm path instead of failing model load.
             try:
                 self.workspace = get_allreduce_workspace(
-                    rank=self.tp_rank,
-                    world_size=self.tp_world,
+                    rank=self.reduce_rank,
+                    world_size=self.reduce_world,
                     max_tokens=MINIMAX_QK_NORM_MAX_TOKEN_NUM,
-                    process_group=get_tp_group().cpu_group,
+                    process_group=self.reduce_group.cpu_group,
                 )
             except Exception as e:
                 logger.warning_once(
@@ -344,8 +369,11 @@ class MiniMaxText01RMSNormTP(CustomOp):
         orig_dtype = x.dtype
         x = x.to(torch.float32)
         variance = x.pow(2).mean(dim=-1, keepdim=True, dtype=torch.float32)
-        if self.tp_world > 1:
-            variance = _all_reduce_variance(variance) / self.tp_world
+        if self.reduce_world > 1:
+            variance = (
+                _all_reduce_variance(variance, self.reduce_group_key)
+                / self.reduce_world
+            )
         x = x * torch.rsqrt(variance + self.variance_epsilon)
         x = (x * self.weight).to(orig_dtype)
         return x
@@ -400,8 +428,9 @@ class MiniMaxText01RMSNormTP(CustomOp):
             k_norm.weight,
             q_size,
             kv_size,
-            q_norm.tp_rank,
-            q_norm.tp_world,
+            q_norm.reduce_rank,
+            q_norm.reduce_world,
+            q_norm.reduce_group_key,
             q_norm.variance_epsilon,
             q_norm.workspace,
         )

--- a/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 import torch
 from torch import nn
 
+from vllm.distributed.layer_parallel_config import get_layer_parallel_config
 from vllm.distributed.parallel_state import (
+    get_attention_tp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     get_tp_group,
@@ -287,6 +289,34 @@ direct_register_custom_op(
 )
 
 
+def _resolve_qk_norm_sharding(
+    prefix: str,
+    num_kv_head_replicas: int,
+    tp_world: int,
+    tp_rank: int,
+) -> tuple[int, int, bool]:
+    """Resolve a qk-norm's weight sharding from the per-layer parallel resolver.
+
+    Mirrors ``QKVParallelLinear``: an attention qk-norm under TPA shards its
+    weight over the attention-TP group, folded by ``num_kv_head_replicas`` for a
+    replicated-KV k_norm (weight sharded by KV-head count, not attn-TP size). A
+    non-attention prefix, or the no-TPA case, resolves to the global TP world.
+
+    Returns ``(weight_shard_world, weight_shard_rank, tpa_active)``. ``tpa_active``
+    is True iff the resolver returned an attention-TP policy for ``prefix`` — the
+    signal that the variance reduction must run over the attention-TP subgroup
+    rather than the global TP group.
+    """
+    lpc = get_layer_parallel_config(None, prefix)
+    eff_size = lpc.tp_size or tp_world
+    eff_rank = tp_rank if lpc.tp_rank is None else lpc.tp_rank
+    return (
+        eff_size // num_kv_head_replicas,
+        eff_rank // num_kv_head_replicas,
+        lpc.tp_size is not None,
+    )
+
+
 @CustomOp.register("minimax_text01_rmsnorm_tp")
 class MiniMaxText01RMSNormTP(CustomOp):
     def __init__(
@@ -294,6 +324,8 @@ class MiniMaxText01RMSNormTP(CustomOp):
         hidden_size: int,
         eps: float = 1e-6,
         *,
+        prefix: str = "",
+        num_kv_head_replicas: int = 1,
         weight_shard_world_size: int | None = None,
         weight_shard_rank: int | None = None,
         reduce_group: "GroupCoordinator | None" = None,
@@ -301,6 +333,30 @@ class MiniMaxText01RMSNormTP(CustomOp):
         super().__init__()
         self.tp_world = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
+
+        # Resolver-native sharding. When the caller passes no explicit
+        # shard/reduce parameters, derive them from the per-layer parallel
+        # resolver, mirroring ``QKVParallelLinear``: an attention qk-norm under
+        # TPA shards its weight and reduces its variance over the attention-TP
+        # group, folded by ``num_kv_head_replicas`` for a replicated-KV k_norm
+        # (weight is sharded by KV-head count, not attn-TP size). Non-attention
+        # prefixes and the no-TPA case resolve to the global TP world, so the
+        # derived values are bit-identical to the pre-resolver behavior.
+        if (
+            weight_shard_world_size is None
+            and weight_shard_rank is None
+            and reduce_group is None
+        ):
+            weight_shard_world_size, weight_shard_rank, tpa_active = (
+                _resolve_qk_norm_sharding(
+                    prefix, num_kv_head_replicas, self.tp_world, self.tp_rank
+                )
+            )
+            if tpa_active:
+                # TPA active for this attention layer: reduce over the attn-TP
+                # subgroup. Off-TPA falls through to the global TP group below.
+                reduce_group = get_attention_tp_group()
+
         self.weight_shard_world = weight_shard_world_size or self.tp_world
         self.weight_shard_rank = (
             self.tp_rank if weight_shard_rank is None else weight_shard_rank

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -33,7 +33,7 @@ from transformers import LlamaConfig
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
-from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.distributed import get_pp_group
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import (
     Attention,
@@ -137,25 +137,13 @@ class LlamaAttention(nn.Module):
         super().__init__()
         layer_idx = extract_layer_index(prefix)
         self.hidden_size = hidden_size
-        tp_size = get_tensor_model_parallel_world_size()
         self.total_num_heads = num_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
-        self.total_num_kv_heads = num_kv_heads
-        if self.total_num_kv_heads >= tp_size:
-            # Number of KV heads is greater than TP size, so we partition
-            # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
-        else:
-            # Number of KV heads is less than TP size, so we replicate
-            # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.total_num_kv_heads = (
+            num_kv_heads if num_kv_heads is not None else num_heads
+        )
 
         head_dim = getattr(config, "head_dim", None)
         self.head_dim = head_dim or self.hidden_size // self.total_num_heads
-        self.q_size = self.num_heads * self.head_dim
-        self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
         self.max_position_embeddings = max_position_embeddings
 
@@ -168,6 +156,10 @@ class LlamaAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
         )
+        self.num_heads = self.qkv_proj.num_heads_per_rank
+        self.num_kv_heads = self.qkv_proj.num_kv_heads_per_rank
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
 
         self.o_proj = RowParallelLinear(
             input_size=self.total_num_heads * self.head_dim,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -158,8 +158,6 @@ class LlamaAttention(nn.Module):
         )
         self.num_heads = self.qkv_proj.num_heads_per_rank
         self.num_kv_heads = self.qkv_proj.num_kv_heads_per_rank
-        self.q_size = self.num_heads * self.head_dim
-        self.kv_size = self.num_kv_heads * self.head_dim
 
         self.o_proj = RowParallelLinear(
             input_size=self.total_num_heads * self.head_dim,
@@ -216,7 +214,7 @@ class LlamaAttention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k, v = self.qkv_proj.split_qkv(qkv)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -34,10 +34,12 @@ from transformers import PretrainedConfig
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (
+    get_attention_tp_group,
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.distributed.layer_parallel_config import get_layer_parallel_config
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
@@ -156,22 +158,24 @@ class MiniMaxM2Attention(nn.Module):
         super().__init__()
         self.hidden_size = hidden_size
         tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        layer_parallel_config = get_layer_parallel_config(self, prefix)
+        attn_tp_size = layer_parallel_config.tp_size or tp_size
+        attn_tp_rank = layer_parallel_config.tp_rank
+        if attn_tp_rank is None:
+            attn_tp_rank = tp_rank
         self.total_num_heads = num_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
+        assert self.total_num_heads % attn_tp_size == 0
         self.total_num_kv_heads = num_kv_heads
-        if self.total_num_kv_heads >= tp_size:
+        if self.total_num_kv_heads >= attn_tp_size:
             # Number of KV heads is greater than TP size, so we partition
             # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
+            assert self.total_num_kv_heads % attn_tp_size == 0
         else:
             # Number of KV heads is less than TP size, so we replicate
             # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+            assert attn_tp_size % self.total_num_kv_heads == 0
         self.head_dim = head_dim or (hidden_size // self.total_num_heads)
-        self.q_size = self.num_heads * self.head_dim
-        self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
         self.max_position_embeddings = max_position_embeddings
 
@@ -184,6 +188,10 @@ class MiniMaxM2Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
         )
+        self.num_heads = self.qkv_proj.num_heads_per_rank
+        self.num_kv_heads = self.qkv_proj.num_kv_heads_per_rank
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
 
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
@@ -214,23 +222,32 @@ class MiniMaxM2Attention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
+        attn_tp_group = get_attention_tp_group()
         self.q_norm = MiniMaxText01RMSNormTP(
-            self.head_dim * self.total_num_heads, eps=rms_norm_eps
+            self.head_dim * self.total_num_heads,
+            eps=rms_norm_eps,
+            weight_shard_world_size=attn_tp_size,
+            weight_shard_rank=attn_tp_rank,
+            reduce_group=attn_tp_group,
         )
-        if self.total_num_kv_heads >= tp_size:
+        if self.total_num_kv_heads >= attn_tp_size:
             self.k_norm = MiniMaxText01RMSNormTP(
-                self.head_dim * self.total_num_kv_heads, eps=rms_norm_eps
+                self.head_dim * self.total_num_kv_heads,
+                eps=rms_norm_eps,
+                weight_shard_world_size=attn_tp_size,
+                weight_shard_rank=attn_tp_rank,
+                reduce_group=attn_tp_group,
             )
         else:
             # KV heads are replicated across TP ranks; shard k_norm weight by
             # total_num_kv_heads rather than tp_size to avoid incorrect sharding.
-            num_kv_head_replicas = tp_size // self.total_num_kv_heads
+            num_kv_head_replicas = attn_tp_size // self.total_num_kv_heads
             self.k_norm = MiniMaxText01RMSNormTP(
                 self.head_dim * self.total_num_kv_heads,
                 eps=rms_norm_eps,
                 weight_shard_world_size=self.total_num_kv_heads,
-                weight_shard_rank=get_tensor_model_parallel_rank()
-                // num_kv_head_replicas,
+                weight_shard_rank=attn_tp_rank // num_kv_head_replicas,
+                reduce_group=attn_tp_group,
             )
 
     def forward(

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -34,9 +34,7 @@ from transformers import PretrainedConfig
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (
-    get_attention_tp_group,
     get_pp_group,
-    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.layer_parallel_config import get_layer_parallel_config
@@ -158,12 +156,8 @@ class MiniMaxM2Attention(nn.Module):
         super().__init__()
         self.hidden_size = hidden_size
         tp_size = get_tensor_model_parallel_world_size()
-        tp_rank = get_tensor_model_parallel_rank()
         layer_parallel_config = get_layer_parallel_config(self, prefix)
         attn_tp_size = layer_parallel_config.tp_size or tp_size
-        attn_tp_rank = layer_parallel_config.tp_rank
-        if attn_tp_rank is None:
-            attn_tp_rank = tp_rank
         self.total_num_heads = num_heads
         assert self.total_num_heads % attn_tp_size == 0
         self.total_num_kv_heads = num_kv_heads
@@ -222,33 +216,22 @@ class MiniMaxM2Attention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
-        attn_tp_group = get_attention_tp_group()
+        # The qk-norms self-resolve their attention-TP sharding + reduce group
+        # from the per-layer parallel resolver (see MiniMaxText01RMSNormTP). The
+        # replicated-KV k_norm case is handled by passing the KV replica factor
+        # that qkv_proj already computed, so this call is identical whether or
+        # not KV heads are replicated across the attention-TP group.
         self.q_norm = MiniMaxText01RMSNormTP(
             self.head_dim * self.total_num_heads,
             eps=rms_norm_eps,
-            weight_shard_world_size=attn_tp_size,
-            weight_shard_rank=attn_tp_rank,
-            reduce_group=attn_tp_group,
+            prefix=f"{prefix}.q_norm",
         )
-        if self.total_num_kv_heads >= attn_tp_size:
-            self.k_norm = MiniMaxText01RMSNormTP(
-                self.head_dim * self.total_num_kv_heads,
-                eps=rms_norm_eps,
-                weight_shard_world_size=attn_tp_size,
-                weight_shard_rank=attn_tp_rank,
-                reduce_group=attn_tp_group,
-            )
-        else:
-            # KV heads are replicated across TP ranks; shard k_norm weight by
-            # total_num_kv_heads rather than tp_size to avoid incorrect sharding.
-            num_kv_head_replicas = attn_tp_size // self.total_num_kv_heads
-            self.k_norm = MiniMaxText01RMSNormTP(
-                self.head_dim * self.total_num_kv_heads,
-                eps=rms_norm_eps,
-                weight_shard_world_size=self.total_num_kv_heads,
-                weight_shard_rank=attn_tp_rank // num_kv_head_replicas,
-                reduce_group=attn_tp_group,
-            )
+        self.k_norm = MiniMaxText01RMSNormTP(
+            self.head_dim * self.total_num_kv_heads,
+            eps=rms_norm_eps,
+            prefix=f"{prefix}.k_norm",
+            num_kv_head_replicas=self.qkv_proj.num_kv_head_replicas,
+        )
 
     def forward(
         self,

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -180,6 +180,9 @@ class _ColumnvLLMParameter(BasevLLMParameter):
         shard_size: int = kwargs["shard_size"]
         shard_id: str = kwargs["shard_id"]
         num_heads: int = kwargs["num_heads"]
+        # Honor an explicit tp_rank kwarg (attention-TP rank under TPA);
+        # fall back to self.tp_rank when unset.
+        tp_rank: int = kwargs.get("tp_rank", self.tp_rank)
 
         # TODO: move these to PackedColumnParameter and PackedvLLMParameter
         if (
@@ -191,7 +194,7 @@ class _ColumnvLLMParameter(BasevLLMParameter):
             )
 
         param_data = self.data
-        shard_id_int = self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
+        shard_id_int = tp_rank if shard_id == "q" else tp_rank // num_heads
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
         loaded_weight = loaded_weight.narrow(
             self.output_dim, shard_id_int * shard_size, shard_size

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -1126,6 +1126,29 @@ class FlashAttentionImpl(AttentionImpl):
             layer._v_scale,
         )
 
+    def _dcp_head_window(self, total_query_heads: int) -> slice:
+        """This DCP rank's contiguous output-head window within a full
+        query-head tensor.
+
+        The DCP path has a two-head-count contract: the FlashAttention kernel
+        computes on ``q_heads`` query heads, but this rank's ``output`` holds
+        ``out_heads``. They are equal under plain DCP. Under TPA-GQA the query
+        carries the DCP group's full head set, so
+        ``q_heads == out_heads * dcp_world_size``; the context branch is
+        reduce-scattered to ``out_heads`` by ``dcp_combine`` and the local query
+        branch is sliced to this rank's window. Returns the
+        ``[start, start + out_heads)`` slice, applied identically to per-head
+        tensors (attention output on dim 1, LSE on dim 0).
+        """
+        dcp_group = get_dcp_group()
+        assert total_query_heads % dcp_group.world_size == 0, (
+            f"TPA-GQA: query heads ({total_query_heads}) must be divisible by "
+            f"dcp_world_size ({dcp_group.world_size})"
+        )
+        out_heads = total_query_heads // dcp_group.world_size
+        start = dcp_group.rank_in_group * out_heads
+        return slice(start, start + out_heads)
+
     def _forward_with_dcp(
         self,
         query: torch.Tensor,
@@ -1191,10 +1214,7 @@ class FlashAttentionImpl(AttentionImpl):
                 num_splits=attn_metadata.max_num_splits,
             )
             if tpa_gqa_mode:
-                dcp_group = get_dcp_group()
-                hpf = query.shape[1] // dcp_group.world_size
-                head_start = dcp_group.rank_in_group * hpf
-                output.copy_(fast_out[:, head_start : head_start + hpf, :])
+                output.copy_(fast_out[:, self._dcp_head_window(fast_out.shape[1]), :])
             return output
 
         # TPA-GQA: Q already carries this attn-rank's heads, so skip the
@@ -1342,19 +1362,9 @@ class FlashAttentionImpl(AttentionImpl):
         # context branch has been reduce-scattered to H/full_tp; slice the
         # query branch to this DCP rank's head window for merge_attn_states.
         if tpa_gqa_mode:
-            dcp_group = get_dcp_group()
-            dcp_size = dcp_group.world_size
-            dcp_rank = dcp_group.rank_in_group
-            total_heads = query_attn_out.shape[1]
-            assert total_heads % dcp_size == 0, (
-                f"TPA-GQA: query_attn_out heads ({total_heads}) must be "
-                f"divisible by dcp_size ({dcp_size})"
-            )
-            heads_per_full_rank = total_heads // dcp_size
-            head_start = dcp_rank * heads_per_full_rank
-            head_end = head_start + heads_per_full_rank
-            query_attn_out = query_attn_out[:, head_start:head_end, :].contiguous()
-            query_lse = query_lse[head_start:head_end, :].contiguous()
+            head_window = self._dcp_head_window(query_attn_out.shape[1])
+            query_attn_out = query_attn_out[:, head_window, :].contiguous()
+            query_lse = query_lse[head_window, :].contiguous()
         assert context_attn_out_cor.shape == query_attn_out.shape
         assert context_lse_cor.shape == query_lse.shape
         merge_attn_states(

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -419,6 +419,28 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                 device=self.device,
             )
 
+            # Pre-grow the workspace for _forward_with_dcp's context-branch
+            # output. CUDA-graph warmup only exercises decode-sized batches
+            # (n <= max_num_seqs), but the prefill DCP context branch is
+            # invoked with up to max_num_batched_tokens. Without this
+            # pre-grow, lock_workspace() at the end of capture happens at
+            # the smaller decode size and prefill batches hit
+            # "Workspace is locked but allocation requires ... MB".
+            total_attn_heads = self.model_config.hf_config.num_attention_heads
+            tp_size = self.parallel_config.tensor_parallel_size
+            # Max per-rank head count in the DCP context branch is the
+            # same under both modes: non-TPA needs num_heads_q*dcp after
+            # all-gather; TPA-GQA needs num_heads_q natively. Under the
+            # TPA invariant TPA*DCP=TP, both equal total/tp*dcp.
+            max_context_heads = (total_attn_heads // tp_size) * self.dcp_world_size
+            max_n = vllm_config.scheduler_config.max_num_batched_tokens
+            _ = current_workspace_manager().get_simultaneous(
+                (
+                    (max_n, max_context_heads, self.headdim),
+                    self.model_config.dtype,
+                ),
+            )
+
         # Sliding window size to be used with the AOT scheduler will be
         # populated on first build() call.
         self.aot_sliding_window: tuple[int, int] | None = None

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -502,11 +502,20 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             else:
                 qkv_dtype = self.kv_cache_dtype
             if aot_schedule:
+                # TPA-GQA skips the pre-attention DCP Q all-gather, so Q
+                # already has H/attn_tp heads with no DCP expansion.
+                from vllm.distributed.parallel_state import is_tpa_gqa_mode
+
+                scheduler_num_heads_q = (
+                    self.num_heads_q
+                    if is_tpa_gqa_mode()
+                    else self.num_heads_q * self.dcp_world_size
+                )
                 return get_scheduler_metadata(
                     batch_size=batch_size,
                     max_seqlen_q=max_query_len,
                     max_seqlen_k=max_seq_len,
-                    num_heads_q=self.num_heads_q * self.dcp_world_size,
+                    num_heads_q=scheduler_num_heads_q,
                     num_heads_kv=self.num_heads_kv,
                     headdim=self.headdim,
                     cache_seqlens=seqlens,
@@ -1116,13 +1125,31 @@ class FlashAttentionImpl(AttentionImpl):
         max_seqlen_q = attn_metadata.max_query_len
         block_table = attn_metadata.block_table
 
+        # TPA-GQA: Q already has per-attn-rank heads, so skip the
+        # cross-DCP all-gather; dcp_combine reduces H/attn_tp → H/full_tp.
+        from vllm.distributed.parallel_state import is_tpa_gqa_mode
+
+        tpa_gqa_mode = is_tpa_gqa_mode()
+
         query = query.contiguous()
         if attn_metadata.max_dcp_context_kv_len == 0:
+            # No cross-DCP context: purely local self-attention. Under TPA-GQA
+            # the query carries H/attn_tp heads and must be sliced to this DCP
+            # rank's H/full_tp window (mirrors the full path's query-branch
+            # slice); a scratch is needed since `output` is only H/full_tp.
+            fast_out = output
+            if tpa_gqa_mode:
+                (fast_out,) = current_workspace_manager().get_simultaneous(
+                    (
+                        (query.shape[0], query.shape[1], self.head_size),
+                        self._dcp_dtype,
+                    ),
+                )
             flash_attn_varlen_func(
                 q=query,
                 k=key,
                 v=value,
-                out=output,
+                out=fast_out,
                 cu_seqlens_q=cu_seqlens_q,
                 max_seqlen_q=max_seqlen_q,
                 cu_seqlens_k=cu_seqlens_q,
@@ -1141,19 +1168,29 @@ class FlashAttentionImpl(AttentionImpl):
                 v_descale=v_descale,
                 num_splits=attn_metadata.max_num_splits,
             )
+            if tpa_gqa_mode:
+                dcp_group = get_dcp_group()
+                hpf = query.shape[1] // dcp_group.world_size
+                head_start = dcp_group.rank_in_group * hpf
+                output.copy_(fast_out[:, head_start : head_start + hpf, :])
             return output
 
-        query_across_dcp = get_dcp_group().all_gather(query, dim=1)
+        # TPA-GQA: Q already carries this attn-rank's heads, so skip the
+        # cross-DCP query all-gather (dcp_combine reduces H/attn_tp -> H/full_tp).
+        context_q = query if tpa_gqa_mode else get_dcp_group().all_gather(query, dim=1)
+        context_num_heads = context_q.shape[1]
         sliding_window_size = (
             list(self.sliding_window) if self.sliding_window is not None else None
         )
-        n = query_across_dcp.shape[0]
+        n = context_q.shape[0]
         num_reqs = cu_seqlens_q.shape[0] - 1
         num_decodes = attn_metadata.num_decode_reqs
         num_context_prefills = attn_metadata.num_prefill_reqs
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_context_prefill_tokens = attn_metadata.num_prefill_tokens
-        split_dcp_context = should_split_fa2_dcp_context_attention(
+        # The split-FA2 context workaround assumes the all-gathered query
+        # layout; under TPA-GQA the query stays local, so use the non-split path.
+        split_dcp_context = not tpa_gqa_mode and should_split_fa2_dcp_context_attention(
             self.vllm_flash_attn_version,
             max_seqlen_q,
             num_reqs,
@@ -1161,10 +1198,15 @@ class FlashAttentionImpl(AttentionImpl):
             num_context_prefills,
         )
         dcp_context_out_tokens = max(n, self._dcp_max_num_tokens)
+        # Head dim = the actual context-branch query head count. By the TPA
+        # invariant (attn_tp*dcp == tp) this equals (num_heads_q // tp) * dcp in
+        # BOTH modes = the pre-grow's max_context_heads, so the workspace stays
+        # CUDA-graph-fixed. NOTE: self.num_heads * dcp is WRONG under TPA, where
+        # self.num_heads is the attn-tp-local count, not num_heads_q // tp.
         dcp_context_out_spec = (
             (
                 dcp_context_out_tokens,
-                self.num_heads * self.dcp_world_size,
+                context_num_heads,
                 self.head_size,
             ),
             self._dcp_dtype,
@@ -1182,7 +1224,7 @@ class FlashAttentionImpl(AttentionImpl):
             assert self.vllm_flash_attn_version is not None
             context_attn_out, context_lse = run_split_fa2_dcp_context_attention(
                 flash_attn_varlen_func,
-                query_across_dcp,
+                context_q,
                 key_cache,
                 value_cache,
                 dcp_context_out,
@@ -1209,7 +1251,7 @@ class FlashAttentionImpl(AttentionImpl):
             )
         else:
             context_attn_out, context_lse = flash_attn_varlen_func(
-                q=query_across_dcp,
+                q=context_q,
                 k=key_cache,
                 v=value_cache,
                 out=dcp_context_out,
@@ -1231,6 +1273,12 @@ class FlashAttentionImpl(AttentionImpl):
                 v_descale=v_descale,
                 num_splits=attn_metadata.max_num_splits,
             )
+        # FA3 with out= may return the underlying base buffer rather than
+        # the sliced view; slice back to the actual head count used here.
+        if context_attn_out.shape[1] != context_num_heads:
+            context_attn_out = context_attn_out[:, :context_num_heads]
+        if context_lse.shape[0] != context_num_heads:
+            context_lse = context_lse[:context_num_heads]
         # FA returns LSE in shape [ H, B ] but DCP combine wants [ B, H ]
         context_attn_out_cor, context_lse_cor = self.dcp_combine(
             context_attn_out,
@@ -1240,11 +1288,18 @@ class FlashAttentionImpl(AttentionImpl):
         )
         context_lse_cor = context_lse_cor.transpose(0, 1).contiguous()
 
+        # Query branch must write to a scratch sized to the query's OWN head
+        # count (H/attn_tp under TPA, != output's H/full_tp), then merge_attn_states
+        # writes the final combined result into `output`. Writing q-attn directly
+        # to `output` mismatches heads under TPA and aliases the merge destination.
+        (dcp_query_out,) = current_workspace_manager().get_simultaneous(
+            ((query.shape[0], query.shape[1], self.head_size), self._dcp_dtype),
+        )
         query_attn_out, query_lse = flash_attn_varlen_func(
             q=query,
             k=key,
             v=value,
-            out=output,
+            out=dcp_query_out,
             cu_seqlens_q=cu_seqlens_q,
             max_seqlen_q=max_seqlen_q,
             cu_seqlens_k=cu_seqlens_q,
@@ -1261,6 +1316,23 @@ class FlashAttentionImpl(AttentionImpl):
             v_descale=v_descale,
             num_splits=attn_metadata.max_num_splits,
         )
+        # Under TPA-GQA the query branch holds H/attn_tp heads while the
+        # context branch has been reduce-scattered to H/full_tp; slice the
+        # query branch to this DCP rank's head window for merge_attn_states.
+        if tpa_gqa_mode:
+            dcp_group = get_dcp_group()
+            dcp_size = dcp_group.world_size
+            dcp_rank = dcp_group.rank_in_group
+            total_heads = query_attn_out.shape[1]
+            assert total_heads % dcp_size == 0, (
+                f"TPA-GQA: query_attn_out heads ({total_heads}) must be "
+                f"divisible by dcp_size ({dcp_size})"
+            )
+            heads_per_full_rank = total_heads // dcp_size
+            head_start = dcp_rank * heads_per_full_rank
+            head_end = head_start + heads_per_full_rank
+            query_attn_out = query_attn_out[:, head_start:head_end, :].contiguous()
+            query_lse = query_lse[head_start:head_end, :].contiguous()
         assert context_attn_out_cor.shape == query_attn_out.shape
         assert context_lse_cor.shape == query_lse.shape
         merge_attn_states(


### PR DESCRIPTION
## Purpose

Implements the per-layer parallelism policy proposed in RFC #42659, with TPA-GQA on FlashAttention as the first concrete realization. Supersedes #36287, addressing review feedback (Lucas Wilkinson: _"the design shouldn't be attention-specific"_) by introducing a framework-owned resolver that lets layers declare what they are and have the framework resolve their parallelism plan.

**Mechanism.** A single module-level function — `get_layer_parallel_config(layer, prefix)` — owned by the framework, turns a layer's identity into its parallelism plan. Shared layer code (`QKVParallelLinear`, attention, weight loaders) consults the resolver in `__init__` instead of reading global TP accessors. A default `LayerParallelConfig` (all fields `None`) means "fall back to the global TP world" — non-adopting layers and the no-TPA case behave bit-identically to today.

**First feature: TPA-GQA on FlashAttention.** `--tensor-parallel-size-attention K` (alias `-tpa K`) decouples attention head parallelism from FFN tensor parallelism, enabling higher DCP ratios for GQA models. Standard DCP requires `TP / DCP >= num_kv_heads`; for Nemotron-49B (8 KV heads) on 16 GPUs that caps DCP at 2. TPA shards attention heads independently (`attention_tp = TP / DCP`), so DCP=4 with TPA=4 becomes possible.

**Backward compatibility.** Two properties enforce BC by construction:
- *Sentinel-fallback at every consult site* — the resolver returns a "no policy active" plan by default; unmigrated layers and the no-TPA case fall back to today's global TP accessors and behave bit-identically.
- *Per-strategy delivery* — each new strategy lands resolver-native for the model families it targets, independently. Existing globals (TP, PP, EP, DCP) stay where they are. A user who changes no CLI flags sees no behavior change.

**Scope of this PR.** Validated end-to-end on the Llama family (and derivatives via inheritance) and on a second model, **MiniMax-M2** (GQA). This PR also includes a bug fix for models with a **TP-reduced qk-norm**: under TPA+DCP such a norm must reduce over the attention-TP subgroup, not the full TP group, otherwise the per-token reduction mixes context-sharded prefill tokens (NaN/empty output). Other architectures that don't consult the resolver fall through to global TP — `-tpa K` is silently a no-op there. FlashInfer DCP TPA-GQA is a known follow-up (binary-blocking numerical bug isolated to FlashInfer's ragged wrapper under real RoPE'd Q/K/V).

## Test Plan


**Unit tests** (resolver semantics, sentinel fallback, attn_tp_rank derivation):
```bash
pytest tests/distributed/test_layer_parallel_config.py -v
```

**GSM8K accuracy** (Llama-3.1-8B-Instruct, GB200×4, FlashAttention, server mode, CUDA graphs ON, full 1319 samples):
```bash
vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --tensor-parallel-size 4 --tensor-parallel-size-attention 2 \
  --decode-context-parallel-size 2 \
  --max-model-len 8192 --max-num-seqs 32 --gpu-memory-utilization 0.85 \
  --attention-config '{"backend":"FLASH_ATTN"}'

lm_eval --model local-completions --tasks gsm8k --num_fewshot 5 \
  --model_args 'model=tpa-test,base_url=http://localhost:8000/v1/completions,tokenizer=meta-llama/Llama-3.1-8B-Instruct,tokenizer_backend=huggingface,tokenized_requests=False,num_concurrent=16'
```

## Test Result

**GSM8K, Llama-3.1-8B-Instruct, 5-shot, full 1319 samples** (server mode, CUDA graphs ON):

Config | flexible-extract | strict-match
-- | -- | --
TP=8, baseline | 0.7794 ± 0.0114 | 0.7081 ± 0.0125
TP=4 TPA=2 DCP=2 + FA | 0.7839 ± 0.0113 | 0.7165 ± 0.0124

Resolver activation confirmed on all 4 ranks:
```
INFO ... [layer_parallel_config.py:86] Per-layer parallel resolver initialized: full_tp=4, attn_tp=2 (TPA mode active)
```

Sanity prompts before the full eval:
"The capital of France is" → " a city of romance, art, fashion, and"</code> (matches non-TPA baseline)
"If a train travels 60 mph for 2.5 hours, how far does it travel?" → "150 miles"


## Test Plan & Results — MiniMax-M2 (second model; TPA-GQA + qk-norm fix)

MiniMax-M2 (GQA, 48 q / 8 kv heads) is enabled as a second model. It exercises the qk-norm fix in this PR: a TP-reduced per-token qk-norm must reduce over the **attention-TP subgroup** under TPA+DCP (not the full TP group), otherwise the per-token reduction mixes context-sharded prefill tokens and produces NaN/empty output.

**Test plan.**
```bash
# TP4: baseline vs TPA+DCP   (TP16: --tensor-parallel-size 16 -tpa 8 -dcp 2 --enable-expert-parallel)
vllm serve nvidia/MiniMax-M2.7-NVFP4 --tensor-parallel-size 4 \
  [--tensor-parallel-size-attention 2 --decode-context-parallel-size 2] \
  --max-model-len 196608 --kv-cache-dtype bfloat16 \
  --attention-config '{"backend":"FLASH_ATTN"}' -cc.cudagraph_mode=FULL
```
GSM8K via vLLM's built-in evaluator (1319, 5-shot). Admission/throughput via AIPerf MoonTrace replay of an agentic 64k-ISL / 90%-prefix-reuse trace with a concurrency sweep.

**Result — GSM8K 1319/5-shot (0 invalid):**

| config | accuracy |
| -- | -- |
| TP4 baseline (DCP1) | 0.9242 |
| TP4 `-tpa 2` DCP2 | 0.9265 |
| TP16 baseline (DCP1) | 0.9265 |
| TP16 `-tpa 8` DCP2 | 0.9136 |

TP4 is exact parity; TP16 is within eval noise (delta ~= 1.2 sigma on the proportion difference).

**Result — throughput / admission** (TP16, agentic 64k / 90%-reuse MoonTrace, concurrency sweep, tok/s per GPU):

| concurrency | baseline (DCP1) | `-tpa 8` DCP2 |
| -- | -- | -- |
| 64  | 48.6 | 65.1 |
| 176 | 57.5 | 97.6 |
| 250 | 74.2 | 129.6 |
| 350 | 79.5 (KV-saturated) | 160.3 |
| 500 | — | 169.7 (peak) |

TPA+DCP Pareto-dominates the pure-TP baseline across the sweep (up to ~2.1x tok/s/GPU at the frontier). With 8 KV heads on 16 ranks the baseline replicates KV 2x, saturating its KV budget and evicting the prefix cache (hit-rate 79% -> 12%), while TPA+DCP reclaims the replication (KV <= 72%, hit-rate held ~79%).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>