### PR TITLE
[Model Runner V2] Fix kv_connector `pre_forward` order

### DIFF
--- a/vllm/v1/worker/gpu/kv_connector.py
+++ b/vllm/v1/worker/gpu/kv_connector.py
@@ -65,8 +65,8 @@ class ActiveKVConnector(KVConnector):
 
         kv_connector_metadata = scheduler_output.kv_connector_metadata
         assert kv_connector_metadata is not None
-        self.kv_connector.bind_connector_metadata(kv_connector_metadata)
         self.kv_connector.handle_preemptions(kv_connector_metadata)
+        self.kv_connector.bind_connector_metadata(kv_connector_metadata)
 
         # TODO: sort out KV Connectors' use of forward_context
         if is_forward_context_available():


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/41286

`VLLM_USE_V2_MODEL_RUNNER=1 pytest tests/v1/kv_connector/unit/test_multi_connector.py::test_multi_example_connector_consistency`

Originally

```bash
        # First three events are from initialization (register_kv_caches,
        # set_host_xfer_buffer_ops, get_handshake_metadata), then generate() events.
>       assert events["storage1-WORKER"][:8] == [
            "register_kv_caches",
            "set_host_xfer_buffer_ops",
            "get_handshake_metadata",
            "handle_preemptions",
            "bind_connector_metadata",
            "start_load_kv",
            "wait_for_layer_load",
            "save_kv_layer",
        ]
E       AssertionError: assert ['register_kv...load_kv', ...] == ['register_kv...load_kv', ...]
E         
E         At index 3 diff: 'bind_connector_metadata' != 'handle_preemptions'
E         Use -v to get more diff
```

Now

```bash
======================================== 1 passed, 17 warnings in 15.16s =========================================
```
