### PR TITLE
[Bugfix][Core] avoid zmq port conflicts with multiple api servers

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -29,6 +29,21 @@ def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
                     s3.bind(("localhost", get_open_port()))
 
 
+def test_get_open_port_above_upper_bound_falls_back_to_os_assigned(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A start port above 65535 must not crash with a raw ``OverflowError``
+    from ``socket.bind``."""
+    monkeypatch.setenv("VLLM_PORT", "65536")
+
+    port = get_open_port()
+    assert 0 < port <= 65535
+
+    ports = get_open_ports_list(count=2, start_port=65536)
+    assert len(ports) == 2
+    assert all(0 < p <= 65535 for p in ports)
+
+
 def test_get_open_ports_list_with_vllm_port(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m:
         m.setenv("VLLM_PORT", "5678")

--- a/tests/v1/engine/test_engine_zmq_addresses.py
+++ b/tests/v1/engine/test_engine_zmq_addresses.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.config import ParallelConfig, VllmConfig
+from vllm.utils.network_utils import split_zmq_path
+from vllm.v1.engine.utils import get_engine_zmq_addresses
+
+
+def test_multi_api_server_zmq_addresses_are_unique_and_bindable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each independent ``get_open_port`` call observes a port as free but
+    does not hold it, so concurrent allocations can return duplicates. The
+    address allocator must hand each API server a distinct, bindable port
+    that also stays clear of the DP master's reserved range."""
+    monkeypatch.setenv("VLLM_PORT", "30000")
+    # Place DP master inside the allocation window (start_port = 31000) so
+    # the test fails if the allocator forgets to skip the reserved range.
+    monkeypatch.setenv("VLLM_DP_MASTER_PORT", "31005")
+
+    parallel_config = MagicMock(spec=ParallelConfig)
+    # dp_size != dp_size_local forces client_local_only=False (TCP path).
+    parallel_config.data_parallel_size = 4
+    parallel_config.data_parallel_size_local = 1
+    parallel_config.data_parallel_rank_local = None
+    parallel_config.data_parallel_master_ip = "127.0.0.1"
+    parallel_config.local_engines_only = False
+    parallel_config.enable_elastic_ep = False
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.parallel_config = parallel_config
+
+    addresses = get_engine_zmq_addresses(vllm_config, num_api_servers=8)
+
+    ports = [int(split_zmq_path(a)[2]) for a in addresses.inputs + addresses.outputs]
+    assert len(ports) == 16
+    assert len(set(ports)) == 16
+    assert all(not 31005 <= port < 31015 for port in ports)
+
+    sockets: list[socket.socket] = []
+    try:
+        for port in ports:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind(("127.0.0.1", port))
+            sockets.append(s)
+    finally:
+        for s in sockets:
+            s.close()
+
+
+def test_multi_api_server_zmq_addresses_local_only_uses_ipc() -> None:
+    """When the client only talks to colocated engines, addresses must be
+    unique IPC paths. No TCP port allocation needed."""
+    parallel_config = MagicMock(spec=ParallelConfig)
+    # dp_size == dp_size_local forces client_local_only=True.
+    parallel_config.data_parallel_size = 4
+    parallel_config.data_parallel_size_local = 4
+    parallel_config.data_parallel_rank_local = None
+    parallel_config.data_parallel_master_ip = "127.0.0.1"
+    parallel_config.local_engines_only = False
+    parallel_config.enable_elastic_ep = False
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.parallel_config = parallel_config
+
+    addresses = get_engine_zmq_addresses(vllm_config, num_api_servers=4)
+
+    all_addresses = addresses.inputs + addresses.outputs
+    assert len(all_addresses) == 8
+    assert len(set(all_addresses)) == 8
+    assert all(split_zmq_path(addr)[0] == "ipc" for addr in all_addresses)

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -175,6 +175,11 @@ def get_open_ports_list(count: int = 5, start_port: int | None = None) -> list[i
     each returned port so the batch is guaranteed unique. Ports falling
     inside the DP master reserved range are skipped.
     """
+    reserved_port_range = range(0)
+    if "VLLM_DP_MASTER_PORT" in os.environ:
+        dp_master_port = envs.VLLM_DP_MASTER_PORT
+        reserved_port_range = range(dp_master_port, dp_master_port + 10)
+
     ports: list[int] = []
     next_port = start_port if start_port is not None else envs.VLLM_PORT
     while len(ports) < count:
@@ -183,11 +188,8 @@ def get_open_ports_list(count: int = 5, start_port: int | None = None) -> list[i
             max_attempts=1000 if next_port is not None else None,
         )
         next_port = port + 1
-        if "VLLM_DP_MASTER_PORT" in os.environ:
-            dp_master_port = envs.VLLM_DP_MASTER_PORT
-            reserved_port_range = range(dp_master_port, dp_master_port + 10)
-            if port in reserved_port_range:
-                continue
+        if port in reserved_port_range:
+            continue
         ports.append(port)
     return ports
 
@@ -200,7 +202,10 @@ def _get_open_port(
     port = start_port
     if port is not None:
         attempts = 0
-        while True:
+        # stop scanning once port is outside valid TCP port range (otherwise
+        # socket.bind raises a raw OverflowError). fall through to the
+        # OS-assigned path.
+        while port <= 65535:
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     s.bind(("", port))
@@ -214,6 +219,11 @@ def _get_open_port(
                     f"Could not find open port after {max_attempts} "
                     f"attempts starting from port {start_port}"
                 )
+        logger.warning(
+            "Port scan starting from %d exhausted the TCP port range."
+            "Falling back to an OS-assigned port",
+            start_port,
+        )
     # try ipv4
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -166,25 +166,30 @@ def get_open_port() -> int:
     return _get_open_port()
 
 
-def get_open_ports_list(count: int = 5) -> list[int]:
+def get_open_ports_list(count: int = 5, start_port: int | None = None) -> list[int]:
     """Get a list of unique open ports.
 
-    When VLLM_PORT is set, scans upward from that port, advancing
-    the start position after each find so every port is unique.
+    When ``start_port`` is provided (``VLLM_PORT`` is set as a fallback),
+    scans upward from that port. Otherwise the first port is OS-assigned and
+    subsequent ports scan upward from it. The scan position advances after
+    each returned port so the batch is guaranteed unique. Ports falling
+    inside the DP master reserved range are skipped.
     """
-    ports_set = set[int]()
-    if envs.VLLM_PORT is not None:
-        next_port = envs.VLLM_PORT
-        for _ in range(count):
-            port = _get_open_port(start_port=next_port, max_attempts=1000)
-            ports_set.add(port)
-            next_port = port + 1
-        return list(ports_set)
-    else:
-        while len(ports_set) < count:
-            ports_set.add(get_open_port())
-
-    return list(ports_set)
+    ports: list[int] = []
+    next_port = start_port if start_port is not None else envs.VLLM_PORT
+    while len(ports) < count:
+        port = _get_open_port(
+            start_port=next_port,
+            max_attempts=1000 if next_port is not None else None,
+        )
+        next_port = port + 1
+        if "VLLM_DP_MASTER_PORT" in os.environ:
+            dp_master_port = envs.VLLM_DP_MASTER_PORT
+            reserved_port_range = range(dp_master_port, dp_master_port + 10)
+            if port in reserved_port_range:
+                continue
+        ports.append(port)
+    return ports
 
 
 def _get_open_port(

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -23,7 +23,11 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils import numa_utils
-from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.utils.network_utils import (
+    get_open_ports_list,
+    get_open_zmq_ipc_path,
+    zmq_socket_ctx,
+)
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.executor import Executor
@@ -36,6 +40,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
+MULTI_API_SERVER_ZMQ_PORT_OFFSET = 1000
 
 
 class CoreEngineState(Enum):
@@ -978,16 +983,40 @@ def get_engine_zmq_addresses(
     if parallel_config.enable_elastic_ep:
         client_local_only = False
 
-    return EngineZmqAddresses(
-        inputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
-            for _ in range(num_api_servers)
-        ],
-        outputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
-            for _ in range(num_api_servers)
-        ],
-    )
+    if client_local_only:
+        return EngineZmqAddresses(
+            inputs=[
+                get_engine_client_zmq_addr(client_local_only, host)
+                for _ in range(num_api_servers)
+            ],
+            outputs=[
+                get_engine_client_zmq_addr(client_local_only, host)
+                for _ in range(num_api_servers)
+            ],
+        )
+    else:
+        # pre-allocate TCP ports up front for the multi-api-server case;
+        # `get_open_port` observes a port as free but does not reserve it, so
+        # independent calls can hand the same port to multiple servers.
+        start_port = (
+            envs.VLLM_PORT + MULTI_API_SERVER_ZMQ_PORT_OFFSET
+            if envs.VLLM_PORT is not None
+            else None
+        )
+        pool = get_open_ports_list(2 * num_api_servers, start_port=start_port)
+        input_ports = pool[:num_api_servers]
+        output_ports = pool[num_api_servers:]
+
+        return EngineZmqAddresses(
+            inputs=[
+                get_engine_client_zmq_addr(client_local_only, host, port=p)
+                for p in input_ports
+            ],
+            outputs=[
+                get_engine_client_zmq_addr(client_local_only, host, port=p)
+                for p in output_ports
+            ],
+        )
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Purpose

When testing large DP deployments (which by default spawn multiple api servers) we noticed that it was possible for vllm to accidentally assign conflicting ports to the different api servers. This is flaky but can cause several large DP deployments to fail with `Address already in use ...`. 

The problem is two fold

1. `get_engine_zmq_addresses` previously called `get_open_port` independently per server. `get_open_port` observes a port as free via a transient bind then closes the socket without holding it, so the same port can be reported free to multiple callers before any of them re-binds.
2. `get_open_ports_list` was bypassing the check on VLLM_DP_MASTER_PORT skip so DP master reserved ports could leak into the allocation
 
This PR fixes both and adds a test to confirm `get_open_ports_list` does not assign conflicting ports.

## Test Plan

Added a new test to confirm 
```
tests/v1/engine/test_engine_zmq_addresses.py
```

## Test Result

Test passes ✅  and our 32 DP deployment works as expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

