### PR TITLE
fix: validate backend block size earlier

### DIFF
--- a/tests/platforms/test_block_size_validation.py
+++ b/tests/platforms/test_block_size_validation.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import CacheConfig
+from vllm.platforms import current_platform
+from vllm.v1.attention.backend import MultipleOf
+
+
+def test_update_block_size_for_backend_rejects_unsupported_user_block_size(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class Backend:
+        @staticmethod
+        def get_supported_kernel_block_sizes():
+            return [MultipleOf(16)]
+
+        @classmethod
+        def supports_block_size(cls, block_size: int | None) -> bool:
+            return block_size is not None and block_size % 16 == 0
+
+        @staticmethod
+        def get_name():
+            return "TEST_BACKEND"
+
+    vllm_config = SimpleNamespace(
+        cache_config=CacheConfig(block_size=8),
+        model_config=SimpleNamespace(is_hybrid=False),
+    )
+    monkeypatch.setattr(
+        type(current_platform),
+        "_find_non_ssm_backend",
+        classmethod(lambda cls, vllm_config: Backend),
+    )
+
+    with pytest.raises(ValueError, match=r"block_size \(8\).*TEST_BACKEND"):
+        current_platform.update_block_size_for_backend(vllm_config)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -474,6 +474,7 @@ class Platform:
         """
         from vllm.config.cache import CacheConfig
         from vllm.config.vllm import set_current_vllm_config
+        from vllm.v1.attention.backend import MultipleOf
 
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
@@ -499,6 +500,22 @@ class Platform:
                     backend_cls.get_name(),
                 )
             cache_config.block_size = preferred
+        else:
+            with set_current_vllm_config(vllm_config):
+                block_size_supported = backend_cls.supports_block_size(
+                    cache_config.block_size
+                )
+                supported_sizes = backend_cls.get_supported_kernel_block_sizes()
+            if not block_size_supported:
+                supported = ", ".join(
+                    f"multiple of {s.base}" if isinstance(s, MultipleOf) else str(s)
+                    for s in supported_sizes
+                )
+                raise ValueError(
+                    f"block_size ({cache_config.block_size}) is not supported "
+                    f"by the {backend_cls.get_name()} attention backend. "
+                    f"Supported kernel block sizes: {supported}."
+                )
 
         # Phase 2: Align block/mamba sizes for hybrid models
         # (may override user settings).


### PR DESCRIPTION
﻿Fixes #42510.

## Summary
- validate user-specified block sizes against the selected attention backend before KV cache setup
- report the backend-supported kernel block sizes in the early error message
- add a lightweight platform regression test so invalid block sizes fail before model loading

## To verify
- `python -m py_compile vllm\\platforms\\interface.py tests\\platforms\\test_block_size_validation.py`
- `python -m ruff check vllm\\platforms\\interface.py tests\\platforms\\test_block_size_validation.py`
- `python -m pytest tests\\platforms\\test_block_size_validation.py -q --confcutdir=tests\\platforms`
- `git diff --check`
