### PR TITLE
[Bugfix] DFlash FP8 KV-Cache

### DIFF
--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -247,8 +247,10 @@ class DFlashQwen3Model(nn.Module):
             [
                 DFlashQwen3DecoderLayer(
                     current_vllm_config,
-                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                     config=self.config,
+                    cache_config=current_vllm_config.cache_config,
+                    quant_config=self.quant_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -116,7 +116,7 @@ class SpecDecodeBaseProposer:
 
         self.max_batch_size = vllm_config.scheduler_config.max_num_seqs
         self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        self.token_arange_np = np.arange(self.max_num_tokens)
+        self.token_arange_np = np.arange(self.max_num_tokens, dtype=np.int32)
 
         # Can be specialized by methods like DFlash to reduce the limit
         self.max_query_tokens = self.max_num_tokens


### PR DESCRIPTION
## Purpose

There are a few crashes that happen when we run DFlash with FP8 KV Cache, here's why:

- We are not currently propagating the Attention `quant_config` or `cache_config` to the DFlash decoder layer.
- The `self.token_arange_np` has a dtype mismatch with `self.arange` in the DFlash setup kernel, so I fix the type for consistency.

## Testing

Currently, there are no supported attention backend combinations with non-causal + FP8 KV-Cache support, see https://github.com/vllm-project/vllm/issues/41559.

In the meantime, I tested this PR by manually disabling the causal attention requirement in DFlash. Notably I still saw very high acceptance rates, >4 AL on GSM8k and a passing score for Qwen3.5 35B FP8.

```bash
python3 -m \
  vllm.entrypoints.cli.main serve \
  Qwen/Qwen3.6-35B-A3B-FP8 \
  --speculative-config '{"method": "dflash", "model": "z-lab/Qwen3.6-35B-A3B-DFlash", "num_speculative_tokens": 7}' \
  --kv-cache-dtype fp8 \
  --tensor-parallel-size 1 \
  --max-model-len 8192 --max-num-batched-tokens 16384 --max-num-seqs 16
```

```
(.venv) bchislett@bchislett-ldt:~/Repos/vllm$ python3 tests/evals/gsm8k/gsm8k_eval.py
Running GSM8K evaluation: 1319 questions, 5-shot

Results:
Accuracy: 0.757
Invalid responses: 0.000
Total latency: 110.351 s
Questions per second: 11.953
Total output tokens: 181264
Output tokens per second: 1642.608
```

baseline, BF16 with no specdec:

```
Results:
Accuracy: 0.764
Invalid responses: 0.000
Total latency: 160.383 s
Questions per second: 8.224
Total output tokens: 174474
Output tokens per second: 1087.860
```