### PR TITLE
[KVConnector][Bugfix] Treat no-connector as no-op success in reset_connector_cache

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -774,6 +774,27 @@ def test_scheduler_reset_prefix_cache():
         assert scheduler.waiting[i] == request
 
 
+def test_reset_connector_cache_no_connector_is_no_op_success():
+    """``reset_connector_cache`` must return True when no connector is
+    configured.
+
+    Without this, ``reset_prefix_cache(reset_connector=True)`` returns
+    ``False`` on every engine that doesn't have a KV connector configured —
+    even when the local prefix cache reset succeeded — and any caller that
+    interprets the return value as "did the reset I asked for succeed?"
+    sees a spurious failure.
+    """
+    scheduler = create_scheduler(enable_prefix_caching=True)
+    assert scheduler.connector is None
+
+    # No-connector reset is treated as success.
+    assert scheduler.reset_connector_cache() is True
+
+    # End-to-end: reset_prefix_cache(reset_connector=True) on an idle
+    # scheduler succeeds with or without a connector.
+    assert scheduler.reset_prefix_cache(reset_connector=True) is True
+
+
 # Note - these test cases mirror some of those in test_rejection_sampler.py
 @pytest.mark.parametrize(
     "spec_tokens,output_tokens,expected",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1932,8 +1932,16 @@ class Scheduler(SchedulerInterface):
 
     def reset_connector_cache(self) -> bool:
         if self.connector is None:
-            logger.warning("reset_connector called but no KV connector is configured.")
-            return False
+            # No connector attached -> nothing to reset, treat as success so
+            # callers that unconditionally request a connector reset (e.g. as
+            # part of a cache-clearing cascade after a weight update) don't
+            # see reset_prefix_cache() flip to False purely because they
+            # didn't configure a connector.
+            logger.debug(
+                "reset_connector requested but no KV connector is configured; "
+                "treating as no-op success."
+            )
+            return True
 
         if self.connector.reset_cache() is False:
             return False


### PR DESCRIPTION
## Summary

`Scheduler.reset_connector_cache()` currently returns `False` when no KV connector is configured, which makes `Scheduler.reset_prefix_cache(reset_running_requests, reset_connector=True)` return `False` on every engine that doesn't have a connector — even when the local prefix cache reset itself succeeded.

A caller that interprets the return value as *"did the reset I asked for succeed?"* (e.g. an RL framework that asks for a clear before a weight update, or an ops tool that pipes the return value into an SLO check) sees a spurious failure for the most common deployment shape (no KV connector configured). The user-facing log line was also a `warning`, even though "no connector exists, so nothing to reset" is the expected steady-state behavior of most engines.

## Change

- Return `True` when `self.connector is None`. There is no external KV store to invalidate, so the operation trivially succeeds; the local prefix cache (handled earlier in `reset_prefix_cache`) decides the real return value.
- Demote the log line from `warning` to `debug`: this branch is hit on every engine without a connector, which is the steady state rather than a misconfiguration.

The `True`/`False`/`None` return contract on `KVConnector.reset_cache` itself (`None` = not implemented, `False` = explicit failure, anything else = success) is unchanged; only the "no connector at all" path moves from a sentinel failure to a sentinel success, matching how `reset_mm_cache` / `reset_encoder_cache` already behave when their target structures are empty.

## Why this is not a duplicate

- `gh pr list --repo vllm-project/vllm --state open --search "reset_connector_cache in:body"` → no results
- `gh pr list --repo vllm-project/vllm --state open --search "reset_connector reset_prefix_cache"` → no results
- `gh issue list --repo vllm-project/vllm --state open --search "reset_connector_cache"` → no results

The only prior PR touching this method is #27170 (which introduced the `reset_connector` parameter). That PR is merged; this is a follow-up correctness fix in the same method.

## Test plan

New unit test added: `tests/v1/core/test_scheduler.py::test_reset_connector_cache_no_connector_is_no_op_success`. It exercises:
1. `Scheduler.reset_connector_cache()` directly returns `True` on a no-connector scheduler.
2. `Scheduler.reset_prefix_cache(reset_connector=True)` end-to-end returns `True` on an idle no-connector scheduler.

Commands run locally:

```bash
pre-commit run --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
# → all hooks Passed (ruff check / format, typos, mypy-3.10, SPDX, etc.)
```

The full pytest invocation (`pytest tests/v1/core/test_scheduler.py::test_reset_connector_cache_no_connector_is_no_op_success`) could not be executed in my local sandbox (the editable `vllm` install points at a different worktree whose precompiled CUDA flash-attention extensions don't match upstream `main`). The standalone logic of the patched branch was sanity-checked with a minimal reproduction (4 cases: no-connector / connector returns True / False / None — all match expectation). CI will be the source of truth for the integration test.

## AI assistance

This patch was authored with assistance from Claude Opus 4.7 (1M context). Every changed line was reviewed by me end-to-end before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)