### PR TITLE
[WIP][Verify] VLLM_BATCH_INVARIANT=1 fixes test_async_scheduling rank flip

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
+
+# Verify hypothesis: vLLM's kernels are batch-shape-dependent by default.
+# Setting this env var forces deterministic block sizes (e.g., flex_attention
+# uses BLOCK_M=BLOCK_N=16 unconditionally), which should make cross-config
+# outputs bit-identical and eliminate the rank=5217<->5218 flake.
+# See examples/features/batch_invariance/reproducibility_offline.py — the
+# comment there is literally:
+#   "Enable batch invariance to get consistent results regardless of scheduling."
+# That's exactly what this test needs.
+os.environ.setdefault("VLLM_BATCH_INVARIANT", "1")
 from itertools import repeat
 from typing import Any
 


### PR DESCRIPTION
## Purpose

<details>
<summary><h3>Root cause</h3></summary>

The `test_async_scheduling` rank=`5217↔5218` flake is caused by cuBLAS GEMM picking a different fp32 algorithm at layer-0 `qkv_proj` when the batch leading dimension (`M`) changes between scheduling configs.

Both answers are valid fp32; they differ by ~1 ULP because the reduction orderings differ. The error propagates through 28 transformer layers and flips a rank-tie at the prompt token.

#### Probe captured

Trigger `18` is the first prefill of `first_prompt` during `GEN_7`, i.e. the same logical event in both configs.

[Buildkite log](https://buildkite.com/organizations/vllm/pipelines/ci/builds/66712/jobs/019e3ba6-f06d-4c85-9c15-1c8e503fccea/log)

```text
[SUBOP_META] baseline cfg1 trigger=18 M=37 pos2701=[1] posvals=[1]
[SUBOP_META] failing  cfg5 trigger=18 M=74 pos2701=[1] posvals=[1]

[SUBOP_OUT]  baseline cfg1 trigger=18 op=qkv_proj         first8[0]=0.1742604374885559
[SUBOP_OUT]  baseline cfg1 trigger=18 op=qkv_proj_recheck first8[0]=0.1742604374885559
[SUBOP_OUT]  baseline cfg1 trigger=18 op=qkv_proj_ref_fp64 first8[0]=0.17426036298274994

[SUBOP_OUT]  failing  cfg5 trigger=18 op=qkv_proj         first8[0]=0.17426040768623352
[SUBOP_OUT]  failing  cfg5 trigger=18 op=qkv_proj_recheck first8[0]=0.17426040768623352
[SUBOP_OUT]  failing  cfg5 trigger=18 op=qkv_proj_ref_fp64 first8[0]=0.17426036298274994
````

#### Reads

1. `qkv_proj == qkv_proj_recheck` in each config
   → cuBLAS is deterministic for a fixed shape; workspace/handle state does not leak.

2. `qkv_proj_ref_fp64` is bit-identical across configs
   → input row, weight, and math are identical; only the fp32 cuBLAS algo differs.

3. `M` differs: `37` vs `74`
   → `M` is the canonical input to cuBLAS heuristic algo selection.

#### Why `M` differs

`M` is the per-step token count chosen by the scheduler, not by sampling params.

With `num_gpu_blocks_override=32`, `async_scheduling=True`, and `preempt=True`, the scheduler may bundle `first_prompt`'s prefill with other in-flight prompts. Baseline, with sync scheduling and no preempt, prefills it alone.

In the captured run, baseline `M` is mostly `37` with a few `47/65`; failing `M` includes `37/38/47/56/74`.

Sampling params (`logprobs=2`, `prompt_logprobs=2`) do not change `M` directly; they only perturb timing under async scheduling. The `GEN_7` / `GEN_8` divergence and `GEN_9` reversion reflect scheduler-state lottery, not the params themselves.

</details>

## Test Plan

## Test Result