### PR TITLE
Fix : crash in DeepSeek V4 _forward_rocm due to stale ffn_norm reference after norm-gate fusion

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1277,7 +1277,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         x, post, comb = self.hc_pre(
             x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
         )
-        x = self.ffn_norm(x)
+        # ffn_norm is now folded into self.ffn.norm_gate; ffn() takes
+        # the pre-norm activation directly.
         x = self.ffn(x, input_ids)
         x = self.hc_post(x, residual, post, comb)
         return x, None, None, None


### PR DESCRIPTION
 

## Purpose

Trigger Scenario: 
DeepSeek V4 inference on AMD ROCm GPUs (MI300X etc.), any request hitting a decoder layer goes through _forward_rocm.
AttributeError: 'DeepseekV4DecoderLayer' object has no attribute 'ffn_norm' — immediate crash, model completely unusable.

Root Cause: 
PR #41263  deleted self.ffn_norm = RMSNorm(...) from DeepseekV4DecoderLayer.__init__ and correctly updated _forward_cuda to remove  the self.ffn_norm(x) call, but overlooked updating _forward_rocm — the AMD GPU forward path. The stale reference crashes on any ROCm execution.

 Fix: 
Remove the single line x = self.ffn_norm(x) from _forward_rocm , leaving the subsequent self.ffn(x, input_ids) untouched — the fused norm is invoked inside self.ffn() already.

## Test Plan

## Test Result

