### PR TITLE
[ROCm][MLA] add VLLM_ROCM_SPARSE_MLA_FP8_DISABLE debug knob for sparse FP8 prefill

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
+    VLLM_ROCM_SPARSE_MLA_FP8_DISABLE: bool = False
     VLLM_ROCM_MOE_PADDING: bool = True
     VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: bool = False
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
@@ -1081,6 +1082,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Pad the fp8 weights to 256 bytes for ROCm
     "VLLM_ROCM_FP8_PADDING": lambda: bool(int(os.getenv("VLLM_ROCM_FP8_PADDING", "1"))),
+    # Debug knob: when set, force the ROCm sparse MLA backend to skip the
+    # FP8 quantization of Q (and the FP8 view of the KV cache) inside
+    # forward_mqa, even when --kv-cache-dtype=fp8 is requested. This makes
+    # it possible to binary-search whether garbage outputs come from the
+    # FP8 path or from the sparse indexing/decode path.
+    "VLLM_ROCM_SPARSE_MLA_FP8_DISABLE": lambda: bool(
+        int(os.getenv("VLLM_ROCM_SPARSE_MLA_FP8_DISABLE", "0"))
+    ),
     # Pad the weights for the moe kernel
     "VLLM_ROCM_MOE_PADDING": lambda: bool(int(os.getenv("VLLM_ROCM_MOE_PADDING", "1"))),
     # Whether to use the shuffled kv cache layout

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
@@ -689,8 +690,16 @@ class ROCMAiterMLASparseImpl(SparseMLAAttentionImpl[ROCMAiterMLASparseMetadata])
             NUM_TOPK_TOKENS=attn_metadata.topk_tokens,
         )
 
-        # write the latent and rope to kv cache
-        fp8_attention = self.kv_cache_dtype.startswith("fp8")
+        # Quantize Q to FP8 and view the KV cache as FP8 when FP8 KV cache
+        # is enabled (the cache itself is written in FP8 by the dispatcher).
+        # VLLM_ROCM_SPARSE_MLA_FP8_DISABLE is a binary-search lever: set it
+        # to 1 to keep Q in bf16 and skip the FP8 view, even when the KV
+        # cache dtype is fp8. Useful for isolating FP8-path bugs from
+        # sparse indexing or decode bugs.
+        fp8_attention = (
+            self.kv_cache_dtype.startswith("fp8")
+            and not envs.VLLM_ROCM_SPARSE_MLA_FP8_DISABLE
+        )
         if fp8_attention:
             original_q_shape = q.shape
             kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(current_platform.fp8_dtype())


### PR DESCRIPTION
## Summary

Open as draft for visibility while the sparse FP8 MLA prefill path is
brought back online on `gfx950` (companion to the dense PR #42509).

This first commit adds a single debug environment variable,
`VLLM_ROCM_SPARSE_MLA_FP8_DISABLE`, to the ROCm sparse MLA backend
(`ROCMAiterMLASparseBackend`). When set, the backend skips the FP8
view of the KV cache and the `scaled_fp8_quant` of Q inside
`forward_mqa`, even when `--kv-cache-dtype=fp8` is requested. Default
is off, so behavior is unchanged for normal users.

Why: in the now-closed #42294 work we saw garbage outputs on sparse
MLA + FP8 KV on MI355X (DSV3.2 indexer path). To bisect cleanly
between **(a) FP8 quant / scales** and **(b) sparse indexing /
decode**, a runtime knob is helpful. The dense path uses
auto-detection (`_fp8_mla_prefill_supported()`) and does not need
this.

## Scope

Touches only the sparse prefill / decode path:

- `vllm/envs.py`: registers the new env var.
- `vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py`:
  gates the existing FP8 quant block on the new env var.

No changes to dense MLA, no changes to the dispatcher.

## Test plan

- [ ] Smoke: sparse MLA + bf16 KV (knob default off, env unset)
      — verify behavior identical to upstream.
- [ ] Smoke: sparse MLA + fp8 KV (knob default off) — measure
      accuracy (gsm8k) and throughput.
- [ ] Smoke: sparse MLA + fp8 KV + `VLLM_ROCM_SPARSE_MLA_FP8_DISABLE=1`
      — verify the FP8 path is bypassed (Q stays bf16, no FP8 view).
- [ ] If accuracy is good with the knob on but bad with it off,
      narrow the bug to the FP8 path. Otherwise narrow to sparse
      indexing/decode and add a follow-up commit.

Companion to #42509 (dense FP8 ASM prefill).