### PR TITLE
Fix Weight loading for  Qwen3.5-MTP and Qwen3-VL using runai_streamer

### DIFF
--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -175,8 +175,8 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
                 param,
                 curr_expert_weight,
                 name,
-                shard_id,
-                expert_id,
+                shard_id=shard_id,
+                expert_id=expert_id,
                 return_success=True,
             )
             if success:

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -152,8 +152,8 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                 param,
                 curr_expert_weight,
                 name,
-                shard_id,
-                expert_id,
+                shard_id=shard_id,
+                expert_id=expert_id,
                 return_success=True,
             )
             if success:


### PR DESCRIPTION

positional args bypass kwargs extraction in TPU weight_loader hook, causing expert_id to be silently lost

## Purpose

the purpose was described in https://github.com/vllm-project/vllm/pull/42521 , but I think it should also apply to Qwen3.5-MTP and Qwen3-VL

## Test Plan

## Test Result
