### PR TITLE
fix: validate xxhash prefix cache dependency

### DIFF
--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -64,6 +64,17 @@ def test_prefix_caching_xxhash_from_cli():
     assert vllm_config.cache_config.prefix_caching_hash_algo == "xxhash_cbor"
 
 
+def test_prefix_caching_xxhash_from_cli_requires_dependency(monkeypatch):
+    from vllm.utils import hashing
+
+    monkeypatch.setattr(hashing, "_xxhash", None)
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--prefix-caching-hash-algo", "xxhash"])
+
+    with pytest.raises(ValueError, match="xxhash.*required"):
+        EngineArgs.from_cli_args(args=args).create_engine_config()
+
+
 def test_defaults_with_usage_context():
     engine_args = EngineArgs(model="facebook/opt-125m")
     vllm_config: VllmConfig = engine_args.create_engine_config(UsageContext.LLM_CLASS)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -235,6 +235,22 @@ class CacheConfig:
             object.__setattr__(self, "user_specified_mamba_block_size", True)
         return self
 
+    @model_validator(mode="after")
+    def _validate_prefix_caching_hash_algo_dependencies(self) -> "CacheConfig":
+        if self.enable_prefix_caching and self.prefix_caching_hash_algo in (
+            "xxhash",
+            "xxhash_cbor",
+        ):
+            from vllm.utils.hashing import _xxhash
+
+            if _xxhash is None:
+                raise ValueError(
+                    "`xxhash` is required when `prefix_caching_hash_algo` is "
+                    f"`{self.prefix_caching_hash_algo}`. Install it with "
+                    "`pip install xxhash`, or use `sha256`/`sha256_cbor`."
+                )
+        return self
+
     @field_validator("calculate_kv_scales", mode="after")
     @classmethod
     def _warn_deprecated_calculate_kv_scales(cls, calculate_kv_scales: bool) -> bool:


### PR DESCRIPTION
## Summary
- Validate the optional xxhash dependency while building CacheConfig when prefix caching is enabled with xxhash or xxhash_cbor.
- Keep the default sha256 path unchanged.
- Add a CLI config test for the missing-dependency case.

Fixes #42720.

## To verify
- python -m ruff check vllm/config/cache.py tests/v1/engine/test_engine_args.py
- python -m py_compile vllm/config/cache.py tests/v1/engine/test_engine_args.py
- direct CacheConfig check for missing xxhash and sha256 fallback

## Notes
- python -m pytest tests/v1/engine/test_engine_args.py -q -k prefix_caching is currently blocked on Windows because tests/conftest.py imports uvloop before reaching this test file.