### PR TITLE
[Bugfix] All pyNCCL copy-only operation to use int8 instead of fp8

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -382,6 +382,15 @@ class PyNcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
+        if tensor.dtype in [
+            torch.float8_e5m2,
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2fnuz,
+        ]:
+            nccl_dtype = ncclDataTypeEnum.from_torch(torch.uint8)
+        else:
+            nccl_dtype = ncclDataTypeEnum.from_torch(tensor.dtype)
         if src == self.rank:
             sendbuff = buffer_type(tensor.data_ptr())
             # NCCL requires the sender also to have a receive buffer
@@ -393,7 +402,7 @@ class PyNcclCommunicator:
             sendbuff,
             recvbuff,
             tensor.numel(),
-            ncclDataTypeEnum.from_torch(tensor.dtype),
+            nccl_dtype,
             src,
             self.comm,
             cudaStream_t(stream.cuda_stream),

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -210,11 +210,14 @@ class PyNcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
+        nccl_dtype = ncclDataTypeEnum.from_torch(
+            torch.uint8 if is_float8_dtype(input_tensor.dtype) else input_tensor.dtype
+        )
         self.nccl.ncclAllGather(
             buffer_type(input_tensor.data_ptr()),
             buffer_type(output_tensor.data_ptr()),
             input_tensor.numel(),
-            ncclDataTypeEnum.from_torch(input_tensor.dtype),
+            nccl_dtype,
             self.comm,
             cudaStream_t(stream.cuda_stream),
         )
@@ -238,6 +241,9 @@ class PyNcclCommunicator:
         if stream is None:
             stream = current_stream()
         assert output_tensor.shape[0] == sum(sizes)
+        nccl_dtype = ncclDataTypeEnum.from_torch(
+            torch.uint8 if is_float8_dtype(input_tensor.dtype) else input_tensor.dtype
+        )
         split_offset = 0
         self.nccl.ncclGroupStart()
         for root, split_size in enumerate(sizes):
@@ -246,7 +252,7 @@ class PyNcclCommunicator:
                 buffer_type(input_tensor.data_ptr()),
                 buffer_type(dst_slice.data_ptr()),
                 dst_slice.numel(),
-                ncclDataTypeEnum.from_torch(input_tensor.dtype),
+                nccl_dtype,
                 root,
                 self.comm,
                 cudaStream_t(stream.cuda_stream),

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -21,7 +21,7 @@ from vllm.distributed.device_communicators.pynccl_wrapper import (
 )
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
-from vllm.utils.torch_utils import current_stream
+from vllm.utils.torch_utils import current_stream, is_float8_dtype
 
 logger = init_logger(__name__)
 
@@ -328,15 +328,9 @@ class PyNcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
-        if tensor.dtype in [
-            torch.float8_e5m2,
-            torch.float8_e4m3fn,
-            torch.float8_e4m3fnuz,
-            torch.float8_e5m2fnuz,
-        ]:
-            nccl_dtype = ncclDataTypeEnum.from_torch(torch.uint8)
-        else:
-            nccl_dtype = ncclDataTypeEnum.from_torch(tensor.dtype)
+        nccl_dtype = ncclDataTypeEnum.from_torch(
+            torch.uint8 if is_float8_dtype(tensor.dtype) else tensor.dtype
+        )
         self.nccl.ncclSend(
             buffer_type(tensor.data_ptr()),
             tensor.numel(),
@@ -355,15 +349,9 @@ class PyNcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
-        if tensor.dtype in [
-            torch.float8_e5m2,
-            torch.float8_e4m3fn,
-            torch.float8_e4m3fnuz,
-            torch.float8_e5m2fnuz,
-        ]:
-            nccl_dtype = ncclDataTypeEnum.from_torch(torch.uint8)
-        else:
-            nccl_dtype = ncclDataTypeEnum.from_torch(tensor.dtype)
+        nccl_dtype = ncclDataTypeEnum.from_torch(
+            torch.uint8 if is_float8_dtype(tensor.dtype) else tensor.dtype
+        )
         self.nccl.ncclRecv(
             buffer_type(tensor.data_ptr()),
             tensor.numel(),
@@ -382,15 +370,9 @@ class PyNcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
-        if tensor.dtype in [
-            torch.float8_e5m2,
-            torch.float8_e4m3fn,
-            torch.float8_e4m3fnuz,
-            torch.float8_e5m2fnuz,
-        ]:
-            nccl_dtype = ncclDataTypeEnum.from_torch(torch.uint8)
-        else:
-            nccl_dtype = ncclDataTypeEnum.from_torch(tensor.dtype)
+        nccl_dtype = ncclDataTypeEnum.from_torch(
+            torch.uint8 if is_float8_dtype(tensor.dtype) else tensor.dtype
+        )
         if src == self.rank:
             sendbuff = buffer_type(tensor.data_ptr())
             # NCCL requires the sender also to have a receive buffer

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -50,6 +50,20 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "nvfp4": torch.uint8,
 }
 
+FLOAT8_DTYPES = frozenset(
+    {
+        torch.float8_e5m2,
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2fnuz,
+    }
+)
+
+
+def is_float8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in FLOAT8_DTYPES
+
+
 TORCH_DTYPE_TO_NUMPY_DTYPE = {
     torch.float16: np.float16,
     torch.float32: np.float32,

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -51,12 +51,9 @@ STR_DTYPE_TO_TORCH_DTYPE = {
 }
 
 FLOAT8_DTYPES = frozenset(
-    {
-        torch.float8_e5m2,
-        torch.float8_e4m3fn,
-        torch.float8_e4m3fnuz,
-        torch.float8_e5m2fnuz,
-    }
+    getattr(torch, name)
+    for name in ["float8_e5m2", "float8_e4m3fn", "float8_e4m3fnuz", "float8_e5m2fnuz"]
+    if hasattr(torch, name)
 )
 
 


### PR DESCRIPTION



## Purpose

For platforms <sm90, fp8 is not available and NCCL might complain even on operation that only move bytes. #34861 added a fix for send/recv, this PR adds the same logic for all the other ops: broadcast, allgather, and all_gatherv.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

