### PR TITLE
[Bugfix] Avoid FULL cudagraph dispatch for DFlash

### DIFF
--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -182,10 +182,16 @@ class CudagraphDispatcher:
             lora_count for lora_count in lora_cases if lora_count
         ]
 
+        spec_config = self.vllm_config.speculative_config
+        skip_full = spec_config is not None and spec_config.use_dflash()
+
         # Note: we create all valid keys for cudagraph here but do not
         # guarantee all keys would be used. For example, if we allow lazy
         # capturing in future PR, some keys may never be triggered.
-        if cudagraph_mode.mixed_mode() != CUDAGraphMode.NONE:
+        mixed_mode = cudagraph_mode.mixed_mode()
+        if skip_full and mixed_mode == CUDAGraphMode.FULL:
+            mixed_mode = CUDAGraphMode.NONE
+        if mixed_mode != CUDAGraphMode.NONE:
             assert self.compilation_config.cudagraph_capture_sizes is not None, (
                 "Cudagraph capture sizes must be set when mixed mode is enabled."
             )
@@ -197,15 +203,16 @@ class CudagraphDispatcher:
                 )
                 # Only relax for PIECEWISE mode. FULL mode needs exact num_reqs
                 # because FA3's scheduler_metadata computation depends on it.
-                if cudagraph_mode.mixed_mode() == CUDAGraphMode.PIECEWISE:
+                if mixed_mode == CUDAGraphMode.PIECEWISE:
                     batch_desc = replace(batch_desc, num_reqs=None, uniform=False)
-                self.add_cudagraph_key(cudagraph_mode.mixed_mode(), batch_desc)
+                self.add_cudagraph_key(mixed_mode, batch_desc)
 
         # if decode cudagraph mode is FULL, and we don't already have mixed
         # mode full cudagraphs then add them here.
         if (
             cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
             and cudagraph_mode.separate_routine()
+            and not skip_full
         ):
             max_num_tokens = (
                 uniform_decode_query_len


### PR DESCRIPTION
## Purpose

Fix a numerical-divergence bug in DFlash speculative decoding under the default `cudagraph_mode=FULL_AND_PIECEWISE`. With more than one in-flight DFlash request, target verification produces wrong logits, which manifests as:

- per-position acceptance dropping sharply at concurrency ≥ 2
- output token counts ballooning to `max_tokens` (length cap reached for most requests in a batch)
- mid-generation arithmetic / token-level corruption (e.g. self-correcting loops like "196 ÷ 2 = 96 ... wait, let me redo this")

`enforce_eager` makes the symptom go away cleanly, which localized the bug to the CUDA graph path; the actual mismatch is the DFlash spec-verify uniform decode dispatching to a `FULL` cuda graph key whose capture/replay does not correctly carry the multi-request verify state. Per-layer GDN metadata writes and the `cudagraph_dispatcher` keying both look self-consistent in isolation, so until the exact offending op in the FULL path is identified this PR takes the conservative route: do not register `FULL` cuda graph keys for DFlash. With the default config the dispatcher then naturally falls back to `PIECEWISE`, keeping torch.compile and piecewise graphs intact (no regression to eager).

Relates to #42505 ("DFlash slower than baseline at concurrency > 8 on Qwen3.5-35B-A3B"): that issue tracks the high-concurrency slowdown which has multiple contributing causes. PR #42704 fixes one of them (off-by-one in `target_layer_ids` consumed by `_maybe_add_hidden_state` in `vllm/v1/worker/gpu_model_runner.py`). This PR is independent — it only touches `vllm/v1/cudagraph_dispatcher.py` and addresses the cuda-graph-side contribution. The two fixes are complementary and do not overlap in code or in the symptoms they remove.

May also help #39928 ("Qwen3.5 DFlash gives strange responses on SM90") since that report is consistent with FULL-graph capture/replay nondeterminism, but I have not run that exact repro.

## Test Plan

1. Lint: `pre-commit run --files vllm/v1/cudagraph_dispatcher.py`
2. Unit sanity (untouched code path, just to make sure dispatcher change does not perturb GDN metadata classification): `pytest tests/v1/attention/test_gdn_metadata_builder.py -v`
3. End-to-end repro on Qwen3.5-4B with the official DFlash drafter (`Qwen3.5-4B-DFlash`), `--attention-backend flash_attn`, `--max-num-seqs 8`, greedy sampling, `max_new_tokens=1024`. Two scenarios are exercised back to back so cudagraph capture state is identical: sequential bs=1 (prompts one at a time) and concurrent bs=2 (2 prompts in flight), on both `gsm8k` (varied prompts) and `math500` (varied prompts), with `num_speculative_tokens` set to 1 and 15.
4. Sanity check that no DFlash request reaches the `max_tokens=1024` cap under greedy decoding when the answer is much shorter than 1024 tokens.

## Test Result

`pre-commit run --files vllm/v1/cudagraph_dispatcher.py` — passes (ruff check, ruff format, typos, mypy, SPDX / import / cuda-API / style checks all green).

End-to-end on Qwen3.5-4B + DFlash, gsm8k, same prompt ×8, `bs=8`, `num_speculative_tokens=1`, greedy, max_new_tokens=1024:

| config                         | concurrent total tokens | hits-max-tokens |
|--------------------------------|-------------------------|-----------------|
| before this PR                 | 3901                    | 7/8             |
| force `PIECEWISE` (probe)      | 2536                    | 0/8             |
| this PR (default config)       | 2536                    | 0/8             |

Varied-prompt benchmarks, `num_speculative_tokens=15`:

| dataset  | concurrent (bs=2 patched) | sequential (bs=1) | hits-max-tokens |
|----------|---------------------------|-------------------|-----------------|
| gsm8k    | 3050                      | 3063              | 0/8             |
| math500  | 3956                      | 3976              | 0/8             |

Concurrent and sequential numbers now line up; before this PR concurrent gsm8k was 3901 with 7/8 capped at the length limit. No request ends on `length` in the patched runs.

`pytest tests/v1/attention/test_gdn_metadata_builder.py` will be re-run by the submitter on the final test machine.

## Notes for Reviewers

- This is a workaround at the dispatcher layer, not a root-cause fix on the capture path itself. I tried to localize the offending op in `GDNAttentionMetadataBuilder.build` (cudagraph FULL branch) and in `_forward_core` (`causal_conv1d_update` + `fused_sigmoid_gating_delta_rule_update`), and they look self-consistent: persistent buffer slices have stable addresses, NULL-padded rows are not read by either kernel, kernel grids are bounded by `num_spec_decodes`. The mismatch is somewhere else in the FULL path (likely an attention backend buffer assumption, but I did not nail it). Happy to file a follow-up issue once the exact culprit is identified.
- Change is limited to DFlash (`spec_config.use_dflash()` guard) and does not affect EAGLE/MTP/draft-model paths.
- AI assistance (Claude / Codex) was used for code reading, hypothesis enumeration, and drafting this PR description. The author has reviewed every line of the change and run the tests above.
