### PR TITLE
[Perf] Defer MoE allreduce and fuse with input layernorm

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -67,7 +67,7 @@ FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
     90: {
         2: 64,  # 64MB
         4: 2,  # 2MB
-        8: 2,  # 2MB (raised from 0.5MB for MoE deferred AR)
+        8: 2,  # 2MB
     },
     100: {
         2: 64,  # 64MB
@@ -88,7 +88,7 @@ _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB: dict[int, dict[int, float]] = {
     90: {
         2: 32,  # 32MB
         4: 2,  # 2MB
-        8: 2,  # 2MB (raised from 0.5MB for MoE deferred AR)
+        8: 2,  # 2MB
     },
     100: {
         2: 32,  # 32MB

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -67,7 +67,7 @@ FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
     90: {
         2: 64,  # 64MB
         4: 2,  # 2MB
-        8: 0.5,  # 0.5MB
+        8: 2,  # 2MB (raised from 0.5MB for MoE deferred AR)
     },
     100: {
         2: 64,  # 64MB
@@ -88,7 +88,7 @@ _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB: dict[int, dict[int, float]] = {
     90: {
         2: 32,  # 32MB
         4: 2,  # 2MB
-        8: 0.5,  # 0.5MB
+        8: 2,  # 2MB (raised from 0.5MB for MoE deferred AR)
     },
     100: {
         2: 32,  # 32MB

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -137,10 +137,8 @@ class PassConfig:
     fuse_minimax_qk_norm: bool = None  # type: ignore[assignment]
     """Enable fused allreduce+RMSNorm for MiniMax QK norm."""
     fuse_moe_allreduce: bool = None  # type: ignore[assignment]
-    """Enable deferred MoE allreduce fusion for MiniMax-M2 decode
-    (≤128 tokens). The MoE skips its internal allreduce; the next
-    layer's input layernorm fuses AR + residual + RMSNorm in one
-    Lamport cluster kernel."""
+    """Defer MoE allreduce into next input layernorm.
+    For MiniMax-M2 decode (≤128 tokens, TP-only) on Hopper."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
     fuse_rope_kvcache_cat_mla: bool = None  # type: ignore[assignment]

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -136,6 +136,11 @@ class PassConfig:
     """Enable flashinfer allreduce fusion."""
     fuse_minimax_qk_norm: bool = None  # type: ignore[assignment]
     """Enable fused allreduce+RMSNorm for MiniMax QK norm."""
+    fuse_moe_allreduce: bool = None  # type: ignore[assignment]
+    """Enable deferred MoE allreduce fusion for MiniMax-M2 decode
+    (≤128 tokens). The MoE skips its internal allreduce; the next
+    layer's input layernorm fuses AR + residual + RMSNorm in one
+    Lamport cluster kernel."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
     fuse_rope_kvcache_cat_mla: bool = None  # type: ignore[assignment]
@@ -227,6 +232,7 @@ class PassConfig:
         "enable_sp",
         "fuse_gemm_comms",
         "fuse_allreduce_rms",
+        "fuse_moe_allreduce",
         "fuse_act_padding",
         "fuse_mla_dual_rms_norm",
         "fuse_rope_kvcache",

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1268,6 +1268,12 @@ class FusedMoEConfig:
     # kernel is free to use inplace or not.
     disable_inplace: bool = True
 
+    # When True, the final allreduce in _maybe_reduce_final_output is
+    # skipped for decode batches (≤128 tokens). The model is expected
+    # to handle the allreduce later, typically fused with the next
+    # layer's input layernorm via trtllm_allreduce_fusion.
+    defer_allreduce: bool = False
+
     def __post_init__(self):
         if self.dp_size > 1:
             logger.debug_once(

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1268,12 +1268,6 @@ class FusedMoEConfig:
     # kernel is free to use inplace or not.
     disable_inplace: bool = True
 
-    # When True, the final allreduce in _maybe_reduce_final_output is
-    # skipped for decode batches (≤128 tokens). The model is expected
-    # to handle the allreduce later, typically fused with the next
-    # layer's input layernorm via trtllm_allreduce_fusion.
-    defer_allreduce: bool = False
-
     def __post_init__(self):
         if self.dp_size > 1:
             logger.debug_once(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -29,7 +29,6 @@ from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
 from vllm.model_executor.layers.fused_moe.router.zero_expert_router import (
     ZeroExpertRouter,
 )
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner_interface import (
     MoERunnerInterface,
 )
@@ -38,8 +37,6 @@ from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExpertsOrder,
 )
 from vllm.platforms import current_platform
-
-logger = init_logger(__name__)
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
     LayerName,
@@ -418,33 +415,17 @@ class MoERunner(MoERunnerInterface):
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not self._fused_output_is_reduced
         ):
-            if self.defer_allreduce and self.moe_config.ep_size <= 1:
-                # Only defer for decode batches within Lamport one-shot
-                # limit (≤128 tokens).  For prefill / large batches the
-                # model won't do the deferred allreduce, so we must
-                # allreduce here to preserve correctness.
-                if states.shape[0] <= 128:
-                    if not torch.compiler.is_compiling():
-                        logger.info_once(
-                            "MoE defer_allreduce: skipping cross_device_reduce_1stage "
-                            "for layer=%s, num_tokens=%s, tp=%s, ep=%s",
-                            getattr(self, "layer_name", "?"),
-                            states.shape[0],
-                            self.moe_config.tp_size,
-                            self.moe_config.ep_size,
-                            scope="moe_defer_allreduce",
-                        )
-                    return states[..., :trunc_size]
-                else:
-                    if not torch.compiler.is_compiling():
-                        logger.warning_once(
-                            "MoE defer_allreduce: batch too large (%s > 128), "
-                            "falling back to internal allreduce for layer=%s",
-                            states.shape[0],
-                            getattr(self, "layer_name", "?"),
-                            scope="moe_defer_skipped",
-                        )
-            states = tensor_model_parallel_all_reduce(states)
+            # Defer the allreduce when requested by the model (e.g.
+            # MiniMax-M2 decode with fuse_moe_allreduce). The model fuses
+            # it with the next input_layernorm via trtllm_allreduce_fusion.
+            # Avoid early-return so torch.compile sees a single exit path.
+            defer = (
+                self.defer_allreduce
+                and self.moe_config.ep_size <= 1
+                and states.shape[0] <= 128
+            )
+            if not defer:
+                states = tensor_model_parallel_all_reduce(states)
 
         return states[..., :trunc_size]
 

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -265,6 +265,11 @@ class MoERunner(MoERunnerInterface):
 
         self._forward_entry = self._select_forward()
 
+        # When True, skip the allreduce in _maybe_reduce_final_output
+        # and let the model fuse it with the next layer's input layernorm.
+        # This flag is set by the model (e.g. MiniMaxM2Model) during init.
+        self.defer_allreduce: bool = False
+
     def _select_forward(self) -> Callable:
         if current_platform.is_tpu() or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
@@ -411,10 +416,15 @@ class MoERunner(MoERunnerInterface):
             # Defer the allreduce when requested by the model (e.g.
             # MiniMax-M2 decode with fuse_moe_allreduce). The model fuses
             # it with the next input_layernorm via trtllm_allreduce_fusion.
-            # Uses self.moe_config.defer_allreduce (a dataclass field set
-            # during init) so Dynamo traces it as a proper constant.
+            #
+            # NOTE: self.defer_allreduce is traced as a Dynamo constant.
+            # When True the AR branch is dead-code-eliminated from the
+            # compiled graph.  If a stale cache captured with defer=False
+            # is loaded, the AR remains.  Always clear the compile cache
+            # after changing the defer flag or toggling fuse_moe_allreduce:
+            #   rm -rf /root/.cache/vllm/torch_compile_cache/*
             if not (
-                self.moe_config.defer_allreduce
+                self.defer_allreduce
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
             ):

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -265,11 +265,6 @@ class MoERunner(MoERunnerInterface):
 
         self._forward_entry = self._select_forward()
 
-        # When True, skip the allreduce in _maybe_reduce_final_output
-        # and let the model fuse it with the next layer's input layernorm.
-        # This flag is set by the model (e.g. MiniMaxM2Model) during init.
-        self.defer_allreduce: bool = False
-
     def _select_forward(self) -> Callable:
         if current_platform.is_tpu() or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
@@ -416,15 +411,10 @@ class MoERunner(MoERunnerInterface):
             # Defer the allreduce when requested by the model (e.g.
             # MiniMax-M2 decode with fuse_moe_allreduce). The model fuses
             # it with the next input_layernorm via trtllm_allreduce_fusion.
-            #
-            # NOTE: self.defer_allreduce is traced as a Dynamo constant.
-            # When True the AR branch is dead-code-eliminated from the
-            # compiled graph.  If a stale cache captured with defer=False
-            # is loaded, the AR remains.  Always clear the compile cache
-            # after changing the defer flag or toggling fuse_moe_allreduce:
-            #   rm -rf /root/.cache/vllm/torch_compile_cache/*
+            # Uses self.moe_config.defer_allreduce (a dataclass field set
+            # during init) so Dynamo traces it as a proper constant.
             if not (
-                self.defer_allreduce
+                self.moe_config.defer_allreduce
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
             ):

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -396,7 +396,6 @@ class MoERunner(MoERunnerInterface):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
 
-    @torch.compiler.disable
     def _maybe_reduce_final_output(
         self,
         states: torch.Tensor,
@@ -408,10 +407,6 @@ class MoERunner(MoERunnerInterface):
         output was individually reduced, the combined sum is all-reduced
         here. Skipped when sequence-parallel is active (SP handles its
         own reduction) or when the early path already reduced both outputs.
-
-        Disabled from torch.compile to make the ``defer_allreduce`` decision
-        outside the compiled graph, so stale compilation caches cannot
-        bake in the wrong branch.
         """
         if (
             not self.moe_config.is_sequence_parallel
@@ -421,6 +416,13 @@ class MoERunner(MoERunnerInterface):
             # Defer the allreduce when requested by the model (e.g.
             # MiniMax-M2 decode with fuse_moe_allreduce). The model fuses
             # it with the next input_layernorm via trtllm_allreduce_fusion.
+            #
+            # NOTE: self.defer_allreduce is traced as a Dynamo constant.
+            # When True the AR branch is dead-code-eliminated from the
+            # compiled graph.  If a stale cache captured with defer=False
+            # is loaded, the AR remains.  Always clear the compile cache
+            # after changing the defer flag or toggling fuse_moe_allreduce:
+            #   rm -rf /root/.cache/vllm/torch_compile_cache/*
             if not (
                 self.defer_allreduce
                 and self.moe_config.ep_size <= 1

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -424,7 +424,7 @@ class MoERunner(MoERunnerInterface):
             # after changing the defer flag or toggling fuse_moe_allreduce:
             #   rm -rf /root/.cache/vllm/torch_compile_cache/*
             if not (
-                self.moe_config.defer_allreduce
+                self.defer_allreduce
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
             ):

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -265,9 +265,6 @@ class MoERunner(MoERunnerInterface):
 
         self._forward_entry = self._select_forward()
 
-        # When True, skip the allreduce in _maybe_reduce_final_output
-        # and let the model fuse it with the next layer's input layernorm.
-        # This flag is set by the model (e.g. MiniMaxM2Model) during init.
         self.defer_allreduce: bool = False
 
     def _select_forward(self) -> Callable:
@@ -413,31 +410,15 @@ class MoERunner(MoERunnerInterface):
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not self._fused_output_is_reduced
         ):
-            # Defer the allreduce when requested by the model (e.g.
-            # MiniMax-M2 decode with fuse_moe_allreduce). The model fuses
-            # it with the next input_layernorm via trtllm_allreduce_fusion.
-            #
-            # NOTE: self.defer_allreduce is traced as a Dynamo constant.
-            # When True the AR branch is dead-code-eliminated from the
-            # compiled graph.  If a stale cache captured with defer=False
-            # is loaded, the AR remains.  Always clear the compile cache
-            # after changing the defer flag or toggling fuse_moe_allreduce:
-            #   rm -rf /root/.cache/vllm/torch_compile_cache/*
             if not (
                 self.defer_allreduce
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
             ):
                 if not torch.compiler.is_compiling():
-                    torch.cuda.nvtx.range_push("DIAG_moe_ar_NOT_deferred")
-                    torch.cuda.nvtx.range_pop()
                     torch.cuda.nvtx.range_push("moe_ar")
                 states = tensor_model_parallel_all_reduce(states)
                 if not torch.compiler.is_compiling():
-                    torch.cuda.nvtx.range_pop()
-            else:
-                if not torch.compiler.is_compiling():
-                    torch.cuda.nvtx.range_push("DIAG_moe_ar_DEFERRED")
                     torch.cuda.nvtx.range_pop()
 
         return states[..., :trunc_size]

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -267,6 +267,7 @@ class MoERunner(MoERunnerInterface):
 
         # When True, skip the allreduce in _maybe_reduce_final_output
         # and let the model fuse it with the next layer's input layernorm.
+        # This flag is set by the model (e.g. MiniMaxM2Model) during init.
         self.defer_allreduce: bool = False
 
     def _select_forward(self) -> Callable:
@@ -395,6 +396,7 @@ class MoERunner(MoERunnerInterface):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
 
+    @torch.compiler.disable
     def _maybe_reduce_final_output(
         self,
         states: torch.Tensor,
@@ -406,10 +408,11 @@ class MoERunner(MoERunnerInterface):
         output was individually reduced, the combined sum is all-reduced
         here. Skipped when sequence-parallel is active (SP handles its
         own reduction) or when the early path already reduced both outputs.
+
+        Disabled from torch.compile to make the ``defer_allreduce`` decision
+        outside the compiled graph, so stale compilation caches cannot
+        bake in the wrong branch.
         """
-        # We don't need to reduce the final output if:
-        # - We are not running with TP or DP
-        # - The MK already reduced the fused output itself.
         if (
             not self.moe_config.is_sequence_parallel
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
@@ -418,13 +421,11 @@ class MoERunner(MoERunnerInterface):
             # Defer the allreduce when requested by the model (e.g.
             # MiniMax-M2 decode with fuse_moe_allreduce). The model fuses
             # it with the next input_layernorm via trtllm_allreduce_fusion.
-            # Avoid early-return so torch.compile sees a single exit path.
-            defer = (
+            if not (
                 self.defer_allreduce
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
-            )
-            if not defer:
+            ):
                 states = tensor_model_parallel_all_reduce(states)
 
         return states[..., :trunc_size]

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
 from vllm.model_executor.layers.fused_moe.router.zero_expert_router import (
     ZeroExpertRouter,
 )
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner_interface import (
     MoERunnerInterface,
 )
@@ -37,6 +38,8 @@ from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExpertsOrder,
 )
 from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
     LayerName,
@@ -265,6 +268,10 @@ class MoERunner(MoERunnerInterface):
 
         self._forward_entry = self._select_forward()
 
+        # When True, skip the allreduce in _maybe_reduce_final_output
+        # and let the model fuse it with the next layer's input layernorm.
+        self.defer_allreduce: bool = False
+
     def _select_forward(self) -> Callable:
         if current_platform.is_tpu() or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
@@ -411,6 +418,32 @@ class MoERunner(MoERunnerInterface):
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not self._fused_output_is_reduced
         ):
+            if self.defer_allreduce and self.moe_config.ep_size <= 1:
+                # Only defer for decode batches within Lamport one-shot
+                # limit (≤128 tokens).  For prefill / large batches the
+                # model won't do the deferred allreduce, so we must
+                # allreduce here to preserve correctness.
+                if states.shape[0] <= 128:
+                    if not torch.compiler.is_compiling():
+                        logger.info_once(
+                            "MoE defer_allreduce: skipping cross_device_reduce_1stage "
+                            "for layer=%s, num_tokens=%s, tp=%s, ep=%s",
+                            getattr(self, "layer_name", "?"),
+                            states.shape[0],
+                            self.moe_config.tp_size,
+                            self.moe_config.ep_size,
+                            scope="moe_defer_allreduce",
+                        )
+                    return states[..., :trunc_size]
+                else:
+                    if not torch.compiler.is_compiling():
+                        logger.warning_once(
+                            "MoE defer_allreduce: batch too large (%s > 128), "
+                            "falling back to internal allreduce for layer=%s",
+                            states.shape[0],
+                            getattr(self, "layer_name", "?"),
+                            scope="moe_defer_skipped",
+                        )
             states = tensor_model_parallel_all_reduce(states)
 
         return states[..., :trunc_size]

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -429,9 +429,15 @@ class MoERunner(MoERunnerInterface):
                 and states.shape[0] <= 128
             ):
                 if not torch.compiler.is_compiling():
+                    torch.cuda.nvtx.range_push("DIAG_moe_ar_NOT_deferred")
+                    torch.cuda.nvtx.range_pop()
                     torch.cuda.nvtx.range_push("moe_ar")
                 states = tensor_model_parallel_all_reduce(states)
                 if not torch.compiler.is_compiling():
+                    torch.cuda.nvtx.range_pop()
+            else:
+                if not torch.compiler.is_compiling():
+                    torch.cuda.nvtx.range_push("DIAG_moe_ar_DEFERRED")
                     torch.cuda.nvtx.range_pop()
 
         return states[..., :trunc_size]

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -428,9 +428,11 @@ class MoERunner(MoERunnerInterface):
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
             ):
-                torch.cuda.nvtx.range_push("moe_ar")
+                if not torch.compiler.is_compiling():
+                    torch.cuda.nvtx.range_push("moe_ar")
                 states = tensor_model_parallel_all_reduce(states)
-                torch.cuda.nvtx.range_pop()
+                if not torch.compiler.is_compiling():
+                    torch.cuda.nvtx.range_pop()
 
         return states[..., :trunc_size]
 

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -424,11 +424,13 @@ class MoERunner(MoERunnerInterface):
             # after changing the defer flag or toggling fuse_moe_allreduce:
             #   rm -rf /root/.cache/vllm/torch_compile_cache/*
             if not (
-                self.defer_allreduce
+                self.moe_config.defer_allreduce
                 and self.moe_config.ep_size <= 1
                 and states.shape[0] <= 128
             ):
+                torch.cuda.nvtx.range_push("moe_ar")
                 states = tensor_model_parallel_all_reduce(states)
+                torch.cuda.nvtx.range_pop()
 
         return states[..., :trunc_size]
 

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -128,16 +128,8 @@ class RMSNorm(CustomOp):
         x: torch.Tensor,
         residual: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Fuse TP allreduce + residual add + RMSNorm into one Lamport kernel.
-
-        Directly calls FlashInfer trtllm allreduce_fusion, bypassing
-        torch.compile pattern matching. Required when ``fused_add_rms_norm``
-        is decomposed to native ops (e.g. ``rms_norm=['native']`` priority),
-        which prevents Pattern 1 from matching in the Inductor pass.
-
-        Falls back to explicit allreduce + forward_native when FlashInfer is
-        unavailable, tp_size <= 1, or workspace allocation fails.
-        """
+        """Fuse TP allreduce + residual add + RMSNorm in one FlashInfer kernel.
+        Falls back to explicit allreduce + forward_native."""
         try:
             import flashinfer.comm as fi_comm
         except ImportError:
@@ -167,8 +159,6 @@ class RMSNorm(CustomOp):
         if workspace is None:
             return self._allreduce_then_norm(x, residual)
 
-        torch.cuda.nvtx.range_push("DIAG_fuse_layernorm_called")
-        torch.cuda.nvtx.range_pop()
         torch.cuda.nvtx.range_push("moe_ar_fused")
         fi_comm.allreduce_fusion(
             input=x,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -122,6 +122,76 @@ class RMSNorm(CustomOp):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         return self.forward_cuda(x, residual)
 
+    @torch.compiler.disable
+    def forward_with_allreduce_fusion(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fuse TP allreduce + residual add + RMSNorm into one Lamport kernel.
+
+        Directly calls FlashInfer trtllm allreduce_fusion, bypassing
+        torch.compile pattern matching. Required when ``fused_add_rms_norm``
+        is decomposed to native ops (e.g. ``rms_norm=['native']`` priority),
+        which prevents Pattern 1 from matching in the Inductor pass.
+
+        Falls back to explicit allreduce + forward_native when FlashInfer is
+        unavailable, tp_size <= 1, or workspace allocation fails.
+        """
+        try:
+            import flashinfer.comm as fi_comm
+        except ImportError:
+            return self._allreduce_then_norm(x, residual)
+
+        from vllm.distributed import (
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+        from vllm.distributed.device_communicators.flashinfer_all_reduce import (
+            get_fi_ar_workspace,
+        )
+        from vllm.distributed.parallel_state import get_tp_group
+
+        tp_size = get_tensor_model_parallel_world_size()
+        if tp_size <= 1:
+            return self._allreduce_then_norm(x, residual)
+
+        workspace = get_fi_ar_workspace(
+            world_size=tp_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=x.shape[0],
+            hidden_dim=self.hidden_size,
+            dtype=x.dtype,
+            group=get_tp_group().device_group,
+        )
+        if workspace is None:
+            return self._allreduce_then_norm(x, residual)
+
+        fi_comm.allreduce_fusion(
+            input=x,
+            workspace=workspace,
+            pattern=fi_comm.AllReduceFusionPattern.kARResidualRMSNorm,
+            launch_with_pdl=True,
+            use_oneshot=True,
+            fp32_acc=True,
+            residual_in=residual,
+            residual_out=residual,
+            norm_out=x,
+            rms_gamma=self.weight.data,
+            rms_eps=self.variance_epsilon,
+        )
+        return x, residual
+
+    def _allreduce_then_norm(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from vllm.distributed import tensor_model_parallel_all_reduce
+
+        x = tensor_model_parallel_all_reduce(x)
+        return self.forward_native(x, residual)
+
     def extra_repr(self) -> str:
         s = f"hidden_size={self.weight.data.size(0)}"
         s += f", eps={self.variance_epsilon}"

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -167,6 +167,8 @@ class RMSNorm(CustomOp):
         if workspace is None:
             return self._allreduce_then_norm(x, residual)
 
+        torch.cuda.nvtx.range_push("DIAG_fuse_layernorm_called")
+        torch.cuda.nvtx.range_pop()
         torch.cuda.nvtx.range_push("moe_ar_fused")
         fi_comm.allreduce_fusion(
             input=x,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -167,6 +167,7 @@ class RMSNorm(CustomOp):
         if workspace is None:
             return self._allreduce_then_norm(x, residual)
 
+        torch.cuda.nvtx.range_push("moe_ar_fused")
         fi_comm.allreduce_fusion(
             input=x,
             workspace=workspace,
@@ -180,6 +181,7 @@ class RMSNorm(CustomOp):
             rms_gamma=self.weight.data,
             rms_eps=self.variance_epsilon,
         )
+        torch.cuda.nvtx.range_pop()
         return x, residual
 
     def _allreduce_then_norm(

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -275,9 +275,6 @@ class MiniMaxM2DecoderLayer(nn.Module):
         layer_idx = int(prefix.split(sep=".")[-1])
 
         self.layer_idx = layer_idx
-        # When True the previous MoE deferred its TP allreduce; fuse
-        # AR + residual + RMSNorm via forward_with_allreduce_fusion
-        # (direct FlashInfer call) before input_layernorm.
         self._defer_ar: bool = False
         self.self_attn = MiniMaxM2Attention(
             hidden_size=self.hidden_size,
@@ -310,28 +307,11 @@ class MiniMaxM2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
     ) -> torch.Tensor:
-        # Mirroring SGLang's pattern: when the previous layer's MoE deferred
-        # its TP allreduce, fuse AR + residual + RMSNorm in one FI kernel.
-        # Only for decode (≤128 tokens); prefill & TP+EP fall back to the
-        # regular path.
         _fuse = (
             self._defer_ar
             and residual is not None
             and hidden_states.shape[0] <= 128
         )
-        if not torch.compiler.is_compiling():
-            if _fuse:
-                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_TRUE")
-                torch.cuda.nvtx.range_pop()
-            elif self._defer_ar and residual is not None:
-                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_FALSE_tokens")
-                torch.cuda.nvtx.range_pop()
-            elif self._defer_ar:
-                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_FALSE_residual")
-                torch.cuda.nvtx.range_pop()
-            else:
-                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_FALSE_defer_ar")
-                torch.cuda.nvtx.range_pop()
         if _fuse:
             hidden_states, residual = self.input_layernorm.forward_with_allreduce_fusion(
                 hidden_states, residual
@@ -408,8 +388,6 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
                 if runner.moe_config.ep_size <= 1:
                     runner.defer_allreduce = True
                     layer._defer_ar = True
-            # Disable fusion when EP is active — the runner keeps its
-            # own AR because deferral isn't safe across EP all-to-all.
             self._fuse_moe_allreduce = self.layers[
                 self.start_layer
             ].block_sparse_moe.experts.runner.defer_allreduce
@@ -450,16 +428,11 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
         ):
-            hidden_states, residual = layer(
-                positions,
-                hidden_states,
-                residual,
-            )
+            hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(
                 aux_hidden_states, idx + 1, hidden_states, residual
             )
 
-        # Fuse the last deferred MoE AR with self.norm.
         last_layer_fused = (
             self._fuse_moe_allreduce
             and hidden_states.shape[0] <= 128

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -275,9 +275,9 @@ class MiniMaxM2DecoderLayer(nn.Module):
         layer_idx = int(prefix.split(sep=".")[-1])
 
         self.layer_idx = layer_idx
-        # When True, do explicit TP allreduce on hidden_states before
-        # input_layernorm, so torch.compile Pattern 1 can fuse AR +
-        # fused_add_rms_norm into trtllm_allreduce_fusion.
+        # When True the previous MoE deferred its TP allreduce; fuse
+        # AR + residual + RMSNorm via forward_with_allreduce_fusion
+        # (direct FlashInfer call) before input_layernorm.
         self._defer_ar: bool = False
         self.self_attn = MiniMaxM2Attention(
             hidden_size=self.hidden_size,
@@ -310,12 +310,16 @@ class MiniMaxM2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
     ) -> torch.Tensor:
-        # Deferred AR: the previous MoE skipped cross_device_reduce_1stage,
-        # so hidden_states is partial.  Use forward_with_allreduce_fusion to
-        # fuse AR + residual + RMSNorm directly via FlashInfer, bypassing
-        # torch.compile pattern matching (which breaks when fused_add_rms_norm
-        # is decomposed to native ops, e.g. under rms_norm=['native'] priority).
-        if self._defer_ar and residual is not None and hidden_states.shape[0] <= 128:
+        # Mirroring SGLang's pattern: when the previous layer's MoE deferred
+        # its TP allreduce, fuse AR + residual + RMSNorm in one FI kernel.
+        # Only for decode (≤128 tokens); prefill & TP+EP fall back to the
+        # regular path.
+        _fuse = (
+            self._defer_ar
+            and residual is not None
+            and hidden_states.shape[0] <= 128
+        )
+        if _fuse:
             hidden_states, residual = self.input_layernorm.forward_with_allreduce_fusion(
                 hidden_states, residual
             )

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -393,13 +393,13 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             for layer in islice(self.layers, self.start_layer, self.end_layer):
                 runner = layer.block_sparse_moe.experts.runner
                 if runner.moe_config.ep_size <= 1:
-                    runner.moe_config.defer_allreduce = True
+                    runner.defer_allreduce = True
                     layer._defer_ar = True
             # Disable fusion when EP is active — the runner keeps its
             # own AR because deferral isn't safe across EP all-to-all.
             self._fuse_moe_allreduce = self.layers[
                 self.start_layer
-            ].block_sparse_moe.experts.runner.moe_config.defer_allreduce
+            ].block_sparse_moe.experts.runner.defer_allreduce
             logger.info_once(
                 "MoE deferred AR: fuse_moe_allreduce=%s, tp_size=%s, ep_size=%s, "
                 "num_layers=%s, hidden_size=%s",

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -393,13 +393,13 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             for layer in islice(self.layers, self.start_layer, self.end_layer):
                 runner = layer.block_sparse_moe.experts.runner
                 if runner.moe_config.ep_size <= 1:
-                    runner.defer_allreduce = True
+                    runner.moe_config.defer_allreduce = True
                     layer._defer_ar = True
             # Disable fusion when EP is active — the runner keeps its
             # own AR because deferral isn't safe across EP all-to-all.
             self._fuse_moe_allreduce = self.layers[
                 self.start_layer
-            ].block_sparse_moe.experts.runner.defer_allreduce
+            ].block_sparse_moe.experts.runner.moe_config.defer_allreduce
             logger.info_once(
                 "MoE deferred AR: fuse_moe_allreduce=%s, tp_size=%s, ep_size=%s, "
                 "num_layers=%s, hidden_size=%s",

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -37,7 +37,6 @@ from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_reduce,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
@@ -312,23 +311,15 @@ class MiniMaxM2DecoderLayer(nn.Module):
         residual: torch.Tensor | None,
     ) -> torch.Tensor:
         # Deferred AR: the previous MoE skipped cross_device_reduce_1stage,
-        # so hidden_states is partial.  Do the TP allreduce here right
-        # before input_layernorm, so torch.compile Pattern 1
-        # (AllReduceFusedAddRMSNormPattern) can fuse AR + residual + RMSNorm
-        # into trtllm_allreduce_fusion(kARResidualRMSNorm).
+        # so hidden_states is partial.  Use forward_with_allreduce_fusion to
+        # fuse AR + residual + RMSNorm directly via FlashInfer, bypassing
+        # torch.compile pattern matching (which breaks when fused_add_rms_norm
+        # is decomposed to native ops, e.g. under rms_norm=['native'] priority).
         if self._defer_ar and residual is not None and hidden_states.shape[0] <= 128:
-            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
-            if not torch.compiler.is_compiling():
-                logger.info_once(
-                    "MoE deferred AR in decoder layer %s: allreduce before "
-                    "input_layernorm, num_tokens=%s",
-                    self.layer_idx,
-                    hidden_states.shape[0],
-                    scope="moe_defer_layer_forward",
-                )
-
-        # Self Attention
-        if residual is None:
+            hidden_states, residual = self.input_layernorm.forward_with_allreduce_fusion(
+                hidden_states, residual
+            )
+        elif residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
@@ -458,16 +449,17 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             and get_pp_group().is_last_rank
         )
         if last_layer_fused:
-            # Do the deferred allreduce before self.norm; Pattern 1
-            # fuses allreduce + fused_add_rms_norm into a single kernel.
-            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+            hidden_states, _ = self.norm.forward_with_allreduce_fusion(
+                hidden_states, residual
+            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        hidden_states, _ = self.norm(hidden_states, residual)
+        if not last_layer_fused:
+            hidden_states, _ = self.norm(hidden_states, residual)
 
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -319,6 +319,19 @@ class MiniMaxM2DecoderLayer(nn.Module):
             and residual is not None
             and hidden_states.shape[0] <= 128
         )
+        if not torch.compiler.is_compiling():
+            if _fuse:
+                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_TRUE")
+                torch.cuda.nvtx.range_pop()
+            elif self._defer_ar and residual is not None:
+                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_FALSE_tokens")
+                torch.cuda.nvtx.range_pop()
+            elif self._defer_ar:
+                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_FALSE_residual")
+                torch.cuda.nvtx.range_pop()
+            else:
+                torch.cuda.nvtx.range_push("DIAG_decoder_fuse_FALSE_defer_ar")
+                torch.cuda.nvtx.range_pop()
         if _fuse:
             hidden_states, residual = self.input_layernorm.forward_with_allreduce_fusion(
                 hidden_states, residual

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -37,7 +37,9 @@ from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
 )
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
@@ -72,6 +74,8 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+
+logger = init_logger(__name__)
 
 
 class MiniMaxM2MoE(nn.Module):
@@ -272,6 +276,10 @@ class MiniMaxM2DecoderLayer(nn.Module):
         layer_idx = int(prefix.split(sep=".")[-1])
 
         self.layer_idx = layer_idx
+        # When True, do explicit TP allreduce on hidden_states before
+        # input_layernorm, so torch.compile Pattern 1 can fuse AR +
+        # fused_add_rms_norm into trtllm_allreduce_fusion.
+        self._defer_ar: bool = False
         self.self_attn = MiniMaxM2Attention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
@@ -303,12 +311,29 @@ class MiniMaxM2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
     ) -> torch.Tensor:
+        # Deferred AR: the previous MoE skipped cross_device_reduce_1stage,
+        # so hidden_states is partial.  Do the TP allreduce here right
+        # before input_layernorm, so torch.compile Pattern 1
+        # (AllReduceFusedAddRMSNormPattern) can fuse AR + residual + RMSNorm
+        # into trtllm_allreduce_fusion(kARResidualRMSNorm).
+        if self._defer_ar and residual is not None and hidden_states.shape[0] <= 128:
+            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+            if not torch.compiler.is_compiling():
+                logger.info_once(
+                    "MoE deferred AR in decoder layer %s: allreduce before "
+                    "input_layernorm, num_tokens=%s",
+                    self.layer_idx,
+                    hidden_states.shape[0],
+                    scope="moe_defer_layer_forward",
+                )
+
         # Self Attention
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
@@ -334,6 +359,8 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
         self.config = config
+
+        self._fuse_moe_allreduce = vllm_config.compilation_config.pass_config.fuse_moe_allreduce
 
         self.vocab_size = config.vocab_size
 
@@ -367,6 +394,28 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             ["hidden_states", "residual"], config.hidden_size
         )
 
+        if self._fuse_moe_allreduce:
+            for layer in islice(self.layers, self.start_layer, self.end_layer):
+                runner = layer.block_sparse_moe.experts.runner
+                if runner.moe_config.ep_size <= 1:
+                    runner.defer_allreduce = True
+                    layer._defer_ar = True
+            # Disable fusion when EP is active — the runner keeps its
+            # own AR because deferral isn't safe across EP all-to-all.
+            self._fuse_moe_allreduce = self.layers[
+                self.start_layer
+            ].block_sparse_moe.experts.runner.defer_allreduce
+            logger.info_once(
+                "MoE deferred AR: fuse_moe_allreduce=%s, tp_size=%s, ep_size=%s, "
+                "num_layers=%s, hidden_size=%s",
+                self._fuse_moe_allreduce,
+                get_tensor_model_parallel_world_size(),
+                self.layers[self.start_layer].block_sparse_moe.experts.runner.moe_config.ep_size,
+                self.end_layer - self.start_layer,
+                self.config.hidden_size,
+                scope="moe_defer_init",
+            )
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -389,18 +438,35 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             residual = intermediate_tensors["residual"]
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
         ):
-            hidden_states, residual = layer(positions, hidden_states, residual)
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                residual,
+            )
             self._maybe_add_hidden_state(
                 aux_hidden_states, idx + 1, hidden_states, residual
             )
+
+        # Fuse the last deferred MoE AR with self.norm.
+        last_layer_fused = (
+            self._fuse_moe_allreduce
+            and hidden_states.shape[0] <= 128
+            and get_pp_group().is_last_rank
+        )
+        if last_layer_fused:
+            # Do the deferred allreduce before self.norm; Pattern 1
+            # fuses allreduce + fused_add_rms_norm into a single kernel.
+            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
+
         hidden_states, _ = self.norm(hidden_states, residual)
 
         if len(aux_hidden_states) > 0:


### PR DESCRIPTION
Fuse the MoE's `cross_device_reduce_1stage` (TP allreduce) with the next layer's
`input_layernorm` (residual + RMSNorm) into a single
`trtllm_allreduce_fusion(kARResidualRMSNorm)` kernel




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

