### PR TITLE
[CPU] Specify required KV cache layout for CPU attention backend

### DIFF
--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -25,6 +25,7 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import (
+    KVCacheLayoutType,
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, CrossAttentionSpec
@@ -93,6 +94,10 @@ class CPUAttentionBackend(AttentionBackend):
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return 2, num_blocks, num_kv_heads, block_size, head_size
+
+    @classmethod
+    def get_required_kv_cache_layout(cls) -> "KVCacheLayoutType | None":
+        return "HND"
 
     @staticmethod
     def use_cascade_attention(*args, **kwargs) -> bool:


### PR DESCRIPTION
Summary
Add get_required_kv_cache_layout() to CPUAttentionBackend to explicitly declare the required KV cache layout as "HND" (Head, N-tokens/block_size, Dim).

Motivation
The CPU attention backend's get_kv_cache_shape already returns the shape (2, num_blocks, num_kv_heads, block_size, head_size), which corresponds to the HND layout. However, it did not override get_required_kv_cache_layout() from the base class, which returns None. When the return value is None, the KV cache manager defaults to using NHD layout — this is incorrect for the CPU backend, as its kernels (cpu_attn_reshape_and_cache, cpu_attention_with_kv_cache) expect the KV cache in HND format [num_blocks, num_kv_heads, block_size, head_size].

This mismatch can lead to silent correctness issues or crashes when the framework performs layout transposition decisions based on the backend's declared layout requirement.

Other backends that use HND layout (e.g., FlashInfer, FlashInfer MLA, Tokenspeed MLA) already declare this explicitly.