### PR TITLE
[Perf][Qwen3.5] Fuse GDN linear_attn qkv|z|b|a into a single GEMM

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -265,6 +265,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         vllm_config: VllmConfig,
         prefix: str = "",
         gqa_interleaved_layout=False,
+        create_in_proj_qkvzba: bool = False,
     ) -> None:
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -321,25 +322,54 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # projection of the input hidden states
         # Qwen3-Next and Qwen3.5 has a different qkv_proj layout,
         # we need to create qkvz_proj adaptively here.
-        # When create_in_proj_qkvz is False (e.g. LoRA enabled in Qwen3.5),
-        # in_proj_qkv and in_proj_z are created separately instead.
-        self.in_proj_qkvz = self.create_qkvz_proj(
-            hidden_size=self.hidden_size,
-            key_dim=self.key_dim,
-            value_dim=self.value_dim,
-            quant_config=quant_config,
-            prefix=f"{prefix}.in_proj_qkvz",
-        )
+        # When create_in_proj_qkvzba is True (Qwen3.5 only, opt-in via
+        # VLLM_GDN_FUSE_QKVZBA=1), all 4 projections (qkv|z|b|a) are fused
+        # into a single MergedColumnParallelLinear, collapsing the 2 GEMMs
+        # (qkvz + ba) into 1.
+        if create_in_proj_qkvzba:
+            assert not gqa_interleaved_layout, (
+                "create_in_proj_qkvzba is only supported with "
+                "gqa_interleaved_layout=False (Qwen3.5)."
+            )
+            # Single fused weight of shape [N_total, hidden_size] where
+            # N_total = key_dim*2 + value_dim*2 + num_v_heads*2 = 12352.
+            # Output_sizes split q/k/v/z/b/a so TP sharding aligns on
+            # head-dim boundaries (mirrors the existing qkvz proj layout).
+            # Loaded from 4 checkpoint shards: in_proj_qkv (covers shards
+            # 0..2 = q,k,v), in_proj_z (shard 3), in_proj_b (shard 4),
+            # in_proj_a (shard 5). Declared in stacked_params_mapping.
+            self.in_proj_qkvzba = MergedColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_sizes=[
+                    self.key_dim,        # q  (shard 0)
+                    self.key_dim,        # k  (shard 1)
+                    self.value_dim,      # v  (shard 2)
+                    self.value_dim,      # z  (shard 3)
+                    self.num_v_heads,    # b  (shard 4)
+                    self.num_v_heads,    # a  (shard 5)
+                ],
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_qkvzba",
+            )
+        else:
+            self.in_proj_qkvz = self.create_qkvz_proj(
+                hidden_size=self.hidden_size,
+                key_dim=self.key_dim,
+                value_dim=self.value_dim,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_qkvz",
+            )
 
-        # ba_proj doesn't support blockwise fp8 quantization.
-        # Qwen3-Next and Qwen3.5 have different in_proj_ba checkpoint
-        # layouts, so we use a factory method to create the projection.
-        self.in_proj_ba = self.create_ba_proj(
-            hidden_size=self.hidden_size,
-            num_v_heads=self.num_v_heads,
-            quant_config=quant_config,
-            prefix=f"{prefix}.in_proj_ba",
-        )
+            # ba_proj doesn't support blockwise fp8 quantization.
+            # Qwen3-Next and Qwen3.5 have different in_proj_ba checkpoint
+            # layouts, so we use a factory method to create the projection.
+            self.in_proj_ba = self.create_ba_proj(
+                hidden_size=self.hidden_size,
+                num_v_heads=self.num_v_heads,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_ba",
+            )
 
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
@@ -690,6 +720,10 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
     ):
         """ROCm forward using AITER Triton fused projection+attention when
         available, otherwise falling back to the generic CUDA path."""
+        if hasattr(self, "in_proj_qkvzba"):
+            # Fall back to the generic CUDA path on ROCm when fully-fused.
+            self.forward_cuda(hidden_states, output)
+            return
         if GDN_AITER_TRITON_AVAILABLE:
             num_tokens = hidden_states.size(0)
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
@@ -735,27 +769,43 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
-
-        if self.gqa_interleaved_layout:
-            # Qwen3-Next: unpack the interleaved GQA layout
-            query, key, value, z, b, a = self.fix_query_key_value_ordering(
-                mixed_qkvz, ba
-            )
-            query, key, value = map(
-                lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
-            )
-            mixed_qkv = torch.cat((query, key, value), dim=-1)
-        else:
-            # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
+        if hasattr(self, "in_proj_qkvzba"):
+            # Fully-fused path (opt-in via VLLM_GDN_FUSE_QKVZBA=1):
+            # 1 GEMM produces [q | k | v | z | b | a] in one shot, then
+            # split into the same shapes the downstream code expects.
+            qkvzba, _ = self.in_proj_qkvzba(hidden_states)
             qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
             z_size = self.value_dim // self.tp_size
-            mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
-            z = z.reshape(z.size(0), -1, self.head_v_dim)
-            b, a = ba.chunk(2, dim=-1)
+            n_v = self.num_v_heads // self.tp_size
+            mixed_qkv, z_flat, b, a = qkvzba.split(
+                [qkv_size, z_size, n_v, n_v], dim=-1
+            )
+            z = z_flat.reshape(z_flat.size(0), -1, self.head_v_dim)
             b = b.contiguous()
             a = a.contiguous()
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
+
+            if self.gqa_interleaved_layout:
+                # Qwen3-Next: unpack the interleaved GQA layout
+                query, key, value, z, b, a = self.fix_query_key_value_ordering(
+                    mixed_qkvz, ba
+                )
+                query, key, value = map(
+                    lambda x: rearrange(x, "l p d -> l (p d)"),
+                    (query, key, value),
+                )
+                mixed_qkv = torch.cat((query, key, value), dim=-1)
+            else:
+                # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
+                qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+                z_size = self.value_dim // self.tp_size
+                mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+                z = z.reshape(z.size(0), -1, self.head_v_dim)
+                b, a = ba.chunk(2, dim=-1)
+                b = b.contiguous()
+                a = a.contiguous()
 
         # ============================================================
         # Part 2: Core Attention (Custom Op)
@@ -793,6 +843,9 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         2. Core attention (custom op)
         3. Output projection
         """
+        assert not hasattr(self, "in_proj_qkvzba"), (
+            "VLLM_GDN_FUSE_QKVZBA isn't supported on XPU."
+        )
         num_tokens = hidden_states.size(0)
 
         # ============================================================
@@ -837,6 +890,9 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         output: torch.Tensor,
     ):
         assert not hasattr(self, "in_proj_qkv"), "lora isn't supported on CPU."
+        assert not hasattr(self, "in_proj_qkvzba"), (
+            "VLLM_GDN_FUSE_QKVZBA isn't supported on CPU."
+        )
 
         mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
         ba, _ = self.in_proj_ba(hidden_states)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only Qwen3.5 Series compatible with HuggingFace weights."""
 
+import os
 import typing
 from collections.abc import Callable, Iterable
 
@@ -104,6 +105,11 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+# Opt-in: fuse GDN linear_attn's qkv|z|b|a into a single GEMM
+# (collapses the 2 GEMMs qkvz + ba per GDN layer into 1). Reduces kernel
+# launch overhead and lets cuBLASLt pick a better tile by enlarging N.
+_VLLM_GDN_FUSE_QKVZBA = bool(int(os.environ.get("VLLM_GDN_FUSE_QKVZBA", "0")))
+
 
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
@@ -138,6 +144,13 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.linear_attn",
                 gqa_interleaved_layout=False,
+                # Fully-fuse qkv|z|b|a into a single GEMM (opt-in via env
+                # var). Disabled with LoRA — adapter routing assumes the
+                # default in_proj_qkvz / in_proj_ba split.
+                create_in_proj_qkvzba=(
+                    _VLLM_GDN_FUSE_QKVZBA
+                    and vllm_config.lora_config is None
+                ),
             )
         elif self.layer_type == "full_attention":
             self.self_attn = Qwen3NextAttention(
@@ -272,11 +285,36 @@ class Qwen3_5Model(Qwen3NextModel):
         return loaded_local_expert
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # In QKVZBA mode (opt-in via env var), all 4 GDN in_proj_* checkpoint
+        # shards land in the single fused in_proj_qkvzba weight.
+        # Output_sizes layout: [q, k, v, z, b, a] = [key, key, value, value, n_v, n_v].
+        # We detect the mode by checking whether any GDN layer was built
+        # with in_proj_qkvzba (avoids referencing self.enable_lora which is
+        # only set on Qwen3_5ForCausalLMBase, not on Qwen3_5Model).
+        _use_qkvzba = _VLLM_GDN_FUSE_QKVZBA and any(
+            hasattr(getattr(layer, "linear_attn", None), "in_proj_qkvzba")
+            for layer in self.layers
+        )
+        if _use_qkvzba:
+            gdn_mapping = [
+                ("in_proj_qkvzba", "in_proj_qkv", (0, 1, 2)),
+                ("in_proj_qkvzba", "in_proj_z", 3),
+                ("in_proj_qkvzba", "in_proj_b", 4),
+                ("in_proj_qkvzba", "in_proj_a", 5),
+            ]
+        else:
+            # Keep the original mapping: in_proj_qkvz packs q/k/v/z and
+            # in_proj_ba packs b/a as separate fused weights.
+            gdn_mapping = [
+                ("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),
+                ("in_proj_qkvz", "in_proj_z", 3),
+                ("in_proj_ba", "in_proj_b", 0),
+                ("in_proj_ba", "in_proj_a", 1),
+            ]
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             # GDN
-            ("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),
-            ("in_proj_qkvz", "in_proj_z", 3),
+            *gdn_mapping,
             # self attention
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -284,8 +322,6 @@ class Qwen3_5Model(Qwen3NextModel):
             # mlp
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
-            ("in_proj_ba", "in_proj_b", 0),
-            ("in_proj_ba", "in_proj_a", 1),
         ]
 
         params_dict = dict(self.named_parameters())
@@ -442,9 +478,20 @@ class Qwen3_5ForCausalLMBase(
             "v_proj",
         ],
         "gate_up_proj": ["gate_proj", "up_proj"],
-        # GDN fused projections.
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
-        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        # GDN fused projections — switched at module-load time based on
+        # VLLM_GDN_FUSE_QKVZBA env var.
+        **(
+            {
+                "in_proj_qkvzba": [
+                    "in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a",
+                ],
+            }
+            if _VLLM_GDN_FUSE_QKVZBA
+            else {
+                "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+                "in_proj_ba": ["in_proj_b", "in_proj_a"],
+            }
+        ),
     }
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -467,6 +514,24 @@ class Qwen3_5ForCausalLMBase(
         self.model = Qwen3_5Model(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+
+        # When LoRA + QKVZBA env var are both set, the QKVZBA fusion is
+        # disabled at the layer level (LoRA needs per-shard adapters), so
+        # the runtime layer is in_proj_qkvz/in_proj_ba — restore the
+        # corresponding packed_modules_mapping so the LoRA loader finds
+        # the right targets.
+        if vllm_config.lora_config and _VLLM_GDN_FUSE_QKVZBA:
+            self.packed_modules_mapping = {
+                k: list(v)
+                for k, v in Qwen3_5ForCausalLMBase.packed_modules_mapping.items()
+            }
+            self.packed_modules_mapping.pop("in_proj_qkvzba", None)
+            self.packed_modules_mapping["in_proj_qkvz"] = [
+                "in_proj_qkv", "in_proj_z",
+            ]
+            self.packed_modules_mapping["in_proj_ba"] = [
+                "in_proj_b", "in_proj_a",
+            ]
 
         if get_pp_group().is_last_rank:
             if config.tie_word_embeddings:
@@ -552,10 +617,18 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     # Qwen3.5 does not support multimodal pruning (EVS).
     supports_multimodal_pruning = False
 
-    packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
-        "in_proj_ba": ["in_proj_b", "in_proj_a"],
-    }
+    packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | (
+        {
+            "in_proj_qkvzba": [
+                "in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a",
+            ],
+        }
+        if _VLLM_GDN_FUSE_QKVZBA
+        else {
+            "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+            "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        }
+    )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
         # protocols have not __init__ method, so we need to use nn.Module.__init__
@@ -570,6 +643,21 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
         # Qwen3.5 does not support multimodal pruning (EVS).
         self.is_multimodal_pruning_enabled = False
+
+        # When LoRA + QKVZBA env var are both set, the QKVZBA fusion is
+        # disabled at the layer level (see Qwen3_5DecoderLayer); restore
+        # the per-shard packed mapping so the LoRA loader finds the
+        # in_proj_qkvz / in_proj_ba targets.
+        if vllm_config.lora_config and _VLLM_GDN_FUSE_QKVZBA:
+            base = Qwen3_5ForConditionalGeneration.packed_modules_mapping
+            self.packed_modules_mapping = {k: list(v) for k, v in base.items()}
+            self.packed_modules_mapping.pop("in_proj_qkvzba", None)
+            self.packed_modules_mapping["in_proj_qkvz"] = [
+                "in_proj_qkv", "in_proj_z",
+            ]
+            self.packed_modules_mapping["in_proj_ba"] = [
+                "in_proj_b", "in_proj_a",
+            ]
 
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.visual = Qwen3_VisionTransformer(
@@ -784,6 +872,20 @@ class Qwen3_5MoeForConditionalGeneration(
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
         # Qwen3.5 does not support multimodal pruning (EVS).
         self.is_multimodal_pruning_enabled = False
+
+        # When LoRA + QKVZBA env var are both set, the QKVZBA fusion is
+        # disabled at the layer level; restore the per-shard packed
+        # mapping so the LoRA loader finds in_proj_qkvz / in_proj_ba.
+        if vllm_config.lora_config and _VLLM_GDN_FUSE_QKVZBA:
+            base = Qwen3_5ForConditionalGeneration.packed_modules_mapping
+            self.packed_modules_mapping = {k: list(v) for k, v in base.items()}
+            self.packed_modules_mapping.pop("in_proj_qkvzba", None)
+            self.packed_modules_mapping["in_proj_qkvz"] = [
+                "in_proj_qkv", "in_proj_z",
+            ]
+            self.packed_modules_mapping["in_proj_ba"] = [
+                "in_proj_b", "in_proj_a",
+            ]
 
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.visual = Qwen3_VisionTransformer(


### PR DESCRIPTION
## Summary

Behind opt-in env var `VLLM_GDN_FUSE_QKVZBA=1`, fully fuse the four GDN
`in_proj_*` weights (qkv, z, b, a) into a single `MergedColumnParallelLinear`.
This collapses the existing 2 GEMMs per GDN layer (`in_proj_qkvz` + `in_proj_ba`)
into 1, reducing per-step launch overhead and letting cuBLASLt pick a better
tile by enlarging the output dimension N (12352 vs 12288 / 64 separately).

Default behavior (env var unset) is unchanged — bit-equivalent to baseline.

## Why

The 4 separate / partially-fused GDN projections show up as a meaningful
small-bf16-GEMM hot path on hybrid linear-attention models like Qwen3.5
on consumer Blackwell GPUs (RTX PRO 6000, sm_120). At small M (decode regime)
the existing 2-GEMM path is bound by kernel launch overhead — the `in_proj_ba`
GEMM in particular is a tiny `M × 2048 → 64` shape that's almost pure overhead.
Fusing all four into one GEMM is a clean launch-overhead win.

## Implementation

* `GatedDeltaNetAttention.__init__` gains `create_in_proj_qkvzba` kwarg
  (default `False`). When `True` (Qwen3.5 only, non-interleaved-GQA), one
  `MergedColumnParallelLinear` is created with output_sizes
  `[key_dim, key_dim, value_dim, value_dim, num_v_heads, num_v_heads]`
  — q/k/v/z/b/a split along output dim so TP sharding aligns on head-dim
  boundaries (mirrors the existing `in_proj_qkvz` layout).
* `forward_cuda` adds a fused branch that does one matmul +
  `split([qkv_size, z_size, n_v, n_v], dim=-1)`.
* `forward_xpu` / `forward_cpu` / `forward_hip` paths stay on the original
  2-GEMM path (assertions / fallback when QKVZBA is enabled).
* Qwen3.5 `packed_modules_mapping` switches at module-load time between
  `{in_proj_qkvz, in_proj_ba}` (default) and `{in_proj_qkvzba}` (when env var
  is set).
* `Qwen3_5Model.load_weights` `stacked_params_mapping` has a matching switch.
  The fused mode is detected at runtime by checking whether any GDN layer was
  built with `in_proj_qkvzba` (avoids hard-coding `self.enable_lora` which does
  not exist on `Qwen3_5Model`).
* When `VLLM_GDN_FUSE_QKVZBA=1` is set but LoRA is also enabled, the QKVZBA
  fusion is silently skipped at the layer level (LoRA requires per-shard
  adapters). The `packed_modules_mapping` is restored to the per-shard
  `{in_proj_qkvz, in_proj_ba}` layout so that weight loading succeeds.

## Bench

Qwen3.5-35B-A3B-NVFP4 on RTX PRO 6000 Blackwell (sm_120), TP=1,
ISL=2000 / OSL=150, `--attention-backend TRITON_ATTN`,
`cudagraph_mode=FULL_DECODE_ONLY`.

All numbers are from the fully-correct code with all weight-loading bugs fixed
(see Notes).

| C  | baseline mean (p99) | fused mean (p99) | Δ%   | passes mean ≤ 10 ms |
|---:|--------------------:|-----------------:|-----:|:-------------------:|
|  1 |  6.16 ms ( 6.17)   |  6.15 ms ( 6.17) | +0.1% |       ✓ / ✓         |
|  3 |  8.70 ms ( 9.14)   |  8.38 ms ( 8.88) | +3.7% |       ✓ / ✓         |
|  5 |  9.82 ms (10.59)   |  9.49 ms (10.30) | +3.3% |       ✓ / ✓         |
|  6 | 10.17 ms (11.30)   |  9.97 ms (10.90) | +1.9% |      ✗ / ✓          |
|  7 | 10.65 ms (12.00)   | 10.41 ms (11.75) | +2.2% |      ✗ / ✗          |
|  8 | 10.78 ms (12.73)   | 10.53 ms (12.23) | +2.4% |      ✗ / ✗          |

Under a `mean TPOT ≤ 10 ms` SLO, max concurrency rises from C=5 to C=6 (+20%);
request throughput at the SLO ceiling rises 1.19× (2.95 → 3.50 req/s,
443 → 525 output tok/s). Improvement is strongest in the
launch-overhead-bound decode regime (C=3..6); at large concurrency it
diminishes as per-kernel time dominates.

## Accuracy

5-prompt greedy probe (math / code / factual / logic / creative,
`temperature=0`, `top_p=1`, `seed=0`) on Qwen3.5-35B-A3B-NVFP4 shows the
fused path produces semantically correct outputs on every prompt.

| prompt   | fused output (first 60 chars)               | semantically correct |
|----------|:--------------------------------------------|:--------------------:|
| code     | `def fibonacci(n):` *(bit-identical)*        |          ✓           |
| math     | `To find the distance traveled, …`           |          ✓           |
| factual  | `Mercury, Venus, Earth, Mars, …, Neptune`    |          ✓           |
| logic    | `Yes. Explanation: … transitive …`           |          ✓           |
| creative | `Mist clings to the peak, …` *(haiku form)*  |          ✓           |

Remaining token-level divergences are bf16 numerical noise from different
cuBLASLt tile selection (expected and benign).

## Test plan

- [x] **Regression** — env unset matches baseline (mean TPOT delta ≤ 0.05 ms).
- [x] **Weight loading** — server log clean of "Parameter not found, skip loading" warnings in both modes.
- [x] **Functional** — fused output semantically correct on 5-prompt greedy probe.
- [x] **End-to-end perf** — `vllm bench serve` sweep across C=1..8.
- [ ] LoRA path (uses opt-out, falls back to per-shard `in_proj_qkvz` / `in_proj_ba`) — manual review only, no LoRA model available for end-to-end test.
- [ ] Qwen3-Next (uses `gqa_interleaved_layout=True` → not affected, asserted at construction time).

## Notes

* AI assistance was used to draft the patch and benchmark scaffolding.
* An earlier revision of this PR had two correctness bugs:
  1. `stacked_params_mapping` was missing the `in_proj_qkvzba` shards, so
     `load_weights` silently skipped all GDN projection weights (model ran
     on random init). Only caught by a greedy-output accuracy probe — bench
     numbers with `--ignore-eos` looked plausible because the model still
     generated tokens.
  2. The non-fused fallback path was missing `("in_proj_ba", "in_proj_b", 0)`
     and `("in_proj_ba", "in_proj_a", 1)` from `stacked_params_mapping`,
     breaking baseline weight loading after the code restructure.
  Both bugs are fixed in the current revision, and accuracy is re-verified.
* Behind opt-in env var by default to keep CI behavior bit-stable. We can
  flip the default in a follow-up after broader CI validation.
* A natural follow-up: apply the same horizontal fusion in Qwen3-Next
  (`gqa_interleaved_layout=True`, needs a different b/a unpacker) and swap
  the fused GEMM for a Triton kernel on small-M decode (~1.5× additional
  kernel speedup shown in lab benchmarks in CUDA-graph mode).
