### PR TITLE
[Bugfix] qwen3_vl_moe: don't transpose 0-D/1-D scale tensors (#40885)

### DIFF
--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -171,13 +171,22 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
             ("gate_up_proj", "up_proj", 1),
         ]
         # Skip loading extra parameters for GPTQ/modelopt models.
+        # The NVFP4 variants (.weight_scale_2 / .input_scale_2) hold the
+        # global per-expert scalar used to invert into the activation
+        # quant scale; they're stored as 1-D tensors (shape [num_experts])
+        # and must not flow through the fused-expert transpose path
+        # below, which assumes a ≥2-D weight tensor (see #40885).
         ignore_suffixes = (
             ".bias",
             "_bias",
             ".weight_scale",
             "_weight_scale",
+            ".weight_scale_2",
+            "_weight_scale_2",
             ".input_scale",
             "_input_scale",
+            ".input_scale_2",
+            "_input_scale_2",
         )
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
@@ -240,10 +249,22 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue
+                    name_mapped = name.replace(weight_name, param_name)
+                    # NVFP4 / ModelOpt quantization metadata
+                    # (.weight_scale, .weight_scale_2, .input_scale,
+                    # .input_scale_2) is stored as 0-D / 1-D scalar
+                    # tensors. The fused-expert transpose below assumes
+                    # a ≥2-D weight tensor, so an unguarded transpose
+                    # raises `IndexError: Dimension out of range
+                    # (expected to be in range of [-1, 0], but got -2)`
+                    # (#40885). Skip these so they fall through to the
+                    # outer else, where the layer's quant-aware
+                    # weight_loader handles them.
+                    if name_mapped.endswith(ignore_suffixes):
+                        continue
                     # Anyway, this is an expert weight and should not be
                     # attempted to load as other weights later
                     is_expert_weight = True
-                    name_mapped = name.replace(weight_name, param_name)
                     if is_pp_missing_parameter(name_mapped, self):
                         continue
                     if is_fused_expert:


### PR DESCRIPTION
`Qwen3VLMoeForCausalLM.load_weights` unconditionally runs `loaded_weight.transpose(-1, -2)` inside the fused-expert branch (line 250). NVFP4 / ModelOpt quantized checkpoints emit per-expert scale tensors (`.weight_scale_2`, `.input_scale_2`, etc.) as 1-D shape `[num_experts]`. Transposing a 1-D tensor raises:

    IndexError: Dimension out of range (expected to be in range of
    [-1, 0], but got -2)

reported on RTX PRO 6000 Blackwell and RTX 5090 with `Code4me2/bu-30b-a3b-preview-NVFP4` (#40885). The same path is hit on any NVFP4-quantized Qwen3-VL MoE checkpoint that uses the ModelOpt quant scheme.

The fix has two pieces, both narrowly scoped:

1. Add `.weight_scale_2` / `_weight_scale_2` and `.input_scale_2` / `_input_scale_2` to the existing `ignore_suffixes` tuple. The two `_2` suffixes hold the per-expert global scalars that ModelOpt produces alongside the FP8 block scales; they're orthogonal to the existing `.weight_scale` / `.input_scale` entries and need their own exclusion.

2. Move the existing `ignore_suffixes` check (which was only on the non-fused branch, line 280) up so it runs *before* setting `is_expert_weight = True` and *before* the fused transpose. With this, NVFP4 scale tensors fall through to the outer else, where the FusedMoE layer's quant-aware `weight_loader` already knows how to load them.

Issue #40885 also calls out two adjacent concerns — ModelOpt's `experts.<proj>.<N>.*` vs vLLM's `experts.<N>.<proj>.*` naming and 3-D packed-tensor unpacking. Those need a larger refactor along the lines of Gemma 4 MoE (#39045's `_weight_iterator`); this PR only addresses the IndexError so the load no longer hard-crashes, and leaves #40885 open for the broader compatibility work.

Manual repro (before / after this PR):

  # Before
  $ vllm serve Code4me2/bu-30b-a3b-preview-NVFP4 \
        --max-model-len 32768 --dtype bfloat16 \
        --gpu-memory-utilization 0.85 --kv-cache-dtype fp8 \
        --max-num-seqs 2
  ...
  File ".../vllm/model_executor/models/qwen3_vl_moe.py", line 250,
    in load_weights
      loaded_weight = loaded_weight.transpose(-1, -2)  # no bias
  IndexError: Dimension out of range (expected to be in range of
              [-1, 0], but got -2)

  # After: load proceeds past this point. Inference correctness for
  # NVFP4 MoE checkpoints still depends on the remaining work in
  # #40885 (name remap + 3-D unpack); this PR just stops the crash
  # and lets the existing quant-aware loaders see the scale params.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

