### PR TITLE
[Model] Support post-norm architecture for EAGLE-3 supeculators

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -199,11 +199,18 @@ class DeepseekV2Eagle3Model(nn.Module):
             ]
         )
 
-        # fc layer for combining auxiliary hidden states (3x hidden size input)
-        if hasattr(self.config, "target_hidden_size"):
-            fc_input_size = self.config.target_hidden_size * 3
-        else:
-            fc_input_size = self.config.hidden_size * 3
+        # fc layer for combining auxiliary hidden states
+        num_aux_hidden_states = getattr(self.config, "num_aux_hidden_states", None)
+        if num_aux_hidden_states is None:
+            eagle_config = getattr(self.config, "eagle_config", None) or {}
+            layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
+            num_aux_hidden_states = len(layer_ids) if layer_ids else 3
+        self.num_aux_hidden_states = num_aux_hidden_states
+
+        target_hidden_size = getattr(
+            self.config, "target_hidden_size", self.config.hidden_size
+        )
+        fc_input_size = target_hidden_size * num_aux_hidden_states
 
         self.fc = ReplicatedLinear(
             input_size=fc_input_size,
@@ -215,6 +222,18 @@ class DeepseekV2Eagle3Model(nn.Module):
             return_bias=False,
         )
 
+        use_fc_norm = getattr(self.config, "fc_norm", False)
+        if use_fc_norm:
+            self.fc_norm = nn.ModuleList(
+                [
+                    RMSNorm(target_hidden_size, eps=self.config.rms_norm_eps)
+                    for _ in range(self.num_aux_hidden_states)
+                ]
+            )
+        else:
+            self.fc_norm = None
+
+        self.norm_output = getattr(self.config, "norm_output", False)
         self.norm = RMSNorm(
             self.config.hidden_size,
             eps=self.config.rms_norm_eps,
@@ -242,8 +261,13 @@ class DeepseekV2Eagle3Model(nn.Module):
                 hidden_states=hidden_states,
                 residual=residual,
             )
+
         hidden_states, hidden_prenorm = self.norm(hidden_states, residual)
-        return hidden_states, hidden_prenorm
+
+        # norm_output variant uses the post-norm hidden states.
+        aux_output = hidden_states if self.norm_output else hidden_prenorm
+
+        return hidden_states, aux_output
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -172,10 +172,19 @@ class LlamaModel(nn.Module):
             ]
         )
         if self.use_aux_hidden_state:
-            if hasattr(self.config, "target_hidden_size"):
-                fc_input_size = self.config.target_hidden_size * 3
-            else:
-                fc_input_size = self.config.hidden_size * 3
+            self.num_aux_hidden_states = getattr(
+                self.config, "num_aux_hidden_states", None
+            )
+            if self.num_aux_hidden_states is None:
+                eagle_config = getattr(self.config, "eagle_config", None) or {}
+                layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
+                self.num_aux_hidden_states = len(layer_ids) if layer_ids else 3
+
+            target_hidden_size = getattr(
+                self.config, "target_hidden_size", self.config.hidden_size
+            )
+            fc_input_size = target_hidden_size * self.num_aux_hidden_states
+
             if self.norm_before_fc:
                 self.input_norm = RMSNorm(
                     fc_input_size,
@@ -183,6 +192,18 @@ class LlamaModel(nn.Module):
                 )
             else:
                 self.input_norm = None
+
+            use_fc_norm = getattr(self.config, "fc_norm", False)
+            if use_fc_norm:
+                self.fc_norm = nn.ModuleList(
+                    [
+                        RMSNorm(target_hidden_size, eps=self.config.rms_norm_eps)
+                        for _ in range(self.num_aux_hidden_states)
+                    ]
+                )
+            else:
+                self.fc_norm = None
+
             self.fc = ReplicatedLinear(
                 input_size=fc_input_size,
                 output_size=self.config.hidden_size,
@@ -192,6 +213,8 @@ class LlamaModel(nn.Module):
                 prefix=maybe_prefix(prefix, "fc"),
                 return_bias=False,
             )
+
+        self.norm_output = getattr(self.config, "norm_output", False)
         self.norm = RMSNorm(
             self.config.hidden_size,
             eps=self.config.rms_norm_eps,
@@ -220,7 +243,11 @@ class LlamaModel(nn.Module):
                 residual=residual,
             )
         hidden_states, hidden_prenorm = self.norm(hidden_states, residual)
-        return hidden_states, hidden_prenorm
+
+        # norm_output variant uses the post-norm hidden states.
+        aux_output = hidden_states if self.norm_output else hidden_prenorm
+
+        return hidden_states, aux_output
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
@@ -310,13 +337,17 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
 
         if self.use_parallel_drafting:
+            aux_count = (
+                self.model.num_aux_hidden_states
+                if self.model.use_aux_hidden_state
+                else 1
+            )
+            target_hidden_size = getattr(
+                self.config, "target_hidden_size", self.config.hidden_size
+            )
             self.register_buffer(
                 "mask_hidden",
-                torch.zeros(
-                    1,
-                    (3 if self.model.use_aux_hidden_state else 1)
-                    * self.config.hidden_size,
-                ),
+                torch.zeros(1, aux_count * target_hidden_size),
                 persistent=False,
             )
 
@@ -371,6 +402,14 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
 
         if self.model.norm_before_fc:
             hidden_states = self.model.input_norm(hidden_states)
+
+        if self.model.fc_norm is not None:
+            chunks = hidden_states.chunk(self.model.num_aux_hidden_states, dim=-1)
+            hidden_states = torch.cat(
+                [norm(chunk) for norm, chunk in zip(self.model.fc_norm, chunks)],
+                dim=-1,
+            )
+
         return self.model.fc(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -183,11 +183,11 @@ class LlamaModel(nn.Module):
             target_hidden_size = getattr(
                 self.config, "target_hidden_size", self.config.hidden_size
             )
-            fc_input_size = target_hidden_size * self.num_aux_hidden_states
+            self.fc_input_size = target_hidden_size * self.num_aux_hidden_states
 
             if self.norm_before_fc:
                 self.input_norm = RMSNorm(
-                    fc_input_size,
+                    self.fc_input_size,
                     eps=self.config.rms_norm_eps,
                 )
             else:
@@ -205,7 +205,7 @@ class LlamaModel(nn.Module):
                 self.fc_norm = None
 
             self.fc = ReplicatedLinear(
-                input_size=fc_input_size,
+                input_size=self.fc_input_size,
                 output_size=self.config.hidden_size,
                 bias=False,
                 params_dtype=vllm_config.model_config.dtype,
@@ -337,17 +337,9 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
 
         if self.use_parallel_drafting:
-            aux_count = (
-                self.model.num_aux_hidden_states
-                if self.model.use_aux_hidden_state
-                else 1
-            )
-            target_hidden_size = getattr(
-                self.config, "target_hidden_size", self.config.hidden_size
-            )
             self.register_buffer(
                 "mask_hidden",
-                torch.zeros(1, aux_count * target_hidden_size),
+                torch.zeros(1, self.model.fc_input_size),
                 persistent=False,
             )
 
@@ -403,6 +395,8 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         if self.model.norm_before_fc:
             hidden_states = self.model.input_norm(hidden_states)
 
+        # `norm_before_fc` adds a single RMSNorm before the FC layer, whereas `fc_norm`
+        # applies separate RMSNorms to each chunk of the hidden states.
         if self.model.fc_norm is not None:
             chunks = hidden_states.chunk(self.model.num_aux_hidden_states, dim=-1)
             hidden_states = torch.cat(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5167,8 +5167,13 @@ class GPUModelRunner(
         layer_ids = getattr(hf_config, "eagle_aux_hidden_state_layer_ids", None)
         if not layer_ids:
             dflash_config = getattr(hf_config, "dflash_config", None)
+            eagle_config = getattr(hf_config, "eagle_config", None)
+
             if dflash_config and isinstance(dflash_config, dict):
                 layer_ids = dflash_config.get("target_layer_ids")
+
+            if eagle_config and isinstance(eagle_config, dict):
+                layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
 
         if layer_ids and isinstance(layer_ids, (list, tuple)):
             return tuple(layer_ids)


### PR DESCRIPTION



## Purpose

Support the post-norm architecture EAGLE-3 models for speculative decoding.

Blog / Twitter Thread: https://x.com/dogacel0/status/2054203929378873661?s=20

1. Support post-norm & individual fc norm architectural changes.
2. Fix a bug in `gpu_model_runner.py` where captured aux layers were not properly configured.

## Test Plan

Run the following script for existing and new gpt-oss speculators.

Existing:
```
num_spec_tokens     : 5
batch (max_num_seqs): 8
num_drafts          : 6590
mean acceptance len : 2.359
  accept@pos 0      : 0.622  (4098)
  accept@pos 1      : 0.356  (2344)
  accept@pos 2      : 0.203  (1339)
  accept@pos 3      : 0.119  (783)
  accept@pos 4      : 0.060  (394)
```

Ours:
```
num_spec_tokens     : 5
batch (max_num_seqs): 8
num_drafts          : 7431
mean acceptance len : 2.346
  accept@pos 0      : 0.610  (4530)
  accept@pos 1      : 0.342  (2544)
  accept@pos 2      : 0.202  (1500)
  accept@pos 3      : 0.120  (891)
  accept@pos 4      : 0.072  (538)
```

The acceptance rate increases especially on deeper positions, longer context and template changes. Those tests just show that both existing and old models work as expected.

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
# spec_decode_gptoss.py
import argparse

from datasets import load_dataset
from transformers import AutoTokenizer

from vllm import LLM, SamplingParams
from vllm.v1.metrics.reader import Counter, Vector

TARGET = "openai/gpt-oss-120b"
# DRAFT  = "RedHatAI/gpt-oss-120b-speculator.eagle3"
# DRAFT = "nvidia/gpt-oss-120b-Eagle3-v3"
DRAFT = "Dogacel/specdrift-gpt-oss-120b-eagle3"

# TARGET = "openai/gpt-oss-20b"
# DRAFT  = "RedHatAI/gpt-oss-20b-speculator.eagle3"
# DRAFT = "Dogacel/specdrift-gpt-oss-20b-eagle3"


def main():
    p = argparse.ArgumentParser()
    p.add_argument("--num_spec_tokens", type=int, default=5)
    p.add_argument("--num_prompts", type=int, default=20)
    p.add_argument("--max_num_seqs", type=int, default=8)
    p.add_argument(
        "--tp", type=int, default=1
    )  # 120B fits on 1xH100 (MXFP4); bump to 2/4 for KV headroom
    p.add_argument("--max_tokens", type=int, default=2048)
    args = p.parse_args()

    tok = AutoTokenizer.from_pretrained(TARGET)
    ds = load_dataset("philschmid/mt-bench", split="train")
    prompts = [
        tok.apply_chat_template(
            [{"role": "user", "content": ex["turns"][0]}],
            tokenize=False,
            add_generation_prompt=True,
        )
        for ex in ds.select(range(args.num_prompts))
    ]

    llm = LLM(
        model=TARGET,
        tensor_parallel_size=1,
        max_num_seqs=8,  # ← drop way down
        max_model_len=4096,  # ← drop further
        gpu_memory_utilization=0.95,  # ← push higher
        enforce_eager=True,  # ← per the RedHatAI 120b card
        enable_prefix_caching=False,
        disable_log_stats=False,
        speculative_config={
            "method": "eagle3",
            "model": DRAFT,
            "num_speculative_tokens": 5,
        },
    )

    sp = SamplingParams(temperature=0.7, max_tokens=args.max_tokens)
    llm.generate(prompts, sp)

    # Pull V1 spec-decode metrics
    metrics = llm.get_metrics()
    num_drafts = num_accepted = 0
    per_pos = None
    for m in metrics:
        if isinstance(m, Counter) and m.name == "vllm:spec_decode_num_drafts":
            num_drafts = m.value
        elif (
            isinstance(m, Counter) and m.name == "vllm:spec_decode_num_accepted_tokens"
        ):
            num_accepted = m.value
        elif (
            isinstance(m, Vector)
            and m.name == "vllm:spec_decode_num_accepted_tokens_per_pos"
        ):
            per_pos = m.values

    mean_al = 1 + num_accepted / max(num_drafts, 1)
    print("-" * 60)
    print(f"num_spec_tokens     : {args.num_spec_tokens}")
    print(f"batch (max_num_seqs): {args.max_num_seqs}")
    print(f"num_drafts          : {num_drafts}")
    print(f"mean acceptance len : {mean_al:.3f}")
    if per_pos:
        for i, c in enumerate(per_pos):
            rate = c / max(num_drafts, 1)
            print(f"  accept@pos {i}      : {rate:.3f}  ({c})")


if __name__ == "__main__":
    main()
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

