### PR TITLE
[Bugfix] _triton_mrope_forward: support GPT-J-style rotation (#42016)

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -29,12 +29,15 @@ def _triton_mrope_forward(
     mrope_section_h: tl.constexpr,
     mrope_section_w: tl.constexpr,
     is_interleaved: tl.constexpr,
+    is_neox_style: tl.constexpr,
 ):
     # Adapted from
     # https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/qwen2vl_mrope.py
     # This version supports flatten input tensors from vllm
     # and supports cos and sin cache with shape (3, num_tokens, head_dim // 2)
     # instead of (3, bsz, seq_len, head_dim), also supports interleaved rotary
+    # and both NeoX-style (pair (i, i+rd/2)) and GPT-J-style (pair (2i, 2i+1))
+    # rotations via the is_neox_style flag.
     pid = tl.program_id(0)
     # locate start address
     q_ptr = q_ptr + pid * (n_qh * hd)
@@ -79,15 +82,24 @@ def _triton_mrope_forward(
     sin_row = t_sin_row + h_sin_row + w_sin_row
 
     # ####################################################################
-    # Load the left and right half of q and k for the current
-    # program instance (i.e. for the current token) separately
+    # Load the two paired halves of q and k for the current token.
+    # NeoX-style pairs (i, i + rd/2) → first half is contiguous low indices.
+    # GPT-J-style pairs (2i, 2i+1) → halves are even / odd elements.
+    # The math below (cos * x1 - sin * x2, ...) is the same either way;
+    # only the offset stride differs, so we branch on is_neox_style.
     # ####################################################################
-    # left half of the head
+    if is_neox_style:
+        first_half_col = tl.arange(0, pad_hd // 2)
+        pair_stride = rd // 2
+    else:
+        first_half_col = tl.arange(0, pad_hd // 2) * 2
+        pair_stride = 1
+
     first_half_q_offsets = (
-        tl.arange(0, pad_n_qh)[:, None] * hd + tl.arange(0, pad_hd // 2)[None, :]
+        tl.arange(0, pad_n_qh)[:, None] * hd + first_half_col[None, :]
     )
     first_half_k_offsets = (
-        tl.arange(0, pad_n_kh)[:, None] * hd + tl.arange(0, pad_hd // 2)[None, :]
+        tl.arange(0, pad_n_kh)[:, None] * hd + first_half_col[None, :]
     )
     first_q_mask = (tl.arange(0, pad_n_qh)[:, None] < n_qh) & (
         tl.arange(0, pad_hd // 2)[None, :] < rd // 2
@@ -103,9 +115,9 @@ def _triton_mrope_forward(
         sin_row.dtype
     )
 
-    # right half of the head
-    second_half_q_offsets = first_half_q_offsets + (rd // 2)
-    second_half_k_offsets = first_half_k_offsets + (rd // 2)
+    # right half (NeoX) / odd elements (GPT-J)
+    second_half_q_offsets = first_half_q_offsets + pair_stride
+    second_half_k_offsets = first_half_k_offsets + pair_stride
     second_q_mask = first_q_mask
     second_k_mask = first_k_mask
 
@@ -139,8 +151,9 @@ def triton_mrope(
     head_size: int,
     rotary_dim: int,
     mrope_interleaved: bool,
+    is_neox_style: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Qwen2VL mrope kernel.
+    """mrope kernel supporting both NeoX-style and GPT-J-style rotation.
 
     Args:
         q: [num_tokens, num_heads * head_size]
@@ -151,6 +164,8 @@ def triton_mrope(
             (T/H/W positions with multimodal inputs)
         mrope_section: [t, h, w]
         head_size: int
+        is_neox_style: True for NeoX (pair (i, i+rd/2)),
+            False for GPT-J / interleaved (pair (2i, 2i+1)).
     """
     n_row, n_q_head_head_dim = q.shape
     n_q_head = n_q_head_head_dim // head_size
@@ -183,6 +198,7 @@ def triton_mrope(
         mrope_section[1],
         mrope_section[2],
         mrope_interleaved,
+        is_neox_style,
     )
     return q, k
 
@@ -349,6 +365,7 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
                 self.head_size,
                 self.rotary_dim,
                 self.mrope_interleaved,
+                self.is_neox_style,
             )
 
             return q.reshape(query_shape), k.reshape(key_shape)


### PR DESCRIPTION
The mrope kernel previously hardcoded NeoX-style rotation (pair (i, i + rd/2)) and produced incorrect output for mrope models which set is_neox_style=False (GLM-OCR, GLM-4.1V) and use GPT-J / interleaved rotation (pair (2i, 2i+1)). Add an is_neox_style constexpr that branches the offset computation; cos/sin loading and rotation math are unchanged. The NeoX path JIT-specializes to the same kernel as before, so Qwen2-VL / Qwen2.5-VL are unaffected.



## Purpose

Fixes #42016: GLM-OCR and GLM-4.1V produce incorrect output on image inputs (text-only generation is unaffected).

`MRotaryEmbedding.forward_cuda` dispatches every 2-D mrope position into `_triton_mrope_forward`, which hardcoded NeoX-style rotation (pairs `(i, i + rotary_dim/2)`). GLM models construct their rotary with `is_neox_style=False` ([`vllm/model_executor/models/glm4.py:124`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/glm4.py#L124)) because they use GPT-J / interleaved rotation (pairs `(2i, 2i+1)`). The kernel never read the flag, so every decoder layer's attention silently received the wrong rotation, corrupting outputs at every layer.

Text-only generation was unaffected because 1-D positions bypass the kernel and fall through to `ApplyRotaryEmb`, which already honors `is_neox_style`.

This PR adds an `is_neox_style: tl.constexpr` parameter to `_triton_mrope_forward` that branches the offset computation:

- **NeoX-style** (`is_neox_style=True`): first half = `arange(rd/2)`, second half = first + `rd/2` (unchanged from before)
- **GPT-J-style** (`is_neox_style=False`): first half = `arange(rd/2) * 2` (even indices), second half = first + `1` (odd indices)

The cos/sin loading is identical between styles (one cos per pair), and the rotation math (`x1 * cos - x2 * sin`, ...) is identical. Only the stride pattern of the loads/stores changes. Triton specializes the constexpr at JIT time, so the NeoX path compiles to the same machine code as today — no runtime branching, no perf hit on Qwen2-VL / Qwen2.5-VL.

The only model family in vLLM that constructs `MRotaryEmbedding` with `is_neox_style=False` is `glm4.py` (covers GLM-4V, GLM-OCR, GLM-4.1V, GLM-4.5V/4.6V). Verified by exhaustive grep of `is_neox_style=False` cross-referenced with `MRotaryEmbedding` construction; `mllama4` is vision-tower-only, `ernie45_vl_moe` uses its own rotary class, all other matches are text-only models without `mrope_section`.

## Test Plan

Tested on AMD MI300 (gfx942), ROCm 7.2, `rocm/vllm-dev:base`.

**Originally failing test (the reported reproduction):**
```bash
pytest -sv tests/models/multimodal/generation/test_common.py::test_multi_image_models[glm_ocr-test_case103]
```

**GPT-J kernel path — every fixture for `is_neox_style=False` multimodal models:**
```bash
pytest -v tests/models/multimodal/generation/test_common.py -k "glm_ocr"
pytest -v tests/models/multimodal/generation/test_common.py -k "glm4_1v and not video"
pytest -v tests/models/multimodal/generation/test_common.py -k "glm4_1v-video"
pytest -v tests/models/multimodal/generation/test_common.py -k "glm4v and not glm4_1v"
```

**NeoX kernel path regression check (unchanged JIT-specialization):**
```bash
pytest -v tests/models/multimodal/generation/test_common.py -k "qwen2_5_vl and (single_image or multi_image)"
pytest -v tests/models/multimodal/generation/test_common.py -k "qwen2_vl and not qwen2_5_vl and (single_image or multi_image)"
pytest -v tests/models/multimodal/generation/test_common.py -k "llama4"
```

**Smoke check — text-only / 1-D position path (logically cannot fire):**
Single-prompt generation via `LLM(...).generate("The capital of France is", max_tokens=30)`:
- `Qwen/Qwen2.5-0.5B-Instruct`
- `unsloth/Llama-3.2-1B-Instruct`
- `microsoft/Phi-3.5-mini-instruct`

**Throughput comparison:**
```bash
vllm bench throughput --model zai-org/GLM-OCR --num-prompts 8 --max-model-len 2048 --enforce-eager --trust-remote-code
```

## Test Result

**GPT-J kernel path (the path this PR fixes):**

| Fixture | Result | Time |
|---|---|---|
| `glm_ocr` (3 single + 3 multi) | ✅ 6 / 6 passed | 3:34 |
| `glm4_1v` (3 single + 3 multi) | ✅ 6 / 6 passed | 11:39 |
| `glm4_1v-video` | ✅ 1 / 1 passed | 2:03 |

The `glm4v` failures are `AttributeError: 'ChatGLMConfig' object has no attribute 'max_length'` raised inside `transformers/configuration_utils.py` during HF reference-runner setup, before the comparator runs. vLLM itself loaded `zai-org/glm-4v-9b` and built the KV cache successfully in all three cases. The error reproduces on `main` with this PR reverted — pre-existing transformers ↔ `trust_remote_code` config incompatibility, unrelated to this PR.

**NeoX kernel path (regression check):**

| Fixture | Result | Time |
|---|---|---|
| `qwen2_5_vl` (3 single + 3 multi) | ✅ 6 / 6 passed | 6:50 |
| `qwen2_vl` (3 single + 3 multi) | ✅ 6 / 6 passed | 5:13 |

**Text-only smoke:**

| Model | Result | Output |
|---|---|---|
| `Qwen/Qwen2.5-0.5B-Instruct` | ✅ | `' Paris. It is the largest city in Europe and the third largest...'` |
| `unsloth/Llama-3.2-1B-Instruct` | ✅ | `' Paris. The Eiffel Tower is located in Paris...'` |
| `microsoft/Phi-3.5-mini-instruct` | ✅ | `' Paris.\n\nParis is the capital city of France...'` |

**Throughput (GLM-OCR, 8 prompts, 1024 output tokens each):**

| Branch | Throughput | Total tok/s | Output tok/s | Output |
|---|---|---|---|---|
| `main` (kernel = NeoX only) | 4.17 req/s | 4800.23 | 533.36 | **incorrect** |
| This PR (kernel supports both styles) | 4.82 req/s | 5552.92 | 616.99 | **correct** |

Throughput is at parity with main (the +15% delta is within single-shot benchmark noise — typically ~10% run-to-run). The NeoX path JIT-specializes to the same machine code as today, so Qwen2-VL / Qwen2.5-VL performance is unchanged.

**Output match against HF reference (qualitative, on the original failing case):**

```
HF gold:  top-1 @ idx 0 = ' Image' (logprob -0.1087)
Pre-fix:  top-1 @ idx 0 = ' ST'    (logprob -1.2777)   # 'STOP sign' instead of 'Image-1:'
This PR:  top-1 @ idx 0 = ' Image' (logprob -0.1089)   # matches HF to 4 decimals
```

---

AI-assistance: this fix was developed with assistance from Claude. The author reviewed every line, ran the reproducer, and stands behind the change.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

