### PR TITLE
[CI/Build] Resolve LMCache wheels by CUDA major

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -837,6 +837,7 @@ ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \
+    --mount=type=bind,source=tools/resolve_kv_connector_requirements.py,target=/tmp/resolve_kv_connector_requirements.py,ro \
     CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
     CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
     CUDA_HOME=/usr/local/cuda; \
@@ -845,16 +846,19 @@ RUN --mount=type=cache,target=/root/.cache/uv \
                 libcublas-dev-${CUDA_VERSION_DASH} \
                 libcusolver-dev-${CUDA_VERSION_DASH}"; \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
+        python3 /tmp/resolve_kv_connector_requirements.py \
+            --input /tmp/kv_connectors.txt \
+            --output /tmp/kv_connectors.resolved.txt \
+            --cuda-major "${CUDA_MAJOR}" && \
+        ( uv pip install --system -r /tmp/kv_connectors.resolved.txt --no-build || ( \
             # if the above fails, install from source
             apt-get update -y && \
             apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
-            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
+            uv pip install --system -r /tmp/kv_connectors.resolved.txt --no-build-isolation && \
             apt-get purge -y ${BUILD_PKGS} && \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \
-        ); \
-        # Force-reinstall the matching CUDA wheel so the correct nixl_ep_cpp.so is installed.
+        ) ) && \
         uv pip install --system --force-reinstall --no-deps nixl-cu${CUDA_MAJOR}; \
     fi
 

--- a/tests/tools/test_resolve_kv_connector_requirements.py
+++ b/tests/tools/test_resolve_kv_connector_requirements.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.resolve_kv_connector_requirements import resolve_requirements
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
+KV_CONNECTOR_REQUIREMENTS = REPO_ROOT / "requirements" / "kv_connectors.txt"
+
+
+def _section_between(text: str, start_marker: str, end_marker: str) -> str:
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return text[start:end]
+
+
+def test_rewrites_kv_connector_requirements_for_cuda12() -> None:
+    content = (
+        "lmcache >= 0.3.9\n"
+        "nixl >= 1.1.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+    resolved = resolve_requirements(content, cuda_major=12)
+
+    assert resolved == (
+        "lmcache >= 0.3.9, < 0.4.5\n"
+        "nixl-cu12 >= 1.1.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+
+def test_rewrites_kv_connector_requirements_for_cuda13() -> None:
+    content = (
+        "lmcache >= 0.3.9\n"
+        "nixl >= 1.1.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+    resolved = resolve_requirements(content, cuda_major=13)
+
+    assert resolved == (
+        "lmcache >= 0.4.5\n"
+        "nixl-cu13 >= 1.1.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+
+def test_preserves_blank_lines_comments_and_indentation() -> None:
+    content = "\n# comment\n  lmcache >= 0.3.9 # cache connector\n\nnixl >= 1.1.0\n"
+
+    resolved = resolve_requirements(content, cuda_major=13)
+
+    assert resolved == (
+        "\n# comment\n  lmcache >= 0.4.5 # cache connector\n\nnixl-cu13 >= 1.1.0\n"
+    )
+
+
+def test_repo_kv_connector_requirements_resolve_cleanly_for_cuda12() -> None:
+    resolved = resolve_requirements(
+        KV_CONNECTOR_REQUIREMENTS.read_text(),
+        cuda_major=12,
+    )
+
+    assert "lmcache >= 0.3.9, < 0.4.5" in resolved
+    assert "nixl-cu12 >= 1.1.0" in resolved
+    assert "cupy-cuda13x" not in resolved
+    assert "\nnixl >=" not in f"\n{resolved}"
+
+
+def test_repo_kv_connector_requirements_resolve_cleanly_for_cuda13() -> None:
+    resolved = resolve_requirements(
+        KV_CONNECTOR_REQUIREMENTS.read_text(),
+        cuda_major=13,
+    )
+
+    assert "lmcache >= 0.4.5" in resolved
+    assert "nixl-cu13 >= 1.1.0" in resolved
+    assert "cupy-cuda12x" not in resolved
+    assert "\nnixl >=" not in f"\n{resolved}"
+
+
+def test_cli_resolves_cuda13_requirements(tmp_path: Path) -> None:
+    input_path = tmp_path / "kv_connectors.txt"
+    output_path = tmp_path / "kv_connectors.resolved.txt"
+    input_path.write_text(
+        "lmcache >= 0.3.9\n"
+        "nixl >= 1.1.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tools" / "resolve_kv_connector_requirements.py"),
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--cuda-major",
+            "13",
+        ],
+        check=True,
+    )
+
+    resolved = output_path.read_text()
+    assert "lmcache >= 0.4.5" in resolved
+    assert "nixl-cu13 >= 1.1.0" in resolved
+    assert "nixl-cu12" not in resolved
+
+
+def test_dockerfile_uses_resolved_kv_connector_requirements() -> None:
+    dockerfile = DOCKERFILE.read_text()
+    kv_section = _section_between(
+        dockerfile,
+        "# install kv_connectors if requested",
+        "ENV VLLM_USAGE_SOURCE production-docker-image",
+    )
+
+    assert "tools/resolve_kv_connector_requirements.py" in kv_section
+    assert "/tmp/kv_connectors.resolved.txt" in kv_section
+    assert "python3 /tmp/resolve_kv_connector_requirements.py" in kv_section
+    assert '--cuda-major "${CUDA_MAJOR}"' in kv_section
+    assert "uv pip install --system -r /tmp/kv_connectors.resolved.txt --no-build" in (
+        kv_section
+    )
+    assert (
+        "uv pip install --system -r /tmp/kv_connectors.resolved.txt "
+        "--no-build-isolation"
+    ) in kv_section

--- a/tools/resolve_kv_connector_requirements.py
+++ b/tools/resolve_kv_connector_requirements.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Resolve CUDA-specific kv connector dependencies for Docker builds."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+_LMCACHE_CUDA13_REQ = "lmcache >= 0.4.5"
+_LMCACHE_CUDA12_REQ = "lmcache >= 0.3.9, < 0.4.5"
+_NAME_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+)
+
+
+def _normalize_name(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def _split_comment(suffix: str) -> tuple[str, str]:
+    if "#" not in suffix:
+        return suffix.rstrip(), ""
+
+    requirement, comment = suffix.split("#", 1)
+    return requirement.rstrip(), f" #{comment}"
+
+
+def _split_requirement(line: str) -> tuple[str, str, str] | None:
+    stripped = line.lstrip()
+    if not stripped or stripped.startswith("#"):
+        return None
+
+    name_start = len(line) - len(stripped)
+    if stripped[0] not in _NAME_CHARS or not stripped[0].isalnum():
+        return None
+
+    name_end = name_start
+    while name_end < len(line) and line[name_end] in _NAME_CHARS:
+        name_end += 1
+
+    return line[:name_start], line[name_start:name_end], line[name_end:]
+
+
+def _replace_requirement(line: str, requirement: str) -> str:
+    split = _split_requirement(line)
+    if split is None:
+        return line
+
+    indent, _, suffix = split
+    _, comment = _split_comment(suffix)
+    return f"{indent}{requirement}{comment}"
+
+
+def _replace_package_name(line: str, replacement: str) -> str:
+    split = _split_requirement(line)
+    if split is None:
+        return line
+
+    indent, _, suffix = split
+    return f"{indent}{replacement}{suffix}"
+
+
+def _package_name(line: str) -> str | None:
+    split = _split_requirement(line)
+    if split is None:
+        return None
+
+    _, name, _ = split
+    return _normalize_name(name)
+
+
+def resolve_requirements(content: str, cuda_major: int) -> str:
+    output_lines: list[str] = []
+    nixl_runtime = f"nixl-cu{cuda_major}"
+    lmcache_req = _LMCACHE_CUDA13_REQ if cuda_major >= 13 else _LMCACHE_CUDA12_REQ
+
+    for line in content.splitlines():
+        package_name = _package_name(line)
+        if package_name is None:
+            output_lines.append(line)
+            continue
+
+        if package_name == "lmcache":
+            line = _replace_requirement(line, lmcache_req)
+        elif package_name == "nixl":
+            line = _replace_package_name(line, nixl_runtime)
+
+        output_lines.append(line)
+
+    return "\n".join(output_lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rewrite kv connector requirements to use CUDA-runtime-specific "
+            "packages during Docker builds."
+        )
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--cuda-major", required=True, type=int)
+    args = parser.parse_args()
+
+    args.output.write_text(
+        resolve_requirements(
+            content=args.input.read_text(),
+            cuda_major=args.cuda_major,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Fixes #37801.

The CUDA 13 optional KV connector Docker install currently lets the generic `lmcache >= 0.3.9` requirement resolve to whatever the latest LMCache wheel is. That was broken before LMCache 0.4.5 because the latest wheel was CUDA-12-linked; after LMCache 0.4.5, the same floating lower bound would also make CUDA 12 images pick the new CUDA 13 default wheel.

This resolves the connector requirements by CUDA major at Docker build time:

- CUDA 13 resolves `lmcache` to `lmcache >= 0.4.5` and `nixl` to `nixl-cu13`.
- CUDA 12 resolves `lmcache` to `lmcache >= 0.3.9, < 0.4.5` and `nixl` to `nixl-cu12`.
- The existing source-build fallback remains available, but the normal CUDA 13 path now uses the released LMCache cu13 wheel instead of rebuilding LMCache from source.

## Duplicate-work check

This is not duplicating #37802. That PR is open but conflicting and predates the LMCache 0.4.5 release; its CUDA 13 path skips the LMCache wheel and rebuilds LMCache from source. This PR uses the newly released LMCache 0.4.5 wheel, whose `c_ops` extension links against `libcudart.so.13`, and also protects CUDA 12 from accidentally resolving that cu13-default wheel.

I checked:

- `gh issue view 37801 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "37801 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "CUDA 13 LMCache"`
- `gh pr list --repo vllm-project/vllm --state open --search "lmcache cu13"`
- `gh pr list --repo vllm-project/vllm --state open --search "lmcache cuda13"`

## Test Plan

- `.venv/bin/python -m pytest --noconftest tests/tools/test_resolve_kv_connector_requirements.py -q`
- `.venv/bin/ruff check tools/resolve_kv_connector_requirements.py tests/tools/test_resolve_kv_connector_requirements.py`
- `.venv/bin/ruff format --check tools/resolve_kv_connector_requirements.py tests/tools/test_resolve_kv_connector_requirements.py`
- `git commit` staged-file pre-commit suite, including ruff, mypy-local, SPDX, forbidden imports, Dockerfile dependency graph, and signoff hooks
- `docker buildx build --check -f docker/Dockerfile .` parsed the Dockerfile successfully; it reported only existing Dockerfile warnings unrelated to this change
- `uv pip compile` sanity checks for generated CUDA 12 and CUDA 13 connector requirement files
- Inspected LMCache cp312 wheel dynamic deps with `readelf -d`: LMCache 0.4.4 needs `libcudart.so.12`; LMCache 0.4.5 needs `libcudart.so.13`

## AI Assistance

This PR was prepared with AI assistance. I reviewed the changed lines, checked the existing issue and stale PR, and ran the listed validation commands.
