### PR TITLE
Add opt-in draft vocab padding for speculative decoding

### DIFF
--- a/tests/config/test_speculative_vocab_padding.py
+++ b/tests/config/test_speculative_vocab_padding.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import SpeculativeConfig
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _FakeModelConfig:
+    def __init__(self, vocab_size: int):
+        self.hf_text_config = SimpleNamespace(vocab_size=vocab_size)
+        self.hf_config = SimpleNamespace(
+            vocab_size=vocab_size,
+            text_config=self.hf_text_config,
+        )
+        self.model_arch_config = SimpleNamespace(vocab_size=vocab_size)
+
+    def get_vocab_size(self) -> int:
+        return self.model_arch_config.vocab_size
+
+    def verify_with_parallel_config(self, parallel_config):
+        pass
+
+
+def _new_speculative_config(
+    *,
+    method: str = "draft_model",
+    allow_vocab_padding: bool = False,
+    use_heterogeneous_vocab: bool = False,
+    target_vocab_size: int = 20,
+    draft_vocab_size: int = 14,
+):
+    config = object.__new__(SpeculativeConfig)
+    config.tensor_parallel_size = None
+    config.num_speculative_tokens = 1
+    config.rejection_sample_method = "standard"
+    config.synthetic_acceptance_rates = None
+    config.synthetic_acceptance_length = None
+    config.method = method
+    config.allow_draft_model_vocab_padding = allow_vocab_padding
+    config.use_heterogeneous_vocab = use_heterogeneous_vocab
+    config.draft_sample_method = "greedy"
+    config.draft_model_unpadded_vocab_size = None
+    config.target_model_config = _FakeModelConfig(target_vocab_size)
+    config.draft_model_config = _FakeModelConfig(draft_vocab_size)
+    config.draft_parallel_config = None
+    return config
+
+
+def test_draft_model_vocab_mismatch_still_rejected_by_default():
+    config = _new_speculative_config()
+
+    with pytest.raises(ValueError, match="same vocabulary size"):
+        SpeculativeConfig.verify_equal_vocab_size_if_draft_model(config)
+
+
+def test_draft_model_vocab_padding_updates_runtime_vocab_size():
+    config = _new_speculative_config(allow_vocab_padding=True)
+
+    SpeculativeConfig._maybe_enable_draft_model_vocab_padding(config)
+
+    assert config.draft_model_unpadded_vocab_size == 14
+    assert config.draft_model_config.get_vocab_size() == 20
+    assert config.draft_model_config.hf_config.vocab_size == 20
+    assert config.draft_model_config.hf_text_config.vocab_size == 20
+    SpeculativeConfig.verify_equal_vocab_size_if_draft_model(config)
+
+
+@pytest.mark.parametrize("method", ["eagle", "mtp", "ngram"])
+def test_draft_model_vocab_padding_only_supports_draft_model(method):
+    config = _new_speculative_config(
+        method=method,
+        allow_vocab_padding=True,
+    )
+
+    with pytest.raises(ValueError, match="method='draft_model'"):
+        SpeculativeConfig._maybe_enable_draft_model_vocab_padding(config)
+
+
+def test_draft_model_vocab_padding_rejects_heterogeneous_vocab_mode():
+    config = _new_speculative_config(
+        allow_vocab_padding=True,
+        use_heterogeneous_vocab=True,
+    )
+
+    with pytest.raises(ValueError, match="cannot be enabled together"):
+        SpeculativeConfig._verify_args(config)
+
+
+@pytest.mark.parametrize(
+    ("target_vocab_size", "draft_vocab_size"),
+    [(20, 20), (14, 20)],
+)
+def test_draft_model_vocab_padding_requires_larger_target_vocab(
+    target_vocab_size,
+    draft_vocab_size,
+):
+    config = _new_speculative_config(
+        allow_vocab_padding=True,
+        target_vocab_size=target_vocab_size,
+        draft_vocab_size=draft_vocab_size,
+    )
+
+    with pytest.raises(ValueError, match="target model vocabulary to be larger"):
+        SpeculativeConfig._maybe_enable_draft_model_vocab_padding(config)

--- a/tests/model_executor/layers/test_vocab_parallel_embedding.py
+++ b/tests/model_executor/layers/test_vocab_parallel_embedding.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _draft_vocab_padding_config(unpadded_vocab_size: int):
+    return SimpleNamespace(
+        model_config=SimpleNamespace(runner_type="draft"),
+        speculative_config=SimpleNamespace(
+            allow_draft_model_vocab_padding=True,
+            draft_model_unpadded_vocab_size=unpadded_vocab_size,
+        ),
+    )
+
+
+def _new_vocab_layer(
+    layer_cls: type[VocabParallelEmbedding],
+    *,
+    rank: int = 0,
+    tp_size: int = 1,
+    vocab_size: int = 20,
+    hidden_size: int = 3,
+    loaded_vocab_size: int | None = None,
+):
+    current_config = (
+        None
+        if loaded_vocab_size is None
+        else _draft_vocab_padding_config(loaded_vocab_size)
+    )
+    with (
+        patch(
+            "vllm.model_executor.layers.vocab_parallel_embedding."
+            "get_current_vllm_config_or_none",
+            return_value=current_config,
+        ),
+        patch(
+            "vllm.model_executor.layers.vocab_parallel_embedding."
+            "get_tensor_model_parallel_rank",
+            return_value=rank,
+        ),
+        patch(
+            "vllm.model_executor.layers.vocab_parallel_embedding."
+            "get_tensor_model_parallel_world_size",
+            return_value=tp_size,
+        ),
+    ):
+        return layer_cls(vocab_size, hidden_size, padding_size=8)
+
+
+@pytest.mark.parametrize("layer_cls", [VocabParallelEmbedding, ParallelLMHead])
+def test_short_loaded_vocab_tensor_requires_opt_in(layer_cls):
+    layer = _new_vocab_layer(layer_cls)
+    loaded_weight = torch.empty(14, 3)
+
+    with pytest.raises(AssertionError):
+        layer.weight_loader(layer.weight, loaded_weight)
+
+
+@pytest.mark.parametrize("layer_cls", [VocabParallelEmbedding, ParallelLMHead])
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+def test_short_loaded_vocab_tensor_is_zero_padded(layer_cls, tp_size):
+    vocab_size = 20
+    loaded_vocab_size = 14
+    hidden_size = 3
+    loaded_weight = torch.arange(
+        loaded_vocab_size * hidden_size, dtype=torch.float32
+    ).view(loaded_vocab_size, hidden_size)
+
+    for rank in range(tp_size):
+        layer = _new_vocab_layer(
+            layer_cls,
+            rank=rank,
+            tp_size=tp_size,
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            loaded_vocab_size=loaded_vocab_size,
+        )
+
+        layer.weight_loader(layer.weight, loaded_weight)
+
+        shard = layer.shard_indices
+        local_start = min(shard.org_vocab_start_index, loaded_vocab_size)
+        local_end = min(shard.org_vocab_end_index, loaded_vocab_size)
+        copied_rows = local_end - local_start
+        expected = torch.zeros_like(layer.weight)
+        if copied_rows > 0:
+            expected[:copied_rows] = loaded_weight[local_start:local_end]
+
+        torch.testing.assert_close(layer.weight, expected)
+
+
+@pytest.mark.parametrize("bad_loaded_vocab_size", [13, 15])
+def test_opt_in_loaded_vocab_size_must_match_recorded_size(bad_loaded_vocab_size):
+    layer = _new_vocab_layer(
+        VocabParallelEmbedding,
+        loaded_vocab_size=14,
+    )
+    loaded_weight = torch.empty(bad_loaded_vocab_size, 3)
+
+    with pytest.raises(ValueError, match="unpadded draft vocab size"):
+        layer.weight_loader(layer.weight, loaded_weight)
+
+
+def test_draft_vocab_padding_rejects_packed_vocab_weight():
+    layer = _new_vocab_layer(VocabParallelEmbedding, loaded_vocab_size=14)
+    layer.weight.packed_dim = 0
+
+    with pytest.raises(ValueError, match="packed weights"):
+        layer.weight_loader(layer.weight, torch.empty(14, 3))
+
+
+def test_draft_vocab_padding_rejects_nonzero_output_dim():
+    layer = _new_vocab_layer(VocabParallelEmbedding, loaded_vocab_size=14)
+    param = torch.nn.Parameter(torch.empty(3, layer.num_embeddings_per_partition))
+    param.output_dim = 1
+
+    with pytest.raises(ValueError, match="output_dim=0"):
+        layer.weight_loader(param, torch.empty(3, 14))
+
+
+def test_full_logits_mask_padded_draft_vocab_rows():
+    layer = _new_vocab_layer(
+        VocabParallelEmbedding,
+        vocab_size=6,
+        hidden_size=1,
+        loaded_vocab_size=4,
+    )
+    layer.weight.data.zero_()
+    layer.weight.data[:4, 0] = torch.tensor([-4.0, -3.0, -2.0, -1.0])
+    processor = LogitsProcessor(vocab_size=6)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.logits_processor.tensor_model_parallel_gather",
+            side_effect=lambda logits: logits,
+        ),
+        patch(
+            "vllm.model_executor.layers.logits_processor."
+            "tensor_model_parallel_all_gather",
+            side_effect=lambda logits: logits,
+        ),
+    ):
+        logits = processor(layer, torch.ones(1, 1))
+
+    assert logits is not None
+    assert torch.isneginf(logits[0, 4:6]).all()
+    torch.testing.assert_close(logits[0, :4], torch.tensor([-4.0, -3.0, -2.0, -1.0]))
+
+
+def test_local_argmax_masks_padded_draft_vocab_rows():
+    layer = _new_vocab_layer(
+        VocabParallelEmbedding,
+        vocab_size=6,
+        hidden_size=1,
+        loaded_vocab_size=4,
+    )
+    layer.weight.data.zero_()
+    layer.weight.data[:4, 0] = torch.tensor([-4.0, -3.0, -2.0, -1.0])
+    processor = LogitsProcessor(vocab_size=6)
+
+    with patch(
+        "vllm.model_executor.layers.logits_processor."
+        "get_tensor_model_parallel_world_size",
+        return_value=1,
+    ):
+        top_tokens = processor.get_top_tokens(layer, torch.ones(1, 1))
+
+    assert top_tokens.item() == 3

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -138,6 +138,10 @@ class SpeculativeConfig:
     for draft token generation. Reduces communication from O(vocab_size) to
     O(2 * tp_size) per token. Only applies to greedy draft selection in
     non-tree speculation."""
+    allow_draft_model_vocab_padding: bool = False
+    """Allow a draft model checkpoint with a suffix-shorter vocabulary to be
+    zero-padded to the target model vocabulary size. This is only supported for
+    draft_model speculative decoding and assumes token IDs are prefix-compatible."""
 
     use_heterogeneous_vocab: bool = False
     """Allow draft and target models to use different vocabularies.
@@ -179,6 +183,8 @@ class SpeculativeConfig:
     """The configuration of the draft model initialized internal."""
     draft_parallel_config: SkipValidation[ParallelConfig] = None  # type: ignore
     """The parallel configuration for the draft model initialized internal."""
+    draft_model_unpadded_vocab_size: int | None = None
+    """The draft checkpoint vocabulary size before opt-in vocab padding."""
 
     # Suffix decoding configuration
     suffix_decoding_max_tree_depth: int = 24
@@ -1061,6 +1067,57 @@ class SpeculativeConfig:
 
         return draft_parallel_config
 
+    @staticmethod
+    def _set_model_config_vocab_size(
+        model_config: ModelConfig, vocab_size: int
+    ) -> None:
+        hf_config = model_config.hf_config
+        hf_text_config = model_config.hf_text_config
+        for hf_config_obj in (
+            hf_config,
+            hf_text_config,
+            getattr(hf_config, "text_config", None),
+        ):
+            if hf_config_obj is not None and hasattr(hf_config_obj, "vocab_size"):
+                hf_config_obj.vocab_size = vocab_size
+        model_config.model_arch_config.vocab_size = vocab_size
+
+    def _maybe_enable_draft_model_vocab_padding(self) -> None:
+        if not self.allow_draft_model_vocab_padding:
+            self.draft_model_unpadded_vocab_size = None
+            return
+
+        if self.method != "draft_model":
+            raise ValueError(
+                "allow_draft_model_vocab_padding is only supported with "
+                "method='draft_model'."
+            )
+        if self.target_model_config is None or self.draft_model_config is None:
+            raise ValueError(
+                "allow_draft_model_vocab_padding requires both target and draft "
+                "model configs."
+            )
+
+        target_vocab_size = self.target_model_config.get_vocab_size()
+        draft_vocab_size = self.draft_model_config.get_vocab_size()
+        if target_vocab_size <= draft_vocab_size:
+            raise ValueError(
+                "allow_draft_model_vocab_padding requires the target model "
+                "vocabulary to be larger than the draft model vocabulary. "
+                f"Got target vocab_size={target_vocab_size}, draft "
+                f"vocab_size={draft_vocab_size}."
+            )
+
+        self.draft_model_unpadded_vocab_size = draft_vocab_size
+        self._set_model_config_vocab_size(self.draft_model_config, target_vocab_size)
+        logger.warning_once(
+            "Zero-padding draft model vocabulary from %d to %d tokens. This "
+            "requires suffix-compatible token IDs; heterogeneous tokenizers or "
+            "token ID reordering are not supported.",
+            draft_vocab_size,
+            target_vocab_size,
+        )
+
     @field_validator("attention_backend", mode="before")
     @classmethod
     def _parse_attention_backend(cls, value: Any) -> Any:
@@ -1125,6 +1182,13 @@ class SpeculativeConfig:
                 "omit it."
             )
 
+        if self.allow_draft_model_vocab_padding and self.use_heterogeneous_vocab:
+            raise ValueError(
+                "allow_draft_model_vocab_padding and use_heterogeneous_vocab "
+                "cannot be enabled together."
+            )
+
+        self._maybe_enable_draft_model_vocab_padding()
         if not self.use_heterogeneous_vocab:
             self.verify_equal_vocab_size_if_draft_model()
         return self

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -100,6 +100,12 @@ class LogitsProcessor(PluggableLayer):
 
         # Remove paddings in vocab (if any).
         if logits is not None:
+            loaded_org_vocab_size = getattr(lm_head, "loaded_org_vocab_size", None)
+            if (
+                loaded_org_vocab_size is not None
+                and loaded_org_vocab_size < self.org_vocab_size
+            ):
+                logits[..., loaded_org_vocab_size : self.org_vocab_size] = -float("inf")
             logits = logits[..., : self.org_vocab_size]
         return logits
 
@@ -129,6 +135,18 @@ class LogitsProcessor(PluggableLayer):
             logits = logits * self.scale
 
         # Mask out padding entries beyond org_vocab_size on this shard.
+        loaded_org_vocab_size = getattr(lm_head, "loaded_org_vocab_size", None)
+        if (
+            loaded_org_vocab_size is not None
+            and loaded_org_vocab_size < lm_head.org_vocab_size
+        ):
+            vocab_start = lm_head.shard_indices.org_vocab_start_index
+            vocab_end = lm_head.shard_indices.org_vocab_end_index
+            mask_start = max(loaded_org_vocab_size, vocab_start) - vocab_start
+            mask_end = vocab_end - vocab_start
+            if mask_start < mask_end:
+                logits[..., mask_start:mask_end] = -float("inf")
+
         num_pad = lm_head.shard_indices.num_org_vocab_padding
         if num_pad > 0:
             logits[..., -num_pad:] = -float("inf")

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
 import vllm.envs as envs
+from vllm.config import get_current_vllm_config_or_none
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -262,6 +263,7 @@ class VocabParallelEmbedding(PluggableLayer):
             self.org_vocab_size_padded + num_added_embeddings, self.padding_size
         )
         assert self.org_vocab_size_padded <= self.num_embeddings_padded
+        self.loaded_org_vocab_size = self._get_loaded_org_vocab_size()
 
         self.shard_indices = self._get_indices(
             self.num_embeddings_padded,
@@ -323,6 +325,25 @@ class VocabParallelEmbedding(PluggableLayer):
             params_dtype=params_dtype,
             weight_loader=self.weight_loader,
         )
+
+    def _get_loaded_org_vocab_size(self) -> int | None:
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return None
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is None:
+            return None
+        if not speculative_config.allow_draft_model_vocab_padding:
+            return None
+        if vllm_config.model_config.runner_type != "draft":
+            return None
+        loaded_org_vocab_size = speculative_config.draft_model_unpadded_vocab_size
+        if (
+            loaded_org_vocab_size is None
+            or loaded_org_vocab_size >= self.org_vocab_size
+        ):
+            return None
+        return loaded_org_vocab_size
 
     @classmethod
     def _get_indices(
@@ -450,6 +471,10 @@ class VocabParallelEmbedding(PluggableLayer):
 
         # If param packed on the same dim we are sharding on, then
         # need to adjust offsets of loaded weight by pack_factor.
+        if self.loaded_org_vocab_size is not None and packed_dim is not None:
+            raise ValueError(
+                "Draft model vocab padding does not support packed weights."
+            )
         if packed_dim is not None and packed_dim == output_dim:
             packed_factor = (
                 param.packed_factor
@@ -462,10 +487,40 @@ class VocabParallelEmbedding(PluggableLayer):
             start_idx = start_idx // packed_factor
             shard_size = shard_size // packed_factor
         else:
-            assert loaded_weight.shape[output_dim] == self.org_vocab_size
+            loaded_vocab_size = loaded_weight.shape[output_dim]
+            if self.loaded_org_vocab_size is None:
+                assert loaded_vocab_size == self.org_vocab_size
+            else:
+                if output_dim != 0:
+                    raise ValueError(
+                        "Draft model vocab padding only supports weights "
+                        "sharded on output_dim=0."
+                    )
+                if self.num_added_embeddings != 0:
+                    raise ValueError(
+                        "Draft model vocab padding does not support added "
+                        "vocabulary embeddings."
+                    )
+                if loaded_vocab_size != self.loaded_org_vocab_size:
+                    raise ValueError(
+                        "Loaded draft vocab size does not match the recorded "
+                        "unpadded draft vocab size. Expected "
+                        f"{self.loaded_org_vocab_size}, got {loaded_vocab_size}."
+                    )
 
         # Copy the data. Select chunk corresponding to current shard.
-        loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+        if self.loaded_org_vocab_size is None:
+            loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+        else:
+            loaded_shard_size = max(
+                min(shard_size, self.loaded_org_vocab_size - start_idx), 0
+            )
+            if loaded_shard_size == 0:
+                loaded_weight = loaded_weight.narrow(output_dim, 0, 0)
+            else:
+                loaded_weight = loaded_weight.narrow(
+                    output_dim, start_idx, loaded_shard_size
+                )
         param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
         param[loaded_weight.shape[0] :].data.fill_(0)
 


### PR DESCRIPTION
## Purpose

This PR adds an explicit opt-in path for draft model vocabulary padding in speculative decoding.

The motivating case is using a smaller Qwen-family draft model with a larger Qwen-family target model where the token IDs are suffix-compatible: the draft model uses the same prefix token IDs, while the target model only adds extra tokens at the tail of the vocabulary.

In my local deployment, I hit this with:

- target model: `DeepSeek-R1-Distill-Qwen-32B-FP8`
- draft model: `DeepSeek-R1-Distill-Qwen-1.5B`

The target and draft vocab sizes differ, so vLLM's current strict speculative decoding checks reject the pair. My first local workaround was to manually edit the draft model `config.json` to the target vocab size, then loosen the vocab embedding loader so a shorter checkpoint weight could be loaded and the missing tail rows would remain zero-filled.

That workaround was enough to make the workload start, but it was too broad for upstream: it made normal model loading accept shorter vocab weights, which could hide real checkpoint/config mismatches, tokenizer incompatibilities, or packed/quantized weight issues. That would be risky for ordinary models and newer Qwen-family models such as Qwen3/Qwen3.5.

This PR narrows the behavior into a guarded opt-in feature:

- adds `SpeculativeConfig.allow_draft_model_vocab_padding`, defaulting to `False`;
- only allows the option for `method == "draft_model"`;
- only allows it when the target vocab size is larger than the draft vocab size;
- records the original draft checkpoint vocab size as `draft_model_unpadded_vocab_size`;
- updates the draft runtime vocab size to the target vocab size, so users do not need to edit the draft model config file manually;
- keeps normal model loading and normal speculative decoding strict by default;
- only allows short-vocab loading for draft runner vocab weights when the loaded checkpoint vocab exactly matches the recorded original draft vocab size;
- rejects unsupported cases such as packed vocab weights, non-`output_dim=0` short loading, and added vocabulary embeddings;
- masks the zero-padded token range in both full-logits and local-argmax draft selection paths so the draft model cannot select synthetic zero-filled lm_head rows.

This is intentionally not a general heterogeneous-tokenizer solution. It only supports suffix-compatible vocab expansion where token IDs already match for the draft vocab prefix. General tokenizer/vocab remapping is a broader problem and is being addressed by the TLI direction in #38174. I checked current open PRs and found no duplicate PR for this narrower opt-in padding path; #38174 targets universal heterogeneous vocabulary speculative decoding, while this PR keeps the existing `draft_model` path strict by default and only adds a small opt-in escape hatch for suffix-compatible vocab expansion.

AI assistance was used to help prepare and validate this change. The human submitter reviewed the changed code and test results.

The local workload that motivated this change was started with:

```bash
vllm serve "/home/rm01/Downloads/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-FP8" \
  --gpu-memory-utilization=0.88 \
  --max-model-len=32000 \
  --served-model-name "DeepSeek-R1-Distill-Qwen-32B-Speculative-1.5B-32K" \
  --enable-prefix-caching \
  --enable-chunked-prefill \
  --speculative-model "/home/rm01/Downloads/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B" \
  --num-speculative-token 5 \
  --speculative-draft-tensor-parallel-size 1 \
  --max_num_batched_tokens 256
```

With this PR, the new opt-in field must be enabled in the speculative config for this suffix-compatible short-draft-vocab case.

## Test Plan

Added targeted tests for:

- default strict behavior when a shorter vocab weight is loaded without opt-in;
- default target/draft vocab mismatch rejection;
- `allow_draft_model_vocab_padding=True` validation for `draft_model` only;
- target vocab size must be larger than draft vocab size;
- draft runtime vocab config update while preserving the original draft vocab metadata;
- TP=1/2/4 short-vocab weight loading with shard-overlap copying and zero-filled missing rows;
- a rank whose shard is fully in the missing suffix remains zero-filled;
- loaded vocab sizes shorter or longer than the recorded original draft vocab size are rejected;
- packed weights and non-`output_dim=0` short loading are rejected;
- full logits mask the padded token range to `-inf`;
- local argmax cannot select zero-filled padded lm_head rows.

Validation commands:

```bash
git diff --check
```

```bash
PYTHONPATH=. .venv/bin/python -m pytest \
  tests/config/test_speculative_vocab_padding.py \
  tests/model_executor/layers/test_vocab_parallel_embedding.py \
  -q
```

```bash
PRE_COMMIT_HOME=/private/tmp/codex-pre-commit .venv/bin/pre-commit run --files \
  vllm/config/speculative.py \
  vllm/model_executor/layers/vocab_parallel_embedding.py \
  vllm/model_executor/layers/logits_processor.py \
  tests/config/test_speculative_vocab_padding.py \
  tests/model_executor/layers/test_vocab_parallel_embedding.py
```

## Test Result

`git diff --check`:

```text
Passed
```

Targeted unit tests:

```text
21 passed, 17 warnings in 0.48s
```

Additional independent validation was provided by @jmamou in
https://github.com/vllm-project/vllm/pull/42775#issuecomment-4544136751.

They tested the same padded-vocab pattern with:

- Target: `Qwen/Qwen2.5-Coder-14B-Instruct` (`vocab_size=152064`)
- Draft: `Qwen/Qwen2.5-Coder-0.5B-Instruct` (`vocab_size=151936`)

The two tokenizers share the same 151,665 actual tokens, and the vocab-size
difference is only tail embedding-row padding. With
`allow_draft_model_vocab_padding=true`, speculative decoding ran cleanly on a
SPEED-Bench `low_entropy.code_completion` workload with no correctness issues
observed across the sweep.

Reported TPOT speedups vs baseline:

| BS | k | TPOT (ms) | speedup |
|---|---|---:|---:|
| 1 | 7 | 110 | 2.82x |
| 4 | 7 | 348 | 1.98x |
| 8 | 5 | 628 | 1.43x |
| 8 | 7 | 609 | 1.48x |

This supports the intended scope of this PR: a narrow opt-in for
same-tokenizer-family models with prefix-compatible token IDs and padded target
vocab tails, while leaving the broader heterogeneous-tokenizer case to #38174.

Pre-commit on changed files:

```text
ruff check..........................................................................................Passed
ruff format.........................................................................................Passed
typos...............................................................................................Passed
clang-format....................................................................(no files to check)Skipped
markdownlint-cli2...............................................................(no files to check)Skipped
Lint GitHub Actions workflow files..............................................(no files to check)Skipped
pip-compile.....................................................................(no files to check)Skipped
pip-compile-rocm................................................................(no files to check)Skipped
pip-compile-xpu.................................................................(no files to check)Skipped
pip-compile-docs................................................................(no files to check)Skipped
reformat test/nightly-torch.txt to be in sync with test/cuda.in.................(no files to check)Skipped
Run mypy locally for lowest supported Python version............................Passed
Lint shell scripts..............................................................(no files to check)Skipped
Lint PNG exports from excalidraw................................................(no files to check)Skipped
Check SPDX headers..............................................................Passed
Check root lazy imports.........................................................Passed
Check for spaces in all filenames...............................................Passed
Update Dockerfile dependency graph..............................................Passed
Check for forbidden imports.....................................................Passed
Prevent new 'torch.cuda' APIs call..............................................Passed
Validate configuration has default values and that each field has a docstring...Passed
Validate docker/versions.json matches Dockerfile................................(no files to check)Skipped
Check attention backend documentation is up to date.............................Passed
Check for boolean ops in with-statements........................................Passed
Suggestion......................................................................Passed
```

