### PR TITLE
[Model Runner V2] Fix prompt logprobs calculation `Sizes of tensors must match` error

### DIFF
--- a/vllm/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm/v1/worker/gpu/sample/prompt_logprob.py
@@ -99,6 +99,7 @@ class PromptLogprobsWorker:
                 continue
 
             req_is_prompt_chunked = is_prompt_chunked[i]
+            req_num_prompt_logprobs = int(num_prompt_logprobs[i])
             start_idx = query_start_loc_np[i]
             end_idx = query_start_loc_np[i + 1]
             assert start_idx < end_idx, (
@@ -107,13 +108,18 @@ class PromptLogprobsWorker:
             if not req_is_prompt_chunked:
                 end_idx -= 1
 
+            width = (
+                prompt_logprobs.shape[1]
+                if req_num_prompt_logprobs == -1
+                else req_num_prompt_logprobs + 1
+            )
             # no logprobs if start_idx >= end_idx
             logprobs = (
                 None
                 if start_idx >= end_idx
                 else LogprobsTensors(
-                    logprob_token_ids=prompt_token_ids[start_idx:end_idx],
-                    logprobs=prompt_logprobs[start_idx:end_idx],
+                    logprob_token_ids=prompt_token_ids[start_idx:end_idx, :width],
+                    logprobs=prompt_logprobs[start_idx:end_idx, :width],
                     selected_token_ranks=prompt_ranks[start_idx:end_idx],
                 )
             )


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/41286

We calculate in batch but should cut for specific request

`VLLM_USE_V2_MODEL_RUNNER=1 pytest -v -s -x 'tests/v1/sample/test_logprobs.py::test_get_logprobs_and_prompt_logprobs[False-0.0-BatchLogprobsComposition.PROMPT]'`

Originally

```bash
^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/vllm-source/vllm/v1/serial_utils.py", line 510, in run_method
(EngineCore pid=325719)     return func(*args, **kwargs)
(EngineCore pid=325719)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore pid=325719)     return func(*args, **kwargs)
(EngineCore pid=325719)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu_worker.py", line 780, in sample_tokens
(EngineCore pid=325719)     return self.model_runner.sample_tokens(grammar_output)
(EngineCore pid=325719)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore pid=325719)     return func(*args, **kwargs)
(EngineCore pid=325719)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/eplb_utils.py", line 24, in wrapper
(EngineCore pid=325719)     result = fn(self, *args, **kwargs)
(EngineCore pid=325719)              ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/model_runner.py", line 1227, in sample_tokens
(EngineCore pid=325719)     prompt_logprobs_dict = self.prompt_logprobs_worker.compute_prompt_logprobs(
(EngineCore pid=325719)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=325719)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/sample/prompt_logprob.py", line 131, in compute_prompt_logprobs
(EngineCore pid=325719)     logprob_token_ids=torch.cat(
(EngineCore pid=325719)                       ^^^^^^^^^^
(EngineCore pid=325719) RuntimeError: Sizes of tensors must match except in dimension 0. Expected size 1 but got size 7 for tensor number 1 in the list.
FAILED
```

Now

```bash
======================= 1 passed, 16 warnings in 29.65s =======================
```