### PR TITLE
fix: [Bug]: kv_cache_offloadig crashes on 0.21.0 - KeyError in self._block_id_to_pending_jobs[bid]

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -55,7 +55,7 @@ class TransferJobStatus:
     non_sliding_window_block_ids: list[int] | None = None
     # Store src block IDs that may be freed before the request finishes.
     # Registered in _block_id_to_pending_jobs at store creation time.
-    sliding_window_block_ids: list[int] | None = None
+    sliding_window_block_ids: set[int] | None = None
 
 
 class GroupOffloadConfig(NamedTuple):
@@ -240,12 +240,12 @@ class OffloadingConnectorScheduler:
         self._job_counter += 1
         return job_id
 
-    def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
+    def _remove_pending_job(
+        self, job_id: int, block_ids: Iterable[int] | None
+    ) -> None:
         for bid in block_ids or ():
-            pending = self._block_id_to_pending_jobs.get(bid)
-            if pending is None:
-                continue
-            pending.discard(job_id)
+            pending = self._block_id_to_pending_jobs[bid]
+            pending.remove(job_id)
             if not pending:
                 del self._block_id_to_pending_jobs[bid]
 
@@ -691,7 +691,7 @@ class OffloadingConnectorScheduler:
             group_sizes: list[int] = []
             block_indices: list[int] = []
             src_block_ids: list[int] = []
-            sliding_window_block_ids: list[int] = []
+            sliding_window_block_ids: set[int] = set()
             non_sliding_window_block_ids: list[int] = []
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
@@ -723,7 +723,7 @@ class OffloadingConnectorScheduler:
                             start_gpu_block_idx = gpu_block_idx + i
                         src_block_ids.append(block_id)
                         if is_sliding_window:
-                            sliding_window_block_ids.append(block_id)
+                            sliding_window_block_ids.add(block_id)
                         else:
                             non_sliding_window_block_ids.append(block_id)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -242,8 +242,10 @@ class OffloadingConnectorScheduler:
 
     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
         for bid in block_ids or ():
-            pending = self._block_id_to_pending_jobs[bid]
-            pending.remove(job_id)
+            pending = self._block_id_to_pending_jobs.get(bid)
+            if pending is None:
+                continue
+            pending.discard(job_id)
             if not pending:
                 del self._block_id_to_pending_jobs[bid]
 


### PR DESCRIPTION
Closes #42761.

## Summary

This PR proposes a minimal fix for the issue _[Bug]: kv_cache_offloadig crashes on 0.21.0 - KeyError in self._block_id_to_pending_jobs[bid]_.

The scheduler cleanup path can currently raise a secondary `KeyError` if a block ID is no longer present in `_block_id_to_pending_jobs`. This change makes cleanup tolerant of already-removed block IDs and uses `discard` so removing an already-absent job ID is also safe.

## Duplicate-work check

Before continuing this PR, I checked for duplicate open work:

- `gh pr list --repo vllm-project/vllm --state open --search "42761 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "kv_cache_offloadig _block_id_to_pending_jobs"`

Both searches returned only this PR, so this is not duplicating another open fix.

## Files changed

- `vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py`

## Local checks

- `gh pr diff 42780 --repo vllm-project/vllm --patch` confirmed the PR is a one-file scheduler change
- Original local checks before opening: diff applied cleanly; one file touched; changed Python parsed; no obvious narrow test target found
- DCO repair: replaced the original commit with an identical-tree commit carrying `Signed-off-by: Nachiket Torwekar <nachiket.torwekar@gmail.com>`
- `gh pr view/checks` confirmed DCO passes after the repair

## AI assistance

AI assistance was used to draft and repair this PR. The changed lines are intentionally narrow and I am prepared to iterate based on maintainer feedback.
