### PR TITLE
[Bugfix] Respect explicit --kv-cache-dtype over checkpoint kv_cache_scheme

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -228,9 +228,14 @@ class Attention(nn.Module, AttentionLayerBase):
             kv_cache_dtype = "auto"
             calculate_kv_scales = False
 
-        # llm-compressor mdls need to set cache_dtype to "fp8" manually.
+        # llm-compressor models declare an FP8 KV-cache scheme in their
+        # checkpoint config. Honor it only when the user did not explicitly
+        # pick a kv_cache_dtype; an explicit choice (e.g. bfloat16) must win.
+        # The "auto" case is normally resolved upstream in
+        # resolve_kv_cache_dtype_string, but we re-apply here defensively in
+        # case anything bypassed that path.
         kv_cache_scheme = getattr(quant_config, "kv_cache_scheme", None)
-        if kv_cache_scheme is not None:
+        if kv_cache_scheme is not None and kv_cache_dtype == "auto":
             kv_cache_dtype = "fp8"
             calculate_kv_scales = False
             if cache_config is not None:


### PR DESCRIPTION



## Purpose

When a compressed-tensors checkpoint declares a kv_cache_scheme, the per-layer Attention init was unconditionally forcing kv_cache_dtype to "fp8" and mutating cache_config.cache_dtype, even when the user passed an explicit --kv-cache-dtype on the CLI. That broke user overrides and also cascaded to draft models in speculative decoding (e.g. dflash non-causal attention, which has no FP8 KV backend on Blackwell).

Validated with poolside/Laguna-XS.2-NVFP4 (declares FP8 KV in its CT config) on B300: --kv-cache-dtype bfloat16 now propagates correctly

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

