### PR TITLE
[Model Runner v2] Support update_config

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -343,6 +343,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         GPUModelRunnerV1.update_config(self, *args, **kwargs)  # type: ignore[arg-type]
 
+        # v2 reads config via self.vllm_config (e.g. in load_model), so keep it
+        # in sync with the attributes the v1 helper just replaced.
+        self.vllm_config.model_config = self.model_config
+        self.vllm_config.load_config = self.load_config
+
     @functools.cached_property
     def main_stream(self) -> torch.cuda.Stream:
         # Cache the default CUDA stream to avoid lookup overhead.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -337,6 +337,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.reset_encoder_cache()
         self.reset_mm_cache()
 
+    def update_config(self, *args, **kwargs) -> None:
+        # TODO(Wentao): Use full version instead of import when fully migrated to v2
+        from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
+
+        GPUModelRunnerV1.update_config(self, *args, **kwargs)  # type: ignore[arg-type]
+
     @functools.cached_property
     def main_stream(self) -> torch.cuda.Stream:
         # Cache the default CUDA stream to avoid lookup overhead.


### PR DESCRIPTION
Mirrors the `reload_weights` delegation added in #42673. Without this, `collective_rpc("update_config", ...)` raises `AttributeError` on the v2 GPUModelRunner — which is now the default for Qwen3 dense generative models per #39337.

## Failing tests this unblocks

- `tests/quantization/test_torchao.py::test_reload_weights`
- `tests/model_executor/model_loader/test_reload.py::test_kv_scale_reload`

Both call `collective_rpc("update_config", ...)` to flip `load_format` from `dummy` to `auto` before reloading real weights.

## Duplicate-work check

- `gh pr list --search "update_config v2 model runner"` — no matching open PR
- Related PRs in flight (`#42697`, `#42759`, `#41732`, `#35536`) touch other v2 gaps; none add `update_config`

## AI assistance

AI-assisted (Claude). Submitter reviewed every line and verified the v1 `update_config` already lives on `vllm/v1/worker/gpu_model_runner.py:4953` and that v2 has the `load_config`/`model_config` attributes it relies on (`vllm/v1/worker/gpu/model_runner.py:112,116`). Unit-test coverage exists at `tests/v1/worker/test_gpu_model_runner.py::test_update_config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)