### PR TITLE
[Bugfix] Fix SWA cache block mask breaking prefix caching with Eagle/MTP

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2600,6 +2600,77 @@ def test_hybrid_cache_blocks_swa_tail_window_only():
             )
 
 
+def test_hybrid_cache_blocks_swa_eagle_disables_mask():
+    """When Eagle/MTP is active, SWA cache block masking must be disabled.
+
+    Eagle changes the SWA hit logic in two ways:
+      1. ``sliding_window_contiguous_blocks += 1`` (needs one more block)
+      2. ``post_pop_blocks = i`` (not ``i + 1``), shifting alignment
+
+    Without the fix the mask skips blocks that eagle's modified lookup
+    needs, resulting in 0 % prefix cache hit rate.  Regression introduced
+    by #42258."""
+    block_size = 8
+    # Full attn bs=32, SWA bs=8, sw=8 -> lcm=32.
+    # Without eagle: mask = [F, F, F, T] per segment (only tail cached).
+    # With eagle: mask disabled -> all blocks cached.
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(
+                    block_size=4 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+            ),
+        ],
+    )
+    manager = KVCacheManager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        use_eagle=True,
+        hash_block_size=block_size,
+    )
+
+    # 8 hash-blocks of 8 tokens (64 tokens, two lcm-aligned segments).
+    token_ids = [i for i in range(8) for _ in range(block_size)]
+    req = make_request("0", token_ids, block_size, sha256)
+    computed_blocks, _ = manager.get_computed_blocks(req)
+    blocks = manager.allocate_slots(
+        req,
+        8 * block_size,
+        len(computed_blocks.blocks[0]) * block_size,
+        computed_blocks,
+    )
+    assert blocks is not None
+    assert len(req.block_hashes) == 8
+
+    pool = manager.block_pool
+    # With eagle active ALL SWA blocks must be cached so the modified
+    # right-to-left lookup can find contiguous runs at shifted positions.
+    for i in range(8):
+        cached = pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
+        assert cached is not None, (
+            f"SWA hash {i} should be cached when eagle is active "
+            f"(mask must be disabled)"
+        )
+
+
 def test_hybrid_cache_blocks_clamped_to_lcm():
     """HybridKVCacheCoordinator.cache_blocks() clamps to lcm_block_size.
     Chunks past the last lcm-aligned boundary can never participate in a

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -15,6 +15,7 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
     SingleTypeKVCacheManager,
+    SlidingWindowManager,
     get_manager_for_kv_cache_spec,
 )
 from vllm.v1.kv_cache_interface import (
@@ -483,6 +484,18 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             for i, (_, group_ids, _) in enumerate(self.attention_groups)
             if any(gid in self.eagle_group_ids for gid in group_ids)
         }
+
+        # Eagle/MTP adds +1 to sliding_window_contiguous_blocks and uses
+        # post_pop_blocks = i (instead of i+1) for alignment.  This makes
+        # the SWA cache-block mask too aggressive — it skips blocks that
+        # eagle's modified lookup actually needs, yielding 0 % hit rate.
+        # Disable the mask for SWA managers inside eagle attention groups.
+        for idx in self.eagle_attn_group_indices:
+            _, group_ids, _ = self.attention_groups[idx]
+            for gid in group_ids:
+                mgr = self.single_type_managers[gid]
+                if isinstance(mgr, SlidingWindowManager):
+                    mgr.eagle_extra_cache_blocks = 1
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         # Cache hits in this coordinator are always a multiple of

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -642,6 +642,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         self, num_cached_blocks: int, num_full_blocks: int, alignment_tokens: int
     ) -> list[bool] | None:
         assert alignment_tokens > self.block_size
+        # Eagle/MTP shifts alignment (post_pop_blocks = i, not i+1) and
+        # requires one extra contiguous block.  The resulting hit pattern
+        # can touch any position in the segment, so the mask must be
+        # disabled — otherwise prefix-cache hit rate drops to 0 %.
+        if getattr(self, 'eagle_extra_cache_blocks', 0):
+            return None
         per_segment = alignment_tokens // self.block_size
         tail = cdiv(self.sliding_window - 1, self.block_size)
         if tail >= per_segment:


### PR DESCRIPTION
## Summary
- PR #42258 introduced `SlidingWindowManager._cache_block_mask()` to skip caching SWA blocks that can never serve a prefix-cache hit. When Eagle/MTP speculative decoding is active, the mask is too aggressive and skips blocks that eagle's modified lookup actually needs, resulting in **0% prefix cache hit rate**.
- Eagle changes the SWA hit logic in two ways: (1) `sliding_window_contiguous_blocks += 1` (needs one extra block) and (2) `post_pop_blocks = i` instead of `i + 1` (shifts alignment). The mask doesn't account for either, so it filters out blocks the lookup requires.
- Fix: detect SWA managers inside eagle attention groups at init time and disable the cache block mask for them, so all SWA blocks are cached when eagle is active.

## Test plan
- [x] New unit test `test_hybrid_cache_blocks_swa_eagle_disables_mask` verifies all SWA blocks are cached when eagle is active (same config as `test_hybrid_cache_blocks_swa_tail_window_only` but with `use_eagle=True`)
- [x] Existing `test_hybrid_cache_blocks_swa_tail_window_only` still passes (non-eagle path unchanged)
- [x] All 62 prefix caching tests pass
- [x] End-to-end verified on DeepSeek V4 Flash (5 KV cache groups: MLA bs=256, SWA bs=64, MTP bs=4/8) with MTP=2: prefix cache hit rate went from 0.0% to ~30% on repeated identical prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)