### PR TITLE
[WIP] Automatic pod snapshotting for quick resume

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -697,6 +697,8 @@ class EngineArgs:
 
     fail_on_environ_validation: bool = False
     gdn_prefill_backend: Literal["flashinfer", "triton"] | None = None
+    enable_snapshot_post_startup: bool = False
+    snapshot_provider: str | None = None
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -1482,6 +1484,19 @@ class EngineArgs:
             default=None,
             help="Select GDN prefill backend.",
         )
+
+        parser.add_argument(
+            "--enable-snapshot-post-startup",
+            action="store_true",
+            help="Enable taking a snapshot after startup.",
+        )
+
+        parser.add_argument(
+            "--snapshot-provider",
+            type=str,
+            default=None,
+            help="The cloud provider for snapshotting.",
+        )
         return parser
 
     @classmethod
@@ -2155,6 +2170,11 @@ class EngineArgs:
 
         if self.gdn_prefill_backend is not None:
             self.additional_config["gdn_prefill_backend"] = self.gdn_prefill_backend
+
+        self.additional_config["enable_snapshot_post_startup"] = (
+            self.enable_snapshot_post_startup
+        )
+        self.additional_config["snapshot_provider"] = self.snapshot_provider
 
         config = VllmConfig(
             model_config=model_config,

--- a/vllm/engine/snapshot/base.py
+++ b/vllm/engine/snapshot/base.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from abc import ABC, abstractmethod
+
+
+class BaseSnapshotProvider(ABC):
+    @abstractmethod
+    def trigger(self) -> None:
+        """Cloud-specific logic to snapshot the Pod/GPU."""
+        pass

--- a/vllm/engine/snapshot/manager.py
+++ b/vllm/engine/snapshot/manager.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+
+from vllm.engine.snapshot.base import BaseSnapshotProvider
+from vllm.plugins import load_plugins_by_group
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotManager:
+    def __init__(self, provider_name: str | None):
+        self.provider = None
+        if provider_name:
+            self.provider = self._find_provider(provider_name)
+
+    def _find_provider(self, name: str) -> BaseSnapshotProvider | None:
+        # Look for plugins registered under 'vllm.snapshot_providers'
+        logger.info("Loading snapshot providers...")
+        providers = load_plugins_by_group("vllm.snapshot_providers")
+        logger.info("Discovered snapshot providers: %s", list(providers.keys()))
+
+        provider_factory = providers.get(name)
+        if not provider_factory:
+            logger.error("Snapshot provider '%s' not found.", name)
+            return None
+
+        try:
+            provider = provider_factory()
+            logger.info("Successfully instantiated snapshot provider: %s", name)
+            return provider
+        except Exception as e:
+            logger.exception(
+                "Failed to instantiate snapshot provider '%s': %s", name, e
+            )
+            return None
+
+    def run_snapshot(self):
+        if self.provider:
+            logger.info("Triggering snapshot...")
+            try:
+                self.provider.trigger()
+                logger.info("Snapshot completed successfully.")
+            except Exception as e:
+                logger.exception("Failed to run snapshot: %s", e)
+        else:
+            logger.warning("No snapshot provider configured or available.")

--- a/vllm/entrypoints/openai/server_utils.py
+++ b/vllm/entrypoints/openai/server_utils.py
@@ -19,7 +19,6 @@ from starlette.datastructures import URL, Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from vllm import envs
-from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.launcher import terminate_if_errored
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorInfo,
@@ -446,8 +445,22 @@ _running_tasks: set[asyncio.Task] = set()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     try:
+        # Trigger snapshot post-startup if enabled
+        engine_client = getattr(app.state, "engine_client", None)
+        if (
+            engine_client is not None
+            and getattr(engine_client, "snapshot_manager", None) is not None
+        ):
+
+            async def _run_snapshot():
+                assert engine_client is not None
+                await asyncio.to_thread(engine_client.snapshot_manager.run_snapshot)
+
+            engine_client.snapshot_task = asyncio.create_task(_run_snapshot())
+            logger.info("Triggered snapshot post-startup task.")
+
         if app.state.log_stats:
-            engine_client: EngineClient = app.state.engine_client
+            engine_client = app.state.engine_client
 
             async def _force_log():
                 while True:

--- a/vllm/entrypoints/serve/instrumentator/health.py
+++ b/vllm/entrypoints/serve/instrumentator/health.py
@@ -28,6 +28,17 @@ async def health(raw_request: Request) -> Response:
         return Response(status_code=200)
     try:
         await client.check_health()
+
+        # Check if snapshot is enabled and in progress/pending
+        if getattr(client, "snapshot_manager", None) is not None:
+            snapshot_task = getattr(client, "snapshot_task", None)
+            if snapshot_task is None or not snapshot_task.done():
+                logger.info(
+                    "Snapshot is still running or pending, returning 503 "
+                    "for health check."
+                )
+                return Response(status_code=503, content="Snapshot in progress")
+
         return Response(status_code=200)
     except EngineDeadError:
         return Response(status_code=503)

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -21,6 +21,7 @@ PLATFORM_PLUGINS_GROUP = "vllm.platform_plugins"
 # async mode.
 STAT_LOGGER_PLUGINS_GROUP = "vllm.stat_logger_plugins"
 
+
 # make sure one process only loads plugins once
 plugins_loaded = False
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -199,6 +199,23 @@ class AsyncLLM(EngineClient):
         else:
             self.profiler = None
 
+        # Setup snapshot manager if enabled
+        additional_config = self.vllm_config.additional_config
+        enable_snapshot = False
+        snapshot_provider = None
+        if isinstance(additional_config, dict):
+            enable_snapshot = additional_config.get(
+                "enable_snapshot_post_startup", False
+            )
+            snapshot_provider = additional_config.get("snapshot_provider", None)
+
+        self.snapshot_manager = None
+        self.snapshot_task = None
+        if enable_snapshot:
+            from vllm.engine.snapshot.manager import SnapshotManager
+
+            self.snapshot_manager = SnapshotManager(snapshot_provider)
+
     @classmethod
     def from_vllm_config(
         cls,

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -14,6 +14,7 @@ from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.parallel_state import get_dp_group
 from vllm.engine.arg_utils import EngineArgs
+from vllm.engine.snapshot.manager import SnapshotManager
 from vllm.inputs import EngineInput, PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -130,6 +131,20 @@ class LLMEngine:
 
         # Don't keep the dummy data in memory
         self.reset_mm_cache()
+
+        # Trigger snapshot if enabled
+        additional_config = self.vllm_config.additional_config
+        enable_snapshot = False
+        snapshot_provider = None
+        if isinstance(additional_config, dict):
+            enable_snapshot = additional_config.get(
+                "enable_snapshot_post_startup", False
+            )
+            snapshot_provider = additional_config.get("snapshot_provider", None)
+
+        self.snapshot_manager = None
+        if enable_snapshot:
+            self.snapshot_manager = SnapshotManager(snapshot_provider)
 
     @classmethod
     def from_vllm_config(
@@ -416,6 +431,13 @@ class LLMEngine:
 
     def apply_model(self, func: Callable[[nn.Module], _R]) -> list[_R]:
         return self.collective_rpc("apply_model", args=(func,))
+
+    def run_snapshot(self) -> None:
+        """Trigger a snapshot of the engine state."""
+        if self.snapshot_manager is not None:
+            self.snapshot_manager.run_snapshot()
+        else:
+            logger.warning("No snapshot provider configured or available.")
 
     def __del__(self):
         dp_group = getattr(self, "dp_group", None)


### PR DESCRIPTION
## Purpose

Introduces automatic pod and GPU snapshotting as an entirely new feature. It establishes a pluggable provider interface via `BaseSnapshotProvider` that is dynamically discovered through the plugin registry by the  `SnapshotManager`. To support this, `enable_snapshot` and `snapshot_provider` configuration optaions are integrated into `EngineArgs`, with automatic invocation wired into the engine lifecycle during startup in `LLMEngine` and `AsyncLLM`. Furthermore, snapshot triggering is natively integrated into the FastAPI server health checks in health, returning a 503 service unavailable status while background snapshots are actively in progress, and complete unit tests are provided in `test_snapshot_manager.py`.

## Test Plan

(1) Unit test implemented
(2) Integration test planned: build image, execute, check for snapshot (GKE-specific for now)

## Test Result

PASS