### PR TITLE
[Quantization] Add ModelOpt FP8/NVFP4 weight-only embedding methods

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -516,3 +516,211 @@ def test_modelopt_mixed_precision_builds_w4a16_sibling_config():
     assert config.nvfp4_config.LinearMethodCls is m.ModelOptNvFp4LinearMethod
     assert config.w4a16_nvfp4_config.quant_method == "W4A16_NVFP4"
     assert config.w4a16_nvfp4_config.LinearMethodCls is m.ModelOptNvFp4W4A16LinearMethod
+
+
+# ---------------------------------------------------------------------------
+# Embedding-quantization dispatch + functional tests
+# ---------------------------------------------------------------------------
+
+
+class _StubLayer(torch.nn.Module):
+    """Minimal stand-in for VocabParallelEmbedding param registration."""
+
+
+def test_modelopt_fp8_config_dispatches_embedding_method():
+    """Per-tensor FP8 (`quant_method="FP8"`) wires the new
+    ``ModelOptFp8EmbeddingMethod`` so VocabParallelEmbedding gets a
+    weight-only FP8 gather. PC_PT / PB_WO variants keep the default
+    unquantized embedding."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8Config,
+        ModelOptFp8EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        UnquantizedEmbeddingMethod,
+    )
+
+    cfg = ModelOptFp8Config(
+        quant_method="FP8",
+        is_checkpoint_fp8_serialized=True,
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+    )
+    assert cfg.EmbeddingMethodCls is ModelOptFp8EmbeddingMethod
+
+    cfg_pcpt = ModelOptFp8Config(
+        quant_method="FP8_PER_CHANNEL_PER_TOKEN",
+        is_checkpoint_fp8_serialized=True,
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+    )
+    assert cfg_pcpt.EmbeddingMethodCls is UnquantizedEmbeddingMethod
+
+
+def test_modelopt_nvfp4_config_dispatches_embedding_method():
+    """NVFP4 (W4A4) wires ``ModelOptNvFp4EmbeddingMethod``. W4A16_NVFP4
+    keeps the default unquantized embedding because its weight is stored
+    Marlin-prepacked and is not row-indexable."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4Config,
+        ModelOptNvFp4EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        UnquantizedEmbeddingMethod,
+    )
+
+    cfg = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    assert cfg.EmbeddingMethodCls is ModelOptNvFp4EmbeddingMethod
+
+    cfg_w4a16 = ModelOptNvFp4Config(
+        quant_method="W4A16_NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    assert cfg_w4a16.EmbeddingMethodCls is UnquantizedEmbeddingMethod
+
+
+def test_modelopt_get_quant_method_dispatches_vocab_embedding():
+    """``ModelOptQuantConfigBase.get_quant_method`` returns the new
+    embedding method for a bare ``VocabParallelEmbedding`` but returns
+    ``None`` for ``ParallelLMHead`` (a subclass we don't quantize) and
+    for prefixes listed in ``exclude_modules``."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8Config,
+        ModelOptFp8EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        ParallelLMHead,
+        VocabParallelEmbedding,
+    )
+
+    cfg = ModelOptFp8Config(
+        quant_method="FP8",
+        is_checkpoint_fp8_serialized=True,
+        kv_cache_quant_method=None,
+        exclude_modules=["model.lm_head"],
+    )
+
+    # Construct a minimal embedding without going through the
+    # quant-method-installing branch — we just need an isinstance match.
+    embed = VocabParallelEmbedding.__new__(VocabParallelEmbedding)
+    assert isinstance(
+        cfg.get_quant_method(embed, prefix="model.embed_tokens"),
+        ModelOptFp8EmbeddingMethod,
+    )
+
+    # Excluded prefix -> None (falls back to UnquantizedEmbeddingMethod
+    # in the layer constructor).
+    assert cfg.get_quant_method(embed, prefix="model.lm_head") is None
+
+    # ParallelLMHead is a subclass; we intentionally don't dispatch it.
+    lm_head = ParallelLMHead.__new__(ParallelLMHead)
+    assert cfg.get_quant_method(lm_head, prefix="model.lm_head_out") is None
+
+
+def test_modelopt_fp8_embedding_matches_reference():
+    """FP8 embedding gather + cast + scale equals the manual reference
+    on the same inputs."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8Config,
+        ModelOptFp8EmbeddingMethod,
+    )
+
+    torch.manual_seed(0)
+    vocab, hidden = 32, 64
+    cfg = ModelOptFp8Config(
+        quant_method="FP8",
+        is_checkpoint_fp8_serialized=True,
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+    )
+    method = ModelOptFp8EmbeddingMethod(cfg)
+
+    layer = _StubLayer()
+    method.create_weights(
+        layer,
+        input_size_per_partition=hidden,
+        output_partition_sizes=[vocab],
+        input_size=hidden,
+        output_size=vocab,
+        params_dtype=torch.bfloat16,
+    )
+
+    # Populate weight as a real fp8 tensor and a per-tensor scale.
+    raw = torch.randn(vocab, hidden) * 4.0
+    fp8_weight = raw.to(torch.float8_e4m3fn)
+    layer.weight.data.copy_(fp8_weight)
+    layer.weight_scale.data.fill_(0.125)
+    layer.input_scale.data.fill_(0.0)
+
+    method.process_weights_after_loading(layer)
+
+    ids = torch.tensor([[0, 5, 7], [31, 16, 3]], dtype=torch.long)
+    out = method.embedding(layer, ids)
+
+    expected = torch.embedding(fp8_weight, ids).to(method.out_dtype) * 0.125
+    torch.testing.assert_close(out, expected, atol=0.0, rtol=0.0)
+    assert out.shape == (*ids.shape, hidden)
+
+
+def test_modelopt_nvfp4_embedding_matches_full_dequant():
+    """NVFP4 embedding gather equals the rows of the full table dequant."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4Config,
+        ModelOptNvFp4EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (  # noqa: E501
+        dequantize_to_dtype,
+    )
+
+    torch.manual_seed(0)
+    vocab, hidden, block = 16, 64, 16
+    cfg = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        group_size=block,
+    )
+    method = ModelOptNvFp4EmbeddingMethod(cfg)
+
+    layer = _StubLayer()
+    method.create_weights(
+        layer,
+        input_size_per_partition=hidden,
+        output_partition_sizes=[vocab],
+        input_size=hidden,
+        output_size=vocab,
+        params_dtype=torch.bfloat16,
+    )
+
+    # Random packed weights and block scales.
+    packed = torch.randint(0, 256, (vocab, hidden // 2), dtype=torch.uint8)
+    scale = (torch.rand(vocab, hidden // block) * 0.5 + 0.25).to(torch.float8_e4m3fn)
+    layer.weight.data.copy_(packed)
+    layer.weight_scale.data.copy_(scale)
+    layer.weight_scale_2.data.fill_(1.0)
+    layer.input_scale.data.fill_(0.0)
+
+    method.process_weights_after_loading(layer)
+
+    ids = torch.tensor([0, 5, 9, 15, 1, 1])
+    out = method.embedding(layer, ids)
+
+    full = dequantize_to_dtype(
+        packed,
+        scale,
+        torch.tensor(1.0),
+        dtype=torch.bfloat16,
+        block_size=block,
+        swizzle=False,
+    )
+    expected = full[ids]
+    torch.testing.assert_close(out, expected, atol=0.0, rtol=0.0)
+    assert out.shape == (ids.shape[0], hidden)

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -724,3 +724,101 @@ def test_modelopt_nvfp4_embedding_matches_full_dequant():
     expected = full[ids]
     torch.testing.assert_close(out, expected, atol=0.0, rtol=0.0)
     assert out.shape == (ids.shape[0], hidden)
+
+
+# ---------------------------------------------------------------------------
+# ModelOptMixedPrecisionConfig embedding dispatch
+# ---------------------------------------------------------------------------
+
+
+def _make_mixed_cfg(quantized_layers: dict):
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8Config,
+        ModelOptMixedPrecisionConfig,
+        ModelOptNvFp4Config,
+    )
+
+    return ModelOptMixedPrecisionConfig(
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+        quantized_layers=quantized_layers,
+        fp8_config=ModelOptFp8Config(
+            quant_method="FP8",
+            is_checkpoint_fp8_serialized=True,
+            kv_cache_quant_method=None,
+            exclude_modules=[],
+        ),
+        nvfp4_config=ModelOptNvFp4Config(
+            quant_method="NVFP4",
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+            group_size=16,
+        ),
+    )
+
+
+def test_modelopt_mixed_config_dispatches_fp8_embedding():
+    """Embedding listed as FP8 in quantized_layers → ModelOptFp8EmbeddingMethod."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+    cfg = _make_mixed_cfg({"model.embed_tokens": {"quant_algo": "FP8"}})
+    embed = VocabParallelEmbedding.__new__(VocabParallelEmbedding)
+    assert isinstance(
+        cfg.get_quant_method(embed, prefix="model.embed_tokens"),
+        ModelOptFp8EmbeddingMethod,
+    )
+
+
+def test_modelopt_mixed_config_dispatches_nvfp4_embedding():
+    """Embedding listed as NVFP4 in quantized_layers → ModelOptNvFp4EmbeddingMethod."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+    cfg = _make_mixed_cfg({"model.embed_tokens": {"quant_algo": "NVFP4"}})
+    embed = VocabParallelEmbedding.__new__(VocabParallelEmbedding)
+    assert isinstance(
+        cfg.get_quant_method(embed, prefix="model.embed_tokens"),
+        ModelOptNvFp4EmbeddingMethod,
+    )
+
+
+def test_modelopt_mixed_config_embedding_not_in_quantized_layers():
+    """Embedding absent from quantized_layers → None (falls back to unquantized)."""
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+    cfg = _make_mixed_cfg({})
+    embed = VocabParallelEmbedding.__new__(VocabParallelEmbedding)
+    assert cfg.get_quant_method(embed, prefix="model.embed_tokens") is None
+
+
+def test_modelopt_mixed_config_lm_head_not_dispatched():
+    """ParallelLMHead (VocabParallelEmbedding subclass) is never quantized
+    via the embedding path — it must go through the linear path instead."""
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        ParallelLMHead,
+    )
+
+    cfg = _make_mixed_cfg({"model.lm_head": {"quant_algo": "FP8"}})
+    lm_head = ParallelLMHead.__new__(ParallelLMHead)
+    # ParallelLMHead is a LinearBase subclass, so it takes the linear branch,
+    # not the embedding branch. get_quant_method returns a linear method, not
+    # an embedding method — assert it is NOT an embedding method.
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8EmbeddingMethod,
+        ModelOptNvFp4EmbeddingMethod,
+    )
+
+    result = cfg.get_quant_method(lm_head, prefix="model.lm_head")
+    assert not isinstance(result, (ModelOptFp8EmbeddingMethod, ModelOptNvFp4EmbeddingMethod))

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -755,6 +755,13 @@ def _make_mixed_cfg(quantized_layers: dict):
             exclude_modules=[],
             group_size=16,
         ),
+        w4a16_nvfp4_config=ModelOptNvFp4Config(
+            quant_method="W4A16_NVFP4",
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+            group_size=16,
+        ),
     )
 
 
@@ -822,3 +829,21 @@ def test_modelopt_mixed_config_lm_head_not_dispatched():
 
     result = cfg.get_quant_method(lm_head, prefix="model.lm_head")
     assert not isinstance(result, (ModelOptFp8EmbeddingMethod, ModelOptNvFp4EmbeddingMethod))
+
+
+def test_modelopt_mixed_config_dispatches_w4a16_nvfp4_embedding():
+    """W4A16_NVFP4 embedding routes to ModelOptNvFp4EmbeddingMethod using
+    w4a16_nvfp4_config — same packed-uint8 layout as NVFP4, Marlin repack
+    is skipped for the row-gather path."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4EmbeddingMethod,
+    )
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+    cfg = _make_mixed_cfg({"model.embed_tokens": {"quant_algo": "W4A16_NVFP4"}})
+    embed = VocabParallelEmbedding.__new__(VocabParallelEmbedding)
+    result = cfg.get_quant_method(embed, prefix="model.embed_tokens")
+    assert isinstance(result, ModelOptNvFp4EmbeddingMethod)
+    assert result.quant_config.quant_method == "W4A16_NVFP4"

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -81,7 +81,11 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     requantize_with_max_scale,
 )
-from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    UnquantizedEmbeddingMethod,
+    VocabParallelEmbedding,
+)
 from vllm.model_executor.parameter import (
     BlockQuantScaleParameter,
     ChannelQuantScaleParameter,
@@ -128,6 +132,10 @@ class ModelOptQuantConfigBase(QuantizationConfig):
     LinearMethodCls: type = LinearMethodBase
     FusedMoEMethodCls: type = FusedMoEMethodBase
     KVCacheMethodCls: type = BaseKVCacheMethod
+    # Subclasses override this to quantize VocabParallelEmbedding layers.
+    # Default keeps embeddings unquantized — the historical behavior before
+    # any ModelOpt format supported embedding quantization.
+    EmbeddingMethodCls: type = UnquantizedEmbeddingMethod
 
     def __init__(
         self,
@@ -212,6 +220,16 @@ class ModelOptQuantConfigBase(QuantizationConfig):
             if getattr(quant_method, "backend", "") == "marlin":
                 quant_method.marlin_input_dtype = get_marlin_input_dtype(prefix)
             return quant_method
+        elif type(layer) is VocabParallelEmbedding:
+            # Only the bare input embedding — ParallelLMHead (a subclass) is
+            # used as a matmul and would need the linear path to handle
+            # quantized weights; tied embeddings have their own pitfalls.
+            # Return None for the default (UnquantizedEmbeddingMethod) so the
+            # embedding layer's constructor installs the fallback itself —
+            # mirrors the LinearBase exclusion path above.
+            if self.EmbeddingMethodCls is UnquantizedEmbeddingMethod:
+                return None
+            return self.EmbeddingMethodCls(self)
 
         return None
 
@@ -385,6 +403,7 @@ class ModelOptFp8Config(ModelOptQuantConfigBase):
         # Select LinearMethod implementation based on quant_algo.
         if self.quant_method == "FP8":
             self.LinearMethodCls = ModelOptFp8LinearMethod
+            self.EmbeddingMethodCls = ModelOptFp8EmbeddingMethod
         elif self.quant_method == "FP8_PER_CHANNEL_PER_TOKEN":
             self.LinearMethodCls = ModelOptFp8PcPtLinearMethod
         elif self.quant_method == "FP8_PB_WO":
@@ -528,6 +547,89 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.fp8_linear.apply_weights(layer, x, bias)
+
+
+class ModelOptFp8EmbeddingMethod(QuantizeMethodBase):
+    """FP8 weight-only embedding for ModelOpt checkpoints.
+
+    Layout (per VocabParallelEmbedding partition):
+        weight        float8_e4m3fn, [vocab_per_partition, hidden]
+        weight_scale  float32,       per-tensor
+        input_scale   float32,       per-tensor (loaded but unused —
+                                      no activation to quantize)
+    """
+
+    def __init__(self, quant_config: ModelOptFp8Config) -> None:
+        self.quant_config = quant_config
+        self.out_dtype = torch.get_default_dtype()
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        del input_size, output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+
+        weight_dtype = (
+            torch.float8_e4m3fn
+            if self.quant_config.is_checkpoint_fp8_serialized
+            else params_dtype
+        )
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=weight_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        if self.quant_config.is_checkpoint_fp8_serialized:
+            weight_scale = PerTensorScaleParameter(
+                data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+                weight_loader=weight_loader,
+            )
+            weight_scale[:] = torch.finfo(torch.float32).min
+            layer.register_parameter("weight_scale", weight_scale)
+            # input_scale is accepted (so the loader sees the same key set
+            # as the linear path) but unused in embedding().
+            input_scale = PerTensorScaleParameter(
+                data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+                weight_loader=weight_loader,
+            )
+            input_scale[:] = torch.finfo(torch.float32).min
+            layer.register_parameter("input_scale", input_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight = layer.weight
+        max_w_scale = layer.weight_scale.max()
+        if not (layer.weight_scale == layer.weight_scale[0]).all():
+            max_w_scale, weight = requantize_with_max_scale(
+                layer.weight, layer.weight_scale, layer.logical_widths
+            )
+        # Keep weight as [vocab, hidden] — no transpose (unlike the linear
+        # path), since torch.embedding gathers along dim 0.
+        layer.weight = Parameter(weight, requires_grad=False)
+        layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
+        if hasattr(layer, "input_scale") and layer.input_scale is not None:
+            layer.input_scale = Parameter(layer.input_scale.max(), requires_grad=False)
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        rows = torch.embedding(layer.weight, input_)
+        return rows.to(self.out_dtype) * layer.weight_scale
 
 
 class ModelOptFp8PcPtLinearMethod(LinearMethodBase):
@@ -1034,6 +1136,7 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         # W4A16_NVFP4   -> W4A16: FP4 Marlin GEMM with bf16/fp16 activations
         if quant_method == "NVFP4":
             self.LinearMethodCls = ModelOptNvFp4LinearMethod
+            self.EmbeddingMethodCls = ModelOptNvFp4EmbeddingMethod
         elif quant_method == "W4A16_NVFP4":
             self.LinearMethodCls = ModelOptNvFp4W4A16LinearMethod
         else:
@@ -1230,6 +1333,129 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
+
+
+class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
+    """NVFP4 weight-only embedding for ModelOpt checkpoints.
+
+    Layout (per VocabParallelEmbedding partition):
+        weight          uint8,            [vocab_per_part, hidden/2]   (2 fp4/byte)
+        weight_scale    float8_e4m3fn,    [vocab_per_part, hidden/16]  (per block)
+        weight_scale_2  float32,          scalar global scale
+
+    Embedding is a row gather: we index_select packed rows + matching scale
+    rows, then dequantize. No GEMM kernel is initialized and no Marlin
+    repack is applied — that path destroys row-indexability.
+    """
+
+    def __init__(self, quant_config: ModelOptNvFp4Config) -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        del input_size, output_size
+        if not self.quant_config.is_checkpoint_nvfp4_serialized:
+            raise ValueError("NVFP4 embedding requires a serialized NVFP4 checkpoint.")
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+
+        if input_size_per_partition % self.quant_config.group_size != 0:
+            raise ValueError(
+                "NVFP4 embedding hidden size "
+                f"({input_size_per_partition}) must be a multiple of group "
+                f"size ({self.quant_config.group_size})."
+            )
+
+        self.params_dtype = params_dtype
+
+        # Two fp4 values are packed into one uint8 along the hidden dim.
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // 2,
+                dtype=torch.uint8,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        # Per-block fp8 scale.
+        weight_scale = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.quant_config.group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+        # Per-tensor fp32 global scale.
+        weight_global_scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale_2", weight_global_scale)
+
+        # input_scale is accepted (so the loader sees the same key set as
+        # the linear path) but unused — embeddings have no activation.
+        input_global_scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("input_scale", input_global_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Collapse the per-shard global scale to a scalar (matches the
+        # linear path at modelopt.py:1314). Embedding has a single shard,
+        # but this keeps behavior uniform with the loader.
+        weight_global_scale = layer.weight_scale_2.max().to(torch.float32)
+        layer.weight_global_scale = Parameter(weight_global_scale, requires_grad=False)
+        del layer.weight_scale_2
+
+        # input_scale is unused; collapse and keep it as a scalar so the
+        # tensor isn't holding per-partition garbage.
+        if hasattr(layer, "input_scale") and layer.input_scale is not None:
+            layer.input_scale = Parameter(
+                layer.input_scale.max().to(torch.float32), requires_grad=False
+            )
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        # Import here to avoid pulling triton at module import time.
+        from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (  # noqa: E501
+            dequantize_to_dtype,
+        )
+
+        flat = input_.flatten()
+        packed_rows = torch.index_select(layer.weight, 0, flat)
+        scale_rows = torch.index_select(layer.weight_scale, 0, flat)
+        # ModelOpt emits embedding scales in linear (un-swizzled) layout
+        # because we skip the Marlin repack. If a future checkpoint stores
+        # them swizzled, set swizzle=True here.
+        out = dequantize_to_dtype(
+            packed_rows,
+            scale_rows,
+            layer.weight_global_scale,
+            dtype=self.params_dtype,
+            block_size=self.quant_config.group_size,
+            swizzle=False,
+        )
+        return out.view(*input_.shape, -1)
 
 
 class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -622,10 +622,15 @@ class ModelOptFp8EmbeddingMethod(QuantizeMethodBase):
             )
         # Keep weight as [vocab, hidden] — no transpose (unlike the linear
         # path), since torch.embedding gathers along dim 0.
-        layer.weight = Parameter(weight, requires_grad=False)
+        # Use .data to unwrap ModelWeightParameter to a plain tensor before
+        # wrapping in Parameter (required by torch dispatch semantics).
+        layer.weight = Parameter(weight.data, requires_grad=False)
         layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
         if hasattr(layer, "input_scale") and layer.input_scale is not None:
             layer.input_scale = Parameter(layer.input_scale.max(), requires_grad=False)
+
+    def apply(self, layer: torch.nn.Module, x: torch.Tensor, bias=None):
+        raise NotImplementedError("FP8 embedding method is not used for linear layers.")
 
     def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
         rows = torch.embedding(layer.weight, input_)
@@ -1456,6 +1461,9 @@ class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
             swizzle=False,
         )
         return out.view(*input_.shape, -1)
+
+    def apply(self, layer: torch.nn.Module, x: torch.Tensor, bias=None):
+        raise NotImplementedError("NVFP4 embedding method is not used for linear layers.")
 
 
 class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
@@ -2649,6 +2657,10 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                 return ModelOptFp8EmbeddingMethod(self.fp8_config)
             if quant_algo == "NVFP4":
                 return ModelOptNvFp4EmbeddingMethod(self.nvfp4_config)
+            if quant_algo == "W4A16_NVFP4":
+                # W4A16_NVFP4 uses the same packed-uint8 weight layout as
+                # NVFP4; skip the Marlin repack and do a row-gather instead.
+                return ModelOptNvFp4EmbeddingMethod(self.w4a16_nvfp4_config)
             return None
 
         return None

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -2644,6 +2644,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                 )
             return None
 
+        if type(layer) is VocabParallelEmbedding:
+            if quant_algo == "FP8":
+                return ModelOptFp8EmbeddingMethod(self.fp8_config)
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4EmbeddingMethod(self.nvfp4_config)
+            return None
+
         return None
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -372,6 +372,7 @@ class LlamaModel(nn.Module, EagleModelMixin):
                 self.vocab_size,
                 config.hidden_size,
                 quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "embed_tokens"),
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -559,6 +559,8 @@ class NemotronHModel(nn.Module, EagleModelMixin):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
         self.has_moe = "E" in config.hybrid_override_pattern


### PR DESCRIPTION
## Purpose

Extend ModelOpt quantization to cover bare `VocabParallelEmbedding` layers so checkpoints whose `embed_tokens` were exported with FP8 or NVFP4 scales load and run instead of failing in `UnquantizedEmbeddingMethod` on the unexpected `weight_scale` / `input_scale` keys.

**Mechanism:**

- Add `EmbeddingMethodCls` to `ModelOptQuantConfigBase` and dispatch it in `get_quant_method()` when `type(layer) is VocabParallelEmbedding`. `ParallelLMHead` (a subclass used as a matmul) and any prefix listed in `exclude_modules` intentionally fall through to the linear / unquantized path.
- `ModelOptFp8EmbeddingMethod`: per-tensor FP8 weights, scalar scale, no transpose (`torch.embedding` gathers along dim 0). Wired for `quant_method="FP8"` only; `FP8_PER_CHANNEL_PER_TOKEN` / `FP8_PB_WO` keep the default unquantized embedding.
- `ModelOptNvFp4EmbeddingMethod`: NVFP4 packed weights with per-block fp8 scales and a scalar global scale. Embedding is a row gather, so the Marlin repack (which destroys row-indexability) is skipped and the gathered rows are dequantized via the existing `nvfp4_emulation_utils.dequantize_to_dtype`. Wired for `quant_method="NVFP4"` only.
- `ModelOptMixedPrecisionConfig.get_quant_method()` extended to dispatch `VocabParallelEmbedding` via `quantized_layers`, supporting `FP8`, `NVFP4`, and `W4A16_NVFP4` embedding formats.
- `LlamaModel` and `NemotronHModel`: pass `quant_config` and `prefix` to `VocabParallelEmbedding` so `get_quant_method` receives the correct layer prefix for dispatch.
- An `input_scale` parameter is registered (but unused) on both methods so the weight loader sees the same key set as the linear path.

## Related PRs

- vLLM: #35660 (related work in this area).
- Model-Optimizer: https://github.com/NVIDIA/Model-Optimizer/pull/1495, https://github.com/NVIDIA/Model-Optimizer/pull/1327.

## Test Plan

```bash
.venv/bin/python -m pytest tests/quantization/test_modelopt.py -v \
  -k "embedding or embed or mixed"
```

## Test Result

Unit tests (all pass, CPU-only):

- `test_modelopt_fp8_config_dispatches_embedding_method` — FP8 wires the new method; PC_PT keeps the default.
- `test_modelopt_nvfp4_config_dispatches_embedding_method` — NVFP4 wires the new method; W4A16_NVFP4 keeps the default.
- `test_modelopt_get_quant_method_dispatches_vocab_embedding` — bare `VocabParallelEmbedding` gets the embedding method, `ParallelLMHead` does not, excluded prefix returns `None`.
- `test_modelopt_fp8_embedding_matches_reference` — gather + cast + scale matches manual reference (atol=0, rtol=0).
- `test_modelopt_nvfp4_embedding_matches_full_dequant` — gathered rows match the corresponding rows of the full-table dequant (atol=0, rtol=0).
- `test_modelopt_mixed_config_dispatches_fp8_embedding` — mixed-precision config routes FP8 embedding correctly.
- `test_modelopt_mixed_config_dispatches_nvfp4_embedding` — mixed-precision config routes NVFP4 embedding correctly.
- `test_modelopt_mixed_config_dispatches_w4a16_nvfp4_embedding` — W4A16_NVFP4 embedding routes to `ModelOptNvFp4EmbeddingMethod` with `w4a16_nvfp4_config`.

End-to-end inference verified on real ModelOpt MIXED_PRECISION checkpoints (SM89 GPU):

| Model | Embedding format | Linear format | Status |
|---|---|---|---|
| LLaMA-3 8B | FP8 | NVFP4 | ✅ Generates correctly |
| LLaMA-3 8B | W4A16_NVFP4 | NVFP4 | ✅ Generates correctly |
| Qwen3.5 4B | FP8 | NVFP4 | ✅ Generates correctly |
| Qwen3.5 4B | W4A16_NVFP4 | NVFP4 | ✅ Generates correctly |
| Nemotron-H 4B | W4A16_NVFP4 | FP8/NVFP4 mix | ✅ Generates correctly |

---

AI assistance (Claude) was used while drafting this change. The submitter has reviewed every line and is responsible for defending the change end-to-end.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan (test command provided).
- [x] End-to-end test results — verified on LLaMA, Qwen3.5, and Nemotron models.
- [ ] Documentation update — not required; behavior is auto-enabled by checkpoint contents.
</details>