### PR TITLE
[WIP][Model Runner V2] support spec decode + mamba align prefix caching

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1894,9 +1894,6 @@ class VllmConfig:
         """Check for features not yet supported by the V2 model runner."""
         unsupported: list[str] = []
 
-        if self.model_config is not None and self.model_config.has_inner_state:
-            unsupported.append("hybrid/mamba models")
-
         if self.parallel_config.prefill_context_parallel_size > 1:
             unsupported.append("prefill context parallelism")
 
@@ -2023,10 +2020,6 @@ class VllmConfig:
                 "Chunked MM input is required because we need the flexibility "
                 "to schedule a multiple of block_size tokens even if they are "
                 "in the middle of a mm input"
-            )
-            # TODO: support align mamba cache mode for model runner v2
-            assert not envs.VLLM_USE_V2_MODEL_RUNNER, (
-                "Model Runner V2 has not yet supported mamba_cache_mode='align'. "
             )
 
     @model_validator(mode="after")

--- a/vllm/model_executor/layers/mamba/mamba_mixer.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer.py
@@ -406,8 +406,17 @@ class MambaMixer(MambaBase, PluggableLayer):
                     1, block_idx_last_scheduled_token_d.unsqueeze(1)
                 ).squeeze(1)
             else:
-                state_indices_tensor_d_input = state_indices_tensor_d
+                if attn_metadata.src_ssm_indices_tensor_d is None:
+                    # Read and write in-place to the same blocks.
+                    state_indices_tensor_d_input = state_indices_tensor_d
+                else:
+                    # Read from separate set of blocks. Used for MRV2's "align"
+                    # mamba cache mode.
+                    state_indices_tensor_d_input = (
+                        attn_metadata.src_ssm_indices_tensor_d
+                    )
                 state_indices_tensor_d_output = state_indices_tensor_d
+
             # 2. Convolution sequence transformation
             conv_out_d = causal_conv1d_update(
                 hidden_states_BC_d.transpose(0, 1),

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -957,8 +957,15 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 #   block_idx_first_scheduled_token_d >
                 #       block_idx_last_computed_token_d
             else:
-                # Without caching, read and write in-place to the same blocks:
-                state_indices_tensor_d_input = state_indices_tensor_d
+                if attn_metadata.src_ssm_indices_tensor_d is None:
+                    # Read and write in-place to the same blocks.
+                    state_indices_tensor_d_input = state_indices_tensor_d
+                else:
+                    # Read from separate set of blocks. Used for MRV2's "align"
+                    # mamba cache mode.
+                    state_indices_tensor_d_input = (
+                        attn_metadata.src_ssm_indices_tensor_d
+                    )
                 state_indices_tensor_d_output = state_indices_tensor_d
 
             # 2. Convolution sequence transformation

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, TypeVar
 
 import torch
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import async_tensor_h2d
@@ -74,6 +75,11 @@ class BaseMambaAttentionMetadata:
     batch_ptr: torch.Tensor | None = None
     token_chunk_offset_ptr: torch.Tensor | None = None
 
+    # When set, the SSM kernel reads from src_ssm_indices_tensor_d and writes
+    # to state_indices_tensor_d. This overrides the default behavior of reading
+    # and writing in-place to state_indices_tensor_d.
+    src_ssm_indices_tensor_d: torch.Tensor | None = None
+
 
 class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
     metadata_cls: type[M]
@@ -107,13 +113,18 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
                 self.compilation_config.max_cudagraph_capture_size,
             )
 
-        if self.vllm_config.cache_config.mamba_cache_mode == "all":
+        mamba_cache_mode = self.vllm_config.cache_config.mamba_cache_mode
+        self.is_mrv2_spec_decode_align_mode: bool = (
+            envs.VLLM_USE_V2_MODEL_RUNNER
+            and self.use_spec_decode
+            and mamba_cache_mode == "align"
+        )
+
+        if mamba_cache_mode == "all":
             max_num_blocks = cdiv(
                 self.vllm_config.model_config.max_model_len,
                 self.kv_cache_spec.block_size,
             )
-            # Speculative decoding not supported with prefix caching,
-            # so keep shape consistent with prefill buffer
             # TODO: reduce this size as needed for decode-only cudagraph capture
             self.state_indices_tensor_d: torch.Tensor = torch.empty(
                 (
@@ -145,6 +156,16 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         if self.num_spec_tokens > 0:
             self.decode_num_accepted_tokens: torch.Tensor = torch.empty(
                 (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
+            )
+
+        self.src_ssm_indices_tensor_d: torch.Tensor | None = None
+        if self.is_mrv2_spec_decode_align_mode:
+            # During MRV2 spec decode + align, this tensor overrides the
+            # indices read from while writing to the SSM staging blocks.
+            self.src_ssm_indices_tensor_d = torch.empty(
+                (self.decode_cudagraph_max_bs, 1 + self.num_spec_tokens),
                 dtype=torch.int32,
                 device=device,
             )
@@ -415,6 +436,35 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             ]
             state_indices_tensor_p = state_indices_tensor_p[:, 0]
 
+        src_ssm_indices_tensor_d = None
+        # Construct separate read tensor for the SSM kernel for
+        # MRV2 + spec decode + align mode.
+        if (
+            self.is_mrv2_spec_decode_align_mode
+            and num_decodes > 0
+            and num_accepted_tokens is not None
+        ):
+            if num_computed_tokens is None:
+                num_computed_tokens = common_attn_metadata.compute_num_computed_tokens()
+            # Get block containing last committed token.
+            committed_block_idx = torch.clamp(
+                (num_computed_tokens[:num_decodes] - 1)
+                // self.kv_cache_spec.block_size,
+                min=0,
+            ).to(torch.int64)
+            committed_phys = (
+                common_attn_metadata.block_table_tensor[:num_decodes]
+                .gather(1, committed_block_idx.unsqueeze(1))
+                .squeeze(1)
+            )
+            # Every column for the SSM read is the committed block
+            # physical ID.
+            src_ssm_indices_tensor_d = (
+                committed_phys.unsqueeze(1)
+                .expand_as(state_indices_tensor_d)
+                .contiguous()
+            )
+
         # Sometimes even with specdec enabled we get single-token prefill chunks that
         # should be treated as decodes but don't have num_accepted_tokens set.
         # These should be fine to process as non-spec decodes since there's only
@@ -465,6 +515,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             has_initial_states_p=has_initial_states_p,
             state_indices_tensor_p=state_indices_tensor_p,
             state_indices_tensor_d=state_indices_tensor_d,
+            src_ssm_indices_tensor_d=src_ssm_indices_tensor_d,
             num_accepted_tokens=num_accepted_tokens,
             query_start_loc_d=query_start_loc_d,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
@@ -493,6 +544,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         num_accepted_tokens = metadata.num_accepted_tokens
         block_idx_last_scheduled_token = metadata.block_idx_last_scheduled_token
         block_idx_last_computed_token = metadata.block_idx_last_computed_token
+        src_ssm_indices_tensor_d = metadata.src_ssm_indices_tensor_d
         if (
             metadata.num_prefills == 0
             and metadata.num_decodes <= self.decode_cudagraph_max_bs
@@ -535,6 +587,14 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
                     : metadata.num_decode_tokens
                 ]
 
+            if src_ssm_indices_tensor_d is not None:
+                assert self.src_ssm_indices_tensor_d is not None
+                self.src_ssm_indices_tensor_d[: metadata.num_decodes].copy_(
+                    src_ssm_indices_tensor_d, non_blocking=True
+                )
+                src_ssm_indices_tensor_d = self.src_ssm_indices_tensor_d[:padded_bs]
+                src_ssm_indices_tensor_d[metadata.num_decodes :] = NULL_BLOCK_ID
+
         return replace(
             metadata,
             state_indices_tensor_d=state_indices_tensor_d,
@@ -542,6 +602,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             num_accepted_tokens=num_accepted_tokens,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
             block_idx_last_computed_token=block_idx_last_computed_token,
+            src_ssm_indices_tensor_d=src_ssm_indices_tensor_d,
         )
 
     def update_block_table(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -981,7 +981,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.req_states.total_len.gpu,
         )
 
-        self.model_state.postprocess_state(input_batch, num_sampled)
+        self.model_state.postprocess_state(
+            input_batch, num_sampled, self.req_states.num_computed_tokens.gpu
+        )
 
     @torch.inference_mode()
     def execute_model(
@@ -1079,6 +1081,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 slot_mappings,
                 self.attn_groups,
                 self.kv_cache_config,
+                scheduler_output.scheduled_spec_decode_tokens,
             )
 
         inputs_embeds = None

--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -161,6 +161,7 @@ class DefaultModelState(ModelState):
         slot_mappings: torch.Tensor,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
+        scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         for_capture: bool = False,
     ) -> dict[str, Any]:
         if cudagraph_mode == CUDAGraphMode.FULL:

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -60,6 +60,7 @@ class ModelState(ABC):
         self,
         input_batch: InputBatch,
         num_sampled: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
     ) -> None:
         return None
 
@@ -91,6 +92,7 @@ class ModelState(ABC):
         slot_mappings: torch.Tensor,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
+        scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         for_capture: bool = False,
     ) -> dict[str, Any]:
         raise NotImplementedError

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -11,7 +11,8 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.attention.backends.utils import mamba_get_block_table_tensor
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
@@ -68,6 +69,15 @@ class MambaHybridModelState(DefaultModelState):
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )
 
+        self.is_spec_decode_align_mode = (
+            vllm_config.num_speculative_tokens > 0
+            and vllm_config.cache_config.mamba_cache_mode == "align"
+        )
+
+        # Used for align mode + spec decoding.
+        self.last_block_tables: tuple[torch.Tensor, ...] | None = None
+        self.last_kv_cache_config: KVCacheConfig | None = None
+
     def prepare_attn(
         self,
         input_batch: InputBatch,
@@ -76,6 +86,7 @@ class MambaHybridModelState(DefaultModelState):
         slot_mappings: torch.Tensor,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
+        scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         for_capture: bool = False,
     ) -> dict[str, Any]:
         if cudagraph_mode == CUDAGraphMode.FULL:
@@ -121,6 +132,12 @@ class MambaHybridModelState(DefaultModelState):
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
         )
+
+        if self.is_spec_decode_align_mode:
+            # Save state needed during postprocess_state.
+            self.last_block_tables = block_tables
+            self.last_kv_cache_config = kv_cache_config
+
         return build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
@@ -142,9 +159,133 @@ class MambaHybridModelState(DefaultModelState):
         self,
         input_batch: InputBatch,
         num_sampled: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
     ) -> None:
+        num_accepted_tokens = torch.clamp(num_sampled, min=1)
         # Chunked prefill does not sample a token, so num_sampled can be 0.
         # Mamba treats num_accepted_tokens=1 as the neutral non-spec value.
-        self.num_accepted_tokens_gpu[input_batch.idx_mapping] = torch.clamp(
-            num_sampled, min=1
+        self.num_accepted_tokens_gpu[input_batch.idx_mapping] = num_accepted_tokens
+        # The last accepted SSM state must be copied from the staging
+        # block to the running block to ensure that the next step's
+        # committed block read is correct.
+        self._copy_ssm_staging_to_committed(
+            input_batch, num_accepted_tokens, num_computed_tokens
         )
+
+    def _copy_ssm_staging_to_committed(
+        self,
+        input_batch: InputBatch,
+        num_accepted_tokens: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+    ) -> None:
+        """Copy conv & SSM state from staging blocks back to committed/working
+        blocks. If the accepted tokens trigger any block boundary crossings,
+        the conv & SSM state must be copied to the completed blocks so that
+        future prefix cache hits read correct state.
+        """
+        if not self.is_spec_decode_align_mode:
+            return
+
+        assert self.last_kv_cache_config is not None
+        assert self.last_block_tables is not None
+
+        needs_copy_mask = num_accepted_tokens > 1
+        if not needs_copy_mask.any():
+            return
+
+        fwd_ctx = self.vllm_config.compilation_config.static_forward_context
+        cache_mode = self.vllm_config.cache_config.mamba_cache_mode
+        num_spec_tokens = self.vllm_config.num_speculative_tokens
+        num_reqs = len(num_accepted_tokens)
+        num_computed = num_computed_tokens[input_batch.idx_mapping][:num_reqs]
+        prev_num_computed = num_computed - num_accepted_tokens
+        for idx, group in enumerate(self.last_kv_cache_config.kv_cache_groups):
+            if not isinstance(group.kv_cache_spec, MambaSpec):
+                continue
+
+            block_table = self.last_block_tables[idx]
+            block_size = group.kv_cache_spec.block_size
+
+            # Source: narrow window from seq_lens to find staging blocks.
+            state_indices_tensor = mamba_get_block_table_tensor(
+                block_table,
+                input_batch.seq_lens,
+                group.kv_cache_spec,
+                cache_mode,
+            )[:num_reqs, : 1 + num_spec_tokens]
+
+            # SSM and conv state sources (last accepted states).
+            src_block = (
+                (num_accepted_tokens - 1)
+                .clamp(max=state_indices_tensor.size(1) - 1)
+                .to(torch.int64)
+            )
+            src_phys = state_indices_tensor.gather(1, src_block.unsqueeze(1)).squeeze(1)
+
+            # Get the SSM state committed block that the next step's
+            # src_ssm_indices_tensor_d will read initial state from.
+            ssm_dst_block_idx = torch.clamp((num_computed - 1) // block_size, min=0).to(
+                torch.int64
+            )
+            ssm_dst_phys = (
+                block_table[:num_reqs]
+                .gather(1, ssm_dst_block_idx.unsqueeze(1))
+                .squeeze(1)
+            )
+
+            # Get the conv state working block that the next step will
+            # read initial state from.
+            conv_dst_block_idx = torch.clamp(
+                (num_computed + num_spec_tokens) // block_size, min=0
+            ).to(torch.int64)
+            conv_dst_phys = (
+                block_table[:num_reqs]
+                .gather(1, conv_dst_block_idx.unsqueeze(1))
+                .squeeze(1)
+            )
+
+            # Get boundary sources and destinations.
+            prev_block_idx = torch.clamp(
+                (prev_num_computed - 1) // block_size, min=0
+            ).to(torch.int64)
+            crossed_boundary_mask = ssm_dst_block_idx > prev_block_idx
+            needs_boundary_copy_mask = needs_copy_mask & crossed_boundary_mask
+            boundary_src_phys = None
+            boundary_dst_phys = None
+            if needs_boundary_copy_mask.any():
+                boundary_pos = (prev_block_idx + 1) * block_size - 1
+                boundary_src_block = (
+                    (boundary_pos - prev_num_computed)
+                    .clamp(min=0, max=num_spec_tokens)
+                    .to(torch.int64)
+                )
+                boundary_src_phys = state_indices_tensor.gather(
+                    1, boundary_src_block.unsqueeze(1)
+                ).squeeze(1)
+                boundary_dst_phys = (
+                    block_table[:num_reqs]
+                    .gather(1, prev_block_idx.unsqueeze(1))
+                    .squeeze(1)
+                )
+
+            for layer_name in group.layer_names:
+                layer = fwd_ctx[layer_name]
+                # NOTE: Will NOT work for all models, only Mamba1, Mamba2, and GDN.
+                conv_state = layer.kv_cache[0]
+                ssm_state = layer.kv_cache[1]
+                src_idx = src_phys[needs_copy_mask].long()
+                # Copy conv state.
+                conv_dst_idx = conv_dst_phys[needs_copy_mask].long()
+                conv_state[conv_dst_idx] = conv_state[src_idx]
+                # Copy SSM state.
+                ssm_dst_idx = ssm_dst_phys[needs_copy_mask].long()
+                ssm_state[ssm_dst_idx] = ssm_state[src_idx]
+
+                # If any boundary crossings occurred, conv & SSM state need to be
+                # copied to the completed blocks for prefix caching.
+                if boundary_src_phys is not None:
+                    assert boundary_dst_phys is not None
+                    bsrc = boundary_src_phys[needs_boundary_copy_mask].long()
+                    bdst = boundary_dst_phys[needs_boundary_copy_mask].long()
+                    ssm_state[bdst] = ssm_state[bsrc]
+                    conv_state[bdst] = conv_state[bsrc]

--- a/vllm/v1/worker/gpu/model_states/whisper.py
+++ b/vllm/v1/worker/gpu/model_states/whisper.py
@@ -126,6 +126,7 @@ class WhisperModelState(ModelState):
         slot_mappings: torch.Tensor,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
+        scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         for_capture: bool = False,
     ) -> dict[str, Any]:
         if cudagraph_mode == CUDAGraphMode.FULL:


### PR DESCRIPTION

## Accuracy Benchmark
**Server Command**
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve Qwen/Qwen3.5-35B-A3B-FP8 \
  -tp 2 -dp 1 \
  --enable-prefix-caching \
  --mamba-cache-mode align \
  --max-num-seqs 64 \
  --attention-config '{"use_trtllm_attention": 0}' \
  --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}' \
  --default-chat-template-kwargs '{"enable_thinking": false}'
```
**Results**
```
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7998|±  |0.0110|
|         |       |strict-match    |     8|exact_match|↑  |0.7968|±  |0.0111|
```

## Performance Benchmark
**Server Command**
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve Qwen/Qwen3.5-35B-A3B-FP8 \
  -tp 2 -dp 1 \
  --enable-prefix-caching \
  --mamba-cache-mode align \
  --max-num-seqs 64 \
  --attention-config '{"use_trtllm_attention": 0}' \
  --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}'
```
**Results**
| Metric | #42406 | This PR | Delta |
|--------|-----------|-----------|-------|
| **General** | | | |
| Successful requests | 512 | 512 | — |
| Failed requests | 0 | 0 | — |
| Max request concurrency | 16 | 16 | — |
| Benchmark duration (s) | 119.40 | 113.97 | -4.5% |
| Total input tokens | 2,167,806 | 2,271,087 | +4.8% |
| Total generated tokens | 262,144 | 262,144 | — |
| Request throughput (req/s) | 4.29 | 4.49 | +4.7% |
| Output token throughput (tok/s) | 2,195.48 | 2,300.20 | +4.8% |
| Peak output token throughput (tok/s) | 1,553.00 | 1,040.00 | -33.0% |
| Peak concurrent requests | 28.00 | 28.00 | — |
| Total token throughput (tok/s) | 20,351.05 | 22,227.97 | +9.2% |
| **Time to First Token** | | | |
| Mean TTFT (ms) | 282.49 | 105.66 | -62.6% |
| Median TTFT (ms) | 145.19 | 84.13 | -42.1% |
| P99 TTFT (ms) | 3,800.32 | 995.73 | -73.8% |
| **Time per Output Token** | | | |
| Mean TPOT (ms) | 6.64 | 6.68 | +0.6% |
| Median TPOT (ms) | 6.59 | 6.61 | +0.3% |
| P99 TPOT (ms) | 10.03 | 7.95 | -20.7% |
| **Inter-token Latency** | | | |
| Mean ITL (ms) | 16.35 | 17.04 | +4.2% |
| Median ITL (ms) | 10.58 | 15.83 | +49.6% |
| P99 ITL (ms) | 105.52 | 38.90 | -63.1% |
| **End-to-end Latency** | | | |
| Mean E2EL (ms) | 3,677.74 | 3,521.25 | -4.3% |
| Median E2EL (ms) | 3,528.08 | 3,468.17 | -1.7% |
| P99 E2EL (ms) | 8,904.19 | 4,462.88 | -49.9% |
| **Speculative Decoding** | | | |
| Acceptance rate (%) | 73.88 | 78.34 | +4.46pp |
| Acceptance length | 2.48 | 2.57 | +3.6% |
| Drafts | 105,785 | 102,119 | -3.5% |
| Draft tokens | 211,570 | 204,238 | -3.5% |
| Accepted tokens | 156,310 | 160,003 | +2.4% |
| Position 0 acceptance (%) | 83.86 | 85.68 | +1.82pp |
| Position 1 acceptance (%) | 63.90 | 71.00 | +7.10pp |