### PR TITLE
[Model] Qwen3-VL-MoE: remap ModelOpt NVFP4 per-expert weight names (#…

### DIFF
--- a/tests/models/test_qwen3_vl_moe_modelopt_remap.py
+++ b/tests/models/test_qwen3_vl_moe_modelopt_remap.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for `_remap_modelopt_qwen3_vl_moe_name` (issue #40885).
+
+ModelOpt-quantized Qwen3-VL-MoE checkpoints (e.g.
+`Code4me2/bu-30b-a3b-preview-NVFP4`) emit per-expert weight tensors
+with the projection name before the expert index and prefix the LLM
+inside the `language_model.` segment of the
+`Qwen3VLMoEForConditionalGeneration` wrapper:
+
+  model.language_model.layers.0.mlp.experts.gate_proj.42.weight
+
+vLLM's `FusedMoE.make_expert_params_mapping` produces weight names
+with the expert index *before* the projection:
+
+  model.layers.0.mlp.experts.42.gate_proj.weight
+
+Until the remap was added, loading such a checkpoint either dropped
+expert weights silently or — when the substring match in
+`load_weights` hit `experts.down_proj` / `experts.gate_up_proj` —
+crashed at `transpose(-1, -2)` on a 1-D scale tensor
+(`IndexError: Dimension out of range (...) but got -2`).
+
+These tests pin the remap behaviour without needing a real checkpoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm.model_executor.models.qwen3_vl_moe import (
+    _remap_modelopt_qwen3_vl_moe_name,
+)
+
+
+@pytest.mark.parametrize(
+    "modelopt_name,expected_vllm_name",
+    [
+        # 2-D weight tensor — the common case.
+        (
+            "model.language_model.layers.0.mlp.experts.gate_proj.42.weight",
+            "model.layers.0.mlp.experts.42.gate_proj.weight",
+        ),
+        (
+            "model.language_model.layers.5.mlp.experts.up_proj.7.weight",
+            "model.layers.5.mlp.experts.7.up_proj.weight",
+        ),
+        (
+            "model.language_model.layers.23.mlp.experts.down_proj.127.weight",
+            "model.layers.23.mlp.experts.127.down_proj.weight",
+        ),
+        # 0-D / 1-D NVFP4 scales — same swap, all suffixes covered.
+        (
+            "model.language_model.layers.0.mlp.experts.gate_proj.42.weight_scale",
+            "model.layers.0.mlp.experts.42.gate_proj.weight_scale",
+        ),
+        (
+            "model.language_model.layers.0.mlp.experts.down_proj.0.weight_scale_2",
+            "model.layers.0.mlp.experts.0.down_proj.weight_scale_2",
+        ),
+        (
+            "model.language_model.layers.0.mlp.experts.up_proj.99.input_scale",
+            "model.layers.0.mlp.experts.99.up_proj.input_scale",
+        ),
+        (
+            "model.language_model.layers.0.mlp.experts.gate_proj.10.input_scale_2",
+            "model.layers.0.mlp.experts.10.gate_proj.input_scale_2",
+        ),
+    ],
+)
+def test_remap_modelopt_nvfp4_names(
+    modelopt_name: str, expected_vllm_name: str
+) -> None:
+    assert _remap_modelopt_qwen3_vl_moe_name(modelopt_name) == expected_vllm_name
+
+
+@pytest.mark.parametrize(
+    "modelopt_name,expected",
+    [
+        # Non-expert tensors keep the language_model strip but no
+        # projection/expert swap (regex doesn't match).
+        (
+            "model.language_model.embed_tokens.weight",
+            "model.embed_tokens.weight",
+        ),
+        (
+            "model.language_model.layers.0.self_attn.q_proj.weight",
+            "model.layers.0.self_attn.q_proj.weight",
+        ),
+        (
+            "model.language_model.layers.0.input_layernorm.weight",
+            "model.layers.0.input_layernorm.weight",
+        ),
+        (
+            "lm_head.weight",
+            "lm_head.weight",
+        ),
+    ],
+)
+def test_remap_strips_language_model_prefix_only(
+    modelopt_name: str, expected: str
+) -> None:
+    assert _remap_modelopt_qwen3_vl_moe_name(modelopt_name) == expected
+
+
+def test_remap_is_idempotent_on_already_vllm_names() -> None:
+    """Passing an already-remapped name through the function again must
+    not damage it. Important because the iterator wraps every weight,
+    including those from non-ModelOpt (non-prefixed) checkpoints."""
+    cases = [
+        "model.layers.0.mlp.experts.42.gate_proj.weight",
+        "model.layers.0.mlp.experts.42.gate_proj.weight_scale_2",
+        "model.embed_tokens.weight",
+    ]
+    for name in cases:
+        once = _remap_modelopt_qwen3_vl_moe_name(name)
+        twice = _remap_modelopt_qwen3_vl_moe_name(once)
+        assert once == name, f"unexpected change: {name!r} → {once!r}"
+        assert twice == once, f"not idempotent: {once!r} → {twice!r}"
+
+
+def test_remap_does_not_touch_non_matching_paths() -> None:
+    """Sanity: text outside the `mlp.experts.<proj>.<digits>.` pattern
+    is untouched even if it superficially resembles the regex."""
+    cases = [
+        # No digits after projection — not an expert weight.
+        "model.layers.0.mlp.experts.gate_proj.weight",
+        # Digit before projection (already vLLM-shaped, see idempotence).
+        "model.layers.0.mlp.experts.42.gate_proj.weight",
+        # Projection name appears outside `experts.` context.
+        "model.layers.0.self_attn.gate_proj_like_name.weight",
+    ]
+    for name in cases:
+        assert _remap_modelopt_qwen3_vl_moe_name(name) == name

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -28,6 +28,7 @@ import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
 
+import regex as re
 import torch
 from transformers.models.qwen3_vl_moe.configuration_qwen3_vl_moe import (
     Qwen3VLMoeConfig,
@@ -63,6 +64,53 @@ from .qwen3_vl import (
 from .utils import is_pp_missing_parameter, maybe_prefix
 
 logger = init_logger(__name__)
+
+# Matches ModelOpt's per-expert quantized weight naming, e.g.
+#   model.language_model.layers.0.mlp.experts.gate_proj.42.weight_scale_2
+# which vLLM's loader expects in the form
+#   model.layers.0.mlp.experts.42.gate_proj.weight_scale_2
+# (experts indexed first, projection second). See #40885.
+_MODELOPT_EXPERT_NAME_RE = re.compile(
+    r"^(?P<prefix>.*\.mlp\.experts\.)"
+    r"(?P<proj>gate_proj|up_proj|down_proj)\."
+    r"(?P<expert>\d+)\."
+    r"(?P<rest>.*)$"
+)
+
+
+def _remap_modelopt_qwen3_vl_moe_name(name: str) -> str:
+    """Normalise a ModelOpt-quantized Qwen3-VL-MoE checkpoint key to the
+    layout vLLM's `Qwen3MoeLLMModel.load_weights` expects.
+
+    Two transformations:
+
+    1. Strip the `language_model.` segment that the HuggingFace
+       `Qwen3VLMoEForConditionalGeneration` wrapper inserts before the
+       inner LLM. vLLM loads the LLM directly here, so paths look like
+       `model.layers.0.…` not `model.language_model.layers.0.…`.
+
+    2. Swap `experts.{proj}.{N}.…` to `experts.{N}.{proj}.…`. ModelOpt
+       emits each expert as its own 2-D tensor with the projection name
+       first and the expert index second; vLLM's
+       `FusedMoE.make_expert_params_mapping` produces weight names with
+       the expert index first.
+
+    The same swap covers all quant suffixes (`.weight`, `.weight_scale`,
+    `.weight_scale_2`, `.input_scale`, `.input_scale_2`) because the
+    regex captures them as `rest`.
+
+    This is a pure rename: shapes and values are untouched, and the
+    function is a no-op on already-vLLM-shaped names (no matching
+    `experts.<proj>.<digits>.` substring).
+    """
+    name = name.replace("model.language_model.", "model.")
+    match = _MODELOPT_EXPERT_NAME_RE.match(name)
+    if match is not None:
+        name = (
+            f"{match.group('prefix')}{match.group('expert')}."
+            f"{match.group('proj')}.{match.group('rest')}"
+        )
+    return name
 
 
 class Qwen3VLMoeProcessingInfo(Qwen3VLProcessingInfo):
@@ -162,6 +210,14 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
         return loaded_local_expert
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Normalise ModelOpt NVFP4 quantized checkpoints. These ship the
+        # `Qwen3VLMoEForConditionalGeneration` wrapper prefix and use
+        # `experts.{proj}.{N}` ordering. The remap function is a no-op
+        # on regular (non-ModelOpt) checkpoints. See #40885.
+        weights = (
+            (_remap_modelopt_qwen3_vl_moe_name(name), weight)
+            for name, weight in weights
+        )
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),


### PR DESCRIPTION
…40885)

ModelOpt-quantized Qwen3-VL-MoE checkpoints (e.g.
`Code4me2/bu-30b-a3b-preview-NVFP4`) emit weights in two patterns that don't match what vLLM's loader expects:

1. **`language_model.` wrapper prefix.** ModelOpt preserves the `Qwen3VLMoEForConditionalGeneration` outer module, so paths look like `model.language_model.layers.0.…` rather than the bare `model.layers.0.…` that `Qwen3MoeLLMModel` registers.

2. **Per-expert tensors with `experts.{proj}.{N}` ordering.** Each expert is a separate 2-D tensor, but the projection name comes *before* the expert index:

       model.language_model.layers.0.mlp.experts.gate_proj.42.weight
       model.language_model.layers.0.mlp.experts.gate_proj.42.weight_scale
       model.language_model.layers.0.mlp.experts.gate_proj.42.weight_scale_2
       model.language_model.layers.0.mlp.experts.gate_proj.42.input_scale

   vLLM's `FusedMoE.make_expert_params_mapping` builds weight names with the expert index *first*:

       model.layers.0.mlp.experts.42.gate_proj.weight

This PR adds a small `_remap_modelopt_qwen3_vl_moe_name` helper that strips the wrapper prefix and swaps `experts.{proj}.{N}` ↔ `experts.{N}.{proj}`. `Qwen3MoeLLMModel.load_weights` now wraps its input iterator through the helper, so the existing expert-mapping loop sees names in vLLM's expected layout without any further changes.

The helper is a no-op on already-vLLM-shaped names, so checkpoints that don't use the ConditionalGeneration wrapper or the ModelOpt per-expert layout (e.g. the original Qwen3-VL-MoE-BF16 release) load unchanged.

Side effect on #40885's IndexError: with the swap applied, the substring check `"experts.gate_up_proj" in name or "experts.down_proj" in name` (which sets `is_fused_expert = True` and triggers `transpose(-1, -2)`) no longer fires on per-expert ModelOpt weights, because the projection name is no longer a direct substring after `experts.`. The crash path described in #40885 is therefore avoided without any change to the transpose logic.

Tests added in `tests/models/test_qwen3_vl_moe_modelopt_remap.py` cover:
  - all four quant suffixes (`.weight`, `.weight_scale`, `.weight_scale_2`, `.input_scale`, `.input_scale_2`)
  - all three projections (`gate_proj`, `up_proj`, `down_proj`)
  - non-expert tensors (embed, attn, norm, lm_head) — prefix strip only, no swap
  - idempotence (already-vLLM names pass through unchanged)
  - non-matching paths (no false positives on `gate_proj_like_name`, etc.)

13 cases pass locally with `pytest -v`.

Closes #40885.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

