### PR TITLE
fix(v1/spec-decode): apply min_p to verified target tokens

### DIFF
--- a/tests/v1/sample/test_min_p_spec_decode.py
+++ b/tests/v1/sample/test_min_p_spec_decode.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``MinPLogitsProcessor.apply_with_spec_decode``.
+
+The bug fixed here is that ``RejectionSampler.apply_logits_processors``
+previously only iterated ``logitsprocs.non_argmax_invariant`` (which excludes
+``MinPLogitsProcessor`` since min_p is argmax-invariant). As a result min_p
+was silently dropped for verified target tokens during speculative decoding,
+and only applied to the bonus token via the regular ``Sampler`` path.
+"""
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig
+from vllm.platforms import current_platform
+from vllm.utils.platform_utils import is_pin_memory_available
+from vllm.v1.sample.logits_processor.builtin import MinPLogitsProcessor
+
+DEVICE_TYPE = current_platform.device_type
+
+
+def _reference_min_p_mask(logits: torch.Tensor, min_p: torch.Tensor) -> torch.Tensor:
+    """Reference: same body as ``MinPLogitsProcessor.apply`` but on a copy."""
+    out = logits.clone()
+    probs = torch.nn.functional.softmax(out, dim=-1)
+    max_p = torch.amax(probs, dim=-1, keepdim=True)
+    threshold = max_p * min_p
+    out.masked_fill_(probs < threshold, -float("inf"))
+    return out
+
+
+def _build_proc(max_num_seqs: int, device: str) -> MinPLogitsProcessor:
+    cfg = VllmConfig()
+    cfg.scheduler_config.max_num_seqs = max_num_seqs
+    proc = MinPLogitsProcessor(
+        vllm_config=cfg,
+        device=torch.device(device),
+        is_pin_memory=is_pin_memory_available(),
+    )
+    return proc
+
+
+def _seed_min_p(proc: MinPLogitsProcessor, values: list[float]) -> None:
+    """Populate the proc's min_p state without going through BatchUpdate."""
+    n = len(values)
+    for i, v in enumerate(values):
+        proc.min_p_cpu[i] = v
+        if v:
+            proc.min_p_count += 1
+    proc.min_p = proc.min_p_device[:n]
+    if proc.use_double_tensor:
+        proc.min_p.copy_(proc.min_p_cpu_tensor[:n], non_blocking=False)
+    proc.min_p.unsqueeze_(1)
+
+
+@pytest.mark.parametrize("device", [DEVICE_TYPE])
+def test_apply_with_spec_decode_noop_when_disabled(device):
+    """No request has min_p > 0 → method must be a pass-through."""
+    proc = _build_proc(max_num_seqs=4, device=device)
+    _seed_min_p(proc, [0.0, 0.0])
+
+    logits = torch.randn(5, 32, device=device)
+    before = logits.clone()
+    out = proc.apply_with_spec_decode(logits, num_draft_tokens=[2, 3])
+    assert torch.equal(out, before)
+
+
+@pytest.mark.parametrize("device", [DEVICE_TYPE])
+def test_apply_with_spec_decode_masks_per_request_rows(device):
+    """Per-row min_p must be expanded from per-request via repeat_interleave.
+
+    Two requests with different min_p, num_draft_tokens=[2, 3] → 5 rows total.
+    Rows 0,1 should be masked using request 0's min_p; rows 2,3,4 using
+    request 1's min_p. Output must match a per-row reference apply.
+    """
+    proc = _build_proc(max_num_seqs=4, device=device)
+    _seed_min_p(proc, [0.1, 0.05])  # request 0 stricter than request 1
+
+    torch.manual_seed(0)
+    logits = torch.randn(5, 64, device=device)
+    expected_min_p = torch.tensor([[0.1], [0.1], [0.05], [0.05], [0.05]], device=device)
+    expected = _reference_min_p_mask(logits, expected_min_p)
+
+    out = proc.apply_with_spec_decode(logits, num_draft_tokens=[2, 3])
+    assert torch.equal(out, expected)
+
+
+@pytest.mark.parametrize("device", [DEVICE_TYPE])
+def test_apply_with_spec_decode_mixed_zero_min_p(device):
+    """A request with min_p=0 must leave its rows untouched while a peer with
+    min_p>0 still gets masking."""
+    proc = _build_proc(max_num_seqs=4, device=device)
+    _seed_min_p(proc, [0.0, 0.2])
+
+    torch.manual_seed(1)
+    logits = torch.randn(4, 32, device=device)
+    expected_min_p = torch.tensor([[0.0], [0.0], [0.2], [0.2]], device=device)
+    expected = _reference_min_p_mask(logits, expected_min_p)
+
+    out = proc.apply_with_spec_decode(logits, num_draft_tokens=[2, 2])
+    assert torch.equal(out, expected)
+    # min_p=0 rows must be byte-identical to input (no masking, no NaN).
+    assert not torch.isinf(out[:2]).any()

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -115,6 +115,41 @@ class MinPLogitsProcessor(LogitsProcessor):
         logits.masked_fill_(invalid_token_mask, -float("inf"))
         return logits
 
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+    ) -> torch.Tensor:
+        """Spec-decode version of apply(): apply min_p row-wise to target
+        logits laid out per-draft-token across all requests.
+
+        ``num_draft_tokens[i]`` is the number of drafted tokens for request
+        ``i``; the logits tensor has shape ``[sum(num_draft_tokens), V]``
+        with one row per drafted position. We expand the per-request
+        ``self.min_p`` tensor to per-row via ``repeat_interleave`` and then
+        run the same softmax / max-prob / threshold / mask logic as
+        ``apply()``.
+        """
+        if not self.min_p_count:
+            return logits
+
+        num_draft_arr = torch.tensor(num_draft_tokens, device="cpu")
+        original_indices = torch.arange(len(num_draft_tokens), device="cpu")
+        repeat_indices_cpu = original_indices.repeat_interleave(num_draft_arr)
+        repeat_indices = repeat_indices_cpu.to(device=logits.device, non_blocking=True)
+
+        # self.min_p has shape [batch_size, 1] (unsqueezed in update_state);
+        # indexing with a 1-D LongTensor of length sum(num_draft_tokens)
+        # broadcasts to shape [sum(num_draft_tokens), 1].
+        min_p_per_row = self.min_p[repeat_indices]
+
+        probability_values = torch.nn.functional.softmax(logits, dim=-1)
+        max_probabilities = torch.amax(probability_values, dim=-1, keepdim=True)
+        adjusted_min_p = max_probabilities.mul_(min_p_per_row)
+        invalid_token_mask = probability_values < adjusted_min_p
+        logits.masked_fill_(invalid_token_mask, -float("inf"))
+        return logits
+
 
 class LogitBiasLogitsProcessor(LogitsProcessor):
     def __init__(self, _, device: torch.device, is_pin_memory: bool):

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -13,7 +13,10 @@ import torch.nn as nn
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
-from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.sample.logits_processor.builtin import (
+    MinPLogitsProcessor,
+    MinTokensLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -339,6 +342,16 @@ class RejectionSampler(nn.Module):
                 predict_bonus_token=False,
                 spec_token_ids=sampling_metadata.spec_token_ids,
             )
+
+        # Argmax-invariant logits processors (e.g. min_p) also need to run
+        # on verified target tokens; otherwise they would only affect the
+        # bonus token via the regular Sampler path and be silently dropped
+        # for the rest of the speculative window.
+        for processor in sampling_metadata.logitsprocs.argmax_invariant:
+            if isinstance(processor, MinPLogitsProcessor):
+                logits = processor.apply_with_spec_decode(
+                    logits, metadata.num_draft_tokens
+                )
         return logits
 
     @staticmethod


### PR DESCRIPTION
### what

`RejectionSampler.apply_logits_processors` only iterates `sampling_metadata.logitsprocs.non_argmax_invariant`, which excludes `MinPLogitsProcessor` (min_p is argmax-invariant). The consequence is that under speculative decoding, min_p is silently dropped on every verified target token — only the bonus token via the regular `Sampler` path honors it.

`SamplingParams._validate_spec_decode` was added to 400 these requests precisely because the behavior was partial. But that guard is the symptom; the actual fix is to apply min_p to the target tokens. This PR does that.

### the change

1. New method `MinPLogitsProcessor.apply_with_spec_decode(logits, num_draft_tokens)` — same softmax / max-prob / threshold / mask body as `apply()`, but expands the per-request `self.min_p` tensor to per-row using `repeat_interleave`, matching the layout of the spec-decode logits tensor (`[sum(num_draft_tokens), V]`).
2. `RejectionSampler.apply_logits_processors` gets a second iteration loop over `logitsprocs.argmax_invariant`, dispatching to `MinPLogitsProcessor.apply_with_spec_decode` (mirrors the existing `MinTokensLogitsProcessor` dispatch).
3. New unit tests in `tests/v1/sample/test_min_p_spec_decode.py`: no-op when disabled, per-request masking via `repeat_interleave`, mixed zero / non-zero `min_p` peers.

`_validate_spec_decode` is left in place — the validator should be relaxed in a follow-up once `logit_bias` is also wired (separate; not in this PR).

### why it matters

Without min_p under spec decoding, Qwen3-Coder-Next 80B-A3B (and similar code-tuned models) hit repetition collapse on long completions — the model emits `      result      result      result …` until the cap. With min_p applied to target logits via this patch, that disappears.

Measured on Qwen3-Coder-Next NVFP4 (vLLM 0.20.0 with this patch + Avarok kernel) on a single GB10:

| | spec off, min_p applied | spec on, no min_p | spec on, **this patch** |
|---|---|---|---|
| 10-prompt sampling-discipline probe (`min_p=0.05, top_p=0.8, top_k=20`) | 0 malformed | high malformed rate (repetition) | **0 malformed** |
| Long-prompt tok/s (k=1) | 34 | (was crashing before 0.20) | **105** |
| k=4 concurrent | stable | unstable on older builds | stable |

The deep fix recovers the spec-decoding speed-up without losing the sampling discipline that prevents repetition collapse on code models.

### testing

```
pytest tests/v1/sample/test_min_p_spec_decode.py -v
```

Three unit tests cover: no-op when no request has min_p>0, per-request masking with mixed num_draft_tokens, and that min_p=0 rows are untouched while a peer with min_p>0 still gets masked.

End-to-end validated against #42744's reproducer (Aider Polyglot Python harness with full anti-repetition stack + spec on).

Closes #42744