### PR TITLE
[Bugfix] DeepSeek V4: support transformers >= 4.57 normalized compress_ratios

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -957,7 +957,26 @@ class DeepseekV4Attention(nn.Module):
         # we do this for because MTP layer is not included
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
-            self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            if hasattr(config, "compress_ratios"):
+                # Legacy form: pre-normalization, the config exposes a list
+                # of per-layer compression ratios directly.
+                raw = config.compress_ratios[layer_id]
+            else:
+                # transformers >= 4.57 normalizes the same JSON field into
+                # ``layer_types`` (list[str]) + ``compress_rates`` (dict
+                # keyed by layer type). Reading ``compress_ratios`` on the
+                # newer config raises AttributeError. Reconstruct the
+                # per-layer ratio from the normalized fields with defensive
+                # getattr fallbacks so a partially-populated config still
+                # loads (``0`` is promoted to ``1`` by ``max(1, ...)`` below).
+                rates = getattr(config, "compress_rates", None) or {}
+                layer_types = getattr(config, "layer_types", None) or []
+                raw = (
+                    rates.get(layer_types[layer_id], 0)
+                    if layer_id < len(layer_types)
+                    else 0
+                )
+            self.compress_ratio = max(1, raw)
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps


### PR DESCRIPTION
## Purpose

Closes #42741.

`DeepseekV4Attention.__init__` reads `config.compress_ratios[layer_id]` directly (`vllm/model_executor/models/deepseek_v4.py:960`). transformers >= 4.57 reshapes the legacy JSON field on `DeepseekV4Config.__init__` into `layer_types` (list[str]) + `compress_rates` (dict[str, int]) and stops exposing `compress_ratios`. Every DSV4 checkpoint then fails to load on vLLM >= 0.20.2:

```
AttributeError: 'DeepseekV4Config' object has no attribute 'compress_ratios'.
Did you mean: 'compress_rates'?
```

Read from the normalized fields when `compress_ratios` is absent. The per-layer ratio is reconstructed via the issue author's documented 1-to-1 mapping:

```
compress_ratios[i] == compress_rates.get(layer_types[i], 0)
```

The existing `max(1, ...)` clamp at the end keeps the downstream invariant (compress ratio is never 0, see line 1019 where `self.compress_ratio > 1` gates `compress_rope_theta`) intact for both paths. Legacy configs with `compress_ratios` keep the original code path, so anyone pinning a pre-4.57 transformers stack sees no behavior change.

## Duplicate-work check

```
gh issue view 42741 --repo vllm-project/vllm --comments    # 0 comments
gh pr list --repo vllm-project/vllm --state all --search "42741 in:body"
gh pr list --repo vllm-project/vllm --state all --search "DeepSeek V4 compress_ratios"
```

No existing PR addresses this bug.

## Test Plan

The CUDA / GPU code path that DSV4 actually exercises is not reachable on a CPU dev box, but the resolution logic is small enough to validate at the Python level with a synthetic config. Twenty assertions covering both schemas:

- Bug repro under the old code: `AttributeError` on a normalized-only config.
- Legacy schema (with `compress_ratios`): 8 layer indices, fixed values match the pre-fix path.
- Normalized schema (`layer_types` + `compress_rates`): 8 layer indices, fixed values match the legacy schema for the same logical mapping.
- Layer type missing from `compress_rates`: falls back to 1 via the `max(1, ...)` clamp.
- `compress_rates is None`: same fallback (covered by `config.compress_rates or {}`).

All twenty cases pass under the fix.

## Test Result

```
=== bug reproduces under OLD code on normalized-only config ===
  AttributeError reproduced: 'types.SimpleNamespace' object has no attribute 'compress_ratios'

=== fixed code: legacy schema unchanged ===
  [OK ] legacy layer 0..7   (1, 4, 4, 128, 128, 1, 1, 1)

=== fixed code: normalized schema produces same values as legacy ===
  [OK ] normalized layer 0..7   (1, 4, 4, 128, 128, 1, 1, 1)

=== fixed code: layer_type missing from compress_rates falls back to 1 ===
  [OK ] full_attention -> 1
  [OK ] unknown_type -> 1

=== fixed code: compress_rates is None handled ===
  [OK ] None rates -> 1
```

`ruff check` and `ruff format --check` clean on the modified file.

## Related work

Same DSV4 bug-report set:
- #42769 / PR #42804: `name_mapped` `UnboundLocalError` in expert loading.
- #42777 / PR #42805: `WeightsMapper.orig_to_new_suffix` non-idempotent.

Issue author originally offered to bundle the three; opening them separately so reviewers can take each independently.

## AI Assistance Disclosure

Per `AGENTS.md`, disclosing that this PR was drafted with AI assistance (Claude Code). I read the surrounding `DeepseekV4Attention.__init__`, traced every downstream use of `self.compress_ratio` (lines 1019, 1049, 1081), confirmed the invariant the existing `max(1, ...)` clamp preserves, and ran the standalone Python repro against both schemas and the documented edge cases. The fix shape is the minimum to handle the schema variation without changing behavior for any config the upstream code already handles correctly.

