### PR TITLE
[ROCm] [Bugfix] Fix DeepSeek V4 Functionality and Accuracy

### DIFF
--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -61,31 +61,35 @@ class MHCPreOp(CustomOp):
         sinkhorn_repeat: int,
         n_splits: int = 1,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        hidden_size = residual.shape[-1]
-        if hidden_size % 256 == 0:
-            return torch.ops.vllm.mhc_pre_aiter(
-                residual,
-                fn,
-                hc_scale,
-                hc_base,
-                rms_eps,
-                hc_pre_eps,
-                hc_sinkhorn_eps,
-                hc_post_mult_value,
-                sinkhorn_repeat,
-            )
-        else:
-            return mhc_kernels.mhc_pre_torch(
-                residual,
-                fn,
-                hc_scale,
-                hc_base,
-                rms_eps,
-                hc_pre_eps,
-                hc_sinkhorn_eps,
-                hc_post_mult_value,
-                sinkhorn_repeat,
-            )
+        # TODO: Reenable aiter after we are at the aiter
+        # version that has this bugfix
+        # https://github.com/ROCm/aiter/commit/b639cb63bcac4672dce33a731fad042a65cb3649
+        # It has accuracy problem at large number of tokens.
+        # hidden_size = residual.shape[-1]
+        # if hidden_size % 256 == 0:
+        #     return torch.ops.vllm.mhc_pre_aiter(
+        #         residual,
+        #         fn,
+        #         hc_scale,
+        #         hc_base,
+        #         rms_eps,
+        #         hc_pre_eps,
+        #         hc_sinkhorn_eps,
+        #         hc_post_mult_value,
+        #         sinkhorn_repeat,
+        #     )
+        # else:
+        return mhc_kernels.mhc_pre_torch(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
 
     def forward_native(self, *args, **kwargs):
         raise NotImplementedError("Native implementation of mhc_pre is not available")
@@ -124,21 +128,25 @@ class MHCPostOp(CustomOp):
         post_layer_mix: torch.Tensor,
         comb_res_mix: torch.Tensor,
     ) -> torch.Tensor:
-        hidden_size = residual.shape[-1]
-        if hidden_size % 256 == 0:
-            return torch.ops.vllm.mhc_post_aiter(
-                x,
-                residual,
-                post_layer_mix,
-                comb_res_mix,
-            )
-        else:
-            return mhc_kernels.mhc_post_torch(
-                x,
-                residual,
-                post_layer_mix,
-                comb_res_mix,
-            )
+        # TODO: Reenable aiter after we are at the aiter
+        # version that has this bugfix
+        # https://github.com/ROCm/aiter/commit/b639cb63bcac4672dce33a731fad042a65cb3649
+        # It has accuracy problem at large number of tokens.
+        # hidden_size = residual.shape[-1]
+        # if hidden_size % 256 == 0:
+        #     return torch.ops.vllm.mhc_post_aiter(
+        #         x,
+        #         residual,
+        #         post_layer_mix,
+        #         comb_res_mix,
+        #     )
+        # else:
+        return mhc_kernels.mhc_post_torch(
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+        )
 
     def forward_native(self, *args, **kwargs):
         raise NotImplementedError("Native implementation of mhc_post is not available")

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -503,27 +503,6 @@ class SparseAttnIndexer(CustomOp):
         assert isinstance(q_quant, torch.Tensor), (
             "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
         )
-        if self.skip_k_cache_insert or not rocm_aiter_ops.is_enabled():
-            from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
-                rocm_aiter_sparse_attn_indexer_native,
-            )
-
-            return rocm_aiter_sparse_attn_indexer_native(
-                hidden_states,
-                _encode_layer_name(self.k_cache.prefix),
-                self.k_cache.kv_cache,
-                q_quant,
-                k,
-                weights,
-                self.quant_block_size,
-                self.scale_fmt,
-                self.topk_tokens,
-                self.head_dim,
-                self.max_model_len,
-                self.max_total_seq_len,
-                self.topk_indices_buffer,
-                skip_k_cache_insert=self.skip_k_cache_insert,
-            )
         if rocm_aiter_ops.is_enabled():
             return torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
                 hidden_states,
@@ -539,5 +518,9 @@ class SparseAttnIndexer(CustomOp):
                 self.max_model_len,
                 self.max_total_seq_len,
                 self.topk_indices_buffer,
+                skip_k_cache_insert=self.skip_k_cache_insert,
             )
-        raise RuntimeError("Sparse attention indexer ROCm path could not be selected.")
+        raise RuntimeError(
+            "Sparse attention indexer ROCm path is only supported on AITER. "
+            "Please enable aiter with VLLM_ROCM_USE_AITER=1"
+        )

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1277,7 +1277,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         x, post, comb = self.hc_pre(
             x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
         )
-        x = self.ffn_norm(x)
+        # ffn_norm is now folded into self.ffn.norm_gate; ffn() takes
+        # the pre-norm activation directly.
         x = self.ffn(x, input_ids)
         x = self.hc_post(x, residual, post, comb)
         return x, None, None, None

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -541,7 +541,11 @@ def rocm_fp8_mqa_logits(
         return fp8_mqa_logits_torch(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
 
 
-def _topk_indices_torch(logits: torch.Tensor, topk_tokens: int) -> torch.Tensor:
+def _topk_indices_torch(
+    logits: torch.Tensor,
+    topk_tokens: int,
+    row_starts: torch.Tensor | None = None,
+) -> torch.Tensor:
     k = min(topk_tokens, logits.shape[-1])
     values, indices = torch.topk(logits, k=k, dim=-1)
     indices = indices.to(torch.int32)
@@ -550,6 +554,12 @@ def _topk_indices_torch(logits: torch.Tensor, topk_tokens: int) -> torch.Tensor:
         torch.full_like(indices, -1, dtype=torch.int32),
         indices,
     )
+    if row_starts is not None:
+        # Match the CUDA top_k_per_row_prefill contract: indices are local to
+        # each row's valid [row_start, row_end) range, not columns in the
+        # concatenated chunk logits matrix.
+        starts = row_starts.to(dtype=torch.int32).view(-1, 1)
+        indices = torch.where(indices < 0, indices, indices - starts)
     if k == topk_tokens:
         return indices
     padded = torch.full(
@@ -576,21 +586,12 @@ def rocm_aiter_sparse_attn_indexer_fake(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor | None,
+    skip_k_cache_insert: bool = False,
 ) -> torch.Tensor:
-    # profile run
-    # NOTE(Chen): create the max possible flattened_kv. So that
-    # profile_run can get correct memory usage.
-    device = hidden_states.device if k is None else k.device
-    _flattened_kv = torch.empty(
-        [total_seq_lens, head_dim + 4], device=device, dtype=torch.uint8
-    )
-    fp8_dtype = current_platform.fp8_dtype()
-    _k_fp8 = _flattened_kv[..., :head_dim].view(fp8_dtype).contiguous()
-    _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
     return topk_indices_buffer
 
 
-def rocm_aiter_sparse_attn_indexer_native(
+def rocm_aiter_sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: LayerNameType,
     kv_cache: torch.Tensor,
@@ -629,6 +630,7 @@ def rocm_aiter_sparse_attn_indexer_native(
             max_model_len,
             total_seq_lens,
             topk_indices_buffer,
+            skip_k_cache_insert,
         )
     layer_attn_metadata = attn_metadata[k_cache_prefix]
     assert isinstance(layer_attn_metadata, DeepseekV32IndexerMetadata)
@@ -709,7 +711,19 @@ def rocm_aiter_sparse_attn_indexer_native(
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
-            topk_indices.copy_(_topk_indices_torch(logits, topk_tokens))
+
+            num_rows = logits.shape[0]
+
+            torch.ops._C.top_k_per_row_prefill(
+                logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
 
     if has_decode:
         decode_metadata = layer_attn_metadata.decode
@@ -747,7 +761,18 @@ def rocm_aiter_sparse_attn_indexer_native(
         )
 
         topk_indices = topk_indices_buffer[:num_decode_tokens, :topk_tokens]
-        topk_indices.copy_(_topk_indices_torch(logits, topk_tokens)[:num_decode_tokens])
+        num_rows = logits.shape[0]
+
+        torch.ops._C.top_k_per_row_decode(
+            logits,
+            next_n,
+            decode_metadata.seq_lens,
+            topk_indices,
+            num_rows,
+            logits.stride(0),
+            logits.stride(1),
+            topk_tokens,
+        )
 
         if decode_metadata.requires_padding:
             # if padded, we need to unpack
@@ -761,39 +786,6 @@ def rocm_aiter_sparse_attn_indexer_native(
             )
 
     return topk_indices_buffer
-
-
-def rocm_aiter_sparse_attn_indexer(
-    hidden_states: torch.Tensor,
-    k_cache_prefix: LayerNameType,
-    kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
-    k: torch.Tensor,
-    weights: torch.Tensor,
-    quant_block_size: int,
-    scale_fmt: str | None,
-    topk_tokens: int,
-    head_dim: int,
-    max_model_len: int,
-    total_seq_lens: int,
-    topk_indices_buffer: torch.Tensor | None,
-) -> torch.Tensor:
-    return rocm_aiter_sparse_attn_indexer_native(
-        hidden_states,
-        k_cache_prefix,
-        kv_cache,
-        q_fp8,
-        k,
-        weights,
-        quant_block_size,
-        scale_fmt,
-        topk_tokens,
-        head_dim,
-        max_model_len,
-        total_seq_lens,
-        topk_indices_buffer,
-        skip_k_cache_insert=False,
-    )
 
 
 def _decode_e8m0_scales(scale: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -591,6 +591,7 @@ def rocm_aiter_sparse_attn_indexer_fake(
 ) -> torch.Tensor:
     return topk_indices_buffer
 
+
 @eager_break_during_capture
 def rocm_aiter_sparse_attn_indexer(
     hidden_states: torch.Tensor,

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -760,7 +760,7 @@ def rocm_aiter_sparse_attn_indexer(
             max_model_len=max_model_len,
         )
 
-        topk_indices = topk_indices_buffer[:num_decode_tokens, :topk_tokens]
+        topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
         num_rows = logits.shape[0]
 
         torch.ops._C.top_k_per_row_decode(


### PR DESCRIPTION



## Purpose

This PR addresses the following issues

1. Functionality broken after this PR https://github.com/vllm-project/vllm/pull/41263 (fixed by removing `x = self.ffn_norm(x)`)
2. Fix the DeepSeek V4 accuracy degradation at high concurrency.

I have added self-review comments to explain the changes.

### Point 2
It is a compounded issue.
1. AITER MHC has accuracy issue when number of tokens is large. New AITER version is coming soon, so the code path is kept documented so that we can easily reenable it in vLLM once we upgrade the AITER version. For now we are falling back to torch implementation.
2. The prefill mqa topk buffer is corrupted by incorrect logic. It is fixed by calling the `torch.ops._C.top_k_per_row_prefill` .


Other changes are code cleaning and also invoking faster kernels e.g. replace `_topk_indices_torch` with `torch.ops._C.top_k_per_row_decode` . 

## Test Plan

lmeval score of `deepseek-ai/DeepSeek-V4-Pro` and `deepseek-ai/DeepSeek-V4-Flash`

Server command
```
#!/bin/bash
max_num_seqs=256
max_model_len=1048576
tensor_parallel_size=8
rm -rf ~/.cache/vllm

export VLLM_ROCM_USE_AITER=1
vllm serve deepseek-ai/DeepSeek-V4-Pro \
    --host localhost \
    --port 8001 \
    --kv-cache-dtype fp8 \
    --block-size 256 \
    --tensor-parallel-size "${tensor_parallel_size}" \
    --max-model-len "${max_model_len}" \
    --tensor-parallel-size 8 \
    --max-num-seqs 256 \
    --distributed-executor-backend mp \
    --trust-remote-code \
    --gpu-memory-utilization 0.6 \
    --moe-backend triton_unfused \
    --tokenizer-mode deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --async-scheduling \
    --enable-prefix-caching \
    --compilation-config '{"mode":3,"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
| tee deepseekv4_graph_mhctriton_block256_topkindicesvllmop_syncmain.log
```

lm eval command:

```bash
#!/bin/bash

SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
LM_EVAL_PYTHON=${LM_EVAL_PYTHON:-"${SCRIPT_DIR}/hfvenv/bin/python"}
MODEL=deepseek-ai/DeepSeek-V4-Pro
"${LM_EVAL_PYTHON}" -m lm_eval --model local-completions --model_args model=$MODEL,base_url=http://0.0.0.0:8001/v1/completions,num_concurrent=256,max_retries=10,max_gen_toks=2048,max_length=1048576,timeout=60000 --batch_size auto --tasks gsm8k --num_fewshot 8 \
  --output_path ./results_graph_numshot8 \
  --log_samples \
| tee lmeval_graph_numshot8.log
```


## Test Result

deepseek-ai/DeepSeek-V4-Pro

```
local-completions ({'model': 'deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://0.0.0.0:8001/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 8, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|_  |0.9553|_  |0.0057|
|     |       |strict-match    |     8|exact_match|_  |0.9560|_  |0.0056|
```

deepseek-ai/DeepSeek-V4-Flash

```
local-completions ({'model': 'deepseek-ai/DeepSeek-V4-Flash', 'base_url': 'http://0.0.0.0:8001/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 8, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|_  |0.9492|_  | 0.006|
|     |       |strict-match    |     8|exact_match|_  |0.9500|_  | 0.006|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

