### PR TITLE
fix: three robustness bugs — is_moe_layer None return, dead structured_outputs check, missing await in batch upload

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -711,7 +711,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 "outputs ('json', 'regex' or 'choice')."
             )
         # you can only either use structured outputs or tools, not both
-        if count > 1 and data.get("tool_choice", "none") not in (
+        if count > 0 and data.get("tool_choice", "none") not in (
             "none",
             "auto",
             "required",

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -382,7 +382,7 @@ async def upload_data(output_url: str, data_or_file: str, from_file: bool) -> No
                                 raise Exception(
                                     f"Failed to upload file.\n"
                                     f"Status: {response.status}\n"
-                                    f"Response: {response.text()}"
+                                    f"Response: {await response.text()}"
                                 )
                 else:
                     async with session.put(output_url, data=data_or_file) as response:
@@ -390,7 +390,7 @@ async def upload_data(output_url: str, data_or_file: str, from_file: bool) -> No
                             raise Exception(
                                 f"Failed to upload data.\n"
                                 f"Status: {response.status}\n"
-                                f"Response: {response.text()}"
+                                f"Response: {await response.text()}"
                             )
 
         except Exception as e:

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -42,8 +42,6 @@ def is_moe_layer(module: torch.nn.Module) -> bool:
         if cls.__name__ == "FusedMoE":
             return True
 
-        for b in cls.__bases__:
-            if _check_bases(b):
-                return True
+        return any(_check_bases(b) for b in cls.__bases__)
 
     return _check_bases(module.__class__)


### PR DESCRIPTION
## Summary

Three targeted robustness fixes for correctness issues found during code review.

### 1. `is_moe_layer()` returns `None` instead of `False`
**File:** `vllm/utils/__init__.py`

The inner `_check_bases` helper had no fallback return when no base class matched `"FusedMoE"`, so it implicitly returned `None`. The outer function `is_moe_layer()` is typed `-> bool` but was returning `None` for non-MoE modules. Refactored using `any()` to always return a proper `bool`.

**Impact:** Used in `base_device_communicator.py` and `elastic_execute.py` for expert-parallel MoE module discovery. While `None` is falsy, it violates the type contract and could cause issues in identity comparisons (`is False`).

### 2. Dead code in `check_structured_outputs_count` validator
**File:** `vllm/entrypoints/openai/chat_completion/protocol.py`

The second validation check (structured outputs vs named `tool_choice`) used `count > 1`, but the first check already raises `ValueError` when `count > 1`. This made the second check **unreachable dead code**. Changed to `count > 0` so the mutual-exclusion validation actually fires when structured outputs are used with a named tool choice.

**Impact:** Without this fix, users can send both `structured_outputs` and a named `tool_choice` simultaneously without getting an error, which leads to silently conflicting output constraints.

### 3. Missing `await` on `response.text()` in batch upload
**File:** `vllm/entrypoints/openai/run_batch.py`

`aiohttp.ClientResponse.text()` is a coroutine that must be `await`ed. Two call sites in `upload_data()` were missing `await`, causing error messages to contain a coroutine repr string (e.g., `<coroutine object ...>`) instead of the actual HTTP response body.

**Impact:** When batch file uploads fail, the error message is useless for debugging.

## Test Plan

- All fixes are minimal, targeted, and do not change control flow beyond the bug site
- Pre-commit hooks (ruff, mypy, typos, SPDX, etc.) all pass