### PR TITLE
[Bugfix][DeepseekV4] Make WeightsMapper head/embed rules idempotent

### DIFF
--- a/tests/models/test_deepseek_v4_weights_mapper.py
+++ b/tests/models/test_deepseek_v4_weights_mapper.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Regression tests for the DeepSeek V4 WeightsMapper.
+
+Covers issue #42777: the suffix rule ``"head.weight": "lm_head.weight"``
+also matched ``lm_head.weight`` because the latter ends with
+``head.weight``, producing ``lm_lm_head.weight`` and breaking the
+parameter lookup. The same anti-pattern affected ``embed.weight``.
+
+The fix moves both rules from the broad-matching ``orig_to_new_suffix``
+to anchored regex entries (``^head\\.weight$`` and ``^embed\\.weight$``)
+in ``orig_to_new_regex``, so already-canonical names are no longer
+caught.
+"""
+
+import pytest
+
+from vllm.model_executor.models.deepseek_v4 import (
+    _make_deepseek_v4_weights_mapper,
+)
+
+
+@pytest.mark.parametrize("expert_dtype", ["fp4", "fp8"])
+def test_legacy_head_weight_is_remapped(expert_dtype: str) -> None:
+    """A legacy ``head.weight`` checkpoint key maps to ``lm_head.weight``."""
+    mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
+    assert mapper.apply_list(["head.weight"]) == ["lm_head.weight"]
+
+
+@pytest.mark.parametrize("expert_dtype", ["fp4", "fp8"])
+def test_canonical_lm_head_weight_is_idempotent(expert_dtype: str) -> None:
+    """An already-canonical ``lm_head.weight`` passes through unchanged."""
+    mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
+    assert mapper.apply_list(["lm_head.weight"]) == ["lm_head.weight"]
+
+
+@pytest.mark.parametrize("expert_dtype", ["fp4", "fp8"])
+def test_legacy_embed_weight_is_remapped(expert_dtype: str) -> None:
+    """A legacy ``embed.weight`` key maps to ``model.embed_tokens.weight``."""
+    mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
+    assert mapper.apply_list(["embed.weight"]) == ["model.embed_tokens.weight"]
+
+
+@pytest.mark.parametrize("expert_dtype", ["fp4", "fp8"])
+def test_canonical_model_embed_tokens_weight_is_idempotent(
+    expert_dtype: str,
+) -> None:
+    """An already-canonical ``model.embed_tokens.weight`` is unchanged."""
+    mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
+    assert mapper.apply_list(["model.embed_tokens.weight"]) == [
+        "model.embed_tokens.weight"
+    ]
+
+
+@pytest.mark.parametrize("expert_dtype", ["fp4", "fp8"])
+def test_unrelated_names_unchanged(expert_dtype: str) -> None:
+    """Tensor names that don't match any rule are returned as-is."""
+    mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
+    for name in [
+        "model.lm_head.weight",
+        "lm_head.bias",
+        "some.completely.unrelated.tensor",
+    ]:
+        assert mapper.apply_list([name]) == [name]
+
+
+def test_existing_ffn_norm_remap_still_fires() -> None:
+    """The ``.ffn_norm.weight`` -> ``.ffn.norm_gate.norm.weight`` rule lives
+    in the same mapper; confirm #42777 didn't regress it."""
+    mapper = _make_deepseek_v4_weights_mapper("fp4")
+    assert mapper.apply_list(["model.layers.0.ffn_norm.weight"]) == [
+        "model.layers.0.ffn.norm_gate.norm.weight"
+    ]

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1605,6 +1605,12 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
         scale_regex = {
             re.compile(r"(\.experts\.\d+\.w[123])\.scale$"): r"\1.weight_scale",
             re.compile(r"\.scale$"): ".weight_scale_inv",
+            # Anchored top-level head/embed rules: prevent the broad
+            # suffix match from re-firing on already-canonical
+            # lm_head.weight / model.embed_tokens.weight (both end with
+            # the bare suffix form).
+            re.compile(r"^head\.weight$"): "lm_head.weight",
+            re.compile(r"^embed\.weight$"): "model.embed_tokens.weight",
         }
     else:
         # FP8 experts use Fp8MoEMethod (block_quant=True), which registers
@@ -1612,6 +1618,8 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
         # there.
         scale_regex = {
             re.compile(r"\.scale$"): ".weight_scale_inv",
+            re.compile(r"^head\.weight$"): "lm_head.weight",
+            re.compile(r"^embed\.weight$"): "model.embed_tokens.weight",
         }
     return WeightsMapper(
         orig_to_new_prefix={
@@ -1623,8 +1631,6 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
         },
         orig_to_new_regex=scale_regex,
         orig_to_new_suffix={
-            "head.weight": "lm_head.weight",
-            "embed.weight": "embed_tokens.weight",
             # Pre-MoE norm + gate are now owned by ``DeepseekV4MoE.norm_gate``
             # (see NormGatedLinear).
             ".ffn_norm.weight": ".ffn.norm_gate.norm.weight",


### PR DESCRIPTION
## Summary

`_make_deepseek_v4_weights_mapper` registers two non-idempotent `orig_to_new_suffix` rules:

```python
"head.weight": "lm_head.weight",
"embed.weight": "embed_tokens.weight",
```

`WeightsMapper._map_name` matches suffixes via `key.endswith(orig)`, so applying the rule to an already-mapped `lm_head.weight` yields `lm_lm_head.weight` and the lookup fails:

```
ValueError: There is no module or parameter named 'lm_lm_head' in DeepseekV4ForCausalLM.
```

A single application to the bare `head.weight` (the DeepSeek-V4 release layout) is correct. The failure I hit came from a downstream quantization wrapper that pre-applies `hf_to_vllm_mapper` to disk names before handing them to `AutoWeightsLoader`, which then applies the mapper a second time. That double-application is being fixed on the wrapper side and is not a vLLM-core defect.

This PR is therefore offered as defense-in-depth hardening, not a core bug fix: an idempotent mapper stays correct if any wrapper or future code path applies it more than once, which is why several vLLM mappers already use anchored patterns. Closing this as out-of-scope is equally reasonable; deferring to maintainers.

## Fix

Move both rules from `orig_to_new_suffix` into anchored `orig_to_new_regex` (`^head\.weight$`, `^embed\.weight$`), so a repeat application is a no-op. `embed.weight` maps directly to `model.embed_tokens.weight` since the `embed.` prefix rule no longer chains once the rewrite is a regex. An explicit identity entry does not work: `_map_name` applies all matching suffix rules with no early break.

## Tests

`tests/models/test_deepseek_v4_weights_mapper.py`, CPU-only, public `WeightsMapper.apply_list`:

- legacy `head.weight` / `embed.weight` still remap
- canonical `lm_head.weight` / `model.embed_tokens.weight` unchanged under repeated application
- both `expert_dtype` branches; unrelated names untouched; `.ffn_norm.weight` still fires

## Related

#42741 and #42769 are unrelated DSV4 loader issues found in the same validation pass.

Related: #42777