### PR TITLE
Validate convert modes against resolved runner

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -303,6 +303,31 @@ def test_auto_runner(model_id, expected_runner_type, expected_convert_type):
     assert config.convert_type == expected_convert_type
 
 
+@pytest.mark.parametrize("convert_type", ["embed", "classify"])
+def test_explicit_convert_requires_pooling_runner(convert_type):
+    with pytest.raises(ValueError, match="--runner pooling"):
+        ModelConfig("distilbert/distilgpt2", runner="auto", convert=convert_type)
+
+
+@pytest.mark.parametrize("convert_type", ["embed", "classify"])
+def test_explicit_convert_with_pooling_runner_initializes_pooler_config(convert_type):
+    config = ModelConfig(
+        "distilbert/distilgpt2", runner="pooling", convert=convert_type
+    )
+
+    assert config.runner_type == "pooling"
+    assert config.convert_type == convert_type
+    assert config.pooler_config is not None
+
+
+def test_auto_convert_generate_runner_keeps_causal_lm_as_generation_model():
+    config = ModelConfig("distilbert/distilgpt2", runner="auto", convert="auto")
+
+    assert config.runner_type == "generate"
+    assert config.convert_type == "none"
+    assert config.pooler_config is None
+
+
 @pytest.mark.parametrize(
     ("model_id", "expected_runner_type", "expected_convert_type"),
     [

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -551,6 +551,15 @@ class ModelConfig:
             architectures, self.runner_type, self.convert
         )
 
+        allowed_converts = _RUNNER_CONVERTS[self.runner_type]
+        if self.convert_type != "none" and self.convert_type not in allowed_converts:
+            raise ValueError(
+                f"`--convert {self.convert_type}` is not supported with "
+                f"`--runner {self.runner}`, which resolved to "
+                f"`--runner {self.runner_type}`. "
+                "Pass `--runner pooling` to adapt the model for pooling tasks."
+            )
+
         if self.runner_type == "generate" and not is_generative_model:
             generate_converts = _RUNNER_CONVERTS["generate"]
             if self.convert_type not in generate_converts:


### PR DESCRIPTION



## Purpose
Fixes #42480

This PR fixes an issue where vLLM accepts explicit `--convert embed` or `--convert classify` for a causal LM, 
but later crashes during engine/model initialization with an internal error:

```text
AssertionError: pooler_config is not None
```

After reproducing the issue, I found that the problem is not that a causal LM cannot be adapted into an embedding or classification pooling model. The actual problem is an inconsistent resolved config state:

``` 
runner_type = generate
convert_type = embed/classify
pooler_config = None
```

In other words, --runner auto --convert embed/classify still resolves a causal LM to the generation runner, while convert_type later causes the model loader to wrap the model with a pooling adapter. The pooling adapters require pooler_config during initialization, but pooler_config is only initialized for the pooling runner. As a result, the server crashes later in the deeper engine/model initialization path.

The valid configuration is:

``` 
vllm serve <causal-lm> --runner pooling --convert embed
vllm serve <causal-lm> --runner pooling --convert classify
```

With that configuration, pooler_config is initialized correctly.

This PR fixes the issue by validating the resolved convert_type against _RUNNER_CONVERTS[self.runner_type] in ModelConfig, after both runner_type and convert_type have been resolved. If the resolved runner does not support the requested convert mode, vLLM now raises a clear ValueError telling users to pass --runner pooling, instead of allowing the invalid state to reach model loading and fail with an internal AssertionError.

This is my first PR to vLLM, so please let me know if anything should be adjusted to better match the project's conventions. I'm happy to update it.

## Test Plan

I added and ran focused `ModelConfig` tests covering the following cases:

- `runner=auto` with explicit `convert=embed/classify` raises a clear `ValueError`
- `runner=pooling` with explicit `convert=embed/classify` still initializes `pooler_config`
- the default causal-LM path with `runner=auto, convert=auto` remains in generation mode and is not affected

Command:

```
python -m pytest \
  tests/test_config.py::test_explicit_convert_requires_pooling_runner \
  tests/test_config.py::test_explicit_convert_with_pooling_runner_initializes_pooler_config \
  tests/test_config.py::test_auto_convert_generate_runner_keeps_causal_lm_as_generation_model \
  -q
```
## Test Result
```

5 passed, 17 warnings in 31.79s

```
The warnings are unrelated local environment warnings from running the source checkout, including the missing generated vllm._version module and torch deprecation warnings.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

