### PR TITLE
Fix: Propagate pinned model revisions into Ultravox secondary weight loading

### DIFF
--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -566,7 +566,7 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
             self.secondary_weights.append(
                 DefaultModelLoader.Source(
                     model_or_path=config.audio_model_id,
-                    revision=None,
+                    revision=vllm_config.model_config.revision,
                     prefix="audio_tower.",
                 )
             )
@@ -576,7 +576,7 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
             self.secondary_weights.append(
                 DefaultModelLoader.Source(
                     model_or_path=config.text_model_id,
-                    revision=None,
+                    revision=vllm_config.model_config.revision,
                     prefix="language_model.",
                 )
             )


### PR DESCRIPTION

Propagate pinned model revisions into Ultravox secondary weight loading

## Purpose

issue
When a user loads an Ultravox model with --revision <tag-or-commit>, vLLM correctly pins the primary model artifacts to that revision, but Ultravox still loads its  secondary audio and text weights with revision=None.

  The audio tower and language-model secondary weights can be fetched from the default branch, typically main, instead of the user-requested revision. This creates version drift inside one model load. In practice, users may see weight/config mismatches, load failures, or incorrect runtime behavior that is hard to diagnose.

  Expected Behavior
  If the user sets --revision, every model artifact involved in that load should resolve from the same pinned revision, including Ultravox secondary weights.

  Root Cause
  UltravoxModel.secondary_weights hardcoded revision=None for both audio_model_id and text_model_id. That bypassed the already-provided vllm_config.model_config.revision  and broke revision propagation at the secondary-weight boundary.

  Fix
  The original revision-propagation bug was not limited to a single model, but to a small set of artifact-loading paths. In the current codebase, the known affected paths  were the ones fixed in PR #42616 plus the remaining Ultravox secondary-weight path addressed here.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

