### PR TITLE
[ROCm][GPT-OSS] Avoid repeated compile-time `cos_sin_cache.to(bf16)` casts in rotary path

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -62,6 +62,17 @@ class RotaryEmbeddingBase(CustomOp):
             self.cos_sin_cache: torch.Tensor
             self.register_buffer("cos_sin_cache", cache, persistent=False)
 
+            # Reuse a precomputed bf16 cache for the AITER compile path.
+            if self.use_aiter and cache.dtype != torch.bfloat16:
+                self.cos_sin_cache_bf16: torch.Tensor | None
+                self.register_buffer(
+                    "cos_sin_cache_bf16",
+                    cache.to(torch.bfloat16),
+                    persistent=False,
+                )
+            else:
+                self.cos_sin_cache_bf16 = None
+
         self.apply_rotary_emb = ApplyRotaryEmb(
             is_neox_style=self.is_neox_style,
         )
@@ -100,6 +111,16 @@ class RotaryEmbeddingBase(CustomOp):
             and self.cos_sin_cache.dtype == query.dtype
         ):
             return cos_sin_cache
+
+        # Reuse precomputed bf16 cache in the AITER compile path.
+        if (
+            self.use_aiter
+            and torch.compiler.is_compiling()
+            and query.dtype == torch.bfloat16
+        ):
+            cache_bf16 = getattr(self, "cos_sin_cache_bf16", None)
+            if cache_bf16 is not None and cache_bf16.device == query.device:
+                return cache_bf16
 
         cos_sin_cache = cos_sin_cache.to(query.device, dtype=query.dtype)
         # Avoid mutating buffers during torch.compile (cudagraph) tracing.


### PR DESCRIPTION
## Summary

- Add a compile-friendly bf16 cache fast path for rotary cos/sin cache matching.
- Materialize and reuse `cos_sin_cache_bf16` when ROCm AITER rotary is active.
- Avoid repeated per-layer bf16 cast nodes in compile mode while preserving non-compile behavior.

## Motivation

In GPT-OSS decode compile graphs, repeated `cos_sin_cache.to(query.device, dtype=query.dtype)` can be emitted per layer in the rotary path.  
Reusing a precomputed bf16 cache removes those repeated cast nodes while keeping existing runtime semantics.

## Implementation

- `vllm/model_executor/layers/rotary_embedding/base.py`
  - During cache init, register optional `cos_sin_cache_bf16` buffer for AITER path.
  - In `_match_cos_sin_cache_dtype`, in AITER compile mode with bf16 query dtype, return `cos_sin_cache_bf16` on same device before fallback cast.

## Test Plan

- [x] Verify no regressions in serve/warmup/perf flow
- [x] Perf comparison shows throughput up and TPOT down vs baseline.
- [x] LM-eval GSM8K (`--limit 256`, chat-template path) remains in baseline-equivalent range.
- [x] FX dump comparison shows bf16 cache buffer reuse replaces repeated compile-time cast nodes.

## Validation Results

Performance vs baseline (`openai/gpt-oss-120b`):

- Throughput improves at conc16/32/64: `+1.89%`, `+1.69%`, `+1.82%`.
- Median TPOT decreases at conc16/32/64: `-3.12%`, `-1.63%`, `-2.30%` (lower is better).

LM-eval GSM8K (`--limit 256`, chat-template path) remains baseline-equivalent:

- baseline flexible exact_match: `0.9062 ± 0.0183`
- PR flexible exact_match: `0.9141 ± 0.0176`
- baseline strict exact_match: `0.1836 ± 0.0242`
- PR strict exact_match: `0.1836 ± 0.0242`

FX dump evidence (decode compile path):

- Before: repeated `_match_cos_sin_cache_dtype` casts appear as `cos_sin_cache.to(query.device, dtype=query.dtype)` across layers.
- After: rotary calls consume `rotary_emb._buffers['cos_sin_cache_bf16']` directly in the compiled graph, indicating the bf16 cache reuse path is active.


