### PR TITLE
[Bugfix][DeepseekV4] Guard expert loader against UnboundLocalError

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1529,6 +1529,7 @@ class DeepseekV4Model(nn.Module):
                         and loaded_weight.dtype == torch.float8_e8m0fnu
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
+                    name_mapped = None
                     for mapping in expert_mapping:
                         param_name, weight_name, expert_id, shard_id = mapping
                         if weight_name not in name:
@@ -1554,6 +1555,13 @@ class DeepseekV4Model(nn.Module):
                         if success:
                             name = name_mapped
                             break
+                    if name_mapped is None:
+                        # No expert mapping matched (e.g. a non-canonical
+                        # checkpoint whose expert tensor names differ from
+                        # this model's expert_mapping); nothing was loaded
+                        # for this weight, so skip it instead of raising
+                        # UnboundLocalError.
+                        continue
                     loaded_params.add(name_mapped)
                     continue
                 elif "attn_sink" in name:

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1530,6 +1530,7 @@ class DeepseekV4Model(nn.Module):
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
                     name_mapped = None
+                    success = False
                     for mapping in expert_mapping:
                         param_name, weight_name, expert_id, shard_id = mapping
                         if weight_name not in name:
@@ -1555,12 +1556,12 @@ class DeepseekV4Model(nn.Module):
                         if success:
                             name = name_mapped
                             break
-                    if name_mapped is None:
-                        # No expert mapping matched (e.g. a non-canonical
-                        # checkpoint whose expert tensor names differ from
-                        # this model's expert_mapping); nothing was loaded
-                        # for this weight, so skip it instead of raising
-                        # UnboundLocalError.
+                    if not success:
+                        # No expert mapping matched, or the loader did not
+                        # load this weight for the current rank (e.g. a
+                        # non-canonical checkpoint, or this rank holds no
+                        # replica). Skip it instead of marking it loaded or
+                        # raising UnboundLocalError.
                         continue
                     loaded_params.add(name_mapped)
                     continue


### PR DESCRIPTION
Suggested fix for #42769.

`DeepseekV4Model.load_weights` adds `name_mapped` to `loaded_params` unconditionally after the `for mapping in expert_mapping` loop, but `name_mapped` is only bound inside the loop, after the `if weight_name not in name: continue` guard. A `.experts.` weight that matches no entry in `expert_mapping` leaves `name_mapped` unbound, so `loaded_params.add(name_mapped)` raises `UnboundLocalError` and aborts checkpoint load.

This initializes `name_mapped = None` before the loop and skips the weight when no mapping matched (consistent with the other unmatched-weight branches in this method, which `continue`), instead of raising. Full repro and trace are in #42769.

The affected path is `load_weights`, which requires a fully instantiated model plus distributed init to exercise; vLLM's existing DSV4 tests are CUDA-gated and cover only pure helpers, so there is no unit-test seam. This is a self-contained unbound-variable guard; glad to add a CUDA integration test if a maintainer prefers.

Closes #42769

## Update

Addressed the automated review in `cd5cd496de`.

The initial fix avoided `UnboundLocalError` by initializing `name_mapped`, but that was not enough: if the expert mapping loop runs and every `weight_loader(..., return_success=True)` call returns `False`, the code could still add a parameter name to `loaded_params` even though no data was loaded for this rank.

The follow-up commit tracks an explicit `success` flag and only records the parameter when the loader reports that it actually loaded the weight. Successful canonical loads are unchanged; this only hardens the unsuccessful mapping / non-local expert path so `loaded_params` remains accurate.
