### PR TITLE
[Bugfix][DeepseekV4] Guard compress_ratios access for transformers >= 4.57

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -957,7 +957,12 @@ class DeepseekV4Attention(nn.Module):
         # we do this for because MTP layer is not included
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
-            self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            if hasattr(config, "compress_ratios") and config.compress_ratios is not None:
+                self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            else:
+                _rates = getattr(config, "compress_rates", {}) or {}
+                _types = getattr(config, "layer_types", [])
+                self.compress_ratio = max(1, _rates.get(_types[layer_id], 0))
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -960,9 +960,10 @@ class DeepseekV4Attention(nn.Module):
             if hasattr(config, "compress_ratios") and config.compress_ratios is not None:
                 self.compress_ratio = max(1, config.compress_ratios[layer_id])
             else:
-                _rates = getattr(config, "compress_rates", {}) or {}
-                _types = getattr(config, "layer_types", [])
-                self.compress_ratio = max(1, _rates.get(_types[layer_id], 0))
+                _rates = getattr(config, "compress_rates", None) or {}
+                _types = getattr(config, "layer_types", None) or []
+                layer_type = _types[layer_id] if layer_id < len(_types) else None
+                self.compress_ratio = max(1, _rates.get(layer_type, 0))
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps


### PR DESCRIPTION
Suggested fix for #42741.

`transformers >= 4.57` normalizes the legacy `compress_ratios` config field into the `compress_rates` + `layer_types` pair, so `DeepseekV4Attention` reading `config.compress_ratios[layer_id]` raises and DeepSeek V4 fails to load on current transformers.

This guards the access with `hasattr` / `is not None` and falls back to the normalized `compress_rates` / `layer_types` representation when the legacy field is absent. Behavior is unchanged for checkpoints/transformers versions that still expose `compress_ratios`. Full repro and environment details are in #42741.

Closes #42741