### PR TITLE
[Bugfix] Fix MultiConnector state corruption in P/D disaggregated con…

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -381,13 +381,23 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     ):
         chosen_connector = self._requests_to_connector.get(request.request_id, -1)
         empty_blocks = blocks.new_empty()
+        # When a specific connector was chosen to load KV for this request,
+        # mask out kv_transfer_params for the others so they don't
+        # incorrectly start async transfers for a request they do not own.
+        # When no connector was chosen (e.g. producer side or no remote
+        # match), leave params intact so producer logic and full-prefix-hit
+        # handling still run.
+        masked_request = request
+        if chosen_connector >= 0:
+            masked_request = copy.copy(request)
+            masked_request.kv_transfer_params = None
         for i, c in enumerate(self._connectors):
             if i == chosen_connector:
                 # Forward call to the chosen connector (if any).
                 c.update_state_after_alloc(request, blocks, num_external_tokens)
             else:
                 # Call with empty blocks for other connectors.
-                c.update_state_after_alloc(request, empty_blocks, 0)
+                c.update_state_after_alloc(masked_request, empty_blocks, 0)
 
     def on_new_request(self, request: "Request") -> None:
         for c in self._connectors:


### PR DESCRIPTION
 fix https://github.com/vllm-project/vllm/issues/42831
  When MultiConnector selects one sub-connector to load KV for a request,
  it passes empty blocks (num_external_tokens=0) to all other
  sub-connectors. Because the original request (with kv_transfer_params)
  was passed to every connector, non-chosen connectors incorrectly started
  async KV transfers for requests they did not own.

  This led to assertion failures when get_finished() later reported these
  requests as done receiving, but their scheduler state no longer matched.

  Fix in MultiConnector.update_state_after_alloc(): when a connector was
  chosen for this request, pass a shallow-copied request with
  kv_transfer_params=None to all other connectors. Their existing
  "if not params: return" guard then correctly skips state updates.
  When no connector was chosen (producer side, full prefix hit), the
  original request is passed through unchanged so producer logic and
  remote block freeing still work.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

