### PR TITLE
[Model][Experimental] DeepSeek V4 w4a4 MegaMoE support

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -168,6 +168,8 @@ if TYPE_CHECKING:
     VLLM_MOE_USE_DEEP_GEMM: bool = True
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
     VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES: bool = True
+    VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: bool = False
+    VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: bool = False
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -1289,6 +1291,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to create TMA-aligned scale tensor when DeepGEMM is used.
     "VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES": lambda: bool(
         int(os.getenv("VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES", "1"))
+    ),
+    "VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS": lambda: bool(
+        int(os.getenv("VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS", "0"))
+    ),
+    "VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND": lambda: bool(
+        int(os.getenv("VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND", "0"))
     ),
     # DeepGemm JITs the kernels on-demand. The warmup attempts to make DeepGemm
     # JIT all the required kernels before model execution so there is no

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -407,11 +407,12 @@ _MEGA_MOE_DG_ENV_APPLIED = False
 
 
 def _apply_mega_moe_dg_env() -> None:
-    """Forward VLLM_DEEPGEMM_MEGA_MOE_* env vars to DeepGEMM internals.
+    """Forward VLLM_DEEPGEMM_MEGA_MOE_* env vars to sgl-deep-gemm internals.
 
-    Experimental: uses external deep_gemm (sgl-deep-gemm) for FP4 acts.
-    TODO(upstream): remove once vendored deep_gemm includes
-    mega_moe_pre_dispatch and FP4-aware buffer sizing.
+    PoC: upstream DeepGEMM does not yet support FP4 activations
+    (use_fp8_dispatch is accepted but ignored). Uses sgl-deep-gemm
+    for FP4-aware buffer sizing and mega_moe_pre_dispatch.
+    Remove once upstream wires use_fp8_dispatch=False end-to-end.
     """
     global _MEGA_MOE_DG_ENV_APPLIED
     if _MEGA_MOE_DG_ENV_APPLIED:
@@ -605,8 +606,8 @@ class DeepseekV4MegaMoEExperts(nn.Module):
 
     def get_symm_buffer(self):
         _apply_mega_moe_dg_env()
-        # Experimental: external deep_gemm for FP4-aware buffer sizing.
-        # TODO: collapse to vendored import once upstream supports FP4 layout.
+        # PoC: sgl-deep-gemm for FP4 buffer sizing (upstream ignores
+        # use_fp8_dispatch). Remove branch when upstream supports it.
         if envs.VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS:
             import deep_gemm
         else:
@@ -671,8 +672,8 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         activation_clamp: float | None,
         fast_math: bool,
     ) -> None:
-        # Experimental: external deep_gemm for mega_moe_pre_dispatch.
-        # TODO: collapse to vendored import once upstream supports this API.
+        # PoC: sgl-deep-gemm provides mega_moe_pre_dispatch for FP4
+        # packing. Remove branch when upstream supports FP4 acts.
         if envs.VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS:
             import deep_gemm
         else:

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
@@ -10,6 +11,7 @@ import torch.nn as nn
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, get_current_vllm_config
+import vllm.envs as envs
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -403,6 +403,26 @@ def make_deepseek_v4_expert_params_mapping(
     ]
 
 
+_MEGA_MOE_DG_ENV_APPLIED = False
+
+
+def _apply_mega_moe_dg_env() -> None:
+    """Forward VLLM_DEEPGEMM_MEGA_MOE_* env vars to DeepGEMM internals.
+
+    Experimental: uses external deep_gemm (sgl-deep-gemm) for FP4 acts.
+    TODO(upstream): remove once vendored deep_gemm includes
+    mega_moe_pre_dispatch and FP4-aware buffer sizing.
+    """
+    global _MEGA_MOE_DG_ENV_APPLIED
+    if _MEGA_MOE_DG_ENV_APPLIED:
+        return
+    if envs.VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS:
+        os.environ.setdefault("DG_USE_FP4_ACTS", "1")
+    if envs.VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND:
+        os.environ.setdefault("DG_USE_MXF4_KIND", "1")
+    _MEGA_MOE_DG_ENV_APPLIED = True
+
+
 class DeepseekV4MegaMoEExperts(nn.Module):
     _symm_buffer_cache: dict[tuple[int, int, int, int, int, int, int], object] = {}
 
@@ -584,7 +604,13 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         self.w2_weight_scale = None
 
     def get_symm_buffer(self):
-        import vllm.third_party.deep_gemm as deep_gemm
+        _apply_mega_moe_dg_env()
+        # Experimental: external deep_gemm for FP4-aware buffer sizing.
+        # TODO: collapse to vendored import once upstream supports FP4 layout.
+        if envs.VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS:
+            import deep_gemm
+        else:
+            import vllm.third_party.deep_gemm as deep_gemm
 
         group = get_ep_group().device_group
         device = torch.accelerator.current_device_index()

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -671,19 +671,41 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         activation_clamp: float | None,
         fast_math: bool,
     ) -> None:
-        import vllm.third_party.deep_gemm as deep_gemm
+        # Experimental: external deep_gemm for mega_moe_pre_dispatch.
+        # TODO: collapse to vendored import once upstream supports this API.
+        if envs.VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS:
+            import deep_gemm
+        else:
+            import vllm.third_party.deep_gemm as deep_gemm
 
         symm_buffer = self.get_symm_buffer()
         num_tokens = hidden_states.shape[0]
-        _stage_deepseek_v4_mega_moe_inputs(
-            hidden_states,
-            topk_weights,
-            topk_ids,
-            symm_buffer.x[:num_tokens],
-            symm_buffer.x_sf[:num_tokens],
-            symm_buffer.topk_idx[:num_tokens],
-            symm_buffer.topk_weights[:num_tokens],
-        )
+
+        use_fp4_acts = envs.VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS
+        if use_fp4_acts:
+            topk_ids_i32 = topk_ids.to(torch.int32)
+            deep_gemm.mega_moe_pre_dispatch(
+                hidden_states,
+                topk_ids_i32,
+                topk_weights,
+                symm_buffer.x,
+                symm_buffer.x_sf,
+                symm_buffer.topk_idx,
+                symm_buffer.topk_weights,
+                num_tokens=num_tokens,
+                group_size=32,
+                use_fp4_acts=True,
+            )
+        else:
+            _stage_deepseek_v4_mega_moe_inputs(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                symm_buffer.x[:num_tokens],
+                symm_buffer.x_sf[:num_tokens],
+                symm_buffer.topk_idx[:num_tokens],
+                symm_buffer.topk_weights[:num_tokens],
+            )
 
         # This method must have been already called during the weight loading phase.
         # We call it again here to cover the dummy weight loading case.


### PR DESCRIPTION
seealso: #42845 https://github.com/deepseek-ai/DeepGEMM/issues/338
## Purpose

MegaMoE currently packs activations as FP8 (E4M3) in the symmetric buffer before dispatch. On Blackwell (SM100), FP4 (E2M1) packing would halve the buffer footprint and unlock the MXF4 mainloop (K=64 dense vs K=32 padded) in DeepGEMM.

However, upstream DeepGEMM does not yet support FP4 activations end-to-end. The `fp8_fp4_mega_moe` kernel hardcodes `a_dtype_t = float_e4m3_t`, `get_symm_buffer_size_for_mega_moe` allocates input token buffers at FP8 width (`hidden` bytes/token), and the dispatch stage TMA loads assume FP8 layout. The `use_fp8_dispatch` parameter exists in the API signature but is not wired through to the buffer sizing or kernel logic. An RFC has been filed at deepseek-ai/DeepGEMM to track this.

This PR provides a **proof-of-concept** using `sgl-deep-gemm>=0.1.0`, which ships a `mega_moe_pre_dispatch()` CUDA kernel that handles E2M1 packing + FP4-aware buffer allocation. Two opt-in env vars, both default off:
- `VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS` -- use `deep_gemm.mega_moe_pre_dispatch()` for E2M1 activation packing instead of the Triton staging kernel
- `VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND` -- switches to `kind::mxf4` mainloop, requires FP4 acts

When enabled, imports external `deep_gemm` for buffer allocation and pre-dispatch. When disabled, vendored `vllm.third_party.deep_gemm` is used as before -- zero change to default path.

Flags forwarded to the external deep_gemm via `os.environ.setdefault("DG_USE_FP4_ACTS", ...)` so explicit `DG_USE_*` overrides still win.

Files: `vllm/envs.py`, `vllm/model_executor/models/deepseek_v4.py`

## Upstream Gap Analysis

Checked deepseek-ai/DeepGEMM (latest, identical to vendored commit 891d57b for the mega module):

- `csrc/apis/mega.hpp`: `get_symm_buffer_size_for_mega_moe` accepts `use_fp8_dispatch` but ignores it -- `input_token_buffer` is always `layout::Data(hidden)` (FP8, 1 byte/element)
- `sm100_fp8_fp4_mega_moe.cuh` line 162-163: `a_dtype_t = cutlass::float_e4m3_t` -- UMMA configured for FP8 activations only
- Dispatch pull stage: TMA loads `kHidden` bytes per token (FP8 width)
- `slice_input_buffers` returns `x` as `[tokens, hidden]` float8, `x_sf` as `[tokens, hidden/128]`

None of these support FP4 activations. Full FP4 activation support requires changes at the C++/CUDA kernel level (buffer sizing, TMA load widths, UMMA A-matrix dtype), which is being tracked via the upstream RFC.

## Test Plan

Hardware: 8x B200 (SM100, 183GB). Accuracy: GSM8K full test set (1319 samples), greedy decoding, max_tokens=2048, concurrency=32.

Dep: `pip install sgl-deep-gemm==0.1.0`

V4-Flash (256 experts, hidden=4096, 43 layers), DP=4:

```bash
# w4a8 baseline
vllm serve /path/to/DeepSeek-V4-Flash \
  --trust-remote-code --kv-cache-dtype fp8 --block-size 256 \
  --enable-expert-parallel --data-parallel-size 4 \
  --moe-backend deep_gemm_mega_moe --enforce-eager

# w4a4 (this PR)
VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1 VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1 \
vllm serve /path/to/DeepSeek-V4-Flash \
  --trust-remote-code --kv-cache-dtype fp8 --block-size 256 \
  --enable-expert-parallel --data-parallel-size 4 \
  --moe-backend deep_gemm_mega_moe --enforce-eager
```

V4-Pro (384 experts, hidden=7168, 61 layers), TP=8:

```bash
# w4a8 baseline
vllm serve /path/to/DeepSeek-V4-Pro \
  --trust-remote-code --kv-cache-dtype fp8 --block-size 256 \
  --enable-expert-parallel --tensor-parallel-size 8 \
  --moe-backend deep_gemm_mega_moe --enforce-eager

# w4a4 (this PR)
VLLM_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1 VLLM_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1 \
vllm serve /path/to/DeepSeek-V4-Pro \
  --trust-remote-code --kv-cache-dtype fp8 --block-size 256 \
  --enable-expert-parallel --tensor-parallel-size 8 \
  --moe-backend deep_gemm_mega_moe --enforce-eager
```

Eval: hit `/v1/chat/completions`, extract final number after `####`, compare against reference.

## Test Result

### Accuracy (GSM8K, 1319 samples, greedy)

V4-Flash: w4a8 93.86% (1238/1319) -> w4a4 94.39% (1245/1319), delta +0.53%
V4-Pro: w4a8 91.81% (1211/1319) -> w4a4 91.13% (1202/1319), delta -0.68%

Both within noise. No meaningful accuracy degradation from FP4 activation packing.

### Performance (V4-Flash, DP=4, 8×B200)

Benchmark config: 500 prompts, input_len=1024, output_len=8, max-concurrency=64, request-rate=inf, `--max-cudagraph-capture-size 512`, random dataset.

| Metric | w4a8 | w4a4 | Delta |
|---|---|---|---|
| Request throughput (req/s) | 11.21 | 17.73 | **+58.2%** |
| Total token throughput (tok/s) | 11,565.65 | 18,294.09 | **+58.2%** |
| Output token throughput (tok/s) | 89.66 | 141.81 | **+58.2%** |
| Mean TTFT (ms) | 3,789.39 | 1,834.52 | **-51.6%** |
| Median TTFT (ms) | 832.51 | 639.82 | **-23.1%** |
| P99 TTFT (ms) | 12,302.93 | 12,063.23 | -1.9% |
| Mean TPOT (ms) | 272.46 | 251.78 | **-7.6%** |
| Median TPOT (ms) | 75.91 | 69.89 | **-7.9%** |

Key takeaway: ~58% throughput improvement, ~52% mean TTFT reduction. The gain is dominated by prefill (MXF4 mainloop K=64 dense vs K=32 padded). Decode TPOT improves ~8% from reduced buffer bandwidth.

## What Happens When Upstream Supports FP4 Acts

Once deepseek-ai/DeepGEMM wires `use_fp8_dispatch=False` through to buffer sizing + kernel:
1. Bump vendored commit in `cmake/external_projects/deepgemm.cmake`
2. Replace `sgl-deep-gemm` path with a Triton FP4 staging kernel (~40 lines, E2M1 bucketize + pack) or use whatever staging API upstream provides
3. Change `get_symm_buffer_for_mega_moe(..., use_fp8_dispatch=False)` -- the parameter already exists
4. Remove import branches (3 sites), drop `sgl-deep-gemm` dep
5. `DG_USE_FP4_ACTS` / `DG_USE_MXF4_KIND` env forwarding likely becomes unnecessary -- remove `_apply_mega_moe_dg_env`
6. Move env vars from experimental to stable

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

