### PR TITLE
Refactor: Pass num_labels explicitly to PoolerClassify instead of reading from global config

### DIFF
--- a/tests/model_executor/layers/test_pooler_activations.py
+++ b/tests/model_executor/layers/test_pooler_activations.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.pooler.activations import (
     LambdaPoolerActivation,
     PoolerClassify,
@@ -18,15 +17,6 @@ from vllm.model_executor.layers.pooler.activations import (
     get_act_fn,
     resolve_classifier_act_fn,
 )
-
-
-@pytest.fixture
-def vllm_config():
-    """VllmConfig with a minimal model_config stub for PoolerClassify."""
-    config = VllmConfig()
-    config.model_config = SimpleNamespace(hf_config=SimpleNamespace(num_labels=0))
-    with set_current_vllm_config(config):
-        yield config
 
 
 # ---------------------------------------------------------------------------
@@ -102,35 +92,38 @@ class TestPoolerMultiLabelClassify:
 # PoolerClassify
 # ---------------------------------------------------------------------------
 class TestPoolerClassify:
-    def test_dynamic_softmax_when_num_labels_ge_2(self):
-        pooler = PoolerClassify(static_num_labels=False)
+    def test_infers_from_shape_when_num_labels_none(self):
+        pooler = PoolerClassify(num_labels=None)
         assert pooler.num_labels is None
         x = torch.randn(2, 5)
         out = pooler(x)
         sums = out.sum(dim=-1)
         assert torch.allclose(sums, torch.ones(2), atol=1e-5)
 
-    def test_dynamic_sigmoid_when_num_labels_lt_2(self):
-        pooler = PoolerClassify(static_num_labels=False)
+    def test_sigmoid_when_num_labels_lt_2(self):
+        pooler = PoolerClassify(num_labels=1)
         x = torch.zeros(1, 1)
         out = pooler(x)
         assert torch.allclose(out, torch.tensor([[0.5]]), atol=1e-5)
 
-    def test_static_default_num_labels_zero_uses_sigmoid(self, vllm_config):
-        pooler = PoolerClassify(static_num_labels=True)
+    def test_num_labels_zero_uses_sigmoid(self):
+        pooler = PoolerClassify(num_labels=0)
         assert pooler.num_labels == 0
         x = torch.zeros(1, 3)
         out = pooler(x)
         assert torch.allclose(out, torch.full((1, 3), 0.5), atol=1e-5)
 
-    def test_static_num_labels_ge_2_uses_softmax(self, vllm_config):
-        vllm_config.model_config.hf_config.num_labels = 4
-        pooler = PoolerClassify(static_num_labels=True)
+    def test_num_labels_ge_2_uses_softmax(self):
+        pooler = PoolerClassify(num_labels=4)
         assert pooler.num_labels == 4
         x = torch.randn(2, 4)
         out = pooler(x)
         sums = out.sum(dim=-1)
         assert torch.allclose(sums, torch.ones(2), atol=1e-5)
+
+    def test_default_num_labels_is_none(self):
+        pooler = PoolerClassify()
+        assert pooler.num_labels is None
 
 
 # ---------------------------------------------------------------------------
@@ -160,24 +153,25 @@ class TestGetActFn:
     def _make_config(**kwargs):
         return SimpleNamespace(**kwargs)
 
-    def test_regression(self, vllm_config):
+    def test_regression(self):
         cfg = self._make_config(problem_type="regression")
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerIdentity)
 
-    def test_single_label_classification(self, vllm_config):
+    def test_single_label_classification(self):
         cfg = self._make_config(
             problem_type="single_label_classification", num_labels=3
         )
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerClassify)
+        assert result.num_labels == 3
 
-    def test_multi_label_classification(self, vllm_config):
+    def test_multi_label_classification(self):
         cfg = self._make_config(problem_type="multi_label_classification")
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerMultiLabelClassify)
 
-    def test_sentence_transformers_activation(self, vllm_config):
+    def test_sentence_transformers_activation(self):
         cfg = self._make_config(
             problem_type="",
             sentence_transformers={
@@ -187,7 +181,7 @@ class TestGetActFn:
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerClassify)
 
-    def test_sbert_activation(self, vllm_config):
+    def test_sbert_activation(self):
         cfg = self._make_config(
             problem_type="",
             sbert_ce_default_activation_function=(
@@ -197,12 +191,12 @@ class TestGetActFn:
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerClassify)
 
-    def test_default_fallback(self, vllm_config):
+    def test_default_fallback(self):
         cfg = self._make_config(problem_type="")
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerClassify)
 
-    def test_sentence_transformers_takes_priority(self, vllm_config):
+    def test_sentence_transformers_takes_priority(self):
         cfg = self._make_config(
             problem_type="",
             sentence_transformers={"activation_fn": "torch.nn.modules.linear.Identity"},
@@ -213,7 +207,7 @@ class TestGetActFn:
         result = get_act_fn(cfg)
         assert isinstance(result, PoolerIdentity)
 
-    def test_rejects_non_torch_activation(self, vllm_config):
+    def test_rejects_non_torch_activation(self):
         cfg = self._make_config(
             problem_type="",
             sentence_transformers={"activation_fn": "os.system"},
@@ -226,10 +220,13 @@ class TestGetActFn:
 # resolve_classifier_act_fn
 # ---------------------------------------------------------------------------
 class TestResolveClassifierActFn:
-    def test_delegates_to_get_act_fn_when_none(self, vllm_config):
-        model_config = vllm_config.model_config
+    def test_delegates_to_get_act_fn_when_none(self):
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(num_labels=3, problem_type="")
+        )
         result = resolve_classifier_act_fn(model_config, act_fn=None)
         assert isinstance(result, PoolerClassify)
+        assert result.num_labels == 3
 
     def test_passes_through_provided_act_fn(self):
         custom = PoolerIdentity()

--- a/vllm/model_executor/layers/pooler/activations.py
+++ b/vllm/model_executor/layers/pooler/activations.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import PretrainedConfig
 
-from vllm.config import ModelConfig, get_current_vllm_config
+from vllm.config import ModelConfig
 from vllm.logger import init_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
 
@@ -23,11 +23,15 @@ def get_act_fn(
     # get classification act_fn
     # Implement alignment with transformers ForSequenceClassificationLoss
     # https://github.com/huggingface/transformers/blob/57bb6db6ee4cfaccc45b8d474dfad5a17811ca60/src/transformers/loss/loss_utils.py#L92
+    num_labels: int | None = None
+    if static_num_labels:
+        num_labels = getattr(config, "num_labels", 0)
+
     problem_type = getattr(config, "problem_type", "")
     if problem_type == "regression":
         return PoolerIdentity()
     if problem_type == "single_label_classification":
-        return PoolerClassify(static_num_labels=static_num_labels)
+        return PoolerClassify(num_labels=num_labels)
     if problem_type == "multi_label_classification":
         return PoolerMultiLabelClassify()
 
@@ -52,7 +56,7 @@ def get_act_fn(
         fn = resolve_obj_by_qualname(function_name)()
         return PoolerActivation.wraps(fn)
 
-    return PoolerClassify(static_num_labels=static_num_labels)
+    return PoolerClassify(num_labels=num_labels)
 
 
 def resolve_classifier_act_fn(
@@ -110,15 +114,8 @@ class PoolerMultiLabelClassify(PoolerActivation):
 
 
 class PoolerClassify(PoolerActivation):
-    def __init__(self, *, static_num_labels: bool = True) -> None:
+    def __init__(self, *, num_labels: int | None = None) -> None:
         super().__init__()
-
-        if static_num_labels:
-            vllm_config = get_current_vllm_config()
-            model_config = vllm_config.model_config
-            num_labels = getattr(model_config.hf_config, "num_labels", 0)
-        else:
-            num_labels = None
 
         if num_labels == 0:
             logger.warning(


### PR DESCRIPTION
## Purpose

Currently `PoolerClassify` accepts a `static_num_labels` boolean, but then internally fetches `num_labels` from `hf_config` via global state. This PR addresses this issue:

- `PoolerClassify` no longer reads `num_labels` from global state via `get_current_vllm_config()`. Instead, it accepts `num_labels` directly as a parameter.
- `get_act_fn` now resolves `num_labels` from the `config` it already receives and passes it through to `PoolerClassify`.
- Tests no longer need a `VllmConfig` context to construct `PoolerClassify` or call `get_act_fn`.
- Acknowledgement:  This a follow-up from a feedback on[ #42824](https://github.com/vllm-project/vllm/pull/42824#discussion_r3253057858) by @yewentao256.

## Test Plan
  - `pytest tests/model_executor/layers/test_pooler_activations.py` 
  - `pytest tests/models/language/pooling/test_classification.py`  
  - `pytest tests/models/language/pooling/test_token_classification.py`
  - `python -m pytest tests/entrypoints/pooling/classify/test_online.py -v` [note: please make sure `pytest-asyncio `is installed]
  -  All pre-commit hooks 

## Test Result
- The tests should all pass. The `test_token_classification.py` may throw numerical precision flakes depending on  the GPU.