### PR TITLE
[Platform][CUDA] Warn on PTX fallback and optionally invalidate Triton cache (sm_121)

### DIFF
--- a/tests/cuda/test_triton_cache_arch_guard.py
+++ b/tests/cuda/test_triton_cache_arch_guard.py
@@ -10,6 +10,7 @@ torch.cuda.get_arch_list() (e.g. sm_121 device falling back to sm_120 PTX).
 from __future__ import annotations
 
 import logging
+import shutil
 
 import pytest
 import torch
@@ -24,6 +25,15 @@ def _reset_guard_cache():
     cuda_platform._maybe_warn_arch_ptx_fallback.cache_clear()
     yield
     cuda_platform._maybe_warn_arch_ptx_fallback.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _local_rank_zero(monkeypatch: pytest.MonkeyPatch):
+    """Default tests to LOCAL_RANK == 0 so the guard's body runs. Individual
+    tests that exercise the non-master short-circuit override this."""
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "LOCAL_RANK", 0)
 
 
 class _ListHandler(logging.Handler):
@@ -174,3 +184,67 @@ def test_get_arch_list_raising_is_handled(
     cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
 
     assert not any("PTX fallback" in r.getMessage() for r in cuda_log.records)
+
+
+def test_non_master_local_rank_is_silent_and_no_wipe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    cuda_log: _ListHandler,
+):
+    """LOCAL_RANK != 0 short-circuits BEFORE the arch check, the warning,
+    and the cache wipe — so worker processes don't race on rmtree or
+    spam the log on multi-GPU nodes."""
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "LOCAL_RANK", 3)
+
+    cache_dir = tmp_path / "triton_cache"
+    cache_dir.mkdir()
+    (cache_dir / "stale.cubin").write_bytes(b"\x00")
+
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_120"])
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", "1")
+    monkeypatch.setattr(envs, "VLLM_FORCE_TRITON_CACHE_INVALIDATE", True)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    # No warning, no wipe.
+    assert not any("PTX fallback" in r.getMessage() for r in cuda_log.records)
+    assert cache_dir.exists() and (cache_dir / "stale.cubin").exists(), (
+        "Non-master worker must not touch the shared cache directory"
+    )
+
+
+def test_rmtree_filenotfound_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    cuda_log: _ListHandler,
+):
+    """If the cache dir disappears between the isdir check and the rmtree
+    (e.g. an external cleaner or another local-master process raced us),
+    we treat that as success — no spurious WARNING."""
+    cache_dir = tmp_path / "triton_cache"
+    cache_dir.mkdir()
+    real_rmtree = shutil.rmtree
+
+    def _vanishes_then_rmtree(path, *a, **kw):
+        # Simulate the race: directory exists at isdir check, gone by rmtree.
+        real_rmtree(path)
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_120"])
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", "1")
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_FORCE_TRITON_CACHE_INVALIDATE", True)
+    monkeypatch.setattr(cuda_platform.shutil, "rmtree", _vanishes_then_rmtree)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    # The PTX-fallback notice still fires, but no "failed to wipe" WARNING.
+    failure_warnings = [
+        r for r in cuda_log.records if "failed to wipe" in r.getMessage()
+    ]
+    assert failure_warnings == []

--- a/tests/cuda/test_triton_cache_arch_guard.py
+++ b/tests/cuda/test_triton_cache_arch_guard.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the Triton-cache PTX-fallback guard in vllm.platforms.cuda.
+
+Covers issue #41871 — stale entries in ~/.triton/cache silently producing
+wrong code when the running GPU's compute capability is not in
+torch.cuda.get_arch_list() (e.g. sm_121 device falling back to sm_120 PTX).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import torch
+
+from vllm.platforms import cuda as cuda_platform
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard_cache():
+    """Reset the @cache on _maybe_warn_arch_ptx_fallback between tests so each
+    test exercises the guard from a clean state."""
+    cuda_platform._maybe_warn_arch_ptx_fallback.cache_clear()
+    yield
+    cuda_platform._maybe_warn_arch_ptx_fallback.cache_clear()
+
+
+class _ListHandler(logging.Handler):
+    """Capture records from a non-propagating vLLM child logger.
+
+    vLLM's `vllm` logger sets propagate=False, so the stock pytest `caplog`
+    fixture (which hooks the root logger) misses records emitted by
+    `vllm.platforms.cuda`. We attach our own handler to that specific
+    logger for the duration of the test.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def cuda_log() -> _ListHandler:
+    handler = _ListHandler()
+    logger = logging.getLogger("vllm.platforms.cuda")
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+
+def test_no_warning_when_arch_is_in_arch_list(
+    monkeypatch: pytest.MonkeyPatch,
+    cuda_log: _ListHandler,
+):
+    """sm_90 device on a torch built with sm_90 → no warning, no wipe."""
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_80", "sm_90"])
+    monkeypatch.delenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", raising=False)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(9, 0)
+
+    assert not any("PTX fallback" in r.getMessage() for r in cuda_log.records)
+
+
+def test_warning_emitted_on_ptx_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    cuda_log: _ListHandler,
+):
+    """sm_121 device on a torch built with sm_120 only → warning emitted,
+    no wipe unless the env var is set."""
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_120"])
+    monkeypatch.delenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", raising=False)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    warnings = [
+        r.getMessage() for r in cuda_log.records if r.levelno == logging.WARNING
+    ]
+    assert any("PTX fallback" in m for m in warnings), warnings
+    assert any("41871" in m for m in warnings), warnings
+
+
+def test_warning_is_emitted_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+    cuda_log: _ListHandler,
+):
+    """Per-process cap-key cache means repeated calls for the same arch only
+    warn once, so workers don't spam the log."""
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_120"])
+    monkeypatch.delenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", raising=False)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    fallback_warnings = [
+        r for r in cuda_log.records if "PTX fallback" in r.getMessage()
+    ]
+    assert len(fallback_warnings) == 1, [r.getMessage() for r in cuda_log.records]
+
+
+def test_env_set_wipes_existing_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    cuda_log: _ListHandler,
+):
+    """With VLLM_FORCE_TRITON_CACHE_INVALIDATE=1, a present cache directory
+    is removed."""
+    cache_dir = tmp_path / "triton_cache"
+    cache_dir.mkdir()
+    (cache_dir / "stale.cubin").write_bytes(b"\x00\x01\x02")
+    assert (cache_dir / "stale.cubin").exists()
+
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_120"])
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", "1")
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_FORCE_TRITON_CACHE_INVALIDATE", True)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    assert not cache_dir.exists(), "Cache dir should have been wiped"
+    assert any("wiped Triton cache" in r.getMessage() for r in cuda_log.records), [
+        r.getMessage() for r in cuda_log.records
+    ]
+
+
+def test_env_set_but_no_cache_directory_logs_info(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    cuda_log: _ListHandler,
+):
+    """If the cache dir doesn't exist, do not raise — log INFO and continue."""
+    cache_dir = tmp_path / "does_not_exist"
+    assert not cache_dir.exists()
+
+    monkeypatch.setattr(torch.cuda, "get_arch_list", lambda: ["sm_120"])
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", "1")
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_FORCE_TRITON_CACHE_INVALIDATE", True)
+
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    assert any("does not exist" in r.getMessage() for r in cuda_log.records), [
+        r.getMessage() for r in cuda_log.records
+    ]
+
+
+def test_get_arch_list_raising_is_handled(
+    monkeypatch: pytest.MonkeyPatch,
+    cuda_log: _ListHandler,
+):
+    """If torch.cuda.get_arch_list() raises (uncommon backends), the guard
+    must stay silent rather than tripping startup."""
+
+    def _boom():
+        raise RuntimeError("backend has no get_arch_list")
+
+    monkeypatch.setattr(torch.cuda, "get_arch_list", _boom)
+    monkeypatch.delenv("VLLM_FORCE_TRITON_CACHE_INVALIDATE", raising=False)
+
+    # Should not raise
+    cuda_platform._maybe_warn_arch_ptx_fallback(12, 1)
+
+    assert not any("PTX fallback" in r.getMessage() for r in cuda_log.records)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -102,6 +102,7 @@ if TYPE_CHECKING:
     VLLM_USE_BYTECODE_HOOK: bool = True
     VLLM_FORCE_AOT_LOAD: bool = False
     VLLM_USE_MEGA_AOT_ARTIFACT: bool = False
+    VLLM_FORCE_TRITON_CACHE_INVALIDATE: bool = False
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
@@ -671,6 +672,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # without re-splitting graph modules. This reduces overhead during model
     # loading by using reconstruct_serializable_fn_from_mega_artifact.
     "VLLM_USE_MEGA_AOT_ARTIFACT": use_mega_aot_artifact,
+    # When set, vLLM wipes the user's Triton kernel cache
+    # (`~/.triton/cache`, or `$TRITON_CACHE_DIR` if set) on startup, but
+    # only when the current GPU's compute capability is NOT present in
+    # `torch.cuda.get_arch_list()` — i.e., when Triton is JIT-compiling
+    # from a PTX fallback. Defends against the silent-correctness mode
+    # described in https://github.com/vllm-project/vllm/issues/41871
+    # (stale cubins from a previous torch/triton combination producing
+    # wrong code on sm_121 etc.).
+    "VLLM_FORCE_TRITON_CACHE_INVALIDATE": lambda: os.environ.get(
+        "VLLM_FORCE_TRITON_CACHE_INVALIDATE", "0"
+    )
+    == "1",
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
@@ -1919,6 +1932,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_MODEL_REDIRECT_PATH",
         "VLLM_HOST_IP",
         "VLLM_FORCE_AOT_LOAD",
+        "VLLM_FORCE_TRITON_CACHE_INVALIDATE",
         "S3_ACCESS_KEY_ID",
         "S3_SECRET_ACCESS_KEY",
         "S3_ENDPOINT_URL",

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -162,11 +162,19 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
 
 @cache
 def _maybe_warn_arch_ptx_fallback(major: int, minor: int) -> None:
-    """Warn (once) when the running GPU's compute capability is not in the
-    arches torch was built against, so all Triton kernels JIT through a PTX
-    fallback. Optionally wipe the on-disk Triton cache to defend against
-    stale cubins silently producing wrong code (see issue #41871).
+    """Warn (once per node) when the running GPU's compute capability is
+    not in the arches torch was built against, so all Triton kernels JIT
+    through a PTX fallback. Optionally wipe the on-disk Triton cache to
+    defend against stale cubins silently producing wrong code (see issue
+    #41871).
+
+    Restricted to ``LOCAL_RANK == 0`` so that on multi-GPU nodes (TP, PP,
+    DP) only the local master logs the warning and touches the shared
+    cache directory — workers don't race on rmtree or spam the log.
     """
+    if envs.LOCAL_RANK != 0:
+        return
+
     sm = f"sm_{major}{minor}"
     try:
         arch_list = list(torch.cuda.get_arch_list())
@@ -208,6 +216,11 @@ def _maybe_warn_arch_ptx_fallback(major: int, minor: int) -> None:
         return
     try:
         shutil.rmtree(cache_dir)
+    except FileNotFoundError:
+        # Another local-master-ish process (or an external cleaner) wiped
+        # the directory between the isdir check above and rmtree. Treat as
+        # success — the goal (no stale cubins) is already achieved.
+        return
     except OSError as e:
         logger.warning(
             "VLLM_FORCE_TRITON_CACHE_INVALIDATE=1 set but failed to wipe "

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -7,6 +7,7 @@ pynvml. However, it should not initialize cuda context.
 from __future__ import annotations
 
 import os
+import shutil
 from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
@@ -157,6 +158,70 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
             pynvml.nvmlShutdown()
 
     return wrapper
+
+
+@cache
+def _maybe_warn_arch_ptx_fallback(major: int, minor: int) -> None:
+    """Warn (once) when the running GPU's compute capability is not in the
+    arches torch was built against, so all Triton kernels JIT through a PTX
+    fallback. Optionally wipe the on-disk Triton cache to defend against
+    stale cubins silently producing wrong code (see issue #41871).
+    """
+    sm = f"sm_{major}{minor}"
+    try:
+        arch_list = list(torch.cuda.get_arch_list())
+    except Exception:
+        # If we can't enumerate arches we cannot reason about the fallback;
+        # skip silently rather than spam logs on every uncommon backend.
+        return
+    if any(a.endswith(sm) for a in arch_list):
+        return
+
+    logger.warning(
+        "Detected compute capability %d.%d (%s) which is NOT in the arches "
+        "torch was built against (%s). Triton kernels will be JIT-compiled "
+        "from a PTX fallback. Stale entries in the Triton kernel cache "
+        "(~/.triton/cache or $TRITON_CACHE_DIR) can silently produce wrong "
+        "code in this mode; see "
+        "https://github.com/vllm-project/vllm/issues/41871 . "
+        "If you see garbled output or malformed tool-call headers, wipe "
+        "the cache or set VLLM_FORCE_TRITON_CACHE_INVALIDATE=1 so vLLM "
+        "wipes it automatically on startup.",
+        major,
+        minor,
+        sm,
+        arch_list,
+    )
+
+    if not envs.VLLM_FORCE_TRITON_CACHE_INVALIDATE:
+        return
+
+    cache_dir = os.environ.get(
+        "TRITON_CACHE_DIR", os.path.expanduser("~/.triton/cache")
+    )
+    if not os.path.isdir(cache_dir):
+        logger.info(
+            "VLLM_FORCE_TRITON_CACHE_INVALIDATE=1 set but Triton cache "
+            "directory %s does not exist; nothing to wipe.",
+            cache_dir,
+        )
+        return
+    try:
+        shutil.rmtree(cache_dir)
+    except OSError as e:
+        logger.warning(
+            "VLLM_FORCE_TRITON_CACHE_INVALIDATE=1 set but failed to wipe "
+            "Triton cache at %s: %s",
+            cache_dir,
+            e,
+        )
+        return
+    logger.warning(
+        "VLLM_FORCE_TRITON_CACHE_INVALIDATE=1: wiped Triton cache at %s "
+        "to avoid stale-cubin silent-correctness issues on %s.",
+        cache_dir,
+        sm,
+    )
 
 
 class CudaPlatformBase(Platform):
@@ -810,6 +875,9 @@ class NvmlCudaPlatform(CudaPlatformBase):
                     "avoid unexpected behavior.",
                     ", ".join(device_names),
                 )
+        cap = cls.get_device_capability(0)
+        if cap is not None:
+            _maybe_warn_arch_ptx_fallback(cap.major, cap.minor)
 
 
 class NonNvmlCudaPlatform(CudaPlatformBase):
@@ -843,6 +911,15 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
     @classmethod
     def get_all_device_numa_nodes(cls) -> list[int] | None:
         return None
+
+    @classmethod
+    def log_warnings(cls):
+        try:
+            cap = cls.get_device_capability(0)
+        except Exception:
+            return
+        if cap is not None:
+            _maybe_warn_arch_ptx_fallback(cap.major, cap.minor)
 
 
 # Autodetect either NVML-enabled or non-NVML platform


### PR DESCRIPTION
Narrow vLLM-side mitigation for #41871: when the running GPU's compute capability isn't in `torch.cuda.get_arch_list()` (e.g. sm_121 GB10 on a torch built for sm_120), Triton JITs every kernel from PTX, and stale entries in `~/.triton/cache` can silently produce wrong code — garbled tokens, malformed Harmony tool-call headers, 500s.

In `CudaPlatform.log_warnings()` (called once per process at import, before any worker spawn or Triton compile):
- Detect the PTX-fallback case and emit a one-time WARNING citing #41871.
- If `VLLM_FORCE_TRITON_CACHE_INVALIDATE=1`, wipe `$TRITON_CACHE_DIR || ~/.triton/cache`.
- Restricted to `LOCAL_RANK == 0` so TP/PP/DP workers don't race on `rmtree` or spam the log.
- Never raises (missing dir → INFO; `FileNotFoundError` race → success; other `OSError` → WARNING + continue).

The deeper Triton-side cache-key fix the issue also proposes is out of scope here — that has to happen upstream in Triton.

### Not a duplicate
- #41871 has no open PR (`gh pr list --search "41871 in:body"` is empty).
- #31607 (SM 12.1 support + Harmony parser robustness) is in adjacent symptom space but fixes CUTLASS fallbacks and parser handling, not the Triton cache.

### Test plan
```bash
.venv/bin/python -m pytest tests/cuda/test_triton_cache_arch_guard.py -v
```
8/8 pass locally. Covers happy path, fallback warning, single-shot caching, env-driven wipe, missing cache dir, `get_arch_list` exception safety, `LOCAL_RANK != 0` short-circuit, and `rmtree` TOCTOU. pre-commit (ruff-check/format, typos, spdx) clean.

Also validated end-to-end on a DGX Spark (sm_121, torch 2.11.0+cu130) — the warning fires on import naming the missing arch and pointing at #41871.

AI assistance was used to draft this change; the submitter reviewed every line and ran the tests on the affected hardware.

Refs #41871
