### PR TITLE
[Bug] Fix integer overflow in activation_kernels.cu pointer arithmetic

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -79,9 +79,16 @@ __global__ void act_and_mul_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., 2, d]
     const int d, const float limit) {
-  const scalar_t* x_ptr = input + blockIdx.x * 2 * d;
+  // `blockIdx.x` is `unsigned int`; multiplying by `d` (`int`) keeps the
+  // result in 32 bits, which overflows once `blockIdx.x * 2 * d` exceeds
+  // INT_MAX (about 2.15 billion). For large hidden sizes this corrupts the
+  // pointer arithmetic and reads/writes the wrong memory. Promote the index
+  // to int64_t first; matches the pattern already used in
+  // `swigluoai_and_mul_kernel` below. See issue #42860.
+  const int64_t token_idx = blockIdx.x;
+  const scalar_t* x_ptr = input + token_idx * 2 * d;
   const scalar_t* y_ptr = x_ptr + d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  scalar_t* out_ptr = out + token_idx * d;
 
   if constexpr (use_vec) {
     using cuda_t = typename CUDATypeConverter<scalar_t>::Type;
@@ -313,9 +320,12 @@ template <typename scalar_t, typename packed_t,
 __global__ void act_and_mul_kernel_with_param(
     scalar_t* __restrict__ out, const scalar_t* __restrict__ input, const int d,
     const float param) {
-  const scalar_t* x_ptr = input + blockIdx.x * 2 * d;
+  // See `act_and_mul_kernel` above for the int64_t-promotion rationale
+  // (overflow at `blockIdx.x * 2 * d` for large hidden sizes). #42860.
+  const int64_t token_idx = blockIdx.x;
+  const scalar_t* x_ptr = input + token_idx * 2 * d;
   const scalar_t* y_ptr = x_ptr + d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  scalar_t* out_ptr = out + token_idx * d;
 
   if constexpr (use_vec) {
     using cuda_t = typename CUDATypeConverter<scalar_t>::Type;
@@ -517,8 +527,12 @@ __global__ void activation_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., d]
     const int d) {
-  const scalar_t* in_ptr = input + blockIdx.x * d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  // See `act_and_mul_kernel` near the top of this file for the
+  // int64_t-promotion rationale (`blockIdx.x * d` overflows int when
+  // `blockIdx.x * d > INT_MAX`). #42860.
+  const int64_t token_idx = blockIdx.x;
+  const scalar_t* in_ptr = input + token_idx * d;
+  scalar_t* out_ptr = out + token_idx * d;
 
   if constexpr (use_vec) {
     // Fast path: 128-bit/256-bit vectorized loop


### PR DESCRIPTION
## Summary

The per-token pointer offsets in three kernels in `csrc/activation_kernels.cu` were computed as `blockIdx.x * 2 * d` (or `blockIdx.x * d`) without promoting the index to a 64-bit type. `blockIdx.x` is `unsigned int` and `d` is `int`, so the product is evaluated in 32-bit arithmetic and overflows once it exceeds `INT_MAX` (about 2.15 billion).

When the overflow occurs the kernel reads / writes the wrong memory and the result is silently incorrect. For the reporter's case in #42860 (`model: royokong/e5-v`, `d = 14336`, `seq_len = 7890`, `batch_size = 19`), the token dimension is `149911`, and `token_idx * 2 * d = 4.29 billion`, crossing the 32-bit boundary at row `~74955`.

## Fix

Adopt the `const int64_t token_idx = blockIdx.x;` pattern already used by `swigluoai_and_mul_kernel` further down in the same file (the only kernel here that was correct), and use `token_idx` instead of `blockIdx.x` in the affected pointer-offset expressions.

Affected kernels (all in `csrc/activation_kernels.cu`):

- `act_and_mul_kernel` (template entry point used by `silu_and_mul`, `gelu_and_mul`, `fatrelu_and_mul`, etc.)
- `act_and_mul_kernel_with_param` (used by activation kernels that take an extra scalar parameter)
- `activation_kernel` (the elementwise `gelu_new`, `gelu_fast`, `gelu_quick` template entry point)

The first occurrence gets a fuller explanatory comment; the others get a one-line back-reference so the rationale stays discoverable without duplication.

## Test plan

- [x] Static review: every `blockIdx.x * <stride>` pointer arithmetic in `csrc/activation_kernels.cu` is now backed by `int64_t token_idx`. `swigluoai_and_mul_kernel` was already correct and is unchanged.
- [ ] On-GPU repro from #42860 (`model royokong/e5-v`, `d=14336`, `seq_len=7890`, `batch_size=19`): cannot run locally (no B300 / equivalent GPU); maintainers with the failing config can verify the corruption is gone. The static fix matches the pattern `swigluoai_and_mul_kernel` already used, so this is the expected behavior under the affected dimensions.

## Out of scope for this PR (flagged so they are not lost)

The same class of 32-bit-multiply pointer-arithmetic pattern exists in:

- `csrc/layernorm_kernels.cu` lines 29, 69, 118, 136, 167-171 (`blockIdx.x * hidden_size`, `blockIdx.x * input_stride`, `blockIdx.x * vec_hidden_size`, etc.)
- `csrc/fused_qknorm_rope_kernel.cu` lines 150, 363 and `csrc/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu` line 157 (warp-index calculations of the form `blockIdx.x * warpsPerBlock + warpId`)

Those follow the same fix shape but live in different code paths and have different exposure profiles. Happy to follow up in separate PRs if maintainers want them addressed.

Fixes #42860.

---

### AI assistance disclosure

This PR was prepared with the assistance of an AI coding tool (Claude). The bug diagnosis, the fix, the static audit of all `blockIdx.x * d` sites in `csrc/activation_kernels.cu`, the int64_t-promotion pattern (matched to the existing `swigluoai_and_mul_kernel`), and the cross-file scan for adjacent occurrences were each reviewed by me, and I am responsible for the contents.
