### PR TITLE
[Bug] Fix integer overflow in layernorm_kernels.cu pointer arithmetic

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -66,7 +66,13 @@ __global__ void rms_norm_kernel(
   }
   __syncthreads();
 
-  scalar_t* out_row = out + blockIdx.x * hidden_size;
+  // `blockIdx.x` is `unsigned int` and `hidden_size` is `int`, so the product
+  // is evaluated in 32-bit arithmetic and overflows when
+  // `blockIdx.x * hidden_size > INT_MAX`. Promote to int64_t. See #42862.
+  // (The `input_row` computation above is already safe because the
+  // `input_stride_d*` strides are `int64_t`, which promotes the multiply.)
+  const int64_t token_idx = blockIdx.x;
+  scalar_t* out_row = out + token_idx * hidden_size;
   auto* v_in = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(input_row);
   auto* v_w = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(weight);
   auto* v_out = reinterpret_cast<vec_n_t<scalar_t, VEC_SIZE>*>(out_row);
@@ -114,9 +120,14 @@ fused_add_rms_norm_kernel(
   auto* __restrict__ weight_v =
       reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
+  // `blockIdx.x * vec_hidden_size` overflows int when the product exceeds
+  // INT_MAX. Promote via int64_t before computing `id`. The `strided_id`
+  // line below is already safe because `vec_input_stride` is `int64_t`,
+  // which promotes the multiply. See #42862.
+  const int64_t token_idx = blockIdx.x;
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    int64_t id = token_idx * vec_hidden_size + idx;
+    int64_t strided_id = token_idx * vec_input_stride + idx;
     _f16Vec<scalar_t, width> temp = input_v[strided_id];
     temp += residual_v[id];
     variance += temp.sum_squares();
@@ -133,8 +144,8 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    int64_t id = token_idx * vec_hidden_size + idx;
+    int64_t strided_id = token_idx * vec_input_stride + idx;
     _f16Vec<scalar_t, width> res = residual_v[id];
     _f16Vec<scalar_t, width> w = weight_v[idx];
     _f16Vec<scalar_t, width> out;
@@ -163,12 +174,16 @@ fused_add_rms_norm_kernel(
   __shared__ float s_variance;
   float variance = 0.0f;
 
+  // `blockIdx.x * hidden_size` overflows int when the product exceeds
+  // INT_MAX. Promote via int64_t. The `input_stride` multiplies are
+  // already safe because `input_stride` is `int64_t`. See #42862.
+  const int64_t token_idx = blockIdx.x;
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * hidden_size + idx];
+    scalar_t z = input[token_idx * input_stride + idx];
+    z += residual[token_idx * hidden_size + idx];
     float x = (float)z;
     variance += x * x;
-    residual[blockIdx.x * hidden_size + idx] = z;
+    residual[token_idx * hidden_size + idx] = z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -181,9 +196,9 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * hidden_size + idx];
+    float x = (float)residual[token_idx * hidden_size + idx];
     float w = (float)weight[idx];
-    input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
+    input[token_idx * input_stride + idx] = (scalar_t)(x * s_variance * w);
   }
 }
 


### PR DESCRIPTION
## Summary

Companion to #42861 for `csrc/layernorm_kernels.cu`. The per-token pointer offsets in three kernels in this file were computed in 32-bit arithmetic when the stride / hidden-size operand was `int`, overflowing once the product exceeded `INT_MAX` (about 2.15 billion).

From #42862, the reporter's failing case (`model royokong/e5-v`, `hidden_size = 4096`, `seq_len = 8129`, `batch_size = 129`) has flat token dimension `1048641`, and `blockIdx.x * hidden_size = 1048641 * 4096 = 4.29 billion`, crossing the 32-bit boundary at row `~524288`.

## Affected sites (all in `csrc/layernorm_kernels.cu`)

| Kernel | Line | Buggy expression |
|--------|------|------------------|
| `rms_norm_kernel` | 69 | `out + blockIdx.x * hidden_size` (the reporter's exact pointer) |
| `fused_add_rms_norm_kernel` (vec specialization) | 118, 136 | `int id = blockIdx.x * vec_hidden_size + idx` used to index `residual_v[id]` |
| `fused_add_rms_norm_kernel` (generic) | 168, 171, 184 | `residual[blockIdx.x * hidden_size + idx]` |

## Sites already safe (left unchanged)

- `rms_norm_kernel` line 29: `blockIdx.x * input_stride_d2` where `input_stride_d2` is `int64_t`, which promotes the multiply.
- `fused_add_rms_norm_kernel` (vec) lines 119, 137: `blockIdx.x * vec_input_stride` where `vec_input_stride` is `int64_t`.
- `fused_add_rms_norm_kernel` (generic) lines 167, 186: same `input_stride` int64_t pattern.
- `rms_norm_kernel` lines 32 - 41: division and modulo of `blockIdx.x` for `batch_idx` / `head_idx` / `seq_idx`, no multiply, no overflow concern.

## Fix

Same pattern as #42861 and the existing `swigluoai_and_mul_kernel` in `activation_kernels.cu`:

```cpp
const int64_t token_idx = blockIdx.x;
// ... use token_idx in place of blockIdx.x in the affected multiplications
```

In the fused_add_rms_norm vec kernel I also widened the local `id` variable from `int` to `int64_t` so it can index the same large flat arrays without truncation when used in the subsequent `residual_v[id]` reads / writes.

## Test plan

- [x] Static review: every `blockIdx.x * <int_operand>` pointer-arithmetic site in `csrc/layernorm_kernels.cu` is now backed by `int64_t token_idx`. Sites with `int64_t` stride operands are unchanged and remain safe.
- [ ] On-GPU repro from #42862 (`model royokong/e5-v`, `hidden_size=4096`, `seq=8129`, `batch=129`): cannot run locally (no equivalent GPU); maintainers with the failing config can verify.

## Out of scope (flagged here so they are not lost)

The same class of 32-bit-multiply pattern exists in:

- `csrc/fused_qknorm_rope_kernel.cu` lines 150, 363
- `csrc/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu` line 157

These are warp-index calculations (`blockIdx.x * warpsPerBlock + warpId`) of a slightly different shape and should be triaged separately. Happy to follow up in a third PR if maintainers want them addressed.

Sibling of #42861 (activation_kernels.cu int overflow). Fixes #42862.

---

### AI assistance disclosure

This PR was prepared with the assistance of an AI coding tool (Claude). The bug diagnosis, the per-site classification into buggy vs already-safe, the int64_t-promotion pattern (matched to #42861 and the existing `swigluoai_and_mul_kernel`), and the cross-file scan for the out-of-scope follow-up sites were each reviewed by me, and I am responsible for the contents.
