### PR TITLE
config: reject --enable-return-routed-experts for non-MoE models at startup

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1467,3 +1467,35 @@ def test_ir_op_priority_ctx():
         # context restored even after exception
         assert ir.ops.rms_norm.get_priority() == ["vllm_c", "native"]
         assert ir.ops.fused_add_rms_norm.get_priority() == ["native"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #42593 — --enable-return-routed-experts on non-MoE models
+# ---------------------------------------------------------------------------
+
+class _FakeModelConfig:
+    """Minimal stand-in for ModelConfig to exercise _verify_return_routed_experts."""
+    def __init__(self, is_moe: bool, model: str = "test-model") -> None:
+        self.is_moe = is_moe
+        self.model = model
+
+
+def test_return_routed_experts_rejected_for_non_moe():
+    """_verify_return_routed_experts raises early for dense (non-MoE) models."""
+    fake = _FakeModelConfig(is_moe=False, model="meta-llama/Meta-Llama-3.1-8B-Instruct")
+    with pytest.raises(ValueError, match="--enable-return-routed-experts requires a MoE model"):
+        ModelConfig._verify_return_routed_experts(fake)
+
+
+def test_return_routed_experts_passes_for_moe():
+    """_verify_return_routed_experts does not raise for MoE models."""
+    fake = _FakeModelConfig(is_moe=True, model="mistralai/Mixtral-8x7B-Instruct-v0.1")
+    ModelConfig._verify_return_routed_experts(fake)  # must not raise
+
+
+def test_return_routed_experts_error_message_contains_model_name():
+    """Error message must include the model name so users know which model failed."""
+    model_name = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    fake = _FakeModelConfig(is_moe=False, model=model_name)
+    with pytest.raises(ValueError, match=model_name):
+        ModelConfig._verify_return_routed_experts(fake)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1101,6 +1101,16 @@ class ModelConfig:
                 "when expert parallelism is enabled."
             )
 
+    def _verify_return_routed_experts(self) -> None:
+        if not self.is_moe:
+            raise ValueError(
+                "--enable-return-routed-experts requires a MoE model "
+                "architecture. The loaded model "
+                f"'{self.model}' does not have routed experts. "
+                "Remove --enable-return-routed-experts from your "
+                "configuration."
+            )
+
     def _try_verify_and_update_model_config(self):
         # Avoid running try_verify_and_update_config multiple times
         if getattr(self, "config_updated", False):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -834,6 +834,8 @@ class VllmConfig:
             self.model_config is not None
             and self.model_config.enable_return_routed_experts
         ):
+            self.model_config._verify_return_routed_experts()
+
             if self.parallel_config.pipeline_parallel_size > 1:
                 raise ValueError(
                     "--enable-return-routed-experts is incompatible with "


### PR DESCRIPTION
## Summary

`--enable-return-routed-experts` is a MoE-only feature, but there was no guard preventing it from being used with dense models (Llama, Mistral, etc.). The server would proceed through full model loading (~4 s, ~15 GiB), torch.compile, and KV cache setup before crashing with an unhelpful `AttributeError: 'LlamaConfig' object has no attribute 'num_experts_per_tok'` deep inside `RoutedExpertsCapturer.__init__`.

This PR adds an early guard that rejects the configuration at engine-arg validation time, before any model weights are loaded, with a clear user-facing message:

```
ValueError: --enable-return-routed-experts requires a MoE model architecture.
The loaded model 'meta-llama/Meta-Llama-3.1-8B-Instruct' does not have routed experts.
Remove --enable-return-routed-experts from your configuration.
```

The fix follows the same pattern as `--enable-expert-parallel`, which already has an equivalent check via `ModelConfig._verify_with_expert_parallelism()`.

**Changes:**
- `vllm/config/model.py`: add `ModelConfig._verify_return_routed_experts()` (mirrors `_verify_with_expert_parallelism`)
- `vllm/config/vllm.py`: call the new method inside the existing `enable_return_routed_experts` block in `VllmConfig.__post_init__`
- `tests/test_config.py`: three unit tests for the new validation method

Fixes #42593