### PR TITLE
[BugFix] Kimi-K2.5: skip vision tower dtype conversion when using quantization

### DIFF
--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -339,9 +339,12 @@ class KimiK25ForConditionalGeneration(
                 quant_config=self._maybe_ignore_quant_config(quant_config),
                 prefix=maybe_prefix(prefix, "vision_tower"),
             )
-            self.vision_tower = self.vision_tower.to(
-                device=self.device, dtype=model_config.dtype
-            )
+            if self._maybe_ignore_quant_config(quant_config) is not None:
+                self.vision_tower = self.vision_tower.to(device=self.device)
+            else:
+                self.vision_tower = self.vision_tower.to(
+                    device=self.device, dtype=model_config.dtype
+                )
 
             self.mm_projector = KimiK25MultiModalProjector(
                 config=config.vision_config,


### PR DESCRIPTION
_maybe_ignore_quant_config returns non-None when the quantization backend supports ViT (e.g. AscendModelSlimConfig). In that case call .to(device) only, avoiding dtype conversion that would corrupt quantized parameters. When it returns None, keep the original device+dtype conversion.