### PR TITLE
[Bugfix] Replace deprecated *ImageProcessorFast in 4 model files (fixes #42870)

### DIFF
--- a/vllm/model_executor/models/cohere2_vision.py
+++ b/vllm/model_executor/models/cohere2_vision.py
@@ -10,8 +10,8 @@ import torch
 from torch import nn
 from transformers import BatchFeature, PretrainedConfig
 from transformers.models.cohere2_vision import Cohere2VisionConfig
-from transformers.models.cohere2_vision.image_processing_cohere2_vision_fast import (  # noqa: E501
-    Cohere2VisionImageProcessorFast,
+from transformers.models.cohere2_vision.image_processing_cohere2_vision import (  # noqa: E501
+    Cohere2VisionImageProcessor,
 )
 from transformers.models.cohere2_vision.processing_cohere2_vision import (
     Cohere2VisionProcessor,
@@ -178,7 +178,7 @@ class Cohere2VisionProcessingInfo(BaseProcessingInfo):
         Calculate the number of image patches for a given image.
         Uses the HF processor to determine the actual number of patches.
         """
-        image_processor: Cohere2VisionImageProcessorFast = processor.image_processor
+        image_processor: Cohere2VisionImageProcessor = processor.image_processor
 
         return image_processor.get_number_of_image_patches(
             image_height,

--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -14,7 +14,7 @@ from transformers.models.gemma3n import (
     Gemma3nTextConfig,
     Gemma3nVisionConfig,
 )
-from transformers.models.siglip import SiglipImageProcessorFast
+from transformers.models.siglip import SiglipImageProcessor
 
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
@@ -183,7 +183,7 @@ class Gemma3nDummyInputsBuilder(BaseDummyInputsBuilder[Gemma3nProcessingInfo]):
             processor.feature_extractor
         )
         audio_len = audio_feature_extractor.fft_length
-        image_processor: SiglipImageProcessorFast = processor.image_processor
+        image_processor: SiglipImageProcessor = processor.image_processor
         img_width = image_processor.size.get("width", 224)
         img_height = image_processor.size.get("height", 224)
 

--- a/vllm/model_executor/models/interns1.py
+++ b/vllm/model_executor/models/interns1.py
@@ -14,8 +14,8 @@ import torch
 import torch.nn as nn
 from transformers import BatchFeature, InternVLProcessor, PretrainedConfig
 from transformers.activations import ACT2FN
-from transformers.models.got_ocr2.image_processing_got_ocr2_fast import (
-    GotOcr2ImageProcessorFast,
+from transformers.models.got_ocr2.image_processing_got_ocr2 import (
+    GotOcr2ImageProcessor,
 )
 from transformers.models.internvl.video_processing_internvl import (
     InternVLVideoProcessor,
@@ -200,7 +200,7 @@ class InternS1ProcessingInfo(BaseProcessingInfo):
         processor: InternVLProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> int:
-        image_processor: GotOcr2ImageProcessorFast = processor.image_processor
+        image_processor: GotOcr2ImageProcessor = processor.image_processor
 
         num_image_patches = image_processor.get_number_of_image_patches(
             image_height,

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -12,8 +12,8 @@ from transformers import BatchFeature
 from transformers.activations import ACT2FN
 from transformers.models.lfm2_vl import Lfm2VlProcessor
 from transformers.models.lfm2_vl.configuration_lfm2_vl import Lfm2VlConfig
-from transformers.models.lfm2_vl.image_processing_lfm2_vl_fast import (
-    Lfm2VlImageProcessorFast,
+from transformers.models.lfm2_vl.image_processing_lfm2_vl import (
+    Lfm2VlImageProcessor,
     find_closest_aspect_ratio,
     round_by_factor,
 )
@@ -88,7 +88,7 @@ class Lfm2VLProcessingInfo(BaseProcessingInfo):
     def get_hf_processor(self, **kwargs):
         return self.ctx.get_hf_processor(Lfm2VlProcessor, **kwargs)
 
-    def get_image_processor(self, **kwargs: object) -> Lfm2VlImageProcessorFast:
+    def get_image_processor(self, **kwargs: object) -> Lfm2VlImageProcessor:
         return self.get_hf_processor(**kwargs).image_processor
 
     def get_default_tok_params(self) -> TokenizeParams:
@@ -197,7 +197,7 @@ class Lfm2VLProcessingInfo(BaseProcessingInfo):
         processor: Lfm2VlProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> tuple[int, int, int]:
-        image_processor: Lfm2VlImageProcessorFast = processor.image_processor
+        image_processor: Lfm2VlImageProcessor = processor.image_processor
 
         mm_kwargs = self.ctx.get_merged_mm_kwargs(mm_kwargs)
         downsample_factor = mm_kwargs.get(
@@ -313,7 +313,7 @@ class Lfm2VLProcessingInfo(BaseProcessingInfo):
         processor: Lfm2VlProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> tuple[int, int]:
-        image_processor: Lfm2VlImageProcessorFast = processor.image_processor
+        image_processor: Lfm2VlImageProcessor = processor.image_processor
 
         mm_kwargs = self.ctx.get_merged_mm_kwargs(mm_kwargs)
         downsample_factor = mm_kwargs.get(


### PR DESCRIPTION
## Summary

Closes #42870. Mirror of #42700's fix, applied to the four model files surfaced by the same transformers-backend refactor (huggingface/transformers#43514).

## Changes

| File | Before | After |
|---|---|---|
| `vllm/model_executor/models/lfm2_vl.py` | `from transformers.models.lfm2_vl.image_processing_lfm2_vl_fast import Lfm2VlImageProcessorFast` | `…image_processing_lfm2_vl import Lfm2VlImageProcessor` |
| `vllm/model_executor/models/gemma3n_mm.py` | `SiglipImageProcessorFast` | `SiglipImageProcessor` |
| `vllm/model_executor/models/interns1.py` | `…image_processing_got_ocr2_fast import GotOcr2ImageProcessorFast` | `…image_processing_got_ocr2 import GotOcr2ImageProcessor` |
| `vllm/model_executor/models/cohere2_vision.py` | `…image_processing_cohere2_vision_fast import Cohere2VisionImageProcessorFast` | `…image_processing_cohere2_vision import Cohere2VisionImageProcessor` |

Type-annotation sites in the same files are updated to the un-suffixed name. Net change is +13 / -13 lines.

## Test plan

End-to-end import probe with `vllm/vllm-openai:v0.20.0`, mounting the patched files over the image's site-packages copies:

```
$ docker run --rm --gpus '"device=1"' \
    -v <patch>/lfm2_vl.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/lfm2_vl.py:ro \
    -v <patch>/gemma3n_mm.py:/.../gemma3n_mm.py:ro \
    -v <patch>/interns1.py:/.../interns1.py:ro \
    -v <patch>/cohere2_vision.py:/.../cohere2_vision.py:ro \
    --entrypoint python3 vllm/vllm-openai:v0.20.0 -W default -c "
        import vllm.model_executor.models.lfm2_vl
        import vllm.model_executor.models.gemma3n_mm
        import vllm.model_executor.models.interns1
        import vllm.model_executor.models.cohere2_vision
    "
=== Testing lfm2_vl ===          ✓ NO ImageProcessor warning
=== Testing gemma3n_mm ===       ✓ NO ImageProcessor warning
=== Testing interns1 ===         ✓ NO ImageProcessor warning
=== Testing cohere2_vision ===   ✓ NO ImageProcessor warning
```

The same probe before this patch (issue #42870 reproduction section) emitted four `Accessing ... Returning ... instead. Behavior may be different and this alias will be removed in future versions.` lines.

## Out of scope (intentional)

- `vllm/transformers_utils/processors/{qwen_vl,glm4v}.py` define vLLM-internal classes that inherit `BaseImageProcessorFast`. They produce **no** ImageProcessor warning under the same import probe — the `Fast` base class is still the canonical export — so they are not touched here.
- Helper functions `find_closest_aspect_ratio` and `round_by_factor` in `lfm2_vl.py` were re-pointed to the un-suffixed module path along with the class name; they are still exported there with the same names.

## Duplicate-work check

```
gh pr list --repo vllm-project/vllm --state open --search "42870 in:body"        # 0 results
gh pr list --repo vllm-project/vllm --state open --search "ImageProcessorFast"   # 0 results
gh pr list --repo vllm-project/vllm --state open --search "image processor backend" # 0 results
```

No open PR addresses the surface listed in #42870 / this patch.