### PR TITLE
Release stale CUDA primary contexts inherited by forked workers

### DIFF
--- a/tests/cuda/test_stale_context_release.py
+++ b/tests/cuda/test_stale_context_release.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test that _release_stale_cuda_primary_contexts cleans up inherited contexts.
+
+When a worker process is forked from a parent that has initialized CUDA on
+multiple devices, the child inherits active primary contexts for all devices.
+This test verifies that the cleanup function correctly releases non-assigned
+contexts while preserving the assigned device's context.
+"""
+
+import ctypes
+from concurrent.futures import ProcessPoolExecutor
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+
+def _get_primary_ctx_state(dev_id: int) -> bool:
+    """Return True if the primary context for dev_id is active."""
+    libcuda = ctypes.CDLL("libcuda.so.1")
+    libcuda.cuInit(0)
+    dev = ctypes.c_int()
+    libcuda.cuDeviceGet(ctypes.byref(dev), dev_id)
+    flags = ctypes.c_uint()
+    state = ctypes.c_int()
+    libcuda.cuDevicePrimaryCtxGetState(
+        dev, ctypes.byref(flags), ctypes.byref(state)
+    )
+    return state.value != 0
+
+
+def _child_test_release(local_rank: int, device_count: int):
+    """Run in a subprocess: activate all contexts, release stale ones."""
+    import torch
+
+    from vllm.v1.worker.gpu_worker import _release_stale_cuda_primary_contexts
+
+    # Activate primary contexts on ALL devices (simulating fork inheritance)
+    for dev_id in range(device_count):
+        torch.cuda.synchronize(dev_id)
+
+    # Verify all contexts are active before cleanup
+    before = {
+        dev_id: _get_primary_ctx_state(dev_id) for dev_id in range(device_count)
+    }
+    assert all(before.values()), f"Expected all contexts active, got {before}"
+
+    # Set device and release stale contexts
+    torch.cuda.set_device(local_rank)
+    _release_stale_cuda_primary_contexts(local_rank)
+
+    # Check results
+    after = {
+        dev_id: _get_primary_ctx_state(dev_id) for dev_id in range(device_count)
+    }
+    return before, after
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda() or torch.cuda.device_count() < 2,
+    reason="Requires at least 2 CUDA devices",
+)
+class TestStaleCudaContextRelease:
+
+    def test_release_stale_contexts_preserves_assigned_device(self):
+        """Verify that only the assigned device's context survives."""
+        device_count = torch.cuda.device_count()
+        local_rank = 1
+
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_child_test_release, local_rank, device_count)
+            before, after = future.result(timeout=30)
+
+        assert after[local_rank], (
+            f"Assigned device {local_rank} context should remain active"
+        )
+        for dev_id in range(device_count):
+            if dev_id != local_rank:
+                assert not after[dev_id], (
+                    f"Device {dev_id} context should have been released"
+                )
+
+    def test_release_noop_for_single_gpu(self):
+        """On single-GPU systems, nothing should be released."""
+        if torch.cuda.device_count() > 1:
+            pytest.skip("Test requires exactly 1 GPU")
+
+        from vllm.v1.worker.gpu_worker import _release_stale_cuda_primary_contexts
+
+        torch.cuda.synchronize(0)
+        _release_stale_cuda_primary_contexts(0)
+        assert _get_primary_ctx_state(0), "Device 0 context should remain"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -103,6 +103,48 @@ class AsyncIntermediateTensors(IntermediateTensors):
         return object.__getattribute__(self, name)
 
 
+def _release_stale_cuda_primary_contexts(local_rank: int) -> None:
+    """Release inherited CUDA primary contexts for non-assigned devices.
+
+    When workers are forked, they inherit the parent's active CUDA primary
+    contexts for all devices. A worker assigned to GPU 1, for example, will
+    have a stale primary context for GPU 0 from the parent process. These
+    stale contexts waste GPU memory and cause failures in external tools
+    that enumerate per-process CUDA contexts (e.g., NVIDIA cuda-checkpoint).
+
+    This function releases primary contexts for all devices other than the
+    worker's assigned device, using the CUDA driver API directly.
+    """
+    import ctypes
+
+    try:
+        libcuda = ctypes.CDLL("libcuda.so.1")
+    except OSError:
+        return
+
+    libcuda.cuInit(0)
+    device_count = torch.cuda.device_count()
+
+    for dev_id in range(device_count):
+        if dev_id == local_rank:
+            continue
+        dev = ctypes.c_int()
+        libcuda.cuDeviceGet(ctypes.byref(dev), dev_id)
+        flags = ctypes.c_uint()
+        state = ctypes.c_int()
+        libcuda.cuDevicePrimaryCtxGetState(
+            dev, ctypes.byref(flags), ctypes.byref(state)
+        )
+        if state.value != 0:
+            libcuda.cuDevicePrimaryCtxRelease(dev)
+            logger.debug(
+                "Released stale CUDA primary context for device %d "
+                "(worker assigned to device %d)",
+                dev_id,
+                local_rank,
+            )
+
+
 class Worker(WorkerBase):
     def __init__(
         self,
@@ -273,6 +315,12 @@ class Worker(WorkerBase):
 
             self.device = torch.device(f"cuda:{self.local_rank}")
             torch.accelerator.set_device_index(self.device)
+
+            # Release inherited CUDA primary contexts for non-assigned GPUs.
+            # When using fork, child processes inherit the parent's active
+            # CUDA contexts. These stale contexts waste memory and prevent
+            # tools like NVIDIA cuda-checkpoint from working correctly.
+            _release_stale_cuda_primary_contexts(self.local_rank)
 
             current_platform.check_if_supports_dtype(self.model_config.dtype)
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -122,20 +122,24 @@ def _release_stale_cuda_primary_contexts(local_rank: int) -> None:
     except OSError:
         return
 
-    libcuda.cuInit(0)
+    if libcuda.cuInit(0) != 0:
+        return
     device_count = torch.cuda.device_count()
 
     for dev_id in range(device_count):
         if dev_id == local_rank:
             continue
         dev = ctypes.c_int()
-        libcuda.cuDeviceGet(ctypes.byref(dev), dev_id)
+        if libcuda.cuDeviceGet(ctypes.byref(dev), dev_id) != 0:
+            continue
         flags = ctypes.c_uint()
         state = ctypes.c_int()
-        libcuda.cuDevicePrimaryCtxGetState(
-            dev, ctypes.byref(flags), ctypes.byref(state)
-        )
-        if state.value != 0:
+        if (
+            libcuda.cuDevicePrimaryCtxGetState(
+                dev, ctypes.byref(flags), ctypes.byref(state)
+            ) == 0
+            and state.value != 0
+        ):
             libcuda.cuDevicePrimaryCtxRelease(dev)
             logger.debug(
                 "Released stale CUDA primary context for device %d "


### PR DESCRIPTION
## Summary

- Release inherited CUDA primary contexts for non-assigned devices in forked worker processes
- When using fork multiprocessing (Linux default), child workers inherit the parent's GPU 0 context even when assigned to GPU 1+
- These stale contexts waste GPU memory and cause NVIDIA `cuda-checkpoint` restore failures ("invalid argument")
- Add `_release_stale_cuda_primary_contexts()` that calls `cuDevicePrimaryCtxRelease()` via ctypes after device setup in `Worker.init_device()`

Fixes #42873

## Context

Discovered while integrating NVIDIA cuda-checkpoint with vLLM for multi-GPU cold start optimization (related to RFC #34303). The stale inherited contexts cause `cuda-checkpoint --action restore` to fail because it tries to restore both the inherited GPU 0 context and the worker's actual GPU 1 context in the same process.

## Why this is not duplicating an existing PR

Searched open PRs and issues - no existing fix for this. The existing `_maybe_force_spawn()` in `system_utils.py` forces spawn when CUDA is already initialized, but doesn't handle the case where fork is used intentionally or where contexts are inherited through other mechanisms.

## AI assistance disclosure

AI assistance was used for code review and drafting. All changes reviewed and validated by the submitter.

## Test plan

- [ ] `tests/cuda/test_stale_context_release.py` - verifies stale contexts are released while preserving the assigned device's context (requires 2+ GPUs)
- [ ] Manually verified with cuda-checkpoint on H100 tp=2: checkpoint/restore cycle passes after fix, fails without it
- [ ] Single-GPU systems: function is a no-op (no contexts to release)

Generated with [Claude Code](https://claude.com/claude-code)
