### PR TITLE
[WIP][Bugfix] Drop workspace allocation for DCP A2A send/recv buffers (#41623)

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -381,8 +381,12 @@ def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
     torch.accelerator.set_device_index(local_rank)
     dist.init_process_group(backend="nccl")
     use_workspace = env.get("USE_WORKSPACE") == "1"
+    workspace_aliased_input = env.get("WORKSPACE_ALIASED_INPUT") == "1"
     if use_workspace:
-        from vllm.v1.worker.workspace import init_workspace_manager
+        from vllm.v1.worker.workspace import (
+            current_workspace_manager,
+            init_workspace_manager,
+        )
 
         init_workspace_manager(torch.device(f"cuda:{local_rank}"))
     try:
@@ -406,6 +410,24 @@ def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
             dtype=dtype,
             generator=generator,
         )
+        if workspace_aliased_input:
+            # Mirror flash_attn._forward_with_dcp: pre-grow the workspace
+            # for the send/recv buffers, then allocate cp_attn_out from it
+            # at offset 0 so dcp_a2a_lse_reduce's would-be send buffer
+            # would alias the pack kernel's input (issue #41623).
+            from vllm.v1.attention.ops.dcp_alltoall import _dcp_a2a_lse_pack_dim
+
+            lse_pack_dim = _dcp_a2a_lse_pack_dim(dtype)
+            send_shape = (world_size, B, h_per_rank, D + lse_pack_dim)
+            current_workspace_manager().get_simultaneous(
+                (send_shape, dtype),
+                (send_shape, dtype),
+            )
+            (workspace_view,) = current_workspace_manager().get_simultaneous(
+                ((B, H, D), dtype),
+            )
+            workspace_view.copy_(cp_attn_out)
+            cp_attn_out = workspace_view
         cp_attn_lse = torch.randn(
             B,
             H,
@@ -478,16 +500,29 @@ def test_distributed_packed_a2a_matches_reference(dtype_name: str):
 @pytest.mark.skipif(
     torch.accelerator.device_count() < 4, reason="Need at least 4 GPUs."
 )
-def test_distributed_packed_a2a_with_workspace_matches_reference():
+@pytest.mark.parametrize(
+    "aliased_input",
+    [False, True],
+    ids=["fresh_input", "workspace_aliased_input"],
+)
+def test_distributed_packed_a2a_with_workspace_matches_reference(
+    aliased_input: bool,
+):
+    # `aliased_input=True` is the regression case for #41623: cp_attn_out
+    # comes from the same workspace bytes the (pre-fix) send buffer would
+    # have aliased.
+    extra_env = {
+        "TEST_DTYPE": "bfloat16",
+        "RETURN_LSE": "1",
+        "LSE_BASE_E": "1",
+        "USE_WORKSPACE": "1",
+    }
+    if aliased_input:
+        extra_env["WORKSPACE_ALIASED_INPUT"] = "1"
     _distributed_run(
         _distributed_packed_a2a_worker,
         world_size=4,
-        extra_env={
-            "TEST_DTYPE": "bfloat16",
-            "RETURN_LSE": "1",
-            "LSE_BASE_E": "1",
-            "USE_WORKSPACE": "1",
-        },
+        extra_env=extra_env,
     )
 
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -26,10 +26,6 @@ import torch
 import torch.distributed as dist
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.workspace import (
-    current_workspace_manager,
-    is_workspace_manager_initialized,
-)
 
 if TYPE_CHECKING:
     from vllm.distributed.parallel_state import GroupCoordinator
@@ -117,13 +113,10 @@ def _dcp_a2a_send_recv_buffers(
     device: torch.device,
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if is_workspace_manager_initialized():
-        send_buffer, recv_buffer = current_workspace_manager().get_simultaneous(
-            (shape, dtype),
-            (shape, dtype),
-        )
-        return send_buffer, recv_buffer
-
+    # Independent buffers, not workspace slices: `cp_attn_out` arrives from
+    # the same workspace manager (e.g. flash_attn's `dcp_context_out`), and a
+    # second `get_simultaneous` would re-slice it starting at offset 0,
+    # aliasing the pack kernel's input with its send target (issue #41623).
     return (
         torch.empty(shape, device=device, dtype=dtype),
         torch.empty(shape, device=device, dtype=dtype),


### PR DESCRIPTION
## Purpose

PR #41160 made `_dcp_a2a_send_recv_buffers` allocate `send_buffer` and `recv_buffer` from `current_workspace_manager().get_simultaneous(...)`. The same workspace manager is also used upstream by `flash_attn._forward_with_dcp` for `dcp_context_out` (and by the MLA decode path for its attention-output buffer). Both call sites land at workspace offset 0, so the second `get_simultaneous` call hands back slices that alias the bytes still being read as `cp_attn_out`. The pack kernel reads `cp_attn_out` and writes `send_buffer` over the same memory; concurrent `(b, h)` programs race on each other's input and the A2A ships corrupted bytes.

A standalone reproducer that primes the workspace, allocates a workspace-backed `cp_attn_out`, then runs `dcp_a2a_lse_reduce`:

| | uint16 lanes differing | max abs diff |
|---|---:|---:|
| Pre-fix | 13 470 / 16 384 | 2.4e+37 |
| Post-fix | 0 / 16 384 | 0.0 |

This PR drops the workspace branch in `_dcp_a2a_send_recv_buffers` and always allocates fresh `torch.empty` buffers — CUDA's caching allocator amortises the per-step cost, and the saved bytes are negligible against the NCCL A2A itself.

## Test Plan

Adds `test_distributed_packed_a2a_with_workspace_matches_reference` parametrized over `aliased_input ∈ {fresh, workspace_aliased}` to `tests/distributed/test_dcp_a2a.py`. The `workspace_aliased` case mirrors the `flash_attn._forward_with_dcp` allocation order and would have caught the bug.

## Test Result

```
tests/distributed/test_dcp_a2a.py::test_distributed_packed_a2a_with_workspace_matches_reference[fresh_input] PASSED
tests/distributed/test_dcp_a2a.py::test_distributed_packed_a2a_with_workspace_matches_reference[workspace_aliased_input] PASSED
```