### PR TITLE
[Perf][MLA] Enable FULL cudagraph capture for TRITON_MLA decode

### DIFF
--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -12,12 +12,14 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
     MLACommonImpl,
     MLACommonMetadata,
+    MLACommonMetadataBuilder,
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import triton
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
+    AttentionCGSupport,
     AttentionLayer,
     AttentionType,
     MultipleOf,
@@ -25,6 +27,10 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
 
 logger = init_logger(__name__)
+
+
+class TritonMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
 
 
 class TritonMLABackend(MLACommonBackend):
@@ -62,6 +68,10 @@ class TritonMLABackend(MLACommonBackend):
     @staticmethod
     def get_impl_cls() -> type["TritonMLAImpl"]:
         return TritonMLAImpl
+
+    @staticmethod
+    def get_builder_cls() -> type["TritonMLAMetadataBuilder"]:
+        return TritonMLAMetadataBuilder
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:


### PR DESCRIPTION
## Purpose

`MLACommonMetadataBuilder` defaults `_cudagraph_support` to `NEVER`, which forces `PIECEWISE` mode and leaves `unified_mla_attention_with_output` outside the captured FULL graph — incurring per-layer Python dispatch on every decode step.

This PR adds `TritonMLAMetadataBuilder` advertising `AttentionCGSupport.UNIFORM_BATCH`, mirroring `FlashInferMLAMetadataBuilder` and `FlashAttnMLAMetadataBuilder`. Capture uses worst-case `max_seq_len`, so the kernel's inline `torch.empty` and data-dependent `num_kv_splits` are replay-safe.

## Test Plan

Bench (Kimi-K2.6, 8×A100 TP=8, 1k/1k × 32 prompts × 16 concurrent):

## Test Result

| | Baseline (PIECEWISE) | FULL+PIECEWISE | Δ |
|---|---:|---:|---:|
| Output throughput (tok/s) | 378  | 431  | +14 % |
| TPOT median (ms)          | 32.0 | 28.9 | -10 % |
| TTFT median (ms)          | 1382 | 1365 | flat  |