### PR TITLE
[Model Runner v2] fix pd accuracy

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -906,11 +906,16 @@ class NixlConnectorWorker:
                 else:
                     self.block_len_per_layer.append(physical_page_size)
 
-                if cache.shape[0] != num_blocks:
+                expected_first_dim = (
+                    self._logical_num_blocks
+                    if self.vllm_config.use_v2_model_runner
+                    else self.num_blocks
+                )
+                if cache.shape[0] != expected_first_dim:
                     raise AssertionError(
                         "All kv cache tensors must have the same number of "
                         f"blocks; layer={layer_name}, "
-                        f"expected_num_blocks={num_blocks}, "
+                        f"expected_num_blocks={expected_first_dim}, "
                         f"cache_shape={tuple(cache.shape)}, "
                         f"cache_stride={tuple(cache.stride())}, "
                         f"layer_spec={type(layer_spec).__name__}, "
@@ -919,7 +924,8 @@ class NixlConnectorWorker:
                         f"{[backend.get_name() for backend in self.attn_backends]}, "
                         f"kv_cache_layout={self.kv_cache_layout}, "
                         "blocks_first="
-                        f"{self.transfer_topo.is_kv_layout_blocks_first}"
+                        f"{self.transfer_topo.is_kv_layout_blocks_first}, "
+                        f"use_v2_model_runner={self.vllm_config.use_v2_model_runner}"
                     )
 
                 if not self.use_mla:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -464,11 +464,14 @@ class NixlConnectorWorker:
                 kernel_block_size,
             )
             assert self.block_size > kernel_block_size
-            self._physical_blocks_per_logical_kv_block = (
-                self.block_size // kernel_block_size
-            )
-            self.block_size = kernel_block_size
-            self.num_blocks *= self._physical_blocks_per_logical_kv_block
+            if self.vllm_config.use_v2_model_runner:
+                self._physical_blocks_per_logical_kv_block = 1
+            else:
+                self._physical_blocks_per_logical_kv_block = (
+                    self.block_size // kernel_block_size
+                )
+                self.block_size = kernel_block_size
+                self.num_blocks *= self._physical_blocks_per_logical_kv_block
 
     def _nixl_handshake(
         self,
@@ -906,16 +909,11 @@ class NixlConnectorWorker:
                 else:
                     self.block_len_per_layer.append(physical_page_size)
 
-                expected_first_dim = (
-                    self._logical_num_blocks
-                    if self.vllm_config.use_v2_model_runner
-                    else self.num_blocks
-                )
-                if cache.shape[0] != expected_first_dim:
+                if cache.shape[0] != num_blocks:
                     raise AssertionError(
                         "All kv cache tensors must have the same number of "
                         f"blocks; layer={layer_name}, "
-                        f"expected_num_blocks={expected_first_dim}, "
+                        f"expected_num_blocks={num_blocks}, "
                         f"cache_shape={tuple(cache.shape)}, "
                         f"cache_stride={tuple(cache.stride())}, "
                         f"layer_spec={type(layer_spec).__name__}, "
@@ -924,8 +922,7 @@ class NixlConnectorWorker:
                         f"{[backend.get_name() for backend in self.attn_backends]}, "
                         f"kv_cache_layout={self.kv_cache_layout}, "
                         "blocks_first="
-                        f"{self.transfer_topo.is_kv_layout_blocks_first}, "
-                        f"use_v2_model_runner={self.vllm_config.use_v2_model_runner}"
+                        f"{self.transfer_topo.is_kv_layout_blocks_first}"
                     )
 
                 if not self.use_mla:


### PR DESCRIPTION



## Purpose
FIX https://github.com/vllm-project/vllm/issues/42846
Related error: https://buildkite.com/vllm/ci/builds/66617/canvas?jid=019e38db-bb6b-4ab4-8378-fa658fc52ac8&tab=output

`_sync_block_size_with_kernel` doubles `self.num_blocks` and halves `self.block_size` so NIXL descriptors walk the cache at the kernel block_size. That matches V1's KV cache layout (V1 reshapes the cache to kernel granularity in `gpu_model_runner._reshape_kv_cache_tensors`), but **not V2's** — V2 (`gpu/attn_utils._reshape_kv_cache`) keeps the tensor at  logical block_size.

## Fix
Skip the `num_blocks *= ratio` / `block_size //= ratio` step under V2 and  pin `_physical_blocks_per_logical_kv_block = 1` so the rest of the NIXL  worker (byte accounting in `register_kv_caches`, descriptor strides in  `_build_fa_local` / `_build_fa_remote`, `_logical_to_kernel_block_ids`)  stays 1:1 with V2's logical-grain cache layout. V1 path is unchanged.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

