### PR TITLE
[Core][Metrics] Expose scheduler queue pressure

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -183,6 +183,7 @@ EXPECTED_METRICS_V1 = [
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
     "vllm:num_requests_waiting_by_reason",
+    "vllm:scheduler_queue_pressure",
     "vllm:kv_cache_usage_perc",
     "vllm:prefix_cache_queries",
     "vllm:prefix_cache_hits",

--- a/tests/v1/metrics/test_scheduler_queue_pressure.py
+++ b/tests/v1/metrics/test_scheduler_queue_pressure.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from prometheus_client import generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+
+from vllm.v1.metrics.loggers import PrometheusStatLogger
+from vllm.v1.metrics.stats import SchedulerStats
+
+
+def _make_vllm_config(max_num_seqs: int):
+    return SimpleNamespace(
+        observability_config=SimpleNamespace(
+            show_hidden_metrics=False,
+            kv_cache_metrics=False,
+        ),
+        model_config=SimpleNamespace(
+            served_model_name="test-model",
+            max_model_len=128,
+        ),
+        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
+        speculative_config=None,
+        kv_transfer_config=None,
+        lora_config=None,
+    )
+
+
+def _get_scheduler_queue_pressure() -> dict[str, float]:
+    values: dict[str, float] = {}
+    metrics_text = generate_latest().decode()
+    for family in text_string_to_metric_families(metrics_text):
+        if family.name != "vllm:scheduler_queue_pressure":
+            continue
+        for sample in family.samples:
+            if sample.name == "vllm:scheduler_queue_pressure":
+                values[sample.labels["reason"]] = sample.value
+    return values
+
+
+def test_scheduler_queue_pressure_normalizes_waiting_reqs_by_capacity():
+    logger = PrometheusStatLogger(_make_vllm_config(max_num_seqs=128))
+
+    logger.record(
+        SchedulerStats(
+            num_waiting_reqs=32,
+            num_skipped_waiting_reqs=16,
+        ),
+        iteration_stats=None,
+    )
+
+    assert _get_scheduler_queue_pressure() == {
+        "capacity": 0.25,
+        "deferred": 0.125,
+    }

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -490,6 +490,27 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 gauge_waiting_by_reason, per_engine_labelvalues_with_reason
             )
 
+        self.scheduler_capacity = vllm_config.scheduler_config.max_num_seqs
+        gauge_queue_pressure = self._gauge_cls(
+            name="vllm:scheduler_queue_pressure",
+            documentation=(
+                "Waiting requests by reason normalized by scheduler capacity "
+                "(max_num_seqs). Reason labels match "
+                "vllm:num_requests_waiting_by_reason."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames + ["reason"],
+        )
+        self.gauge_queue_pressure: dict[str, dict[int, Gauge]] = {}
+        for waiting_reason in [WAITING_REASON_CAPACITY, WAITING_REASON_DEFERRED]:
+            per_engine_labelvalues_with_reason = {
+                idx: labelvalues + [waiting_reason]
+                for idx, labelvalues in per_engine_labelvalues.items()
+            }
+            self.gauge_queue_pressure[waiting_reason] = create_metric_per_engine(
+                gauge_queue_pressure, per_engine_labelvalues_with_reason
+            )
+
         gauge_engine_sleep_state = self._gauge_cls(
             name="vllm:engine_sleep_state",
             documentation=(
@@ -1077,6 +1098,12 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
             self.gauge_waiting_by_reason[WAITING_REASON_DEFERRED][engine_idx].set(
                 scheduler_stats.num_skipped_waiting_reqs
+            )
+            self.gauge_queue_pressure[WAITING_REASON_CAPACITY][engine_idx].set(
+                scheduler_stats.num_waiting_reqs / self.scheduler_capacity
+            )
+            self.gauge_queue_pressure[WAITING_REASON_DEFERRED][engine_idx].set(
+                scheduler_stats.num_skipped_waiting_reqs / self.scheduler_capacity
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
 


### PR DESCRIPTION
## Summary

Adds `vllm:scheduler_queue_pressure{reason="capacity|deferred"}` as a normalized scheduler backlog signal:

- `capacity` = requests waiting on scheduler capacity / `max_num_seqs`
- `deferred` = requests deferred by transient constraints / `max_num_seqs`

This builds on the waiting-by-reason metric from https://github.com/vllm-project/vllm/pull/38435. Raw waiting request counts are useful, but a normalized pressure signal is easier for control planes to compare across replicas with different scheduler capacity.

## Testing

- `uv run --no-sync ruff check vllm/v1/metrics/loggers.py tests/entrypoints/serve/instrumentator/test_metrics.py tests/v1/metrics/test_scheduler_queue_pressure.py`
- `uv run --no-sync python -m py_compile vllm/v1/metrics/loggers.py tests/entrypoints/serve/instrumentator/test_metrics.py tests/v1/metrics/test_scheduler_queue_pressure.py`
