### PR TITLE
[feature] [xgrammar] support `patternProperties`/`propertyNames`/`unevaluatedProperties` kw for object types

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -42,14 +42,6 @@ def unsupported_array_schemas():
 
 
 @pytest.fixture
-def unsupported_object_schemas():
-    return [
-        {"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}},
-        {"type": "object", "patternProperties": {"^S": {"type": "string"}}},
-    ]
-
-
-@pytest.fixture
 def supported_schema():
     return {
         "type": "object",
@@ -76,6 +68,15 @@ def supported_schema():
                     "city": {"type": "string"},
                 },
             },
+            "student": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "grade": {"type": "string"},
+                },
+                "required": ["name", "grade"],
+                "patternProperties": {"^grade$": {"type": "string"}},
+            },
         },
         "minProperties": 1,
         "maxProperties": 100,
@@ -89,7 +90,6 @@ def supported_schema():
         "unsupported_integer_schemas",
         "unsupported_number_schemas",
         "unsupported_array_schemas",
-        "unsupported_object_schemas",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+from xgrammar import Grammar
+from xgrammar.testing import _is_grammar_accept_string
 
 from vllm.v1.structured_output.backend_xgrammar import (
     has_xgrammar_unsupported_json_features,
@@ -10,13 +12,19 @@ from vllm.v1.structured_output.backend_xgrammar import (
 pytestmark = pytest.mark.cpu_test
 
 
+def grammar_accepts(schema: dict, text: str) -> bool:
+    return _is_grammar_accept_string(Grammar.from_json_schema(schema), text)
+
+
 @pytest.fixture
 def unsupported_string_schemas():
     return [
         {"type": "string", "format": "non_existing_format"},
+        # TODO(arpera):
         # pattern/format is compiled but length bounds are silently dropped,
         # so the combination must be rejected instead of producing quietly
         # wrong output
+        # https://github.com/mlc-ai/xgrammar/issues/749
         {"type": "string", "pattern": "^a+$", "maxLength": 2},
         {"type": "string", "pattern": "^a+$", "minLength": 3},
         {"type": "string", "format": "email", "maxLength": 10},
@@ -48,7 +56,40 @@ def unsupported_array_schemas():
 
 
 @pytest.fixture
-def supported_schema():
+def unsupported_property_names_combinations():
+    return [
+        # TODO(arpera):
+        # this case is not covered by xgrammar, so we should report this bug to xgrammar
+        # xgrammar drops propertyNames whenever patternProperties is present,
+        # so "grade_12" matches the pattern and escapes the name constraint
+        {
+            "type": "object",
+            "patternProperties": {"^grade_[0-9]+$": {"type": "integer"}},
+            "propertyNames": {"pattern": "^grade_[0-9]$"},  # does NOT match "grade_12"
+        },
+        # propertyNames makes xgrammar discard the sibling additionalProperties
+        # value schema: https://github.com/mlc-ai/xgrammar/issues/826
+        {
+            "type": "object",
+            "propertyNames": {"pattern": "^[a-z]+$"},
+            "additionalProperties": {"type": "integer"},
+        },
+        # propertyNames is a string schema that conventionally omits "type", so
+        # it escapes the string check while xgrammar drops its length bound all
+        # the same: https://github.com/mlc-ai/xgrammar/issues/749
+        {
+            "type": "object",
+            "propertyNames": {"pattern": "^a+$", "maxLength": 2},
+        },
+    ]
+
+
+@pytest.fixture
+def supported_frankenstein_schema():
+    # IMPORTANT(arpera):
+    # Do NOT add more keywords here! This schema is overcrowded enough that a new
+    # keyword can end up having no effect on the compiled grammar while the
+    # test still passes. Give a new keyword its own fixture and named test.
     return {
         "type": "object",
         "properties": {
@@ -89,6 +130,19 @@ def supported_schema():
     }
 
 
+@pytest.fixture
+def property_names_schema():
+    return {"type": "object", "propertyNames": {"pattern": "^[a-z_]+$"}}
+
+
+@pytest.fixture
+def pattern_properties_schema():
+    return {
+        "type": "object",
+        "patternProperties": {"^grade_[0-9]+$": {"type": "integer"}},
+    }
+
+
 @pytest.mark.parametrize(
     "schema_type",
     [
@@ -96,6 +150,7 @@ def supported_schema():
         "unsupported_integer_schemas",
         "unsupported_number_schemas",
         "unsupported_array_schemas",
+        "unsupported_property_names_combinations",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):
@@ -106,7 +161,29 @@ def test_unsupported_json_features_by_type(schema_type, request):
         )
 
 
-def test_supported_json_features(supported_schema):
-    assert not has_xgrammar_unsupported_json_features(supported_schema), (
-        "Schema should be supported"
+@pytest.mark.parametrize(
+    "schema_type",
+    [
+        "supported_frankenstein_schema",
+        "pattern_properties_schema",
+        "property_names_schema",
+    ],
+)
+def test_supported_json_features(schema_type, request):
+    schema = request.getfixturevalue(schema_type)
+    assert not has_xgrammar_unsupported_json_features(schema), (
+        f"Schema should be supported: {schema}"
     )
+
+
+def test_property_names_constrains_keys(property_names_schema):
+    assert grammar_accepts(property_names_schema, '{"score": 5}')
+    assert grammar_accepts(property_names_schema, '{"score": "seven"}')
+    assert not grammar_accepts(property_names_schema, '{"Score": 5}')
+    assert not grammar_accepts(property_names_schema, '{"score_1": 5}')
+
+
+def test_pattern_properties_constrains_keys_and_values(pattern_properties_schema):
+    assert grammar_accepts(pattern_properties_schema, '{"grade_1": 5}')
+    assert not grammar_accepts(pattern_properties_schema, '{"other": 5}')
+    assert not grammar_accepts(pattern_properties_schema, '{"grade_1": "five"}')

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -78,10 +78,10 @@ def supported_schema():
                 "type": "object",
                 "properties": {
                     "name": {"type": "string"},
-                    "grade": {"type": "string"},
                 },
-                "required": ["name", "grade"],
-                "patternProperties": {"^grade$": {"type": "string"}},
+                "required": ["name"],
+                "patternProperties": {"^grade_[0-9]+$": {"type": "integer"}},
+                "propertyNames": {"pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"},
             },
         },
         "minProperties": 1,

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -115,14 +115,6 @@ def supported_frankenstein_schema():
                     "city": {"type": "string"},
                 },
             },
-            "student": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                },
-                "required": ["name"],
-                "patternProperties": {"^grade_[0-9]+$": {"type": "integer"}},
-            },
         },
         "minProperties": 1,
         "maxProperties": 100,

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -48,14 +48,6 @@ def unsupported_array_schemas():
 
 
 @pytest.fixture
-def unsupported_object_schemas():
-    return [
-        {"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}},
-        {"type": "object", "patternProperties": {"^S": {"type": "string"}}},
-    ]
-
-
-@pytest.fixture
 def supported_schema():
     return {
         "type": "object",
@@ -82,6 +74,15 @@ def supported_schema():
                     "city": {"type": "string"},
                 },
             },
+            "student": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "grade": {"type": "string"},
+                },
+                "required": ["name", "grade"],
+                "patternProperties": {"^grade$": {"type": "string"}},
+            },
         },
         "minProperties": 1,
         "maxProperties": 100,
@@ -95,7 +96,6 @@ def supported_schema():
         "unsupported_integer_schemas",
         "unsupported_number_schemas",
         "unsupported_array_schemas",
-        "unsupported_object_schemas",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -122,7 +122,6 @@ def supported_frankenstein_schema():
                 },
                 "required": ["name"],
                 "patternProperties": {"^grade_[0-9]+$": {"type": "integer"}},
-                "propertyNames": {"pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"},
             },
         },
         "minProperties": 1,

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -81,6 +81,59 @@ def unsupported_property_names_combinations():
             "type": "object",
             "propertyNames": {"pattern": "^a+$", "maxLength": 2},
         },
+        # xgrammar emits named `properties` separately from `propertyNames` and
+        # only applies `propertyNames` in its additional-properties branch, so a
+        # key declared in `properties` escapes the name constraint regardless of
+        # what `propertyNames` contains.
+        {
+            "type": "object",
+            "properties": {"Bad": {"type": "integer"}},
+            "required": ["Bad"],
+            "propertyNames": {"pattern": "^[a-z]+$"},
+        },
+        {
+            "type": "object",
+            "properties": {"Bad": {"type": "integer"}},
+            "propertyNames": {"enum": ["good"]},
+        },
+        # xgrammar's propertyNames-only branch falls back to an unconstrained
+        # value type, so it drops unevaluatedProperties whether it restricts
+        # values (a schema) or forbids them (false).
+        {
+            "type": "object",
+            "propertyNames": {"pattern": "^[a-z]+$"},
+            "unevaluatedProperties": {"type": "integer"},
+        },
+        {
+            "type": "object",
+            "propertyNames": {"pattern": "^[a-z]+$"},
+            "unevaluatedProperties": False,
+        },
+    ]
+
+
+@pytest.fixture
+def unsupported_pattern_properties_combinations():
+    return [
+        # JSON Schema requires a property matched by both `properties` and
+        # `patternProperties` to satisfy both (conjunction), but xgrammar
+        # compiles them as alternative branches, so satisfying either one is
+        # enough.
+        {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "patternProperties": {"^x$": {"type": "integer"}},
+        },
+        # The same alternative-branches problem applies to overlapping
+        # patternProperties patterns: a key matching both patterns only has to
+        # satisfy one of them.
+        {
+            "type": "object",
+            "patternProperties": {
+                "^a[a-z]*$": {"type": "string"},
+                "^[a-z]*z$": {"type": "integer"},
+            },
+        },
     ]
 
 
@@ -142,6 +195,7 @@ def pattern_properties_schema():
         "unsupported_number_schemas",
         "unsupported_array_schemas",
         "unsupported_property_names_combinations",
+        "unsupported_pattern_properties_combinations",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):

--- a/tests/v1/structured_output/test_validation.py
+++ b/tests/v1/structured_output/test_validation.py
@@ -137,7 +137,7 @@ def test_unsupported_grammar_is_a_client_error(backend, structured_outputs):
 @pytest.mark.parametrize(
     "schema, expected_backend",
     [
-        # multipleOf is unsupported by xgrammar, patternProperties also by guidance.
+        # multipleOf is unsupported by xgrammar.
         (
             {
                 "type": "object",
@@ -145,8 +145,13 @@ def test_unsupported_grammar_is_a_client_error(backend, structured_outputs):
             },
             "guidance",
         ),
+        # patternProperties + properties is also unsupported by guidance.
         (
-            {"type": "object", "patternProperties": {"^a": {"type": "string"}}},
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "patternProperties": {"^a$": {"type": "string"}},
+            },
             "outlines",
         ),
     ],

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -244,12 +244,6 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         ):
             return True
 
-        # Unsupported keywords for objects
-        if obj.get("type") == "object" and any(
-            key in obj for key in ("patternProperties", "propertyNames")
-        ):
-            return True
-
         # Recursively check all nested objects and arrays
         for value in obj.values():
             if isinstance(value, dict):

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -236,6 +236,12 @@ STRING_SUPPORTED_FORMATS = {
 }
 
 
+def _has_pattern_and_length_bounds(schema: dict[str, Any]) -> bool:
+    return ("pattern" in schema or "format" in schema) and (
+        "minLength" in schema or "maxLength" in schema
+    )
+
+
 def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
     """Check if JSON schema contains features unsupported by xgrammar."""
 
@@ -269,10 +275,30 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         # the compiled EBNF: pattern/format grammars come out byte-identical
         # with and without the length keywords, while maxLength alone lowers
         # to {0, N} correctly.
+        if obj.get("type") == "string" and _has_pattern_and_length_bounds(obj):
+            return True
+
+        # propertyNames validates names, so it is a string schema even when it
+        # omits "type", which is the form that escapes the check above.
         if (
-            obj.get("type") == "string"
-            and ("pattern" in obj or "format" in obj)
-            and ("minLength" in obj or "maxLength" in obj)
+            obj.get("type") == "object"
+            and isinstance(obj.get("propertyNames"), dict)
+            and _has_pattern_and_length_bounds(obj["propertyNames"])
+        ):
+            return True
+
+        # FIXME: xgrammar drops propertyNames whenever patternProperties is
+        # present, and beside an additionalProperties value schema it discards
+        # that schema instead, so either way a constraint is lost without an
+        # error. Remove once these are fixed:
+        # https://github.com/mlc-ai/xgrammar/issues/826
+        if (
+            obj.get("type") == "object"
+            and "propertyNames" in obj
+            and (
+                "patternProperties" in obj
+                or isinstance(obj.get("additionalProperties"), dict)
+            )
         ):
             return True
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -276,12 +276,6 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         ):
             return True
 
-        # Unsupported keywords for objects
-        if obj.get("type") == "object" and any(
-            key in obj for key in ("patternProperties", "propertyNames")
-        ):
-            return True
-
         # Recursively check all nested objects and arrays
         for value in obj.values():
             if isinstance(value, dict):

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -287,18 +287,27 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         ):
             return True
 
-        # FIXME: xgrammar drops propertyNames whenever patternProperties is
-        # present, and beside an additionalProperties value schema it discards
-        # that schema instead, so either way a constraint is lost without an
-        # error. Remove once these are fixed:
+        # FIXME: propertyNames conflicts with properties/patternProperties/
+        # additionalProperties/unevaluatedProperties under xgrammar.
         # https://github.com/mlc-ai/xgrammar/issues/826
         if (
             obj.get("type") == "object"
             and "propertyNames" in obj
             and (
-                "patternProperties" in obj
+                "properties" in obj
+                or "patternProperties" in obj
                 or isinstance(obj.get("additionalProperties"), dict)
+                or obj.get("unevaluatedProperties", True) is not True
             )
+        ):
+            return True
+
+        # FIXME: multiple patternProperties, or patternProperties alongside
+        # properties, conflict under xgrammar.
+        if (
+            obj.get("type") == "object"
+            and "patternProperties" in obj
+            and ("properties" in obj or len(obj["patternProperties"]) > 1)
         ):
             return True
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -306,7 +306,7 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         # properties, conflict under xgrammar.
         if (
             obj.get("type") == "object"
-            and "patternProperties" in obj
+            and isinstance(obj.get("patternProperties"), dict)
             and ("properties" in obj or len(obj["patternProperties"]) > 1)
         ):
             return True


### PR DESCRIPTION



## Purpose

Support `patternProperties` and `propertyNames` keywords for `object` types in JSON schema for xgrammar structured output backend. Makes openai-compatible endpoint more feature-complete by covering more JSON schema under a structured output engine. This is supported since `xgrammar>=0.2.1` by mlc-ai/xgrammar#594.

## Test Plan

[The corresponding unit test](./tests/v1/structured_output/test_utils.py) has been updated so that it can be tested continuously in CI pipeline.

## Test Result

Via CI result.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

