### PR TITLE
[MRV2][CI] Add update_config method for V2 Runner

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -28,7 +28,7 @@ import torch
 import torch.nn as nn
 
 from vllm.compilation.counter import compilation_counter
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, update_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.parallel_state import (
     get_dcp_group,
@@ -261,6 +261,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # on the last PP rank.
             tasks.extend(PoolingRunner.get_supported_tasks(self.model))
         return tuple(tasks)
+
+    def update_config(self, overrides: dict[str, Any]) -> None:
+        allowed_config_names = {"load_config", "model_config"}
+        for config_name, config_overrides in overrides.items():
+            assert config_name in allowed_config_names, (
+                f"Config `{config_name}` not supported. "
+                f"Allowed configs: {allowed_config_names}"
+            )
+            config = getattr(self, config_name)
+            new_config = update_config(config, config_overrides)
+            setattr(self, config_name, new_config)
 
     def load_model(self, load_dummy_weights: bool = False, *args, **kwargs) -> None:
         time_before_load = time.perf_counter()


### PR DESCRIPTION
## Purpose
there are some case and ut (like quantization/test_torchao.py::test_reload_weights ) will call `update_config` method which is a V1 Runner API. 

usages:
- https://github.com/vllm-project/vllm/blob/main/tests/quantization/test_torchao.py#L200-L202
- https://github.com/vllm-project/vllm/blob/main/tests/model_executor/model_loader/test_reload.py#L324-L327
- https://github.com/vllm-project/vllm/blob/main/examples/rl/skip_loading_weights_in_engine_init.py#L40-L42

I am not certain we should avoid such usage or just add this API to make CI pass.

failed CI: https://buildkite.com/vllm/ci/builds/66603#019e37be-565e-46fe-82be-71d5806d9dcf

## Test Plan
pytest -vs tests/quantization/test_torchao.py::test_reload_weights

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

