### PR TITLE
[Feature]: Support DDTree speculative decoding

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -51,8 +51,14 @@ MTPModelTypes = Literal[
 ]
 NgramGPUTypes = Literal["ngram_gpu"]
 DFlashModelTypes = Literal["dflash"]
+DDTreeModelTypes = Literal["ddtree"]
 EagleModelTypes = Literal[
-    "eagle", "eagle3", "extract_hidden_states", MTPModelTypes, DFlashModelTypes
+    "eagle",
+    "eagle3",
+    "extract_hidden_states",
+    MTPModelTypes,
+    DFlashModelTypes,
+    DDTreeModelTypes,
 ]
 SpeculativeMethod = Literal[
     "ngram",
@@ -267,6 +273,7 @@ class SpeculativeConfig:
             "eagle3",
             "extract_hidden_states",
             "dflash",
+            "ddtree",
         )
         factors.append(uses_aux_hidden_states)
 
@@ -568,7 +575,7 @@ class SpeculativeConfig:
                 )
 
                 # Automatically detect the method
-                if self.method in ("eagle", "eagle3", "dflash"):
+                if self.method in ("eagle", "eagle3", "dflash", "ddtree"):
                     pass
                 # examples:
                 # yuhuili/EAGLE-LLaMA3-Instruct-8B
@@ -612,7 +619,7 @@ class SpeculativeConfig:
                     )
 
                 # Replace hf_config for EAGLE draft_model
-                if self.method in ("eagle", "eagle3", "dflash"):
+                if self.method in ("eagle", "eagle3", "dflash", "ddtree"):
                     from vllm.transformers_utils.configs.eagle import EAGLEConfig
                     from vllm.transformers_utils.configs.speculators import (
                         SpeculatorsConfig,
@@ -632,7 +639,7 @@ class SpeculativeConfig:
                         self.draft_model_config.hf_config = eagle_config
                         self.update_arch_()
 
-                if self.method == "dflash":
+                if self.method in ("dflash", "ddtree"):
                     self.parallel_drafting = True
 
                 if self.num_speculative_tokens is not None and hasattr(
@@ -957,10 +964,13 @@ class SpeculativeConfig:
         return slots_per_req
 
     def use_eagle(self) -> bool:
-        return self.method in ("eagle", "eagle3", "mtp", "dflash")
+        return self.method in ("eagle", "eagle3", "mtp", "dflash", "ddtree")
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"
+
+    def use_ddtree(self) -> bool:
+        return self.method == "ddtree"
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -868,6 +868,18 @@ class VllmConfig:
             self.model_config.disable_cascade_attn = True
 
         if (
+            self.speculative_config is not None
+            and self.speculative_config.use_ddtree()
+            and self.attention_config.backend is not None
+            and self.attention_config.backend.name != "TREE_ATTN"
+        ):
+            raise ValueError(
+                "DDTree speculative decoding requires "
+                "attention_config.backend = 'TREE_ATTN'. "
+                f"Got: {self.attention_config.backend.name!r}."
+            )
+
+        if (
             self.model_config is not None
             and self.model_config.multimodal_config is not None
             and self.model_config.multimodal_config.mm_tensor_ipc == "torch_shm"

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -620,6 +620,13 @@ def maybe_override_with_speculators(
     verifier_model = speculators_config["verifier"]["name_or_path"]
     model = tokenizer = verifier_model
 
+    # Apply explicit user overrides (e.g. method='ddtree') on top of the
+    # extracted model defaults, so user-provided values always take precedence.
+    if vllm_speculative_config is not None:
+        for key in ("method", "num_speculative_tokens"):
+            if key in vllm_speculative_config:
+                speculative_config[key] = vllm_speculative_config[key]
+
     return model, tokenizer, speculative_config
 
 

--- a/vllm/v1/attention/backends/tree_attn.py
+++ b/vllm/v1/attention/backends/tree_attn.py
@@ -38,6 +38,10 @@ class TreeAttentionBackend(AttentionBackend):
     ]
     forward_includes_kv_cache_update: bool = False
 
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        return True
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [MultipleOf(16)]
@@ -91,6 +95,7 @@ class TreeAttentionMetadata:
     num_decodes: int = 0
 
     tree_attn_bias: torch.Tensor | None = None
+    causal: bool = True
 
     # Cached Prefill/decode metadata.
     _cached_prefill_metadata: "TreeAttentionMetadata | None" = None
@@ -118,6 +123,7 @@ class TreeAttentionMetadata:
             seq_lens=kv_seqlens,
             block_table=self.block_table[self.num_decodes :],
             slot_mapping=self.slot_mapping[self.num_decode_tokens :],
+            causal=self.causal,
         )
         return self._cached_prefill_metadata
 
@@ -144,6 +150,7 @@ class TreeAttentionMetadata:
             block_table=self.block_table[: self.num_decodes],
             slot_mapping=self.slot_mapping[: self.num_decode_tokens],
             tree_attn_bias=self.tree_attn_bias,
+            causal=self.causal,
         )
         return self._cached_decode_metadata
 
@@ -177,6 +184,9 @@ class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadat
         )
 
         self.reorder_batch_threshold = self.tree_attn_bias.shape[0]
+        # Decode threshold used in build(); may differ from reorder_batch_threshold
+        # when DDTree uses per-request 3D biases (see _update_target_tree_attn_bias).
+        self._tree_decode_threshold = self.tree_attn_bias.shape[0]
 
     def build(
         self,
@@ -184,7 +194,7 @@ class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadat
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> TreeAttentionMetadata:
-        decode_threshold = self.tree_attn_bias.shape[0]
+        decode_threshold = self._tree_decode_threshold
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
                 common_attn_metadata, decode_threshold=decode_threshold
@@ -212,6 +222,7 @@ class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadat
             block_table=block_table,
             slot_mapping=slot_mapping,
             tree_attn_bias=self.tree_attn_bias,
+            causal=common_attn_metadata.causal,
         )
 
     def build_for_drafting(
@@ -229,7 +240,9 @@ class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadat
             # Slice the tree attention bias for drafting. Exclude
             # the root level.
             start, end = 1, 1 + common_attn_metadata.max_query_len
-            self.tree_attn_bias = self.tree_attn_bias[start:end, start:end].contiguous()
+            self.tree_attn_bias = self.tree_attn_bias[
+                ..., start:end, start:end
+            ].contiguous()
 
         # Build attention bias.
         attn_metadata = self.build(0, common_attn_metadata, fast_build=True)
@@ -408,7 +421,7 @@ class TreeAttentionImpl(AttentionImpl):
                 seqused_k=prefill_meta.seq_lens,
                 max_seqlen_k=prefill_meta.max_seq_len,
                 softmax_scale=self.scale,
-                causal=True,
+                causal=prefill_meta.causal,
                 alibi_slopes=self.alibi_slopes,
                 window_size=self.sliding_window,
                 block_table=prefill_meta.block_table,
@@ -419,24 +432,104 @@ class TreeAttentionImpl(AttentionImpl):
             )
 
         if decode_meta := attn_metadata.decode_metadata:
-            unified_attention(
-                q=query[:num_decode_tokens],
-                k=key_cache,
-                v=value_cache,
-                out=output[:num_decode_tokens],
-                cu_seqlens_q=decode_meta.query_start_loc,
-                max_seqlen_q=decode_meta.max_query_len,
-                seqused_k=decode_meta.seq_lens,
-                max_seqlen_k=decode_meta.max_seq_len,
-                softmax_scale=self.scale,
-                causal=True,
-                alibi_slopes=self.alibi_slopes,
-                qq_bias=decode_meta.tree_attn_bias,
-                window_size=self.sliding_window,
-                block_table=decode_meta.block_table,
-                softcap=self.logits_soft_cap,
-                q_descale=None,  # Not supported
-                k_descale=layer._k_scale.expand(descale_shape),
-                v_descale=layer._v_scale.expand(descale_shape),
-            )
+            tree_bias = decode_meta.tree_attn_bias
+            if tree_bias is not None and tree_bias.numel() == 0:
+                tree_bias = None
+
+            # Determine whether to use the 3D per-request DDTree bias.
+            # Guard: if the batch shrank since the bias was built (requests
+            # finished between propose and this execute_model call),
+            # ns_tokens goes negative, causing a Triton OOB.  Fall back to
+            # plain causal attention for this transition step.
+            # The next propose call rebuilds a correctly-sized bias.
+            use_3d_bias = tree_bias is not None and tree_bias.ndim == 3
+            if use_3d_bias:
+                assert tree_bias is not None
+                num_spec = tree_bias.shape[0]
+                N1 = tree_bias.shape[-1]  # = N+1 tokens per spec request
+                num_nonspec = attn_metadata.num_decodes - num_spec
+                ns_tokens = num_decode_tokens - num_spec * N1
+                if ns_tokens < 0:
+                    use_3d_bias = False
+
+            if use_3d_bias:
+                # tree_bias is shape [num_spec, N+1, N+1] — one [N+1, N+1] matrix per
+                # spec-decode request. The Triton kernel indexes it by seq_idx (position
+                # within the call), so the call must contain ONLY spec-decode requests;
+                # mixing non-spec requests at the front would shift seq_idx and cause
+                # wrong or out-of-bounds bias lookups.
+                #
+                # To make this work, the decode batch is always ordered:
+                #   [non-spec (regular decodes + short extends)] then [spec-decodes]
+                # guaranteed by reorder_batch_threshold = N (set when the
+                # bias is built).
+                #
+                # We therefore split into two unified_attention calls:
+                #   call 1: non-spec requests, no qq_bias (plain causal)
+                #   call 2: spec-decode requests only, qq_bias=tree_bias
+                #           (seq_idx=0..num_spec-1)
+                if num_nonspec > 0:
+                    unified_attention(
+                        q=query[:ns_tokens],
+                        k=key_cache,
+                        v=value_cache,
+                        out=output[:ns_tokens],
+                        cu_seqlens_q=decode_meta.query_start_loc[: num_nonspec + 1],
+                        max_seqlen_q=N1 - 1,
+                        seqused_k=decode_meta.seq_lens[:num_nonspec],
+                        max_seqlen_k=decode_meta.max_seq_len,
+                        softmax_scale=self.scale,
+                        causal=True,
+                        alibi_slopes=self.alibi_slopes,
+                        window_size=self.sliding_window,
+                        block_table=decode_meta.block_table[:num_nonspec],
+                        softcap=self.logits_soft_cap,
+                        q_descale=None,
+                        k_descale=layer._k_scale.expand((num_nonspec, key.shape[1])),
+                        v_descale=layer._v_scale.expand((num_nonspec, key.shape[1])),
+                    )
+
+                # Spec-decode requests: adjust cu_seqlens_q to start from 0.
+                spec_cu_q = decode_meta.query_start_loc[num_nonspec:] - ns_tokens
+                unified_attention(
+                    q=query[ns_tokens:num_decode_tokens],
+                    k=key_cache,
+                    v=value_cache,
+                    out=output[ns_tokens:num_decode_tokens],
+                    cu_seqlens_q=spec_cu_q,
+                    max_seqlen_q=N1,
+                    seqused_k=decode_meta.seq_lens[num_nonspec:],
+                    max_seqlen_k=decode_meta.max_seq_len,
+                    softmax_scale=self.scale,
+                    causal=True,
+                    alibi_slopes=self.alibi_slopes,
+                    qq_bias=tree_bias,
+                    window_size=self.sliding_window,
+                    block_table=decode_meta.block_table[num_nonspec:],
+                    softcap=self.logits_soft_cap,
+                    q_descale=None,
+                    k_descale=layer._k_scale.expand((num_spec, key.shape[1])),
+                    v_descale=layer._v_scale.expand((num_spec, key.shape[1])),
+                )
+            else:
+                unified_attention(
+                    q=query[:num_decode_tokens],
+                    k=key_cache,
+                    v=value_cache,
+                    out=output[:num_decode_tokens],
+                    cu_seqlens_q=decode_meta.query_start_loc,
+                    max_seqlen_q=decode_meta.max_query_len,
+                    seqused_k=decode_meta.seq_lens,
+                    max_seqlen_k=decode_meta.max_seq_len,
+                    softmax_scale=self.scale,
+                    causal=decode_meta.causal,
+                    alibi_slopes=self.alibi_slopes,
+                    qq_bias=tree_bias,
+                    window_size=self.sliding_window,
+                    block_table=decode_meta.block_table,
+                    softcap=self.logits_soft_cap,
+                    q_descale=None,  # Not supported
+                    k_descale=layer._k_scale.expand(descale_shape),
+                    v_descale=layer._v_scale.expand(descale_shape),
+                )
         return output

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -155,6 +155,7 @@ def compute_tile_loop_bounds(
     IS_3D: tl.constexpr,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    IS_CAUSAL: tl.constexpr = True,
 ):
     """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
     derived ``max_seq_prefix_len`` used for per-tile masking.
@@ -183,6 +184,8 @@ def compute_tile_loop_bounds(
         # image bidirectional attention ranges require a full range
         # including q_block padding to make sure doc mask is correct
         max_seq_prefix_len = tl.maximum(max_seq_prefix_len, seq_len)
+    elif not IS_CAUSAL:
+        max_seq_prefix_len = seq_len
     else:
         max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
 
@@ -263,11 +266,13 @@ def compute_kv_seq_mask(
     seq_offset,
     seq_idx,
     mm_prefix_range_ptr,
+    max_seq_prefix_len,
     SLIDING_WINDOW: tl.constexpr,
     USE_MM_PREFIX: tl.constexpr,
     MAX_MM_RANGES: tl.constexpr,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    IS_CAUSAL: tl.constexpr = True,
 ):
     """Build the KV mask for one tile.
 
@@ -280,19 +285,22 @@ def compute_kv_seq_mask(
     are non-default — the launcher zeros ``CHUNK_LOOKBACK`` whenever
     sliding window is disabled.
     """
-    # Compute attention mask: causal by default (key <= query)
-    seq_mask = seq_offset[None, :] <= query_abs_pos
+    # Compute attention mask: causal (key <= query) or fully open for non-causal.
+    if IS_CAUSAL:
+        seq_mask = seq_offset[None, :] <= query_abs_pos
+    else:
+        seq_mask = seq_offset[None, :] < (query_abs_pos * 0 + max_seq_prefix_len)
 
     # Apply sliding window / chunked attention to base mask
     # BEFORE mm_prefix OR.
     # Order must match FlexAttention:
     #   (causal AND sliding_window) OR mm_prefix
-    if CHUNK_LOOKBACK > -1:
+    if IS_CAUSAL and CHUNK_LOOKBACK > -1:
         seq_mask = seq_mask & (
             (query_abs_pos // CHUNK_SIZE - seq_offset[None, :] // CHUNK_SIZE)
             <= CHUNK_LOOKBACK
         )
-    elif SLIDING_WINDOW > 0:
+    elif IS_CAUSAL and SLIDING_WINDOW > 0:
         seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
 
     # PrefixLM: extend mask with bidirectional ranges for multimodal tokens.

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -90,6 +90,8 @@ def kernel_unified_attention(
     query_stride_1: tl.int64,  # int, should be equal to head_size
     output_stride_0: tl.int64,  # int
     output_stride_1: tl.int64,  # int, should be equal to head_size
+    qq_bias_stride_batch: tl.int64,  # stride(0) for 3-D bias [B, N, N];
+    # 0 broadcasts a shared 2-D bias [N, N] to all requests
     qq_bias_stride_0: tl.int64,  # int
     BLOCK_SIZE: tl.constexpr,  # int
     TILE_SIZE: tl.constexpr,  # int must be power of 2
@@ -129,6 +131,7 @@ def kernel_unified_attention(
     # to ``[segm_idx, segm_idx+1) × tiles_per_segment`` and writes
     # per-segment partials, finalized by ``reduce_segments``.
     IS_3D: tl.constexpr,
+    IS_CAUSAL: tl.constexpr = True,
     # KV cache quantization mode handled inside this kernel via constexpr
     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
     # FP8_PER_TOKEN_HEAD (3).
@@ -208,7 +211,11 @@ def kernel_unified_attention(
         )
 
     if USE_QQ_BIAS:
-        qq_bias_row_ptrs = qq_bias_ptr + query_pos[:, None] * qq_bias_stride_0
+        qq_bias_row_ptrs = (
+            qq_bias_ptr
+            + seq_idx * qq_bias_stride_batch
+            + query_pos[:, None] * qq_bias_stride_0
+        )
 
     loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
         context_len,
@@ -226,6 +233,7 @@ def kernel_unified_attention(
         IS_3D,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        IS_CAUSAL,
     )
 
     # iterate through tiles (now limited to the sliding window range)
@@ -289,11 +297,13 @@ def kernel_unified_attention(
             seq_offset,
             seq_idx,
             mm_prefix_range_ptr,
+            max_seq_prefix_len,
             SLIDING_WINDOW,
             USE_MM_PREFIX,
             MAX_MM_RANGES,
             CHUNK_LOOKBACK,
             CHUNK_SIZE,
+            IS_CAUSAL,
         )
 
         # S : (BLOCK_M, TILE_SIZE)
@@ -539,7 +549,6 @@ def unified_attention(
     # Chunked attention: restrict attention to aligned blocks with lookback.
     chunk_lookback=-1,
 ):
-    assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
 
     if sinks is not None:
@@ -685,7 +694,10 @@ def unified_attention(
         query_stride_1=q.stride(1),
         output_stride_0=out.stride(0),
         output_stride_1=out.stride(1),
-        qq_bias_stride_0=qq_bias.stride(0) if use_qq_bias else 0,
+        qq_bias_stride_batch=(
+            qq_bias.stride(0) if (use_qq_bias and qq_bias.ndim == 3) else 0
+        ),
+        qq_bias_stride_0=(qq_bias.stride(-2) if use_qq_bias else 0),
         BLOCK_SIZE=block_size,
         TILE_SIZE=tile_size,
         HEAD_SIZE=head_size,
@@ -720,6 +732,7 @@ def unified_attention(
         NUM_SEGMENTS_PER_SEQ=num_segments,
         USE_FP8=output_scale is not None,
         IS_3D=use_3d,
+        IS_CAUSAL=causal,
         KV_QUANT_MODE=kv_quant_mode,
         CHUNK_LOOKBACK=chunk_lookback,
         CHUNK_SIZE=chunk_size,

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -82,8 +82,9 @@ def get_attn_backend(
         block_size = None
 
     speculative_config = vllm_config.speculative_config
-    use_non_causal = (
-        speculative_config is not None and speculative_config.method == "dflash"
+    use_non_causal = speculative_config is not None and speculative_config.method in (
+        "dflash",
+        "ddtree",
     )
 
     attn_selector_config = AttentionSelectorConfig(

--- a/vllm/v1/spec_decode/ddtree.py
+++ b/vllm/v1/spec_decode/ddtree.py
@@ -55,7 +55,8 @@ def build_ddtree_tree(
         node_depths:    int64[num_nodes] — 1-based depth (root=0, children=1, …).
         node_ranks:     int64[num_nodes] — top-k rank at each node's depth position.
         parents:    list[num_nodes+1] — parent index per node; parents[0]==-1 (root).
-        child_maps: list[num_nodes+1] of dicts — child_maps[i][token_id] = child index.
+        child_maps: list[num_nodes+1] of dicts —
+            ``child_maps[i][token_id]`` = child index.
         visibility:     bool[num_nodes+1, num_nodes+1] — ancestor-only attention mask.
     """
     if budget <= 0 or draft_logits.shape[0] == 0:

--- a/vllm/v1/spec_decode/ddtree.py
+++ b/vllm/v1/spec_decode/ddtree.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DDTree: Diffusion Draft Tree for speculative decoding.
+
+Implements the tree construction and traversal algorithms from:
+  "Accelerating Speculative Decoding with Block Diffusion Draft Trees"
+  Ringel & Romano, arXiv:2604.12989
+
+DDTree builds a draft tree from DFlash's per-position probability
+distributions using a best-first heap, then verifies the whole tree
+in a single target-model forward pass using ancestor-only attention.
+"""
+
+import heapq
+import os
+
+import numpy as np
+import torch
+from typing_extensions import override
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.tree_attn import TreeAttentionMetadataBuilder
+from vllm.v1.spec_decode.dflash import DFlashProposer
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+logger = init_logger(__name__)
+
+
+def build_ddtree_tree(
+    draft_logits: torch.Tensor,
+    budget: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    list[int],
+    list[dict[int, int]],
+    torch.Tensor,
+]:
+    """Build a draft tree from DFlash per-position logits.
+
+    Uses a best-first heap to select the ``budget`` most-probable token
+    paths according to the draft model's output distributions.
+
+    Args:
+        draft_logits: Float tensor of shape ``[depth, vocab_size]``.
+            Raw (un-softmaxed) logits for each speculative position,
+            as produced by the DFlash draft model.
+        budget: Maximum number of non-root tree nodes to expand.
+
+    Returns:
+        node_token_ids: int64[num_nodes] — token id at each non-root node.
+        node_depths:    int64[num_nodes] — 1-based depth (root=0, children=1, …).
+        node_ranks:     int64[num_nodes] — top-k rank at each node's depth position.
+        parents:    list[num_nodes+1] — parent index per node; parents[0]==-1 (root).
+        child_maps: list[num_nodes+1] of dicts — child_maps[i][token_id] = child index.
+        visibility:     bool[num_nodes+1, num_nodes+1] — ancestor-only attention mask.
+    """
+    if budget <= 0 or draft_logits.shape[0] == 0:
+        visibility = torch.zeros((1, 1), dtype=torch.bool)
+        visibility[0, 0] = True
+        return (
+            torch.empty(0, dtype=torch.long),
+            torch.empty(0, dtype=torch.long),
+            torch.empty(0, dtype=torch.long),
+            [-1],
+            [{}],
+            visibility,
+        )
+
+    depth_limit = int(draft_logits.shape[0])
+    topk = min(budget, draft_logits.shape[-1])
+
+    # Compute normalised log-probabilities for the top-k tokens at each
+    # position.  Move to CPU immediately; the heap runs on the CPU.
+    logits = draft_logits.float()
+    top_logits, top_token_ids = torch.topk(logits, k=topk, dim=-1)
+    log_z = torch.logsumexp(logits, dim=-1, keepdim=True)
+    top_log_probs_np = (
+        (top_logits - log_z).to(device="cpu", dtype=torch.float32).numpy()
+    )
+    top_token_ids_np = top_token_ids.to(device="cpu", dtype=torch.long).numpy()
+
+    node_token_ids_np = np.empty(budget, dtype=np.int64)
+    node_depths_np = np.empty(budget, dtype=np.int64)
+    node_ranks_np = np.empty(budget, dtype=np.int64)
+    # parents_np[0] == -1 (root); parents_np[i] for i >= 1 is the
+    # parent node index.
+    parents_np = np.empty(budget + 1, dtype=np.int32)
+    parents_np[0] = -1
+    child_maps: list[dict[int, int]] = [{}]
+    node_count = 0
+
+    # Best-first heap. Each entry is a candidate node not yet added to the tree.
+    # Entry: (-logw, ranks, parent_index, depth, rank, logw)
+    #
+    #   -logw        — negated accumulated path log-prob; min-heap pops the
+    #                  highest log-prob candidate first
+    #   ranks        — tuple of top-k indices taken at each depth along this
+    #                  path, e.g. (0, 1) = rank-0 at depth 1, rank-1 at depth 2;
+    #                  used only as a tiebreaker when two entries have equal logw
+    #   parent_index — insertion-order index of this candidate's parent node
+    #                  (root=0, first inserted node=1, second=2, ...)
+    #   depth        — 1-based depth of this candidate (root is depth 0)
+    #   rank         — index k into top_token_ids_np[depth-1, k] for this token;
+    #                  rank 0 = most probable token at this depth position
+    #   logw         — accumulated path log-prob (non-negated); kept separately
+    #                  so sibling/child expansions can do arithmetic on the raw
+    #                  sum without re-extracting it from the negated first field
+    first_logw = float(top_log_probs_np[0, 0])
+    heap: list[tuple] = [(-first_logw, (0,), 0, 1, 0, first_logw)]
+
+    while heap and node_count < budget:
+        _, ranks, parent_index, depth, rank, logw = heapq.heappop(heap)
+        token_id = int(top_token_ids_np[depth - 1, rank])
+        current_index = node_count + 1
+
+        node_token_ids_np[node_count] = token_id
+        node_depths_np[node_count] = depth
+        node_ranks_np[node_count] = rank
+        parents_np[current_index] = parent_index
+        child_maps.append({})
+        child_maps[parent_index][token_id] = current_index
+        node_count += 1
+
+        # Push sibling: same parent, next rank at the same depth.
+        if rank + 1 < topk:
+            sibling_logw = (
+                logw
+                - float(top_log_probs_np[depth - 1, rank])
+                + float(top_log_probs_np[depth - 1, rank + 1])
+            )
+            heapq.heappush(
+                heap,
+                (
+                    -sibling_logw,
+                    ranks[:-1] + (rank + 1,),
+                    parent_index,
+                    depth,
+                    rank + 1,
+                    sibling_logw,
+                ),
+            )
+
+        # Push first child: go one level deeper, take rank-0 token.
+        if depth < depth_limit:
+            child_logw = logw + float(top_log_probs_np[depth, 0])
+            heapq.heappush(
+                heap,
+                (
+                    -child_logw,
+                    ranks + (0,),
+                    current_index,
+                    depth + 1,
+                    0,
+                    child_logw,
+                ),
+            )
+
+    # Build the ancestor-only visibility (attention) mask.
+    # visibility[i, j] == True  iff  j is an ancestor of i (or j == i).
+    current_length = 1 + node_count
+    visibility_np = np.zeros((current_length, current_length), dtype=np.bool_)
+    visibility_np[0, 0] = True
+    for idx in range(1, current_length):
+        p = int(parents_np[idx])
+        visibility_np[idx, :idx] = visibility_np[p, :idx]
+        visibility_np[idx, idx] = True
+
+    return (
+        torch.from_numpy(node_token_ids_np[:node_count]),
+        torch.from_numpy(node_depths_np[:node_count]),
+        torch.from_numpy(node_ranks_np[:node_count]),
+        parents_np[:current_length].tolist(),
+        child_maps,
+        torch.from_numpy(visibility_np),
+    )
+
+
+def follow_verified_tree(
+    child_maps: list[dict[int, int]],
+    posterior_token_ids: list[int],
+) -> tuple[list[int], int]:
+    """Walk the verified tree to find the longest accepted path.
+
+    After the target model runs a forward pass over the whole tree, this
+    function greedily follows the path of accepted tokens from the root.
+
+    Args:
+        child_maps: As returned by :func:`build_ddtree_tree`.
+        posterior_token_ids: List of token ids sampled from the target
+            model's logits, one per tree node (root included, in node
+            index order).
+
+    Returns:
+        accepted_indices: Node indices (including root at 0) that form
+            the accepted prefix.
+        bonus_token_id: The next token id to emit after the accepted
+            prefix (sampled by the target model at the last accepted
+            node).
+    """
+    accepted_indices = [0]
+    current_index = 0
+    next_token = int(posterior_token_ids[current_index])
+
+    while next_token in child_maps[current_index]:
+        current_index = child_maps[current_index][next_token]
+        accepted_indices.append(current_index)
+        next_token = int(posterior_token_ids[current_index])
+
+    return accepted_indices, next_token
+
+
+def ddtree_verify(
+    logits: torch.Tensor,
+    target_logits_indices: torch.Tensor,
+    bonus_logits_indices: torch.Tensor,
+    draft_token_ids: torch.Tensor,
+    child_maps: list[list[dict[int, int]]],
+    budget: int,
+    batch_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Tree-aware verification for DDTree speculative decoding.
+
+    After the target model's forward pass over all tree nodes (with
+    ancestor-only attention), this function traces the longest accepted
+    path through the tree per request using the target model's per-node
+    greedy predictions.
+
+    In contrast to flat spec-decode rejection sampling (which scans
+    draft tokens left-to-right), DDTree must follow tree edges: after
+    accepting a node, the next comparison is against that node's
+    children, not its siblings.
+
+    Args:
+        logits:                float[num_logits, vocab_size] — target model logits.
+        target_logits_indices: int[batch * budget] — logit row per draft node.
+        bonus_logits_indices:  int[batch] — logit row for the last node per request.
+        draft_token_ids:       int[batch * budget] — draft tokens in tree-node order.
+        child_maps:            list[batch] of per-request dicts from build_ddtree_tree.
+        budget:                number of draft nodes per request (root excluded).
+        batch_size:            number of requests in the batch.
+        device:                target device for the returned tensor.
+
+    Returns:
+        int32[batch, budget+1] — accepted path tokens + bonus token, -1 padded.
+    """
+
+    # posterior[r][i]   = target's argmax at node i's position, req r
+    # posterior[r][B]   = target's argmax at the last node (bonus), req r
+    # Example (batch=2, budget=3, vocab=3):
+    #   target_logits_indices = [0, 1, 2, 3, 4, 5]   # 6 rows, one per (req, node) pair
+    #
+    #   logits[0] = [0.1, 0.9, 0.1] - token 1   (req 0, node 0)
+    #   logits[1] = [0.5, 0.1, 0.3] - token 0   (req 0, node 1)
+    #   logits[2] = [0.1, 0.1, 0.6] - token 2   (req 0, node 2)
+    #   logits[3] = [0.8, 0.1, 0.1] - token 0   (req 1, node 0)
+    #   logits[4] = [0.1, 0.6, 0.1] - token 1   (req 1, node 1)
+    #   logits[5] = [0.2, 0.1, 0.7] - token 2   (req 1, node 2)
+    #
+    #   .argmax()  = [1, 0, 2, 0, 1, 2]
+    #   .view(2,3) = [[1, 0, 2],   <- req 0
+    #                 [0, 1, 2]]   <- req 1
+    node_posterior = (
+        logits[target_logits_indices].argmax(dim=-1).view(batch_size, budget)
+    )
+    bonus_posterior = logits[bonus_logits_indices].argmax(dim=-1)
+
+    node_posterior_cpu = node_posterior.cpu().tolist()
+    bonus_posterior_cpu = bonus_posterior.cpu().tolist()
+    draft_tokens_cpu = draft_token_ids.view(batch_size, budget).cpu().tolist()
+
+    _dbg = os.environ.get("DDTREE_DEBUG") == "1"
+
+    output = torch.full((batch_size, budget + 1), -1, dtype=torch.int32)
+
+    for r in range(batch_size):
+        posterior = node_posterior_cpu[r] + [bonus_posterior_cpu[r]]
+
+        accepted_indices, bonus_token = follow_verified_tree(child_maps[r], posterior)
+
+        if _dbg and r == 0:
+            print(
+                f"[ddtree_verify] draft={draft_tokens_cpu[r]}"
+                f" posterior={posterior[:budget]}"
+                f" acc_len={len(accepted_indices)}"
+                f" maps={child_maps[r]}"
+            )
+
+        out_pos = 0
+        for node_idx in accepted_indices[1:]:
+            output[r, out_pos] = draft_tokens_cpu[r][node_idx - 1]
+            out_pos += 1
+        output[r, out_pos] = bonus_token
+
+    return output.to(device)
+
+
+class DDTreeProposer(DFlashProposer):
+    """DFlash proposer with a dynamic best-first draft tree.
+
+    Each proposal step:
+    1. Runs the DFlash draft model to obtain per-position logits.
+    2. Calls :func:`build_ddtree_tree` per request on its own draft logits
+       to select the ``budget`` most-probable tree nodes via a best-first heap.
+    3. Updates the target model's ``TreeAttentionMetadataBuilder`` with
+       the new visibility mask so the next verification pass uses the
+       correct ancestor-only attention bias.
+    4. Returns per-request draft tokens in tree-node order.
+
+    Each request gets its own tree topology derived from its own draft logits.
+
+    Requirements:
+    - attention_config.backend = "TREE_ATTN": needed for per-request
+      ancestor-only attention masking over the draft tree.
+    - speculative_config.method = "ddtree": selects this proposer.
+
+    Example (budget=4, num_speculative_tokens=4):
+
+        DFlash produces marginal logits for 4 depth positions.
+        For this example, assume probabilities are concentrated enough
+        that the tree only branches to depth 2.
+        root token = "The"
+
+        Top-5 most probable sequences by cumulative log-prob:
+          rank 1: "The" -> cat -> sat
+          rank 2: "The" -> cat -> ran
+          rank 3: "The" -> dog -> sat
+          rank 4: "The" -> cat -> red
+          rank 5: "The" -> dog -> ran
+
+        budget=4 means: expand top-4 nodes from the heap:
+          pop 1: cat   (root->cat)       -> node 1
+          pop 2: sat   (root->cat->sat)  -> node 2  child of node 1
+          pop 3: dog   (root->dog)       -> node 3
+          pop 4: sat   (root->dog->sat)  -> node 4  child of node 3
+          stop.  rank 5 (dog->ran) NOT in tree — out of budget.
+
+                    root ("The")          <- node 0
+                   /            \\
+                cat               dog     <- node 1, node 3
+                 |                 |
+                sat               sat    <- node 2, node 4
+
+        child_maps:
+          child_maps[0] = {cat: 1, dog: 3}
+          child_maps[1] = {sat: 2}
+          child_maps[2] = {}                  <- leaf
+          child_maps[3] = {sat: 4}
+          child_maps[4] = {}                  <- leaf
+
+        draft output: [batch, budget=4] in node-index order
+          [cat, sat, dog, sat]
+           ^1   ^2   ^3   ^4
+
+        visibility mask [5, 5]  (budget+1 nodes including root)
+        rule: row i attends to col j iff j is an ancestor of i (or j==i)
+
+              0  1  2  3  4
+          0 [ T  F  F  F  F ]  root
+          1 [ T  T  F  F  F ]  cat           (sees root, itself)
+          2 [ T  T  T  F  F ]  sat under cat (sees root, cat, itself)
+          3 [ T  F  F  T  F ]  dog           (sees root, itself)
+          4 [ T  F  F  T  T ]  sat under dog (sees root, dog, itself)
+
+        note: nodes 2 and 4 are both "sat" but attend to different contexts.
+
+        verification examples:
+          target predicts [cat, sat, ...]:
+            node 0 -> cat in child_maps[0] -> node 1  accepted
+            node 1 -> sat in child_maps[1] -> node 2  accepted
+            node 2 -> no children          -> stop
+            result: "The cat sat" + bonus token
+
+          target predicts [dog, sat, ...]:
+            node 0 -> dog in child_maps[0] -> node 3  accepted
+            node 3 -> sat in child_maps[3] -> node 4  accepted
+            node 4 -> no children          -> stop
+            result: "The dog sat" + bonus token
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ) -> None:
+        assert vllm_config.speculative_config is not None
+        assert vllm_config.speculative_config.method == "ddtree"
+        super().__init__(vllm_config, device, runner)
+
+        self._runner = runner
+        self._budget = self.num_speculative_tokens
+        self._child_maps: list[list[dict[int, int]]] | None = None
+        self._node_depths: list[torch.Tensor] | None = None
+
+    @override
+    def build_per_group_and_layer_attn_metadata(
+        self,
+        cad: CommonAttentionMetadata,
+        draft_index: int = 0,
+    ) -> tuple[list[object], dict[str, object]]:
+        # Skip DFlashProposer's causal=False assertion; tree attention enforces
+        # non-causal masking via qq_bias, not via the causal flag.
+        return SpecDecodeBaseProposer.build_per_group_and_layer_attn_metadata(
+            self, cad, draft_index
+        )
+
+    @override
+    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Build a per-request dynamic tree and return draft tokens.
+
+        Overrides the DFlash greedy argmax with a heap-based tree built
+        independently for each request from its own logits.  Each request
+        gets its own tree topology (child_maps) and visibility mask, allowing
+        heterogeneous batches to have different speculative paths.
+
+        Args:
+            hidden_states: [batch * depth, hidden_size] — the DFlash
+                model's output hidden states for the speculative positions.
+
+        Returns:
+            [batch * budget] int64 — flattened draft token IDs in
+            tree-node order, varying per request.
+        """
+        depth = self.num_speculative_tokens  # DFlash depth == num_spec_tokens
+        batch_size = hidden_states.shape[0] // depth
+
+        logits = self.model.compute_logits(hidden_states)
+        vocab_size = logits.shape[-1]
+        logits_per_req = logits.float().view(batch_size, depth, vocab_size)
+
+        all_child_maps: list[list[dict[int, int]]] = []
+        all_draft_tokens: list[torch.Tensor] = []
+        all_visibility: list[torch.Tensor] = []
+        all_node_depths: list[torch.Tensor] = []
+        target_size = self._budget + 1  # [N+1, N+1] per request
+
+        for r in range(batch_size):
+            (
+                node_token_ids,
+                node_depths,
+                _,
+                _,
+                child_maps,
+                visibility,
+            ) = build_ddtree_tree(logits_per_req[r], budget=self._budget)
+            all_child_maps.append(child_maps)
+
+            # Draft tokens for this request, padded to budget.
+            tokens = node_token_ids.to(self.device)
+            budget_actual = tokens.shape[0]
+            if budget_actual < self._budget:
+                tokens = torch.cat(
+                    [tokens, tokens.new_zeros(self._budget - budget_actual)]
+                )
+            all_draft_tokens.append(tokens)
+
+            # Node depths padded to budget; unused slots get sequential depths
+            # so their positions stay consistent (non-zero depth avoids root clash).
+            depths = node_depths.to(self.device, dtype=torch.long)
+            if budget_actual < self._budget:
+                pad = torch.arange(
+                    budget_actual + 1,
+                    budget_actual + 1 + (self._budget - budget_actual),
+                    dtype=torch.long,
+                    device=self.device,
+                )
+                depths = torch.cat([depths, pad])
+            all_node_depths.append(depths)
+
+            # Visibility mask padded to [target_size, target_size].
+            vis_size = visibility.shape[0]  # budget_actual + 1
+            if vis_size < target_size:
+                padded = torch.zeros(target_size, target_size, dtype=torch.bool)
+                padded[:vis_size, :vis_size] = visibility
+                visibility = padded
+            all_visibility.append(visibility)
+
+        self._child_maps = all_child_maps
+        self._node_depths = all_node_depths
+
+        # Stack per-request masks: [batch, N+1, N+1] → 3D qq_bias.
+        stacked = torch.stack(all_visibility, dim=0)  # [batch, N+1, N+1]
+        tree_attn_bias = torch.where(
+            stacked.to(self.device),
+            torch.zeros(1, dtype=torch.float32, device=self.device),
+            torch.full((1,), float("-inf"), dtype=torch.float32, device=self.device),
+        )
+        self._update_target_tree_attn_bias(tree_attn_bias)
+
+        draft = torch.stack(all_draft_tokens, dim=0)  # [batch, budget]
+        return draft.reshape(-1).to(torch.long)  # [batch * budget]
+
+    def _update_target_tree_attn_bias(self, tree_attn_bias: torch.Tensor) -> None:
+        """Push a new tree_attn_bias to all TreeAttentionMetadataBuilders.
+
+        Called after each propose step so the target model's next
+        verification pass uses the freshly-built tree topology.
+        """
+        if self._runner is None:
+            return
+        found_tree_attn = False
+        for attn_groups in self._runner.attn_groups:
+            for attn_group in attn_groups:
+                builder = attn_group.get_metadata_builder()
+                if isinstance(builder, TreeAttentionMetadataBuilder):
+                    builder.tree_attn_bias = tree_attn_bias
+                    # N = budget; reorder threshold = N so spec-decodes (q_len=N+1)
+                    # land in region 2 (long_extend) after regular decodes (region 0),
+                    # giving forward() a clean split point.
+                    builder.reorder_batch_threshold = tree_attn_bias.shape[-2] - 1
+                    # build() still needs to include spec-decodes in the decode
+                    # bucket (not prefill), so keep decode threshold at N+1.
+                    builder._tree_decode_threshold = tree_attn_bias.shape[-2]
+                    found_tree_attn = True
+        assert found_tree_attn, (
+            "DDTreeProposer requires the target model to use the TREE_ATTN "
+            "attention backend. Set attention_config.backend = 'TREE_ATTN' "
+            "in your vllm config."
+        )

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -25,7 +25,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         runner=None,
     ):
         assert vllm_config.speculative_config is not None
-        assert vllm_config.speculative_config.method == "dflash"
+        assert vllm_config.speculative_config.method in ("dflash", "ddtree")
         super().__init__(
             vllm_config=vllm_config,
             device=device,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -92,7 +92,12 @@ class SpecDecodeBaseProposer:
             1 if not self.parallel_drafting else self.num_speculative_tokens
         )
         self.net_num_new_slots_per_request = self.extra_slots_per_request - (
-            1 if (self.pass_hidden_states_to_model and self.method != "dflash") else 0
+            1
+            if (
+                self.pass_hidden_states_to_model
+                and self.method not in ("dflash", "ddtree")
+            )
+            else 0
         )
         self.needs_extra_input_slots = self.net_num_new_slots_per_request > 0
 
@@ -422,7 +427,7 @@ class SpecDecodeBaseProposer:
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
-        if self.method in ("eagle3", "dflash"):
+        if self.method in ("eagle3", "dflash", "ddtree"):
             assert isinstance(
                 self.model,
                 (
@@ -825,7 +830,7 @@ class SpecDecodeBaseProposer:
         return per_group_attn_metadata, per_layer_attn_metadata
 
     def model_returns_tuple(self) -> bool:
-        return self.method not in ("mtp", "draft_model", "dflash")
+        return self.method not in ("mtp", "draft_model", "dflash", "ddtree")
 
     def prepare_next_token_ids_cpu(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -165,6 +165,7 @@ from vllm.v1.sample.logits_processor.interface import LogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.sample.sampler import Sampler
+from vllm.v1.spec_decode.ddtree import DDTreeProposer, ddtree_verify
 from vllm.v1.spec_decode.dflash import DFlashProposer
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
@@ -521,6 +522,7 @@ class GPUModelRunner(
                 | SuffixDecodingProposer
                 | EagleProposer
                 | DFlashProposer
+                | DDTreeProposer
                 | DraftModelProposer
                 | MedusaProposer
                 | ExtractHiddenStatesProposer
@@ -552,6 +554,9 @@ class GPUModelRunner(
                 self._ngram_pinned_val_buf = torch.zeros(
                     self.max_num_reqs, dtype=torch.int32, pin_memory=True
                 )
+            elif self.speculative_config.use_ddtree():
+                self.drafter = DDTreeProposer(self.vllm_config, self.device, self)
+                self.use_aux_hidden_state_outputs = True
             elif self.speculative_config.use_dflash():
                 self.drafter = DFlashProposer(self.vllm_config, self.device, self)
                 self.use_aux_hidden_state_outputs = True
@@ -2000,6 +2005,54 @@ class GPUModelRunner(
             self.positions[:total_num_scheduled_tokens],
         )
 
+        # DDTree: override tree node positions with depth-based values for RoPE.
+        # Slot mapping above was computed from sequential positions (needed for
+        # unique KV slots per sibling); depth-based positions are only for RoPE
+        # so that siblings at the same depth share a position ID.
+        _ddtree_drafter = getattr(self, "drafter", None)
+        if (
+            scheduler_output.scheduled_spec_decode_tokens
+            and isinstance(_ddtree_drafter, DDTreeProposer)
+            and _ddtree_drafter._node_depths is not None
+        ):
+            for r_spec_idx, req_id in enumerate(
+                scheduler_output.scheduled_spec_decode_tokens
+            ):
+                # New requests (just finished prefill) are appended to
+                # scheduled_spec_decode_tokens but have no _node_depths entry yet.
+                #   scheduled_spec_decode_tokens = {req-abc: [...], req-xyz: [...],
+                #                                   req-999: [...]}
+                #   _node_depths = [tensor([1,1,2,2,3,...]), tensor([1,2,1,3,...])]
+                #                   req-abc                  req-xyz  (req-999 missing)
+                # Skip them — correct next step when _node_depths rebuilds.
+                if r_spec_idx >= len(_ddtree_drafter._node_depths):
+                    continue
+                # DDTree positions are non-monotonic — unlike DFlash/standard decoding
+                # where positions strictly increase (c+1, c+2, c+3, ...), siblings at
+                # the same tree depth share one position ID so RoPE treats them as
+                # alternatives for the same output slot:
+                #
+                #   tree:          root (c)
+                #                 /    \
+                #             "cat"   "dog"    ← depth 1, both get position c+1
+                #             /   \
+                #          "sat" "ran"         ← depth 2, both get position c+2
+                #           /
+                #         "on"                 ← depth 3, gets position c+3
+                #
+                #   flat node order:  ["cat", "dog", "sat", "ran", "on"]
+                #   depths:           [  1,     1,     2,     2,     3 ]
+                #   positions:        [ c+1,   c+1,   c+2,   c+2,  c+3 ]
+                req_idx = self.input_batch.req_id_to_index[req_id]
+                token_start = int(cu_num_tokens[req_idx]) - int(
+                    num_scheduled_tokens[req_idx]
+                )
+                context_len = int(self.input_batch.num_computed_tokens_cpu[req_idx])
+                depths = _ddtree_drafter._node_depths[r_spec_idx]  # [budget] on GPU
+                self.positions[
+                    token_start + 1 : token_start + 1 + _ddtree_drafter._budget
+                ] = context_len + depths
+
         # Copy the tensors to the GPU.
         self._prepare_input_ids(
             scheduler_output,
@@ -2298,7 +2351,9 @@ class GPUModelRunner(
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, (EagleProposer, DFlashProposer)):
+                if isinstance(
+                    self.drafter, (EagleProposer, DFlashProposer, DDTreeProposer)
+                ):
                     if self.drafter.kv_cache_gid == kv_cache_gid:
                         spec_decode_common_attn_metadata = cm
                 else:
@@ -3347,12 +3402,62 @@ class GPUModelRunner(
             draft_token_ids_cpu, _ = self._get_draft_token_ids_cpu()
             self.input_batch.update_async_spec_token_ids(draft_token_ids_cpu)
 
-        sampler_output = self.rejection_sampler(
-            spec_decode_metadata,
-            None,  # draft_probs
-            logits,
-            sampling_metadata,
-        )
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.use_ddtree()
+            and isinstance(self.drafter, DDTreeProposer)
+            and self.drafter._child_maps is not None
+            # Only use tree-aware verify when every request in the batch is
+            # in spec-decode mode.  When regular-decode requests are mixed in
+            # (e.g. during the first few steps when some prompts are still in
+            # prefill), fall back to the rejection sampler.
+            and len(self.drafter._child_maps)
+            == len(spec_decode_metadata.num_draft_tokens)
+            # All spec-decode requests must have exactly budget draft tokens;
+            # finishing requests may have fewer, which breaks view(batch, budget).
+            and sum(spec_decode_metadata.num_draft_tokens)
+            == self.drafter._budget * len(self.drafter._child_maps)
+        ):
+            assert logits is not None
+            batch_size = len(spec_decode_metadata.num_draft_tokens)
+            output_token_ids = ddtree_verify(
+                logits=logits,
+                target_logits_indices=spec_decode_metadata.target_logits_indices,
+                bonus_logits_indices=spec_decode_metadata.bonus_logits_indices,
+                draft_token_ids=spec_decode_metadata.draft_token_ids,
+                child_maps=self.drafter._child_maps,
+                budget=self.drafter._budget,
+                batch_size=batch_size,
+                device=self.device,
+            )
+            sampler_output = SamplerOutput(
+                sampled_token_ids=output_token_ids,
+                logprobs_tensors=None,
+            )
+        else:
+            # Fall back to flat rejection sampler — fires when batch is mixed
+            # (some requests still in prefill) or a request has fewer than
+            # budget tokens (finishing). ddtree_verify needs view(batch, budget)
+            # which requires uniform token counts.
+            #
+            # Won't crash but acceptance collapses to ~1 token: the sampler
+            # treats tree siblings as a sequential chain, so after accepting
+            # the rank-0 depth-1 token it checks its sibling as if it follows:
+            #   actual tree:       root
+            #                     /    \
+            #                  "cat"  "dog"   <- siblings, both depth 1
+            #                  /
+            #                "sat"            <- depth 2
+            #
+            #   sampler sees:  root -> "cat" -> "dog"?  no -> stop (accepted 1)
+            #   ddtree_verify: root -> "cat" -> "sat"?  yes -> (accepted 2+)
+            # Resumes correctly next step when batch is uniform again.
+            sampler_output = self.rejection_sampler(
+                spec_decode_metadata,
+                None,  # draft_probs
+                logits,
+                sampling_metadata,
+            )
         return sampler_output
 
     def _bookkeeping_sync(
@@ -4238,6 +4343,7 @@ class GPUModelRunner(
                     self.drafter,
                     EagleProposer
                     | DFlashProposer
+                    | DDTreeProposer
                     | DraftModelProposer
                     | ExtractHiddenStatesProposer,
                 )
@@ -4633,10 +4739,12 @@ class GPUModelRunner(
         elif (
             spec_config.use_eagle()
             or spec_config.use_dflash()
+            or spec_config.use_ddtree()
             or spec_config.uses_draft_model()
         ):
             assert isinstance(
-                self.drafter, EagleProposer | DFlashProposer | DraftModelProposer
+                self.drafter,
+                EagleProposer | DFlashProposer | DDTreeProposer | DraftModelProposer,
             )
 
             if spec_config.disable_padded_drafter_batch:
@@ -5548,6 +5656,7 @@ class GPUModelRunner(
                     self.drafter,
                     EagleProposer
                     | DFlashProposer
+                    | DDTreeProposer
                     | DraftModelProposer
                     | ExtractHiddenStatesProposer,
                 )
@@ -6316,7 +6425,8 @@ class GPUModelRunner(
             or self.speculative_config.uses_draft_model()
         ):
             assert isinstance(
-                self.drafter, EagleProposer | DFlashProposer | DraftModelProposer
+                self.drafter,
+                EagleProposer | DFlashProposer | DDTreeProposer | DraftModelProposer,
             )
             self.drafter.initialize_attn_backend(kv_cache_config, kernel_block_sizes)
 
@@ -6369,7 +6479,10 @@ class GPUModelRunner(
         ):
             assert isinstance(
                 self.drafter,
-                EagleProposer | DFlashProposer | ExtractHiddenStatesProposer,
+                EagleProposer
+                | DFlashProposer
+                | DDTreeProposer
+                | ExtractHiddenStatesProposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 


### PR DESCRIPTION

https://github.com/vllm-project/vllm/issues/40809
Add **DDTree** (Diffusion Draft Tree) speculative decoding, implementing the draft-tree construction algorithm from [arXiv:2604.12989](https://arxiv.org/abs/2604.12989) ("Accelerating Speculative Decoding with Block Diffusion Draft Trees", Ringel & Romano).

DDTree extends the existing DFlash proposer with a dynamic, per-request best-first draft tree instead of a flat greedy sequence. Each proposal step:

1. Runs the DFlash draft model to get per-position logits.
2. Builds an independent draft tree per request via a best-first heap (`build_ddtree_tree`), selecting the `budget` most-probable token paths.
3. Pushes a per-batch `[batch, N+1, N+1]` ancestor-only attention mask to the `TreeAttentionMetadataBuilder` so the target model verifies the full tree in a single forward pass.
4. Uses depth-based RoPE positions (siblings at the same depth share a position ID) so attention correctly treats siblings as alternatives for the same output slot.

Tree verification (`ddtree_verify`) traces the longest accepted path through each request's tree using the target model's greedy predictions.

New config: `speculative_config.method = "ddtree"` with `attention_config.backend = "TREE_ATTN"` required.

# Test Plan

**Model:** `nm-testing/dflash-qwen3-8b-speculators` (Qwen3-8B + DFlash draft)  
**Dataset:** ShareGPT (200 prompts) | **budget:** 64 | `--max-num-seqs 16` | `--max-model-len 4096` | `--enforce-eager`  
**GPU:** NVIDIA RTX 5090 Laptop (24 GiB)

| method | tok/s | req/s | acc\_len | acc\_rate |
|--------|-------|-------|----------|-----------|
| dflash | 130.4 | 0.59  | 2.318    | 0.021     |
| ddtree | 179.7 | 0.81  | 3.406    | 0.038     |

DDTree vs DFlash: acceptance\_len **+1.089** · throughput **+49.3 tok/s (+37.8%)**

> Note: budget=64 is required for meaningful tree branching. At budget=8 the tree is nearly as shallow as a flat chain and gains are modest. `--max-num-seqs 16` is needed to avoid 5090 OOM at this budget/vocab size (Qwen3 vocab ≈ 152k). Extra test with better GPU is needed 

```
.venv/bin/python benchmark_ddtree_sharegpt.py \
    --model nm-testing/dflash-qwen3-8b-speculators \
    --dataset-path /tmp/sharegpt.json \
    --trust-remote-code \
    --num-speculative-tokens 64 \
    --num-prompts 200 \
    --enforce-eager \
    --max-model-len 4096 \
    --max-num-seqs 16 \
    --methods dflash ddtree

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

