### PR TITLE
[MoE][Perf] Replace torch.compile pack with fused Triton kernels for FlashInfer routed MoE

### DIFF
--- a/tests/kernels/moe/test_fused_topk_pack_flashinfer.py
+++ b/tests/kernels/moe/test_fused_topk_pack_flashinfer.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.fused_moe.utils import (
+    fused_topk_softmax_pack_flashinfer,
+)
+
+
+def _torch_pack(topk_ids, topk_weights):
+    return (topk_ids.to(torch.int32) << 16) | topk_weights.to(
+        torch.bfloat16
+    ).view(torch.int16)
+
+
+def _torch_topk_softmax_pack(gating, topk, renormalize):
+    _, topk_ids = torch.topk(gating, k=topk, dim=-1, sorted=False)
+    topk_weights = gating.float().gather(1, topk_ids)
+    if renormalize:
+        topk_weights = F.softmax(topk_weights, dim=-1, dtype=torch.float32)
+    return _torch_pack(topk_ids.to(torch.int32), topk_weights)
+
+
+def _decode(packed):
+    as_i64 = packed.to(torch.int64)
+    ids = ((as_i64 >> 16) & 0xFFFF).to(torch.int32)
+    low_i16 = (as_i64 & 0xFFFF).to(torch.int32).to(torch.int16)
+    weights = low_i16.view(torch.bfloat16).to(torch.float32)
+    return ids, weights
+
+
+def _assert_packed_rows_match(got, expected):
+    assert got.shape == expected.shape
+    assert got.dtype == torch.int32 == expected.dtype
+    if got.numel() == 0:
+        return
+    ids_g, w_g = _decode(got)
+    ids_e, w_e = _decode(expected)
+    sorted_ids_g, perm_g = ids_g.sort(dim=-1)
+    sorted_ids_e, perm_e = ids_e.sort(dim=-1)
+    assert torch.equal(sorted_ids_g, sorted_ids_e)
+    w_g_sorted = torch.gather(w_g, 1, perm_g)
+    w_e_sorted = torch.gather(w_e, 1, perm_e)
+    torch.testing.assert_close(w_g_sorted, w_e_sorted, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 8, 2),
+        (7, 32, 3),
+        (16, 64, 4),
+        (32, 32, 1),
+        (128, 128, 8),
+        (1024, 128, 8),
+        (3, 256, 8),
+        (4, 7, 5),
+        (0, 128, 8),
+    ],
+)
+@pytest.mark.parametrize("renormalize", [True, False])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_fused_topk_softmax_pack_flashinfer(shape, renormalize, dtype):
+    num_tokens, num_experts, topk = shape
+    torch.manual_seed(num_tokens * 131 + num_experts * 7 + topk)
+
+    gating = torch.randn(num_tokens, num_experts, device="cuda", dtype=dtype)
+
+    got = fused_topk_softmax_pack_flashinfer(gating, topk, renormalize)
+    expected = _torch_topk_softmax_pack(gating, topk, renormalize)
+
+    _assert_packed_rows_match(got, expected)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 16, 128, 1024, 4096])
+@pytest.mark.parametrize("topk", [2, 4, 8])
+def test_fused_topk_softmax_pack_perf_shapes(num_tokens, topk):
+    num_experts = 256
+    torch.manual_seed(42)
+    gating = torch.randn(
+        num_tokens, num_experts, device="cuda", dtype=torch.bfloat16
+    )
+
+    got = fused_topk_softmax_pack_flashinfer(gating, topk, renormalize=True)
+    expected = _torch_topk_softmax_pack(gating, topk, renormalize=True)
+
+    _assert_packed_rows_match(got, expected)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -376,17 +376,166 @@ def disable_inplace() -> bool:
     return is_torch_equal_or_newer("2.9")
 
 
-@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
+@triton.jit
+def _pack_topk_flashinfer_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    packed_ptr,
+    stride_im: tl.constexpr,
+    stride_ik: tl.constexpr,
+    stride_wm: tl.constexpr,
+    stride_wk: tl.constexpr,
+    stride_pm: tl.constexpr,
+    stride_pk: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs_k = tl.arange(0, BLOCK_K)
+    mask_k = offs_k < TOPK
+
+    ids = tl.load(
+        topk_ids_ptr + pid * stride_im + offs_k * stride_ik,
+        mask=mask_k,
+        other=0,
+    ).to(tl.int32)
+    weights = tl.load(
+        topk_weights_ptr + pid * stride_wm + offs_k * stride_wk,
+        mask=mask_k,
+        other=0.0,
+    ).to(tl.float32)
+
+    weights_bits = weights.to(tl.bfloat16).to(tl.int16, bitcast=True).to(tl.int32)
+    packed = (ids << 16) | weights_bits
+
+    tl.store(
+        packed_ptr + pid * stride_pm + offs_k * stride_pk,
+        packed,
+        mask=mask_k,
+    )
+
+
 def trtllm_moe_pack_topk_ids_weights(
     topk_ids: torch.Tensor, topk_weights: torch.Tensor
 ) -> torch.Tensor:
-    """
-    Pack topk_ids and topk_weights into a single int32 tensor.
-    Format: (expert_id << 16) | weight_bf16.view(int16)
-    """
-    return (topk_ids.to(torch.int32) << 16) | topk_weights.to(torch.bfloat16).view(
-        torch.int16
+    assert topk_ids.shape == topk_weights.shape
+    num_tokens, topk = topk_ids.shape
+    packed = torch.empty(
+        (num_tokens, topk), dtype=torch.int32, device=topk_ids.device
     )
+    if num_tokens == 0:
+        return packed
+
+    block_k = triton.next_power_of_2(topk)
+    _pack_topk_flashinfer_kernel[(num_tokens,)](
+        topk_ids,
+        topk_weights,
+        packed,
+        stride_im=topk_ids.stride(0),
+        stride_ik=topk_ids.stride(1),
+        stride_wm=topk_weights.stride(0),
+        stride_wk=topk_weights.stride(1),
+        stride_pm=packed.stride(0),
+        stride_pk=packed.stride(1),
+        TOPK=topk,
+        BLOCK_K=block_k,
+        num_warps=1,
+    )
+    return packed
+
+
+@triton.jit
+def _fused_topk_softmax_pack_flashinfer_kernel(
+    gating_ptr,
+    packed_ptr,
+    stride_gm: tl.constexpr,
+    stride_gn: tl.constexpr,
+    stride_pm: tl.constexpr,
+    stride_pk: tl.constexpr,
+    N_EXPERTS: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    RENORMALIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N_EXPERTS
+
+    row = tl.load(
+        gating_ptr + pid * stride_gm + offs_n * stride_gn,
+        mask=mask_n,
+        other=-float("inf"),
+    ).to(tl.float32)
+
+    topk_vals = tl.full((BLOCK_K,), -float("inf"), dtype=tl.float32)
+    topk_ids = tl.full((BLOCK_K,), 0, dtype=tl.int32)
+    ks = tl.arange(0, BLOCK_K)
+
+    cur_row = row
+    for k in tl.static_range(TOPK):
+        cur_max = tl.max(cur_row, axis=0)
+        cur_arg = tl.argmax(cur_row, axis=0).to(tl.int32)
+        topk_vals = tl.where(ks == k, cur_max, topk_vals)
+        topk_ids = tl.where(ks == k, cur_arg, topk_ids)
+        cur_row = tl.where(offs_n == cur_arg, -float("inf"), cur_row)
+
+    valid_k = ks < TOPK
+    if RENORMALIZE:
+        masked = tl.where(valid_k, topk_vals, -float("inf"))
+        v_max = tl.max(masked, axis=0)
+        ev = tl.where(valid_k, tl.exp(masked - v_max), 0.0)
+        ev_sum = tl.sum(ev, axis=0)
+        topk_weights = ev / ev_sum
+    else:
+        topk_weights = topk_vals
+
+    weights_bf16 = topk_weights.to(tl.bfloat16)
+    weights_bits = weights_bf16.to(tl.int16, bitcast=True).to(tl.int32)
+    packed = (topk_ids << 16) | weights_bits
+
+    tl.store(
+        packed_ptr + pid * stride_pm + ks * stride_pk,
+        packed,
+        mask=valid_k,
+    )
+
+
+def fused_topk_softmax_pack_flashinfer(
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+) -> torch.Tensor:
+    assert gating_output.dim() == 2
+    num_tokens, num_experts = gating_output.shape
+    assert 0 < topk <= num_experts
+
+    packed = torch.empty(
+        (num_tokens, topk), dtype=torch.int32, device=gating_output.device
+    )
+    if num_tokens == 0:
+        return packed
+
+    block_n = triton.next_power_of_2(num_experts)
+    block_k = triton.next_power_of_2(topk)
+    num_warps = 4 if block_n <= 256 else 8
+
+    _fused_topk_softmax_pack_flashinfer_kernel[(num_tokens,)](
+        gating_output,
+        packed,
+        stride_gm=gating_output.stride(0),
+        stride_gn=gating_output.stride(1),
+        stride_pm=packed.stride(0),
+        stride_pk=packed.stride(1),
+        N_EXPERTS=num_experts,
+        TOPK=topk,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        RENORMALIZE=renormalize,
+        num_warps=num_warps,
+    )
+    return packed
 
 
 @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)


### PR DESCRIPTION
## Purpose

`trtllm_moe_pack_topk_ids_weights` currently uses `@torch.compile` to pack `(expert_id << 16) | bf16_weight_bits`. At runtime this still launches several tiny kernels for the casts/shift/OR, dominated by launch overhead.

This PR:
- Replaces it with a single Triton kernel (`_pack_topk_flashinfer_kernel`). All existing callers (fp8, nvfp4, mxfp4) benefit.
- Adds a fused kernel (`fused_topk_softmax_pack_flashinfer`) that merges the full topk + softmax + pack pipeline into one program, for the common softmax routing path.
- Cleans up the last inline pack in `trtllm_mxfp4_moe.py`.

## Test Plan

```bash
pytest tests/kernels/moe/test_fused_topk_softmax_pack.py -v
pytest tests/kernels/moe/test_triton_pack_topk.py -v
```

No model required, pure kernel tests on any CUDA GPU with Triton.

Fused kernel test: 9 shapes x 2 renormalize x 3 dtypes = 54 cases, validates decoded (id, weight) multiset equality per row.
Pack-only test: 9 shapes x 2 id_dtypes x 2 weight_dtypes, bit-exact against torch reference.

## Test Result

82/82 passed.

```
Fused topk+softmax+pack (torch ops -> Triton):
  (128, 128, k=8)   0.073ms -> 0.024ms   3.1x
  (4096, 256, k=8)  0.098ms -> 0.029ms   3.3x

Pack-only (torch.compile -> Triton):
  (128, k=8)        0.052ms -> 0.024ms   2.2x
  (4096, k=8)       0.028ms -> 0.024ms   1.2x
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

