### PR TITLE
docs: clarify CUDA nightly wheel index priority

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -61,6 +61,17 @@ uv pip install -U vllm \
     --extra-index-url https://wheels.vllm.ai/nightly # add variant subdirectory here if needed
 ```
 
+!!! tip "Nightly wheel index priority"
+
+    Keep `uv`'s default index priority when installing from vLLM nightly
+    indices. Do not add `--index-strategy unsafe-best-match` for these
+    commands: if the latest PyPI release has a higher public version than the
+    nightly wheel, best-match resolution can select the PyPI wheel instead of
+    the requested CUDA variant. To force a CUDA variant, add the variant
+    subdirectory to the vLLM index URL, for example
+    `https://wheels.vllm.ai/nightly/cu129`, and verify the installed vLLM
+    version includes the expected CUDA variant suffix.
+
 !!! warning "`pip` caveat"
 
     Using `pip` to install from nightly indices is _not supported_, because `pip` combines packages from `--extra-index-url` and the default index, choosing only the latest version, which makes it difficult to install a development version prior to the released version. In contrast, `uv` gives the extra index [higher priority than the default index](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes).


### PR DESCRIPTION



## Purpose

Addresses #42338

This PR clarifies the CUDA nightly wheel installation docs to warn users against adding `--index-strategy unsafe-best-match` when installing from vLLM nightly indices.

With best-match resolution, a stable PyPI release can be selected over the requested nightly CUDA-variant wheel if PyPI has a higher public version. This can install a wheel linked against a different CUDA version than expected.

## Test Plan

- `git diff --check HEAD~1 HEAD`

## Test Result

Passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

