### PR TITLE
Add DeepSeek-V4 XPU support with FP8 KV cache

### DIFF
--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -550,6 +550,16 @@ class xpu_ops:
         # kv_cache: [num_block, block_size, head_dim + 4]
         kv_cache.view(-1, kv_cache.shape[-1]).index_copy_(0, slot_mapping, k)
 
+        if not hasattr(xpu_ops, '_insert_debug_count'):
+            xpu_ops._insert_debug_count = 0
+        xpu_ops._insert_debug_count += 1
+        if xpu_ops._insert_debug_count <= 3:
+            print(f"[XPU indexer_k_quant_and_cache] tokens={k_fp8.shape[0]} "
+                  f"head_dim={head_dim} quant_block_size={quant_block_size} "
+                  f"scale_range=[{k_scale.min().item():.6f}, {k_scale.max().item():.6f}] "
+                  f"scale_fmt={scale_fmt} "
+                  f"kv_cache_shape={kv_cache.shape} slot_mapping[:5]={slot_mapping[:5].tolist()}")
+
     @staticmethod
     def cp_gather_indexer_k_quant_cache(
         kv_cache: torch.Tensor,
@@ -559,67 +569,256 @@ class xpu_ops:
         cu_seq_lens: torch.Tensor,
     ) -> None:
         """
-        Args:
-            kv_cache: [num_blocks, block_size, cache_stride] - quantized KV cache
-                    Layout per block: [k_values, scale_values]
-                    - k_values: [block_size * head_dim]
-                    - scale_values: [block_size * head_dim * 4 / quant_block_size]
-            dst_k: [num_tokens, head_dim] - output tensor for K values
-            dst_scale: [num_tokens, head_dim / quant_block_size * 4]
-                - output tensor for scale values
-            block_table: [batch_size, num_blocks] - block table for indexing
-            cu_seq_lens: [batch_size + 1] - cumulative sequence lengths
+        Gather K and scale from quantized indexer cache.
+
+        Cache layout is BLOCK-PACKED (same as CUDA):
+          kv_cache: [num_blocks, block_size, head_dim + scale_per_token] uint8
+          But physically, the Triton compressor writes:
+            FP8 data at: block_start + pos * head_dim
+            Scale at: block_start + block_size * head_dim + pos * 4
+          This is equivalent to viewing the block as:
+            k_region: cache_flat[block_start : block_start + bs*dim]
+            scale_region: cache_flat[block_start + bs*dim : block_start + bs*(dim+4)]
         """
         batch_size = block_table.size(0)
         num_tokens = dst_k.size(0)
         head_dim = dst_k.size(1)
         cache_block_size = kv_cache.size(1)
-        quant_block_size = head_dim * 4 // dst_scale.size(1)
+        scale_per_token = dst_scale.size(1)  # = 4
+        block_stride = kv_cache.stride(0)  # bytes per block (may include padding)
+        head_dim = dst_k.size(1)  # = TOKEN_STRIDE used by Triton compressor
+        cache_block_size = kv_cache.size(1)
+        scale_per_token = dst_scale.size(1)  # = 4
 
-        # For each token, find which batch it belongs to using searchsorted
-        token_indices = torch.arange(num_tokens, device=dst_k.device) + 1
-        # cu_seq_lens is [batch_size + 1], we need to find which interval each
-        # token belongs to
-        batch_indices = torch.searchsorted(cu_seq_lens, token_indices) - 1
+        # The cache uses BLOCK-PACKED layout where Triton kernels write with
+        # raw pointer math:
+        #   K for pos j: block_start + j * head_dim
+        #   Scale for pos j: block_start + block_size * head_dim + j * scale_per_token
+        # block_start = physical_block_idx * block_stride
+        # The tensor may have inter-block padding (stride(0) > block_size * width).
+        # Use as_strided to create a flat byte view of the full storage range.
+        num_blocks = kv_cache.size(0)
+        total_bytes = num_blocks * block_stride
+        cache_flat = torch.as_strided(kv_cache, (total_bytes,), (1,))
+
+        # For each token index [0, num_tokens), find batch and in-seq position
+        token_indices = torch.arange(num_tokens, device=dst_k.device)
+        batch_indices = (
+            torch.searchsorted(cu_seq_lens, token_indices, right=True) - 1
+        )
         batch_indices = torch.clamp(batch_indices, 0, batch_size - 1)
 
-        # Calculate the in-batch sequence index for each token
-        inbatch_seq_indices = token_indices - cu_seq_lens[batch_indices]
+        # In-batch sequence position (0-based)
+        inbatch_seq_pos = token_indices - cu_seq_lens[batch_indices]
 
-        # Find which block each token belongs to
-        block_indices_in_table = inbatch_seq_indices // cache_block_size
-        physical_block_indices = block_table[batch_indices, block_indices_in_table]
+        # Block index in table and in-block offset
+        block_indices_in_table = inbatch_seq_pos // cache_block_size
+        inblock_offsets = inbatch_seq_pos % cache_block_size
 
-        # Calculate the offset within each block
-        inblock_offsets = (inbatch_seq_indices - 1) % cache_block_size
+        # Physical block indices
+        physical_block_indices = block_table[
+            batch_indices, block_indices_in_table
+        ]
 
-        # Calculate strides
-        block_stride = kv_cache.stride(0)  # stride for each block
+        # Compute byte offsets in block-packed layout
+        block_starts = physical_block_indices.to(torch.int64) * block_stride
+        # FP8 K at: block_start + pos * head_dim
+        k_offsets = block_starts + inblock_offsets.to(torch.int64) * head_dim
+        # Scale at: block_start + block_size * head_dim + pos * 4
+        scale_offsets = (
+            block_starts
+            + cache_block_size * head_dim
+            + inblock_offsets.to(torch.int64) * scale_per_token
+        )
 
-        # Flatten kv_cache for easier indexing
-        kv_cache_flat = kv_cache.view(-1)
-
-        # Calculate source offset for K values for all tokens (vectorized)
-        src_block_offsets = physical_block_indices * block_stride
-        src_k_offsets = src_block_offsets + inblock_offsets * head_dim
-
-        # Gather K values using advanced indexing
-        # Create indices for all elements we need to gather
-        k_indices = src_k_offsets.unsqueeze(1) + torch.arange(
+        # Gather K bytes [num_tokens, head_dim]
+        k_byte_indices = k_offsets[:, None] + torch.arange(
             head_dim, device=dst_k.device
-        )
-        dst_k[:] = kv_cache_flat[k_indices]
+        )[None, :]
+        k_bytes = cache_flat[k_byte_indices.flatten()].view(num_tokens, head_dim)
+        dst_k_uint8 = dst_k.view(torch.uint8).view(-1, head_dim)
+        dst_k_uint8[:] = k_bytes
 
-        # Calculate source offset for scale values (vectorized)
-        # Scales are stored after all K values for each block
-        scale_size = head_dim * 4 // quant_block_size
-        src_scale_offsets = src_block_offsets + head_dim + inblock_offsets * scale_size
-
-        # Gather scale values
-        scale_indices = src_scale_offsets.unsqueeze(1) + torch.arange(
-            scale_size, device=dst_scale.device
+        # Gather scale bytes [num_tokens, 4]
+        scale_byte_indices = scale_offsets[:, None] + torch.arange(
+            scale_per_token, device=dst_k.device
+        )[None, :]
+        scale_bytes = cache_flat[scale_byte_indices.flatten()].view(
+            num_tokens, scale_per_token
         )
-        dst_scale[:] = kv_cache_flat[scale_indices]
+        dst_scale[:] = scale_bytes
+
+    @staticmethod
+    def fp8_mqa_logits(
+        q: torch.Tensor,
+        kv: tuple[torch.Tensor, torch.Tensor],
+        weights: torch.Tensor,
+        cu_seqlen_ks: torch.Tensor,
+        cu_seqlen_ke: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute FP8 MQA logits (non-paged, for prefill indexer).
+
+        Pure PyTorch implementation for XPU. Adapted from ROCm fallback.
+
+        Args:
+            q: [M, H, D] fp8 query
+            kv: (k_fp8 [N, D] fp8, k_scales [N] float32)
+            weights: [M, H] float32 routing weights
+            cu_seqlen_ks: [M] int32 start indices (inclusive)
+            cu_seqlen_ke: [M] int32 end indices (exclusive)
+
+        Returns:
+            logits: [M, N] float32
+        """
+        k_fp8, scale = kv
+        seq_len_kv = k_fp8.shape[0]
+        k = k_fp8.to(torch.bfloat16)
+        q_bf16 = q.to(torch.bfloat16)
+        device = q.device
+
+        mask_lo = (
+            torch.arange(seq_len_kv, device=device)[None, :]
+            >= cu_seqlen_ks[:, None]
+        )
+        mask_hi = (
+            torch.arange(seq_len_kv, device=device)[None, :]
+            < cu_seqlen_ke[:, None]
+        )
+        mask = mask_lo & mask_hi
+
+        # score: [H, M, N] = einsum("mhd,nd->hmn")
+        score = torch.einsum("mhd,nd->hmn", q_bf16, k).float() * scale
+        # weights: [M, H] -> [H, M, 1]
+        logits = (
+            score.relu() * weights.unsqueeze(-1).transpose(0, 1)
+        ).sum(dim=0)
+        logits = logits.masked_fill(~mask, float("-inf"))
+
+        return logits
+
+    @staticmethod
+    def fp8_paged_mqa_logits(
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        weights: torch.Tensor,
+        seq_lens: torch.Tensor,
+        block_table: torch.Tensor,
+        schedule_metadata: torch.Tensor | None,
+        max_model_len: int,
+    ) -> torch.Tensor:
+        """Compute FP8 paged MQA logits (for decode indexer).
+
+        Pure PyTorch, handles BLOCK-PACKED cache layout:
+          kv_cache: [num_blocks, block_size, head_dim + 4] uint8
+          But physically, within each block:
+            FP8 K at: block_start + pos * head_dim
+            Scale at: block_start + block_size * head_dim + pos * 4
+
+        Args:
+            q: [B, next_n, H, D] or [B*next_n, H, D] bf16/fp8 query
+            kv_cache: [num_blocks, block_size, head_dim + 4] uint8 (may be 4D)
+            weights: [B*next_n, H] float32
+            seq_lens: [B, next_n] or [B] int32 context lengths
+            block_table: [B, max_blocks_per_seq] int32
+            schedule_metadata: unused on XPU
+            max_model_len: int
+
+        Returns:
+            logits: [B*next_n, max_model_len] float32
+        """
+        from vllm.utils.math_utils import cdiv
+
+        fp8_dtype = current_platform.fp8_dtype()
+        # kv_cache may be 4D [num_blocks, block_size, 1, head_width] after unsqueeze
+        if kv_cache.ndim == 4:
+            kv_cache = kv_cache.squeeze(2)
+        block_size = kv_cache.shape[1]
+        dim = kv_cache.shape[2] - 4  # head_dim
+        block_stride = kv_cache.stride(0)  # bytes per block
+
+        # Handle q shape
+        if q.ndim == 4:
+            batch_size, next_n = q.shape[0], q.shape[1]
+        elif q.ndim == 3:
+            batch_size = q.shape[0]
+            next_n = 1
+            q = q.unsqueeze(1)
+        else:
+            raise ValueError(f"Unexpected q shape: {q.shape}")
+
+        # Handle seq_lens
+        if seq_lens.ndim == 2:
+            context_lens = seq_lens[:, -1]  # [B]
+        else:
+            context_lens = seq_lens  # [B]
+
+        device = q.device
+        logits = torch.full(
+            [batch_size * next_n, max_model_len],
+            float("-inf"),
+            device=device,
+            dtype=torch.float32,
+        )
+
+        # Flatten cache for raw byte access (block-packed layout)
+        num_cache_blocks = kv_cache.shape[0]
+        total_bytes = num_cache_blocks * block_stride
+        cache_flat = torch.as_strided(kv_cache, (total_bytes,), (1,))
+
+        for i in range(batch_size):
+            seq_len = int(context_lens[i].item())
+            if seq_len <= 0:
+                continue
+            num_pages = cdiv(seq_len, block_size)
+            pages = block_table[i, :num_pages]
+            padded_seq_len = num_pages * block_size
+
+            # Gather K and scale from block-packed layout
+            # For each page, K region: [page_start, page_start + bs*dim)
+            # Scale region: [page_start + bs*dim, page_start + bs*dim + bs*4)
+            page_starts = pages.to(torch.int64) * block_stride
+
+            # K indices: for each page p, for each pos j: page_start + j*dim + d
+            pos_offsets = torch.arange(block_size, device=device)
+            dim_offsets = torch.arange(dim, device=device)
+            # [num_pages, block_size, dim]
+            k_indices = (
+                page_starts[:, None, None]
+                + pos_offsets[None, :, None] * dim
+                + dim_offsets[None, None, :]
+            )
+            k_uint8 = cache_flat[k_indices.reshape(-1)].reshape(
+                padded_seq_len, dim
+            )
+            k_fp8 = k_uint8.view(fp8_dtype).to(torch.float32)
+
+            # Scale indices: for each page p, for each pos j:
+            #   page_start + bs*dim + j*4 + byte
+            scale_byte_offsets = torch.arange(4, device=device)
+            scale_indices = (
+                page_starts[:, None, None]
+                + block_size * dim
+                + pos_offsets[None, :, None] * 4
+                + scale_byte_offsets[None, None, :]
+            )
+            scale_uint8 = cache_flat[scale_indices.reshape(-1)].reshape(
+                padded_seq_len, 4
+            )
+            k_scale = scale_uint8.view(torch.float32)  # [padded_seq_len, 1]
+
+            for n in range(next_n):
+                q_i = q[i, n].to(torch.float32)  # [H, D]
+                w_i = weights[i * next_n + n]  # [H]
+
+                # Compute per-head scores: [H, padded_seq_len]
+                scores = torch.mm(q_i, k_fp8[:padded_seq_len].T)  # [H, S]
+                scores = scores * k_scale[:padded_seq_len].T  # broadcast scale
+                scores = torch.relu(scores)
+                # Weight and sum over heads
+                weighted = (scores * w_i[:, None]).sum(dim=0)  # [S]
+                logits[i * next_n + n, :seq_len] = weighted[:seq_len]
+
+        return logits
 
     @staticmethod
     def top_k_per_row_prefill(
@@ -668,7 +867,22 @@ class xpu_ops:
         )
         row_indices = torch.arange(padded_num_tokens, device=device) // next_n
         next_n_offset = torch.arange(padded_num_tokens, device=device) % next_n
-        index_end_pos = (seq_lens[row_indices] - next_n + next_n_offset).unsqueeze(1)
+
+        # seq_lens can be 1D [B] or 2D [B, next_n]. Normalize to per-token
+        # context lengths.
+        if seq_lens.ndim == 2:
+            # 2D: each row has per-spec-token context lengths
+            # Gather the correct context_len for each (batch, spec_pos) pair
+            seq_lens_flat = seq_lens.reshape(-1)  # [B * next_n]
+            # Each padded token i maps to seq_lens[i // next_n, i % next_n]
+            per_token_lens = seq_lens_flat[
+                row_indices * next_n + next_n_offset
+            ]  # [padded_num_tokens]
+            index_end_pos = (per_token_lens - 1).unsqueeze(1)
+        else:
+            index_end_pos = (
+                seq_lens[row_indices] - next_n + next_n_offset
+            ).unsqueeze(1)
         # index_end_pos: [B * N, 1]
         mask = positions <= index_end_pos
         # mask: [B * N, L]

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -307,6 +307,9 @@ _POSSIBLE_FP8_BLOCK_KERNELS: dict[
     PlatformEnum.CPU: [
         CPUFp8BlockScaledMMKernel,
     ],
+    PlatformEnum.XPU: [
+        TritonFp8BlockScaledMMKernel,
+    ],
 }
 
 _POSSIBLE_WFP8A16_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] = {

--- a/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/triton.py
@@ -159,8 +159,8 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
 class TritonFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     @classmethod
     def is_supported(cls, compute_capability=None):
-        if not current_platform.is_cuda_alike():
-            return False, "only cuda like devices are supported."
+        if not (current_platform.is_cuda_alike() or current_platform.is_xpu()):
+            return False, "only cuda-like and xpu devices are supported."
         return True, None
 
     def apply_block_scaled_mm(

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -169,9 +169,9 @@ class SiluAndMulWithClamp(CustomOp):
     def __init__(self, swiglu_limit: float, *, compile_native: bool = True):
         super().__init__(compile_native=compile_native)
         self.swiglu_limit = float(swiglu_limit)
-        if current_platform.is_rocm():
+        if current_platform.is_rocm() or current_platform.is_xpu():
             self._forward_method = self.forward_native
-        elif current_platform.is_cuda_alike() or current_platform.is_xpu():
+        elif current_platform.is_cuda_alike():
             self.op = torch.ops._C.silu_and_mul_with_clamp
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
@@ -190,7 +190,7 @@ class SiluAndMulWithClamp(CustomOp):
         return out
 
     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
-        return self.forward_cuda(x)
+        return self.forward_native(x)
 
 
 # --8<-- [start:mul_and_silu]

--- a/vllm/model_executor/layers/deepseek_compressor.py
+++ b/vllm/model_executor/layers/deepseek_compressor.py
@@ -300,7 +300,7 @@ class DeepseekCompressor(nn.Module):
         state_cache = self.state_cache.kv_cache
         # kv_state stored in first half, score_state stored in second half
         state_width = state_cache.shape[-1] // 2
-        pdl_kwargs = {} if current_platform.is_rocm() else {"launch_pdl": False}
+        pdl_kwargs = {} if current_platform.is_rocm() or current_platform.is_xpu() else {"launch_pdl": False}
 
         # Store the KV and score (with fused APE addition) in the state.
         # NOTE: PDL is disabled — both this kernel and _fused_kernel below

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -201,10 +201,14 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         # Pick fp8_einsum recipe based on GPU arch:
         # SM90: FP32 block scales stay [g, r/128, d/128] → sfb_gran_mn=128
         # SM100: INT32 packed scales become [g, r, ...] → sfb_gran_mn=1
-        cap = current_platform.get_device_capability()
-        assert cap is not None, "DeepseekV4 attention requires a CUDA device"
-        self._einsum_recipe = (1, 128, 128) if cap.major <= 9 else (1, 1, 128)
-        self._tma_aligned_scales = cap.major >= 10
+        if current_platform.is_xpu():
+            self._einsum_recipe = (1, 128, 128)
+            self._tma_aligned_scales = False
+        else:
+            cap = current_platform.get_device_capability()
+            assert cap is not None, "DeepseekV4 attention requires a CUDA device"
+            self._einsum_recipe = (1, 128, 128) if cap.major <= 9 else (1, 1, 128)
+            self._tma_aligned_scales = cap.major >= 10
 
         self.rotary_emb = mla_modules.rotary_emb
         self.indexer_rotary_emb = mla_modules.indexer_rotary_emb
@@ -228,7 +232,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         # [0]: GEMM start / post-GEMM event0. [1..3]: GEMM done events;
         # [1] doubles as post-GEMM event1. Reuse is safe: GEMM fully joins
         # before post-GEMM starts.
-        self.ln_events = [torch.cuda.Event() for _ in range(4)]
+        self.ln_events = [current_platform.Event() for _ in range(4)]
 
         assert cache_config is not None, "DeepseekV4 attention requires cache_config"
         self.swa_cache_layer = DeepseekV4SWACache(
@@ -305,8 +309,8 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         )
         o = o_padded[:, : self.n_local_heads, :]
 
-        # Keep ROCm on the BF16 reference wo_a path util kernel ready.
-        if current_platform.is_rocm():
+        # Keep ROCm / XPU on the BF16 reference wo_a path until kernel ready.
+        if current_platform.is_rocm() or current_platform.is_xpu():
             z = rocm_inv_rope_einsum(
                 self.rotary_emb,
                 o,
@@ -536,6 +540,24 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         assert swa_metadata is not None
 
         swa_kv_cache = self.swa_cache_layer.kv_cache
+
+        if current_platform.is_xpu():
+            from vllm.v1.attention.ops.deepseek_v4_ops.xpu_qnorm_rope_kv_fp8_insert import (  # noqa: E501
+                xpu_qnorm_rope_kv_fp8_insert,
+            )
+
+            xpu_qnorm_rope_kv_fp8_insert(
+                q,
+                kv,
+                swa_kv_cache,
+                swa_metadata.slot_mapping,
+                positions.to(torch.int64),
+                self.rotary_emb.cos_sin_cache,
+                self.eps,
+                swa_metadata.block_size,
+            )
+            return
+
         swa_kv_cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
 
         # Horizontally fused:
@@ -660,7 +682,7 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         self.prefix = prefix  # Alias for compatibility with compressor
 
         self.aux_stream = aux_stream
-        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+        self.ln_events = [current_platform.Event(), current_platform.Event()]
 
         # Determine padded head count for FlashMLA
         if num_heads not in self.SUPPORTED_HEAD_COUNTS:
@@ -696,9 +718,11 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             f"DeepseekV4 only supports fp8 kv-cache format for now, "
             f"got {kv_cache_dtype}"
         )
-        assert issubclass(self.get_attn_backend(), FlashMLASparseBackend), (
-            "Only FlashMLA Sparse Attention backend is supported for DeepseekV4 for now"
-        )
+        if not current_platform.is_xpu():
+            assert issubclass(self.get_attn_backend(), FlashMLASparseBackend), (
+                "Only FlashMLA Sparse Attention backend is supported "
+                "for DeepseekV4 for now"
+            )
         # FlashMLA Sparse Attention fp8 backend uses "fp8_ds_mla" kv-cache format
         # Automatically convert fp8 kv-cache format to "fp8_ds_mla"
         if (
@@ -851,6 +875,14 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         swa_indices = swa_metadata.decode_swa_indices
         swa_lens = swa_metadata.decode_swa_lens
 
+        if current_platform.is_xpu():
+            assert swa_indices is not None and swa_lens is not None
+            self._forward_decode_xpu(
+                q, kv_cache, swa_only, topk_indices, topk_lens,
+                swa_indices, swa_lens, output,
+            )
+            return
+
         # We treat queries in the same seq as different queries
         # and later we only attend by generated indices.
         # q arrives pre-padded to self.padded_heads by the outer wrapper.
@@ -903,6 +935,39 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             extra_indices_in_kvcache=topk_indices,
             extra_topk_length=topk_lens,
             out=output.unsqueeze(1),
+        )
+
+    def _forward_decode_xpu(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor | None,
+        swa_only: bool,
+        topk_indices: torch.Tensor | None,
+        topk_lens: torch.Tensor | None,
+        swa_indices: torch.Tensor,
+        swa_lens: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        """XPU decode: dequant FP8 pages to BF16 then Triton sparse MLA."""
+        from vllm.v1.attention.ops.deepseek_v4_ops.xpu_sparse_decode_fp8 import (
+            xpu_sparse_decode_fp8,
+        )
+
+        xpu_sparse_decode_fp8(
+            q=q,
+            kv_cache=kv_cache,
+            swa_kv_cache=self.swa_cache_layer.kv_cache,
+            swa_only=swa_only,
+            topk_indices=topk_indices,
+            topk_lens=topk_lens,
+            swa_indices=swa_indices,
+            swa_lens=swa_lens,
+            attn_sink=self.attn_sink,
+            softmax_scale=self.scale,
+            head_dim=self.head_dim,
+            nope_head_dim=self.nope_head_dim,
+            rope_head_dim=self.rope_head_dim,
+            out=output,
         )
 
     def _forward_prefill(
@@ -1014,15 +1079,31 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 M,
                 N,
             )
-            flash_mla_sparse_fwd(
-                q=q[query_start:query_end],
-                kv=kv.view(-1, 1, q.shape[-1]),
-                indices=combined_indices.unsqueeze(1),
-                sm_scale=self.scale,
-                attn_sink=self.attn_sink,
-                topk_length=combined_lens,
-                out=output[query_start:query_end],
-            )
+            if current_platform.is_xpu():
+                from vllm.v1.attention.ops.deepseek_v4_ops.xpu_sparse_mla_bf16 import (  # noqa: E501
+                    xpu_sparse_mla_bf16,
+                )
+
+                kv_ws = kv[:chunk_size].reshape(-1, q.shape[-1])
+
+                xpu_sparse_mla_bf16(
+                    q=q[query_start:query_end],
+                    kv_workspace=kv_ws,
+                    topk_indices=combined_indices,
+                    topk_lens=combined_lens,
+                    softmax_scale=self.scale,
+                    out=output[query_start:query_end],
+                )
+            else:
+                flash_mla_sparse_fwd(
+                    q=q[query_start:query_end],
+                    kv=kv.view(-1, 1, q.shape[-1]),
+                    indices=combined_indices.unsqueeze(1),
+                    sm_scale=self.scale,
+                    attn_sink=self.attn_sink,
+                    topk_length=combined_lens,
+                    out=output[query_start:query_end],
+                )
 
 
 class DeepseekV4IndexerCache(torch.nn.Module, AttentionLayerBase):

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -277,6 +277,8 @@ def _get_priority_backends() -> list[Mxfp4MoeBackend]:
     """
     if current_platform.is_rocm():
         return [Mxfp4MoeBackend.AITER_MXFP4_BF16]
+    if current_platform.is_xpu():
+        return [Mxfp4MoeBackend.XPU]
     _AVAILABLE_BACKENDS = [
         Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
         Mxfp4MoeBackend.DEEPGEMM_MXFP4,
@@ -1417,10 +1419,20 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
+    elif mxfp4_backend == Mxfp4MoeBackend.XPU:
+        # No additional transformation needed for XPU backend
+        return (
+            w13_weight,
+            w2_weight,
+            w13_weight_scale,
+            w2_weight_scale,
+            w13_bias,
+            w2_bias,
+        )
     else:
         raise ValueError(
             f"Unsupported mxfp4_backend for Mxfp4MoEMethod: {mxfp4_backend}. "
-            f"Expected TRTLLM, Triton, or AITER backend."
+            f"Expected TRTLLM, Triton, AITER, or XPU backend."
         )
 
 

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -57,6 +57,52 @@ def vllm_topk_sigmoid(
     return topk_weights, topk_indices
 
 
+def _topk_softplus_sqrt_torch(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+    input_tokens: torch.Tensor | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, ...]:
+    """Pure PyTorch fallback for topk_softplus_sqrt (XPU/CPU)."""
+    # scores = sqrt(softplus(gating_output))
+    scores = torch.sqrt(F.softplus(gating_output.float()))
+
+    # Bias is used for expert SELECTION only, not for weight computation.
+    # Using biased scores as weights flattens the distribution when the bias
+    # is near-uniform (e.g., DSv4-Flash where all biases ≈ 8.08).
+    if e_score_correction_bias is not None:
+        scores_for_choice = scores + e_score_correction_bias.float()
+    else:
+        scores_for_choice = scores
+
+    topk = topk_weights.shape[-1]
+
+    if hash_indices_table is not None and input_tokens is not None:
+        # Hash MoE: expert indices predetermined by lookup table
+        # hash_indices_table: [vocab_size, topk] mapping token_id -> expert_ids
+        expert_ids = hash_indices_table[input_tokens.long()]  # [M, topk]
+        topk_indices.copy_(expert_ids)
+        # Gather weights from unbiased scores
+        weights = scores.gather(1, expert_ids.long())
+    else:
+        # Standard topk selection using biased scores
+        _, indices = torch.topk(scores_for_choice, k=topk, dim=-1)
+        topk_indices.copy_(indices)
+        # Gather weights from unbiased scores
+        weights = scores.gather(1, indices)
+
+    if renormalize:
+        weights = weights / (weights.sum(dim=-1, keepdim=True).clamp(min=1e-20))
+
+    topk_weights.copy_(weights * routed_scaling_factor)
+    return topk_weights, topk_indices
+
+
 def vllm_topk_softplus_sqrt(
     topk_weights: torch.Tensor,
     topk_indices: torch.Tensor,
@@ -68,6 +114,21 @@ def vllm_topk_softplus_sqrt(
     hash_indices_table: torch.Tensor | None = None,
     routed_scaling_factor: float = 1.0,
 ) -> tuple[torch.Tensor, ...]:
+    from vllm.platforms import current_platform
+
+    if current_platform.is_xpu() or current_platform.is_cpu():
+        return _topk_softplus_sqrt_torch(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            e_score_correction_bias,
+            input_tokens,
+            hash_indices_table,
+            routed_scaling_factor,
+        )
+
     ops.topk_hash_softplus_sqrt(
         topk_weights,
         topk_indices,

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -94,6 +94,31 @@ class MHCPreOp(CustomOp):
     def forward_native(self, *args, **kwargs):
         raise NotImplementedError("Native implementation of mhc_pre is not available")
 
+    def forward_xpu(
+        self,
+        residual: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        rms_eps: float,
+        hc_pre_eps: float,
+        hc_sinkhorn_eps: float,
+        hc_post_mult_value: float,
+        sinkhorn_repeat: int,
+        n_splits: int = 1,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return mhc_kernels.mhc_pre_torch(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+
 
 # --8<-- [start:mhc_post]
 @CustomOp.register("mhc_post")
@@ -151,7 +176,19 @@ class MHCPostOp(CustomOp):
     def forward_native(self, *args, **kwargs):
         raise NotImplementedError("Native implementation of mhc_post is not available")
 
-
+    def forward_xpu(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+    ) -> torch.Tensor:
+        return mhc_kernels.mhc_post_torch(
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+        )
 # --8<-- [start:hc_head]
 @CustomOp.register("hc_head")
 class HCHeadOp(CustomOp):
@@ -229,6 +266,36 @@ class HCHeadOp(CustomOp):
 
     def forward_native(self, *args, **kwargs):
         raise NotImplementedError("Native implementation of hc_head is not available")
+
+    def forward_xpu(
+        self,
+        hidden_states: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        rms_norm_eps: float,
+        hc_eps: float,
+    ) -> torch.Tensor:
+        hc_mult, hidden_size = hidden_states.shape[-2:]
+        outer_shape = hidden_states.shape[:-2]
+        hs_flat = hidden_states.view(-1, hc_mult, hidden_size)
+        num_tokens = hs_flat.shape[0]
+
+        out = torch.empty(
+            num_tokens, hidden_size, dtype=torch.bfloat16, device=hidden_states.device
+        )
+        torch.ops.vllm.hc_head_triton(
+            hs_flat,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            out,
+            hidden_size,
+            rms_norm_eps,
+            hc_eps,
+            hc_mult,
+        )
+        return out.view(*outer_shape, hidden_size)
 
 
 # --8<-- [start:mhc_fused_post_pre]

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -173,7 +173,12 @@ class QuantFP8(CustomOp):
         scale_ub: torch.Tensor | None = None,
         use_triton: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # XPU can use same code path as CUDA.
+        # For dynamic group quantization, use the registered custom op so that
+        # torch.compile treats it as opaque and doesn't try to compile the
+        # underlying Triton kernel (Intel Triton can't handle fp8e4nv types).
+        if self.is_group_quant and not self.static:
+            return torch.ops.vllm.triton_per_token_group_quant_fp8(
+                x, self.group_size)
         return self.forward_cuda(x, scale, scale_ub, use_triton)
 
     def forward_native(

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -861,7 +861,7 @@ def w8a8_triton_block_scaled_mm(
     # Triton cannot currently bind E8M0 scale tensors directly. On ROCm,
     # DeepSeek-V4 checkpoints store block scales in exponent-only E8M0 format,
     # so decode them to fp32 before launching the kernel.
-    if current_platform.is_rocm():
+    if current_platform.is_rocm() or current_platform.is_xpu():
         if As.dtype == torch.float8_e8m0fnu:
             As = _upcast_e8m0_to_fp32(As).contiguous()
         if Bs.dtype == torch.float8_e8m0fnu:

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -168,13 +168,22 @@ def sparse_attn_indexer(
         # scale_fmt can be None, but the function expects str
         assert scale_fmt is not None
         assert not use_fp4_cache, "Unfused FP4 Insert is not supported yet"
-        ops.indexer_k_quant_and_cache(
-            k,
-            kv_cache,
-            slot_mapping,
-            quant_block_size,
-            scale_fmt,
-        )
+        if current_platform.is_xpu():
+            xpu_ops.indexer_k_quant_and_cache(
+                k,
+                kv_cache,
+                slot_mapping,
+                quant_block_size,
+                scale_fmt,
+            )
+        else:
+            ops.indexer_k_quant_and_cache(
+                k,
+                kv_cache,
+                slot_mapping,
+                quant_block_size,
+                scale_fmt,
+            )
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
     if has_prefill:
@@ -198,13 +207,22 @@ def sparse_attn_indexer(
             k_scale = k_scale_full[: chunk.total_seq_lens]
 
             if not chunk.skip_kv_gather:
-                ops.cp_gather_indexer_k_quant_cache(
-                    kv_cache,
-                    k_quant,
-                    k_scale,
-                    chunk.block_table,
-                    chunk.cu_seq_lens,
-                )
+                if current_platform.is_xpu():
+                    xpu_ops.cp_gather_indexer_k_quant_cache(
+                        kv_cache,
+                        k_quant,
+                        k_scale,
+                        chunk.block_table,
+                        chunk.cu_seq_lens,
+                    )
+                else:
+                    ops.cp_gather_indexer_k_quant_cache(
+                        kv_cache,
+                        k_quant,
+                        k_scale,
+                        chunk.block_table,
+                        chunk.cu_seq_lens,
+                    )
 
             q_slice = q_quant[chunk.token_start : chunk.token_end]
             q_scale_slice = (
@@ -222,14 +240,23 @@ def sparse_attn_indexer(
                 q_slice_cast = q_slice
                 k_quant_cast = k_quant
                 k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
-            logits = fp8_fp4_mqa_logits(
-                (q_slice_cast, q_scale_slice),
-                (k_quant_cast, k_scale_cast),
-                weights[chunk.token_start : chunk.token_end],
-                chunk.cu_seqlen_ks,
-                chunk.cu_seqlen_ke,
-                clean_logits=False,
-            )
+            if current_platform.is_xpu():
+                logits = xpu_ops.fp8_mqa_logits(
+                    q_slice_cast,
+                    (k_quant_cast, k_scale_cast),
+                    weights[chunk.token_start : chunk.token_end],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                )
+            else:
+                logits = fp8_fp4_mqa_logits(
+                    (q_slice_cast, q_scale_slice),
+                    (k_quant_cast, k_scale_cast),
+                    weights[chunk.token_start : chunk.token_end],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    clean_logits=False,
+                )
             num_rows = logits.shape[0]
 
             topk_indices = topk_indices_buffer[
@@ -309,16 +336,27 @@ def sparse_attn_indexer(
             if use_fp4_cache
             else padded_q_quant_decode_tokens
         )
-        logits = fp8_fp4_paged_mqa_logits(
-            (padded_q_quant_cast, padded_q_scale),
-            kv_cache,
-            weights[:num_padded_tokens],
-            seq_lens,
-            decode_metadata.block_table,
-            decode_metadata.schedule_metadata,
-            max_model_len=max_model_len,
-            clean_logits=False,
-        )
+        if current_platform.is_xpu():
+            logits = xpu_ops.fp8_paged_mqa_logits(
+                padded_q_quant_decode_tokens,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                decode_metadata.schedule_metadata,
+                max_model_len,
+            )
+        else:
+            logits = fp8_fp4_paged_mqa_logits(
+                (padded_q_quant_cast, padded_q_scale),
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                decode_metadata.schedule_metadata,
+                max_model_len=max_model_len,
+                clean_logits=False,
+            )
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1292,7 +1292,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         res_mix: torch.Tensor | None,
         residual: torch.Tensor | None,
     ) -> torch.Tensor:
-        if current_platform.is_rocm():
+        if current_platform.is_rocm() or current_platform.is_xpu():
             return self._forward_rocm(
                 x, positions, input_ids, post_mix, res_mix, residual
             )
@@ -1327,10 +1327,10 @@ class DeepseekV4Model(nn.Module):
         # DeepseekV4MultiHeadLatentAttentionWrapper.attn_gemm_parallel_execute
         # (compressor kv_score, indexer.weights_proj, indexer.compressor
         # kv_score). fused_wqa_wkv stays on the default stream.
-        # Disable them on ROCm because of hang issues.
+        # Disable them on ROCm / XPU because of hang issues / no overlap.
         aux_stream_list = (
             None
-            if current_platform.is_rocm()
+            if current_platform.is_rocm() or current_platform.is_xpu()
             else [torch.cuda.Stream() for _ in range(3)]
         )
 

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -367,7 +367,8 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             _LAYER_TYPE_C4A: None,
             _LAYER_TYPE_C128A: None,
         }
-        if num_decode_tokens == 0 or current_platform.is_rocm():
+        if num_decode_tokens == 0 or current_platform.is_rocm() \
+                or current_platform.is_xpu():
             return out
         for layer_type in self._layer_types:
             # get_mla_metadata() is the official FlashMLA entry point that

--- a/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
@@ -243,7 +243,7 @@ def _fused_inv_rope_fp8_quant_kernel_impl(
         (scale_inner * tma_aligned_T, 1, tma_aligned_T),
     )
     grid = (tma_aligned_T, n_groups * heads_per_group)
-    pdl_kwargs = {} if current_platform.is_rocm() else {"launch_pdl": False}
+    pdl_kwargs = {} if current_platform.is_rocm() or current_platform.is_xpu() else {"launch_pdl": False}
     _fused_inv_rope_fp8_quant_per_head[grid](
         o,
         positions,

--- a/vllm/v1/attention/ops/deepseek_v4_ops/xpu_qnorm_rope_kv_fp8_insert.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/xpu_qnorm_rope_kv_fp8_insert.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""XPU Triton replacement for fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert.
+
+Does: Q per-head RMSNorm + GPT-J RoPE, KV GPT-J RoPE + UE8M0 FP8 quant + insert.
+Uses the existing quantize_and_insert_k_cache for the FP8 portion.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+HEAD_DIM = 512
+ROPE_DIM = 64
+NOPE_DIM = HEAD_DIM - ROPE_DIM
+HALF_ROPE = ROPE_DIM // 2
+
+
+@triton.jit
+def _xpu_qnorm_rope_kernel(
+    q_ptr,          # [num_tokens, num_heads, HEAD_DIM]
+    kv_ptr,         # [num_tokens, HEAD_DIM]
+    kv_out_ptr,     # [num_tokens, HEAD_DIM] bf16 (RoPE-applied kv for cache insert)
+    position_ids_ptr,
+    cos_sin_cache_ptr,
+    eps: tl.constexpr,
+    num_tokens,
+    num_heads: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    HALF_ROPE: tl.constexpr,
+):
+    """Apply per-head RMSNorm + GPT-J RoPE on Q, GPT-J RoPE on KV.
+
+    GPT-J interleaved format: pairs are (data[2i], data[2i+1]).
+    cos_sin_cache layout: [max_pos, ROPE_DIM] with first HALF_ROPE=cos,
+    second HALF_ROPE=sin.
+    """
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    if token_idx >= num_tokens:
+        return
+
+    pos = tl.load(position_ids_ptr + token_idx).to(tl.int64)
+
+    # Load cos/sin for this position
+    rope_pair_idx = tl.arange(0, HALF_ROPE)
+    cos_val = tl.load(cos_sin_cache_ptr + pos * ROPE_DIM + rope_pair_idx).to(
+        tl.float32
+    )
+    sin_val = tl.load(
+        cos_sin_cache_ptr + pos * ROPE_DIM + HALF_ROPE + rope_pair_idx
+    ).to(tl.float32)
+
+    if head_idx < num_heads:
+        # ========== Q: per-head RMSNorm + GPT-J RoPE ==========
+        q_base = q_ptr + token_idx * num_heads * HEAD_DIM + head_idx * HEAD_DIM
+
+        # Load full head
+        offs = tl.arange(0, HEAD_DIM)
+        q_vals = tl.load(q_base + offs).to(tl.float32)
+
+        # RMSNorm (no weight)
+        sq_sum = tl.sum(q_vals * q_vals, axis=0)
+        rms = tl.rsqrt(sq_sum / HEAD_DIM + eps)
+        q_vals = q_vals * rms
+
+        # Store ONLY the NoPE portion (positions 0..NOPE_DIM-1)
+        nope_mask = offs < NOPE_DIM
+        tl.store(q_base + offs, q_vals.to(q_ptr.type.element_ty), mask=nope_mask)
+
+        # GPT-J interleaved RoPE on the last ROPE_DIM dimensions:
+        even_offs = NOPE_DIM + rope_pair_idx * 2
+        odd_offs = NOPE_DIM + rope_pair_idx * 2 + 1
+
+        # Re-load original values at rope positions and normalize
+        q_even = tl.load(q_base + even_offs).to(tl.float32) * rms
+        q_odd = tl.load(q_base + odd_offs).to(tl.float32) * rms
+
+        new_even = q_even * cos_val - q_odd * sin_val
+        new_odd = q_even * sin_val + q_odd * cos_val
+
+        # Store rotated RoPE values
+        tl.store(q_base + even_offs, new_even.to(q_ptr.type.element_ty))
+        tl.store(q_base + odd_offs, new_odd.to(q_ptr.type.element_ty))
+    else:
+        # ========== KV: GPT-J RoPE only ==========
+        kv_base = kv_ptr + token_idx * HEAD_DIM
+        kv_out_base = kv_out_ptr + token_idx * HEAD_DIM
+
+        # Copy full KV unchanged first
+        offs = tl.arange(0, HEAD_DIM)
+        kv_full = tl.load(kv_base + offs)
+        tl.store(kv_out_base + offs, kv_full)
+
+        # GPT-J interleaved RoPE on the last ROPE_DIM dimensions
+        even_offs = NOPE_DIM + rope_pair_idx * 2
+        odd_offs = NOPE_DIM + rope_pair_idx * 2 + 1
+
+        kv_even = tl.load(kv_base + even_offs).to(tl.float32)
+        kv_odd = tl.load(kv_base + odd_offs).to(tl.float32)
+
+        new_even = kv_even * cos_val - kv_odd * sin_val
+        new_odd = kv_even * sin_val + kv_odd * cos_val
+
+        tl.store(kv_out_base + even_offs, new_even.to(kv_out_ptr.type.element_ty))
+        tl.store(kv_out_base + odd_offs, new_odd.to(kv_out_ptr.type.element_ty))
+
+
+def xpu_qnorm_rope_kv_fp8_insert(
+    q: torch.Tensor,         # [num_tokens, num_heads, HEAD_DIM] bf16, in-place
+    kv: torch.Tensor,        # [num_tokens, HEAD_DIM] bf16
+    swa_kv_cache: torch.Tensor,  # [num_blocks, block_size, 584] or flat uint8
+    slot_mapping: torch.Tensor,  # [num_tokens] int64
+    positions: torch.Tensor,     # [num_tokens] int64
+    cos_sin_cache: torch.Tensor, # [max_pos, ROPE_DIM]
+    eps: float,
+    block_size: int,
+):
+    """XPU Triton: qnorm+rope on Q, rope on KV, then FP8 UE8M0 quant+insert."""
+    from vllm.v1.attention.ops.deepseek_v4_ops.cache_utils import (
+        quantize_and_insert_k_cache,
+    )
+
+    num_tokens = q.shape[0]
+    num_heads = q.shape[1]
+
+    # Allocate temp buffer for RoPE-applied KV
+    kv_roped = torch.empty_like(kv)
+
+    # Grid: one program per (token, head_or_kv)
+    # head_idx < num_heads: process Q head
+    # head_idx == num_heads: process KV
+    grid = (num_tokens, num_heads + 1)
+    _xpu_qnorm_rope_kernel[grid](
+        q,
+        kv,
+        kv_roped,
+        positions,
+        cos_sin_cache,
+        eps,
+        num_tokens,
+        num_heads=num_heads,
+        HEAD_DIM=HEAD_DIM,
+        ROPE_DIM=ROPE_DIM,
+        NOPE_DIM=NOPE_DIM,
+        HALF_ROPE=HALF_ROPE,
+    )
+
+    # FP8 UE8M0 quant + paged insert (reuse existing Triton kernel)
+    # swa_kv_cache may be [num_blocks, block_size, 584] or [num_blocks, flat]
+    # quantize_and_insert_k_cache expects [num_blocks, block_bytes] uint8
+    cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
+    quantize_and_insert_k_cache(
+        kv_roped,
+        cache_2d,
+        slot_mapping,
+        block_size=block_size,
+    )

--- a/vllm/v1/attention/ops/deepseek_v4_ops/xpu_sparse_decode_fp8.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/xpu_sparse_decode_fp8.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""XPU sparse decode for DeepSeek V4 with FP8 KV cache.
+
+Strategy: dequantize FP8 UE8M0 KV cache pages to BF16 on the fly,
+then reuse the BF16 sparse MLA attention kernel (xpu_sparse_mla_bf16).
+This keeps the external KV cache layout identical to CUDA/ROCm.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from vllm.v1.attention.ops.deepseek_v4_ops.xpu_sparse_mla_bf16 import (
+    xpu_sparse_mla_bf16,
+)
+
+# FP8 DS MLA cache layout constants
+TOKEN_FP8_DIM = 448       # NoPE portion in FP8
+TOKEN_BF16_DIM = 64       # RoPE portion in BF16
+TOKEN_SCALE_DIM = 8       # UE8M0 scales per token
+QUANT_BLOCK_SIZE = 64     # Elements per quant block
+OUTPUT_DIM = 512          # = TOKEN_FP8_DIM + TOKEN_BF16_DIM after dequant
+TOKEN_DATA_SIZE = TOKEN_FP8_DIM + TOKEN_BF16_DIM * 2  # 576 bytes per token
+
+
+@triton.jit
+def _dequant_gather_slots_kernel(
+    # Output workspace: [total_slots, OUTPUT_DIM] bf16
+    out_ptr,
+    # FP8 paged cache base pointer (uint8 flat)
+    cache_ptr,
+    # Global slot indices: [total_slots] int32
+    indices_ptr,
+    # Cache geometry
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,  # 576
+    block_stride: tl.int64,  # k_cache.stride(0) — total uint8 per block
+    fp8_dim: tl.constexpr,   # 448
+    bf16_dim: tl.constexpr,  # 64
+    scale_dim: tl.constexpr, # 8
+    quant_block: tl.constexpr,  # 64
+    output_dim: tl.constexpr,   # 512
+    n_quant_blocks: tl.constexpr,  # 7
+):
+    """Dequantize scattered FP8 slots into a flat BF16 workspace.
+
+    Grid: [total_slots] — one program per slot to gather.
+
+    Cache block layout (block_size tokens):
+      [0, block_size*576): Token data, each token 448 FP8 + 128 BF16
+      [block_size*576, block_size*576 + block_size*8): Scales
+    """
+    pid = tl.program_id(0)
+
+    # Load global slot index
+    slot_idx = tl.load(indices_ptr + pid).to(tl.int64)
+
+    # Output pointer for this slot
+    out_row_ptr = out_ptr + pid * output_dim
+
+    # Handle invalid slots (index < 0): write zeros
+    if slot_idx < 0:
+        zero = tl.zeros([quant_block], dtype=tl.bfloat16)
+        for i in tl.static_range(0, 512, 64):
+            offsets = i + tl.arange(0, quant_block)
+            mask = offsets < output_dim
+            tl.store(out_row_ptr + offsets, zero, mask=mask)
+        return
+
+    # Compute block and position within block
+    block_idx = slot_idx // cache_block_size
+    pos_in_block = slot_idx % cache_block_size
+
+    # Block base pointer
+    block_base = cache_ptr + block_idx * block_stride
+
+    # Token data: at offset pos_in_block * token_data_size within block
+    token_data_ptr = block_base + pos_in_block * token_data_size
+
+    # Scale: after all token data, at offset
+    # cache_block_size * token_data_size + pos_in_block * scale_dim
+    scale_region_offset = tl.cast(cache_block_size, tl.int64) * token_data_size
+    token_scale_ptr = block_base + scale_region_offset + pos_in_block * scale_dim
+
+    # ========== Dequantize FP8 portion (448 elements) ==========
+    for qblock_idx in tl.static_range(n_quant_blocks):
+        qblock_start = qblock_idx * quant_block
+        offsets = qblock_start + tl.arange(0, quant_block)
+        mask = offsets < fp8_dim
+
+        # Load FP8 as uint8 and bitcast
+        x_uint8 = tl.load(token_data_ptr + offsets, mask=mask, other=0)
+        x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
+        x_float = x_fp8.to(tl.float32)
+
+        # Load UE8M0 scale: scale = 2^(stored_value - 127)
+        encoded_scale = tl.load(token_scale_ptr + qblock_idx)
+        exponent = encoded_scale.to(tl.float32) - 127.0
+        scale = tl.exp2(exponent)
+
+        # Dequantize and store as bf16
+        x_dequant = x_float * scale
+        tl.store(out_row_ptr + offsets, x_dequant.to(tl.bfloat16), mask=mask)
+
+    # ========== Copy BF16 portion (64 elements) directly ==========
+    bf16_src_ptr = (token_data_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+    bf16_out_ptr = (out_row_ptr + fp8_dim).to(tl.pointer_type(tl.bfloat16))
+
+    for j in tl.static_range(bf16_dim // 16):
+        chunk_offsets = j * 16 + tl.arange(0, 16)
+        bf16_vals = tl.load(bf16_src_ptr + chunk_offsets)
+        tl.store(bf16_out_ptr + chunk_offsets, bf16_vals)
+
+
+def dequant_gather_slots(
+    out: torch.Tensor,          # [total_slots, 512] bf16, pre-allocated
+    cache: torch.Tensor,        # [num_blocks, block_size, head_bytes] uint8
+    indices: torch.Tensor,      # [total_slots] int32, global slot IDs
+    cache_block_size: int,      # block_size for this cache
+) -> None:
+    """Dequantize FP8 UE8M0 pages at scattered slot indices into bf16."""
+    total_slots = indices.shape[0]
+    if total_slots == 0:
+        return
+
+    block_stride = cache.stride(0)
+
+    _dequant_gather_slots_kernel[(total_slots,)](
+        out,
+        cache,
+        indices,
+        cache_block_size=cache_block_size,
+        token_data_size=TOKEN_DATA_SIZE,
+        block_stride=block_stride,
+        fp8_dim=TOKEN_FP8_DIM,
+        bf16_dim=TOKEN_BF16_DIM,
+        scale_dim=TOKEN_SCALE_DIM,
+        quant_block=QUANT_BLOCK_SIZE,
+        output_dim=OUTPUT_DIM,
+        n_quant_blocks=7,
+    )
+
+
+def xpu_sparse_decode_fp8(
+    q: torch.Tensor,              # [num_tokens, num_heads, head_dim]
+    kv_cache: torch.Tensor | None,  # [num_blocks, block_size, head_bytes] uint8
+    swa_kv_cache: torch.Tensor,     # [num_blocks, swa_block_size, head_bytes] uint8
+    swa_only: bool,
+    topk_indices: torch.Tensor | None,  # [num_tokens, 1, topk] global slot IDs
+    topk_lens: torch.Tensor | None,
+    swa_indices: torch.Tensor,          # [num_tokens, 1, swa_k] global slot IDs
+    swa_lens: torch.Tensor,
+    attn_sink: torch.Tensor,
+    softmax_scale: float,
+    head_dim: int,
+    nope_head_dim: int,
+    rope_head_dim: int,
+    out: torch.Tensor,              # [num_tokens, num_heads, head_dim]
+) -> None:
+    """XPU decode: dequant FP8 pages to BF16, then BF16 sparse MLA attention.
+
+    Keeps external FP8 KV cache layout identical to CUDA/ROCm.
+    Performance is slower due to on-the-fly dequant, but correctness is
+    guaranteed by reusing the validated BF16 attention kernel.
+    """
+    num_tokens = q.shape[0]
+    device = q.device
+
+    # Determine max topk and swa widths
+    if not swa_only and topk_indices is not None:
+        topk_idx_2d = topk_indices.squeeze(1) if topk_indices.dim() == 3 else topk_indices
+        max_topk = topk_idx_2d.shape[1]
+    else:
+        topk_idx_2d = None
+        max_topk = 0
+
+    swa_idx_2d = swa_indices.squeeze(1) if swa_indices.dim() == 3 else swa_indices
+    max_swa = swa_idx_2d.shape[1]
+
+    K_total = max_topk + max_swa
+
+    # Allocate flat workspace: [num_tokens * K_total, 512] bf16
+    workspace = torch.empty(
+        (num_tokens * K_total, OUTPUT_DIM), dtype=torch.bfloat16, device=device
+    )
+    ws_3d = workspace.view(num_tokens, K_total, OUTPUT_DIM)
+
+    # Dequant+gather topk slots from compressed cache
+    if not swa_only and topk_idx_2d is not None and kv_cache is not None:
+        topk_flat = topk_idx_2d.reshape(-1).to(torch.int32)
+        topk_buf = torch.empty(
+            (num_tokens * max_topk, OUTPUT_DIM), dtype=torch.bfloat16, device=device
+        )
+        compressed_block_size = kv_cache.shape[1]
+        dequant_gather_slots(topk_buf, kv_cache, topk_flat, compressed_block_size)
+        ws_3d[:, :max_topk, :] = topk_buf.view(num_tokens, max_topk, OUTPUT_DIM)
+
+    # Dequant+gather SWA slots
+    swa_flat = swa_idx_2d.reshape(-1).to(torch.int32)
+    swa_buf = torch.empty(
+        (num_tokens * max_swa, OUTPUT_DIM), dtype=torch.bfloat16, device=device
+    )
+    swa_block_size = swa_kv_cache.shape[1]
+    dequant_gather_slots(swa_buf, swa_kv_cache, swa_flat, swa_block_size)
+
+    ws_3d[:, max_topk:, :] = swa_buf.view(num_tokens, max_swa, OUTPUT_DIM)
+
+    # Build combined indices into the flat workspace and combined lengths.
+    # Workspace layout per token t: [topk_0..topk_{max_topk-1}, swa_0..swa_{max_swa-1}]
+    # Flat index for token t, position p = t * K_total + p
+    #
+    # IMPORTANT: The attention kernel uses combined_lens as a position cutoff —
+    # it only reads indices[0..combined_lens-1]. So indices must be PACKED
+    # contiguously: [valid_topk_indices..., valid_swa_indices..., -1 padding...]
+    if not swa_only and topk_lens is not None:
+        combined_lens = (topk_lens + swa_lens).to(torch.int32)
+    else:
+        combined_lens = swa_lens.to(torch.int32)
+
+    max_combined = int(combined_lens.max().item()) if combined_lens.numel() > 0 else 0
+    # Round up to BLOCK_K alignment for kernel efficiency
+    from vllm.v1.attention.ops.deepseek_v4_ops.xpu_sparse_mla_bf16 import BLOCK_K
+    max_combined_padded = ((max_combined + BLOCK_K - 1) // BLOCK_K) * BLOCK_K
+
+    # Build packed index table: [num_tokens, max_combined_padded]
+    # Each token t: [topk_0..topk_{tlen-1}, swa_0..swa_{slen-1}, -1 padding]
+    # Vectorized: for each token, topk indices are t*K_total + 0..tlen-1,
+    #             swa indices are t*K_total + max_topk + 0..slen-1
+    combined_indices = torch.full(
+        (num_tokens, max_combined_padded),
+        fill_value=-1,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    token_offsets = torch.arange(
+        num_tokens, device=device, dtype=torch.int32
+    ) * K_total  # [B]
+
+    if not swa_only and topk_lens is not None:
+        # Pack topk: for each token, write t*K_total + 0..tlen-1 at positions 0..tlen-1
+        max_tlen = int(topk_lens.max().item())
+        topk_range = torch.arange(max_tlen, device=device, dtype=torch.int32).unsqueeze(0)
+        topk_valid = topk_range < topk_lens.unsqueeze(1)
+        topk_ws_indices = token_offsets.unsqueeze(1) + topk_range
+        combined_indices[:, :max_tlen] = torch.where(
+            topk_valid, topk_ws_indices, torch.tensor(-1, dtype=torch.int32, device=device)
+        )
+        # Pack swa after topk: positions tlen..tlen+slen-1
+        # Since tlen varies per token, we need per-token offset
+        swa_range = torch.arange(max_swa, device=device, dtype=torch.int32).unsqueeze(0)
+        swa_valid = swa_range < swa_lens.unsqueeze(1)
+        swa_ws_indices = token_offsets.unsqueeze(1) + max_topk + swa_range
+        # Write at position topk_lens[t] + swa_pos for each token
+        for t_idx in range(num_tokens):
+            tlen = int(topk_lens[t_idx].item())
+            slen = int(swa_lens[t_idx].item())
+            combined_indices[t_idx, tlen:tlen + slen] = (
+                swa_ws_indices[t_idx, :slen]
+            )
+    else:
+        # SWA-only: pack swa indices at positions 0..slen-1
+        swa_range = torch.arange(max_swa, device=device, dtype=torch.int32).unsqueeze(0)
+        swa_valid = swa_range < swa_lens.unsqueeze(1)
+        swa_ws_indices = token_offsets.unsqueeze(1) + swa_range  # max_topk=0
+        combined_indices[:, :max_swa] = torch.where(
+            swa_valid, swa_ws_indices, torch.tensor(-1, dtype=torch.int32, device=device)
+        )
+
+    # Call BF16 sparse MLA kernel
+    xpu_sparse_mla_bf16(
+        q=q,
+        kv_workspace=workspace,
+        topk_indices=combined_indices,
+        topk_lens=combined_lens,
+        softmax_scale=softmax_scale,
+        out=out,
+    )

--- a/vllm/v1/attention/ops/deepseek_v4_ops/xpu_sparse_mla_bf16.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/xpu_sparse_mla_bf16.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# pyright: reportUnknownVariableType=none, reportUnknownMemberType=none, reportUnknownArgumentType=none, reportUnknownParameterType=none, reportMissingParameterType=none, reportCallIssue=none, reportUnreachable=none, reportPrivateImportUsage=none, reportUnusedCallResult=none
+"""bf16 Triton C4 sparse prefill over a contiguous KV workspace.
+
+This kernel targets the DeepSeek V4 main MLA sparse prefill path on XPU.
+It performs top-k indexed FlashAttention over a contiguous KV workspace with
+an online softmax update per ``(token, head)`` program.
+
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+HEAD_DIM = 512
+BLOCK_K = 64
+
+
+@triton.jit
+def _xpu_sparse_mla_bf16_kernel(
+    q_ptr,
+    kv_ptr,
+    topk_indices_ptr,
+    topk_lens_ptr,
+    out_ptr,
+    softmax_scale,
+    q_stride_t,
+    q_stride_h,
+    kv_stride_s,
+    topk_stride_t,
+    out_stride_t,
+    out_stride_h,
+    K_MAX: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    t = tl.program_id(0)
+    h = tl.program_id(1)
+
+    d_off = tl.arange(0, D)
+    q = tl.load(q_ptr + t * q_stride_t + h * q_stride_h + d_off).to(tl.float32)
+    topk_len = tl.load(topk_lens_ptr + t)
+
+    m_i = tl.full((), float("-inf"), tl.float32)
+    d_i = tl.zeros((), tl.float32)
+    num_i = tl.zeros((D,), tl.float32)
+
+    for k_start in tl.range(0, K_MAX, BLOCK_K):
+        k_off = k_start + tl.arange(0, BLOCK_K)
+        valid = k_off < topk_len
+        slot = tl.load(
+            topk_indices_ptr + t * topk_stride_t + k_off,
+            mask=valid,
+            other=-1,
+        ).to(tl.int32)
+        valid = valid & (slot >= 0)
+        valid_count = tl.sum(valid.to(tl.int32), axis=0)
+        block_has_values = valid_count > 0
+
+        k = tl.load(
+            kv_ptr + slot[:, None] * kv_stride_s + d_off[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        logits = tl.sum(k * q[None, :], axis=1) * softmax_scale
+        logits = tl.where(valid, logits, float("-inf"))
+
+        m_block = tl.max(logits, axis=0)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp(m_i - m_new)
+        p = tl.exp(logits - m_new)
+        p = tl.where(valid, p, 0.0)
+
+        d_next = d_i * alpha + tl.sum(p, axis=0)
+        num_next = num_i * alpha + tl.sum(p[:, None] * k, axis=0)
+        d_i = tl.where(block_has_values, d_next, d_i)
+        num_i = tl.where(block_has_values, num_next, num_i)
+        m_i = tl.where(block_has_values, m_new, m_i)
+
+    out = tl.where(d_i > 0, num_i / d_i, tl.zeros_like(num_i))
+    tl.store(out_ptr + t * out_stride_t + h * out_stride_h + d_off, out.to(tl.bfloat16))
+
+
+def xpu_sparse_mla_bf16(
+    q: torch.Tensor,
+    kv_workspace: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_lens: torch.Tensor,
+    softmax_scale: float,
+    out: torch.Tensor,
+) -> None:
+    assert q.dtype == torch.bfloat16
+    assert kv_workspace.dtype == torch.bfloat16
+    assert out.dtype == torch.bfloat16
+    assert topk_indices.dtype == torch.int32
+    assert topk_lens.dtype == torch.int32
+    assert q.dim() == 3
+    assert kv_workspace.dim() == 2
+    assert topk_indices.dim() == 2
+    assert topk_lens.dim() == 1
+    assert q.shape[-1] == HEAD_DIM
+    assert kv_workspace.shape[-1] == HEAD_DIM
+    assert out.shape == q.shape
+    assert topk_indices.shape[0] == q.shape[0]
+    assert topk_lens.shape == (q.shape[0],)
+
+    T, H, D = q.shape
+    k_max = topk_indices.shape[1]
+
+    grid = (T, H)
+    _xpu_sparse_mla_bf16_kernel[grid](
+        q,
+        kv_workspace,
+        topk_indices,
+        topk_lens,
+        out,
+        float(softmax_scale),
+        q.stride(0),
+        q.stride(1),
+        kv_workspace.stride(0),
+        topk_indices.stride(0),
+        out.stride(0),
+        out.stride(1),
+        K_MAX=k_max,
+        D=D,
+        BLOCK_K=BLOCK_K,
+        num_warps=16,
+    )
+
+
+__all__ = ["xpu_sparse_mla_bf16"]

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -468,12 +468,13 @@ def fp8_mqa_logits_torch(
     seq_len_kv = k_fp8.shape[0]
     k = k_fp8.to(torch.bfloat16)
     q = q.to(torch.bfloat16)
+    device = q.device
 
     mask_lo = (
-        torch.arange(0, seq_len_kv, device="cuda")[None, :] >= cu_seqlen_ks[:, None]
+        torch.arange(0, seq_len_kv, device=device)[None, :] >= cu_seqlen_ks[:, None]
     )
     mask_hi = (
-        torch.arange(0, seq_len_kv, device="cuda")[None, :] < cu_seqlen_ke[:, None]
+        torch.arange(0, seq_len_kv, device=device)[None, :] < cu_seqlen_ke[:, None]
     )
     mask = mask_lo & mask_hi
 
@@ -1355,7 +1356,7 @@ def _rocm_sparse_attn_prefill_ragged_triton(
     assert kv.ndim == 2, f"expected kv=[skv,d], got {kv.shape}"
     assert indices.ndim == 1, f"expected indices=[nnz], got {indices.shape}"
     assert indptr.ndim == 1, f"expected indptr=[sq+1], got {indptr.shape}"
-    assert q.is_cuda and kv.is_cuda and indices.is_cuda and indptr.is_cuda
+    assert not q.is_cpu and not kv.is_cpu and not indices.is_cpu and not indptr.is_cpu
 
     indices = _as_int32_contiguous_1d(indices)
     indptr = _as_int32_contiguous_1d(indptr)
@@ -1459,10 +1460,10 @@ def _rocm_sparse_attn_decode_ragged_triton(
     )
     assert main_indptr.ndim == 1, f"expected main_indptr=[b+1], got {main_indptr.shape}"
     assert (
-        q.is_cuda
-        and main_cache.is_cuda
-        and main_indices.is_cuda
-        and main_indptr.is_cuda
+        not q.is_cpu
+        and not main_cache.is_cpu
+        and not main_indices.is_cpu
+        and not main_indptr.is_cpu
     )
 
     main_indices = _as_int32_contiguous_1d(main_indices)


### PR DESCRIPTION
## [XPU] Add DeepSeek-V4 XPU support

### Summary

This PR enables DeepSeek-V4-Flash to run on Intel XPU with functional correctness. The model uses FP8 KV cache (same as CUDA path) and routes XPU-incompatible operations to PyTorch/Triton fallbacks.

**Validated**: GSM8k 50 samples TP=4, **98% strict-match**.

### Changes

#### Attention (`deepseek_v4_attention.py`, `sparse_attn_indexer.py`)

- Add XPU decode path (`_forward_decode_xpu`) that dequants FP8 paged cache to bf16 then runs Triton sparse MLA
- Route indexer ops (`indexer_k_quant_and_cache`, `cp_gather_indexer_k_quant_cache`, `fp8_mqa_logits`, `fp8_paged_mqa_logits`) to PyTorch implementations in `_xpu_ops.py`
- Add `forward_xpu` for MHC Pre/Post/Fuse (calls `mhc_pre_torch`/`mhc_post_torch` — no tilelang on XPU)
- Skip FlashMLA tile_scheduler_metadata build on XPU (not used)
- Disable aux_stream parallelism on XPU (no overlap benefit)

#### New Triton kernels (3 files)

| File | Description |
|------|-------------|
| `xpu_qnorm_rope_kv_fp8_insert.py` | Fused QNorm + RoPE + KV cache insert for SWA compressor |
| `xpu_sparse_decode_fp8.py` | Sparse decode: dequant FP8 pages → bf16 → Triton attention |
| `xpu_sparse_mla_bf16.py` | C4A sparse prefill over contiguous bf16 KV workspace |

#### Quantization (`scaled_mm/triton.py`, `linear/__init__.py`, `input_quant_fp8.py`, `fp8_utils.py`)

- Register `TritonFp8BlockScaledMMKernel` for XPU platform (FP8 block-scaled GEMM via Triton)
- Dynamic group quant: route to `torch.ops.vllm.triton_per_token_group_quant_fp8` custom op (avoids torch.compile trying to trace FP8 Triton internals)
- Upcast E8M0 block scales to fp32 on XPU (same as ROCm path)

#### MoE routing (`fused_topk_bias_router.py`)

- Add `_topk_softplus_sqrt_torch`: pure PyTorch fallback for `topk_softplus_sqrt` scoring on XPU/CPU
- Key fix: bias is used for expert **selection** only, not for weight computation (prevents near-uniform routing weights)

#### Platform compatibility (misc)

- `SiluAndMulWithClamp`: XPU uses `forward_native` (no `_C.silu_and_mul_with_clamp` op)
- `fused_inv_rope_fp8_quant`: skip `launch_pdl` kwarg on XPU
- `rocm_aiter_mla_sparse.py`: replace `"cuda"` device literals with `q.device`; replace `.is_cuda` asserts with `not .is_cpu`
- `deepseek_v4.py`: XPU reuses ROCm forward path (sequential execution, no aux streams)
- `deepseek_compressor.py`: minor guard fix

#### `_xpu_ops.py` (+260 lines)

- `cp_gather_indexer_k_quant_cache`: rewritten to handle BLOCK-PACKED cache layout with `as_strided` flat byte view
- `fp8_mqa_logits`: prefill indexer logits via einsum (bf16 dequant → score → relu → weight)
- `fp8_paged_mqa_logits`: decode indexer logits with paged FP8 cache (block-table lookup + dequant)
- `indexer_k_quant_and_cache`: FP8 quantize + cache insert

### Known limitations / future work

- **MoE**: `_topk_softplus_sqrt_torch` is a PyTorch loop fallback; needs SYCL/Triton fused kernel
- **Indexer logits**: pure PyTorch einsum; needs dedicated SYCL MQA kernel for performance
- **FP8 MLA sparse attention**: decode dequants entire pages to bf16 before Triton; native FP8 paged attention would eliminate this copy
- **MHC**: using `mhc_pre_torch`/`mhc_post_torch` (no Triton fusion yet)
- **top_k**: using `torch.topk`; SYCL specialized kernel needed for decode