### PR TITLE
Revert checkpoint specific workaround in Transformers modelling backend

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -353,14 +353,6 @@ class Base(
         for source, target in ccm.items():
             orig_to_new_regex[re.compile(source)] = target
 
-        # Gemma3 checkpoints saved with older Transformers versions include an
-        # extra `vision_model` level that the current AutoModel no longer has.
-        vision_tower = getattr(self.model, "vision_tower", None)
-        if vision_tower is not None and not hasattr(vision_tower, "vision_model"):
-            orig_to_new_regex[
-                re.compile(r"^(?:model\.)?vision_tower\.vision_model\.(.+)")
-            ] = r"model.vision_tower.\1"
-
         # Handle unexpected weights which should be ignored
         if self.model._keys_to_ignore_on_load_unexpected is not None:
             for key in self.model._keys_to_ignore_on_load_unexpected:


### PR DESCRIPTION
Revert checkpoint specific workaround added in https://github.com/vllm-project/vllm/pull/42909/changes#diff-e9cbc9ec70c6280e43e3f95bb193fed1a66a12f08768442840e8affebf475c5f

This kind of fix does not belong in in the Transformers modelling backend. 