### PR TITLE
[Bugfix][KVConnector][NIXL] Sync engine_id across nodes for headless multi-node deployments

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -63,6 +63,7 @@ from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    get_world_group,
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -202,6 +203,24 @@ class NixlConnectorWorker:
             logger.error("NIXL is not available")
             raise RuntimeError("NIXL is not available")
         logger.info("Initializing NIXL wrapper")
+
+        # Multi-node TP/PP deployments launched with `--headless` parse
+        # the CLI independently on each node, so the default-factory
+        # uuid4 in `KVTransferConfig.__post_init__` diverges across
+        # nodes that logically belong to the same engine. NIXL handshake
+        # validates that the remote agent reports the engine_id we
+        # expect, and any divergence surfaces as
+        #   "Remote NIXL agent engine ID mismatch."
+        # at decode time. Broadcast rank 0's engine_id over the engine
+        # world group so every worker in this engine agrees on identity
+        # before the NIXL agent is constructed (the wrapper's name is
+        # registered with the side channel during init).
+        if torch.distributed.is_initialized():
+            world_group = get_world_group()
+            if world_group.world_size > 1:
+                engine_id = world_group.broadcast_object(engine_id, src=0)
+                if vllm_config.kv_transfer_config is not None:
+                    vllm_config.kv_transfer_config.engine_id = engine_id
         logger.info("Initializing NIXL worker %s", engine_id)
 
         # Config.


### PR DESCRIPTION
## Purpose

Fix a latent bug that breaks NIXL handshake whenever a single engine is launched as a multi-node TP or PP deployment via `--headless`.

Each `vllm serve --headless` invocation independently parses CLI → builds its own `VllmConfig` → runs `KVTransferConfig.__post_init__`, which sets `engine_id = str(uuid.uuid4())` when not explicitly provided. Within a node the uuid is propagated to workers by the executor (pickle/Ray), but across nodes there is no synchronization, so each node ends up with a different uuid for what is logically the same engine.

When a PD peer (decode side) tries to handshake with this engine, the worker on rank 0 reports `uuid_A` while the worker on rank `N` (on a follower node) reports `uuid_B`. The handshake fails with:

```
RuntimeError: Remote NIXL agent engine ID mismatch.
Expected <uuid_A>, received <uuid_B>.
```

Reproduction is straightforward — any multi-node TP (or PP) engine where TP/PP spans nodes via the `mp` executor backend + `--headless`, used as either the prefill or decode side of a NIXL-connected PD pair.

Single-node TP is unaffected (single CLI parse). Multi-node via Ray is unaffected (config is serialized from the head). The bug is specific to `mp` + `--headless`.

DP is not affected: `NixlConnectorScheduler` already disambiguates DP siblings by `side_channel_port + data_parallel_index` rather than by `engine_id`, and DP engines run in separate process worlds.

## Fix

In `NixlConnectorWorker.__init__`, before the NIXL agent is constructed, broadcast rank 0's `engine_id` over `get_world_group()` (the world of this engine's worker ranks). All ranks within the engine then agree on identity.

- No-op when `torch.distributed` is not initialized (preserves existing unit tests that instantiate the worker without a process group).
- No-op when `world_size == 1` (single-rank deployments).
- The synced value is written back to `vllm_config.kv_transfer_config.engine_id` so any downstream reader sees the same identity.
- `get_world_group()` is the engine-wide world, which covers TP×PP×EP within one DP replica — so the fix handles any combination of model-parallelism that spans nodes.

## Test Plan

- Unit tests in `tests/v1/kv_connector/unit/` instantiate `NixlConnectorWorker` directly, without a torch.distributed process group; the new code is guarded by `torch.distributed.is_initialized()` so these tests are unaffected. Verified by inspection — please run them in CI.
- Manual repro: 1P+1D PD deployment with TP=8 split across two 4-GPU nodes (`mp` backend, follower node started with `--headless`). Before this patch, every request reliably fails the NIXL handshake on remote-engine-id mismatch. With this patch, decode side connects to prefill and serves completions normally.

## Test Result

Manual smoke test (TP=8 prefill + TP=8 decode, each across 2 nodes, total 4 nodes):

```
Before patch: RuntimeError: Remote NIXL agent engine ID mismatch.
              Expected <uuid_A>, received <uuid_B>.
After patch:  HTTP 200, completion served end-to-end (32 tokens).
```

Linting/formatting:

```
$ ruff check vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
All checks passed!
$ ruff format --check vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
1 file already formatted
```

## Notes

This is a minimal, targeted fix in the connector worker. An alternative would be to move `engine_id` resolution out of `KVTransferConfig.__post_init__` into `VllmConfig.__post_init__` and derive it deterministically from `(master_addr, master_port, kv_role)` when `nnodes > 1 and backend == "mp"`. That approach also works but touches more surface area and assumes rendezvous coordinates uniquely identify the deployment. The broadcast approach is local to the connector that has the bug and uses the existing synchronization primitive that vLLM already provides.