### PR TITLE
[Bugfix] Fix DSV4 MTP after ROCm mHC integration

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1261,10 +1261,12 @@ class DeepseekV4DecoderLayer(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
         input_ids: torch.Tensor | None,
-        post_mix: torch.Tensor | None,
-        res_mix: torch.Tensor | None,
-        residual: torch.Tensor | None,
-    ) -> torch.Tensor:
+        post_mix: torch.Tensor | None = None,
+        res_mix: torch.Tensor | None = None,
+        residual: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
+    ]:
         residual = x
         x, post, comb = self.hc_pre(
             x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
@@ -1288,10 +1290,12 @@ class DeepseekV4DecoderLayer(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
         input_ids: torch.Tensor | None,
-        post_mix: torch.Tensor | None,
-        res_mix: torch.Tensor | None,
-        residual: torch.Tensor | None,
-    ) -> torch.Tensor:
+        post_mix: torch.Tensor | None = None,
+        res_mix: torch.Tensor | None = None,
+        residual: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
+    ]:
         if current_platform.is_rocm():
             return self._forward_rocm(
                 x, positions, input_ids, post_mix, res_mix, residual

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -146,9 +146,10 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         hidden_states, residual, post_mix, res_mix = self.mtp_block(
             positions=positions, x=hidden_states, input_ids=None
         )
-        hidden_states = self.mtp_block.hc_post(
-            hidden_states, residual, post_mix, res_mix
-        )
+        if current_platform.is_cuda():
+            hidden_states = self.mtp_block.hc_post(
+                hidden_states, residual, post_mix, res_mix
+            )
         # Return the flat pre-hc_head residual so it can be re-fed as the
         # next spec step's `previous_hidden_states` when
         # num_speculative_tokens > 1. hc_head is deferred to compute_logits.
@@ -235,7 +236,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         hidden_states = hidden_states.view(
             -1, mtp_layer.hc_mult, mtp_layer.config.hidden_size
         )
-        hidden_states = self.hc_head_op(
+        hidden_states = mtp_layer.hc_head_op(
             hidden_states,
             mtp_layer.hc_head_fn,
             mtp_layer.hc_head_scale,


### PR DESCRIPTION
## Purpose

This fixes the DSV4 MTP path (again) after #41946 split the decoder layer into CUDA/ROCm helpers plus a dispatching `forward()`.

I previously attempted to fix this in #42320, but that PR was written against the older decoder-layer shape. After it was rebased, the HC-state defaults landed on `_forward_cuda()` but not on the public `DeepseekV4DecoderLayer.forward()` method that `torch.compile` binds to, so DSV4 MTP still failed with:

```text
TypeError: missing required positional argument: post_mix
torch._dynamo.exc.Unsupported: failed to bind arguments when attempting to inline
```

This PR restores those defaults on `forward()`.

It also fixes the next runtime failure in draft-token sampling:

```text
AttributeError: 'DeepSeekV4MultiTokenPredictor' object has no attribute 'hc_head_op'
```

#41946 moved `hc_head` to `HCHeadOp`, but instantiated it on each MTP layer while `compute_logits()` called `self.hc_head_op`. This PR calls `mtp_layer.hc_head_op(...)`, matching the actual owner.

Finally, the MTP path now mirrors the main DSV4 model by applying the deferred final `hc_post()` only on CUDA. ROCm already applies it inside `_forward_rocm()` and returns `None` HC state.

## Accuracy Test (GB300)

```bash
CUDA_VISIBLE_DEVICES=3 vllm serve deepseek-ai/DeepSeek-V4-Flash \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --no-enable-flashinfer-autotune \
  --attention_config.use_fp4_indexer_cache=True \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --speculative_config '{"method":"mtp","num_speculative_tokens":2}'
```

```bash
lm_eval --model local-completions --model_args model=deepseek-ai/DeepSeek-V4-Flash,base_url=http://localhost:8000/v1/completions,num_concurrent=256,max_retries=10,max_gen_toks=2048,max_length=1048576,timeout=60000 --batch_size auto --tasks gsm8k --num_fewshot 8

2026-05-17:19:32:01 INFO     [loggers.evaluation_tracker:316] Output path not provided, skipping saving results aggregated
local-completions ({'model': 'deepseek-ai/DeepSeek-V4-Flash', 'base_url': 'http://localhost:8000/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 8, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9530|±  |0.0058|
|     |       |strict-match    |     8|exact_match|↑  |0.9538|±  |0.0058|
```