### PR TITLE
Fix `--convert` passed without `--runner` on causal models

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -546,7 +546,9 @@ class ModelConfig:
         is_generative_model = registry.is_text_generation_model(architectures, self)
         is_pooling_model = registry.is_pooling_model(architectures, self)
 
-        self.runner_type = self._get_runner_type(architectures, self.runner)
+        self.runner_type = self._get_runner_type(
+            architectures, self.runner, self.convert
+        )
         self.convert_type = self._get_convert_type(
             architectures, self.runner_type, self.convert
         )
@@ -884,11 +886,15 @@ class ModelConfig:
         self,
         architectures: list[str],
         runner: RunnerOption,
+        convert: ConvertOption,
     ) -> RunnerType:
         if runner != "auto":
             return runner
 
-        runner_type = self._get_default_runner_type(architectures)
+        if convert in {"auto", "none"}:
+            runner_type = self._get_default_runner_type(architectures)
+        else:
+            runner_type = "pooling"
 
         # Don't log the most common case
         if runner_type != "generate":


### PR DESCRIPTION
https://docs.vllm.ai/en/latest/models/pooling_models/#model-conversion indicates that `--runner` could be automatically set to `pooling` if the model doesn't natively support the conversion task. This means that `_get_runner_type` should account for the user passed `convert`.

This PR adds the case that `--convert` is explicitly passed to `_get_runner_type`.

Fixes https://github.com/vllm-project/vllm/issues/42480

Supersedes https://github.com/vllm-project/vllm/pull/42820