### PR TITLE
[Bugfix] Fix speculative logprobs for generative scoring

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -82,6 +82,8 @@ def create_sampling_metadata(
     repetition_penalties: list[float] | None = None,
     bad_words_token_ids: dict[int, list[list[int]]] | None = None,
     allowed_token_ids_mask: torch.Tensor | None = None,
+    max_num_logprobs: int | None = None,
+    logprob_token_ids: dict[int, list[int]] | None = None,
 ) -> SamplingMetadata:
     """Create a v1 sampling metadata object with all_greedy set
     to the given value. Either all greedy or all random sampling
@@ -115,7 +117,7 @@ def create_sampling_metadata(
         top_p=top_p,
         top_k=top_k,
         generators=generators,
-        max_num_logprobs=None,
+        max_num_logprobs=max_num_logprobs,
         no_penalties=no_penalties,
         prompt_token_ids=prompt_token_ids,
         frequency_penalties=frequency_penalties,
@@ -126,6 +128,7 @@ def create_sampling_metadata(
         allowed_token_ids_mask=allowed_token_ids_mask,
         bad_words_token_ids={} if bad_words_token_ids is None else bad_words_token_ids,
         logitsprocs=LogitsProcessors(),
+        logprob_token_ids=logprob_token_ids,
     )
 
 
@@ -303,6 +306,54 @@ def test_parametrized_cases(rejection_sampler, spec_tokens, output_tokens, expec
     )
     expected_tensor = torch.tensor(expected, dtype=torch.int, device=logits.device)
     assert torch.equal(output.sampled_token_ids, expected_tensor)
+
+
+def test_specific_logprob_token_ids_with_bonus_logits():
+    """Spec decode should keep full bonus logits and return requested token logprobs."""
+    vocab_size = 10
+    spec_tokens = [[1], [2]]
+    sampled_tokens = [1, 5, 2, 6]
+    logits = torch.full((4, vocab_size), -10.0, device=DEVICE_TYPE)
+    for row, token_id in enumerate(sampled_tokens):
+        logits[row, token_id] = 10.0
+    logits[:, 7] = 3.0
+    logits[:, 8] = 4.0
+
+    metadata = SpecDecodeMetadata.make_dummy(spec_tokens, device=logits.device)
+    metadata.target_logits_indices = torch.tensor([0, 2], device=logits.device)
+    metadata.bonus_logits_indices = torch.tensor([1, 3], device=logits.device)
+    sampling_metadata = create_sampling_metadata(
+        all_greedy=True,
+        max_num_logprobs=2,
+        logprob_token_ids={0: [5, 7], 1: [6, 8]},
+    )
+
+    rejection_sampler = RejectionSampler(Sampler())
+    output = rejection_sampler(
+        metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=sampling_metadata,
+    )
+
+    expected_tokens = torch.tensor([[1, 5], [2, 6]], device=logits.device)
+    assert torch.equal(output.sampled_token_ids, expected_tokens)
+
+    assert output.logprobs_tensors is not None
+    expected_logprob_token_ids = torch.tensor(
+        [[1, 5, 7], [5, 5, 7], [2, 6, 8], [6, 6, 8]],
+        dtype=torch.int32,
+        device=logits.device,
+    )
+    assert torch.equal(
+        output.logprobs_tensors.logprob_token_ids, expected_logprob_token_ids
+    )
+
+    final_logits = torch.stack((logits[0], logits[1], logits[2], logits[3]))
+    expected_logprobs = final_logits.log_softmax(dim=-1).gather(
+        -1, expected_logprob_token_ids.to(torch.int64)
+    )
+    torch.testing.assert_close(output.logprobs_tensors.logprobs, expected_logprobs)
 
 
 ########################### Tests for Random Sampling ###################

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1287,9 +1287,9 @@ class DeepseekV4DecoderLayer(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
         input_ids: torch.Tensor | None,
-        post_mix: torch.Tensor | None,
-        res_mix: torch.Tensor | None,
-        residual: torch.Tensor | None,
+        post_mix: torch.Tensor | None = None,
+        res_mix: torch.Tensor | None = None,
+        residual: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if current_platform.is_rocm():
             return self._forward_rocm(

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -235,7 +235,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         hidden_states = hidden_states.view(
             -1, mtp_layer.hc_mult, mtp_layer.config.hidden_size
         )
-        hidden_states = self.hc_head_op(
+        hidden_states = mtp_layer.hc_head_op(
             hidden_states,
             mtp_layer.hc_head_fn,
             mtp_layer.hc_head_scale,

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -131,6 +131,7 @@ class RejectionSampler(nn.Module):
             sampling_metadata=replace(
                 sampling_metadata,
                 max_num_logprobs=-1,
+                logprob_token_ids=None,
             ),
             predict_bonus_token=True,
             # Override the logprobs mode to return logits because they are
@@ -187,6 +188,7 @@ class RejectionSampler(nn.Module):
                 target_logits if self.is_processed_logprobs_mode else raw_target_logits,
                 bonus_sampler_output.logprobs_tensors.logprobs,
                 output_token_ids,
+                sampling_metadata.logprob_token_ids,
             )
 
         return SamplerOutput(
@@ -202,6 +204,7 @@ class RejectionSampler(nn.Module):
         target_logits: torch.Tensor,
         bonus_logits: torch.Tensor,
         sampled_token_ids: torch.Tensor,
+        logprob_token_ids: dict[int, list[int]] | None,
     ) -> LogprobsTensors:
         cu_num_sampled_tokens = torch.zeros_like(metadata.cu_num_sampled_tokens)
         cu_num_sampled_tokens[1:] = metadata.cu_num_sampled_tokens[:-1]
@@ -237,10 +240,61 @@ class RejectionSampler(nn.Module):
             if self.is_logits_logprobs_mode
             else self.sampler.compute_logprobs(accepted_logits)
         )
+        if logprob_token_ids:
+            return self._gather_specific_logprobs(
+                accepted_logits,
+                accepted_logprobs,
+                logprob_token_ids,
+                sampled_token_ids.shape[-1],
+                accepted_tokens.to(torch.int64),
+            )
         return self.sampler.gather_logprobs(
             accepted_logprobs,
             max_num_logprobs,
             accepted_tokens.to(torch.int64),
+        )
+
+    @staticmethod
+    def _gather_specific_logprobs(
+        logits: torch.Tensor,
+        logprobs: torch.Tensor,
+        logprob_token_ids: dict[int, list[int]],
+        num_positions_per_req: int,
+        sampled_token_ids: torch.Tensor,
+    ) -> LogprobsTensors:
+        num_positions = logprobs.shape[0]
+        max_num_token_ids = max(
+            len(token_ids) for token_ids in logprob_token_ids.values()
+        )
+
+        token_ids_cpu = torch.zeros(
+            (num_positions, max_num_token_ids + 1), dtype=torch.int64
+        )
+        valid_mask_cpu = torch.zeros_like(token_ids_cpu, dtype=torch.bool)
+        valid_mask_cpu[:, 0] = True
+        for req_idx, token_ids in logprob_token_ids.items():
+            start = req_idx * num_positions_per_req
+            end = min(start + num_positions_per_req, num_positions)
+            num_token_ids = len(token_ids)
+            token_ids_cpu[start:end, 1 : num_token_ids + 1] = torch.as_tensor(
+                token_ids, dtype=torch.int64
+            )
+            valid_mask_cpu[start:end, 1 : num_token_ids + 1] = True
+
+        token_ids = token_ids_cpu.to(logprobs.device, non_blocking=True)
+        valid_mask = valid_mask_cpu.to(logprobs.device, non_blocking=True)
+        token_ids[:, 0] = sampled_token_ids
+
+        selected_logprobs = logprobs.gather(-1, token_ids)
+        selected_logprobs.masked_fill_(~valid_mask, float("-inf"))
+
+        sampled_logits = logits.gather(-1, sampled_token_ids.unsqueeze(-1))
+        sampled_token_ranks = (logits > sampled_logits).sum(dim=-1)
+
+        return LogprobsTensors(
+            logprob_token_ids=token_ids.to(torch.int32),
+            logprobs=selected_logprobs,
+            selected_token_ranks=sampled_token_ranks,
         )
 
     @staticmethod

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -247,6 +247,7 @@ class RejectionSampler(nn.Module):
                 logprob_token_ids,
                 sampled_token_ids.shape[-1],
                 accepted_tokens.to(torch.int64),
+                getattr(self.sampler, "pin_memory", False),
             )
         return self.sampler.gather_logprobs(
             accepted_logprobs,
@@ -261,6 +262,7 @@ class RejectionSampler(nn.Module):
         logprob_token_ids: dict[int, list[int]],
         num_positions_per_req: int,
         sampled_token_ids: torch.Tensor,
+        pin_memory: bool,
     ) -> LogprobsTensors:
         num_positions = logprobs.shape[0]
         max_num_token_ids = max(
@@ -268,9 +270,15 @@ class RejectionSampler(nn.Module):
         )
 
         token_ids_cpu = torch.zeros(
-            (num_positions, max_num_token_ids + 1), dtype=torch.int64
+            (num_positions, max_num_token_ids + 1),
+            dtype=torch.int64,
+            pin_memory=pin_memory,
         )
-        valid_mask_cpu = torch.zeros_like(token_ids_cpu, dtype=torch.bool)
+        valid_mask_cpu = torch.zeros(
+            (num_positions, max_num_token_ids + 1),
+            dtype=torch.bool,
+            pin_memory=pin_memory,
+        )
         valid_mask_cpu[:, 0] = True
         for req_idx, token_ids in logprob_token_ids.items():
             start = req_idx * num_positions_per_req


### PR DESCRIPTION
Fixes #42592.

## Summary

This fixes a rejection sampler crash that can happen when `/generative_scoring` requests with `logprob_token_ids` are batched together with speculative decoding requests.

The root cause is that the rejection sampler asks the sampler for bonus logits while `logprob_token_ids` metadata is still attached. In that case, the sampler returns specific-token logprobs shaped like `[batch, num_requested_tokens + 1]` instead of full-vocab logits. The rejection sampler then tries to write those rows into a full-vocab tensor, producing the shape mismatch reported in the issue.

This PR:

- requests full-vocab bonus logits by clearing `logprob_token_ids` only for the bonus-token sampling pass
- gathers the requested `logprob_token_ids` after target and bonus logits have been assembled
- adds a focused regression test for specific-token logprobs with bonus logits
- fixes two DeepSeek-V4/MTP call-path preconditions hit while reproducing the issue with the real DeepSeek-V4-Flash model

## Reproduction and validation

Real-model reproduction used the local DeepSeek-V4-Flash checkout with MTP enabled and `/generative_scoring` requests mixed with chat completions. 

Reproduced before the sampler fix:

- DeepSeek-V4-Flash + MTP + mixed `/v1/chat/completions` and  `/generative_scoring`
- observed:
  `RuntimeError: shape mismatch: value tensor of shape [26, 3] cannot be broadcast to indexing result of shape [26, 129280]`

Verified after the fix:

- DeepSeek-V4-Flash + MTP + 10 concurrent chat requests + 4 scoring requests returned 200 for all requests

## Tests

- `python -m pytest tests/v1/sample/test_rejection_sampler.py::test_specific_logprob_token_ids_with_bonus_logits -q`
  - 1 passed
- `python -m pytest tests/v1/sample/test_rejection_sampler.py -q`
  - 66 passed
- `python -m pytest tests/entrypoints/openai/generative_scoring/test_generative_scoring.py -q`
  - 10 passed

AI assistance was used for investigation, implementation, local reproduction, validation, and PR preparation. The submitting human is responsible for reviewing every changed line and defending the change end to end.
