### PR TITLE
[Build] Use no-guess-dev version scheme to fix version mismatch on release branches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ lora_filesystem_resolver = "vllm.plugins.lora_resolvers.filesystem_resolver:regi
 lora_hf_hub_resolver = "vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_hub_resolver"
 
 [tool.setuptools_scm]
-# no extra settings needed, presence enables setuptools-scm
+version_scheme = "no-guess-dev"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Purpose

If not an intendeted behaviour, this will fix #42932 

## Test Plan

## Test Result

Confirmed locally,

```bash
  guess-next-dev (current): 0.19.1.dev2+g28e80db3a   ←  implies 0.19.1
  no-guess-dev   (fix):     0.19.0.post1.dev2+g28e80db3a   ← stays in 0.19.0 range
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

