### PR TITLE
[bugfix] Add package name to vllm setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1028,6 +1028,7 @@ else:
     }
 
 setup(
+    name="vllm",
     # static metadata should rather go in pyproject.toml
     version=get_vllm_version(),
     ext_modules=ext_modules,


### PR DESCRIPTION



## Purpose

Add the package name `vllm` to `setup.py`.

This ensures the package metadata explicitly declares the project name when invoking `setup()`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

