### PR TITLE
[ROCm][Bugfix][MLA] Fix FP8 KV cache for sparse MLA decode on gfx950 (DSv3.2)

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -944,9 +944,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_range = getattr(self, "k_range", torch.tensor(1.0))
         v_range = getattr(self, "v_range", torch.tensor(1.0))
 
-        self._q_scale.copy_(torch.abs(q).max() / q_range)
-        # kv_c_normed is the compressed KV representation; use it for k/v
-        kv_abs_max = torch.abs(kv_c_normed).max()
+        self._q_scale.copy_(q.abs().amax() / q_range)
+        # concat_and_cache_mla writes both kv_c_normed and k_pe into the
+        # FP8 cache with this _k_scale; k_pe (RoPE, ~[-1,1]) is typically
+        # much larger than kv_c_normed (~[-0.1,0.1] after RMSNorm), so
+        # calibrating on kv_c_normed alone saturates k_pe to ±FP8 max
+        # and destroys positional information.
+        kv_abs_max = torch.maximum(kv_c_normed.abs().amax(), k_pe.abs().amax())
         self._k_scale.copy_(kv_abs_max / k_range)
         self._v_scale.copy_(kv_abs_max / v_range)
         self._q_scale_float = self._q_scale.item()

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -342,6 +342,27 @@ class ROCMAiterMLASparseMetadata(AttentionMetadata):
     reduce_partial_map: torch.Tensor | None = None
 
 
+def _needs_fp8_pad_to_64_for_aiter_native(num_heads: int) -> bool:
+    """Workaround: only ``nhead==32`` is broken on gfx950 + FP8 sparse decode.
+
+    The AITER MLA decode kernel has a native
+    ``q.fp8 + kv.fp8 + max_seqlen_q==1`` path for ``nhead==64`` on gfx950
+    (asm_mla.cu, ``gqa_ratio==64``).  ``nhead==16``/``64`` are also
+    natively supported.  ``nhead==32`` (DSv3.2 TP=4 per-rank) is not:
+    the python wrapper folds it to ``nhead==16`` which lacks a working
+    sparse fp8 kernel on this arch and silently produces empty output.
+
+    Padding ``nhead 32 -> 64`` (Q-head replication; MQA is per-head
+    independent so this is exact) routes to the native ``gqa_ratio==64``
+    kernel.  TODO: remove once AITER ships a native sparse fp8 kernel
+    for ``nhead==32``/``max_seqlen_q==1`` on gfx950.
+    """
+    if not current_platform.is_rocm():
+        return False
+    device_name = getattr(current_platform, "get_device_name", lambda: "")().lower()
+    return "mi35" in device_name and num_heads == 32
+
+
 @dataclass
 class ROCMAiterMLASparseMetadataBuilder(
     AttentionMetadataBuilder[ROCMAiterMLASparseMetadata]
@@ -420,6 +441,15 @@ class ROCMAiterMLASparseMetadataBuilder(
         else:
             kv_cache_dtype_str = "bf16"
         kv_dtype = dtypes.d_dtypes.get(kv_cache_dtype_str, dtypes.bf16)
+
+        # Match what forward_mqa will pass to the kernel when the gfx950
+        # FP8 pad-to-64 workaround triggers; get_mla_metadata_info_v1's
+        # buffer sizes depend on both nhead and q_dtype.
+        if kv_cache_dtype_str == "fp8" and _needs_fp8_pad_to_64_for_aiter_native(
+            self.num_heads
+        ):
+            q_dtype = dtypes.fp8
+            self._num_attention_heads = 64
 
         (
             (work_meta_data_size, work_meta_data_type),
@@ -612,15 +642,24 @@ class ROCMAiterMLASparseImpl(SparseMLAAttentionImpl[ROCMAiterMLASparseMetadata])
         assert indexer is not None
         self.topk_indices_buffer: torch.Tensor | None = indexer.topk_indices_buffer
 
+        # Cached so forward_mqa avoids the device-name lookup per call.
+        # See _needs_fp8_pad_to_64_for_aiter_native.
+        self._fp8_pad_to_64_for_aiter_native = _needs_fp8_pad_to_64_for_aiter_native(
+            self.num_heads
+        )
+
     def _forward_mla(
         self,
         layer: AttentionLayer,
         q: torch.Tensor,  # [sq, heads, d_qk]
         kv_c_and_k_pe_cache: torch.Tensor,  # [blocks, heads, d_qk]
         attn_metadata: ROCMAiterMLASparseMetadata,
+        fp8_pad_factor: int = 1,
     ) -> torch.Tensor:
         num_tokens = q.shape[0]
         mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(self.num_heads)
+        if fp8_pad_factor > 1:
+            mla_num_heads *= fp8_pad_factor
         output = torch.empty(
             [num_tokens, mla_num_heads, self.kv_lora_rank],
             dtype=attn_metadata.attn_out_dtype,
@@ -657,6 +696,12 @@ class ROCMAiterMLASparseImpl(SparseMLAAttentionImpl[ROCMAiterMLASparseMetadata])
             **mla_kwargs,
         )
 
+        if fp8_pad_factor > 1:
+            # Undo the gfx950 FP8 nhead-pad (see forward_mqa); duplicate
+            # heads are identical so every fp8_pad_factor-th row is the
+            # exact original output.  contiguous() because downstream
+            # reshapes (e.g. _v_up_proj) require it.
+            output = output[:, ::fp8_pad_factor, :].contiguous()
         return AiterMLAHelper.get_mla_unpadded_o(self.num_heads, output)
 
     def forward_mqa(
@@ -689,16 +734,32 @@ class ROCMAiterMLASparseImpl(SparseMLAAttentionImpl[ROCMAiterMLASparseMetadata])
             NUM_TOPK_TOKENS=attn_metadata.topk_tokens,
         )
 
-        # write the latent and rope to kv cache
+        # FP8 KV: view uint8 storage as fp8 (kernel applies _k_scale on
+        # read) and pre-quant Q with _q_scale.  On gfx950 nhead=32 also
+        # needs to be padded up to 64 to hit the native fp8 kernel
+        # (see _needs_fp8_pad_to_64_for_aiter_native); MQA-style
+        # attention is per-head independent, so duplicating Q heads
+        # gives an exact result we can subsample after the kernel.
         fp8_attention = self.kv_cache_dtype.startswith("fp8")
+        fold_factor = 1
         if fp8_attention:
+            if kv_c_and_k_pe_cache.dtype != current_platform.fp8_dtype():
+                kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
+                    current_platform.fp8_dtype()
+                )
             original_q_shape = q.shape
-            kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(current_platform.fp8_dtype())
-            q, _ = ops.scaled_fp8_quant(q.view(q.shape[0], -1), layer._q_scale)
-            q = q.view(original_q_shape)
+            q_flat, _ = ops.scaled_fp8_quant(q.view(q.shape[0], -1), layer._q_scale)
+            q = q_flat.view(original_q_shape)
+            if self._fp8_pad_to_64_for_aiter_native:
+                fold_factor = 64 // self.num_heads
+                q = q.repeat_interleave(fold_factor, dim=1)
         mla_padded_q = AiterMLAHelper.get_mla_padded_q(self.num_heads, q)
         attn_out = self._forward_mla(
-            layer, mla_padded_q, kv_c_and_k_pe_cache, attn_metadata
+            layer,
+            mla_padded_q,
+            kv_c_and_k_pe_cache,
+            attn_metadata,
+            fp8_pad_factor=fold_factor,
         )
 
         return attn_out, None


### PR DESCRIPTION
## Summary

Fixes empty / garbage output from the ROCm sparse MLA backend when running DSv3.2 with `--kv-cache-dtype=fp8` on gfx950 (MI35x, TP=4). On this configuration the AITER decode kernel has no working `q.fp8 + kv.fp8 + max_seqlen_q == 1` path for `nhead == 32`; the python wrapper's simulation that folds `nhead == 32 → 16` returns empty output, and the `fp8_attention` block added in #41217 silently routed into it. Pad Q's heads `32 → 64` so the kernel takes its native `gqa_ratio == 64` path, then strip the duplicate output rows. MQA-style attention is per-head independent so this is exact.

Also fixes a related FP8 K-scale calibration bug in `MLAAttention.calc_kv_scales` that affected MLA paths when `--calculate-kv-scales` was set: `_k_scale` was derived from `|kv_c_normed|.max()` only, but `concat_and_cache_mla` writes both `kv_c_normed` and `k_pe` into the FP8 cache with the same scale. `k_pe` (RoPE) lies in roughly `[-1, 1]` while `kv_c_normed` is `< 0.1` after RMSNorm, so the old calibration saturated `k_pe` to ±FP8 max. Take `max(|kv_c_normed|, |k_pe|)` instead.

## Validation

Hardware: 4 × MI355X (gfx950), TP=4, image `amdsiloai/vllm-private:nightly_SHA0fa8884_42532_42838_42864_39177_41675_aiterv0.1.14-rc0_aiterPR3075`, DSv3.2, sparse MLA backend (`ROCM_AITER_MLA_SPARSE`), v1 engine, `--max-model-len 4096`.

`lm_eval --tasks gsm8k --num_fewshot 5`, full 1319 samples, two runs each:

| Config | flexible-extract | strict-match |
|---|---|---|
| bf16 KV (baseline) — run 1 / 2 | 0.8415 / 0.8453 | 0.8453 / 0.8506 |
| **fp8 KV with this PR + `--calculate-kv-scales`** — run 1 / 2 | **0.9507 / 0.9500** | **0.9515 / 0.9507** |

Without this PR, FP8 KV produces empty / garbage output and is unusable. With this PR, FP8 KV is functional and reaches ~95% on GSM8K — actually higher than the bf16 baseline on this image, because the bf16 sparse path also routes through the same broken `nhead == 32 → 16` simulation that we're bypassing. Fixing bf16 sparse separately is out of scope here.

`vllm bench serve` random workload, ignore-eos:

| Config | mc=8 in=1000 out=100, out tok/s | mc=32 in=2000 out=1000, out tok/s |
|---|---|---|
| bf16 KV (baseline) | 318.12 | 810.32 |
| fp8 KV with this PR | 301.80 (-5%) | 779.56 (-4%) |

The ~4% drop comes from the pad-to-64 doubling per-step attention compute. At this workload the decode step is dominated by MoE expert loads, not KV reads, so FP8's halved KV bandwidth doesn't pay off here. The actual production benefit of FP8 KV is the half-size cache in HBM (more concurrent requests / longer context fit at the same memory budget); a future native AITER `nhead == 32 + max_seqlen_q == 1 + fp8` kernel on gfx950 (or wiring up a `nhead == 16 × 2` split using the existing native `nhead == 16` path) would eliminate the 2× compute waste and let FP8 KV beat bf16 KV on raw throughput too. Tracked as the `TODO` in `_needs_fp8_pad_to_64_for_aiter_native`.

## Scope and risk

- ROCm sparse MLA backend file `vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py` and `vllm/model_executor/layers/attention/mla_attention.py`.
- Pad-to-64 path is gated to `current_platform.is_rocm() AND device_name contains "mi35" AND num_heads == 32`; all other configurations follow exactly the same code path as before.
- The `_k_scale` calibration change only activates with `--calculate-kv-scales`; default behavior is unchanged.
- Not tested on MI300X (gfx942) FP8 KV with sparse MLA — that path stays unchanged.

Made with [Cursor](https://cursor.com)
