### PR TITLE
[Bugfix] Reject non-object JSON bodies with HTTP 400

### DIFF
--- a/tests/entrypoints/serve/utils/test_validate_json_request.py
+++ b/tests/entrypoints/serve/utils/test_validate_json_request.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the ``validate_json_request`` FastAPI dependency.
+
+These tests cover the body-type guard that rejects non-object JSON payloads
+(e.g. ``[]``, ``true``, ``null``, ``123``) with HTTP 400 before they reach
+pydantic model_validators that assume the input is a dict.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.exceptions import RequestValidationError
+
+from vllm.entrypoints.serve.utils.api_utils import validate_json_request
+
+
+def _make_request(body, content_type: str = "application/json"):
+    request = MagicMock()
+    request.headers = {"content-type": content_type}
+    if isinstance(body, BaseException):
+        request.json = AsyncMock(side_effect=body)
+    else:
+        request.json = AsyncMock(return_value=body)
+    return request
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body, type_name",
+    [
+        ([], "list"),
+        ([1, 2, 3], "list"),
+        (True, "bool"),
+        (False, "bool"),
+        (None, "NoneType"),
+        (123, "int"),
+        (1.5, "float"),
+        ("abc", "str"),
+    ],
+)
+async def test_non_object_body_rejected(body, type_name):
+    request = _make_request(body)
+    with pytest.raises(RequestValidationError) as exc_info:
+        await validate_json_request(request)
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert f"got {type_name}" in errors[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{}, {"model": "x", "messages": []}])
+async def test_object_body_accepted(body):
+    # Empty dict and well-formed dict bodies must pass — downstream
+    # pydantic validation is responsible for field-level checks.
+    request = _make_request(body)
+    await validate_json_request(request)
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_passes_through():
+    # JSON parse errors are intentionally not handled here; the existing
+    # FastAPI/Pydantic path surfaces them as ``RequestValidationError``
+    # with ``type='json_invalid'``. The dependency must not double-raise.
+    request = _make_request(json.JSONDecodeError("Expecting value", "", 0))
+    await validate_json_request(request)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content_type",
+    ["text/plain", "application/xml", "", "multipart/form-data"],
+)
+async def test_non_json_content_type_rejected(content_type):
+    request = _make_request({}, content_type=content_type)
+    with pytest.raises(RequestValidationError) as exc_info:
+        await validate_json_request(request)
+    errors = exc_info.value.errors()
+    assert "Unsupported Media Type" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_json_content_type_with_charset_accepted():
+    # ``application/json; charset=utf-8`` is the common form sent by many
+    # HTTP clients and must be treated as JSON.
+    request = _make_request({}, content_type="application/json; charset=utf-8")
+    await validate_json_request(request)

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -4,6 +4,7 @@
 import asyncio
 import dataclasses
 import functools
+import json
 import os
 from argparse import Namespace
 from logging import Logger
@@ -345,4 +346,15 @@ async def validate_json_request(raw_request: Request):
     if media_type != "application/json":
         raise RequestValidationError(
             errors=["Unsupported Media Type: Only 'application/json' is allowed"]
+        )
+
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError:
+        # Let FastAPI/Pydantic surface JSON parse errors through the normal path.
+        return
+
+    if not isinstance(body, dict):
+        raise RequestValidationError(
+            errors=[f"Request body must be a JSON object, got {type(body).__name__}"]
         )


### PR DESCRIPTION
## Purpose

Sending a JSON body that is not an object (e.g. `[]`, `true`, `null`, `123`, `\"str\"`) to OpenAI-compatible endpoints such as `/v1/chat/completions` currently passes the Content-Type-only check in `validate_json_request` and can crash deeper in the request pipeline with:

```
AttributeError: '<type>' object has no attribute 'get'
```

The generic exception handler then maps that to **HTTP 500 Internal Server Error**, even though the cause is a malformed client request that should be **HTTP 400 Bad Request**.

This PR adds a body-type guard in the `validate_json_request` dependency so that any non-object JSON body is rejected with a clear `RequestValidationError` → HTTP 400 **before** reaching pydantic model_validators. JSON parse errors continue to flow through the existing FastAPI/Pydantic path unchanged.

The fix applies to every endpoint that uses `validate_json_request` (chat completions, completions, embeddings, classify, score, rerank, pooling, Anthropic `/v1/messages`, internal RPC endpoints, etc.), all of which expect JSON object bodies per their OpenAI / Anthropic schemas.

## Test Plan

New unit tests in `tests/entrypoints/openai/test_validate_json_request.py` cover:

- Non-object JSON bodies (`[]`, `[1,2,3]`, `True`, `False`, `None`, `123`, `1.5`, `\"abc\"`) → `RequestValidationError` with descriptive \"got <type>\" message.
- Valid object bodies (`{}`, `{\"model\":\"x\",\"messages\":[]}`) → no exception (downstream pydantic handles field-level validation).
- `JSONDecodeError` from `request.json()` → passes through unchanged so FastAPI/Pydantic's existing \"json_invalid\" 400 path is preserved.
- Non-JSON `Content-Type` (text/plain, application/xml, empty, multipart) → existing \"Unsupported Media Type\" path still raised.
- `application/json; charset=utf-8` → accepted (matches existing behavior).

Run:

```bash
pytest tests/entrypoints/openai/test_validate_json_request.py -v
```

## Test Result

The fix was additionally validated outside the test suite using a minimal FastAPI reproducer that mirrors vLLM's `validate_json_request` + `validation_exception_handler` + generic `exception_handler` chain. Comparing pre-fix vs. post-fix behavior for the same payloads:

| Body | Before fix | After fix |
|------|-----------|-----------|
| `[]` | **500** `'list' object has no attribute 'get'` | **400** `Request body must be a JSON object, got list` |
| `true` | **500** `'bool' object has no attribute 'get'` | **400** `... got bool` |
| `123` | **500** `'int' object has no attribute 'get'` | **400** `... got int` |
| `null` | 400 (already handled by Pydantic field-required) | 400 (handled by guard) |
| `{}` (missing fields) | 400 (Pydantic) | 400 (Pydantic) — no regression |
| valid object | 200 | 200 — no regression |

## AI Assistance Disclosure

This change was developed with AI assistance (Claude Opus 4.7). The human submitter reviewed every changed line, validated behavior end-to-end with the minimal FastAPI reproducer described above, and confirmed pre-commit / ruff / typos / mypy all pass on the modified files. Attribution is included as a `Co-authored-by: Claude` commit trailer per the vLLM CONTRIBUTING guide.