### PR TITLE
[Bugfix] Fix duplicate Qwen3 XML function close recovery

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -8,8 +8,8 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
-
 from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
+
 
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
@@ -73,16 +73,16 @@ class TestQwen3xmlToolParser(ToolParserTests):
         )
 
     def test_function_name_is_cleared_after_function_end(self):
-          parser = StreamingXMLToolCallParser()
-          parser._start_element("tool_call", {})
-          parser._start_element("function", {"name": "search"})
-          parser._start_element("parameter", {"name": "query"})
-          parser._char_data("manager")
-          parser._end_element("parameter")
-          parser._end_element("function")
+        parser = StreamingXMLToolCallParser()
+        parser._start_element("tool_call", {})
+        parser._start_element("function", {"name": "search"})
+        parser._start_element("parameter", {"name": "query"})
+        parser._char_data("manager")
+        parser._end_element("parameter")
+        parser._end_element("function")
 
-          delta_count = len(parser.deltas)
-          parser._auto_close_open_parameter_if_needed("tool_call")
+        delta_count = len(parser.deltas)
+        parser._auto_close_open_parameter_if_needed("tool_call")
 
-          assert parser.current_function_name is None
-          assert len(parser.deltas) == delta_count
+        assert parser.current_function_name is None
+        assert len(parser.deltas) == delta_count

--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -9,6 +9,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTests,
 )
 
+from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
 
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
@@ -70,3 +71,18 @@ class TestQwen3xmlToolParser(ToolParserTests):
             },
             supports_typed_arguments=False,
         )
+
+    def test_function_name_is_cleared_after_function_end(self):
+          parser = StreamingXMLToolCallParser()
+          parser._start_element("tool_call", {})
+          parser._start_element("function", {"name": "search"})
+          parser._start_element("parameter", {"name": "query"})
+          parser._char_data("manager")
+          parser._end_element("parameter")
+          parser._end_element("function")
+
+          delta_count = len(parser.deltas)
+          parser._auto_close_open_parameter_if_needed("tool_call")
+
+          assert parser.current_function_name is None
+          assert len(parser.deltas) == delta_count

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -925,6 +925,7 @@ class StreamingXMLToolCallParser:
                 )
                 self._emit_delta(delta)
             self.current_function_open = False
+            self.current_function_name = None
 
         elif name == "tool_call":
             # Before ending tool_call,


### PR DESCRIPTION
## Summary

Clear `current_function_name` when the Qwen3 XML streaming tool parser closes a `<function>` element.

The parser already sets `current_function_open = False` after emitting the closing JSON object for a function, but it leaves `current_function_name` populated. Some fallback recovery paths use `current_function_name` as evidence that a function is still active and can call `_end_element("function")` again after a normal function close. In streaming tool-call output this can emit a duplicate closing brace in arguments, for example:

```json
{"query": "manager"}}
```

## Changes

- Clear current_function_name when handling a function end element.
- Add a regression test that closes a function normally, invokes auto-close recovery, and verifies no additional delta is emitted.

## Testing

pytest tests/tool_parsers/test_qwen3xml_tool_parser.py

## Documentation

No documentation update is needed. This is an internal parser state fix and does not change user-facing APIs.

## AI Assistance Disclosure

This PR description and the initial patch were prepared with AI assistance and reviewed by the author.