### PR TITLE
[Bugfix][DeepSeek V4] Resolve expert_dtype for FP8 checkpoints missing the field

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -75,6 +75,50 @@ from .utils import (
 
 _DEEPSEEK_V4_EXPERT_DTYPES = ("fp4", "fp8")
 
+# Map ``quantization_config.quant_method`` values that may be observed in the
+# wild to the DeepSeek V4 expert layout they imply. Used as a secondary signal
+# when ``hf_config.expert_dtype`` is missing (some FP8 checkpoints, including
+# DeepSeek-V4-Flash-Base-FP8, ship without it).
+_QUANT_METHOD_TO_EXPERT_DTYPE = {
+    "fp8": "fp8",
+    "deepseek_v4_fp8": "fp8",
+    "mxfp4": "fp4",
+    "fp4": "fp4",
+    "nvfp4": "fp4",
+}
+
+
+def _resolve_deepseek_v4_expert_dtype(hf_config) -> str:
+    """Return the DeepSeek V4 expert layout, inferring it when needed.
+
+    Resolution order:
+
+      1. Honor ``hf_config.expert_dtype`` if present (authoritative).
+      2. Otherwise, peek at ``hf_config.quantization_config.quant_method``
+         and map it via ``_QUANT_METHOD_TO_EXPERT_DTYPE`` so an FP8
+         checkpoint without an explicit ``expert_dtype`` field still
+         picks the FP8 expert dispatch instead of falling through to the
+         MXFP4 path.
+      3. Fall back to ``"fp4"`` (matches upstream's historical default
+         for legacy DSv4 checkpoints).
+    """
+    explicit = getattr(hf_config, "expert_dtype", None)
+    if explicit is not None:
+        return explicit
+
+    qcfg = getattr(hf_config, "quantization_config", None)
+    if qcfg is not None:
+        if isinstance(qcfg, dict):
+            quant_method = qcfg.get("quant_method")
+        else:
+            quant_method = getattr(qcfg, "quant_method", None)
+        if quant_method is not None:
+            inferred = _QUANT_METHOD_TO_EXPERT_DTYPE.get(quant_method)
+            if inferred is not None:
+                return inferred
+
+    return "fp4"
+
 
 class DeepseekV4MLP(nn.Module):
     def __init__(
@@ -162,7 +206,7 @@ class DeepseekV4FP8Config(Fp8Config):
                 # vllm_config not yet set; defer the decision until a
                 # later call lands inside set_current_vllm_config.
                 return "fp4"
-            expert_dtype = getattr(hf_config, "expert_dtype", "fp4")
+            expert_dtype = _resolve_deepseek_v4_expert_dtype(hf_config)
             if expert_dtype not in _DEEPSEEK_V4_EXPERT_DTYPES:
                 raise ValueError(
                     f"Unsupported DeepSeek V4 expert_dtype={expert_dtype!r}; "
@@ -748,12 +792,15 @@ class DeepseekV4MoE(nn.Module):
             raise NotImplementedError(
                 "DeepSeek V4 MegaMoE currently supports sqrtsoftplus routing only."
             )
-        if self.use_mega_moe and getattr(config, "expert_dtype", "fp4") != "fp4":
-            raise NotImplementedError(
-                "DeepSeek V4 MegaMoE only supports fp4 experts; got expert_dtype="
-                f"{config.expert_dtype!r}. Drop --kernel-config moe_backend="
-                "deep_gemm_mega_moe for this checkpoint."
-            )
+        if self.use_mega_moe:
+            resolved_expert_dtype = _resolve_deepseek_v4_expert_dtype(config)
+            if resolved_expert_dtype != "fp4":
+                raise NotImplementedError(
+                    "DeepSeek V4 MegaMoE only supports fp4 experts; got "
+                    f"expert_dtype={resolved_expert_dtype!r}. Drop "
+                    "--kernel-config moe_backend=deep_gemm_mega_moe for this "
+                    "checkpoint."
+                )
 
         self.gate = GateLinear(
             config.hidden_size,
@@ -1650,7 +1697,7 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
 
         config = vllm_config.model_config.hf_config
         self.config = config
-        expert_dtype = getattr(config, "expert_dtype", "fp4")
+        expert_dtype = _resolve_deepseek_v4_expert_dtype(config)
         if expert_dtype != "fp4":
             self.hf_to_vllm_mapper = _make_deepseek_v4_weights_mapper(expert_dtype)
 


### PR DESCRIPTION


## Purpose

## Summary

DeepSeek V4 routes experts through one of two dispatch paths (`fp4` / `fp8`) based on `hf_config.expert_dtype`. The DeepSeek-V4-Flash-Base-FP8 checkpoint (and other in-the-wild FP8 conversions) does **not** set `expert_dtype` in its HF config — only `quantization_config.quant_method = "fp8"`.

Before this change, every call site did:

```python
expert_dtype = getattr(hf_config, "expert_dtype", "fp4")
```

so an FP8 base model silently fell through to the FP4/MXFP4 expert dispatch, producing either a hard load failure or numerically broken outputs depending on the kernel path.

This PR adds a single resolver — `_resolve_deepseek_v4_expert_dtype()` — that:

1. Honors `hf_config.expert_dtype` if present (unchanged authoritative behavior).
2. Otherwise infers it from `quantization_config.quant_method` via a small mapping (`fp8`, `deepseek_v4_fp8` → `fp8`; `fp4`, `nvfp4`, `mxfp4` → `fp4`). Works whether `quantization_config` is a dict or an object.
3. Falls back to `"fp4"` to preserve the historical default for legacy DSv4 checkpoints.

All three call sites in `vllm/model_executor/models/deepseek_v4.py` are routed through the new helper:

- `DeepseekV4FP8Config._select_expert_dtype` — drives the FP8 quant config selection.
- `DeepseekV4MoE.__init__` — MegaMoE FP4-only guard now reports the resolved dtype in its error message.
- `DeepseekV4ForCausalLM.__init__` — drives whether `_make_deepseek_v4_weights_mapper` is wired up for non-FP4 layouts.

## Why a resolver instead of patching the HF config

- Keeps the inference local to the model file; no monkey-patching of `hf_config`.
- Centralizes the policy so future expert layouts only need a single map update.
- Leaves the explicit `expert_dtype` field as the source of truth when checkpoints provide it.

## Files changed

- `vllm/model_executor/models/deepseek_v4.py` (+55 / −8)
