### PR TITLE
Fix DFlash prefix cache corruption due to missing lookahead block

### DIFF
--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -132,19 +132,23 @@ def test_dflash_first_prefill_query_window_fits_allocated_blocks():
 
 
 def test_dflash_drafter_window_reserves_bonus_token():
-    # DFlash's drafter window is num_spec + 1 with the extra slot as bonus token
+    # DFlash's drafter window is num_spec + 1 (the extra slot is the bonus token),
+    # so max_seq_len + num_spec + 1 must stay within the draft model's max len.
+    input_fits_in_drafter = GPUModelRunner._input_fits_in_drafter
     dflash_runner = SimpleNamespace(
         num_spec_tokens=NUM_SPECULATIVE_TOKENS,
         effective_drafter_max_model_len=100,
         speculative_config=_dflash_speculative_config(NUM_SPECULATIVE_TOKENS),
     )
-    assert GPUModelRunner._input_fits_in_drafter(dflash_runner, 96)  # 96 + 4 == 100
-    assert not GPUModelRunner._input_fits_in_drafter(dflash_runner, 97)  # 97 + 4 > 100
+    # window = 4, so 96 fits (96 + 4 == 100) but 97 does not (97 + 4 == 101)
+    assert input_fits_in_drafter(dflash_runner, SimpleNamespace(max_seq_len=96))
+    assert not input_fits_in_drafter(dflash_runner, SimpleNamespace(max_seq_len=97))
+    assert not input_fits_in_drafter(dflash_runner, None)  # no metadata
 
-    # Other drafters don't reserve the bonus token, so 97 still fits
+    # Other drafters don't reserve the bonus token, so 97 fits (97 + 3 == 100).
     plain_runner = SimpleNamespace(
         num_spec_tokens=NUM_SPECULATIVE_TOKENS,
         effective_drafter_max_model_len=100,
         speculative_config=SimpleNamespace(use_dflash=lambda: False),
     )
-    assert GPUModelRunner._input_fits_in_drafter(plain_runner, 97)  # 97 + 3 == 100
+    assert input_fits_in_drafter(plain_runner, SimpleNamespace(max_seq_len=97))

--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from tests.v1.core.utils import create_requests
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
+    VllmConfig,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+# Matches defaults from tests/v1/spec_decode/test_eagle.py
+DFLASH_TARGET_DIR = "Qwen/Qwen3-8B"
+DFLASH_DRAFT_DIR = "z-lab/Qwen3-8B-DFlash-b16"
+
+BLOCK_SIZE = 16
+NUM_BLOCKS = 8
+NUM_SPECULATIVE_TOKENS = 3
+
+
+def _dflash_speculative_config(num_speculative_tokens: int) -> SpeculativeConfig:
+    model_config = ModelConfig(
+        model=DFLASH_TARGET_DIR,
+        runner="generate",
+        max_model_len=100,
+        trust_remote_code=True,
+    )
+    return SpeculativeConfig(
+        target_model_config=model_config,
+        target_parallel_config=ParallelConfig(),
+        model=DFLASH_DRAFT_DIR,
+        method="dflash",
+        num_speculative_tokens=num_speculative_tokens,
+    )
+
+
+def _create_dflash_scheduler(num_speculative_tokens: int) -> Scheduler:
+    speculative_config = _dflash_speculative_config(num_speculative_tokens)
+    model_config = speculative_config.target_model_config
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=16,
+        max_num_batched_tokens=8192,
+        max_model_len=model_config.max_model_len,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    cache_config = CacheConfig(
+        block_size=BLOCK_SIZE,
+        gpu_memory_utilization=0.9,
+        cache_dtype="auto",
+        enable_prefix_caching=False,
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=scheduler_config,
+        model_config=model_config,
+        cache_config=cache_config,
+        parallel_config=ParallelConfig(),
+        speculative_config=speculative_config,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=NUM_BLOCKS,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=BLOCK_SIZE,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            )
+        ],
+    )
+    cache_config.num_gpu_blocks = NUM_BLOCKS
+    return Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        block_size=BLOCK_SIZE,
+        log_stats=True,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+    )
+
+
+def test_dflash_prefill_reserves_lookahead_blocks():
+    scheduler = _create_dflash_scheduler(NUM_SPECULATIVE_TOKENS)
+
+    assert scheduler.num_lookahead_tokens == NUM_SPECULATIVE_TOKENS + 1
+
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=BLOCK_SIZE,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == BLOCK_SIZE
+    # prefill block + one lookahead block
+    assert len(output.scheduled_new_reqs[0].block_ids[0]) == 2
+
+
+def test_dflash_first_prefill_query_window_fits_allocated_blocks():
+    scheduler = _create_dflash_scheduler(NUM_SPECULATIVE_TOKENS)
+
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=BLOCK_SIZE,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    block_ids = output.scheduled_new_reqs[0].block_ids[0]
+    query_positions = range(BLOCK_SIZE, BLOCK_SIZE + scheduler.num_lookahead_tokens)
+
+    assert all(pos // BLOCK_SIZE < len(block_ids) for pos in query_positions)
+
+
+def test_dflash_drafter_window_reserves_bonus_token():
+    # DFlash's drafter window is num_spec + 1 with the extra slot as bonus token
+    dflash_runner = SimpleNamespace(
+        num_spec_tokens=NUM_SPECULATIVE_TOKENS,
+        effective_drafter_max_model_len=100,
+        speculative_config=_dflash_speculative_config(NUM_SPECULATIVE_TOKENS),
+    )
+    assert GPUModelRunner._input_fits_in_drafter(dflash_runner, 96)  # 96 + 4 == 100
+    assert not GPUModelRunner._input_fits_in_drafter(dflash_runner, 97)  # 97 + 4 > 100
+
+    # Other drafters don't reserve the bonus token, so 97 still fits
+    plain_runner = SimpleNamespace(
+        num_spec_tokens=NUM_SPECULATIVE_TOKENS,
+        effective_drafter_max_model_len=100,
+        speculative_config=SimpleNamespace(use_dflash=lambda: False),
+    )
+    assert GPUModelRunner._input_fits_in_drafter(plain_runner, 97)  # 97 + 3 == 100

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4362,6 +4362,17 @@ class GPUModelRunner(
 
         return None
 
+    def _input_fits_in_drafter(self, max_seq_len: int) -> bool:
+        assert self.speculative_config is not None
+        # DFlash queries one extra token (the bonus token) beyond num_spec_tokens
+        num_drafter_query_tokens = self.num_spec_tokens + (
+            1 if self.speculative_config.use_dflash() else 0
+        )
+        return (
+            max_seq_len + num_drafter_query_tokens
+            <= self.effective_drafter_max_model_len
+        )
+
     @torch.inference_mode
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
@@ -4441,9 +4452,11 @@ class GPUModelRunner(
         propose_drafts_after_bookkeeping = False
         if spec_config is not None:
             # Decide whether to run the drafter or zero out draft tokens.
-            input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
-                spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
-                <= self.effective_drafter_max_model_len
+            input_fits_in_drafter = (
+                spec_decode_common_attn_metadata is not None
+                and self._input_fits_in_drafter(
+                    spec_decode_common_attn_metadata.max_seq_len
+                )
             )
             use_gpu_toks = (
                 spec_config.use_eagle()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4362,14 +4362,18 @@ class GPUModelRunner(
 
         return None
 
-    def _input_fits_in_drafter(self, max_seq_len: int) -> bool:
+    def _input_fits_in_drafter(
+        self, common_attn_metadata: CommonAttentionMetadata | None
+    ) -> bool:
+        if common_attn_metadata is None:
+            return False
         assert self.speculative_config is not None
         # DFlash queries one extra token (the bonus token) beyond num_spec_tokens
         num_drafter_query_tokens = self.num_spec_tokens + (
             1 if self.speculative_config.use_dflash() else 0
         )
         return (
-            max_seq_len + num_drafter_query_tokens
+            common_attn_metadata.max_seq_len + num_drafter_query_tokens
             <= self.effective_drafter_max_model_len
         )
 
@@ -4452,11 +4456,8 @@ class GPUModelRunner(
         propose_drafts_after_bookkeeping = False
         if spec_config is not None:
             # Decide whether to run the drafter or zero out draft tokens.
-            input_fits_in_drafter = (
-                spec_decode_common_attn_metadata is not None
-                and self._input_fits_in_drafter(
-                    spec_decode_common_attn_metadata.max_seq_len
-                )
+            input_fits_in_drafter = self._input_fits_in_drafter(
+                spec_decode_common_attn_metadata
             )
             use_gpu_toks = (
                 spec_config.use_eagle()


### PR DESCRIPTION
## Summary

Fixes a KV cache corruption bug in DFlash that causes persistent MGL degradation under prefix caching with concurrency.

## How we found this

While trying out DFlash, under high concurrency with prefix caching enabled, we observed MGL degradation on requests that were otherwise running correctly. Their KV cache was being corrupted by other newly-arriving prefix-hit requests. We saw a steady decrease in MGL. Specifically, those new request's first DFlash drafter pass was writing KV into shared prefix blocks because their slot mapping was never set up (no lookahead blocks were allocated for them). We didn't see this degradation in sglang under the same workload, which confirmed this was a vllm-specific bug. Once we traced the corruption back to the missing block allocation on first prefill, the fix was straightforward.

## Root cause

The target prefill and the first drafter pass run in the same scheduler step for both Eagle and DFlash. The DFlash drafter issues `num_spec_tokens + 1` query tokens (1 bonus token + N mask tokens) at positions beyond the prefill.

These positions require allocated KV blocks because DFlash draft attention is bidirectional and the drafter writes KV at future positions via block table lookup. If the block table doesn't cover those positions, the drafter writes into the wrong block.

The scheduler had this logic when allocating blocks for a new request:

```python
effective_lookahead_tokens = (
    0 if request.num_computed_tokens == 0 else self.num_lookahead_tokens
)
```

From the comment it looks like this was added as a P/D disaggregation edge case guard to avoid allocating extra blocks for brand-new requests. However, `request.num_computed_tokens` is still 0 at the point where `allocate_slots` is called for a new request's first scheduling pass (it's only updated after allocation succeeds, at a later line). This means zero lookahead blocks are allocated at prefill time, yet the DFlash drafter immediately needs to write KV beyond the allocated range.

When the correct blocks don't exist, the drafter ends up writing KV into the last prefill block instead...which with prefix caching is shared across requests. It silently overwrites valid prefill KV data in that block.

**Without prefix caching:** The corrupted last block belongs only to the current request. In the next scheduling step, `request.num_computed_tokens > 0`, so lookahead blocks are allocated correctly. The drafter has one bad step...and then recovers. This is likely why MGL impact was negligible without prefix caching and we still saw good speedups with DFlash.

**With prefix caching under concurrency:** Multiple requests share the same prefix blocks. When a new request's drafter writes KV into the wrong block, it corrupts a shared prefix block. All other requests using that prefix...including ones that were running fine...now read corrupted KV. This is what we observed: MGL degradation on healthy requests, caused by new arrivals corrupting their shared prefix cache. Kind of only impacts MGL in a special case where the unalloted KV blocks are overwritten very fast due to high prefix-hit and conurrency.

## Changes

~~### 1. Scheduler (`vllm/v1/core/sched/scheduler.py`)~~

~~- Added `self.use_dflash` flag, initialized from `speculative_config.use_dflash()`.~~
~~- Set `self.num_lookahead_tokens = self.num_spec_tokens + 1` for DFlash (the +1 is for the bonus token position).~~
~~- When DFlash is active, unconditionally allocate lookahead blocks regardless of `request.num_computed_tokens`:~~

```python
if self.use_dflash:
    effective_lookahead_tokens = self.num_lookahead_tokens
else:
    effective_lookahead_tokens = (
        0 if request.num_computed_tokens == 0
        else self.num_lookahead_tokens
    )
```

EDIT: The scheduler fix (reserving `num_spec_tokens + 1` lookahead slots for DFlash on first prefill, and narrowing the `num_computed_tokens == 0` guard) landed separately in [#43733](https://github.com/vllm-project/vllm/pull/43733). This PR is rebased on top of it and no longer touches the scheduler.

### 2. GPU Model Runner (`vllm/v1/worker/gpu_model_runner.py`)

Fixed the drafter input-fit check. The existing code used `max_seq_len + self.num_spec_tokens` to decide if a sequence fits within the drafter's max model length. For DFlash, the drafter actually queries `num_spec_tokens + 1` positions (bonus + masks), so sequences could be incorrectly admitted:

```python
num_drafter_query_tokens = self.num_spec_tokens + (
    1 if spec_config.use_dflash() else 0
)
```

## Test plan

- Added `tests/v1/spec_decode/test_dflash_lookahead.py` with three unit tests:

## Test Result

```bash
.venv/bin/python -m pytest tests/v1/spec_decode/test_dflash_lookahead.py -v
=================================================================================================== test session starts ===================================================================================================

tests/v1/spec_decode/test_dflash_lookahead.py::test_dflash_prefill_reserves_lookahead_blocks PASSED                                                                                                                 [ 33%]
tests/v1/spec_decode/test_dflash_lookahead.py::test_dflash_first_prefill_query_window_fits_allocated_blocks PASSED                                                                                                  [ 66%]
tests/v1/spec_decode/test_dflash_lookahead.py::test_dflash_drafter_window_reserves_bonus_token PASSED                                                                                                               [100%]

```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

