### PR TITLE
Revert "[Perf] Wire silu_and_mul_per_block_quant into TritonFP8MoE (MiniMax-M2)" (#42497)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -31,9 +31,6 @@ from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache,
     moe_kernel_quantize_input,
 )
-from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    is_deep_gemm_e8m0_used,
-)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8Dynamic128Sym,
@@ -286,36 +283,20 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
                 top_k_num=top_k_num,
             )
 
+        self.activation(
+            activation, intermediate_cache2, intermediate_cache1.view(-1, N)
+        )
+
         a2q_scale: torch.Tensor | None = None
 
-        # Fuse SiLU+Mul + FP8 block quantize into a single kernel
-        # when conditions permit (gated SiLU, fp8 block quant with
-        # group_size=128, no LoRA requiring the BF16 intermediate).
-        if (
-            activation == MoEActivation.SILU
-            and self.quant_config.use_fp8_w8a8
-            and self.block_shape == [128, 128]
-            and lora_context is None
-            and not is_deep_gemm_e8m0_used()
-        ):
-            qintermediate_cache2, a2q_scale = ops.silu_and_mul_per_block_quant(
-                intermediate_cache1.view(-1, N),
-                group_size=128,
-                quant_dtype=current_platform.fp8_dtype(),
-            )
-        else:
-            self.activation(
-                activation, intermediate_cache2, intermediate_cache1.view(-1, N)
-            )
-
-            qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
-                intermediate_cache2,
-                a2_scale,
-                self.quant_dtype,
-                self.per_act_token_quant,
-                self.block_shape,
-                quantization_emulation=self.quantization_emulation,
-            )
+        qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
+            intermediate_cache2,
+            a2_scale,
+            self.quant_dtype,
+            self.per_act_token_quant,
+            self.block_shape,
+            quantization_emulation=self.quantization_emulation,
+        )
 
         invoke_fused_moe_triton_kernel(
             qintermediate_cache2,


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/42497

**Reason:** This PR is linked to 1 new CI failure in [build #66633](https://buildkite.com/vllm/ci/builds/66633):
- `MoE Refactor Integration Test (B200 - TEMPORARY)` — GSM8K accuracy regression (0.207 < 0.210 threshold) in `test_gsm8k_correctness[Nemotron-Nano-30B-Fp8-ModelOpt-fi-trtllm]`

The PR changed `vllm/model_executor/layers/fused_moe/experts/triton_moe.py` (wiring `silu_and_mul_per_block_quant` into TritonFP8MoE), which directly affects the MoE integration test.

---
*Auto-generated by CI failure analyzer.*