### PR TITLE
[Kernel] Replace union type-punning UB with std::bit_cast in sampler

### DIFF
--- a/csrc/sampler.cu
+++ b/csrc/sampler.cu
@@ -3,6 +3,8 @@
 
 #include <torch/cuda.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <array>
+#include <bit>
 
 #ifndef USE_ROCM
   #include <cub/cub.cuh>
@@ -109,11 +111,6 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads,
   } else {
     static_assert(sizeof(WideT) % sizeof(T) == 0);
     constexpr int items_per_scalar = sizeof(WideT) / sizeof(T);
-    // TODO: it's UB
-    union {
-      WideT scalar;
-      T array[items_per_scalar];
-    } wide;
 
     int skip_cnt =
         (reinterpret_cast<size_t>(in) % sizeof(WideT))
@@ -127,11 +124,11 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads,
     const idxT len_cast = (len - skip_cnt) / items_per_scalar;
 
     for (idxT i = thread_rank; i < len_cast; i += num_threads) {
-      wide.scalar = in_cast[i];
+      auto items = std::bit_cast<std::array<T, items_per_scalar>>(in_cast[i]);
       const idxT real_i = skip_cnt + i * items_per_scalar;
 #pragma unroll
       for (int j = 0; j < items_per_scalar; ++j) {
-        f(wide.array[j], real_i + j);
+        f(items[j], real_i + j);
       }
     }
 


### PR DESCRIPTION
## Purpose
The vectorized_process helper used union type-punning to reinterpret a float4 wide load as individual elements, which is undefined behavior in C++. Replace with std::bit_cast (C++20) for well-defined semantics and identical codegen.
## Test Plan
Build vllm and run sampler tests
## Test Result
```
(vllm) root@openshiftai-vllm:~/vllm# .venv/bin/python -m pytest tests/v1/sample/test_sampler.py -v
======================================================= test session starts =======================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /root/vllm/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /root/vllm
configfile: pyproject.toml
plugins: rerunfailures-16.2, forked-1.6.0, mock-3.15.1, cov-7.1.0, hypothesis-6.152.7, schemathesis-4.18.5, anyio-4.13.0, shard-0.1.2, timeout-2.4.0, asyncio-1.3.0, buildkite-test-collector-0.1.9, typeguard-4.5.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 72 items                                                                                                                
Running 72 items in this shard: tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-32-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-1-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-1-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-2-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-2-cuda:1], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-32-cuda:0], tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-32-cuda:1]

tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-1-cuda:0] PASSED                                        [  1%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-1-cuda:1] PASSED                                        [  2%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-2-cuda:0] PASSED                                        [  4%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-2-cuda:1] PASSED                                        [  5%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-32-cuda:0] PASSED                                       [  6%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[-2.0-32-cuda:1] PASSED                                       [  8%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-1-cuda:0] PASSED                                         [  9%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-1-cuda:1] PASSED                                         [ 11%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-2-cuda:0] PASSED                                         [ 12%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-2-cuda:1] PASSED                                         [ 13%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-32-cuda:0] PASSED                                        [ 15%]
tests/v1/sample/test_sampler.py::test_sampler_presence_penalty[2.0-32-cuda:1] PASSED                                        [ 16%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-1-cuda:0] PASSED                                       [ 18%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-1-cuda:1] PASSED                                       [ 19%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-2-cuda:0] PASSED                                       [ 20%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-2-cuda:1] PASSED                                       [ 22%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-32-cuda:0] PASSED                                      [ 23%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[-2.0-32-cuda:1] PASSED                                      [ 25%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-1-cuda:0] PASSED                                        [ 26%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-1-cuda:1] PASSED                                        [ 27%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-2-cuda:0] PASSED                                        [ 29%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-2-cuda:1] PASSED                                        [ 30%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-32-cuda:0] PASSED                                       [ 31%]
tests/v1/sample/test_sampler.py::test_sampler_frequency_penalty[2.0-32-cuda:1] PASSED                                       [ 33%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-1-cuda:0] PASSED                                       [ 34%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-1-cuda:1] PASSED                                       [ 36%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-2-cuda:0] PASSED                                       [ 37%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-2-cuda:1] PASSED                                       [ 38%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-32-cuda:0] PASSED                                      [ 40%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[0.1-32-cuda:1] PASSED                                      [ 41%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-1-cuda:0] PASSED                                       [ 43%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-1-cuda:1] PASSED                                       [ 44%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-2-cuda:0] PASSED                                       [ 45%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-2-cuda:1] PASSED                                       [ 47%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-32-cuda:0] PASSED                                      [ 48%]
tests/v1/sample/test_sampler.py::test_sampler_repetition_penalty[1.9-32-cuda:1] PASSED                                      [ 50%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-1-cuda:0] PASSED                                          [ 51%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-1-cuda:1] PASSED                                          [ 52%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-2-cuda:0] PASSED                                          [ 54%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-2-cuda:1] PASSED                                          [ 55%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-32-cuda:0] PASSED                                         [ 56%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[0-32-cuda:1] PASSED                                         [ 58%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-1-cuda:0] PASSED                                          [ 59%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-1-cuda:1] PASSED                                          [ 61%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-2-cuda:0] PASSED                                          [ 62%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-2-cuda:1] PASSED                                          [ 63%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-32-cuda:0] PASSED                                         [ 65%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[1-32-cuda:1] PASSED                                         [ 66%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-1-cuda:0] PASSED                                          [ 68%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-1-cuda:1] PASSED                                          [ 69%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-2-cuda:0] PASSED                                          [ 70%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-2-cuda:1] PASSED                                          [ 72%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-32-cuda:0] PASSED                                         [ 73%]
tests/v1/sample/test_sampler.py::test_sampler_allowed_token_ids[2-32-cuda:1] PASSED                                         [ 75%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-1-cuda:0] PASSED                                 [ 76%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-1-cuda:1] PASSED                                 [ 77%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-2-cuda:0] PASSED                                 [ 79%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-2-cuda:1] PASSED                                 [ 80%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-32-cuda:0] PASSED                                [ 81%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths0-32-cuda:1] PASSED                                [ 83%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-1-cuda:0] PASSED                                 [ 84%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-1-cuda:1] PASSED                                 [ 86%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-2-cuda:0] PASSED                                 [ 87%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-2-cuda:1] PASSED                                 [ 88%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-32-cuda:0] PASSED                                [ 90%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths1-32-cuda:1] PASSED                                [ 91%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-1-cuda:0] PASSED                                 [ 93%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-1-cuda:1] PASSED                                 [ 94%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-2-cuda:0] PASSED                                 [ 95%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-2-cuda:1] PASSED                                 [ 97%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-32-cuda:0] PASSED                                [ 98%]
tests/v1/sample/test_sampler.py::test_sampler_bad_words[bad_words_lengths2-32-cuda:1] PASSED                                [100%]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
