### PR TITLE
[PoC] Soft-pin recently-hit prefix-cache entries in get_new_blocks

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -181,6 +181,38 @@ class BlockPool:
 
         self.metrics_collector = metrics_collector
 
+    @property
+    def _recent_hit_hashes(self):
+        """Bounded recent-hit set used by get_new_blocks to soft-pin
+        recently-hit prefix-cache entries against eviction. See
+        get_new_blocks() for the rationale.
+        """
+        rh = self.__dict__.get("_recent_hit_hashes_storage")
+        if rh is None:
+            from collections import OrderedDict
+            rh = OrderedDict()
+            self.__dict__["_recent_hit_hashes_storage"] = rh
+        return rh
+
+    @property
+    def _recent_hit_cap(self) -> int:
+        """Cap for the recent-hit set. Sized to cover roughly the whole
+        pool of cacheable blocks — `cached_block_hash_to_block` cannot
+        hold meaningfully more than `num_gpu_blocks` keys at once, so a
+        cap of 2x pool size leaves room for transient over-allocation
+        without exposing us to unbounded memory growth.
+        """
+        return max(self.num_gpu_blocks * 2, 1024)
+
+    def _record_hit(self, key) -> None:
+        rh = self._recent_hit_hashes
+        if key in rh:
+            rh.move_to_end(key)
+        else:
+            rh[key] = True
+            if len(rh) > self._recent_hit_cap:
+                rh.popitem(last=False)
+
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
     ) -> list[KVCacheBlock] | None:
@@ -196,6 +228,7 @@ class BlockPool:
             The cached blocks if exists, or None.
         """
         cached_blocks = []
+        keys_visited = []
         for group_id in kv_cache_group_ids:
             block_hash_with_group_id = make_block_hash_with_group_id(
                 block_hash, group_id
@@ -206,6 +239,10 @@ class BlockPool:
             if not block:
                 return None
             cached_blocks.append(block)
+            keys_visited.append(block_hash_with_group_id)
+        # Soft-pin recently-hit keys (see _recent_hit_hashes docstring).
+        for key in keys_visited:
+            self._record_hit(key)
         return cached_blocks
 
     def cache_full_blocks(
@@ -333,7 +370,13 @@ class BlockPool:
     def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
         """Get new blocks from the free block pool.
 
-        Note that we do not check block cache in this function.
+        With prefix-caching enabled, walks the free queue and prefers blocks
+        whose hash is not in the recent-hit set (see _recent_hit_hashes).
+        This soft-pins recently-hit prefix-cache entries against eviction:
+        without this preference, the strict head-of-LRU popleft destroys
+        cache keys that were just successfully serving hits — a pathology
+        for workloads that share a prefix across many requests (e.g.
+        DeepSeek-V4-Flash chat-template prelude, see #32802 family).
 
         Args:
             num_blocks: The number of blocks to allocate.
@@ -344,22 +387,70 @@ class BlockPool:
         if num_blocks > self.get_num_free_blocks():
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        if not self.enable_caching:
+            ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+            for block in ret:
+                assert block.ref_cnt == 0
+                block.ref_cnt += 1
+                if self.metrics_collector:
+                    self.metrics_collector.on_block_allocated(block)
+            return ret
 
-        # In order to only iterate the list once, we duplicated code a bit
-        if self.enable_caching:
-            for block in ret:
-                self._maybe_evict_cached_block(block)
-                assert block.ref_cnt == 0
-                block.ref_cnt += 1
-                if self.metrics_collector:
-                    self.metrics_collector.on_block_allocated(block)
+        # Caching enabled: walk the queue and prefer blocks not in the
+        # recent-hit set. Scan budget sized dynamically so that we can
+        # always walk past every recent-hit block plus a working margin
+        # for the request itself — but bounded by the actual queue length.
+        recent = self._recent_hit_hashes
+        safe: list[KVCacheBlock] = []
+        high_value: list[KVCacheBlock] = []
+
+        # Worst case: every recent-hit block is at the head of the queue
+        # and we must walk past all of them before finding unprotected
+        # blocks. Add 2× the request size as headroom. Cap at the free
+        # queue length so we never scan more than what exists.
+        scan_budget = min(
+            len(recent) * 2 + num_blocks * 2,
+            self.free_block_queue.num_free_blocks,
+        )
+        scanned = 0
+        curr = self.free_block_queue.fake_free_list_head.next_free_block
+        tail = self.free_block_queue.fake_free_list_tail
+        while (
+            curr is not None
+            and curr is not tail
+            and len(safe) < num_blocks
+            and scanned < scan_budget
+        ):
+            nxt = curr.next_free_block
+            scanned += 1
+            bh = curr.block_hash
+            if bh is None or bh not in recent:
+                safe.append(curr)
+            else:
+                high_value.append(curr)
+            curr = nxt
+
+        if len(safe) >= num_blocks:
+            ret = safe[:num_blocks]
         else:
-            for block in ret:
-                assert block.ref_cnt == 0
-                block.ref_cnt += 1
-                if self.metrics_collector:
-                    self.metrics_collector.on_block_allocated(block)
+            # Not enough safe blocks within scan budget; fall back to
+            # high_value blocks we already passed, then continue walking
+            # if still short.
+            ret = safe + high_value[: num_blocks - len(safe)]
+            while len(ret) < num_blocks and curr is not None and curr is not tail:
+                nxt = curr.next_free_block
+                ret.append(curr)
+                curr = nxt
+
+        for block in ret:
+            self.free_block_queue.remove(block)
+
+        for block in ret:
+            self._maybe_evict_cached_block(block)
+            assert block.ref_cnt == 0
+            block.ref_cnt += 1
+            if self.metrics_collector:
+                self.metrics_collector.on_block_allocated(block)
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:


### PR DESCRIPTION
# [PoC] Soft-pin recently-hit prefix-cache entries in `get_new_blocks`

## Summary

`BlockPool.get_new_blocks` currently allocates by strict head-of-LRU `popleft_n`, which destroys prefix-cache entries on every block reassignment — even when the pool is mostly empty. For workloads where multiple requests share a prefix (notably the chat-template prelude in DeepSeek-V4-Flash and similar hybrid models), each new request's allocation evicts the previous request's first-block cache, dropping the hybrid-coordinator hit rate to 0% on re-sent prompts.

This PR adds a bounded recent-hit set: every `get_cached_block` success records the resolved `BlockHashWithGroupId` keys. `get_new_blocks` then walks the free queue and prefers blocks whose hash is **not** in the set, falling back to recently-hit blocks only when the scan budget is exhausted.

**This is a proof-of-concept / workaround**, not a polished fix. See "Known limitations" below.

## Motivation

Detailed report and instrumentation in **#42948**. Background: #32802 (GPT-OSS hybrid + EAGLE) was closed by #33524 with the explicit note that "for more complicated models with multiple attention groups, this PR does not fully address the issue". DeepSeek-V4-Flash is exactly such a model: 5 KV-cache groups in 4 attention-groups, plus the chat-template prelude makes every request's first block hash to the same value across all 5 groups.

Full instrumentation logs in #42948 show:
- `cache_evicted=0` reported by the LRU-eviction counter (no eviction-by-pressure happens), yet
- the cache entry for shared prefix hashes vanishes between A's HIT (A.2) and the next request, and stays gone for A.3, causing a full cold prefill of a 374k-token prompt.

KV-pool utilization stays at <10% throughout. The pool has 54k blocks; A and B together use a small fraction.

## Reproduction

Deterministic, runs in <5 minutes against any vLLM serving DSv4-Flash (or any hybrid-cache model where multiple requests share a prefix):

```python
import hashlib, urllib.request, json, time

def long_prompt(seed, target_tokens=250_000):
    chunks = []
    for i in range(target_tokens // 50):
        h = hashlib.md5(f"{seed}-{i}".encode()).hexdigest()
        chunks.append(f"Section {i} [{h}]: This is filler text with seed {seed}, iteration {i}, hash {h}, padding " + "x"*100)
    return "\n".join(chunks)

PROMPT_A = long_prompt("alpha")
PROMPT_B = long_prompt("bravo")

def send(prompt, label):
    body = {
        "model": "deepseek-ai/DeepSeek-V4-Flash",
        "messages": [{"role": "user", "content": prompt + "\n\nReply 'ok' only."}],
        "max_tokens": 3, "temperature": 0.0, "stream": False,
        "chat_template_kwargs": {"enable_thinking": False},
    }
    # POST and measure prefix_cache_hits_total / queries_total delta

send(PROMPT_A, "A.1"); time.sleep(1)
send(PROMPT_A, "A.2"); time.sleep(1)   # expected ~100% hit
send(PROMPT_B, "B");   time.sleep(1)   # cold for new prefix
send(PROMPT_A, "A.3")                   # expected ~100% hit, was 0% before this PR
```

### Before this PR

| Step | Wall    | Hit-rate |
|------|---------|----------|
| A.1  | ~50s    | 0%       |
| A.2  | ~1s     | 100%     |
| B    | ~43s    | 0%       |
| **A.3** | **~50s** | **0%** (BUG) |

### After this PR

| Step | Wall    | Hit-rate |
|------|---------|----------|
| A.1  | ~50s    | 0%       |
| A.2  | ~1s     | 100%     |
| B    | ~43s    | 0%       |
| **A.3** | **~1s** | **100%** ✓ |

### Stress test (5 unique 250k-token prefixes interspersed)

```
A.1     :  5.86s   99.5%
A.2     :  1.03s  100.0%
B.1     :  1.05s  100.0%
A.3     :  1.07s  100.0%  (A survives B)
C.1     : 43.51s    1.3%  (new prefix, cold)
A.4     :  0.97s  100.0%  (A survives C)
D.1     : 42.57s    0.0%
A.5     :  1.16s  100.0%  (A survives D)
E.1     : 48.35s    1.3%
A.6     :  1.05s  100.0%  (A survives 4 intervening prefixes)
```

`recent_set_size` grew from 1.5k → 3.1k entries during the run. Scan budget stayed comfortably within bounds; no fallback to high-value blocks was triggered.

## Sizing

Both the recent-hit set cap and the scan budget are dynamic, based on the actual pool:

- **Recent-hit cap**: `2 × num_gpu_blocks` (memory bounded by pool size; for a 14M-token pool ≈ 110k entries ≈ 5 MB)
- **Scan budget**: `min(2 × len(recent_hit_set) + 2 × num_blocks, num_free_blocks)` — sized so we can walk past every recent-hit block in the worst case, with headroom for the request, but capped by the queue length.

## Known limitations

This is explicitly a PoC, not a final fix:

1. **Heuristic, not principled.** "Was hit recently" is a proxy for "will likely be hit again". It works for the chat-template-prelude pattern but adds policy where the original code had clean LRU semantics. Very-high-churn workloads could outrun the recent-hit set.
2. **Linear walk in a hot path.** `get_new_blocks` is called on every allocation; the queue walk is O(scan_budget). Real-world overhead at very high allocation rates wasn't measured.
3. **No TTL on the recent-hit set.** Entries sit until cap eviction or restart. Workloads that hit a stale prefix once then never again would needlessly protect it.
4. **Doesn't address the architectural mismatch.** vLLM conflates "free physical block" with "cached prefix entry"; a two-tier pool, refcount-based pinning, or stale-marking on eviction would all be cleaner long-term solutions.

Happy for this PR to be the starting point of a conversation about the right direction rather than the merge candidate itself. The instrumentation that found the bug (DIAG-logging patches in `kv_cache_coordinator.py`, `block_pool.py`, `single_type_kv_cache_manager.py`) is available on request — could go into a separate observability PR if useful for future debugging.

## Testing

- Confirmed deterministic repro fails on stock v0.20.1, passes with this patch.
- Validated stress-test pattern (5 unique 250k-token prefixes, A repeated 6 times across the sequence) — A's prefix-cache survives all intervening prefixes, 100% hit-rate every time.
- Patched against `main` at HEAD as of 2026-05-18; passed local syntax check.
- Did not run the full vLLM test suite (no GPU on hand for the standard CI flow). Functional behavior on the GPU-side path (KV cache write/read) is unchanged — this PR only changes the choice of which physical block gets reassigned, not what happens after.

## Related

- **#42948** — DSv4-specific bug report with full instrumentation logs and root-cause analysis (this PR is the proposed PoC workaround)
- #32802 — GPT-OSS variant, closed by #33524, explicitly defers "more complicated models with multiple attention groups"
- #40902 — DeepSeek V4 roadmap (does not currently cover this)
