### PR TITLE
[Test][1/N] Add Platform-Aware Test Skip Mechanism

### DIFF
--- a/tests/compile/fullgraph/test_multimodal_compile.py
+++ b/tests/compile/fullgraph/test_multimodal_compile.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pytest
 
+from tests.utils import requires_platform
 from vllm.compilation.counter import compilation_counter
 from vllm.config import VllmConfig
 from vllm.config.compilation import CompilationMode
-from vllm.platforms import current_platform
 
 
 def test_compile():
@@ -16,7 +16,7 @@ def test_compile():
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 def test_qwen2_5_vl_compilation(vllm_runner, monkeypatch):
     """Test that Qwen2.5-VL vision submodules are compiled.
 
@@ -50,7 +50,7 @@ def test_qwen2_5_vl_compilation(vllm_runner, monkeypatch):
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
 @pytest.mark.forked
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 def test_qwen2_5_vl_no_vit_compilation(vllm_runner, monkeypatch):
     """Test that Qwen2.5-VL vision submodules are not compiled when the
     config is passed off

--- a/tests/compile/fusions_e2e/test_tp2_ar_rms.py
+++ b/tests/compile/fusions_e2e/test_tp2_ar_rms.py
@@ -37,9 +37,7 @@ from .models import (
     qwen3_a3b_fp8,
 )
 
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Only test CUDA/ROCm"
-)
+pytestmark = requires_platform("cuda_alike")
 
 
 @multi_gpu_test(num_gpus=2)
@@ -195,7 +193,7 @@ def test_tp2_ar_rms_fp4_fusions(
 @pytest.mark.parametrize("n_layers", [4])
 @pytest.mark.parametrize("custom_ops", tuple(custom_ops_combos("rms_norm")))
 @pytest.mark.parametrize("inductor_graph_partition", INDUCTOR_GRAPH_PARTITION)
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 def test_tp2_ar_rms_fusions(
     model_name: str,
     matches_fn: Callable[[int], Matches],

--- a/tests/compile/fusions_e2e/test_tp2_ar_rms.py
+++ b/tests/compile/fusions_e2e/test_tp2_ar_rms.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import pytest
 
+from tests.utils import requires_platform
 from vllm.config import PassConfig
 from vllm.platforms import current_platform
 
@@ -59,7 +60,7 @@ pytestmark = pytest.mark.skipif(
 @pytest.mark.parametrize("n_layers", [4])
 @pytest.mark.parametrize("custom_ops", custom_ops_combos("quant_fp8", "rms_norm"))
 @pytest.mark.parametrize("inductor_graph_partition", INDUCTOR_GRAPH_PARTITION)
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+@requires_platform("cuda")
 def test_tp2_ar_rms_fp8_fusions(
     model_name: str,
     matches_fn: Callable[[int], Matches],
@@ -129,7 +130,7 @@ def test_tp2_ar_rms_fp8_fusions(
 @pytest.mark.parametrize("custom_ops", custom_ops_combos("rms_norm"))
 @pytest.mark.parametrize("inductor_graph_partition", INDUCTOR_GRAPH_PARTITION)
 @pytest.mark.skipif(not is_blackwell(), reason="Blackwell required for fp4")
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+@requires_platform("cuda")
 def test_tp2_ar_rms_fp4_fusions(
     model_name: str,
     matches_fn: Callable[[int], Matches],
@@ -194,7 +195,7 @@ def test_tp2_ar_rms_fp4_fusions(
 @pytest.mark.parametrize("n_layers", [4])
 @pytest.mark.parametrize("custom_ops", tuple(custom_ops_combos("rms_norm")))
 @pytest.mark.parametrize("inductor_graph_partition", INDUCTOR_GRAPH_PARTITION)
-@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="Only test CUDA/ROCm")
+@requires_platform("gpu")
 def test_tp2_ar_rms_fusions(
     model_name: str,
     matches_fn: Callable[[int], Matches],

--- a/tests/compile/fusions_e2e/test_tp2_async_tp.py
+++ b/tests/compile/fusions_e2e/test_tp2_async_tp.py
@@ -6,7 +6,6 @@ import pytest
 
 from tests.utils import requires_platform
 from vllm.config import PassConfig
-from vllm.platforms import current_platform
 
 from ...utils import multi_gpu_test
 from .common import (
@@ -26,7 +25,7 @@ from .models import (
     qwen3_a3b,
 )
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+pytestmark = requires_platform("cuda")
 
 
 @multi_gpu_test(num_gpus=2)

--- a/tests/compile/fusions_e2e/test_tp2_async_tp.py
+++ b/tests/compile/fusions_e2e/test_tp2_async_tp.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import pytest
 
+from tests.utils import requires_platform
 from vllm.config import PassConfig
 from vllm.platforms import current_platform
 
@@ -102,7 +103,7 @@ def test_tp2_async_tp_fp8_fusions(
 @pytest.mark.parametrize("custom_ops", custom_ops_combos("rms_norm"))
 @pytest.mark.parametrize("inductor_graph_partition", INDUCTOR_GRAPH_PARTITION)
 @pytest.mark.skipif(not is_blackwell(), reason="Blackwell required for fp4")
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+@requires_platform("cuda")
 def test_tp2_async_tp_nvfp4_fusions(
     model_name: str,
     matches_fn: Callable[[int], Matches],

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -6,7 +6,7 @@ import torch
 
 import vllm.envs as envs
 from tests.compile.backend import TestBackend
-from tests.utils import TestFP8Layer, multi_gpu_test
+from tests.utils import TestFP8Layer, multi_gpu_test, requires_platform
 from vllm.compilation.passes.fusion.rms_quant_fusion import RMSNormQuantFusionPass
 from vllm.compilation.passes.fusion.sequence_parallelism import SequenceParallelismPass
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
@@ -38,7 +38,7 @@ from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+pytestmark = requires_platform("cuda")
 
 FP8_DTYPE = current_platform.fp8_dtype()
 prompts = [

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -294,7 +294,7 @@ def _run_fusion_test(
 @pytest.mark.parametrize("kernel_groupshape", KERNEL_GROUPSHAPE_COMBINATIONS)
 @pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
 @pytest.mark.parametrize("enable_quant_fp8_custom_op", [True, False])
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 def test_fusion_rmsnorm_quant(
     dtype,
     hidden_size,

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -9,7 +9,7 @@ import vllm.config
 import vllm.ir.ops
 import vllm.plugins
 from tests.compile.backend import TestBackend
-from tests.utils import TestFP8Layer
+from tests.utils import TestFP8Layer, requires_platform
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.passes.fusion.matcher_utils import QUANT_OPS
 from vllm.compilation.passes.fusion.rms_quant_fusion import (
@@ -294,9 +294,7 @@ def _run_fusion_test(
 @pytest.mark.parametrize("kernel_groupshape", KERNEL_GROUPSHAPE_COMBINATIONS)
 @pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
 @pytest.mark.parametrize("enable_quant_fp8_custom_op", [True, False])
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Only test on CUDA and ROCm"
-)
+@requires_platform("gpu")
 def test_fusion_rmsnorm_quant(
     dtype,
     hidden_size,

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -272,7 +272,7 @@ elif current_platform.is_rocm():
     # quant_fp4 only has the custom impl
     + list(flat_product(BACKENDS_FP4, PATTERN_TEST_MODELS_FP4, [""])),
 )
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 @pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
 def test_attention_quant_pattern(
     num_qo_heads: int,

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -6,7 +6,7 @@ import pytest
 import torch._dynamo
 
 from tests.compile.backend import LazyInitPass, TestBackend
-from tests.utils import TestFP8Layer, flat_product
+from tests.utils import TestFP8Layer, flat_product, requires_platform
 from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
 from vllm._custom_ops import cutlass_scaled_fp4_mm, scaled_fp4_quant
 from vllm.compilation.passes.fusion.attn_quant_fusion import (
@@ -272,9 +272,7 @@ elif current_platform.is_rocm():
     # quant_fp4 only has the custom impl
     + list(flat_product(BACKENDS_FP4, PATTERN_TEST_MODELS_FP4, [""])),
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Only test ROCm or CUDA"
-)
+@requires_platform("gpu")
 @pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
 def test_attention_quant_pattern(
     num_qo_heads: int,

--- a/tests/compile/passes/test_mla_attn_quant_fusion.py
+++ b/tests/compile/passes/test_mla_attn_quant_fusion.py
@@ -402,7 +402,7 @@ if current_platform.is_cuda():
     )
     + list(flat_product(BACKENDS_MLA_FP4, PATTERN_TEST_MODELS_MLA_FP4, [""])),
 )
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 @pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
 def test_mla_attention_quant_pattern(
     num_heads: int,

--- a/tests/compile/passes/test_mla_attn_quant_fusion.py
+++ b/tests/compile/passes/test_mla_attn_quant_fusion.py
@@ -6,7 +6,7 @@ import pytest
 import torch._dynamo
 
 from tests.compile.backend import LazyInitPass, TestBackend
-from tests.utils import TestFP8Layer, flat_product
+from tests.utils import TestFP8Layer, flat_product, requires_platform
 from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
 from vllm._custom_ops import cutlass_scaled_fp4_mm, scaled_fp4_quant
 from vllm.compilation.passes.fusion.matcher_utils import QUANT_OPS
@@ -402,9 +402,7 @@ if current_platform.is_cuda():
     )
     + list(flat_product(BACKENDS_MLA_FP4, PATTERN_TEST_MODELS_MLA_FP4, [""])),
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Only test ROCm or CUDA"
-)
+@requires_platform("gpu")
 @pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
 def test_mla_attention_quant_pattern(
     num_heads: int,

--- a/tests/compile/passes/test_vllm_fusion_pattern_matcher_pass.py
+++ b/tests/compile/passes/test_vllm_fusion_pattern_matcher_pass.py
@@ -77,7 +77,7 @@ def vllm_config():
     )
 
 
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 def test_register_tracks_patterns(vllm_config):
     """register() appends each VllmPatternReplacement to _pattern_replacements."""
     with vllm.config.set_current_vllm_config(vllm_config):
@@ -88,7 +88,7 @@ def test_register_tracks_patterns(vllm_config):
     assert len(two._pattern_replacements) == 2
 
 
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 def test_uuid_stable(vllm_config):
     """Two instances of the same pass class produce identical uuids."""
     with vllm.config.set_current_vllm_config(vllm_config):
@@ -101,7 +101,7 @@ def test_uuid_stable(vllm_config):
     assert p2.uuid() != p3.uuid()
 
 
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 @pytest.mark.parametrize("N", [1, 2, 4])
 def test_matched_count_and_match_table(vllm_config, N):
     """matched_count and match_table reflect the number of matched patterns."""

--- a/tests/compile/passes/test_vllm_fusion_pattern_matcher_pass.py
+++ b/tests/compile/passes/test_vllm_fusion_pattern_matcher_pass.py
@@ -6,13 +6,13 @@ import torch
 
 import vllm.config
 from tests.compile.backend import TestBackend
+from tests.utils import requires_platform
 from vllm.compilation.passes.vllm_inductor_pass import (
     VllmFusionPatternMatcherPass,
     VllmPatternMatcherPass,
     VllmPatternReplacement,
 )
 from vllm.config import CompilationConfig, CompilationMode, VllmConfig
-from vllm.platforms import current_platform
 
 
 class ReluToAbsPattern(VllmPatternReplacement):
@@ -77,7 +77,7 @@ def vllm_config():
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="Requires CUDA")
+@requires_platform("gpu")
 def test_register_tracks_patterns(vllm_config):
     """register() appends each VllmPatternReplacement to _pattern_replacements."""
     with vllm.config.set_current_vllm_config(vllm_config):
@@ -88,7 +88,7 @@ def test_register_tracks_patterns(vllm_config):
     assert len(two._pattern_replacements) == 2
 
 
-@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="Requires CUDA")
+@requires_platform("gpu")
 def test_uuid_stable(vllm_config):
     """Two instances of the same pass class produce identical uuids."""
     with vllm.config.set_current_vllm_config(vllm_config):
@@ -101,7 +101,7 @@ def test_uuid_stable(vllm_config):
     assert p2.uuid() != p3.uuid()
 
 
-@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="Requires CUDA")
+@requires_platform("gpu")
 @pytest.mark.parametrize("N", [1, 2, 4])
 def test_matched_count_and_match_table(vllm_config, N):
     """matched_count and match_table reflect the number of matched patterns."""

--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 
 
@@ -51,7 +52,7 @@ def run_cuda_test_in_thread(device_input, expected_device_id):
 class TestSetCudaContext:
     """Test suite for the set_cuda_context function."""
 
-    @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
+    @requires_platform("cuda")
     @pytest.mark.parametrize(
         argnames="device_input,expected_device_id",
         argvalues=[
@@ -70,7 +71,7 @@ class TestSetCudaContext:
             success, message = future.result(timeout=30)
         assert success, message
 
-    @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
+    @requires_platform("cuda")
     def test_set_cuda_context_invalid_device_type(self):
         """Test error handling for invalid device type."""
         with pytest.raises(ValueError, match="Expected a cuda device"):

--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -9,10 +9,10 @@ import ray
 import torch
 import torch.distributed as dist
 
+from tests.utils import requires_platform
 from vllm import _custom_ops as ops
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce  # noqa
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
-from vllm.platforms import current_platform
 
 from ..utils import (
     ensure_model_parallel_initialized,
@@ -113,9 +113,7 @@ def eager_quickreduce(
         torch.testing.assert_close(out, inp * tp_size, atol=2.5, rtol=0.1)
 
 
-@pytest.mark.skipif(
-    not current_platform.is_rocm(), reason="only test quick allreduce for rocm"
-)
+@requires_platform("rocm")
 @pytest.mark.parametrize("quant_mode", ["FP", "INT8", "INT6", "INT4"])
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("pipeline_parallel_size", [1, 2])
@@ -188,9 +186,7 @@ def qr_variable_input(rank, world_size):
         num += 1
 
 
-@pytest.mark.skipif(
-    not current_platform.is_rocm(), reason="only test quick allreduce for rocm"
-)
+@requires_platform("rocm")
 @pytest.mark.parametrize("tp_size", [4, 8])
 @pytest.mark.parametrize("pipeline_parallel_size", [1])
 def test_custom_quick_allreduce_variable_input(tp_size, pipeline_parallel_size):

--- a/tests/kernels/attention/test_aiter_flash_attn.py
+++ b/tests/kernels/attention/test_aiter_flash_attn.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -85,7 +86,7 @@ def ref_paged_attn(
     return torch.cat(outputs, dim=0)
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="Only ROCm is supported")
+@requires_platform("rocm")
 @pytest.mark.parametrize(
     "seq_lens", [[(10, 1328), (5, 18), (129, 463)], [(8, 523), (24, 37), (3, 2011)]]
 )

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from tests.kernels.utils import DEFAULT_OPCHECK_TEST_UTILS, opcheck
+from tests.utils import requires_platform
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.quant_utils import scaled_dequantize
 from vllm.platforms import current_platform
@@ -1062,7 +1063,7 @@ def test_cp_gather_cache_mla(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.cpu_model
-@pytest.mark.skipif(not current_platform.is_cpu(), reason="CPU only")
+@requires_platform("cpu")
 @torch.inference_mode()
 def test_concat_and_cache_mla_cpu(
     kv_lora_rank: int,

--- a/tests/kernels/attention/test_deepgemm_attention.py
+++ b/tests/kernels/attention/test_deepgemm_attention.py
@@ -5,6 +5,7 @@ import random
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     _ceil_to_ue8m0,
@@ -90,7 +91,7 @@ def _ref_fp8_mqa_logits(
     return logits
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+@requires_platform("cuda")
 @pytest.mark.skipif(not has_deep_gemm(), reason="DeepGEMM not available")
 @pytest.mark.skipif(
     not current_platform.has_device_capability(90), reason="SM90 and SM100 only"
@@ -200,7 +201,7 @@ def _ref_fp8_fp4_paged_mqa_logits(
     return logits
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+@requires_platform("cuda")
 @pytest.mark.skipif(not has_deep_gemm(), reason="DeepGEMM not available")
 @pytest.mark.skipif(
     not current_platform.has_device_capability(90), reason="SM90 and SM100 only"

--- a/tests/kernels/attention/test_mla_decode_cpu.py
+++ b/tests/kernels/attention/test_mla_decode_cpu.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from torch import Tensor
 
 import vllm._custom_ops as ops
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 from vllm.utils.math_utils import cdiv
 
 
@@ -43,7 +43,7 @@ def ref_mla(
 @pytest.mark.parametrize("dtype", [torch.float, torch.half, torch.bfloat16])
 @pytest.mark.parametrize("varlen", [False, True])
 @pytest.mark.cpu_model
-@pytest.mark.skipif(not current_platform.is_cpu(), reason="CPU only")
+@requires_platform("cpu")
 def test_mla_decode_cpu(
     bs: int,
     mean_seq_len: int,

--- a/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
+++ b/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_rocm(), reason="Only used by ROCm"
-)
+pytestmark = requires_platform("rocm")
 
 NOPE_HEAD_DIM = 448
 ROPE_HEAD_DIM = 64

--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -185,7 +185,7 @@ def run_dispatch_test(
             apply_rotary_emb.forward = original_forward
 
 
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 @pytest.mark.parametrize("test_case", get_test_cases(), ids=lambda tc: tc.name)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 def test_rotary_embedding_dispatch(

--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -16,13 +16,13 @@ from dataclasses import dataclass
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.config import (
     CompilationConfig,
     VllmConfig,
     get_cached_compilation_config,
     set_current_vllm_config,
 )
-from vllm.platforms import current_platform
 
 CUDA_DEVICES = ["cuda:0"]
 
@@ -185,9 +185,7 @@ def run_dispatch_test(
             apply_rotary_emb.forward = original_forward
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Skipping CUDA/ROCm only tests."
-)
+@requires_platform("gpu")
 @pytest.mark.parametrize("test_case", get_test_cases(), ids=lambda tc: tc.name)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 def test_rotary_embedding_dispatch(

--- a/tests/kernels/core/test_fused_q_kv_rmsnorm.py
+++ b/tests/kernels/core/test_fused_q_kv_rmsnorm.py
@@ -13,13 +13,10 @@ from __future__ import annotations
 import pytest
 import torch
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 from vllm.v1.attention.ops.deepseek_v4_ops import fused_q_kv_rmsnorm
 
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_cuda_alike(),
-    reason="fused_q_kv_rmsnorm requires a CUDA/ROCm device",
-)
+pytestmark = requires_platform("cuda_alike")
 
 
 def _ref_rmsnorm(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:

--- a/tests/kernels/core/test_mrope.py
+++ b/tests/kernels/core/test_mrope.py
@@ -56,7 +56,7 @@ MODELS_TO_TEST = [
 num_tokens_list = [11, 8192]
 
 
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 @pytest.mark.parametrize(
     "model_info, model_name",
     [
@@ -124,7 +124,7 @@ def test_mrope(
     torch.testing.assert_close(key_native, key_cuda, atol=atol, rtol=rtol)
 
 
-@requires_platform("gpu")
+@requires_platform("cuda_alike")
 @pytest.mark.parametrize(
     "model_info, model_name",
     [

--- a/tests/kernels/core/test_mrope.py
+++ b/tests/kernels/core/test_mrope.py
@@ -5,8 +5,8 @@ from typing import NamedTuple
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.model_executor.layers.rotary_embedding import get_rope
-from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_config
 from vllm.utils.torch_utils import set_random_seed
 
@@ -56,9 +56,7 @@ MODELS_TO_TEST = [
 num_tokens_list = [11, 8192]
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Skipping CUDA/ROCm only tests."
-)
+@requires_platform("gpu")
 @pytest.mark.parametrize(
     "model_info, model_name",
     [
@@ -126,9 +124,7 @@ def test_mrope(
     torch.testing.assert_close(key_native, key_cuda, atol=atol, rtol=rtol)
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Skipping CUDA/ROCm only tests."
-)
+@requires_platform("gpu")
 @pytest.mark.parametrize(
     "model_info, model_name",
     [

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -13,16 +13,14 @@ from tests.ir.ir_test_utils import (
     supported_providers,
 )
 from tests.kernels.allclose_default import get_default_rtol
+from tests.utils import requires_platform
 from vllm import ir
 from vllm.platforms import current_platform
 
 rms_norm_native = ir.ops.rms_norm.impls["native"].impl_fn
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
-    reason="Currently only kernels on CUDA, ROCm and XPU",
-)
+@requires_platform("gpu")
 def test_rms_norm_registration():
     expected = {
         "native": True,
@@ -45,10 +43,7 @@ def test_rms_norm_registration():
 @pytest.mark.parametrize("n_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("hidden_size", COMMON_HIDDEN_SIZES)
 @pytest.mark.parametrize("epsilon", [1e-6, 1e-5])
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
-    reason="Currently only kernels on CUDA, ROCm and XPU",
-)
+@requires_platform("gpu")
 class TestRMSNorm:
     @classmethod
     def setup_class(cls, **kwargs):
@@ -144,10 +139,7 @@ def test_aiter_rejects_unsupported_dtypes():
 fused_add_rms_norm_native = ir.ops.fused_add_rms_norm.impls["native"].impl_fn
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
-    reason="Currently only kernels on CUDA, ROCm and XPU",
-)
+@requires_platform("gpu")
 def test_fused_add_rms_norm_registration():
     expected = {
         "native": True,
@@ -171,10 +163,7 @@ def test_fused_add_rms_norm_registration():
 @pytest.mark.parametrize("n_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("hidden_size", COMMON_HIDDEN_SIZES)
 @pytest.mark.parametrize("epsilon", [1e-6, 1e-5])
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
-    reason="Currently only kernels on CUDA, ROCm and XPU",
-)
+@requires_platform("gpu")
 class TestFusedAddRMSNorm:
     @classmethod
     def setup_class(cls, **kwargs):

--- a/tests/kernels/moe/test_fused_topk.py
+++ b/tests/kernels/moe/test_fused_topk.py
@@ -8,11 +8,11 @@ Run `pytest tests/kernels/moe/test_fused_topk.py`.
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     fused_topk_bias,
 )
 from vllm.model_executor.layers.fused_moe.router.fused_topk_router import fused_topk
-from vllm.platforms import current_platform
 
 
 def torch_topk(
@@ -44,9 +44,7 @@ def torch_topk(
     return topk_weights, topk_ids
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize("num_tokens", [1, 33, 56])
 @pytest.mark.parametrize("hidden_size", [1024, 2048])
 @pytest.mark.parametrize("num_experts", [6, 16])
@@ -88,9 +86,7 @@ def test_fused_topk(
     torch.testing.assert_close(topk_ids_ref.to(torch.int32), topk_ids, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize("num_tokens", [1, 33, 56])
 @pytest.mark.parametrize("hidden_size", [1024, 2048])
 @pytest.mark.parametrize("num_experts", [6, 16])
@@ -137,9 +133,7 @@ def test_fused_topk_bias(
     torch.testing.assert_close(topk_ids_ref.to(torch.int32), topk_ids, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize("num_experts", [6, 8, 16])
 @pytest.mark.parametrize("topk", [3, 4])
 @pytest.mark.parametrize("scoring_func", ["softmax", "sigmoid"])
@@ -204,9 +198,7 @@ def test_fused_topk_nan_inf_clamp(
         )
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize("num_experts", [6, 8, 16])
 @pytest.mark.parametrize("topk", [3, 4])
 @pytest.mark.parametrize("scoring_func", ["softmax", "sigmoid"])

--- a/tests/kernels/moe/test_grouped_topk.py
+++ b/tests/kernels/moe/test_grouped_topk.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 import vllm.envs as envs
+from tests.utils import requires_platform
 from vllm.config import (
     CompilationConfig,
     VllmConfig,
@@ -19,13 +20,10 @@ from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopk,
     fused_grouped_topk,
 )
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize("n_token", [1, 33, 64])
 @pytest.mark.parametrize("n_hidden", [1024, 2048])
 @pytest.mark.parametrize(

--- a/tests/kernels/moe/test_modular_oai_triton_moe.py
+++ b/tests/kernels/moe/test_modular_oai_triton_moe.py
@@ -24,6 +24,7 @@ from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.testing import assert_close
 
+from tests.utils import requires_platform
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
@@ -34,7 +35,6 @@ from vllm.model_executor.layers.fused_moe.experts.gpt_oss_triton_kernels_moe imp
     UnfusedOAITritonExperts,
 )
 from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEKernel
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 from .utils import make_dummy_moe_config, shuffle_weight
@@ -206,9 +206,7 @@ def oai_triton_moe_impl(
     )
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("m,n,k", MNK)
 @pytest.mark.parametrize("num_experts", [32, 128])

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -22,6 +22,7 @@ from tests.kernels.moe.utils import (
     modular_triton_fused_moe,
 )
 from tests.kernels.utils import opcheck, stack_and_dev, torch_experts, torch_moe
+from tests.utils import requires_platform
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fused_moe import (
     MoEActivation,
@@ -1267,7 +1268,7 @@ def test_moe_sum(m: int, topk: int, k: int, dtype: torch.dtype):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("with_bias", [False, True])
 @pytest.mark.parametrize("activation", [MoEActivation.SILU])
-@pytest.mark.skipif(not current_platform.is_cpu(), reason="CPU only test")
+@requires_platform("cpu")
 def test_cpu_fused_moe_basic(
     m: int,
     n: int,

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from tests.kernels.moe.utils import make_dummy_moe_config
+from tests.utils import requires_platform
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoeBackend,
     select_unquantized_moe_backend,
@@ -92,9 +93,7 @@ def test_select_default_backend_by_platform(
     "vllm.model_executor.layers.fused_moe.oracle.unquantized.rocm_aiter_ops.is_fused_moe_enabled",
     return_value=True,
 )
-@pytest.mark.skipif(
-    not current_platform.is_rocm(), reason="ROCm-specific backend selection test"
-)
+@requires_platform("rocm")
 def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
     """Test ROCm backend selection when AITER is available."""
     with patch(
@@ -120,9 +119,7 @@ def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
     "vllm.model_executor.layers.fused_moe.experts.trtllm_bf16_moe.TrtLlmBf16Experts.is_supported_config",
     return_value=(True, None),
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
+@requires_platform("cuda")
 def test_select_cuda_flashinfer_trtllm_backend(mock_is_supported_trtllm, monkeypatch):
     """Test CUDA backend selection when FlashInfer TRTLLM is available and enabled."""
     with (
@@ -161,9 +158,7 @@ def test_select_cuda_flashinfer_trtllm_backend(mock_is_supported_trtllm, monkeyp
     "vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe.FlashInferExperts.is_supported_config",
     return_value=(True, None),
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
+@requires_platform("cuda")
 def test_select_cuda_flashinfer_cutlass_backend(
     mock_has_flashinfer,
     mock_is_supported_trtllm,

--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -11,6 +11,7 @@ from tests.kernels.quant_utils import (
     native_per_token_group_quant_fp8,
     native_w8a8_block_matmul,
 )
+from tests.utils import requires_platform
 from vllm.config import VllmConfig
 from vllm.model_executor.kernels.linear.scaled_mm.cutlass import cutlass_scaled_mm
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
@@ -135,9 +136,7 @@ def test_w8a8_block_fp8_matmul(M, N, K, block_size, out_dtype, seed):
     assert rel_diff < 0.001
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
-)
+@requires_platform("cuda")
 @torch.inference_mode()
 def test_w8a8_block_fp8_cutlass_matmul():
     # Test simple case where weight.shape % 128 != 0,

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.model_executor.layers.quantization.utils import fp8_utils, int8_utils
-from vllm.platforms import current_platform
 
 
 @pytest.mark.parametrize(
@@ -76,9 +76,7 @@ def test_per_token_group_quant_fp8(
     ],
 )
 @pytest.mark.parametrize("poisoned_scales", [False, True])
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="DeepGEMM not available on this platform"
-)
+@requires_platform("cuda")
 def test_per_token_group_quant_fp8_packed(
     num_tokens, hidden_dim, group_size, poisoned_scales
 ):
@@ -156,9 +154,7 @@ def test_per_token_group_quant_fp8_packed(
     )
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="DeepGEMM not available on this platform"
-)
+@requires_platform("cuda")
 def test_per_token_group_quant_fp8_packed_all_zero():
     """All-zero input must produce well-defined UE8M0 scale bytes via the eps
     floor in the kernel's UE8M0 path. Locks down the all-zero behavior before
@@ -215,9 +211,7 @@ def test_per_token_group_quant_fp8_packed_all_zero():
     assert torch.equal(actual, expected), "All-zero scale bytes mismatch"
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="DeepGEMM not available on this platform"
-)
+@requires_platform("cuda")
 def test_per_token_group_quant_fp8_packed_mantissa_rounds_up():
     """Inputs whose absmax/max_8bit produces a non-power-of-2 force the
     mantissa-rounding-up branch (exp_byte += 1). Locks down this behavior
@@ -285,9 +279,7 @@ def test_per_token_group_quant_fp8_packed_mantissa_rounds_up():
         (1, 384),  # extreme: 1 group, 1 mn row -> both axes padded
     ],
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="DeepGEMM not available on this platform"
-)
+@requires_platform("cuda")
 def test_per_token_group_quant_fp8_packed_zero_fills_padded_output_q(
     num_tokens, hidden_dim
 ):

--- a/tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py
+++ b/tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py
@@ -11,7 +11,7 @@ Run `pytest tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py`.
 
 import pytest
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ from vllm.platforms import current_platform
     ],
 )
 @pytest.mark.parametrize("max_tokens", [32])
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="Should only run on ROCm")
+@requires_platform("rocm")
 def test_rocm_compressed_tensors_w4a16_e2e(
     vllm_runner, example_prompts, model_path, max_tokens
 ):

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -7,6 +7,7 @@ import torch
 
 import vllm._custom_ops as ops
 from tests.kernels.quant_utils import ref_dynamic_per_tensor_fp8_quant
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 from vllm.platforms.rocm import on_gfx950
 from vllm.utils.platform_utils import num_compute_units
@@ -124,7 +125,7 @@ def pad_fp8(weight):
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("padded_a", [False, True])
 @pytest.mark.parametrize("bias_mode", BIAS_MODES)
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@requires_platform("rocm")
 @pytest.mark.skipif(not on_gfx950(), reason="only meant for gfx950")
 def test_rocm_wvsplitkrc_kernel(xnorm, n, k, m, dtype, seed, padded_a, bias_mode):
     torch.manual_seed(seed)
@@ -176,7 +177,7 @@ def test_rocm_wvsplitkrc_kernel(xnorm, n, k, m, dtype, seed, padded_a, bias_mode
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("rows_per_block", [2, 4, 8, 16])
 @pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@requires_platform("rocm")
 @torch.inference_mode()
 def test_rocm_llmm1_kernel(n, k, m, dtype, rows_per_block, seed):
     torch.manual_seed(seed)
@@ -196,7 +197,7 @@ def test_rocm_llmm1_kernel(n, k, m, dtype, rows_per_block, seed):
 @pytest.mark.parametrize("n,k,m", NKM_FACTORS_WVSPLITK)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@requires_platform("rocm")
 @pytest.mark.parametrize("bias_mode", BIAS_MODES)
 @pytest.mark.parametrize("padded_a", [False, True])
 @pytest.mark.parametrize("padded_b", [False, True])

--- a/tests/kernels/quantization/test_triton_scaled_mm.py
+++ b/tests/kernels/quantization/test_triton_scaled_mm.py
@@ -10,6 +10,7 @@ import importlib
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -55,7 +56,7 @@ def get_8bit_types():
 )
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("num_logprobs", [10])
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="Should only run on ROCm")
+@requires_platform("rocm")
 def test_rocm_compressed_tensors_w8a8(
     vllm_runner, example_prompts, model_path, max_tokens, num_logprobs
 ):

--- a/tests/kernels/quantization/test_triton_w4a16.py
+++ b/tests/kernels/quantization/test_triton_w4a16.py
@@ -11,6 +11,7 @@ import importlib
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -107,7 +108,7 @@ def _w4a16_reference(
     return out.to(a_mk.dtype)
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@requires_platform("rocm")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize(
     "M,K,N,G,has_zp",
@@ -162,7 +163,7 @@ def test_triton_w4a16_gemm_matches_reference(dtype, M, K, N, G, has_zp):
     torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@requires_platform("rocm")
 def test_triton_w4a16_gemm_requires_contiguous_inputs():
     if not torch.cuda.is_available():
         pytest.skip("CUDA/HIP device not available")
@@ -185,7 +186,7 @@ def test_triton_w4a16_gemm_requires_contiguous_inputs():
         )
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@requires_platform("rocm")
 def test_triton_w4a16_process_weights_after_loading_repacks_layout():
     if not torch.cuda.is_available():
         pytest.skip("CUDA/HIP device not available")

--- a/tests/kernels/quantization/test_w4a16_kernel_selection.py
+++ b/tests/kernels/quantization/test_w4a16_kernel_selection.py
@@ -6,18 +6,17 @@
 Run `pytest tests/kernels/quantization/test_w4a16_kernel_selection.py`.
 """
 
-import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.model_executor.kernels.linear import (
     MPLinearLayerConfig,
     choose_mp_linear_kernel,
 )
-from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@requires_platform("rocm")
 def test_choose_mp_linear_kernel_picks_triton_w4a16_for_uint4b8():
     # int4 weights, 16-bit activations (CT W4A16 typical config).
     K, N = 1024, 256
@@ -35,7 +34,7 @@ def test_choose_mp_linear_kernel_picks_triton_w4a16_for_uint4b8():
     assert kernel_type.__name__ == "TritonW4A16LinearKernel"
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@requires_platform("rocm")
 def test_choose_mp_linear_kernel_picks_triton_w4a16_for_uint4_asymmetric():
     # Asymmetric int4 weights should also be supported (explicit zero points).
     K, N = 512, 512

--- a/tests/kernels/test_apply_repetition_penalties.py
+++ b/tests/kernels/test_apply_repetition_penalties.py
@@ -4,11 +4,11 @@ import pytest
 import torch
 
 from tests.kernels.utils import opcheck
+from tests.utils import requires_platform
 from vllm._custom_ops import (
     apply_repetition_penalties_cuda,
     apply_repetition_penalties_torch,
 )
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 NUM_SEQS = [1, 2, 3, 4, 8, 13, 17, 32, 37, 256, 1023, 1024, 1025]
@@ -24,9 +24,7 @@ DTYPES = [torch.float32, torch.float16]
 @pytest.mark.parametrize("repetition_penalty", REPETITION_PENALTY_VALUES)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test for checking CUDA kernel"
-)
+@requires_platform("cuda")
 @torch.inference_mode()
 def test_apply_repetition_penalties(
     num_seqs: int,
@@ -81,9 +79,7 @@ def test_apply_repetition_penalties(
     )
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test for checking CUDA kernel"
-)
+@requires_platform("cuda")
 @torch.inference_mode()
 def test_apply_repetition_penalties_zero_seqs() -> None:
     """

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import torch
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 from vllm.utils.torch_utils import set_random_seed
 
 # Test parameters
@@ -158,7 +158,7 @@ def validate_topk_against_reference(
 @pytest.mark.parametrize("num_rows", NUM_ROWS)
 @pytest.mark.parametrize("top_k", TOP_K_VALUES)
 @pytest.mark.parametrize("clean_logits", [True, False])
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @torch.inference_mode()
 def test_top_k_per_row(
     num_rows: int,
@@ -273,7 +273,7 @@ def _run_top_k_per_row_decode_test(
 @pytest.mark.parametrize("next_n", NEXT_N)
 @pytest.mark.parametrize("clean_logits", [True, False])
 @pytest.mark.parametrize("data_generation", DATA_GENERATION)
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @torch.inference_mode()
 def test_top_k_per_row_decode(
     top_k: int,
@@ -292,7 +292,7 @@ def test_top_k_per_row_decode(
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @pytest.mark.parametrize("clean_logits", [True, False])
 @torch.inference_mode()
 def test_top_k_per_row_decode_large_vocab_size(clean_logits: bool) -> None:
@@ -310,7 +310,7 @@ def test_top_k_per_row_decode_large_vocab_size(clean_logits: bool) -> None:
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @pytest.mark.parametrize(
     "seq_len_range,test_id",
     [
@@ -524,7 +524,7 @@ def run_large_context_topk_test(
             Torch: {torch_vals.sort(descending=True)[0][:10]}"""
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -623,7 +623,7 @@ def test_persistent_topk_correctness(test_config: dict) -> None:
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -683,7 +683,7 @@ def test_persistent_topk_algorithm_paths(test_config: dict) -> None:
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @torch.inference_mode()
 def test_persistent_topk_stress() -> None:
     """
@@ -710,7 +710,7 @@ def test_persistent_topk_stress() -> None:
         )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -790,7 +790,7 @@ def test_persistent_topk(test_config: dict, top_k: int) -> None:
     )
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@requires_platform("cuda")
 @pytest.mark.parametrize("top_k", [512, 2048])
 @torch.inference_mode()
 def test_persistent_topk_padded_stride(top_k: int) -> None:

--- a/tests/lora/test_punica_xpu_ops.py
+++ b/tests/lora/test_punica_xpu_ops.py
@@ -10,8 +10,8 @@ from tests.lora.utils import (
     generate_data,
     generate_data_for_expand_nslices,
 )
+from tests.utils import requires_platform
 from vllm.lora.ops.xpu_ops import bgmv_expand, bgmv_expand_slice, bgmv_shrink
-from vllm.platforms import current_platform
 
 
 def torch_bgmv_expand(
@@ -234,7 +234,7 @@ SEED = [0]
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("seed", SEED)
 @pytest.mark.parametrize("op_type", ["shrink", "expand"])
-@pytest.mark.skipif(not current_platform.is_xpu(), reason="skip for non xpu platform")
+@requires_platform("xpu")
 def test_bgmv(
     batches: int,
     num_loras: int,
@@ -275,7 +275,7 @@ def test_bgmv(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("seed", SEED)
-@pytest.mark.skipif(not current_platform.is_xpu(), reason="skip for non xpu platform")
+@requires_platform("xpu")
 def test_bgmv_expand_nslices(
     batches: int,
     num_loras: int,

--- a/tests/model_executor/test_oink_integration.py
+++ b/tests/model_executor/test_oink_integration.py
@@ -5,7 +5,7 @@ import types
 
 import pytest
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 
 
 def _test_oink_availability_impl(
@@ -53,7 +53,7 @@ def _test_oink_availability_impl(
         ((10, 0), True, True, True, True),
     ],
 )
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test on CUDA")
+@requires_platform("cuda")
 def test_oink_availability_checks(
     device_capability: tuple[int, int],
     has_rmsnorm: bool,

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass, field
 
 import pytest
 
+from tests.utils import requires_platform
 from vllm.multimodal.video import sample_frames_from_video
-from vllm.platforms import current_platform
 
 from ....conftest import IMAGE_ASSETS, VIDEO_ASSETS
 from ....utils import create_new_process_for_each_test
@@ -119,7 +119,7 @@ def get_compilation_config():
 
 
 @pytest.mark.parametrize("model_id", params_with_marks(MODEL_CONFIGS))
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@requires_platform("cuda")
 @create_new_process_for_each_test()
 def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
     config = MODEL_CONFIGS[model_id]
@@ -161,7 +161,7 @@ def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
 
 
 @pytest.mark.parametrize("model_id", params_with_marks(MODEL_CONFIGS))
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@requires_platform("cuda")
 @create_new_process_for_each_test()
 def test_vit_cudagraph_video(model_id, vllm_runner, video_assets):
     config = MODEL_CONFIGS[model_id]

--- a/tests/models/multimodal/pooling/test_llava_next.py
+++ b/tests/models/multimodal/pooling/test_llava_next.py
@@ -5,10 +5,8 @@ import pytest
 import torch.nn.functional as F
 from transformers import AutoModelForImageTextToText
 
-from vllm.platforms import current_platform
-
 from ....conftest import IMAGE_ASSETS, HfRunner, PromptImageInput, VllmRunner
-from ....utils import large_gpu_test
+from ....utils import large_gpu_test, requires_platform
 from ...utils import check_embeddings_close
 
 # Llava Next embedding implementation is only supported by CUDA.
@@ -22,10 +20,7 @@ from ...utils import check_embeddings_close
 #    RuntimeError: Calling torch.linalg.cholesky on a CPU tensor
 #    requires compiling PyTorch with LAPACK. Please use PyTorch
 #    built with LAPACK support.
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_cuda(),
-    reason="Llava Next model uses op that is only supported in CUDA",
-)
+pytestmark = requires_platform("cuda")
 
 llama3_template = "<|start_header_id|>user<|end_header_id|>\n\n{}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n \n"  # noqa: E501
 

--- a/tests/models/quantization/test_fp8.py
+++ b/tests/models/quantization/test_fp8.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm.platforms import current_platform
+from tests.utils import requires_platform
 from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from ..utils import check_logprobs_close
 
@@ -118,7 +119,7 @@ def test_models(
 
 
 @pytest.mark.cpu_model
-@pytest.mark.skipif(not current_platform.is_cpu(), reason="test for the CPU backend.")
+@requires_platform("cpu")
 @pytest.mark.parametrize(
     "kv_cache_dtype,base_model,test_model",
     [

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -6,17 +6,14 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.model_executor.models.deepseek_v4 import (
     DeepseekV4MegaMoEExperts,
     _stage_deepseek_v4_mega_moe_inputs,
     make_deepseek_v4_expert_params_mapping,
 )
-from vllm.platforms import current_platform
 
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_cuda(),
-    reason="DeepSeek V4 MegaMoE requires CUDA",
-)
+pytestmark = (requires_platform("cuda"),)
 
 
 def test_deepseek_v4_mega_moe_expert_mapping():

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     _merge_multimodal_embeddings,
@@ -174,7 +175,7 @@ class raise_if_cuda_sync:
         torch.cuda.set_sync_debug_mode(self.previous_debug_mode)
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 def test_merge_multimodal_embeddings_no_sync():
     inputs_embeds = torch.zeros(
         [5, 10], dtype=torch.bfloat16, device=f"{DEVICE_TYPE}:0"

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -16,6 +16,7 @@ from compressed_tensors.quantization import (
 )
 
 from tests.models.utils import check_logprobs_close
+from tests.utils import requires_platform
 from vllm.model_executor.kernels.linear import (
     Fp8BlockScaledMMLinearKernel,
 )
@@ -290,9 +291,7 @@ def test_compressed_tensors_w8a8_dynamic_per_token(
         ),
     ],
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="The tests are skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 def test_compressed_tensors_wNa16(vllm_runner, wNa16_args):
     model, strategy, group, pack_factor, symmetric, has_g_idx = wNa16_args
     with vllm_runner(model, enforce_eager=True) as llm:
@@ -346,9 +345,7 @@ def test_compressed_tensors_fp8(vllm_runner):
         assert output
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 def test_compressed_tensors_kv_cache_fp8_per_tensor(vllm_runner):
     model_path = "nm-testing/TinyLlama-1.1B-Chat-v1.0-kvcache-fp8-tensor"
     with vllm_runner(model_path) as llm:
@@ -356,9 +353,7 @@ def test_compressed_tensors_kv_cache_fp8_per_tensor(vllm_runner):
         assert output
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 def test_compressed_tensors_kv_cache_fp8_per_attn_head(vllm_runner):
     model_path = "nm-testing/TinyLlama-1.1B-Chat-v1.0-kvcache-fp8-attn_head"
     try:
@@ -442,9 +437,7 @@ def test_compressed_tensors_w4a8_fp8(vllm_runner, args):
         assert output
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
-)
+@requires_platform("cuda")
 @pytest.mark.parametrize(
     "model,prompt,exp_perplexity",
     [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1721,6 +1721,74 @@ requires_fp8 = pytest.mark.skipif(
     "Ada architecture, compute capability 8.9+)",
 )
 
+# ---------------------------------------------------------------------------
+# Unified platform-aware skip helpers (RFC #39158)
+# ---------------------------------------------------------------------------
+# Accepted platform names for requires_platform().
+_PLATFORM_CHECKS: dict[str, Callable[[], bool]] = {
+    "cuda": current_platform.is_cuda,
+    "rocm": current_platform.is_rocm,
+    "cpu": current_platform.is_cpu,
+    "xpu": current_platform.is_xpu,
+    "tpu": current_platform.is_tpu,
+    "gpu": current_platform.is_cuda_alike,
+}
+
+
+def requires_platform(*platforms: str) -> pytest.MarkDecorator:
+    """Return a pytest mark that skips the test unless the current platform
+    matches at least one of the given names.
+
+    Accepted values: "cuda", "rocm", "cpu", "xpu", "tpu", "gpu"
+    ("gpu" matches both CUDA and ROCm).
+
+    Example::
+
+        @requires_platform("cuda")
+        def test_cutlass_scaled_mm(): ...
+
+
+        @requires_platform("cuda", "rocm")
+        def test_paged_attention(): ...
+
+
+        # Module-level — skip the whole file on non-CUDA platforms
+        pytestmark = requires_platform("cuda")
+    """
+    unknown = set(platforms) - _PLATFORM_CHECKS.keys()
+    if unknown:
+        raise ValueError(
+            f"requires_platform: unknown platform(s) {unknown}. "
+            f"Accepted: {set(_PLATFORM_CHECKS)}"
+        )
+    match = any(_PLATFORM_CHECKS[p]() for p in platforms)
+    return pytest.mark.skipif(
+        not match,
+        reason=(
+            f"Requires platform(s) {platforms}, "
+            f"current platform is {current_platform._enum.name}"
+        ),
+    )
+
+
+def requires_capability(min_capability: int) -> pytest.MarkDecorator:
+    """Return a pytest mark that skips the test unless the device has compute
+    capability >= *min_capability*.
+
+    *min_capability* is an integer where, e.g., ``80`` means SM 8.0 (A100)
+    and ``90`` means SM 9.0 (H100).
+
+    Example::
+
+        @requires_platform("cuda", "rocm")
+        @requires_capability(90)
+        def test_fp8_marlin(): ...
+    """
+    return pytest.mark.skipif(
+        not current_platform.has_device_capability(min_capability),
+        reason=f"Requires compute capability >= {min_capability}",
+    )
+
 
 def large_gpu_test(*, min_gb: int):
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1731,7 +1731,8 @@ _PLATFORM_CHECKS: dict[str, Callable[[], bool]] = {
     "cpu": current_platform.is_cpu,
     "xpu": current_platform.is_xpu,
     "tpu": current_platform.is_tpu,
-    "gpu": current_platform.is_cuda_alike,
+    "cuda_alike": current_platform.is_cuda_alike,
+    "gpu": lambda: current_platform.is_cuda_alike() or current_platform.is_xpu(),
 }
 
 
@@ -1739,8 +1740,8 @@ def requires_platform(*platforms: str) -> pytest.MarkDecorator:
     """Return a pytest mark that skips the test unless the current platform
     matches at least one of the given names.
 
-    Accepted values: "cuda", "rocm", "cpu", "xpu", "tpu", "gpu"
-    ("gpu" matches both CUDA and ROCm).
+    Accepted values: "cuda", "rocm", "cpu", "xpu", "tpu", "gpu", "cuda_alike"
+    ("gpu" matches CUDA, ROCm, and XPU; "cuda_alike" matches CUDA and ROCm).
 
     Example::
 

--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -7,14 +7,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 
 # ROCm-specific attention backend selection tests
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_rocm(), reason="ROCm-specific tests"
-)
+pytestmark = requires_platform("rocm")
 
 
 @pytest.fixture

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from tests.utils import create_new_process_for_each_test
+from tests.utils import create_new_process_for_each_test, requires_platform
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import (
@@ -267,7 +267,7 @@ class TestCudagraphDispatcher:
         assert dispatcher.get_capture_descs() == []
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 class TestCUDAGraphWrapper:
     def setup_method(self):
         self.vllm_config = _create_vllm_config(CompilationConfig())
@@ -415,7 +415,7 @@ def _run_and_monitor_call(
 
 
 @create_new_process_for_each_test("spawn")
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 def test_capture_replay_bypass_logic():
     comp_config = CompilationConfig(
         mode=CompilationMode.VLLM_COMPILE,
@@ -484,7 +484,7 @@ def test_capture_replay_bypass_logic():
 
 
 @create_new_process_for_each_test("spawn")
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 def test_nested_wrappers():
     """Tests a scenario with a PIECEWISE wrapper inside a FULL one."""
     comp_config = CompilationConfig(

--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -17,7 +17,7 @@ from typing import Any
 import pytest
 import torch
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 from vllm.v1.worker.encoder_cudagraph import (
     EncoderCudaGraphManager,
 )
@@ -462,7 +462,7 @@ def _make_video_mm_kwargs(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 class TestEncoderCudaGraphCaptureReplay:
     def setup_method(self):
         self.device = torch.device("cuda:0")
@@ -737,7 +737,7 @@ _VIDEO_MAX_BATCH = 4
 _VIDEO_MAX_FRAMES = 8  # 2 frames per item at max_batch_size=4
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@requires_platform("cuda")
 class TestEncoderCudaGraphVideoReplay:
     def setup_method(self):
         self.device = torch.device("cuda:0")

--- a/tests/v1/e2e/general/test_pooling_chunked_prefill.py
+++ b/tests/v1/e2e/general/test_pooling_chunked_prefill.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import pytest
 import torch.nn as nn
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 
 prompt = """
 Generals gathered in their masses
@@ -68,7 +67,7 @@ def retrieve_chunks(self):
     return chunks
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
+@requires_platform("cuda")
 def test_pooling_chunked_prefill(vllm_runner, monkeypatch):
     """Test chunked prefill for pooling models with LastPool."""
 
@@ -121,7 +120,7 @@ def test_pooling_chunked_prefill(vllm_runner, monkeypatch):
         assert chunks[0] == prompt_len
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
+@requires_platform("cuda")
 def test_pooling_prefix_cache(vllm_runner, monkeypatch):
     """Test chunked prefill for pooling models with LastPool."""
 

--- a/tests/v1/e2e/spec_decode/test_lora_with_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/test_lora_with_spec_decode.py
@@ -8,10 +8,10 @@ This script contains:
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm import LLM, SamplingParams
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.lora.request import LoRARequest
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 LORA_TEST_PROMPT_MAP: dict[str, str] = {}
@@ -36,7 +36,7 @@ Numbers should be represented as integers only.
 SEED = 42
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
+@requires_platform("cuda")
 @pytest.mark.parametrize(
     "model_setup",
     [

--- a/tests/v1/kv_connector/unit/test_rixl_gpu_mem_diag.py
+++ b/tests/v1/kv_connector/unit/test_rixl_gpu_mem_diag.py
@@ -12,12 +12,9 @@ import gc
 import pytest
 import torch
 
-from vllm.platforms import current_platform
+from tests.utils import requires_platform
 
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_rocm(),
-    reason="ROCm platform required",
-)
+pytestmark = requires_platform("rocm")
 
 
 def _mb(b: int) -> float:

--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 
+from tests.utils import requires_platform
 from vllm.platforms import current_platform
 from vllm.v1.spec_decode.utils import (
     PADDING_SLOT_ID,
@@ -15,8 +16,7 @@ DEVICE_TYPE = current_platform.device_type
 
 # Skip if no CUDA - Triton kernel requires GPU
 pytest.importorskip("triton")
-if not current_platform.is_cuda_alike() and not current_platform.is_xpu():
-    pytest.skip("CUDA/XPU required for EAGLE kernel tests", allow_module_level=True)
+pytestmark = requires_platform("gpu")
 
 
 def _reference_eagle_step_slot_mapping(


### PR DESCRIPTION



## Purpose
Please note this is a vibe-coded PR.

1/N of https://github.com/vllm-project/vllm/issues/39158 
add `requires_platform` marker 
replace usage like:
- `pytestmark = pytest.mark.skipif(
    not current_platform.is_cuda_alike(), reason="Only test CUDA/ROCm"
)
`
- pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

