### PR TITLE
[Perf] `zeros` -> `empty` to remove additional fill

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -57,11 +57,11 @@ def create_fp4_scale_tensor(
         rounded_m = round_up(m, 128)
         scale_n = n // block_size
         rounded_n = round_up(scale_n, 4)
-        return torch.zeros(
+        return torch.empty(
             (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
         )
     else:
-        return torch.zeros((m, n // block_size), device=device, dtype=torch.uint8)
+        return torch.empty((m, n // block_size), device=device, dtype=torch.uint8)
 
 
 def create_fp4_output_tensors(

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -1032,7 +1032,6 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             )
 
         core_attn_out.zero_()
-        z_out.zero_()
         num_tokens_all = qkvz.shape[0]
         mixed_qkv, z, b, a = self.prepare_gdn_attention_core_inputs(
             qkvz, ba, num_tokens_all

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -255,7 +255,7 @@ def silu_mul_quant_fp8_packed_triton(
     if output_q is None:
         output_q = torch.empty((M, N_2), dtype=fp8_dtype, device=input.device)
 
-    output_scale_packed = torch.zeros(
+    output_scale_packed = torch.empty(
         (num_packed_groups, tma_aligned_M),
         dtype=torch.int32,
         device=input.device,

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -454,7 +454,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             )
         else:
             # Mixed batch: decodes first (guaranteed by reorder_batch).
-            attn_out = torch.zeros(
+            attn_out = torch.empty(
                 N, self.num_heads, self.head_size, device=device, dtype=q.dtype
             )
 


### PR DESCRIPTION
## Purpose

`zeros` -> `empty` to remove additional fill:

- switch FP4 quant output-scale allocation from `torch.zeros` to `torch.empty` in `vllm/_custom_ops.py`
- switch packed FP8 scale allocation from `torch.zeros` to `torch.empty` in `vllm/model_executor/layers/quantization/utils/fp8_utils.py`
- switch TurboQuant mixed-batch `attn_out` allocation from `torch.zeros` to `torch.empty`
- remove a redundant `z_out.zero_()` in GDN attention, since `z_out[:] = z` immediately overwrites the buffer


## Test

Covered in unit tests