### PR TITLE
[Attention] Support skip-softmax attention (BLASST) through TRTLLM flashinfer backends

### DIFF
--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -53,6 +53,16 @@ class AttentionConfig:
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
 
+    trtllm_skip_softmax_prefill_threshold_scale_factor: float | None = None
+    """Skip-softmax threshold scale factor for the flashinfer TRT-LLM prefill
+    kernels. `None` disables skip-softmax (standard attention).
+    See https://arxiv.org/abs/2512.12087."""
+
+    trtllm_skip_softmax_decode_threshold_scale_factor: float | None = None
+    """Skip-softmax threshold scale factor for the flashinfer TRT-LLM decode
+    kernels. `None` disables skip-softmax (standard attention).
+    See https://arxiv.org/abs/2512.12087."""
+
     flex_attn_block_m: int | None = None
     """Triton kernel BLOCK_M tile size for flex attention.
     Must be a power of 2 >= 16. If None and VLLM_BATCH_INVARIANT=1,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1321,10 +1321,23 @@ class FlashInferImpl(AttentionImpl):
 
         self.support_trtllm_attn = can_use_trtllm_attention(num_heads, num_kv_heads)
         vllm_config = get_current_vllm_config_or_none()
+        attention_config = (
+            vllm_config.attention_config if vllm_config is not None else None
+        )
         self.supports_quant_query_input = (
             self.support_trtllm_attn
-            and vllm_config is not None
-            and not vllm_config.attention_config.disable_flashinfer_q_quantization
+            and attention_config is not None
+            and not attention_config.disable_flashinfer_q_quantization
+        )
+        self.trtllm_skip_softmax_prefill_threshold_scale_factor: float | None = (
+            attention_config.trtllm_skip_softmax_prefill_threshold_scale_factor
+            if attention_config is not None
+            else None
+        )
+        self.trtllm_skip_softmax_decode_threshold_scale_factor: float | None = (
+            attention_config.trtllm_skip_softmax_decode_threshold_scale_factor
+            if attention_config is not None
+            else None
         )
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
@@ -1685,6 +1698,9 @@ class FlashInferImpl(AttentionImpl):
                     o_sf_scale=self.o_sf_scale,
                     out=out,
                     kv_cache_sf=prefill_kv_block_scales,
+                    skip_softmax_threshold_scale_factor=(
+                        self.trtllm_skip_softmax_prefill_threshold_scale_factor
+                    ),
                 )
 
                 if needs_fp8_out:
@@ -1823,6 +1839,9 @@ class FlashInferImpl(AttentionImpl):
                     q_len_per_req=q_len_per_req,
                     kv_cache_sf=(
                         nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
+                    ),
+                    skip_softmax_threshold_scale_factor=(
+                        self.trtllm_skip_softmax_decode_threshold_scale_factor
                     ),
                 )
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 import torch
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
 
+from vllm.config import get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
@@ -152,6 +153,13 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
 
+        vllm_config = get_current_vllm_config_or_none()
+        self.trtllm_skip_softmax_decode_threshold_scale_factor: float | None = (
+            vllm_config.attention_config.trtllm_skip_softmax_decode_threshold_scale_factor
+            if vllm_config is not None
+            else None
+        )
+
     def forward_mqa(
         self,
         q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -199,6 +207,9 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
             max_seq_len=attn_metadata.max_seq_len,
             bmm1_scale=self.bmm1_scale,
             bmm2_scale=self.bmm2_scale,
+            skip_softmax_threshold_scale_factor=(
+                self.trtllm_skip_softmax_decode_threshold_scale_factor
+            ),
         )
 
         # Flatten the output for consistent shape

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
@@ -307,6 +307,13 @@ class FlashInferMLASparseImpl(SparseMLAAttentionImpl[FlashInferMLASparseMetadata
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
 
+        vllm_config = get_current_vllm_config_or_none()
+        self.trtllm_skip_softmax_decode_threshold_scale_factor: float | None = (
+            vllm_config.attention_config.trtllm_skip_softmax_decode_threshold_scale_factor
+            if vllm_config is not None
+            else None
+        )
+
         # fp8 query quantization is required when using fp8 kv_cache,
         # as the TRTLLM-GEN sparse MLA kernel requires matching dtypes
         # for query and kv_cache (mixed bf16+fp8 is not supported).
@@ -361,5 +368,8 @@ class FlashInferMLASparseImpl(SparseMLAAttentionImpl[FlashInferMLASparseMetadata
             bmm1_scale=self.bmm1_scale,
             bmm2_scale=self.bmm2_scale,
             sparse_mla_top_k=attn_metadata.topk_tokens,
+            skip_softmax_threshold_scale_factor=(
+                self.trtllm_skip_softmax_decode_threshold_scale_factor
+            ),
         )
         return o.view(-1, o.shape[-2], o.shape[-1]), None


### PR DESCRIPTION
## Purpose

FlashInfer's TRT-LLM attention kernels (`trtllm_batch_context_with_kv_cache`, `trtllm_batch_decode_with_kv_cache`, `trtllm_batch_decode_with_kv_cache_mla`) accept a `skip_softmax_threshold_scale_factor` argument that enables skip-softmax attention as described in [BLASST (arXiv:2512.12087)](https://arxiv.org/abs/2512.12087). This PR surfaces that knob through `AttentionConfig` so it can be set at LLM init / via CLI.

Defaults are `None` so zero behavior change unless opted into. Inspired by sgl-project/sglang#19089 (which used env vars).

## Usage

```bash
vllm serve <model> \
  --attention-config.trtllm_skip_softmax_prefill_threshold_scale_factor 1000.0 \
  --attention-config.trtllm_skip_softmax_decode_threshold_scale_factor 20.0
```

or

```bash
vllm serve <model> \
  --attention-config '{"trtllm_skip_softmax_prefill_threshold_scale_factor": 1000.0, "trtllm_skip_softmax_decode_threshold_scale_factor": 20.0}'
```

Calibrated per-model thresholds are needed for accuracy-sensitive use; see the BLASST paper for the calibration procedure.

## Test Plan

Smoke eval on B300 with `VLLM_ATTENTION_BACKEND=FLASHINFER` to force the TRTLLM kernel path, gsm8k 5-shot:

| Model | Config | flexible-extract | strict-match |
| --- | --- | --- | --- |
| Qwen2.5-1.5B-Instruct (100 samples) | baseline | 0.53 ± 0.050 | 0.34 ± 0.048 |
| Qwen2.5-1.5B-Instruct (100 samples) | prefill=1000, decode=20 | 0.47 ± 0.050 | 0.33 ± 0.047 |
| Qwen3.6-35B-A3B-NVFP4 (250 samples) | baseline | 0.252 ± 0.028 | 0.196 ± 0.025 |
| Qwen3.6-35B-A3B-NVFP4 (250 samples) | prefill=1000, decode=20 | 0.292 ± 0.029 | 0.252 ± 0.028 |

Plumbing works end-to-end through both prefill and decode TRTLLM kernels (MHA + NVFP4 MoE). The uncalibrated thresholds here are illustrative — real use needs per-model calibration.
