### PR TITLE
[Core][Perf] Optimize sliding window cache hit search

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -481,3 +481,74 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"but allocator pulled {len(new_blocks)}"
         )
         total_computed = num_tokens
+
+
+def test_sliding_window_strided_probe_stress():
+    """Stress test with large N and low hit rate for strided probe."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=32,
+    )
+    W = 8  # ceil((32-1)/4)
+
+    block_pool = BlockPool(
+        num_gpu_blocks=2000, enable_caching=True, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    def run_case(block_is_cached, expected_length):
+        block_hash_list = [
+            BlockHash(str(i).encode()) for i in range(len(block_is_cached))
+        ]
+        block_pool.cached_block_hash_to_block._cache.clear()
+
+        for i, (block_hash, is_cached) in enumerate(
+            zip(block_hash_list, block_is_cached)
+        ):
+            if is_cached:
+                block_pool.cached_block_hash_to_block.insert(
+                    make_block_hash_with_group_id(block_hash, 0),
+                    block_pool.blocks[i + 10],
+                )
+
+        computed_blocks = manager.find_longest_cache_hit(
+            block_hashes=block_hash_list,
+            max_length=len(block_is_cached) * block_size,
+            kv_cache_group_ids=[0],
+            block_pool=block_pool,
+            kv_cache_spec=sliding_window_spec,
+            use_eagle=False,
+            alignment_tokens=block_size,
+        )[0]
+        assert len(computed_blocks) == expected_length
+
+    N = 1000
+
+    run_case([False] * N, 0)
+
+    pattern = [False] * (N - W) + [True] * W
+    run_case(pattern, N)
+
+    mid = N // 2
+    pattern = [False] * mid + [True] * W + [False] * (N - mid - W)
+    run_case(pattern, mid + W)
+
+    pattern = [True] * (W - 1) + [False] * (N - W + 1)
+    run_case(pattern, W - 1)
+
+    random.seed(42)
+    pattern = [False] * N
+    for i in range(0, N, W + 1):
+        pattern[i] = True
+    run_case(pattern, 1)
+
+    pattern = [False] * N
+    pattern[100 : 100 + W] = [True] * W
+    pattern[800 : 800 + W] = [True] * W
+    run_case(pattern, 800 + W)
+
+    run_case([True] * N, N)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -575,44 +575,93 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # the last matched block.
             sliding_window_contiguous_blocks += 1
 
-        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
-        # optimize the time complexity from O(max_num_blocks) to
-        # O(max_num_blocks / sliding_window_contiguous_blocks +
-        # sliding_window_contiguous_blocks),
-        # which is good for low cache hit rate scenarios.
         max_num_blocks = max_length // kv_cache_spec.block_size
         computed_blocks = tuple(
             [block_pool.null_block] * max_num_blocks
             for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
-        num_contiguous_blocks = 0
         match_found = False
-        # Search from right to left and early stop when a match is found.
-        for i in range(max_num_blocks - 1, -1, -1):
-            if cached_block := block_pool.get_cached_block(
-                block_hashes[i], kv_cache_group_ids
+
+        # Strided probe + expand: probe every sliding_window_contiguous_blocks-th
+        # position right-to-left. Any valid window of
+        # sliding_window_contiguous_blocks consecutive cached blocks must contain
+        # at least one position that falls on a stride boundary, so we only need
+        # O(max_num_blocks / sliding_window_contiguous_blocks) probes. On a hit,
+        # expand O(sliding_window_contiguous_blocks) to find the full run.
+        # This optimizes time complexity from O(max_num_blocks) to
+        # O(max_num_blocks / sliding_window_contiguous_blocks +
+        # sliding_window_contiguous_blocks),
+        probe = max_num_blocks - 1
+        stride = max(sliding_window_contiguous_blocks, 1)
+        while probe >= 0 and not match_found:
+            if not block_pool.get_cached_block(block_hashes[probe], kv_cache_group_ids):
+                probe -= stride
+                continue
+
+            run_start = probe
+            run_end = probe
+
+            while (
+                run_end + 1 < max_num_blocks
+                and run_end - probe < sliding_window_contiguous_blocks - 1
+                and block_pool.get_cached_block(
+                    block_hashes[run_end + 1], kv_cache_group_ids
+                )
             ):
-                # Skip prefix matching check if the block is not aligned with
-                # `alignment_tokens`.
-                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
-                    post_pop_blocks = i if use_eagle else i + 1
-                    if (post_pop_blocks * block_size) % alignment_tokens != 0:
+                run_end += 1
+
+            while (
+                run_start - 1 >= 0
+                and probe - run_start < sliding_window_contiguous_blocks - 1
+                and block_pool.get_cached_block(
+                    block_hashes[run_start - 1], kv_cache_group_ids
+                )
+            ):
+                run_start -= 1
+
+            run_length = run_end - run_start + 1
+
+            if run_length >= sliding_window_contiguous_blocks:
+                window_end = run_end
+                if block_size != alignment_tokens:
+                    while (
+                        window_end >= run_start + sliding_window_contiguous_blocks - 1
+                    ):
+                        post_pop = window_end if use_eagle else window_end + 1
+                        if (post_pop * block_size) % alignment_tokens == 0:
+                            break
+                        window_end -= 1
+                    else:
+                        probe = run_start - stride
                         continue
-                # Add the cached block to the computed blocks.
-                for computed, cached in zip(computed_blocks, cached_block):
-                    computed[i] = cached
-                num_contiguous_blocks += 1
-                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
-                    # Trim the trailing blocks.
-                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
-                    # when sliding_window_contiguous_blocks=2.
-                    for computed in computed_blocks:
-                        del computed[i + num_contiguous_blocks :]
-                    match_found = True
-                    break
+
+                window_start = window_end - sliding_window_contiguous_blocks + 1
+                for i in range(window_start, window_end + 1):
+                    cached_block = block_pool.get_cached_block(
+                        block_hashes[i], kv_cache_group_ids
+                    )
+                    if cached_block:
+                        for computed, cached in zip(computed_blocks, cached_block):
+                            computed[i] = cached
+
+                for computed in computed_blocks:
+                    del computed[window_end + 1 :]
+                match_found = True
             else:
-                num_contiguous_blocks = 0
+                probe = run_start - stride
+
+        if not match_found:
+            num_contiguous_blocks = 0
+            for i in range(min(max_num_blocks, sliding_window_contiguous_blocks)):
+                if cached_block := block_pool.get_cached_block(
+                    block_hashes[i], kv_cache_group_ids
+                ):
+                    for computed, cached in zip(computed_blocks, cached_block):
+                        computed[i] = cached
+                    num_contiguous_blocks = i + 1
+                else:
+                    break
         if not match_found:
             # The first `num_contiguous_blocks` is a cache hit even if
             # `num_contiguous_blocks < sliding_window_contiguous_blocks`.


### PR DESCRIPTION
## Purpose

Use a strided probe + expand algorithm to find the rightmost valid window of consecutive cached blocks, reducing time complexity from O(max_num_blocks) to
 O(max_num_blocks / sliding_window_contiguous_blocks+sliding_window_contiguous_blocks).

## Test Plan
Run kv cache tests and use this perf script to comapre perfomance 
```
import time
import random
import torch

from vllm.v1.core.block_pool import BlockPool
from vllm.v1.core.kv_cache_utils import BlockHash, make_block_hash_with_group_id
from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
from vllm.v1.kv_cache_interface import SlidingWindowSpec


def bench(name, manager, block_pool, block_hash_list, spec, block_size, N, iters=1000):
    # Warm up
    manager.find_longest_cache_hit(
        block_hashes=block_hash_list,
        max_length=N * block_size,
        kv_cache_group_ids=[0],
        block_pool=block_pool,
        kv_cache_spec=spec,
        use_eagle=False,
        alignment_tokens=block_size,
    )

    start = time.perf_counter()
    for _ in range(iters):
        manager.find_longest_cache_hit(
            block_hashes=block_hash_list,
            max_length=N * block_size,
            kv_cache_group_ids=[0],
            block_pool=block_pool,
            kv_cache_spec=spec,
            use_eagle=False,
            alignment_tokens=block_size,
        )
    elapsed = time.perf_counter() - start
    print(f"  {name}: {elapsed*1000:.2f} ms total, {elapsed/iters*1e6:.1f} us/call")
    return elapsed


def setup(N, hit_rate, sliding_window, block_size):
    spec = SlidingWindowSpec(
        block_size=block_size,
        num_kv_heads=1,
        head_size=1,
        dtype=torch.float32,
        sliding_window=sliding_window,
    )
    block_pool = BlockPool(
        num_gpu_blocks=N + 100, enable_caching=True, hash_block_size=block_size
    )
    manager = SlidingWindowManager(
        spec,
        block_pool=block_pool,
        enable_caching=True,
        kv_cache_group_id=0,
        max_admission_blocks_per_request=10**9,
    )

    random.seed(123)
    block_is_cached = [random.random() < hit_rate for _ in range(N)]
    block_hash_list = [BlockHash(str(i).encode()) for i in range(N)]

    block_pool.cached_block_hash_to_block._cache.clear()
    for i, (bh, is_cached) in enumerate(zip(block_hash_list, block_is_cached)):
        if is_cached:
            block_pool.cached_block_hash_to_block.insert(
                make_block_hash_with_group_id(bh, 0),
                block_pool.blocks[i + 10],
            )

    return manager, block_pool, block_hash_list, spec


if __name__ == "__main__":
    configs = [
        # (N, hit_rate, sliding_window, block_size, description)
        (10000, 0.0,  64, 4, "N=10000, 0% hit rate, W=16"),
        (10000, 0.05, 64, 4, "N=10000, 5% hit rate, W=16"),
        (10000, 0.2,  64, 4, "N=10000, 20% hit rate, W=16"),
        (10000, 0.9,  64, 4, "N=10000, 90% hit rate, W=16"),
        (10000, 0.0,  32, 4, "N=10000, 0% hit rate, W=8"),
        (50000, 0.0,  64, 4, "N=50000, 0% hit rate, W=16"),
        (50000, 0.01, 64, 4, "N=50000, 1% hit rate, W=16"),
    ]

    print("Sliding Window Cache Hit Search - Performance Benchmark")
    print("=" * 60)
    for N, hit_rate, sw, bs, desc in configs:
        print(f"\n{desc}:")
        manager, block_pool, bh_list, spec = setup(N, hit_rate, sw, bs)
        bench("strided_probe", manager, block_pool, bh_list, spec, bs, N)
    print("\n" + "=" * 60)
```
## Test Result
```
| Scenario                         | Original (µs) | PR (µs) |
|----------------------------------|--------------|---------|
| N=10000, 0% hits, W=16           | 3141.6       | 222.5   |
| N=10000, 5% hits, W=16           | 3571.6       | 267.7   |
| N=10000, 20% hits, W=16          | 4136.8       | 396.6   |
| N=10000, 90% hits, W=16          | 51.0         | 53.1    |
| N=10000, 0% hits, W=8            | 3134.8       | 518.9   |
| N=50000, 0% hits, W=16           | 15690.3      | 1102.7  |
| N=50000, 1% hits, W=16           | 17062.6      | 1278.9  |
```
```
(vllm) root@openshiftai-vllm:~/vllm# .venv/bin/python -m pytest -v tests/v1/core/test_single_type_kv_cache_manager.py
======================================================= test session starts =======================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /root/vllm/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /root/vllm
configfile: pyproject.toml
plugins: rerunfailures-16.2, forked-1.6.0, mock-3.15.1, cov-7.1.0, hypothesis-6.152.7, schemathesis-4.18.5, anyio-4.13.0, shard-0.1.2, timeout-2.4.0, asyncio-1.3.0, buildkite-test-collector-0.1.9, typeguard-4.5.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9 items                                                                                                                 
Running 9 items in this shard: tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_possible_cached_prefix, tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_possible_cached_prefix, tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_remove_skipped_blocks, tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_remove_skipped_blocks, tests/v1/core/test_single_type_kv_cache_manager.py::test_get_num_blocks_to_allocate, tests/v1/core/test_single_type_kv_cache_manager.py::test_evictable_cached_blocks_not_double_allocated, tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_get_num_blocks_to_allocate, tests/v1/core/test_single_type_kv_cache_manager.py::test_predictor_matches_allocator_blocks_calculation_with_admission_cap, tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_strided_probe_stress

tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_possible_cached_prefix PASSED              [ 11%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_possible_cached_prefix PASSED                       [ 22%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_remove_skipped_blocks PASSED               [ 33%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_remove_skipped_blocks PASSED                        [ 44%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_get_num_blocks_to_allocate PASSED                                  [ 55%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_evictable_cached_blocks_not_double_allocated PASSED                [ 66%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_get_num_blocks_to_allocate PASSED          [ 77%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_predictor_matches_allocator_blocks_calculation_with_admission_cap PASSED [ 88%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_strided_probe_stress PASSED                         [100%]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

