### PR TITLE
[CI/Build] Bump nvidia-cutlass-dsl to 4.5.1

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -21,7 +21,7 @@ nvidia-cudnn-frontend>=1.13.0,<1.19.0
 fastsafetensors >= 0.2.2
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
-nvidia-cutlass-dsl[cu13]==4.5.0
+nvidia-cutlass-dsl[cu13]==4.5.1
 quack-kernels>=0.3.3
 
 # Tokenspeed_MLA for faster mla with spec decode


### PR DESCRIPTION
## Purpose

`cute-dsl 4.5.1` fixes FI Blackwell GDN failures. With the previous pin `==4.5.0` (introduced in #42342), FlashInfer's Blackwell GDN prefill kernel hits a JIT compile ICE during warmup. Bumping the pin to `==4.5.1` unblocks GDN without any source change on the FlashInfer side.

## Test Result

Hardware: 1xGB200

### Functional

**FlashInfer GDN unit tests**:

```
pytest -q tests/gdn/test_prefill_delta_rule.py
```

| `nvidia-cutlass-dsl` | passed | skipped | failed |
| --- | --- | --- | --- |
| `4.5.0` (current pin, stock FI) | 1547 | 480 | 16 (all `test_checkpoint_correctness`, same MLIR ICE) |
| `4.5.1` (this PR) | 1563 | 480 | 0 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>