### PR TITLE
[MISC] Fix symm_mem cap-equal gate; log AR backend selection

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -114,6 +114,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 # currently be an MI300 series.
                 self.qr_comm = QuickAllReduce(group=self.cpu_group, device=self.device)
 
+        if self.world_size > 1:
+            self._log_all_reduce_backend_selection()
+
         if self.use_all2all:
             if self.all2all_backend in ("naive", "allgather_reducescatter"):
                 from .all2all import AgRsAll2AllManager
@@ -170,6 +173,51 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 self.all2all_manager.__class__.__name__,
                 scope="global",
             )
+
+    def _log_all_reduce_backend_selection(self) -> None:
+        """Log the all-reduce backends that are active for this group.
+
+        The dispatch chain in ``all_reduce`` tries backends in this order and
+        falls through to the next one if the current backend rejects the
+        input (size/dtype gates) or is disabled. The list of "enabled"
+        backends below is the subset of potential backends that may be
+        chosen at dispatch time for this group; the actual per-call choice
+        depends on the input tensor.
+        """
+        all_potential_ar_backends = [
+            "NCCL_SYMM_MEM",
+            "QUICK_REDUCE",
+            "FLASHINFER",
+            "CUSTOM",
+            "SYMM_MEM",
+            "PYNCCL",
+        ]
+        enabled_ar_backends: list[str] = []
+        if (
+            self.pynccl_comm is not None
+            and not self.pynccl_comm.disabled
+            and is_symmetric_memory_enabled()
+        ):
+            enabled_ar_backends.append("NCCL_SYMM_MEM")
+        if self.qr_comm is not None and not self.qr_comm.disabled:
+            enabled_ar_backends.append("QUICK_REDUCE")
+        if self.fi_ar_comm is not None and not self.fi_ar_comm.disabled:
+            enabled_ar_backends.append("FLASHINFER")
+        if self.ca_comm is not None and not self.ca_comm.disabled:
+            enabled_ar_backends.append("CUSTOM")
+        if self.symm_mem_comm is not None and not self.symm_mem_comm.disabled:
+            enabled_ar_backends.append("SYMM_MEM")
+        if self.pynccl_comm is not None and not self.pynccl_comm.disabled:
+            enabled_ar_backends.append("PYNCCL")
+
+        logger.info_once(
+            "Using %s all-reduce backends (in dispatch order) for group "
+            "'%s' out of potential backends: %s.",
+            "[" + ", ".join(f"'{b}'" for b in enabled_ar_backends) + "]",
+            self.unique_name or "<unnamed>",
+            "[" + ", ".join(f"'{b}'" for b in all_potential_ar_backends) + "]",
+            scope="local",
+        )
 
     def all_reduce(self, input_):
         # since currently we perform copy input -> symm_input -> out-of-place AR

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -7,6 +7,7 @@ from torch.distributed import ProcessGroup
 
 import vllm.envs as envs
 from vllm.distributed.device_communicators.all_reduce_utils import (
+    NCCL_SYMM_MEM_ALL_REDUCE_CONFIG,
     should_nccl_symm_mem_allreduce,
 )
 from vllm.distributed.device_communicators.pynccl import register_nccl_symmetric_ops
@@ -193,10 +194,16 @@ class CudaCommunicator(DeviceCommunicatorBase):
             "PYNCCL",
         ]
         enabled_ar_backends: list[str] = []
+        # Mirror the static preconditions of `should_nccl_symm_mem_allreduce`:
+        # VLLM_BATCH_INVARIANT off, NCCL symm mem enabled, and world_size meets
+        # NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["min_world_size"]. The per-tensor-size
+        # check inside that function stays as a runtime decision.
         if (
             self.pynccl_comm is not None
             and not self.pynccl_comm.disabled
             and is_symmetric_memory_enabled()
+            and not envs.VLLM_BATCH_INVARIANT
+            and self.world_size >= NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["min_world_size"]
         ):
             enabled_ar_backends.append("NCCL_SYMM_MEM")
         if self.qr_comm is not None and not self.qr_comm.disabled:

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -195,15 +195,27 @@ class CudaCommunicator(DeviceCommunicatorBase):
         ]
         enabled_ar_backends: list[str] = []
         # Mirror the static preconditions of `should_nccl_symm_mem_allreduce`:
-        # VLLM_BATCH_INVARIANT off, NCCL symm mem enabled, and world_size meets
-        # NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["min_world_size"]. The per-tensor-size
-        # check inside that function stays as a runtime decision.
+        # VLLM_BATCH_INVARIANT off, NCCL symm mem enabled, world_size meets
+        # min_world_size, and world_size either has a tuned entry in
+        # `custom_ar_preferred_ranges` or is greater than
+        # `always_use_above_world_size`. World sizes that fail the latter (e.g.
+        # 5/6/7 with the default config) never dispatch NCCL symm mem
+        # regardless of input. The per-tensor-size check inside the function
+        # stays as a runtime decision.
+        nccl_symm_ws_ok = self.world_size >= NCCL_SYMM_MEM_ALL_REDUCE_CONFIG[
+            "min_world_size"
+        ] and (
+            self.world_size
+            in NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["custom_ar_preferred_ranges"]
+            or self.world_size
+            > NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["always_use_above_world_size"]
+        )
         if (
             self.pynccl_comm is not None
             and not self.pynccl_comm.disabled
             and is_symmetric_memory_enabled()
             and not envs.VLLM_BATCH_INVARIANT
-            and self.world_size >= NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["min_world_size"]
+            and nccl_symm_ws_ok
         ):
             enabled_ar_backends.append("NCCL_SYMM_MEM")
         if self.qr_comm is not None and not self.qr_comm.disabled:
@@ -223,7 +235,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             "[" + ", ".join(f"'{b}'" for b in enabled_ar_backends) + "]",
             self.unique_name or "<unnamed>",
             "[" + ", ".join(f"'{b}'" for b in all_potential_ar_backends) + "]",
-            scope="local",
+            scope="global",
         )
 
     def all_reduce(self, input_):

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -121,7 +121,7 @@ class SymmMemCommunicator:
         inp_size = inp.numel() * inp.element_size()
         if inp_size % 4 != 0:
             return False
-        return inp_size < self.max_size
+        return inp_size <= self.max_size
 
     def all_reduce(
         self, inp: torch.Tensor, *, out: torch.Tensor | None = None


### PR DESCRIPTION


## Summary

Two small changes in `vllm/distributed/device_communicators/`:

- **Fix misprint in `SymmMemCommunicator.should_use_symm_mem`** — the size gate
  used a strict less-than (`inp_size < self.max_size`), which silently rejected
  tensors whose byte size exactly equals the per-capability symm_mem cap and
  fell back to PyNCCL even though the buffer was sized to fit them. Changed to
  `<=` so cap-equal tensors take the symm_mem path as intended.

- **Add startup logging for all-reduce backend selection** in
  `CudaCommunicator.__init__`. Mirrors the existing attention-backend and
  Fp8/Int8/NvFP4 MoE-backend `info_once` logs, so the per-group AR dispatch
  chain is observable at server start. Example output:

  ```text
  [cuda_communicator.py:308] Using ['CUSTOM', 'SYMM_MEM', 'PYNCCL'] all-reduce backends (in dispatch order) for group 'tp:0' out of potential backends: ['NCCL_SYMM_MEM', 'QUICK_REDUCE', 'FLASHINFER', 'CUSTOM', 'SYMM_MEM', 'PYNCCL'].
  [cuda_communicator.py:308] Using ['PYNCCL'] all-reduce backends (in dispatch order) for group 'ep:0' out of potential backends: ['NCCL_SYMM_MEM', 'QUICK_REDUCE', 'FLASHINFER', 'CUSTOM', 'SYMM_MEM', 'PYNCCL'].
  ```

  The list reflects the chain order tried by `all_reduce` (per-call gates decide which backend actually serves a given input).


## Testing

Tested on B300, Qwen3.5-397B, tep8 where most of all-reduce sizes exactly equal to 64M:

```bash
vllm serve nvidia/Qwen3.5-397B-A17B-NVFP4 \
    --port 8000 \
    --tensor-parallel-size 8 \
    --enable-expert-parallel \
    --no-enable-prefix-caching \
    --language-model-only \
    --attention-backend FLASHINFER

vllm bench serve \
    --backend vllm \
    --model nvidia/Qwen3.5-397B-A17B-NVFP4 \
    --port 8000 --endpoint /v1/completions \
    --dataset-name random \
    --random-input 32000 --random-output 2 \
    --max-concurrency 128 \
    --num-prompt 384 \
    --ignore-eos --temperature 0.0 --disable-tqdm
```

Result: 384/384 requests successful.
