### PR TITLE
[codex] Add Robometer RFM pooling model support

### DIFF
--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -1490,6 +1490,38 @@ def test_parse_chat_messages_openai_format_image_url(
     _assert_mm_uuids(mm_uuids, 1, expected_uuids=[None])
 
 
+def test_parse_chat_messages_openai_format_video_alias(
+    phi3v_model_config,
+    video_url,
+):
+    content = [
+        {"type": "video", "video_url": {"url": video_url}},
+        {"type": "text", "text": "What's in the video?"},
+    ]
+    conversation, mm_data, mm_uuids = parse_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": content,
+            }
+        ],
+        phi3v_model_config,
+        content_format="openai",
+    )
+
+    assert conversation == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "video"},
+                {"type": "text", "text": "What's in the video?"},
+            ],
+        }
+    ]
+    _assert_mm_data_inputs(mm_data, {"video": 1})
+    _assert_mm_uuids(mm_uuids, 1, expected_uuids=[None], modality="video")
+
+
 def test_parse_chat_messages_rejects_too_many_images_in_one_message(
     phi3v_model_config,
     image_url,
@@ -2261,6 +2293,42 @@ def test_parse_chat_messages_video_vision_chunk(
                 {"type": "text", "text": "Analyze this video."},
                 {
                     "type": "video_url",
+                    "video_url": {"url": video_url},
+                },
+            ],
+        }
+    ]
+
+    conversation, mm_data, mm_uuids = parse_chat_messages(
+        messages,
+        kimi_k2_5_model_config,
+        content_format="string",
+    )
+
+    placeholder = "<|kimi_k25_video_placeholder|>"
+    expected_conversation = [
+        {
+            "role": "user",
+            "content": f"{placeholder}\nAnalyze this video.",
+        }
+    ]
+
+    assert conversation == expected_conversation
+    _assert_mm_data_is_vision_chunk_input(mm_data, 1)
+    _assert_mm_uuids(mm_uuids, 1, expected_uuids=[None], modality="vision_chunk")
+
+
+def test_parse_chat_messages_video_alias_vision_chunk(
+    kimi_k2_5_model_config,
+    video_url,
+):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Analyze this video."},
+                {
+                    "type": "video",
                     "video_url": {"url": video_url},
                 },
             ],

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -728,6 +728,7 @@ _TOKEN_CLASSIFICATION_EXAMPLE_MODELS = {
     "ModernBertForTokenClassification": _HfExamplesInfo(
         "disham993/electrical-ner-ModernBERT-base"
     ),
+    "RFM": _HfExamplesInfo("aliangdw/Robometer-4B"),
 }
 
 _SEQUENCE_CLASSIFICATION_EXAMPLE_MODELS = {

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -156,7 +156,7 @@ class VideoURL(TypedDict, total=False):
 class ChatCompletionContentPartVideoParam(TypedDict, total=False):
     video_url: Required[VideoURL]
 
-    type: Required[Literal["video_url"]]
+    type: Required[Literal["video_url", "video"]]
     """The type of the content part."""
 
 
@@ -1274,6 +1274,7 @@ MM_PARSER_MAP: dict[
     "input_audio": lambda part: _InputAudioParser(part).get("input_audio", None),
     "refusal": lambda part: _RefusalParser(part).get("refusal", None),
     "video_url": lambda part: _VideoParser(part).get("video_url", {}).get("url", None),
+    "video": lambda part: _VideoParser(part).get("video_url", {}).get("url", None),
 }
 
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -541,6 +541,21 @@ class Qwen2ForRewardModelConfig(VerifyAndUpdateConfig):
             pooler_config.use_activation = False
 
 
+class RFMConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+        pooler_config = model_config.pooler_config
+        hf_config = model_config.hf_config
+
+        if pooler_config.tok_pooling_type is None:
+            pooler_config.tok_pooling_type = "STEP"
+        if pooler_config.step_tag_id is None:
+            text_config = getattr(hf_config, "text_config", hf_config)
+            pooler_config.step_tag_id = text_config.vocab_size - 1
+        if pooler_config.use_activation is None:
+            pooler_config.use_activation = False
+
+
 class Qwen3ForSequenceClassificationConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
@@ -653,6 +668,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "Qwen3VLForSequenceClassification": Qwen3VLForSequenceClassificationConfig,
     "Qwen3_5ForConditionalGeneration": Qwen3_5ForConditionalGenerationConfig,
     "Qwen3_5MoeForConditionalGeneration": Qwen3_5ForConditionalGenerationConfig,
+    "RFM": RFMConfig,
     "VoyageQwen3BidirectionalEmbedModel": VoyageQwen3BidirectionalEmbedModelConfig,
     "XLMRobertaModel": JinaRobertaModelConfig,
 }

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -302,6 +302,7 @@ _TOKEN_CLASSIFICATION_MODELS = {
         "qwen3_asr_forced_aligner",
         "Qwen3ASRForcedAlignerForTokenClassification",
     ),
+    "RFM": ("rfm", "RFM"),
 }
 
 _SEQUENCE_CLASSIFICATION_MODELS = {

--- a/vllm/model_executor/models/rfm.py
+++ b/vllm/model_executor/models/rfm.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch import nn
+from transformers import Qwen3VLProcessor
+
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_classify
+from vllm.multimodal import MULTIMODAL_REGISTRY
+
+from .interfaces_base import VllmModelForPooling
+from .qwen3_vl import (
+    Qwen3VLDummyInputsBuilder,
+    Qwen3VLForConditionalGeneration,
+    Qwen3VLMultiModalProcessor,
+    Qwen3VLProcessingInfo,
+)
+
+ROBOMETER_SPECIAL_TOKENS = (
+    "<|split_token|>",
+    "<|reward_token|>",
+    "<|pref_token|>",
+    "<|sim_token|>",
+    "<|prog_token|>",
+)
+
+
+def ensure_robometer_special_tokens(tokenizer: object) -> None:
+    get_vocab = getattr(tokenizer, "get_vocab", None)
+    add_special_tokens = getattr(tokenizer, "add_special_tokens", None)
+    if not callable(get_vocab) or not callable(add_special_tokens):
+        return
+
+    vocab = get_vocab()
+    missing_tokens = [token for token in ROBOMETER_SPECIAL_TOKENS if token not in vocab]
+    if missing_tokens:
+        add_special_tokens({"additional_special_tokens": missing_tokens})
+
+
+class RFMProcessingInfo(Qwen3VLProcessingInfo):
+    def get_hf_processor(self, **kwargs: object) -> Qwen3VLProcessor:
+        model_config = self.ctx.model_config
+        processor_name = model_config.tokenizer or "Qwen/Qwen3-VL-4B-Instruct"
+        tokenizer = self.ctx.tokenizer
+        if tokenizer is not None:
+            ensure_robometer_special_tokens(tokenizer)
+
+        processor = Qwen3VLProcessor.from_pretrained(
+            processor_name,
+            revision=model_config.tokenizer_revision,
+            trust_remote_code=model_config.trust_remote_code,
+            tokenizer=tokenizer,
+            use_fast=kwargs.pop("use_fast", True),
+            **kwargs,
+        )
+        ensure_robometer_special_tokens(processor.tokenizer)
+        return processor
+
+
+class RobometerHead(nn.Module):
+    """Robometer progress, success, preference, and similarity heads."""
+
+    def __init__(
+        self,
+        progress_head: nn.Module,
+        success_head: nn.Module,
+        preference_head: nn.Module,
+        similarity_head: nn.Module,
+    ) -> None:
+        super().__init__()
+        self.progress_head = progress_head
+        self.success_head = success_head
+        self.preference_head = preference_head
+        self.similarity_head = similarity_head
+
+    @property
+    def progress_dim(self) -> int:
+        progress_out = self.progress_head[-1]
+        assert isinstance(progress_out, nn.Linear)
+        return progress_out.out_features
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.cat(
+            (
+                self.progress_head(hidden_states),
+                self.success_head(hidden_states),
+                self.preference_head(hidden_states),
+                self.similarity_head(hidden_states),
+            ),
+            dim=-1,
+        )
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen3VLMultiModalProcessor,
+    info=RFMProcessingInfo,
+    dummy_inputs=Qwen3VLDummyInputsBuilder,
+)
+class RFM(Qwen3VLForConditionalGeneration, VllmModelForPooling):
+    """Robometer reward model based on Qwen3-VL.
+
+    The pooling output is a token-classification tensor whose last dimension is
+    `[progress_logits, success_logit, preference_logit, similarity_logit]`.
+    Robometer-4B uses 10 discrete progress bins, so its output dimension is 13.
+    """
+
+    is_pooling_model = True
+    default_tok_pooling_type = "STEP"
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+        hf_config = vllm_config.model_config.hf_config
+        hidden_size = hf_config.text_config.hidden_size
+        progress_bins = getattr(
+            hf_config,
+            "progress_discrete_bins",
+            getattr(hf_config, "num_progress_bins", 10),
+        )
+
+        head_size = hidden_size // 2
+        params_dtype = vllm_config.model_config.head_dtype
+        self.progress_head = nn.Sequential(
+            nn.Linear(hidden_size, head_size, dtype=params_dtype),
+            nn.LayerNorm(head_size, dtype=params_dtype),
+            nn.GELU(),
+            nn.Dropout(0.1),
+            nn.Linear(head_size, progress_bins, dtype=params_dtype),
+        )
+        self.success_head = nn.Sequential(
+            nn.Linear(hidden_size, head_size, dtype=params_dtype),
+            nn.LayerNorm(head_size, dtype=params_dtype),
+            nn.GELU(),
+            nn.Dropout(0.1),
+            nn.Linear(head_size, 1, dtype=params_dtype),
+        )
+        self.preference_head = nn.Sequential(
+            nn.Linear(hidden_size, head_size, dtype=params_dtype),
+            nn.LayerNorm(head_size, dtype=params_dtype),
+            nn.GELU(),
+            nn.Dropout(0.1),
+            nn.Linear(head_size, 1, dtype=params_dtype),
+        )
+        self.similarity_head = nn.Sequential(
+            nn.Linear(hidden_size, head_size, dtype=params_dtype),
+            nn.LayerNorm(head_size, dtype=params_dtype),
+            nn.GELU(),
+            nn.Dropout(0.1),
+            nn.Linear(head_size, 1, dtype=params_dtype),
+        )
+        self.robometer_head = RobometerHead(
+            self.progress_head,
+            self.success_head,
+            self.preference_head,
+            self.similarity_head,
+        )
+        self.frame_pool_attn = nn.Linear(
+            hidden_size,
+            1,
+            bias=False,
+            dtype=vllm_config.model_config.head_dtype,
+        )
+
+        pooler_config = vllm_config.model_config.pooler_config
+        assert pooler_config is not None
+        self.pooler = pooler_for_token_classify(
+            pooler_config, classifier=self.robometer_head
+        )


### PR DESCRIPTION
## Summary

Adds support for Robometer/RFM checkpoints such as `aliangdw/Robometer-4B` as Qwen3-VL based token-classification pooling models.

The implementation keeps the Robometer-specific wrapper in `rfm.py`, reuses the existing Qwen3-VL multimodal processor/model path, and adds the Robometer heads/checkpoint names expected by the published weights.

## Details

- Register `RFM` as a token-classification model.
- Add an `RFMConfig` update hook so Robometer defaults to token-wise `STEP` pooling at `<|prog_token|>` and raw logits.
- Reconstruct Robometer special tokens when the checkpoint repo does not ship tokenizer files. Adding the official special tokens to `Qwen/Qwen3-VL-4B-Instruct` yields the checkpoint vocab size of `151674`; `<|prog_token|>` resolves to `151673`.
- Add progress, success, preference, similarity heads and `frame_pool_attn` with names matching the checkpoint.

## Duplicate-work check

No issue number was provided. I checked for existing open PRs covering this work:

- `gh pr list --repo vllm-project/vllm --state open --search "Robometer" --json number,title,url,headRefName,author --limit 20` -> `[]`
- `gh pr list --repo vllm-project/vllm --state open --search "RFM" --json number,title,url,headRefName,author --limit 20` -> `[]`
- `gh pr list --repo vllm-project/vllm --state open --search "qwen3_vl pooling" --json number,title,url,headRefName,author --limit 20` -> `[]`
- `gh pr list --repo vllm-project/vllm --state open --search "aliangdw Robometer-4B"` -> no results

## Validation

Local:

- `./.venv/bin/pre-commit run ruff-check --files vllm/model_executor/models/rfm.py vllm/model_executor/models/config.py vllm/model_executor/models/registry.py tests/models/registry.py` -> passed
- `./.venv/bin/python -m py_compile vllm/model_executor/models/rfm.py vllm/model_executor/models/config.py vllm/model_executor/models/registry.py tests/models/registry.py` -> passed
- Registry/config smoke confirmed `RFM` loads as a multimodal pooling model and resolves to `token_classify` with `tok_pooling_type='STEP'`, `step_tag_id=151673`, `use_activation=False`.
- Commit hooks ran through pre-commit and passed.

Modal A10G:

- Loaded `aliangdw/Robometer-4B` with `tokenizer=Qwen/Qwen3-VL-4B-Instruct`, `runner=pooling`, `dtype=bfloat16`.
- Served via the OpenAI-compatible API server stack and posted to `/pooling` with the Robometer progress prompt, one image, `<|prog_token|>`, and `chat_template_kwargs={"add_vision_id": true, "enable_thinking": false, "fps": 1}`.
- Response was HTTP 200 with one output row and 13 logits, matching one progress token and the Robometer head layout.

Note: local `tests/models/test_registry.py -k RFM` executes the test body but fails during teardown on this Mac due a PyTorch MPS allocator internal assert in `torch.accelerator.empty_cache()`; CUDA validation was performed on Modal instead.

## AI assistance

AI assistance was used to inspect the Robometer implementation, implement this patch, and run validation. The submitting human should review every changed line and rerun relevant tests before marking ready for review.
