### PR TITLE
[Bugfix] Add 12.1 to CUDA_SUPPORTED_ARCHS for CUDA-13 builds (sm_121a/GB10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,18 @@ if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    # starting from CUDA 12.9 and Blackwell (10.0), we use family-specific targets (10.0f, 12.0f, etc)
    # to support the whole generation without specifying all sub-architectures
    # see: https://developer.nvidia.com/blog/nvidia-blackwell-and-nvidia-cuda-12-9-introduce-family-specific-architecture-features/
-  set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0")
+   # 12.1 is listed explicitly because the FP8 Marlin kernels (MARLIN_FP8_ARCHS,
+   # MARLIN_MOE_FP8_ARCHS) request plain 12.1 (no suffix) and need it to survive the
+   # intersection at line 185 below. Without 12.1 here, sm_121a is dropped from
+   # CUDA_ARCHS and no sm_121a Marlin SASS is generated; the matching runtime
+   # arch check in csrc/quantization/marlin/marlin.cu is also relaxed to allow
+   # the whole sm_12x family (matching the existing MoE path in
+   # csrc/moe/marlin_moe_wna16/ops.cu). Without both, FP8 quant inference on
+   # GB10 / DGX Spark (sm_121a) fails with cudaErrorNoKernelImageForDevice
+   # (binary missing) or a TORCH_CHECK failure (runtime guard). The 12.0f
+   # family targets used by MLA/SCALED_MM/FP4/CUTLASS_MOE_DATA already cover
+   # sm_121 via family-compatibility and are unaffected by this change.
+  set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0;12.1")
 elseif(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
   set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;10.3;12.0;12.1")

--- a/csrc/quantization/marlin/marlin.cu
+++ b/csrc/quantization/marlin/marlin.cu
@@ -400,10 +400,12 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
                 "Turing only support FP16 or INT8 activation.");
   }
   if (a_type == vllm::kFE4M3fn) {
+    TORCH_CHECK(major_capability * 10 + minor_capability >= 89,
+                "FP8 only support Ada Lovelace or newer GPUs.");
     TORCH_CHECK(
         major_capability * 10 + minor_capability == 89 ||
-            major_capability * 10 + minor_capability == 120,
-        "Marlin W4A8-FP8 only support SM89 or SM120 device (It is slower than "
+            major_capability == 12,
+        "Marlin W4A8-FP8 only support SM89 or SM12x device (It is slower than "
         "Marlin W4A16 on other devices).");
   }
 


### PR DESCRIPTION
## Summary

Two coupled changes that together unblock FP8 Marlin inference on NVIDIA GB10 / DGX Spark (sm_121a) under CUDA 13:

1. **`CMakeLists.txt`**: add `12.1` to `CUDA_SUPPORTED_ARCHS` in the CUDA-13 branch so `12.1a` survives the intersection at L185-187 and the Marlin codegen emits sm_121a kernel binaries.
2. **`csrc/quantization/marlin/marlin.cu`**: update the non-MoE FP8 runtime arch check to accept `major_capability == 12` (the entire SM12x family) instead of the literal `sm_120`, mirroring the existing MoE pattern in `csrc/moe/marlin_moe_wna16/ops.cu:446-454`.

Without (1), the kernel binary is missing → `cudaErrorNoKernelImageForDevice`. Without (2), the kernel binary is present but the runtime `TORCH_CHECK` rejects sm_121 before the kernel launches → `"Marlin W4A8-FP8 only support SM89 or SM120 device"` failure. Both fixes are required for FP8 Marlin to actually run on GB10.

This completes the SM12x-family work started by [#35568](https://github.com/vllm-project/vllm/pull/35568), which migrated the *MoE* Marlin C++ runtime check from the literal `== 120` to `major_capability == 12` and updated kernel codegen on both paths, but missed the non-MoE C++ runtime check. The Python validator (`marlin_utils.py`) and test gates already accept the SM12x family — only the non-MoE C++ runtime check was still on the stale literal.

## Why the CUDA-13 `CUDA_SUPPORTED_ARCHS` needs `12.1`

Two `cuda_archs_loose_intersection()` calls unconditionally request `12.1` (no suffix):

- `CMakeLists.txt:392`: `MARLIN_FP8_ARCHS "8.9;12.0;12.1"`
- `CMakeLists.txt:1113`: `MARLIN_MOE_FP8_ARCHS "8.9;12.0;12.1"`

Per the file comments, these are gated on sm_89 (RTX 40x0) and the SM12x family. On sm_121 (GB10) they need `12.1a` to be present in the post-intersection `CUDA_ARCHS`.

With `TORCH_CUDA_ARCH_LIST="12.0a 12.1a"`:

| | CUDA_SUPPORTED_ARCHS | Post-intersection CUDA_ARCHS |
|---|---|---|
| Pre-patch | `7.5;...;12.0` | `12.0a` (12.1a dropped — no `12.1` base for symmetric match) |
| Post-patch | `7.5;...;12.0;12.1` | `12.0a;12.1a` (both base-matches succeed) |

The CUDA-12.8 branch already lists `12.1` in `CMakeLists.txt:107`; this restores parity for CUDA-13.

## Why the runtime check also needs to change

Non-MoE Marlin runtime FP8 gate before this patch at `csrc/quantization/marlin/marlin.cu:402-408`:

```cpp
if (a_type == vllm::kFE4M3fn) {
    TORCH_CHECK(
        major_capability * 10 + minor_capability == 89 ||
            major_capability * 10 + minor_capability == 120,
        "Marlin W4A8-FP8 only support SM89 or SM120 device ...");
}
```

After the patch, this block becomes byte-identical to the MoE path at `csrc/moe/marlin_moe_wna16/ops.cu:446-454`:

```cpp
if (a_type == vllm::kFE4M3fn) {
    TORCH_CHECK(major_capability * 10 + minor_capability >= 89,
                "FP8 only support Ada Lovelace or newer GPUs.");
    TORCH_CHECK(
        major_capability * 10 + minor_capability == 89 ||
            major_capability == 12,
        "Marlin W4A8-FP8 only support SM89 or SM12x device ...");
}
```

`major_capability == 12` is the validated bound for the SM12x family per PR #35568's rationale: it covers sm_120 (RTX 5090) + sm_121 (GB10 / DGX Spark) which share the FP8 MMA instruction `mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32` at the same hardware tier, but won't accidentally match a future sm_13x family.

## Note on other 12.x kernels in the CUDA-13 branch

The kernels in the CUDA-13 branch that ship `12.0f` family targets (MLA at L1005, SCALED_MM at L732, FP4 at L904, CUTLASS_MOE_DATA at L875) are unaffected by this patch — their `12.0f` SRC matches `12.0a` via the `[af]$`-base or family-fallback paths in `cmake/utils.cmake:368-388`, and the family target covers sm_121 via NVIDIA's CUDA 12.9+ family-compat semantics at runtime. The patch only affects kernel sets whose SRC requests `12.1` without a suffix, plus the corresponding runtime guard.

## Verification on GB10

Run on NVIDIA GB10 (sm_121a), CUDA 13.0, `TORCH_CUDA_ARCH_LIST="12.0a 12.1a"`.

**cmake STATUS output, unpatched vs patched:**

```
# UNPATCHED
-- CUDA target architectures: 12.0a;12.1a
-- CUDA supported target architectures: 12.0a               ← 12.1a dropped
-- Marlin generation script hash: ...(ARCH:12.0a)            ← no sm_121a
-- Marlin MOE generation script hash with arch: ...(ARCH:12.0a)

# PATCHED
-- CUDA target architectures: 12.0a;12.1a
-- CUDA supported target architectures: 12.0a;12.1a         ← 12.1a survives
-- Marlin generation script hash: ...(ARCH:12.0a,12.1a)     ← sm_121a generated
-- Marlin MOE generation script hash with arch: ...(ARCH:12.0a,12.1a)
```

**Binary inspection (cuobjdump) of the resulting `_C.abi3.so`:**

```
Pre-patch:  sm_80 sm_90 sm_120a
Post-patch: sm_80 sm_90 sm_120a sm_121a
```

**Symmetry with MoE Marlin runtime check:**

```
$ diff csrc/quantization/marlin/marlin.cu:402-410 \
       csrc/moe/marlin_moe_wna16/ops.cu:446-454
(no output — byte-identical)
```

## Why this is not a duplicate of #31740

PR #31740 (open since 2026-01-05) proposes the byte-identical CMakeLists change but as one line of a `+1090 / -60` feature PR (platform detection, MLA changes, fused_moe configs, Jenkinsfile, etc.). Its current state on `main`:

- `mergeStateStatus: DIRTY` — merge conflicts unresolved
- Last update: 2026-03-12 (2+ months stale)
- Only AI-bot reviews (cursor, copilot-pr-reviewer); no human reviewer approval
- Does not touch the non-MoE runtime check (`marlin.cu:402-408`) either — same gap as #35568

The approach in this PR is materially different per AGENTS.md:
- Focused minimal fix targeting only the regressions in `CUDA_SUPPORTED_ARCHS` + the matching non-MoE runtime guard
- No merge conflicts; no bundled unrelated changes
- Rebased on current main; byte-symmetric with the MoE runtime check pattern landed by #35568

---

*This PR is AI-assisted. Code authored with Claude.*
