### PR TITLE
Add parallel drafting to v2 model runner unsupported features

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1992,6 +1992,10 @@ class VllmConfig:
             elif speculative_config.method not in ("eagle", "eagle3", "mtp"):
                 unsupported.append(f"speculative method '{speculative_config.method}'")
 
+            # V2 EagleSpeculator does not support parallel_drafting (required by PEagle)
+            if speculative_config.parallel_drafting:
+                unsupported.append("parallel drafting for speculative decoding")
+
             if (
                 speculative_config.method == "eagle3"
                 and self.parallel_config.pipeline_parallel_size > 1


### PR DESCRIPTION



## Purpose
Add parallel_drafting to unsupported V2 features to fix acceptance rate collapse introduced by PR [#39337.](https://github.com/vllm-project/vllm/pull/39337) V2 EagleSpeculator lacks parallel_drafting support, causing P-EAGLE models to fall back to sequential mode with degraded multi-token acceptance. The speculators-correctness test has been failing https://buildkite.com/vllm/ci/builds/66633/table?jid=019e39ac-baaa-4a3c-9e37-7b5a7eb73cec&tab=output

## Test Plan
Tested `tests/v1/spec_decode/test_speculators_correctness.py::test_speculators_correctness[peagle]` locally.

## Test Result
```
===== Spec Decode Metrics =====
  num_drafts:              66849
  num_draft_tokens:        267396
  num_accepted_tokens:     89024
  draft_tokens_per_step:   4.00
  overall_acceptance_rate: 0.3329
  acceptance_len (1+acc/drafts): 2.3317
  per-position accepted tokens: [45145, 25136, 13110, 5633]
  per-position acceptance rates:
    pos 0: 0.6753
    pos 1: 0.3760
    pos 2: 0.1961
    pos 3: 0.0843
===============================

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

