### PR TITLE
[ROCm][MLA] Fix workspace-lock regression in FP8 ASM prefill (PR #42509)

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -326,6 +326,51 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             num_head_k,
         )
 
+        # FIX for PR #42509 regression: _mla_fp8_prefill_attn() requests its
+        # per-call scratch (logits/attn_lse/final_lse) from current_workspace_manager()
+        # *lazily* at the first prefill request -- but by then
+        # gpu_model_runner.lock_workspace() has already fired. Without pre-growing
+        # the workspace here, the assertion at workspace.py:_ensure_workspace_size
+        # ("Workspace is locked but allocation ... requires X MB, current size 0 MB")
+        # fails every request and the benchmark reports 0 successful completions.
+        #
+        # We grow the workspace once now with a worst-case flat float32 buffer that
+        # comfortably exceeds the largest plausible
+        #   (num_partial_tiles * tile_q, nhead, v_head_dim)
+        # logits tensor, so subsequent calls reuse this buffer without growth.
+        try:
+            from vllm.v1.worker.workspace import (
+                current_workspace_manager,
+                is_workspace_manager_initialized,
+            )
+        except Exception:  # noqa: BLE001
+            current_workspace_manager = None  # type: ignore[assignment]
+            is_workspace_manager_initialized = None  # type: ignore[assignment]
+
+        if (
+            current_workspace_manager is not None
+            and is_workspace_manager_initialized is not None
+            and is_workspace_manager_initialized()
+        ):
+            # 256 MB is ~8x the ~30 MB observed at TP=4 Kimi-K2.6-MXFP4 with
+            # max_qlen=2148; still tiny vs KV-cache and weight memory.
+            _FP8_PREFILL_WORKSPACE_PREALLOC_BYTES = 256 * 1024 * 1024
+            try:
+                current_workspace_manager().get_simultaneous(
+                    ((_FP8_PREFILL_WORKSPACE_PREALLOC_BYTES // 4,), torch.float32),
+                )
+                logger.info(
+                    "FP8 MLA prefill workspace pre-grown to %d MB to satisfy "
+                    "lazy scratch allocation before lock_workspace()",
+                    _FP8_PREFILL_WORKSPACE_PREALLOC_BYTES // (1024 * 1024),
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "FP8 MLA prefill workspace pre-grow failed (%s); first "
+                    "prefill request may still hit the workspace-lock assertion.",
+                    e,
+                )
+
     def _build_fp8_prefill_ps_metadata(
         self,
         metadata: AiterMLAMetadata,


### PR DESCRIPTION


## Purpose
`_mla_fp8_prefill_attn` requests its per-call scratch tensors (`logits`, `attn_lse`, `final_lse`) from
`current_workspace_manager().get_simultaneous(...)` lazily at the first prefill request. However by that point `gpu_model_runner.lock_workspace()` has already fired, so the workspace cannot grow:

  AssertionError: Workspace is locked but allocation from
  'rocm_aiter_mla.py:767:_mla_fp8_prefill_attn' requires 30.29 MB,
  current size is 0.00 MB. Workspace growth is not allowed after locking.

This makes every FP8 MLA prefill request fail on `gfx950` once `_fp8_mla_prefill_supported()` returns True (i.e. AITER >= the build that exports `mla_prefill_ps_asm_fwd` + `mla_reduce_v1`).

Repro on `vllm/vllm-openai-rocm:nightly-ff712f6447093d07747c88680b9d006b119f5890` (May-17 ROCm nightly) with Kimi-K2.6-MXFP4 at TP=4, ISL/OSL=1024,1024, conc=4: 0/40 successful requests, total throughput 0 tok/s.

Fix: at the end of `AiterMLAMetadataBuilder._init_fp8_prefill_ps_buffers()` (which already runs before `lock_workspace()`), perform a one-shot `current_workspace_manager().get_simultaneous(...)` of a worst-case flat float32 buffer (256 MB, ~8x the ~30 MB observed need). Subsequent runtime `get_simultaneous` calls from `_mla_fp8_prefill_attn` reuse this buffer without further growth.

## Test Plan
e2e Kimik2.6 run

## Test Result
After fix, same config: 40/40 successful, mean TTFT 176 ms, mean TPOT 9.58 ms, total throughput 797 tok/s (199 tok/s per GPU) - matching the pre-#42509 baseline within run-to-run variance.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

