### PR TITLE
platform: replace current_platform.is_tpu() with device_name check at hardware-gating sites

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -266,7 +266,9 @@ class MoERunner(MoERunnerInterface):
         self._forward_entry = self._select_forward()
 
     def _select_forward(self) -> Callable:
-        if current_platform.is_tpu() or current_platform.is_cpu():
+        # Use `device_name == "tpu"` so this applies to torchtpu (OOT
+        # plugin) as well as the in-tree TpuPlatform.
+        if current_platform.device_name == "tpu" or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
             # will switch to using the moe_forward custom op.
             # Note: CPU doesn't require wrapped _forward_impl.


### PR DESCRIPTION
## Context


A pytorch TPU backend, torchtpu (https://developers.googleblog.com/torchtpu-running-pytorch-natively-on-tpus-at-google-scale/), is being used to develop torchtpu-vllm, as an out-of-tree vLLM platform plugin. It's more PyTorch-native and vllm-native: built on torch_tpu and inheriting/subclassing vLLM's standard GPUModelRunner, WorkerBase, FusedMoE, single process per worker etc. — using the full vLLM runtime with TPU-specific seams (Pallasattention, JAX mesh, AOT bucket precompile). 
 
 The existing tpu backend (in core registration) bypassses much more of the vllm runtime, and calls jax (via native jax or torchax to dispatch-based trace to jax).
 

## Summary

`current_platform.is_tpu()` returns True only when `_enum == PlatformEnum.TPU`. Out-of-tree platform plugins targeting TPU hardware register with `_enum = PlatformEnum.OOT` per the [plugin docs](https://docs.vllm.ai/en/latest/design/plugin_system/), so `is_tpu()` returns False for them even though they're functionally on TPU. This forced OOT TPU integrations (currently only `tpu_inference`, which `vllm/platforms/tpu.py` itself re-exports) to monkey-patch every site that gates on TPU-hardware-specific behavior.

