### PR TITLE
fix: cap ngram gpu drafts by max model length

### DIFF
--- a/tests/v1/spec_decode/test_ngram.py
+++ b/tests/v1/spec_decode/test_ngram.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import numpy as np
+import pytest
+import torch
 
 from vllm.config import (
+    CompilationConfig,
+    CompilationMode,
     ModelConfig,
     SpeculativeConfig,
     VllmConfig,
@@ -202,3 +208,48 @@ def test_ngram_proposer():
     assert len(result[0]) == 2
     assert np.array_equal(result[0], np.array([middle_integer + 2, middle_integer + 3]))
     assert np.array_equal(result[1], np.array([]))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_ngram_gpu_proposer_respects_max_model_len():
+    from vllm.v1.spec_decode.ngram_proposer_gpu import NgramGPUKernel
+
+    device = torch.device("cuda")
+    k = 2
+    max_model_len = 6
+    vllm_config = SimpleNamespace(
+        compilation_config=CompilationConfig(mode=CompilationMode.NONE),
+        speculative_config=SimpleNamespace(
+            prompt_lookup_min=2,
+            prompt_lookup_max=2,
+            num_speculative_tokens=k,
+        ),
+        model_config=SimpleNamespace(max_model_len=max_model_len),
+        scheduler_config=SimpleNamespace(max_num_seqs=3),
+    )
+    kernel = NgramGPUKernel(vllm_config=vllm_config, device=device)
+
+    token_ids_gpu = torch.tensor(
+        [
+            [1, 2, 3, 1, 2, 3],
+            [1, 2, 3, 1, 2, 0],
+            [1, 2, 1, 2, 0, 0],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    num_tokens_no_spec = torch.tensor([6, 5, 4], dtype=torch.int32, device=device)
+    combined_mask = torch.ones(3, dtype=torch.bool, device=device)
+
+    draft_tokens, num_valid_draft_tokens = kernel(
+        num_tokens_no_spec,
+        token_ids_gpu,
+        combined_mask,
+    )
+
+    assert draft_tokens.cpu().tolist() == [
+        [-1, -1],
+        [3, -1],
+        [1, 2],
+    ]
+    assert num_valid_draft_tokens.cpu().tolist() == [0, 1, 2]

--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -200,6 +200,18 @@ class NgramGPUKernel(nn.Module):
 
         draft_tokens = torch.where(combined_mask.unsqueeze(1), results, -1)
 
+        # Do not propose draft tokens beyond the target model context budget.
+        remaining_model_len = (self.max_model_len - num_tokens_no_spec).clamp(
+            min=0, max=self.k
+        )
+        draft_positions = torch.arange(self.k, device=device).unsqueeze(0)
+        within_model_len = draft_positions < remaining_model_len.unsqueeze(1)
+        draft_tokens = torch.where(
+            within_model_len,
+            draft_tokens,
+            torch.full_like(draft_tokens, -1),
+        )
+
         # Count leading contiguous valid (non -1) tokens per request.
         is_valid = draft_tokens != -1  # [batch, k]
         cum_valid = is_valid.int().cumsum(dim=1)  # [batch, k]


### PR DESCRIPTION



## Purpose

Fixes #42533.

This PR makes the V1 `ngram_gpu` speculative proposer respect the remaining `max_model_len` budget before reporting valid draft tokens.

The CPU n-gram proposer already caps proposals by the remaining model length. This change applies the same invariant to the GPU path by masking draft positions where `position >= max_model_len - current_length` before computing `num_valid_draft_tokens`.

The cap intentionally uses `max_model_len - current_length` to match the existing CPU n-gram proposer behavior and the fix direction described in #42533.

Duplicate-work check: before opening this PR, I verified that #42533 was open and unassigned, had no linked branches or pull requests, and that PR searches for `42533` and `ngram_gpu max_model_len` did not show an open PR addressing the same fix.

This PR was prepared with AI assistance. I reviewed the changed files and ran the listed tests locally.

## Test Plan

- `python -m py_compile vllm/v1/spec_decode/ngram_proposer_gpu.py tests/v1/spec_decode/test_ngram.py`
- `git diff --check`
- `python -m ruff check vllm/v1/spec_decode/ngram_proposer_gpu.py tests/v1/spec_decode/test_ngram.py`
- `python -m ruff format --check vllm/v1/spec_decode/ngram_proposer_gpu.py tests/v1/spec_decode/test_ngram.py`
- `pytest tests/v1/spec_decode/test_ngram.py::test_ngram_gpu_proposer_respects_max_model_len -q --confcutdir=tests/v1/spec_decode`

## Test Result

All commands passed. The focused CUDA regression test passed locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

