### PR TITLE
[Perf][Kernel] Fused QK-RMSNorm + mRoPE CUDA kernel for Qwen3-VL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,8 @@ set(VLLM_EXT_SRC
   "csrc/cuda_utils_kernels.cu"
   "csrc/custom_all_reduce.cu"
   "csrc/torch_bindings.cpp"
-  "csrc/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu")
+  "csrc/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu"
+  "csrc/fused_qknorm_mrope_kernel.cu")
 
 if(VLLM_GPU_LANG STREQUAL "CUDA")
   list(APPEND VLLM_EXT_SRC

--- a/csrc/fused_qknorm_mrope_kernel.cu
+++ b/csrc/fused_qknorm_mrope_kernel.cu
@@ -361,7 +361,12 @@ void fused_qk_norm_mrope(
   int64_t half_rd = cos.size(2);
   int64_t rotary_dim = half_rd * 2;
   TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even");
-  TORCH_CHECK(rotary_dim <= head_dim, "rotary_dim must be <= head_dim");
+  // The kernel processes all rotary lanes inside a single warp; requiring
+  // rotary_dim == head_dim guarantees all 32 threads participate in the NeoX
+  // __shfl_xor_sync / __syncwarp calls and avoids warp divergence issues.
+  TORCH_CHECK(rotary_dim == head_dim,
+              "fused_qk_norm_mrope requires rotary_dim == head_dim; "
+              "partial rotary is not supported by this kernel");
   TORCH_CHECK(mrope_section_t + mrope_section_h <= half_rd,
               "mrope_section_t + mrope_section_h must be <= rotary_dim/2");
 
@@ -380,6 +385,18 @@ void fused_qk_norm_mrope(
 
   auto device_id = qkv.get_device();
   auto stream = at::cuda::getCurrentCUDAStream(device_id);
+
+  // BFloat16 requires SM80+. Check here to give a clear error rather than
+  // silently returning early inside the kernel (same constraint as
+  // fused_qk_norm_rope).
+  if (qkv.scalar_type() == at::kBFloat16 ||
+      cos.scalar_type() == at::kBFloat16) {
+    auto* dev_prop = at::cuda::getDeviceProperties(device_id);
+    TORCH_CHECK(dev_prop->major >= 8,
+                "fused_qk_norm_mrope with BFloat16 requires SM80 (Ampere) "
+                "or newer; device SM is ",
+                dev_prop->major, ".", dev_prop->minor);
+  }
 
   VLLM_DISPATCH_HALF_TYPES(qkv.scalar_type(), "fused_qk_norm_mrope", [&] {
     using qkv_scalar_t = scalar_t;

--- a/csrc/fused_qknorm_mrope_kernel.cu
+++ b/csrc/fused_qknorm_mrope_kernel.cu
@@ -1,0 +1,399 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ *
+ * Fused per-head QK RMSNorm + multimodal RoPE (mRoPE) kernel.
+ *
+ * mRoPE uses three separate position streams (time/height/width) stored as
+ *   cos: [3, num_tokens, rotary_dim/2]
+ *   sin: [3, num_tokens, rotary_dim/2]
+ * instead of a flat cos_sin_cache indexed by scalar position IDs.
+ *
+ * Section boundaries (mrope_section_t, mrope_section_h) determine which
+ * stream each half-dimension index maps to:
+ *   [0, t_end)           → time stream
+ *   [t_end, h_end)       → height stream
+ *   [h_end, rotary_dim/2) → width stream
+ */
+
+#include <cmath>
+#include <cuda_runtime.h>
+#include <type_traits>
+
+#include <torch/cuda.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "cuda_compat.h"
+#include "dispatch_utils.h"
+#include "type_convert.cuh"
+
+#define MROPE_CHECK_TYPE(x, st)                                        \
+  TORCH_CHECK(x.scalar_type() == st, #x " dtype is ", x.scalar_type(), \
+              ", while ", st, " is expected")
+#define MROPE_CHECK_TH_CUDA(x) \
+  TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
+#define MROPE_CHECK_CONTIGUOUS(x) \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define MROPE_CHECK_INPUT(x) \
+  MROPE_CHECK_TH_CUDA(x);    \
+  MROPE_CHECK_CONTIGUOUS(x)
+
+#ifdef USE_ROCM
+  #define MROPE_FINAL_MASK 0xffffffffffffffffULL
+#else
+  #define MROPE_FINAL_MASK 0xffffffff
+#endif
+
+namespace vllm::fused_qknorm_mrope {
+
+template <typename T>
+__inline__ __device__ T warpReduceSum(T val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val += __shfl_xor_sync(MROPE_FINAL_MASK, val, mask, 32);
+  return val;
+}
+
+template <typename T, int num>
+struct packed_as;
+template <>
+struct packed_as<uint, 1> {
+  using type = uint;
+};
+template <>
+struct packed_as<uint, 2> {
+  using type = uint2;
+};
+template <>
+struct packed_as<uint, 4> {
+  using type = uint4;
+};
+
+template <typename T>
+inline __device__ __host__ T divUp(T m, T n) {
+  return (m + n - 1) / n;
+}
+
+// One warp processes one (token, Q/K-head) pair.
+// cos_void / sin_void each have shape [3, num_tokens, half_rd]
+//   stream 0 (time):   offset [0, num_tokens * half_rd)
+//   stream 1 (height): offset [num_tokens * half_rd, 2 * num_tokens * half_rd)
+//   stream 2 (width):  offset [2 * num_tokens * half_rd, 3 * num_tokens *
+//   half_rd)
+template <typename scalar_t_in, typename scalar_t_cache, int head_dim,
+          bool interleave>
+__global__ void fusedQKNormMRopeKernel(
+    void* qkv_void, int const num_heads_q, int const num_heads_k,
+    int const num_heads_v, float const eps, void const* q_weight_void,
+    void const* k_weight_void,
+    void const* cos_void,  // [3, num_tokens, rotary_dim/2]
+    void const* sin_void,  // [3, num_tokens, rotary_dim/2]
+    int const num_tokens, int const rotary_dim, int const mrope_section_t,
+    int const mrope_section_h) {
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
+  if constexpr ((std::is_same_v<scalar_t_in, c10::BFloat16>) ||
+                std::is_same_v<scalar_t_cache, c10::BFloat16>) {
+    return;
+  } else {
+#endif
+
+    using Converter = vllm::_typeConvert<scalar_t_in>;
+    static_assert(Converter::exists,
+                  "Input QKV dtype not supported for this CUDA architecture.");
+    using T_in = typename Converter::hip_type;
+    using T2_in = typename Converter::packed_hip_type;
+
+    using CacheConverter = vllm::_typeConvert<scalar_t_cache>;
+    static_assert(CacheConverter::exists,
+                  "Cache dtype not supported for this CUDA architecture.");
+    using T_cache = typename CacheConverter::hip_type;
+
+    T_in* qkv = reinterpret_cast<T_in*>(qkv_void);
+    T_in const* q_weight = reinterpret_cast<T_in const*>(q_weight_void);
+    T_in const* k_weight = reinterpret_cast<T_in const*>(k_weight_void);
+    T_cache const* cos_base = reinterpret_cast<T_cache const*>(cos_void);
+    T_cache const* sin_base = reinterpret_cast<T_cache const*>(sin_void);
+
+    int const warpsPerBlock = blockDim.x / 32;
+    int const warpId = threadIdx.x / 32;
+    int const laneId = threadIdx.x % 32;
+
+    int const globalWarpIdx = blockIdx.x * warpsPerBlock + warpId;
+    int const total_qk_heads = num_heads_q + num_heads_k;
+    int const tokenIdx = globalWarpIdx / total_qk_heads;
+    int const localHeadIdx = globalWarpIdx % total_qk_heads;
+
+    if (tokenIdx >= num_tokens) return;
+
+    bool const isQ = localHeadIdx < num_heads_q;
+    int const headIdx = isQ ? localHeadIdx : localHeadIdx - num_heads_q;
+    int const num_heads = num_heads_q + num_heads_k + num_heads_v;
+
+    static_assert(head_dim % (32 * 2) == 0, "head_dim must be divisible by 64");
+    constexpr int numElemsPerThread = head_dim / 32;
+    constexpr int elemSizeBytes = numElemsPerThread * sizeof(__nv_bfloat16);
+    static_assert(elemSizeBytes % 4 == 0,
+                  "elemSizeBytes must be a multiple of 4");
+    constexpr int vecSize = elemSizeBytes / 4;
+    using vec_T = typename packed_as<uint, vecSize>::type;
+
+    int offsetWarp;
+    if (isQ) {
+      offsetWarp = tokenIdx * num_heads * head_dim + headIdx * head_dim;
+    } else {
+      offsetWarp = tokenIdx * num_heads * head_dim + num_heads_q * head_dim +
+                   headIdx * head_dim;
+    }
+    int const offsetThread = offsetWarp + laneId * numElemsPerThread;
+
+    float sumOfSquares = 0.0f;
+    float elements[numElemsPerThread];
+
+    // Load elements and accumulate sum of squares for RMSNorm.
+    {
+      vec_T vec = *reinterpret_cast<vec_T const*>(&qkv[offsetThread]);
+      constexpr int num_packed_elems = elemSizeBytes / sizeof(T2_in);
+#pragma unroll
+      for (int i = 0; i < num_packed_elems; i++) {
+        T2_in packed_val = *(reinterpret_cast<T2_in*>(&vec) + i);
+        float2 vals = Converter::convert(packed_val);
+        sumOfSquares += vals.x * vals.x + vals.y * vals.y;
+        elements[2 * i] = vals.x;
+        elements[2 * i + 1] = vals.y;
+      }
+    }
+
+    sumOfSquares = warpReduceSum(sumOfSquares);
+    float rms_rcp = rsqrtf(sumOfSquares / static_cast<float>(head_dim) + eps);
+
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      int const dim = laneId * numElemsPerThread + i;
+      float weight = isQ ? Converter::convert(q_weight[dim])
+                         : Converter::convert(k_weight[dim]);
+      elements[i] *= rms_rcp * weight;
+    }
+
+    // mRoPE: select cos/sin stream per half-dim based on section boundaries.
+    int const half_rd = rotary_dim / 2;
+    int const t_end = mrope_section_t;
+    int const h_end = mrope_section_t + mrope_section_h;
+
+    T_cache const* t_cos = cos_base + tokenIdx * half_rd;
+    T_cache const* h_cos = cos_base + (num_tokens + tokenIdx) * half_rd;
+    T_cache const* w_cos = cos_base + (2 * num_tokens + tokenIdx) * half_rd;
+    T_cache const* t_sin = sin_base + tokenIdx * half_rd;
+    T_cache const* h_sin = sin_base + (num_tokens + tokenIdx) * half_rd;
+    T_cache const* w_sin = sin_base + (2 * num_tokens + tokenIdx) * half_rd;
+
+    float elements2[numElemsPerThread];
+    int const rotary_lanes = rotary_dim / numElemsPerThread;
+
+    if (laneId < rotary_lanes) {
+      if constexpr (interleave) {
+        // Interleaved style: consecutive pairs (x0, x1) rotate together.
+#pragma unroll
+        for (int i = 0; i < numElemsPerThread / 2; ++i) {
+          int const idx0 = 2 * i;
+          int const idx1 = 2 * i + 1;
+          int const dim_idx = laneId * numElemsPerThread + idx0;
+          float const val0 = elements[idx0];
+          float const val1 = elements[idx1];
+          int const half_dim = dim_idx / 2;
+
+          T_cache cos_raw = (half_dim < t_end)   ? VLLM_LDG(t_cos + half_dim)
+                            : (half_dim < h_end) ? VLLM_LDG(h_cos + half_dim)
+                                                 : VLLM_LDG(w_cos + half_dim);
+          T_cache sin_raw = (half_dim < t_end)   ? VLLM_LDG(t_sin + half_dim)
+                            : (half_dim < h_end) ? VLLM_LDG(h_sin + half_dim)
+                                                 : VLLM_LDG(w_sin + half_dim);
+          float const cos_val = CacheConverter::convert(cos_raw);
+          float const sin_val = CacheConverter::convert(sin_raw);
+
+          elements[idx0] = val0 * cos_val - val1 * sin_val;
+          elements[idx1] = val0 * sin_val + val1 * cos_val;
+        }
+      } else {
+        // NeoX style: left half [0, half_rd) and right half [half_rd, rd).
+        __syncwarp();
+        int const pairOffset = half_rd / numElemsPerThread;
+#pragma unroll
+        for (int i = 0; i < numElemsPerThread; i++) {
+          elements2[i] =
+              __shfl_xor_sync(MROPE_FINAL_MASK, elements[i], pairOffset);
+          if (laneId < pairOffset) elements2[i] = -elements2[i];
+
+          int dim_idx = laneId * numElemsPerThread + i;
+          dim_idx = (dim_idx * 2) % rotary_dim;
+          int const half_dim = dim_idx / 2;
+
+          T_cache cos_raw = (half_dim < t_end)   ? VLLM_LDG(t_cos + half_dim)
+                            : (half_dim < h_end) ? VLLM_LDG(h_cos + half_dim)
+                                                 : VLLM_LDG(w_cos + half_dim);
+          T_cache sin_raw = (half_dim < t_end)   ? VLLM_LDG(t_sin + half_dim)
+                            : (half_dim < h_end) ? VLLM_LDG(h_sin + half_dim)
+                                                 : VLLM_LDG(w_sin + half_dim);
+          float const cos_val = CacheConverter::convert(cos_raw);
+          float const sin_val = CacheConverter::convert(sin_raw);
+
+          elements[i] = elements[i] * cos_val + elements2[i] * sin_val;
+        }
+        __syncwarp();
+      }
+    }
+
+    // Store.
+    {
+      vec_T vec;
+      constexpr int num_packed_elems = elemSizeBytes / sizeof(T2_in);
+#pragma unroll
+      for (int i = 0; i < num_packed_elems; i++) {
+        T2_in packed_val = Converter::convert(
+            make_float2(elements[2 * i], elements[2 * i + 1]));
+        *(reinterpret_cast<T2_in*>(&vec) + i) = packed_val;
+      }
+      *reinterpret_cast<vec_T*>(&qkv[offsetThread]) = vec;
+    }
+
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
+  }
+#endif
+}
+
+#define DISPATCH_MROPE_INTERLEAVE(interleave, INTERLEAVE, ...) \
+  if (interleave) {                                            \
+    const bool INTERLEAVE = true;                              \
+    __VA_ARGS__                                                \
+  } else {                                                     \
+    const bool INTERLEAVE = false;                             \
+    __VA_ARGS__                                                \
+  }
+
+template <typename scalar_t_in, typename scalar_t_cache>
+void launchFusedQKNormMRope(void* qkv, int const num_tokens,
+                            int const num_heads_q, int const num_heads_k,
+                            int const num_heads_v, int const head_dim,
+                            int const rotary_dim, float const eps,
+                            void const* q_weight, void const* k_weight,
+                            void const* cos, void const* sin,
+                            bool const interleave, int const mrope_section_t,
+                            int const mrope_section_h, cudaStream_t stream) {
+  constexpr int blockSize = 256;
+  int const warpsPerBlock = blockSize / 32;
+  int const totalQKHeads = num_heads_q + num_heads_k;
+  int const totalWarps = num_tokens * totalQKHeads;
+  int const gridSize = divUp(totalWarps, warpsPerBlock);
+  dim3 gridDim(gridSize);
+  dim3 blockDim(blockSize);
+
+  switch (head_dim) {
+    case 64:
+      DISPATCH_MROPE_INTERLEAVE(interleave, INTERLEAVE, {
+        fusedQKNormMRopeKernel<scalar_t_in, scalar_t_cache, 64, INTERLEAVE>
+            <<<gridDim, blockDim, 0, stream>>>(
+                qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
+                k_weight, cos, sin, num_tokens, rotary_dim, mrope_section_t,
+                mrope_section_h);
+      });
+      break;
+    case 128:
+      DISPATCH_MROPE_INTERLEAVE(interleave, INTERLEAVE, {
+        fusedQKNormMRopeKernel<scalar_t_in, scalar_t_cache, 128, INTERLEAVE>
+            <<<gridDim, blockDim, 0, stream>>>(
+                qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
+                k_weight, cos, sin, num_tokens, rotary_dim, mrope_section_t,
+                mrope_section_h);
+      });
+      break;
+    case 256:
+      DISPATCH_MROPE_INTERLEAVE(interleave, INTERLEAVE, {
+        fusedQKNormMRopeKernel<scalar_t_in, scalar_t_cache, 256, INTERLEAVE>
+            <<<gridDim, blockDim, 0, stream>>>(
+                qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
+                k_weight, cos, sin, num_tokens, rotary_dim, mrope_section_t,
+                mrope_section_h);
+      });
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported head dimension for fused_qk_norm_mrope: ",
+                  head_dim);
+  }
+}
+
+}  // namespace vllm::fused_qknorm_mrope
+
+// Host entry point registered as torch op.
+void fused_qk_norm_mrope(
+    torch::Tensor& qkv,       // [num_tokens, (nq+nk+nv)*head_dim], in-place
+    int64_t num_heads_q,      // Q heads (per TP rank)
+    int64_t num_heads_k,      // K heads (per TP rank)
+    int64_t num_heads_v,      // V heads (per TP rank)
+    int64_t head_dim,         // dimension per head
+    double eps,               // RMSNorm epsilon
+    torch::Tensor& q_weight,  // [head_dim]
+    torch::Tensor& k_weight,  // [head_dim]
+    torch::Tensor& cos,       // [3, num_tokens, rotary_dim/2]
+    torch::Tensor& sin,       // [3, num_tokens, rotary_dim/2]
+    bool is_neox,             // true → NeoX (non-interleaved) style
+    int64_t mrope_section_t,  // half-dims mapped to time stream
+    int64_t mrope_section_h   // half-dims mapped to height stream
+) {
+  MROPE_CHECK_INPUT(qkv);
+  MROPE_CHECK_INPUT(q_weight);
+  MROPE_CHECK_INPUT(k_weight);
+  MROPE_CHECK_INPUT(cos);
+  MROPE_CHECK_INPUT(sin);
+
+  TORCH_CHECK(qkv.dim() == 2,
+              "qkv must be 2D: [num_tokens, total_heads * head_dim]");
+  TORCH_CHECK(q_weight.dim() == 1, "q_weight must be 1D: [head_dim]");
+  TORCH_CHECK(k_weight.dim() == 1, "k_weight must be 1D: [head_dim]");
+  TORCH_CHECK(cos.dim() == 3, "cos must be 3D: [3, num_tokens, rotary_dim/2]");
+  TORCH_CHECK(sin.dim() == 3, "sin must be 3D: [3, num_tokens, rotary_dim/2]");
+  TORCH_CHECK(cos.size(0) == 3 && sin.size(0) == 3,
+              "cos/sin first dimension must be 3 (t/h/w streams)");
+
+  int64_t num_tokens = qkv.size(0);
+  TORCH_CHECK(cos.size(1) == num_tokens, "cos.size(1) must match num_tokens");
+  TORCH_CHECK(sin.size(1) == num_tokens, "sin.size(1) must match num_tokens");
+
+  int64_t half_rd = cos.size(2);
+  int64_t rotary_dim = half_rd * 2;
+  TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even");
+  TORCH_CHECK(rotary_dim <= head_dim, "rotary_dim must be <= head_dim");
+  TORCH_CHECK(mrope_section_t + mrope_section_h <= half_rd,
+              "mrope_section_t + mrope_section_h must be <= rotary_dim/2");
+
+  int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
+  TORCH_CHECK(qkv.size(1) == total_heads * head_dim,
+              "qkv.size(1) must equal (nq+nk+nv)*head_dim");
+  TORCH_CHECK(q_weight.size(0) == head_dim,
+              "q_weight size must match head_dim");
+  TORCH_CHECK(k_weight.size(0) == head_dim,
+              "k_weight size must match head_dim");
+  TORCH_CHECK(qkv.scalar_type() == q_weight.scalar_type() &&
+                  qkv.scalar_type() == k_weight.scalar_type(),
+              "qkv, q_weight and k_weight must share dtype");
+  TORCH_CHECK(cos.scalar_type() == sin.scalar_type(),
+              "cos and sin must share dtype");
+
+  auto device_id = qkv.get_device();
+  auto stream = at::cuda::getCurrentCUDAStream(device_id);
+
+  VLLM_DISPATCH_HALF_TYPES(qkv.scalar_type(), "fused_qk_norm_mrope", [&] {
+    using qkv_scalar_t = scalar_t;
+    VLLM_DISPATCH_FLOATING_TYPES(cos.scalar_type(), "fused_qk_norm_mrope", [&] {
+      using cache_scalar_t = scalar_t;
+      vllm::fused_qknorm_mrope::launchFusedQKNormMRope<qkv_scalar_t,
+                                                       cache_scalar_t>(
+          qkv.data_ptr(), static_cast<int>(num_tokens),
+          static_cast<int>(num_heads_q), static_cast<int>(num_heads_k),
+          static_cast<int>(num_heads_v), static_cast<int>(head_dim),
+          static_cast<int>(rotary_dim), static_cast<float>(eps),
+          q_weight.data_ptr(), k_weight.data_ptr(), cos.data_ptr(),
+          sin.data_ptr(), !is_neox, static_cast<int>(mrope_section_t),
+          static_cast<int>(mrope_section_h), stream);
+    });
+  });
+}

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -74,6 +74,13 @@ void fused_qk_norm_rope(torch::Tensor& qkv, int64_t num_heads_q,
                         bool is_neox, torch::Tensor& position_ids,
                         int64_t forced_token_heads_per_warp);
 
+void fused_qk_norm_mrope(torch::Tensor& qkv, int64_t num_heads_q,
+                         int64_t num_heads_k, int64_t num_heads_v,
+                         int64_t head_dim, double eps, torch::Tensor& q_weight,
+                         torch::Tensor& k_weight, torch::Tensor& cos,
+                         torch::Tensor& sin, bool is_neox,
+                         int64_t mrope_section_t, int64_t mrope_section_h);
+
 void fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::Tensor& q, torch::Tensor const& kv, torch::Tensor& k_cache,
     torch::Tensor const& slot_mapping, torch::Tensor const& position_ids,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -159,6 +159,16 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "int forced_token_heads_per_warp=-1) -> ()");
   ops.impl("fused_qk_norm_rope", torch::kCUDA, &fused_qk_norm_rope);
 
+  // Fused per-head QK RMSNorm + multimodal RoPE (mRoPE) for models like
+  // Qwen3-VL. cos/sin shape: [3, num_tokens, rotary_dim/2] (time/height/width
+  // streams).
+  ops.def(
+      "fused_qk_norm_mrope(Tensor! qkv, int num_heads_q, "
+      "int num_heads_k, int num_heads_v, int head_dim, float eps, "
+      "Tensor q_weight, Tensor k_weight, Tensor cos, Tensor sin, "
+      "bool is_neox, int mrope_section_t, int mrope_section_h) -> ()");
+  ops.impl("fused_qk_norm_mrope", torch::kCUDA, &fused_qk_norm_mrope);
+
   // Horizontally-fused DeepseekV4-MLA: per-head RMSNorm + GPT-J RoPE for Q, and
   // GPT-J RoPE + UE8M0 FP8 quant + paged cache insert for KV, all in one
   // kernel launch.

--- a/tests/kernels/test_fused_qknorm_mrope.py
+++ b/tests/kernels/test_fused_qknorm_mrope.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for fused QK-RMSNorm + mRoPE kernel (Qwen3-VL style)."""
+
+import pytest
+import torch
+
+from tests.kernels.utils import opcheck
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.mrope import (
+    MRotaryEmbedding,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+DTYPES = [torch.bfloat16, torch.float16]
+IS_NEOX = [True, False]
+EPS_VALUES = [1e-5, 1e-6]
+SEEDS = [42]
+CUDA_DEVICES = ["cuda:0"]
+
+# Qwen3-VL typical config: head_dim=128, mrope_section=[16,24,24]
+HEAD_CONFIGS = [
+    (16, 4, 128, [16, 24, 24]),  # Qwen3-VL-like
+    (8, 2, 64, [8, 12, 12]),  # smaller head_dim=64
+]
+
+
+def _reference_qk_norm_mrope(
+    qkv: torch.Tensor,
+    mrope: MRotaryEmbedding,
+    q_norm: RMSNorm,
+    k_norm: RMSNorm,
+    positions: torch.Tensor,  # [3, num_tokens]
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Unfused reference: separate RMSNorm + Triton mRoPE."""
+    q_size = num_heads_q * head_dim
+    kv_size = num_heads_kv * head_dim
+
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+    # QK RMSNorm (float32 reference for numerical stability)
+    q_by_head = q.view(*q.shape[:-1], q.shape[-1] // head_dim, head_dim)
+    q_by_head = q_norm.forward_native(q_by_head)
+    q = q_by_head.view(q.shape)
+
+    k_by_head = k.view(*k.shape[:-1], k.shape[-1] // head_dim, head_dim)
+    k_by_head = k_norm.forward_native(k_by_head)
+    k = k_by_head.view(k.shape)
+
+    # mRoPE via Triton kernel
+    q, k = mrope.forward_cuda(positions, q, k)
+
+    return torch.cat([q, k, v], dim=-1)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="fused_qk_norm_mrope requires CUDA or ROCm",
+)
+@pytest.mark.skipif(
+    not hasattr(torch.ops._C, "fused_qk_norm_mrope"),
+    reason="fused_qk_norm_mrope custom op not compiled",
+)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_neox", IS_NEOX)
+@pytest.mark.parametrize("eps", EPS_VALUES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize(
+    "num_heads_q,num_heads_kv,head_dim,mrope_section", HEAD_CONFIGS
+)
+@torch.inference_mode()
+def test_fused_qk_norm_mrope_matches_reference(
+    default_vllm_config,
+    device: str,
+    dtype: torch.dtype,
+    is_neox: bool,
+    eps: float,
+    seed: int,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+    mrope_section: list[int],
+):
+    torch.set_default_device(device)
+    set_random_seed(seed)
+    num_tokens = 8
+
+    total_dim = (num_heads_q + 2 * num_heads_kv) * head_dim
+    qkv_base = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
+    qkv_fused = qkv_base.clone()
+
+    # 2-D mRoPE positions: [3, num_tokens] — random small values
+    positions = torch.stack(
+        [
+            torch.arange(num_tokens, device=device, dtype=torch.long),
+            torch.arange(num_tokens, device=device, dtype=torch.long),
+            torch.arange(num_tokens, device=device, dtype=torch.long),
+        ]
+    )  # [3, num_tokens]
+
+    q_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
+    k_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
+    q_norm.weight.data.normal_(mean=1.0, std=0.1)
+    k_norm.weight.data.normal_(mean=1.0, std=0.1)
+
+    rotary_dim = head_dim  # full rotary for simplicity
+    mrope = MRotaryEmbedding(
+        head_size=head_dim,
+        rotary_dim=rotary_dim,
+        max_position_embeddings=4096,
+        base=10000.0,
+        is_neox_style=is_neox,
+        dtype=dtype,
+        mrope_section=mrope_section,
+    ).to(device)
+
+    # Reference: unfused path
+    ref = _reference_qk_norm_mrope(
+        qkv=qkv_base,
+        mrope=mrope,
+        q_norm=q_norm,
+        k_norm=k_norm,
+        positions=positions,
+        num_heads_q=num_heads_q,
+        num_heads_kv=num_heads_kv,
+        head_dim=head_dim,
+    )
+
+    # Prepare cos/sin for the fused kernel
+    cos_sin_cache = mrope._match_cos_sin_cache_dtype(qkv_fused)
+    cos_sin = cos_sin_cache[positions]  # [3, num_tokens, rotary_dim]
+    cos, sin = cos_sin.chunk(2, dim=-1)  # each [3, num_tokens, half_rd]
+    cos = cos.contiguous()
+    sin = sin.contiguous()
+
+    # opcheck verifies aliasing / schema correctness
+    opcheck(
+        torch.ops._C.fused_qk_norm_mrope,
+        (
+            qkv_fused.clone(),
+            num_heads_q,
+            num_heads_kv,
+            num_heads_kv,
+            head_dim,
+            eps,
+            q_norm.weight,
+            k_norm.weight,
+            cos,
+            sin,
+            is_neox,
+            mrope_section[0],
+            mrope_section[1],
+        ),
+    )
+
+    torch.ops._C.fused_qk_norm_mrope(
+        qkv_fused,
+        num_heads_q,
+        num_heads_kv,
+        num_heads_kv,
+        head_dim,
+        eps,
+        q_norm.weight,
+        k_norm.weight,
+        cos,
+        sin,
+        is_neox,
+        mrope_section[0],
+        mrope_section[1],
+    )
+
+    atol, rtol = (2e-3, 2e-3) if dtype == torch.float16 else (1e-2, 1e-2)
+    torch.testing.assert_close(qkv_fused, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="fused_qk_norm_mrope requires CUDA or ROCm",
+)
+@pytest.mark.skipif(
+    not hasattr(torch.ops._C, "fused_qk_norm_mrope"),
+    reason="fused_qk_norm_mrope custom op not compiled",
+)
+@pytest.mark.parametrize("num_tokens", [1, 4, 32, 256])
+@torch.inference_mode()
+def test_fused_qk_norm_mrope_varying_lengths(
+    default_vllm_config,
+    num_tokens: int,
+):
+    """Verify the kernel handles varying sequence lengths correctly."""
+    device = "cuda:0"
+    dtype = torch.bfloat16
+    num_heads_q, num_heads_kv, head_dim = 16, 4, 128
+    mrope_section = [16, 24, 24]
+    eps = 1e-6
+    rotary_dim = head_dim
+
+    torch.set_default_device(device)
+    set_random_seed(0)
+
+    total_dim = (num_heads_q + 2 * num_heads_kv) * head_dim
+    qkv_base = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
+    qkv_fused = qkv_base.clone()
+
+    positions = torch.stack(
+        [
+            torch.arange(num_tokens, device=device, dtype=torch.long),
+            torch.arange(num_tokens, device=device, dtype=torch.long),
+            torch.arange(num_tokens, device=device, dtype=torch.long),
+        ]
+    )
+
+    q_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
+    k_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
+
+    mrope = MRotaryEmbedding(
+        head_size=head_dim,
+        rotary_dim=rotary_dim,
+        max_position_embeddings=4096,
+        base=10000.0,
+        is_neox_style=True,
+        dtype=dtype,
+        mrope_section=mrope_section,
+    ).to(device)
+
+    ref = _reference_qk_norm_mrope(
+        qkv=qkv_base,
+        mrope=mrope,
+        q_norm=q_norm,
+        k_norm=k_norm,
+        positions=positions,
+        num_heads_q=num_heads_q,
+        num_heads_kv=num_heads_kv,
+        head_dim=head_dim,
+    )
+
+    cos_sin_cache = mrope._match_cos_sin_cache_dtype(qkv_fused)
+    cos_sin = cos_sin_cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    cos = cos.contiguous()
+    sin = sin.contiguous()
+
+    torch.ops._C.fused_qk_norm_mrope(
+        qkv_fused,
+        num_heads_q,
+        num_heads_kv,
+        num_heads_kv,
+        head_dim,
+        eps,
+        q_norm.weight,
+        k_norm.weight,
+        cos,
+        sin,
+        True,
+        mrope_section[0],
+        mrope_section[1],
+    )
+
+    torch.testing.assert_close(qkv_fused, ref, atol=1e-2, rtol=1e-2)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -357,6 +357,42 @@ def fused_qk_norm_rope(
     )
 
 
+def fused_qk_norm_mrope(
+    qkv: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+) -> None:
+    """Fused per-head QK RMSNorm + mRoPE (in-place on qkv).
+
+    cos/sin shape: [3, num_tokens, rotary_dim/2] — time/height/width streams.
+    """
+    torch.ops._C.fused_qk_norm_mrope(
+        qkv,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        cos,
+        sin,
+        is_neox,
+        mrope_section_t,
+        mrope_section_h,
+    )
+
+
 def apply_repetition_penalties_torch(
     logits: torch.Tensor,
     prompt_mask: torch.Tensor,

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -30,6 +30,7 @@ import torch
 from torch import nn
 from transformers import Qwen3Config
 
+import vllm._custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
@@ -42,7 +43,7 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
-from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding, get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import set_default_rope_theta
@@ -148,15 +149,51 @@ class Qwen3Attention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-        q_by_head = self.q_norm(q_by_head)
-        q = q_by_head.view(q.shape)
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-        k_by_head = self.k_norm(k_by_head)
-        k = k_by_head.view(k.shape)
-        q, k = self.rotary_emb(positions, q, k)
+
+        # When mRoPE positions ([3, num_tokens]) are provided and the fused
+        # kernel is available, run QK-RMSNorm + mRoPE in a single pass.
+        if (
+            positions.ndim == 2
+            and isinstance(self.rotary_emb, MRotaryEmbedding)
+            and self.rotary_emb.mrope_section is not None
+            and hasattr(torch.ops._C, "fused_qk_norm_mrope")
+        ):
+            cos_sin_cache = self.rotary_emb._match_cos_sin_cache_dtype(qkv)
+            cos_sin = cos_sin_cache[positions]  # [3, num_tokens, rotary_dim]
+            cos, sin = cos_sin.chunk(2, dim=-1)  # each [3, num_tokens, half_rd]
+            cos = cos.contiguous()
+            sin = sin.contiguous()
+            mrope_section = self.rotary_emb.mrope_section
+            ops.fused_qk_norm_mrope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                cos,
+                sin,
+                self.rotary_emb.is_neox_style,
+                mrope_section[0],
+                mrope_section[1],
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            q_by_head = q.view(
+                *q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim
+            )
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
+            k_by_head = k.view(
+                *k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim
+            )
+            k_by_head = self.k_norm(k_by_head)
+            k = k_by_head.view(k.shape)
+            q, k = self.rotary_emb(positions, q, k)
+
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output


### PR DESCRIPTION
## Purpose

Fixes / part of #43021. Contributes to the broader fusion work tracker #36066.

For Qwen3-VL, the current attention forward pass dispatches three separate CUDA kernel launches: q_norm, k_norm, and rotary_emb (Triton mRoPE). Each intermediate result is written to global memory and re-read by the next kernel. This PR replaces those three launches with a single fused_qk_norm_mrope CUDA kernel that processes each token-head pair in one warp pass, eliminating intermediate global-memory round-trips.

## Changes

- csrc/fused_qknorm_mrope_kernel.cu: New CUDA kernel (fusedQKNormMRopeKernel)
- csrc/ops.h: Declaration for fused_qk_norm_mrope
- csrc/torch_bindings.cpp: Torch op registration
- CMakeLists.txt: Build integration
- vllm/_custom_ops.py: Python wrapper
- vllm/model_executor/models/qwen3.py: Call fused kernel when mRoPE positions detected
- tests/kernels/test_fused_qknorm_mrope.py: Correctness tests against unfused reference

## Design

mRoPE cos/sin tensors have shape [3, num_tokens, rotary_dim/2] with three streams: time, height, width. The mrope_section_t and mrope_section_h boundaries determine per-half-dim stream selection at runtime. The existing unfused path is preserved as a fallback, so text-only Qwen3 is unaffected.

Supported configs: head_dim in {64, 128, 256}; NeoX and interleaved rotation styles; BF16 and FP16 QKV.

## Why not duplicate of #31763

PR #31763 is a DRAFT targeting Qwen2.5-Omni-7B SplitMrope -- a different model and a Python-level transformation, not a CUDA kernel fusion.

## Test Plan

```
pre-commit run --all-files
.venv/bin/python -m pytest tests/kernels/test_fused_qknorm_mrope.py -v
```

Tests parametrize over dtype (bf16, fp16), is_neox (True/False), eps, head configs, and sequence lengths 1-256, comparing the fused kernel output to the reference unfused path (RMSNorm + Triton mRoPE).

Note: CI requires a maintainer to add the "verified" label before automated test runs.

## AI Assistance

This PR was developed with the assistance of Claude (Anthropic). All code was reviewed line by line and the author understands and can defend each change.
