### PR TITLE
[Core][KV-transfer] MoRIIO multi-node TP prefill→decode dispatch

### DIFF
--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -308,6 +308,7 @@ async def handle_request(api: str, request: Request):
                 "remote_block_ids"
             ]
             req_data["kv_transfer_params"]["transfer_id"] = prefill_kv["transfer_id"]
+            req_data["kv_transfer_params"]["remote_hosts"] = prefill_kv.get("remote_hosts")
 
         req_data["kv_transfer_params"]["remote_dp_size"] = prefill_instance_endpoint[
             "dp_size"
@@ -315,6 +316,7 @@ async def handle_request(api: str, request: Request):
         req_data["kv_transfer_params"]["remote_tp_size"] = prefill_instance_endpoint[
             "tp_size"
         ]
+        req_data["kv_transfer_params"]["tp_size"] = prefill_instance_endpoint["tp_size"]
 
         if selected_prefill_dp_rank is not None:
             req_data["kv_transfer_params"]["remote_dp_rank"] = selected_prefill_dp_rank

--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -308,7 +308,9 @@ async def handle_request(api: str, request: Request):
                 "remote_block_ids"
             ]
             req_data["kv_transfer_params"]["transfer_id"] = prefill_kv["transfer_id"]
-            req_data["kv_transfer_params"]["remote_hosts"] = prefill_kv.get("remote_hosts")
+            req_data["kv_transfer_params"]["remote_hosts"] = prefill_kv.get(
+                "remote_hosts"
+            )
 
         req_data["kv_transfer_params"]["remote_dp_size"] = prefill_instance_endpoint[
             "dp_size"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -320,6 +320,11 @@ class ReqMeta:
     remote_engine_id: str
     tp_size: int
     remote_dp_size: int
+    # Ordered list of all prefill-instance host IPs for multi-node TP.
+    # Each decode worker picks remote_hosts[tp_rank // ranks_per_node] as its
+    # actual peer host for handshake + post-transfer notify. None or len<=1
+    # falls back to single-host behaviour (remote_host).
+    remote_hosts: list[str] | None = None
 
 
 class MoRIIOConnectorMetadata(KVConnectorMetadata):
@@ -370,6 +375,7 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
                 kv_transfer_params.get("remote_tp_size", 1),
             ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
+            remote_hosts=kv_transfer_params.get("remote_hosts"),
         )
         if write_mode:
             self.reqs_to_save[request_id] = _req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -362,7 +362,13 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_port=remote_handshake_port,
             remote_handshake_port=remote_handshake_port,
             remote_notify_port=remote_notify_port,
-            tp_size=kv_transfer_params.get("tp_size", 1),
+            # Defense-in-depth: callers (e.g. moriio_toy_proxy_server in
+            # READ-mode multi-node TP) may forward `remote_tp_size` only.
+            # Read `tp_size` first, fall back to `remote_tp_size`, default 1.
+            tp_size=kv_transfer_params.get(
+                "tp_size",
+                kv_transfer_params.get("remote_tp_size", 1),
+            ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
         )
         if write_mode:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import logging
 import math
+import os
 import queue
 import threading
 import time
@@ -252,10 +253,26 @@ class MoRIIOConnectorScheduler:
         self.engine_id: EngineId = engine_id
         self.mode = get_moriio_mode()
         self.host_ip = get_ip()
+        # Multi-node TP: VLLM_MORIIO_NODE_HOSTS holds the ordered list of host
+        # IPs in this engine's TP group (rank 0 first). Surfaced to the peer
+        # side via request_finished's kv_transfer_params so the consumer
+        # workers can dial the correct producer host for their tp_rank. For
+        # single-node TP, falls back to [host_ip].
+        node_hosts_env = os.environ.get("VLLM_MORIIO_NODE_HOSTS", "").strip()
+        if node_hosts_env:
+            self.node_hosts: list[str] = [
+                h.strip() for h in node_hosts_env.split(",") if h.strip()
+            ]
+        else:
+            self.node_hosts = [self.host_ip]
         self.handshake_port = self.kv_transfer_config.kv_connector_extra_config[
             "handshake_port"
         ]
-        logger.info("Initializing MoRIIO Scheduler engine_id = %s", engine_id)
+        logger.info(
+            "Initializing MoRIIO Scheduler engine_id = %s node_hosts = %s",
+            engine_id,
+            self.node_hosts,
+        )
 
         self.side_notify_port = self.kv_transfer_config.kv_connector_extra_config[
             "notify_port"
@@ -602,6 +619,10 @@ class MoRIIOConnectorScheduler:
             remote_engine_id=self.engine_id,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             transfer_id=params["transfer_id"],
+            # Multi-node TP: list of all prefill-instance host IPs in this
+            # engine's TP group (rank 0 first). Decode workers use this to
+            # pick the correct producer host per their tp_rank.
+            remote_hosts=self.node_hosts,
         )
 
 
@@ -1072,6 +1093,25 @@ class MoRIIOConnectorWorker:
 
         return {remote_agent_name}
 
+    def _pick_remote_host(self, meta: ReqMeta) -> str:
+        """Resolve the per-worker peer host for multi-node TP prefill-decode.
+
+        For TP=16 sym 1P1D (2 prefill nodes + 2 decode nodes), the prefill KV
+        cache for ranks [0..7] lives on prefill-head and for [8..15] lives on
+        prefill-worker. Each decode worker has a fixed self.tp_rank and must
+        dial the prefill node that owns its half of the KV.
+
+        meta.remote_hosts is the ordered prefill-side host list (rank 0
+        first). If unset or length 1, falls back to meta.remote_host
+        (single-host behaviour, preserves TP=8 and monolithic correctness).
+        """
+        if meta.remote_hosts and len(meta.remote_hosts) > 1:
+            ranks_per_node = max(1, int(meta.tp_size) // len(meta.remote_hosts))
+            node_idx = self.tp_rank // ranks_per_node
+            if 0 <= node_idx < len(meta.remote_hosts):
+                return meta.remote_hosts[node_idx]
+        return meta.remote_host
+
     def _background_moriio_handshake(
         self, req_id: ReqId, remote_engine_id: EngineId, meta: ReqMeta
     ):
@@ -1080,7 +1120,9 @@ class MoRIIOConnectorWorker:
         if remote_engine_id is not None:
             fut = self._handshake_futures.get(remote_engine_id)
         if fut is None:
-            host = meta.remote_host
+            # Multi-node TP: pick the producer host for this worker's tp_rank.
+            # For single-node TP this returns meta.remote_host unchanged.
+            host = self._pick_remote_host(meta)
             port = int(meta.remote_handshake_port)
             tp_size = int(meta.tp_size)
             remote_dp_size = int(meta.remote_dp_size)
@@ -1394,12 +1436,19 @@ class MoRIIOConnectorWorker:
             meta.remote_engine_id,
             req_id,
         )
+        # Multi-node TP: remote_host here is used by _read_blocks to record the
+        # post-transfer notify callback address (so prefill can free its KV
+        # blocks). For multi-node prefill the notify must go to the prefill
+        # node that actually owns this worker's KV slice, not the prefill
+        # head. _pick_remote_host returns meta.remote_host unchanged for
+        # single-host setups, preserving TP=8 / monolithic behaviour.
+        actual_remote_host = self._pick_remote_host(meta)
         self._read_blocks(
             request_id=req_id,
             dst_engine_id=meta.remote_engine_id,
             local_block_ids=meta.local_block_ids,
             remote_block_ids=meta.remote_block_ids,
-            remote_host=meta.remote_host,
+            remote_host=actual_remote_host,
             remote_notify_port=meta.remote_notify_port,
         )
 


### PR DESCRIPTION
## Purpose

Fix multi-node TP=16 prefill→decode dispatch in the MoRI-IO KV connector.
When prefill spans two hosts (rank 0-7 on `P_NODE`, rank 8-15 on `P2_NODE`),
each decode rank must dial **the producer rank that holds its KV blocks**.
Today, every decode rank dials a single `remote_host` parsed from
`request_id`, which always resolves to the prefill *head*. Decode ranks
8-15 then handshake the wrong producer (always the head, never the
worker), the subsequent MoRI-IO RDMA read never completes, and the
engine wedges at `shm_broadcast.py:698` (repeated `No available shared
memory broadcast block found in 60 seconds`).

This PR makes the proxy forward the prefill TP-group host list and adds
worker-side rank→host dispatch.

## Changes

**Connector (`moriio_common.py`, `moriio_connector.py`):**

- `MoRIIOConnectorScheduler` reads `VLLM_MORIIO_NODE_HOSTS` at init and
  emits the ordered TP-group host list in `request_finished`'s
  `kv_transfer_params.remote_hosts`.
- `ReqMeta` gains a `remote_hosts` field; `MoRIIOConnectorMetadata.add_new_req`
  populates it from `kv_transfer_params`.
- `MoRIIOConnectorWorker._pick_remote_host(meta)` picks
  `remote_hosts[tp_rank // (tp_size // len(remote_hosts))]` when
  `len(remote_hosts) > 1`, falling back to `meta.remote_host` for
  single-host setups. Used by `_background_moriio_handshake` and
  `_read_blocks_for_req` so both the handshake dial and the
  post-transfer notify callback route to the correct prefill node per
  rank.
- `ReqMeta.tp_size` reads `tp_size` first, then `remote_tp_size`,
  defaulting to 1 — defense-in-depth so a caller forwarding only
  `remote_tp_size` still resolves correctly.

**Reference proxy (`examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py`):**

- READ-mode `handle_request`: forward `remote_hosts` from `prefill_response`
  into the decode-side `kv_transfer_params`.
- Forward bare `tp_size` alongside `remote_tp_size` (always, not just READ).

## Backward compatibility

TP=8 1P1D and any single-host setup short-circuits at
`len(remote_hosts) <= 1`, so behavior is unchanged. The proxy fix only
changes behavior when the prefill side actually produces a multi-entry
`remote_hosts` list (gated by `VLLM_MORIIO_NODE_HOSTS`).

## Not a duplicate of

- **#39276** (raviguptaamd) — DP `engine_id` collision in headless
  multi-node disagg + `kv_transfer_params` caching across scheduler
  steps. Different parallelism dimension (DP, not TP) and different
  failure (engine routing vs. per-rank handshake target).
- **#41753** (simondanielsson) — XGMI transport backend; no overlap
  with the routing layer this PR touches.
- **#42928** (esmeetu) — NIXL connector's engine_id sync; not MoRIIO.

Searched open PRs/issues on 2026-05-19 with `MoRIIO multi-node`,
`MoRIIO TP=16`, `remote_hosts`, `kv_connector multi-node TP`,
`kv_transfer multi-node TP=16` — nothing else targets the per-rank
prefill dispatch path.

## Verification

### Software stack on every node

| | version |
|---|---|
| OS | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Kernel | Linux 6.8.0-110-generic, x86_64 |
| ROCm | 7.2.0 |
| Python | 3.12 (container) |
| vLLM | base = upstream `main` @ `4a4fdabe2`, plus this PR |
| NCCL | 2.26.6 (vendored in vLLM) |
| Container | internal build of upstream vLLM `main` + MoRI-IO connector |

### Hardware

| | per node |
|---|---|
| GPU | 8× AMD Instinct MI300X (gfx942), 192 GB HBM, SCLK ~2050 MHz |
| NIC | 10× Broadcom Thor (PCI vendor `0x14e4`) |
| Fabric | RDMA over 100 GbE, MoRI-IO transport (UCX + NCCL HCAs above) |

4 nodes total for the TP=16 sym 1P1D experiment (2 prefill + 2 decode).
Proxy runs on the prefill head.

### Cluster topology used for the experiment

| role | IP | TP ranks |
|---|---|---|
| prefill head + proxy | `$P_NODE` | rank 0-7 |
| prefill worker | `$P2_NODE` | rank 8-15 |
| decode head | `$DH_NODE` | rank 0-7 |
| decode worker | `$DW_NODE` | rank 8-15 |

### Launch invocations

**Reference proxy** (on prefill head, `$P_NODE`):
```bash
python3 examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py \
  --port 10001
```

**Prefill head** (`$P_NODE`, `--node-rank 0`):
```bash
VLLM_HOST_IP=$P_NODE \
VLLM_NIXL_SIDE_CHANNEL_HOST=$P_NODE \
VLLM_NIXL_SIDE_CHANNEL_PORT=6300 \
VLLM_MORIIO_NODE_HOSTS=$P_NODE,$P2_NODE \
VLLM_ENABLE_V1_MULTIPROCESSING=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
VLLM_MORI_PD_ROLE=prefill \
vllm serve deepseek-ai/DeepSeek-R1-0528 \
  --served-model-name DeepSeek-R1-0528 \
  --tensor-parallel-size 16 \
  --max-model-len 16384 --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.80 \
  --block-size 1 --no-enable-prefix-caching \
  --kv-cache-dtype fp8_e4m3 --dtype auto --trust-remote-code \
  --distributed-executor-backend mp \
  --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":1}' \
  --nnodes 2 --node-rank 0 --master-addr $P2_NODE --master-port 29500 \
  --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"$P_NODE","proxy_port":36367,"proxy_ping_port":36367,"http_port":8100,"handshake_port":6301,"notify_port":61005}}' \
  --host 0.0.0.0 --port 8100
```

**Prefill worker** (`$P2_NODE`, `--node-rank 1 --headless`): same
shape, with `--headless`, `--node-rank 1`, `VLLM_HOST_IP=$P2_NODE`,
and the same `VLLM_MORIIO_NODE_HOSTS=$P_NODE,$P2_NODE`.

**Decode head** (`$DH_NODE`, `--node-rank 0`): same shape with
`kv_role=kv_consumer`, `VLLM_MORI_PD_ROLE=decode`,
`VLLM_MORIIO_NODE_HOSTS=$DH_NODE,$DW_NODE`, `--http_port 8200`,
`--master-addr $DW_NODE`. **Decode worker** (`$DW_NODE`): the
`--headless` counterpart on `--node-rank 1`.

### Resolved vLLM config (from the prefill head's startup log)

```text
INFO 05-15 10:58:24 [utils.py:240] non-default args:
  {'host': '0.0.0.0', 'port': 8100,
   'model': 'deepseek-ai/DeepSeek-R1-0528',
   'trust_remote_code': True,
   'max_model_len': 16384,
   'served_model_name': ['DeepSeek-R1-0528'],
   'distributed_executor_backend': 'mp',
   'master_addr': '$P2_NODE', 'master_port': 29500,
   'nnodes': 2,
   'tensor_parallel_size': 16,
   'block_size': 1,
   'gpu_memory_utilization': 0.8,
   'kv_cache_dtype': 'fp8_e4m3',
   'enable_prefix_caching': False,
   'max_num_batched_tokens': 8192,
   'speculative_config': {'method': 'deepseek_mtp',
                          'num_speculative_tokens': 1},
   'kv_transfer_config': KVTransferConfig(
       kv_connector='MoRIIOConnector', kv_role='kv_producer', ...
       kv_connector_extra_config={
         'proxy_ip': '$P2_NODE', 'proxy_port': 36367,
         'http_port': 8100, 'handshake_port': 6301, 'notify_port': 61005})}

INFO 05-15 10:59:07 [core.py:109] Initializing a V1 LLM engine (v0.1.dev0)
  with config:
   dtype=torch.bfloat16, max_seq_len=16384,
   tensor_parallel_size=16, pipeline_parallel_size=1, data_parallel_size=1,
   quantization=fp8, kv_cache_dtype=fp8_e4m3,
   enable_chunked_prefill=True (auto), enable_prefix_caching=False,
   speculative_config=SpeculativeConfig(method='mtp',
                                        num_spec_tokens=1),
   compilation: VLLM_COMPILE, CUDAGraphMode.FULL_AND_PIECEWISE,
   moe_backend=AITER Fp8 MoE,
   attention_backend(decode)=ROCM_AITER_MLA,
   attention_backend(prefill)=FLASH_ATTN MLA,
   sampler=aiter (ROCm)
```

### Workload driver

`lm_eval` on the proxy port, gsm8k test split (1319 prompts):

```bash
python3 -m lm_eval --model local-chat-completions --apply_chat_template \
  --tasks gsm8k \
  --model_args 'model=DeepSeek-R1-0528,base_url=http://$P_NODE:10001/v1/chat/completions,api_key=EMPTY,max_retries=5,num_concurrent=30,timeout=1800,tokenized_requests=False,max_length=16384' \
  --gen_kwargs max_tokens=12288,temperature=0,top_p=1 \
  --log_samples --output_path ./gsm8k-output
```

### Pre-fix observation

`results/exp34-tp16-sym-1p1d-cycle12/`, 2026-05-15 08:53 UTC, same
hardware and launch as above except this PR is not applied. gsm8k
progresses to **141 / 1319** prompts then the prefill engine wedges
and floods the log with a 60-second-interval message:

```text
(EngineCore pid=1118) INFO 05-15 08:53:11 [shm_broadcast.py:698] No available shared memory broadcast block found in 60 seconds.
(EngineCore pid=1118) INFO 05-15 08:54:11 [shm_broadcast.py:698] No available shared memory broadcast block found in 60 seconds.
(EngineCore pid=1118) INFO 05-15 08:55:11 [shm_broadcast.py:698] No available shared memory broadcast block found in 60 seconds.
...
```

Root cause confirmed by inspecting decode-worker handshake logs: decode
ranks 8-15 dial `$P_NODE` (the prefill head) for KV blocks that
actually live on `$P2_NODE`, the RDMA read never completes, and
`shm_broadcast` waits on the unrendered tensor.

### Post-fix observation

`results/exp34-tp16-sym-1p1d-cycle3-v2/`, 2026-05-15 11:50 UTC, with
this PR applied. gsm8k completes **1319 / 1319** in one run:

```json
"results": {
  "gsm8k": {
    "exact_match,strict-match": 0.9492039423805914,
    "exact_match_stderr,strict-match": 0.006048352096878092,
    "exact_match,flexible-extract": 0.9476876421531463,
    "exact_match_stderr,flexible-extract": 0.006133057708959227
  }
}
"n-samples": {"gsm8k": {"original": 1319, "effective": 1319}}
```

Decode ranks 8-15 now handshake `$P2_NODE` (correct producer); no
`shm_broadcast.py:698` spam on either prefill engine.

### In-tree unit tests

The existing five tests in
`tests/v1/kv_connector/unit/test_moriio_connector.py` still pass (no
regression — they cover the single-host `remote_host` path that this
PR keeps as a fallback):

```bash
pytest tests/v1/kv_connector/unit/test_moriio_connector.py -v
# ✓ test_write_mode_saves_local_block_ids
# ✓ test_write_mode_with_chunked_prefill_saves_local_block_ids
# ✓ test_read_mode_loads_remote_block_ids
# ✓ test_register_kv_caches
# ✓ test_moriio_handshake_returns_metadata
```

These tests do **not** exercise the new `_pick_remote_host` multi-host
branch or the `remote_hosts` plumbing; the new branch is covered only
by the end-to-end cluster run above. Happy to add a targeted unit test
if reviewers prefer.

### Lint

```bash
pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py \
  vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py \
  examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
pre-commit run mypy-3.10 \
  --files vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py \
          vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py \
  --hook-stage manual
# All hooks: Passed.
```

## AI assistance disclosure

This change was drafted with AI assistance (Claude Code). The diff is
~70 lines across 3 files. I (chaemin.lim@mangoboost.io) have reviewed
and defend each changed line; the exact run artifacts (eval JSON +
server logs) are under
`results/exp34-tp16-sym-1p1d-cycle3-v2/accuracy/gsm8k/c30/results_2026-05-15T11-50-18.020558.json`
and `results/exp34-tp16-sym-1p1d-cycle3-v2/server_logs/20260515_105747/`,
available on request. The intent and fallback semantics in
`_pick_remote_host` and the `remote_tp_size` read-order were authored
to match the existing single-host code paths so that TP=8 / monolithic
deployments cannot regress.