### PR TITLE
[CI] De-flake renderers/test_hf.py::test_resolve_content_format_fallbacks[Qwen/Qwen-VL-string]

### DIFF
--- a/tests/models/multimodal/conftest.py
+++ b/tests/models/multimodal/conftest.py
@@ -5,9 +5,19 @@
 import os
 import warnings
 
+import pytest
 import torch
 
+from tests.utils import prewarm_hf_cache
 from vllm.platforms import current_platform
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prewarm_hf_cache():
+    # tokenization_qwen.py downloads SimSun.ttf from
+    # qianwen-res.oss-cn-beijing.aliyuncs.com; both Qwen/Qwen-VL and
+    # Qwen/Qwen-VL-Chat look it up from the Chat repo.
+    prewarm_hf_cache([("Qwen/Qwen-VL-Chat", "SimSun.ttf")])
 
 
 def pytest_configure(config):

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -423,11 +423,6 @@ def test_processing_correctness(
         )
     if model_id == "jinaai/jina-reranker-m0":
         pytest.skip("Fix later")
-    if model_id in {"Qwen/Qwen-VL", "Qwen/Qwen-VL-Chat"}:
-        pytest.skip(
-            "Qwen-VL tokenizer requires downloading a font file from "
-            "servers that often refuse connections in CI"
-        )
     if model_id == "mistralai/Voxtral-Mini-4B-Realtime-2602":
         pytest.skip(
             "Voxtral Realtime doesn't make use of any place-holder "

--- a/tests/renderers/conftest.py
+++ b/tests/renderers/conftest.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.utils import prewarm_hf_cache
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prewarm_hf_cache():
+    # tokenization_qwen.py downloads SimSun.ttf from
+    # qianwen-res.oss-cn-beijing.aliyuncs.com; both Qwen/Qwen-VL and
+    # Qwen/Qwen-VL-Chat look it up from the Chat repo.
+    prewarm_hf_cache([("Qwen/Qwen-VL-Chat", "SimSun.ttf")])

--- a/tests/tokenizers_/conftest.py
+++ b/tests/tokenizers_/conftest.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.utils import prewarm_hf_cache
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prewarm_hf_cache():
+    # tokenization_qwen.py downloads SimSun.ttf from
+    # qianwen-res.oss-cn-beijing.aliyuncs.com; both Qwen/Qwen-VL and
+    # Qwen/Qwen-VL-Chat look it up from the Chat repo.
+    prewarm_hf_cache([("Qwen/Qwen-VL-Chat", "SimSun.ttf")])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,6 +33,8 @@ import pytest
 import requests
 import torch
 import torch.nn.functional as F
+from huggingface_hub import hf_hub_download
+from huggingface_hub.constants import HF_HUB_OFFLINE
 from openai.types.completion import Completion
 from typing_extensions import ParamSpec
 
@@ -44,6 +46,7 @@ from vllm.distributed import (
 )
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.cli.serve import ServeSubcommand
+from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     _KernelT,
     init_fp8_linear_kernel,
@@ -61,7 +64,28 @@ from vllm.utils.torch_utils import (
     set_random_seed,  # noqa: F401 - re-exported for use in test files
 )
 
+logger = init_logger(__name__)
+
 FP8_DTYPE = current_platform.fp8_dtype()
+
+
+def prewarm_hf_cache(assets: list[tuple[str, str]]) -> None:
+    """Pre-populate the HF cache for (repo_id, filename) pairs that upstream
+    trust_remote_code modules would otherwise fetch from third-party CDNs
+    (often unreachable from US-based CI)."""
+    if HF_HUB_OFFLINE:
+        return
+    for repo_id, filename in assets:
+        try:
+            hf_hub_download(repo_id=repo_id, filename=filename)
+        except Exception as e:
+            logger.warning(
+                "Failed to prefetch %s/%s: %r. Tests depending on this asset may fail.",
+                repo_id,
+                filename,
+                e,
+            )
+
 
 if current_platform.is_rocm():
     from amdsmi import (


### PR DESCRIPTION
## Purpose

Upstream `tokenization_qwen.py` (loaded via `trust_remote_code`) fetches `SimSun.ttf` from `qianwen-res.oss-cn-beijing.aliyuncs.com` at import time — flaky from AWS us-west-2 CI ([buildkite #66759](https://buildkite.com/vllm/ci/builds/66759/canvas?sid=019e3ce4-cb29-4a7d-9af6-a85828ade079&tab=output)). Pre-populate the HF cache via a session-scoped autouse fixture so upstream's `try_to_load_from_cache` hits and the CDN call is skipped. Also drops the now-redundant `pytest.skip` from #31932.

## Test Plan

With HF cache cleared (`rm -rf ~/.cache/huggingface/hub/models--Qwen--Qwen-VL-Chat`):

```
pytest -v tests/tokenizers_/test_basic.py::test_tokenizer_like_protocol \
          "tests/renderers/test_hf.py::test_resolve_content_format_fallbacks[Qwen/Qwen-VL-string]" \
          "tests/renderers/test_hf.py::test_resolve_content_format_fallbacks[Qwen/Qwen-VL-Chat-string]"
```

Also `HF_HUB_OFFLINE=1 pytest ...` to verify the offline guard short-circuits the prefetch.

## Test Result

`3 passed in 37.05s` — same 3 tests that fail in [buildkite #66759](https://buildkite.com/vllm/ci/builds/66759/canvas?sid=019e3ce4-cb29-4a7d-9af6-a85828ade079&tab=output). Offline guard: cache stays empty, prefetch skipped as intended.