### PR TITLE
[Bugfix][KV-transfer] MoRIIO add_new_req: tolerate short request_ids

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -347,17 +347,51 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         transfer_id = kv_transfer_params["transfer_id"]
 
         # Parse host/ports from the request_id. The router embeds both zmq_addresses
-        # in the request_id
-        peer_zmq = get_peer_zmq_from_request_id(request_id, is_producer=write_mode)
-        remote_host, remote_handshake_port, remote_notify_port = (
-            parse_moriio_zmq_address(peer_zmq)
-        )
+        # in the request_id. Some cleanup-path requests (e.g. those that hit the
+        # external prefix cache and take the "aborted before scheduling" branch
+        # in `request_finished`) surface a short internal request_id without
+        # the proxy's `___prefill_addr_...` prefix; `get_peer_zmq_from_request_id`
+        # raises ValueError on those. Fall back to `kv_transfer_params.remote_hosts`
+        # (proxy already forwards it for multi-node TP) and MoRIIO's default
+        # well-known ports, which match the kv_connector_extra_config the runner
+        # scripts pass on every container. Only the request_id parse path is
+        # affected; once we have a valid host/port triple we proceed as before.
+        try:
+            peer_zmq = get_peer_zmq_from_request_id(request_id, is_producer=write_mode)
+            remote_host, remote_handshake_port, remote_notify_port = (
+                parse_moriio_zmq_address(peer_zmq)
+            )
+        except ValueError:
+            # Normalize remote_hosts: callers may pass a list (per-rank host
+            # vector from the proxy) or a single host string from older
+            # proxy versions. A bare string would silently slice into "1."
+            # for "172.30.0.1" if we just did remote_hosts[0].
+            remote_hosts_raw = kv_transfer_params.get("remote_hosts") or []
+            if isinstance(remote_hosts_raw, str):
+                remote_hosts = [remote_hosts_raw] if remote_hosts_raw else []
+            else:
+                remote_hosts = list(remote_hosts_raw)
+            if not remote_hosts:
+                raise ValueError(
+                    f"MoRIIO add_new_req: could not resolve peer host/ports "
+                    f"for {request_id!r}; neither request_id parse nor "
+                    f"kv_transfer_params.remote_hosts provided them"
+                ) from None
+            remote_host = remote_hosts[0]
+            remote_handshake_port = int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT)
+            remote_notify_port = int(MoRIIOConstants.DEFAULT_NOTIFY_PORT)
 
+        # Cleanup-path requests (the same "aborted before scheduling" branch
+        # that surfaces a short request_id) can also omit remote_block_ids
+        # and remote_engine_id. Use .get() defaults so we don't crash the
+        # same EngineCore the request_id fallback above is meant to keep
+        # alive — an empty block list is the correct no-op for an aborted
+        # request.
         _req = ReqMeta(
             transfer_id=transfer_id,
             local_block_ids=local_block_ids,
-            remote_block_ids=kv_transfer_params["remote_block_ids"],
-            remote_engine_id=kv_transfer_params["remote_engine_id"],
+            remote_block_ids=kv_transfer_params.get("remote_block_ids", []),
+            remote_engine_id=kv_transfer_params.get("remote_engine_id", ""),
             remote_host=remote_host,
             remote_port=remote_handshake_port,
             remote_handshake_port=remote_handshake_port,


### PR DESCRIPTION
## Purpose

Make `MoRIIOConnectorMetadata.add_new_req` tolerate "short" internal
`request_id`s. Today, the function unconditionally parses the peer's
zmq_address from `request_id` and raises `ValueError` when the prefix
is missing — killing `EngineCore`.

Repro (in our cluster harness, multi-node TP=16 1P1D, DeepSeek-R1,
external prefix cache enabled): after ~141/1319 requests the prefill
engine takes the *"aborted before scheduling"* branch in
`request_finished` (typical when the external prefix cache returns a
hit and the scheduler reclaims the slot before dispatch). The engine
then surfaces a 16-hex internal `request_id` to the KV connector, and:

```text
ValueError: Cannot parse peer zmq_address from request_id: '<16-hex-id>'
```

…propagates out of `add_new_req`, taking `EngineCore` with it. This PR
follows #43063 — both are needed for TP=16 1P1D to make it past
~141/1319 in a gsm8k run.

## Changes

`vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py`:
wrap the `get_peer_zmq_from_request_id` / `parse_moriio_zmq_address`
calls in a `try/except ValueError`. On parse failure, fall back to:

- `remote_host` ← `kv_transfer_params.remote_hosts[0]` (with
  `isinstance(remote_hosts_raw, str)` guard for the string-vs-list
  serialization case — addresses the gemini-code-assist review
  feedback). The proxy already forwards `remote_hosts` for multi-node
  TP via #43063; a single-host setup gets a one-entry list.
- `remote_handshake_port` ← `MoRIIOConstants.DEFAULT_HANDSHAKE_PORT` (6301).
- `remote_notify_port`    ← `MoRIIOConstants.DEFAULT_NOTIFY_PORT` (61005).

If `kv_transfer_params.remote_hosts` is also empty, we re-raise —
preserves the connector's intent of refusing to silently leak
producer KV blocks.

In addition, the `ReqMeta` construction now uses `kv_transfer_params.get()`
with safe defaults for `remote_block_ids` (`[]`) and `remote_engine_id`
(`""`) — also from the gemini review. Cleanup-path requests (the same
"aborted before scheduling" branch that surfaces a short `request_id`)
can omit these, and accessing them with `[]` would crash the same
EngineCore the request_id fallback above is meant to keep alive.

## Backward compatibility

Happy-path requests (those whose `request_id` carries the router's
`___prefill_addr_..._UUID` prefix) take the original
`parse_moriio_zmq_address` branch unchanged. The fallback is only
reached when that parse raises, i.e. exactly the short-id case the
original code crashed on.

## Not a duplicate of

- **#39276** (raviguptaamd) — DP `engine_id` collision +
  `kv_transfer_params` caching across scheduler steps. Different
  failure mode (engine routing vs. `request_id` parse failure on
  cleanup-path requests).
- **#41753** (simondanielsson) — XGMI transport, not the metadata
  resolution path this PR touches.
- **#42928** (esmeetu) — NIXL connector, not MoRIIO.

Searched on 2026-05-19 for `MoRIIO add_new_req`, `request_id parse`,
`remote_hosts fallback` — nothing else targets this specific path.

## Verification

### Software stack on every node

| | version |
|---|---|
| OS | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Kernel | Linux 6.8.0-110-generic, x86_64 |
| ROCm | 7.2.0 |
| Python | 3.12 (container) |
| vLLM | upstream `main` @ `4a4fdabe2` + this PR + #43063 |
| Container | internal build of upstream vLLM `main` + MoRI-IO connector |

### Hardware

| | per node |
|---|---|
| GPU | 8× AMD Instinct MI300X (gfx942), 192 GB HBM |
| NIC | 10× Broadcom Thor (PCI vendor `0x14e4`) |
| Fabric | RDMA over 100 GbE, MoRI-IO transport |

4 nodes total (2 prefill + 2 decode), proxy on prefill head.

### Cluster topology

| role | IP | TP ranks |
|---|---|---|
| prefill head + proxy | `$P_NODE` | rank 0-7 |
| prefill worker | `$P2_NODE` | rank 8-15 |
| decode head | `$DH_NODE` | rank 0-7 |
| decode worker | `$DW_NODE` | rank 8-15 |

### Launch invocation (relevant flags)

Reference proxy:
```bash
python3 examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py \
  --port 10001
```

`vllm serve` on each role (prefill head shown):

```bash
VLLM_HOST_IP=$P_NODE \
VLLM_MORIIO_NODE_HOSTS=$P_NODE,$P2_NODE \
VLLM_MORI_PD_ROLE=prefill \
vllm serve deepseek-ai/DeepSeek-R1-0528 \
  --served-model-name DeepSeek-R1-0528 \
  --tensor-parallel-size 16 \
  --max-model-len 16384 --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.80 \
  --block-size 1 --no-enable-prefix-caching \
  --kv-cache-dtype fp8_e4m3 --dtype auto --trust-remote-code \
  --distributed-executor-backend mp \
  --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":1}' \
  --nnodes 2 --node-rank 0 --master-addr $P2_NODE --master-port 29500 \
  --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"$P_NODE","proxy_port":36367,"proxy_ping_port":36367,"http_port":8100,"handshake_port":6301,"notify_port":61005}}' \
  --host 0.0.0.0 --port 8100
```

Symmetric flags on prefill-worker (`--headless`, `--node-rank 1`),
decode-head (`kv_role=kv_consumer`,
`VLLM_MORIIO_NODE_HOSTS=$DH_NODE,$DW_NODE`), and decode-worker.

### Resolved vLLM config (from the prefill head's startup log)

```text
non-default args: {
  'tensor_parallel_size': 16, 'block_size': 1,
  'max_model_len': 16384, 'max_num_batched_tokens': 8192,
  'gpu_memory_utilization': 0.8, 'kv_cache_dtype': 'fp8_e4m3',
  'enable_prefix_caching': False,
  'speculative_config': {'method': 'deepseek_mtp',
                         'num_speculative_tokens': 1},
  'kv_transfer_config': KVTransferConfig(
      kv_connector='MoRIIOConnector', kv_role='kv_producer', ...)
}

Initializing a V1 LLM engine (v0.1.dev0) with:
  dtype=torch.bfloat16, tensor_parallel_size=16, quantization=fp8,
  kv_cache_dtype=fp8_e4m3, enable_chunked_prefill=True,
  speculative_config=SpeculativeConfig(method='mtp', num_spec_tokens=1),
  attention_backend(decode)=ROCM_AITER_MLA,
  attention_backend(prefill)=FLASH_ATTN MLA,
  moe_backend=AITER Fp8 MoE
```

### Workload driver

gsm8k via `lm_eval` (1319 prompts, `num_concurrent=30`,
`max_tokens=12288`, `temperature=0`), pointed at the proxy on the
prefill head.

### Pre-fix observation

`results/exp34-tp16-sym-1p1d-cycle12/`, 2026-05-15 08:53 UTC, same
hardware and launch as above except this PR and #43063 are not
applied. gsm8k progresses to **141 / 1319** prompts, then EngineCore
crashes:

```text
ValueError: Cannot parse peer zmq_address from request_id: '<16-hex-id>'
  at moriio_common.add_new_req
```

(The prefill engine hits the `aborted before scheduling` branch — the
external prefix cache returned a hit and reclaimed the slot before the
scheduler dispatched it. The 16-hex internal `request_id` has no
`___prefill_addr_..._UUID` prefix to parse.)

### Post-fix observation

`results/exp34-tp16-sym-1p1d-cycle3-v2/`, 2026-05-15 11:50 UTC, with
this PR and #43063 both applied. gsm8k completes **1319 / 1319** in
one run:

```json
"results": {
  "gsm8k": {
    "exact_match,strict-match": 0.9492039423805914,
    "exact_match_stderr,strict-match": 0.006048352096878092,
    "exact_match,flexible-extract": 0.9476876421531463,
    "exact_match_stderr,flexible-extract": 0.006133057708959227
  }
}
```

No `ValueError` from `add_new_req` — the cleanup-path short-id requests
take the fallback branch and return cleanly.

### In-tree unit tests

```bash
pytest tests/v1/kv_connector/unit/test_moriio_connector.py -v
# ✓ test_write_mode_saves_local_block_ids
# ✓ test_write_mode_with_chunked_prefill_saves_local_block_ids
# ✓ test_read_mode_loads_remote_block_ids
# ✓ test_register_kv_caches
# ✓ test_moriio_handshake_returns_metadata
```

All five pass (no regression). The existing tests don't construct
short-id / missing-`kv_transfer_params` inputs to exercise the new
fallback branch; that path is only exercised by the end-to-end
cluster run above. Happy to add a targeted unit test if reviewers
want.

### Lint

```bash
pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
pre-commit run mypy-3.10 --files \
  vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py \
  --hook-stage manual
# All hooks: Passed.
```

## Gemini-code-assist review response

Both items raised in the automated review are addressed in the current
commit (see "Changes" above):

1. **`remote_hosts` list-vs-string handling** — explicit
   `isinstance(remote_hosts_raw, str)` branch + `list()` conversion
   otherwise; empty list re-raises.
2. **`.get()` on optional keys** — `remote_block_ids` and
   `remote_engine_id` now use `.get()` with safe defaults so that
   cleanup-path requests (the same code path this PR exists to
   protect) don't crash on the next `[]` access.

## AI assistance disclosure

This PR was drafted with AI assistance (Claude Code). The diff is 1
file, ~40 lines, isolated to the parse-fallback path. I
(chaemin.lim@mangoboost.io) have reviewed and defend each changed
line; the fallback values (`DEFAULT_HANDSHAKE_PORT`,
`DEFAULT_NOTIFY_PORT`, `remote_hosts[0]`) are the same constants the
runner harness already configures on every MoRIIO container, so the
fallback is provably consistent with the deployment-time config rather
than a guess.