### PR TITLE
[Bugfix] Gate persistent MLA metadata behind VLLM_AITER_MLA_PERSISTENT_METADATA

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -115,6 +115,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
+    VLLM_AITER_MLA_PERSISTENT_METADATA: bool = False
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
@@ -1043,6 +1044,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MLA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MLA", "True").lower() in ("true", "1")
+    ),
+    # Whether to take the persistent qh128 MLA metadata fast path. Off by
+    # default because on gfx942 the persistent
+    # mla_a8w8_qh128_m32x4_n16x2_msk0_ps ASM kernel faults with
+    # "Write access to a read-only page" during warmup. Opt in by setting
+    # VLLM_AITER_MLA_PERSISTENT_METADATA=1 once the regression is verified
+    # fixed in your deployment.
+    "VLLM_AITER_MLA_PERSISTENT_METADATA": lambda: (
+        os.getenv("VLLM_AITER_MLA_PERSISTENT_METADATA", "False").lower()
+        in ("true", "1")
     ),
     # Whether to use aiter mha ops.
     # By default is enabled.

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -7,6 +7,7 @@ from typing import ClassVar, Final
 
 import torch
 
+import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
@@ -154,6 +155,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         self.compilation_config = vllm_config.compilation_config
         self.decode_attn_out_dtype = vllm_config.model_config.dtype
+
+        # Cache the gfx942 MAF workaround flag at builder init so the hot
+        # `_build_decode` path doesn't do an `os.getenv` lookup per batch.
+        # See VLLM_AITER_MLA_PERSISTENT_METADATA in vllm.envs for the
+        # MAF context.
+        self._use_persistent_metadata: bool = envs.VLLM_AITER_MLA_PERSISTENT_METADATA
 
         # Store the kernel block size from the spec. When kernel_block_size=1
         # (no spec-dec), behavior is identical to the original. When > 1
@@ -483,8 +490,17 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # We track whether persistent metadata was successfully computed
         # so forward_mqa can skip passing it (falling back to the kernel
         # computing its own metadata internally, like v0.18.0).
+        # MAF H1 WORKAROUND: forcibly skip the persistent-metadata fast path.
+        # On gfx942 with DP=8 (each rank has full nhead=128), the persistent
+        # qh128 MLA ASM kernel (`mla_a8w8_qh128_m32x4_n16x2_msk0_ps`) faults
+        # with "Write access to a read-only page" during warmup. With the
+        # env flag off, the kernel computes metadata internally (v0.18.0
+        # path) — slightly slower but stable. Re-enable by setting
+        # VLLM_AITER_MLA_PERSISTENT_METADATA=1. We resolve via vllm.envs
+        # (`_use_persistent_metadata` cached at class scope) rather than
+        # `os.getenv` here because this builder runs once per decode batch.
         has_persistent_metadata = False
-        if max_qo_len == 1:
+        if max_qo_len == 1 and self._use_persistent_metadata:
             from aiter import get_mla_metadata_v1
 
             get_mla_metadata_v1(


### PR DESCRIPTION
## Purpose

On AMD gfx942 with DP=8 (each rank carries the full `nhead=128` since
TP=1 within each DP rank), the persistent `qh128` MLA ASM kernel
`mla_a8w8_qh128_m32x4_n16x2_msk0_ps` faults with

```text
HSA_STATUS_ERROR_MEMORY_FAULT … Write access to a read-only page
```

during warmup, killing the worker before any request lands. The same
code path is harmless when the persistent-metadata fast-path is **not**
taken — the kernel computes metadata internally (v0.18.0 behavior),
slightly slower per call but does not fault.

This PR gates the persistent-metadata fast path behind a new env
variable `VLLM_AITER_MLA_PERSISTENT_METADATA` (default `False`, i.e.
OFF). Users on gfx942 with a stable persistent-path deployment can
opt back in explicitly with `VLLM_AITER_MLA_PERSISTENT_METADATA=1`.

## Changes

- `vllm/envs.py`: register `VLLM_AITER_MLA_PERSISTENT_METADATA: bool =
  False` with the standard env-var registration helper, alongside the
  other `VLLM_AITER_*` knobs.
- `vllm/v1/attention/backends/mla/rocm_aiter_mla.py`:
  - Cache the env-var lookup once at builder init time as
    `self._use_persistent_metadata: bool = envs.VLLM_AITER_MLA_PERSISTENT_METADATA`
    (per gemini-code-assist review — avoid per-decode-batch `os.getenv`
    overhead in the metadata-build hot path).
  - Guard the persistent-metadata fast-path with `if max_qo_len == 1
    and self._use_persistent_metadata`.
  - Comment block documents the gfx942 fault and how to re-enable.

About 28 lines added / 1 line modified across 2 files.

## Backward compatibility

Behavior change only takes effect on `max_qo_len == 1` (decode-only).
Previously this path was *always* taken; now it requires explicit
opt-in. For deployments where the persistent path was working, set
`VLLM_AITER_MLA_PERSISTENT_METADATA=1` to restore the prior behavior.

## Not a duplicate of

Searched on 2026-05-19 for `aiter MLA`, `rocm_aiter_mla`,
`mla_a8w8_qh128`, `HSA_STATUS_ERROR_MEMORY_FAULT`, `Write access to a
read-only page` — no open PR or issue tracks this fault path.

## Verification

### Software stack

| | version |
|---|---|
| OS | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Kernel | Linux 6.8.0-110-generic, x86_64 |
| ROCm | 7.2.0 |
| Python | 3.12 (container) |
| vLLM | upstream `main` @ `4a4fdabe2` + this PR |
| aiter | bundled with the container (`module_aiter_core` JIT) |
| Container | internal build of upstream vLLM `main` + MoRI-IO connector |

### Hardware

| | per node |
|---|---|
| GPU | 8× AMD Instinct MI300X (gfx942), 192 GB HBM |
| NIC | 10× Broadcom Thor (PCI vendor `0x14e4`) |

This PR's fault path reproduces on a single node (DP=8). The end-to-end
benchmark below uses 1P1D across two nodes to exercise the warmup +
serve path under real load.

### Cluster topology used for the benchmark

| role | IP | layout |
|---|---|---|
| prefill node + proxy | `$P_NODE` | TP=1, DP=8, EP=8, MoRI all2all |
| decode node | `$D_NODE` | TP=1, DP=8, EP=8, MoRI all2all |

(Warmup repro is local: any single gfx942 node with the launch flags
below, *without* this PR, will fault during MLA metadata build.)

### Launch invocation

`vllm serve` per role (prefill node shown — the decode side is
symmetric with `kv_role=kv_consumer`):

```bash
VLLM_HOST_IP=$P_NODE \
VLLM_NIXL_SIDE_CHANNEL_HOST=$P_NODE \
VLLM_ENABLE_V1_MULTIPROCESSING=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
VLLM_MORI_PD_ROLE=prefill \
vllm serve deepseek-ai/DeepSeek-R1-0528 \
  --served-model-name DeepSeek-R1-0528 \
  --tensor-parallel-size 1 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend mori \
  --max-model-len 10240 --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.80 \
  --block-size 1 --no-enable-prefix-caching \
  --kv-cache-dtype fp8_e4m3 --dtype auto --trust-remote-code \
  --distributed-executor-backend mp \
  --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":3,"draft_acceptance_method":"deepseek_v3_relaxed","speculative_token_ratio":0.5,"speculative_token_topk":3}' \
  --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"$P_NODE","proxy_port":36367,"proxy_ping_port":36367,"http_port":8100,"handshake_port":6301,"notify_port":61005}}' \
  --host 0.0.0.0 --port 8100
```

To opt back into the persistent fast-path:
```bash
VLLM_AITER_MLA_PERSISTENT_METADATA=1 vllm serve ...
```

### Pre-fix observation

Without this PR, on any single gfx942 node with DP≥8 and the flags
above:

```text
HSA_STATUS_ERROR_MEMORY_FAULT: Agent: 0xXXX, Address: 0xYYY (Write access to a read-only page)
  at mla_a8w8_qh128_m32x4_n16x2_msk0_ps
```

All 8 DP workers crash during warmup before serving a request.

### Post-fix observation

Three artifacts demonstrate the gate works:

1. **Warmup** completes on all 8 DP workers on the same hardware where
   the pre-fix crash repros. Server starts, registers with the proxy,
   accepts the gsm8k smoke test.

2. **1P1D end-to-end sweep** with this PR (and #43068) applied, MTP-3
   + relaxed-acceptance speculative decoding (r=0.5, k=3),
   8k1k workload, `random_input_len=8192 random_output_len=1024
   ignore_eos=True`. From
   `results/exp85-vllm-mtp3-relax05-k3-dp8ep-1p1d/`:

   | concurrency | done/total | Gen tok/s/GPU | TPOT (ms) | E2E (s) |
   |---|---|---|---|---|
   | 6 | 60/60 | 11.7 | 25.3 | 25.3 |
   | 9 | 90/90 | 19.2 | 41.3 | 25.6 |
   | 30 | 300/300 | 52.5 | 38.5 | 30.5 |
   | 77 | 770/770 | 100.3 | 31.4 | 40.7 |
   | 154 | 1540/1540 | 128.2 | 30.2 | 65.8 |
   | 256 | 2560/2560 | 131.5 | 28.5 | 107.0 |
   | 512 | **5051/5120** | **132.4** | 28.7 | 210.0 |

   (The c=512 row's 69 missed requests are unrelated proxy-level TCP
   resets at the burst start, not MLA — separately diagnosed against
   `aiohttp ClientOSError: [Errno 104] Connection reset by peer`.)

3. **Opt-in path** (`VLLM_AITER_MLA_PERSISTENT_METADATA=1`)
   reproduces the original HSA fault on the same hardware → the gate
   is correctly wired; the env-var actually controls the branch.

### In-tree unit tests

There is no `test_rocm_aiter_mla.py` covering the
`AiterMLAMetadataBuilder._build_decode` persistent-vs-internal-metadata
branch in vLLM's tree. Closest existing tests:

```bash
pytest tests/rocm/aiter/test_mla_fp8_support_check.py -v
pytest tests/v1/attention/test_mla_backends.py -v
```

Neither construct the `max_qo_len == 1` decode path with the persistent
fast-path enabled — so they pass before and after this PR.
**Happy to add a builder-level test that toggles
`VLLM_AITER_MLA_PERSISTENT_METADATA` and asserts the branch taken if
reviewers prefer.**

### Lint

```bash
pre-commit run --files \
  vllm/envs.py vllm/v1/attention/backends/mla/rocm_aiter_mla.py
pre-commit run mypy-3.10 --files \
  vllm/v1/attention/backends/mla/rocm_aiter_mla.py vllm/envs.py \
  --hook-stage manual
# All hooks: Passed.
```

## Gemini-code-assist review response

The review's first item is addressed: the env-var is read **once** at
builder init (`self._use_persistent_metadata`); the hot path in
`_build_decode` reads the cached bool, not `os.getenv`.

The review's second item (hoisting `from aiter import
get_mla_metadata_v1` to module top) is intentionally **not** applied:
every other `aiter` import in this file is inline (see lines 49, 196,
284, 347, 504, 703, 711) because `aiter` is an optional ROCm-only
dependency. Hoisting one of them to module top would either break
import on non-ROCm builds or require a try/except guard inconsistent
with the rest of the file.

## AI assistance disclosure

This PR was drafted with AI assistance (Claude Code). The diff is 2
files, +28 / -1. I (chaemin.lim@mangoboost.io) have reviewed and
defend each changed line. The env-var name follows the existing
`VLLM_AITER_*` convention; opt-in default off matches vLLM's general
posture for kernels with a known regression on a specific hardware
target.