### PR TITLE
[Bugfix] MoriAll2AllManager: pass num_qp_per_pe and quant_type explicitly

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -742,6 +742,10 @@ class MoriAll2AllManager(All2AllManagerBase):
             kernel_type=kernel_type,
             rdma_block_num=rdma_block_num,
             gpu_per_node=min(8, num_ep_ranks),
+            # Match SGLang config — vLLM was relying on mori defaults for
+            # these two fields, which may not be what mori expects on gfx942.
+            num_qp_per_pe=2,
+            quant_type="fp8_direct_cast" if scale_dim > 0 else "none",
         )
 
     def _make_handle(self, **kwargs):


### PR DESCRIPTION
## Purpose

`MoriAll2AllManager` constructs `EpDispatchCombineConfig` without
specifying `num_qp_per_pe` and `quant_type`, relying on mori's defaults.
On gfx942 those defaults do not match what the dispatch kernel expects
once the MoE layer enables FP8 (per-expert scale > 0). The mismatch
surfaces downstream as an MoE dispatch error during model warmup —
silent at config time, visible only when the first batch hits the
expert-parallel path.

SGLang's MoRI integration already passes both fields explicitly. This
PR mirrors that choice on the vLLM side so the two stacks initialize
MoRI dispatch with the same config on gfx942.

## Changes

`vllm/distributed/device_communicators/all2all.py`,
`MoriAll2AllManager`:

```python
ep_dispatch_combine_config = EpDispatchCombineConfig(
    ...,
    gpu_per_node=min(8, num_ep_ranks),
    # Match SGLang config — vLLM was relying on mori defaults for
    # these two fields, which may not be what mori expects on gfx942.
    num_qp_per_pe=2,
    quant_type="fp8_direct_cast" if scale_dim > 0 else "none",
)
```

4 lines added. Existing fields and call sites are untouched.

## Backward compatibility

When `scale_dim == 0` (no FP8 scales), `quant_type` falls back to
`"none"`, which is what mori's default produces today. Pre-FP8 paths
see no observable change. FP8 paths get the correct dispatch kernel
selected upfront rather than failing at first use.

`num_qp_per_pe=2` matches the value SGLang has shipped since
upstream-mori commit `9a83e02` (the kernel was tuned with this value;
mori's default of 1 produces a different QP topology that the gfx942
kernel doesn't expect).

## Not a duplicate of

Searched on 2026-05-19 for `MoriAll2AllManager`, `EpDispatchCombineConfig`,
`num_qp_per_pe`, `quant_type fp8_direct_cast`, `MoRI EP dispatch` —
no open PR or issue tracks this field plumbing in vLLM.

## Verification

### Software stack

| | version |
|---|---|
| OS | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Kernel | Linux 6.8.0-110-generic, x86_64 |
| ROCm | 7.2.0 |
| Python | 3.12 (container) |
| vLLM | upstream `main` @ `4a4fdabe2` + this PR |
| mori | upstream commit `9a83e02` (vendored in container) |
| Container | internal build of upstream vLLM `main` + MoRI-IO connector |

### Hardware

| | per node |
|---|---|
| GPU | 8× AMD Instinct MI300X (gfx942), 192 GB HBM |
| NIC | 10× Broadcom Thor (PCI vendor `0x14e4`) |
| Fabric | RDMA over 100 GbE |

The MoE-dispatch failure path reproduces on a single node with
DP=8 EP=8 FP8. The end-to-end benchmark below uses 1P1D across two
nodes for the full P/D experiment.

### Cluster topology

| role | IP | layout |
|---|---|---|
| prefill node + proxy | `$P_NODE` | TP=1, DP=8, EP=8, MoRI all2all |
| decode node | `$D_NODE` | TP=1, DP=8, EP=8, MoRI all2all |

### Launch invocation

`vllm serve` on the prefill node (decode is symmetric with
`kv_role=kv_consumer`):

```bash
VLLM_HOST_IP=$P_NODE \
VLLM_ENABLE_V1_MULTIPROCESSING=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
VLLM_MORI_PD_ROLE=prefill \
vllm serve deepseek-ai/DeepSeek-R1-0528 \
  --served-model-name DeepSeek-R1-0528 \
  --tensor-parallel-size 1 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend mori \
  --max-model-len 10240 --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.80 \
  --block-size 1 --no-enable-prefix-caching \
  --kv-cache-dtype fp8_e4m3 --dtype auto --trust-remote-code \
  --distributed-executor-backend mp \
  --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":3,"draft_acceptance_method":"deepseek_v3_relaxed","speculative_token_ratio":0.7,"speculative_token_topk":10}' \
  --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"$P_NODE","proxy_port":36367,"proxy_ping_port":36367,"http_port":8100,"handshake_port":6301,"notify_port":61005}}' \
  --host 0.0.0.0 --port 8100
```

This selects the `MoriAll2AllManager` code path (the file this PR
modifies). With FP8 quantization on the MoE weights, the manager
constructs `EpDispatchCombineConfig` with `scale_dim > 0`, exercising
the new `quant_type="fp8_direct_cast"` branch.

### Pre-fix observation

Without this PR, with the launch flags above, the first batch through
the MoE dispatch fails. The engine never reaches a serving state;
warmup tensor-parallel exchanges never complete.

(The failure is silent at startup — the `EpDispatchCombineConfig`
constructor accepts the defaults — but the first forward through MoE
dispatch surfaces an upstream-mori dispatch error.)

### Post-fix observation

End-to-end sweep with this PR (and #43067) applied, MTP-3 +
relaxed-acceptance (r=0.7, k=10), 8k1k workload
(`random_input_len=8192 random_output_len=1024 ignore_eos=True`).
From `results/exp86-vllm-mtp3-relax07-k10-dp8ep-1p1d/`:

| concurrency | done/total | Gen tok/s/GPU | TPOT (ms) | E2E (s) |
|---|---|---|---|---|
| 6 | 60/60 | 11.8 | 26.5 | 26.5 |
| 9 | 90/90 | 20.7 | 45.6 | 23.5 |
| 30 | 300/300 | 52.8 | 38.8 | 30.0 |
| 77 | 770/770 | 103.2 | 32.5 | 40.2 |
| 154 | 1540/1540 | 128.0 | 29.6 | 66.0 |
| 256 | 2560/2560 | 130.9 | 27.4 | 107.2 |
| 512 | **5027/5120** | **132.9** | 27.5 | 210.6 |

A second run with different MTP knobs (r=0.5, k=3,
`exp85-vllm-mtp3-relax05-k3-dp8ep-1p1d`) produces the same warmup
behavior (132.4 gen tok/s/GPU at c=512), confirming the dispatch
config is correct regardless of speculative settings.

(The c=512 row's missed requests are unrelated TCP resets at the burst
start, separately diagnosed.)

### In-tree unit tests

There is no `test_all2all.py` in the vLLM tree that exercises
`MoriAll2AllManager`'s `EpDispatchCombineConfig` construction. The
closest existing path is:

```bash
pytest tests/distributed/test_torchrun_example.py -v
```

…which validates other `All2AllManager` subclasses but does not bring
mori up. The new lines this PR touches are exercised end-to-end by the
benchmark above, not by a unit test. **Happy to add a small unit test
that constructs `MoriAll2AllManager._make_all2all_kwargs()` with
`scale_dim > 0` and asserts `quant_type == "fp8_direct_cast"` if
reviewers want.**

### Lint

```bash
pre-commit run --files vllm/distributed/device_communicators/all2all.py
pre-commit run mypy-3.10 \
  --files vllm/distributed/device_communicators/all2all.py \
  --hook-stage manual
# All hooks: Passed.
```

## AI assistance disclosure

This PR was drafted with AI assistance (Claude Code). The diff is 1
file, +4. I (chaemin.lim@mangoboost.io) have reviewed and defend each
changed line; the chosen values mirror SGLang's MoRI integration (same
underlying mori kernel), so vLLM and SGLang now initialize identically
on gfx942.