### PR TITLE
[CI] Fix "AMD: Entrypoints Integration (API Server openai - Part 1)"

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -311,6 +311,8 @@ class OpenAIServingChat(OpenAIServing):
                     self.default_sampling_params,
                 )
 
+            await self._validate_sampling_params(sampling_params)
+
             self._log_inputs(
                 sub_request_id,
                 engine_input,

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -177,6 +177,8 @@ class OpenAIServingCompletion(OpenAIServing):
                     self.default_sampling_params,
                 )
 
+            await self._validate_sampling_params(sampling_params)
+
             request_id_item = f"{request_id}-{i}"
 
             self._log_inputs(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -390,6 +390,18 @@ class OpenAIServing(BeamSearchOnlineMixin):
 
         return None
 
+    async def _validate_sampling_params(
+        self,
+        params: SamplingParams | BeamSearchParams,
+    ) -> None:
+        # Run validation up-front so streaming requests fail with a clean
+        # JSON 400 from FastAPI's exception_handler instead of an
+        # HTTP 200 + SSE error frame on a half-closed keep-alive socket.
+        if isinstance(params, BeamSearchParams):
+            return
+        supported_tasks = await self.engine_client.get_supported_tasks()
+        self.input_processor._validate_params(params, supported_tasks)
+
     @staticmethod
     def _base_request_id(
         raw_request: Request | None, default: str | None = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -443,6 +443,8 @@ class OpenAIServingResponses(OpenAIServing):
                 default_max_tokens, self.default_sampling_params
             )
 
+            await self._validate_sampling_params(sampling_params)
+
             trace_headers = (
                 None
                 if raw_request is None

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -469,6 +469,8 @@ class OpenAISpeechToText(OpenAIServing):
         if request.response_format == "verbose_json":
             sampling_params.logprobs = 1
 
+        await self._validate_sampling_params(sampling_params)
+
         engine_request_ids = [
             request_id if len(engine_inputs) == 1 else f"{request_id}-{idx}"
             for idx in range(len(engine_inputs))


### PR DESCRIPTION
## Purpose

Fix AMD CI flake `test_too_many_chat_logprobs[zephyr-lora]` ([#66799](https://buildkite.com/vllm/ci/builds/66799/canvas?sid=019e3e25-3716-4ace-8373-ce539de5947d&tab=output)).

Streaming `SamplingParams` validation runs lazily inside the SSE generator, after `StreamingResponse` commits `HTTP 200`. The resulting `HTTP 200 + SSE error frame` races httpx's keep-alive pool against uvicorn's 5s timer. AMD MI300 latency trips it deterministically; NVIDIA L4 hits the same path (same `200 OK` in build #66799) but finishes well under 5s, so it passes by luck.

Validate up-front so invalid requests uniformly return `HTTP 400 + JSON` for both `stream=True/False`.

## Test Plan

Repro on a `zephyr-7b-beta` + LoRA server: curl `top_logprobs=21` (stream) and `top_logprobs=30` (non-stream); run `test_too_many_chat_logprobs`, adjacent logprobs tests, and `test_too_many_completion_logprobs`.

## Test Result

On NVIDIA GB10:
- curl `stream=True, top_logprobs=21` → `HTTP 400 + JSON` (was `200 + SSE`)
- curl `stream=False, top_logprobs=30` → `HTTP 400 + JSON` (unchanged)
- `test_too_many_chat_logprobs` (both params) PASSED
- 12/12 adjacent logprobs tests PASSED
- `test_too_many_completion_logprobs` PASSED