### PR TITLE
[CI] Disable V2 model runner for LoRA configs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,43 +148,6 @@ def test_is_default_v2_model_runner_model(model_config, expected):
     assert VllmConfig._is_default_v2_model_runner_model(config) is expected
 
 
-def _make_v2_unsupported_feature_shim(**overrides):
-    """Build a self shim where no unsupported clauses fire by default."""
-    defaults = dict(
-        model_config=None,
-        speculative_config=None,
-        reasoning_config=None,
-        ec_transfer_config=None,
-        lora_config=None,
-        parallel_config=SimpleNamespace(
-            prefill_context_parallel_size=1,
-            tensor_parallel_size=1,
-            pipeline_parallel_size=1,
-            enable_dbo=False,
-        ),
-        compilation_config=SimpleNamespace(
-            mode=CompilationMode.VLLM_COMPILE,
-            pass_config=SimpleNamespace(enable_sp=False),
-        ),
-        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False),
-    )
-    return SimpleNamespace(**(defaults | overrides))
-
-
-@pytest.mark.parametrize(
-    ("lora_config", "expected_lora_unsupported"),
-    [(SimpleNamespace(), True), (None, False)],
-)
-def test_v2_model_runner_unsupported_features_lora(
-    lora_config, expected_lora_unsupported
-):
-    config = _make_v2_unsupported_feature_shim(lora_config=lora_config)
-
-    unsupported = VllmConfig._get_v2_model_runner_unsupported_features(config)
-
-    assert ("LoRA" in unsupported) is expected_lora_unsupported
-
-
 @pytest.mark.skip_global_cleanup
 def test_with_hf_config_populates_missing_architectures_from_causal_lm_mapping(
     monkeypatch,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,6 +148,43 @@ def test_is_default_v2_model_runner_model(model_config, expected):
     assert VllmConfig._is_default_v2_model_runner_model(config) is expected
 
 
+def _make_v2_unsupported_feature_shim(**overrides):
+    """Build a self shim where no unsupported clauses fire by default."""
+    defaults = dict(
+        model_config=None,
+        speculative_config=None,
+        reasoning_config=None,
+        ec_transfer_config=None,
+        lora_config=None,
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            tensor_parallel_size=1,
+            pipeline_parallel_size=1,
+            enable_dbo=False,
+        ),
+        compilation_config=SimpleNamespace(
+            mode=CompilationMode.VLLM_COMPILE,
+            pass_config=SimpleNamespace(enable_sp=False),
+        ),
+        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False),
+    )
+    return SimpleNamespace(**(defaults | overrides))
+
+
+@pytest.mark.parametrize(
+    ("lora_config", "expected_lora_unsupported"),
+    [(SimpleNamespace(), True), (None, False)],
+)
+def test_v2_model_runner_unsupported_features_lora(
+    lora_config, expected_lora_unsupported
+):
+    config = _make_v2_unsupported_feature_shim(lora_config=lora_config)
+
+    unsupported = VllmConfig._get_v2_model_runner_unsupported_features(config)
+
+    assert ("LoRA" in unsupported) is expected_lora_unsupported
+
+
 @pytest.mark.skip_global_cleanup
 def test_with_hf_config_populates_missing_architectures_from_causal_lm_mapping(
     monkeypatch,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2004,6 +2004,7 @@ class VllmConfig:
 
         # TODO: V2 ModelCudaGraphManager does not capture LoRA-specialized
         # graphs; capture and execute disagree on BatchDescriptor.has_lora.
+        # Context: https://github.com/vllm-project/vllm/pull/43084
         if self.lora_config is not None:
             unsupported.append("LoRA")
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2002,6 +2002,11 @@ class VllmConfig:
             # TODO: add reasoning budget enforcement to ModelRunnerV2.
             unsupported.append("reasoning budget enforcement")
 
+        # TODO: V2 ModelCudaGraphManager does not capture LoRA-specialized
+        # graphs; capture and execute disagree on BatchDescriptor.has_lora.
+        if self.lora_config is not None:
+            unsupported.append("LoRA")
+
         if self.parallel_config.enable_dbo:
             unsupported.append("dual batch overlap")
 


### PR DESCRIPTION
## Purpose

Fixes #42999

Nightly CI #66835 fails `test_batch_inference_correctness[model_setup0]` on Qwen3-1.7B + LoRA with `RuntimeError: CUDA graphs must be captured on a non-default stream` on both the [H200](https://buildkite.com/vllm/ci/builds/66835/canvas?sid=019e3ed4-25a7-4891-a764-6ee0625bcd6f&tab=output) and [B200](https://buildkite.com/vllm/ci/builds/66835/canvas?sid=019e3ed4-25a8-429c-83e9-2cc713a425a5&tab=output) variants.

#39337 added `Qwen3ForCausalLM` to the V2 default whitelist. V2 `ModelCudaGraphManager` captures with `BatchDescriptor(has_lora=False)` but `execute_model` looks up `has_lora=True` when LoRA is configured — keys mismatch, PIECEWISE replay misses, capture falls into the default stream and crashes.

Add LoRA to `_get_v2_model_runner_unsupported_features` so LoRA configs transparently fall back to V1 (mirrors #43010, #42955). Explicit `VLLM_USE_V2_MODEL_RUNNER=1` now raises a clear `ValueError`.

Follow-up: implement V2 LoRA cudagraph specialization so this clause can be removed.

## Test Plan

`pytest tests/test_config.py -k v2_model_runner_unsupported_features_lora`

## Test Result

Both parametrized cases pass.