### PR TITLE
[Test] Replace zephyr-7b-beta (7B) with SmolLM2-135M in tokenization test

### DIFF
--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -16,7 +16,7 @@ MODEL_NAME = "Qwen/Qwen3-1.7B"
 def server():
     from .conftest import BASE_TEST_ENV
 
-    args = ["--reasoning-parser", "qwen3", "--max_model_len", "5000"]
+    args = ["--reasoning-parser", "qwen3", "--max_model_len", "8192"]
     env_dict = {
         **BASE_TEST_ENV,
         "VLLM_ENABLE_RESPONSES_API_STORE": "1",

--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -9,7 +9,7 @@ from tests.utils import RemoteOpenAIServer
 
 from .conftest import validate_streaming_event_stack
 
-MODEL_NAME = "Qwen/Qwen3-8B"
+MODEL_NAME = "Qwen/Qwen3-0.6B"
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -9,14 +9,14 @@ from tests.utils import RemoteOpenAIServer
 
 from .conftest import validate_streaming_event_stack
 
-MODEL_NAME = "Qwen/Qwen3-1.7B"
+MODEL_NAME = "Qwen/Qwen3-8B"
 
 
 @pytest.fixture(scope="module")
 def server():
     from .conftest import BASE_TEST_ENV
 
-    args = ["--reasoning-parser", "qwen3", "--max_model_len", "8192"]
+    args = ["--reasoning-parser", "qwen3", "--max_model_len", "5000"]
     env_dict = {
         **BASE_TEST_ENV,
         "VLLM_ENABLE_RESPONSES_API_STORE": "1",

--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -9,7 +9,7 @@ from tests.utils import RemoteOpenAIServer
 
 from .conftest import validate_streaming_event_stack
 
-MODEL_NAME = "Qwen/Qwen3-0.6B"
+MODEL_NAME = "Qwen/Qwen3-1.7B"
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/serve/tokenize/test_tokenization.py
+++ b/tests/entrypoints/serve/tokenize/test_tokenization.py
@@ -9,7 +9,7 @@ from tests.utils import RemoteOpenAIServer
 from vllm.tokenizers import get_tokenizer
 
 # any model with a chat template should work here
-MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
+MODEL_NAME = "HuggingFaceTB/SmolLM2-135M-Instruct"
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/serve/tokenize/test_tokenization.py
+++ b/tests/entrypoints/serve/tokenize/test_tokenization.py
@@ -9,7 +9,7 @@ from tests.utils import RemoteOpenAIServer
 from vllm.tokenizers import get_tokenizer
 
 # any model with a chat template should work here
-MODEL_NAME = "HuggingFaceH4/zephyr-7b-beta"
+MODEL_NAME = "Qwen/Qwen3-0.6B"
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/serve/tokenize/test_tokenization.py
+++ b/tests/entrypoints/serve/tokenize/test_tokenization.py
@@ -9,7 +9,7 @@ from tests.utils import RemoteOpenAIServer
 from vllm.tokenizers import get_tokenizer
 
 # any model with a chat template should work here
-MODEL_NAME = "Qwen/Qwen3-0.6B"
+MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- Replace `HuggingFaceH4/zephyr-7b-beta` (7B) with `HuggingFaceTB/SmolLM2-135M-Instruct` (135M) in `tests/entrypoints/serve/tokenize/test_tokenization.py`
- This test only validates the `/tokenize`, `/detokenize`, and `/tokenizer_info` endpoints — no model inference occurs, so any model with a chat template works (as the existing code comment notes)
- ~50x model size reduction, saving ~7GB GPU memory for this test server

## Affected tests
All tests in `tests/entrypoints/serve/tokenize/test_tokenization.py`:
- `test_tokenize_completions`
- `test_tokenize_chat`
- `test_tokenize_chat_with_tools`
- `test_tokenize_with_return_token_strs`
- `test_detokenize`
- `test_tokenizer_info_basic`
- `test_tokenizer_info_schema`
- `test_tokenizer_info_consistency_with_tokenize`
- `test_tokenizer_info_chat_template`

These run in the **Entrypoints Unit Tests** CI job.

## Test plan
- [x] All 9 tests pass in CI (build [#67000](https://buildkite.com/vllm/ci/builds/67000))

🤖 Generated with [Claude Code](https://claude.com/claude-code)