### PR TITLE
[Core][Ray] Fix get_node_ip and driver_ip on multi-NIC nodes

### DIFF
--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -72,6 +72,37 @@ def get_ip() -> str:
     return "0.0.0.0"
 
 
+def get_ray_node_ip() -> str | None:
+    """Return the current Ray node's IP as registered in ``ray.nodes()``.
+
+    This is the IP passed to ``ray start --node-ip-address`` and is what
+    Ray uses for cluster RPC. Returns ``None`` when Ray is not
+    initialized, when the current node cannot be located in
+    ``ray.nodes()``, or on any error. Callers should fall back to
+    :func:`get_ip` (which respects ``VLLM_HOST_IP``) in that case.
+
+    The point of this helper is multi-NIC nodes (e.g. WiFi default
+    route + dedicated cluster NIC such as a Mellanox DAC). vLLM's
+    :func:`get_ip` falls back to ``socket.connect(("8.8.8.8", 80))``
+    which returns the default-route interface IP — which may not be
+    the IP Ray actually uses for cross-host RPC. ``ray.nodes()`` is
+    authoritative.
+    """
+    try:
+        import ray
+        if not ray.is_initialized():
+            return None
+        node_id = ray.get_runtime_context().get_node_id()
+        for node in ray.nodes():
+            if node.get("NodeID") == node_id and node.get("Alive"):
+                ip = node.get("NodeManagerAddress")
+                if ip and ip != "127.0.0.1":
+                    return ip
+    except Exception:
+        pass
+    return None
+
+
 def test_loopback_bind(address: str, family: int) -> bool:
     try:
         s = socket.socket(family, socket.SOCK_DGRAM)

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -15,7 +15,8 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils.network_utils import (
-    get_distributed_init_method,
+    get_ray_node_ip,
+   get_distributed_init_method,
     get_ip,
     get_open_port,
 )
@@ -195,7 +196,11 @@ class RayDistributedExecutor(Executor):
             bundle_indices = bundle_indices[: self.parallel_config.world_size]
 
         worker_metadata: list[RayWorkerMetaData] = []
-        driver_ip = get_ip()
+        # VLLM_HOST_IP takes precedence; otherwise prefer Ray's
+        # NodeManagerAddress (see get_ray_node_ip docstring for the
+        # multi-NIC rationale).
+        import vllm.envs as envs
+        driver_ip = envs.VLLM_HOST_IP or get_ray_node_ip() or get_ip()
         for rank, bundle_id in enumerate(bundle_indices):
             scheduling_strategy = PlacementGroupSchedulingStrategy(
                 placement_group=placement_group,

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -16,7 +16,7 @@ from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
-from vllm.utils.network_utils import get_ip
+from vllm.utils.network_utils import get_ip, get_ray_node_ip
 from vllm.v1.outputs import AsyncModelRunnerOutput
 from vllm.v1.serial_utils import run_method
 from vllm.v1.worker.worker_base import WorkerWrapperBase
@@ -91,6 +91,18 @@ try:
                 raise e
 
         def get_node_ip(self) -> str:
+            # VLLM_HOST_IP takes precedence (user explicit override).
+            # Otherwise prefer Ray's authoritative NodeManagerAddress,
+            # which matches `ray start --node-ip-address`. Multi-NIC
+            # nodes (e.g. WiFi + Mellanox) need this because
+            # get_ip()'s socket(8.8.8.8) fallback returns the
+            # default-route IP, not the cluster IP.
+            import vllm.envs as envs
+            if envs.VLLM_HOST_IP:
+                return envs.VLLM_HOST_IP
+            ip = get_ray_node_ip()
+            if ip:
+                return ip
             return get_ip()
 
         def get_node_and_gpu_ids(self) -> tuple[str, list[int]]:


### PR DESCRIPTION
## Summary

vLLM's `get_ip()` falls back to `socket.connect(("8.8.8.8", 80))` which returns the default-route interface IP. On nodes with both a routed interface (WiFi, Internet) and a dedicated cluster NIC (Mellanox DAC, InfiniBand), this returns the wrong IP, breaking vLLM's unique-IP check in `ray_executor.py` with:

```
RuntimeError: Every node should have a unique IP address. Got N nodes
with N+1 unique IP addresses {...}
```

even when each Ray node has a single, distinct IP on the cluster network.

Setting `VLLM_HOST_IP` works on the driver but vLLM's `WORKER_SPECIFIC_ENV_VARS` prevents it from being propagated to worker actors, so workers still get the wrong IP.

## Fix

This PR fixes two call sites in `vllm/v1/executor`:

- `ray_utils.py`: `RayWorkerWrapper.get_node_ip`
- `ray_executor.py`: `driver_ip = get_ip()`

Both now prefer Ray's authoritative node IP (`ray.nodes()[i]["NodeManagerAddress"]`) which contains the IP that was passed to `ray start --node-ip-address`. If Ray is not initialized or the lookup fails, both fall back to the original `get_ip()` so non-Ray callers are unaffected.

This makes `VLLM_HOST_IP` largely redundant for Ray deployments since Ray already knows each node's correct IP via `--node-ip-address`. The env var is still honored as the top-priority override; the new code path only fires when `VLLM_HOST_IP` is unset and Ray is initialized.

## Reproduction (pre-patch)

```bash
# On master with WiFi default route (192.168.1.94) + cluster NIC (10.40.40.1)
ray start --address=PC2:6379 --node-ip-address=10.40.40.1

# Driver on PC2 (cluster 10.40.40.2 + WiFi 192.168.1.92)
vllm serve <model> --distributed-executor-backend ray --pipeline-parallel-size 2
# → RuntimeError: Every node should have a unique IP address.
#   Got 1 nodes with 2 unique IP addresses {'192.168.1.92', '10.40.40.2'}
```

## Verification (post-patch)

Tested on a 2-node cluster: Mellanox ConnectX-3 40GbE DAC between an i9-13900K master (10.40.40.1) and an i7-10700K PC2 (10.40.40.2), with WiFi up on both nodes (default route).

```
=== ray.nodes() (authoritative) ===
  alive=True ip=10.40.40.2 hostname=rx5700xt
  alive=True ip=10.40.40.1 hostname=cortex-node

=== Actor IPs via PATCHED RayWorkerWrapper.get_node_ip ===
  node 10.40.40.2: actor returned ip=10.40.40.2  ✓
  node 10.40.40.1: actor returned ip=10.40.40.1  ✓

=== Local socket(8.8.8.8) trick (pre-patch fallback) ===
  default-route IP = 192.168.1.94    ← would break vLLM unique-IP check
```

Without the patch the master actor would return `192.168.1.94`, collide with the WiFi IP on PC2, and trip the raise. Post-patch, the cluster forms cleanly and vLLM PP=3 / Ray-backed runs proceed.

## Test plan

- [x] Manual: 2-node Ray cluster over Mellanox DAC with WiFi default routes — pre-patch fails, post-patch succeeds.
- [x] Python syntax check on patched files (`python3 -m py_compile`).
- [ ] Adding an automated test would require a Ray cluster fixture with multiple interfaces; happy to follow up if reviewers want one.

## Backwards compatibility

The new code path is gated on `ray.is_initialized()` and wrapped in a try/except that falls back to `get_ip()`. Single-node Ray, non-Ray executors, and CI environments without a `ray.nodes()` table are unaffected.
