### PR TITLE
[Bugfix][Compile] Bound Inductor `OperatorIssue.operator_str` to avoid IR `__str__` recursion hang

### DIFF
--- a/tests/test_inductor_operator_str_patch.py
+++ b/tests/test_inductor_operator_str_patch.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the OperatorIssue.operator_str patch in env_override.py.
+
+Validates that `_apply_inductor_operator_str_patch` replaces an
+`OperatorIssue`-shaped class's `operator_str` with a bounded version that:
+
+  * Renders cheap, useful types (primitives, ``torch.dtype``,
+    ``torch.device``, ``torch.Size``, primitive containers) by value so
+    the "Creating implicit fallback for: ..." log line stays useful.
+  * Never calls ``__str__``/``__repr__`` on opaque arguments — which is
+    what was hanging Inductor for many minutes when a deep DAG-shaped IR
+    flowed into a fallback custom op (e.g. ``vllm.all_reduce.default``
+    with the ROCm AITER MLA fused-RoPE+KV-cache+concat pass enabled).
+"""
+
+import time
+
+import pytest
+import torch
+
+from vllm.env_override import _apply_inductor_operator_str_patch
+
+
+def _fresh_operator_issue():
+    """Return a stub class shaped like ``torch._inductor.exc.OperatorIssue``.
+
+    Each call returns a fresh class so each test gets an unpatched
+    starting point and tests cannot interfere with each other or with
+    the real patch installed on import.
+    """
+
+    class _OperatorIssueStub:
+        @staticmethod
+        def operator_str(target, args, kwargs):  # pragma: no cover - unused
+            # Mimic the real (unbounded) implementation just well enough
+            # that any test which forgets to patch will fail loudly.
+            lines = [f"target: {target}"]
+            lines += [f"args[{i}]: {a}" for i, a in enumerate(args)]
+            if kwargs:
+                lines.append(
+                    "kwargs: {"
+                    + ", ".join(f"{k}={v}" for k, v in kwargs.items())
+                    + "}"
+                )
+            return "\n".join(lines)
+
+    return _OperatorIssueStub
+
+
+class _StrCounter:
+    """Object that counts every ``__str__``/``__repr__`` invocation.
+
+    Used as a stand-in for an ``IRNode``-shaped object whose stringifier
+    is the unbounded recursion we are trying to avoid.
+    """
+
+    def __init__(self):
+        self.calls = 0
+
+    def __str__(self):
+        self.calls += 1
+        return "<should-not-be-called>"
+
+    def __repr__(self):
+        self.calls += 1
+        return "<should-not-be-called>"
+
+
+class _ExplodingStr:
+    """Object whose stringifier deliberately raises.
+
+    The unpatched ``operator_str`` would surface this exception (or hang
+    on a recursive variant); the patched version must never invoke it.
+    """
+
+    def __str__(self):  # pragma: no cover - must never be called
+        raise RuntimeError("operator_str should never call __str__ on opaque args")
+
+    __repr__ = __str__
+
+
+class TestApplyInductorOperatorStrPatch:
+    def test_opaque_args_use_type_and_id_not_str(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        opaque1 = _StrCounter()
+        opaque2 = _StrCounter()
+        out = cls.operator_str(
+            "vllm.all_reduce.default", [opaque1], {"group": opaque2}
+        )
+
+        assert opaque1.calls == 0, "opaque arg must not be stringified"
+        assert opaque2.calls == 0, "opaque kwarg must not be stringified"
+        assert "tests.test_inductor_operator_str_patch._StrCounter@" in out
+        assert f"@{id(opaque1):#x}" in out
+        assert f"@{id(opaque2):#x}" in out
+
+    def test_opaque_args_with_raising_stringifier_do_not_raise(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        out = cls.operator_str("op", [_ExplodingStr()], {"k": _ExplodingStr()})
+
+        assert "tests.test_inductor_operator_str_patch._ExplodingStr@" in out
+
+    def test_primitive_args_rendered_by_value(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        out = cls.operator_str(
+            "op",
+            [1, 2.5, True, "tp", None],
+            {"flag": False, "name": "hidden"},
+        )
+
+        assert "args[0]: 1" in out
+        assert "args[1]: 2.5" in out
+        assert "args[2]: True" in out
+        assert "args[3]: 'tp'" in out
+        assert "args[4]: None" in out
+        assert "flag=False" in out
+        assert "name='hidden'" in out
+
+    def test_torch_metadata_types_rendered_by_value(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        out = cls.operator_str(
+            "op",
+            [torch.float16, torch.device("cpu"), torch.Size([4682, 16384])],
+            {},
+        )
+
+        assert "args[0]: torch.float16" in out
+        assert "args[1]: device(type='cpu')" in out
+        assert "args[2]: torch.Size([4682, 16384])" in out
+
+    def test_primitive_containers_rendered_by_value(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        out = cls.operator_str("op", [[1, 2, 3], (4, 5)], {})
+
+        assert "args[0]: [1, 2, 3]" in out
+        assert "args[1]: (4, 5)" in out
+
+    def test_mixed_container_falls_back_to_type_and_id(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        opaque = _StrCounter()
+        mixed = [1, opaque]
+        out = cls.operator_str("op", [mixed], {})
+
+        assert opaque.calls == 0
+        assert "builtins.list@" in out
+        assert f"@{id(mixed):#x}" in out
+
+    def test_format_shape_target_args_kwargs(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        out = cls.operator_str("vllm.all_reduce.default", [1, 2], {"k": "v"})
+
+        assert "  target: vllm.all_reduce.default" in out
+        assert "  args[0]: 1" in out
+        assert "  args[1]: 2" in out
+        assert "  kwargs: {k='v'}" in out
+
+    def test_no_kwargs_line_when_kwargs_empty(self):
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        out = cls.operator_str("op", [1], {})
+
+        assert "kwargs:" not in out
+
+    def test_bounded_runtime_on_pathological_arg(self):
+        """Regression: 100 args with O(N) slow `__str__` must not be called.
+
+        The original hang was combinatorial; we don't try to reproduce
+        the full DAG explosion here. Instead we assert the stronger
+        contract that the patched function does not invoke ``__str__``
+        on opaque args at all, and verify it returns within a tiny
+        wall-clock budget regardless of how slow those stringifiers are.
+        """
+        cls = _fresh_operator_issue()
+        _apply_inductor_operator_str_patch(cls)
+
+        class _SlowStr:
+            def __str__(self):  # pragma: no cover - must never be called
+                time.sleep(10.0)
+                return "slow"
+
+            __repr__ = __str__
+
+        args = [_SlowStr() for _ in range(100)]
+        start = time.perf_counter()
+        out = cls.operator_str("op", args, {})
+        elapsed = time.perf_counter() - start
+
+        # The unpatched implementation would take ~1000 seconds on this
+        # input; one second is a generous upper bound that gives the
+        # test ample headroom on slow CI hardware.
+        assert elapsed < 1.0, f"patched operator_str too slow: {elapsed:.3f}s"
+        assert out.count("args[") == 100
+
+    def test_idempotent(self):
+        cls = _fresh_operator_issue()
+
+        _apply_inductor_operator_str_patch(cls)
+        first_fn = cls.operator_str
+        _apply_inductor_operator_str_patch(cls)
+
+        assert cls.operator_str is first_fn
+
+    def test_sentinel_attribute_set(self):
+        cls = _fresh_operator_issue()
+
+        assert not getattr(cls, "_vllm_safe_operator_str_patched", False)
+
+        _apply_inductor_operator_str_patch(cls)
+
+        assert cls._vllm_safe_operator_str_patched is True  # type: ignore[attr-defined]
+
+
+def test_patch_applied_in_current_environment():
+    """Integration: verify the real torch class is patched on import.
+
+    ``vllm.env_override`` is imported transitively when ``vllm`` itself
+    is imported, so by the time this test runs the real
+    ``torch._inductor.exc.OperatorIssue`` should already carry the
+    sentinel.
+    """
+    pytest.importorskip("torch._inductor.exc")
+    from torch._inductor.exc import OperatorIssue
+
+    import vllm.env_override  # noqa: F401  - ensure patch has been applied
+
+    assert getattr(OperatorIssue, "_vllm_safe_operator_str_patched", False) is True
+
+    # Sanity-check the bounded format on the real class with an opaque
+    # arg whose `__str__` would otherwise be called.
+    counter = _StrCounter()
+    out = OperatorIssue.operator_str("op", [counter], {})
+    assert counter.calls == 0
+    assert "@" in out

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -758,3 +758,69 @@ def _patch_cpp_indirect_assert_if_needed():
 
 
 _patch_cpp_indirect_assert_if_needed()
+# ===================================================
+# Inductor OperatorIssue.operator_str unbounded IR stringification fix
+# ===================================================
+# When Inductor encounters a custom op with no registered lowering, it
+# logs an INFO-level "Creating implicit fallback for: ..." message via
+# `torch/_inductor/graph.py:1285`:
+#
+#   log.info("Creating implicit fallback for:\n%s",
+#            error.operator_str(target, args, kwargs))
+#
+# `OperatorIssue.operator_str` eagerly does `f"args[{i}]: {arg}"` on every
+# IR argument, which triggers `IRNode.__str__` (`torch/_inductor/ir.py:6650`).
+# That method recursively expands every dataclass field with no cycle/depth
+# protection, so on a DAG-shaped IR it stringifies the same subgraph
+# combinatorially. With deep IR (e.g. the view/slice/scatter chain produced
+# by vLLM's `fused_rope_unified_mla_kv_cache_update` feeding into a custom
+# all_reduce op when both `fuse_rope_kvcache_cat_mla` and
+# `use_inductor_graph_partition` are enabled), this turns the INFO log into
+# a multi-minute hang that eventually exhausts the Python recursion limit.
+#
+# Fix: replace `OperatorIssue.operator_str` with a bounded version that
+# represents each arg by its type and id, instead of calling its `__str__`.
+# This keeps the diagnostic message useful (target + arg types are still
+# logged) while making the call O(num_args) instead of O(2^depth).
+#
+# Upstream PyTorch should add depth/cycle protection to `IRNode.__str__`;
+# this workaround can be removed once that lands.
+
+
+def _apply_inductor_operator_str_patch():
+    """Bound IR stringification inside Inductor's OperatorIssue.operator_str.
+
+    Idempotent: marks the class with `_vllm_safe_operator_str_patched`
+    after the first apply.
+    """
+    import textwrap
+
+    import torch._inductor.exc as _iexc
+
+    if getattr(_iexc.OperatorIssue, "_vllm_safe_operator_str_patched", False):
+        return
+
+    def _safe_arg_repr(a):
+        try:
+            return f"{type(a).__module__}.{type(a).__name__}@{id(a):#x}"
+        except Exception:
+            return "<unrepr-able>"
+
+    @staticmethod
+    def _patched_operator_str(target, args, kwargs):
+        lines = [f"target: {target}"] + [
+            f"args[{i}]: {_safe_arg_repr(arg)}" for i, arg in enumerate(args)
+        ]
+        if kwargs:
+            lines.append(
+                "kwargs: {"
+                + ", ".join(f"{k}={_safe_arg_repr(v)}" for k, v in kwargs.items())
+                + "}"
+            )
+        return textwrap.indent("\n".join(lines), "  ")
+
+    _iexc.OperatorIssue.operator_str = _patched_operator_str
+    _iexc.OperatorIssue._vllm_safe_operator_str_patched = True  # type: ignore[attr-defined]
+
+
+_apply_inductor_operator_str_patch()

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -779,28 +779,54 @@ _patch_cpp_indirect_assert_if_needed()
 # a multi-minute hang that eventually exhausts the Python recursion limit.
 #
 # Fix: replace `OperatorIssue.operator_str` with a bounded version that
-# represents each arg by its type and id, instead of calling its `__str__`.
-# This keeps the diagnostic message useful (target + arg types are still
-# logged) while making the call O(num_args) instead of O(2^depth).
+# never calls `__str__` on opaque IR-like arguments. Primitives and a
+# handful of cheap torch metadata types (`torch.dtype`, `torch.device`,
+# `torch.Size`) are still rendered by value so the diagnostic stays
+# useful for the common cases (e.g. `group_name="tp"`, shapes, dtypes).
+# Anything else falls back to `type@id`. This makes the call O(num_args)
+# instead of O(2^depth), regardless of IR shape.
 #
 # Upstream PyTorch should add depth/cycle protection to `IRNode.__str__`;
 # this workaround can be removed once that lands.
 
 
-def _apply_inductor_operator_str_patch():
+def _apply_inductor_operator_str_patch(operator_issue_cls):
     """Bound IR stringification inside Inductor's OperatorIssue.operator_str.
+
+    Replaces `operator_issue_cls.operator_str` with a version that never
+    calls `__str__`/`__repr__` on opaque arguments, so a deep DAG-shaped
+    IR can no longer turn the diagnostic log into a multi-minute hang.
 
     Idempotent: marks the class with `_vllm_safe_operator_str_patched`
     after the first apply.
     """
     import textwrap
 
-    import torch._inductor.exc as _iexc
-
-    if getattr(_iexc.OperatorIssue, "_vllm_safe_operator_str_patched", False):
+    if getattr(operator_issue_cls, "_vllm_safe_operator_str_patched", False):
         return
 
+    # Types that are guaranteed to have a cheap, bounded `repr()` and
+    # whose values are useful in fallback diagnostics. Everything else is
+    # represented by `{module}.{name}@{id:#x}` so we never trigger an
+    # unbounded `IRNode.__str__` recursion.
+    _safe_repr_types = (
+        int,
+        float,
+        bool,
+        str,
+        type(None),
+        torch.dtype,
+        torch.device,
+        torch.Size,
+    )
+
     def _safe_arg_repr(a):
+        if isinstance(a, _safe_repr_types):
+            return repr(a)
+        if isinstance(a, (tuple, list)) and all(
+            isinstance(x, _safe_repr_types) for x in a
+        ):
+            return repr(a)
         try:
             return f"{type(a).__module__}.{type(a).__name__}@{id(a):#x}"
         except Exception:
@@ -819,8 +845,15 @@ def _apply_inductor_operator_str_patch():
             )
         return textwrap.indent("\n".join(lines), "  ")
 
-    _iexc.OperatorIssue.operator_str = _patched_operator_str
-    _iexc.OperatorIssue._vllm_safe_operator_str_patched = True  # type: ignore[attr-defined]
+    operator_issue_cls.operator_str = _patched_operator_str
+    operator_issue_cls._vllm_safe_operator_str_patched = True  # type: ignore[attr-defined]
 
 
-_apply_inductor_operator_str_patch()
+def _patch_inductor_operator_str():
+    """Apply the bounded `OperatorIssue.operator_str` workaround on import."""
+    import torch._inductor.exc as _iexc
+
+    _apply_inductor_operator_str_patch(_iexc.OperatorIssue)
+
+
+_patch_inductor_operator_str()


### PR DESCRIPTION
## Summary

Fixes a multi-minute `torch.compile` hang that occurs when Inductor logs the `INFO`-level
"Creating implicit fallback for: ..." diagnostic for a vLLM custom op
whose IR argument is a deep DAG-shaped subgraph. Replaces
`torch._inductor.exc.OperatorIssue.operator_str` with a bounded version
that never invokes `IRNode.__str__` on opaque arguments, mirroring the
existing torch-Inductor workarounds in `vllm/env_override.py`
(`memory_plan_reuse_patched`, `should_partition_patched`,
`_apply_cpp_indirect_assert_patch`, `_apply_fxgraphcache_pickle_patch`,
…).

## Relationship to #42129

#42129 by @okorzh-amd (and reproduced by @rbrugaro-amd on
Kimi-K2-Thinking-MXFP4) targets the same hang from a different angle:
it patches `torch._inductor.lowering.FALLBACK_ALLOW_LIST` so any
`vllm::*`/`vllm_aiter::*` op skips the implicit-fallback slow path
entirely, including its diagnostic log line.

The two fixes are complementary, not competing:

* **#42129 is a per-op perf optimization** for vLLM/vLLM-aiter custom
  ops on the Inductor fallback path. It also avoids the `get_decompositions`
  lookup, which is a small but real win on graphs with many such ops.
* **This PR is a defense-in-depth fix for the underlying torch bug**:
  `IRNode.__str__` lacks depth/cycle protection
  ([`torch/_inductor/ir.py:6650`](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/ir.py#L6650)),
  so any caller of `operator_str(...)` on a deep DAG-shaped IR argument
  can hang — not only `vllm::*`/`vllm_aiter::*` ops. With #42129 alone,
  any non-vLLM op that lands on the diagnostic path (third-party custom
  ops, future namespaces, certain aten paths) would still hit the same
  combinatorial recursion.

I'd be glad to land both — in either order — and defer to maintainers
on whether one of them is sufficient. If only one is preferred, this PR
also addresses the two follow-up asks @zou3519 left on #42129:

* Lives in `vllm/env_override.py` (the canonical place for these
  Inductor monkey-patches).
* Ships with a regression test (`tests/test_inductor_operator_str_patch.py`).

## Problem

On Kimi-K2.5-MXFP4 with ROCm, running with:

* `--compilation-config.pass_config.enable_fuse_rope_kvcache_cat_mla=true`
* `--compilation-config.use_inductor_graph_partition=true`
* `--max-num-batched-tokens 16384`

vLLM startup hangs deterministically during Inductor lowering of the
`(4682, 16384)` compile range. `py-spy dump` shows a ~1000-frame stack
inside `torch._inductor.ir.IRNode.__str__`, hanging forever.

Root cause:

1. In the `(4682, 16384)` compile range, `RocmAiterAllReduceFusionPass`
   skips fusion because the message size exceeds AITER's hard-coded
   ~64 MiB IPC ring-buffer cap, so `vllm.all_reduce.default` appears as
   a standalone op.
2. Inductor has no registered lowering for `vllm.all_reduce.default`,
   so `GraphLowering.call_function` constructs an implicit
   `FallbackKernel`.
3. As part of that path it logs at
   [`torch/_inductor/graph.py:1285`](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/graph.py#L1285):

   ```python
   log.info(
       "Creating implicit fallback for:\n%s",
       error.operator_str(target, args, kwargs),
   )
   ```

4. `OperatorIssue.operator_str` does `f"args[{i}]: {arg}"` on every IR
   argument, which calls `IRNode.__str__` at
   [`torch/_inductor/ir.py:6650`](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/ir.py#L6650).
   That method recursively expands every dataclass field with **no
   cycle protection and no depth limit**.

5. The MLA fused RoPE + KV-cache-update + concat pass feeds a deep
   view/slice/scatter chain into the all-reduce. The IR is a DAG (the
   same `StorageBox`/`Pointwise` nodes referenced from many fields), so
   straightforward recursive stringification visits the same subgraph
   combinatorially: `O(2^depth)` work. For Kimi's MLA chain this is
   multiple minutes of CPU before `RecursionError`.

This is a pure logging-path hang: the fallback kernel construction
would succeed, but the diagnostic log line never returns.

The bug is fundamentally in upstream PyTorch (`IRNode.__str__` should
have depth/cycle protection). That fix has not landed in any released
torch, so we patch defensively in `vllm/env_override.py`. 

## Fix

Replace `torch._inductor.exc.OperatorIssue.operator_str` with a bounded
version that:

* Renders cheap, useful types — `int`, `float`, `bool`, `str`, `None`,
  `torch.dtype`, `torch.device`, `torch.Size`, and lists/tuples whose
  elements are all in that whitelist — by value via `repr()`. This
  keeps the common cases (`group_name="tp"`, dtypes, shapes,
  stride lists) legible in the log.
* Represents anything else as `{type.__module__}.{type.__name__}@{id:#x}`,
  so `IRNode.__str__` is never invoked.
* Preserves the existing output shape (`target:` / `args[i]:` /
  `kwargs:`), so log scrapers and reproduction-by-log keep working.
* Costs `O(num_args)` regardless of IR depth.
* Has no side-effects on the compiled graph; only the INFO log line
  changes form.

Applied at import time in `vllm/env_override.py` via the same
`_apply_*_patch(class) + _patch_*_if_needed()` pattern used by the
neighboring patches (`_apply_fxgraphcache_pickle_patch`, etc.), with
an idempotent `_vllm_safe_operator_str_patched` sentinel attribute on
the class. The patch can be removed once depth/cycle protection lands
in `IRNode.__str__` upstream.

Example post-fix log output for the same fallback:

```text
[INFO] Creating implicit fallback for:
  target: vllm.all_reduce.default
  args[0]: torch._inductor.ir.StorageBox@0x7f6a40c12e90
  kwargs: {group_name='tp'}
```

## Tests

`tests/test_inductor_operator_str_patch.py` (mirrors the existing
`tests/test_fxgraphcache_pickle_patch.py` pattern):

* **Bug-class contract**: opaque args' `__str__`/`__repr__` are never
  called, even when one of them would deliberately raise.
* **Whitelist preserved**: primitives, `torch.dtype`/`torch.device`/
  `torch.Size`, and primitive containers are rendered by value.
* **No fan-in into nested IR**: a list with even one opaque element
  falls back to `type@id` rather than recursing.
* **Output shape preserved**: `target` / `args[i]` / `kwargs` lines
  match the original format (so log scrapers keep working); empty
  kwargs is fully omitted.
* **Pathological-runtime regression**: 100 args whose `__str__` would
  `time.sleep(10)` each must complete the patched call in <1 s.
* **Idempotency + sentinel**: re-applying is a no-op;
  `_vllm_safe_operator_str_patched` is set after first apply.
* **Integration**: real `torch._inductor.exc.OperatorIssue` carries the
  sentinel after `import vllm.env_override`, and a real call with a
  counter-instrumented arg confirms `__str__` is not invoked.

```
$ pytest tests/test_inductor_operator_str_patch.py -q
12 passed in 2.28s
```

## End-to-end validation

Reproduced the original failure on Kimi-K2.5-MXFP4 + ROCm + 4×MI355X:

```bash
vllm serve amd/Kimi-K2.5-MXFP4 -tp 4 \
    --port 8004 \
    --no-enable-prefix-caching \
    --max-num-batched-tokens 16384 \
    --gpu-memory-utilization 0.95 \
    -cc.pass_config.fuse_rope_kvcache_cat_mla=True \
    -cc.use_inductor_graph_partition=True \
    --trust-remote-code --kv-cache-dtype fp8
```

Before the patch:

* Hangs during Inductor lowering of the `(4682, 16384)` compile range.
* `py-spy dump` shows ~1000-frame stack in `IRNode.__str__` →
  `__repr__` → dataclass field recursion.

After the patch:

* Same command completes compilation in the expected single-digit
  minutes and serves requests normally.
* INFO log shows the bounded fallback message exactly once per compile
  range that hits the un-fused `vllm.all_reduce` path.
* A subsequent trace on a pure-decode batch (`mc=32`) confirms that
  the AR+RMS fusion is still active in the `(1, 4681)` range
  (`aiter_reduce_scatter` + `aiter_local_device_load_rmsnorm` ops
  present), so the patch has not regressed the fused path.

## Notes on this rebase

The rebase against `main` involved a single conflict in
`vllm/env_override.py`. Upstream commit `1ac10f159`
(`Revert "[torch.compile] Add patch for fullgraph compilation"`,
#42913) removed `_patch_should_realize_on_reuse` from this file; my
original commit was anchored just after that function. Resolved by
dropping the now-removed block (deferring to the upstream revert) and
keeping only the operator_str patch + the review-followup commit.

This change was developed with AI assistance.