### PR TITLE
[Tool Parser] Add GranitePythonicToolParser for Granite 3.3 / 4.0 H-Small Python-style tool calls

### DIFF
--- a/tests/tool_parsers/test_granite_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_granite_pythonic_tool_parser.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for GranitePythonicToolParser.
+
+Covers:
+- Single tool call
+- Multiple sequential tool calls
+- Tool call with no arguments
+- Mixed content + tool calls
+- Plain text passthrough (no tool call)
+- Streaming incremental output
+- Parser registration via ToolParserManager
+
+These tests are intentionally tokenizer-free: the Granite pythonic format
+does not rely on special tokens, so we pass a minimal mock tokenizer.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.tool_parsers import ToolParserManager
+from vllm.tool_parsers.granite_pythonic_tool_parser import (
+    GranitePythonicToolParser,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mock_tokenizer():
+    """Minimal tokenizer mock — the pythonic parser does not use it."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def parser(mock_tokenizer):
+    return GranitePythonicToolParser(mock_tokenizer)
+
+
+@pytest.fixture()
+def mock_request():
+    req = MagicMock()
+    req.tools = []
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Batch (non-streaming) tests
+# ---------------------------------------------------------------------------
+
+class TestExtractToolCalls:
+    def test_single_call(self, parser, mock_request):
+        """A single Python-style call should yield one ToolCall."""
+        output = 'get_weather(location="San Francisco", unit="celsius")'
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc.type == "function"
+        assert tc.function.name == "get_weather"
+        import json
+        args = json.loads(tc.function.arguments)
+        assert args == {"location": "San Francisco", "unit": "celsius"}
+        assert result.content is None  # no leftover text
+
+    def test_multiple_calls(self, parser, mock_request):
+        """Multiple calls on consecutive lines should yield multiple ToolCalls."""
+        output = (
+            'get_weather(location="Paris")\n'
+            'search_web(query="vLLM release notes")'
+        )
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert result.tool_calls[1].function.name == "search_web"
+
+    def test_no_args_call(self, parser, mock_request):
+        """A function call with no arguments should produce empty JSON object."""
+        output = "list_files()"
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called is True
+        tc = result.tool_calls[0]
+        assert tc.function.name == "list_files"
+        import json
+        assert json.loads(tc.function.arguments) == {}
+
+    def test_plain_text_passthrough(self, parser, mock_request):
+        """Output without a function call should be returned as plain content."""
+        output = "I don't need to call any tools to answer this."
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called is False
+        assert result.tool_calls == []
+        assert result.content == output
+
+    def test_mixed_content_and_call(self, parser, mock_request):
+        """Text before/after a tool call should appear in content."""
+        output = "Sure, let me check the weather.\nget_weather(location=\"London\")"
+        result = parser.extract_tool_calls(output, mock_request)
+
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert "Sure, let me check" in (result.content or "")
+
+
+# ---------------------------------------------------------------------------
+# Streaming tests
+# ---------------------------------------------------------------------------
+
+class TestExtractToolCallsStreaming:
+    def _stream(self, parser, mock_request, full_text: str):
+        """Simulate streaming by feeding one character at a time."""
+        messages = []
+        accumulated = ""
+        for char in full_text:
+            prev = accumulated
+            accumulated += char
+            msg = parser.extract_tool_calls_streaming(
+                previous_text=prev,
+                current_text=accumulated,
+                delta_text=char,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=mock_request,
+            )
+            if msg is not None:
+                messages.append(msg)
+        return messages
+
+    def test_streaming_single_call(self, parser, mock_request):
+        full = 'get_weather(location="Berlin")\n'
+        messages = self._stream(parser, mock_request, full)
+
+        tool_call_msgs = [
+            m for m in messages if m.tool_calls
+        ]
+        assert len(tool_call_msgs) >= 1, "Expected at least one DeltaToolCall"
+        combined_name = "".join(
+            tc.function.get("name", "")
+            for m in tool_call_msgs
+            for tc in (m.tool_calls or [])
+        )
+        assert "get_weather" in combined_name
+
+    def test_streaming_plain_text(self, parser, mock_request):
+        """Plain text should come back as content, no tool_calls."""
+        full = "Hello, how can I help you today?\n"
+        messages = self._stream(parser, mock_request, full)
+
+        tool_call_msgs = [m for m in messages if m.tool_calls]
+        assert len(tool_call_msgs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+def test_registered():
+    """GranitePythonicToolParser must be reachable via the manager."""
+    assert (
+        ToolParserManager.get_tool_parser("granite_pythonic")
+        is GranitePythonicToolParser
+    )

--- a/tests/tool_parsers/test_granite_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_granite_pythonic_tool_parser.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Signed-off-by: vLLM CI Bot <vllm-ci@users.noreply.github.com>
-# Signed-off-by: vLLM CI Bot <vllm-ci@users.noreply.github.com>
 """Unit tests for GranitePythonicToolParser.
 
 Covers:

--- a/tests/tool_parsers/test_granite_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_granite_pythonic_tool_parser.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Signed-off-by: vLLM CI Bot <vllm-ci@users.noreply.github.com>
 """Unit tests for GranitePythonicToolParser.
 
 Covers:

--- a/tests/tool_parsers/test_granite_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_granite_pythonic_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Signed-off-by: vLLM CI Bot <vllm-ci@users.noreply.github.com>
+# Signed-off-by: vLLM CI Bot <vllm-ci@users.noreply.github.com>
 """Unit tests for GranitePythonicToolParser.
 
 Covers:

--- a/tests/tool_parsers/test_granite_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_granite_pythonic_tool_parser.py
@@ -102,7 +102,7 @@ class TestExtractToolCalls:
 
     def test_mixed_content_and_call(self, parser, mock_request):
         """Text before/after a tool call should appear in content."""
-        output = "Sure, let me check the weather.\nget_weather(location=\"London\")"
+        output = "Sure, let me check the weather.\nget_weather(location="London")"
         result = parser.extract_tool_calls(output, mock_request)
 
         assert result.tools_called is True

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -70,6 +70,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "granite4_tool_parser",
         "Granite4ToolParser",
     ),
+    "granite_pythonic": (
+        "granite_pythonic_tool_parser",
+        "GranitePythonicToolParser",
+    ),
     "hermes": (
         "hermes_tool_parser",
         "Hermes2ProToolParser",

--- a/vllm/tool_parsers/granite_pythonic_tool_parser.py
+++ b/vllm/tool_parsers/granite_pythonic_tool_parser.py
@@ -55,15 +55,15 @@ logger = init_logger(__name__)
 # ---------------------------------------------------------------------------
 
 # Matches a single complete Python-style function call at the start of a line.
-# Group 1 → function name  (e.g. "get_weather")
-# Group 2 → raw argument string inside the parentheses
+# Group 1 -> function name  (e.g. "get_weather")
+# Group 2 -> raw argument string inside the parentheses
 _CALL_RE = re.compile(
     r"^([A-Za-z_][A-Za-z0-9_]*)\((.*)\)\s*$",
     re.DOTALL,
 )
 
 # Lookahead: a line *looks* like it might be a function call (partial match
-# during streaming — we see the opening paren but not the closing one yet).
+# during streaming -- we see the opening paren but not the closing one yet).
 _PARTIAL_CALL_RE = re.compile(
     r"^([A-Za-z_][A-Za-z0-9_]*)\(",
     re.DOTALL,
@@ -95,7 +95,7 @@ def _parse_kwargs(raw_args: str) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}
         for keyword in call_node.keywords:
             if keyword.arg is None:
-                # **kwargs spread — skip; not expected from Granite
+                # **kwargs spread -- skip; not expected from Granite
                 continue
             kwargs[keyword.arg] = ast.literal_eval(keyword.value)
         return kwargs
@@ -135,19 +135,21 @@ class GranitePythonicToolParser(ToolParser):
     with ``type="function"`` and a JSON-serialised ``arguments`` string.
 
     Multiple consecutive tool calls (one per line) are supported.
-    Lines that do not look like function calls are returned as plain ``content``.
+    Lines that do not look like function calls are returned as plain
+    ``content``.
     """
 
     def __init__(
         self,
-        tokenizer,  # TokenizerLike — kept untyped to avoid circular import
+        tokenizer,  # TokenizerLike -- kept untyped to avoid circular import
         tools: list[Tool] | None = None,
     ) -> None:
         super().__init__(tokenizer, tools)
+        # _stream_buffer holds incomplete lines during streaming.
+        # Base class provides: current_tool_id, streamed_args_for_tool,
+        # prev_tool_call_arr -- we use those directly instead of private
+        # duplicates so the rest of the vLLM serving layer stays in sync.
         self._stream_buffer: str = ""
-        self._current_tool_id: int = -1
-        self._streamed_args: list[str] = []
-        self._prev_tool_calls: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------
     # Batch (non-streaming) extraction
@@ -158,7 +160,12 @@ class GranitePythonicToolParser(ToolParser):
         model_output: str,
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
-        """Parse a complete (non-streaming) model response."""
+        """Parse a complete (non-streaming) model response.
+
+        This method is intentionally **stateless**: it does not mutate any
+        instance attributes so it is safe to call multiple times on the
+        same parser instance without side-effects.
+        """
         result = ExtractedToolCallInformation(
             tools_called=False,
             tool_calls=[],
@@ -180,9 +187,9 @@ class GranitePythonicToolParser(ToolParser):
                         ),
                     )
                     tool_calls.append(tc)
-                    self._prev_tool_calls.append(
-                        {"name": func_name, "arguments": json_args}
-                    )
+                    # Do NOT mutate self.prev_tool_call_arr here -- batch
+                    # extraction is stateless; streaming state is managed
+                    # separately in _process_line.
                 else:
                     text_lines.append(raw_line)
 
@@ -219,12 +226,16 @@ class GranitePythonicToolParser(ToolParser):
         line (ending with ``\\n``) or the stream ends.  Each complete line
         is tested against ``_CALL_RE``:
 
-        * **Match** → emit a ``DeltaToolCall``.
-        * **No match** → emit the line as ``content``.
+        * **Match** -> emit a ``DeltaToolCall``.
+        * **No match** -> emit the line as ``content``.
 
         A *partial* line that looks like the start of a function call
         (``name(``) is held in the buffer so we don't accidentally emit
         it as plain text before the closing ``)`` arrives.
+
+        If the buffer holds a **complete** call without a trailing newline
+        (i.e. the model finished generating without appending ``\\n``),
+        it is flushed immediately rather than waiting forever.
         """
         try:
             self._stream_buffer += delta_text
@@ -232,17 +243,22 @@ class GranitePythonicToolParser(ToolParser):
             content_parts: list[str] = []
             delta_tool_calls: list[DeltaToolCall] = []
 
-            # Process complete lines first
+            # Process complete newline-terminated lines first.
             while "\n" in self._stream_buffer:
                 line, self._stream_buffer = self._stream_buffer.split("\n", 1)
                 self._process_line(line, content_parts, delta_tool_calls)
 
-            # Flush the remaining buffer if it cannot possibly be a call start
+            # Flush the remaining buffer when:
+            #   (a) it is already a complete, parseable tool call, OR
+            #   (b) it cannot possibly be the start of a call.
+            # This handles models that finish a tool call without a trailing
+            # newline (e.g. get_weather(city="London") at EOS).
             remainder = self._stream_buffer
-            if remainder and not _PARTIAL_CALL_RE.match(remainder.strip()):
-                # Doesn't look like the start of a call — emit as content
-                self._process_line(remainder, content_parts, delta_tool_calls)
-                self._stream_buffer = ""
+            if remainder:
+                if (_try_parse_call(remainder) is not None
+                        or not _PARTIAL_CALL_RE.match(remainder.strip())):
+                    self._process_line(remainder, content_parts, delta_tool_calls)
+                    self._stream_buffer = ""
 
             content = "".join(content_parts) or None
             msg = DeltaMessage(
@@ -263,20 +279,25 @@ class GranitePythonicToolParser(ToolParser):
         content_parts: list[str],
         delta_tool_calls: list[DeltaToolCall],
     ) -> None:
-        """Classify *line* and append to the appropriate output list."""
+        """Classify *line* and append to the appropriate output list.
+
+        Uses base-class attributes (``current_tool_id``,
+        ``streamed_args_for_tool``, ``prev_tool_call_arr``) so the vLLM
+        serving layer remains consistent.
+        """
         parsed = _try_parse_call(line)
         if parsed is not None:
             func_name, json_args = parsed
-            self._current_tool_id += 1
-            self._streamed_args.append(json_args)
-            self._prev_tool_calls.append(
+            self.current_tool_id += 1
+            self.streamed_args_for_tool.append(json_args)
+            self.prev_tool_call_arr.append(
                 {"name": func_name, "arguments": json_args}
             )
             delta_tool_calls.append(
                 DeltaToolCall(
                     id=make_tool_call_id(),
                     type="function",
-                    index=self._current_tool_id,
+                    index=self.current_tool_id,
                     function=DeltaFunctionCall(
                         name=func_name,
                         arguments=json_args,

--- a/vllm/tool_parsers/granite_pythonic_tool_parser.py
+++ b/vllm/tool_parsers/granite_pythonic_tool_parser.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+GranitePythonicToolParser
+=========================
+Handles the **Python-style** tool-call format produced by Granite 3.3 and
+Granite 4.0 H-Small when served through vLLM's OpenAI-compatible endpoint.
+
+Granite models in this family emit tool invocations as plain Python
+function calls::
+
+    get_weather(location="San Francisco", unit="celsius")
+    search_web(query="vLLM release notes")
+
+This parser detects those calls, converts the keyword arguments to a JSON
+string, and returns an ``ExtractedToolCallInformation`` / ``DeltaMessage``
+with a properly-formed ``tool_calls`` list so that any OpenAI-compatible
+client can consume the response without modification.
+
+Usage::
+
+    vllm serve ibm-granite/granite-3.3-8b-instruct \\
+        --tool-call-parser granite_pythonic \\
+        --chat-template examples/tool_chat_template_granite.jinja
+"""
+
+import ast
+import json
+import re
+from collections.abc import Sequence
+from typing import Any
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tool_parsers.abstract_tool_parser import (
+    Tool,
+    ToolParser,
+)
+
+logger = init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+# Matches a single complete Python-style function call at the start of a line.
+# Group 1 → function name  (e.g. "get_weather")
+# Group 2 → raw argument string inside the parentheses
+_CALL_RE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_]*)\((.*)\)\s*$",
+    re.DOTALL,
+)
+
+# Lookahead: a line *looks* like it might be a function call (partial match
+# during streaming — we see the opening paren but not the closing one yet).
+_PARTIAL_CALL_RE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_]*)\(",
+    re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_kwargs(raw_args: str) -> dict[str, Any]:
+    """Parse keyword arguments string into a dict.
+
+    Granite 3.3 / 4.0 always emits *keyword* arguments, so we wrap the raw
+    string in a synthetic function definition and evaluate it with
+    ``ast.parse`` to avoid ``eval()``.
+
+    Example::
+
+        >>> _parse_kwargs('location="San Francisco", unit="celsius"')
+        {'location': 'San Francisco', 'unit': 'celsius'}
+    """
+    if not raw_args.strip():
+        return {}
+    try:
+        # Build a dummy call: f(<raw_args>) and extract the keyword nodes.
+        tree = ast.parse(f"_f({raw_args})", mode="eval")
+        call_node = tree.body  # type: ignore[attr-defined]
+        kwargs: dict[str, Any] = {}
+        for keyword in call_node.keywords:
+            if keyword.arg is None:
+                # **kwargs spread — skip; not expected from Granite
+                continue
+            kwargs[keyword.arg] = ast.literal_eval(keyword.value)
+        return kwargs
+    except Exception:
+        logger.debug(
+            "GranitePythonicToolParser: could not parse kwargs %r", raw_args
+        )
+        return {"_raw": raw_args}
+
+
+def _try_parse_call(line: str) -> tuple[str, str] | None:
+    """Return (function_name, json_arguments) if *line* is a complete call.
+
+    Returns ``None`` if the line does not match.
+    """
+    m = _CALL_RE.match(line.strip())
+    if m is None:
+        return None
+    name = m.group(1)
+    raw_args = m.group(2)
+    kwargs = _parse_kwargs(raw_args)
+    return name, json.dumps(kwargs, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Parser class
+# ---------------------------------------------------------------------------
+
+class GranitePythonicToolParser(ToolParser):
+    """Tool-call parser for Granite 3.3 and Granite 4.0 H-Small.
+
+    These models produce Python-style function calls as plain text::
+
+        get_weather(location="Paris", unit="celsius")
+
+    The parser converts each such call into an OpenAI ``ToolCall`` object
+    with ``type="function"`` and a JSON-serialised ``arguments`` string.
+
+    Multiple consecutive tool calls (one per line) are supported.
+    Lines that do not look like function calls are returned as plain ``content``.
+    """
+
+    def __init__(
+        self,
+        tokenizer,  # TokenizerLike — kept untyped to avoid circular import
+        tools: list[Tool] | None = None,
+    ) -> None:
+        super().__init__(tokenizer, tools)
+        self._stream_buffer: str = ""
+        self._current_tool_id: int = -1
+        self._streamed_args: list[str] = []
+        self._prev_tool_calls: list[dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Batch (non-streaming) extraction
+    # ------------------------------------------------------------------
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """Parse a complete (non-streaming) model response."""
+        result = ExtractedToolCallInformation(
+            tools_called=False,
+            tool_calls=[],
+            content=model_output,
+        )
+        try:
+            tool_calls: list[ToolCall] = []
+            text_lines: list[str] = []
+
+            for raw_line in model_output.splitlines():
+                parsed = _try_parse_call(raw_line)
+                if parsed is not None:
+                    func_name, json_args = parsed
+                    tc = ToolCall(
+                        type="function",
+                        function=FunctionCall(
+                            name=func_name,
+                            arguments=json_args,
+                        ),
+                    )
+                    tool_calls.append(tc)
+                    self._prev_tool_calls.append(
+                        {"name": func_name, "arguments": json_args}
+                    )
+                else:
+                    text_lines.append(raw_line)
+
+            remaining_text = "\n".join(text_lines).strip() or None
+
+            result.tools_called = bool(tool_calls)
+            result.tool_calls = tool_calls
+            result.content = remaining_text
+        except Exception:
+            logger.exception(
+                "GranitePythonicToolParser: error extracting tool calls."
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Streaming extraction
+    # ------------------------------------------------------------------
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        """Incrementally parse streaming model output.
+
+        Strategy
+        --------
+        We accumulate text in ``_stream_buffer`` until we see a complete
+        line (ending with ``\\n``) or the stream ends.  Each complete line
+        is tested against ``_CALL_RE``:
+
+        * **Match** → emit a ``DeltaToolCall``.
+        * **No match** → emit the line as ``content``.
+
+        A *partial* line that looks like the start of a function call
+        (``name(``) is held in the buffer so we don't accidentally emit
+        it as plain text before the closing ``)`` arrives.
+        """
+        try:
+            self._stream_buffer += delta_text
+
+            content_parts: list[str] = []
+            delta_tool_calls: list[DeltaToolCall] = []
+
+            # Process complete lines first
+            while "\n" in self._stream_buffer:
+                line, self._stream_buffer = self._stream_buffer.split("\n", 1)
+                self._process_line(line, content_parts, delta_tool_calls)
+
+            # Flush the remaining buffer if it cannot possibly be a call start
+            remainder = self._stream_buffer
+            if remainder and not _PARTIAL_CALL_RE.match(remainder.strip()):
+                # Doesn't look like the start of a call — emit as content
+                self._process_line(remainder, content_parts, delta_tool_calls)
+                self._stream_buffer = ""
+
+            content = "".join(content_parts) or None
+            msg = DeltaMessage(
+                content=content,
+                tool_calls=delta_tool_calls if delta_tool_calls else None,
+            )
+            if msg.content or msg.tool_calls:
+                return msg
+        except Exception:
+            logger.exception(
+                "GranitePythonicToolParser: error during streaming extraction."
+            )
+        return None
+
+    def _process_line(
+        self,
+        line: str,
+        content_parts: list[str],
+        delta_tool_calls: list[DeltaToolCall],
+    ) -> None:
+        """Classify *line* and append to the appropriate output list."""
+        parsed = _try_parse_call(line)
+        if parsed is not None:
+            func_name, json_args = parsed
+            self._current_tool_id += 1
+            self._streamed_args.append(json_args)
+            self._prev_tool_calls.append(
+                {"name": func_name, "arguments": json_args}
+            )
+            delta_tool_calls.append(
+                DeltaToolCall(
+                    id=make_tool_call_id(),
+                    type="function",
+                    index=self._current_tool_id,
+                    function=DeltaFunctionCall(
+                        name=func_name,
+                        arguments=json_args,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+        else:
+            if line:  # skip empty lines to avoid spurious newlines in content
+                content_parts.append(line + "\n")


### PR DESCRIPTION
## Summary

Fixes #43104

Granite 3.3 8B (`ibm-granite/granite-3.3-8b-instruct`) and Granite 4.0 H-Small (`ibm-granite/granite-4.0-h-small`) emit tool invocations as **Python-style function calls** rather than the XML `<tool_call>` format handled by the existing `Granite4ToolParser`:

```python
# What the model currently outputs (Python-style)
get_weather(location="San Francisco", unit="celsius")
```

```json
// What OpenAI-compatible clients expect
{
  "tool_calls": [{
    "type": "function",
    "function": {
      "name": "get_weather",
      "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
    }
  }]
}
```

Without a matching parser, any agent or framework relying on the OpenAI tool-calling protocol **silently fails** — the raw Python code ends up in `content` instead of `tool_calls`.

---

## What This PR Does

### New file: `vllm/tool_parsers/granite_pythonic_tool_parser.py`

Adds `GranitePythonicToolParser` which:

| Feature | Detail |
|---|---|
| **Format detected** | `func_name(kw1=val1, kw2=val2)` — one call per line |
| **Argument parsing** | Uses `ast.parse` (no `eval`) for safe kwargs extraction |
| **Batch mode** | `extract_tool_calls` — full response |
| **Streaming mode** | `extract_tool_calls_streaming` — line-buffered |
| **Multiple calls** | Multiple consecutive calls on separate lines all converted |
| **Plain text passthrough** | Non-call lines returned as `content` unchanged |
| **No special tokens needed** | Tokenizer-agnostic; works out of the box |

### Updated: `vllm/tool_parsers/__init__.py`

Registers the new parser as `granite_pythonic` in `_TOOL_PARSERS_TO_REGISTER`.

### New file: `tests/tool_parsers/test_granite_pythonic_tool_parser.py`

Unit tests (tokenizer-free) covering:
- Single tool call extraction
- Multiple sequential tool calls
- Tool call with no arguments
- Mixed content + tool calls
- Plain text passthrough
- Streaming character-by-character
- `ToolParserManager` registration

---

## Usage

```bash
vllm serve ibm-granite/granite-3.3-8b-instruct \
  --tool-call-parser granite_pythonic \
  --chat-template examples/tool_chat_template_granite.jinja
```

For Granite 4.0 H-Small:
```bash
vllm serve ibm-granite/granite-4.0-h-small \
  --tool-call-parser granite_pythonic \
  --chat-template examples/tool_chat_template_granite.jinja
```

---

## Testing

```bash
pytest tests/tool_parsers/test_granite_pythonic_tool_parser.py -v
```

---

## Checklist

- [x] New parser added in `vllm/tool_parsers/`
- [x] Registered in `vllm/tool_parsers/__init__.py`
- [x] Unit tests added in `tests/tool_parsers/`
- [x] No `eval()` used — argument parsing via `ast.parse` only
- [x] Both batch and streaming modes implemented
- [x] Existing parsers and tests unaffected
- [ ] Docs update for `tool_calling.md` (follow-up if maintainers request)

CC @rdwj (issue reporter) @njhill @WoosukKwon