### PR TITLE
[Perf][Spec Decode] add force_max_spec_tokens for FULL cudagraph

### DIFF
--- a/docs/features/speculative_decoding/suffix.md
+++ b/docs/features/speculative_decoding/suffix.md
@@ -12,6 +12,28 @@ Suffix Decoding can achieve better performance for tasks with high repetition, s
 !!! tip "Suffix Decoding Speculative Tokens"
     Suffix Decoding will speculate a dynamic number of tokens for each request at each decoding step, so the `num_speculative_tokens` configuration specifies the *maximum* number of speculative tokens. It is suggested to use a high number such as `16` or `32` (default).
 
+!!! tip "Enabling FULL CUDA Graph Dispatch"
+    Because Suffix Decoding produces a dynamic number of draft tokens per request, CUDA Graph dispatch typically falls back to PIECEWISE mode. Set `force_max_spec_tokens=true` in the speculative config to pad all non-empty draft lists to `num_speculative_tokens`, ensuring uniform batch size and enabling FULL CUDA Graph dispatch for better latency.
+
+    ```python
+    llm = LLM(
+        model="Qwen/Qwen3-8B",
+        tensor_parallel_size=1,
+        speculative_config={
+            "method": "suffix",
+            "num_speculative_tokens": 5,
+            "force_max_spec_tokens": True,
+        },
+    )
+    ```
+
+    The padding token is the model's `eos_token_id`, which is verified and rejected by the rejection sampler at the non-target positions. Empty lists (`[]`, e.g. from skipped requests) are never padded.
+
+    This feature is most effective when the speculative acceptance length is high. In agent workloads with acceptance lengths of 2.5–3, average ITL can be reduced by ~15% (measured on MiniMaxM2, TP8+EP, Ascend Hardware). When `force_max_spec_tokens` is disabled (default), behavior is unchanged.
+
+    !!! note
+        This option is currently only supported for `method='suffix'`.
+
 ```python
 from vllm import LLM, SamplingParams
 

--- a/tests/v1/spec_decode/test_suffix_decoding_force_max.py
+++ b/tests/v1/spec_decode/test_suffix_decoding_force_max.py
@@ -52,7 +52,7 @@ def _make_vllm_config(
     return cfg
 
 
-def _make_mock_tokenizer(eos_token_id: int = PAD_TOKEN_ID):
+def _make_mock_tokenizer(eos_token_id: int | None = PAD_TOKEN_ID):
     mock_tokenizer = MagicMock()
     mock_tokenizer.eos_token_id = eos_token_id
     return mock_tokenizer
@@ -81,6 +81,21 @@ class TestSuffixDecodingForceMaxSpecTokens:
             patch(
                 CACHED_TOKENIZER_FROM_CONFIG,
                 return_value=None,
+            ),
+        ):
+            proposer = SuffixDecodingProposer(vllm_config)
+            assert proposer.force_max_spec_tokens is False
+            assert proposer._pad_token_id == -1
+            assert proposer._pad_template == []
+
+    def test_init_tokenizer_no_eos_disables_force(self):
+        vllm_config = _make_vllm_config(force_max_spec_tokens=True)
+        mock_tokenizer = _make_mock_tokenizer(eos_token_id=None)
+        with (
+            patch(SUFFIX_DECODING_CACHE, autospec=True),
+            patch(
+                CACHED_TOKENIZER_FROM_CONFIG,
+                return_value=mock_tokenizer,
             ),
         ):
             proposer = SuffixDecodingProposer(vllm_config)

--- a/tests/v1/spec_decode/test_suffix_decoding_force_max.py
+++ b/tests/v1/spec_decode/test_suffix_decoding_force_max.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm.config import SpeculativeConfig, VllmConfig
+from vllm.config.compilation import (
+    CompilationConfig,
+    CompilationMode,
+    CUDAGraphMode,
+)
+from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
+
+PAD_TOKEN_ID = 151645
+SUFFIX_DECODING_CACHE = "arctic_inference.suffix_decoding.SuffixDecodingCache"
+CACHED_TOKENIZER_FROM_CONFIG = (
+    "vllm.v1.spec_decode.suffix_decoding.cached_tokenizer_from_config"
+)
+
+
+def _make_vllm_config(
+    force_max_spec_tokens: bool = True,
+    num_speculative_tokens: int = 3,
+    max_model_len: int = 4096,
+) -> VllmConfig:
+    """
+    Build a VllmConfig with minimal fields for testing.
+    Uses VllmConfig.__new__() to bypass Pydantic validation,
+    since we supply MagicMock objects instead of real ModelConfig
+    / SchedulerConfig instances to avoid HF model downloads in CI.
+    """
+    cfg = VllmConfig.__new__(VllmConfig)
+    cfg.compilation_config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        custom_ops=["none"],
+        splitting_ops=[],
+        compile_sizes=[],
+        cudagraph_mode=CUDAGraphMode.NONE,
+    )
+    cfg.speculative_config = SpeculativeConfig(
+        method="suffix",
+        num_speculative_tokens=num_speculative_tokens,
+        force_max_spec_tokens=force_max_spec_tokens,
+    )
+    mock_model_config = MagicMock()
+    mock_model_config.max_model_len = max_model_len
+    cfg.model_config = mock_model_config
+    mock_scheduler_config = MagicMock()
+    mock_scheduler_config.max_num_seqs = 256
+    cfg.scheduler_config = mock_scheduler_config
+    return cfg
+
+
+def _make_mock_tokenizer(eos_token_id: int = PAD_TOKEN_ID):
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.eos_token_id = eos_token_id
+    return mock_tokenizer
+
+
+class TestSuffixDecodingForceMaxSpecTokens:
+    def test_init_reads_force_max_spec_tokens(self):
+        vllm_config = _make_vllm_config(force_max_spec_tokens=True)
+        mock_tokenizer = _make_mock_tokenizer(eos_token_id=PAD_TOKEN_ID)
+        with (
+            patch(SUFFIX_DECODING_CACHE, autospec=True),
+            patch(
+                CACHED_TOKENIZER_FROM_CONFIG,
+                return_value=mock_tokenizer,
+            ),
+        ):
+            proposer = SuffixDecodingProposer(vllm_config)
+            assert proposer.force_max_spec_tokens is True
+            assert proposer._pad_token_id == PAD_TOKEN_ID
+            assert proposer._pad_template == [PAD_TOKEN_ID] * 3
+
+    def test_init_tokenizer_none_disables_force(self):
+        vllm_config = _make_vllm_config(force_max_spec_tokens=True)
+        with (
+            patch(SUFFIX_DECODING_CACHE, autospec=True),
+            patch(
+                CACHED_TOKENIZER_FROM_CONFIG,
+                return_value=None,
+            ),
+        ):
+            proposer = SuffixDecodingProposer(vllm_config)
+            assert proposer.force_max_spec_tokens is False
+            assert proposer._pad_token_id == -1
+            assert proposer._pad_template == []
+
+    def test_init_default_disabled(self):
+        vllm_config = _make_vllm_config(force_max_spec_tokens=False)
+        with (
+            patch(SUFFIX_DECODING_CACHE, autospec=True),
+            patch(
+                CACHED_TOKENIZER_FROM_CONFIG,
+                return_value=MagicMock(),
+            ),
+        ):
+            proposer = SuffixDecodingProposer(vllm_config)
+            assert proposer.force_max_spec_tokens is False
+            assert proposer._pad_token_id == -1
+            assert proposer._pad_template == []
+
+    def test_propose_pads_short_lists(self):
+        """Verify short draft lists are padded to num_speculative_tokens."""
+        vllm_config = _make_vllm_config(force_max_spec_tokens=True)
+        mock_tokenizer = _make_mock_tokenizer()
+        with (
+            patch(SUFFIX_DECODING_CACHE, autospec=True) as mock_cache_cls,
+            patch(
+                CACHED_TOKENIZER_FROM_CONFIG,
+                return_value=mock_tokenizer,
+            ),
+        ):
+            mock_cache = mock_cache_cls.return_value
+            mock_cache.active_requests = set()
+            mock_cache.cached_requests = set()
+            mock_cache.speculate.side_effect = [
+                MagicMock(token_ids=[1]),
+                MagicMock(token_ids=[4, 5]),
+            ]
+
+            proposer = SuffixDecodingProposer(vllm_config)
+
+            mock_batch = MagicMock()
+            mock_batch.req_ids = {0: "req_0", 1: "req_1", 2: "req_2"}
+            mock_batch.num_tokens_no_spec = [5, 5, 5]
+            mock_batch.req_id_to_index = {"req_0": 0, "req_1": 1, "req_2": 2}
+            mock_batch.num_prompt_tokens = [100, 100, 100]
+            mock_batch.token_ids_cpu = torch.zeros((3, 4096), dtype=torch.long)
+            sampled_token_ids = [[100], [200, 300], []]
+
+            result = proposer.propose(mock_batch, sampled_token_ids, None)
+
+            assert result == [
+                [1, PAD_TOKEN_ID, PAD_TOKEN_ID],
+                [4, 5, PAD_TOKEN_ID],
+                [],
+            ]
+
+    def test_propose_disabled_does_nothing(self):
+        """Verify no-op when force_max_spec_tokens is False."""
+        vllm_config = _make_vllm_config(force_max_spec_tokens=False)
+        with (
+            patch(SUFFIX_DECODING_CACHE, autospec=True) as mock_cache_cls,
+            patch(
+                CACHED_TOKENIZER_FROM_CONFIG,
+                return_value=MagicMock(),
+            ),
+        ):
+            mock_cache = mock_cache_cls.return_value
+            mock_cache.active_requests = set()
+            mock_cache.cached_requests = set()
+            mock_cache.speculate.return_value = MagicMock(
+                token_ids=[1, 2, 3, 4, 5, 6],
+            )
+
+            proposer = SuffixDecodingProposer(vllm_config)
+
+            mock_batch = MagicMock()
+            mock_batch.req_ids = {0: "req_0"}
+            mock_batch.num_tokens_no_spec = [5]
+            mock_batch.req_id_to_index = {"req_0": 0}
+            mock_batch.num_prompt_tokens = [100]
+            mock_batch.token_ids_cpu = torch.zeros((1, 4096), dtype=torch.long)
+            sampled_token_ids = [[100, 200]]
+
+            result = proposer.propose(mock_batch, sampled_token_ids, None)
+
+            assert result == [[1, 2, 3, 4, 5, 6]]

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -130,6 +130,11 @@ class SpeculativeConfig:
     speculative input batches can contain sequences of different lengths,
     which may only be supported by certain attention backends. This currently
     only affects the EAGLE method of speculation."""
+    force_max_spec_tokens: bool = Field(default=False)
+    """Force speculative decoding proposers to produce exactly
+    num_speculative_tokens draft tokens per request per step.
+    When enabled, proposers will pad short drafts with eos_token_id.
+    Currently only applies to method='suffix' (Suffix Decoding)."""
     use_local_argmax_reduction: bool = False
     """Use vocab-parallel local argmax instead of all-gathering full logits
     for draft token generation. Reduces communication from O(vocab_size) to

--- a/vllm/v1/spec_decode/suffix_decoding.py
+++ b/vllm/v1/spec_decode/suffix_decoding.py
@@ -3,7 +3,11 @@
 import torch
 
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.v1.worker.gpu_input_batch import InputBatch
+
+logger = init_logger(__name__)
 
 
 class SuffixDecodingProposer:
@@ -32,6 +36,22 @@ class SuffixDecodingProposer:
             max_cached_requests=config.suffix_decoding_max_cached_requests,
         )
 
+        self.force_max_spec_tokens = config.force_max_spec_tokens
+        self._pad_token_id = -1
+        self._pad_template = []
+        if self.force_max_spec_tokens:
+            tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+            if tokenizer is None:
+                logger.warning(
+                    "force_max_spec_tokens is enabled but tokenizer is not "
+                    "available (skip_tokenizer_init=True). "
+                    "Disabling force_max_spec_tokens."
+                )
+                self.force_max_spec_tokens = False
+            else:
+                self._pad_token_id = tokenizer.eos_token_id
+                self._pad_template = [self._pad_token_id] * self.num_speculative_tokens
+
     def propose(
         self,
         input_batch: InputBatch,
@@ -44,6 +64,8 @@ class SuffixDecodingProposer:
         Propose speculative tokens for each request in the input batch. Suffix Decoding
         will speculate a dynamic number of tokens for each request every decoding step,
         so each entry in the returned list may have different lengths.
+        When force_max_spec_tokens is enabled, all non-empty entries
+        will be padded to num_speculative_tokens.
         """
         draft_token_ids: list[list[int]] = []
         for i, sampled_ids in enumerate(sampled_token_ids):
@@ -87,6 +109,8 @@ class SuffixDecodingProposer:
             )
 
             draft_token_ids.append(draft.token_ids)
+            if self.force_max_spec_tokens:
+                draft_token_ids[-1].extend(self._pad_template[len(draft.token_ids) :])
 
         # Stop requests that were not seen in the input batch.
         for req_id in (

--- a/vllm/v1/spec_decode/suffix_decoding.py
+++ b/vllm/v1/spec_decode/suffix_decoding.py
@@ -41,10 +41,10 @@ class SuffixDecodingProposer:
         self._pad_template = []
         if self.force_max_spec_tokens:
             tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
-            if tokenizer is None:
+            if tokenizer is None or tokenizer.eos_token_id is None:
                 logger.warning(
                     "force_max_spec_tokens is enabled but tokenizer is not "
-                    "available (skip_tokenizer_init=True). "
+                    "available or does not have an eos_token_id. "
                     "Disabling force_max_spec_tokens."
                 )
                 self.force_max_spec_tokens = False
@@ -98,19 +98,26 @@ class SuffixDecodingProposer:
             # we extract the pattern from the end of the input.
             start = max(0, num_tokens - self.max_tree_depth)
             pattern = input_batch.token_ids_cpu[i, start:num_tokens]
+            max_spec_tokens = min(
+                self.num_speculative_tokens, self.max_model_len - num_tokens - 1
+            )
             draft = self.suffix_cache.speculate(
                 req_id,
                 pattern,
-                max_spec_tokens=min(
-                    self.num_speculative_tokens, self.max_model_len - num_tokens - 1
-                ),
+                max_spec_tokens=max_spec_tokens,
                 max_spec_factor=self.max_spec_factor,
                 min_token_prob=self.min_token_prob,
             )
 
-            draft_token_ids.append(draft.token_ids)
-            if self.force_max_spec_tokens:
-                draft_token_ids[-1].extend(self._pad_template[len(draft.token_ids) :])
+            if (
+                self.force_max_spec_tokens
+                and max_spec_tokens >= self.num_speculative_tokens
+            ):
+                draft_token_ids.append(
+                    draft.token_ids + self._pad_template[len(draft.token_ids) :]
+                )
+            else:
+                draft_token_ids.append(draft.token_ids)
 
         # Stop requests that were not seen in the input batch.
         for req_id in (


### PR DESCRIPTION
## Purpose

Suffix speculative decoding produces non-uniform draft token batches, causing CUDA Graph to fall back to PIECEWISE dispatch. This PR introduces `force_max_spec_tokens` to pad batches to a uniform size, recovering FULL graph dispatch.

### Problem

Each call to `SuffixDecodingProposer.propose()` may return a different number of draft tokens per request. When requests in a batch have varying `num_scheduled_tokens`, CUDA Graph dispatch degrades from FULL to PIECEWISE mode — losing the latency benefits of graph capture. Only a fraction of decode steps can use FULL graph under the default behavior:

| Unpadded Tokens | Padded Tokens | Runtime Mode | Count |
|---|---|---|---|
| 1 | 4 | PIECEWISE | 173 |
| 2 | 4 | PIECEWISE | 138 |
| 3 | 4 | PIECEWISE | 25 |
| 4 | 4 | FULL | 15 |

### Solution

Add `force_max_spec_tokens` (default `False`) to `SpeculativeConfig`. When enabled, `SuffixDecodingProposer` pads all non-empty draft token lists to `num_speculative_tokens` with `eos_token_id`, ensuring every request in the batch has the same `num_scheduled_tokens` and enabling FULL CUDA Graph dispatch.

## Test Plan

Unit tests in `tests/v1/spec_decode/test_suffix_decoding_force_max.py` cover initialization (reading config, constructing pad template, graceful disable when tokenizer is unavailable), `propose()` behavior (padding short drafts, leaving empty lists untouched), and the default-disabled path. Run with:

```bash
.venv/bin/python -m pytest tests/v1/spec_decode/test_suffix_decoding_force_max.py -v
```

Manual validation — launch server with `force_max_spec_tokens=true` and verify CUDA Graph dispatch stats:

```bash
VLLM_USE_FLASHINFER_SAMPLER=0 \
vllm serve \
  --model "Qwen/Qwen3-0.6B" \
  --max-model-len 4096 \
  --gpu-memory-utilization 0.8 \
  --cudagraph-metrics \
  --speculative-config '{"method":"suffix","num_speculative_tokens":3,"suffix_decoding_max_cached_requests":80,"force_max_spec_tokens":true}' \
  --cudagraph-capture-sizes 4 8 12 16 20 24 28 32 36 40 44 48 52 56 60 64 72 80 88 96 104 112 120 128 136 144 152 160 168 176 184 192 200 208 216 224 232 240 248 256
```

## Test Result

### CUDA Graph dispatch

After enabling `force_max_spec_tokens=true`, nearly all decode steps hit FULL graph:

| Unpadded Tokens | Padded Tokens | Runtime Mode | Count |
|---|---|---|---|
| 4 | 4 | FULL | 1200 |
| 9 | 16 | PIECEWISE | 3 |

### Benchmark (Qwen/Qwen3-0.6B, `num_speculative_tokens=3`)

**Baseline (original suffix decoding)**

| Concurrency | Throughput (tok/s) | TPOT (ms) | ITL (ms) | TTFT (ms) | P99 ITL (ms) | Acc. Length |
|---|---|---|---|---|---|---|
| 1 | 248.06 | 4.01 | 7.88 | 23.05 | 9.08 | 2.19 |
| 4 | 665.61 | 5.91 | 11.20 | 22.78 | 12.99 | 2.03 |
| 8 | 1186.19 | 6.43 | 13.16 | 28.59 | 15.52 | 2.14 |
| 16 | 1613.75 | 9.45 | 18.65 | 40.35 | 22.50 | 2.07 |

**+force_max_spec_tokens (FULL graph)**

| Concurrency | Throughput (tok/s) | TPOT (ms) | ITL (ms) | TTFT (ms) | P99 ITL (ms) | Acc. Length |
|---|---|---|---|---|---|---|
| 1 | 255.15 | 3.91 | 8.16 | 15.81 | 9.21 | 2.10 |
| 4 | 747.53 | 5.15 | 10.41 | 22.17 | 11.84 | 2.03 |
| 8 | 1183.44 | 6.53 | 13.28 | 28.68 | 15.43 | 2.04 |
| 16 | 1584.03 | 9.53 | 18.99 | 44.06 | 24.44 | 2.00 |

### Production validation (MiniMaxM2, TP8+EP, Ascend)

At 8 concurrency, average ITL drops **~15%** with `force_max_spec_tokens=true`, confirming the benefit scales with model size and acceptance length.