### PR TITLE
[CI failure] Temporarily disable using persistent cache for flashinfer autotune

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -106,6 +106,12 @@ def kernel_warmup(worker: "Worker"):
         )
 
 
+# TODO: remove once FlashInfer upstream fixes the persistent file cache
+# to resolve collisions like `use_8x4_sf_layout=True/False`, which causes
+# invalid tactics to be chosen
+_FLASHINFER_USE_PERSISTENT_CACHE = False
+
+
 def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     """
     Autotune FlashInfer operations.
@@ -121,6 +127,15 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     """
     import vllm.utils.flashinfer as fi_utils
     from vllm.distributed.parallel_state import get_world_group
+
+    if not _FLASHINFER_USE_PERSISTENT_CACHE:
+        with torch.inference_mode(), fi_utils.autotune():
+            runner._dummy_run(
+                num_tokens=runner.scheduler_config.max_num_batched_tokens,
+                skip_eplb=True,
+                is_profile=True,
+            )
+        return
 
     world = get_world_group()
     is_leader = world.rank_in_group == 0

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -135,6 +135,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
                 skip_eplb=True,
                 is_profile=True,
             )
+        get_world_group().barrier()
         return
 
     world = get_world_group()


### PR DESCRIPTION
## Purpose
It appears that flashinfer autotune file cache is inadequate to discriminate kernel parameters like `use_8x4_sf_layout` in its file cache keys, resulting in invalid tactics being chosen with colliding calls:

```

(EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159]   File "/usr/local/lib/python3.12/dist-packages/flashinfer/gemm/gemm_base.py", line 6627, in forward
--
  | (EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159]     self._gemm_runner(
  | (EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159]   File "python/tvm_ffi/cython/function.pxi", line 929, in tvm_ffi.core.Function.__call__
  | (EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159]   File "<unknown>", line 0, in __tvm_ffi_trtllm_gemm
  | (EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159]   File "<unknown>", line 0, in flashinfer::trtllm_gemm(long, long, tvm::ffi::TensorView, tvm::ffi::TensorView, tvm::ffi::TensorView, tvm::ffi::TensorView, tvm::ffi::TensorView, tvm::ffi::Optional<tvm::ffi::TensorView, void>, tvm::ffi::TensorView, bool, long)
  | (EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159]   File "/workspace/csrc/trtllm_gemm_runner.cu", line 143, in void flashinfer::TrtllmGenGemmRunner::run(int64_t, int64_t, int64_t, const void*, const void*, const void*, const void*, void*, void*, void*, void*, CUstream, int32_t, int64_t)
  | (EngineCore pid=9381) ERROR 05-19 11:25:35 [core.py:1159] RuntimeError: Check failed: (config.mOptions.mSfLayoutB == mOptions.sfLayoutB) is false: Invalid sf layout in run

```

This PR works around the issue by temporarily disable using persistent cache for flashinfer autotune and falls back to the original way of autotuning within each rank separately (the in-memory cache still works properly). Will look into the proper fix in upstream flashinfer.

cc: @mgoin @mmangkad

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

