### PR TITLE
[bug] fix WeightTransferConfig.backend to allow for all strings

### DIFF
--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -173,20 +173,7 @@ class TestEngineRegistry:
 
     def test_create_engine_invalid_backend(self):
         """Test factory raises for invalid backend."""
-        # Pydantic validates Literal types at construction, so we can't create
-        # a config with an invalid backend. Instead, we test by directly
-        # accessing the registry or using model_construct to bypass validation.
-        from pydantic import ValidationError
-
-        # Test that Pydantic prevents invalid backend at construction
-        with pytest.raises(ValidationError):
-            WeightTransferConfig(backend="invalid")
-
-        # Test factory error by creating a config with valid backend but
-        # then manually modifying the backend attribute (bypassing validation)
-        config = WeightTransferConfig(backend="nccl")
-        # Use object.__setattr__ to bypass Pydantic validation
-        object.__setattr__(config, "backend", "invalid")
+        config = WeightTransferConfig(backend="invalid")
         parallel_config = create_mock_parallel_config()
         with pytest.raises(ValueError, match="Invalid weight transfer backend"):
             WeightTransferEngineFactory.create_engine(config, parallel_config)

--- a/vllm/config/weight_transfer.py
+++ b/vllm/config/weight_transfer.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Literal
-
 from vllm.config.utils import config
 
 
@@ -9,5 +7,7 @@ from vllm.config.utils import config
 class WeightTransferConfig:
     """Configuration for weight transfer during RL training."""
 
-    backend: Literal["nccl", "ipc"] = "nccl"
-    """The backend to use for weight transfer."""
+    backend: str = "nccl"
+    """The backend to use for weight transfer. Validated against the
+    `WeightTransferEngineFactory` registry at engine creation time.
+    """


### PR DESCRIPTION



## Purpose

WeightTransferConfig dataclass currently only allows `'ipc'` and `'nccl'`, third-party weight transfer backends have to either patch this file or use `object.__setattr__` to bypass pydantic. Change backend to str type, which is still validated against the `WeightTransferEngineFactory ` at runtime. 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

