### PR TITLE
[Model Runner V2] Fix `CUDA graphs must be captured on a non-default stream.` issue

### DIFF
--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -721,6 +721,11 @@ def current_stream() -> torch.cuda.Stream:
                     "Fail to set current stream, current platform "
                     "may not support current_stream with torch API"
                 )
+    elif (
+        current_platform.is_rocm() or current_platform.is_cuda()
+    ) and _current_stream_tls.value.cuda_stream == 0:
+        # recreate the dedicated execution stream on demand.
+        torch.cuda.set_stream(torch.cuda.Stream())
     return _current_stream_tls.value
 
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -46,7 +46,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
-from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, current_stream
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
@@ -350,8 +350,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
     @functools.cached_property
     def main_stream(self) -> torch.cuda.Stream:
-        # Cache the default CUDA stream to avoid lookup overhead.
-        return torch.cuda.current_stream(self.device)
+        # return vLLM's non-default execution stream.
+        return current_stream()
 
     def get_kv_cache_spec(self):
         return get_kv_cache_spec(self.vllm_config)


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/41286

`VLLM_USE_V2_MODEL_RUNNER=1 pytest tests/v1/e2e/spec_decode/test_lora_with_spec_decode.py::test_batch_inference_correctness[model_setup0]`

Originally

```bash
(EngineCore pid=3118313)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
(EngineCore pid=3118313)     return self._call_impl(*args, **kwargs)
(EngineCore pid=3118313)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3118313)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
(EngineCore pid=3118313)     return forward_call(*args, **kwargs)
(EngineCore pid=3118313)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3118313)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/qwen3.py", line 323, in forward
(EngineCore pid=3118313)     hidden_states = self.model(
(EngineCore pid=3118313)                     ^^^^^^^^^^^
(EngineCore pid=3118313)   File "/home/yewentao256/vllm-source/vllm/compilation/decorators.py", line 520, in __call__
(EngineCore pid=3118313)     return self.aot_compiled_fn(self, *args, **kwargs)
(EngineCore pid=3118313)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3118313)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_dynamo/aot_compile.py", line 224, in __call__
(EngineCore pid=3118313)     return self.fn(*args, **kwargs)
(EngineCore pid=3118313)            ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3118313)   File "/home/yewentao256/vllm-source/vllm/model_executor/models/qwen2.py", line 389, in forward
(EngineCore pid=3118313)     def forward(
(EngineCore pid=3118313)   File "/home/yewentao256/vllm-source/vllm/compilation/caching.py", line 217, in __call__
(EngineCore pid=3118313)     return self.optimized_call(*args, **kwargs)
(EngineCore pid=3118313)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3118313)   File "<string>", line 145, in execution_fn
(EngineCore pid=3118313)   File "/home/yewentao256/vllm-source/vllm/compilation/cuda_graph.py", line 318, in __call__
(EngineCore pid=3118313)     with torch.cuda.graph(
(EngineCore pid=3118313)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 257, in __enter__
(EngineCore pid=3118313)     self.cuda_graph.capture_begin(
(EngineCore pid=3118313)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/cuda/graphs.py", line 115, in capture_begin
(EngineCore pid=3118313)     super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
(EngineCore pid=3118313) RuntimeError: CUDA graphs must be captured on a non-default stream. (However, after capture, it's ok to replay them on the default stream.)
```

Now

```bash
============================== 1 passed, 19 warnings in 68.27s (0:01:08) ==============================
```

Note that this is a quick fix for current CI issue in main.