### PR TITLE
[Frontend] Implement GET /v1/models/{model_id} retrieve endpoint

### DIFF
--- a/tests/entrypoints/openai/models/test_models.py
+++ b/tests/entrypoints/openai/models/test_models.py
@@ -54,3 +54,24 @@ async def test_check_models(client: openai.AsyncOpenAI, qwen3_lora_files):
     assert served_model.root == MODEL_NAME
     assert all(lora_model.root == qwen3_lora_files for lora_model in lora_models)
     assert lora_models[0].id == "qwen3-lora"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_base_model(client: openai.AsyncOpenAI):
+    model = await client.models.retrieve(MODEL_NAME)
+    assert model.id == MODEL_NAME
+    assert model.root == MODEL_NAME
+
+
+@pytest.mark.asyncio
+async def test_retrieve_lora_model(client: openai.AsyncOpenAI, qwen3_lora_files):
+    model = await client.models.retrieve("qwen3-lora")
+    assert model.id == "qwen3-lora"
+    assert model.root == qwen3_lora_files
+
+
+@pytest.mark.asyncio
+async def test_retrieve_unknown_model(client: openai.AsyncOpenAI):
+    with pytest.raises(openai.NotFoundError) as exc_info:
+        await client.models.retrieve("this-model-does-not-exist")
+    assert "does not exist" in str(exc_info.value)

--- a/vllm/entrypoints/openai/models/api_router.py
+++ b/vllm/entrypoints/openai/models/api_router.py
@@ -2,10 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from http import HTTPStatus
+
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.utils import create_error_response
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -23,6 +26,27 @@ async def show_available_models(raw_request: Request):
 
     models_ = await handler.show_available_models()
     return JSONResponse(content=models_.model_dump())
+
+
+# `{model_id:path}` accepts forward slashes so HuggingFace-style IDs
+# (e.g. `meta-llama/Llama-3.1-8B-Instruct`) match without URL-encoding.
+@router.get("/v1/models/{model_id:path}")
+async def retrieve_model(model_id: str, raw_request: Request):
+    handler = models(raw_request)
+
+    card = await handler.retrieve_model(model_id)
+    if card is None:
+        error = create_error_response(
+            message=f"The model `{model_id}` does not exist.",
+            err_type="NotFoundError",
+            status_code=HTTPStatus.NOT_FOUND,
+            param="model",
+        )
+        return JSONResponse(
+            status_code=HTTPStatus.NOT_FOUND,
+            content=error.model_dump(),
+        )
+    return JSONResponse(content=card.model_dump())
 
 
 def attach_router(app: FastAPI):

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -72,6 +72,14 @@ class OpenAIModelRegistry:
             ]
         )
 
+    async def retrieve_model(self, model_id: str) -> ModelCard | None:
+        """Return the ModelCard for `model_id`, or None if not served."""
+        model_list = await self.show_available_models()
+        for card in model_list.data:
+            if card.id == model_id:
+                return card
+        return None
+
 
 class OpenAIServingModels:
     """Shared instance to hold data about the loaded base model(s) and adapters.
@@ -156,6 +164,15 @@ class OpenAIServingModels:
         ]
         model_list.data.extend(lora_cards)
         return model_list
+
+    async def retrieve_model(self, model_id: str) -> ModelCard | None:
+        """Return the ModelCard for `model_id`, including loaded LoRA adapters,
+        or None if not served."""
+        model_list = await self.show_available_models()
+        for card in model_list.data:
+            if card.id == model_id:
+                return card
+        return None
 
     async def load_lora_adapter(
         self, request: LoadLoRAAdapterRequest, base_model_name: str | None = None


### PR DESCRIPTION
## Purpose

vLLM's OpenAI-compatible server registers `GET /v1/models` (list) but does not implement the corresponding `GET /v1/models/{model_id}` (retrieve) endpoint that is part of the [OpenAI API spec](https://developers.openai.com/api/reference/resources/models/methods/retrieve). The official OpenAI Python SDK's `client.models.retrieve(model_id)` therefore receives FastAPI's default `{"detail": "Not Found"}` 404 instead of a `ModelCard`.

This PR adds the missing route.

### Repro (before this change)
```bash
vllm serve meta-llama/Llama-3.1-8B-Instruct
```
```python
from openai import OpenAI
c = OpenAI(base_url="http://localhost:8000/v1", api_key="x")
c.models.list()                                       # works
c.models.retrieve("meta-llama/Llama-3.1-8B-Instruct") # openai.NotFoundError: 404 {'detail': 'Not Found'}
```

## Changes

- `vllm/entrypoints/openai/models/serving.py`: add `retrieve_model(model_id)` to both `OpenAIModelRegistry` (base-model-only, engine-free) and `OpenAIServingModels` (includes loaded LoRA adapters).
- `vllm/entrypoints/openai/models/api_router.py`: register `@router.get("/v1/models/{model_id:path}")`. The `:path` converter is required so HuggingFace-style IDs containing a forward slash match without URL-encoding. Unknown IDs return a structured error via `create_error_response` matching the shape used by `/v1/chat/completions` for unknown models.