### PR TITLE
fix: clamp negative prompt token metrics

### DIFF
--- a/tests/v1/metrics/test_loggers.py
+++ b/tests/v1/metrics/test_loggers.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.v1.metrics.loggers import _inc_counter_nonnegative
+
+
+class FakeCounter:
+    def __init__(self):
+        self.values: list[int] = []
+
+    def inc(self, value: int):
+        if value < 0:
+            raise ValueError("Negative value not allowed")
+        self.values.append(value)
+
+
+def test_inc_counter_nonnegative_clamps_negative_values():
+    counter = FakeCounter()
+
+    _inc_counter_nonnegative(counter, -3)
+    _inc_counter_nonnegative(counter, 4)
+
+    assert counter.values == [0, 4]

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -41,6 +41,10 @@ AggregateStatLoggerFactory = type["AggregateStatLoggerBase"]
 StatLoggerFactory = AggregateStatLoggerFactory | PerEngineStatLoggerFactory
 
 
+def _inc_counter_nonnegative(counter: Counter, value: int) -> None:
+    counter.inc(max(value, 0))
+
+
 class StatLoggerBase(ABC):
     """Interface for logging metrics.
 
@@ -1153,10 +1157,13 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         # Labeled prompt token counters by source
         pts = iteration_stats.prompt_token_stats
         for source in PromptTokenStats.ALL_SOURCES:
-            self.counter_prompt_tokens_by_source[source][engine_idx].inc(
+            _inc_counter_nonnegative(
+                self.counter_prompt_tokens_by_source[source][engine_idx],
                 pts.get_by_source(source)
             )
-        self.counter_prompt_tokens_cached[engine_idx].inc(pts.cached_tokens)
+        _inc_counter_nonnegative(
+            self.counter_prompt_tokens_cached[engine_idx], pts.cached_tokens
+        )
         self.counter_generation_tokens[engine_idx].inc(
             iteration_stats.num_generation_tokens
         )


### PR DESCRIPTION
﻿## Summary
- clamp prompt-token Prometheus counter increments at zero before recording per-source and cached-token stats
- keep the raw `PromptTokenStats` values unchanged so the fix is limited to Counter semantics
- add a focused helper test for negative values

Fixes #43031.

## Validation
- `python -m py_compile vllm\v1\metrics\loggers.py tests\v1\metrics\test_loggers.py`
- `python -m ruff check vllm\v1\metrics\loggers.py tests\v1\metrics\test_loggers.py`
- `git diff --check upstream/main..HEAD`

## Notes
- I could not run `pytest tests\v1\metrics\test_loggers.py -q` on this Windows machine because the repository-level pytest `conftest.py` imports `uvloop`, which is not available on Windows. The targeted files compile and pass ruff locally.
