### PR TITLE
[ci] Move language models tests (hybrid) back to L4

### DIFF
--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -34,7 +34,6 @@ steps:
     torch_nightly: {}
 
 - label: Language Models Tests (Hybrid) %N
-  device: h200_35gb
   key: language-models-tests-hybrid
   timeout_in_minutes: 75
   source_file_dependencies:


### PR DESCRIPTION
It starts failing more on H200 MIG