### PR TITLE
[Spec Decode] Support non-MTP speculation for NemotronH

### DIFF
--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -172,10 +172,15 @@ class LlamaModel(nn.Module):
             ]
         )
         if self.use_aux_hidden_state:
+            num_aux_features = getattr(self.config, "num_aux_layers", None)
+            if num_aux_features is None:
+                aux_ids = getattr(self.config, "eagle_aux_hidden_state_layer_ids", None)
+                num_aux_features = len(aux_ids) if aux_ids is not None else 3
+            self.num_aux_layers = num_aux_features
             if hasattr(self.config, "target_hidden_size"):
-                fc_input_size = self.config.target_hidden_size * 3
+                fc_input_size = self.config.target_hidden_size * num_aux_features
             else:
-                fc_input_size = self.config.hidden_size * 3
+                fc_input_size = self.config.hidden_size * num_aux_features
             if self.norm_before_fc:
                 self.input_norm = RMSNorm(
                     fc_input_size,
@@ -314,7 +319,11 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
                 "mask_hidden",
                 torch.zeros(
                     1,
-                    (3 if self.model.use_aux_hidden_state else 1)
+                    (
+                        self.model.num_aux_layers
+                        if self.model.use_aux_hidden_state
+                        else 1
+                    )
                     * self.config.hidden_size,
                 ),
                 persistent=False,

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -64,9 +64,12 @@ from vllm.model_executor.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
     HasInnerState,
     IsHybrid,
     MixtureOfExperts,
+    SupportsEagle,
+    SupportsEagle3,
     SupportsLoRA,
     SupportsMambaPrefixCaching,
     SupportsPP,
@@ -539,7 +542,7 @@ ALL_DECODER_LAYER_TYPES = {
 
 
 @support_torch_compile
-class NemotronHModel(nn.Module):
+class NemotronHModel(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -605,11 +608,17 @@ class NemotronHModel(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer)
+        ):
             hidden_states, residual = layer(
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
+            )
+            self._maybe_add_hidden_state(
+                aux_hidden_states, idx + 1, hidden_states, residual
             )
 
         if not get_pp_group().is_last_rank:
@@ -617,6 +626,9 @@ class NemotronHModel(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm_f(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def is_spec_layer(self, config: NemotronHConfig, weight_name: str) -> bool:
@@ -767,6 +779,8 @@ class NemotronHForCausalLM(
     HasInnerState,
     SupportsLoRA,
     SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
     IsHybrid,
     SupportsQuant,
     MixtureOfExperts,


### PR DESCRIPTION
## Purpose

Adds specdec support for NemotronH: EAGLE3, P-EAGLE, DFlash.

Also allows for EAGLE-based speculators to use a number of aux features other than 3 or 0. 

## Testing

Works locally. Models not yet released.
