### PR TITLE
[Bugfix] Allow float16/bfloat16 as kv_cache_dtype in Triton attention ops

### DIFF
--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -354,6 +354,7 @@ def triton_reshape_and_cache_flash(
         "auto",
         "float16",
         "bfloat16",
+        "float32",
     ) or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
@@ -537,6 +538,7 @@ def triton_reshape_and_cache_flash_diffkv(
         "auto",
         "float16",
         "bfloat16",
+        "float32",
     ) or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -350,7 +350,11 @@ def triton_reshape_and_cache_flash(
     block_stride = key_cache.stride()[0]
     page_stride = key_cache.stride()[1]
 
-    assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
+    assert kv_cache_dtype in (
+        "auto",
+        "float16",
+        "bfloat16",
+    ) or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
     kv_cache_torch_dtype = (
@@ -529,7 +533,11 @@ def triton_reshape_and_cache_flash_diffkv(
     block_stride = kv_cache.stride()[0]
     page_stride = kv_cache.stride()[1]
 
-    assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
+    assert kv_cache_dtype in (
+        "auto",
+        "float16",
+        "bfloat16",
+    ) or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
     kv_cache_torch_dtype = (


### PR DESCRIPTION
## Summary

Fix an `AssertionError` raised when `kv_cache_dtype` is `"float16"`, `"bfloat16"`, or `"float32"` in the Triton attention backend (`reshape_and_cache_flash` and `reshape_and_cache_flash_mla`).

**Root cause:** The assert in both functions only accepted `"auto"` or quantized types (fp8*, nvfp4, etc.):

```python
# Before (too strict)
assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
    f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
)
```

But `flash_attn.py` explicitly lists `"float16"` and `"bfloat16"` as valid `kv_cache_dtype` values (line 193: `return kv_cache_dtype in ["auto", "float16", "bfloat16"]`). Additionally, `"float32"` is listed as a supported dtype in the downstream error message (line 387). When passed, the downstream code handles all three correctly — `is_quantized_kv_cache()` returns `False`, so `kv_cache_torch_dtype = key_cache.dtype` (same as the `"auto"` path, no casting).

**Fix:** Expand the assert to include `"float16"`, `"bfloat16"`, and `"float32"` alongside `"auto"`.

Fixes #43109

## Why this is not a duplicate

No other open PR addresses issue #43109. Verified with:
```
gh pr list --repo vllm-project/vllm --state open --search "43109 in:body"
```
Only this PR appeared.

## Test Plan

- [x] Manually verified the downstream code path for `"float16"`/`"bfloat16"`/`"float32"` is safe — `is_quantized_kv_cache()` returns `False` for all three, so `kv_cache_torch_dtype = key_cache.dtype` (identical to `"auto"` path, no casting)
- [x] Confirmed `flash_attn.py` line 193 already accepts `"float16"` and `"bfloat16"` as valid values
- [x] Confirmed `"float32"` is listed as supported in the downstream error message at line 387
- [ ] Full CI test suite — awaiting maintainer trigger (pre-commit gate requires reviewer approval)

## AI Assistance

Parts of this fix were developed with AI (Claude) assistance.

Co-authored-by: Claude <claude@anthropic.com>