### PR TITLE
[Cohere] Enable Cohere MoE

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -378,7 +378,7 @@ th {
 | `BloomForCausalLM` | BLOOM, BLOOMZ, BLOOMChat | `bigscience/bloom`, `bigscience/bloomz`, etc. | | ✅︎ |
 | `ChatGLMModel`, `ChatGLMForConditionalGeneration` | ChatGLM | `zai-org/chatglm2-6b`, `zai-org/chatglm3-6b`, `thu-coai/ShieldLM-6B-chatglm3`, etc. | ✅︎ | ✅︎ |
 | `CohereForCausalLM`, `Cohere2ForCausalLM` | Command-R, Command-A | `CohereLabs/c4ai-command-r-v01`, `CohereLabs/c4ai-command-r7b-12-2024`, `CohereLabs/c4ai-command-a-03-2025`, `CohereLabs/command-a-reasoning-08-2025`, etc. | ✅︎ | ✅︎ |
-| `Cohere2MoeForCausalLM` | Command (MoE) | (model checkpoints loaded with `trust_remote_code=True`) | ✅︎ | ✅︎ |
+| `Cohere2MoeForCausalLM` | Command-A+ | `CohereLabs/command-a-plus-05-2026`, etc. | ✅︎ | ✅︎ |
 | `CwmForCausalLM` | CWM | `facebook/cwm`, etc. | ✅︎ | ✅︎ |
 | `DbrxForCausalLM` | DBRX | `databricks/dbrx-base`, `databricks/dbrx-instruct`, etc. | | ✅︎ |
 | `DeciLMForCausalLM` | DeciLM | `nvidia/Llama-3_3-Nemotron-Super-49B-v1`, etc. | ✅︎ | ✅︎ |

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -241,6 +241,7 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "Cohere2MoeForCausalLM": _HfExamplesInfo(
         "CohereLabs/command-a-plus-05-2026",
         trust_remote_code=True,
+        is_available_online=False,
     ),
     "CwmForCausalLM": _HfExamplesInfo("facebook/cwm", min_transformers_version="4.58"),
     # FIXME: databricks/dbrx-instruct has been deleted

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -239,9 +239,8 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
         trust_remote_code=True,
     ),
     "Cohere2MoeForCausalLM": _HfExamplesInfo(
-        "/host/engines/cohere-moe",
+        "CohereLabs/command-a-plus-05-2026",
         trust_remote_code=True,
-        is_available_online=False,
     ),
     "CwmForCausalLM": _HfExamplesInfo("facebook/cwm", min_transformers_version="4.58"),
     # FIXME: databricks/dbrx-instruct has been deleted


### PR DESCRIPTION

Follow up to https://github.com/vllm-project/vllm/pull/42078

Turns on Cohere Command A+ model (official name) withing vLLM code. The official HF repo will be `CohereLabs/command-a-plus-05-2026`.

Cmd to run the model:
Install vLLM and dependencies
```
uv pip install -U vllm --torch-backend=auto
uv pip install cohere_melody>=0.9.0
```
Start server
```
vllm serve CohereLabs/command-a-plus-05-2026 -tp 4 --tool-call-parser cohere_command4 --reasoning-parser cohere_command4 --enable-auto-tool-choice
```
Send request
```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "CohereLabs/command-a-plus-05-2026",
    "messages": [
      {"role": "user", "content": "Write a one sentence greeting."}
    ],
    "max_tokens": 64,
    "temperature": 0.9
  }'
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

