### PR TITLE
[Bugfix] Fix 
  DeepSeek V4 ImportError when cutlass/quack versions are           
  incompatible

### DIFF
--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -471,6 +471,20 @@ def has_fbgemm_gpu() -> bool:
     return _has_module("fbgemm_gpu")
 
 
+@cache
 def has_cutedsl() -> bool:
-    """Whether the optional `cutelass` package is available."""
-    return _has_module("cutlass")
+    """Whether the optional CuteDSL packages (cutlass + quack) are available
+    and mutually compatible.
+
+    Uses a real import attempt rather than a spec lookup so that version
+    incompatibilities between ``cutlass`` and ``quack`` (e.g. a missing
+    ``Arch`` symbol in ``cutlass.base_dsl``) are caught here and the caller
+    can fall back to the Triton path gracefully.
+    """
+    try:
+        import cutlass  # noqa: F401
+        import quack.compile_utils  # noqa: F401
+
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
  ## What                                                           
                                                                    
  has_cutedsl() in vllm/utils/import_utils.py used                  
  importlib.util.find_spec("cutlass") which only checks whether the 
  module exists on disk, not whether it imports successfully. When
  quack is incompatible with the installed cutlass build (e.g.
  Arch removed from cutlass.base_dsl), has_cutedsl() returns
  True, causing the lazy import of fused_indexer_q_cutedsl to crash
  at runtime with:                                                  
   
      ImportError: cannot import name 'Arch' from 'cutlass.base_dsl'
                                                                  
  ## Fix

  Replace the find_spec check with a real import attempt of both
  cutlass and quack.compile_utils. Any exception returns False,
  letting callers in fused_indexer_q.py and cache_utils.py fall     
  back to the existing Triton path. Added @cache to avoid repeated
  import overhead across call sites.                                
                                                                    
  ## Why this is not a duplicate
                                                                    
  Searched open PRs for has_cutedsl, cutlass base_dsl Arch, and   
  quack importerror deepseek. No existing PR addresses this.

  ## Tests

  The CUDA kernel tests                                             
  (tests/kernels/test_fused_indexer_q_rope_quant.py)
  require a GPU and were not run locally. Logic was verified via    
  simulation:                                                     

  - cutlass not installed -> False
  - cutlass installed, quack incompatible (ImportError on Arch) ->
  False                                                             
  - Both installed and compatible -> True
                                                                    
  The existing tests mock fused_indexer_q.has_cutedsl directly and
  are
  unaffected by this change.

  ## AI assistance

  This fix was developed with Claude Code assistance. All changed   
  lines
  reviewed and understood by the submitter.                         
                                                                  
  Fixes #43141
  EOF
