### PR TITLE
fix: route Kimi forced tools through native parser

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -565,6 +565,10 @@ class TestAdjustRequest:
         structural_tag_json = result.structured_outputs.structural_tag
         assert SECTION_BEGIN in structural_tag_json
         assert "functions.calculate" in structural_tag_json
+        # Auto free-form text must exclude <|tool_call_begin|> so the model
+        # cannot emit a bare tool-call marker outside the section.
+        auto_format = json.loads(structural_tag_json)["format"]
+        assert TOOL_BEGIN in auto_format["excludes"]
 
     @pytest.mark.parametrize(
         "enable_in_reasoning,thinking,expected_reasoning_prefix",

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -605,6 +605,63 @@ class TestAdjustRequest:
             expected_reasoning_prefix
         )
 
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "required",
+            {"type": "function", "function": {"name": "calculate"}},
+        ],
+    )
+    @pytest.mark.parametrize(
+        "enable_in_reasoning,thinking",
+        [(False, True), (True, True), (True, False), (False, False)],
+    )
+    def test_forced_choice_grammar_from_tool_parser_couples_to_prefix(
+        self, monkeypatch, parser, tool_choice, enable_in_reasoning, thinking
+    ):
+        # Parser-owned grammar is claimed (reasoning_ended=True engine side) iff
+        # the structural tag has NO reasoning prefix. With no prefix the engine
+        # would otherwise defer the bitmask during reasoning, so the forced tool
+        # would not be enforced from token 0. With a prefix (reasoning on),
+        # enable_in_reasoning drives the grammar from token 0 instead, and the
+        # flag is left unset so the reasoning parser can still extract reasoning
+        # (setting it would suppress extraction and leak </think> into content).
+        monkeypatch.setattr(
+            "vllm.tool_parsers.kimi_k2_tool_parser."
+            "get_enable_structured_outputs_in_reasoning",
+            lambda: enable_in_reasoning,
+        )
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice=tool_choice,
+            chat_template_kwargs={"thinking": thinking},
+        )
+
+        result = parser.adjust_request(request)
+
+        has_prefix = _has_reasoning_prefix(_structural_tag_format(result))
+        expected_gftp = not (enable_in_reasoning and thinking)
+        assert has_prefix is (enable_in_reasoning and thinking)
+        assert result._grammar_from_tool_parser is expected_gftp
+        # The invariant: parser-owned grammar iff no reasoning prefix.
+        assert result._grammar_from_tool_parser is (not has_prefix)
+
+    def test_grammar_from_tool_parser_not_set_without_structural_tag(self, parser):
+        # tool_choice="none" takes the base adjust_request path and must not
+        # claim parser-owned grammar (the engine keeps its reasoning gate).
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice="none",
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result._grammar_from_tool_parser is False
+
     def test_structural_tag_reasoning_prefix_ignores_include_reasoning_visibility(
         self, monkeypatch, parser
     ):

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -14,8 +14,10 @@ from tests.tool_parsers.utils import (
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.kimi_k2_tool_parser import KimiK2ToolParser
+from vllm.tool_parsers.structural_tag_registry import get_kimi_k2_structural_tag
 
 MODEL = "moonshotai/Kimi-K2-Instruct"
 
@@ -43,6 +45,39 @@ def _tool(tool_id: str, args: str) -> str:
 
 def _wrap(*tool_strs: str) -> str:
     return SECTION_BEGIN + "".join(tool_strs) + SECTION_END
+
+
+def _calculator_tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "Evaluate a mathematical expression",
+            "parameters": {
+                "type": "object",
+                "properties": {"expression": {"type": "string"}},
+                "required": ["expression"],
+            },
+        },
+    }
+
+
+def _structural_tag_format(request: ChatCompletionRequest) -> dict:
+    assert request.structured_outputs is not None
+    assert request.structured_outputs.structural_tag is not None
+    return json.loads(request.structured_outputs.structural_tag)["format"]
+
+
+def _has_reasoning_prefix(format_: dict) -> bool:
+    elements = format_.get("elements", [])
+    if not elements:
+        return False
+    first = elements[0]
+    return (
+        first.get("type") == "tag"
+        and first.get("begin") == ""
+        and first.get("end") == "</think>"
+    )
 
 
 class TestExtractToolCalls:
@@ -459,6 +494,206 @@ class TestStreamingEdgeCases:
 
 
 class TestAdjustRequest:
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "required",
+            {"type": "function", "function": {"name": "calculate"}},
+        ],
+    )
+    def test_forced_choices_use_kimi_structural_tag(self, parser, tool_choice):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice=tool_choice,
+        )
+
+        result = parser.adjust_request(request)
+
+        assert KimiK2ToolParser.supports_required_and_named is False
+        assert result.response_format is None
+        assert result.skip_special_tokens is False
+        assert result.structured_outputs is not None
+
+        structural_tag = json.loads(result.structured_outputs.structural_tag)
+        structural_tag_json = json.dumps(structural_tag)
+        assert SECTION_BEGIN in structural_tag_json
+        assert "functions.calculate" in structural_tag_json
+        assert ARG_BEGIN in structural_tag_json
+
+    def test_forced_choice_replaces_existing_structured_output_constraint(self, parser):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice="required",
+        )
+        request.structured_outputs = StructuredOutputsParams(
+            json={"type": "object"},
+            disable_additional_properties=True,
+            whitespace_pattern=r"\s*",
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.structured_outputs is not None
+        assert result.structured_outputs.json is None
+        assert result.structured_outputs.structural_tag is not None
+        assert result.structured_outputs.disable_additional_properties is True
+        assert result.structured_outputs.whitespace_pattern == r"\s*"
+
+    def test_auto_strict_tool_calling_uses_kimi_structural_tag(
+        self, monkeypatch, parser
+    ):
+        monkeypatch.setattr(
+            "vllm.tool_parsers.abstract_tool_parser.VLLM_ENFORCE_STRICT_TOOL_CALLING",
+            True,
+        )
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice="auto",
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.skip_special_tokens is False
+        assert result.structured_outputs is not None
+        assert result.structured_outputs.structural_tag is not None
+        structural_tag_json = result.structured_outputs.structural_tag
+        assert SECTION_BEGIN in structural_tag_json
+        assert "functions.calculate" in structural_tag_json
+
+    @pytest.mark.parametrize(
+        "enable_in_reasoning,thinking,expected_reasoning_prefix",
+        [
+            (False, True, False),
+            (True, True, True),
+            (True, False, False),
+        ],
+    )
+    def test_structural_tag_reasoning_prefix_follows_bitmask_phase(
+        self,
+        monkeypatch,
+        parser,
+        enable_in_reasoning,
+        thinking,
+        expected_reasoning_prefix,
+    ):
+        monkeypatch.setattr(
+            "vllm.tool_parsers.kimi_k2_tool_parser."
+            "get_enable_structured_outputs_in_reasoning",
+            lambda: enable_in_reasoning,
+        )
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice="required",
+            chat_template_kwargs={"thinking": thinking},
+        )
+
+        result = parser.adjust_request(request)
+
+        assert _has_reasoning_prefix(_structural_tag_format(result)) is (
+            expected_reasoning_prefix
+        )
+
+    def test_structural_tag_reasoning_prefix_ignores_include_reasoning_visibility(
+        self, monkeypatch, parser
+    ):
+        monkeypatch.setattr(
+            "vllm.tool_parsers.kimi_k2_tool_parser."
+            "get_enable_structured_outputs_in_reasoning",
+            lambda: True,
+        )
+        formats = []
+        for include_reasoning in (True, False):
+            request = ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "What is 2 + 2?"}],
+                tools=[_calculator_tool()],
+                tool_choice="required",
+                include_reasoning=include_reasoning,
+                chat_template_kwargs={"thinking": True},
+            )
+
+            result = parser.adjust_request(request)
+            format_ = _structural_tag_format(result)
+
+            assert _has_reasoning_prefix(format_) is True
+            formats.append(format_)
+
+        assert formats[0] == formats[1]
+
+    def test_structural_tag_accepts_native_whitespace(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice="required",
+        )
+        assert request.tools is not None
+
+        tag = get_kimi_k2_structural_tag(request.tools, "required", False)
+        structural_tag_json = json.dumps(tag.model_dump())
+
+        assert TOOL_BEGIN in structural_tag_json
+        assert r"\\s*" in structural_tag_json
+        assert "functions.calculate:" in structural_tag_json
+        assert ARG_BEGIN in structural_tag_json
+
+    def test_structural_tag_strict_false_disables_argument_guidance(self):
+        tool = _calculator_tool()
+        tool["function"]["strict"] = False
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[tool],
+            tool_choice="required",
+        )
+        assert request.tools is not None
+
+        tag = get_kimi_k2_structural_tag(request.tools, "required", False)
+        structural_tag_json = json.dumps(tag.model_dump())
+
+        assert '"json_schema": true' in structural_tag_json
+
+    def test_structural_tag_rejects_xgrammar_unsupported_schema(self):
+        tool = _calculator_tool()
+        tool["function"]["parameters"] = {
+            "type": "object",
+            "patternProperties": {"^x-": {"type": "string"}},
+        }
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Call the tool"}],
+            tools=[tool],
+            tool_choice="required",
+        )
+        assert request.tools is not None
+
+        with pytest.raises(ValueError, match="not supported by xgrammar"):
+            get_kimi_k2_structural_tag(request.tools, "required", False)
+
+    def test_required_structural_tag_requires_tools(self):
+        with pytest.raises(ValueError, match="at least one tool"):
+            get_kimi_k2_structural_tag([], "required", False)
+
+    def test_structural_tag_rejects_unknown_tool_choice(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "What is 2 + 2?"}],
+            tools=[_calculator_tool()],
+            tool_choice="required",
+        )
+        assert request.tools is not None
+
+        with pytest.raises(ValueError, match="Unsupported Kimi K2 tool choice"):
+            get_kimi_k2_structural_tag(request.tools, "invalid", False)  # type: ignore[arg-type]
+
     def test_sets_skip_special_tokens_false(self, parser):
         request = MagicMock(spec=ChatCompletionRequest)
         request.tools = [{"type": "function", "function": {"name": "test"}}]

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from collections.abc import Sequence
 
 import regex as re
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import (
@@ -18,10 +20,15 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
+)
+from vllm.tool_parsers.structural_tag_registry import (
+    get_enable_structured_outputs_in_reasoning,
+    get_model_structural_tag,
 )
 from vllm.tool_parsers.utils import partial_tag_overlap
 
@@ -29,6 +36,8 @@ logger = init_logger(__name__)
 
 
 class KimiK2ToolParser(ToolParser):
+    supports_required_and_named = False
+
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)
 
@@ -63,12 +72,57 @@ class KimiK2ToolParser(ToolParser):
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
-        request = super().adjust_request(request)
+        structure_tag = None
+        chat_request = None
+        if (
+            isinstance(request, ChatCompletionRequest)
+            and request.tools
+            and (
+                request.tool_choice == "required"
+                or isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
+            )
+        ):
+            chat_request = request
+            structure_tag = self.get_structural_tag(chat_request)
+
+        if structure_tag is None:
+            request = super().adjust_request(request)
+        else:
+            structural_tag = json.dumps(structure_tag.model_dump())
+            assert chat_request is not None
+            if chat_request.structured_outputs is not None:
+                chat_request.structured_outputs = StructuredOutputsParams(
+                    structural_tag=structural_tag,
+                    disable_any_whitespace=(
+                        chat_request.structured_outputs.disable_any_whitespace
+                    ),
+                    disable_additional_properties=(
+                        chat_request.structured_outputs.disable_additional_properties
+                    ),
+                    whitespace_pattern=chat_request.structured_outputs.whitespace_pattern,
+                )
+            else:
+                chat_request.structured_outputs = StructuredOutputsParams(
+                    structural_tag=structural_tag
+                )
+            chat_request.response_format = None
+            request = chat_request
+
         if request.tools and request.tool_choice != "none":
             # Ensure special-token markers appear as literal text in
             # current_text so we can do pure text-based parsing.
             request.skip_special_tokens = False
         return request
+
+    def get_structural_tag(self, request: ChatCompletionRequest):
+        chat_template_kwargs = request.chat_template_kwargs or {}
+        thinking = bool(chat_template_kwargs.get("thinking", True))
+        return get_model_structural_tag(
+            model="kimi_k2",
+            tools=request.tools,
+            tool_choice=request.tool_choice,
+            reasoning=(get_enable_structured_outputs_in_reasoning() and thinking),
+        )
 
     def extract_tool_calls(
         self,

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -117,12 +117,24 @@ class KimiK2ToolParser(ToolParser):
     def get_structural_tag(self, request: ChatCompletionRequest):
         chat_template_kwargs = request.chat_template_kwargs or {}
         thinking = bool(chat_template_kwargs.get("thinking", True))
-        return get_model_structural_tag(
+        reasoning = get_enable_structured_outputs_in_reasoning() and thinking
+        structural_tag = get_model_structural_tag(
             model="kimi_k2",
             tools=request.tools,
             tool_choice=request.tool_choice,
-            reasoning=(get_enable_structured_outputs_in_reasoning() and thinking),
+            reasoning=reasoning,
         )
+        # Parser-owned grammar from the first generated token, but only when the
+        # tag has no reasoning prefix (``reasoning`` is False). In that case the
+        # engine would otherwise defer the bitmask during reasoning and the
+        # forced tool would not be enforced from token 0, so we set
+        # ``reasoning_ended=True`` here. When the tag *does* carry a
+        # ``<think>...</think>`` prefix (reasoning on), ``enable_in_reasoning``
+        # already drives the grammar from token 0; leaving this flag unset lets
+        # the reasoning parser extract the reasoning content (setting it would
+        # suppress extraction and leak ``</think>`` into ``content``).
+        request._grammar_from_tool_parser = not reasoning
+        return structural_tag
 
     def extract_tool_calls(
         self,

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -323,7 +323,7 @@ def get_kimi_k2_structural_tag(
                     end=section_end,
                 )
             ],
-            excludes=think_exclude_tokens,
+            excludes=[*think_exclude_tokens, tool_call_begin],
         )
 
     elif tool_choice == "forced":

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -13,6 +13,7 @@ from xgrammar.structural_tag import (
     AnyTextFormat,
     ConstStringFormat,
     JSONSchemaFormat,
+    RegexFormat,
     SequenceFormat,
     TagFormat,
     TagsWithSeparatorFormat,
@@ -22,6 +23,9 @@ from xgrammar.structural_tag import (
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
+)
+from vllm.v1.structured_output.backend_xgrammar import (
+    has_xgrammar_unsupported_json_features,
 )
 
 SimplifiedToolChoice = Literal["auto", "required", "forced"]
@@ -107,6 +111,19 @@ def _get_function_parameters(function: Any) -> dict[str, Any] | bool:
     if function.parameters is None:
         return True
     return function.parameters
+
+
+def _get_xgrammar_supported_function_parameters(function: Any) -> dict[str, Any] | bool:
+    """Return function parameters after applying xgrammar compatibility checks."""
+
+    parameters = _get_function_parameters(function)
+    if isinstance(parameters, dict) and has_xgrammar_unsupported_json_features(
+        parameters
+    ):
+        raise ValueError(
+            "The provided JSON schema contains features not supported by xgrammar."
+        )
+    return parameters
 
 
 _enable_structured_outputs_in_reasoning: bool = False
@@ -235,6 +252,111 @@ def get_deepseek_v4_structural_tag(
                 ConstStringFormat(value=function_calls_end),
             ]
         )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=think_tag_end)
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+
+
+@register_model_structural_tag("kimi_k2")
+def get_kimi_k2_structural_tag(
+    tools: list[ChatCompletionToolsParam],
+    tool_choice: SimplifiedToolChoice,
+    reasoning: bool,
+) -> StructuralTag:
+    """Build Kimi K2 native tool-call structural tags."""
+
+    section_begin = "<|tool_calls_section_begin|>"
+    section_end = "<|tool_calls_section_end|>"
+    tool_call_begin = "<|tool_call_begin|>"
+    argument_begin = "<|tool_call_argument_begin|>"
+    tool_call_end = "<|tool_call_end|>"
+    think_tag_end = "</think>"
+    think_exclude_tokens = ["<think>", "</think>"]
+    whitespace = RegexFormat(pattern=r"\s*")
+
+    tags = []
+    for tool in tools:
+        function = tool.function
+        tags.append(
+            TagFormat(
+                begin=tool_call_begin,
+                content=SequenceFormat(
+                    elements=[
+                        whitespace,
+                        ConstStringFormat(value=f"functions.{function.name}:"),
+                        RegexFormat(pattern=r"\d+"),
+                        whitespace,
+                        ConstStringFormat(value=argument_begin),
+                        whitespace,
+                        JSONSchemaFormat(
+                            json_schema=_get_xgrammar_supported_function_parameters(
+                                function
+                            ),
+                        ),
+                        whitespace,
+                    ]
+                ),
+                end=tool_call_end,
+            )
+        )
+
+    if tool_choice == "auto":
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[section_begin],
+            tags=[
+                TagFormat(
+                    begin=section_begin,
+                    content=SequenceFormat(
+                        elements=[
+                            whitespace,
+                            TagsWithSeparatorFormat(
+                                tags=tags,
+                                separator="",
+                                at_least_one=True,
+                            ),
+                            whitespace,
+                        ]
+                    ),
+                    end=section_end,
+                )
+            ],
+            excludes=think_exclude_tokens,
+        )
+
+    elif tool_choice == "forced":
+        if len(tags) != 1:
+            raise ValueError("Forced tool choice must resolve to exactly one tool.")
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=section_begin),
+                whitespace,
+                tags[0],
+                whitespace,
+                ConstStringFormat(value=section_end),
+            ]
+        )
+
+    elif tool_choice == "required":
+        if not tags:
+            raise ValueError("Required tool choice must resolve to at least one tool.")
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=section_begin),
+                whitespace,
+                TagsWithSeparatorFormat(
+                    tags=tags,
+                    separator="",
+                    at_least_one=True,
+                ),
+                whitespace,
+                ConstStringFormat(value=section_end),
+            ]
+        )
+    else:
+        raise ValueError(f"Unsupported Kimi K2 tool choice: {tool_choice}")
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)


### PR DESCRIPTION
## Purpose

Fix Kimi K2/K2.6 forced-tool routing for Chat Completions requests that use the native `kimi_k2` tool parser with `tool_choice="required"` or a named function `tool_choice`.

Kimi emits native marker-formatted tool calls, not the generic JSON tool-call array used by vLLM's fallback required/named path. This PR makes `KimiK2ToolParser` opt out of that generic helper and installs a Kimi-native structural tag for required/named requests, so constrained generation and parser extraction use the same marker format.

Duplicate-work check: open PR searches for `Kimi required named tool_choice structural tag`, `Kimi forced tools native parser`, `Kimi supports_required_and_named false`, `Kimi tool_choice required native markers`, and `tool_choice required Kimi K2 parser` found one partial overlap: #44934. That PR only sets `supports_required_and_named = False`; this PR also constrains required/named generation to Kimi's native structural tag. Related required-tool PRs such as #35936 and #44447 target other parser formats.

This PR does not change `tool_choice="none"`. No docs update is needed. AI assistance was used; I reviewed the changed code and test results.

## Test Plan

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py::TestAdjustRequest -q
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -q
pre-commit run --files \
  vllm/tool_parsers/kimi_k2_tool_parser.py \
  vllm/tool_parsers/structural_tag_registry.py \
  tests/tool_parsers/test_kimi_k2_tool_parser.py
git diff --check origin/main...HEAD
```

## Test Result

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py::TestAdjustRequest -q
# 16 passed, 2 warnings in 2.60s
```

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -q
# 63 passed, 2 warnings in 6.23s
```

```bash
pre-commit run --files \
  vllm/tool_parsers/kimi_k2_tool_parser.py \
  vllm/tool_parsers/structural_tag_registry.py \
  tests/tool_parsers/test_kimi_k2_tool_parser.py
# Passed
```

```bash
git diff --check origin/main...HEAD
# Passed
```

Current PR checks are green: GitHub pre-commit passed, Buildkite PR CI passed, and ReadTheDocs passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable.
</details>
