### PR TITLE
Fix int32 overflow in csrc/layernorm_kernels.cu indexing

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -24,9 +24,10 @@ __global__ void rms_norm_kernel(
   __shared__ float s_variance;
   float variance = 0.0f;
   const scalar_t* input_row;
+  const int64_t row_idx = static_cast<int64_t>(blockIdx.x);
   if constexpr (NUM_DIMS == 2) {
     // 2D for layernorm normal case [batch_size, hidden]
-    input_row = input + blockIdx.x * input_stride_d2;
+    input_row = input + row_idx * input_stride_d2;
   } else if constexpr (NUM_DIMS == 3) {
     // 3D for q/k norm [batch_size, num_heads, head_size]
     int batch_idx = blockIdx.x / input_shape_d2;
@@ -66,7 +67,7 @@ __global__ void rms_norm_kernel(
   }
   __syncthreads();
 
-  scalar_t* out_row = out + blockIdx.x * hidden_size;
+  scalar_t* out_row = out + row_idx * hidden_size;
   auto* v_in = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(input_row);
   auto* v_w = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(weight);
   auto* v_out = reinterpret_cast<vec_n_t<scalar_t, VEC_SIZE>*>(out_row);
@@ -101,6 +102,9 @@ fused_add_rms_norm_kernel(
 
   const int vec_hidden_size = hidden_size / width;
   const int64_t vec_input_stride = input_stride / width;
+  const int64_t row_idx = static_cast<int64_t>(blockIdx.x);
+  const int64_t residual_offset = row_idx * vec_hidden_size;
+  const int64_t input_offset = row_idx * vec_input_stride;
   __shared__ float s_variance;
   float variance = 0.0f;
   /* These and the argument pointers are all declared `restrict` as they are
@@ -114,8 +118,8 @@ fused_add_rms_norm_kernel(
       reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    int64_t id = residual_offset + idx;
+    int64_t strided_id = input_offset + idx;
     _f16Vec<scalar_t, width> temp = input_v[strided_id];
     temp += residual_v[id];
     variance += temp.sum_squares();
@@ -132,8 +136,8 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    int64_t id = residual_offset + idx;
+    int64_t strided_id = input_offset + idx;
     _f16Vec<scalar_t, width> temp = residual_v[id];
     temp *= s_variance;
     temp *= weight_v[idx];
@@ -154,13 +158,16 @@ fused_add_rms_norm_kernel(
     const float epsilon, const int num_tokens, const int hidden_size) {
   __shared__ float s_variance;
   float variance = 0.0f;
+  const int64_t row_idx = static_cast<int64_t>(blockIdx.x);
+  const int64_t input_offset = row_idx * input_stride;
+  const int64_t residual_offset = row_idx * hidden_size;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * hidden_size + idx];
+    scalar_t z = input[input_offset + idx];
+    z += residual[residual_offset + idx];
     float x = (float)z;
     variance += x * x;
-    residual[blockIdx.x * hidden_size + idx] = z;
+    residual[residual_offset + idx] = z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -173,9 +180,8 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * hidden_size + idx];
-    input[blockIdx.x * input_stride + idx] =
-        ((scalar_t)(x * s_variance)) * weight[idx];
+    float x = (float)residual[residual_offset + idx];
+    input[input_offset + idx] = ((scalar_t)(x * s_variance)) * weight[idx];
   }
 }
 

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -71,6 +71,46 @@ def test_rms_norm(
         )
 
 
+@torch.inference_mode()
+def test_rms_norm_large_num_tokens_uses_64_bit_row_offsets() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required to exercise the layernorm CUDA kernel")
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    torch.cuda.empty_cache()
+
+    hidden_size = 4096
+    num_tokens = 1048641
+    dtype = torch.float16
+    element_size = torch.empty((), dtype=dtype).element_size()
+    required_bytes = 2 * num_tokens * hidden_size * element_size
+    margin_bytes = 1 << 30
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    if free_bytes < required_bytes + margin_bytes:
+        pytest.skip(
+            "large layernorm overflow test requires "
+            f"{(required_bytes + margin_bytes) / 2**30:.1f} GiB free CUDA "
+            f"memory, found {free_bytes / 2**30:.1f} GiB"
+        )
+
+    x = torch.empty((num_tokens, hidden_size), dtype=dtype, device=device)
+    out = torch.empty_like(x)
+    weight = torch.ones(hidden_size, dtype=dtype, device=device)
+    overflow_row = num_tokens - 1
+
+    # This issue shape exceeds 2^32 elements. A 32-bit row offset wraps and
+    # leaves this row untouched, while the fixed kernel writes the expected 0s.
+    x[overflow_row].zero_()
+    out[overflow_row].fill_(float("nan"))
+
+    torch.ops._C.rms_norm(out, x, weight, 1e-6)
+    torch.cuda.synchronize(device)
+
+    expected = torch.zeros(hidden_size, dtype=dtype, device=device)
+    torch.testing.assert_close(out[overflow_row], expected, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("add_residual", ADD_RESIDUAL)


### PR DESCRIPTION
## Summary

1. Read the four kernels in `csrc/layernorm_kernels.cu` to enumerate every site that multiplies `blockIdx.x` by a per-row stride. Build a checklist before editing.
2. Apply minimal-surface casts: `auto row_offset = static_cast<int64_t>(blockIdx.x) * hidden_size;` and use `row_offset` in pointer arithmetic. Avoid changing the kernel signatures.
3. Sanity-check that the comparison loop bounds (`i < hidden_size / VEC_SIZE`) and shared-memory variables remain 32-bit - only the *row-offset multiplication* needs widening.
4. Add a test in `tests/kernels/core/test_layernorm.py` that exercises a shape over the `int32` boundary. Use `pytest.skip` with `torch.cuda.mem_get_info()` to skip when the device cannot allocate it - large memory is required to actually exercise the overflow.
5. Run `pytest tests/kernels/core/test_layernorm.py -x` locally; document the test command and a brief description of the host capacity needed in the PR description.

AI was used for assistance.
