### PR TITLE
Fix int32 overflow in csrc/activation_kernels.cu indexing

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -34,9 +34,11 @@ __global__ void act_and_mul_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., 2, d]
     const int d) {
-  const scalar_t* x_ptr = input + blockIdx.x * 2 * d;
+  const int64_t row_input = static_cast<int64_t>(blockIdx.x) * 2 * d;
+  const int64_t row_output = static_cast<int64_t>(blockIdx.x) * d;
+  const scalar_t* x_ptr = input + row_input;
   const scalar_t* y_ptr = x_ptr + d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  scalar_t* out_ptr = out + row_output;
 
   if constexpr (use_vec) {
     using cuda_t = typename CUDATypeConverter<scalar_t>::Type;
@@ -256,9 +258,11 @@ template <typename scalar_t, typename packed_t,
 __global__ void act_and_mul_kernel_with_param(
     scalar_t* __restrict__ out, const scalar_t* __restrict__ input, const int d,
     const float param) {
-  const scalar_t* x_ptr = input + blockIdx.x * 2 * d;
+  const int64_t row_input = static_cast<int64_t>(blockIdx.x) * 2 * d;
+  const int64_t row_output = static_cast<int64_t>(blockIdx.x) * d;
+  const scalar_t* x_ptr = input + row_input;
   const scalar_t* y_ptr = x_ptr + d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  scalar_t* out_ptr = out + row_output;
 
   if constexpr (use_vec) {
     using cuda_t = typename CUDATypeConverter<scalar_t>::Type;
@@ -460,8 +464,9 @@ __global__ void activation_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., d]
     const int d) {
-  const scalar_t* in_ptr = input + blockIdx.x * d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  const int64_t row_offset = static_cast<int64_t>(blockIdx.x) * d;
+  const scalar_t* in_ptr = input + row_offset;
+  scalar_t* out_ptr = out + row_offset;
 
   if constexpr (use_vec) {
     // Fast path: 128-bit/256-bit vectorized loop

--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -27,6 +27,7 @@ NUM_TOKENS = [7, 83, 2048]  # Arbitrary values for testing
 D = [512, 13824]  # Arbitrary values for testing
 SEEDS = [0]
 CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)]
+INT32_MAX = torch.iinfo(torch.int32).max
 
 
 @pytest.mark.parametrize(
@@ -112,6 +113,52 @@ def test_act_and_mul(
         opcheck(fn, (out, x, layer.alpha, layer.limit))
     elif activation != "swiglustep_and_mul":
         opcheck(fn, (out, x))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")
+@torch.inference_mode()
+def test_silu_and_mul_large_row_offset_over_int32(default_vllm_config) -> None:
+    num_tokens = 149910
+    d = 14336
+    input_cols = 2 * d
+    dtype = torch.float16
+    device = torch.device("cuda:0")
+
+    assert num_tokens * input_cols == 4_298_219_520
+    assert num_tokens * input_cols > INT32_MAX
+
+    element_size = torch.empty((), dtype=dtype).element_size()
+    required_bytes = num_tokens * (input_cols + d) * element_size
+    reserve_bytes = 1 << 30
+
+    torch.cuda.set_device(device)
+    torch.cuda.empty_cache()
+    free_bytes, _ = torch.cuda.mem_get_info()
+    if free_bytes < required_bytes + reserve_bytes:
+        pytest.skip(
+            "Not enough free CUDA memory for large activation overflow test: "
+            f"need {(required_bytes + reserve_bytes) / 2**30:.1f} GiB, "
+            f"have {free_bytes / 2**30:.1f} GiB"
+        )
+
+    x = torch.empty((num_tokens, input_cols), dtype=dtype, device=device)
+    out = torch.empty((num_tokens, d), dtype=dtype, device=device)
+
+    idx = torch.arange(d, dtype=torch.float32, device=device)
+    gate = ((idx % 251) - 125) / 32
+    up = ((idx % 127) - 63) / 16
+    x[-1, :d].copy_(gate.to(dtype))
+    x[-1, d:].copy_(up.to(dtype))
+
+    # The old 32-bit row offset for the final token wrapped into this window.
+    wrapped_offset = ((num_tokens - 1) * input_cols) & 0xFFFFFFFF
+    assert wrapped_offset != (num_tokens - 1) * input_cols
+    x.flatten()[wrapped_offset : wrapped_offset + 2 * d].fill_(0.25)
+
+    torch.ops._C.silu_and_mul(out, x)
+
+    ref_out = torch.nn.functional.silu(x[-1, :d]) * x[-1, d:]
+    torch.testing.assert_close(out[-1], ref_out, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

1. Read `csrc/activation_kernels.cu` end-to-end and enumerate every multiplication of `blockIdx.x` by `d` (or any per-row stride). Build the patch list before editing.
2. For each site, introduce a local `int64_t row_x = static_cast<int64_t>(blockIdx.x) * 2 * d;` (and `row_out = static_cast<int64_t>(blockIdx.x) * d;`) and use those for the pointer arithmetic. Keep the loop indices that walk inside a row at 32-bit - only the row offset needs widening.
3. Mirror the test pattern from plan 022 in `tests/kernels/core/test_activation.py`: build a shape that crosses the `int32` boundary, gate it on `torch.cuda.mem_get_info()` so the skip path keeps CI green on small-memory runners.
4. Run `pytest tests/kernels/core/test_activation.py -x` locally to confirm no small-case regression.

AI was used for assistance.
