### PR TITLE
Mark chat_template_kwargs as not-yet-wired for the Responses API in docs

### DIFF
--- a/docs/serving/openai_compatible_server.md
+++ b/docs/serving/openai_compatible_server.md
@@ -252,6 +252,9 @@ Code example: [examples/online_serving/openai_responses_client_with_tools.py](..
 
 The following extra parameters in the request object are supported:
 
+!!! note
+    `chat_template_kwargs` is accepted on the Responses API for forward compatibility, but reasoning/thinking kwargs such as `enable_thinking=False` may not take effect until [#37739](https://github.com/vllm-project/vllm/pull/37739) is complete; see [#42962](https://github.com/vllm-project/vllm/issues/42962). Use the [Chat API](#chat-api) when those kwargs must be honored.
+
 ??? code
 
     ```python

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -208,6 +208,17 @@ class ResponsesRequest(OpenAIBaseModel):
         default=None,
         description=("Additional kwargs to pass to the HF processor."),
     )
+    chat_template_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional keyword args to pass to the template renderer. "
+            "Status: accepted on the Responses API for forward compatibility, "
+            "but full propagation through chat-template and reasoning paths is "
+            "tracked in vLLM issue #42962 and PR #37739. Some kwargs, such as "
+            "enable_thinking=False, may not yet take effect on this endpoint; "
+            "use the Chat API when those kwargs must be honored."
+        ),
+    )
     priority: int = Field(
         default=0,
         description=(


### PR DESCRIPTION
## Summary

1. Read `vllm/entrypoints/openai/responses/protocol.py` around the `--8<-- [start:responses-extra-params]` block and confirm the current `description=` text for `chat_template_kwargs`.
2. Read `docs/serving/online_serving/openai_compatible_server.md` to see what surrounding prose exists for the Responses-API "Extra parameters" subsection.
3. Update the field description in `protocol.py` to add a "Status:" sentence: that the field is reserved on the Responses API and full kwarg propagation is tracked in #37739 / #42962; specifically that `enable_thinking=False` is not yet honored on this endpoint and callers needing it should fall back to `chat.completions`.
4. If the docs file has any non-generated prose asserting feature parity with chat.completions, add a single matching caveat sentence.
5. Build the docs locally (`mkdocs build` if `mkdocs.yml` is at the repo root) to confirm the description renders cleanly with the cross-reference links.

AI was used for assistance.
