### PR TITLE
[Bug] Fix fused_qk_norm_rope 32-bit QKV offset overflow

### DIFF
--- a/csrc/libtorch_stable/fused_qknorm_rope_kernel.cu
+++ b/csrc/libtorch_stable/fused_qknorm_rope_kernel.cu
@@ -16,6 +16,7 @@
 
 #include <cmath>
 #include <cuda_runtime.h>
+#include <limits>
 #include <type_traits>
 
 #include "torch_utils.h"
@@ -111,7 +112,7 @@ __global__ void fusedQKNormRopeKernel(
     void const* k_weight_void,       // RMSNorm weights for key
     void const* cos_sin_cache_void,  // Pre-computed cos/sin cache
     int64_t const* position_ids,     // Position IDs for RoPE
-    int const num_tokens,            // Number of tokens
+    int64_t const num_tokens,        // Number of tokens
     int const rotary_dim             // Dimension for RoPE
 ) {
 #if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
@@ -146,14 +147,15 @@ __global__ void fusedQKNormRopeKernel(
 
     // Calculate global warp index to determine which head/token this warp
     // processes
-    int const globalWarpIdx = blockIdx.x * warpsPerBlock + warpId;
+    int64_t const globalWarpIdx =
+        static_cast<int64_t>(blockIdx.x) * warpsPerBlock + warpId;
 
     // Total number of attention heads (Q and K)
     int const total_qk_heads = num_heads_q + num_heads_k;
 
     // Determine which token and head type (Q or K) this warp processes
-    int const tokenIdx = globalWarpIdx / total_qk_heads;
-    int const localHeadIdx = globalWarpIdx % total_qk_heads;
+    int64_t const tokenIdx = globalWarpIdx / total_qk_heads;
+    int const localHeadIdx = static_cast<int>(globalWarpIdx % total_qk_heads);
 
     // Skip if this warp is assigned beyond the number of tokens
     if (tokenIdx >= num_tokens) return;
@@ -177,17 +179,20 @@ __global__ void fusedQKNormRopeKernel(
         4;  // Use packed_as<uint, vecSize> to perform loading/saving.
     using vec_T = typename tensorrt_llm::common::packed_as<uint, vecSize>::type;
 
-    int offsetWarp;  // Offset for the warp
+    int64_t offsetWarp;  // Offset for the warp
     if (isQ) {
       // Q segment: token offset + head offset within Q segment
-      offsetWarp = tokenIdx * num_heads * head_dim + headIdx * head_dim;
+      offsetWarp = tokenIdx * num_heads * head_dim +
+                   static_cast<int64_t>(headIdx) * head_dim;
     } else {
       // K segment: token offset + entire Q segment + head offset within K
       // segment
-      offsetWarp = tokenIdx * num_heads * head_dim + num_heads_q * head_dim +
-                   headIdx * head_dim;
+      offsetWarp = tokenIdx * num_heads * head_dim +
+                   static_cast<int64_t>(num_heads_q) * head_dim +
+                   static_cast<int64_t>(headIdx) * head_dim;
     }
-    int offsetThread = offsetWarp + laneId * numElemsPerThread;
+    int64_t const offsetThread =
+        offsetWarp + static_cast<int64_t>(laneId) * numElemsPerThread;
 
     // Sum of squares for RMSNorm
     float sumOfSquares = 0.0f;
@@ -315,7 +320,8 @@ __global__ void fusedQKNormRopeKernelNTokenHeads(
     void* qkv_void, int const num_heads_q, int const num_heads_k,
     int const num_heads_v, float const eps, void const* q_weight_void,
     void const* k_weight_void, void const* cos_sin_cache_void,
-    int64_t const* position_ids, int const num_tokens, int const rotary_dim) {
+    int64_t const* position_ids, int64_t const num_tokens,
+    int const rotary_dim) {
 #if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
   if constexpr ((std::is_same_v<scalar_t_in, c10::BFloat16>) ||
                 std::is_same_v<scalar_t_cache, c10::BFloat16>) {
@@ -359,9 +365,10 @@ __global__ void fusedQKNormRopeKernelNTokenHeads(
     int const head_chunks_per_token =
         (total_qk_heads + HEADS_PER_WARP - 1) / HEADS_PER_WARP;
 
-    int const warp_global = blockIdx.x * warpsPerBlock + warpId;
-    int const tokenIdx = warp_global / head_chunks_per_token;
-    int const headChunk = warp_global % head_chunks_per_token;
+    int64_t const warp_global =
+        static_cast<int64_t>(blockIdx.x) * warpsPerBlock + warpId;
+    int64_t const tokenIdx = warp_global / head_chunks_per_token;
+    int const headChunk = static_cast<int>(warp_global % head_chunks_per_token);
     int const first_head = headChunk * HEADS_PER_WARP;
     int const num_heads_this_warp =
         (first_head + HEADS_PER_WARP <= total_qk_heads)
@@ -390,14 +397,17 @@ __global__ void fusedQKNormRopeKernelNTokenHeads(
       int const localHeadIdx = first_head + k;
       bool const isQ = localHeadIdx < num_heads_q;
       int const headIdx = isQ ? localHeadIdx : localHeadIdx - num_heads_q;
-      int offWarp;
+      int64_t offWarp;
       if (isQ) {
-        offWarp = tokenIdx * num_heads * head_dim + headIdx * head_dim;
+        offWarp = tokenIdx * num_heads * head_dim +
+                  static_cast<int64_t>(headIdx) * head_dim;
       } else {
-        offWarp = tokenIdx * num_heads * head_dim + num_heads_q * head_dim +
-                  headIdx * head_dim;
+        offWarp = tokenIdx * num_heads * head_dim +
+                  static_cast<int64_t>(num_heads_q) * head_dim +
+                  static_cast<int64_t>(headIdx) * head_dim;
       }
-      int const offThread = offWarp + laneId * numElemsPerThread;
+      int64_t const offThread =
+          offWarp + static_cast<int64_t>(laneId) * numElemsPerThread;
       char* smem_dst =
           this_warp_head_smem + k * qkv_tile_bytes + laneId * elemSizeBytes;
       cp_async_shared_global_ca(smem_dst,
@@ -445,14 +455,17 @@ __global__ void fusedQKNormRopeKernelNTokenHeads(
       bool const isQ = localHeadIdx < num_heads_q;
       int const headIdx = isQ ? localHeadIdx : localHeadIdx - num_heads_q;
 
-      int offsetWarp;
+      int64_t offsetWarp;
       if (isQ) {
-        offsetWarp = tokenIdx * num_heads * head_dim + headIdx * head_dim;
+        offsetWarp = tokenIdx * num_heads * head_dim +
+                     static_cast<int64_t>(headIdx) * head_dim;
       } else {
-        offsetWarp = tokenIdx * num_heads * head_dim + num_heads_q * head_dim +
-                     headIdx * head_dim;
+        offsetWarp = tokenIdx * num_heads * head_dim +
+                     static_cast<int64_t>(num_heads_q) * head_dim +
+                     static_cast<int64_t>(headIdx) * head_dim;
       }
-      int const offsetThread = offsetWarp + laneId * numElemsPerThread;
+      int64_t const offsetThread =
+          offsetWarp + static_cast<int64_t>(laneId) * numElemsPerThread;
 
       // === Part 1: QK Norm (read from smem; group 0 already done). ===
       float sumOfSquares = 0.0f;
@@ -548,7 +561,7 @@ __global__ void fusedQKNormRopeKernelNTokenHeads(
   }
 
 template <typename scalar_t_in, typename scalar_t_cache>
-void launchFusedQKNormRope(void* qkv, int const num_tokens,
+void launchFusedQKNormRope(void* qkv, int64_t const num_tokens,
                            int const num_heads_q, int const num_heads_k,
                            int const num_heads_v, int const head_dim,
                            int const rotary_dim, float const eps,
@@ -558,9 +571,12 @@ void launchFusedQKNormRope(void* qkv, int const num_tokens,
   constexpr int blockSize = 256;
   int const warpsPerBlock = blockSize / 32;
   int const totalQKHeads = num_heads_q + num_heads_k;
-  int const totalWarps = num_tokens * totalQKHeads;
-  int const gridSize = common::divUp(totalWarps, warpsPerBlock);
-  dim3 gridDim(gridSize);
+  int64_t const totalWarps = num_tokens * totalQKHeads;
+  int64_t const gridSize =
+      common::divUp(totalWarps, static_cast<int64_t>(warpsPerBlock));
+  STD_TORCH_CHECK(gridSize <= std::numeric_limits<int>::max(),
+                  "Grid size exceeds CUDA dim3 x limit: ", gridSize);
+  dim3 gridDim(static_cast<unsigned int>(gridSize));
   dim3 blockDim(blockSize);
   switch (head_dim) {
     case 64:
@@ -597,7 +613,7 @@ void launchFusedQKNormRope(void* qkv, int const num_tokens,
 // When token_heads_per_warp == 1, delegates to the 1-head baseline above.
 template <typename scalar_t_in, typename scalar_t_cache>
 void launchFusedQKNormRopeNTokenHeads(
-    void* qkv, int const num_tokens, int const num_heads_q,
+    void* qkv, int64_t const num_tokens, int const num_heads_q,
     int const num_heads_k, int const num_heads_v, int const head_dim,
     int const rotary_dim, float const eps, void const* q_weight,
     void const* k_weight, void const* cos_sin_cache, bool const interleave,
@@ -640,9 +656,12 @@ void launchFusedQKNormRopeNTokenHeads(
   // Grid: one warp per (token, head_chunk); same token → reuse cos/sin in smem.
   int const head_chunks_per_token =
       (totalQKHeads + token_heads_per_warp - 1) / token_heads_per_warp;
-  int const total_warps = num_tokens * head_chunks_per_token;
-  int const gridSize = common::divUp(total_warps, warpsPerBlock);
-  dim3 gridDim(gridSize);
+  int64_t const total_warps = num_tokens * head_chunks_per_token;
+  int64_t const gridSize =
+      common::divUp(total_warps, static_cast<int64_t>(warpsPerBlock));
+  STD_TORCH_CHECK(gridSize <= std::numeric_limits<int>::max(),
+                  "Grid size exceeds CUDA dim3 x limit: ", gridSize);
+  dim3 gridDim(static_cast<unsigned int>(gridSize));
   dim3 blockDim(blockSize);
   // Cache element size: float=4, bfloat16=2 (host-safe; kernel uses same
   // layout).
@@ -805,7 +824,7 @@ void fused_qk_norm_rope(
               using cache_scalar_t = scalar_t;
               tensorrt_llm::kernels::launchFusedQKNormRopeNTokenHeads<
                   qkv_scalar_t, cache_scalar_t>(
-                  qkv.data_ptr(), static_cast<int>(num_tokens),
+                  qkv.data_ptr(), num_tokens,
                   static_cast<int>(num_heads_q), static_cast<int>(num_heads_k),
                   static_cast<int>(num_heads_v), static_cast<int>(head_dim),
                   static_cast<int>(cos_sin_cache.size(1)),

--- a/tests/kernels/core/test_fused_qk_norm_rope.py
+++ b/tests/kernels/core/test_fused_qk_norm_rope.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 import pytest
 import torch
 
@@ -144,3 +146,109 @@ def test_fused_qk_norm_rope_matches_reference(
         atol=ATOL,
         rtol=RTOL,
     )
+
+
+@pytest.mark.optional
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="fused_qk_norm_rope custom op requires cuda and rocm platform",
+)
+@pytest.mark.skipif(
+    os.getenv("VLLM_TEST_LARGE_FUSED_QK_NORM_ROPE_OVERFLOW") != "1",
+    reason="large 4GiB fused_qk_norm_rope overflow regression is manual",
+)
+@pytest.mark.parametrize(
+    ("forced_token_heads_per_warp", "num_heads_q", "num_heads_k", "head_dim"),
+    [
+        pytest.param(1, 8, 8, 256, id="base_head_dim_256"),
+        pytest.param(4, 32, 32, 64, id="ntokenheads_head_dim_64"),
+    ],
+)
+@torch.inference_mode()
+def test_fused_qk_norm_rope_large_qkv_offsets(
+    default_vllm_config,
+    forced_token_heads_per_warp: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_dim: int,
+):
+    torch.set_default_device("cuda:0")
+
+    num_heads_v = 0
+    eps = 1e-6
+    rotary_dim = 64
+    dtype = torch.float16
+
+    row_dim = (num_heads_q + num_heads_k + num_heads_v) * head_dim
+    overflow_token = (2**31) // row_dim
+    num_tokens = overflow_token + 2
+
+    qkv_bytes = num_tokens * row_dim * torch.empty((), dtype=dtype).element_size()
+    torch.cuda.empty_cache()
+    free_bytes, _ = torch.cuda.mem_get_info()
+    if free_bytes < qkv_bytes + 2 * 1024**3:
+        pytest.skip(
+            "large fused_qk_norm_rope overflow regression needs about 6GiB "
+            f"free CUDA memory, got {free_bytes / 2**30:.2f}GiB"
+        )
+
+    probes = torch.tensor(
+        [0, overflow_token - 1, overflow_token, overflow_token + 1],
+        device="cuda",
+        dtype=torch.long,
+    )
+    qkv = torch.empty((num_tokens, row_dim), device="cuda", dtype=dtype)
+    qkv.zero_()
+    # Keep the 4GiB manual test fast while making probed rows meaningful.
+    qkv.index_copy_(
+        0,
+        probes,
+        torch.randn((probes.numel(), row_dim), device="cuda", dtype=dtype),
+    )
+
+    q_weight = torch.ones((head_dim,), device="cuda", dtype=dtype)
+    k_weight = torch.ones((head_dim,), device="cuda", dtype=dtype)
+    cos_sin_cache = torch.zeros((1, rotary_dim), device="cuda", dtype=torch.float32)
+    cos_sin_cache[:, : rotary_dim // 2] = 1.0
+    position_ids = torch.zeros((num_tokens,), device="cuda", dtype=torch.int64)
+
+    before = qkv.index_select(0, probes).clone()
+
+    def reference_rows(rows: torch.Tensor) -> torch.Tensor:
+        rows_f = rows.float()
+        q_size = num_heads_q * head_dim
+        k_size = num_heads_k * head_dim
+
+        q = rows_f[:, :q_size].view(rows.shape[0], num_heads_q, head_dim)
+        k = rows_f[:, q_size : q_size + k_size].view(
+            rows.shape[0], num_heads_k, head_dim
+        )
+        v = rows_f[:, q_size + k_size :]
+
+        q = q / torch.sqrt((q * q).mean(dim=-1, keepdim=True) + eps)
+        k = k / torch.sqrt((k * k).mean(dim=-1, keepdim=True) + eps)
+        return torch.cat(
+            [q.reshape(rows.shape[0], q_size), k.reshape(rows.shape[0], k_size), v],
+            dim=-1,
+        ).to(dtype)
+
+    expected = reference_rows(before)
+
+    torch.ops._C.fused_qk_norm_rope(
+        qkv,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        True,
+        position_ids,
+        forced_token_heads_per_warp,
+    )
+    torch.cuda.synchronize()
+
+    after = qkv.index_select(0, probes)
+    torch.testing.assert_close(after, expected, atol=3e-3, rtol=3e-3)


### PR DESCRIPTION
## Summary

- promote `fused_qk_norm_rope` per-token QKV pointer-offset arithmetic from 32-bit `int` to `int64_t`
- keep `num_tokens` 64-bit through the host launch and device kernel signatures, avoiding a silent wrapper-side truncation
- compute host warp counts in `int64_t` and guard CUDA grid x against `INT_MAX`
- add a guarded/manual large-offset regression for the `>2^31` contiguous-QKV element boundary, covering both the base kernel and the `NTokenHeads` kernel path

## Root cause

`csrc/fused_qknorm_rope_kernel.cu` computed global warp indices and QKV offsets with `int` arithmetic. For large but feasible contiguous QKV tensors, expressions like `tokenIdx * num_heads * head_dim` can exceed `INT_MAX`, causing the fused kernel to address the wrong QKV memory and potentially crash with CUDA illegal memory access.

The repro uses `row_dim = 4096`, so token `524288` starts exactly past the 32-bit signed offset boundary.

## Regression coverage

The guarded manual test is enabled with `VLLM_TEST_LARGE_FUSED_QK_NORM_ROPE_OVERFLOW=1` and checks probe rows `[0, 524287, 524288, 524289]` against an unfused RMSNorm reference.

It covers:

- base path: `forced_token_heads_per_warp=1`, `num_heads_q=8`, `num_heads_k=8`, `head_dim=256`
- `NTokenHeads` path: `forced_token_heads_per_warp=4`, `num_heads_q=32`, `num_heads_k=32`, `head_dim=64`

Both cases keep `row_dim = 4096`, exercising the same `INT_MAX` element-offset boundary.

## Related context

- #42861 fixes the same overflow class in `activation_kernels.cu` and lists `fused_qknorm_rope` as out of scope.
- #42862 tracks `layernorm_kernels.cu`; this PR is for `fused_qknorm_rope_kernel.cu`.

## Validation

Independent A100 proof rerun on 2026-05-21 using a GCP `a2-highgpu-1g` A100-SXM4-40GB VM with `CUDA_LAUNCH_BLOCKING=1`. The focused runtime proof built only `csrc/fused_qknorm_rope_kernel.cu` from each checked-out tree and registered the existing `torch.ops._C.fused_qk_norm_rope` signature; no production code was modified for validation.

Environment:

- GPU: NVIDIA A100-SXM4-40GB
- Driver: 580.126.20
- CUDA: nvcc 12.9; driver reports CUDA 13.0
- Python: 3.10.12
- PyTorch: 2.9.1+cu129

SHAs tested:

- Base: `be16785998087f80ffac08b980603241e5da16ab`
- Head: `5bef4e32accfd31d6a5985fd54c3363e5851b5c1`
- Current GitHub merge-ref: `985573f4f699a2bce9aaa015edbe65bd3b0a24d3`

Focused before/after proof:

| Case | Base expected | Base actual | Head expected | Head actual | Merge-ref expected | Merge-ref actual |
| --- | --- | --- | --- | --- | --- | --- |
| `base_head_dim_256` | fail | CUDA illegal memory access | pass | pass, max abs error `0.00048828125` | pass | pass, max abs error `0.00048828125` |
| `ntokenheads_head_dim_64` | fail | CUDA illegal memory access | pass | pass, max abs error `0.0` | pass | pass, max abs error `0.0` |

The probe rows for both large-offset cases were `[0, 524287, 524288, 524289]`, covering the signed 32-bit element-offset boundary.

Regression / no-regression checks:

- `git diff --check`: passed on head and merge-ref.
- Existing nearby test coverage: `tests/kernels/core/test_fused_qk_norm_rope.py::test_fused_qk_norm_rope_matches_reference` passed on head and merge-ref: `24 passed, 2 deselected, 3 warnings`.
- Normal-offset smoke coverage passed on head and merge-ref:
  - ordinary small offset, `head_dim=64`, base path: pass, max abs error `0.0`
  - ordinary medium offset, `head_dim=256`, base path: pass, max abs error `0.001953125`
  - ordinary medium offset, `head_dim=64`, `NTokenHeads` path: pass, max abs error `0.001953125`
- Boundary-near-overflow coverage:
  - below-boundary `head_dim=256`: base/head/merge-ref pass
  - above-boundary `head_dim=256`: base fails with CUDA illegal memory access; head and merge-ref pass
- Import sanity: `import vllm` passed on head and merge-ref in the validation environment.
- No new CUDA illegal memory access, device assert, shape mismatch, dtype mismatch, or nondeterministic crash appeared in head or merge-ref regression runs.

Notes on existing-test harness isolation:

- The source checkout was not installed as a full vLLM wheel, so the selected existing pytest run patched only vLLM platform metadata to CUDA in the harness.
- The selected existing pytest run injected a minimal `tests.kernels.utils.opcheck` shim to avoid importing unrelated custom ops absent from the focused single-op extension build; schema/autograd opcheck plus output comparison still ran.

## Current check status

- `pre-run-check` is failing before CI because the PR does not have a `ready` or `verified` label and the author has fewer than 4 merged PRs. The failing job reports: `PR must have the 'verified' or 'ready' (which also triggers tests) label or the author must have at least 4 merged PRs (found 0).`
- Read the Docs now passes at the current head.
- DCO now passes (sign-off amended 2026-07-30 with a content-identical commit; tree hash unchanged).

## AI assistance disclosure

This PR was prepared with the assistance of an AI coding tool. The repro, fix, duplicate check, and validation results were reviewed before submission.

## Current-master forward-port (2026-07-09)

Current GitHub head: `3af511295f28` (identical tree to `89876f0c`, re-signed for DCO on 2026-07-30). It forward-ports the same 64-bit offset arithmetic and guarded regression into the current `csrc/libtorch_stable/fused_qknorm_rope_kernel.cu` path. The A100 measurements above apply to predecessor head `5bef4e32accfd31d6a5985fd54c3363e5851b5c1` and its then-current merge ref, not to this exact forward-port head; no fresh A100 claim is made for `89876f0c`. The current hosted state is Read the Docs green, while project pre-commit remains skipped behind the contributor/label `pre-run-check` gate.

