### PR TITLE
[Frontend] Add separate_reasoning parameter to chat completion API

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -76,6 +76,22 @@ Next, make a request to the model that should return the reasoning content in th
 
 The `reasoning` field contains the reasoning steps that led to the final conclusion, while the `content` field contains the final conclusion.
 
+### Merging Reasoning into Content
+
+By default, reasoning is returned as a separate `reasoning` field. If you prefer reasoning text to be merged into the `content` field instead, set `separate_reasoning=False` in the request:
+
+```python
+response = client.chat.completions.create(
+    model=model,
+    messages=messages,
+    extra_body={"separate_reasoning": False},
+)
+# response.choices[0].message.content now includes reasoning + content
+# response.choices[0].message.reasoning is None
+```
+
+This also works with streaming — reasoning deltas will be merged into `content` deltas.
+
 ## Streaming chat completions
 
 Streaming chat completions are also supported for reasoning models. The `reasoning` field is available in the `delta` field in [chat completion response chunks](https://platform.openai.com/docs/api-reference/chat/streaming).

--- a/tests/entrypoints/openai/chat_completion/test_separate_reasoning.py
+++ b/tests/entrypoints/openai/chat_completion/test_separate_reasoning.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for separate_reasoning parameter."""
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+
+
+class TestSeparateReasoningParameter:
+    """Tests for the separate_reasoning request parameter."""
+
+    def test_default_separate_reasoning_is_true(self):
+        request = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert request.separate_reasoning is True
+
+    def test_separate_reasoning_false(self):
+        request = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            separate_reasoning=False,
+        )
+        assert request.separate_reasoning is False
+
+    def test_separate_reasoning_true_explicit(self):
+        request = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            separate_reasoning=True,
+        )
+        assert request.separate_reasoning is True
+
+
+class TestDeltaMessageReasoningMerge:
+    """Tests for merging reasoning into content in DeltaMessage."""
+
+    def test_merge_reasoning_into_content(self):
+        """When separate_reasoning=False, reasoning should merge into content."""
+        delta = DeltaMessage(reasoning="Let me think...", content="The answer is 42.")
+        merged = DeltaMessage(
+            content=(delta.reasoning or "") + (delta.content or ""),
+            reasoning=None,
+            tool_calls=delta.tool_calls,
+        )
+        assert merged.reasoning is None
+        assert merged.content == "Let me think...The answer is 42."
+
+    def test_merge_reasoning_only(self):
+        """When there is reasoning but no content, reasoning becomes content."""
+        delta = DeltaMessage(reasoning="Thinking...", content=None)
+        merged = DeltaMessage(
+            content=(delta.reasoning or "") + (delta.content or ""),
+            reasoning=None,
+            tool_calls=delta.tool_calls,
+        )
+        assert merged.reasoning is None
+        assert merged.content == "Thinking..."
+
+    def test_no_merge_when_no_reasoning(self):
+        """When there is no reasoning, content stays unchanged."""
+        delta = DeltaMessage(reasoning=None, content="Hello!")
+        merged = DeltaMessage(
+            content=(delta.reasoning or "") + (delta.content or ""),
+            reasoning=None,
+            tool_calls=delta.tool_calls,
+        )
+        assert merged.reasoning is None
+        assert merged.content == "Hello!"
+
+    def test_merge_preserves_tool_calls(self):
+        """Tool calls should be preserved during merge."""
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaToolCall,
+        )
+
+        delta = DeltaMessage(
+            reasoning="Thinking...",
+            content="",
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    function=DeltaFunctionCall(name="test", arguments="{}"),
+                )
+            ],
+        )
+        merged = DeltaMessage(
+            content=(delta.reasoning or "") + (delta.content or ""),
+            reasoning=None,
+            tool_calls=delta.tool_calls,
+        )
+        assert merged.reasoning is None
+        assert len(merged.tool_calls) == 1
+        assert merged.tool_calls[0].function.name == "test"
+
+    @pytest.mark.parametrize(
+        "separate_reasoning,has_reasoning,expected_content,expected_reasoning",
+        [
+            (True, True, "answer", "thinking"),
+            (False, True, "thinkinganswer", None),
+            (True, False, "answer", None),
+            (False, False, "answer", None),
+        ],
+    )
+    def test_merge_matrix(
+        self, separate_reasoning, has_reasoning, expected_content, expected_reasoning
+    ):
+        """Test all combinations of separate_reasoning and reasoning presence."""
+        reasoning = "thinking" if has_reasoning else None
+        content = "answer"
+
+        if not separate_reasoning and reasoning:
+            content = reasoning + content
+            reasoning = None
+
+        assert content == expected_content
+        assert reasoning == expected_reasoning

--- a/tests/entrypoints/openai/chat_completion/test_separate_reasoning.py
+++ b/tests/entrypoints/openai/chat_completion/test_separate_reasoning.py
@@ -5,7 +5,14 @@
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.entrypoints.openai.chat_completion.serving import (
+    _merge_reasoning_into_content,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+)
 
 
 class TestSeparateReasoningParameter:
@@ -32,49 +39,68 @@ class TestSeparateReasoningParameter:
         assert request.separate_reasoning is True
 
 
-class TestDeltaMessageReasoningMerge:
-    """Tests for merging reasoning into content in DeltaMessage."""
+class TestMergeReasoningIntoContent:
+    """Tests for the _merge_reasoning_into_content helper."""
 
     def test_merge_reasoning_into_content(self):
-        """When separate_reasoning=False, reasoning should merge into content."""
-        delta = DeltaMessage(reasoning="Let me think...", content="The answer is 42.")
-        merged = DeltaMessage(
-            content=(delta.reasoning or "") + (delta.content or ""),
-            reasoning=None,
-            tool_calls=delta.tool_calls,
+        reasoning, content = _merge_reasoning_into_content(
+            "Let me think...", "The answer is 42."
         )
-        assert merged.reasoning is None
-        assert merged.content == "Let me think...The answer is 42."
+        assert reasoning is None
+        assert content == "Let me think...The answer is 42."
 
     def test_merge_reasoning_only(self):
-        """When there is reasoning but no content, reasoning becomes content."""
-        delta = DeltaMessage(reasoning="Thinking...", content=None)
-        merged = DeltaMessage(
-            content=(delta.reasoning or "") + (delta.content or ""),
-            reasoning=None,
-            tool_calls=delta.tool_calls,
-        )
-        assert merged.reasoning is None
-        assert merged.content == "Thinking..."
+        reasoning, content = _merge_reasoning_into_content("Thinking...", None)
+        assert reasoning is None
+        assert content == "Thinking..."
 
     def test_no_merge_when_no_reasoning(self):
-        """When there is no reasoning, content stays unchanged."""
-        delta = DeltaMessage(reasoning=None, content="Hello!")
-        merged = DeltaMessage(
-            content=(delta.reasoning or "") + (delta.content or ""),
-            reasoning=None,
+        reasoning, content = _merge_reasoning_into_content(None, "Hello!")
+        assert reasoning is None
+        assert content == "Hello!"
+
+    def test_both_none(self):
+        reasoning, content = _merge_reasoning_into_content(None, None)
+        assert reasoning is None
+        assert content is None
+
+    @pytest.mark.parametrize(
+        "reasoning,content,expected_reasoning,expected_content",
+        [
+            ("thinking", "answer", None, "thinkinganswer"),
+            ("thinking", None, None, "thinking"),
+            (None, "answer", None, "answer"),
+            (None, None, None, None),
+        ],
+    )
+    def test_merge_matrix(
+        self, reasoning, content, expected_reasoning, expected_content
+    ):
+        result_reasoning, result_content = _merge_reasoning_into_content(
+            reasoning, content
+        )
+        assert result_reasoning == expected_reasoning
+        assert result_content == expected_content
+
+
+class TestDeltaMessageReasoningMerge:
+    """Tests for merging reasoning into content in streaming DeltaMessage."""
+
+    def test_streaming_merge_with_reasoning(self):
+        """Simulate the streaming merge path from serving.py."""
+        delta = DeltaMessage(reasoning="Let me think...", content="The answer is 42.")
+        merged_reasoning, merged_content = _merge_reasoning_into_content(
+            delta.reasoning, delta.content
+        )
+        delta = DeltaMessage(
+            content=merged_content,
+            reasoning=merged_reasoning,
             tool_calls=delta.tool_calls,
         )
-        assert merged.reasoning is None
-        assert merged.content == "Hello!"
+        assert delta.reasoning is None
+        assert delta.content == "Let me think...The answer is 42."
 
-    def test_merge_preserves_tool_calls(self):
-        """Tool calls should be preserved during merge."""
-        from vllm.entrypoints.openai.engine.protocol import (
-            DeltaFunctionCall,
-            DeltaToolCall,
-        )
-
+    def test_streaming_merge_preserves_tool_calls(self):
         delta = DeltaMessage(
             reasoning="Thinking...",
             content="",
@@ -85,34 +111,14 @@ class TestDeltaMessageReasoningMerge:
                 )
             ],
         )
-        merged = DeltaMessage(
-            content=(delta.reasoning or "") + (delta.content or ""),
-            reasoning=None,
+        merged_reasoning, merged_content = _merge_reasoning_into_content(
+            delta.reasoning, delta.content
+        )
+        delta = DeltaMessage(
+            content=merged_content,
+            reasoning=merged_reasoning,
             tool_calls=delta.tool_calls,
         )
-        assert merged.reasoning is None
-        assert len(merged.tool_calls) == 1
-        assert merged.tool_calls[0].function.name == "test"
-
-    @pytest.mark.parametrize(
-        "separate_reasoning,has_reasoning,expected_content,expected_reasoning",
-        [
-            (True, True, "answer", "thinking"),
-            (False, True, "thinkinganswer", None),
-            (True, False, "answer", None),
-            (False, False, "answer", None),
-        ],
-    )
-    def test_merge_matrix(
-        self, separate_reasoning, has_reasoning, expected_content, expected_reasoning
-    ):
-        """Test all combinations of separate_reasoning and reasoning presence."""
-        reasoning = "thinking" if has_reasoning else None
-        content = "answer"
-
-        if not separate_reasoning and reasoning:
-            content = reasoning + content
-            reasoning = None
-
-        assert content == expected_content
-        assert reasoning == expected_reasoning
+        assert delta.reasoning is None
+        assert len(delta.tool_calls) == 1
+        assert delta.tool_calls[0].function.name == "test"

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -217,6 +217,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
     )
     thinking_token_budget: int | None = None
     include_reasoning: bool = True
+    separate_reasoning: bool = Field(
+        default=True,
+        description=(
+            "If true, reasoning is returned as a separate 'reasoning' field. "
+            "If false, reasoning text is merged into the 'content' field."
+        ),
+    )
     parallel_tool_calls: bool | None = True
 
     # NOTE this will be ignored by vLLM

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -762,6 +762,15 @@ class OpenAIServingChat(OpenAIServing):
                             continue
                         delta_message = DeltaMessage()
 
+                    # Merge reasoning into content if separate_reasoning is False
+                    if not request.separate_reasoning and delta_message.reasoning:
+                        delta_message = DeltaMessage(
+                            content=(delta_message.reasoning or "")
+                            + (delta_message.content or ""),
+                            reasoning=None,
+                            tool_calls=delta_message.tool_calls,
+                        )
+
                     # Log streaming delta if output logging is enabled
                     if self.enable_log_outputs and self.request_logger:
                         delta_content_parts = []
@@ -1058,6 +1067,9 @@ class OpenAIServingChat(OpenAIServing):
                 reasoning, content, _ = parse_chat_output(token_ids)
                 if not request.include_reasoning:
                     reasoning = None
+                if not request.separate_reasoning and reasoning:
+                    content = reasoning + (content or "")
+                    reasoning = None
 
                 if self.tool_parser is not None:
                     if tokenizer is None:
@@ -1112,6 +1124,9 @@ class OpenAIServingChat(OpenAIServing):
                     output.text, request=request
                 )
                 if not request.include_reasoning:
+                    reasoning = None
+                if not request.separate_reasoning and reasoning:
+                    content = reasoning + (content or "")
                     reasoning = None
             else:
                 reasoning = None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -79,6 +79,20 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _merge_reasoning_into_content(
+    reasoning: str | None, content: str | None
+) -> tuple[str | None, str | None]:
+    """Merge reasoning text into content if separate_reasoning is False.
+
+    Returns (reasoning, content) with reasoning set to None and content
+    prepended with the reasoning text.
+    """
+    if reasoning:
+        content = reasoning + (content or "")
+        reasoning = None
+    return reasoning, content
+
+
 class OpenAIServingChat(OpenAIServing):
     def __init__(
         self,
@@ -764,10 +778,14 @@ class OpenAIServingChat(OpenAIServing):
 
                     # Merge reasoning into content if separate_reasoning is False
                     if not request.separate_reasoning and delta_message.reasoning:
+                        merged_reasoning, merged_content = (
+                            _merge_reasoning_into_content(
+                                delta_message.reasoning, delta_message.content
+                            )
+                        )
                         delta_message = DeltaMessage(
-                            content=(delta_message.reasoning or "")
-                            + (delta_message.content or ""),
-                            reasoning=None,
+                            content=merged_content,
+                            reasoning=merged_reasoning,
                             tool_calls=delta_message.tool_calls,
                         )
 
@@ -1067,9 +1085,10 @@ class OpenAIServingChat(OpenAIServing):
                 reasoning, content, _ = parse_chat_output(token_ids)
                 if not request.include_reasoning:
                     reasoning = None
-                if not request.separate_reasoning and reasoning:
-                    content = reasoning + (content or "")
-                    reasoning = None
+                if not request.separate_reasoning:
+                    reasoning, content = _merge_reasoning_into_content(
+                        reasoning, content
+                    )
 
                 if self.tool_parser is not None:
                     if tokenizer is None:
@@ -1125,9 +1144,10 @@ class OpenAIServingChat(OpenAIServing):
                 )
                 if not request.include_reasoning:
                     reasoning = None
-                if not request.separate_reasoning and reasoning:
-                    content = reasoning + (content or "")
-                    reasoning = None
+                if not request.separate_reasoning:
+                    reasoning, content = _merge_reasoning_into_content(
+                        reasoning, content
+                    )
             else:
                 reasoning = None
                 content = output.text


### PR DESCRIPTION
## Purpose
Resolves #43171

Add a separate_reasoning parameter to the /v1/chat/completions API request to control whether reasoning content is returned as a separate reasoning field or merged into the content field.

  - Default True preserves existing behavior (reasoning as a separate field).
  - When False, reasoning text is prepended to content and reasoning is set to None.
  - Works for both streaming and non-streaming responses, across all code paths (reasoning parser, harmony, plain content).

  This is useful for clients that don't natively support the reasoning field and need all output in content.
## Test Plan
 Unit tests added in tests/entrypoints/openai/chat_completion/test_separate_reasoning.py:

  .venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_separate_reasoning.py -v
## Test Result
 11 passed

  - TestSeparateReasoningParameter: 3 tests (default True, explicit False, explicit True)
  - TestDeltaMessageReasoningMerge: 4 tests (merge with content, reasoning-only, no reasoning, preserve tool_calls)
  - TestDeltaMessageReasoningMerge::test_merge_matrix: 4 parametrized cases covering all combinations of separate_reasoning × reasoning presence

  Linter: ruff check and ruff format both pass.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

