### PR TITLE
[Bugfix][LoRA] Skip qkvz n_slices HACK for FusedMoEWithLoRA

### DIFF
--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -604,7 +604,15 @@ class LoRAModelManager:
                 subloras: list[LoRALayerWeights | None] = []
                 # HACK: overrides replacements for qkvz = qkv + z case.
                 # Any better methods to handle this case?
-                if n_slices != len(replacements):
+                # Skip for FusedMoEWithLoRA: the trim above already aligns
+                # ``replacements`` with the per-slot length of
+                # ``lora_a_stacked``; re-expanding to ``n_slices`` here drives
+                # ``module.lora_a_stacked[i]`` past its actual length and
+                # raises IndexError during dummy LoRA warmup.
+                if (
+                    n_slices != len(replacements)
+                    and module.__class__.__name__ != "FusedMoEWithLoRA"
+                ):
                     replacements = [f"slice_{i}" for i in range(n_slices)]
                 for i, r in enumerate(replacements):
                     lora = LoRALayerWeights.create_dummy_lora_weights(


### PR DESCRIPTION
## Purpose

Fix `IndexError: list index out of range` raised from `create_dummy_lora` during `profile_run` whenever a model wraps its experts with `FusedMoEWithLoRA`.

### Root cause

PR #37912 (commit `48698b1b9`, [Bugfix] Fuse Qwen3.5 in_qkvz_proj forwarding with LoRA enabled) introduced an unconditional HACK in `vllm/lora/model_manager.py` inside `create_dummy_lora`:

```python
n_slices = getattr(module, "n_slices", len(replacements))
if module.__class__.__name__ == "FusedMoEWithLoRA":
    replacements = replacements[
        : len(module.lora_a_stacked) // self.lora_slots
    ]
subloras: list[LoRALayerWeights | None] = []
# HACK: overrides replacements for qkvz = qkv + z case.
# Any better methods to handle this case?
if n_slices != len(replacements):
    replacements = [f"slice_{i}" for i in range(n_slices)]
for i, r in enumerate(replacements):
    lora = LoRALayerWeights.create_dummy_lora_weights(
        module_name + "." + r,
        module.lora_a_stacked[i].shape[-1],
        ...
    )
```

The HACK was added to support `qkvz` (`q + k + v + z`, e.g. Qwen3.5 `in_qkvz_proj`), where `module.n_slices == 4` but `packed_modules_mapping[parts[-1]]` returns only 3 entries (`q`, `k`, `v`).

For `FusedMoEWithLoRA`, the branch immediately above already explicitly trims `replacements` to `len(module.lora_a_stacked) // self.lora_slots` — the per-slot length of the stacked LoRA tensors. When `packed_modules_mapping["experts"]` carries every `num_experts * weights_per_expert` entry (see `process_packed_modules_mapping` in `vllm/lora/utils.py`), the trim shrinks `replacements` so its length matches the per-slot count.

The HACK then sees `n_slices != len(replacements)` and re-expands `replacements` back to `n_slices` synthetic `slice_{i}` names, after which the loop indexes `module.lora_a_stacked[i]` past its actual length and raises:

```
IndexError: list index out of range
  File "vllm/lora/model_manager.py", line 612, in create_dummy_lora
    module.lora_a_stacked[i].shape[-1],
```

The error surfaces from the standard warmup path:

```
gpu_worker.profile_run()
  -> gpu_model_runner._dummy_run()
    -> maybe_dummy_run_with_lora()
      -> lora_manager.add_dummy_lora(rank=...)
        -> adapter_manager.create_dummy_lora()  <-- crash
```

### Fix

Skip the qkvz HACK whenever the wrapper is `FusedMoEWithLoRA`. The explicit trim above is already authoritative for that branch (its length always matches the actual per-slot `lora_a_stacked` count, by construction of the populate loop in `FusedMoEWithLoRA.create_lora_weights`).

```python
if (
    n_slices != len(replacements)
    and module.__class__.__name__ != "FusedMoEWithLoRA"
):
    replacements = [f"slice_{i}" for i in range(n_slices)]
```

- The qkvz path is preserved verbatim (the wrapper class there is a `ColumnParallelLinearWithLoRA` subclass, not `FusedMoEWithLoRA`).
- For `FusedMoEWithLoRA`, the dummy-LoRA names produced are now the real per-expert weight names from `packed_modules_mapping` (e.g. `experts.0.w1`) instead of generic `slice_{i}` placeholders, which also aligns the dummy entries with what `PackedLoRALayerWeights.pack_moe` already expects.

## Test Plan

Reproduction:
1. Run any MoE+LoRA workload that exercises `FusedMoEWithLoRA` (e.g. DeepSeek-V3-style architecture with LoRA enabled, `enable_lora=True`, `max_loras>=1`, any non-trivial `max_lora_rank`).
2. Engine startup goes through `profile_run` → `add_dummy_lora` → `create_dummy_lora`.

Expected behavior on `main` (pre-fix): worker crashes with the `IndexError` trace above; the engine never reaches the serving loop.

Expected behavior with this PR: dummy LoRA warmup completes, KV cache profiling succeeds, the engine starts and serves requests normally.

## Test Result

Verified end-to-end on a DeepSeek-V3-style 9B MoE model with `FusedMoEWithLoRA` (`local_num_experts > 0`, `_w13_slices == 2`, `max_loras = 4`) in an LoRA-enabled vLLM rollout used for RL training:

- Before fix: every TP/EP worker crashes in `create_dummy_lora` with `IndexError: list index out of range`; the engine never reaches the serving loop.
- After fix: `profile_run` completes cleanly; the engine progresses to KV cache initialization and starts serving LoRA-tagged requests.

No regression observed for non-MoE LoRA workloads (existing `qkvz` and standard QKV/MergedColumn LoRA paths are unaffected by the added `class_name != "FusedMoEWithLoRA"` guard).

Happy to add a unit test under `tests/lora/` if reviewers prefer — current LoRA tests for `FusedMoEWithLoRA` are at the integration level (`tests/lora/test_gptoss_tp.py`), so a regression test for `create_dummy_lora` would need a small fixture / mocked manager. Pointers welcome.