### PR TITLE
fix(platforms): raise AttributeError on missing Platform attribute

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -875,7 +875,7 @@ class Platform:
             self.device_type,
             key,
         )
-        return None
+        raise AttributeError(key)
 
     def get_global_graph_pool(self) -> Any:
         """


### PR DESCRIPTION


## Purpose

Make `Platform.__getattr__` ([vllm/platforms/interface.py](vllm/platforms/interface.py)) comply with the Python data-model protocol.

Previously, when an attribute was missing on both the `Platform` subclass and the underlying `torch.<device_type>` module, `__getattr__` logged a warning and **returned `None`** instead of raising `AttributeError`. Per the [Python data model](https://docs.python.org/3/reference/datamodel.html#object.__getattr__), `__getattr__` must either return a value or raise `AttributeError`; returning `None` silently breaks every standard introspection primitive built on top of that contract:

- `hasattr(current_platform, "anything")` always returned `True`, so any feature-detection code against `current_platform` was effectively dead. A concrete example exists in the tree today: `numa_utils._is_auto_numa_available` guards on `hasattr(current_platform, "get_all_device_numa_nodes")`, which under the old behavior could never return `False` — it would fall through, call the missing method, and get `None`.
- `getattr(current_platform, "x", default)` silently dropped `default` (the three-arg `getattr` only consults its default when `AttributeError` is raised).
- `None` returned from a missing attribute is indistinguishable from a legit `None` value, conflating "missing" and "present-but-None".

The fix is one line: replace the trailing `return None` with `raise AttributeError(key)`. The existing dunder short-circuit and the `logger.warning(...)` are kept so that genuine misuses still leave a breadcrumb in the logs before the exception propagates.

### Diff

```diff
 def __getattr__(self, key: str):
     # Pickle checks dunder methods like __getstate__. If we return None
     # for them, pickle treats it like a real value and tries to call it.
     if key.startswith("__") and key.endswith("__"):
         raise AttributeError(key)

     device = getattr(torch, self.device_type, None)
     if device is not None and hasattr(device, key):
         attr = getattr(device, key)
         # NOTE: `hasattr(device, key)=True` can only avoid AttributeError,
         # but the value of this attr could be `None`.
         if attr is not None:
             return attr

     logger.warning(
         "Current platform %s does not have '%s' attribute.",
         self.device_type,
         key,
     )
-    return None
+    raise AttributeError(key)
```

## Test Plan

This is a behavioral fix on a fallback path that is not exercised on the happy path (every platform subclass — `CudaPlatform`, `RocmPlatform`, `XpuPlatform`, `TpuPlatform`, `CpuPlatform` — defines its real attributes directly on the class, so `__getattr__` is only entered for *missing* names). I therefore verified the change via targeted Python-level checks rather than a new pytest suite:

```python
from vllm.platforms import current_platform

# 1. Real attributes still resolve via normal attribute lookup
#    (__getattr__ is not entered).
assert current_platform.device_type  # e.g. "cuda"

# 2. Missing attributes now raise AttributeError, so hasattr/getattr work.
assert not hasattr(current_platform, "definitely_missing_xxx")
assert getattr(current_platform, "definitely_missing_xxx", "fallback") == "fallback"

# 3. Dunder probes (pickle/copy/deepcopy) keep working — the existing
#    dunder short-circuit is preserved.
import pickle, copy
pickle.dumps(current_platform)
copy.deepcopy(current_platform)
```

I also audited every `current_platform.<attr>` / `getattr(current_platform, ...)` call site in the repo: all of them either access an attribute that is defined on the platform subclass (so `__getattr__` is never entered) or access a `torch.<device>` API guarded by `is_cuda` / `is_rocm` / `is_xpu` / `is_tpu` checks, so the stricter `AttributeError` behavior cannot regress any existing caller.

## Test Result

- `hasattr(current_platform, "missing_attr")` → was `True`, now `False`. ✅
- `getattr(current_platform, "missing_attr", "x")` → was `None`, now `"x"`. ✅
- `pickle.dumps(current_platform)` / `copy.deepcopy(current_platform)` →
  unchanged (dunder short-circuit preserved). ✅
- `numa_utils._is_auto_numa_available()` on platforms that don't implement
  `get_all_device_numa_nodes` → previously fell through the `hasattr` guard
  and returned `None` from the attribute access; now correctly takes the
  `hasattr → False` early-return branch. ✅
- No platform subclass exposes a real attribute whose value is `None` and
  relies on the old "missing → None" coercion (verified by grep), so no
  caller observably changes on the happy path.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

