### PR TITLE
[V1][SpecDecode] Resume relaxed acceptance for thinking-mode tokens (port of #22238)

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -261,6 +261,26 @@ class SpeculativeConfig:
     during rejection sampling. This comes at the cost of additional GPU memory
     usage."""
 
+    # Relaxed acceptance for thinking phase (ported from vLLM PR #22238).
+    # Only applies to greedy rejection sampling. During the model's thinking
+    # phase (token IDs between `<think>` and `</think>` as detected by the
+    # configured reasoning_parser), a draft token is accepted if it appears
+    # in the target model's top-K candidates AND its probability is at least
+    # P(top1) * relax_ratio. Outside the thinking phase, strict acceptance is
+    # used. See [[relaxed-acceptance-notes]] for background.
+    relaxed_thinking: bool = False
+    """Enable relaxed acceptance during thinking phase."""
+    relax_ratio: float = 1.0
+    """Multiplicative ratio in (0, 1]. P(candidate) >= P(top1) * relax_ratio
+    is required for candidate to be eligible. Used when relaxed_thinking is
+    enabled."""
+    relax_top_k: int = 1
+    """Top-K cutoff for candidate set. Used when relaxed_thinking is enabled."""
+    reasoning_parser: str | None = None
+    """Reasoning parser name (e.g. 'deepseek_r1') used to detect thinking
+    phase token boundaries via its start_token_id/end_token_id attributes.
+    Required when relaxed_thinking is enabled."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -124,6 +124,10 @@ class CachedRequestData:
     new_block_ids: list[tuple[list[int], ...] | None]
     num_computed_tokens: list[int]
     num_output_tokens: list[int]
+    # Per-request thinking phase flag (PR #22238 relaxed acceptance).
+    # Aligned with req_ids. Used by gpu_model_runner to build the
+    # thinking_states tensor passed into the rejection sampler.
+    thinking_states: list[bool] = field(default_factory=list)
 
     # Version of dataclass repr with token IDs obfuscated.
     def anon_repr(self) -> str:
@@ -174,6 +178,7 @@ class CachedRequestData:
             new_block_ids=[],
             num_computed_tokens=[],
             num_output_tokens=[],
+            thinking_states=[],
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -47,7 +47,11 @@ from vllm.v1.core.sched.request_queue import (
     SchedulingPolicy,
     create_request_queue,
 )
-from vllm.v1.core.sched.utils import check_stop, remove_all
+from vllm.v1.core.sched.utils import (
+    check_stop,
+    maybe_update_thinking_state,
+    remove_all,
+)
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
@@ -211,6 +215,11 @@ class Scheduler(SchedulerInterface):
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = self.num_lookahead_tokens = 0
+        # Relaxed acceptance (PR #22238). Default off; only the rejection
+        # sampler kernel changes behaviour when self.relaxed_thinking is True.
+        self.relaxed_thinking = False
+        self.think_start_token_id: int | None = None
+        self.think_end_token_id: int | None = None
         if speculative_config:
             self.num_spec_tokens = speculative_config.num_speculative_tokens
             if speculative_config.use_eagle():
@@ -218,6 +227,57 @@ class Scheduler(SchedulerInterface):
                 self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
+            if getattr(speculative_config, "relaxed_thinking", False):
+                self.relaxed_thinking = True
+                relax_ratio = speculative_config.relax_ratio
+                relax_top_k = speculative_config.relax_top_k
+                if not (0 < relax_ratio <= 1):
+                    raise ValueError(
+                        "relax_ratio must be in (0, 1] when relaxed_thinking "
+                        f"is enabled, got {relax_ratio}."
+                    )
+                if not speculative_config.reasoning_parser:
+                    raise ValueError(
+                        "reasoning_parser must be set when relaxed_thinking is enabled."
+                    )
+                logger.info(
+                    "Enable relaxed thinking, relax_ratio=%s, relax_top_k=%s",
+                    relax_ratio,
+                    relax_top_k,
+                )
+                from transformers import AutoTokenizer
+
+                from vllm.reasoning import ReasoningParserManager
+
+                tokenizer = AutoTokenizer.from_pretrained(
+                    vllm_config.model_config.tokenizer
+                )
+                parser_cls = ReasoningParserManager.get_reasoning_parser(
+                    speculative_config.reasoning_parser
+                )
+                if parser_cls is None:
+                    raise TypeError(
+                        f"reasoning_parser '{speculative_config.reasoning_parser}'"
+                        " has not been registered."
+                    )
+                parser = parser_cls(tokenizer)
+                logger.info("Use reasoning parser: %s", parser)
+                if hasattr(parser, "start_token_id") and hasattr(
+                    parser, "end_token_id"
+                ):
+                    self.think_start_token_id = parser.start_token_id
+                    self.think_end_token_id = parser.end_token_id
+                elif hasattr(parser, "think_start_token_id") and hasattr(
+                    parser, "think_end_token_id"
+                ):
+                    self.think_start_token_id = parser.think_start_token_id
+                    self.think_end_token_id = parser.think_end_token_id
+                else:
+                    raise AttributeError(
+                        "Reasoning parser must expose (start_token_id, "
+                        "end_token_id) or (think_start_token_id, "
+                        "think_end_token_id) attributes."
+                    )
 
         # Create the KV cache manager.
         if hash_block_size is None:
@@ -1047,6 +1107,7 @@ class Scheduler(SchedulerInterface):
         all_token_ids: dict[str, list[int]] = {}
         num_computed_tokens: list[int] = []
         num_output_tokens: list[int] = []
+        thinking_states: list[bool] = []
         resumed_req_ids = set()
 
         num_running_reqs = len(running_reqs)
@@ -1082,6 +1143,10 @@ class Scheduler(SchedulerInterface):
             num_output_tokens.append(
                 req.num_output_tokens + req.num_output_placeholders
             )
+            # Relaxed acceptance (PR #22238). Empty list when feature off so
+            # downstream code doesn't have to special-case.
+            if self.relaxed_thinking:
+                thinking_states.append(req.thinking_state)
 
         return CachedRequestData(
             req_ids=req_ids,
@@ -1091,6 +1156,7 @@ class Scheduler(SchedulerInterface):
             new_block_ids=new_block_ids,
             num_computed_tokens=num_computed_tokens,
             num_output_tokens=num_output_tokens,
+            thinking_states=thinking_states,
         )
 
     def _try_schedule_encoder_inputs(
@@ -1654,6 +1720,13 @@ class Scheduler(SchedulerInterface):
         # to return empty token ids for the request.
         stopped = False
         for num_new, output_token_id in enumerate(new_token_ids, 1):
+            if self.relaxed_thinking:
+                maybe_update_thinking_state(
+                    request=request,
+                    new_token_id=output_token_id,
+                    think_start_token_id=self.think_start_token_id,
+                    think_end_token_id=self.think_end_token_id,
+                )
             request.append_output_token_ids(output_token_id)
 
             # Check for stop and update request state.

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -128,3 +128,20 @@ def check_stop(request: Request, max_model_len: int) -> bool:
         return True
 
     return False
+
+
+def maybe_update_thinking_state(
+    request: "Request",
+    new_token_id: int,
+    think_start_token_id: int | None = None,
+    think_end_token_id: int | None = None,
+) -> None:
+    """Flip request.thinking_state on `<think>` / `</think>` token boundaries.
+
+    Ported from vLLM PR #22238 for relaxed acceptance during thinking phase.
+    Called per output token by the scheduler when relaxed_thinking is enabled.
+    """
+    if think_start_token_id is not None and new_token_id == think_start_token_id:
+        request.thinking_state = True
+    if think_end_token_id is not None and new_token_id == think_end_token_id:
+        request.thinking_state = False

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -97,6 +97,9 @@ class Request:
         self.status = RequestStatus.WAITING
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: int | str | None = None
+        # Per-request flag for relaxed acceptance (PR #22238). Flipped by the
+        # scheduler's per-token hook when <think>/</think> boundaries are seen.
+        self.thinking_state: bool = False
 
         # P/D: Connector-specific KV transfer parameters.
         self.kv_transfer_params: dict[str, Any] | None = None

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -92,6 +92,10 @@ class RejectionSampler(nn.Module):
         # [num_tokens + batch_size, vocab_size]
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        relaxed_thinking: bool = False,
+        relax_ratio: float = 1.0,
+        relax_top_k: int = 1,
+        thinking_states: torch.Tensor | None = None,
     ) -> SamplerOutput:
         """
         Args:
@@ -176,6 +180,10 @@ class RejectionSampler(nn.Module):
             sampling_metadata,
             synthetic_mode=self.synthetic_mode,
             synthetic_conditional_rates=self.synthetic_conditional_rates,
+            relaxed_thinking=relaxed_thinking,
+            relax_ratio=relax_ratio,
+            relax_top_k=relax_top_k,
+            thinking_states=thinking_states,
         )
 
         logprobs_tensors = None
@@ -406,6 +414,10 @@ def rejection_sample(
     sampling_metadata: SamplingMetadata,
     synthetic_mode: bool = False,
     synthetic_conditional_rates: torch.Tensor | None = None,
+    relaxed_thinking: bool = False,
+    relax_ratio: float = 1.0,
+    relax_top_k: int = 1,
+    thinking_states: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
@@ -448,20 +460,53 @@ def rejection_sample(
         )
 
     if not sampling_metadata.all_random:
-        # Rejection sampling for greedy sampling requests.
-        target_argmax = target_logits.argmax(dim=-1)
-        rejection_greedy_sample_kernel[(batch_size,)](
-            output_token_ids,
-            cu_num_draft_tokens,
-            draft_token_ids,
-            target_argmax,
-            bonus_token_ids,
-            is_greedy,
-            max_spec_len,
-            uniform_probs,
-            synthetic_conditional_rates,
-            SYNTHETIC_MODE=synthetic_mode,
+        # Relaxed acceptance (PR #22238) — greedy path only, no synthetic mode.
+        # Falls back to strict greedy kernel when feature off OR when
+        # thinking_states empty (e.g. relaxed enabled but no req in thinking
+        # phase yet in this batch).
+        use_relaxed = (
+            relaxed_thinking
+            and not synthetic_mode
+            and thinking_states is not None
+            and thinking_states.numel() == batch_size
         )
+        if use_relaxed:
+            # target_probs computed early for relaxed path.
+            relaxed_target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+            topk_values, topk_indices = torch.topk(
+                relaxed_target_probs, k=relax_top_k, dim=-1
+            )
+            topk_indices = topk_indices.to(torch.int32).contiguous()
+            topk_values = topk_values.contiguous()
+            relaxed_thinking_sample_kernel[(batch_size,)](
+                output_token_ids,
+                cu_num_draft_tokens,
+                draft_token_ids,
+                topk_values,
+                topk_indices,
+                bonus_token_ids,
+                is_greedy,
+                max_spec_len,
+                thinking_states,
+                relax_ratio,
+                K=relax_top_k,
+                num_warps=1,
+            )
+        else:
+            # Rejection sampling for greedy sampling requests.
+            target_argmax = target_logits.argmax(dim=-1)
+            rejection_greedy_sample_kernel[(batch_size,)](
+                output_token_ids,
+                cu_num_draft_tokens,
+                draft_token_ids,
+                target_argmax,
+                bonus_token_ids,
+                is_greedy,
+                max_spec_len,
+                uniform_probs,
+                synthetic_conditional_rates,
+                SYNTHETIC_MODE=synthetic_mode,
+            )
         if sampling_metadata.all_greedy:
             return output_token_ids
 
@@ -919,3 +964,81 @@ def sample_recovered_tokens_kernel(
             recovered_id = v + local_id
 
     tl.store(output_token_ids_ptr + token_idx, recovered_id)
+
+
+# Relaxed acceptance kernel (PR #22238 port).
+# For each draft position:
+#   strict path  (thinking=False): accept iff draft_id == argmax(target)
+#   relaxed path (thinking=True):  accept iff draft_id is in target's top-K
+#                                  AND P(draft_id) >= P(top1) * relax_ratio
+# On reject, the rest of the draft positions for this request are dropped.
+# If all draft positions accepted, append the request's bonus token.
+@triton.jit(do_not_specialize=["max_spec_len"])
+def relaxed_thinking_sample_kernel(
+    output_token_ids_ptr,  # [batch_size, max_spec_len + 1]
+    cu_num_draft_tokens_ptr,  # [batch_size]
+    draft_token_ids_ptr,  # [num_tokens]
+    topk_values_ptr,  # [num_tokens, K] flattened, fp32
+    topk_indices_ptr,  # [num_tokens, K] flattened, int32
+    bonus_token_ids_ptr,  # [batch_size]
+    is_greedy_ptr,  # [batch_size] or None
+    max_spec_len,
+    thinking_states_ptr,  # [batch_size] bool/uint8
+    relax_ratio,  # float scalar
+    K: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    # Same FIXME as rejection_greedy_sample_kernel re profiling-run shapes.
+    is_greedy = True if is_greedy_ptr is None else tl.load(is_greedy_ptr + req_idx)
+    if not is_greedy:
+        return
+
+    start_idx = 0 if req_idx == 0 else tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+    end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    num_draft_tokens = end_idx - start_idx
+
+    thinking_flag = tl.load(thinking_states_ptr + req_idx)
+    thinking = thinking_flag != 0
+
+    rejected = False
+    for pos in range(num_draft_tokens):
+        if not rejected:
+            draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
+            top1_prob = tl.load(topk_values_ptr + (start_idx + pos) * K)
+            top1_id = tl.load(topk_indices_ptr + (start_idx + pos) * K).to(tl.int32)
+
+            cur_accepted = False
+            chosen = top1_id
+            if thinking:
+                # Relaxed: scan top-K, accept first match meeting prob floor.
+                for i in range(K):
+                    if not cur_accepted:
+                        cand_prob = tl.load(topk_values_ptr + (start_idx + pos) * K + i)
+                        cand_id = tl.load(
+                            topk_indices_ptr + (start_idx + pos) * K + i
+                        ).to(tl.int32)
+                        if (cand_prob >= top1_prob * relax_ratio) and (
+                            draft_token_id == cand_id
+                        ):
+                            chosen = draft_token_id
+                            cur_accepted = True
+            else:
+                # Strict: argmax match.
+                if draft_token_id == top1_id:
+                    chosen = draft_token_id
+                    cur_accepted = True
+
+            if not cur_accepted:
+                rejected = True
+
+            tl.store(
+                output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                chosen,
+            )
+
+    if not rejected:
+        bonus_token_id = tl.load(bonus_token_ids_ptr + req_idx)
+        tl.store(
+            output_token_ids_ptr + req_idx * (max_spec_len + 1) + num_draft_tokens,
+            bonus_token_id,
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3467,6 +3467,7 @@ class GPUModelRunner(
         self,
         logits: torch.Tensor | None,
         spec_decode_metadata: SpecDecodeMetadata | None,
+        scheduler_output: "SchedulerOutput | None" = None,
     ) -> SamplerOutput:
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
@@ -3486,11 +3487,39 @@ class GPUModelRunner(
             self.input_batch.update_async_spec_token_ids(draft_token_ids_cpu)
 
         draft_probs = self._get_spec_decode_draft_probs(spec_decode_metadata)
+
+        # Relaxed acceptance (PR #22238). Only build the thinking_states tensor
+        # when the feature is enabled in speculative_config. Falls back to
+        # strict path inside the sampler if tensor not provided.
+        relaxed_thinking = False
+        relax_ratio = 1.0
+        relax_top_k = 1
+        thinking_states_tensor: torch.Tensor | None = None
+        if self.speculative_config is not None and getattr(
+            self.speculative_config, "relaxed_thinking", False
+        ):
+            relaxed_thinking = True
+            relax_ratio = self.speculative_config.relax_ratio
+            relax_top_k = self.speculative_config.relax_top_k
+            if (
+                scheduler_output is not None
+                and scheduler_output.scheduled_cached_reqs.thinking_states
+            ):
+                thinking_states_tensor = torch.tensor(
+                    scheduler_output.scheduled_cached_reqs.thinking_states,
+                    dtype=torch.bool,
+                    device=self.device,
+                )
+
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,
             draft_probs,
             logits,
             sampling_metadata,
+            relaxed_thinking=relaxed_thinking,
+            relax_ratio=relax_ratio,
+            relax_top_k=relax_top_k,
+            thinking_states=thinking_states_tensor,
         )
         return sampler_output
 
@@ -4330,7 +4359,9 @@ class GPUModelRunner(
             )
 
         with record_function_or_nullcontext("gpu_model_runner: sample"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            sampler_output = self._sample(
+                logits, spec_decode_metadata, scheduler_output
+            )
 
         self._update_states_after_model_execute(
             sampler_output.sampled_token_ids, scheduler_output


### PR DESCRIPTION
> **Draft.** Code is ready for an early lint/sanity pass; the full
> end-to-end data sweep (r × k grid at n=500) is still in progress.
> Body will be updated with the sweep table before flipping to ready;
> the PR may be revised or closed depending on what the data shows.

## Purpose

This PR is a continuation of #22238 and #21506, both of which closed
via the stale bot in December 2025 without merge. The feature: during
reasoning models' thinking phase (tokens between `<think>` and
`</think>` as identified by `reasoning_parser`), use a **relaxed
greedy acceptance rule** for speculative decoding:

```
accept iff   draft_id ∈ topK(target_probs)
         AND P(draft_id) >= P(target_top1) * relax_ratio
```

Outside the thinking phase, falls back to the standard strict-greedy
acceptance. Random-sampling path is unchanged (same scope as #22238).

The original PR's only stated concern from a maintainer was *"what is
this feature mainly for, and who will be using this?"* — we attempt
to answer that directly below.

### Who would use this

DeepSeek-R1 / QwQ / similar reasoning-tuned models where the
thinking phase is the dominant portion of the output (we measured ~85%
of output tokens lying inside `<think>`…`</think>` on DeepSeek-R1-0528
gsm8k samples) and where users are willing to trade a bounded amount
of strict accuracy for higher acceptance-length / throughput. The
feature is **opt-in (default OFF)**, so deployments that need strict
accuracy guarantees are not affected.

Smoke data on a single gfx942 node (DeepSeek-R1-0528, no PD, c=30,
100 gsm8k samples):

| config | flex | strict | acc_len | avg AR | per-pos (0/1/2) |
|---|---|---|---|---|---|
| strict (baseline) | 0.98 | 0.98 | 2.697 | 56.56% | 0.844 / 0.558 / 0.294 |
| relaxed (r=0.7, k=3) | 0.94 | 0.94 | 2.876 | 62.49% | 0.896 / 0.635 / 0.344 |

This is one data point; a larger sweep across `r × k` at 500 samples
is in progress and will replace this row before the PR is flipped to
ready. If the sweep doesn't show a usable region, the PR will be
revised or closed.

## Changes

7 files, +288 / -16 lines. Mirrors #22238's file scope; the only
differences are (a) `vllm/config/speculative.py` instead of
`vllm/config/__init__.py` (the config module was split since #22238
was filed), and (b) the OOB fix below.

- **`vllm/config/speculative.py`**: add four `SpeculativeConfig`
  fields with safe defaults:
  ```
  relaxed_thinking: bool      = False  # default OFF
  relax_ratio:      float     = 1.0    # 1.0 ≡ no relaxation
  relax_top_k:      int       = 1      # k=1 ≡ strict greedy
  reasoning_parser: str|None  = None
  ```
- **`vllm/v1/sample/rejection_sampler.py`**: new Triton kernel
  `relaxed_thinking_sample_kernel`; the sampler's main path now reads
  the four config fields plus a `thinking_states` tensor (per-request
  in-thinking-phase bool) and gates the relaxed branch on
  `use_relaxed = relaxed_thinking AND thinking_states is not None AND
  thinking_states.numel() == batch_size`.
- **`vllm/v1/core/sched/scheduler.py`** + **`output.py`** +
  **`utils.py`** + **`request.py`**: track whether each request is
  currently inside a `<think>` block based on
  `reasoning_parser`-provided start/end token IDs, and forward the
  bit through `CachedRequestData` to the worker.
- **`vllm/v1/worker/gpu_model_runner.py`**: assemble the per-batch
  `thinking_states` tensor and pass it into the sampler.

The signal is currently batch-level (one bool per request, applied
uniformly across that request's draft tokens in the verify step). A
per-token mask would let mid-batch transitions through the thinking
boundary be sampled more precisely; we went with the batch-level
form because it mirrors the design in #22238, but the kernel is
straightforward to extend if reviewers prefer per-token granularity.

### Fix on top of #22238

#22238's automated review flagged a critical bug: in some branches
`_make_cached_request_data` left `thinking_states` empty, and the
kernel — which expects one entry per batch row — read out-of-bounds.
This port populates the state explicitly in every branch, and the
sampler short-circuits (`use_relaxed = False`) if the tensor's size
doesn't match the batch, eliminating the OOB path.

## Backward compatibility

- All four `SpeculativeConfig` fields default to values that produce
  identical behavior to pre-patch (`relaxed_thinking=False` skips the
  entire relaxed path; `relax_ratio=1.0` + `relax_top_k=1` would
  reduce to strict greedy even if the flag were on).
- Random-sampling speculative decoding is untouched.
- No change to existing rejection-sampler kernels — the relaxed
  kernel is a new entry point, not a modification of the strict one.

## Not a duplicate of

- **#22238** (CLOSED 2025-12-10) — same feature, V1. This PR is a
  re-port onto current main + the OOB fix above. Closed by stale bot.
- **#21506** (CLOSED 2025-12-10) — earlier V1 attempt, same author,
  same fate.
- **#21157** (CLOSED 2025-07-18) — WIP that closed the day it was
  filed.
- **#35355** — "add acceptance_threshold argument" — a related but
  distinct knob; threshold is a scalar applied to all tokens
  regardless of thinking phase.
- **#34668** (MERGED) — "Spec decoding with thinking budget" —
  bounds the *number* of thinking tokens; orthogonal to acceptance.
- **#38045** (MERGED) — "force a specific acceptance rate" —
  debugging hook for testing rejection sampling; not a production
  knob.

SGLang's parallel effort (sgl-project/sglang#7702 and #8068) is
still open; if there's interest, the two stacks could share a
config schema.

Searched on 2026-05-19 for `relaxed acceptance`, `draft acceptance`,
`thinking speculative`, `relax_ratio`, `deepseek_v3_relaxed`,
`relax_top_k` — nothing else is actively driving this in vLLM.

## Verification status

- `pre-commit run --files <all 7 changed files>` — passes (ruff
  check, ruff format, mypy-3.10, SPDX, lazy-imports, forbidden-imports,
  attention-backend docs, etc.).
- Cherry-pick onto current `main` is clean (0 conflicts).
- Smoke run data above is the only end-to-end result so far; full
  cluster repro (AMD MI300X, DeepSeek-R1-0528, 1P1D) will be added
  with the sweep results.

## AI assistance disclosure

Drafted with AI assistance (Claude Code). I (chaemin.lim@mangoboost.io)
am the human submitter, have reviewed each changed line, and will
defend the change through review. The code itself is a direct port of
#22238 plus the OOB fix described above; the port was prepared by my
colleague (`Co-authored-by` trailer in the commit) and is being
submitted under my account because I'm carrying the upstream
conversation across our team's MoRI-IO PRs (#43063, #43065, #43067,
#43068).