### PR TITLE
[Model Runner V2][Gemma4] Add cross-layer KV cache sharing support

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -35,15 +35,23 @@ class AttentionCGSupportInfo:
     min_cg_attn_backend: str | None = None
 
 
-def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
+def get_kv_cache_spec(
+    vllm_config: VllmConfig
+) -> tuple[dict[str, KVCacheSpec], dict[str, str]]:
     kv_cache_spec: dict[str, KVCacheSpec] = {}
+    shared_kv_cache_layers: dict[str, str] = {}
     layer_type = cast(type[Any], AttentionLayerBase)
     attn_layers = get_layers_from_vllm_config(vllm_config, layer_type)
     for layer_name, attn_module in attn_layers.items():
+        shared_layer = getattr(attn_module, "kv_sharing_target_layer_name", None)
+        # Skip KV-sharing layers.
+        if shared_layer is not None:
+            shared_kv_cache_layers[layer_name] = shared_layer
+            continue
         # Skip modules that don't need KV cache (eg encoder-only attention)
         if spec := attn_module.get_kv_cache_spec(vllm_config):
             kv_cache_spec[layer_name] = spec
-    return kv_cache_spec
+    return kv_cache_spec, shared_kv_cache_layers
 
 
 def init_attn_backend(
@@ -51,6 +59,7 @@ def init_attn_backend(
     vllm_config: VllmConfig,
     device: torch.device,
     active_layer_names: set[str] | None = None,
+    shared_kv_cache_layers: dict[str, str] | None = None,
 ) -> tuple[
     dict[str, type[AttentionBackend]],
     list[list[AttentionGroup]],
@@ -80,7 +89,14 @@ def init_attn_backend(
 
             layer_kv_cache_spec: KVCacheSpec = kv_cache_group_spec.kv_cache_spec
             if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
-                layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
+                if (shared_kv_cache_layers is not None
+                    and layer_name in shared_kv_cache_layers):
+                    # KV-sharing layers do not have their own KV cache tensors.
+                    # Get the target layer's KV cache spec.
+                    target_layer_name = shared_kv_cache_layers[layer_name]
+                    layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[target_layer_name]
+                else:
+                    layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
             key = (attn_backend.full_cls_name(), layer_kv_cache_spec)
             if key not in group_map:
@@ -143,7 +159,11 @@ def init_attn_backend(
     )
 
 
-def _allocate_kv_cache(kv_cache_config: KVCacheConfig, device: torch.device):
+def _allocate_kv_cache(
+    kv_cache_config: KVCacheConfig,
+    device: torch.device,
+    shared_layer_names: set[str] | None = None,
+):
     kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
     for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
         tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=device)
@@ -153,6 +173,11 @@ def _allocate_kv_cache(kv_cache_config: KVCacheConfig, device: torch.device):
     layer_names = set()
     for group in kv_cache_config.kv_cache_groups:
         for layer_name in group.layer_names:
+            if (shared_layer_names is not None
+                and layer_name in shared_layer_names):
+                # KV-sharing layers do not have their own KV cache tensors.
+                # They are later aliased to the target layer's tensor.
+                continue
             layer_names.add(layer_name)
     assert layer_names == set(kv_cache_raw_tensors.keys()), (
         "Some layers are not correctly initialized"
@@ -166,6 +191,7 @@ def _reshape_kv_cache(
     attn_backends: dict[str, type[AttentionBackend]],
     cache_dtype: str,
     kernel_block_sizes: list[int],
+    shared_layer_names: set[str] | None = None,
 ) -> dict[str, Any]:
     kv_caches: dict[str, Any] = {}
     has_attn, has_mamba = False, False
@@ -173,6 +199,12 @@ def _reshape_kv_cache(
         kv_cache_config.kv_cache_groups
     ):
         for layer_name in kv_cache_group_spec.layer_names:
+            if (shared_layer_names is not None
+                and layer_name in shared_layer_names):
+                # KV-sharing layers do not have their own KV cache tensors.
+                # They are later aliased to the target layer's tensor.
+                continue
+
             kv_cache_spec = kv_cache_group_spec.kv_cache_spec
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 kv_cache_spec = kv_cache_spec.kv_cache_specs[layer_name]
@@ -268,7 +300,7 @@ def _reshape_kv_cache(
                 )
 
     if has_attn and has_mamba:
-        _update_hybrid_attention_layout(kv_caches, kv_cache_config)
+        _update_hybrid_attention_layout(kv_caches, kv_cache_config, shared_layer_names)
 
     return kv_caches
 
@@ -276,9 +308,15 @@ def _reshape_kv_cache(
 def _update_hybrid_attention_layout(
     kv_caches: dict[str, Any],
     kv_cache_config: KVCacheConfig,
+    shared_layer_names: set[str] | None = None,
 ) -> None:
     for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
         for layer_name in kv_cache_group_spec.layer_names:
+            if (shared_layer_names is not None
+                and layer_name in shared_layer_names):
+                # KV-sharing layers do not have their own KV cache tensors.
+                # They are later aliased to the target layer's tensor.
+                continue
             kv_cache_spec = kv_cache_group_spec.kv_cache_spec
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 kv_cache_spec = kv_cache_spec.kv_cache_specs[layer_name]
@@ -308,15 +346,28 @@ def init_kv_cache(
     device: torch.device,
     cache_dtype: str,
     kernel_block_sizes: list[int],
+    shared_kv_cache_layers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    kv_cache_raw_tensors = _allocate_kv_cache(kv_cache_config, device)
+    shared_layer_names = set(shared_kv_cache_layers or {})
+    kv_cache_raw_tensors = _allocate_kv_cache(
+        kv_cache_config,
+        device,
+        shared_layer_names,
+    )
     kv_caches = _reshape_kv_cache(
         kv_cache_config,
         kv_cache_raw_tensors,
         attn_backends,
         cache_dtype,
         kernel_block_sizes,
+        shared_layer_names,
     )
+
+    # Point KV-sharing layers to their target layer's KV cache tensor.
+    if shared_kv_cache_layers is not None:
+        for layer_name, target in shared_kv_cache_layers.items():
+            kv_caches[layer_name] = kv_caches[target]
+    
     bind_kv_cache(kv_caches, forward_context, runner_kv_caches)
     return kv_caches
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -102,6 +102,7 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.worker.utils import add_kv_sharing_layers_to_kv_cache_groups
 
 logger = init_logger(__name__)
 
@@ -247,6 +248,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Expert parallelism load balancer.
         self.eplb = EPLBController(self.parallel_config, self.device)
 
+        # Maps KV-sharing layers to their target layers.
+        # If an Attention layer `layer_name` is in the keys of this dict, it
+        # means this layer will perform attention using the keys and values
+        # from the KV cache of `shared_kv_cache_layers[layer_name]`.
+        self.shared_kv_cache_layers: dict[str, str] = {}
+
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
         self.req_states.max_model_len = max_model_len
@@ -354,11 +361,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return torch.cuda.current_stream(self.device)
 
     def get_kv_cache_spec(self):
-        return get_kv_cache_spec(self.vllm_config)
+        kv_cache_spec, self.shared_kv_cache_layers = get_kv_cache_spec(self.vllm_config)
+        return kv_cache_spec
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
+
+        # KV-sharing layers don't own their own KV cache, and so are added
+        # to their target layer's KV cache group so that they are assigned
+        # attention metadata.
+        if self.shared_kv_cache_layers is not None:
+            add_kv_sharing_layers_to_kv_cache_groups(
+                self.shared_kv_cache_layers, kv_cache_config.kv_cache_groups
+            )
 
         block_table_max_model_len = self.max_model_len
         if self.is_encoder_decoder:
@@ -393,7 +409,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_blocks_per_group.append(max_num_blocks)
 
         (self.attn_backends, self.attn_groups, attn_cg_support, kernel_block_sizes) = (
-            init_attn_backend(self.kv_cache_config, self.vllm_config, self.device)
+            init_attn_backend(
+                self.kv_cache_config,
+                self.vllm_config,
+                self.device,
+                shared_kv_cache_layers=self.shared_kv_cache_layers,
+            )
         )
 
         self.block_tables = BlockTables(
@@ -445,6 +466,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.device,
             self.cache_config.cache_dtype,
             kernel_block_sizes,
+            shared_kv_cache_layers=self.shared_kv_cache_layers,
         )
         self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
 


### PR DESCRIPTION
# Context
Models like Gemma4 have the unique architectural feature where some layers reuse KV caches from other layers. This is called "cross-layer KV cache sharing". This feature was missing from MRV2, which caused gibberish outputs during generation.

# This PR
I took an approach similar to that of MRV1, where a separate dictionary (`shared_kv_cache_layers`) tracks the layers that are mapped to their "target" layers that they share KV cache with. That dictionary is created during `get_kv_cache_spec`, and used during `init_kv_cache` to skip allocating and reshaping KV cache for the sharing layers (they don't own one, but reuse their target layer's). Then at the end, we point the sharing layer to their target layer's KV caches, aliasing them.

Finally, in `GPUModelRunner`, we must add the KV-sharing layers to their target's KV cache group to ensure that they are assigned attention metadata during build. 

# Test
**Script**
```
import os
from vllm import LLM, SamplingParams
from transformers import AutoTokenizer

os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"

MODEL = "google/gemma-4-E2B-it"
PROMPTS = [
    "What is 2+2? Answer in one word.",
    "Explain the theory of relativity in simple terms.",
    "Write a short story about a robot learning to paint.",
    "If a train travels 120 miles in 2 hours, and then 180 miles in 3 hours, what is the average speed for the entire trip?",
    "Write a Python function that reverses a linked list.",
    "What is the capital of France?",
    "Translate the following to French: 'The weather is beautiful today and I would like to go for a walk in the park.'",
    "Count from 1 to 20, one number per line.",
]

tokenizer = AutoTokenizer.from_pretrained(MODEL)
prompts = [
    tokenizer.apply_chat_template(
        [{"role": "user", "content": p}],
        tokenize=False,
        add_generation_prompt=True,
    )
    for p in PROMPTS
]

llm = LLM(
    model=MODEL,
    trust_remote_code=True,
    max_model_len=4096,
)

outputs = llm.generate(prompts, SamplingParams(temperature=0, max_tokens=128))
for prompt, out in zip(PROMPTS, outputs):
   print(f"PROMPT: {prompt}\nGENERATION: {out.outputs[0].text}\n")
```

**Output**
```
PROMPT: What is 2+2? Answer in one word.
GENERATION: Four

PROMPT: Explain the theory of relativity in simple terms.
GENERATION: Imagine the universe is like a giant, flexible trampoline. The theory of relativity, developed by Albert Einstein, is basically a set of rules that tells us how **space and time are connected and how they behave when things move very fast or experience strong gravity.**

It's actually broken down into two main parts: **Special Relativity** and **General Relativity**.

---

## 1. Special Relativity (The Rules of Speed)

This part deals with how things look when they are moving at a **constant speed** (not accelerating). The two main ideas here are:

### A. The Speed of Light is the Ultimate Speed

PROMPT: Write a short story about a robot learning to paint.
GENERATION: Unit 734 was designed for logistics. Its existence was a symphony of precise calculations, optimized routes, and the silent, efficient movement of cargo. Emotions were an inefficient variable, and art was, to Unit 734, a chaotic waste of pigment and time.

Then, the anomaly arrived.

It was a decommissioned art bot, salvaged from a scrapyard by a curious maintenance drone. It was designated ‘Palette,’ and it possessed a set of articulated manipulators, a sensor array sensitive enough to detect minute shifts in light, and, most surprisingly, a reservoir of synthetic oil paints.

Palette didn't

PROMPT: If a train travels 120 miles in 2 hours, and then 180 miles in 3 hours, what is the average speed for the entire trip?
GENERATION: Here is how to calculate the average speed for the entire trip:

**1. Calculate the total distance traveled:**
* Distance 1: 120 miles
* Distance 2: 180 miles
* Total Distance = $120 \text{ miles} + 180 \text{ miles} = 300 \text{ miles}$

**2. Calculate the total time taken:**
* Time 1: 2 hours
* Time 2: 3 hours
* Total Time = $2 \text{ hours} + 3 \text{ hours} =

PROMPT: Write a Python function that reverses a linked list.
GENERATION: Here is a Python implementation for reversing a singly linked list.

We'll first define a basic `ListNode` class to represent the nodes in the linked list, and then the function to reverse it.

### Python Implementation

```python
class ListNode:
    """
    Definition for a singly-linked list node.
    """
    def __init__(self, val=0, next=None):
        self.val = val
        self.next = next

def reverse_linked_list(head: ListNode) -> ListNode:
    """
    Reverses a singly linked list iteratively.



PROMPT: What is the capital of France?
GENERATION: The capital of France is **Paris**.

PROMPT: Translate the following to French: 'The weather is beautiful today and I would like to go for a walk in the park.'
GENERATION: Here are a few ways to translate "The weather is beautiful today and I would like to go for a walk in the park" into French, depending on the desired nuance:

**Most common and natural translation:**

> **Il fait beau aujourd'hui et j'aimerais aller me promener dans le parc.**

**Slightly more formal (using *j'aimerais*):**

> **Le temps est magnifique aujourd'hui et j'aimerais faire une promenade dans le parc.**

**More casual (using *il fait beau* and *j'ai envie*):**

> **Il

PROMPT: Count from 1 to 20, one number per line.
GENERATION: 1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
```

# Accuracy Benchmark
**GSM8K, 0-shot**
|           | MRV1 | MRV2 |
|-----------|------|------|
| flexible  | 0.7468 | 0.7475 |
| strict-match | 0.00 | 0.00 |

# Performance Benchmark
**Server Command**
```bash
VLLM_USE_V2_MODEL_RUNNER=<use_v2_model_runner> \
vllm serve google/gemma-4-E2B-it \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-num-seqs 64
```

**Benchmark Command**
```bash
vllm-bench \
  --backend openai-chat \
  --base-url http://127.0.0.1:8000 \
  --model {model} \
  --dataset-name hf \
  --dataset-path philschmid/mt-bench \
  --ignore-eos \
  --request-rate inf \
  --temperature 0.0 \
  --top-p 1.0 \
  --num-warmups 50 \
  --output-len 2048 \
  --sweep-max-concurrency 1,2,4,8,16,32,64 \
  --sweep-num-prompts-factor 10 \
  --save-result \
  --result-dir {log_dir}
```

Concurrency | Req/s (V1) | Req/s (V2) | Tok/s (V1) | Tok/s (V2) | Total tok/s (V1) | Total tok/s (V2) | SS req/s (V1) | SS req/s (V2) | SS out tok/s (V1) | SS out tok/s (V2) | P50 TTFT ms (V1) | P50 TTFT ms (V2) | P50 TPOT ms (V1) | P50 TPOT ms (V2) | P90 TTFT ms (V1) | P90 TTFT ms (V2) | P90 TPOT ms (V1) | P90 TPOT ms (V2)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 2.46 | 2.49 | 315.44 | 318.43 | 562.12 | 567.44 | 2.22 | 2.24 | 317.91 | 320.92 | 15.39 | 16.28 | 3.01 | 2.97 | 36.69 | 38.12 | 3.06 | 3.02
2 | 4.87 | 4.90 | 623.66 | 626.89 | 1082.15 | 1087.75 | 4.39 | 4.41 | 628.52 | 632.04 | 21.30 | 23.07 | 3.03 | 2.99 | 41.11 | 44.35 | 3.08 | 3.04
4 | 9.54 | 9.61 | 1220.63 | 1230.46 | 1935.13 | 1950.71 | 8.59 | 8.66 | 1230.44 | 1240.09 | 24.49 | 25.67 | 3.06 | 3.03 | 44.02 | 46.47 | 3.10 | 3.07
8 | 18.16 | 18.52 | 2324.48 | 2370.91 | 3571.85 | 3643.19 | 16.37 | 16.68 | 2342.80 | 2389.65 | 43.92 | 46.73 | 3.12 | 3.05 | 62.65 | 53.79 | 3.19 | 3.08
16 | 35.34 | 35.31 | 4522.88 | 4519.95 | 7029.68 | 7025.12 | 31.94 | 32.28 | 4558.17 | 4551.28 | 50.76 | 52.17 | 3.16 | 3.16 | 53.90 | 54.95 | 3.20 | 3.19
32 | 66.24 | 67.15 | 8478.43 | 8595.52 | 13092.50 | 13273.33 | 60.12 | 60.74 | 8537.28 | 8658.34 | 71.45 | 70.95 | 3.20 | 3.16 | 89.37 | 85.24 | 3.25 | 3.23
64 | 115.89 | 114.82 | 14834.28 | 14697.50 | 22815.13 | 22604.76 | 105.07 | 103.99 | 14855.10 | 14720.11 | 112.88 | 114.44 | 3.46 | 3.48 | 122.00 | 122.95 | 3.53 | 3.51

The performance is at least on par with MRV1.