### PR TITLE
[CI] Lower granite-4.0-h-tiny gsm8k threshold for Hybrid SSM NixlConnector PD accuracy tests (4 GPUs)

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -9,7 +9,10 @@ BASE_URL = "http://localhost:8192/v1"
 NUM_CONCURRENT = 100
 TASK = "gsm8k"
 FILTER = "exact_match,strict-match"
-RTOL = 0.03
+# TODO(#43186): Widened from 0.03 to absorb chunk_scan/SSU numeric jitter
+# on granite-4.0-h-tiny under NIXL PD; tighten when the kernel divergence
+# is fixed.
+RTOL = 0.05
 
 # Model-specific expected values
 EXPECTED_VALUES = {

--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -19,7 +19,7 @@ EXPECTED_VALUES = {
     "deepseek-ai/DeepSeek-V2-Lite-Chat": 0.65,
     "google/gemma-3-4b-it": 0.74,
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": 0.84,
-    "ibm-granite/granite-4.0-h-tiny": 0.80,
+    "ibm-granite/granite-4.0-h-tiny": 0.75,
     "Qwen/Qwen3.5-0.8B": 0.33,
 }
 

--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -19,7 +19,7 @@ EXPECTED_VALUES = {
     "deepseek-ai/DeepSeek-V2-Lite-Chat": 0.65,
     "google/gemma-3-4b-it": 0.74,
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": 0.84,
-    "ibm-granite/granite-4.0-h-tiny": 0.75,
+    "ibm-granite/granite-4.0-h-tiny": 0.77,
     "Qwen/Qwen3.5-0.8B": 0.33,
 }
 


### PR DESCRIPTION
Failing build: [Hybrid SSM NixlConnector PD accuracy tests (4 GPUs)](https://buildkite.com/vllm/ci/builds/66835/canvas?sid=019e3ed4-250f-4035-99b7-e6c0ba9162c1&tab=output)

## Purpose

`ibm-granite/granite-4.0-h-tiny` gsm8k under NIXL PD disagg shifted from ~0.80 to a wider, lower-mean distribution after #42430 rerouted the D-side 1-token recompute from `mamba_chunk_scan_combined_varlen` to `selective_state_update`.

Investigated the kernel divergence with a fp64 reference at bf16 inputs (the granite dtype). Both kernels hit the bf16 ULP floor (~3.7e-3 vs fp64), but they land at different points within that ball — chunk_scan goes through bf16 matmul with intermediate bf16 casts, while SSU keeps the SSM step in fp32 throughout. Neither is "more correct"; they just produce different bf16 outputs of similar magnitude error. The model's published gsm8k baseline was measured under chunk_scan's specific error pattern, so the SSU-routed recompute lands in a slightly different numeric regime and flips a few greedy-decode tokens.

Per maintainer feedback, set `expected=0.77` and widen `RTOL=0.03 → 0.05` to absorb the observed run-to-run jitter, with a TODO pointing back here for the kernel-level follow-up.

Observed measurements across recent CI runs of this test:
- #66759: 0.7498
- #66782: 0.7415
- #66835: 0.7559
- recent rerun: 0.78

Spread ~0.04 over 4 runs. `expected=0.77` with `RTOL=0.05` gives a passing window of (0.72, 0.82), covering all four measurements with ~2 pp margin.

The underlying kernel divergence (`tl.dot` bf16 cast in chunk_scan vs fp32 reduce in SSU) is left for a separate change.

## Test Plan

## Test Result