### PR TITLE
[Kernel] Fuse Qwen2/3-MoE shared-expert sigmoid gate into a Triton kernel

### DIFF
--- a/tests/kernels/moe/test_fused_shared_expert_gate.py
+++ b/tests/kernels/moe/test_fused_shared_expert_gate.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for `fused_shared_expert_gate`.
+
+Run `pytest tests/kernels/moe/test_fused_shared_expert_gate.py`.
+
+The Triton fusion replaces the three-kernel `F.sigmoid(linear(x)) * out`
+tail of `Qwen2MoeMLP.forward` / `Qwen3MoeMLP.forward`. This test
+parametrizes over real Qwen3-Next-style shapes (`K=2048`, hidden=2048)
+plus a smaller config and mask-boundary token counts (`N=1`, `N=7`) to
+exercise the within-block masking path.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.fused_moe.shared_expert_gate import (
+    fused_shared_expert_gate,
+)
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="fused_shared_expert_gate requires a Triton-capable GPU (CUDA or ROCm).",
+)
+
+
+def _reference(
+    x: torch.Tensor, weight: torch.Tensor, out: torch.Tensor
+) -> torch.Tensor:
+    return F.sigmoid(F.linear(x, weight)) * out
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 33, 1024, 7177, 8192])
+@pytest.mark.parametrize("hidden_size", [1024, 2048])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_shared_expert_gate_matches_reference(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+):
+    torch.manual_seed(0)
+    device = "cuda"
+    x = torch.randn((num_tokens, hidden_size), device=device, dtype=dtype)
+    weight = torch.randn((1, hidden_size), device=device, dtype=dtype)
+    out = torch.randn((num_tokens, hidden_size), device=device, dtype=dtype)
+
+    expected = _reference(x, weight, out)
+    actual = fused_shared_expert_gate(x, weight, out)
+
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+    # Tolerance matches the existing pattern in tests/kernels/ for bf16
+    # row-fused ops; fp16 comfortably fits the same bound.
+    torch.testing.assert_close(actual, expected, atol=3.125e-2, rtol=2e-2)
+
+
+def test_fused_shared_expert_gate_fallback_on_unsupported_shape():
+    """A non-2D `x` must fall back to the PyTorch reference."""
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    # 3D input -- the Triton kernel is 2D-only, so the wrapper must
+    # dispatch to the PyTorch reference path. `F.sigmoid(F.linear(...))`
+    # broadcasts the `[B, N, 1]` gate against the `[B, N, K]` output, so
+    # the reference expression is well-defined and we can compare equality.
+    x = torch.randn((2, 16, 2048), device=device, dtype=dtype)
+    out = torch.randn((2, 16, 2048), device=device, dtype=dtype)
+    weight = torch.randn((1, 2048), device=device, dtype=dtype)
+
+    expected = _reference(x, weight, out)
+    actual = fused_shared_expert_gate(x, weight, out)
+
+    assert actual.shape == expected.shape
+    torch.testing.assert_close(actual, expected, atol=3.125e-2, rtol=2e-2)

--- a/tests/kernels/moe/test_fused_shared_expert_gate.py
+++ b/tests/kernels/moe/test_fused_shared_expert_gate.py
@@ -74,3 +74,53 @@ def test_fused_shared_expert_gate_fallback_on_unsupported_shape():
 
     assert actual.shape == expected.shape
     torch.testing.assert_close(actual, expected, atol=3.125e-2, rtol=2e-2)
+
+
+def test_fused_shared_expert_gate_handles_sliced_row_stride():
+    """Non-K row stride (column slice) with unit inner stride hits the kernel.
+
+    Regression test for the gemini-code-assist review on #43190: ensures the
+    kernel indexes rows by the actual `stride(0)` rather than assuming
+    `row * K`, so that views over a wider allocation still produce correct
+    results instead of silently corrupting data.
+    """
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    K = 2048
+    N = 64
+    x_base = torch.randn((N, 2 * K), device=device, dtype=dtype)
+    out_base = torch.randn((N, 2 * K), device=device, dtype=dtype)
+    x = x_base[:, :K]
+    out = out_base[:, :K]
+    weight = torch.randn((1, K), device=device, dtype=dtype)
+    assert x.stride() == (2 * K, 1)
+    assert out.stride() == (2 * K, 1)
+    assert not x.is_contiguous()
+
+    expected = _reference(x, weight, out)
+    actual = fused_shared_expert_gate(x, weight, out)
+
+    assert actual.shape == expected.shape
+    torch.testing.assert_close(actual, expected, atol=3.125e-2, rtol=2e-2)
+
+
+def test_fused_shared_expert_gate_falls_back_on_non_unit_inner_stride():
+    """Non-unit inner stride must trigger the PyTorch fallback path."""
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    K = 1024
+    N = 32
+    x_base = torch.randn((N, 2 * K), device=device, dtype=dtype)
+    out_base = torch.randn((N, 2 * K), device=device, dtype=dtype)
+    x = x_base[:, ::2]
+    out = out_base[:, ::2]
+    weight = torch.randn((1, K), device=device, dtype=dtype)
+    assert x.stride(1) == 2
+
+    expected = _reference(x, weight, out)
+    actual = fused_shared_expert_gate(x, weight, out)
+
+    assert actual.shape == expected.shape
+    torch.testing.assert_close(actual, expected, atol=3.125e-2, rtol=2e-2)

--- a/vllm/model_executor/layers/fused_moe/shared_expert_gate.py
+++ b/vllm/model_executor/layers/fused_moe/shared_expert_gate.py
@@ -24,6 +24,9 @@ def _fused_shared_expert_gate_kernel(
     weight_ptr,
     out_ptr,
     y_ptr,
+    stride_x_n,
+    stride_out_n,
+    stride_y_n,
     K: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
@@ -31,12 +34,14 @@ def _fused_shared_expert_gate_kernel(
     offsets = tl.arange(0, BLOCK_K)
     mask = offsets < K
 
-    x = tl.load(x_ptr + row * K + offsets, mask=mask, other=0.0).to(tl.float32)
+    x = tl.load(x_ptr + row * stride_x_n + offsets, mask=mask, other=0.0).to(tl.float32)
     weight = tl.load(weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
     gate = tl.sigmoid(tl.sum(x * weight, axis=0))
 
-    out = tl.load(out_ptr + row * K + offsets, mask=mask, other=0.0).to(tl.float32)
-    tl.store(y_ptr + row * K + offsets, out * gate, mask=mask)
+    out = tl.load(out_ptr + row * stride_out_n + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    tl.store(y_ptr + row * stride_y_n + offsets, out * gate, mask=mask)
 
 
 def fused_shared_expert_gate(
@@ -48,8 +53,12 @@ def fused_shared_expert_gate(
 
     Specialised for a one-row gate weight (``weight.shape == [1, K]``), as
     produced by ``ReplicatedLinear(hidden_size, 1)`` in the Qwen2/3-MoE
-    shared-expert blocks. For any other shape, the function falls back to
-    the PyTorch reference so callers can use it unconditionally.
+    shared-expert blocks. The kernel handles arbitrary row strides on ``x``,
+    ``out``, and the output ``y`` (so views with non-K row stride are fine),
+    but assumes unit stride along the inner ``K`` dimension. For any input
+    that violates these requirements -- including the unit-inner-stride
+    requirement on ``weight`` -- the function falls back to the PyTorch
+    reference so callers can use it unconditionally.
 
     Args:
         x: Shared-expert input, shape ``[N, K]``.
@@ -57,8 +66,8 @@ def fused_shared_expert_gate(
         out: Shared-expert MLP output, shape ``[N, K]``.
 
     Returns:
-        ``[N, K]`` tensor equal to ``sigmoid(x @ weight.T) * out`` within
-        bf16/fp16 tolerance.
+        Contiguous ``[N, K]`` tensor equal to ``sigmoid(x @ weight.T) * out``
+        within bf16/fp16 tolerance.
     """
     if (
         x.ndim != 2
@@ -67,15 +76,21 @@ def fused_shared_expert_gate(
         or weight.shape[0] != 1
         or x.shape != out.shape
         or weight.shape[1] != x.shape[1]
+        or x.stride(1) != 1
+        or out.stride(1) != 1
+        or weight.stride(1) != 1
     ):
         return F.sigmoid(F.linear(x, weight)) * out
 
-    y = torch.empty_like(out)
+    y = torch.empty_like(out, memory_format=torch.contiguous_format)
     _fused_shared_expert_gate_kernel[(x.shape[0],)](
         x,
         weight,
         out,
         y,
+        x.stride(0),
+        out.stride(0),
+        y.stride(0),
         K=x.shape[1],
         BLOCK_K=triton.next_power_of_2(x.shape[1]),
         num_warps=8,

--- a/vllm/model_executor/layers/fused_moe/shared_expert_gate.py
+++ b/vllm/model_executor/layers/fused_moe/shared_expert_gate.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused Triton kernel for the Qwen2/3-MoE shared-expert sigmoid gate.
+
+Replaces the three-kernel `F.sigmoid(linear(x)) * out` tail of
+`Qwen2MoeMLP.forward` / `Qwen3MoeMLP.forward` with a single row-fused
+pass that removes the two HBM-resident intermediates.
+
+The wrapper is shape-guarded and silently falls back to the PyTorch
+reference (`F.sigmoid(F.linear(x, weight)) * out`) for any input shape
+this kernel does not handle, so it is safe to use behind the existing
+`expert_gate` call sites without further checks.
+"""
+
+import torch
+import torch.nn.functional as F
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _fused_shared_expert_gate_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    y_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < K
+
+    x = tl.load(x_ptr + row * K + offsets, mask=mask, other=0.0).to(tl.float32)
+    weight = tl.load(weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.sigmoid(tl.sum(x * weight, axis=0))
+
+    out = tl.load(out_ptr + row * K + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(y_ptr + row * K + offsets, out * gate, mask=mask)
+
+
+def fused_shared_expert_gate(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``F.sigmoid(F.linear(x, weight)) * out`` in a single pass.
+
+    Specialised for a one-row gate weight (``weight.shape == [1, K]``), as
+    produced by ``ReplicatedLinear(hidden_size, 1)`` in the Qwen2/3-MoE
+    shared-expert blocks. For any other shape, the function falls back to
+    the PyTorch reference so callers can use it unconditionally.
+
+    Args:
+        x: Shared-expert input, shape ``[N, K]``.
+        weight: Gate weight, shape ``[1, K]``.
+        out: Shared-expert MLP output, shape ``[N, K]``.
+
+    Returns:
+        ``[N, K]`` tensor equal to ``sigmoid(x @ weight.T) * out`` within
+        bf16/fp16 tolerance.
+    """
+    if (
+        x.ndim != 2
+        or out.ndim != 2
+        or weight.ndim != 2
+        or weight.shape[0] != 1
+        or x.shape != out.shape
+        or weight.shape[1] != x.shape[1]
+    ):
+        return F.sigmoid(F.linear(x, weight)) * out
+
+    y = torch.empty_like(out)
+    _fused_shared_expert_gate_kernel[(x.shape[0],)](
+        x,
+        weight,
+        out,
+        y,
+        K=x.shape[1],
+        BLOCK_K=triton.next_power_of_2(x.shape[1]),
+        num_warps=8,
+    )
+    return y

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -30,7 +30,6 @@ from itertools import islice
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 from torch import nn
 from transformers import Qwen2MoeConfig
 
@@ -43,6 +42,9 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
     fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.fused_moe.shared_expert_gate import (
+    fused_shared_expert_gate,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -117,7 +119,7 @@ class Qwen2MoeMLP(nn.Module):
         out, _ = self.down_proj(out)
 
         if self.expert_gate is not None:
-            out = F.sigmoid(self.expert_gate(x)[0]) * out
+            out = fused_shared_expert_gate(x, self.expert_gate.weight, out)
 
         return out
 

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -29,7 +29,6 @@ from itertools import islice
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 from torch import nn
 
 from vllm.compilation.decorators import support_torch_compile
@@ -46,6 +45,9 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
     fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.fused_moe.shared_expert_gate import (
+    fused_shared_expert_gate,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -129,7 +131,7 @@ class Qwen3MoeMLP(nn.Module):
         out, _ = self.down_proj(out)
 
         if self.expert_gate is not None:
-            out = F.sigmoid(self.expert_gate(x)[0]) * out
+            out = fused_shared_expert_gate(x, self.expert_gate.weight, out)
 
         return out
 


### PR DESCRIPTION
## Purpose

Resolves #43187.

`Qwen2MoeMLP.forward` / `Qwen3MoeMLP.forward` currently apply the shared-expert gate as `F.sigmoid(self.expert_gate(x)[0]) * out`, which dispatches three separate GPU kernels with two `[N, 1]` HBM-resident intermediates (the linear logits and the sigmoid of those logits). Because the gate weight is `ReplicatedLinear(hidden_size, 1)`, the "matmul" is really a per-row dot product, so the trip through cuBLAS / hipBLAS is pure overhead on top of the avoidable extra reads/writes.

This PR introduces `fused_shared_expert_gate`, a row-fused Triton kernel under `vllm/model_executor/layers/fused_moe/shared_expert_gate.py`, that loads `x`, the gate weight, and `out` once per row and stores the final result. Both `qwen2_moe.py` and `qwen3_moe.py` swap their three-kernel tail for a single call into this helper.

The wrapper is shape-guarded and silently falls back to the PyTorch reference (`F.sigmoid(F.linear(x, weight)) * out`) for any input shape this kernel does not handle, so it is safe to use unconditionally behind the existing `expert_gate` call sites.

### Relationship to existing FSE work

Complementary to #39280 (AITER FSE), not overlapping. FSE (`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`, default `False`) bypasses the call site at the MoE-block level on ROCm + AITER with explicit opt-in. For NVIDIA, ROCm with AITER off, ROCm + AITER + default, and all `qwen3_moe.py` configs (FSE PR did not touch the duplicate gate code), the slow 3-kernel path runs today. The wrapper here is a no-op when FSE is enabled — the two never execute simultaneously. See #43187 for the full discussion (also covers #37800, the open PR proposing to flip the FSE default on ROCm).

## Test Plan

Inside a Triton-capable GPU container (CUDA or ROCm):

    PYTHONPATH=/path/to/vllm pytest tests/kernels/moe/test_fused_shared_expert_gate.py -v

The new test parametrizes over real Qwen3-Next-style shapes (`K ∈ {1024, 2048}`, `N ∈ {1, 7, 33, 1024, 7177, 8192}`, `dtype ∈ {bf16, fp16}`) plus a 3D-input fallback case that exercises the shape-guard path.

## Test Result

### Correctness (25/25 passing)

Inside `vllm/vllm-openai-rocm:nightly` on MI355x (gfx950), GPU 0:

    ======================= 25 passed, 17 warnings in 10.66s =======================

### End-to-end throughput

Single MI355x, `Qwen3-Next-80B-A3B-Instruct-FP8`, vLLM 0.19.1, TP=1, AITER on, FSE off. Output throughput Δ (fused vs baseline) across three workload shapes × three concurrencies:

| Workload | CONC=16 | CONC=32 | CONC=64 | mean |
| --- | ---: | ---: | ---: | ---: |
| balanced (ISL=OSL=1024) | +2.69% | +7.09% | +4.18% | **+4.65%** |
| decode-heavy (ISL=1024 / OSL=8192) | +5.99% | +6.96% | +6.12% | **+6.36%** |
| prefill-heavy (ISL=8192 / OSL=1024) | +3.87% | +12.68% | +14.32% | **+10.29%** |

Kernel-only microbench (bf16, MI355x) shows 1.22–1.36× on real Qwen3-Next shapes (`N ∈ {1024, 7177, 8192}`, `K=2048`). Detailed Pareto plots and per-cell numbers in a benchmark HTML available on request — happy to attach if reviewers want them.

I will re-run on `main` HEAD once direction is approved; the call sites at the v0.19.1 commit and current main HEAD are unchanged, so the numbers should carry over.

---

### AI assistance disclosure (per AGENTS.md §1)

This PR was prepared with AI assistance (Cursor + Claude). The submitting human (`@haofrank`) reviewed every changed line, designed the test matrix, ran pytest + bench on MI355x, and is responsible for the contribution end-to-end. See the `Co-authored-by: Claude` and `Co-authored-by: Cursor` trailers on the commit.

cc @sighingnow @vadiklyutiy (qwen models codeowners), @mgoin @pavanimajety @zyongye (fused_moe codeowners), @tlrmchlsmth @WoosukKwon @yewentao256 (tests/kernels codeowners), @tpopp @dllehr-amd (FSE authors), @ChuanLi1101 (#37800 author).