### PR TITLE
Enable mermaid diagrams in the docs

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -119,7 +119,11 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   # For content tabs
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:


### PR DESCRIPTION
Adds the necessary MkDocs config to enable mermaid diagrams in the docs