### PR TITLE
Fix: Gate DeepSeek V4 FP8 CuTe DSL dispatch by GPU capability

### DIFF
--- a/tests/kernels/test_fused_indexer_q_rope_quant.py
+++ b/tests/kernels/test_fused_indexer_q_rope_quant.py
@@ -194,3 +194,46 @@ def test_fused_indexer_q_rope_quant_matches_unfused(
         f"weights mismatch: max abs diff "
         f"{(weights_ref - weights_fused).abs().max().item()}"
     )
+
+
+def test_fp8_cutedsl_dispatch_requires_sm90(monkeypatch):
+    import vllm.models.deepseek_v4.common.ops.fused_indexer_q as fused_indexer_q
+
+    fallback_called = False
+
+    class FakeTritonKernel:
+        def __getitem__(self, grid):
+            def launcher(*args, **kwargs):
+                nonlocal fallback_called
+                fallback_called = True
+
+            return launcher
+
+    monkeypatch.setattr(fused_indexer_q, "has_cutedsl", lambda: True)
+    monkeypatch.setattr(
+        fused_indexer_q.current_platform,
+        "has_device_capability",
+        lambda capability: False,
+    )
+    monkeypatch.setattr(
+        fused_indexer_q,
+        "_fused_indexer_q_rope_quant_kernel",
+        FakeTritonKernel(),
+    )
+
+    q = torch.empty((1, N_HEAD, HEAD_DIM), dtype=torch.bfloat16)
+    positions = torch.empty((1,), dtype=torch.int64)
+    cos_sin_cache = torch.empty((MAX_POS, ROPE_DIM), dtype=torch.float32)
+    weights = torch.empty((1, N_HEAD), dtype=torch.bfloat16)
+
+    fused_indexer_q.fused_indexer_q_rope_quant(
+        positions,
+        q,
+        cos_sin_cache,
+        weights,
+        HEAD_DIM**-0.5,
+        N_HEAD**-0.5,
+        use_fp4=False,
+    )
+
+    assert fallback_called

--- a/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
@@ -3,6 +3,7 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_cutedsl
 
@@ -398,7 +399,7 @@ def fused_indexer_q_rope_quant(
         ), index_weights_out
 
     index_q_fp8 = torch.empty_like(index_q, dtype=torch.float8_e4m3fn)
-    if has_cutedsl():
+    if has_cutedsl() and current_platform.has_device_capability(90):
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.fused_indexer_q_cutedsl import (
             fused_indexer_q_rope_quant_fp8_cutedsl,


### PR DESCRIPTION
 
## Purpose

Issue:
  When cutlass is installed on a CUDA GPU below SM90, the FP8 DeepSeek V4 indexer dispatch enters the CuTe DSL kernel because it only checks has_cutedsl().
  The FP8 indexer path may fail during kernel compilation or execution on unsupported GPUs, instead of using the existing Triton fallback.


  Root cause:
  The dispatch condition checked package availability but not GPU compute capability. 
  The CuTe DSL FP8 kernel should run only on SM90+ GPUs. Older GPUs should continue using the Triton implementation.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

