### PR TITLE
[Bugfix] fix device mismatch in MiniCPM-o-4_5 resampler

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -378,7 +378,9 @@ class Resampler4_5(Resampler2_5):
                     )  # D
 
             pos_embed_2d.append(
-                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
+                self.pos_embed[:tgt_h, :tgt_w, :]
+                .reshape((tgt_h * tgt_w, -1))
+                .to(device=device, dtype=dtype)
             )  # patches * D
             key_padding_mask[i, patch_len[i] :] = True
 


### PR DESCRIPTION



## Purpose
Fix below error for model `openbmb/MiniCPM-o-4_5`:
```
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962]     return forward_call(*args, **kwargs)
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962]   File "/workspace/vllm/vllm/model_executor/models/minicpmv.py", line 422, in forward
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962]     k = x + pos_embed_2d
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962]         ~~^~~~~~~~~~~~~~
(Worker_TP0 pid=52450) ERROR 05-20 07:47:18 [multiproc_executor.py:962] RuntimeError: Expected all tensors to be on the same device, but found at least two devices, xpu:0 and cpu!

```
## Test Plan
```
VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/basic/offline_inference/generate.py --model openbmb/MiniCPM-o-4_5  --enforce-eager -tp=2 --trust_remote_code
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

