### PR TITLE
[CI] De-flake test_models for bigscience/bloom-560m

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1204,6 +1204,15 @@ def try_get_dense_modules(
         return None
 
 
+def _read_safetensors_metadata_in_dir(local_dir: Path) -> dict[str, Any]:
+    return {
+        param_name: info
+        for file_path in local_dir.glob("*.safetensors")
+        if file_path.is_file()
+        for param_name, info in parse_safetensors_file_metadata(file_path).items()
+    }
+
+
 def get_safetensors_params_metadata(
     model: str,
     *,
@@ -1212,24 +1221,36 @@ def get_safetensors_params_metadata(
     """
     Get the safetensors parameters metadata for remote/local model repository.
     """
-    full_metadata = {}
     if (model_path := Path(model)).exists():
-        safetensors_to_check = model_path.glob("*.safetensors")
-        full_metadata = {
-            param_name: info
-            for file_path in safetensors_to_check
-            if file_path.is_file()
-            for param_name, info in parse_safetensors_file_metadata(file_path).items()
+        return _read_safetensors_metadata_in_dir(model_path)
+
+    repo_mt = try_get_safetensors_metadata(model, revision=revision)
+    if repo_mt and (files_mt := repo_mt.files_metadata):
+        return {
+            param_name: asdict(info)
+            for file_mt in files_mt.values()
+            for param_name, info in file_mt.tensors.items()
         }
-    else:
-        repo_mt = try_get_safetensors_metadata(model, revision=revision)
-        if repo_mt and (files_mt := repo_mt.files_metadata):
-            full_metadata = {
-                param_name: asdict(info)
-                for file_mt in files_mt.values()
-                for param_name, info in file_mt.tensors.items()
-            }
-    return full_metadata
+
+    # Hub fetch failed (e.g. 429, network unreachable). Fall back to the
+    # local HF cache: weights may already be cached from a prior run, and
+    # weight loading itself uses the same cache.
+    try:
+        local_dir = huggingface_hub.snapshot_download(
+            repo_id=model,
+            revision=revision,
+            allow_patterns=["*.safetensors"],
+            local_files_only=True,
+        )
+    except huggingface_hub.errors.LocalEntryNotFoundError as e:
+        logger.warning_once(
+            "Could not retrieve safetensors metadata for %s "
+            "(Hub fetch failed and no local cache snapshot is available): %s.",
+            model,
+            str(e),
+        )
+        return {}
+    return _read_safetensors_metadata_in_dir(Path(local_dir))
 
 
 def _download_mistral_config_file(model, revision) -> dict:


### PR DESCRIPTION
## Purpose

`vllm/transformers_utils/config.py::get_safetensors_params_metadata` queries the HuggingFace Hub for tensor dtypes during `dtype="auto"` resolution. When the Hub returns 429 or is unreachable, the call returns empty; `_resolve_auto_dtype` then silently substitutes bf16 on bf16-capable platforms, even when the cached checkpoint is fp16. Weight loading itself already uses the local HF cache, so the metadata lookup is the only step that depends on Hub reachability.

Manifests as a flaky CI failure on `test_common.py::test_models[*-bigscience/bloom-560m]` ([failing run](https://buildkite.com/vllm/ci/builds/67040/canvas?sid=019e4367-f097-4f59-aa24-9de2852e90f3&tab=output)): bloom-560m's near-uniform first-token logits in bf16 collapse to a 5-way top-K tie, HF and vLLM resolve the tie differently, `check_logprobs_close` fails.

### Failing build log

```
ERROR 05-20 04:16:14 [repo_utils.py:47] 429 Too Many Requests: you have reached your 'resolvers' rate limit.
ERROR 05-20 04:16:14 [repo_utils.py:47] Url: https://huggingface.co/bigscience/bloom-560m/resolve/main/model.safetensors.
...
INFO 05-20 04:16:16 [model.py:2046] Downcasting torch.float32 to torch.bfloat16.
...
AssertionError: Test3:
hf:  {1411: -3.636173725128174, 20: -3.636173725128174, 2175: -3.636173725128174, 2933: -3.636173725128174, 36: -3.636173725128174}
vllm: {2175: ..., 7572: ..., 21430: ..., 1411: ..., 36: ...}
```

### Fix

When the Hub call yields no metadata, call `huggingface_hub.snapshot_download` with `local_files_only=True` and parse safetensors metadata from the locally cached files using the existing `parse_safetensors_file_metadata` helper.

### Verification

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Hub OK | fp16 | fp16 |
| Hub down + cache hit (the CI failure scenario) | bf16 (wrong) | fp16 (correct) |
| Hub down + cache miss | bf16 (existing fallback) | bf16 (preserved) |

## Test Plan

## Test Result