### PR TITLE
[Bugfix] Preserve reasoning, content, and role fields on streaming boundary delta transitions

### DIFF
--- a/tests/parser/test_streaming.py
+++ b/tests/parser/test_streaming.py
@@ -163,3 +163,38 @@ def test_parse_delta_reasoning_only_thinking_disabled(tokenizer, request_obj):
     assert "Hello" in content
     assert "assist" in content
     assert len(tool_calls) == 0
+
+
+def test_parse_delta_transition_chunk(tokenizer, request_obj):
+    parser = make_parser(tokenizer, reasoning=True, tool=True)
+
+    # Step 1: initial reasoning chunk
+    res1 = parser.parse_delta(
+        delta_text="<think>let me think",
+        delta_token_ids=tokenizer.encode(
+            "<think>let me think", add_special_tokens=False
+        ),
+        request=request_obj,
+        prompt_token_ids=[],
+    )
+    assert res1 is not None
+    assert "let me think" in res1.reasoning
+    assert len(res1.tool_calls) == 0
+
+    # Step 2: transition chunk containing both the end of reasoning and the tool call
+    transition_text = (
+        " about this</think>"
+        '<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"city": "Dallas"}}\n</tool_call>'
+    )
+    res2 = parser.parse_delta(
+        delta_text=transition_text,
+        delta_token_ids=tokenizer.encode(transition_text, add_special_tokens=False),
+        request=request_obj,
+    )
+    assert res2 is not None
+    # Verify that the reasoning component is NOT overwritten and lost!
+    assert "about this" in res2.reasoning
+    # Verify that the tool call component is also captured!
+    assert len(res2.tool_calls) > 0
+    assert res2.tool_calls[0].function.name == "get_weather"

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -634,6 +634,13 @@ class DelegatingParser(Parser):
             return False
         return self._reasoning_parser.is_reasoning_end(input_ids)
 
+    def is_reasoning_end_streaming(
+        self, input_ids: list[int], delta_ids: list[int]
+    ) -> bool:
+        if self._reasoning_parser is None:
+            return False
+        return self._reasoning_parser.is_reasoning_end_streaming(input_ids, delta_ids)
+
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if self._reasoning_parser is None:
             return input_ids
@@ -667,11 +674,11 @@ class DelegatingParser(Parser):
 
         current_text = state.previous_text + delta_text
         current_token_ids = state.previous_token_ids + delta_token_ids
-        delta_message: DeltaMessage | None = None
+        reasoning_delta: DeltaMessage | None = None
 
         # Reasoning extraction
         if self._in_reasoning_phase(state):
-            delta_message = self.extract_reasoning_streaming(
+            reasoning_delta = self.extract_reasoning_streaming(
                 previous_text=state.previous_text,
                 current_text=current_text,
                 delta_text=delta_text,
@@ -679,17 +686,21 @@ class DelegatingParser(Parser):
                 current_token_ids=current_token_ids,
                 delta_token_ids=delta_token_ids,
             )
-            # Hand off remaining content to tool parser
-            if self._tool_parser and self.is_reasoning_end(delta_token_ids):
+            # Hand off remaining content to tool parser or content
+            if self.is_reasoning_end_streaming(current_token_ids, delta_token_ids):
                 state.reasoning_ended = True
                 current_token_ids = self.extract_content_ids(delta_token_ids)
-                if delta_message and delta_message.content:
-                    current_text = delta_message.content
-                    delta_message.content = None
+                if reasoning_delta and reasoning_delta.content:
+                    current_text = reasoning_delta.content
+                    if self._tool_parser:
+                        reasoning_delta.content = None
                 else:
                     current_text = ""
+                delta_text = current_text
+                delta_token_ids = current_token_ids
 
         # Tool call extraction
+        tool_delta: DeltaMessage | None = None
         if self._in_tool_call_phase(state):
             if not state.tool_call_text_started:
                 state.tool_call_text_started = True
@@ -698,7 +709,7 @@ class DelegatingParser(Parser):
                 delta_text = current_text
                 delta_token_ids = current_token_ids
 
-            delta_message, state.function_name_returned = (
+            tool_delta, state.function_name_returned = (
                 self._extract_tool_calls_streaming(
                     previous_text=state.previous_text,
                     current_text=current_text,
@@ -713,11 +724,24 @@ class DelegatingParser(Parser):
                 )
             )
             if (
-                delta_message
-                and delta_message.tool_calls
-                and delta_message.tool_calls[0].id is not None
+                tool_delta
+                and tool_delta.tool_calls
+                and tool_delta.tool_calls[0].id is not None
             ):
                 state.history_tool_call_cnt += 1
+
+        delta_message: DeltaMessage | None = None
+        if tool_delta is not None:
+            delta_message = tool_delta
+            if reasoning_delta is not None:
+                if reasoning_delta.reasoning:
+                    delta_message.reasoning = reasoning_delta.reasoning
+                if delta_message.content is None and reasoning_delta.content:
+                    delta_message.content = reasoning_delta.content
+                if delta_message.role is None and reasoning_delta.role:
+                    delta_message.role = reasoning_delta.role
+        else:
+            delta_message = reasoning_delta
 
         # No phase active: pass through as content
         if (


### PR DESCRIPTION

## Purpose
This PR fixes a bug in `DelegatingParser.parse_delta` where reasoning content (and other metadata) is silently overwritten and lost when a single streaming token chunk spans across the transition boundary from the reasoning phase to the content/tool-call phase (which is extremely common during Speculative Decoding / MTP).

### Root Cause
When a boundary-spanning chunk (e.g. ` think about this</think><tool_call>{\"name\"`) arrives:
1. The reasoning block in `parse_delta` extracts the reasoning content (`" think about this"`) and assigns it to `delta_message`.
2. It detects the end of the reasoning phase and transitions the state (`state.reasoning_ended = True`).
3. In the same call, since the state has transitioned, the tool-call parser is immediately invoked on the remaining portion of the chunk.
4. The tool-call parser returns a new `DeltaMessage` (for the tool calls) and overwrites the `delta_message` variable, completely discarding the reasoning/content extracted in step 1.

---

## Comparative Analysis & Why This Is Not a Duplicate

There are two open PRs addressing this issue: [#42691](https://github.com/vllm-project/vllm/pull/42691) and [#43055](https://github.com/vllm-project/vllm/pull/43055). This PR does not duplicate them; instead, it proposes a **superior, best-of-both-worlds architectural approach**:

| Dimension | PR #42691 | PR #43055 | This PR (Our Solution) |
| :--- | :--- | :--- | :--- |
| **Boundary Detection** | Uses `is_reasoning_end_streaming` (fixes token-split bugs) | Uses `is_reasoning_end` (vulnerable to token-split bugs) | **Uses `is_reasoning_end_streaming` (robust)** |
| **Preserved Fields** | Only `reasoning` (drops `content` or `role` if set) | `reasoning`, `content`, `role` | **`reasoning`, `content`, `role` (complete)** |
| **Code Architecture** | Reuses `delta_message` via ad-hoc save/restore variables | Reuses `delta_message` via ad-hoc save/restore variables | **Decoupled variables (`reasoning_delta` & `tool_delta`) with clean merge at the end** |
| **No-Tool Transition** | Supported | Not handled | **Supported** |

### Key Improvements in This PR:
1. **Decoupled Variable Design**: Instead of mutably overwriting and restoring fields on the same `delta_message` object back-and-forth, we isolate the outputs of the reasoning and tool-calling phases into separate `reasoning_delta` and `tool_delta` variables. We then perform a clean, pure merge at the end of the function.
2. **Robust Boundary Check + All-Field Merging**: We combine the streaming-aware boundary check `is_reasoning_end_streaming` from #42691 (to handle `</think>` being sliced across token boundaries) with the complete field restoration (`reasoning`, `content`, and `role`) from #43055.

---

## Proposed Changes

### [vllm/parser/abstract_parser.py](file:///Users/jihuihuang/.superset/worktrees/vllm/fix/transition-reasoning-tool-overwrite/vllm/parser/abstract_parser.py)
* Overrode `is_reasoning_end_streaming` in `DelegatingParser` to properly delegate to the underlying reasoning parser's streaming-aware method.
* Updated `parse_delta` to separate phase outputs and cleanly merge all set fields (`reasoning`, `content`, `role`) at the final step.
* Handled the no-tool-parser transition case by updating `delta_text` and `delta_token_ids` to the remaining content when reasoning ends, while preserving the content of the reasoning chunk if no tool parser is active.

### [tests/parser/test_streaming.py](file:///Users/jihuihuang/.superset/worktrees/vllm/fix/transition-reasoning-tool-overwrite/tests/parser/test_streaming.py)
* Added `test_parse_delta_transition_chunk` regression test to simulate a single boundary-spanning chunk containing both the end of reasoning (`</think>`) and a tool call.

---

## Test Plan

### Automated Tests
Run the streaming parser test suite bypassing the local PyTorch MPS allocator cleanup issue:
```bash
.venv/bin/python -m pytest tests/parser/test_streaming.py -v --noconftest
```

**Results:**
```

======================== 6 passed, 2 warnings in 17.25s ========================
```

### Linters and Typecheckers
Ran all pre-commit hooks on modified files:
```bash
.venv/bin/pre-commit run --files vllm/parser/abstract_parser.py tests/parser/test_streaming.py
```
*




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

