### PR TITLE
[Cleanup]Simplify UnitaryKVCacheCoordinator hash_block_size assert

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -361,9 +361,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             self.block_size *= dcp_world_size
         if pcp_world_size > 1:
             self.block_size *= pcp_world_size
-        # For models using only Mamba, block_size is set to max_model_len when
-        # prefix caching is disabled, and hash_block_size validation is skipped.
-        assert not enable_caching or (hash_block_size == self.block_size), (
+        assert hash_block_size == self.block_size, (
             "UnitaryKVCacheCoordinator assumes hash_block_size == block_size"
         )
         assert len(self.kv_cache_config.kv_cache_groups) == 1, (


### PR DESCRIPTION

## Purpose

Simplify `UnitaryKVCacheCoordinator`'s `hash_block_size` invariant: `get_kv_cache_coordinator` only constructs this class when prefix caching is enabled, so `not enable_caching` in the assertion was dead code. Remove the misleading Mamba/NoPrefixCache comment that described `KVCacheCoordinatorNoPrefixCache` behavior, not this class.

## Test Plan

None

## Test Result

None
