### PR TITLE
Fix FlashInfer TRTLLM NvFP4 monolithic MoE routing

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -159,7 +159,7 @@ def get_routing_method_type(
 
     if scoring_func == "softmax":
         if renormalize:
-            return RoutingMethodType.Renormalize
+            return RoutingMethodType.RenormalizeNaive
         else:
             return RoutingMethodType.Default
 

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -308,6 +308,15 @@ class TrtLlmNvFp4ExpertsMonolithic(
             and self.routing_method_type != RoutingMethodType.Llama4
         )
 
+        routing_method_type = self.routing_method_type
+        if routing_method_type == RoutingMethodType.Renormalize:
+            # vLLM's fused_topk_softmax(..., renormalize=True) semantics are
+            # softmax -> topk -> renormalize. FlashInfer TRTLLM names that
+            # path RenormalizeNaive; Renormalize means topk -> softmax. Using
+            # Renormalize here selects a different router path in the fused
+            # monolithic kernel and can quickly diverge into repetitive text.
+            routing_method_type = RoutingMethodType.RenormalizeNaive
+
         # Currently FI requires bfloat16 routing bias.
         # https://github.com/flashinfer-ai/flashinfer/issues/2909
         if e_score_correction_bias is not None:
@@ -343,7 +352,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
             local_expert_offset=self.ep_rank * self.local_num_experts,
             local_num_experts=self.local_num_experts,
             routed_scaling_factor=routed_scaling_factor,
-            routing_method_type=self.routing_method_type,
+            routing_method_type=int(routing_method_type),
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
         )[0]

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -308,15 +308,6 @@ class TrtLlmNvFp4ExpertsMonolithic(
             and self.routing_method_type != RoutingMethodType.Llama4
         )
 
-        routing_method_type = self.routing_method_type
-        if routing_method_type == RoutingMethodType.Renormalize:
-            # vLLM's fused_topk_softmax(..., renormalize=True) semantics are
-            # softmax -> topk -> renormalize. FlashInfer TRTLLM names that
-            # path RenormalizeNaive; Renormalize means topk -> softmax. Using
-            # Renormalize here selects a different router path in the fused
-            # monolithic kernel and can quickly diverge into repetitive text.
-            routing_method_type = RoutingMethodType.RenormalizeNaive
-
         # Currently FI requires bfloat16 routing bias.
         # https://github.com/flashinfer-ai/flashinfer/issues/2909
         if e_score_correction_bias is not None:
@@ -352,7 +343,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
             local_expert_offset=self.ep_rank * self.local_num_experts,
             local_num_experts=self.local_num_experts,
             routed_scaling_factor=routed_scaling_factor,
-            routing_method_type=int(routing_method_type),
+            routing_method_type=self.routing_method_type,
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
         )[0]


### PR DESCRIPTION
## Summary

This MR fixes the FlashInfer TRTLLM NvFP4 monolithic MoE path for Qwen3.5 MoE NVFP4 models.

The monolithic TRTLLM NvFP4 kernel was receiving vLLM routing metadata with subtly different semantics from FlashInfer TRTLLM. For Qwen3.5 MoE NVFP4 checkpoints, this caused the fused monolithic path to select the wrong routing behavior and quickly diverge into low-quality or repetitive generations. The fix keeps the monolithic implementation enabled and corrects the inputs passed to the FlashInfer TRTLLM fused MoE kernel instead of bypassing the issue via the modular path.

## Motivation

`TrtLlmNvFp4ExpertsMonolithic` uses FlashInfer's `trtllm_fp4_block_scale_moe` kernel to fuse routing and expert execution. vLLM's `RoutingMethodType.Renormalize` corresponds to the common `fused_topk_softmax(..., renormalize=True)` behavior:

1. softmax over router logits
2. top-k selection
3. renormalization over selected experts

FlashInfer TRTLLM, however, names this behavior `RenormalizeNaive`. Its `Renormalize` mode means a different route:

1. top-k selection
2. softmax over selected experts

Passing vLLM `Renormalize` directly to the FlashInfer TRTLLM monolithic kernel therefore selected a different router path. On the tested Qwen3.5 MoE NVFP4 checkpoint, this made the monolithic path produce incorrect and repetitive output.

## Changes



1. Map vLLM `RoutingMethodType.Renormalize` to FlashInfer TRTLLM `RoutingMethodType.RenormalizeNaive` .
   - Source: `vllm/model_executor/layers/fused_moe/config.py:162`

## Validation

### Backend and code path validation

using FlashInfer TRTLLM NvFP4 monolithic MoE path.

### GSM8K evaluation

I evaluated the Qwen3.5 MoE NVFP4 checkpoint(fine-tuned) with the `flashinfer_trtllm` NvFP4 MoE backend before and after this fix.

Because only the GSM8K test split was available locally during this run, this comparison uses zero-shot GSM8K (`num_shots=0`) on the full 1,319-question test set. Both runs used the same model, backend, decoding parameters, and `max_model_len=4096`.

#### Commands

Before fix:

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONNOUSERSITE=1 FLASHINFER_DISABLE_VERSION_CHECK=1 \
GSM8K_MONOLITHIC_VARIANT=before PYTHONUNBUFFERED=1 \
python /path_to_root/compare_moe_backend_out/gsm8k/run_gsm8k_eval.py \
  --variant before \
  --model /path_to_model \
  --out /path_to_root/compare_moe_backend_out/gsm8k/before_fix.json \
  --num-questions 1319 \
  --num-shots 0 \
  --max-tokens 256 \
  --max-model-len 4096
```

After fix:

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONNOUSERSITE=1 FLASHINFER_DISABLE_VERSION_CHECK=1 \
PYTHONUNBUFFERED=1 \
python /path_to_root/compare_moe_backend_out/gsm8k/run_gsm8k_eval.py \
  --variant after \
  --model /path_to_model \
  --out /path_to_root/compare_moe_backend_out/gsm8k/after_fix.json \
  --num-questions 1319 \
  --num-shots 0 \
  --max-tokens 256 \
  --max-model-len 4096
```

#### Results

| Variant | Accuracy | Correct / Total | Invalid Rate | Latency | Output Tokens |
|---|---:|---:|---:|---:|---:|
| Before fix | 0.016679 | 22 / 1319 | 0.131160 | 44.80s | 333,580 |
| After fix | 0.687642 | 907 / 1319 | 0.007582 | 52.49s | 225,048 |

The fix improves GSM8K accuracy by `+0.670963` absolute, from `1.67%` to `68.76%`, and reduces invalid responses from `13.12%` to `0.76%`. The after-fix run also produces substantially fewer output tokens, which is consistent with eliminating the previous repetitive/garbage generations.

