### PR TITLE
[Bugfix][Gemma4MoE] Fix AutoRound quantized Gemma4 MoE loading

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import TYPE_CHECKING
+
 import torch
 from torch.nn.parameter import Parameter
 
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization import QuantizationConfig
 
 
 @PluggableLayer.register("gate_linear")
@@ -32,6 +37,7 @@ class GateLinear(ReplicatedLinear):
         bias: bool = False,
         out_dtype: torch.dtype | None = None,
         params_dtype: torch.dtype | None = None,
+        quant_config: "QuantizationConfig | None" = None,
         force_fp32_compute: bool = False,
         prefix: str = "",
     ):
@@ -39,7 +45,10 @@ class GateLinear(ReplicatedLinear):
             (9, 0)
         ) or current_platform.is_device_capability_family(100)
         can_use_specialized_kernels = (
-            current_platform.is_cuda() and is_hopper_or_blackwell and not bias
+            quant_config is None
+            and current_platform.is_cuda()
+            and is_hopper_or_blackwell
+            and not bias
         )
 
         # If fp32 compute is required and no specialized kernel is available,
@@ -52,7 +61,7 @@ class GateLinear(ReplicatedLinear):
             output_size,
             bias=bias,
             params_dtype=params_dtype,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=prefix,
         )
         self.out_dtype = out_dtype
@@ -109,7 +118,11 @@ class GateLinear(ReplicatedLinear):
             return output, None
 
         # Tier 3: F.linear (ReplicatedLinear)
-        if self.out_dtype is not None and x.dtype != self.weight.dtype:
+        if (
+            self.out_dtype is not None
+            and hasattr(self, "weight")
+            and x.dtype != self.weight.dtype
+        ):
             x = x.to(self.weight.dtype)
         output, output_bias = super().forward(x)
         if self.out_dtype is not None and output.dtype != self.out_dtype:

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -366,12 +366,14 @@ class AutoGPTQLinearMethod(LinearMethodBase):
             # By setting scale_dim == None, weight_loader will
             # repeat the scales on each GPU in TP>1 case.
             scales_and_zp_input_dim = None
-            scales_and_zp_size = input_size // group_size
+            scales_and_zp_size = (input_size + group_size - 1) // group_size
         else:
             # By setting scale_dim == 0, weight_loader will
             # shard the scales in TP>1 case.
             scales_and_zp_input_dim = 0
-            scales_and_zp_size = input_size_per_partition // group_size
+            scales_and_zp_size = (
+                input_size_per_partition + group_size - 1
+            ) // group_size
 
         # Quantized weights
         qweight = PackedvLLMParameter(

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -13,7 +13,6 @@ from vllm.model_executor.layers.fused_moe import (
     RoutedExperts,
     SharedExperts,
 )
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     int4_w4a16_moe_quant_config,
@@ -367,10 +366,6 @@ class MoeWNA16Method(FusedMoEMethodBase):
     ) -> torch.Tensor:
         from vllm.model_executor.layers.fused_moe import fused_experts
 
-        assert layer.activation == MoEActivation.SILU, (
-            f"Only SiLU activation is supported, not {layer.activation}."
-        )
-
         return fused_experts(
             x,
             layer.w13_qweight,
@@ -378,6 +373,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             inplace=not self.moe.disable_inplace,
+            activation=layer.activation,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -89,6 +89,27 @@ def _remap_gemma4_expert_weight_name(name: str) -> str:
     return re.sub(r"(?<!\.moe)\.experts\.(\d+)\.", r".moe.experts.\1.", name)
 
 
+def _maybe_add_k_eq_v_quant_config(
+    config,
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> None:
+    if quant_config is None or not getattr(config, "attention_k_eq_v", False):
+        return
+
+    extra_config = getattr(quant_config, "extra_config", None)
+    if not isinstance(extra_config, dict):
+        return
+
+    for layer_idx, layer_type in enumerate(config.layer_types):
+        if layer_type != "full_attention":
+            continue
+        k_proj = maybe_prefix(prefix, f"layers.{layer_idx}.self_attn.k_proj")
+        v_proj = maybe_prefix(prefix, f"layers.{layer_idx}.self_attn.v_proj")
+        if k_proj in extra_config and v_proj not in extra_config:
+            extra_config[v_proj] = dict(extra_config[k_proj])
+
+
 @triton.jit
 def _gemma4_routing_kernel(
     gating_ptr,
@@ -286,6 +307,7 @@ class Gemma4Router(nn.Module):
             config.num_experts,
             bias=False,
             out_dtype=torch.float32,
+            quant_config=quant_config,
             prefix=f"{prefix}.proj",
         )
 
@@ -961,6 +983,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         config = _get_text_config(vllm_config.model_config.hf_config)
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
+        _maybe_add_k_eq_v_quant_config(config, quant_config, prefix)
         self.config = config
         self.quant_config = quant_config
 


### PR DESCRIPTION
## Purpose

Fix AutoRound-quantized Gemma4 MoE checkpoints so they can load and generate valid text in vLLM.

This PR fixes several issues found while serving Gemma4 MoE AutoRound checkpoints:

- Pass `quant_config` into Gemma4 router `GateLinear`, so quantized router weights such as `router.proj.qweight` are registered and loaded correctly.
- Use the actual MoE activation in WNA16 fused experts instead of assuming SiLU; Gemma4 MoE uses `gelu_tanh`.
- Allocate GPTQ `scales`/`qzeros` rows with ceil division when `input_size` is not divisible by `group_size`, avoiding silently dropped tail groups.
- Mirror `k_proj` quant config to `v_proj` for Gemma4 `attention_k_eq_v` full-attention layers, so fused `qkv_proj` sees consistent quant settings for AutoRound mixed-bit checkpoints.

Duplicate-work check: I checked related open PR searches for `Gemma4 AutoRound`, `Gemma4 MoE quantization`, `AutoRound quantization`, and `k_eq_v quant config`. I did not find an open PR that covers this exact fix set. 

## Test Plan

Commands/checks used:

```bash
vllm serve Intel/gemma-4-26B-A4B-it-int4-AutoRound 
vllm serve Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
```

Both servers were queried through /v1/chat/completions with a simple  prompt.

## Test Result

Pure int4 AutoRound Gemma4 MoE checkpoint: server loaded successfully and returned normal text.
Mixed AutoRound Gemma4 MoE checkpoint: server loaded successfully and returned normal text.

### Before this fix:

The pure int4 AutoRound checkpoint failed during loading because the Gemma4 router projection did not register quantized weights.
After partial loading fixes, generation could become corrupted because the GPTQ tail group scales/qzeros were truncated.
The mixed AutoRound checkpoint failed on fused qkv_proj because attention_k_eq_v layers duplicated K weights into V but did not mirror the per-layer quant config.

### After this fix:

Both tested AutoRound Gemma4 MoE checkpoints load.
Both produce readable, coherent responses in the local serving path.

