### PR TITLE
[Bugfix][CI] Add missing import of pad_nvfp4_activation_for_cutlass in flashinfer

### DIFF
--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -5,6 +5,7 @@ import torch
 
 from vllm._custom_ops import scaled_fp4_quant
 from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    pad_nvfp4_activation_for_cutlass,
     pad_nvfp4_weight_for_cutlass,
     slice_nvfp4_output,
     swizzle_blockscale,


### PR DESCRIPTION
## Purpose
- PR #40082 introduced `FlashInferB12xNvFp4LinearKernel` which calls `pad_nvfp4_activation_for_cutlass` but forgot to add it to the import block, causing a mypy `[name-defined]` error in CI.
- Adds the missing import from `nvfp4_utils`.

## Test Plan
CI mypy check passes on `vllm/model_executor/kernels/linear/nvfp4/flashinfer.py`