### PR TITLE
[Model Runner V2][Spec Decode] Add Gemma4 MTP support

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -62,7 +62,6 @@ from vllm.v1.attention.backends.utils import (
     KVCacheLayoutType,
     get_dcp_local_seq_lens,
     get_kv_cache_layout,
-    get_num_attention_heads_from_layers,
     get_per_layer_parameters,
     infer_global_hyperparameters,
     split_decodes_and_prefills,
@@ -608,10 +607,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.use_dcp and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
 
-        # Compatible with models with non-uniform per-layer head counts.
-        self.num_qo_heads = get_num_attention_heads_from_layers(
-            vllm_config, layer_names
-        ) or self.model_config.get_num_attention_heads(self.vllm_config.parallel_config)
+        self.num_qo_heads = self.model_config.get_num_attention_heads(
+            self.vllm_config.parallel_config
+        )
 
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -30,10 +30,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import (
-    get_kv_cache_layout,
-    get_num_attention_heads_from_layers,
-)
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
 from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
@@ -142,10 +139,9 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         self.block_size = kv_cache_spec.block_size
 
         model_config = vllm_config.model_config
-        # Compatible with models with non-uniform per-layer head counts.
-        self.num_heads_q = get_num_attention_heads_from_layers(
-            vllm_config, layer_names
-        ) or model_config.get_num_attention_heads(vllm_config.parallel_config)
+        self.num_heads_q = model_config.get_num_attention_heads(
+            vllm_config.parallel_config
+        )
         self.num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
         self.headdim = model_config.get_head_size()
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -136,32 +136,6 @@ def get_per_layer_parameters(
     return per_layer_params
 
 
-def get_num_attention_heads_from_layers(
-    vllm_config: VllmConfig, layer_names: list[str]
-) -> int | None:
-    """Per-TP-rank ``num_heads`` shared by the named Attention layers.
-
-    Use in metadata builders whose plan-time allocations depend on the
-    head count: the model-wide ``get_num_attention_heads()`` is wrong
-    for models with non-uniform per-layer head counts. All layers in
-    one attention group must agree on ``num_heads``; this is asserted.
-    Returns ``None`` when no matching Attention layer is found.
-    """
-    attn_layers = get_layers_from_vllm_config(
-        vllm_config,
-        AttentionLayerBase,  # type: ignore[type-abstract]
-        layer_names,
-    )
-    if not attn_layers:
-        return None
-    heads = {layer.impl.num_heads for layer in attn_layers.values()}
-    assert len(heads) == 1, (
-        f"All layers in one attention group must share num_heads; "
-        f"got {heads} for {layer_names}."
-    )
-    return heads.pop()
-
-
 def infer_global_hyperparameters(
     per_layer_params: dict[str, PerLayerParameters],
 ) -> PerLayerParameters:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -103,6 +103,7 @@ from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
 )
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
+from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
@@ -307,7 +308,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.use_aux_hidden_state_outputs:
                 assert self.speculative_config is not None
                 set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
-            if self.speculator is not None:
+            if isinstance(self.speculator, DraftModelSpeculator):
                 self.speculator.load_model(self.model)
                 eplb_models_added = self.eplb.maybe_register_speculator(
                     self.speculator, self.speculative_config, load_dummy_weights
@@ -457,7 +458,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculator.init_cudagraph_manager(cudagraph_mode)
 
         check_attention_cp_compatibility(self.vllm_config)
-        if self.speculator is not None:
+        if isinstance(self.speculator, DraftModelSpeculator):
             # HACK(woosuk)
             self.speculator.set_attn(
                 self.model_state, self.kv_cache_config, self.block_tables

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -8,8 +8,21 @@ from vllm.config import VllmConfig
 def init_speculator(vllm_config: VllmConfig, device: torch.device):
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
-    if speculative_config.use_eagle():
-        from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
+    if speculative_config.use_gemma4_mtp():
+        from vllm.v1.worker.gpu.spec_decode.gemma4.speculator import (
+            Gemma4Speculator,
+        )
+
+        return Gemma4Speculator(vllm_config, device)
+    elif speculative_config.method == "mtp":
+        from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
+
+        return MTPSpeculator(vllm_config, device)
+    elif speculative_config.use_eagle():
+        from vllm.v1.worker.gpu.spec_decode.eagle.speculator import (
+            EagleSpeculator,
+        )
 
         return EagleSpeculator(vllm_config, device)
-    raise NotImplementedError(f"{speculative_config.method} is not supported yet.")
+    else:
+        raise NotImplementedError(f"{speculative_config.method} is not supported yet.")

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
@@ -19,8 +19,8 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 
-class PrefillEagleCudaGraphManager(CudaGraphManager):
-    """Eagle CudaGraphManager for prefill, using pre-built attention states
+class PrefillSpeculatorCudaGraphManager(CudaGraphManager):
+    """CudaGraphManager for draft prefill, using pre-built attention states
     from the target model's capture."""
 
     def capture(
@@ -56,9 +56,8 @@ class PrefillEagleCudaGraphManager(CudaGraphManager):
         super().capture(create_forward_fn, progress_bar_desc)
 
 
-class DecodeEagleCudaGraphManager(CudaGraphManager):
-    """Eagle CudaGraphManager for decode draft generation, building its own
-    attention metadata from scratch."""
+class DecodeSpeculatorCudaGraphManager(CudaGraphManager):
+    """CudaGraphManager for draft decode, building its own attention metadata."""
 
     def capture(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -1,0 +1,795 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor, set_forward_context
+from vllm.logger import init_logger
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    AttentionStatePair,
+    BatchExecutionDescriptor,
+    get_uniform_token_count,
+)
+from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+    DecodeSpeculatorCudaGraphManager,
+    PrefillSpeculatorCudaGraphManager,
+)
+from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+
+logger = init_logger(__name__)
+
+
+class AutoRegressiveSpeculator(DraftModelSpeculator):
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        super().__init__(vllm_config, device)
+
+        self.hidden_states = torch.zeros(
+            self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
+        )
+        self.current_draft_step = torch.tensor(0, dtype=torch.int64, device=device)
+        self.last_token_indices = torch.zeros(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
+
+        self.supports_mm_inputs = MULTIMODAL_REGISTRY.supports_multimodal_inputs(
+            self.draft_model_config
+        )
+        if self.supports_mm_inputs:
+            self.inputs_embeds = torch.zeros(
+                self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
+            )
+
+        self.prefill_cudagraph_manager: PrefillSpeculatorCudaGraphManager | None = None
+        self.decode_cudagraph_manager: DecodeSpeculatorCudaGraphManager | None = None
+
+    @property
+    def advance_draft_positions(self) -> bool:
+        """
+        Whether to increment positions and seq_lens between draft steps.
+
+        True for Eagle/standard MTP (each step produces new KV).
+        False for Gemma4 MTP (Q-only, shares target KV, constant positions).
+        """
+        return True
+
+    @property
+    def model_returns_tuple(self) -> bool:
+        """
+        Whether the draft model's forward() returns a tuple.
+
+        True: returns (last_hidden_states, hidden_states) — Eagle, Gemma4 MTP.
+        False: returns a single tensor used for both — standard MTP (DeepSeek).
+        """
+        return True
+
+    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        # Initialize cudagraph manager for draft prefill (draft position 0).
+        self.prefill_cudagraph_manager = PrefillSpeculatorCudaGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            self.num_speculative_steps + 1,
+        )
+
+        # PIECEWISE cudagraphs are not supported for draft decodes.
+        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        else:
+            cudagraph_mode = CUDAGraphMode.NONE
+
+        # Initialize cudagraph manager for draft decodes (draft positions > 0).
+        self.decode_cudagraph_manager = DecodeSpeculatorCudaGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            decode_query_len=1,
+        )
+
+    def capture(
+        self,
+        attn_states: dict[BatchExecutionDescriptor, AttentionStatePair],
+    ) -> None:
+        logger.info("Capturing model for speculator...")
+        # Reset indices to zeros to prevent stale values from prior
+        # dummy runs to cause out-of-bounds indexing during capture.
+        self.last_token_indices.zero_()
+
+        # Capture the prefill routine (model forward + compute_logits +
+        # sample).
+        # For FULL graphs, the entire routine is recorded as one graph.
+        # For PIECEWISE, only the model's compiled regions are captured
+        # and the rest (compute_logits, gumbel_sample) runs eagerly.
+        assert self.prefill_cudagraph_manager is not None
+        if self.prefill_cudagraph_manager.use_breakable_cg:
+            self.prefill_cudagraph_manager.init_breakable_cg_runner(self.model)
+        self.prefill_cudagraph_manager.capture(
+            self._prefill,
+            attn_states,
+            progress_bar_desc="Capturing prefill CUDA graphs",
+        )
+
+        if self.num_speculative_steps == 1:
+            return
+
+        # Capture the decode draft generation routine (model forward +
+        # sample + update_draft_inputs) for a single
+        # step.
+        assert self.decode_cudagraph_manager is not None
+        self.decode_cudagraph_manager.capture(
+            self._generate_draft,
+            self.model_state,
+            self.input_buffers,
+            self.block_tables,
+            self.attn_groups,
+            self.kv_cache_config,
+            progress_bar_desc="Capturing decode CUDA graphs",
+        )
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        input_batch: InputBatch,
+        attn_metadata: dict[str, Any],
+        slot_mappings: dict[str, torch.Tensor],
+        # [num_tokens, hidden_size]
+        last_hidden_states: torch.Tensor,
+        # num_layers x [num_tokens, hidden_size]
+        aux_hidden_states: list[torch.Tensor] | None,
+        # [num_reqs]
+        num_sampled: torch.Tensor,
+        # [num_reqs]
+        num_rejected: torch.Tensor,
+        # [max_num_reqs]
+        last_sampled: torch.Tensor,
+        # [max_num_reqs]
+        next_prefill_tokens: torch.Tensor,
+        # [max_num_reqs]
+        temperature: torch.Tensor,
+        # [max_num_reqs]
+        seeds: torch.Tensor,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_profile: bool = False,
+    ) -> torch.Tensor:
+        num_tokens = input_batch.num_tokens_after_padding
+        num_reqs = input_batch.num_reqs
+        max_query_len = input_batch.num_scheduled_tokens.max()
+        max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
+        self.draft_max_seq_len = min(
+            max_seq_len + self.num_speculative_steps, self.max_model_len
+        )
+
+        # NOTE(woosuk): To avoid CPU-GPU synchronization without CPU knowing the
+        # number of rejected tokens, we maintain the size of input_ids and
+        # hidden_states the same as the target model's. This means, we pad each
+        # request's query length to include any rejected positions. By doing so,
+        # we can also reuse the attention metadata (e.g., query_start_loc,
+        # seq_lens) of the target model.
+        if aux_hidden_states:
+            assert self.method == "eagle3"
+            hidden_states = self.model.combine_hidden_states(
+                torch.cat(aux_hidden_states, dim=-1)
+            )
+        else:
+            hidden_states = last_hidden_states
+        self.hidden_states[:num_tokens].copy_(hidden_states)
+
+        self._copy_request_inputs(
+            num_reqs,
+            input_batch.idx_mapping,
+            temperature,
+            seeds,
+        )
+
+        # Get the input ids and last token indices for the speculator.
+        prepare_prefill_inputs(
+            self.last_token_indices,
+            self.current_draft_step,
+            self.input_buffers,
+            input_batch,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            next_prefill_tokens,
+            self.max_num_reqs,
+        )
+
+        # When all requests are decoding (no true prefills), each has
+        # num_speculative_steps + 1 tokens, enabling FULL graph replay.
+        uniform_token_count = get_uniform_token_count(
+            num_reqs,
+            # Use the actual number of tokens without padding added by
+            # the target model during FULL cudagraph.
+            input_batch.num_tokens,
+            max_query_len,
+        )
+        prefill_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
+            self.prefill_cudagraph_manager,
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            dp_size=self.dp_size,
+            dp_rank=self.dp_rank,
+            need_eager=is_profile,
+        )
+
+        if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
+            # Replay the full graph for draft prefill.
+            assert self.prefill_cudagraph_manager is not None
+            self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
+        else:
+            # The target model's attention metadata and slot mappings
+            # can directly be used for draft prefill, because of the
+            # identical batch shape and KV cache layout.
+            self._prefill(
+                num_reqs,
+                prefill_batch_desc.num_tokens,
+                attn_metadata,
+                slot_mappings,
+                num_tokens_across_dp=num_tokens_across_dp,
+                cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
+                mm_inputs=mm_inputs,
+            )
+
+        if self.num_speculative_steps == 1:
+            # Early exit.
+            return self.draft_tokens[:num_reqs, :1]
+
+        # Prepare the inputs for the decode steps.
+        prepare_decode_inputs(
+            self.draft_tokens[:num_reqs, 0],
+            input_batch.seq_lens,
+            num_rejected,
+            self.input_buffers,
+            self.max_model_len,
+            self.max_num_reqs,
+            advance_draft_positions=self.advance_draft_positions,
+        )
+
+        # Each request produces exactly 1 token per draft generation step,
+        # enabling FULL graph replay.
+        decode_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
+            self.decode_cudagraph_manager,
+            num_reqs,
+            num_reqs,
+            uniform_token_count=1,
+            dp_size=self.dp_size,
+            dp_rank=self.dp_rank,
+            need_eager=is_profile,
+        )
+
+        # Generate the remaining num_speculative_steps - 1 draft tokens.
+        self._multi_step_decode(
+            num_reqs,
+            dummy_run and skip_attn_for_dummy_run,
+            decode_batch_desc,
+            num_tokens_across_dp,
+        )
+
+        return self.draft_tokens[:num_reqs]
+
+    def sample_draft(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        draft_step: torch.Tensor,
+        draft_logits: torch.Tensor | None,
+    ) -> torch.Tensor:
+        logits = self.model.compute_logits(hidden_states)
+        if draft_logits is not None:
+            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
+            # used for draft and target sampling.
+            return gumbel_sample(
+                logits,
+                idx_mapping,
+                temperature,
+                seeds,
+                positions + 1,
+                apply_temperature=True,
+                output_processed_logits=draft_logits,
+                output_processed_logits_col=draft_step,
+                use_fp64=self.use_fp64_gumbel,
+            )
+        else:
+            return logits.argmax(dim=-1)
+
+    @torch.inference_mode()
+    def _run_model(
+        self,
+        num_tokens: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
+        with set_forward_context(
+            attn_metadata,
+            self.vllm_config,
+            num_tokens=num_tokens,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            num_tokens_across_dp=num_tokens_across_dp,
+            slot_mapping=slot_mappings,
+            batch_descriptor=batch_descriptor,
+        ):
+            inputs_embeds = None
+            if self.supports_mm_inputs:
+                # Merge multimodal embeddings with input ids.
+                mm_embeds, is_mm_embed = mm_inputs or (None, None)
+                num_input_tokens = (
+                    is_mm_embed.shape[0] if is_mm_embed is not None else num_tokens
+                )
+                self.inputs_embeds[:num_input_tokens] = self.model.embed_input_ids(
+                    self.input_buffers.input_ids[:num_input_tokens],
+                    multimodal_embeddings=mm_embeds,
+                    is_multimodal=is_mm_embed,
+                )
+                inputs_embeds = self.inputs_embeds[:num_tokens]
+
+            model_inputs = dict(
+                input_ids=self.input_buffers.input_ids[:num_tokens],
+                positions=self.input_buffers.positions[:num_tokens],
+                hidden_states=self.hidden_states[:num_tokens],
+                inputs_embeds=inputs_embeds,
+            )
+            if cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE:
+                # Draft prefill with PIECEWISE cudagraph (compiled PW or breakable),
+                # chosen inside run_pw_graph.
+                assert self.prefill_cudagraph_manager is not None
+                ret_hidden_states = self.prefill_cudagraph_manager.run_pw_graph(
+                    self.model, model_inputs
+                )
+            else:
+                # Eager (NONE): call the raw model directly.
+                ret_hidden_states = self.model(**model_inputs)
+        if self.model_returns_tuple:
+            last_hidden_states, hidden_states = ret_hidden_states
+        else:
+            last_hidden_states = ret_hidden_states
+            hidden_states = ret_hidden_states
+        return last_hidden_states, hidden_states
+
+    def _prefill(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+    ) -> None:
+        last_token_indices = self.last_token_indices[:num_reqs]
+        positions = self.input_buffers.positions[last_token_indices]
+        idx_mapping = self.idx_mapping[:num_reqs]
+
+        last_hidden_states, hidden_states = self._run_model(
+            num_tokens,
+            attn_metadata,
+            slot_mappings,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            mm_inputs=mm_inputs,
+        )
+        sample_hidden_states = last_hidden_states[last_token_indices]
+
+        self.draft_tokens[:num_reqs, 0] = self.sample_draft(
+            sample_hidden_states,
+            positions,
+            idx_mapping,
+            self.temperature,
+            self.seeds,
+            self.current_draft_step,
+            self.draft_logits,
+        )
+        self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
+        self.input_buffers.positions[:num_reqs] = positions
+
+    def _multi_step_decode(
+        self,
+        num_reqs: int,
+        skip_attn: bool,
+        batch_desc: BatchExecutionDescriptor,
+        num_tokens_across_dp: torch.Tensor | None,
+    ) -> None:
+        positions = self.input_buffers.positions[:num_reqs]
+        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
+        idx_mapping = self.idx_mapping[:num_reqs]
+
+        attn_metadata = None
+        slot_mappings_by_layer = None
+        for step in range(1, self.num_speculative_steps):
+            # Rebuild every step when positions advance, or just once
+            # on the first step when positions are constant (Gemma4 MTP).
+            if not skip_attn and (self.advance_draft_positions or step == 1):
+                slot_mappings = self.block_tables.compute_slot_mappings(
+                    idx_mapping,
+                    query_start_loc,
+                    positions,
+                    batch_desc.num_tokens,
+                )
+                slot_mappings_by_layer = build_slot_mappings_by_layer(
+                    slot_mappings, self.kv_cache_config
+                )
+                attn_metadata = self._build_draft_attn_metadata(
+                    num_reqs=num_reqs,
+                    num_reqs_padded=batch_desc.num_reqs or num_reqs,
+                    num_tokens_padded=batch_desc.num_tokens,
+                )
+
+            # Update the current draft step.
+            self.current_draft_step.fill_(step)
+
+            # Generate draft tokens for the current step.
+            if batch_desc.cg_mode == CUDAGraphMode.FULL:
+                assert self.decode_cudagraph_manager is not None
+                self.decode_cudagraph_manager.run_fullgraph(batch_desc)
+            else:
+                self._generate_draft(
+                    num_reqs,
+                    batch_desc.num_tokens,
+                    attn_metadata,
+                    slot_mappings_by_layer,
+                    num_tokens_across_dp=num_tokens_across_dp,
+                    cudagraph_runtime_mode=batch_desc.cg_mode,
+                )
+
+    def _generate_draft(
+        self,
+        num_reqs: int,
+        num_tokens_padded: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    ) -> None:
+        idx_mapping = self.idx_mapping[:num_reqs]
+        positions = self.input_buffers.positions[:num_reqs]
+        # Run the draft model forward pass.
+        last_hidden_states, hidden_states = self._run_model(
+            num_tokens_padded,
+            attn_metadata,
+            slot_mappings,
+            num_tokens_across_dp,
+            cudagraph_runtime_mode,
+        )
+        last_hidden_states = last_hidden_states[:num_reqs]
+
+        # Sample the draft tokens.
+        draft_tokens = self.sample_draft(
+            last_hidden_states,
+            positions,
+            idx_mapping,
+            self.temperature,
+            self.seeds,
+            self.current_draft_step,
+            self.draft_logits,
+        )
+
+        # Update the inputs for the next step.
+        update_draft_inputs(
+            draft_tokens,
+            self.current_draft_step,
+            hidden_states,
+            self.draft_tokens,
+            self.hidden_states,
+            self.input_buffers,
+            num_reqs,
+            self.max_model_len,
+            self.num_speculative_steps,
+            advance_draft_positions=self.advance_draft_positions,
+        )
+
+
+@triton.jit
+def _prepare_prefill_inputs_kernel(
+    last_token_indices_ptr,
+    draft_current_step_ptr,
+    draft_input_ids_ptr,
+    draft_positions_ptr,
+    draft_query_start_loc_ptr,
+    draft_seq_lens_ptr,
+    target_input_ids_ptr,
+    target_positions_ptr,
+    idx_mapping_ptr,
+    last_sampled_ptr,
+    next_prefill_tokens_ptr,
+    num_sampled_ptr,
+    num_rejected_ptr,
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    max_num_reqs,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    num_reqs = tl.num_programs(0)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
+
+    query_start = tl.load(query_start_loc_ptr + req_idx)
+    query_end = tl.load(query_start_loc_ptr + req_idx + 1)
+    query_len = query_end - query_start
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+
+    # Get the true query length and next token after accounting for rejected tokens.
+    num_rejected = tl.load(num_rejected_ptr + req_idx)
+    query_len -= num_rejected
+
+    num_sampled = tl.load(num_sampled_ptr + req_idx)
+    if num_sampled > 0:
+        next_token = tl.load(last_sampled_ptr + req_state_idx).to(tl.int32)
+    else:
+        # Chunked prefilling.
+        # Get the next prefill token.
+        next_token = tl.load(next_prefill_tokens_ptr + req_state_idx)
+
+    # Shift target_input_ids by one.
+    for i in range(1, query_len, BLOCK_SIZE):
+        block = i + tl.arange(0, BLOCK_SIZE)
+        mask = block < query_len
+        input_ids = tl.load(target_input_ids_ptr + query_start + block, mask=mask)
+        tl.store(draft_input_ids_ptr + query_start + block - 1, input_ids, mask=mask)
+
+    last_token_index = query_start + query_len - 1
+    tl.store(last_token_indices_ptr + req_idx, last_token_index)
+    tl.store(draft_input_ids_ptr + last_token_index, next_token)
+
+    # Copy positions.
+    for i in range(0, query_len, BLOCK_SIZE):
+        block = i + tl.arange(0, BLOCK_SIZE)
+        mask = block < query_len
+        target_pos = tl.load(target_positions_ptr + query_start + block, mask=mask)
+        tl.store(draft_positions_ptr + query_start + block, target_pos, mask=mask)
+
+    # Copy query start locations.
+    tl.store(draft_query_start_loc_ptr + req_idx, query_start)
+    # Copy sequence lengths.
+    tl.store(draft_seq_lens_ptr + req_idx, seq_len)
+    if req_idx == (num_reqs - 1):
+        # Reset the current draft step to 0.
+        tl.store(draft_current_step_ptr, 0)
+        # Pad query_start_loc for CUDA graphs.
+        for i in range(num_reqs, max_num_reqs + 1, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs + 1
+            tl.store(draft_query_start_loc_ptr + block, query_end, mask=mask)
+        # Pad seq_lens for CUDA graphs.
+        for i in range(num_reqs, max_num_reqs, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs
+            tl.store(draft_seq_lens_ptr + block, 0, mask=mask)
+        # Pad last_token_indices for CUDA graphs.
+        for i in range(num_reqs, max_num_reqs, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs
+            tl.store(last_token_indices_ptr + block, 0, mask=mask)
+
+
+def prepare_prefill_inputs(
+    # [num_reqs]
+    last_token_indices: torch.Tensor,
+    current_draft_step: torch.Tensor,
+    input_buffers: InputBuffers,
+    input_batch: InputBatch,
+    # [num_reqs]
+    num_sampled: torch.Tensor,
+    # [num_reqs]
+    num_rejected: torch.Tensor,
+    # [max_num_reqs]
+    last_sampled: torch.Tensor,
+    # [max_num_reqs]
+    next_prefill_tokens: torch.Tensor,
+    max_num_reqs,
+) -> torch.Tensor:
+    num_reqs = input_batch.num_reqs
+    _prepare_prefill_inputs_kernel[(num_reqs,)](
+        last_token_indices,
+        current_draft_step,
+        input_buffers.input_ids,
+        input_buffers.positions,
+        input_buffers.query_start_loc,
+        input_buffers.seq_lens,
+        input_batch.input_ids,
+        input_batch.positions,
+        input_batch.idx_mapping,
+        last_sampled,
+        next_prefill_tokens,
+        num_sampled,
+        num_rejected,
+        input_batch.query_start_loc,
+        input_batch.seq_lens,
+        max_num_reqs,
+        BLOCK_SIZE=1024,
+    )
+    return last_token_indices
+
+
+@triton.jit
+def _prepare_decode_inputs_kernel(
+    draft_tokens_ptr,
+    draft_tokens_stride,
+    target_seq_lens_ptr,
+    num_rejected_ptr,
+    input_ids_ptr,
+    positions_ptr,
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    max_model_len,
+    max_num_reqs,
+    BLOCK_SIZE: tl.constexpr,
+    ADVANCE_DRAFT_POSITIONS: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    num_reqs = tl.num_programs(0) - 1
+    if req_idx == num_reqs:
+        # Compute query_start_loc. Pad it with the last query_start_loc
+        # for CUDA graphs.
+        for i in range(0, max_num_reqs + 1, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            q = tl.where(block < num_reqs, block, num_reqs)
+            mask = block < max_num_reqs + 1
+            tl.store(query_start_loc_ptr + block, q, mask=mask)
+        # Pad seq_lens for CUDA graphs.
+        for i in range(req_idx, max_num_reqs, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs
+            tl.store(seq_lens_ptr + block, 0, mask=mask)
+        return
+
+    # draft token -> input id.
+    draft_token = tl.load(draft_tokens_ptr + req_idx * draft_tokens_stride)
+    tl.store(input_ids_ptr + req_idx, draft_token)
+
+    if ADVANCE_DRAFT_POSITIONS:
+        # Compute position and seq_lens.
+        # NOTE(woosuk): To prevent out-of-range access, we clamp these values
+        # if they reach the max model length.
+        position = tl.load(positions_ptr + req_idx)
+        position = tl.minimum(position + 1, max_model_len - 1)
+        tl.store(positions_ptr + req_idx, position)
+
+        target_seq_len = tl.load(target_seq_lens_ptr + req_idx)
+        num_rejected = tl.load(num_rejected_ptr + req_idx)
+        seq_len = target_seq_len - num_rejected
+        seq_len = tl.minimum(seq_len + 1, max_model_len)
+        tl.store(seq_lens_ptr + req_idx, seq_len)
+
+
+def prepare_decode_inputs(
+    draft_tokens: torch.Tensor,
+    target_seq_lens: torch.Tensor,
+    num_rejected: torch.Tensor,
+    input_buffers: InputBuffers,
+    max_model_len: int,
+    max_num_reqs: int,
+    advance_draft_positions: bool = True,
+):
+    num_reqs = draft_tokens.shape[0]
+    _prepare_decode_inputs_kernel[(num_reqs + 1,)](
+        draft_tokens,
+        draft_tokens.stride(0),
+        target_seq_lens,
+        num_rejected,
+        input_buffers.input_ids,
+        input_buffers.positions,
+        input_buffers.query_start_loc,
+        input_buffers.seq_lens,
+        max_model_len,
+        max_num_reqs,
+        BLOCK_SIZE=1024,
+        ADVANCE_DRAFT_POSITIONS=advance_draft_positions,
+    )
+
+
+@triton.jit
+def _update_draft_inputs_kernel(
+    output_draft_tokens_ptr,
+    output_draft_tokens_stride,
+    next_input_hidden_states_ptr,
+    next_input_hidden_states_stride,
+    input_ids_ptr,
+    positions_ptr,
+    seq_lens_ptr,
+    draft_tokens_ptr,
+    current_draft_step_ptr,
+    hidden_states_ptr,
+    hidden_states_stride,
+    hidden_size,
+    max_model_len,
+    num_speculative_steps,
+    BLOCK_SIZE: tl.constexpr,
+    ADVANCE_DRAFT_POSITIONS: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    # Write the sampled draft token into self.draft_tokens[req_idx, step].
+    draft_token = tl.load(draft_tokens_ptr + req_idx)
+    step = tl.load(current_draft_step_ptr)
+    tl.store(
+        output_draft_tokens_ptr + req_idx * output_draft_tokens_stride + step,
+        draft_token,
+    )
+
+    if step >= num_speculative_steps - 1:
+        # This is the final step. Skip updating draft forward inputs.
+        return
+
+    # Write the sampled draft token into the input ids tensor for the next
+    # forward pass.
+    tl.store(input_ids_ptr + req_idx, draft_token)
+
+    # Copy hidden states into the input hidden states tensor for the next
+    # forward pass.
+    for i in range(0, hidden_size, BLOCK_SIZE):
+        block = i + tl.arange(0, BLOCK_SIZE)
+        mask = block < hidden_size
+        hidden_states = tl.load(
+            hidden_states_ptr + req_idx * hidden_states_stride + block,
+            mask=mask,
+        )
+        tl.store(
+            next_input_hidden_states_ptr
+            + req_idx * next_input_hidden_states_stride
+            + block,
+            hidden_states,
+            mask=mask,
+        )
+
+    if ADVANCE_DRAFT_POSITIONS:
+        # Increment position and seq_lens.
+        # NOTE(woosuk): To prevent out-of-range access, we clamp these values
+        # if they reach the max model length.
+        position = tl.load(positions_ptr + req_idx)
+        position = tl.minimum(position + 1, max_model_len - 1)
+        tl.store(positions_ptr + req_idx, position)
+
+        seq_len = tl.load(seq_lens_ptr + req_idx)
+        seq_len = tl.minimum(seq_len + 1, max_model_len)
+        tl.store(seq_lens_ptr + req_idx, seq_len)
+
+
+def update_draft_inputs(
+    draft_tokens: torch.Tensor,
+    current_draft_step: torch.Tensor,
+    hidden_states: torch.Tensor,
+    output_draft_tokens: torch.Tensor,
+    next_input_hidden_states: torch.Tensor,
+    input_buffers: InputBuffers,
+    num_reqs: int,
+    max_model_len: int,
+    num_speculative_steps: int,
+    advance_draft_positions: bool = True,
+):
+    _, hidden_size = hidden_states.shape
+    _update_draft_inputs_kernel[(num_reqs,)](
+        output_draft_tokens,
+        output_draft_tokens.stride(0),
+        next_input_hidden_states,
+        next_input_hidden_states.stride(0),
+        input_buffers.input_ids,
+        input_buffers.positions,
+        input_buffers.seq_lens,
+        draft_tokens,
+        current_draft_step,
+        hidden_states,
+        hidden_states.stride(0),
+        hidden_size,
+        max_model_len,
+        num_speculative_steps,
+        BLOCK_SIZE=1024,
+        ADVANCE_DRAFT_POSITIONS=advance_draft_positions,
+    )

--- a/vllm/v1/worker/gpu/spec_decode/gemma4/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/gemma4/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gemma4 MTP (Multi-Token Prediction) speculator for speculative decoding.
+
+The Gemma4 assistant model runs all decoder layers per draft step
+(producing one token), and all its attention layers share KV cache
+with the target model via cross-model KV sharing.
+"""
+
+from collections import defaultdict
+
+import torch.nn as nn
+
+from vllm.compilation.backends import set_model_tag
+from vllm.config import VllmConfig, replace
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader import get_model
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    AutoRegressiveSpeculator,
+)
+
+logger = init_logger(__name__)
+
+
+class Gemma4Speculator(AutoRegressiveSpeculator):
+    @property
+    def advance_draft_positions(self) -> bool:
+        # Gemma4 MTP is Q-only and reads K/V from the target's existing cache.
+        # No new KV slots are written, so positions and seq_lens stay fixed.
+        return False
+
+    @property
+    def model_returns_tuple(self) -> bool:
+        # forward() returns (draft_hidden_states, backbone_hidden_states).
+        # The proposer uses draft_hidden_states for compute_logits and
+        # backbone_hidden_states for the hidden-state feedback buffer.
+        return True
+
+    def load_draft_model(
+        self,
+        target_model: nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> nn.Module:
+        draft_vllm_config = self._create_draft_vllm_config()
+        with set_model_tag("eagle_head"):
+            draft_model = get_model(
+                vllm_config=draft_vllm_config,
+                model_config=self.speculative_config.draft_model_config,
+                load_config=self.speculative_config.draft_load_config,
+            )
+        self._setup_gemma4_kv_sharing(draft_model, target_attn_layer_names)
+        self._share_embeddings(draft_model, target_model)
+        return draft_model
+
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        """Preserve the target's forced TRITON_ATTN backend for draft layers.
+
+        Gemma4 forces TRITON_ATTN due to heterogeneous head dimensions
+        (head_dim=256 sliding, global_head_dim=512 full). The base class
+        resets attention_config.backend to None for draft models, causing
+        sliding layers to fall back to FLASH_ATTN which cannot handle
+        KV-shared cache. Override to carry the target's backend through.
+        """
+        draft_model_config = self.speculative_config.draft_model_config
+        draft_vllm_config = replace(
+            self.vllm_config,
+            model_config=draft_model_config,
+        )
+        target_backend = self.vllm_config.attention_config.backend
+        if target_backend is not None:
+            draft_vllm_config = replace(
+                draft_vllm_config,
+                attention_config=replace(
+                    draft_vllm_config.attention_config,
+                    backend=target_backend,
+                ),
+            )
+        return draft_vllm_config
+
+    def _setup_gemma4_kv_sharing(
+        self,
+        model: nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> None:
+        """Wire draft layers to share KV with the target model.
+
+        Each draft decoder layer is mapped to the last non-KV-shared
+        target layer of the same attention type (sliding or full).
+        """
+        draft_config = self.speculative_config.draft_model_config.hf_config
+        draft_text_config = draft_config.get_text_config()
+        target_config = self.vllm_config.model_config.hf_config
+        target_text_config = target_config.get_text_config()
+        target_layer_types = getattr(target_text_config, "layer_types", [])
+
+        if not (hasattr(model, "model") and hasattr(model.model, "layers")):
+            return
+
+        target_num_kv_shared = getattr(target_text_config, "num_kv_shared_layers", 0)
+        num_non_shared = len(target_layer_types) - target_num_kv_shared
+        type_to_target_indices: dict[str, list[int]] = defaultdict(list)
+        for idx, lt in enumerate(target_layer_types[:num_non_shared]):
+            type_to_target_indices[lt].append(idx)
+
+        target_prefix = "model.layers"
+        for name in target_attn_layer_names:
+            if ".layers." in name:
+                target_prefix = name.split(".layers.")[0] + ".layers"
+                break
+
+        draft_layer_types = getattr(draft_text_config, "layer_types", [])
+        for draft_idx, layer in enumerate(model.model.layers):
+            if not hasattr(layer, "self_attn"):
+                continue
+            attn = getattr(layer.self_attn, "attn", None)
+            if attn is None:
+                continue
+
+            draft_layer_type = (
+                draft_layer_types[draft_idx]
+                if draft_idx < len(draft_layer_types)
+                else "full_attention"
+            )
+            candidates = type_to_target_indices.get(draft_layer_type, [])
+            if not candidates:
+                logger.warning(
+                    "No target layer of type '%s' for draft layer %d",
+                    draft_layer_type,
+                    draft_idx,
+                )
+                continue
+
+            target_idx = candidates[-1]
+            target_layer_name = f"{target_prefix}.{target_idx}.self_attn.attn"
+            attn.kv_sharing_target_layer_name = target_layer_name
+            logger.info(
+                "Gemma4 MTP: draft layer %d (%s) -> %s",
+                draft_idx,
+                draft_layer_type,
+                target_layer_name,
+            )
+
+    def _share_embeddings(
+        self,
+        draft_model: nn.Module,
+        target_model: nn.Module,
+    ) -> None:
+        target_language_model = (
+            target_model.get_language_model()
+            if hasattr(target_model, "get_language_model")
+            else target_model
+        )
+        if get_pp_group().world_size == 1:
+            target_embed = getattr(target_language_model.model, "embed_tokens", None)
+            if target_embed is not None:
+                del draft_model.model.embed_tokens
+                draft_model.model.embed_tokens = target_embed

--- a/vllm/v1/worker/gpu/spec_decode/mtp/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -9,7 +9,11 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 
-class EagleSpeculator(AutoRegressiveSpeculator):
+class MTPSpeculator(AutoRegressiveSpeculator):
+    @property
+    def model_returns_tuple(self) -> bool:
+        return False
+
     def load_draft_model(
         self,
         target_model: nn.Module,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from abc import ABC, abstractmethod
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config.compilation import CUDAGraphMode
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.attn_utils import (
+    build_attn_metadata,
+    init_attn_backend,
+)
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    AttentionStatePair,
+    BatchExecutionDescriptor,
+)
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+
+
+class BaseSpeculator(ABC):
+    @abstractmethod
+    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        pass
+
+    @abstractmethod
+    def capture(
+        self,
+        attn_states: dict[BatchExecutionDescriptor, AttentionStatePair],
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def propose(
+        self,
+        input_batch: InputBatch,
+        attn_metadata: dict[str, Any],
+        slot_mappings: dict[str, torch.Tensor],
+        # [num_tokens, hidden_size]
+        last_hidden_states: torch.Tensor,
+        # num_layers x [num_tokens, hidden_size]
+        aux_hidden_states: list[torch.Tensor] | None,
+        # [num_reqs]
+        num_sampled: torch.Tensor,
+        # [num_reqs]
+        num_rejected: torch.Tensor,
+        # [max_num_reqs]
+        last_sampled: torch.Tensor,
+        # [max_num_reqs]
+        next_prefill_tokens: torch.Tensor,
+        # [max_num_reqs]
+        temperature: torch.Tensor,
+        # [max_num_reqs]
+        seeds: torch.Tensor,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_profile: bool = False,
+    ) -> torch.Tensor:
+        pass
+
+
+class DraftModelSpeculator(BaseSpeculator):
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        self.vllm_config = vllm_config
+        self.device = device
+
+        assert vllm_config.speculative_config is not None
+        self.speculative_config = vllm_config.speculative_config
+        self.method = self.speculative_config.method
+        self.num_speculative_steps = self.speculative_config.num_speculative_tokens
+        self.draft_model_config = self.speculative_config.draft_model_config
+
+        self.scheduler_config = vllm_config.scheduler_config
+        self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.max_model_len = vllm_config.model_config.max_model_len
+        self.draft_max_seq_len = self.max_model_len
+        # We need to get the hidden size from the draft model config because
+        # the draft model's hidden size can be different from the target model's
+        # hidden size (e.g., Llama 3.3 70B).
+        self.hidden_size = self.draft_model_config.get_hidden_size()
+        # Widen for HC-multiplexed residuals (e.g. DeepSeek V4 feeds the MTP
+        # draft the target's pre-hc_head (T, hc_mult * hidden_size) residual).
+        # Non-HC models default to hc_mult=1 and are unaffected.
+        hc_mult = getattr(self.draft_model_config.hf_config, "hc_mult", 1)
+        self.hidden_size = self.hidden_size * hc_mult
+        self.vocab_size = self.draft_model_config.get_vocab_size()
+        self.dtype = vllm_config.model_config.dtype
+        self.use_fp64_gumbel = vllm_config.model_config.use_fp64_gumbel
+
+        # DP configuration
+        self.dp_size = vllm_config.parallel_config.data_parallel_size
+        self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+
+        self.input_buffers = InputBuffers(
+            max_num_reqs=self.max_num_reqs,
+            max_num_tokens=self.max_num_tokens,
+            device=device,
+        )
+        self.idx_mapping = torch.zeros(
+            self.max_num_reqs, dtype=torch.int32, device=device
+        )
+        self.temperature = torch.zeros(
+            self.max_num_reqs, dtype=torch.float32, device=device
+        )
+        self.seeds = torch.zeros(self.max_num_reqs, dtype=torch.int64, device=device)
+        self.draft_tokens = torch.zeros(
+            self.max_num_reqs,
+            self.num_speculative_steps,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.arange = torch.arange(
+            self.max_num_reqs + 1, dtype=torch.int32, device="cpu"
+        )
+
+        self.draft_logits: torch.Tensor | None = None
+        if self.speculative_config.draft_sample_method == "probabilistic":
+            self.draft_logits = torch.zeros(
+                self.max_num_reqs,
+                self.num_speculative_steps,
+                self.vocab_size,
+                dtype=torch.float32,
+                device=device,
+            )
+
+    @abstractmethod
+    def load_draft_model(
+        self,
+        target_model: nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> nn.Module:
+        pass
+
+    def load_model(self, target_model: nn.Module) -> None:
+        target_attn_layer_names = set(
+            get_layers_from_vllm_config(
+                self.vllm_config,
+                AttentionLayerBase,  # type: ignore[type-abstract]
+            ).keys()
+        )
+
+        self.model = self.load_draft_model(target_model, target_attn_layer_names)
+
+        all_attn_layers = set[str](
+            get_layers_from_vllm_config(
+                self.vllm_config,
+                AttentionLayerBase,  # type: ignore[type-abstract]
+            ).keys()
+        )
+        self.draft_attn_layer_names = all_attn_layers - target_attn_layer_names
+
+    def set_attn(
+        self,
+        model_state: ModelState,
+        kv_cache_config: KVCacheConfig,
+        block_tables: BlockTables,
+    ) -> None:
+        self.model_state = model_state
+        self.kv_cache_config = kv_cache_config
+        self.attn_groups, _, _ = init_attn_backend(
+            kv_cache_config,
+            self.vllm_config,
+            self.device,
+            active_layer_names=self.draft_attn_layer_names,
+        )
+        self.block_tables = block_tables
+
+    def _build_draft_attn_metadata(
+        self,
+        num_reqs: int,
+        num_reqs_padded: int,
+        num_tokens_padded: int,
+    ) -> dict[str, Any] | None:
+        query_start_loc_cpu = torch.clamp(
+            self.arange[: num_reqs_padded + 1], max=num_reqs
+        )
+        block_tables = [
+            x[:num_reqs_padded] for x in self.block_tables.input_block_tables
+        ]
+        slot_mappings = self.block_tables.slot_mappings[:, :num_tokens_padded]
+        attn_metadata = build_attn_metadata(
+            attn_groups=self.attn_groups,
+            num_reqs=num_reqs_padded,
+            num_tokens=num_tokens_padded,
+            query_start_loc_gpu=self.input_buffers.query_start_loc[
+                : num_reqs_padded + 1
+            ],
+            query_start_loc_cpu=query_start_loc_cpu,
+            max_query_len=1,
+            seq_lens=self.input_buffers.seq_lens[:num_reqs_padded],
+            max_seq_len=self.draft_max_seq_len,
+            block_tables=block_tables,
+            slot_mappings=slot_mappings,
+            kv_cache_config=self.kv_cache_config,
+        )
+        return attn_metadata
+
+    def _copy_request_inputs(
+        self,
+        num_reqs: int,
+        # [num_reqs]
+        idx_mapping: torch.Tensor,
+        # [max_num_reqs]
+        temperature: torch.Tensor,
+        # [max_num_reqs]
+        seeds: torch.Tensor,
+    ) -> None:
+        # Copy temperature, seeds, and idx mapping to the pre-allocated buffers.
+        # NOTE(woosuk): For draft sampling, we only consider the temperature
+        # and ignore the other sampling parameters such as top_k and top_p,
+        # for simplicity and performance.
+        # While this may slightly degrade the acceptance rate, it does not
+        # affect the output distribution after rejection sampling.
+        self.temperature.copy_(temperature)
+        self.seeds.copy_(seeds)
+        self.idx_mapping[:num_reqs].copy_(idx_mapping)


### PR DESCRIPTION
# Context
Gemma4 MTP is currently not supported in MRV2, but was added to MRV1 in [this PR](https://github.com/vllm-project/vllm/pull/41745). The minimal changes needed for MRV2 include:
- Constant positions across draft steps
- Wiring up draft layers to reuse the KV cache of the final target model layer of the same attention group.
- Returning tuple of tensors: (draft_hidden_states, backbone_hidden_states) from draft model forward, where the former is in the draft model's down-projected space.

To support those extra features in MRV1, a new proposer subclass was created for Gemma4 specifically.

# This PR

The monolithic `EagleSpeculator` in `vllm/v1/worker/gpu/spec_decode/speculator.py` is refactored into a layered hierarchy:

- **`BaseSpeculator`** (`spec_decode/speculator.py`) — minimal abstract interface (`init_cudagraph_manager`, `capture`, `propose`) the model runner calls into. Keeps the contract small so non-model-backed speculators can plug in without inheriting draft-model machinery.
- **`ModelBackedSpeculator`** (`spec_decode/speculator.py`) — shared state for any speculator that runs a draft model: buffer allocation, DP config, `load_model`/`set_attn` plumbing, draft attention metadata construction, and `_copy_inputs_from_target`. Declares `load_draft_model` as the abstract extension point.
- **`AutoRegressiveSpeculator`** (`spec_decode/autoregressive/speculator.py`) — the autoregressive draft loop: CUDA graph capture, `propose`, prefill + multi-step decode, and the Triton kernels for input prep. The main overrideable hooks are:
  - `advance_draft_positions` — whether to increment positions/seq_lens between draft steps. `True` for Eagle/MTP (new KV each step), `False` for Gemma4 (Q-only, constant positions).
  - `model_returns_tuple` — whether `forward()` returns `(last_hidden_states, hidden_states)` or a single tensor. `True` for Eagle/Gemma4, `False` for standard MTP.
  - `load_draft_model` — loads draft weights and performs model-specific wiring (KV sharing, embedding sharing, backend overrides). The primary extension point for subclasses.
  - `sample_draft` — converts hidden states to draft token IDs via `compute_logits` + argmax or Gumbel sampling.
- **`EagleSpeculator`** (`spec_decode/eagle/speculator.py`) — thin subclass that only overrides `load_draft_model` to call `load_eagle_model`.
- **`MTPSpeculator`** (`spec_decode/mtp/speculator.py`) — overrides `model_returns_tuple` (`False` for standard MTP like DeepSeek) and `load_draft_model` (calls `load_eagle_model`, the baseline behavior).
- **`Gemma4Speculator`** (`spec_decode/gemma4/speculator.py`) — overrides `advance_draft_positions` (`False` for constant Q-only positions) and `load_draft_model` (wires KV sharing between draft and target attention layers, preserves the target's `TRITON_ATTN` backend, and shares the target's `embed_tokens`).

`AutoRegressiveSpeculator` is essentially the old `EagleSpeculator`, with eagle-specific terms removed and methods reorganized for readability. Methods not prefixed with `_` form the override surface for subclasses.


# Performance Benchmark
## Gemma4 + MTP
**Server Command**
```bash
VLLM_USE_V2_MODEL_RUNNER=<use_v2_model_runner> \
vllm serve google/gemma-4-E2B-it \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-num-seqs 64
  --speculative_config '{"model":"google/gemma-4-E2B-it-assistant","num_speculative_tokens":2}'
```

**Benchmark Command**
```bash
vllm-bench \
  --backend openai-chat \
  --base-url http://127.0.0.1:8000 \
  --model {model} \
  --dataset-name hf \
  --dataset-path philschmid/mt-bench \
  --ignore-eos \
  --request-rate inf \
  --temperature <temperature> \
  --top-p 1.0 \
  --num-warmups 50 \
  --output-len 2048 \
  --sweep-max-concurrency 1,2,4,8,16,32,64 \
  --sweep-num-prompts-factor 10 \
  --save-result \
  --result-dir {log_dir}
```

### Temperature = 0.0
| Concurrency | Req/s (V1) | Req/s (V2) | Tok/s (V1) | Tok/s (V2) | Total tok/s (V1) | Total tok/s (V2) | SS req/s (V1) | SS req/s (V2) | SS out tok/s (V1) | SS out tok/s (V2) | P50 TTFT ms (V1) | P50 TTFT ms (V2) | P50 TPOT ms (V1) | P50 TPOT ms (V2) | P90 TTFT ms (V1) | P90 TTFT ms (V2) | P90 TPOT ms (V1) | P90 TPOT ms (V2) |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 | 2.46 | 2.49 | 315.44 | 318.43 | 562.12 | 567.44 | 2.22 | 2.24 | 317.91 | 320.92 | 15.39 | 16.28 | 3.01 | 2.97 | 36.69 | 38.12 | 3.06 | 3.02 |
| 2 | 4.87 | 4.90 | 623.66 | 626.89 | 1082.15 | 1087.75 | 4.39 | 4.41 | 628.52 | 632.04 | 21.30 | 23.07 | 3.03 | 2.99 | 41.11 | 44.35 | 3.08 | 3.04 |
| 4 | 9.54 | 9.61 | 1220.63 | 1230.46 | 1935.13 | 1950.71 | 8.59 | 8.66 | 1230.44 | 1240.09 | 24.49 | 25.67 | 3.06 | 3.03 | 44.02 | 46.47 | 3.10 | 3.07 |
| 8 | 18.16 | 18.52 | 2324.48 | 2370.91 | 3571.85 | 3643.19 | 16.37 | 16.68 | 2342.80 | 2389.65 | 43.92 | 46.73 | 3.12 | 3.05 | 62.65 | 53.79 | 3.19 | 3.08 |
| 16 | 35.34 | 35.31 | 4522.88 | 4519.95 | 7029.68 | 7025.12 | 31.94 | 32.28 | 4558.17 | 4551.28 | 50.76 | 52.17 | 3.16 | 3.16 | 53.90 | 54.95 | 3.20 | 3.19 |
| 32 | 66.24 | 67.15 | 8478.43 | 8595.52 | 13092.50 | 13273.33 | 60.12 | 60.74 | 8537.28 | 8658.34 | 71.45 | 70.95 | 3.20 | 3.16 | 89.37 | 85.24 | 3.25 | 3.23 |
| 64 | 115.89 | 114.82 | 14834.28 | 14697.50 | 22815.13 | 22604.76 | 105.07 | 103.99 | 14855.10 | 14720.11 | 112.88 | 114.44 | 3.46 | 3.48 | 122.00 | 122.95 | 3.53 | 3.51 |

### Temperature = 1.0
| Concurrency | Req/s (V1) | Req/s (V2) | Tok/s (V1) | Tok/s (V2) | Total tok/s (V1) | Total tok/s (V2) | SS req/s (V1) | SS req/s (V2) | SS out tok/s (V1) | SS out tok/s (V2) | P50 TTFT ms (V1) | P50 TTFT ms (V2) | P50 TPOT ms (V1) | P50 TPOT ms (V2) | P90 TTFT ms (V1) | P90 TTFT ms (V2) | P90 TPOT ms (V1) | P90 TPOT ms (V2) |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 | 2.25 | 2.40 | 287.90 | 307.35 | 513.05 | 547.70 | 2.02 | 2.16 | 290.16 | 309.75 | 15.85 | 16.99 | 3.32 | 3.08 | 37.73 | 40.38 | 3.37 | 3.12 |
| 2 | 4.42 | 4.66 | 565.31 | 596.12 | 980.90 | 1034.36 | 3.98 | 4.19 | 569.93 | 600.75 | 21.71 | 24.46 | 3.35 | 3.15 | 41.36 | 45.92 | 3.41 | 3.20 |
| 4 | 8.63 | 9.09 | 1104.66 | 1163.47 | 1751.28 | 1844.51 | 7.77 | 8.19 | 1113.32 | 1172.86 | 23.25 | 25.73 | 3.41 | 3.21 | 45.20 | 45.53 | 3.48 | 3.25 |
| 8 | 16.59 | 16.96 | 2123.00 | 2170.78 | 3262.24 | 3335.66 | 14.96 | 15.28 | 2137.77 | 2181.31 | 41.97 | 48.81 | 3.49 | 3.36 | 47.01 | 53.63 | 3.55 | 3.38 |
| 16 | 31.65 | 32.46 | 4051.60 | 4154.96 | 6297.19 | 6457.84 | 28.91 | 29.70 | 4080.25 | 4182.73 | 49.66 | 53.69 | 3.58 | 3.46 | 58.73 | 59.21 | 3.62 | 3.49 |
| 32 | 60.09 | 61.04 | 7691.51 | 7812.94 | 11877.34 | 12064.85 | 54.73 | 55.18 | 7743.17 | 7870.85 | 77.81 | 79.36 | 3.57 | 3.49 | 88.64 | 92.54 | 3.63 | 3.52 |
| 64 | 104.86 | 106.20 | 13422.70 | 13593.42 | 20644.12 | 20906.69 | 95.05 | 96.23 | 13459.67 | 13645.97 | 110.96 | 111.46 | 3.94 | 3.85 | 118.31 | 123.01 | 4.00 | 3.95 |

MRV2 consistently outperforms MRV1, except in the concurrency=64 case for all-greedy requests. I believe this is because of the centroid logit masking optimization performed [here](https://github.com/vllm-project/vllm/blob/2a43b407c5093b1255a172139da6a5151f410b7a/vllm/v1/spec_decode/gemma4.py#L107C25-L107C60) in MRV1. This optimization has not been implemented in this PR.

## Regression Sanity Check
### Llama3 8B + Eagle (3 spec tokens)
| Concurrency | Req/s (Main) | Req/s (#43241) | Tok/s (Main) | Tok/s (#43241) | Total tok/s (Main) | Total tok/s (#43241) | SS req/s (Main) | SS req/s (#43241) | SS out tok/s (Main) | SS out tok/s (#43241) | P50 TTFT ms (Main) | P50 TTFT ms (#43241) | P50 TPOT ms (Main) | P50 TPOT ms (#43241) | P90 TTFT ms (Main) | P90 TTFT ms (#43241) | P90 TPOT ms (Main) | P90 TPOT ms (#43241) |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 | 2.87 | 2.93 | 367.78 | 374.70 | 614.89 | 626.45 | 2.73 | 2.78 | 202.86 | 203.16 | 16.14 | 15.66 | 2.52 | 2.53 | 16.62 | 16.05 | 3.44 | 3.29 |
| 2 | 6.09 | 5.95 | 779.36 | 761.43 | 1202.38 | 1174.72 | 5.93 | 5.94 | 414.13 | 414.52 | 17.83 | 16.95 | 2.42 | 2.48 | 21.24 | 21.93 | 3.15 | 3.07 |
| 4 | 11.89 | 11.94 | 1522.28 | 1528.32 | 2303.19 | 2312.32 | 11.47 | 11.80 | 810.18 | 812.07 | 17.36 | 16.32 | 2.46 | 2.38 | 24.80 | 21.29 | 3.06 | 3.04 |
| 8 | 22.54 | 22.80 | 2884.55 | 2918.86 | 4411.62 | 4464.09 | 22.64 | 22.77 | 1576.17 | 1583.62 | 17.97 | 17.37 | 2.56 | 2.53 | 24.96 | 23.34 | 3.13 | 3.12 |
| 16 | 41.69 | 42.30 | 5336.33 | 5414.93 | 8107.93 | 8227.37 | 41.35 | 41.78 | 2892.28 | 2933.82 | 22.98 | 21.93 | 2.74 | 2.73 | 30.82 | 29.13 | 3.42 | 3.40 |
| 32 | 69.00 | 71.73 | 8831.86 | 9181.05 | 13424.17 | 13954.93 | 68.73 | 71.38 | 4780.56 | 4959.25 | 27.36 | 26.03 | 3.30 | 3.19 | 40.25 | 35.52 | 4.05 | 3.88 |
| 64 | 101.65 | 106.28 | 13010.85 | 13603.87 | 19690.51 | 20587.98 | 100.31 | 104.75 | 6970.65 | 7286.05 | 36.30 | 34.91 | 4.52 | 4.30 | 56.06 | 53.79 | 5.57 | 5.29 |

### Qwen3 8B + Eagle3 (3 spec tokens)
| Concurrency | Req/s (Main) | Req/s (#43241) | Tok/s (Main) | Tok/s (#43241) | Total tok/s (Main) | Total tok/s (#43241) | SS req/s (Main) | SS req/s (#43241) | SS out tok/s (Main) | SS out tok/s (#43241) | P50 TTFT ms (Main) | P50 TTFT ms (#43241) | P50 TPOT ms (Main) | P50 TPOT ms (#43241) | P90 TTFT ms (Main) | P90 TTFT ms (#43241) | P90 TPOT ms (Main) | P90 TPOT ms (#43241) |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 | 3.49 | 3.41 | 447.01 | 436.58 | 775.11 | 757.02 | 3.32 | 3.24 | 199.94 | 199.87 | 16.60 | 16.63 | 2.10 | 2.17 | 17.37 | 17.76 | 2.39 | 2.47 |
| 2 | 7.10 | 6.98 | 908.56 | 893.92 | 1432.41 | 1409.32 | 6.92 | 6.93 | 411.86 | 411.55 | 18.45 | 18.75 | 1.99 | 2.07 | 24.85 | 24.07 | 2.32 | 2.27 |
| 4 | 13.75 | 13.49 | 1760.02 | 1727.29 | 2694.69 | 2644.58 | 13.30 | 13.30 | 814.71 | 806.87 | 18.39 | 18.50 | 2.08 | 2.08 | 27.25 | 27.69 | 2.34 | 2.42 |
| 8 | 26.33 | 26.06 | 3369.87 | 3335.89 | 5212.60 | 5160.03 | 26.15 | 25.84 | 1553.41 | 1532.09 | 19.70 | 23.03 | 2.15 | 2.16 | 28.90 | 32.26 | 2.43 | 2.47 |
| 16 | 46.60 | 46.93 | 5964.86 | 6006.47 | 9186.26 | 9250.34 | 45.93 | 46.26 | 2758.56 | 2787.10 | 24.54 | 24.66 | 2.44 | 2.42 | 37.69 | 33.39 | 2.77 | 2.73 |
| 32 | 75.55 | 75.55 | 9670.61 | 9670.06 | 14834.44 | 14833.61 | 74.38 | 74.43 | 4455.19 | 4452.30 | 31.29 | 30.99 | 2.99 | 2.98 | 64.45 | 63.14 | 3.47 | 3.58 |
| 64 | 95.97 | 94.76 | 12284.28 | 12129.52 | 18745.15 | 18508.99 | 93.90 | 94.00 | 5613.19 | 5603.75 | 57.34 | 57.46 | 4.71 | 4.75 | 107.12 | 108.14 | 5.75 | 5.69 |

### Deepseek V3.2 + MTP
| Concurrency | Req/s (Main) | Req/s (#43241) | Tok/s (Main) | Tok/s (#43241) | Total tok/s (Main) | Total tok/s (#43241) | SS req/s (Main) | SS req/s (#43241) | SS out tok/s (Main) | SS out tok/s (#43241) | P50 TTFT ms (Main) | P50 TTFT ms (#43241) | P50 TPOT ms (Main) | P50 TPOT ms (#43241) | P90 TTFT ms (Main) | P90 TTFT ms (#43241) | P90 TPOT ms (Main) | P90 TPOT ms (#43241) |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 | 0.90 | 0.91 | 115.79 | 116.48 | 193.31 | 194.46 | 0.86 | 0.86 | 66.90 | 67.29 | 254.78 | 253.72 | 6.54 | 6.52 | 271.17 | 265.54 | 7.43 | 7.37 |
| 2 | 1.38 | 1.40 | 176.58 | 179.34 | 272.29 | 276.55 | 1.31 | 1.34 | 103.21 | 104.93 | 273.98 | 259.99 | 9.26 | 9.09 | 508.99 | 274.72 | 10.18 | 9.92 |
| 4 | 2.03 | 2.04 | 259.34 | 260.52 | 391.42 | 393.19 | 1.95 | 1.96 | 150.32 | 150.78 | 277.13 | 262.46 | 13.28 | 13.24 | 520.40 | 481.38 | 14.65 | 14.24 |
| 8 | 2.64 | 2.81 | 338.13 | 360.23 | 515.71 | 549.42 | 2.55 | 2.73 | 193.44 | 207.22 | 282.39 | 270.10 | 20.89 | 19.89 | 532.78 | 511.48 | 24.35 | 22.91 |
| 16 | 3.36 | 3.68 | 429.59 | 470.43 | 650.87 | 712.74 | 3.23 | 3.53 | 248.05 | 269.68 | 298.08 | 286.13 | 35.34 | 31.88 | 760.52 | 704.33 | 40.30 | 36.46 |
| 32 | 4.26 | 4.55 | 544.96 | 581.81 | 825.74 | 881.56 | 4.10 | 4.38 | 312.42 | 334.28 | 531.02 | 488.65 | 55.87 | 51.73 | 810.89 | 762.54 | 66.50 | 66.34 |
| 64 | 6.08 | 6.50 | 778.72 | 831.48 | 1175.27 | 1254.89 | 5.84 | 6.24 | 444.83 | 475.41 | 761.49 | 703.14 | 81.91 | 77.09 | 824.05 | 781.41 | 96.37 | 89.89 |

This refactor did not result in regressions for any of the above tested models, which cover a variety of spec decode methods.

# Future Work
As mentioned in the performance benchmark section, the centroid logit masking optimization that can be performed in the all-greedy case has not yet been ported over to MRV2 in this PR. That change will require some further changes to the speculator API, and I don't want to overcomplicate this PR right now. The performance achieved without that optimization is already competitive with MRV1.