### PR TITLE
[Fix] fp32 residual dtype leak in GemmaRMSNorm.forward_native

### DIFF
--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -190,3 +190,31 @@ def test_gemma_rms_norm_mixed_input_weight_dtype(default_vllm_config) -> None:
 
     assert out.dtype == x.dtype
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_gemma_rms_norm_residual_dtype(default_vllm_config, dtype) -> None:
+    """Verify that GemmaRMSNorm returns residual in the original dtype.
+
+    Regression test for a bug where the fp16 path upcasted x+residual to fp32
+    but never cast the residual back, leaking fp32 tensors downstream.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    device = CUDA_DEVICES[0]
+    num_tokens, hidden_size = 32, 1024
+
+    layer = GemmaRMSNorm(hidden_size, eps=1e-6).to(device=device)
+    layer.weight.data.normal_(mean=0.0, std=0.1)
+
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    residual = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+
+    out, residual_out = layer(x, residual)
+
+    assert out.dtype == dtype, f"out dtype {out.dtype} != expected {dtype}"
+    assert residual_out.dtype == dtype, (
+        f"residual dtype {residual_out.dtype} != expected {dtype}"
+    )

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -167,7 +167,9 @@ class GemmaRMSNorm(CustomOp):
         # ir.ops.rms_norm handles fp32 upcast internally
         out = ir.ops.rms_norm(x, weight, self.variance_epsilon)
         return (
-            out.to(orig_dtype) if residual is None else (out.to(orig_dtype), residual)
+            out.to(orig_dtype)
+            if residual is None
+            else (out.to(orig_dtype), residual.to(orig_dtype))
         )
 
     def forward_cuda(


### PR DESCRIPTION

## Purpose
Fixes issue #42588

GemmaRMSNorm.forward_native upcasts x+residual to fp32 for numerical stability but only casts the output back to orig_dtype, returning the residual in fp32. This causes dtype mismatches in downstream layers (e.g. DFlash speculative decoding on ROCm) when the fp32 residual propagates through the model.

Cast residual back to orig_dtype in the return path, matching the contract established by RMSNorm.forward_native.

Signed-off-by: Giuseppe Grossi ggrossi@amd.com
## Test Plan

## Test Result
Verified end-to-end on Qwen/Qwen3.6-27B using MI300 hardware  

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
