### PR TITLE
[Bugfix] Use json.loads before ast.literal_eval in qwen3xml_tool_parser

### DIFF
--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -821,7 +821,10 @@ class StreamingXMLToolCallParser:
                         raw_for_parse = raw_text + "\n"
                     else:
                         raw_for_parse = raw_text
-                    parsed_value = ast.literal_eval(raw_for_parse)
+                    try:
+                        parsed_value = json.loads(raw_for_parse.strip())
+                    except (json.JSONDecodeError, ValueError):
+                        parsed_value = ast.literal_eval(raw_for_parse)
                     output_arguments = json.dumps(parsed_value, ensure_ascii=False)
                 except Exception:
                     # Fallback: output as string as-is


### PR DESCRIPTION
## Summary

Fixes #43238

**Root cause:** `StreamingXMLToolCallParser._end_element` parses deferred parameters (arrays/objects) using `ast.literal_eval`. This works for simple string arrays like `["a", "b"]` since Python and JSON agree on that syntax - but fails silently for arrays of objects containing JSON booleans/null (`true`, `false`, `null`), which are not valid Python literals.

When `ast.literal_eval` raises `ValueError`, the `except` block calls `json.dumps` on the raw string, so the client receives the argument as a JSON-encoded string instead of a native array:

```
# Broken: questions is a string, not an array
{"questions": "\n[{\"question\": \"...\", \"multiSelect\": false}]\n"}
```

**Fix:** Try `json.loads` first (handles all valid JSON including `true`/`false`/`null`), fall back to `ast.literal_eval` only if that fails (preserves handling of any non-standard model output using Python-style single-quoted strings).

```python
# Before:
parsed_value = ast.literal_eval(raw_for_parse)

# After:
try:
    parsed_value = json.loads(raw_for_parse.strip())
except (json.JSONDecodeError, ValueError):
    parsed_value = ast.literal_eval(raw_for_parse)
```

`qwen3coder_tool_parser.py` already follows this `json.loads`-first pattern and is unaffected.

## Test Plan

- [x] Verified root cause: `ast.literal_eval('[{"multiSelect": false}]')` raises `ValueError`
- [x] Verified fix: `json.loads('[{"multiSelect": false}]')` returns a native list
- [x] Confirmed `qwen3coder_tool_parser.py` already uses `json.loads` first (no change needed)
- [x] Outer `except Exception` fallback is preserved for complete parse failures

> **Note:** Parts of this fix were developed with AI (Claude) assistance.