### PR TITLE
[Bugfix][compressed-tensors] Wrap `is_static_input_scheme` with `bool()` for `input_quant=None` schemes

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -662,7 +662,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 if is_fp8_w8a8_supported:
                     return CompressedTensorsW8A8Fp8(
                         weight_quant=weight_quant,
-                        is_static_input_scheme=(
+                        is_static_input_scheme=bool(
                             input_quant and not input_quant.dynamic
                         ),
                     )
@@ -676,7 +676,7 @@ class CompressedTensorsConfig(QuantizationConfig):
 
             # note: input_quant can be None
             if self._is_fp8_w8a16(weight_quant, input_quant):
-                is_static_input_scheme = input_quant and not input_quant.dynamic
+                is_static_input_scheme = bool(input_quant and not input_quant.dynamic)
                 return CompressedTensorsW8A16Fp8(
                     weight_quant=weight_quant,
                     is_static_input_scheme=is_static_input_scheme,
@@ -697,7 +697,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 )
 
             if self._is_dynamic_token_w4a8_int(weight_quant, input_quant):
-                is_static_input_scheme = input_quant and not input_quant.dynamic
+                is_static_input_scheme = bool(input_quant and not input_quant.dynamic)
                 return CompressedTensorsW4A8Int(
                     num_bits=weight_quant.num_bits,
                     strategy=weight_quant.strategy,


### PR DESCRIPTION
## Purpose

In `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py`, `is_static_input_scheme` is assigned `input_quant and not input_quant.dynamic` at three call sites. When `input_quant` is `None` — common for weight-only schemes such as NVFP4 weight-only and FP8_BLOCK with `input_activations=None` — Python short-circuits the `and` and yields `None`, not `False`.

Most call sites get the right behavior accidentally via Python truthiness. The trap is anything that does an identity-compare (`is False`/`is True`) or passes the value to a function annotated to take `bool` — those quietly do the wrong thing without an obvious error.

This wraps the three offending expressions in `bool(...)` so the typed contract is honored regardless of `input_quant` being `None` or a `QuantizationArgs`.

## Sites changed

Three distinct sites in `_get_scheme_from_parts`:

1. `CompressedTensorsW8A8Fp8(...)` inline kwarg (multi-line parenthesized form) — line ~665.
2. `_is_fp8_w8a16` branch assignment that flows into `CompressedTensorsW8A16Fp8(...)` — line ~679.
3. `_is_dynamic_token_w4a8_int` branch assignment that flows into `CompressedTensorsW4A8Int(...)` — line ~700.

The fourth nearby site at line ~674 (`is_static_input_scheme=not input_quant.dynamic`) already evaluates to `bool` and is unchanged.

## Reproducer

A `QuantizationScheme` with `format="float-quantized"` + `weights=...` + `input_activations=None` — i.e. weight-only schemes for FP8_BLOCK or NVFP4 — produces a model whose serve-side `is_static_input_scheme` is `None` rather than `False`. This trips identity comparisons or `bool`-typed downstream callers.

## Test plan

The diff is three string replacements that wrap an existing expression with `bool(...)`. No semantic change for any case where `input_quant` is a `QuantizationArgs` instance (truthiness already aligned with `bool` for those). For `input_quant is None`, the result moves from `None` to `False`, which is the documented contract.

## Test result

Local syntax check passes. The existing test suite for compressed-tensors schemes should pass unchanged; if a new unit test is desired for the `input_quant=None` case asserting the returned type is `bool`, happy to add it in a follow-up commit on this PR.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) The necessary documentation update
</details>
