### PR TITLE
Fix MRV2 Gumbel sampling for non-finite logits

### DIFF
--- a/tests/v1/sample/test_gumbel.py
+++ b/tests/v1/sample/test_gumbel.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.sample.gumbel import (
+    _FP32_ONE_MINUS_EPS,
+    _FP32_TINY,
+    _FP64_ONE_MINUS_EPS,
+)
+
+pytest.importorskip("triton")
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required for Gumbel sampler tests", allow_module_level=True)
+
+
+@triton.jit
+def _gumbel_nonfinite_logits_regression_kernel(
+    out_value,
+    out_is_nan,
+    USE_FP64: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    block = tl.arange(0, BLOCK_SIZE)
+    mask = block < BLOCK_SIZE
+
+    if USE_FP64:
+        logits = tl.full((BLOCK_SIZE,), float("-inf"), tl.float64)
+        # Deterministically reproduce the upper-endpoint uniform draw that
+        # previously made Gumbel noise infinite.
+        u = tl.full((BLOCK_SIZE,), 1.0, tl.float64)
+        u = tl.minimum(u, _FP64_ONE_MINUS_EPS)
+    else:
+        logits = tl.full((BLOCK_SIZE,), float("-inf"), tl.float32)
+        u = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+        u = tl.minimum(tl.maximum(u, _FP32_TINY), _FP32_ONE_MINUS_EPS)
+
+    gumbel_noise = -tl.log(-tl.log(u))
+    finite = logits > float("-inf")
+    logits = tl.where(mask & finite, logits + gumbel_noise, float("-inf"))
+
+    value = tl.max(logits, axis=0)
+    tl.store(out_value, value)
+    tl.store(out_is_nan, (value != value).to(tl.int32))
+
+
+@pytest.mark.parametrize("use_fp64", [False, True])
+def test_gumbel_noise_does_not_turn_negative_inf_logits_into_nan(use_fp64: bool):
+    value_dtype = torch.float64 if use_fp64 else torch.float32
+    value = torch.empty((), device="cuda", dtype=value_dtype)
+    is_nan = torch.empty((), device="cuda", dtype=torch.int32)
+
+    _gumbel_nonfinite_logits_regression_kernel[(1,)](
+        value,
+        is_nan,
+        USE_FP64=use_fp64,
+        BLOCK_SIZE=1024,
+        num_warps=1,
+    )
+    torch.cuda.synchronize()
+
+    assert not bool(is_nan.item())
+    assert torch.isneginf(value).item()

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -14,6 +14,14 @@ from vllm.triton_utils import HAS_TRITON, tl, triton
 _FP32_TINY = (
     tl.constexpr(float.fromhex("0x1p-126")) if HAS_TRITON else float.fromhex("0x1p-126")
 )
+_FP32_ONE_MINUS_EPS = (
+    tl.constexpr(float.fromhex("0x1.fffffep-1"))
+    if HAS_TRITON
+    else float.fromhex("0x1.fffffep-1")
+)
+_FP64_ONE_MINUS_EPS = (
+    tl.constexpr(0.9999999999999999) if HAS_TRITON else 0.9999999999999999
+)
 
 
 @triton.jit
@@ -127,13 +135,15 @@ def gumbel_block_argmax(
 
         if USE_FP64:
             u = tl_rand64(gumbel_seed, block, includes_zero=False)
+            u = tl.minimum(u, _FP64_ONE_MINUS_EPS)
         else:
             u = tl.rand(gumbel_seed, block)
-            u = tl.maximum(u, _FP32_TINY)
+            u = tl.minimum(tl.maximum(u, _FP32_TINY), _FP32_ONE_MINUS_EPS)
         gumbel_noise = -tl.log(-tl.log(u))
 
         # Apply gumbel noise.
-        logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
+        finite = logits > float("-inf")
+        logits = tl.where(mask & finite, logits + gumbel_noise, float("-inf"))
 
     value, idx = tl.max(logits, axis=0, return_indices=True)
     return value, idx


### PR DESCRIPTION
## Summary

Fix MRV2 Gumbel sampling when the candidate logits contain `-inf` entries.

The current Gumbel path only clamps the uniform draw away from zero. If the
draw reaches the upper endpoint after floating-point rounding, the Gumbel
noise becomes `inf`. Adding that noise to a masked/non-candidate `-inf` logit
produces `NaN`, and a subsequent Triton reduction can return an invalid token
index.

This change:

- clamps fp32/fp64 uniform draws away from both `0` and `1`;
- only adds Gumbel noise to finite logits;
- adds a CUDA/Triton regression test that deterministically reproduces the
  `-inf + inf -> NaN` edge case.

## Why this matters

We hit this downstream in a Kimi K2.6 MRV2 speculative decoding deployment with
DCP8 and Eagle/MTP. The failure surfaced during spec-decode/logprobs warmup as
an invalid sampled token id and then a CUDA illegal memory access:

```text
Invalid sampled token ids for spec logprobs:
count=1 vocab=163840 idx=[508] vals=[9223372034707292159]
```

The DCP8/Kimi setup makes the bug easy to trigger, but the root cause is not
DCP-specific. It is the generic Gumbel sampler being asked to sample from
residual logits where rejected tokens are represented as `-inf`.

A minimal deterministic reproduction of the arithmetic issue is:

```python
logits = -inf
u = 1.0
gumbel_noise = -log(-log(u))  # inf
logits + gumbel_noise        # NaN
```

After this patch, the same case stays `-inf` and does not poison the reduction.

## Tests

```text
python3 - <<'PY'
import importlib.util
path = "tests/v1/sample/test_gumbel.py"
spec = importlib.util.spec_from_file_location("test_gumbel_direct", path)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
mod.test_gumbel_noise_does_not_turn_negative_inf_logits_into_nan(False)
mod.test_gumbel_noise_does_not_turn_negative_inf_logits_into_nan(True)
print("direct test passed")
PY
python3 -m py_compile vllm/v1/worker/gpu/sample/gumbel.py tests/v1/sample/test_gumbel.py
git diff --check
```

I could not run the repository pytest entrypoint in this local container because
`tests/conftest.py` imports `tblib`, which is not installed in the environment:

```text
ModuleNotFoundError: No module named 'tblib'
```
