### PR TITLE
[CI/Build] Bump flashinfer to v0.6.11.post3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -639,7 +639,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.11.post2
+ARG FLASHINFER_VERSION=0.6.11.post3
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -217,13 +217,13 @@ RUN pip install setuptools==75.6.0 packaging==23.2 ninja==1.11.1.3 build==1.2.2.
 
 
 # build flashinfer for torch nightly from source around 10 mins
-# release version: v0.6.11.post2
+# release version: v0.6.11.post3
 # todo(elainewy): cache flashinfer build result for faster build
 ENV CCACHE_DIR=/root/.cache/ccache
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/uv \
     echo "git clone flashinfer..." \
-    && git clone --depth 1 --branch v0.6.11.post2 --recursive https://github.com/flashinfer-ai/flashinfer.git \
+    && git clone --depth 1 --branch v0.6.11.post3 --recursive https://github.com/flashinfer-ai/flashinfer.git \
     && cd flashinfer \
     && git submodule update --init --recursive \
     && echo "finish git clone flashinfer..." \

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.11.post2"
+      "default": "0.6.11.post3"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,8 @@ torchaudio==2.11.0
 # These must be updated alongside torch
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.11.post2
-flashinfer-cubin==0.6.11.post2
+flashinfer-python==0.6.11.post3
+flashinfer-cubin==0.6.11.post3
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
 # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to


### PR DESCRIPTION
## Purpose

* Bump FlashInfer from `v0.6.11.post2` to `v0.6.11.post3`.

## What's in post3

[Release diff](https://github.com/flashinfer-ai/flashinfer/compare/v0.6.11.post2...v0.6.11.post3) - 3 commits:
- Replace SM120 W4A16 MoE kernels (reorganized under `flashinfer/fused_moe/cute_dsl/blackwell_sm12x/`)
- Address AI review feedback
- bump version to v0.6.11.post3

The top-level `flashinfer.fused_moe.b12x_fused_moe` entry point used by vLLM's `flashinfer_b12x_moe` wrapper is preserved (changes are underneath the API), so no upstream call-site updates are needed.

## Files changed

Version-string-only updates, mirroring #41711:
- `docker/Dockerfile` - `FLASHINFER_VERSION` arg
- `docker/Dockerfile.nightly_torch` - source-build tag
- `docker/versions.json` - default
- `requirements/cuda.txt` - `flashinfer-python` and `flashinfer-cubin` pins

## Duplicate-work check

Searched open PRs for `0.6.11.post3` and `Bump flashinfer` - no open PR currently bumps the version files. PRs #42235 and #43003 reference post3 in comments but do not modify the pinned version.

## Test plan

- vLLM CI exercises the flashinfer integration path on PR runs.
- vLLM-side surface: only version-pin edits in 4 config files; no vLLM source changes.
- The only behavior change comes from the post2->post3 delta upstream - primarily an SM120 W4A16 MoE kernel rewrite under `flashinfer.fused_moe.cute_dsl.blackwell_sm12x.*`. vLLM's `flashinfer_b12x_moe` wrapper imports `b12x_fused_moe` (still present), so no call-site changes needed.

## AI assistance

This change was prepared with AI assistance (Claude Code). I reviewed every changed line and authored the commit.
