### PR TITLE
[LMCache MP Connector] Report cache hit stats in KVTransferParams

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -938,17 +938,16 @@ class LMCacheMPConnectorUpstream(KVConnectorBase_V1):
         if (
             params is not None
             and return_params is not None
-            and "num_lmcache_extra_cached_tokens" in params
+            and "cached_token_stats" in params
         ):
             request_tracker = self._get_request_tracker(request.request_id)
-            num_extra_cached_blocks = max(
-                0,
-                request_tracker.num_lmcache_hit_blocks
-                - request_tracker.num_vllm_hit_blocks,
-            )
-            return_params["num_lmcache_extra_cached_tokens"] = (
-                num_extra_cached_blocks * self.vllm_block_size
-            )
+            num_vllm = request_tracker.num_vllm_hit_blocks * self.vllm_block_size
+            num_lmcache = request_tracker.num_lmcache_hit_blocks * self.vllm_block_size
+            return_params["cached_token_stats"] = {
+                "num_vllm_cached_tokens": num_vllm,
+                "num_lmcache_cached_tokens": num_lmcache,
+                "num_lmcache_extra_cached_tokens": max(0, num_lmcache - num_vllm),
+            }
 
         # Clean up request tracker to prevent memory leak
         self._cleanup_request_tracker(request.request_id)


### PR DESCRIPTION



## Purpose

  Add per-request cache hit statistics to the MP connector's `request_finished`
  response via `KVTransferParams`, so callers can see how many tokens were cached
  by vLLM's APC vs LMCache.

  Previously, the MP connector's `request_finished` always returned `(True, None)` —
  no cache usage stats were surfaced. This adds an opt-in `cached_token_stats` field
  that reports:

  - `num_vllm_cached_tokens` — tokens found in vLLM's GPU APC
  - `num_lmcache_cached_tokens` — tokens found in LMCache's L1/L2 (includes APC overlap)
  - `num_lmcache_extra_cached_tokens` — tokens LMCache provided beyond APC (the actual
    compute savings from LMCache)

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

