### PR TITLE
[Gemma4][Bugfix] Add LoRA support for Gemma4 MoE 26B model

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1536,6 +1536,8 @@ class Gemma4ForCausalLM(
             "up_proj",
         ],
     }
+    # Gemma4 MoE LoRA weights are 3D-packed (all experts in one tensor)
+    is_3d_moe_weight: bool = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         config = _get_text_config(vllm_config.model_config.hf_config)
@@ -1592,6 +1594,16 @@ class Gemma4ForCausalLM(
         self.num_expert_groups = 1
         self.num_shared_experts = 0
         self.num_redundant_experts = 0
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        num_experts = getattr(self.config, "num_experts", None) or 0
+        return fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=num_experts,
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1596,13 +1596,14 @@ class Gemma4ForCausalLM(
         self.num_redundant_experts = 0
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
-        num_experts = getattr(self.config, "num_experts", None) or 0
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=num_experts,
+            num_experts=self.num_logical_experts,
+        )
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Purpose

Fix LoRA serving for Gemma4 MoE models. The following command fails without this fix:

```bash
vllm serve /path/to/gemma-4-26B-A4B-it/ \
  --tensor_parallel_size 8 \
  --enable-lora \
  --max_lora_rank 128 \
  --lora-modules '{"name": "model", "path": "/path/to/lora"}'
```

**Error:**
```
AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented
```

## Changes

Two additions to `Gemma4ForCausalLM`:

### 1. `get_expert_mapping()`

Required by `process_packed_modules_mapping()` in `vllm/lora/utils.py` for any MoE model. Without it the error above is raised unconditionally.

### 2. `is_3d_moe_weight = True`

Gemma4 LoRA adapters use **3D-packed expert weights** — a single tensor covering all experts rather than per-expert tensors. Confirmed from actual trained adapter weight shapes:

| Tensor | Shape | Interpretation |
|--------|-------|----------------|
| `experts.lora_A` | `[8192, 704]` | 128 experts × rank 64, intermediate_size 704 |
| `experts.lora_B` | `[2816, 8192]` | hidden_size 2816, 128 experts × rank 64 |
| `experts.base_layer.lora_A` | `[8192, 2816]` | gate_up, 128 experts × rank 64 |
| `experts.base_layer.lora_B` | `[1408, 8192]` | gate_up output, 128 experts × rank 64 |

Without `is_3d_moe_weight = True` (default is `False`), `process_packed_modules_mapping()` enters the per-expert branch and populates `packed_modules_mapping["experts"]` with entries like `["experts.0.gate_proj", "experts.1.gate_proj", ...]`. This mismatches the 3D adapter format and forces `model_manager.py` into a heuristic fallback path rather than the correct `FusedMoE3DWithLoRA` loading path.

## Test Plan

Tested with a Gemma 4 26B-A4B-it model and a LoRA adapter trained via axolotl (rank 64, target modules: attention projections + MoE experts):

```bash
vllm serve /path/to/gemma-4-26B-A4B-it/ \
  --tensor_parallel_size 8 \
  --served_model_name base_model \
  --enable-lora \
  --max_lora_rank 128 \
  --lora-modules '{"name": "model", "path": "/path/to/lora"}'
```

- Before fix: `AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented`
- After fix: server starts and LoRA loads successfully. Able to run inferences with lora active. 