### PR TITLE
[CI] Add composed-schema regression tests for DeepSeek V3.2/V4 parsers

### DIFF
--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -221,6 +221,99 @@ class TestExtractToolCalls:
         assert args == {"value": 42}
         assert isinstance(args["value"], int)
 
+    @pytest.mark.skip_global_cleanup
+    def test_composed_schema_converts_object_and_array_params(self):
+        """Composed JSON Schema types must still drive DSML type coercion."""
+        tool = ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="set_timer",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "wait": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {"const": "until"},
+                                        "date": {"type": "string"},
+                                    },
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {"const": "for"},
+                                        "minutes": {"type": "number"},
+                                    },
+                                },
+                            ],
+                        },
+                        "patches": {
+                            "oneOf": [
+                                {"type": "array", "items": {"type": "object"}},
+                                {"type": "null"},
+                            ],
+                        },
+                    },
+                },
+            ),
+        )
+        parser = make_parser(tools=[tool])
+        model_output = (
+            f"{FC_START}\n"
+            f'{INV_START}set_timer">\n'
+            f'{PARAM_START}wait" string="false">'
+            f'{{"type":"for","minutes":2880}}'
+            f"{PARAM_END}\n"
+            f'{PARAM_START}patches" string="false">'
+            f'[{{"op":"replace","path":"/schedule","value":"quiet"}}]'
+            f"{PARAM_END}\n"
+            f"{INV_END}\n"
+            f"{FC_END}"
+        )
+        result = parser.extract_tool_calls(model_output, None)
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {
+            "wait": {"type": "for", "minutes": 2880},
+            "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
+        }
+        assert isinstance(args["wait"], dict)
+        assert isinstance(args["patches"], list)
+
+    @pytest.mark.skip_global_cleanup
+    def test_string_attr_true_preserves_literal_for_composed_schema(self):
+        tool = ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="set_timer",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "wait": {
+                            "anyOf": [
+                                {"type": "object"},
+                                {"type": "null"},
+                            ],
+                        },
+                    },
+                },
+            ),
+        )
+        parser = make_parser(tools=[tool])
+        model_output = (
+            f"{FC_START}\n"
+            f'{INV_START}set_timer">\n'
+            f'{PARAM_START}wait" string="true">'
+            f'{{"type":"for","minutes":2880}}'
+            f"{PARAM_END}\n"
+            f"{INV_END}\n"
+            f"{FC_END}"
+        )
+        result = parser.extract_tool_calls(model_output, None)
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"wait": '{"type":"for","minutes":2880}'}
+
     def test_arguments_wrapper_repaired(self):
         """A single 'arguments' wrapper parameter must be unwrapped when it
         is not part of the tool schema and the inner object matches schema fields."""
@@ -580,6 +673,50 @@ class TestExtractToolCallsStreaming:
         args = json.loads(args_str)
         assert args == {"value": "42"}
         assert isinstance(args["value"], str)
+
+    @pytest.mark.skip_global_cleanup
+    def test_composed_schema_conversion_in_streaming(self):
+        tool = ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="set_timer",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "wait": {
+                            "anyOf": [
+                                {"type": "object"},
+                                {"type": "null"},
+                            ],
+                        },
+                        "patches": {
+                            "oneOf": [
+                                {"type": "array", "items": {"type": "object"}},
+                                {"type": "null"},
+                            ],
+                        },
+                    },
+                },
+            ),
+        )
+        parser = make_parser(tools=[tool])
+        full_text = (
+            f"{FC_START}\n"
+            f'{INV_START}set_timer">\n'
+            f'{PARAM_START}wait" string="false">'
+            f'{{"type":"for","minutes":2880}}'
+            f"{PARAM_END}\n"
+            f'{PARAM_START}patches" string="false">'
+            f'[{{"op":"replace","path":"/schedule","value":"quiet"}}]'
+            f"{PARAM_END}\n"
+            f"{INV_END}\n"
+            f"{FC_END}"
+        )
+        deltas = self._stream(parser, full_text)
+        args = json.loads(self._reconstruct_args(deltas))
+        assert args == {
+            "wait": {"type": "for", "minutes": 2880},
+            "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
+        }
 
     def test_multiple_tools_streaming(self, parser):
         full_text = (

--- a/tests/tool_parsers/test_deepseekv4_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv4_tool_parser.py
@@ -236,3 +236,52 @@ def test_extract_tool_calls_arguments_wrapper():
     assert result.tools_called
     args = json.loads(result.tool_calls[0].function.arguments)
     assert args == {"location": "Beijing"}
+
+
+@pytest.mark.skip_global_cleanup
+def test_composed_schema_converts_object_and_array_params():
+    tool = ChatCompletionToolsParam(
+        type="function",
+        function={
+            "name": "set_timer",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "wait": {
+                        "anyOf": [
+                            {"type": "object"},
+                            {"type": "null"},
+                        ],
+                    },
+                    "patches": {
+                        "allOf": [
+                            {"type": "array", "items": {"type": "object"}},
+                        ],
+                    },
+                },
+            },
+        },
+    )
+    parser = make_parser(tools=[tool])
+    request = make_request(tools=[tool])
+    model_output = (
+        f"{TC_START}\n"
+        f'{INV_START}set_timer">\n'
+        f'{PARAM_START}wait" string="false">'
+        f'{{"type":"for","minutes":2880}}'
+        f"{PARAM_END}\n"
+        f'{PARAM_START}patches" string="false">'
+        f'[{{"op":"replace","path":"/schedule","value":"quiet"}}]'
+        f"{PARAM_END}\n"
+        f"{INV_END}\n"
+        f"{TC_END}"
+    )
+
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    args = json.loads(result.tool_calls[0].function.arguments)
+    assert args == {
+        "wait": {"type": "for", "minutes": 2880},
+        "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
+    }


### PR DESCRIPTION


## Purpose

Add DeepSeek V3.2/V4 DSML parser regression coverage for tool arguments whose
JSON Schema types are expressed through composed schemas.

The relevant failing pattern is an object or array parameter defined with a
schema such as `anyOf`, `oneOf`, or `allOf`. If a parser only reads a direct
top-level `schema["type"]`, these structured parameters can fall back to
`string` and surface to OpenAI-compatible clients as JSON-encoded strings:

```json
{
  "wait": "{\"type\":\"for\",\"minutes\":2880}",
  "patches": "[{\"op\":\"replace\",\"path\":\"/schedule\",\"value\":\"quiet\"}]"
}
```

The expected engine behavior is to preserve the requested tool schema shape
inside `function.arguments`: object-valued properties should decode as JSON
objects and array-valued properties should decode as JSON arrays, even when
their types are expressed through composed schemas:

```json
{
  "wait": {
    "type": "for",
    "minutes": 2880
  },
  "patches": [
    {
      "op": "replace",
      "path": "/schedule",
      "value": "quiet"
    }
  ]
}
```

Current vLLM `main` already contains the source behavior through #43019, which
replaced the DeepSeek parser's local coercion path with the shared
`find_tool_properties`, `extract_types_from_schema`, and `coerce_to_schema_type`
helpers. This PR is intentionally scoped to targeted parser-level coverage for
composed-schema cases:

- DeepSeek V3.2 superclass path: `anyOf` object/null, `anyOf` array/null, and
  literal `string="true"` behavior.
- DeepSeek V4 parser path: composed-schema object and `allOf` array arguments.

Why this is not duplicating existing upstream work:

- #43019 fixed the source behavior and added broader coercion coverage, but did
  not include these composed-schema parser regressions.
- #30797, #41531, and #42879 were adjacent: array/object conversion, nested
  wrapper repair, and streaming delta handling respectively. They do not make
  these tests redundant.

This PR is not intended to solve higher-level agent/tool-loop issues such as
missing one of several requested tool calls, false success after a no-op tool
result, or state-sensitive confirmation of a settings revert. Those are
semantically important, but they are outside this parser coverage because there
is no malformed DSML argument to coerce in those cases.

AI assistance was used to analyze the reproducer, compare related upstream work, and prepare this coverage. 
I (the human) took a look at this and it seems alright, but I'm not yet a vllm expert (let's see if I can go 2-2-2 for useful PRs vs PRs opened vs days elapsed though, wahoooo)

## Test Plan

Run the focused DeepSeek V3.2/V4 composed-schema parser tests:

```bash
PYTHONPATH=. .venv/bin/python -m pytest \
  tests/tool_parsers/test_deepseekv32_tool_parser.py \
  tests/tool_parsers/test_deepseekv4_tool_parser.py \
  -q -k composed_schema
```

Run ruff on the touched parser files:

```bash
uvx ruff check \
  tests/tool_parsers/test_deepseekv32_tool_parser.py \
  tests/tool_parsers/test_deepseekv4_tool_parser.py \
  vllm/tool_parsers/deepseekv32_tool_parser.py

uvx ruff format --check \
  tests/tool_parsers/test_deepseekv32_tool_parser.py \
  tests/tool_parsers/test_deepseekv4_tool_parser.py \
  vllm/tool_parsers/deepseekv32_tool_parser.py
```

## Test Result

Focused vLLM parser tests:

```text
4 passed, 50 deselected, 3 warnings in 0.16s
```

Ruff results:

```text
uvx ruff check ...          -> All checks passed!
uvx ruff format --check ... -> 3 files already formatted
```

Pre-fix negative evidence was captured before #43019 landed upstream. Applying
only the composed-schema tests to the earlier parser implementation failed with
object and array arguments returned as JSON strings:

```text
2 failed, 1 passed
```

Representative failing shape from that run:

```text
{'wait': '{"type":"for","minutes":2880}',
 'patches': '[{"op":"replace","path":"/schedule","value":"quiet"}]'}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not required for this parser-only coverage.
</details>


