### PR TITLE
[KV Connector] Skip stale KV xfer completion notifications in scheduler

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2139,9 +2139,14 @@ class Scheduler(SchedulerInterface):
             self.connector.update_connector_output(kv_connector_output)
 
         # KV Connector:: update recv and send status from last step.
+        # KV xfer completion is async: the request may already be cleaned up
+        # when its lifecycle is shorter than the KV write latency (e.g.
+        # Mooncake). Skip stale notifications instead of asserting.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                logger.debug("Dropping stale finished_recving for request %s", req_id)
+                continue
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
@@ -2150,7 +2155,9 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                logger.debug("Dropping stale finished_sending for request %s", req_id)
+                continue
             self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(


### PR DESCRIPTION
## Purpose

In P/D (prefill/decode) disaggregated setups, KV transfer completion notifications from the worker-side connector are asynchronous. When a request's lifecycle ends before the underlying KV write completes — observed under load with the Mooncake connector when request lifecycle < KV write latency — the scheduler has already removed the request from `self.requests` by the time the late `finished_recving` / `finished_sending` callback arrives. The `assert req_id in self.requests` in `_update_from_kv_xfer_finished` then aborts the engine process.

Same underlying issue as #37837.

This change drops late notifications for unknown request ids instead of asserting, with a `logger.debug` line so the drops remain observable.
