### PR TITLE
[CI][Bugfix] Fix cutlass fp8 gemm padded test

### DIFF
--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -206,7 +206,16 @@ def test_cutlass_fp8_gemm_padded(
 
     baseline = baseline_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
 
+    # process_weights_after_loading pad b to 16
+    pad_k = (16 - k % 16) % 16
+    pad_n = (16 - n % 16) % 16
+    if pad_k > 0 or pad_n > 0:
+        b = torch.nn.functional.pad(b.t().contiguous(), (0, pad_k, 0, pad_n)).t()
+        if pad_n > 0 and scale_b.numel() > 1:
+            scale_b = torch.nn.functional.pad(scale_b, (0, pad_n), value=1.0)
+
     kernel = object.__new__(CutlassFP8ScaledMMLinearKernel)
+    kernel.logical_output_size = n
     out = kernel.apply_scaled_mm(
         A=a,
         B=b,


### PR DESCRIPTION



## Purpose
- Fix failling test_cutlass_fp8_gemm_padded tests on main: https://buildkite.com/vllm/ci/builds/67233/canvas?jid=019e4743-eaa9-4afc-8714-a85acfea8dfa&tab=output
```
FAILED kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_gemm_padded[True-b_scale_group_shape0-a_scale_group_shape0-32-3420-1280] - AttributeError: 'CutlassFP8ScaledMMLinearKernel' object has no attribute 'logical_output_size'
```

## Test Plan
```
pytest -s -v tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_gemm_padded
```

## Test Result
All tests passed on H200
```
===================================================================== 48 passed, 17 warnings in 17.42s ======================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

