### PR TITLE
[Bugfix] Qwen3-VL(-MoE): pass architectures to with_hf_config for pipeline parallelism

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1691,7 +1691,10 @@ class Qwen3VLForConditionalGeneration(
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3LLMForCausalLM(
-                vllm_config=vllm_config.with_hf_config(config.text_config),
+                vllm_config=vllm_config.with_hf_config(
+                    config.text_config,
+                    architectures=["Qwen3ForCausalLM"],
+                ),
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1892,7 +1892,10 @@ class Qwen3VLForConditionalGeneration(
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3LLMForCausalLM(
-                vllm_config=vllm_config.with_hf_config(config.text_config),
+                vllm_config=vllm_config.with_hf_config(
+                    config.text_config,
+                    architectures=["Qwen3ForCausalLM"],
+                ),
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -447,7 +447,10 @@ class Qwen3VLMoeForConditionalGeneration(
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3MoeLLMForCausalLM(
-                vllm_config=vllm_config.with_hf_config(config.text_config),
+                vllm_config=vllm_config.with_hf_config(
+                    config.text_config,
+                    architectures=["Qwen3MoeForCausalLM"],
+                ),
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -275,7 +275,10 @@ class Qwen3VLMoeForConditionalGeneration(
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3MoeLLMForCausalLM(
-                vllm_config=vllm_config.with_hf_config(config.text_config),
+                vllm_config=vllm_config.with_hf_config(
+                    config.text_config,
+                    architectures=["Qwen3MoeForCausalLM"],
+                ),
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 


### PR DESCRIPTION
## Purpose

Fixes #43271.

Qwen3-VL-MoE (and dense Qwen3-VL) crash at engine init with `--pipeline-parallel-size > 1`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  Value error, No model architectures are specified
```

The inner language model is constructed from `config.text_config`, whose `architectures` is `None` (architectures only exist on the top-level config). `with_hf_config()` does not infer them, so the language model's `ModelConfig` ends up with an empty architectures list and `registry.inspect_model_cls` raises.

This passes the text-model architecture explicitly, matching the convention already used by the sibling models that construct the same language-model classes:

- `qwen3_omni_moe_thinker.py` → `architectures=["Qwen3MoeForCausalLM"]`
- `qwen3_asr.py` → `architectures=["Qwen3ForCausalLM"]`

## Not a duplicate

Checked for existing work before opening this (`gh pr list --search "qwen3_vl_moe"`, plus an issue/PR search for "Qwen3-VL pipeline parallel architectures") — no open issue or PR addresses this. Filed as #43271 with this PR as the fix.

## Test Plan

Serve a Qwen3-VL-MoE checkpoint across 2 nodes with pipeline parallelism:

```
vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking-AWQ \
  --tensor-parallel-size 1 --pipeline-parallel-size 2 \
  --nnodes 2 --node-rank 0 (and node-rank 1 --headless on the second node)
```

## Test Result

- **Before:** crashes at init with the traceback above.
- **After:** the engine initializes, loads weights, allocates the KV cache, and serves correct completions. Verified end-to-end on 2× NVIDIA DGX Spark (GB10), `pipeline_parallel_size=2, tensor_parallel_size=1`, generating coherent output.

Scope note: validated end-to-end on the **MoE** path (`qwen3_vl_moe.py`). The dense `qwen3_vl.py` has the identical construction and the same latent bug; the fix uses the same idiom and the matching architecture value (`Qwen3ForCausalLM`) per `qwen3_asr.py`.

---

*This PR was prepared with AI assistance (Claude Code). All changed lines were reviewed and the fix was validated end-to-end by the submitter.*
