### PR TITLE
fix: prevent silent performance degradation by allowing custom all-reduce for cap-equal tensors

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -241,7 +241,7 @@ class CustomAllreduce:
         # for 4 or more non NVLink-capable GPUs, custom allreduce provides
         # little performance improvement over NCCL.
         if self.world_size == 2 or self.fully_connected:
-            return inp_size < self.max_size
+            return inp_size <= self.max_size
         return False
 
     def all_reduce(


### PR DESCRIPTION

prevent silent performance degradation by allowing custom all-reduce for cap-equal tensors

## Purpose
 
The issue is triggered when custom all-reduce is enabled (typically with 2 GPUs or a fully-connected topology) and the input
     tensor's byte size exactly equals the pre-allocated max_size of the custom all-reduce IPC buffer.

 The system erroneously decides that the tensor is too large for the custom buffer. It skips the highly-optimized custom all-reduce  path and falls back to a slower generic backend (like PyNCCL). This leads to a silent drop in communication performance, though it does not cause  crashes or data corruption.

Expected Behavior: 
Since the buffer is allocated with exactly max_size bytes, a tensor of exactly max_size bytes should perfectly fit and be accepted by the custom all-reduce kernel to maximize performance.
  
Root Cause: 
Because the physical memory allocated (self.buffer_ptrs) is exactly max_size bytes, and the C++ operator is instructed that the buffer can hold up to  max_size bytes, an input tensor where inp_size == self.max_size will fit perfectly without overflowing. Therefore, the boundary check should include  equality (<=). 
A logic flaw in the boundary condition check within custom_all_reduce.py (should_custom_ar). The code used a strict inequality (inp_size <  self.max_size) instead of an inclusive one, effectively rejecting inputs that equaled the upper capacity limit.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

