### PR TITLE
[Perf] Add MiniMax-M2 FP32 router GEMM kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1205,22 +1205,27 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
                    " in CUDA target architectures")
   endif()
 
-  # DeepSeek V3 router GEMM kernel - requires SM90+
-  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
-    cuda_archs_loose_intersection(DSV3_ROUTER_GEMM_ARCHS "9.0a;10.0f;11.0f" "${CUDA_ARCHS}")
-  else()
-    cuda_archs_loose_intersection(DSV3_ROUTER_GEMM_ARCHS "9.0a;10.0a;10.1a;10.3a" "${CUDA_ARCHS}")
-  endif()
-  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.0 AND DSV3_ROUTER_GEMM_ARCHS)
+  # FP32 router GEMM (H=3072, E=256, M<=32) and DeepSeek V3 router GEMM
+  # kernels both require SM90+ and CUDA >= 12.0.
+  cuda_archs_sm90plus(SM90PLUS_ROUTER_GEMM_ARCHS "${CUDA_ARCHS}")
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.0 AND SM90PLUS_ROUTER_GEMM_ARCHS)
+    set(FP32_ROUTER_GEMM_SRC
+      "csrc/moe/fp32_router_gemm_entry.cu"
+      "csrc/moe/fp32_router_gemm.cu")
+    set_gencode_flags_for_srcs(
+      SRCS "${FP32_ROUTER_GEMM_SRC}"
+      CUDA_ARCHS "${SM90PLUS_ROUTER_GEMM_ARCHS}")
+    list(APPEND VLLM_MOE_EXT_SRC "${FP32_ROUTER_GEMM_SRC}")
+
     set(DSV3_ROUTER_GEMM_SRC
       "csrc/moe/dsv3_router_gemm_entry.cu"
       "csrc/moe/dsv3_router_gemm_float_out.cu"
       "csrc/moe/dsv3_router_gemm_bf16_out.cu")
     set_gencode_flags_for_srcs(
       SRCS "${DSV3_ROUTER_GEMM_SRC}"
-      CUDA_ARCHS "${DSV3_ROUTER_GEMM_ARCHS}")
+      CUDA_ARCHS "${SM90PLUS_ROUTER_GEMM_ARCHS}")
     list(APPEND VLLM_MOE_EXT_SRC "${DSV3_ROUTER_GEMM_SRC}")
-    message(STATUS "Building DSV3 router GEMM kernel for archs: ${DSV3_ROUTER_GEMM_ARCHS}")
+    message(STATUS "Building DSV3 router GEMM kernel for archs: ${SM90PLUS_ROUTER_GEMM_ARCHS}")
 
     # DeepSeek V4 fused RMSNorm + router GEMV - same arch gating as DSV3.
     set(DSV4_NORM_ROUTER_GEMM_SRC
@@ -1228,11 +1233,11 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "csrc/moe/dsv4_norm_router_gemm_kernel.cu")
     set_gencode_flags_for_srcs(
       SRCS "${DSV4_NORM_ROUTER_GEMM_SRC}"
-      CUDA_ARCHS "${DSV3_ROUTER_GEMM_ARCHS}")
+      CUDA_ARCHS "${SM90PLUS_ROUTER_GEMM_ARCHS}")
     list(APPEND VLLM_MOE_EXT_SRC "${DSV4_NORM_ROUTER_GEMM_SRC}")
-    message(STATUS "Building DSV4 norm+router GEMV kernel for archs: ${DSV3_ROUTER_GEMM_ARCHS}")
+    message(STATUS "Building DSV4 norm+router GEMV kernel for archs: ${SM90PLUS_ROUTER_GEMM_ARCHS}")
   else()
-    message(STATUS "Not building DSV3 router GEMM kernel as no compatible archs found"
+    message(STATUS "Not building FP32/DSV3 router GEMM kernels as no compatible archs found"
                    " (requires SM90+ and CUDA >= 12.0)")
   endif()
 endif()

--- a/benchmarks/kernels/benchmark_router_gemm.py
+++ b/benchmarks/kernels/benchmark_router_gemm.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch.nn.functional as F
+
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.transformers_utils.config import get_config
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+# Dimensions supported by the DSV3 specialized kernel
+DSV3_SUPPORTED_NUM_EXPERTS = [256, 384]
+DSV3_SUPPORTED_HIDDEN_SIZES = [7168]
+
+# Dimensions supported by the fp32 specialized kernel (MiniMax-M2)
+FP32_SUPPORTED_NUM_EXPERTS = [256]
+FP32_SUPPORTED_HIDDEN_SIZES = [3072]
+FP32_MAX_TOKENS = 32
+
+
+def get_batch_size_range(max_batch_size):
+    return [2**x for x in range(14) if 2**x <= max_batch_size]
+
+
+def get_model_params(config):
+    if config.architectures[0] in (
+        "DeepseekV2ForCausalLM",
+        "DeepseekV3ForCausalLM",
+        "DeepseekV32ForCausalLM",
+    ):
+        num_experts = config.n_routed_experts
+        hidden_size = config.hidden_size
+    elif config.architectures[0] in ("MiniMaxM2ForCausalLM",):
+        num_experts = config.num_local_experts
+        hidden_size = config.hidden_size
+    else:
+        raise ValueError(f"Unsupported architecture: {config.architectures}")
+    return num_experts, hidden_size
+
+
+def get_benchmark(model, max_batch_size, trust_remote_code):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["batch_size"],
+            x_vals=get_batch_size_range(max_batch_size),
+            x_log=False,
+            line_arg="provider",
+            line_vals=[
+                "torch",
+                "vllm",
+            ],
+            line_names=["PyTorch", "vLLM"],
+            styles=([("blue", "-"), ("red", "-")]),
+            ylabel="TFLOPs",
+            plot_name=f"{model} router gemm throughput",
+            args={},
+        )
+    )
+    def benchmark(batch_size, provider):
+        config = get_config(model=model, trust_remote_code=trust_remote_code)
+        num_experts, hidden_size = get_model_params(config)
+
+        is_hopper_or_blackwell = current_platform.is_device_capability(
+            90
+        ) or current_platform.is_device_capability_family(100)
+        allow_dsv3_router_gemm = (
+            is_hopper_or_blackwell
+            and num_experts in DSV3_SUPPORTED_NUM_EXPERTS
+            and hidden_size in DSV3_SUPPORTED_HIDDEN_SIZES
+        )
+        is_fp32_router_model = (
+            is_hopper_or_blackwell
+            and num_experts in FP32_SUPPORTED_NUM_EXPERTS
+            and hidden_size in FP32_SUPPORTED_HIDDEN_SIZES
+        )
+        allow_fp32_router_gemm = is_fp32_router_model and batch_size <= FP32_MAX_TOKENS
+
+        # Weight dtype: fp32 kernel requires fp32 weights; others use bf16.
+        weight_dtype = torch.float32 if is_fp32_router_model else torch.bfloat16
+        mat_a = torch.randn(
+            (batch_size, hidden_size), dtype=torch.bfloat16, device="cuda"
+        ).contiguous()
+        mat_b = torch.randn(
+            (num_experts, hidden_size), dtype=weight_dtype, device="cuda"
+        ).contiguous()
+
+        quantiles = [0.5, 0.2, 0.8]
+
+        if provider == "torch":
+
+            def runner():
+                if allow_fp32_router_gemm:
+                    F.linear(mat_a.float(), mat_b)
+                else:
+                    F.linear(mat_a, mat_b)
+        elif provider == "vllm":
+
+            def runner():
+                if allow_dsv3_router_gemm:
+                    ops.dsv3_router_gemm(mat_a, mat_b, torch.bfloat16)
+                elif allow_fp32_router_gemm:
+                    ops.fp32_router_gemm(mat_a, mat_b)
+                elif is_fp32_router_model:
+                    # batch_size > FP32_MAX_TOKENS: fall back to F.linear
+                    F.linear(mat_a.float(), mat_b)
+                else:
+                    F.linear(mat_a, mat_b)
+
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            runner, quantiles=quantiles
+        )
+
+        def tflops(t_ms):
+            flops = 2 * batch_size * hidden_size * num_experts
+            return flops / (t_ms * 1e-3) / 1e12
+
+        return tflops(ms), tflops(max_ms), tflops(min_ms)
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser()
+    parser.add_argument("--model", type=str, default="MiniMaxAI/MiniMax-M2.7")
+    parser.add_argument("--max-batch-size", default=16, type=int)
+    parser.add_argument("--trust-remote-code", action="store_true")
+    args = parser.parse_args()
+
+    # Get the benchmark function
+    benchmark = get_benchmark(args.model, args.max_batch_size, args.trust_remote_code)
+    # Run performance benchmark
+    benchmark.run(print_data=True)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -449,6 +449,16 @@ function(cuda_archs_loose_intersection OUT_CUDA_ARCHS SRC_CUDA_ARCHS TGT_CUDA_AR
   set(${OUT_CUDA_ARCHS} ${_CUDA_ARCHS} PARENT_SCOPE)
 endfunction()
 
+
+function(cuda_archs_sm90plus OUT_CUDA_ARCHS TGT_CUDA_ARCHS)
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(_archs "9.0a;10.0f;11.0f" "${TGT_CUDA_ARCHS}")
+  else()
+    cuda_archs_loose_intersection(_archs "9.0a;10.0a;10.1a;10.3a" "${TGT_CUDA_ARCHS}")
+  endif()
+  set(${OUT_CUDA_ARCHS} ${_archs} PARENT_SCOPE)
+endfunction()
+
 #
 # Override the GPU architectures detected by cmake/torch and filter them by
 # `GPU_SUPPORTED_ARCHES`. Sets the final set of architectures in

--- a/csrc/moe/fp32_router_gemm.cu
+++ b/csrc/moe/fp32_router_gemm.cu
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// Router GEMM: activation(T) x weight(fp32) -> fp32, H=3072, E=256, M<=32.
+// Supports bf16 or fp32 activation; weight is always fp32.
+// Adapted from dsv3_router_gemm_float_out.cu.
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include "dsv3_router_gemm_utils.h"
+
+// ---------------------------------------------------------------------------
+// Load helpers
+// ---------------------------------------------------------------------------
+
+// Load VPT fp32 values from the weight matrix (always fp32).
+//   VPT=4 when activation is fp32 (one float4 load)
+//   VPT=8 when activation is bf16 (two float4 loads)
+template <int VPT>
+__device__ __forceinline__ void load_weight(float const* ptr, float* dst);
+
+template <>
+__device__ __forceinline__ void load_weight<4>(float const* ptr, float* dst) {
+  float4 v = *reinterpret_cast<float4 const*>(ptr);
+  dst[0] = v.x;
+  dst[1] = v.y;
+  dst[2] = v.z;
+  dst[3] = v.w;
+}
+
+template <>
+__device__ __forceinline__ void load_weight<8>(float const* ptr, float* dst) {
+  float4 v0 = *reinterpret_cast<float4 const*>(ptr);
+  float4 v1 = *reinterpret_cast<float4 const*>(ptr + 4);
+  dst[0] = v0.x;
+  dst[1] = v0.y;
+  dst[2] = v0.z;
+  dst[3] = v0.w;
+  dst[4] = v1.x;
+  dst[5] = v1.y;
+  dst[6] = v1.z;
+  dst[7] = v1.w;
+}
+
+// Load VPT activation values and convert to fp32.
+template <typename T, int VPT>
+__device__ __forceinline__ void load_activation(T const* ptr, float* dst);
+
+// fp32 activation: one float4 load, no conversion needed.
+template <>
+__device__ __forceinline__ void load_activation<float, 4>(float const* ptr,
+                                                          float* dst) {
+  float4 v = *reinterpret_cast<float4 const*>(ptr);
+  dst[0] = v.x;
+  dst[1] = v.y;
+  dst[2] = v.z;
+  dst[3] = v.w;
+}
+
+// bf16 activation: one uint4 load (8 × bf16) + element-wise conversion.
+template <>
+__device__ __forceinline__ void load_activation<__nv_bfloat16, 8>(
+    __nv_bfloat16 const* ptr, float* dst) {
+  uint4 v = *reinterpret_cast<uint4 const*>(ptr);
+  __nv_bfloat16 const* bf16_ptr = reinterpret_cast<__nv_bfloat16 const*>(&v);
+#pragma unroll
+  for (int i = 0; i < 8; i++) dst[i] = __bfloat162float(bf16_ptr[i]);
+}
+
+// ---------------------------------------------------------------------------
+// Kernel
+// ---------------------------------------------------------------------------
+
+// InputT : type of activation (float or __nv_bfloat16)
+// Weight is always fp32; output is always fp32.
+// VPT = 16 / sizeof(InputT):  4 for fp32, 8 for bf16
+template <typename InputT, int kBlockSize, int kNumTokens, int kNumExperts,
+          int kHiddenDim>
+__global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
+    float* out, InputT const* mat_a, float const* mat_b) {
+  constexpr int VPT = 16 / sizeof(InputT);
+  constexpr int k_elems_per_k_iteration = VPT * kBlockSize;
+  constexpr int k_iterations = kHiddenDim / k_elems_per_k_iteration;
+  constexpr int kWarpSize = 32;
+  constexpr int kNumWarps = kBlockSize / kWarpSize;
+
+  int const n_idx = blockIdx.x;
+  int const tid = threadIdx.x;
+  int const warpId = tid / kWarpSize;
+  int const laneId = tid % kWarpSize;
+
+  float acc[kNumTokens] = {};
+  __shared__ float sm_reduction[kNumTokens][kNumWarps];
+
+  float const* b_col = mat_b + n_idx * kHiddenDim;
+
+  int k_bases[k_iterations];
+#pragma unroll
+  for (int ki = 0; ki < k_iterations; ki++) {
+    k_bases[ki] = ki * k_elems_per_k_iteration + tid * VPT;
+  }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  asm volatile("griddepcontrol.launch_dependents;");
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  for (int ki = 0; ki < k_iterations; ki++) {
+    int const k_base = k_bases[ki];
+
+    float b_float[VPT];
+    load_weight<VPT>(b_col + k_base, b_float);
+
+#pragma unroll
+    for (int m_idx = 0; m_idx < kNumTokens; m_idx++) {
+      float a_float[VPT];
+      load_activation<InputT, VPT>(mat_a + m_idx * kHiddenDim + k_base,
+                                   a_float);
+#pragma unroll
+      for (int k = 0; k < VPT; k++) {
+        acc[m_idx] += a_float[k] * b_float[k];
+      }
+    }
+  }
+
+  // Warp-level butterfly reduction
+#pragma unroll
+  for (int m = 0; m < kNumTokens; m++) {
+    float sum = acc[m];
+    sum += __shfl_xor_sync(0xffffffff, sum, 16);
+    sum += __shfl_xor_sync(0xffffffff, sum, 8);
+    sum += __shfl_xor_sync(0xffffffff, sum, 4);
+    sum += __shfl_xor_sync(0xffffffff, sum, 2);
+    sum += __shfl_xor_sync(0xffffffff, sum, 1);
+    if (laneId == 0) sm_reduction[m][warpId] = sum;
+  }
+
+  __syncthreads();
+
+  if (tid == 0) {
+#pragma unroll
+    for (int m = 0; m < kNumTokens; m++) {
+      float final_sum = 0.0f;
+#pragma unroll
+      for (int w = 0; w < kNumWarps; w++) final_sum += sm_reduction[m][w];
+      out[m * kNumExperts + n_idx] = final_sum;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Launcher
+// ---------------------------------------------------------------------------
+
+template <typename InputT, int kNumTokens, int kNumExperts, int kHiddenDim>
+void invokeFp32RouterGemm(float* output, InputT const* mat_a,
+                          float const* mat_b, cudaStream_t stream) {
+  constexpr int kBlockSize = 128;
+  cudaLaunchConfig_t config;
+  config.gridDim = kNumExperts;
+  config.blockDim = kBlockSize;
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  config.numAttrs = 1;
+  config.attrs = attrs;
+  cudaLaunchKernelEx(&config,
+                     fp32_router_gemm_kernel<InputT, kBlockSize, kNumTokens,
+                                             kNumExperts, kHiddenDim>,
+                     output, mat_a, mat_b);
+}
+
+// ---------------------------------------------------------------------------
+// Explicit instantiations: M=1..32, E=256, H=3072, for both input types
+// ---------------------------------------------------------------------------
+
+#define INSTANTIATE(T, M)                              \
+  template void invokeFp32RouterGemm<T, M, 256, 3072>( \
+      float*, T const*, float const*, cudaStream_t);
+
+#define INSTANTIATE_ALL(T) \
+  INSTANTIATE(T, 1)        \
+  INSTANTIATE(T, 2)        \
+  INSTANTIATE(T, 3)        \
+  INSTANTIATE(T, 4)        \
+  INSTANTIATE(T, 5)        \
+  INSTANTIATE(T, 6)        \
+  INSTANTIATE(T, 7)        \
+  INSTANTIATE(T, 8)        \
+  INSTANTIATE(T, 9)        \
+  INSTANTIATE(T, 10)       \
+  INSTANTIATE(T, 11)       \
+  INSTANTIATE(T, 12)       \
+  INSTANTIATE(T, 13)       \
+  INSTANTIATE(T, 14)       \
+  INSTANTIATE(T, 15)       \
+  INSTANTIATE(T, 16)       \
+  INSTANTIATE(T, 17)       \
+  INSTANTIATE(T, 18)       \
+  INSTANTIATE(T, 19)       \
+  INSTANTIATE(T, 20)       \
+  INSTANTIATE(T, 21)       \
+  INSTANTIATE(T, 22)       \
+  INSTANTIATE(T, 23)       \
+  INSTANTIATE(T, 24)       \
+  INSTANTIATE(T, 25)       \
+  INSTANTIATE(T, 26)       \
+  INSTANTIATE(T, 27)       \
+  INSTANTIATE(T, 28)       \
+  INSTANTIATE(T, 29)       \
+  INSTANTIATE(T, 30)       \
+  INSTANTIATE(T, 31)       \
+  INSTANTIATE(T, 32)
+
+INSTANTIATE_ALL(float)
+INSTANTIATE_ALL(__nv_bfloat16)
+
+#undef INSTANTIATE_ALL
+#undef INSTANTIATE

--- a/csrc/moe/fp32_router_gemm.cu
+++ b/csrc/moe/fp32_router_gemm.cu
@@ -104,7 +104,6 @@ __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
   }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  asm volatile("griddepcontrol.launch_dependents;");
   asm volatile("griddepcontrol.wait;");
 #endif
 
@@ -149,6 +148,11 @@ __global__ __launch_bounds__(128, 1) void fp32_router_gemm_kernel(
       out[m * kNumExperts + n_idx] = final_sum;
     }
   }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  __syncthreads();
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +170,7 @@ void invokeFp32RouterGemm(float* output, InputT const* mat_a,
   config.stream = stream;
   cudaLaunchAttribute attrs[1];
   attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  attrs[0].val.programmaticStreamSerializationAllowed = getEnvEnablePDL();
   config.numAttrs = 1;
   config.attrs = attrs;
   cudaLaunchKernelEx(&config,

--- a/csrc/moe/fp32_router_gemm_entry.cu
+++ b/csrc/moe/fp32_router_gemm_entry.cu
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/all.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include "core/registration.h"
+#include "dsv3_router_gemm_utils.h"
+
+static constexpr int FP32_NUM_EXPERTS = 256;
+static constexpr int FP32_HIDDEN_DIM = 3072;
+static constexpr int FP32_MAX_TOKENS = 32;
+
+// Forward declarations — 4 template params must match fp32_router_gemm.cu
+template <typename InputT, int kNumTokens, int kNumExperts, int kHiddenDim>
+void invokeFp32RouterGemm(float* output, InputT const* mat_a,
+                          float const* mat_b, cudaStream_t stream);
+
+template <typename InputT>
+void dispatchFp32RouterGemm(int num_tokens, float* output, InputT const* mat_a,
+                            float const* mat_b, cudaStream_t stream) {
+  switch (num_tokens) {
+#define HANDLE(M)                                                              \
+  case M:                                                                      \
+    invokeFp32RouterGemm<InputT, M, FP32_NUM_EXPERTS, FP32_HIDDEN_DIM>(       \
+        output, mat_a, mat_b, stream);                                         \
+    break;
+    HANDLE(1)  HANDLE(2)  HANDLE(3)  HANDLE(4)  HANDLE(5)  HANDLE(6)
+    HANDLE(7)  HANDLE(8)  HANDLE(9)  HANDLE(10) HANDLE(11) HANDLE(12)
+    HANDLE(13) HANDLE(14) HANDLE(15) HANDLE(16) HANDLE(17) HANDLE(18)
+    HANDLE(19) HANDLE(20) HANDLE(21) HANDLE(22) HANDLE(23) HANDLE(24)
+    HANDLE(25) HANDLE(26) HANDLE(27) HANDLE(28) HANDLE(29) HANDLE(30)
+    HANDLE(31) HANDLE(32)
+#undef HANDLE
+  }
+}
+
+void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
+                      const at::Tensor& mat_a,  // [num_tokens, hidden_dim]
+                      const at::Tensor& mat_b   // [num_experts, hidden_dim]
+) {
+  TORCH_CHECK(output.dim() == 2 && mat_a.dim() == 2 && mat_b.dim() == 2);
+
+  const int num_tokens = mat_a.size(0);
+  const int num_experts = mat_b.size(0);
+  const int hidden_dim = mat_a.size(1);
+
+  TORCH_CHECK(
+      mat_a.size(1) == mat_b.size(1),
+      "fp32_router_gemm: mat_a and mat_b must have the same hidden_dim");
+  TORCH_CHECK(hidden_dim == FP32_HIDDEN_DIM,
+              "fp32_router_gemm: expected hidden_dim=", FP32_HIDDEN_DIM,
+              ", got ", hidden_dim);
+  TORCH_CHECK(num_experts == FP32_NUM_EXPERTS,
+              "fp32_router_gemm: expected num_experts=", FP32_NUM_EXPERTS,
+              ", got ", num_experts);
+  TORCH_CHECK(num_tokens >= 1 && num_tokens <= FP32_MAX_TOKENS,
+              "fp32_router_gemm: num_tokens must be in [1, ", FP32_MAX_TOKENS,
+              "], got ", num_tokens);
+  TORCH_CHECK(mat_a.dtype() == at::kFloat || mat_a.dtype() == at::kBFloat16,
+              "fp32_router_gemm: mat_a must be float32 or bfloat16");
+  TORCH_CHECK(mat_b.dtype() == at::kFloat,
+              "fp32_router_gemm: mat_b (weight) must be float32");
+  TORCH_CHECK(output.dtype() == at::kFloat,
+              "fp32_router_gemm: output must be float32");
+
+  const int sm = getSMVersion();
+  TORCH_CHECK(sm >= 90, "fp32_router_gemm: requires SM90+, got SM", sm);
+
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  float* out_ptr = reinterpret_cast<float*>(output.mutable_data_ptr());
+  float const* mat_b_ptr = reinterpret_cast<float const*>(mat_b.data_ptr());
+
+  if (mat_a.dtype() == at::kBFloat16) {
+    auto const* mat_a_ptr =
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr());
+    dispatchFp32RouterGemm(num_tokens, out_ptr, mat_a_ptr, mat_b_ptr, stream);
+  } else {
+    auto const* mat_a_ptr = reinterpret_cast<float const*>(mat_a.data_ptr());
+    dispatchFp32RouterGemm(num_tokens, out_ptr, mat_a_ptr, mat_b_ptr, stream);
+  }
+}
+
+TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
+  m.impl("fp32_router_gemm", &fp32_router_gemm);
+}

--- a/csrc/moe/fp32_router_gemm_entry.cu
+++ b/csrc/moe/fp32_router_gemm_entry.cu
@@ -3,6 +3,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/all.h>
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
@@ -43,11 +44,24 @@ void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
                       const at::Tensor& mat_b   // [num_experts, hidden_dim]
 ) {
   TORCH_CHECK(output.dim() == 2 && mat_a.dim() == 2 && mat_b.dim() == 2);
+  TORCH_CHECK(output.is_cuda() && mat_a.is_cuda() && mat_b.is_cuda(),
+              "fp32_router_gemm: all tensors must be CUDA tensors");
+  TORCH_CHECK(output.get_device() == mat_a.get_device() &&
+                  output.get_device() == mat_b.get_device(),
+              "fp32_router_gemm: all tensors must be on the same CUDA device");
+  TORCH_CHECK(output.is_contiguous() && mat_a.is_contiguous() &&
+                  mat_b.is_contiguous(),
+              "fp32_router_gemm: all tensors must be contiguous");
 
   const int num_tokens = mat_a.size(0);
   const int num_experts = mat_b.size(0);
   const int hidden_dim = mat_a.size(1);
 
+  TORCH_CHECK(output.size(0) == num_tokens && output.size(1) == num_experts,
+              "fp32_router_gemm: output must have shape [num_tokens, "
+              "num_experts], got [",
+              output.size(0), ", ", output.size(1), "], expected [",
+              num_tokens, ", ", num_experts, "]");
   TORCH_CHECK(
       mat_a.size(1) == mat_b.size(1),
       "fp32_router_gemm: mat_a and mat_b must have the same hidden_dim");
@@ -57,8 +71,8 @@ void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
   TORCH_CHECK(num_experts == FP32_NUM_EXPERTS,
               "fp32_router_gemm: expected num_experts=", FP32_NUM_EXPERTS,
               ", got ", num_experts);
-  TORCH_CHECK(num_tokens >= 1 && num_tokens <= FP32_MAX_TOKENS,
-              "fp32_router_gemm: num_tokens must be in [1, ", FP32_MAX_TOKENS,
+  TORCH_CHECK(num_tokens >= 0 && num_tokens <= FP32_MAX_TOKENS,
+              "fp32_router_gemm: num_tokens must be in [0, ", FP32_MAX_TOKENS,
               "], got ", num_tokens);
   TORCH_CHECK(mat_a.dtype() == at::kFloat || mat_a.dtype() == at::kBFloat16,
               "fp32_router_gemm: mat_a must be float32 or bfloat16");
@@ -67,6 +81,11 @@ void fp32_router_gemm(at::Tensor& output,       // [num_tokens, num_experts]
   TORCH_CHECK(output.dtype() == at::kFloat,
               "fp32_router_gemm: output must be float32");
 
+  if (num_tokens == 0) {
+    return;
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(mat_a));
   const int sm = getSMVersion();
   TORCH_CHECK(sm >= 90, "fp32_router_gemm: requires SM90+, got SM", sm);
 

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -5,12 +5,12 @@
 void topk_softmax(torch::Tensor& topk_weights, torch::Tensor& topk_indices,
                   torch::Tensor& token_expert_indices,
                   torch::Tensor& gating_output, bool renormalize,
-                  std::optional<torch::Tensor> bias);
+                  std::optional<torch::Tensor> bias, bool enable_pdl);
 
 void topk_sigmoid(torch::Tensor& topk_weights, torch::Tensor& topk_indices,
                   torch::Tensor& token_expert_indices,
                   torch::Tensor& gating_output, bool renormalize,
-                  std::optional<torch::Tensor> bias);
+                  std::optional<torch::Tensor> bias, bool enable_pdl);
 
 void topk_softplus_sqrt(torch::Tensor& topk_weights,
                         torch::Tensor& topk_indices,
@@ -83,4 +83,8 @@ void dsv3_router_gemm(torch::Tensor& output, const torch::Tensor& mat_a,
 void dsv4_norm_router_gemm(at::Tensor& logits, at::Tensor& normed_x,
                            at::Tensor const& x, at::Tensor const& norm_weight,
                            at::Tensor const& gate_weight, double eps);
+
+// BF16/FP32 x FP32 -> FP32 router GEMM for H=3072, E=256, M<=32 (SM90+)
+void fp32_router_gemm(torch::Tensor& output, const torch::Tensor& mat_a,
+                      const torch::Tensor& mat_b);
 #endif

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -319,7 +319,8 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
     const int thread_row = warp_base_row + thread_row_in_warp;
 
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000) && \
+    defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     if constexpr (ENABLE_PDL) {
         asm volatile("griddepcontrol.wait;");
     }
@@ -585,7 +586,8 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
         }
     }
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000) && \
+    defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     if constexpr (ENABLE_PDL) {
         asm volatile("griddepcontrol.launch_dependents;");
     }
@@ -621,7 +623,7 @@ void topkGatingLauncherHelper(const InputType* input, const bool* finished, floa
     const int num_blocks = (num_warps + WARPS_PER_TB - 1) / WARPS_PER_TB;
 
     dim3 block_dim(WARP_SIZE_PARAM, WARPS_PER_TB);
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && (CUDA_VERSION >= 12000)
     if (enable_pdl) {
         cudaLaunchConfig_t config;
         config.gridDim = num_blocks;

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -265,7 +265,7 @@ __launch_bounds__(TPB) __global__ void moeTopK(
 */
 
 template <int VPT, int NUM_EXPERTS, int WARPS_PER_CTA, int BYTES_PER_LDG, int WARP_SIZE_PARAM, typename IndType,
-          typename InputType = float, ScoringFunc SF>
+          typename InputType = float, ScoringFunc SF = SCORING_SOFTMAX, bool ENABLE_PDL = false>
 __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
     void topkGating(const InputType* input, const bool* finished, float* output, const int num_rows, IndType* indices,
         int* source_rows, const int k, const int start_expert, const int end_expert, const bool renormalize,
@@ -317,6 +317,14 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
     // We compute row offset for each thread sub-group
     const int thread_row_in_warp = threadIdx.x / THREADS_PER_ROW;
     const int thread_row = warp_base_row + thread_row_in_warp;
+
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    if constexpr (ENABLE_PDL) {
+        asm volatile("griddepcontrol.launch_dependents;");
+        asm volatile("griddepcontrol.wait;");
+    }
+#endif
 
     // Threads with indices out of bounds should early exit here.
     if (thread_row >= num_rows)
@@ -577,6 +585,7 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
             }
         }
     }
+
 }
 
 namespace detail
@@ -597,7 +606,7 @@ struct TopkConstants
 template <int EXPERTS, int WARPS_PER_TB, int WARP_SIZE_PARAM, int MAX_BYTES_PER_LDG, typename IndType, typename InputType, ScoringFunc SF>
 void topkGatingLauncherHelper(const InputType* input, const bool* finished, float* output, IndType* indices,
     int* source_row, const int num_rows, const int k, const int start_expert, const int end_expert, const bool renormalize,
-    const float* bias, cudaStream_t stream)
+    const float* bias, bool enable_pdl, cudaStream_t stream)
 {
     static constexpr int BYTES_PER_LDG = MIN(MAX_BYTES_PER_LDG, sizeof(InputType) * EXPERTS);
     using Constants = detail::TopkConstants<EXPERTS, BYTES_PER_LDG, WARP_SIZE_PARAM, InputType>;
@@ -607,7 +616,27 @@ void topkGatingLauncherHelper(const InputType* input, const bool* finished, floa
     const int num_blocks = (num_warps + WARPS_PER_TB - 1) / WARPS_PER_TB;
 
     dim3 block_dim(WARP_SIZE_PARAM, WARPS_PER_TB);
-    topkGating<VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, WARP_SIZE_PARAM, IndType, InputType, SF><<<num_blocks, block_dim, 0, stream>>>(
+#ifndef USE_ROCM
+    if (enable_pdl) {
+        cudaLaunchConfig_t config;
+        config.gridDim = num_blocks;
+        config.blockDim = block_dim;
+        config.dynamicSmemBytes = 0;
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = 1;
+        config.numAttrs = 1;
+        config.attrs = attrs;
+        cudaLaunchKernelEx(
+            &config,
+            topkGating<VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, WARP_SIZE_PARAM, IndType, InputType, SF, true>,
+            input, finished, output, num_rows, indices, source_row, k, start_expert, end_expert, renormalize, bias);
+        return;
+    }
+#endif
+    topkGating<VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, WARP_SIZE_PARAM, IndType, InputType, SF, false>
+        <<<num_blocks, block_dim, 0, stream>>>(
         input, finished, output, num_rows, indices, source_row, k, start_expert, end_expert, renormalize, bias);
 }
 
@@ -619,7 +648,7 @@ void topkGatingLauncherHelper(const InputType* input, const bool* finished, floa
                              IndType, InputType, SF>(                         \
         gating_output, nullptr, topk_weights, topk_indices,                   \
         token_expert_indices, num_tokens, topk, 0, num_experts, renormalize,  \
-        bias, stream);
+        bias, enable_pdl, stream);
 #else
   #define LAUNCH_TOPK(NUM_EXPERTS, WARPS_PER_TB, MAX_BYTES)                    \
     if (WARP_SIZE == 64) {                                                     \
@@ -627,13 +656,13 @@ void topkGatingLauncherHelper(const InputType* input, const bool* finished, floa
                                IndType, InputType, SF>(                        \
           gating_output, nullptr, topk_weights, topk_indices,                  \
           token_expert_indices, num_tokens, topk, 0, num_experts, renormalize, \
-          bias, stream);                                                       \
+          bias, enable_pdl, stream);                                           \
     } else if (WARP_SIZE == 32) {                                              \
       topkGatingLauncherHelper<NUM_EXPERTS, WARPS_PER_TB, 32, MAX_BYTES,       \
                                IndType, InputType, SF>(                        \
           gating_output, nullptr, topk_weights, topk_indices,                  \
           token_expert_indices, num_tokens, topk, 0, num_experts, renormalize, \
-          bias, stream);                                                       \
+          bias, enable_pdl, stream);                                           \
     } else {                                                                   \
       assert(false &&                                                          \
              "Unsupported warp size. Only 32 and 64 are supported for ROCm");  \
@@ -652,6 +681,7 @@ void topkGatingKernelLauncher(
     const int topk,
     const bool renormalize,
     const float* bias,
+    bool enable_pdl,
     cudaStream_t stream) {
     static constexpr int WARPS_PER_TB = 4;
     static constexpr int BYTES_PER_LDG_POWER_OF_2 = 16;
@@ -745,6 +775,7 @@ void dispatch_topk_launch(
     torch::Tensor& softmax_workspace,
     int num_tokens, int num_experts, int topk, bool renormalize,
     std::optional<torch::Tensor> bias,
+    bool enable_pdl,
     cudaStream_t stream)
  {
     const float* bias_ptr = nullptr;
@@ -765,7 +796,7 @@ void dispatch_topk_launch(
             token_expert_indices.data_ptr<int>(),
             softmax_workspace.data_ptr<float>(),
             num_tokens, num_experts, topk, renormalize,
-            bias_ptr, stream);
+            bias_ptr, enable_pdl, stream);
     } else if (topk_indices.scalar_type() == at::ScalarType::UInt32) {
         vllm::moe::topkGatingKernelLauncher<uint32_t, ComputeType, SF>(
             reinterpret_cast<const ComputeType*>(gating_output.data_ptr()),
@@ -774,7 +805,7 @@ void dispatch_topk_launch(
             token_expert_indices.data_ptr<int>(),
             softmax_workspace.data_ptr<float>(),
             num_tokens, num_experts, topk, renormalize,
-            bias_ptr, stream);
+            bias_ptr, enable_pdl, stream);
     } else {
         TORCH_CHECK(topk_indices.scalar_type() == at::ScalarType::Long);
         vllm::moe::topkGatingKernelLauncher<int64_t, ComputeType, SF>(
@@ -784,7 +815,7 @@ void dispatch_topk_launch(
             token_expert_indices.data_ptr<int>(),
             softmax_workspace.data_ptr<float>(),
             num_tokens, num_experts, topk, renormalize,
-            bias_ptr, stream);
+            bias_ptr, enable_pdl, stream);
     }
 }
 
@@ -794,7 +825,8 @@ void topk_softmax(
     torch::Tensor& token_expert_indices,        // [num_tokens, topk]
     torch::Tensor& gating_output,               // [num_tokens, num_experts]
     bool renormalize,
-    std::optional<torch::Tensor> bias)
+    std::optional<torch::Tensor> bias,
+    bool enable_pdl)
 {
     const int num_experts = gating_output.size(-1);
     const auto num_tokens = gating_output.numel() / num_experts;
@@ -812,15 +844,15 @@ void topk_softmax(
     if (gating_output.scalar_type() == at::ScalarType::Float) {
         dispatch_topk_launch<float, vllm::moe::SCORING_SOFTMAX>(gating_output, topk_weights, topk_indices,
             token_expert_indices, softmax_workspace, num_tokens, num_experts, topk, renormalize,
-            bias, stream);
+            bias, enable_pdl, stream);
     } else if (gating_output.scalar_type() == at::ScalarType::Half) {
         dispatch_topk_launch<__half, vllm::moe::SCORING_SOFTMAX>(gating_output, topk_weights, topk_indices,
             token_expert_indices, softmax_workspace, num_tokens, num_experts, topk, renormalize,
-            bias, stream);
+            bias, enable_pdl, stream);
     } else if (gating_output.scalar_type() == at::ScalarType::BFloat16) {
         dispatch_topk_launch<__nv_bfloat16, vllm::moe::SCORING_SOFTMAX>(gating_output, topk_weights, topk_indices,
             token_expert_indices, softmax_workspace, num_tokens, num_experts, topk, renormalize,
-            bias, stream);
+            bias, enable_pdl, stream);
     } else {
         TORCH_CHECK(false, "Unsupported gating_output data type: ", gating_output.scalar_type());
     }
@@ -832,7 +864,8 @@ void topk_sigmoid(
     torch::Tensor& token_expert_indices,        // [num_tokens, topk]
     torch::Tensor& gating_output,               // [num_tokens, num_experts]
     bool renormalize,
-    std::optional<torch::Tensor> bias)
+    std::optional<torch::Tensor> bias,
+    bool enable_pdl)
 {
     const int num_experts = gating_output.size(-1);
     const auto num_tokens = gating_output.numel() / num_experts;
@@ -850,15 +883,15 @@ void topk_sigmoid(
     if (gating_output.scalar_type() == at::ScalarType::Float) {
         dispatch_topk_launch<float, vllm::moe::SCORING_SIGMOID>(gating_output, topk_weights, topk_indices,
             token_expert_indices, workspace, num_tokens, num_experts, topk, renormalize,
-            bias, stream);
+            bias, enable_pdl, stream);
     } else if (gating_output.scalar_type() == at::ScalarType::Half) {
         dispatch_topk_launch<__half, vllm::moe::SCORING_SIGMOID>(gating_output, topk_weights, topk_indices,
             token_expert_indices, workspace, num_tokens, num_experts, topk, renormalize,
-            bias, stream);
+            bias, enable_pdl, stream);
     } else if (gating_output.scalar_type() == at::ScalarType::BFloat16) {
         dispatch_topk_launch<__nv_bfloat16, vllm::moe::SCORING_SIGMOID>(gating_output, topk_weights, topk_indices,
             token_expert_indices, workspace, num_tokens, num_experts, topk, renormalize,
-            bias, stream);
+            bias, enable_pdl, stream);
     } else {
         TORCH_CHECK(false, "Unsupported gating_output data type: ", gating_output.scalar_type());
     }

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -321,7 +321,6 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     if constexpr (ENABLE_PDL) {
-        asm volatile("griddepcontrol.launch_dependents;");
         asm volatile("griddepcontrol.wait;");
     }
 #endif
@@ -585,6 +584,12 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE_PARAM) __global__
             }
         }
     }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    if constexpr (ENABLE_PDL) {
+        asm volatile("griddepcontrol.launch_dependents;");
+    }
+#endif
 
 }
 

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -6,14 +6,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
   m.def(
       "topk_softmax(Tensor! topk_weights, Tensor! topk_indices, Tensor! "
       "token_expert_indices, Tensor gating_output, bool renormalize, Tensor? "
-      "bias) -> ()");
+      "bias, bool enable_pdl=False) -> ()");
   m.impl("topk_softmax", torch::kCUDA, &topk_softmax);
 
   // Apply topk sigmoid to the gating outputs.
   m.def(
       "topk_sigmoid(Tensor! topk_weights, Tensor! topk_indices, Tensor! "
       "token_expert_indices, Tensor gating_output, bool renormalize, Tensor? "
-      "bias) -> ()");
+      "bias, bool enable_pdl=False) -> ()");
   m.impl("topk_sigmoid", torch::kCUDA, &topk_sigmoid);
 
   m.def(
@@ -131,6 +131,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "dsv4_norm_router_gemm(Tensor! logits, Tensor! normed_x, Tensor x, "
       "Tensor norm_weight, Tensor gate_weight, float eps) -> ()");
   // conditionally compiled so impl registration is in source file
+
+  // BF16/FP32 x FP32 -> FP32 router GEMM for H=3072, E=256, M<=32 (SM90+)
+  // conditionally compiled so impl registration is in source file
+  m.def("fp32_router_gemm(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()");
 #endif
 }
 

--- a/tests/kernels/test_fp32_router_gemm.py
+++ b/tests/kernels/test_fp32_router_gemm.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for fp32_router_gemm kernel: activation×weight→fp32, H=3072, E=256.
+
+Correctness baseline: F.linear in float32.
+"""
+
+import pytest
+import torch
+
+from vllm._custom_ops import fp32_router_gemm
+
+NUM_EXPERTS = 256
+HIDDEN_DIM = 3072
+# Absolute tolerance for fp32 kernel vs float64 reference
+ATOL_FP32 = 2e-4
+ATOL_BF16 = 2e-2  # bf16 activation has lower precision
+
+
+def _requires_sm90():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 90:
+        pytest.skip(f"fp32_router_gemm requires SM90+, got SM{major}{minor}")
+
+
+def _ref(mat_a: torch.Tensor, mat_b: torch.Tensor) -> torch.Tensor:
+    """Reference: F.linear in float32 on GPU."""
+    return torch.nn.functional.linear(mat_a.float(), mat_b.float())
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16, 32])
+def test_fp32_activation(num_tokens: int):
+    """fp32 activation → fp32 output should match reference closely."""
+    _requires_sm90()
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    mat_a = torch.randn(num_tokens, HIDDEN_DIM, dtype=torch.float32, device=device)
+    mat_b = torch.randn(NUM_EXPERTS, HIDDEN_DIM, dtype=torch.float32, device=device)
+
+    out = fp32_router_gemm(mat_a, mat_b)
+    ref = _ref(mat_a, mat_b)
+
+    assert out.shape == (num_tokens, NUM_EXPERTS)
+    assert out.dtype == torch.float32
+    torch.testing.assert_close(out, ref, atol=ATOL_FP32, rtol=0)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16, 32])
+def test_bf16_activation(num_tokens: int):
+    """bf16 activation → fp32 output should match reference within bf16 error."""
+    _requires_sm90()
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    mat_a_bf16 = torch.randn(
+        num_tokens, HIDDEN_DIM, dtype=torch.bfloat16, device=device
+    )
+    mat_b = torch.randn(NUM_EXPERTS, HIDDEN_DIM, dtype=torch.float32, device=device)
+
+    out = fp32_router_gemm(mat_a_bf16, mat_b)
+    ref = _ref(mat_a_bf16, mat_b).to(device)
+
+    assert out.shape == (num_tokens, NUM_EXPERTS)
+    assert out.dtype == torch.float32
+    torch.testing.assert_close(out, ref, atol=ATOL_BF16, rtol=0)
+
+
+def test_output_shape_and_dtype():
+    """Basic shape and dtype checks."""
+    _requires_sm90()
+    device = torch.device("cuda")
+    mat_a = torch.randn(4, HIDDEN_DIM, dtype=torch.float32, device=device)
+    mat_b = torch.randn(NUM_EXPERTS, HIDDEN_DIM, dtype=torch.float32, device=device)
+    out = fp32_router_gemm(mat_a, mat_b)
+    assert out.shape == (4, NUM_EXPERTS)
+    assert out.dtype == torch.float32
+    assert out.device.type == "cuda"

--- a/tests/kernels/test_fp32_router_gemm.py
+++ b/tests/kernels/test_fp32_router_gemm.py
@@ -12,7 +12,7 @@ from vllm._custom_ops import fp32_router_gemm
 
 NUM_EXPERTS = 256
 HIDDEN_DIM = 3072
-# Absolute tolerance for fp32 kernel vs float64 reference
+# Absolute tolerance for fp32 kernel vs float32 reference
 ATOL_FP32 = 2e-4
 ATOL_BF16 = 2e-2  # bf16 activation has lower precision
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2397,6 +2397,31 @@ def dsv4_norm_router_gemm(
     return normed_x, logits
 
 
+def fp32_router_gemm(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.empty(
+        hidden_states.shape[0],
+        router_weight.shape[0],
+        device=hidden_states.device,
+        dtype=torch.float32,
+    )
+    torch.ops._moe_C.fp32_router_gemm(output, hidden_states, router_weight)
+    return output
+
+
+if hasattr(torch.ops, "_moe_C") and hasattr(torch.ops._moe_C, "fp32_router_gemm"):
+
+    @register_fake("_moe_C::fp32_router_gemm")
+    def fp32_router_gemm_fake(
+        output: torch.Tensor,
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+    ) -> None:
+        return
+
+
 def topk_softmax(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
@@ -2404,6 +2429,7 @@ def topk_softmax(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     e_score_correction_bias: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> None:
     torch.ops._moe_C.topk_softmax(
         topk_weights,
@@ -2412,6 +2438,7 @@ def topk_softmax(
         gating_output,
         renormalize,
         e_score_correction_bias,
+        enable_pdl,
     )
 
 
@@ -2422,6 +2449,7 @@ def topk_sigmoid(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     e_score_correction_bias: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> None:
     torch.ops._moe_C.topk_sigmoid(
         topk_weights,
@@ -2430,6 +2458,7 @@ def topk_sigmoid(
         gating_output,
         renormalize,
         e_score_correction_bias,
+        enable_pdl,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -98,6 +98,8 @@ class FusedMoE(PluggableLayer):
                                       output. It is applied to the experts output
                                       instead of the topk_weights when this feature is
                                       not supported by the router (or the experts).
+        enable_router_pdl: Whether fused top-k routing kernels should join a
+                           Programmatic Dependent Launch chain.
     """
 
     # --8<-- [end:fused_moe]
@@ -142,6 +144,7 @@ class FusedMoE(PluggableLayer):
         apply_routed_scale_to_output: bool = False,
         zero_expert_type: str | None = None,
         hash_indices_table: torch.Tensor | None = None,
+        enable_router_pdl: bool = False,
     ):
         super().__init__()
 
@@ -312,6 +315,7 @@ class FusedMoE(PluggableLayer):
             zero_expert_type=zero_expert_type,
             num_logical_experts=self.logical_num_experts,
             hash_indices_table=self.hash_indices_table,
+            enable_pdl=enable_router_pdl,
         )
         self.routing_method_type: RoutingMethodType = self.router.routing_method_type
 

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -24,6 +24,7 @@ def vllm_topk_softmax(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     e_score_correction_bias: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, ...]:
     ops.topk_softmax(
         topk_weights,
@@ -32,6 +33,7 @@ def vllm_topk_softmax(
         gating_output,
         renormalize,
         e_score_correction_bias,
+        enable_pdl,
     )
 
     return topk_weights, topk_indices
@@ -44,6 +46,7 @@ def vllm_topk_sigmoid(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     e_score_correction_bias: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, ...]:
     ops.topk_sigmoid(
         topk_weights,
@@ -52,6 +55,7 @@ def vllm_topk_sigmoid(
         gating_output,
         renormalize,
         e_score_correction_bias,
+        enable_pdl,
     )
 
     return topk_weights, topk_indices

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -33,7 +33,7 @@ def vllm_topk_softmax(
         gating_output,
         renormalize,
         e_score_correction_bias,
-        enable_pdl,
+        enable_pdl=enable_pdl,
     )
 
     return topk_weights, topk_indices
@@ -55,7 +55,7 @@ def vllm_topk_sigmoid(
         gating_output,
         renormalize,
         e_score_correction_bias,
-        enable_pdl,
+        enable_pdl=enable_pdl,
     )
 
     return topk_weights, topk_indices
@@ -111,6 +111,7 @@ def fused_topk_bias(
     input_tokens: torch.Tensor | None = None,
     hash_indices_table: torch.Tensor | None = None,
     routed_scaling_factor: float = 1.0,
+    enable_pdl: bool = False,
 ):
     if not rocm_aiter_ops.is_fused_moe_enabled():
         assert hidden_states.size(0) == gating_output.size(0), (
@@ -140,6 +141,7 @@ def fused_topk_bias(
                 gating_output,
                 renormalize,
                 e_score_correction_bias,
+                enable_pdl=enable_pdl,
             )
             if routed_scaling_factor != 1.0:
                 topk_weights *= routed_scaling_factor
@@ -152,6 +154,7 @@ def fused_topk_bias(
                 gating_output,
                 renormalize,
                 e_score_correction_bias,
+                enable_pdl=enable_pdl,
             )
             if routed_scaling_factor != 1.0:
                 topk_weights *= routed_scaling_factor
@@ -247,6 +250,7 @@ class FusedTopKBiasRouter(BaseRouter):
         *,
         scoring_func: str = "sigmoid",
         hash_indices_table: torch.Tensor | None = None,
+        enable_pdl: bool = False,
     ):
         super().__init__(
             top_k=top_k,
@@ -260,6 +264,7 @@ class FusedTopKBiasRouter(BaseRouter):
         self.routed_scaling_factor = routed_scaling_factor
         self.scoring_func = scoring_func
         self._hash_indices_table = hash_indices_table
+        self.enable_pdl = enable_pdl
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
@@ -293,6 +298,7 @@ class FusedTopKBiasRouter(BaseRouter):
             input_tokens=input_ids,
             hash_indices_table=self._hash_indices_table,
             routed_scaling_factor=self.routed_scaling_factor,
+            enable_pdl=self.enable_pdl,
         )
 
         return topk_weights, topk_ids

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -20,6 +20,7 @@ def vllm_topk_softmax(
     token_expert_indices: torch.Tensor,
     gating_output: torch.Tensor,
     renormalize: bool = False,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, ...]:
     ops.topk_softmax(
         topk_weights,
@@ -27,6 +28,7 @@ def vllm_topk_softmax(
         token_expert_indices,
         gating_output,
         renormalize,
+        enable_pdl=enable_pdl,
     )
 
     return topk_weights, topk_indices
@@ -38,6 +40,7 @@ def vllm_topk_sigmoid(
     token_expert_indices: torch.Tensor,
     gating_output: torch.Tensor,
     renormalize: bool = False,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, ...]:
     ops.topk_sigmoid(
         topk_weights,
@@ -45,6 +48,7 @@ def vllm_topk_sigmoid(
         token_expert_indices,
         gating_output,
         renormalize,
+        enable_pdl=enable_pdl,
     )
 
     return topk_weights, topk_indices

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -77,6 +77,7 @@ def fused_topk(
     renormalize: bool,
     indices_type: torch.dtype | None = None,
     scoring_func: str = "softmax",
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
 
@@ -96,20 +97,30 @@ def fused_topk(
     )
 
     if scoring_func == "softmax":
-        topk_func = dispatch_topk_softmax_func(
-            use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
-        )
+        use_rocm_aiter = rocm_aiter_ops.is_fused_moe_enabled()
+        topk_func = dispatch_topk_softmax_func(use_rocm_aiter=use_rocm_aiter)
+        pdl_kwargs = {} if use_rocm_aiter else {"enable_pdl": enable_pdl}
         topk_weights, topk_ids = topk_func(
-            topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            **pdl_kwargs,
         )
 
         return topk_weights, topk_ids, token_expert_indices
     elif scoring_func == "sigmoid":
-        topk_func = dispatch_topk_sigmoid_func(
-            use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
-        )
+        use_rocm_aiter = rocm_aiter_ops.is_fused_moe_enabled()
+        topk_func = dispatch_topk_sigmoid_func(use_rocm_aiter=use_rocm_aiter)
+        pdl_kwargs = {} if use_rocm_aiter else {"enable_pdl": enable_pdl}
         topk_weights, topk_ids = topk_func(
-            topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            **pdl_kwargs,
         )
 
         return topk_weights, topk_ids, token_expert_indices
@@ -128,6 +139,7 @@ class FusedTopKRouter(BaseRouter):
         renormalize: bool = True,
         eplb_state: EplbLayerState | None = None,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
+        enable_pdl: bool = False,
     ):
         super().__init__(
             top_k=top_k,
@@ -137,6 +149,7 @@ class FusedTopKRouter(BaseRouter):
         )
         self.renormalize = renormalize
         self.scoring_func = scoring_func
+        self.enable_pdl = enable_pdl
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
@@ -164,6 +177,7 @@ class FusedTopKRouter(BaseRouter):
             renormalize=self.renormalize,
             indices_type=indices_type,
             scoring_func=self.scoring_func,
+            enable_pdl=self.enable_pdl,
         )
 
         return topk_weights, topk_ids

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -6,15 +6,17 @@ from torch.nn.parameter import Parameter
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
 
 
 @PluggableLayer.register("gate_linear")
 class GateLinear(ReplicatedLinear):
-    """MoE gate linear layer with three-tier GEMM dispatch:
+    """MoE gate linear layer with multi-tier GEMM dispatch:
 
-    1. DSV3 specialized kernel (SM90+, batch<=16, supported dims)
-    2. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 + fp32 out_dtype)
-    3. F.linear via ReplicatedLinear (ultimate fallback)
+    1. DSV3 specialized kernel (SM90+, fp32 out, M<=16, H=7168, E=256/384)
+    2. fp32 specialized kernel  (SM90+, fp32 in/out, M<=32, H=3072, E=256)
+    3. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 weight + fp32 out_dtype)
+    4. F.linear via ReplicatedLinear (ultimate fallback)
 
     The ``out_dtype`` attribute is mutable and can be set after init
     (e.g. when the required dtype depends on the expert quantization
@@ -24,6 +26,11 @@ class GateLinear(ReplicatedLinear):
     # Dimensions supported by the DSV3 specialized kernel
     DSV3_SUPPORTED_NUM_EXPERTS = [256, 384]
     DSV3_SUPPORTED_HIDDEN_SIZES = [7168]
+
+    # Dimensions supported by the fp32 specialized kernel
+    FP32_SUPPORTED_NUM_EXPERTS = [256]
+    FP32_SUPPORTED_HIDDEN_SIZES = [3072]
+    FP32_MAX_TOKENS = 32
 
     def __init__(
         self,
@@ -43,7 +50,7 @@ class GateLinear(ReplicatedLinear):
         )
 
         # If fp32 compute is required and no specialized kernel is available,
-        # store weights in fp32 so Tier 3 computes in fp32 natively.
+        # store weights in fp32 so the final fallback computes in fp32 natively.
         if force_fp32_compute and not can_use_specialized_kernels:
             params_dtype = torch.float32
 
@@ -63,6 +70,16 @@ class GateLinear(ReplicatedLinear):
             self.allow_specialized_router_gemm
             and output_size in self.DSV3_SUPPORTED_NUM_EXPERTS
             and input_size in self.DSV3_SUPPORTED_HIDDEN_SIZES
+        )
+
+        # fp32 specialized kernel eligibility (SM90+, exact dims, fp32 weight)
+        self.allow_fp32_router_gemm = (
+            not bias
+            and self.weight.dtype == torch.float32
+            and current_platform.is_cuda()
+            and is_hopper_or_blackwell
+            and output_size in self.FP32_SUPPORTED_NUM_EXPERTS
+            and input_size in self.FP32_SUPPORTED_HIDDEN_SIZES
         )
 
         # cuBLAS bf16→fp32 eligibility
@@ -103,15 +120,47 @@ class GateLinear(ReplicatedLinear):
             )
             return output, None
 
-        # Tier 2: cuBLAS bf16→fp32
+        # Tier 2: fp32 specialized kernel (H=3072, E=256, M<=32)
+        # Dispatch is wrapped in a custom op so that torch.compile/CUDA-graph
+        # capture does not freeze the runtime num_tokens branch.
+        if self.allow_fp32_router_gemm:
+            output = torch.ops.vllm.fp32_router_gemm_dispatch(x, self.weight)
+            return output, None
+
+        # Tier 3: cuBLAS bf16→fp32
         if self.allow_cublas_router_gemm and x.dtype == torch.bfloat16:
             output = torch.mm(x, self.weight.T, out_dtype=torch.float32)
             return output, None
 
-        # Tier 3: F.linear (ReplicatedLinear)
+        # Tier 4: F.linear (ReplicatedLinear)
         if self.out_dtype is not None and x.dtype != self.weight.dtype:
             x = x.to(self.weight.dtype)
         output, output_bias = super().forward(x)
         if self.out_dtype is not None and output.dtype != self.out_dtype:
             output = output.to(self.out_dtype)
         return output, output_bias
+
+
+_FP32_ROUTER_GEMM_MAX_TOKENS = GateLinear.FP32_MAX_TOKENS
+
+
+def fp32_router_gemm_dispatch_impl(
+    x: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    if x.shape[0] <= _FP32_ROUTER_GEMM_MAX_TOKENS:
+        return ops.fp32_router_gemm(x, weight)
+    else:
+        return torch.nn.functional.linear(x.float(), weight)
+
+
+def fp32_router_gemm_dispatch_fake(
+    x: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
+
+
+direct_register_custom_op(
+    op_name="fp32_router_gemm_dispatch",
+    op_func=fp32_router_gemm_dispatch_impl,
+    fake_impl=fp32_router_gemm_dispatch_fake,
+)

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -123,7 +123,10 @@ class GateLinear(ReplicatedLinear):
         # Tier 2: fp32 specialized kernel (H=3072, E=256, M<=32)
         # Dispatch is wrapped in a custom op so that torch.compile/CUDA-graph
         # capture does not freeze the runtime num_tokens branch.
-        if self.allow_fp32_router_gemm:
+        if self.allow_fp32_router_gemm and x.dtype in (
+            torch.float32,
+            torch.bfloat16,
+        ):
             output = torch.ops.vllm.fp32_router_gemm_dispatch(x, self.weight)
             return output, None
 
@@ -147,10 +150,12 @@ _FP32_ROUTER_GEMM_MAX_TOKENS = GateLinear.FP32_MAX_TOKENS
 def fp32_router_gemm_dispatch_impl(
     x: torch.Tensor, weight: torch.Tensor
 ) -> torch.Tensor:
+    import vllm._custom_ops as ops
+
     if x.shape[0] <= _FP32_ROUTER_GEMM_MAX_TOKENS:
         return ops.fp32_router_gemm(x, weight)
     else:
-        return torch.nn.functional.linear(x.float(), weight)
+        return torch.mm(x.float(), weight.T)
 
 
 def fp32_router_gemm_dispatch_fake(

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -14,7 +14,8 @@ class GateLinear(ReplicatedLinear):
     """MoE gate linear layer with multi-tier GEMM dispatch:
 
     1. DSV3 specialized kernel (SM90+, fp32 out, M<=16, H=7168, E=256/384)
-    2. fp32 specialized kernel  (SM90+, fp32 in/out, M<=32, H=3072, E=256)
+    2. fp32 specialized kernel  (SM90+, bf16/fp32 in, fp32 out,
+       M<=32, H=3072, E=256)
     3. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 weight + fp32 out_dtype)
     4. F.linear via ReplicatedLinear (ultimate fallback)
 

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -260,6 +260,7 @@ class GroupedTopKRouter(BaseRouter):
         num_fused_shared_experts: int = 0,
         eplb_state: EplbLayerState | None = None,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
+        enable_pdl: bool = False,
     ):
         super().__init__(
             top_k=top_k,
@@ -274,6 +275,7 @@ class GroupedTopKRouter(BaseRouter):
         self.routed_scaling_factor = routed_scaling_factor
         self.e_score_correction_bias = e_score_correction_bias
         self.num_fused_shared_experts = num_fused_shared_experts
+        self.enable_pdl = enable_pdl
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
@@ -312,6 +314,7 @@ class GroupedTopKRouter(BaseRouter):
                     e_score_correction_bias=self.e_score_correction_bias.data,
                     topk=self.top_k,
                     renormalize=self.renormalize,
+                    enable_pdl=self.enable_pdl,
                 )
                 if self.routed_scaling_factor != 1.0:
                     topk_weights *= self.routed_scaling_factor
@@ -322,6 +325,7 @@ class GroupedTopKRouter(BaseRouter):
                     topk=self.top_k,
                     renormalize=self.renormalize,
                     indices_type=indices_type,
+                    enable_pdl=self.enable_pdl,
                 )
             return topk_weights, topk_ids
 

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -59,6 +59,7 @@ def create_fused_moe_router(
     zero_expert_type: str | None = None,
     num_logical_experts: int | None = None,
     hash_indices_table: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> FusedMoERouter:
     """
     Factory function to create the appropriate FusedMoERouter subclass based on
@@ -158,6 +159,7 @@ def create_fused_moe_router(
             e_score_correction_bias=e_score_correction_bias,
             num_fused_shared_experts=num_fused_shared_experts,
             indices_type_getter=indices_type_getter,
+            enable_pdl=enable_pdl,
         )
         if (
             grouped_topk_router.routing_method_type != RoutingMethodType.Unspecified
@@ -195,6 +197,7 @@ def create_fused_moe_router(
             indices_type_getter=indices_type_getter,
             scoring_func=scoring_func,
             hash_indices_table=hash_indices_table,
+            enable_pdl=enable_pdl,
         )
 
     if (
@@ -219,4 +222,5 @@ def create_fused_moe_router(
         renormalize=renormalize,
         scoring_func=scoring_func,
         indices_type_getter=indices_type_getter,
+        enable_pdl=enable_pdl,
     )

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -43,10 +43,10 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
     fused_moe_make_expert_params_mapping,
 )
+from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
-    ReplicatedLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -113,12 +113,12 @@ class MiniMaxM2MoE(nn.Module):
             router_logits_dtype=torch.float32,
         )
 
-        self.gate = ReplicatedLinear(
+        self.gate = GateLinear(
             config.hidden_size,
             config.num_local_experts,
             bias=False,
+            out_dtype=torch.float32,
             params_dtype=torch.float32,
-            quant_config=None,
             prefix=f"{prefix}.gate",
         )
 
@@ -130,9 +130,9 @@ class MiniMaxM2MoE(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
-
         # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states.to(torch.float32))
+        # Dtype conversion (bf16->fp32) is handled inside the kernel.
+        router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -23,6 +23,7 @@
 # limitations under the License.
 """Inference-only MiniMaxM2 model."""
 
+import os
 from collections.abc import Iterable
 from itertools import islice
 from typing import Any
@@ -61,6 +62,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from .interfaces import EagleModelMixin, SupportsEagle3, SupportsLoRA, SupportsPP
@@ -72,6 +74,17 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+
+
+def _enable_router_pdl() -> bool:
+    is_hopper_or_blackwell = current_platform.is_device_capability(
+        (9, 0)
+    ) or current_platform.is_device_capability_family(100)
+    return (
+        current_platform.is_cuda()
+        and is_hopper_or_blackwell
+        and os.getenv("TRTLLM_ENABLE_PDL") == "1"
+    )
 
 
 class MiniMaxM2MoE(nn.Module):
@@ -111,6 +124,7 @@ class MiniMaxM2MoE(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.experts",
             router_logits_dtype=torch.float32,
+            enable_router_pdl=_enable_router_pdl(),
         )
 
         self.gate = GateLinear(


### PR DESCRIPTION



## Purpose

This PR adds a specialized FP32 router GEMM path for MiniMax-M2. This is a scoped version of the MiniMax-M2 gate optimization from #38445 without the NVFP4 path. Credit to @jeejeelee for the original direction and implementation work.

related discussion https://vllm-dev.slack.com/archives/C09D4R4MYLR/p1775591605037309


## Test Plan

<details>
<summary>Correctness and benchmark commands</summary>

Correctness:

```bash
CUDA_VISIBLE_DEVICES=0 pytest -q -s tests/kernels/test_fp32_router_gemm.py
```

Additional max-error check against `torch.nn.functional.linear(x.float(), w)`:

```bash
CUDA_VISIBLE_DEVICES=0 python3 - <<'PY'
import torch
import torch.nn.functional as F
from vllm import _custom_ops as ops

torch.manual_seed(0)
H, E = 3072, 256

for precision, matmul_precision in [("default", None), ("fp32_high", "high")]:
    if matmul_precision is not None:
        torch.set_float32_matmul_precision(matmul_precision)
    else:
        torch.set_float32_matmul_precision("highest")

    for dtype, atol in [(torch.bfloat16, 2e-2), (torch.float32, 2e-4)]:
        for M in [1, 2, 3, 4, 7, 8, 15, 16, 31, 32]:
            x = torch.randn(M, H, device="cuda", dtype=dtype).contiguous()
            w = torch.randn(E, H, device="cuda", dtype=torch.float32).contiguous()
            out = ops.fp32_router_gemm(x, w)
            ref = F.linear(x.float(), w)
            err = (out - ref).abs()
            print(f"prec={precision} {dtype} M={M}",
                  "max_abs=", err.max().item(),
                  "mean_abs=", err.mean().item(),
                  "pass=", bool(torch.allclose(out, ref, atol=atol, rtol=0)))
PY
```

Accuracy:

```bash
python3 tests/evals/gsm8k/gsm8k_eval.py
```

Microbenchmark:

```bash
CUDA_VISIBLE_DEVICES=0 TRTLLM_ENABLE_PDL=0 \
python3 benchmarks/kernels/benchmark_router_gemm.py \
  --model MiniMaxAI/MiniMax-M2.7 \
  --max-batch-size 32 \
  --trust-remote-code

CUDA_VISIBLE_DEVICES=0 TRTLLM_ENABLE_PDL=1 \
python3 benchmarks/kernels/benchmark_router_gemm.py \
  --model MiniMaxAI/MiniMax-M2.7 \
  --max-batch-size 32 \
  --trust-remote-code
```

Serving benchmark:

Server launch variants tested:

```bash
TRTLLM_ENABLE_PDL=1 vllm serve /model/minimax-m2.7 \
  -tp 4 \
  --tool-call-parser minimax_m2 \
  --reasoning-parser minimax_m2 \
  --enable-auto-tool-choice \
  --trust-remote-code \
  --no-enable-prefix-caching

TRTLLM_ENABLE_PDL=0 vllm serve /model/minimax-m2.7 \
  -tp 4 \
  --tool-call-parser minimax_m2 \
  --reasoning-parser minimax_m2 \
  --enable-auto-tool-choice \
  --trust-remote-code \
  --no-enable-prefix-caching
```

Benchmark command:

```bash
export MODEL=/model/minimax-m2.7
export PORT=8000

vllm bench serve \
  --backend openai-chat \
  --model "$MODEL" \
  --endpoint /v1/chat/completions \
  --host 127.0.0.1 \
  --port "$PORT" \
  --dataset-name random \
  --num-prompts 128 \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 0.0 \
  --num-warmups 16 \
  --request-rate inf \
  --max-concurrency 16 \
  --save-result

vllm bench serve \
  --backend openai-chat \
  --model "$MODEL" \
  --endpoint /v1/chat/completions \
  --host 127.0.0.1 \
  --port "$PORT" \
  --dataset-name random \
  --num-prompts 128 \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 0.0 \
  --num-warmups 16 \
  --request-rate inf \
  --max-concurrency 8 \
  --save-result
```

</details>

## Test Result

Summary: serving benchmark on H800, TP=4

| Config | Concurrency | Total tok/s | Mean TPOT (ms) | Total tok/s delta | TPOT delta |
|---|---:|---:|---:|---:|---:|
| before PR | 16 | 7790.78 | 17.18 | baseline | baseline |
| after PR, `TRTLLM_ENABLE_PDL=0` | 16 | 8239.03 | 16.02 | +5.8% | -6.8% |
| after PR, `TRTLLM_ENABLE_PDL=1` | 16 | 8127.72 | 16.30 | +4.3% | -5.1% |
| before PR | 8 | TBD | TBD | baseline | baseline |
| after PR, `TRTLLM_ENABLE_PDL=0` | 8 | 5742.62 | 11.40 | TBD | TBD |
| after PR, `TRTLLM_ENABLE_PDL=1` | 8 | 5722.89 | 11.46 | TBD | TBD |

Accuracy:

| Metric | Before | After (`TP4`, `PDL=0/1`) |
|---|---:|---:|
| gsm8k | ~0.92 | 0.920 / 0.923 |

<details>
<summary>Correctness results</summary>

Correctness:

```text
13 passed, 16 warnings in 3.26s
```

Additional max-error check:

```text
prec=default torch.bfloat16 M=1 max_abs= 3.814697265625e-05 mean_abs= 9.896233677864075e-06 pass= True
prec=default torch.bfloat16 M=2 max_abs= 6.103515625e-05 mean_abs= 1.0900897905230522e-05 pass= True
prec=default torch.bfloat16 M=3 max_abs= 4.673004150390625e-05 mean_abs= 1.0053938240162097e-05 pass= True
prec=default torch.bfloat16 M=4 max_abs= 3.814697265625e-05 mean_abs= 1.0253861546516418e-05 pass= True
prec=default torch.bfloat16 M=7 max_abs= 6.103515625e-05 mean_abs= 1.2296851309656631e-05 pass= True
prec=default torch.bfloat16 M=8 max_abs= 5.340576171875e-05 mean_abs= 1.2036529369652271e-05 pass= True
prec=default torch.bfloat16 M=15 max_abs= 5.53131103515625e-05 mean_abs= 1.2322170732659288e-05 pass= True
prec=default torch.bfloat16 M=16 max_abs= 6.103515625e-05 mean_abs= 1.2327080185059458e-05 pass= True
prec=default torch.bfloat16 M=31 max_abs= 6.103515625e-05 mean_abs= 9.407965080754366e-06 pass= True
prec=default torch.bfloat16 M=32 max_abs= 6.103515625e-05 mean_abs= 9.411050996277481e-06 pass= True
prec=default torch.float32 M=1 max_abs= 3.0517578125e-05 mean_abs= 8.818693459033966e-06 pass= True
prec=default torch.float32 M=2 max_abs= 4.57763671875e-05 mean_abs= 9.83034260571003e-06 pass= True
prec=default torch.float32 M=3 max_abs= 4.57763671875e-05 mean_abs= 9.48490014707204e-06 pass= True
prec=default torch.float32 M=4 max_abs= 5.340576171875e-05 mean_abs= 9.826384484767914e-06 pass= True
prec=default torch.float32 M=7 max_abs= 5.7220458984375e-05 mean_abs= 1.2004881682514679e-05 pass= True
prec=default torch.float32 M=8 max_abs= 5.340576171875e-05 mean_abs= 1.2546559446491301e-05 pass= True
prec=default torch.float32 M=15 max_abs= 6.103515625e-05 mean_abs= 1.2333870472502895e-05 pass= True
prec=default torch.float32 M=16 max_abs= 7.62939453125e-05 mean_abs= 1.221662387251854e-05 pass= True
prec=default torch.float32 M=31 max_abs= 7.62939453125e-05 mean_abs= 9.509156370768324e-06 pass= True
prec=default torch.float32 M=32 max_abs= 7.62939453125e-05 mean_abs= 9.350329492008314e-06 pass= True
prec=fp32_high torch.bfloat16 M=1 max_abs= 3.0517578125e-05 mean_abs= 8.903443813323975e-06 pass= True
prec=fp32_high torch.bfloat16 M=2 max_abs= 0.044440269470214844 mean_abs= 0.009015086106956005 pass= False
prec=fp32_high torch.bfloat16 M=3 max_abs= 0.0346832275390625 mean_abs= 0.008942199870944023 pass= False
prec=fp32_high torch.bfloat16 M=4 max_abs= 0.04113006591796875 mean_abs= 0.009151562117040157 pass= False
prec=fp32_high torch.bfloat16 M=7 max_abs= 0.04279804229736328 mean_abs= 0.008998721837997437 pass= False
prec=fp32_high torch.bfloat16 M=8 max_abs= 0.0445556640625 mean_abs= 0.009134004823863506 pass= False
prec=fp32_high torch.bfloat16 M=15 max_abs= 0.03853607177734375 mean_abs= 0.009143132716417313 pass= False
prec=fp32_high torch.bfloat16 M=16 max_abs= 0.04340171813964844 mean_abs= 0.00932237133383751 pass= False
prec=fp32_high torch.bfloat16 M=31 max_abs= 0.04761219024658203 mean_abs= 0.009131493046879768 pass= False
prec=fp32_high torch.bfloat16 M=32 max_abs= 0.04586029052734375 mean_abs= 0.009119704365730286 pass= False
prec=fp32_high torch.float32 M=1 max_abs= 3.4332275390625e-05 mean_abs= 8.806586265563965e-06 pass= True
prec=fp32_high torch.float32 M=2 max_abs= 0.05176544189453125 mean_abs= 0.013077953830361366 pass= False
prec=fp32_high torch.float32 M=3 max_abs= 0.051513671875 mean_abs= 0.01334131509065628 pass= False
prec=fp32_high torch.float32 M=4 max_abs= 0.05275726318359375 mean_abs= 0.013239540159702301 pass= False
prec=fp32_high torch.float32 M=7 max_abs= 0.06198310852050781 mean_abs= 0.013133209198713303 pass= False
prec=fp32_high torch.float32 M=8 max_abs= 0.06512451171875 mean_abs= 0.013000346720218658 pass= False
prec=fp32_high torch.float32 M=15 max_abs= 0.06135368347167969 mean_abs= 0.013118076138198376 pass= False
prec=fp32_high torch.float32 M=16 max_abs= 0.061614990234375 mean_abs= 0.012958699837327003 pass= False
prec=fp32_high torch.float32 M=31 max_abs= 0.06546783447265625 mean_abs= 0.012923624366521835 pass= False
prec=fp32_high torch.float32 M=32 max_abs= 0.07131576538085938 mean_abs= 0.012893503531813622 pass= False
```

</details>

<details>
<summary>Accuracy results</summary>

Command:

```bash
python3 tests/evals/gsm8k/gsm8k_eval.py
```

| Metric | Before | After (`TP4`, `PDL=0`) | After (`TP4`, `PDL=1`) |
|---|---:|---:|---:|
| gsm8k | ~0.92 | 0.920 | 0.923 |

</details>

<details>
<summary>Router GEMM microbenchmark results</summary>

Microbenchmark on Hopper, `TRTLLM_ENABLE_PDL=0`:

| batch_size | PyTorch TFLOPs | vLLM TFLOPs |
|---:|---:|---:|
| 1 | 0.312044 | 0.776409 |
| 2 | 0.267624 | 1.491871 |
| 4 | 0.525618 | 2.600903 |
| 8 | 0.787964 | 4.359729 |
| 16 | 1.515117 | 6.503215 |
| 32 | 3.487280 | 7.970897 |

Microbenchmark on Hopper, `TRTLLM_ENABLE_PDL=1`:

| batch_size | PyTorch TFLOPs | vLLM TFLOPs |
|---:|---:|---:|
| 1 | 0.310701 | 0.916735 |
| 2 | 0.263064 | 1.719504 |
| 4 | 0.522884 | 3.029809 |
| 8 | 0.783282 | 4.936780 |
| 16 | 1.514976 | 6.998538 |
| 32 | 3.495466 | 8.353478 |

</details>

<details>
<summary>Full serving benchmark outputs</summary>

TP4 before PR:

```text
============ Serving Benchmark Result ============
Successful requests:                     128
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  152.04
Total input tokens:                      1053440
Total generated tokens:                  131072
Request throughput (req/s):              0.84
Output token throughput (tok/s):         862.09
Peak output token throughput (tok/s):    1039.00
Peak concurrent requests:                26.00
Total token throughput (tok/s):          7790.78
---------------Time to First Token----------------
Mean TTFT (ms):                          1417.27
Median TTFT (ms):                        1432.74
P99 TTFT (ms):                           4043.75
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.18
Median TPOT (ms):                        17.21
P99 TPOT (ms):                           18.69
---------------Inter-token Latency----------------
Mean ITL (ms):                           22.76
Median ITL (ms):                         15.93
P99 ITL (ms):                            235.74
==================================================
```

TP4 after PR, `TRTLLM_ENABLE_PDL=0`:

```text
============ Serving Benchmark Result ============
Successful requests:                     128
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  143.77
Total input tokens:                      1053440
Total generated tokens:                  131072
Request throughput (req/s):              0.89
Output token throughput (tok/s):         911.69
Peak output token throughput (tok/s):    1104.00
Peak concurrent requests:                26.00
Total token throughput (tok/s):          8239.03
---------------Time to First Token----------------
Mean TTFT (ms):                          1574.59
Median TTFT (ms):                        1644.48
P99 TTFT (ms):                           4183.01
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.02
Median TPOT (ms):                        16.11
P99 TPOT (ms):                           17.38
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.43
Median ITL (ms):                         14.99
P99 ITL (ms):                            233.26
==================================================
============ Serving Benchmark Result ============
Successful requests:                     128
Failed requests:                         0
Maximum request concurrency:             8
Benchmark duration (s):                  206.27
Total input tokens:                      1053440
Total generated tokens:                  131072
Request throughput (req/s):              0.62
Output token throughput (tok/s):         635.45
Peak output token throughput (tok/s):    736.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          5742.62
---------------Time to First Token----------------
Mean TTFT (ms):                          1222.23
Median TTFT (ms):                        1407.24
P99 TTFT (ms):                           2039.90
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.40
Median TPOT (ms):                        11.33
P99 TPOT (ms):                           12.45
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.35
Median ITL (ms):                         11.15
P99 ITL (ms):                            22.48
==================================================
```

TP4 after PR, `TRTLLM_ENABLE_PDL=1`:

```text
============ Serving Benchmark Result ============
Successful requests:                     128
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  145.74
Total input tokens:                      1053440
Total generated tokens:                  131072
Request throughput (req/s):              0.88
Output token throughput (tok/s):         899.37
Peak output token throughput (tok/s):    1104.00
Peak concurrent requests:                25.00
Total token throughput (tok/s):          8127.72
---------------Time to First Token----------------
Mean TTFT (ms):                          1532.83
Median TTFT (ms):                        1434.39
P99 TTFT (ms):                           4178.46
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.30
Median TPOT (ms):                        16.38
P99 TPOT (ms):                           17.64
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.26
Median ITL (ms):                         15.08
P99 ITL (ms):                            233.00
==================================================
============ Serving Benchmark Result ============
Successful requests:                     128
Failed requests:                         0
Maximum request concurrency:             8
Benchmark duration (s):                  206.98
Total input tokens:                      1053440
Total generated tokens:                  131072
Request throughput (req/s):              0.62
Output token throughput (tok/s):         633.27
Peak output token throughput (tok/s):    744.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          5722.89
---------------Time to First Token----------------
Mean TTFT (ms):                          1211.84
Median TTFT (ms):                        1412.39
P99 TTFT (ms):                           2036.89
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.46
Median TPOT (ms):                        11.37
P99 TPOT (ms):                           12.47
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.29
Median ITL (ms):                         11.15
P99 ITL (ms):                            22.51
==================================================
```

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
