### PR TITLE
[Perf][Core] Use power-of-two-choices for DP engine selection at large DP

### DIFF
--- a/tests/v1/engine/test_dplb_engine_selection.py
+++ b/tests/v1/engine/test_dplb_engine_selection.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Algorithm-only tests for DPLBAsyncMPClient engine selection.
+
+These tests exercise ``_select_engine_by_load`` (and the surrounding
+``get_core_engine_for_request`` glue) without requiring CUDA, ZMQ, or any
+multi-process engine setup. The dispatch logic is pure Python: a full scan
+for small DP sizes and power-of-two-choices above a threshold.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from unittest.mock import patch
+
+import pytest
+
+from vllm.pooling_params import PoolingParams
+from vllm.sampling_params import SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.core_client import DPLBAsyncMPClient
+
+
+def _make_sampling_request(request_id: str = "rid") -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=time.time(),
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def _make_pooling_request(
+    request_id: str = "rid",
+) -> EngineCoreRequest:
+    """Plain pooling request without late-interaction routing hints."""
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=None,
+        pooling_params=PoolingParams(task="token_embed"),
+        arrival_time=time.time(),
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def _make_client(
+    num_engines: int,
+    *,
+    counts: list[list[int]] | None = None,
+    eng_start_index: int = 0,
+    client_count: int = 1,
+) -> DPLBAsyncMPClient:
+    client = object.__new__(DPLBAsyncMPClient)
+    client.client_count = client_count
+    client.reqs_in_flight = {}
+    client.core_engines = [bytes([i, 0]) for i in range(num_engines)]
+    client.lb_engines = (
+        counts if counts is not None else [[0, 0] for _ in range(num_engines)]
+    )
+    client.eng_start_index = eng_start_index
+    return client
+
+
+# --- Full-scan path (small DP) -----------------------------------------------
+
+
+def test_full_scan_picks_lowest_score_at_or_below_threshold():
+    """At <= _P2C_FULL_SCAN_MAX_ENGINES, deterministic full scan still rules."""
+
+    threshold = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES
+    counts = [[2, 1], [0, 0], [3, 4], [5, 0]][:threshold]
+    client = _make_client(len(counts), counts=[list(c) for c in counts])
+
+    request = _make_sampling_request()
+    chosen = client.get_core_engine_for_request(request)
+
+    # Index 1 has score 0; everyone else > 0.
+    assert chosen == client.core_engines[1]
+    assert client.lb_engines[1][0] == 1
+
+
+def test_full_scan_respects_eng_start_index_for_tied_zero_load():
+    """Cold-start fairness: clients with different start indices spread."""
+
+    # All zero-load engines; the first engine encountered (= eng_start_index)
+    # wins because of strict ``<`` in the scan.
+    counts = [[0, 0], [0, 0], [0, 0]]
+    for start in range(len(counts)):
+        client = _make_client(
+            len(counts),
+            counts=[list(c) for c in counts],
+            eng_start_index=start,
+        )
+        chosen = client.get_core_engine_for_request(_make_sampling_request())
+        assert chosen == client.core_engines[start]
+
+
+# --- P2C path (large DP) -----------------------------------------------------
+
+
+def test_p2c_returns_one_of_the_two_sampled_engines():
+    """Above threshold, the chosen engine must be one of the two sampled."""
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 4
+    counts = [[i, 0] for i in range(num_engines)]
+    client = _make_client(num_engines, counts=[list(c) for c in counts])
+
+    # Force ``random.randrange`` to return a known pair; the helper uses
+    # ``a = randrange(N)``, ``b = randrange(N - 1)``, then bumps b if b >= a.
+    target_a, target_b = 2, 7
+    raw_b = target_b - 1  # because the impl bumps b when b >= a (a=2 < raw_b)
+    with patch.object(random, "randrange", side_effect=[target_a, raw_b]):
+        chosen_idx = client._select_engine_by_load()
+
+    # Engine 2 has score 8, engine 7 has score 28; P2C picks the lower.
+    assert chosen_idx == target_a
+
+
+def test_p2c_avoids_picking_the_same_engine_twice():
+    """``b += 1`` trick: when ``randrange(N-1)`` collides with ``a``, skip."""
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 4
+    client = _make_client(num_engines)
+
+    # ``a=3``, ``raw_b=3`` → after the bump the second pick must be 4, not 3.
+    seen_pairs: list[tuple[int, int]] = []
+    real_choice = []
+
+    def fake_randrange(n: int) -> int:
+        if n == num_engines:
+            return 3
+        if n == num_engines - 1:
+            return 3
+        raise AssertionError(f"unexpected randrange({n}) call")
+
+    with patch.object(random, "randrange", side_effect=fake_randrange):
+        # Use a tie-aware count layout so we can verify which pair was sampled.
+        client.lb_engines[3] = [10, 0]
+        client.lb_engines[4] = [0, 0]
+        chosen = client._select_engine_by_load()
+        seen_pairs.append((3, 4))
+        real_choice.append(chosen)
+
+    # b was forced to collide with a (both 3); the bump must move b to 4,
+    # which has the lower score → 4 wins.
+    assert real_choice == [4]
+    # And the helper never inspected an out-of-range index.
+    assert all(0 <= idx < num_engines for pair in seen_pairs for idx in pair)
+
+
+@pytest.mark.parametrize("num_engines", [5, 6, 8])
+def test_p2c_full_enumeration_covers_all_distinct_ordered_pairs(num_engines):
+    """Sweep every ``(a, raw_b)`` the RNG can yield and verify the
+    ``b += 1 if b >= a`` trick maps to **every** ordered distinct
+    ``(a, b)`` pair exactly once -- i.e. P((a, b)) = 1 / (N * (N - 1))
+    is uniform over distinct ordered pairs, with no missing pair and no
+    double-counted pair.
+
+    Verifies the math invariant via the actual helper, not just by
+    re-deriving the mapping. We pin scores so that
+    ``lb_engines[i] = [0, i]`` -> score_i = i, so the helper's
+    ``score_a <= score_b`` tie-break deterministically returns
+    ``min(a, b)`` and lets us assert the chosen index agrees with the
+    bump-resolved pair we expect.
+
+    N values are restricted to the P2C path (``> _P2C_FULL_SCAN_MAX_ENGINES``)
+    because the trick only fires there; N <= 4 takes the deterministic
+    full scan and never invokes ``random.randrange``.
+    """
+    counts = [[0, i] for i in range(num_engines)]
+    client = _make_client(num_engines, counts=[list(c) for c in counts])
+
+    expected_pairs = {
+        (i, j) for i in range(num_engines) for j in range(num_engines) if i != j
+    }
+    seen_pairs: set[tuple[int, int]] = set()
+
+    for a in range(num_engines):
+        for raw_b in range(num_engines - 1):
+            b = raw_b + 1 if raw_b >= a else raw_b
+            with patch.object(random, "randrange", side_effect=[a, raw_b]):
+                returned = client._select_engine_by_load()
+            # Monotonic counts -> helper deterministically returns min(a, b).
+            assert returned == min(a, b), (
+                f"(a={a}, raw_b={raw_b}, b={b}): expected {min(a, b)}, got {returned}"
+            )
+            seen_pairs.add((a, b))
+
+    assert seen_pairs == expected_pairs, (
+        f"missing pairs: {expected_pairs - seen_pairs}; "
+        f"unexpected pairs: {seen_pairs - expected_pairs}"
+    )
+    # No collision in the (a, raw_b) -> (a, b) mapping.
+    assert len(seen_pairs) == num_engines * (num_engines - 1)
+
+
+def test_p2c_distribution_does_not_starve_any_engine_under_uniform_load():
+    """Statistical sanity: with all-zero load, every engine gets picked."""
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 12  # 16
+    client = _make_client(num_engines)
+
+    rng = random.Random(0xBADC0FFEE)
+    seen: set[int] = set()
+    with patch.object(random, "randrange", side_effect=rng.randrange):
+        for _ in range(2000):
+            seen.add(client._select_engine_by_load())
+
+    assert seen == set(range(num_engines)), (
+        f"P2C starved engines: missing={set(range(num_engines)) - seen}"
+    )
+
+
+def test_p2c_increment_path_updates_only_chosen_engine_counter():
+    """``get_core_engine_for_request`` bumps only the picked engine's counter."""
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 4
+    counts = [[0, 0] for _ in range(num_engines)]
+    client = _make_client(num_engines, counts=[list(c) for c in counts], client_count=3)
+
+    target_a, target_b = 1, 5
+    raw_b = target_b - 1
+    with patch.object(random, "randrange", side_effect=[target_a, raw_b]):
+        chosen = client.get_core_engine_for_request(_make_sampling_request("r1"))
+
+    assert chosen == client.core_engines[target_a]
+    assert client.lb_engines[target_a][0] == 3  # client_count bumped
+    for i in range(num_engines):
+        if i != target_a:
+            assert client.lb_engines[i] == [0, 0]
+    assert client.reqs_in_flight["r1"] == chosen
+
+
+# --- DP rank short-circuit (unaffected by load-balancing path) ---------------
+
+
+def test_explicit_data_parallel_rank_bypasses_load_balancer():
+    """A request with an explicit DP rank must skip the score-based picker."""
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 4
+    # Pre-load the load counters so the lb path would NOT pick rank 0.
+    counts = [[100, 100]] + [[0, 0]] * (num_engines - 1)
+    client = _make_client(num_engines, counts=[list(c) for c in counts])
+
+    request = _make_sampling_request("r-pinned")
+    request.data_parallel_rank = 0
+    chosen = client.get_core_engine_for_request(request)
+
+    assert chosen == client.core_engines[0]
+    # No counter increment when DP rank is explicit.
+    assert client.lb_engines[0] == [100, 100]
+
+
+# --- Threshold behavior consistency ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_engines",
+    [1, 2, 3, DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES],
+)
+def test_full_scan_path_does_not_call_random(num_engines):
+    """Full scan must not touch ``random.randrange`` at all."""
+
+    client = _make_client(num_engines)
+    with patch.object(random, "randrange") as mocked:
+        client._select_engine_by_load()
+    assert mocked.call_count == 0
+
+
+def test_p2c_path_calls_randrange_exactly_twice():
+    """P2C invokes randrange twice: one for ``a``, one for ``b``."""
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 4
+    client = _make_client(num_engines)
+    with patch.object(random, "randrange", side_effect=[0, 1]) as mocked:
+        client._select_engine_by_load()
+    assert mocked.call_count == 2
+
+
+def test_p2c_breaks_score_ties_in_favor_of_first_sample():
+    """Tie-break: ``score_a <= score_b`` keeps ``a`` when scores match.
+
+    The contract this locks in is ``deterministic-under-mocked-RNG``:
+    given the same RNG outputs, the helper returns a stable engine. The
+    actual cross-request fairness comes from ``a`` itself being uniform
+    over ``[0, N)`` -- not from "first sample wins" semantics, which is
+    just an implementation byproduct.
+    """
+
+    num_engines = DPLBAsyncMPClient._P2C_FULL_SCAN_MAX_ENGINES + 4
+    counts = [[2, 1] for _ in range(num_engines)]  # everyone identical
+    client = _make_client(num_engines, counts=[list(c) for c in counts])
+
+    target_a, target_b = 1, 6
+    raw_b = target_b - 1
+    with patch.object(random, "randrange", side_effect=[target_a, raw_b]):
+        chosen_idx = client._select_engine_by_load()
+    assert chosen_idx == target_a

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import queue
+import random
 import sys
 import uuid
 import weakref
@@ -1381,6 +1382,18 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
     """Asyncio-compatible client for multi-proc, multi-engine (data parallel)
     EngineCore. Load-balances between multiple engine processes."""
 
+    # When num_engines is small, the deterministic full scan is essentially
+    # free and yields a perfect load distribution. Above this threshold the
+    # per-request O(N) scan starts to dominate the dispatch path, so we
+    # switch to power-of-two-choices: sample two distinct engines uniformly
+    # at random and pick the lower-load one. P2C is O(1) per request and is
+    # expected to reduce imbalance well within the 100 ms coordinator stats
+    # refresh window for the short-lived ``waiting * 4 + running`` score we
+    # use here -- the classic "balls into bins" O(log log N) result assumes
+    # fully shared state which we don't have, but the local frontend view
+    # plus periodic refresh is close enough in practice.
+    _P2C_FULL_SCAN_MAX_ENGINES = 4
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -1417,34 +1430,63 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 request.pooling_params, len(self.core_engines)
             )
         ) is None:
-            current_counts = self.lb_engines
-            # TODO use P2C alg for larger DP sizes
-            num_engines = len(current_counts)
+            eng_index = self._select_engine_by_load()
+            # Increment local waiting count for better balancing between stats
+            # updates from the coordinator (which happen every 100ms).
+            self.lb_engines[eng_index][0] += self.client_count
+
+        chosen_engine = self.core_engines[eng_index]
+        # Record which engine is chosen for this request, to handle aborts.
+        self.reqs_in_flight[request.request_id] = chosen_engine
+        return chosen_engine
+
+    def _select_engine_by_load(self) -> int:
+        """Pick the engine index minimizing the local load score.
+
+        For small DP sizes the deterministic full scan starting from
+        ``eng_start_index`` keeps perfect cold-start spread across multiple
+        clients. Beyond ``_P2C_FULL_SCAN_MAX_ENGINES`` we switch to
+        power-of-two-choices: sample two distinct engines uniformly at
+        random and return the lower-load one.
+        """
+        counts = self.lb_engines
+        num_engines = len(counts)
+
+        if num_engines <= self._P2C_FULL_SCAN_MAX_ENGINES:
             min_score = sys.maxsize
             eng_index = 0
             for i in range(num_engines):
                 # Start from client_index to help with balancing when engines
                 # are empty.
                 idx = (self.eng_start_index + i) % num_engines
-                waiting, running = current_counts[idx]
+                waiting, running = counts[idx]
                 score = waiting * 4 + running
                 if score < min_score:
                     min_score = score
                     eng_index = idx
-            # Increment local waiting count for better balancing between stats
-            # updates from the coordinator (which happen every 100ms).
-            current_counts[eng_index][0] += self.client_count
             # Rotate the scan start so that ties (equal scores, e.g. right
             # after a coordinator stats reset when engines look equally loaded)
             # don't systematically favor the same engine. This removes the
             # fixed tie-break bias without affecting load-aware decisions when
-            # scores actually differ.
+            # scores actually differ. Only the deterministic full scan needs
+            # this; the P2C path below is already randomized. The waiting-count
+            # increment happens once in get_core_engine_for_request, covering
+            # both the full-scan and P2C paths.
             self.eng_start_index = (self.eng_start_index + 1) % num_engines
+            return eng_index
 
-        chosen_engine = self.core_engines[eng_index]
-        # Record which engine is chosen for this request, to handle aborts.
-        self.reqs_in_flight[request.request_id] = chosen_engine
-        return chosen_engine
+        # P2C: sample two distinct engines uniformly at random. The
+        # ``b += 1 if b >= a`` trick draws ``b`` from the remaining
+        # ``num_engines - 1`` slots without an explicit reject loop.
+        a = random.randrange(num_engines)
+        b = random.randrange(num_engines - 1)
+        if b >= a:
+            b += 1
+        waiting_a, running_a = counts[a]
+        waiting_b, running_b = counts[b]
+        score_a = waiting_a * 4 + running_a
+        score_b = waiting_b * 4 + running_b
+        return a if score_a <= score_b else b
 
     async def call_utility_async(self, method: str, *args) -> Any:
         # Only the result from the first engine is returned.


### PR DESCRIPTION
## Summary

`DPLBAsyncMPClient.get_core_engine_for_request` performed an O(N) scan
over all data-parallel engines on every request to pick the lowest-load
one. The source carried a `# TODO use P2C alg for larger DP sizes`. This
change implements that TODO behind a small threshold:

- **`num_engines <= 4`**: existing deterministic full scan starting from
  `eng_start_index` (perfect cold-start fairness across multiple
  clients). Byte-for-byte identical to the legacy code path.
- **`num_engines > 4`**: power-of-two-choices — sample two distinct
  engines uniformly at random and return the one with the lower
  `waiting * 4 + running` score. O(1) per request, well-known to keep
  imbalance to O(log log N) for short-lived load scoring.

The local optimistic counter
(`self.lb_engines[eng_index][0] += self.client_count`) and `reqs_in_flight`
bookkeeping are unchanged.

## Why a threshold instead of always P2C

Because `random.randrange` overhead actually outpaces a tight Python loop
at very small N. Per-call latency, CPython 3.12, Mac:

```
   N |   full_scan_us |     p2c_us |  speedup
--------------------------------------------------
   2 |          0.185 |      0.435 |    0.43x
   4 |          0.280 |      0.415 |    0.67x
   8 |          0.478 |      0.403 |    1.19x
  16 |          0.879 |      0.401 |    2.19x
  32 |          1.714 |      0.400 |    4.29x
  64 |          3.166 |      0.407 |    7.78x
 128 |          5.696 |      0.413 |   13.78x
```

So small-DP deployments (the common case) keep the legacy behavior, while
large-DP / elastic-EP clusters get the constant-time path where it
actually matters.

## Why this is not a duplicate

```
gh pr list -R vllm-project/vllm --state all --search "P2C power of two choices"
# 0 hits
gh pr list -R vllm-project/vllm --state all --search "data parallel load balance"
# Hits target other concerns: #40795 (token-level LB), #40285 (first-req
# routing drift), #43202 (external LB), #41164 (external DP LB GPU
# visibility). None overlap with the per-request engine-selection
# inner loop.
```

## Test plan

```
.venv/bin/python -m pytest tests/v1/engine/test_dplb_engine_selection.py
# 13 passed (full scan path, P2C path, threshold dispatch, DP-rank short-circuit, tie-break)

pre-commit run --files \
    vllm/v1/engine/core_client.py \
    tests/v1/engine/test_dplb_engine_selection.py
# Passed: ruff check / ruff format / typos / mypy / SPDX / boolean-ops / forbidden-imports / lazy imports / ...
```

The existing legacy DPLB tests
(`test_dplb_late_interaction_sticky_routing`,
`test_dplb_non_late_interaction_still_uses_lb`) live in
`tests/v1/engine/test_engine_core_client.py`, which is module-skipped on
non-CUDA platforms. Their N=3 setup falls into the unchanged full-scan
branch and stays valid.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude). I reviewed every
changed line, ran the tests above locally, and am responsible for
defending the change end-to-end.