### PR TITLE
[Bugfix] Validate JSON in kimi_k2 tool call arguments

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -148,8 +148,8 @@ class TestExtractToolCalls:
             # id format: "something:digit"
             assert tc.id.split(":")[-1].isdigit()
 
-    def test_invalid_json_still_extracted(self, parser):
-        """Tool calls with invalid JSON are still returned (arguments as-is)."""
+    def test_invalid_json_skipped(self, parser):
+        """Tool calls with invalid JSON are skipped; valid ones kept."""
         model_output = (
             "Help. "
             + SECTION_BEGIN
@@ -158,9 +158,9 @@ class TestExtractToolCalls:
             + SECTION_END
         )
         content, tool_calls = run_tool_extraction(parser, model_output, streaming=False)
-        assert len(tool_calls) == 2
-        assert tool_calls[0].function.name == "bad"
-        assert tool_calls[1].function.name == "good"
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "good"
+        assert json.loads(tool_calls[0].function.arguments) == {"city": "Shanghai"}
 
     def test_invalid_funcall_id_skipped(self, parser):
         """Tool calls with malformed id (no colon+digit) are skipped."""

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from collections.abc import Sequence
 
 import regex as re
@@ -96,6 +97,15 @@ class KimiK2ToolParser(ToolParser):
                     function_id, function_args = match
                     # function_id: functions.get_weather:0 or get_weather:0
                     function_name = function_id.split(":")[0].split(".")[-1]
+                    try:
+                        json.loads(function_args)
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning(
+                            "Skipping tool call '%s' with invalid JSON: %s",
+                            function_name,
+                            function_args,
+                        )
+                        continue
                     tool_calls.append(
                         ToolCall(
                             id=function_id,


### PR DESCRIPTION
## Purpose

`KimiK2ToolParser.extract_tool_calls()` passes regex-extracted arguments directly to `FunctionCall.arguments` without JSON validation. Malformed JSON (e.g. truncated output from `max_tokens`) reaches the client as a successful HTTP 200 response, causing downstream `json.loads()` to crash.

This PR adds `json.loads()` validation before emitting each tool call. Invalid entries are skipped with a warning log.

Fixes #41739

## Test Plan

```
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -v
```

## Test Result

50 passed, 0 failed. Updated `test_invalid_json_still_extracted` to `test_invalid_json_skipped` to assert the new behavior (malformed tool calls are skipped, valid ones kept).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
