### PR TITLE
[CI] De-flake v1/tracing/test_traces by forcing spawn

### DIFF
--- a/tests/v1/tracing/conftest.py
+++ b/tests/v1/tracing/conftest.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Force `spawn` for EngineCore: tests here start an in-process gRPC
+server, which makes vLLM's default fork() of EngineCore inherit dirty
+gRPC state and intermittently SIGSEGV.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def use_spawn_for_v1_tracing(monkeypatch):
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")


### PR DESCRIPTION
## Purpose

`tests/v1/tracing/test_traces` segfaults intermittently. The shared `trace_service` fixture starts an in-process gRPC server; vLLM's default `os.fork()` of EngineCore then inherits dirty gRPC state (`fork_posix.cc:71 Other threads are currently calling into gRPC, skipping fork() handlers`), and a background gRPC thread later SIGSEGVs.

Observed failures:
- [#66806](https://buildkite.com/vllm/ci/builds/66806/canvas?sid=019e3e45-c4a4-40d8-8a29-4143cb3da8f7&tab=output)
- [#67277](https://buildkite.com/vllm/ci/builds/67277/canvas?sid=019e480d-8dd2-4a49-955e-fea267451e6a&tab=output)

Fix: a local `tests/v1/tracing/conftest.py` autouse fixture sets `VLLM_WORKER_MULTIPROC_METHOD=spawn`, so EngineCore launches a fresh exec'd interpreter and inherits no gRPC state. Mirrors `tests/lora/test_whisper.py:27-30`.

## Test Plan

## Test Result