### PR TITLE
[Bugfix][DSV4] Default scale_fmt to "ue8m0" instead of hard-subscript

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -906,7 +906,7 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{prefix}.wo_b",
         )
         self.softmax_scale = self.head_dim**-0.5
-        self.scale_fmt = config.quantization_config["scale_fmt"]
+        self.scale_fmt = config.quantization_config.get("scale_fmt", "ue8m0")
 
         self.rope_parameters = config.rope_scaling
 


### PR DESCRIPTION
## Purpose

`DeepseekV4Attention.__init__` at `vllm/models/deepseek_v4/nvidia/model.py:909` does a hard subscript:

```python
self.scale_fmt = config.quantization_config["scale_fmt"]
```

If a quantization config does not include the `scale_fmt` field, server init crashes with `KeyError: 'scale_fmt'` before any weight is loaded.

The DSV4 model already treats `"ue8m0"` as the canonical default elsewhere — `vllm/models/deepseek_v4/attention.py:1116` sets `self.scale_fmt = "ue8m0"` for the non-quantized init path. This change applies the same default at line 909 for the case where the field is absent from a config that is otherwise valid.

## When this bites

This trips configs produced by llm-compressor recipes that do not explicitly set `scale_fmt`. Most reference NVFP4-FP8 / FP8-block recipes for DSV4-class models do not set it; the `scale_fmt` field is a vLLM convention that hasn't been documented in compressed-tensors as a required field. A user calibrating against a working recipe and serving against current vLLM `main` hits a `KeyError` at engine init, with the field name as the only clue to the fix.

## Change

```diff
-        self.scale_fmt = config.quantization_config["scale_fmt"]
+        self.scale_fmt = config.quantization_config.get("scale_fmt", "ue8m0")
```

## Test plan

- No semantic change for configs that explicitly carry `scale_fmt` — `.get("scale_fmt", "ue8m0")` returns the present value, identical to the previous `["scale_fmt"]` behavior.
- For configs missing the field, the load path now succeeds with the documented-elsewhere default instead of crashing.
- Same default value `"ue8m0"` is already used at `vllm/models/deepseek_v4/attention.py:1116`, so the two init paths are now consistent.

## Test result

Local syntax check passes. Engine init proceeds past `DeepseekV4Attention.__init__` for a quantized config lacking `scale_fmt`. Subsequent load behaves identically to a config with `scale_fmt: "ue8m0"` explicitly set.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) The necessary documentation update
</details>
