### PR TITLE
[CI] Pin protoc binary in rust-build stages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -240,20 +240,21 @@ ARG BUILD_OS
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install protoc (used by tonic-build/prost-build) and a basic C toolchain
-# (some rust crates compile C in their build.rs scripts).
+# Install a basic C toolchain (some rust crates compile C in their build.rs
+# scripts) and unzip (used to extract the pinned protoc release below).
 RUN if [ "${BUILD_OS}" = "manylinux" ]; then \
         dnf install -y --setopt=install_weak_deps=False \
-            ca-certificates curl git gcc gcc-c++ make \
-            protobuf-compiler protobuf-devel \
+            ca-certificates curl git gcc gcc-c++ make unzip \
         && dnf clean all && rm -rf /var/cache/dnf; \
     else \
         apt-get update -y \
         && apt-get install -y --no-install-recommends \
-            ca-certificates curl git build-essential \
-            protobuf-compiler libprotobuf-dev \
+            ca-certificates curl git build-essential unzip \
         && rm -rf /var/lib/apt/lists/*; \
     fi
+
+COPY tools/install_protoc.sh /tmp/install_protoc.sh
+RUN /tmp/install_protoc.sh && rm /tmp/install_protoc.sh
 
 # Install rustup; the toolchain itself is pinned by rust/rust-toolchain.toml.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -90,9 +90,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl git build-essential \
-        protobuf-compiler libprotobuf-dev \
+        ca-certificates curl git build-essential unzip \
     && rm -rf /var/lib/apt/lists/*
+
+COPY tools/install_protoc.sh /tmp/install_protoc.sh
+RUN /tmp/install_protoc.sh && rm /tmp/install_protoc.sh
 
 # Install rustup; the toolchain itself is pinned by rust/rust-toolchain.toml.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -102,9 +102,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl git build-essential \
-        protobuf-compiler libprotobuf-dev \
+        ca-certificates curl git build-essential unzip \
     && rm -rf /var/lib/apt/lists/*
+
+COPY tools/install_protoc.sh /tmp/install_protoc.sh
+RUN /tmp/install_protoc.sh && rm /tmp/install_protoc.sh
 
 # Install rustup; the toolchain itself is pinned by rust/rust-toolchain.toml.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -130,10 +130,12 @@ RUN if [ ! -f ${COMMON_WORKDIR}/vllm/rust/Cargo.toml ]; then \
         exit 1; \
     fi
 
-# protoc is used by tonic-build/prost-build.
 RUN apt-get update -q -y && apt-get install -q -y --no-install-recommends \
-        protobuf-compiler libprotobuf-dev \
+        ca-certificates curl unzip \
     && rm -rf /var/lib/apt/lists/*
+
+COPY tools/install_protoc.sh /tmp/install_protoc.sh
+RUN /tmp/install_protoc.sh && rm /tmp/install_protoc.sh
 
 # Install rustup; the toolchain itself is pinned by rust/rust-toolchain.toml.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -6,9 +6,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl git build-essential \
-        protobuf-compiler libprotobuf-dev \
+        ca-certificates curl git build-essential unzip \
     && rm -rf /var/lib/apt/lists/*
+
+COPY tools/install_protoc.sh /tmp/install_protoc.sh
+RUN /tmp/install_protoc.sh && rm /tmp/install_protoc.sh
 
 # Install rustup; the toolchain itself is pinned by rust/rust-toolchain.toml.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \

--- a/tools/install_protoc.sh
+++ b/tools/install_protoc.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install a pinned protoc binary from upstream GitHub releases.
+#
+# Distro protobuf-compiler packages vary widely in version (e.g.
+# AlmaLinux/RHEL 8 ships protoc 3.5, predating the
+# --experimental_allow_proto3_optional flag the rust frontend's build.rs
+# passes), so we pin the protoc version here instead.
+#
+# Override the version via the PROTOC_VERSION env var.
+# Requires: curl, unzip, root privileges.
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "Must be run as root" >&2
+  exit 1
+fi
+
+VERSION="${PROTOC_VERSION:-34.2}"
+
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    # protoc release archives use "aarch_64" (with an underscore), not
+    # "aarch64". Don't "fix" this.
+    aarch64|arm64) URL_ARCH="aarch_64" ;;
+    x86_64|amd64)  URL_ARCH="x86_64" ;;
+    *) echo "Unsupported arch for protoc binary: ${ARCH}" >&2; exit 1 ;;
+esac
+
+URL="https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-${URL_ARCH}.zip"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+echo "Downloading: ${URL}"
+curl -fsSL -o "${TMPDIR}/protoc.zip" "${URL}"
+unzip -q -o "${TMPDIR}/protoc.zip" -d /usr/local
+echo "Installed $(protoc --version)"


### PR DESCRIPTION
## Summary

The `rust-build` stage added in #40848 fails on manylinux2_28 builders because their distro protoc (3.5 from RHEL/AlmaLinux 8 AppStream) is older than the `--experimental_allow_proto3_optional` flag that the rust frontend's `build.rs` passes:

```
protoc failed: Unknown flag: --experimental_allow_proto3_optional
```

CI failure: [release-v2 build 1837](https://buildkite.com/organizations/vllm/pipelines/release-v2/builds/1837/jobs/019e48f5-64b0-4848-bc47-8b1ae94eeecb/log)

## Fix

Replace the distro `protobuf-compiler` install in all five rust-build stages with a pinned protoc binary from upstream GitHub releases, via a new `tools/install_protoc.sh` helper that mirrors the existing `tools/install_gdrcopy.sh` pattern.

## Test plan

- [x] Reproduced the failure locally with protoc 3.11.4 (same error, same build-script hash).
- [x] `cargo build --release --bin vllm-rs --features native-tls-vendored` succeeds with the new pin (protoc 34.2).
- [x] CI: confirm `release-v2` rust-build succeeds on manylinux2_28-builder. Passed at https://buildkite.com/vllm/release-v2/builds/1843/canvas