### PR TITLE
[Bugfix] Handle chunked prefill without new blocks in P2pNcclConnector

### DIFF
--- a/tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
+++ b/tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import KVTransferConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector import (
+    P2pNcclConnector,
+    P2pNcclConnectorMetadata,
+)
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_kv_cache_config(block_size: int) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=8,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype="float32",
+                ),
+            )
+        ],
+    )
+
+
+def _make_vllm_config(block_size: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="P2pNcclConnector",
+            kv_role="kv_producer",
+        ),
+    )
+
+
+def _make_scheduler_output(
+    *,
+    scheduled_new_reqs: list[NewRequestData] | None = None,
+    scheduled_cached_reqs: CachedRequestData | None = None,
+    num_scheduled_tokens: dict[str, int],
+) -> SchedulerOutput:
+    return SchedulerOutput(
+        scheduled_new_reqs=scheduled_new_reqs or [],
+        scheduled_cached_reqs=scheduled_cached_reqs or CachedRequestData.make_empty(),
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+
+def test_producer_handles_chunked_prefill_without_new_blocks() -> None:
+    block_size = 16
+    req_id = "req-1"
+    prompt_token_ids = list(range(20))
+    block_ids = [0, 1]
+    connector = P2pNcclConnector(
+        _make_vllm_config(block_size),
+        KVConnectorRole.SCHEDULER,
+        _make_kv_cache_config(block_size),
+    )
+
+    first_chunk = _make_scheduler_output(
+        scheduled_new_reqs=[
+            NewRequestData(
+                req_id=req_id,
+                prompt_token_ids=prompt_token_ids,
+                mm_features=[],
+                sampling_params=None,
+                pooling_params=None,
+                block_ids=(block_ids,),
+                num_computed_tokens=0,
+                lora_request=None,
+            )
+        ],
+        num_scheduled_tokens={req_id: 17},
+    )
+
+    connector.build_connector_meta(first_chunk)
+
+    final_chunk_without_new_blocks = _make_scheduler_output(
+        scheduled_cached_reqs=CachedRequestData(
+            req_ids=[req_id],
+            resumed_req_ids=set(),
+            new_token_ids=[[]],
+            all_token_ids={},
+            new_block_ids=[None],
+            num_computed_tokens=[17],
+            num_output_tokens=[0],
+        ),
+        num_scheduled_tokens={req_id: 3},
+    )
+
+    metadata = connector.build_connector_meta(final_chunk_without_new_blocks)
+
+    assert isinstance(metadata, P2pNcclConnectorMetadata)
+    assert len(metadata.requests) == 1
+    request_meta = metadata.requests[0]
+    assert request_meta.request_id == req_id
+    assert request_meta.block_ids.tolist() == block_ids
+    assert request_meta.num_tokens == len(prompt_token_ids)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -431,10 +431,13 @@ class P2pNcclConnector(KVConnectorBase_V1):
                 num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
                 num_tokens = num_scheduled_tokens + num_computed_tokens
                 assert req_id in self.chunked_prefill
-                assert new_block_ids is not None
-                block_ids = new_block_ids[0]
-                if not resumed_from_preemption:
-                    block_ids = self.chunked_prefill[req_id][0] + block_ids
+                if new_block_ids is None:
+                    assert not resumed_from_preemption
+                    block_ids = self.chunked_prefill[req_id][0]
+                elif resumed_from_preemption:
+                    block_ids = new_block_ids[0]
+                else:
+                    block_ids = self.chunked_prefill[req_id][0] + new_block_ids[0]
                 prompt_token_ids = self.chunked_prefill[req_id][1]
                 assert prompt_token_ids is not None
                 # the request's prompt is chunked prefill again


### PR DESCRIPTION
## Summary

Fixes #28860.

`P2pNcclConnector` assumed every subsequent chunked prefill scheduler step provides `new_block_ids`. That is not true when the step only consumes tokens that fit in already allocated KV blocks. In that case, the scheduler can legitimately report `new_block_ids=None`, and the connector should reuse the block ids saved from the earlier chunk instead of asserting.

This PR updates the producer-side chunked prefill metadata path to:
- reuse saved chunked-prefill block ids when `new_block_ids is None`
- preserve the existing resumed-from-preemption path
- continue appending newly allocated block ids when they exist

The added regression test models the failing allocation pattern with `block_size=16`, a 20-token prompt, and a first chunk of 17 scheduled tokens. The final chunk has no newly allocated KV block, so `new_block_ids=None` should still produce metadata using the previously saved block ids.

## Duplicate-work check

I checked for overlapping open issues and PRs before opening this PR:

- `gh issue view 28860 --repo vllm-project/vllm --comments`
- `gh issue view 33092 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "28860 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "33092 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "P2pNcclConnector" --limit 20`
- `gh pr list --repo vllm-project/vllm --state open --search "chunked prefill P2pNcclConnector"`

This is not duplicating an existing PR:

- #33117 addresses a different `req_id not in chunked_prefill` path and still leaves `assert new_block_ids is not None` in place.
- #33947, #34747, and #42931 address P2P NCCL coordination / request-id mismatch issues.
- #37265 addresses a DeepSeek KV layout `NoneType` tensor issue.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_p2p_nccl_connector.py -q
.venv/bin/pre-commit run ruff-check --files \
  vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py \
  tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
.venv/bin/pre-commit run ruff-format --files \
  vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py \
  tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
```

## Test Results

```text
1 passed, 16 warnings in 0.67s
ruff check: Passed
ruff format: Passed
```

## AI Assistance

I used AI assistance to analyze the failure mode, write the minimal regression test, and prepare this PR. I reviewed the changed lines and ran the test commands above.
