### PR TITLE
[CI] Fix CPU tests failing on `tl.exp2` import

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -93,6 +93,10 @@ class TritonPlaceholder(types.ModuleType):
 
 
 class TritonLanguagePlaceholder(types.ModuleType):
+    # Mirrors every `triton.language.X` referenced at module-import time in
+    # vllm/ (outside @triton.jit). Names left absent must keep raising
+    # AttributeError so `hasattr(triton.language, ...)` capability probes
+    # (e.g. `gather`, `make_tensor_descriptor`) return False on CPU-only builds.
     def __init__(self):
         super().__init__("triton.language")
         self.constexpr = None
@@ -101,5 +105,6 @@ class TritonLanguagePlaceholder(types.ModuleType):
         self.int32 = None
         self.tensor = None
         self.exp = None
+        self.exp2 = None
         self.log = None
         self.log2 = None

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -93,10 +93,6 @@ class TritonPlaceholder(types.ModuleType):
 
 
 class TritonLanguagePlaceholder(types.ModuleType):
-    # Mirrors every `triton.language.X` referenced at module-import time in
-    # vllm/ (outside @triton.jit). Names left absent must keep raising
-    # AttributeError so `hasattr(triton.language, ...)` capability probes
-    # (e.g. `gather`, `make_tensor_descriptor`) return False on CPU-only builds.
     def __init__(self):
         super().__init__("triton.language")
         self.constexpr = None


### PR DESCRIPTION
## Purpose

PR #43195 added module-level `exp2 = tl.exp2` in `vllm/model_executor/layers/fla/ops/op.py`, which crashes CPU CI because `TritonLanguagePlaceholder` (in `vllm/triton_utils/importing.py`) didn't expose `exp2`. Add it next to `exp`/`log`/`log2`; the whitelist stays explicit so `hasattr(triton.language, ...)` capability probes (e.g. `gather`, `make_tensor_descriptor`) keep returning `False` on CPU.

Failing CI steps fixed:
- [Multi-Modal Processor (CPU) #67370](https://buildkite.com/vllm/ci/builds/67370/canvas?sid=019e49c2-ca13-48fe-92a8-a6cb6099f2cc&tab=output)
- [Async Engine, Inputs, Utils, Worker, Config (CPU) #67383](https://buildkite.com/vllm/ci/builds/67383)

## Test Plan

## Test Result