### PR TITLE
fix: parse Qwen3 XML deferred args as JSON first

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -2,12 +2,20 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.qwen3xml_tool_parser import Qwen3XMLToolParser
 
 
 class TestQwen3xmlToolParser(ToolParserTests):
@@ -70,3 +78,53 @@ class TestQwen3xmlToolParser(ToolParserTests):
             },
             supports_typed_arguments=False,
         )
+
+
+def test_complex_array_arguments_parse_json_literals(
+    default_tokenizer: TokenizerLike,
+):
+    tools = [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "ask_user_question",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "questions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "question": {"type": "string"},
+                                    "multiSelect": {"type": "boolean"},
+                                    "answer": {"type": "null"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+    ]
+    model_output = """<tool_call>
+<function=ask_user_question>
+<parameter=questions>
+[{"question": "Favorite color?", "multiSelect": false, "answer": null}]
+</parameter>
+</function>
+</tool_call>"""
+
+    parser = Qwen3XMLToolParser(default_tokenizer, tools=tools)
+    request = ChatCompletionRequest(model="qwen3", messages=[], tools=tools)
+
+    result = parser.extract_tool_calls(model_output, request=request)
+
+    args = json.loads(result.tool_calls[0].function.arguments)
+    assert args["questions"] == [
+        {
+            "question": "Favorite color?",
+            "multiSelect": False,
+            "answer": None,
+        }
+    ]

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -821,7 +821,10 @@ class StreamingXMLToolCallParser:
                         raw_for_parse = raw_text + "\n"
                     else:
                         raw_for_parse = raw_text
-                    parsed_value = ast.literal_eval(raw_for_parse)
+                    try:
+                        parsed_value = json.loads(raw_for_parse)
+                    except json.JSONDecodeError:
+                        parsed_value = ast.literal_eval(raw_for_parse)
                     output_arguments = json.dumps(parsed_value, ensure_ascii=False)
                 except Exception:
                     # Fallback: output as string as-is


### PR DESCRIPTION
﻿## Summary
- parse deferred Qwen3 XML complex parameters with JSON first, then keep `ast.literal_eval` as the fallback for Python-style literals
- preserve native arrays/objects when model output contains JSON `false` / `true` / `null`
- add a regression test for an array-of-objects parameter containing JSON boolean and null values

Fixes #43238

## To verify
- python -m ruff check vllm/tool_parsers/qwen3xml_tool_parser.py tests/tool_parsers/test_qwen3xml_tool_parser.py
- python -m ruff format --check vllm/tool_parsers/qwen3xml_tool_parser.py tests/tool_parsers/test_qwen3xml_tool_parser.py
- python -m py_compile vllm/tool_parsers/qwen3xml_tool_parser.py tests/tool_parsers/test_qwen3xml_tool_parser.py
- git diff --check
- parser smoke: JSON false/null array-of-objects stays a list
- parser smoke: Python single-quoted object still falls back through literal_eval

`python -m pytest tests/tool_parsers/test_qwen3xml_tool_parser.py::test_complex_array_arguments_parse_json_literals -q` could not run on this Windows host because vLLM imports `uvloop`, and `uvloop` does not support Windows. I confirmed that by attempting `python -m pip install uvloop`, which fails during wheel requirements with `RuntimeError: uvloop does not support Windows at the moment`.
