### PR TITLE
feat: complete support for ML3 NVFP4 CuteDSL MoE with EPLB

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -777,6 +777,7 @@ class EplbState:
                         eplb_model_state,
                         new_physical_to_logical_map=new_physical_to_logical_map,
                     )
+                    _run_after_eplb_rearrangement_hooks(eplb_model_state.model)
 
                 if is_main_rank:
                     assert start_event is not None
@@ -1171,7 +1172,19 @@ def _move_to_workspace(
 
     if result.layer_idx == model_state.model.num_moe_layers - 1:
         model_state.rebalanced = False
+        _run_after_eplb_rearrangement_hooks(model_state.model)
 
     # Reset pending_result before unblocking the async worker
     model_state.pending_result = None
     result.consumed_event.record()
+
+
+def _run_after_eplb_rearrangement_hooks(model: MixtureOfExperts) -> None:
+    """Invoke quant_method.after_eplb_rearrangement on every MoE layer.
+
+    Lets quant methods refresh derived per-expert state (e.g. fused
+    activation x weight scales for NVFP4) that EPLB's Parameter
+    rearrangement won't touch on its own.
+    """
+    for moe_layer in model.moe_layers:
+        moe_layer.quant_method.after_eplb_rearrangement(moe_layer)

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -286,10 +286,25 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             and not self.use_deepseek_fp8_block_scale
         ):
             # FP8 per-tensor path: use global alphas/scales; do not pass input_sf
+            if self.moe_config.moe_parallel_config.enable_eplb:
+                # Account for weight scale rearrangement with EPLB
+                # TODO (varun): This is wasteful recomputation on every step.
+                # Hook this computation to EPLB rearrangement directly.
+
+                assert self.w1_scale is not None and self.w2_scale is not None
+                assert self.a1_scale is not None and self.a2_scale is not None
+                # w13_weight_scale * w13_input_scale
+                g1_alphas = (self.w1_scale * self.a1_scale).squeeze()
+                # w2_weight_scale * w2_input_scale
+                g2_alphas = (self.w2_scale * self.a2_scale).squeeze()
+            else:
+                # Use precomputed g1_alphas, g2_alphas
+                g1_alphas, g2_alphas = self.g1_alphas, self.g2_alphas
+
             quant_scales = [
-                self.g1_alphas,  # w13_weight_scale * w13_input_scale
+                g1_alphas,  # w13_weight_scale * w13_input_scale
                 self.a2_gscale,  # 1.0 / w2_input_scale
-                self.g2_alphas,  # w2_weight_scale * w2_input_scale
+                g2_alphas,  # w2_weight_scale * w2_input_scale
                 self.a1_scale,
             ]
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -147,6 +147,23 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     def supports_eplb(self) -> bool:
         return False
 
+    def after_eplb_rearrangement(
+        self,
+        layer: "RoutedExperts",  # type: ignore[name-defined] # noqa: F821
+    ) -> None:
+        """Refresh any quant-method state that depends on the per-expert
+        ordering after EPLB has rearranged the registered Parameters.
+
+        EPLB moves registered expert Parameters in-place via P2P, but
+        quant methods often hold *derived* per-expert tensors (e.g. the
+        reciprocal of a global scale, with activation scales fused in)
+        that are separate tensors with their own storage. Those won't
+        be touched by the rearrangement. Override this to re-derive
+        them in place so kernel references stay in sync. Default no-op
+        for methods with no such derived state.
+        """
+        return
+
     @property
     def method_name(self) -> str:
         return self.__class__.__name__

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -16,11 +16,23 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
     convert_to_nvfp4_moe_kernel_format,
     is_global_sf_supported_for_nvfp4_backend,
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+
+# Backends for which we've verified EPLB rearrangement preserves the
+# layout the kernel expects (registered Parameters are per-expert
+# leading-dim contiguous, derived scales get refreshed in the
+# after_eplb_rearrangement hook).
+_EPLB_SUPPORTED_NVFP4_BACKENDS = frozenset(
+    {
+        NvFp4MoeBackend.FLASHINFER_CUTEDSL,
+        NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
+    }
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
@@ -54,6 +66,15 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
             self.nvfp4_backend
         )
+
+    @property
+    def supports_eplb(self) -> bool:
+        # Online / static rearrangement is wired up only for the
+        # CuteDSL backends. Other NVFP4 backends still need their
+        # post-process layout (e.g. TRTLLM weight pre-shuffle, Marlin
+        # repacking) audited for per-expert leading-dim contiguity
+        # before EPLB can rearrange them safely.
+        return self.nvfp4_backend in _EPLB_SUPPORTED_NVFP4_BACKENDS
 
     def create_weights(
         self,
@@ -221,9 +242,35 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
         replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
         replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
+
+        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            # flashinfer's convert_sf_to_mma_layout returns a strided
+            # permuted view (shape (32, 4, m_t, 4, k_t, E)) of contiguous
+            # storage laid out as (E, m_t, k_t, 32, 4, 4). EPLB needs a
+            # per-expert leading-dim contiguous view to slice/move
+            # individual experts. The MMA view's permute is
+            # (3, 4, 1, 5, 2, 0); its inverse is (5, 2, 4, 0, 1, 3),
+            # which lands on the underlying (E, ...) contiguous layout
+            # while sharing storage. Register that as the Parameter and
+            # stash the MMA view on the layer as a plain tensor
+            # attribute for the kernel to consume via
+            # get_fused_moe_quant_config.
+            w13_scale_eplb_view = w13_scale.permute(5, 2, 4, 0, 1, 3)
+            w2_scale_eplb_view = w2_scale.permute(5, 2, 4, 0, 1, 3)
+            assert w13_scale_eplb_view.is_contiguous(), (
+                "Expected the inverse-permuted scale view to be contiguous; "
+                "flashinfer's convert_sf_to_mma_layout storage layout may "
+                "have changed."
+            )
+            assert w2_scale_eplb_view.is_contiguous()
+            layer.w13_weight_scale_mma_view = w13_scale
+            layer.w2_weight_scale_mma_view = w2_scale
+            replace_parameter(layer, "w13_weight_scale", w13_scale_eplb_view)
+            replace_parameter(layer, "w2_weight_scale", w2_scale_eplb_view)
+        else:
+            replace_parameter(layer, "w13_weight_scale", w13_scale)
+            replace_parameter(layer, "w2_weight_scale", w2_scale)
         layer.w13_weight_scale_2 = w13_scale_2
         layer.w2_weight_scale_2 = w2_scale_2
         layer.w13_input_scale = a13_scale
@@ -250,14 +297,46 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
+        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            # Kernel consumes the strided MMA-layout view; the
+            # registered Parameter is the E-leading view of the same
+            # storage so EPLB can rearrange per-expert. Both alias the
+            # same memory -- updates from either propagate.
+            w13_scale = layer.w13_weight_scale_mma_view
+            w2_scale = layer.w2_weight_scale_mma_view
+        else:
+            w13_scale = layer.w13_weight_scale
+            w2_scale = layer.w2_weight_scale
         return make_nvfp4_moe_quant_config(
             backend=self.nvfp4_backend,
-            w13_scale=layer.w13_weight_scale,
-            w2_scale=layer.w2_weight_scale,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
             w13_scale_2=layer.w13_weight_scale_2,
             w2_scale_2=layer.w2_weight_scale_2,
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
+        )
+
+    def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
+        if self.nvfp4_backend not in _EPLB_SUPPORTED_NVFP4_BACKENDS:
+            return
+        # EPLB moves the registered Parameters (w13_weight,
+        # w13_weight_scale, w13_weight_global_scale, w13_input_global_scale,
+        # and their w2 counterparts) per-expert. But the kernel-facing
+        # derived tensor layer.w13_weight_scale_2 holds the fused
+        # product (1 / w13_weight_global_scale) * w13_input_scale (see
+        # FlashInferCuteDSLExperts.process_weights_after_loading, which
+        # does the .mul_ in place). Its storage is independent of
+        # w13_weight_global_scale, so it doesn't get rearranged with the
+        # globals. Re-derive it in place so the kernel's captured
+        # references stay in sync. ``w13_input_scale`` is a max-broadcast
+        # scalar -- invariant under expert permutation, no refresh
+        # needed.
+        layer.w13_weight_scale_2.copy_(
+            (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale
+        )
+        layer.w2_weight_scale_2.copy_(
+            (1.0 / layer.w2_weight_global_scale) * layer.w2_input_scale
         )
 
     def apply_monolithic(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -920,6 +920,36 @@ class MixtureOfExperts(Protocol):
     ) -> None: ...
 
 
+def get_mixture_of_experts_model(model: object) -> MixtureOfExperts | None:
+    """
+    Given an arbitrary model,
+     - if the model itself is a MixtureOfExperts, return the model directly.
+     - if the model is a multi-modal model, and its `language_model` is a
+       MixtureOfExperts, return the `language_model`.
+     - if neither, return None.
+
+    :param model: Model being served.
+    :type model: object
+    :return: Return MixtureOfExperts instance contained within the model.
+    :rtype: MixtureOfExperts | None
+    """
+
+    if is_mixture_of_experts(model):
+        return model
+
+    if isinstance(model, SupportsMultiModal):
+        try:
+            mm_language_model = model.get_language_model()
+            return (
+                mm_language_model if is_mixture_of_experts(mm_language_model) else None
+            )
+        except (NotImplementedError, AttributeError):
+            logger.info_once("Cannot fetch language_model from MultiModal model")
+            return None
+
+    return None
+
+
 def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:
     return (
         isinstance(model, MixtureOfExperts) and getattr(model, "num_moe_layers", 0) > 0

--- a/vllm/v1/worker/gpu/eplb_utils.py
+++ b/vllm/v1/worker/gpu/eplb_utils.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import is_mixture_of_experts
+from vllm.model_executor.models.interfaces import get_mixture_of_experts_model
 
 logger = init_logger(__name__)
 
@@ -64,7 +64,8 @@ class EPLBController:
             return False
 
         draft_model = speculator.model
-        if not is_mixture_of_experts(draft_model):
+        draft_moe_model = get_mixture_of_experts_model(draft_model)
+        if draft_moe_model is None:
             return False
 
         assert not self.parallel_config.enable_elastic_ep, (
@@ -74,7 +75,7 @@ class EPLBController:
         assert speculative_config.draft_model_config is not None
         assert self.state is not None
         self.state.add_model(
-            draft_model,
+            draft_moe_model,
             speculative_config.draft_model_config,
         )
         self._has_registered_models = True
@@ -89,12 +90,15 @@ class EPLBController:
         if not self.parallel_config.enable_eplb or load_dummy_weights:
             return False
 
-        if not is_mixture_of_experts(model):
+        moe_model = get_mixture_of_experts_model(model)
+        if moe_model is None:
             return False
 
-        logger.info_once("EPLB is enabled for model %s.", model_config.model)
+        logger.info_once(
+            "EPLB is enabled for MoE part of model %s.", model_config.model
+        )
         assert self.state is not None
-        self.state.add_model(model, model_config)
+        self.state.add_model(moe_model, model_config)
         self._has_registered_models = True
         return True
 
@@ -128,10 +132,11 @@ class EPLBController:
         expanded_physical_to_logical: torch.Tensor,
         old_num_physical_experts: int,
     ) -> None:
-        assert is_mixture_of_experts(model)
+        moe_model = get_mixture_of_experts_model(model)
+        assert moe_model is not None
 
         self.state = EplbState.from_mapping(
-            model=model,
+            model=moe_model,
             model_config=model_config,
             device=self.device,
             parallel_config=self.parallel_config,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -77,7 +77,7 @@ from vllm.model_executor.models.interfaces import (
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsXDRoPE,
-    is_mixture_of_experts,
+    get_mixture_of_experts_model,
     supports_eagle3,
     supports_mrope,
     supports_multimodal_pruning,
@@ -3173,8 +3173,7 @@ class GPUModelRunner(
             return
 
         assert self.eplb_state is not None
-        model = self.get_model()
-        assert is_mixture_of_experts(model)
+        assert get_mixture_of_experts_model(self.get_model()) is not None
         self.eplb_state.step(
             is_dummy,
             is_profile,
@@ -3187,10 +3186,11 @@ class GPUModelRunner(
         old_num_physical_experts: int,
     ) -> None:
         model = self.get_model()
-        assert is_mixture_of_experts(model)
+        moe_model = get_mixture_of_experts_model(model)
+        assert moe_model is not None
 
         self.eplb_state = EplbState.from_mapping(
-            model=model,
+            model=moe_model,
             model_config=self.model_config,
             device=self.device,
             parallel_config=self.parallel_config,
@@ -4886,10 +4886,16 @@ class GPUModelRunner(
                 if hasattr(self, "drafter"):
                     logger.info_once("Loading drafter model...")
                     self.drafter.load_model(self.model)
+
                     if (
-                        hasattr(self.drafter, "model")
-                        and is_mixture_of_experts(self.drafter.model)
-                        and self.parallel_config.enable_eplb
+                        self.parallel_config.enable_eplb
+                        and hasattr(self.drafter, "model")
+                        and (
+                            drafter_moe_model := get_mixture_of_experts_model(
+                                self.drafter.model
+                            )
+                        )
+                        is not None
                     ):
                         assert not self.parallel_config.enable_elastic_ep, (
                             "Elastic EP is not supported with drafter model."
@@ -4898,7 +4904,7 @@ class GPUModelRunner(
                         assert spec_config is not None
                         assert spec_config.draft_model_config is not None
                         logger.info_once(
-                            "EPLB is enabled for drafter model %s.",
+                            "EPLB is enabled for MoE part of drafter model %s.",
                             spec_config.draft_model_config.model,
                         )
                         if self.eplb_state is None:
@@ -4906,7 +4912,7 @@ class GPUModelRunner(
                                 self.parallel_config, self.device
                             )
                         self.eplb_state.add_model(
-                            self.drafter.model,
+                            drafter_moe_model,
                             spec_config.draft_model_config,
                         )
                         eplb_models += 1
@@ -4934,17 +4940,18 @@ class GPUModelRunner(
                     self.model.set_aux_hidden_state_layers(aux_layers)
 
                 if (
-                    is_mixture_of_experts(self.model)
-                    and self.parallel_config.enable_eplb
+                    self.parallel_config.enable_eplb
                     and not load_dummy_weights
+                    and (moe_model := get_mixture_of_experts_model(self.model))
+                    is not None
                 ):
                     logger.info_once(
-                        "EPLB is enabled for model %s.",
+                        "EPLB is enabled for MoE part of model %s.",
                         self.model_config.model,
                     )
                     assert self.eplb_state is not None
                     self.eplb_state.add_model(
-                        self.model,
+                        moe_model,
                         self.model_config,
                     )
                     eplb_models += 1
@@ -4984,8 +4991,8 @@ class GPUModelRunner(
         )  # Temporary hack for dynamic res video w/o support for bs>1 yet
 
         if (
-            is_mixture_of_experts(self.model)
-            and self.parallel_config.enable_eplb
+            self.parallel_config.enable_eplb
+            and get_mixture_of_experts_model(self.model) is not None
             and not load_dummy_weights
             and self.eplb_state is not None
             and self.eplb_state.is_async


### PR DESCRIPTION
## Summary

Enable EPLB weight rearrangement for NVFP4 MoE on the FlashInfer CuteDSL backends (Standard and Batched). Previously `CompressedTensorsW4A4Nvfp4MoEMethod` returned `supports_eplb = False`, so any `--enable-eplb` invocation against an NVFP4 checkpoint failed at the `FusedMoE.__init__` gate. This unblocks both online and static (`--eplb-config.load_path`) rearrangement on Mistral-Large-3-NVFP4 and any other NVFP4 MoE using a CuteDSL kernel.

## Background

EPLB rearrangement needs two things from a quant method:

1. **Registered Parameters whose leading dim is `local_num_experts` and is contiguous in storage**, so `rearrange_expert_weights_inplace` can do per-expert P2P send/recv against the layer's real tensors.
2. **A way to refresh any derived per-expert state** that lives outside the registered Parameters (e.g. fused scale products in tensor attributes), since EPLB only touches Parameters.

NVFP4 CuteDSL violates both today:

- After `process_weights_after_loading`, `w13_weight_scale` / `w2_weight_scale` are *strided permuted views* (`(32, 4, m_t, 4, k_t, E)`) returned by flashinfer's `convert_sf_to_mma_layout`. Per its docstring, the underlying storage *is* `(E, m_t, k_t, 32, 4, 4)` contiguous — but the registered Parameter doesn't expose that.
- `layer.w13_weight_scale_2` and `layer.w2_weight_scale_2` are *separate tensors* (own storage), holding the kernel-facing `(1 / w_global_scale) * input_scale` fused product. The expert's `process_weights_after_loading` mutates them in-place via `.mul_(input_scale)`. EPLB rearranges `w13_weight_global_scale` (a Parameter) without knowing about the derived fused product, so after rearrangement the kernel reads scale_2 against the old expert ordering.

## Changes

### 1. Per-expert leading-dim view of MMA-layout scales — `compressed_tensors_moe_w4a4_nvfp4.py`

For the `FLASHINFER_CUTEDSL` backend, the inverse permute of `(3, 4, 1, 5, 2, 0)` is `(5, 2, 4, 0, 1, 3)`. Applying it to the MMA view returns to the underlying `(E, m_t, k_t, 32, 4, 4)` contiguous layout while sharing storage. The new flow in `process_weights_after_loading`:

- Register the E-leading inverse-permuted view as the `Parameter` (visible to EPLB's `get_expert_weights`).
- Stash the original MMA view as `layer.w{13,2}_weight_scale_mma_view` (plain tensor attribute, not in `named_parameters()`).
- `get_fused_moe_quant_config` reads from `_mma_view` for CuteDSL so the kernel still consumes the strided MMA layout.

`is_contiguous()` is asserted on the inverse-permuted view to fail-fast if flashinfer ever changes the underlying storage layout.

The `FLASHINFER_CUTEDSL_BATCHED` backend goes through `prepare_nvfp4_moe_layer_for_fi_or_cutlass`, which produces E-leading contiguous scales via `swizzle_blockscale`. No permute trick needed; it works as-is.

### 2. `after_eplb_rearrangement` hook — `fused_moe_method_base.py` + `eplb_state.py`

- New no-op default `FusedMoEMethodBase.after_eplb_rearrangement(layer)`.
- `_run_after_eplb_rearrangement_hooks(model)` iterates `model.moe_layers` and dispatches; called from both rearrangement paths:
  - Sync: right after `_commit_eplb_maps` in `EplbState.rearrange`.
  - Async: in `_move_to_workspace` once the last layer commits.
- NVFP4 override refreshes `w13/w2_weight_scale_2` in place via `.copy_()` of `(1 / w_global_scale) * input_scale`, so the kernel's captured quant_config reference picks up the new expert ordering without needing to be rebuilt. `input_scale` is the max-broadcast scalar (invariant under permutation), so no refresh is needed for it.

### 3. Backend-scoped `supports_eplb`

`_EPLB_SUPPORTED_NVFP4_BACKENDS = {FLASHINFER_CUTEDSL, FLASHINFER_CUTEDSL_BATCHED}`. Other NVFP4 backends (TRTLLM pre-shuffle, Cutlass, Marlin, Emulation) still need their post-process layouts audited for per-expert leading-dim contiguity before they can be opted in — leaving them at `False` is the safe default rather than silently breaking them.

## Test plan

End-to-end validation on a P/D-disaggregated Mistral-Large-3-675B-Instruct-2512-NVFP4 deployment on B200:

- [x] **MMLU-Pro accuracy eval** — `nemo-evaluator run_eval --eval_type mmlu_pro` against the chat-completions endpoint after the throughput benchmark on each deployment. **Accuracy: 0.7958** (single decode-worker sweep point). This is the load-bearing test for this PR: it's exactly the case the broken-rearrangement diagnosis predicted would fail — routing tables pointing at moved physical slots, the kernel reading the *old* fused scales, etc. would all show up as a large MMLU-Pro drop.