### PR TITLE
[DO NOT MERGE] Add kernel-side KV cache NaN/Inf detection for MLA concat_and_cache

### DIFF
--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -31,7 +31,8 @@ void reshape_and_cache_flash(torch::Tensor& key, torch::Tensor& value,
 void concat_and_cache_mla(torch::Tensor& kv_c, torch::Tensor& k_pe,
                           torch::Tensor& kv_cache, torch::Tensor& slot_mapping,
                           const std::string& kv_cache_dtype,
-                          torch::Tensor& scale);
+                          torch::Tensor& scale,
+                          std::optional<torch::Tensor> nan_flag = std::nullopt);
 
 // NOTE: k_pe and kv_c order is flipped compared to concat_and_cache_mla
 void concat_and_cache_mla_rope_fused(

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -388,6 +388,34 @@ __global__ void reshape_and_cache_flash_kernel(
   }
 }
 
+// nan_flag bit layout (FP8 KV cache only):
+//   bit 0 = FP8 NaN in kv_c write    (byte & 0x7F) == 0x7F
+//   bit 1 = FP8 NaN in k_pe write
+//   bit 2 = Inf in kv_c source
+//   bit 3 = Inf in k_pe source
+//   bit 4 = NaN in kv_c source
+//   bit 5 = NaN in k_pe source
+
+__device__ __forceinline__ bool is_inf_bits(__nv_bfloat16 v) {
+  return (*reinterpret_cast<const uint16_t*>(&v) & 0x7FFFu) == 0x7F80u;
+}
+__device__ __forceinline__ bool is_inf_bits(uint16_t v) {
+  return (v & 0x7FFFu) == 0x7C00u;
+}
+__device__ __forceinline__ bool is_inf_bits(float v) {
+  return (__float_as_uint(v) & 0x7FFFFFFFu) == 0x7F800000u;
+}
+
+__device__ __forceinline__ bool is_nan_bits(__nv_bfloat16 v) {
+  return (*reinterpret_cast<const uint16_t*>(&v) & 0x7FFFu) > 0x7F80u;
+}
+__device__ __forceinline__ bool is_nan_bits(uint16_t v) {
+  return (v & 0x7FFFu) > 0x7C00u;
+}
+__device__ __forceinline__ bool is_nan_bits(float v) {
+  return (__float_as_uint(v) & 0x7FFFFFFFu) > 0x7F800000u;
+}
+
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 __global__ void concat_and_cache_mla_kernel(
     const scalar_t* __restrict__ kv_c,  // [num_tokens, kv_lora_rank]
@@ -402,7 +430,8 @@ __global__ void concat_and_cache_mla_kernel(
     const int kv_lora_rank,                    //
     const int pe_dim,                          //
     const int block_size,                      //
-    const float* scale                         //
+    const float* scale,                        //
+    int32_t* nan_flag  // nullable
 ) {
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
@@ -414,7 +443,8 @@ __global__ void concat_and_cache_mla_kernel(
   const int64_t block_offset = slot_idx % block_size;
 
   auto copy = [&](const scalar_t* __restrict__ src, cache_t* __restrict__ dst,
-                  int src_stride, int dst_stride, int size, int offset) {
+                  int src_stride, int dst_stride, int size, int offset,
+                  int nan_bit, int inf_bit) {
     for (int i = threadIdx.x; i < size; i += blockDim.x) {
       const int64_t src_idx = token_idx * src_stride + i;
       const int64_t dst_idx =
@@ -422,14 +452,30 @@ __global__ void concat_and_cache_mla_kernel(
       if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
         dst[dst_idx] = src[src_idx];
       } else {
-        dst[dst_idx] =
-            fp8::scaled_convert<cache_t, scalar_t, kv_dt>(src[src_idx], *scale);
+        scalar_t sv = src[src_idx];
+        cache_t out =
+            fp8::scaled_convert<cache_t, scalar_t, kv_dt>(sv, *scale);
+        dst[dst_idx] = out;
+        if (nan_flag != nullptr) {
+          int hit = 0;
+          if ((static_cast<uint8_t>(out) & 0x7Fu) == 0x7Fu) {
+            atomicOr(&nan_flag[0], (1 << nan_bit)); hit = 1;
+          }
+          if (is_inf_bits(sv)) {
+            atomicOr(&nan_flag[0], (1 << inf_bit)); hit = 1;
+          }
+          if (is_nan_bits(sv)) {
+            atomicOr(&nan_flag[0], (1 << (inf_bit + 2))); hit = 1;
+          }
+          if (hit)
+            atomicMin(&nan_flag[1], static_cast<int32_t>(token_idx));
+        }
       }
     }
   };
 
-  copy(kv_c, kv_cache, kv_c_stride, block_stride, kv_lora_rank, 0);
-  copy(k_pe, kv_cache, k_pe_stride, block_stride, pe_dim, kv_lora_rank);
+  copy(kv_c, kv_cache, kv_c_stride, block_stride, kv_lora_rank, 0, 0, 2);
+  copy(k_pe, kv_cache, k_pe_stride, block_stride, pe_dim, kv_lora_rank, 1, 3);
 }
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
@@ -446,7 +492,8 @@ __global__ void concat_and_cache_ds_mla_kernel(
     const int kv_lora_rank,                    //
     const int pe_dim,                          //
     const int block_size,                      //
-    const float* scale                         //
+    const float* scale,                        //
+    int32_t* nan_flag  // nullable — same bit layout as concat_and_cache_mla_kernel
 ) {
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
@@ -481,6 +528,19 @@ __global__ void concat_and_cache_ds_mla_kernel(
     const int64_t dst_idx = kv_lora_rank / 2 + 8 + pe_idx_start;
     // Vectorized store of two 16-bit values, performed as one 32-bit store
     *reinterpret_cast<int32_t*>(&kv_cache_16bit[dst_idx]) = vals;
+    // RoPE is stored as bf16 (no FP8 conversion) — check source for Inf/NaN
+    if (nan_flag != nullptr) {
+      const scalar_t* pe_vals = reinterpret_cast<const scalar_t*>(&vals);
+      int hit = 0;
+      if (is_inf_bits(pe_vals[0]) || is_inf_bits(pe_vals[1])) {
+        atomicOr(&nan_flag[0], (1 << 3)); hit = 1;
+      }
+      if (is_nan_bits(pe_vals[0]) || is_nan_bits(pe_vals[1])) {
+        atomicOr(&nan_flag[0], (1 << 5)); hit = 1;
+      }
+      if (hit)
+        atomicMin(&nan_flag[1], static_cast<int32_t>(token_idx));
+    }
     return;
   }
 
@@ -533,6 +593,23 @@ __global__ void concat_and_cache_ds_mla_kernel(
   // Store as aligned 64-bit writes
   *reinterpret_cast<uint64_t*>(&kv_cache[dst_idx_base]) =
       *reinterpret_cast<const uint64_t*>(result);
+
+  // Check FP8 output for NaN and source bf16 for Inf/NaN
+  if (nan_flag != nullptr) {
+    int fp8_nan = 0, src_inf = 0, src_nan = 0;
+#pragma unroll
+    for (int i = 0; i < 8; i++) {
+      fp8_nan |= ((result[i] & 0x7Fu) == 0x7Fu);
+      src_inf |= is_inf_bits(vals[i]);
+      src_nan |= is_nan_bits(vals[i]);
+    }
+    int hit = 0;
+    if (fp8_nan) { atomicOr(&nan_flag[0], (1 << 0)); hit = 1; }
+    if (src_inf) { atomicOr(&nan_flag[0], (1 << 2)); hit = 1; }
+    if (src_nan) { atomicOr(&nan_flag[0], (1 << 4)); hit = 1; }
+    if (hit)
+      atomicMin(&nan_flag[1], static_cast<int32_t>(token_idx));
+  }
 }
 
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
@@ -810,10 +887,9 @@ void reshape_and_cache_flash(
           reinterpret_cast<CACHE_T*>(kv_cache.data_ptr()),              \
           slot_mapping.data_ptr<int64_t>(), block_stride, entry_stride, \
           kv_c_stride, k_pe_stride, kv_lora_rank, pe_dim, block_size,   \
-          reinterpret_cast<const float*>(scale.data_ptr()));
+          reinterpret_cast<const float*>(scale.data_ptr()),             \
+          nan_flag_ptr);
 
-// KV_T is the data type of key and value tensors.
-// CACHE_T is the stored data type of kv-cache.
 #define CALL_CONCAT_AND_CACHE_DS_MLA(KV_T, CACHE_T, KV_DTYPE)           \
   vllm::concat_and_cache_ds_mla_kernel<KV_T, CACHE_T, KV_DTYPE>         \
       <<<grid, block, 0, stream>>>(                                     \
@@ -822,7 +898,8 @@ void reshape_and_cache_flash(
           reinterpret_cast<CACHE_T*>(kv_cache.data_ptr()),              \
           slot_mapping.data_ptr<int64_t>(), block_stride, entry_stride, \
           kv_c_stride, k_pe_stride, kv_lora_rank, pe_dim, block_size,   \
-          reinterpret_cast<const float*>(scale.data_ptr()));
+          reinterpret_cast<const float*>(scale.data_ptr()),             \
+          nan_flag_ptr);
 
 void concat_and_cache_mla(
     torch::Tensor& kv_c,          // [num_tokens, kv_lora_rank]
@@ -830,7 +907,8 @@ void concat_and_cache_mla(
     torch::Tensor& kv_cache,      // [num_blocks, block_size, (kv_lora_rank +
                                   // pe_dim)]
     torch::Tensor& slot_mapping,  // [num_tokens] or [num_actual_tokens]
-    const std::string& kv_cache_dtype, torch::Tensor& scale) {
+    const std::string& kv_cache_dtype, torch::Tensor& scale,
+    std::optional<torch::Tensor> nan_flag) {
   // NOTE(woosuk): In vLLM V1, key.size(0) can be different from
   // slot_mapping.size(0) because of padding for CUDA graphs.
   // In vLLM V0, key.size(0) is always equal to slot_mapping.size(0) because
@@ -866,6 +944,10 @@ void concat_and_cache_mla(
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(kv_c));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  int32_t* nan_flag_ptr = nan_flag.has_value()
+      ? nan_flag.value().data_ptr<int32_t>()
+      : nullptr;
 
   if (kv_cache_dtype == "fp8_ds_mla") {
     dim3 grid(num_tokens);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -381,7 +381,8 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "                     Tensor! kv_cache,"
       "                     Tensor slot_mapping,"
       "                     str kv_cache_dtype,"
-      "                     Tensor scale) -> ()");
+      "                     Tensor scale,"
+      "                     Tensor? nan_flag) -> ()");
   cache_ops.impl("concat_and_cache_mla", torch::kCUDA, &concat_and_cache_mla);
 
   // Rotate Q and K, then write to kv cache for MLA

--- a/tools/jit_cache_nan.py
+++ b/tools/jit_cache_nan.py
@@ -1,0 +1,75 @@
+"""JIT-compile cache_kernels.cu with kernel-side NaN/Inf detection.
+
+Compiles only cache_kernels.cu as a standalone extension via nvcc,
+avoiding a full cmake rebuild. Exposes concat_and_cache_mla with the
+nan_flag parameter.
+
+Usage (from /opt/vllm-source):
+    python tools/jit_cache_nan.py
+"""
+import os
+import textwrap
+
+import torch.utils.cpp_extension as cpp_ext
+from torch.utils.cpp_extension import load
+
+# Remove conversion-blocking flags that torch adds by default.
+# cmake does the same for CUDA >= 12.0 (see cmake/utils.cmake).
+for flag in [
+    "-D__CUDA_NO_HALF_OPERATORS__",
+    "-D__CUDA_NO_HALF_CONVERSIONS__",
+    "-D__CUDA_NO_BFLOAT16_CONVERSIONS__",
+    "-D__CUDA_NO_HALF2_OPERATORS__",
+]:
+    while flag in cpp_ext.COMMON_NVCC_FLAGS:
+        cpp_ext.COMMON_NVCC_FLAGS.remove(flag)
+
+SRC_DIR = "/opt/vllm-source/csrc"
+BUILD_DIR = "/tmp/jit_build/cache_nan"
+os.makedirs(BUILD_DIR, exist_ok=True)
+
+# Normalize arch list — torch JIT doesn't understand "10.0f" (cmake-only syntax)
+arch = os.environ.get("TORCH_CUDA_ARCH_LIST", "")
+if arch:
+    os.environ["TORCH_CUDA_ARCH_LIST"] = "10.0a"
+
+BINDING_SRC = textwrap.dedent("""\
+    #include <torch/extension.h>
+    #include <c10/util/Optional.h>
+
+    void concat_and_cache_mla(torch::Tensor& kv_c, torch::Tensor& k_pe,
+                              torch::Tensor& kv_cache, torch::Tensor& slot_mapping,
+                              const std::string& kv_cache_dtype, torch::Tensor& scale,
+                              std::optional<torch::Tensor> nan_flag);
+
+    PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+        m.def("concat_and_cache_mla", &concat_and_cache_mla,
+              "Concat and cache MLA with NaN/Inf detection",
+              py::arg("kv_c"), py::arg("k_pe"), py::arg("kv_cache"),
+              py::arg("slot_mapping"), py::arg("kv_cache_dtype"), py::arg("scale"),
+              py::arg("nan_flag") = py::none());
+    }
+""")
+
+binding_path = os.path.join(SRC_DIR, "cache_nan_binding.cpp")
+with open(binding_path, "w") as f:
+    f.write(BINDING_SRC)
+
+mod = load(
+    name="cache_nan_ext",
+    sources=[
+        binding_path,
+        os.path.join(SRC_DIR, "cache_kernels.cu"),
+    ],
+    extra_include_paths=[SRC_DIR],
+    build_directory=BUILD_DIR,
+    extra_cflags=["-O3"],
+    extra_cuda_cflags=[
+        "-O3",
+        "--use_fast_math",
+        "-DENABLE_FP8",
+    ],
+    verbose=True,
+)
+
+print(f"cache_nan_ext built: {mod}")

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2640,6 +2640,9 @@ def reshape_and_cache_flash(
     )
 
 
+import cache_nan_ext as _cache_nan_ext
+
+
 def concat_and_cache_mla(
     kv_c: torch.Tensor,
     k_pe: torch.Tensor,
@@ -2647,9 +2650,10 @@ def concat_and_cache_mla(
     slot_mapping: torch.Tensor,
     kv_cache_dtype: str,
     scale: torch.Tensor,
+    nan_flag: torch.Tensor | None = None,
 ) -> None:
-    torch.ops._C_cache_ops.concat_and_cache_mla(
-        kv_c, k_pe, kv_cache, slot_mapping, kv_cache_dtype, scale
+    _cache_nan_ext.concat_and_cache_mla(
+        kv_c, k_pe, kv_cache, slot_mapping, kv_cache_dtype, scale, nan_flag
     )
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -206,6 +206,11 @@ if TYPE_CHECKING:
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
     VLLM_SSM_CONV_STATE_LAYOUT: Literal["SD", "DS"] | None = None
     VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
+    VLLM_NAN_CHECK_COMPONENTS: str = "all"
+    VLLM_NAN_KV_WRITE_CHECK: bool = True
+    VLLM_NAN_KV_POST_WRITE_CHECK: bool = True
+    VLLM_NAN_MOE_COMBINE_CHECK: bool = True
+    VLLM_KV_CACHE_NAN_AUDIT: int = 0
     VLLM_USE_NVFP4_CT_EMULATIONS: bool = False
     VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: Literal[
         "FP", "INT8", "INT6", "INT4", "NONE"
@@ -1561,6 +1566,31 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # or bad hardware but it may add compute overhead.
     "VLLM_COMPUTE_NANS_IN_LOGITS": lambda: bool(
         int(os.getenv("VLLM_COMPUTE_NANS_IN_LOGITS", "0"))
+    ),
+    # Comma-separated component IDs for selective NaN check barriers.
+    # "all" = every checkpoint (default), "none" = no checkpoints,
+    # e.g. "2,7,10" = only QKV_PROJ, ATTENTION, MOE.
+    "VLLM_NAN_CHECK_COMPONENTS": lambda: os.getenv(
+        "VLLM_NAN_CHECK_COMPONENTS", "all"
+    ),
+    # Enable pre-write KV cache NaN checks (nan_sticky_check on kv inputs).
+    "VLLM_NAN_KV_WRITE_CHECK": lambda: bool(
+        int(os.getenv("VLLM_NAN_KV_WRITE_CHECK", "1"))
+    ),
+    # Enable post-write KV cache NaN checks (reads back written slots).
+    # Disable with VLLM_NAN_KV_POST_WRITE_CHECK=0 to save ~550 MB CUDA
+    # graph memory (fancy-index + bitwise intermediates x 61 layers).
+    "VLLM_NAN_KV_POST_WRITE_CHECK": lambda: bool(
+        int(os.getenv("VLLM_NAN_KV_POST_WRITE_CHECK", "1"))
+    ),
+    # Enable expert_nan_inf_latch checks around EP combine in MoE runner.
+    "VLLM_NAN_MOE_COMBINE_CHECK": lambda: bool(
+        int(os.getenv("VLLM_NAN_MOE_COMBINE_CHECK", "1"))
+    ),
+    # Audit KV cache for NaN before every N-th model call.
+    # 0 = disabled (default), N > 0 = check every N steps.
+    "VLLM_KV_CACHE_NAN_AUDIT": lambda: int(
+        os.getenv("VLLM_KV_CACHE_NAN_AUDIT", "0")
     ),
     # Controls whether or not emulations are used for NVFP4
     # generations on machines < 100 for compressed-tensors

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -780,3 +780,269 @@ direct_register_custom_op(
     mutates_args=["output", "output_block_scale"],
     fake_impl=unified_attention_with_output_fake,
 )
+
+
+# ---------------------------------------------------------------------------
+# NaN / Inf detection custom ops
+# ---------------------------------------------------------------------------
+
+NAN_COMPONENT_EMBEDDING = 0
+NAN_COMPONENT_INPUT_LN = 1
+NAN_COMPONENT_QKV_PROJ = 2
+NAN_COMPONENT_Q_A_LN = 3
+NAN_COMPONENT_Q_B_PROJ = 4
+NAN_COMPONENT_KV_A_LN = 5
+NAN_COMPONENT_ROTARY = 6
+NAN_COMPONENT_ATTENTION = 7
+NAN_COMPONENT_O_PROJ = 8
+NAN_COMPONENT_POST_ATTN_LN = 9
+NAN_COMPONENT_MOE = 10
+NAN_COMPONENT_PRE_NORM_HIDDEN = 11
+NAN_COMPONENT_PRE_NORM_RESIDUAL = 12
+NAN_COMPONENT_MLP_OUTPUT = 14
+NAN_COMPONENT_KV_CACHE_IN = 15
+NAN_COMPONENT_ATTN_WORKSPACE = 16
+NAN_COMPONENT_ATTN_Q_ABSORBED = 17
+NAN_COMPONENT_ATTN_FA3_OUT = 18
+NAN_COMPONENT_ATTN_V_UP_PROJ = 19
+NAN_COMPONENT_ATTN_MHA_OUT = 20
+NAN_COMPONENT_ATTN_MQA_Q = 21
+NAN_COMPONENT_KV_CACHE_IN_KPE = 22
+NAN_COMPONENT_KV_CACHE_IN_COMPILED = 23
+NAN_COMPONENT_KV_CACHE_IN_KPE_COMPILED = 24
+NAN_COMPONENT_KV_CACHE_POST_WRITE = 25
+NAN_COMPONENT_KV_CACHE_POST_WRITE_COMPILED = 26
+NAN_COMPONENT_KV_CACHE_PRE_FORWARD = 27
+NAN_COMPONENT_MLP_INPUT = 28
+NAN_COMPONENT_MLP_GATE_UP = 29
+NAN_COMPONENT_MLP_ACT = 30
+NAN_COMPONENT_MLP_DOWN = 31
+NAN_COMPONENT_MOE_ROUTED_OUT = 32
+NAN_COMPONENT_MOE_SHARED_OUT = 33
+NAN_COMPONENT_MOE_AFTER_SCALE = 34
+NAN_COMPONENT_MOE_AFTER_SHARED_ADD = 35
+NAN_COMPONENT_MOE_EXPERT_INPUT = 36
+NAN_COMPONENT_MOE_EXPERT_INPUT_INF = 37
+NAN_COMPONENT_MOE_EXPERT_GEMM1 = 38
+NAN_COMPONENT_MOE_EXPERT_GEMM1_INF = 39
+NAN_COMPONENT_MOE_EXPERT_GEMM2 = 40
+NAN_COMPONENT_MOE_EXPERT_GEMM2_INF = 41
+NAN_COMPONENT_MOE_FUSED_OUT = 42
+NAN_COMPONENT_MOE_FUSED_OUT_INF = 43
+NAN_COMPONENT_MOE_TOPK_WEIGHTS = 44
+NAN_COMPONENT_MOE_TOPK_WEIGHTS_INF = 45
+NAN_COMPONENT_MOE_FINALIZE = 46
+NAN_COMPONENT_MOE_FINALIZE_INF = 47
+NAN_COMPONENT_MOE_PRE_COMBINE = 48
+NAN_COMPONENT_MOE_PRE_COMBINE_INF = 49
+NAN_COMPONENT_MOE_POST_COMBINE = 50
+NAN_COMPONENT_MOE_POST_COMBINE_INF = 51
+
+NAN_COMPONENT_NAMES = {
+    NAN_COMPONENT_EMBEDDING: "embedding",
+    NAN_COMPONENT_INPUT_LN: "input_ln",
+    NAN_COMPONENT_QKV_PROJ: "qkv_proj",
+    NAN_COMPONENT_Q_A_LN: "q_a_ln",
+    NAN_COMPONENT_Q_B_PROJ: "q_b_proj",
+    NAN_COMPONENT_KV_A_LN: "kv_a_ln",
+    NAN_COMPONENT_ROTARY: "rotary",
+    NAN_COMPONENT_ATTENTION: "attention",
+    NAN_COMPONENT_O_PROJ: "o_proj",
+    NAN_COMPONENT_POST_ATTN_LN: "post_attn_ln",
+    NAN_COMPONENT_MOE: "moe",
+    NAN_COMPONENT_PRE_NORM_HIDDEN: "pre_norm_hidden",
+    NAN_COMPONENT_PRE_NORM_RESIDUAL: "pre_norm_residual",
+    NAN_COMPONENT_MLP_OUTPUT: "mlp_output",
+    NAN_COMPONENT_KV_CACHE_IN: "kv_cache_in",
+    NAN_COMPONENT_ATTN_WORKSPACE: "attn_workspace",
+    NAN_COMPONENT_ATTN_Q_ABSORBED: "attn_q_absorbed",
+    NAN_COMPONENT_ATTN_FA3_OUT: "attn_fa3_out",
+    NAN_COMPONENT_ATTN_V_UP_PROJ: "attn_v_up_proj",
+    NAN_COMPONENT_ATTN_MHA_OUT: "attn_mha_out",
+    NAN_COMPONENT_ATTN_MQA_Q: "attn_mqa_q",
+    NAN_COMPONENT_KV_CACHE_IN_KPE: "kv_cache_in_kpe",
+    NAN_COMPONENT_KV_CACHE_IN_COMPILED: "kv_cache_in_compiled",
+    NAN_COMPONENT_KV_CACHE_IN_KPE_COMPILED: "kv_cache_in_kpe_compiled",
+    NAN_COMPONENT_KV_CACHE_POST_WRITE: "kv_cache_post_write",
+    NAN_COMPONENT_KV_CACHE_POST_WRITE_COMPILED: "kv_cache_post_write_compiled",
+    NAN_COMPONENT_KV_CACHE_PRE_FORWARD: "kv_cache_pre_forward",
+    NAN_COMPONENT_MLP_INPUT: "mlp_input",
+    NAN_COMPONENT_MLP_GATE_UP: "mlp_gate_up",
+    NAN_COMPONENT_MLP_ACT: "mlp_act",
+    NAN_COMPONENT_MLP_DOWN: "mlp_down",
+    NAN_COMPONENT_MOE_ROUTED_OUT: "moe_routed_out",
+    NAN_COMPONENT_MOE_SHARED_OUT: "moe_shared_out",
+    NAN_COMPONENT_MOE_AFTER_SCALE: "moe_after_scale",
+    NAN_COMPONENT_MOE_AFTER_SHARED_ADD: "moe_after_shared_add",
+    NAN_COMPONENT_MOE_EXPERT_INPUT: "moe_expert_input",
+    NAN_COMPONENT_MOE_EXPERT_INPUT_INF: "moe_expert_input_inf",
+    NAN_COMPONENT_MOE_EXPERT_GEMM1: "moe_expert_gemm1",
+    NAN_COMPONENT_MOE_EXPERT_GEMM1_INF: "moe_expert_gemm1_inf",
+    NAN_COMPONENT_MOE_EXPERT_GEMM2: "moe_expert_gemm2",
+    NAN_COMPONENT_MOE_EXPERT_GEMM2_INF: "moe_expert_gemm2_inf",
+    NAN_COMPONENT_MOE_FUSED_OUT: "moe_fused_out",
+    NAN_COMPONENT_MOE_FUSED_OUT_INF: "moe_fused_out_inf",
+    NAN_COMPONENT_MOE_TOPK_WEIGHTS: "moe_topk_weights",
+    NAN_COMPONENT_MOE_TOPK_WEIGHTS_INF: "moe_topk_weights_inf",
+    NAN_COMPONENT_MOE_FINALIZE: "moe_finalize",
+    NAN_COMPONENT_MOE_FINALIZE_INF: "moe_finalize_inf",
+    NAN_COMPONENT_MOE_PRE_COMBINE: "moe_input",
+    NAN_COMPONENT_MOE_PRE_COMBINE_INF: "moe_router_logits",
+    NAN_COMPONENT_MOE_POST_COMBINE: "moe_post_combine",
+    NAN_COMPONENT_MOE_POST_COMBINE_INF: "moe_post_combine_inf",
+}
+
+_NAN_ENABLED_COMPONENTS: frozenset[int] | None = None
+
+
+def nan_check_enabled(component_id: int) -> bool:
+    """Return True if the NaN barrier for this component should fire."""
+    global _NAN_ENABLED_COMPONENTS
+    if _NAN_ENABLED_COMPONENTS is None:
+        import vllm.envs as envs
+        raw = envs.VLLM_NAN_CHECK_COMPONENTS
+        if raw == "all":
+            _NAN_ENABLED_COMPONENTS = frozenset(range(52))
+        elif raw == "none":
+            _NAN_ENABLED_COMPONENTS = frozenset()
+        else:
+            _NAN_ENABLED_COMPONENTS = frozenset(
+                int(x.strip()) for x in raw.split(","))
+    return component_id in _NAN_ENABLED_COMPONENTS
+
+
+def nan_first_component(tensor: torch.Tensor, flag_all: torch.Tensor,
+                        flag_real: torch.Tensor, flag_padded: torch.Tensor,
+                        component_id: int,
+                        real_mask: torch.Tensor) -> None:
+    if not tensor.is_floating_point() or tensor.element_size() == 1:
+        return
+    flat = tensor.reshape(tensor.shape[0], -1)
+    token_sums = flat.sum(dim=-1)
+    mask_n = real_mask[:token_sums.shape[0]]
+
+    s_all = token_sums.sum()
+    _nan_latch_flag(flag_all, s_all != s_all, component_id)
+
+    real_sums = torch.where(mask_n, token_sums, 0.0)
+    s_real = real_sums.sum()
+    _nan_latch_flag(flag_real, s_real != s_real, component_id)
+
+    padded_sums = torch.where(mask_n, 0.0, token_sums)
+    s_padded = padded_sums.sum()
+    _nan_latch_flag(flag_padded, s_padded != s_padded, component_id)
+
+
+def _nan_latch_flag(flag: torch.Tensor, detected: torch.Tensor,
+                    component_id: int) -> None:
+    not_yet = (flag[0] == -1)
+    write = (detected & not_yet).to(torch.int32)
+    flag[0] = flag[0] * (1 - write) + component_id * write
+
+
+def nan_first_component_fake(tensor: torch.Tensor, flag_all: torch.Tensor,
+                             flag_real: torch.Tensor,
+                             flag_padded: torch.Tensor, component_id: int,
+                             real_mask: torch.Tensor) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="nan_first_component",
+    op_func=nan_first_component,
+    mutates_args=["flag_all", "flag_real", "flag_padded"],
+    fake_impl=nan_first_component_fake,
+)
+
+
+def nan_sticky_check(tensor: torch.Tensor, flag: torch.Tensor) -> None:
+    if not tensor.is_floating_point() or tensor.element_size() == 1:
+        return
+    s = tensor.sum()
+    has_nan = (s != s).to(torch.int32)
+    flag[0] = torch.maximum(flag[0], has_nan)
+
+
+def nan_sticky_check_fake(tensor: torch.Tensor, flag: torch.Tensor) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="nan_sticky_check",
+    op_func=nan_sticky_check,
+    mutates_args=["flag"],
+    fake_impl=nan_sticky_check_fake,
+)
+
+
+def expert_nan_inf_latch(tensor: torch.Tensor, flag: torch.Tensor,
+                         nan_component_id: int,
+                         inf_component_id: int) -> None:
+    if not tensor.is_floating_point() or tensor.element_size() == 1:
+        return
+    s = tensor.sum()
+    _nan_latch_flag(flag, s != s, nan_component_id)
+    _nan_latch_flag(flag, torch.isinf(s), inf_component_id)
+
+
+def expert_nan_inf_latch_fake(tensor: torch.Tensor, flag: torch.Tensor,
+                              nan_component_id: int,
+                              inf_component_id: int) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="expert_nan_inf_latch",
+    op_func=expert_nan_inf_latch,
+    mutates_args=["flag"],
+    fake_impl=expert_nan_inf_latch_fake,
+)
+
+
+def nan_kv_cache_post_write_check(
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    flag: torch.Tensor,
+    per_layer_flag: torch.Tensor | None,
+    layer_idx: int,
+) -> None:
+    if kv_cache.numel() == 0:
+        return
+    flat_slots = slot_mapping.flatten()
+    safe_slots = torch.clamp(flat_slots, min=0)
+    valid_mask = (flat_slots >= 0)
+
+    kv_flat = kv_cache.reshape(-1, kv_cache.shape[-1])
+    written = kv_flat[safe_slots]
+
+    if written.dtype == torch.uint8:
+        has_nan_per_slot = ((written & 0x7F) == 0x7F).any(dim=-1)
+        has_nan = (has_nan_per_slot & valid_mask).any().to(torch.int32)
+    else:
+        slot_sums = written.sum(dim=-1)
+        valid_sums = torch.where(valid_mask, slot_sums, 0.0)
+        s = valid_sums.sum()
+        has_nan = (s != s).to(torch.int32)
+    flag[0] = torch.maximum(flag[0], has_nan)
+
+    if per_layer_flag is not None and layer_idx >= 0:
+        per_layer_flag[layer_idx] = torch.maximum(
+            per_layer_flag[layer_idx], has_nan)
+
+
+def nan_kv_cache_post_write_check_fake(
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    flag: torch.Tensor,
+    per_layer_flag: torch.Tensor | None,
+    layer_idx: int,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="nan_kv_cache_post_write_check",
+    op_func=nan_kv_cache_post_write_check,
+    mutates_args=["flag", "per_layer_flag"],
+    fake_impl=nan_kv_cache_post_write_check_fake,
+)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -218,6 +218,7 @@ from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention.attention import (
     _init_kv_cache_quant,
     get_attention_context,
+    nan_check_enabled,
     set_default_quant_scales,
     should_load_quant_weights,
 )
@@ -519,6 +520,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             compile_native=True,
         )
 
+        # NaN origin tracking — assigned by model runner.
+        self._nan_flag: torch.Tensor | None = None
+        self._nan_flag_real: torch.Tensor | None = None
+        self._nan_flag_padded: torch.Tensor | None = None
+        self._nan_real_mask: torch.Tensor | None = None
+        self._nan_kv_write_ever: torch.Tensor | None = None
+        self._nan_kv_post_write_ever: torch.Tensor | None = None
+        self._nan_kv_post_write_per_layer: torch.Tensor | None = None
+        self._nan_layer_idx: int = -1
+
     @property
     def chunked_prefill_workspace_size(self) -> int:
         if self._chunked_prefill_workspace_size is None:
@@ -562,14 +573,37 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             assert isinstance(slot_mapping, dict), (
                 f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
             )
+            if self._nan_flag is not None and nan_check_enabled(15):
+                torch.ops.vllm.nan_first_component(
+                    kv_c_normed, self._nan_flag,
+                    self._nan_flag_real, self._nan_flag_padded,
+                    15, self._nan_real_mask)
+            if self._nan_flag is not None and nan_check_enabled(22):
+                torch.ops.vllm.nan_first_component(
+                    k_pe, self._nan_flag,
+                    self._nan_flag_real, self._nan_flag_padded,
+                    22, self._nan_real_mask)
+            if self._nan_kv_write_ever is not None:
+                torch.ops.vllm.nan_sticky_check(
+                    kv_c_normed, self._nan_kv_write_ever)
+                torch.ops.vllm.nan_sticky_check(
+                    k_pe, self._nan_kv_write_ever)
+            layer_slot_mapping = slot_mapping.get(self.layer_name)
             self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
                 kv_c_normed,
                 k_pe,
                 self_kv_cache,
-                slot_mapping.get(self.layer_name),
+                layer_slot_mapping,
                 self.kv_cache_dtype,
                 self._k_scale,
             )
+            if (self._nan_kv_post_write_ever is not None
+                    and layer_slot_mapping is not None):
+                torch.ops.vllm.nan_kv_cache_post_write_check(
+                    self_kv_cache, layer_slot_mapping,
+                    self._nan_kv_post_write_ever,
+                    self._nan_kv_post_write_per_layer,
+                    self._nan_layer_idx)
             output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
             self.forward_impl(
                 q,
@@ -582,6 +616,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             return output
         else:
             encoded = _encode_layer_name(self.layer_name)
+            if self._nan_flag is not None and nan_check_enabled(23):
+                torch.ops.vllm.nan_first_component(
+                    kv_c_normed, self._nan_flag,
+                    self._nan_flag_real, self._nan_flag_padded,
+                    23, self._nan_real_mask)
+            if self._nan_flag is not None and nan_check_enabled(24):
+                torch.ops.vllm.nan_first_component(
+                    k_pe, self._nan_flag,
+                    self._nan_flag_real, self._nan_flag_padded,
+                    24, self._nan_real_mask)
+            if self._nan_kv_write_ever is not None:
+                torch.ops.vllm.nan_sticky_check(
+                    kv_c_normed, self._nan_kv_write_ever)
+                torch.ops.vllm.nan_sticky_check(
+                    k_pe, self._nan_kv_write_ever)
             kv_cache_dummy_dep = torch.ops.vllm.unified_mla_kv_cache_update(
                 kv_c_normed,
                 k_pe,
@@ -589,6 +638,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self.kv_cache_dtype,
                 self._k_scale,
             )
+            if self._nan_kv_post_write_ever is not None:
+                torch.ops.vllm.nan_kv_cache_post_write_check_compiled(
+                    self.layer_name,
+                    self._nan_kv_post_write_ever,
+                    self._nan_kv_post_write_per_layer,
+                    self._nan_layer_idx,
+                    kv_cache_dummy_dep,
+                )
             output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
             torch.ops.vllm.unified_mla_attention_with_output(
                 q,
@@ -1034,6 +1091,48 @@ direct_register_custom_op(
     op_name="unified_mla_kv_cache_update",
     op_func=unified_mla_kv_cache_update,
     fake_impl=unified_mla_kv_cache_update_fake,
+)
+
+
+def nan_kv_cache_post_write_check_compiled(
+    layer_name: str,
+    flag: torch.Tensor,
+    per_layer_flag: torch.Tensor | None,
+    layer_idx: int,
+    dummy_dep: torch.Tensor,
+) -> None:
+    from vllm.model_executor.layers.attention.attention import (
+        nan_kv_cache_post_write_check,
+    )
+    forward_context = get_forward_context()
+    attn_layer = forward_context.no_compile_layers[layer_name]
+    kv_cache = attn_layer.kv_cache
+    if kv_cache.numel() == 0:
+        return
+    slot_mapping = forward_context.slot_mapping
+    assert isinstance(slot_mapping, dict)
+    layer_slot_mapping = slot_mapping.get(layer_name)
+    if layer_slot_mapping is not None:
+        nan_kv_cache_post_write_check(
+            kv_cache, layer_slot_mapping, flag,
+            per_layer_flag, layer_idx)
+
+
+def nan_kv_cache_post_write_check_compiled_fake(
+    layer_name: str,
+    flag: torch.Tensor,
+    per_layer_flag: torch.Tensor | None,
+    layer_idx: int,
+    dummy_dep: torch.Tensor,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="nan_kv_cache_post_write_check_compiled",
+    op_func=nan_kv_cache_post_write_check_compiled,
+    mutates_args=["flag", "per_layer_flag"],
+    fake_impl=nan_kv_cache_post_write_check_compiled_fake,
 )
 
 

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -915,6 +915,7 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
         slot_mapping: torch.Tensor,
         kv_cache_dtype: str,
         k_scale: torch.Tensor,
+        nan_flag: "torch.Tensor | None" = None,
     ) -> None:
         if kv_cache.numel() == 0:
             return
@@ -927,6 +928,7 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             slot_mapping.flatten(),
             kv_cache_dtype=kv_cache_dtype,
             scale=k_scale,
+            nan_flag=nan_flag,
         )
 
 
@@ -995,6 +997,7 @@ class SparseMLAAttentionImpl(AttentionImplBase[T], Generic[T]):
         slot_mapping: torch.Tensor,
         kv_cache_dtype: str,
         k_scale: torch.Tensor,
+        nan_flag: "torch.Tensor | None" = None,
     ) -> None:
         if kv_cache.numel() == 0:
             return
@@ -1007,6 +1010,7 @@ class SparseMLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             slot_mapping.flatten(),
             kv_cache_dtype=kv_cache_dtype,
             scale=k_scale,
+            nan_flag=nan_flag,
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1291,6 +1291,23 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         pooler_outputs = model_runner_output.pooler_output
         num_nans_in_logits = model_runner_output.num_nans_in_logits
+        nan_origin_component = model_runner_output.nan_origin_component
+        nan_origin_component_real = model_runner_output.nan_origin_component_real
+        nan_origin_component_padded = model_runner_output.nan_origin_component_padded
+        nan_in_hidden_states = model_runner_output.nan_in_hidden_states
+        nan_first_layer_hidden = model_runner_output.nan_first_layer_hidden
+        nan_first_layer_residual = model_runner_output.nan_first_layer_residual
+        nan_real_output = model_runner_output.nan_real_output
+        nan_padded_output = model_runner_output.nan_padded_output
+        nan_kv_write_ever = model_runner_output.nan_kv_write_ever
+        nan_kv_post_write_ever = model_runner_output.nan_kv_post_write_ever
+        nan_kv_post_write_first_layer = (
+            model_runner_output.nan_kv_post_write_first_layer)
+        kv_cache_nan_total_blocks = model_runner_output.kv_cache_nan_total_blocks
+        kv_cache_nan_affected_layers = (
+            model_runner_output.kv_cache_nan_affected_layers)
+        kv_cache_nan_per_layer = model_runner_output.kv_cache_nan_per_layer
+        kv_cache_nan_block_ids = model_runner_output.kv_cache_nan_block_ids
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
 
@@ -1588,9 +1605,59 @@ class Scheduler(SchedulerInterface):
                     )
             finished_req_ids.clear()
 
+        # Compute NaN source/phase info for metrics.
+        nan_in_logits = (num_nans_in_logits is not None
+                         and any(v > 0 for v in num_nans_in_logits.values()))
+        nan_in_final_norm = nan_in_hidden_states
+        nan_in_lm_head = nan_in_logits and not nan_in_hidden_states
+        has_any_nans = (nan_origin_component >= 0 or nan_in_logits
+                        or nan_in_hidden_states
+                        or nan_real_output or nan_padded_output)
+        nan_phase: str | None = None
+        if has_any_nans:
+            batch_has_prefill = False
+            batch_has_decode = False
+            for req_id, num_tokens in num_scheduled_tokens.items():
+                request = self.requests.get(req_id)
+                if request is None:
+                    continue
+                computed_before = request.num_computed_tokens - num_tokens
+                if computed_before < request.num_prompt_tokens:
+                    batch_has_prefill = True
+                else:
+                    batch_has_decode = True
+                if batch_has_prefill and batch_has_decode:
+                    break
+            if batch_has_prefill and batch_has_decode:
+                nan_phase = "mixed"
+            elif batch_has_prefill:
+                nan_phase = "prefill"
+            else:
+                nan_phase = "decode"
+
+        from vllm.model_executor.layers.attention.attention import (
+            NAN_COMPONENT_NAMES,
+        )
+        nan_origin_name = NAN_COMPONENT_NAMES.get(nan_origin_component)
+        nan_origin_name_real = NAN_COMPONENT_NAMES.get(
+            nan_origin_component_real)
+        nan_origin_name_padded = NAN_COMPONENT_NAMES.get(
+            nan_origin_component_padded)
+
         if (
             stats := self.make_stats(
-                spec_decoding_stats, kv_connector_stats, cudagraph_stats, perf_stats
+                spec_decoding_stats, kv_connector_stats, cudagraph_stats,
+                perf_stats,
+                nan_origin_component, nan_origin_name,
+                nan_origin_component_real, nan_origin_name_real,
+                nan_origin_component_padded, nan_origin_name_padded,
+                nan_in_logits, nan_in_final_norm, nan_in_lm_head,
+                nan_first_layer_hidden, nan_first_layer_residual,
+                nan_real_output, nan_padded_output, nan_phase,
+                nan_kv_write_ever, nan_kv_post_write_ever,
+                nan_kv_post_write_first_layer,
+                kv_cache_nan_total_blocks, kv_cache_nan_affected_layers,
+                kv_cache_nan_per_layer, kv_cache_nan_block_ids,
             )
         ) is not None:
             # Return stats to only one of the front-ends.
@@ -1962,6 +2029,27 @@ class Scheduler(SchedulerInterface):
         kv_connector_stats: KVConnectorStats | None = None,
         cudagraph_stats: CUDAGraphStat | None = None,
         perf_stats: PerfStats | None = None,
+        nan_origin_component: int = -1,
+        nan_origin_name: str | None = None,
+        nan_origin_component_real: int = -1,
+        nan_origin_name_real: str | None = None,
+        nan_origin_component_padded: int = -1,
+        nan_origin_name_padded: str | None = None,
+        nan_in_logits: bool = False,
+        nan_in_final_norm: bool = False,
+        nan_in_lm_head: bool = False,
+        nan_first_layer_hidden: int = -1,
+        nan_first_layer_residual: int = -1,
+        nan_real_output: bool = False,
+        nan_padded_output: bool = False,
+        nan_phase: str | None = None,
+        nan_kv_write_ever: bool = False,
+        nan_kv_post_write_ever: bool = False,
+        nan_kv_post_write_first_layer: int = -1,
+        kv_cache_nan_total_blocks: int = 0,
+        kv_cache_nan_affected_layers: int = 0,
+        kv_cache_nan_per_layer: list[int] | None = None,
+        kv_cache_nan_block_ids: list[list[int]] | None = None,
     ) -> SchedulerStats | None:
         if not self.log_stats:
             return None
@@ -1992,6 +2080,27 @@ class Scheduler(SchedulerInterface):
             kv_connector_stats=connector_stats_payload,
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
+            nan_origin_component=nan_origin_component,
+            nan_origin_name=nan_origin_name,
+            nan_origin_component_real=nan_origin_component_real,
+            nan_origin_name_real=nan_origin_name_real,
+            nan_origin_component_padded=nan_origin_component_padded,
+            nan_origin_name_padded=nan_origin_name_padded,
+            nan_in_logits=nan_in_logits,
+            nan_in_final_norm=nan_in_final_norm,
+            nan_in_lm_head=nan_in_lm_head,
+            nan_first_layer_hidden=nan_first_layer_hidden,
+            nan_first_layer_residual=nan_first_layer_residual,
+            nan_real_output=nan_real_output,
+            nan_padded_output=nan_padded_output,
+            nan_phase=nan_phase,
+            nan_kv_write_ever=nan_kv_write_ever,
+            nan_kv_post_write_ever=nan_kv_post_write_ever,
+            nan_kv_post_write_first_layer=nan_kv_post_write_first_layer,
+            kv_cache_nan_total_blocks=kv_cache_nan_total_blocks,
+            kv_cache_nan_affected_layers=kv_cache_nan_affected_layers,
+            kv_cache_nan_per_layer=kv_cache_nan_per_layer or [],
+            kv_cache_nan_block_ids=kv_cache_nan_block_ids or [],
         )
 
     def make_spec_decoding_stats(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -147,6 +147,42 @@ class LoggingStatLogger(StatLoggerBase):
         self.num_corrupted_reqs += iteration_stats.num_corrupted_reqs
         self.num_preemptions += iteration_stats.num_preempted_reqs
 
+    def _track_nan_stats(self, scheduler_stats: SchedulerStats):
+        if scheduler_stats.nan_phase:
+            origin_real = scheduler_stats.nan_origin_name_real or "none"
+            origin_all = scheduler_stats.nan_origin_name or "none"
+            extras = []
+            if scheduler_stats.nan_in_final_norm:
+                extras.append("final_norm")
+            if scheduler_stats.nan_in_lm_head:
+                extras.append("lm_head")
+            if scheduler_stats.nan_in_logits:
+                extras.append("logits")
+            if scheduler_stats.nan_real_output:
+                extras.append("REAL_OUTPUT")
+            if scheduler_stats.nan_padded_output:
+                extras.append("padded_output")
+
+            layer_info = ""
+            if scheduler_stats.nan_first_layer_hidden >= 0:
+                layer_info += (f" first_layer_hidden="
+                              f"{scheduler_stats.nan_first_layer_hidden}")
+            if scheduler_stats.nan_first_layer_residual >= 0:
+                layer_info += (f" first_layer_residual="
+                              f"{scheduler_stats.nan_first_layer_residual}")
+            extra_str = f" also_in={'+'.join(extras)}" if extras else ""
+            pad_info = ""
+            if origin_all != origin_real:
+                pad_info = f" origin_all_tokens={origin_all}"
+            logger.warning(
+                "NaN ORIGIN(real): %s during %s phase%s%s%s",
+                origin_real,
+                scheduler_stats.nan_phase,
+                layer_info,
+                extra_str,
+                pad_info,
+            )
+
     def _get_throughput(self, tracked_stats: int, now: float) -> float:
         # Compute summary metrics for tracked stats
         delta_time = now - self.last_log_time
@@ -190,6 +226,8 @@ class LoggingStatLogger(StatLoggerBase):
                 self.last_scheduler_stats = scheduler_stats
             if (perf_stats := scheduler_stats.perf_stats) and self._enable_perf_stats():
                 self.perf_metrics_logging.observe(perf_stats)
+            if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
+                self._track_nan_stats(scheduler_stats)
         if mm_cache_stats:
             self.mm_caching_metrics.observe(mm_cache_stats)
 
@@ -538,6 +576,206 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.counter_corrupted_requests = create_metric_per_engine(
                 counter_corrupted_requests, per_engine_labelvalues
             )
+
+            counter_nan_occurrences = self._counter_cls(
+                name="vllm:nan_occurrences_total",
+                documentation=(
+                    "Number of forward steps where NaN was first produced "
+                    "by a given component, labeled by source and batch phase."
+                ),
+                labelnames=labelnames + ["source", "phase"],
+            )
+            self.counter_nan_occurrences: dict[
+                tuple[str, str], dict[int, Counter]
+            ] = {}
+            from vllm.model_executor.layers.attention.attention import (
+                NAN_COMPONENT_NAMES,
+            )
+            all_sources = list(NAN_COMPONENT_NAMES.values()) + [
+                "logits", "final_norm", "lm_head",
+                "real_output", "padded_output",
+            ]
+            for source in all_sources:
+                for phase in ("prefill", "decode", "mixed"):
+                    self.counter_nan_occurrences[(source, phase)] = {
+                        idx: counter_nan_occurrences.labels(
+                            model_name, str(idx), dp_rank, local_rank,
+                            source, phase
+                        )
+                        for idx in engine_indexes
+                    }
+
+            gauge_nan_origin = self._gauge_cls(
+                name="vllm:nan_origin_component",
+                documentation=(
+                    "Component ID that first produced NaN this step "
+                    "(-1 = no NaN)."
+                ),
+                labelnames=labelnames,
+            )
+            self.gauge_nan_origin = create_metric_per_engine(
+                gauge_nan_origin, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_origin.values():
+                g.set(-1)
+
+            gauge_nan_origin_real = self._gauge_cls(
+                name="vllm:nan_origin_component_real",
+                documentation=(
+                    "Sticky component ID that first produced NaN in REAL "
+                    "tokens (-1 = no NaN ever in real tokens)."
+                ),
+                labelnames=labelnames,
+            )
+            self.gauge_nan_origin_real = create_metric_per_engine(
+                gauge_nan_origin_real, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_origin_real.values():
+                g.set(-1)
+
+            gauge_nan_origin_padded = self._gauge_cls(
+                name="vllm:nan_origin_component_padded",
+                documentation=(
+                    "Sticky component ID that first produced NaN in PADDED "
+                    "tokens (-1 = no NaN ever in padded tokens)."
+                ),
+                labelnames=labelnames,
+            )
+            self.gauge_nan_origin_padded = create_metric_per_engine(
+                gauge_nan_origin_padded, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_origin_padded.values():
+                g.set(-1)
+
+            gauge_nan_first_layer_hidden = self._gauge_cls(
+                name="vllm:nan_first_layer_hidden",
+                documentation=(
+                    "First decoder layer index where hidden_states "
+                    "contains NaN (-1 if none)."
+                ),
+                labelnames=labelnames,
+            )
+            self.gauge_nan_first_layer_hidden = create_metric_per_engine(
+                gauge_nan_first_layer_hidden, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_first_layer_hidden.values():
+                g.set(-1)
+
+            gauge_nan_first_layer_residual = self._gauge_cls(
+                name="vllm:nan_first_layer_residual",
+                documentation=(
+                    "First decoder layer index where residual "
+                    "contains NaN (-1 if none)."
+                ),
+                labelnames=labelnames,
+            )
+            self.gauge_nan_first_layer_residual = create_metric_per_engine(
+                gauge_nan_first_layer_residual, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_first_layer_residual.values():
+                g.set(-1)
+
+            gauge_nan_kv_write_ever = self._gauge_cls(
+                name="vllm:nan_kv_write_ever",
+                documentation=(
+                    "Sticky flag: 1 if NaN was ever detected in KV cache "
+                    "write inputs on this rank. Never resets to 0."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_nan_kv_write_ever = create_metric_per_engine(
+                gauge_nan_kv_write_ever, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_kv_write_ever.values():
+                g.set(0)
+
+            gauge_nan_kv_post_write_ever = self._gauge_cls(
+                name="vllm:nan_kv_post_write_ever",
+                documentation=(
+                    "Sticky flag: 1 if NaN detected in KV cache "
+                    "AFTER write (post-quantization). Never resets."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_nan_kv_post_write_ever = create_metric_per_engine(
+                gauge_nan_kv_post_write_ever, per_engine_labelvalues
+            )
+            for g in self.gauge_nan_kv_post_write_ever.values():
+                g.set(0)
+
+            gauge_nan_kv_post_write_first_layer = self._gauge_cls(
+                name="vllm:nan_kv_post_write_first_layer",
+                documentation=(
+                    "First decoder layer index where NaN was written "
+                    "to KV cache (post-quantization). -1 = none. Sticky."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_nan_kv_post_write_first_layer = (
+                create_metric_per_engine(
+                    gauge_nan_kv_post_write_first_layer,
+                    per_engine_labelvalues
+                )
+            )
+            for g in self.gauge_nan_kv_post_write_first_layer.values():
+                g.set(-1)
+
+        if envs.VLLM_KV_CACHE_NAN_AUDIT > 0:
+            gauge_kv_nan_total = self._gauge_cls(
+                name="vllm:kv_cache_nan_total_blocks",
+                documentation=(
+                    "Total KV cache blocks containing NaN across all layers."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_kv_nan_total = create_metric_per_engine(
+                gauge_kv_nan_total, per_engine_labelvalues
+            )
+            for g in self.gauge_kv_nan_total.values():
+                g.set(0)
+            gauge_kv_nan_layers = self._gauge_cls(
+                name="vllm:kv_cache_nan_affected_layers",
+                documentation=(
+                    "Number of KV cache layers containing at least one "
+                    "NaN block."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_kv_nan_layers = create_metric_per_engine(
+                gauge_kv_nan_layers, per_engine_labelvalues
+            )
+            for g in self.gauge_kv_nan_layers.values():
+                g.set(0)
+            self._gauge_kv_nan_per_layer = self._gauge_cls(
+                name="vllm:kv_cache_nan_blocks_per_layer",
+                documentation="NaN blocks in KV cache per layer.",
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames + ["layer"],
+            )
+            self._gauge_kv_nan_block_ids = self._gauge_cls(
+                name="vllm:kv_cache_nan_block_ids",
+                documentation=(
+                    "NaN block count per layer; blocks label lists "
+                    "affected block indices."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames + ["layer", "blocks"],
+            )
+            self._prev_nan_block_keys: dict[int, set[tuple[str, str]]] = {
+                eid: set() for eid in per_engine_labelvalues
+            }
+            num_layers = getattr(
+                vllm_config.model_config.hf_config,
+                "num_hidden_layers", 0)
+            for lv in per_engine_labelvalues.values():
+                for layer in range(num_layers):
+                    self._gauge_kv_nan_per_layer.labels(
+                        *lv, str(layer)).set(0)
 
         counter_prefix_cache_queries = self._counter_cls(
             name="vllm:prefix_cache_queries",
@@ -1135,6 +1373,76 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_max_lora: self.max_lora,
                 }
                 self.gauge_lora_info.labels(**lora_info_labels).set_to_current_time()
+
+            if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
+                self.gauge_nan_origin[engine_idx].set(
+                    scheduler_stats.nan_origin_component)
+                self.gauge_nan_origin_real[engine_idx].set(
+                    scheduler_stats.nan_origin_component_real)
+                self.gauge_nan_origin_padded[engine_idx].set(
+                    scheduler_stats.nan_origin_component_padded)
+                if scheduler_stats.nan_phase:
+                    phase = scheduler_stats.nan_phase
+                    if scheduler_stats.nan_origin_name_real:
+                        self.counter_nan_occurrences[
+                            (scheduler_stats.nan_origin_name_real, phase)
+                        ][engine_idx].inc()
+                    if scheduler_stats.nan_in_logits:
+                        self.counter_nan_occurrences[
+                            ("logits", phase)][engine_idx].inc()
+                    if scheduler_stats.nan_in_final_norm:
+                        self.counter_nan_occurrences[
+                            ("final_norm", phase)][engine_idx].inc()
+                    if scheduler_stats.nan_in_lm_head:
+                        self.counter_nan_occurrences[
+                            ("lm_head", phase)][engine_idx].inc()
+                    if scheduler_stats.nan_real_output:
+                        self.counter_nan_occurrences[
+                            ("real_output", phase)][engine_idx].inc()
+                    if scheduler_stats.nan_padded_output:
+                        self.counter_nan_occurrences[
+                            ("padded_output", phase)][engine_idx].inc()
+                self.gauge_nan_first_layer_hidden[engine_idx].set(
+                    scheduler_stats.nan_first_layer_hidden)
+                self.gauge_nan_first_layer_residual[engine_idx].set(
+                    scheduler_stats.nan_first_layer_residual)
+                if scheduler_stats.nan_kv_write_ever:
+                    self.gauge_nan_kv_write_ever[engine_idx].set(1)
+                if scheduler_stats.nan_kv_post_write_ever:
+                    self.gauge_nan_kv_post_write_ever[engine_idx].set(1)
+                if scheduler_stats.nan_kv_post_write_first_layer >= 0:
+                    self.gauge_nan_kv_post_write_first_layer[
+                        engine_idx].set(
+                        scheduler_stats.nan_kv_post_write_first_layer)
+
+            if envs.VLLM_KV_CACHE_NAN_AUDIT > 0:
+                self.gauge_kv_nan_total[engine_idx].set(
+                    scheduler_stats.kv_cache_nan_total_blocks)
+                self.gauge_kv_nan_layers[engine_idx].set(
+                    scheduler_stats.kv_cache_nan_affected_layers)
+                lv = self.per_engine_labelvalues[engine_idx]
+                for layer_idx, count in enumerate(
+                    scheduler_stats.kv_cache_nan_per_layer
+                ):
+                    self._gauge_kv_nan_per_layer.labels(
+                        *lv, str(layer_idx)
+                    ).set(count)
+                cur_keys: set[tuple[str, str]] = set()
+                for layer_idx, blk_ids in enumerate(
+                    scheduler_stats.kv_cache_nan_block_ids
+                ):
+                    if not blk_ids:
+                        continue
+                    layer_s = str(layer_idx)
+                    blocks_s = ",".join(str(b) for b in blk_ids)
+                    cur_keys.add((layer_s, blocks_s))
+                    self._gauge_kv_nan_block_ids.labels(
+                        *lv, layer_s, blocks_s).set(len(blk_ids))
+                prev = self._prev_nan_block_keys[engine_idx]
+                for key in prev - cur_keys:
+                    self._gauge_kv_nan_block_ids.labels(
+                        *lv, key[0], key[1]).set(0)
+                self._prev_nan_block_keys[engine_idx] = cur_keys
 
         if mm_cache_stats is not None:
             self.counter_mm_cache_queries[engine_idx].inc(mm_cache_stats.queries)

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -197,6 +197,29 @@ class SchedulerStats:
 
     perf_stats: PerfStats | None = None
 
+    nan_origin_component: int = -1
+    nan_origin_name: str | None = None
+    nan_origin_component_real: int = -1
+    nan_origin_name_real: str | None = None
+    nan_origin_component_padded: int = -1
+    nan_origin_name_padded: str | None = None
+    nan_in_logits: bool = False
+    nan_in_final_norm: bool = False
+    nan_in_lm_head: bool = False
+    nan_first_layer_hidden: int = -1
+    nan_first_layer_residual: int = -1
+    nan_real_output: bool = False
+    nan_padded_output: bool = False
+    nan_kv_write_ever: bool = False
+    nan_kv_post_write_ever: bool = False
+    nan_kv_post_write_first_layer: int = -1
+    nan_phase: str | None = None
+
+    kv_cache_nan_total_blocks: int = 0
+    kv_cache_nan_affected_layers: int = 0
+    kv_cache_nan_per_layer: list[int] = field(default_factory=list)
+    kv_cache_nan_block_ids: list[list[int]] = field(default_factory=list)
+
 
 @dataclass
 class RequestStateStats:

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -265,6 +265,23 @@ class ModelRunnerOutput:
     # req_id -> num_nans_in_logits
     num_nans_in_logits: dict[str, int] | None = None
 
+    nan_origin_component: int = -1
+    nan_origin_component_real: int = -1
+    nan_origin_component_padded: int = -1
+    nan_in_hidden_states: bool = False
+    nan_first_layer_hidden: int = -1
+    nan_first_layer_residual: int = -1
+    nan_real_output: bool = False
+    nan_padded_output: bool = False
+    nan_kv_write_ever: bool = False
+    nan_kv_post_write_ever: bool = False
+    nan_kv_post_write_first_layer: int = -1
+
+    kv_cache_nan_total_blocks: int = 0
+    kv_cache_nan_affected_layers: int = 0
+    kv_cache_nan_per_layer: list[int] = field(default_factory=list)
+    kv_cache_nan_block_ids: list[list[int]] = field(default_factory=list)
+
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -513,6 +513,27 @@ class GPUModelRunner(
         Will be lazily initialized when the model is loaded.
         """
 
+        # NaN origin tracking. Three sticky int32 flags (never reset).
+        self._nan_origin_flag: torch.Tensor | None = None
+        self._nan_origin_flag_real: torch.Tensor | None = None
+        self._nan_origin_flag_padded: torch.Tensor | None = None
+        self._nan_real_mask: torch.Tensor | None = None
+        self._nan_per_layer_hidden: torch.Tensor | None = None
+        self._nan_per_layer_residual: torch.Tensor | None = None
+
+        # KV cache NaN write tracking.
+        self._nan_kv_write_ever: torch.Tensor | None = None
+        self._nan_kv_post_write_ever: torch.Tensor | None = None
+        self._nan_kv_post_write_per_layer: torch.Tensor | None = None
+
+        # KV cache NaN audit state.
+        self._kv_audit_interval: int = envs.VLLM_KV_CACHE_NAN_AUDIT
+        self._kv_audit_step: int = 0
+        self._kv_audit_total_blocks: int = 0
+        self._kv_audit_affected_layers: int = 0
+        self._kv_audit_per_layer: list[int] = []
+        self._kv_audit_block_ids: list[list[int]] = []
+
         # Lazy initializations
         # self.model: nn.Module  # Set after load_model
         # Initialize in initialize_kv_cache
@@ -3523,8 +3544,27 @@ class GPUModelRunner(
         list[int],
     ]:
         num_nans_in_logits = {}
+        nan_origin_component = -1
+        nan_origin_component_real = -1
+        nan_origin_component_padded = -1
+        nan_first_layer_hidden = -1
+        nan_first_layer_residual = -1
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             num_nans_in_logits = self._get_nans_in_logits(logits)
+            if self._nan_origin_flag is not None:
+                nan_origin_component = int(self._nan_origin_flag.item())
+                nan_origin_component_real = int(
+                    self._nan_origin_flag_real.item())
+                nan_origin_component_padded = int(
+                    self._nan_origin_flag_padded.item())
+                h_flags = self._nan_per_layer_hidden
+                r_flags = self._nan_per_layer_residual
+                if h_flags is not None and h_flags.any():
+                    nan_first_layer_hidden = int(
+                        h_flags.nonzero(as_tuple=True)[0][0].item())
+                if r_flags is not None and r_flags.any():
+                    nan_first_layer_residual = int(
+                        r_flags.nonzero(as_tuple=True)[0][0].item())
 
         num_reqs = self.input_batch.num_reqs
         discard_sampled_tokens_req_indices = np.nonzero(
@@ -3645,6 +3685,11 @@ class GPUModelRunner(
             req_ids_output_copy,
             req_id_to_index_output_copy,
             invalid_req_indices,
+            nan_origin_component,
+            nan_origin_component_real,
+            nan_origin_component_padded,
+            nan_first_layer_hidden,
+            nan_first_layer_residual,
         )
 
     @contextmanager
@@ -4202,6 +4247,54 @@ class GPUModelRunner(
             self.model_config.is_encoder_decoder and num_encoder_reqs > 0
         )
 
+        # KV cache NaN audit — runs outside CUDA graph boundary.
+        if self._kv_audit_interval > 0 and self.kv_caches:
+            self._kv_audit_step += 1
+            if self._kv_audit_step >= self._kv_audit_interval:
+                self._kv_audit_step = 0
+                (self._kv_audit_total_blocks,
+                 self._kv_audit_affected_layers,
+                 self._kv_audit_per_layer,
+                 self._kv_audit_block_ids) = (
+                    self._audit_kv_cache_nans())
+
+        # Update real-token mask for NaN tracking.
+        if self._nan_origin_flag is not None:
+            num_real = scheduler_output.total_num_scheduled_tokens
+            self._nan_real_mask.fill_(False)
+            self._nan_real_mask[:num_real] = True
+
+            from vllm.model_executor.layers.attention.attention import (
+                NAN_COMPONENT_KV_CACHE_PRE_FORWARD,
+                nan_check_enabled,
+            )
+            if nan_check_enabled(NAN_COMPONENT_KV_CACHE_PRE_FORWARD):
+                all_latched = (self._nan_origin_flag.item() != -1)
+                real_latched = (self._nan_origin_flag_real.item() != -1)
+                padded_latched = (self._nan_origin_flag_padded.item() != -1)
+                if not (all_latched and real_latched and padded_latched):
+                    kv_has_nan = False
+                    for kv in self.kv_caches:
+                        if kv.numel() == 0:
+                            continue
+                        if kv.element_size() == 1:
+                            raw = kv.view(torch.uint8)
+                            if ((raw & 0x7F) == 0x7F).any().item():
+                                kv_has_nan = True
+                                break
+                        else:
+                            if torch.isnan(kv).any().item():
+                                kv_has_nan = True
+                                break
+                    if kv_has_nan:
+                        cid = NAN_COMPONENT_KV_CACHE_PRE_FORWARD
+                        if not all_latched:
+                            self._nan_origin_flag.fill_(cid)
+                        if not real_latched:
+                            self._nan_origin_flag_real.fill_(cid)
+                        if not padded_latched:
+                            self._nan_origin_flag_padded.fill_(cid)
+
         # Run the model.
         # Use persistent buffers for CUDA graphs.
         # When spec decode is enabled, defer connector finalization
@@ -4483,6 +4576,11 @@ class GPUModelRunner(
                 req_ids_output_copy,
                 req_id_to_index_output_copy,
                 invalid_req_indices,
+                nan_origin_component,
+                nan_origin_component_real,
+                nan_origin_component_padded,
+                nan_first_layer_hidden,
+                nan_first_layer_residual,
             ) = self._bookkeeping_sync(
                 scheduler_output,
                 sampler_output,
@@ -4509,6 +4607,23 @@ class GPUModelRunner(
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
 
+        # Collect KV cache NaN state (outside CUDA graph).
+        nan_kv_write_ever = False
+        nan_kv_post_write_ever = False
+        nan_kv_post_write_first_layer = -1
+        nan_in_hidden_states = False
+        nan_real_output = False
+        nan_padded_output = False
+        if self._nan_kv_write_ever is not None:
+            nan_kv_write_ever = bool(self._nan_kv_write_ever.item())
+        if self._nan_kv_post_write_ever is not None:
+            nan_kv_post_write_ever = bool(self._nan_kv_post_write_ever.item())
+        if (self._nan_kv_post_write_per_layer is not None
+                and self._nan_kv_post_write_per_layer.any()):
+            nan_kv_post_write_first_layer = int(
+                self._nan_kv_post_write_per_layer.nonzero(
+                    as_tuple=True)[0][0].item())
+
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
             output = ModelRunnerOutput(
                 req_ids=req_ids_output_copy,
@@ -4521,6 +4636,21 @@ class GPUModelRunner(
                 if self.supports_mm_inputs
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
+                nan_origin_component=nan_origin_component,
+                nan_origin_component_real=nan_origin_component_real,
+                nan_origin_component_padded=nan_origin_component_padded,
+                nan_in_hidden_states=nan_in_hidden_states,
+                nan_first_layer_hidden=nan_first_layer_hidden,
+                nan_first_layer_residual=nan_first_layer_residual,
+                nan_real_output=nan_real_output,
+                nan_padded_output=nan_padded_output,
+                nan_kv_write_ever=nan_kv_write_ever,
+                nan_kv_post_write_ever=nan_kv_post_write_ever,
+                nan_kv_post_write_first_layer=nan_kv_post_write_first_layer,
+                kv_cache_nan_total_blocks=self._kv_audit_total_blocks,
+                kv_cache_nan_affected_layers=self._kv_audit_affected_layers,
+                kv_cache_nan_per_layer=self._kv_audit_per_layer,
+                kv_cache_nan_block_ids=self._kv_audit_block_ids,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts=None,
             )
@@ -5147,6 +5277,9 @@ class GPUModelRunner(
             self.get_model(), "requires_sequential_video_encoding"
         )  # Temporary hack for dynamic res video w/o support for bs>1 yet
 
+        if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
+            self._setup_nan_detection_flags()
+
         if (
             self._moe_model is not None
             and self.parallel_config.enable_eplb
@@ -5456,6 +5589,113 @@ class GPUModelRunner(
             return num_nans_in_logits
         except IndexError:
             return {}
+
+    def _setup_nan_detection_flags(self) -> None:
+        """Pre-allocate shared NaN origin flags and assign to modules."""
+        from vllm.model_executor.layers.attention.mla_attention import (
+            MLAAttention,
+        )
+        from vllm.model_executor.models.deepseek_v2 import (
+            DeepseekV2DecoderLayer,
+        )
+
+        self._nan_origin_flag = torch.full(
+            (1,), -1, dtype=torch.int32, device=self.device)
+        self._nan_origin_flag_real = torch.full(
+            (1,), -1, dtype=torch.int32, device=self.device)
+        self._nan_origin_flag_padded = torch.full(
+            (1,), -1, dtype=torch.int32, device=self.device)
+        self._nan_real_mask = torch.zeros(
+            self.max_num_tokens, dtype=torch.bool, device=self.device)
+        self._nan_kv_write_ever = torch.zeros(
+            1, dtype=torch.int32, device=self.device)
+        self._nan_kv_post_write_ever = torch.zeros(
+            1, dtype=torch.int32, device=self.device)
+
+        num_layers = sum(
+            1 for m in self.model.modules()
+            if isinstance(m, DeepseekV2DecoderLayer)
+        )
+        self._nan_per_layer_hidden = torch.zeros(
+            num_layers, dtype=torch.bool, device=self.device)
+        self._nan_per_layer_residual = torch.zeros(
+            num_layers, dtype=torch.bool, device=self.device)
+        self._nan_kv_post_write_per_layer = torch.zeros(
+            num_layers, dtype=torch.int32, device=self.device)
+
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            VocabParallelEmbedding,
+        )
+        for name, module in self.model.named_modules():
+            if isinstance(module, VocabParallelEmbedding):
+                w = module.weight.data
+                nan_mask = torch.isnan(w)
+                if nan_mask.any():
+                    nan_rows = nan_mask.any(dim=-1).nonzero(
+                        as_tuple=True)[0]
+                    nan_count = int(nan_mask.sum().item())
+                    logger.error(
+                        "EMBEDDING WEIGHT NaN: %s has %d NaN values "
+                        "in %d/%d rows (first 10 rows: %s)",
+                        name, nan_count, len(nan_rows), w.shape[0],
+                        nan_rows[:10].tolist())
+                else:
+                    logger.info(
+                        "Embedding weight check OK: %s [%s] all finite",
+                        name, list(w.shape))
+
+        for module in self.model.modules():
+            if isinstance(module, Attention):
+                module._nan_flag = self._nan_origin_flag
+                module._nan_flag_real = self._nan_origin_flag_real
+                module._nan_flag_padded = self._nan_origin_flag_padded
+                module._nan_real_mask = self._nan_real_mask
+            elif isinstance(module, MLAAttention):
+                module._nan_flag = self._nan_origin_flag
+                module._nan_flag_real = self._nan_origin_flag_real
+                module._nan_flag_padded = self._nan_origin_flag_padded
+                module._nan_real_mask = self._nan_real_mask
+                if envs.VLLM_NAN_KV_WRITE_CHECK:
+                    module._nan_kv_write_ever = self._nan_kv_write_ever
+                if envs.VLLM_NAN_KV_POST_WRITE_CHECK:
+                    module._nan_kv_post_write_ever = (
+                        self._nan_kv_post_write_ever)
+                    module._nan_kv_post_write_per_layer = (
+                        self._nan_kv_post_write_per_layer)
+                parts = module.layer_name.split('.')
+                for i, p in enumerate(parts):
+                    if p == 'layers' and i + 1 < len(parts):
+                        module._nan_layer_idx = int(parts[i + 1])
+                        break
+
+    @staticmethod
+    def _has_nan_per_block(kv: torch.Tensor) -> torch.Tensor:
+        """Return bool tensor of shape (shape[0],) indicating NaN blocks."""
+        if kv.element_size() == 1:
+            raw = kv.reshape(kv.shape[0], -1).view(torch.uint8)
+            return ((raw & 0x7F) == 0x7F).any(dim=1)
+        return torch.isnan(kv.reshape(kv.shape[0], -1)).any(dim=1)
+
+    def _audit_kv_cache_nans(
+        self,
+    ) -> tuple[int, int, list[int], list[list[int]]]:
+        """Scan KV cache tensors for NaN blocks, per layer."""
+        per_layer: list[int] = []
+        block_ids: list[list[int]] = []
+        total = 0
+        affected = 0
+        for layer_idx, kv in enumerate(self.kv_caches):
+            nan_mask = self._has_nan_per_block(kv)
+            count = int(nan_mask.sum().item())
+            per_layer.append(count)
+            total += count
+            if count > 0:
+                affected += 1
+                block_ids.append(
+                    nan_mask.nonzero(as_tuple=False).flatten().tolist())
+            else:
+                block_ids.append([])
+        return total, affected, per_layer, block_ids
 
     @contextmanager
     def maybe_randomize_inputs(


### PR DESCRIPTION
Adds an optional nan_flag tensor to concat_and_cache_mla kernels that detects FP8 NaN in written values and NaN/Inf in source bf16 values using atomicOr bit flags and atomicMin token index tracking.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

