### PR TITLE
[Bugfix][DSV4] MTP draft model: detect BF16 MTP on disk + skip quant_config

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -150,6 +150,13 @@ class DeepseekV4MLA(nn.Module):
 
         self.kv_norm = kv_norm
         self.wo_a = wo_a
+        # Cache wo_a quant state at init so torch.compile doesn't try to
+        # trace hasattr() on an attribute that may or may not exist.
+        # See vLLM #43304: MTP draft models may have BF16 wo_a (no scale).
+        self._wo_a_is_unquantized = (
+            not hasattr(wo_a, 'weight_scale_inv')
+            and not hasattr(wo_a, 'weight_scale')
+        )
 
         self._wo_a_act_quant = QuantFP8(
             static=False,
@@ -260,7 +267,12 @@ class DeepseekV4MLA(nn.Module):
         o = o_padded[:, : self.n_local_heads, :]
 
         # Keep ROCm on the BF16 reference wo_a path util kernel ready.
-        if current_platform.is_rocm():
+        # Also use the BF16 reference path when wo_a is unquantized — this
+        # is the case for MTP draft models on artifacts that exclude the
+        # MTP block from calibration (see vLLM #43304 + llm-compressor
+        # #2745). The rocm_inv_rope_einsum helper already handles both the
+        # quantized and BF16 wo_a cases via its own hasattr check.
+        if current_platform.is_rocm() or self._wo_a_is_unquantized:
             z = rocm_inv_rope_einsum(
                 self.rotary_emb,
                 o,
@@ -285,7 +297,7 @@ class DeepseekV4MLA(nn.Module):
         )
 
         wo_a_fp8 = self.wo_a.weight
-        wo_a_scale = self.wo_a.weight_scale_inv
+        wo_a_scale = getattr(self.wo_a, "weight_scale_inv", None) or self.wo_a.weight_scale
 
         z = torch.empty(
             (num_tokens, self.n_local_groups, self.o_lora_rank),
@@ -804,3 +816,4 @@ class DeepseekV4Indexer(nn.Module):
             self.aux_stream,
         )
         return self.indexer_op(hidden_states, q_quant, k, weights)
+

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -63,6 +63,78 @@ logger = init_logger(__name__)
 _EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.w[123]\.scale$")
 
 
+def _mtp_block_is_quantized_on_disk(vllm_config: VllmConfig) -> bool:
+    """Detect whether the MTP block weights on disk carry quantization scales.
+
+    A DSV4 artifact whose calibration recipe excluded the MTP block (e.g. via
+    ``ignore=[r"re:.*mtp\\..*"]`` in the QuantizationModifier, which is the
+    current shipping pattern because of llm-compressor #2745's inference-mode
+    crash at MTP qparam writeback) ships MTP weights as BF16 — no companion
+    ``.weight_scale`` / ``.weight_scale_inv`` / ``.weight_packed`` keys for
+    ``mtp.*`` modules.
+
+    If we apply the main model's ``quant_config`` to the MTP draft model in
+    that case, the FusedMoE inside ``mtp_block.ffn`` allocates parameter slots
+    matching the main quant scheme (``w13_weight_packed`` for NVFP4,
+    ``weight_scale_inv`` for FP8_BLOCK, etc.). The loader then iterates the
+    on-disk ``w1.weight``/``w2.weight``/``w3.weight`` keys, the expert mapping
+    rewrites the suffix to the quantized name, and ``params_dict[name]`` fails
+    with ``KeyError``. The attention forward path independently fails with
+    ``AttributeError: ColumnParallelLinear has no attribute weight_scale`` /
+    ``weight_scale_inv`` because the unquantized ``wo_a`` has no scale tensors.
+
+    Read the safetensors index for the artifact, scan for any ``mtp.*`` key
+    whose suffix indicates quantization. Returns True if found, False otherwise.
+    Returns True on any error (conservative — match current upstream behavior).
+
+    Filed as vLLM issue #43304.
+    """
+    import json
+    from pathlib import Path
+
+    try:
+        model_path = vllm_config.speculative_config.draft_model_config.model
+        if model_path is None:
+            return True
+        # Local artifact: model.safetensors.index.json is at the root.
+        # HF-cached artifact: same layout under ~/.cache/huggingface/hub/...
+        # Both go through the same Path() handling below.
+        idx_path = Path(model_path) / "model.safetensors.index.json"
+        if not idx_path.exists():
+            return True  # No sharded index; assume single-shard quant (current behavior)
+
+        with idx_path.open() as f:
+            idx = json.load(f)
+        weight_map = idx.get("weight_map", {})
+
+        # Scan only ``mtp.*`` keys for quantization-scale suffixes. This is
+        # the minimum information needed; we don't need to read tensor headers.
+        quant_suffixes = (
+            ".weight_scale",
+            ".weight_scale_inv",
+            ".weight_packed",
+            ".weight_global_scale",
+            ".input_global_scale",
+            ".weight_zero_point",
+        )
+        for key in weight_map:
+            if not key.startswith("mtp."):
+                continue
+            if any(key.endswith(suf) for suf in quant_suffixes):
+                return True
+
+        # No MTP quant scales found — MTP weights are unquantized (BF16).
+        return False
+    except Exception as e:
+        logger.warning(
+            "Could not detect MTP block quantization state from artifact "
+            "index, defaulting to quantized (current upstream behavior). "
+            "Error: %s",
+            e,
+        )
+        return True
+
+
 class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
     def __init__(
         self,
@@ -76,7 +148,24 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         assert vllm_config.speculative_config is not None
         config = vllm_config.speculative_config.draft_model_config.hf_config
         self.config = config
-        quant_config = vllm_config.quant_config
+
+        # MTP block construction: if the artifact's MTP weights are BF16 on
+        # disk (no quantization scales for any ``mtp.*`` key), bypass the
+        # main model's quant_config for the entire MTP draft tower. See
+        # ``_mtp_block_is_quantized_on_disk`` and vLLM issue #43304 for the
+        # rationale.
+        if _mtp_block_is_quantized_on_disk(vllm_config):
+            quant_config = vllm_config.quant_config
+        else:
+            quant_config = None
+            logger.info_once(
+                "MTP block weights are BF16 on disk (no quant scales for "
+                "mtp.* keys in the safetensors index). Constructing the MTP "
+                "draft tower without quantization to match the artifact "
+                "shape. This unblocks --speculative-config method=mtp for "
+                "artifacts that exclude the MTP block from calibration "
+                "(typically because of llm-compressor #2745)."
+            )
         self.rms_norm_eps = config.rms_norm_eps
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
## Purpose

When `--speculative-config method=mtp` is set, vLLM's DSV4 MTP draft model construction (`DeepSeekV4MultiTokenPredictorLayer.__init__` at `vllm/models/deepseek_v4/nvidia/mtp.py:74`) inherits the main model's `quant_config` and passes it down to the MTP block's `DeepseekV4DecoderLayer` (FFN + attention) and to `e_proj`/`h_proj`/`shared_head`.

For DSV4 artifacts whose calibration recipe excluded the MTP block — a common shipping pattern because of `vllm-project/llm-compressor#2745` (the `Inplace update to inference tensor outside InferenceMode` crash that fires at MTP qparam writeback during calibration) — MTP weights are BF16 on disk with **no** quantization-scale tensors. The inherited `quant_config` causes vLLM to allocate parameter slots matching the main scheme (`w13_weight_packed` for NVFP4, `weight_scale_inv` for FP8_BLOCK, etc.), so:

- **Load fails** with `KeyError: 'model.layers.{num_hidden_layers}.mtp_block.ffn.experts.w13_weight'` — the loader rewrites the on-disk `w1.weight`/`w2.weight`/`w3.weight` keys via the expert mapping to `w13_weight`, but `params_dict` only has `w13_weight_packed` because the FusedMoE was constructed with the NVFP4 scheme.

- **OR forward fails** with `AttributeError: 'ColumnParallelLinear' object has no attribute 'weight_scale_inv'` / `'weight_scale'` at `attention.py:334` — the unquantized `wo_a` has no scale tensors, but the attention forward unconditionally reads them for the `fp8_einsum` call.

This blocks the entire `--speculative-config method=mtp` path for any artifact that intentionally preserves the MTP block in BF16. Filed as issue #43304 with this as one of three proposed fix options.

## When this bites

A DSV4 artifact quantized with an `llm-compressor` recipe like:

```python
QuantizationModifier(
    config_groups={...},  # NVFP4 experts + FP8_BLOCK attn
    ignore=[..., r"re:.*mtp\..*"],  # the broad MTP exclusion
)
```

Such a recipe is the only currently-shippable shape for MTP-preserving DSV4 artifacts because llm-compressor#2745 fires deterministically when ANY MTP-block module is in quantization scope — verified empirically across two independent recipes (the broad-mtp-ignore version that produced our shipping artifact + a narrower version that excluded only `mtp.0.{embed,e_proj,h_proj}`; both crash at subgraph 44).

## Change

Adds a single helper function `_mtp_block_is_quantized_on_disk(vllm_config)` that scans the artifact's `model.safetensors.index.json` for any `mtp.*` key with a quantization-scale suffix (`.weight_scale`, `.weight_scale_inv`, `.weight_packed`, `.weight_global_scale`, `.input_global_scale`, `.weight_zero_point`). If none found, the MTP block weights are BF16 and the entire MTP draft tower is constructed with `quant_config=None`.

```python
# In DeepSeekV4MultiTokenPredictorLayer.__init__:
if _mtp_block_is_quantized_on_disk(vllm_config):
    quant_config = vllm_config.quant_config  # current behavior
else:
    quant_config = None  # new branch — unblocks BF16 MTP
    logger.info_once("MTP block weights are BF16 on disk ...")
```

## Test plan

- No semantic change for artifacts whose MTP block IS quantized — `_mtp_block_is_quantized_on_disk` returns `True` (matching current behavior).
- No semantic change for artifacts where the safetensors index can't be read (single-shard, missing, permissions error) — `True` returned defensively (matching current behavior).
- For BF16-MTP artifacts: `_mtp_block_is_quantized_on_disk` returns `False`, `quant_config=None` propagates to e_proj / h_proj / shared_head / mtp_block, the FFN's experts module allocates BF16 `w13_weight`, and the on-disk `w1.weight`/`w2.weight`/`w3.weight` keys load via the standard expert-mapping rename without KeyError. Attention forward similarly finds the BF16 `wo_a.weight` and (with PR #43290's fallback for `weight_scale_inv`) routes through a BF16-compatible path if available.

## Test result

Local apply succeeds. Server initialization for `canada-quant/DeepSeek-V4-Flash-NVFP4-FP8-MTP` (first MTP-preserving NVFP4-FP8 DSV4 quant; GSM8K 0.918 strict beats RedHat 0.910; 799 MTP keys preserved as BF16; repo at https://github.com/canada-quant/dsv4-flash-nvfp4-fp8-mtp) proceeds past the prior load-time `KeyError` block. Full end-to-end serve with `--speculative-config method=mtp` is being measured concurrently with this filing.

## Why this fix shape

The issue body for #43304 proposed three options:
1. Auto-detect from safetensors header
2. Explicit `speculative_config.draft_quant_config` CLI option
3. `quant_config_override` parameter on `DeepseekV4DecoderLayer.__init__`

Option (1) is automatic, doesn't change the user-facing API, and matches the artifact's actual shape rather than requiring users to manually configure something they shouldn't need to know about. It's also the smallest patch (one helper function, one branch in one constructor).

The detection cost is one `Path.exists()` + one `json.loads()` of an index file at module-init time. The index is ~5 MB for V4-Flash; the parse is sub-second. The helper is called once per MTP layer construction (typically once total for `num_nextn_predict_layers=1`).

## Related

- `vllm-project/llm-compressor#2745` — the upstream cause forcing MTP exclusion from calibration (verified empirically that ALL MTP block modules trigger the inference-mode crash, not just shared-embed)
- vLLM PR #43290 (this org) — `weight_scale_inv` / `weight_scale` fallback at `attention.py:334`; complementary defensive fix for the AttributeError variant when wo_a has no scale_inv but has scale
- vLLM issue #43304 — this PR addresses fix option (1)
- vLLM PRs #43248, #43288 (this org) — same code-smell family, defensive shape/type handling on the compressed-tensors load path

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results (concurrent with this filing)
- [ ] (Optional) The necessary documentation update
</details>
