### PR TITLE
Add prefill and decode step metrics

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -128,6 +128,42 @@ def test_schedule_multimodal_requests():
         assert len(encoder_input) == 1
 
 
+def test_scheduler_stats_prefill_and_decode_step_counters():
+    scheduler = create_scheduler(max_num_batched_tokens=1024, max_num_seqs=2)
+    requests = create_requests(num_requests=2, num_tokens=8)
+
+    scheduler.add_request(requests[0])
+    scheduler_output0 = scheduler.schedule()
+    stats = scheduler.make_stats()
+    assert stats is not None
+    assert stats.num_prefill_steps == 1
+    assert stats.num_decode_steps == 0
+
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[requests[0].request_id],
+        req_id_to_index={requests[0].request_id: 0},
+        sampled_token_ids=[[0]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(scheduler_output0, model_runner_output)
+
+    scheduler_output1 = scheduler.schedule()
+    stats = scheduler.make_stats()
+    assert stats is not None
+    assert stats.num_prefill_steps == 1
+    assert stats.num_decode_steps == 1
+    scheduler.update_from_output(scheduler_output1, model_runner_output)
+
+    scheduler.add_request(requests[1])
+    scheduler.schedule()
+    stats = scheduler.make_stats()
+    assert stats is not None
+    assert stats.num_prefill_steps == 2
+    assert stats.num_decode_steps == 2
+
+
 def test_async_scheduling_pp_allows_rescheduling_with_output_placeholders():
     """Async scheduling + PP: allow multi-step in-flight scheduling per request"""
     scheduler = create_scheduler(async_scheduling=True, pipeline_parallel_size=2)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -56,7 +56,7 @@ from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
-from vllm.v1.utils import record_function_or_nullcontext
+from vllm.v1.utils import compute_iteration_details, record_function_or_nullcontext
 
 logger = init_logger(__name__)
 
@@ -106,6 +106,8 @@ class Scheduler(SchedulerInterface):
             if self.scheduler_config.max_num_scheduled_tokens
             else self.scheduler_config.max_num_batched_tokens
         )
+        self.num_prefill_steps = 0
+        self.num_decode_steps = 0
         self.max_model_len = vllm_config.model_config.max_model_len
         self.enable_kv_cache_events = (
             self.kv_events_config is not None
@@ -901,6 +903,13 @@ class Scheduler(SchedulerInterface):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
         )
+
+        if self.log_stats and scheduler_output.total_num_scheduled_tokens > 0:
+            iteration_details = compute_iteration_details(scheduler_output)
+            if iteration_details.num_ctx_requests > 0:
+                self.num_prefill_steps += 1
+            if iteration_details.num_generation_requests > 0:
+                self.num_decode_steps += 1
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store
@@ -1986,6 +1995,8 @@ class Scheduler(SchedulerInterface):
             kv_cache_eviction_events=eviction_events,
             spec_decoding_stats=spec_stats,
             kv_connector_stats=connector_stats_payload,
+            num_prefill_steps=self.num_prefill_steps,
+            num_decode_steps=self.num_decode_steps,
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
         )

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -668,6 +668,27 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             counter_generation_tokens, per_engine_labelvalues
         )
 
+        counter_prefill_steps = self._counter_cls(
+            name="vllm:prefill_steps",
+            documentation="Number of scheduler steps containing prefill work.",
+            labelnames=labelnames,
+        )
+        self.counter_prefill_steps = create_metric_per_engine(
+            counter_prefill_steps, per_engine_labelvalues
+        )
+
+        counter_decode_steps = self._counter_cls(
+            name="vllm:decode_steps",
+            documentation="Number of scheduler steps containing decode work.",
+            labelnames=labelnames,
+        )
+        self.counter_decode_steps = create_metric_per_engine(
+            counter_decode_steps, per_engine_labelvalues
+        )
+
+        self.last_num_prefill_steps = {idx: 0 for idx in engine_indexes}
+        self.last_num_decode_steps = {idx: 0 for idx in engine_indexes}
+
         self.counter_request_success: dict[FinishReason, dict[int, Counter]] = {}
         counter_request_success_base = self._counter_cls(
             name="vllm:request_success",
@@ -1079,6 +1100,34 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+
+            num_prefill_steps_delta = (
+                scheduler_stats.num_prefill_steps
+                - self.last_num_prefill_steps[engine_idx]
+            )
+            if num_prefill_steps_delta < 0:
+                self.last_num_prefill_steps[engine_idx] = (
+                    scheduler_stats.num_prefill_steps
+                )
+            elif num_prefill_steps_delta > 0:
+                self.counter_prefill_steps[engine_idx].inc(num_prefill_steps_delta)
+                self.last_num_prefill_steps[engine_idx] = (
+                    scheduler_stats.num_prefill_steps
+                )
+
+            num_decode_steps_delta = (
+                scheduler_stats.num_decode_steps
+                - self.last_num_decode_steps[engine_idx]
+            )
+            if num_decode_steps_delta < 0:
+                self.last_num_decode_steps[engine_idx] = (
+                    scheduler_stats.num_decode_steps
+                )
+            elif num_decode_steps_delta > 0:
+                self.counter_decode_steps[engine_idx].inc(num_decode_steps_delta)
+                self.last_num_decode_steps[engine_idx] = (
+                    scheduler_stats.num_decode_steps
+                )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -190,6 +190,9 @@ class SchedulerStats:
     spec_decoding_stats: SpecDecodingStats | None = None
     kv_connector_stats: dict[str, Any] | None = None
 
+    num_prefill_steps: int = 0
+    num_decode_steps: int = 0
+
     waiting_lora_adapters: dict[str, int] = field(default_factory=dict)
     running_lora_adapters: dict[str, int] = field(default_factory=dict)
 


### PR DESCRIPTION
## Summary

Add two V1 scheduler step counters to Prometheus metrics:

- `vllm:prefill_steps`: number of scheduler steps containing prefill/context work
- `vllm:decode_steps`: number of scheduler steps containing decode/generation work

Mixed prefill+decode steps increment both counters. The scheduler stores cumulative counts in `SchedulerStats`, and the Prometheus logger exports counter deltas per engine.