### PR TITLE
Correcting the mock classes for MM GC tests

### DIFF
--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 import torch
 
+from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
 from vllm.platforms import current_platform
 from vllm.v1.worker.encoder_cudagraph import (
     EncoderCudaGraphManager,
@@ -75,7 +76,7 @@ class _MockVllmConfig:
         self.parallel_config = _MockParallelConfig()
 
 
-class _MockModel:
+class _MockModel(SupportsEncoderCudaGraph):
     """Minimal mock implementing SupportsEncoderCudaGraph for __init__."""
 
     def __init__(self, min_budget: int = 4, max_budget: int = 128):
@@ -250,15 +251,13 @@ def _count_output_tokens(
     return sum(t * (h // m) * (w // m) for t, h, w in grid_thw_list)
 
 
-class SimpleMockViTModel(torch.nn.Module):
+class SimpleMockViTModel(torch.nn.Module, SupportsEncoderCudaGraph):
     """Minimal ViT model for CUDA graph tests.
 
     Implements the SupportsEncoderCudaGraph protocol by providing
     all required methods. The forward pass projects patches and
     simulates spatial merge by averaging groups of m^2 patches.
     """
-
-    supports_encoder_cudagraph = True
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Purpose

Add postprocess_encoder_output to the testing mock classes, addressing the change introduced by #42224

cc @JisoLya

## Test Plan

```sh
pytest tests/v1/cudagraph/test_encoder_cudagraph.py
```

## Test Result


Before

```text
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphCaptureReplay::test_execute_returns_one_tensor_per_image - AttributeError: 'SimpleMockViTModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphCaptureReplay::test_execute_output_tokens_per_image - AttributeError: 'SimpleMockViTModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphCaptureReplay::test_hit_counter_increments_by_num_images - AttributeError: 'SimpleMockViTModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphCaptureReplay::test_chunking_when_images_exceed_max_batch - AttributeError: 'SimpleMockViTModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphVideoReplay::test_video_execute_returns_one_tensor_per_video - AttributeError: 'SimpleMockViTVideoModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphVideoReplay::test_video_output_tokens_per_item - AttributeError: 'SimpleMockViTVideoModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphVideoReplay::test_video_hit_counter_increments_by_num_videos - AttributeError: 'SimpleMockViTVideoModel' object has no attribute 'postprocess_encoder_output'
FAILED tests/v1/cudagraph/test_encoder_cudagraph.py::TestEncoderCudaGraphVideoReplay::test_image_and_video_share_manager - AttributeError: 'SimpleMockViTVideoModel' object has no attribute 'postprocess_encoder_output'
================================================================== 8 failed, 41 passed, 16 warnings in 21.41s ==================================================================
```

After

```text
======================================================================= 49 passed, 16 warnings in 20.84s =======================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

