### PR TITLE
[Bugfix] Normalize int16 PCM in load_audio_pyav (fixes Gemma 4 audio ASR hallucination)

### DIFF
--- a/tests/multimodal/test_audio.py
+++ b/tests/multimodal/test_audio.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # test_audio.py
 import math
+import wave
+from io import BytesIO
 from unittest.mock import patch
 
 import numpy as np
@@ -788,3 +790,54 @@ class TestAudioChunking:
         )
 
         assert len(chunks_48k) >= 2
+
+
+class TestLoadAudioPyAV:
+    """Regression tests for `load_audio_pyav` (PyAV/FFmpeg audio loader)."""
+
+    @staticmethod
+    def _int16_wav(signal: np.ndarray, sr: int) -> BytesIO:
+        """Encode a float waveform in [-1, 1] as an int16-PCM WAV buffer."""
+        pcm = (np.clip(signal, -1.0, 1.0) * 32767.0).astype("<i2")
+        buf = BytesIO()
+        with wave.open(buf, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)  # 16-bit
+            wf.setframerate(sr)
+            wf.writeframes(pcm.tobytes())
+        buf.seek(0)
+        return buf
+
+    @pytest.mark.parametrize("sr_arg", [None, 22050, 8000])
+    def test_int16_pcm_is_normalized(self, sr_arg):
+        """An int16-PCM WAV must decode to a normalized float32 waveform.
+
+        Regression test for the Gemma 4 audio/ASR hallucination (#40095):
+        when no resample was needed (``sr=None`` -> ``sr == native_sr``),
+        ``load_audio_pyav`` appended raw int16 frames and cast them to
+        float32 *without scaling*, so the waveform came out at ~±32768
+        instead of ±1.0 and every downstream log-mel feature was wrong.
+        """
+        pytest.importorskip("av")
+        from vllm.multimodal.media.audio import load_audio_pyav
+
+        native_sr = 22050
+        amplitude = 0.5
+        t = np.linspace(0.0, 1.0, native_sr, endpoint=False)
+        signal = amplitude * np.sin(2 * np.pi * 440.0 * t)
+
+        waveform, out_sr = load_audio_pyav(
+            self._int16_wav(signal, native_sr), sr=sr_arg
+        )
+
+        assert waveform.dtype == np.float32
+        assert waveform.ndim == 1
+        peak = float(np.max(np.abs(waveform)))
+        # The bug produced a peak of ~16384 (amplitude * 32768); a correctly
+        # normalized waveform stays within [-1, 1] ...
+        assert peak <= 1.0, f"waveform not normalized (peak={peak})"
+        # ... and preserves the amplitude rather than merely clipping.
+        assert peak == pytest.approx(amplitude, abs=0.05)
+        # Sample rate is returned as an int (like load_audio_soundfile).
+        assert isinstance(out_sr, int)
+        assert out_sr == (sr_arg or native_sr)

--- a/vllm/multimodal/media/audio.py
+++ b/vllm/multimodal/media/audio.py
@@ -69,7 +69,12 @@ def load_audio_pyav(
             stream = container.streams.audio[0]
             stream.thread_type = "AUTO"
             native_sr = stream.rate
-            sr = sr or native_sr
+            # Coerce to int: the `sr` type hint allows float, but
+            # av.AudioResampler(rate=...) expects an int (a float can raise
+            # TypeError on some PyAV versions). Doing it here also keeps the
+            # returned sample rate an int, consistent with
+            # load_audio_soundfile.
+            sr = int(round(sr or native_sr))
 
             chunks: list[npt.NDArray] = []
             # Always decode through an AudioResampler set to float planar

--- a/vllm/multimodal/media/audio.py
+++ b/vllm/multimodal/media/audio.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import math
 from io import BytesIO
 from pathlib import Path
 
@@ -73,24 +72,31 @@ def load_audio_pyav(
             sr = sr or native_sr
 
             chunks: list[npt.NDArray] = []
-            needs_resampling = not math.isclose(
-                float(sr),
-                float(native_sr),
-                rel_tol=0.0,
-                abs_tol=1e-6,
-            )
-            resampler = (
-                av.AudioResampler(format="fltp", layout="mono", rate=sr)
-                if needs_resampling
-                else None
+            # Always decode through an AudioResampler set to float planar
+            # ("fltp"). Besides resampling, the resampler normalises the
+            # sample FORMAT: integer-PCM sources (the common WAV case) are
+            # converted to float32 in [-1, 1].
+            #
+            # The previous code only used the resampler when the sample
+            # rate actually changed; otherwise it appended
+            # ``frame.to_ndarray()`` directly. For an int16-PCM stream that
+            # returns raw int16 samples, and the subsequent
+            # ``.astype(np.float32)`` casts WITHOUT scaling — yielding a
+            # waveform at ~±32768 instead of ±1.0 (32768x too loud). Every
+            # downstream log-mel feature is then shifted by ~ln(32768)≈10.4,
+            # which is exactly what corrupts Gemma 4 audio/ASR (the model
+            # receives out-of-distribution features and hallucinates).
+            resampler = av.AudioResampler(
+                format="fltp",
+                layout="mono" if mono else stream.layout,
+                rate=sr,
             )
             for frame in container.decode(stream):
-                if needs_resampling:
-                    assert resampler is not None
-                    for out_frame in resampler.resample(frame):
-                        chunks.append(out_frame.to_ndarray())
-                else:
-                    chunks.append(frame.to_ndarray())
+                for out_frame in resampler.resample(frame):
+                    chunks.append(out_frame.to_ndarray())
+            # Flush samples buffered inside the resampler.
+            for out_frame in resampler.resample(None):
+                chunks.append(out_frame.to_ndarray())
     except ValueError:
         raise
     except Exception as e:


### PR DESCRIPTION
## Purpose

`load_audio_pyav` can return a waveform at raw int16 scale (~±32768)
instead of normalized float `[-1, 1]`, corrupting every downstream audio
feature. This is the root cause of the Gemma 4 audio/ASR hallucination
reported in #40095.

### Root cause

`load_audio_pyav` only routes frames through an `AudioResampler` when the
sample rate actually changes:

```python
needs_resampling = not math.isclose(float(sr), float(native_sr), ...)
resampler = av.AudioResampler(format="fltp", layout="mono", rate=sr) if needs_resampling else None
for frame in container.decode(stream):
    if needs_resampling:
        for out_frame in resampler.resample(frame):
            chunks.append(out_frame.to_ndarray())
    else:
        chunks.append(frame.to_ndarray())          # <-- native int16 frames
...
audio = np.concatenate(chunks, axis=-1).astype(np.float32)
```

When no resample is needed (e.g. `AudioMediaIO.load_bytes` calls
`load_audio(..., sr=None)`, so `sr` becomes `native_sr`), frames are taken
via `frame.to_ndarray()`. For an integer-PCM stream — the common WAV case —
that returns raw **int16** samples, and the subsequent `.astype(np.float32)`
casts **without scaling**. The waveform ends up at ~±32768 instead of ±1.0.

Every downstream log-mel feature is then shifted by ~`ln(32768)` ≈ 10.4,
so audio models receive wildly out-of-distribution input. For Gemma 4
audio this yields a fixed, content-independent transcription
("Hello, good morning, I'm calling to inquire about ...") regardless of
the spoken audio.

`load_audio_soundfile` reads `dtype="float32"` (normalized), so the bug
only surfaces on the PyAV fallback path — which is always taken when
`soundfile` is not installed.

### Fix

Always decode through `AvAudioResampler(format="fltp")`. Besides
resampling, the resampler normalizes the sample **format** — integer PCM
is converted to float32 in `[-1, 1]` — even when the rate is unchanged.
The resampler is also flushed (`resample(None)`) so trailing buffered
samples are not dropped.

### Verification

For a 16 kHz mono speech clip, `input_features` fed to the Gemma 4 audio
tower before vs. after the fix, compared against the HF `transformers`
reference:

| | mean | std | max |
|---|---|---|---|
| transformers reference | −2.93 | 2.63 | 2.80 |
| vLLM **before** | +5.57 | 6.10 | 13.19 |
| vLLM **after** | −2.93 | 2.63 | 2.80 |

After the fix Gemma 4 transcription is correct (verbatim transcript)
instead of the content-independent hallucination.

Fixes #40095

## Test Plan

- Decoded an int16 WAV via `load_audio_pyav` with `sr=None`; output is now
  float32 in `[-1, 1]` (previously ~±32768).
- End-to-end Gemma 4 E2B ASR over the OpenAI `input_audio` API now returns
  a correct transcript.

## Test Result

Gemma 4 audio transcription matches the `transformers` reference; the
`input_features` statistics above confirm the waveform scale is fixed.
