### PR TITLE
[BugFix] Add triton lang placeholder for exp2

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -4,7 +4,6 @@
 import os
 import types
 from importlib.util import find_spec
-
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 
@@ -103,3 +102,4 @@ class TritonLanguagePlaceholder(types.ModuleType):
         self.exp = None
         self.log = None
         self.log2 = None
+        self.exp2 = None


### PR DESCRIPTION

## Purpose

Fixes `AttributeError: module 'triton.language' has no attribute 'exp2`` observed when running GDN models on platforms that don't support triton. This was introduced by: https://github.com/vllm-project/vllm/pull/43195

## Test Plan

running: https://github.com/vllm-project/vllm/blob/main/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh

## Test Result

qwen 3.5 smoke test passes

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [Y] The test plan, such as providing test command.
- [Y] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

