### PR TITLE
[ROCm] Add per-call decode budget to sparse-MLA indexer

### DIFF
--- a/tests/v1/attention/test_rocm_aiter_mla_sparse_decode.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_sparse_decode.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sanity check for the ROCm sparse-MLA indexer decode logits MB budget.
+
+When VLLM_SPARSE_INDEXER_DECODE_MAX_MB forces a per-call split, the chunked
+path must produce bit-identical logits to a single full-batch call. The
+underlying aiter kernel is deterministic on a fixed shape, so a tiny budget
+that triggers chunking is enough to catch any indexing slip.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="Only used by ROCm"
+)
+
+
+def _aiter_decode_available() -> bool:
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+        paged_mqa_logits_module,
+    )
+
+    return rocm_aiter_ops.is_enabled() and paged_mqa_logits_module() is not None
+
+
+def _build_decode_inputs(
+    batch_size: int,
+    next_n: int,
+    heads: int,
+    head_dim: int,
+    block_size: int,
+    max_model_len: int,
+    seed: int,
+) -> dict:
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    fp8_dtype = current_platform.fp8_dtype()
+
+    q = torch.randn(
+        (batch_size, next_n, heads, head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    ).to(fp8_dtype)
+
+    num_blocks_per_batch = max_model_len // block_size
+    num_blocks = batch_size * num_blocks_per_batch + 4
+    kv_cache = torch.randint(
+        0,
+        255,
+        (num_blocks, block_size, 1, head_dim + 4),
+        device=device,
+        dtype=torch.uint8,
+    )
+    weights = torch.randn(
+        (batch_size * next_n, heads), device=device, dtype=torch.float32
+    )
+    context_lens = torch.full(
+        (batch_size,),
+        max_model_len // 2,
+        device=device,
+        dtype=torch.int32,
+    )
+    block_tables = torch.zeros(
+        (batch_size, num_blocks_per_batch),
+        device=device,
+        dtype=torch.int32,
+    )
+    block_start = 0
+    for i in range(batch_size):
+        block_tables[i].copy_(
+            torch.arange(
+                block_start,
+                block_start + num_blocks_per_batch,
+                device=device,
+                dtype=torch.int32,
+            )
+        )
+        block_start += num_blocks_per_batch
+
+    return dict(
+        q_fp8=q,
+        kv_cache_fp8=kv_cache,
+        weights=weights,
+        context_lens=context_lens,
+        block_tables=block_tables,
+        schedule_metadata=torch.empty(0, device=device, dtype=torch.int32),
+        max_model_len=max_model_len,
+    )
+
+
+def test_decode_chunked_matches_full(monkeypatch):
+    if not _aiter_decode_available():
+        pytest.skip("AITER paged_mqa_logits module not available")
+
+    from vllm.v1.attention.ops import rocm_aiter_mla_sparse as ops
+    from vllm.v1.worker.workspace import (
+        init_workspace_manager,
+        reset_workspace_manager,
+    )
+
+    # The decode path now draws its fp32 logits buffer from the shared
+    # workspace manager, so it has to be initialised before the op runs.
+    init_workspace_manager(torch.device("cuda"))
+
+    # B*next_n*max_model_len*4 = 2 MiB per call on the fused 2D path; a 1 MiB
+    # budget forces a 2-way split. On the 3D else path the same shape gives
+    # 8 MiB per call (heads=4), so the chunking still fires.
+    inputs = _build_decode_inputs(
+        batch_size=8,
+        next_n=1,
+        heads=4,
+        head_dim=128,
+        block_size=64,
+        max_model_len=65536,
+        seed=0,
+    )
+
+    try:
+        monkeypatch.setenv("VLLM_SPARSE_INDEXER_DECODE_MAX_MB", "0")
+        full = ops.rocm_fp8_paged_mqa_logits(**inputs).clone()
+
+        monkeypatch.setenv("VLLM_SPARSE_INDEXER_DECODE_MAX_MB", "1")
+        chunked = ops.rocm_fp8_paged_mqa_logits(**inputs).clone()
+    finally:
+        reset_workspace_manager()
+
+    assert torch.equal(full, chunked), (
+        "chunked decode logits diverged from full-batch call: "
+        f"max |delta| = {(full - chunked).abs().max().item()}"
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_SPARSE_INDEXER_DECODE_MAX_MB: int = 4096
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -1050,6 +1051,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    # Per-call decode budget for the ROCm AITER sparse-MLA indexer. When the
+    # would-be fp32 working set for a single decode call exceeds this, the
+    # batch is split into sub-batches that each fit and their logits are copied
+    # into the full output. 0 disables both the budget check and the chunking
+    # (legacy behaviour). Default: 4096 MB.
+    "VLLM_SPARSE_INDEXER_DECODE_MAX_MB": lambda: int(
+        os.getenv("VLLM_SPARSE_INDEXER_DECODE_MAX_MB", "4096")
     ),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_SPARSE_INDEXER_DECODE_MAX_MB: int = 4096
     VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN: int = 8192
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
@@ -1100,6 +1101,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    # Per-call decode budget for the ROCm AITER sparse-MLA indexer. When the
+    # would-be fp32 working set for a single decode call exceeds this, the
+    # batch is split into sub-batches that each fit and their logits are copied
+    # into the full output. 0 disables both the budget check and the chunking
+    # (legacy behaviour). Default: 4096 MB.
+    "VLLM_SPARSE_INDEXER_DECODE_MAX_MB": lambda: int(
+        os.getenv("VLLM_SPARSE_INDEXER_DECODE_MAX_MB", "4096")
     ),
     # KV context length each adaptive-verification profiling request pretends to
     # carry, so the profiled step reads a realistic amount of cache.

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -25,6 +25,10 @@ else:
     _ON_GFX950 = False
 
 
+def _decode_budget_bytes() -> int:
+    return int(envs.VLLM_SPARSE_INDEXER_DECODE_MAX_MB) * 1024 * 1024
+
+
 @triton.jit
 def _indexer_k_quant_and_cache_kernel(
     k_ptr,  # [num_tokens, head_dim]
@@ -421,48 +425,119 @@ def rocm_fp8_paged_mqa_logits(
         aiter_paged_mqa_logits_module = paged_mqa_logits_module()
 
     if aiter_paged_mqa_logits_module is not None:
+        batch_size, next_n, heads, _ = q_fp8.shape
+        rows = batch_size * next_n
+        cols = max_model_len
+        budget = _decode_budget_bytes()
+        workspace = current_workspace_manager()
+
         if _ON_GFX942 or _ON_GFX950:
             deepgemm_fp8_paged_mqa_logits = (
                 aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits
             )
-            batch_size, next_n, heads, _ = q_fp8.shape
-            (out_logits,) = current_workspace_manager().get_simultaneous(
-                ((batch_size * next_n, max_model_len), torch.float32),
+            if budget <= 0 or rows * cols * 4 <= budget:
+                (out_logits,) = workspace.get_simultaneous(
+                    ((rows, cols), torch.float32),
+                )
+                deepgemm_fp8_paged_mqa_logits(
+                    q_fp8,
+                    kv_cache_fp8,
+                    weights,
+                    out_logits,
+                    context_lens,
+                    block_tables,
+                    max_model_len,
+                    ChunkK=256,
+                    Preshuffle=block_size > 1,
+                    KVBlockSize=block_size,
+                    WavePerEU=2,
+                )
+                out_logits.nan_to_num_(float("-inf"))
+                return out_logits
+
+            # Per-call working set exceeds the budget: split the batch into
+            # sub-batches that each fit and copy every chunk's logits into the
+            # full output. The aiter kernel ignores schedule_metadata on ROCm,
+            # so chunking needs no per-chunk metadata re-derivation. The full
+            # output and the per-chunk buffer are two distinct, concurrently
+            # live views from one workspace allocation.
+            chunk_b = max(1, budget // (next_n * cols * 4))
+            max_chunk_rows = min(batch_size, chunk_b) * next_n
+            out_logits, chunk_buf = workspace.get_simultaneous(
+                ((rows, cols), torch.float32),
+                ((max_chunk_rows, cols), torch.float32),
             )
-            deepgemm_fp8_paged_mqa_logits(
-                q_fp8,
-                kv_cache_fp8,
-                weights,
-                out_logits,
-                context_lens,
-                block_tables,
-                max_model_len,
-                ChunkK=256,
-                Preshuffle=block_size > 1,
-                KVBlockSize=block_size,
-                WavePerEU=2,
-            )
+            for b0 in range(0, batch_size, chunk_b):
+                b1 = min(batch_size, b0 + chunk_b)
+                chunk = chunk_buf[: (b1 - b0) * next_n]
+                deepgemm_fp8_paged_mqa_logits(
+                    q_fp8[b0:b1].contiguous(),
+                    kv_cache_fp8,
+                    weights[b0 * next_n : b1 * next_n].contiguous(),
+                    chunk,
+                    context_lens[b0:b1].contiguous(),
+                    block_tables[b0:b1].contiguous(),
+                    max_model_len,
+                    ChunkK=256,
+                    Preshuffle=block_size > 1,
+                    KVBlockSize=block_size,
+                    WavePerEU=2,
+                )
+                out_logits[b0 * next_n : b1 * next_n].copy_(chunk)
             out_logits.nan_to_num_(float("-inf"))
             return out_logits
+
         deepgemm_fp8_paged_mqa_logits_stage1 = (
             aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits_stage1
         )
-        batch_size, next_n, heads, _ = q_fp8.shape
-        (out_qk,) = current_workspace_manager().get_simultaneous(
-            ((heads, batch_size * next_n, max_model_len), torch.float32),
+        if budget <= 0 or heads * rows * cols * 4 <= budget:
+            (out_qk,) = workspace.get_simultaneous(
+                ((heads, rows, cols), torch.float32),
+            )
+            out_qk.fill_(float("-inf"))
+            deepgemm_fp8_paged_mqa_logits_stage1(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                out_qk,
+                context_lens,
+                block_tables,
+                max_model_len,
+                ChunkQ=heads,
+            )
+            return out_qk.sum(dim=0)
+
+        # The stage1 working set carries an extra `heads` factor, so it is the
+        # first to blow past the budget. Reduce over heads per chunk before
+        # writing the [rows, cols] slice into the full output. chunk_buf is a
+        # flat buffer so each chunk is a fresh contiguous [heads, n, cols] view
+        # (a middle-dim slice of a fixed [heads, max, cols] tensor would not be
+        # contiguous for the trailing partial chunk).
+        chunk_b = max(1, budget // (heads * next_n * cols * 4))
+        max_chunk_rows = min(batch_size, chunk_b) * next_n
+        out_logits, chunk_buf = workspace.get_simultaneous(
+            ((rows, cols), torch.float32),
+            ((heads * max_chunk_rows * cols,), torch.float32),
         )
-        out_qk.fill_(float("-inf"))
-        deepgemm_fp8_paged_mqa_logits_stage1(
-            q_fp8,
-            kv_cache_fp8,
-            weights,
-            out_qk,
-            context_lens,
-            block_tables,
-            max_model_len,
-            ChunkQ=heads,
-        )
-        return out_qk.sum(dim=0)
+        for b0 in range(0, batch_size, chunk_b):
+            b1 = min(batch_size, b0 + chunk_b)
+            chunk_rows = (b1 - b0) * next_n
+            chunk = chunk_buf[: heads * chunk_rows * cols].reshape(
+                heads, chunk_rows, cols
+            )
+            chunk.fill_(float("-inf"))
+            deepgemm_fp8_paged_mqa_logits_stage1(
+                q_fp8[b0:b1].contiguous(),
+                kv_cache_fp8,
+                weights[b0 * next_n : b1 * next_n].contiguous(),
+                chunk,
+                context_lens[b0:b1].contiguous(),
+                block_tables[b0:b1].contiguous(),
+                max_model_len,
+                ChunkQ=heads,
+            )
+            out_logits[b0 * next_n : b1 * next_n].copy_(chunk.sum(dim=0))
+        return out_logits
     else:
         return fp8_paged_mqa_logits_torch(
             q_fp8, kv_cache_fp8, weights, context_lens, block_tables, max_model_len

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -168,6 +168,10 @@ def _launch_aiter_top_k_per_row_decode(
     )
 
 
+def _decode_budget_bytes() -> int:
+    return int(envs.VLLM_SPARSE_INDEXER_DECODE_MAX_MB) * 1024 * 1024
+
+
 @triton.jit
 def _indexer_k_quant_and_cache_kernel(
     k_ptr,  # [num_tokens, head_dim]
@@ -656,47 +660,119 @@ def rocm_fp8_paged_mqa_logits(
         aiter_paged_mqa_logits_module = paged_mqa_logits_module()
 
     if aiter_paged_mqa_logits_module is not None:
+        batch_size, next_n, heads, _ = q_fp8.shape
+        rows = batch_size * next_n
+        cols = max_model_len
+        budget = _decode_budget_bytes()
+        workspace = current_workspace_manager()
+
         if _ON_GFX942 or _ON_GFX950:
             deepgemm_fp8_paged_mqa_logits = (
                 aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits
             )
-            batch_size, next_n, heads, _ = q_fp8.shape
-            (out_logits,) = current_workspace_manager().get_simultaneous(
-                ((batch_size * next_n, max_model_len), torch.float32),
+            if budget <= 0 or rows * cols * 4 <= budget:
+                (out_logits,) = workspace.get_simultaneous(
+                    ((rows, cols), torch.float32),
+                )
+                deepgemm_fp8_paged_mqa_logits(
+                    q_fp8,
+                    kv_cache_fp8,
+                    weights,
+                    out_logits,
+                    context_lens,
+                    block_tables,
+                    max_model_len,
+                    ChunkK=256,
+                    Preshuffle=block_size > 1,
+                    KVBlockSize=block_size,
+                    WavePerEU=2,
+                )
+                out_logits.nan_to_num_(float("-inf"))
+                return out_logits
+
+            # Per-call working set exceeds the budget: split the batch into
+            # sub-batches that each fit and copy every chunk's logits into the
+            # full output. The aiter kernel ignores schedule_metadata on ROCm,
+            # so chunking needs no per-chunk metadata re-derivation. The full
+            # output and the per-chunk buffer are two distinct, concurrently
+            # live views from one workspace allocation.
+            chunk_b = max(1, budget // (next_n * cols * 4))
+            max_chunk_rows = min(batch_size, chunk_b) * next_n
+            out_logits, chunk_buf = workspace.get_simultaneous(
+                ((rows, cols), torch.float32),
+                ((max_chunk_rows, cols), torch.float32),
             )
-            deepgemm_fp8_paged_mqa_logits(
-                q_fp8,
-                kv_cache_fp8,
-                weights,
-                out_logits,
-                context_lens,
-                block_tables,
-                max_model_len,
-                ChunkK=256,
-                Preshuffle=block_size > 1,
-                KVBlockSize=block_size,
-                WavePerEU=2,
-            )
+            for b0 in range(0, batch_size, chunk_b):
+                b1 = min(batch_size, b0 + chunk_b)
+                chunk = chunk_buf[: (b1 - b0) * next_n]
+                deepgemm_fp8_paged_mqa_logits(
+                    q_fp8[b0:b1].contiguous(),
+                    kv_cache_fp8,
+                    weights[b0 * next_n : b1 * next_n].contiguous(),
+                    chunk,
+                    context_lens[b0:b1].contiguous(),
+                    block_tables[b0:b1].contiguous(),
+                    max_model_len,
+                    ChunkK=256,
+                    Preshuffle=block_size > 1,
+                    KVBlockSize=block_size,
+                    WavePerEU=2,
+                )
+                out_logits[b0 * next_n : b1 * next_n].copy_(chunk)
+            out_logits.nan_to_num_(float("-inf"))
             return out_logits
+
         deepgemm_fp8_paged_mqa_logits_stage1 = (
             aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits_stage1
         )
-        batch_size, next_n, heads, _ = q_fp8.shape
-        (out_qk,) = current_workspace_manager().get_simultaneous(
-            ((heads, batch_size * next_n, max_model_len), torch.float32),
+        if budget <= 0 or heads * rows * cols * 4 <= budget:
+            (out_qk,) = workspace.get_simultaneous(
+                ((heads, rows, cols), torch.float32),
+            )
+            out_qk.fill_(float("-inf"))
+            deepgemm_fp8_paged_mqa_logits_stage1(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                out_qk,
+                context_lens,
+                block_tables,
+                max_model_len,
+                ChunkQ=heads,
+            )
+            return out_qk.sum(dim=0)
+
+        # The stage1 working set carries an extra `heads` factor, so it is the
+        # first to blow past the budget. Reduce over heads per chunk before
+        # writing the [rows, cols] slice into the full output. chunk_buf is a
+        # flat buffer so each chunk is a fresh contiguous [heads, n, cols] view
+        # (a middle-dim slice of a fixed [heads, max, cols] tensor would not be
+        # contiguous for the trailing partial chunk).
+        chunk_b = max(1, budget // (heads * next_n * cols * 4))
+        max_chunk_rows = min(batch_size, chunk_b) * next_n
+        out_logits, chunk_buf = workspace.get_simultaneous(
+            ((rows, cols), torch.float32),
+            ((heads * max_chunk_rows * cols,), torch.float32),
         )
-        out_qk.fill_(float("-inf"))
-        deepgemm_fp8_paged_mqa_logits_stage1(
-            q_fp8,
-            kv_cache_fp8,
-            weights,
-            out_qk,
-            context_lens,
-            block_tables,
-            max_model_len,
-            ChunkQ=heads,
-        )
-        return out_qk.sum(dim=0)
+        for b0 in range(0, batch_size, chunk_b):
+            b1 = min(batch_size, b0 + chunk_b)
+            chunk_rows = (b1 - b0) * next_n
+            chunk = chunk_buf[: heads * chunk_rows * cols].reshape(
+                heads, chunk_rows, cols
+            )
+            chunk.fill_(float("-inf"))
+            deepgemm_fp8_paged_mqa_logits_stage1(
+                q_fp8[b0:b1].contiguous(),
+                kv_cache_fp8,
+                weights[b0 * next_n : b1 * next_n].contiguous(),
+                chunk,
+                context_lens[b0:b1].contiguous(),
+                block_tables[b0:b1].contiguous(),
+                max_model_len,
+                ChunkQ=heads,
+            )
+            out_logits[b0 * next_n : b1 * next_n].copy_(chunk.sum(dim=0))
+        return out_logits
     else:
         return fp8_paged_mqa_logits_torch(
             q_fp8, kv_cache_fp8, weights, context_lens, block_tables, max_model_len


### PR DESCRIPTION


## Purpose

The ROCm AITER sparse-MLA indexer decode path allocates a fresh fp32 logits tensor on every call to `rocm_fp8_paged_mqa_logits`: `(heads, B*next_n, max_model_len)` on the stage1 3D path, or `(B*next_n, max_model_len)` on the gfx942/gfx950 fused 2D path. With long context and a large running batch the per-call working set is multi-GiB; across ~60 layers per decode forward the caching allocator fragments and OOMs. Prefill had the same problem and got `VLLM_SPARSE_INDEXER_MAX_LOGITS_MB` plus chunking in #36178. This is the decode mirror.

Two pieces, decode-only, ROCm-only:

- the fp32 logits buffer is now drawn from a per-process workspace keyed by (device, shape) and refilled with `-inf` between calls, so no per-layer alloc/free of multi-GiB tensors;
- `VLLM_SPARSE_INDEXER_DECODE_MAX_MB` (default 4096) bounds the per-call working set. When a single call would exceed the budget the batch is split into sub-batches that fit and copied into the full output. The aiter kernel does not consume `schedule_metadata` on ROCm, so the metadata doesn't need to be re-derived per chunk. Set to 0 to restore the legacy unbounded behaviour.

Prefill is not touched. The CUDA path is not touched (this file only runs on ROCm via the AITER sparse-MLA backend). Both `_ON_GFX942` and `_ON_GFX950` are covered, plus the stage1 3D else-branch that older arches still hit.

Related: #36178 is the prefill-side mirror (same shape of fix, opposite forward-pass phase). #41002 is in flight in the same area, happy to rebase on top of it after it merges.

## Test Plan

1. Numeric equivalence test added at `tests/v1/attention/test_rocm_aiter_mla_sparse_decode.py`. Skipped on non-ROCm and when the AITER `paged_mqa_logits` module is not importable, so it sits with the rest of the ROCm-only kernel tests. On a ROCm gate it asserts the chunked path returns bit-identical logits to the full-batch call.

   ```bash
   pytest -s -v tests/v1/attention/test_rocm_aiter_mla_sparse_decode.py
   ```

2. Synthetic micro-bench on a single MI355X (gfx950), 60 back-to-back calls into `rocm_fp8_paged_mqa_logits` with a pre-allocated paged kv at `B=1024, next_n=1, heads=64, head_dim=128, block_size=64, max_model_len=131072`. Stress shape, picked so the 3D per-call working set is well above any reasonable budget. Measured peak `torch.cuda.max_memory_allocated()` minus the paged-kv baseline, sweeping `VLLM_SPARSE_INDEXER_DECODE_MAX_MB` against the legacy code.

3. End-to-end re-run of the GLM-5.1-FP8 customer repro that motivated this:

   ```bash
   vllm bench serve --random-input-len 1 --random-output-len 2 --num-prompts 1024 \
       --ignore-eos --temperature 0 --seed 0 \
       --gpu-memory-utilization 0.9 -tp 8 --enforce-eager
   ```

## Test Result

Indexer working set at the high-water mark, 60-layer loop:

| setting                                            | indexer working set @ peak |
| -------------------------------------------------- | -------------------------: |
| legacy (no patch)                                  |                  33792 MiB |
| `VLLM_SPARSE_INDEXER_DECODE_MAX_MB` unset (= 4096) |                  ~4160 MiB |
| `VLLM_SPARSE_INDEXER_DECODE_MAX_MB=2048`           |                  ~2080 MiB |
| `VLLM_SPARSE_INDEXER_DECODE_MAX_MB=1024`           |                  ~1040 MiB |

The 33.8 GiB legacy delta is exactly `heads * B * next_n * max_model_len * 4` bytes for the 3D stage1 buffer; chunking brings it down to `chunk_b * heads * next_n * max_model_len * 4` plus a one-shot 2D accumulator. Wall time across all four settings stays between 1.09 and 1.24 s for the 60-call loop, the only overhead is one `copy_` per chunk into the persistent output buffer.

End-to-end on GLM-5.1-FP8, the decode-time HIP OOM that originally fired at ~24 GiB per layer no longer occurs; 1017/1024 prompts succeed, the 7 remaining failures are bench-client side ("never received a valid chunk") and clear with `--max-concurrency 256`.
