### PR TITLE
Allow native KV cache dtype in Triton cache update

### DIFF
--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -13,13 +13,6 @@ from vllm.utils.torch_utils import is_quantized_kv_cache
 
 FP8_MIN, FP8_MAX = get_fp8_min_max()
 
-# Native KV-cache dtypes are valid cache storage modes for this Triton
-# update path. This matters for ModelOpt NVFP4 on Ampere (A100/SM80 and
-# RTX 30xx/SM86): those checkpoints may request FP8 KV cache from their
-# ModelOpt metadata, but users can explicitly select BF16 KV cache to keep
-# the KV-store path native while still running NVFP4 weights. The wrapper
-# must not reject explicit native cache dtype strings before reaching the
-# non-FP8 store path below.
 _NATIVE_KV_CACHE_DTYPES = {"auto", "float16", "bfloat16", "float32", "half", "float"}
 
 

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -13,6 +13,21 @@ from vllm.utils.torch_utils import is_quantized_kv_cache
 
 FP8_MIN, FP8_MAX = get_fp8_min_max()
 
+# Native KV-cache dtypes are valid cache storage modes for this Triton
+# update path. This matters for ModelOpt NVFP4 on Ampere (A100/SM80 and
+# RTX 30xx/SM86): those checkpoints may request FP8 KV cache from their
+# ModelOpt metadata, but users can explicitly select BF16 KV cache to keep
+# the KV-store path native while still running NVFP4 weights. The wrapper
+# must not reject explicit native cache dtype strings before reaching the
+# non-FP8 store path below.
+_NATIVE_KV_CACHE_DTYPES = {"auto", "float16", "bfloat16", "float32", "half", "float"}
+
+
+def _is_supported_kv_cache_dtype(kv_cache_dtype: str) -> bool:
+    return kv_cache_dtype in _NATIVE_KV_CACHE_DTYPES or is_quantized_kv_cache(
+        kv_cache_dtype
+    )
+
 
 @triton.jit
 def reshape_and_cache_kernel_flash(
@@ -350,7 +365,7 @@ def triton_reshape_and_cache_flash(
     block_stride = key_cache.stride()[0]
     page_stride = key_cache.stride()[1]
 
-    assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
+    assert _is_supported_kv_cache_dtype(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
     kv_cache_torch_dtype = (
@@ -529,7 +544,7 @@ def triton_reshape_and_cache_flash_diffkv(
     block_stride = kv_cache.stride()[0]
     page_stride = kv_cache.stride()[1]
 
-    assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
+    assert _is_supported_kv_cache_dtype(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
     kv_cache_torch_dtype = (


### PR DESCRIPTION
  # Allow native KV cache dtype in Triton cache update

  ## Purpose

  Some models advertise quantized KV cache, but explicit unquantized KV cache should still be accepted when the user selects it. The bug is broader than one model: this Triton cache update path rejected explicit native KV dtype strings before reaching the valid non-FP8 store path.

  ## Test Plan

  Run Gemma4 26B NVFP4 on A100 with explicit BF16 KV cache.

  ```bash
  vllm serve nvidia/Gemma-4-26B-A4B-NVFP4 \
    --served-model-name gemma4-nvfp4-sanity \
    --quantization modelopt \
    --tensor-parallel-size 1 \
    --kv-cache-dtype bfloat16 \
    --tool-call-parser gemma4 \
    --reasoning-parser gemma4 \
    --enable-auto-tool-choice \
    --trust-remote-code \
    --max-model-len 4096 \
    --max-num-batched-tokens 2560 \
    --max-num-seqs 1 \
    --gpu-memory-utilization 0.85

```

  ## Test Result

  Passed on A100/SM80. This test also needs https://github.com/vllm-project/vllm/pull/42610 and https://github.com/vllm-project/vllm/pull/43379 as part of the verification test.

```
  server ready after 140s
  RESPONSE identity: content='vllm-sanity-ok' tool_calls=[]
  RESPONSE math: content='42' tool_calls=[]
  RESPONSE tool_parser: content='' tool_calls=[{'type': 'function',
  'function': {'name': 'get_weather', 'arguments': '{\n  "city":
  "Paris"\n}'}}]
  PASS vllm_serve_sanity
```

  ## Details

  In vllm/model_executor/layers/attention/attention.py, quantized checkpoints with kv_cache_scheme set FP8 KV cache only when kv_cache_dtype == "auto".

  If the user explicitly sets --kv-cache-dtype bfloat16, that explicit choice is supposed to win.

  The failure was later in vllm/v1/attention/ops/triton_reshape_and_cache_flash.py: it accepted only "auto" or quantized KV cache strings. So explicit native dtypes such as "bfloat16", "float16", "float32", "half", or "float" could be rejected even though the non-FP8 store path is valid.

  Consequently, any model reaching this v1 Triton FlashAttention cache update path with explicit native KV cache dtype can hit the same validation bug.

  This became important for Gemma / ModelOpt NVFP4 on Ampere because auto can select FP8 KV cache from metadata, but on A100/SM80 explicit BF16 KV cache keeps the KV-store path native while still using NVFP4 weights.

Signed-off-by: Michael Gschwind <mgschwind@nvidia.com>