### PR TITLE
[MoE] Add VLLM_FP8_MOE_BACKEND to override FP8-expert routing indepently of --moe-backend

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -187,6 +187,10 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_MOE_BACKEND: Literal["throughput", "latency", "masked_gemm"] = (
         "latency"
     )
+    VLLM_FP8_MOE_BACKEND: (
+        Literal["triton", "deep_gemm", "cutlass", "flashinfer_trtllm",
+                "flashinfer_cutlass", "marlin", "aiter"] | None
+    ) = None
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
@@ -1550,6 +1554,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
             "latency",
             ["throughput", "latency", "masked_gemm"],
         ),
+    ),
+    # FP8 MoE backend override. `--moe-backend` is consumed by both the
+    # NVFP4 and FP8 dispatchers; FP4-only kernels (e.g. flashinfer_b12x)
+    # have no FP8 equivalent. Set this to route FP8 experts in mixed-
+    # precision checkpoints to a different backend.
+    "VLLM_FP8_MOE_BACKEND": env_with_choices(
+        "VLLM_FP8_MOE_BACKEND",
+        None,
+        ["triton", "deep_gemm", "cutlass", "flashinfer_trtllm",
+         "flashinfer_cutlass", "marlin", "aiter"],
     ),
     # Override the directory for the FlashInfer autotune config cache.
     "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR": lambda: os.getenv(

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -202,7 +202,15 @@ def backend_to_kernel_cls(
 
 
 def map_fp8_backend(runner_backend: MoEBackend) -> Fp8MoeBackend:
-    """Map user's MoEBackend to Fp8MoeBackend."""
+    """Map user's MoEBackend to Fp8MoeBackend.
+
+    ``--moe-backend`` is consumed by both the NVFP4 and FP8 dispatchers.
+    For FP4-only kernels (e.g. ``flashinfer_b12x``), the FP8 dispatcher
+    has no equivalent and the mapping below would otherwise raise. Set
+    ``VLLM_FP8_MOE_BACKEND`` to override only the FP8-side routing while
+    keeping the user's ``--moe-backend`` value for the NVFP4 path.
+    """
+    effective = envs.VLLM_FP8_MOE_BACKEND or runner_backend
     mapping = {
         "triton": Fp8MoeBackend.TRITON,
         "deep_gemm": Fp8MoeBackend.DEEPGEMM,
@@ -212,10 +220,12 @@ def map_fp8_backend(runner_backend: MoEBackend) -> Fp8MoeBackend:
         "marlin": Fp8MoeBackend.MARLIN,
         "aiter": Fp8MoeBackend.AITER,
     }
-    if backend := mapping.get(runner_backend):
+    if backend := mapping.get(effective):
         return backend
+    src = ("VLLM_FP8_MOE_BACKEND env var"
+           if envs.VLLM_FP8_MOE_BACKEND else "--moe-backend")
     raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for FP8 MoE. "
+        f"FP8 MoE backend='{effective}' (from {src}) is not supported. "
         f"Expected one of {list(mapping.keys())}."
     )
 


### PR DESCRIPTION
## Purpose

`--moe-backend` is consumed by **both** the NVFP4 dispatcher (`oracle/nvfp4.py:map_nvfp4_backend`) and the FP8 dispatcher (`oracle/fp8.py:map_fp8_backend`). For FP4-only kernels — e.g. `flashinfer_b12x`, registered in the NVFP4 oracle by PR #40082 — the FP8 dispatcher has no corresponding backend, so on any **mixed-precision** checkpoint (NVFP4 experts + FP8 experts in the same model) `map_fp8_backend` raises at engine init:

```text
ValueError: moe_backend='flashinfer_b12x' is not supported for FP8 MoE.
  Expected one of ['triton', 'deep_gemm', 'cutlass', 'flashinfer_trtllm',
                   'flashinfer_cutlass', 'marlin', 'aiter'].
```

This blocks every mixed-precision checkpoint that pairs NVFP4 expert layers with FP8 ones — e.g. `nvidia/Qwen3.6-35B-A3B-2.06GB-per-token` on DGX Spark (GB10 / sm_121a). Such checkpoints are the norm for the 2.06GB-per-token family.

**Change:**

Introduce `VLLM_FP8_MOE_BACKEND` so callers can route FP8 experts to a different backend while keeping `--moe-backend=flashinfer_b12x` for the NVFP4 majority.

- `vllm/envs.py`: declare `VLLM_FP8_MOE_BACKEND` (literal of valid FP8 backend strings, default `None`).
- `vllm/model_executor/layers/fused_moe/oracle/fp8.py`: `map_fp8_backend` reads `envs.VLLM_FP8_MOE_BACKEND` as an override before consulting `runner_backend`; error message identifies the source.

Unset behavior is unchanged — only callers that explicitly set the env var see the new dispatch.

**Alternatives considered:**

1. **Extend b12x to handle FP8 experts** — not feasible; b12x is FP4-only by construction (class docstring: *"Only NVFP4 (kNvfp4Static/kNvfp4Dynamic) quantization is supported"*).
2. **Auto-fall-back inside `map_fp8_backend`** — opaque to callers and surprising; an explicit env-var opt-in is safer until the FP4/FP8 split is formalized in `--moe-backend`.
3. **Per-layer-class backend selection in the model card** — larger refactor; this env var is the minimal unblocker.

**Risk:** Low. Adds one env var (default unset → unchanged behavior). `map_fp8_backend` only branches when the env var is set; the existing error path is preserved for misconfigured values.

## Test Plan

**Hardware:** DGX Spark (GB10, sm_121a)
**Container:** `vllm/vllm-openai:nightly-aarch64` + this PR + the b12x-W4A16-supports companion PR
**Model:** `nvidia/Qwen3.6-35B-A3B-2.06GB-per-token` (modelopt-native, mixed NVFP4 + FP8 experts)
**Tooling:** FlashInfer `0.6.11.post3`, cutlass-dsl trio `4.5.1`

**Recipe:**

```bash
export VLLM_NVFP4_GEMM_BACKEND=flashinfer-b12x
export VLLM_USE_FLASHINFER_MOE_FP4=1
export VLLM_FP8_MOE_BACKEND=flashinfer_cutlass    # THIS PR — routes FP8 experts via FI-cutlass
export FLASHINFER_DISABLE_VERSION_CHECK=1
export CUTE_DSL_ARCH=sm_121a

vllm serve nvidia/Qwen3.6-35B-A3B-2.06GB-per-token \
    --tensor-parallel-size 1 --trust-remote-code --dtype auto \
    --kv-cache-dtype fp8 --attention-backend FLASHINFER \
    --gpu-memory-utilization 0.85 --max-model-len 40960 \
    --max-num-seqs 4 --max-num-batched-tokens 8192 \
    --enable-chunked-prefill --async-scheduling --enable-prefix-caching \
    --moe-backend=flashinfer_b12x --quantization=modelopt \
    --compilation-config '{"pass_config":{"fuse_norm_quant":true,"fuse_act_quant":true,"fuse_attn_quant":false}}' \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":3.12,"moe_backend":"triton"}'
```

**Benchmark (aiperf):** K=3 AL=3.12, BS=1 / concurrency=1, ISL=2048 + 32K user-context (total ISL=34,831), OSL=1024, 10 warmup + 60 measured requests, `--use-server-token-count --streaming`.

**Negative test (without `VLLM_FP8_MOE_BACKEND` set):** verify the error path still triggers and the message correctly identifies the source.

## Test Result

**Without this PR** (current behavior on mixed-precision checkpoint):

```text
ValueError: moe_backend='flashinfer_b12x' is not supported for FP8 MoE.
  Expected one of ['triton', 'deep_gemm', 'cutlass', 'flashinfer_trtllm',
                   'flashinfer_cutlass', 'marlin', 'aiter'].
```

Serve dies at engine init; no throughput measurement possible.

**With this PR + `VLLM_FP8_MOE_BACKEND=flashinfer_cutlass`:**

| Metric | Value |
|---|---:|
| Output Token Throughput | **91.00 tok/s** |
| Output Token Throughput / user | 97.42 tok/s/user |
| TTFT | 746.81 ms |
| ITL | 10.27 ms |
| Request Latency | 11,249.37 ms |
| MTP acceptance length | 3.15 (target 3.12) ✓ |
| Requests / errors | 60 / 0 |

**With this PR + env var unset** (regression sanity): same error as "Without this PR" above is raised, now annotated with `(from --moe-backend)` to disambiguate the source.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
