### PR TITLE
[Bugfix][Frontend] Fix (inadverted) regression when text is emitted before a tool call severely hurting agentic behavior

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -47,7 +47,9 @@ from vllm.entrypoints.openai.responses.serving import (
     extract_tool_types,
 )
 from vllm.entrypoints.openai.responses.streaming_events import (
+    SimpleStreamingEventProcessor,
     StreamingState,
+    _StateType,
 )
 from vllm.inputs import tokens_input
 from vllm.outputs import CompletionOutput, RequestOutput
@@ -202,6 +204,92 @@ def test_response_created_event_uses_public_json_schema_alias() -> None:
     assert event.response.text is not None
     assert event.response.text.format is not None
     assert event.response.text.format.model_dump(by_alias=True)["schema"] == schema
+
+
+def test_simple_streaming_omits_preamble_message_before_tool_call() -> None:
+    processor = SimpleStreamingEventProcessor()
+    preamble = "I'll inspect the file first."
+    completion = CompletionOutput
+
+    content_delta = DeltaMessage(content=preamble)
+    target_state, tool_call = processor.resolve_target_state(content_delta)
+    content_events = processor.open(target_state, tool_call)
+    content_events.extend(
+        processor.emit_delta(
+            content_delta,
+            completion(
+                index=0,
+                text=preamble,
+                token_ids=[],
+                cumulative_logprob=None,
+                logprobs=None,
+            ),
+        )
+    )
+    tool_delta = DeltaMessage(
+        tool_calls=[
+            DeltaToolCall(
+                index=0,
+                function=DeltaFunctionCall(
+                    name="exec_command",
+                    arguments='{"cmd": "ls"}',
+                ),
+            )
+        ]
+    )
+
+    target_state, tool_call = processor.resolve_target_state(tool_delta)
+    assert target_state == _StateType.TOOL_CALL
+    tool_events = processor.close_current(
+        include_message_content=target_state != _StateType.TOOL_CALL
+    )
+    tool_events.extend(processor.open(target_state, tool_call))
+    tool_events.extend(
+        processor.emit_delta(
+            tool_delta,
+            completion(
+                index=0,
+                text="",
+                token_ids=[],
+                cumulative_logprob=None,
+                logprobs=None,
+            ),
+        )
+    )
+    message_done = next(
+        event
+        for event in tool_events
+        if (
+            event.type == "response.output_item.done"
+            and event.item.type == "message"
+        )
+    )
+    function_added = next(
+        event
+        for event in tool_events
+        if (
+            event.type == "response.output_item.added"
+            and event.item.type == "function_call"
+        )
+    )
+
+    assert [
+        event.delta
+        for event in content_events
+        if event.type == "response.output_text.delta"
+    ] == [preamble]
+    assert [
+        event.text
+        for event in tool_events
+        if event.type == "response.output_text.done"
+    ] == [""]
+    assert message_done.item.content == []
+    assert function_added.item.name == "exec_command"
+    assert [
+        event.delta
+        for event in tool_events
+        if event.type == "response.function_call_arguments.delta"
+    ] == ['{"cmd": "ls"}']
 
 
 class TestInitializeToolSessions:

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -259,10 +259,7 @@ def test_simple_streaming_omits_preamble_message_before_tool_call() -> None:
     message_done = next(
         event
         for event in tool_events
-        if (
-            event.type == "response.output_item.done"
-            and event.item.type == "message"
-        )
+        if (event.type == "response.output_item.done" and event.item.type == "message")
     )
     function_added = next(
         event
@@ -279,9 +276,7 @@ def test_simple_streaming_omits_preamble_message_before_tool_call() -> None:
         if event.type == "response.output_text.delta"
     ] == [preamble]
     assert [
-        event.text
-        for event in tool_events
-        if event.type == "response.output_text.done"
+        event.text for event in tool_events if event.type == "response.output_text.done"
     ] == [""]
     assert message_done.item.content == []
     assert function_added.item.name == "exec_command"

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -700,6 +700,32 @@ class TestHarmonyPreambleStreaming:
         assert "response.content_part.done" in type_names
         assert "response.output_item.done" in type_names
 
+    def test_preamble_done_omits_text_before_builtin_tool(self) -> None:
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_previous_item_done_events,
+        )
+
+        previous = self._make_previous_item(
+            channel="commentary",
+            recipient=None,
+            text="I'll run Python.",
+        )
+        state = StreamingState()
+        state.current_item_id = "msg_test"
+        state.current_output_index = 0
+        state.current_content_index = 0
+
+        events = emit_previous_item_done_events(
+            previous,
+            state,
+            next_recipient="python",
+        )
+
+        output_item_done = next(
+            event for event in events if event.type == "response.output_item.done"
+        )
+        assert output_item_done.item.content == []
+
     def test_commentary_with_recipient_no_preamble_done(self) -> None:
         """commentary + recipient='functions.X' should route to function call
         done, not preamble done."""

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1419,7 +1419,8 @@ class OpenAIServingResponses(OpenAIServing):
                 continue
 
             if processor.needs_transition(target_state, tool_call):
-                for event in processor.close_current():
+                include_message_content = target_state != _StateType.TOOL_CALL
+                for event in processor.close_current(include_message_content):
                     yield _increment_sequence_number_and_return(event)
                 for event in processor.open(target_state, tool_call):
                     yield _increment_sequence_number_and_return(event)
@@ -1456,7 +1457,10 @@ class OpenAIServingResponses(OpenAIServing):
                 if len(ctx.parser.messages) > 0:
                     previous_item = ctx.parser.messages[-1]
                     for event in emit_previous_item_done_events(
-                        previous_item, state, ctx.function_tool_names
+                        previous_item,
+                        state,
+                        ctx.function_tool_names,
+                        ctx.parser.current_recipient,
                     ):
                         yield _increment_sequence_number_and_return(event)
                 state.reset_for_new_item()

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -376,11 +376,13 @@ def emit_code_interpreter_delta_events(
 def emit_text_output_done_events(
     text: str,
     state: StreamingState,
+    include_message_content: bool = True,
 ) -> list[StreamingResponsesResponse]:
     """Emit events when a final text output item completes."""
+    output_text = text if include_message_content else ""
     text_content = ResponseOutputText(
         type="output_text",
-        text=text,
+        text=output_text,
         annotations=[],
     )
     events: list[StreamingResponsesResponse] = []
@@ -390,7 +392,7 @@ def emit_text_output_done_events(
             sequence_number=-1,
             output_index=state.current_output_index,
             content_index=state.current_content_index,
-            text=text,
+            text=output_text,
             logprobs=[],
             item_id=state.current_item_id,
         )
@@ -414,7 +416,7 @@ def emit_text_output_done_events(
                 id=state.current_item_id,
                 type="message",
                 role="assistant",
-                content=[text_content],
+                content=[text_content] if output_text else [],
                 status="completed",
             ),
         )
@@ -598,6 +600,7 @@ def emit_previous_item_done_events(
     previous_item: HarmonyMessage,
     state: StreamingState,
     function_tool_names: frozenset[str] | None = None,
+    next_recipient: str | None = None,
 ) -> list[StreamingResponsesResponse]:
     """Emit done events for the previous item when expecting a new start.
 
@@ -622,8 +625,17 @@ def emit_previous_item_done_events(
         return emit_reasoning_done_events(text, state)
     elif previous_item.channel in ("commentary", "final"):
         # Preambles (commentary with no recipient) and final messages
-        # are both user-visible text.
-        return emit_text_output_done_events(text, state)
+        # are both user-visible text. The conversation text is purpusefully
+        # omitted when it immediately precedes a tool call.
+        include_content = not is_function_recipient(
+            next_recipient,
+            function_tool_names,
+        )
+        return emit_text_output_done_events(
+            text,
+            state,
+            include_message_content=include_content,
+        )
     return []
 
 
@@ -894,10 +906,12 @@ def emit_simple_content_delta(
 
 def emit_simple_content_done(
     state: SimpleStreamingState,
+    include_message_content: bool = True,
 ) -> list[StreamingResponsesResponse]:
+    output_text = state.accumulated_text if include_message_content else ""
     part = ResponseOutputText(
         type="output_text",
-        text=state.accumulated_text,
+        text=output_text,
         annotations=[],
     )
     events: list[StreamingResponsesResponse] = [
@@ -906,7 +920,7 @@ def emit_simple_content_done(
             sequence_number=-1,
             output_index=state.output_index,
             content_index=state.content_index,
-            text=state.accumulated_text,
+            text=output_text,
             logprobs=[],
             item_id=state.current_item_id,
         ),
@@ -926,7 +940,7 @@ def emit_simple_content_done(
                 id=state.current_item_id,
                 type="message",
                 role="assistant",
-                content=[part] if state.accumulated_text else [],
+                content=[part] if output_text else [],
                 status="completed",
                 summary=[],
             ),
@@ -1195,8 +1209,16 @@ class SimpleStreamingEventProcessor:
             and self.state.tool_call_index != tool_call.index
         )
 
-    def close_current(self) -> list[StreamingResponsesResponse]:
+    def close_current(
+        self,
+        include_message_content: bool = True,
+    ) -> list[StreamingResponsesResponse]:
         """Close the current state and emit its 'done' event sequence."""
+        if self.state.current_state == _StateType.CONTENT:
+            return emit_simple_content_done(
+                self.state,
+                include_message_content=include_message_content,
+            )
         handlers = self._STATE_HANDLERS.get(self.state.current_state)
         if handlers is None:
             return []

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -627,9 +627,12 @@ def emit_previous_item_done_events(
         # Preambles (commentary with no recipient) and final messages
         # are both user-visible text. The conversation text is purposefully
         # omitted when it immediately precedes a tool call.
-        include_content = not is_function_recipient(
-            next_recipient,
-            function_tool_names,
+        include_content = not (
+            next_recipient is not None
+            and is_function_recipient(
+                next_recipient,
+                function_tool_names,
+            )
         )
         return emit_text_output_done_events(
             text,

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -629,9 +629,13 @@ def emit_previous_item_done_events(
         # omitted when it immediately precedes a tool call.
         include_content = not (
             next_recipient is not None
-            and is_function_recipient(
-                next_recipient,
-                function_tool_names,
+            and (
+                is_function_recipient(next_recipient, function_tool_names)
+                or next_recipient == "python"
+                or next_recipient.startswith("mcp.")
+                or next_recipient.startswith("browser.")
+                or next_recipient.startswith("container.")
+                or is_mcp_tool_by_namespace(next_recipient, function_tool_names)
             )
         )
         return emit_text_output_done_events(

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -625,7 +625,7 @@ def emit_previous_item_done_events(
         return emit_reasoning_done_events(text, state)
     elif previous_item.channel in ("commentary", "final"):
         # Preambles (commentary with no recipient) and final messages
-        # are both user-visible text. The conversation text is purpusefully
+        # are both user-visible text. The conversation text is purposefully
         # omitted when it immediately precedes a tool call.
         include_content = not is_function_recipient(
             next_recipient,


### PR DESCRIPTION
## Purpose

It seems the behavior of the Responses API inadvertently drifted in commit `146f44b77d`, when streaming tool calling support was added. Before this commit, the completion text in the message immediately preceding a tool call was omitted from the assistant transcript. After this commit, this was also preserved in the assistant transcript. I did several tests using Codex with Qwen-3.5 models. After commit `146f44b77d`, performance on all my tool-calling benchmarks dropped to near zero with Codex using the Qwen-3.5-27B model. This drift seems to have been an unintended side effect of commit `146f44b77d`. This PR keeps the streamed preamble assistant text visible, but specifically omits it from the completed message item when the next item is a tool call. I also added a new small test to validate that this does not drift in the future.

Note: The test added in this PR was initially implemented with Codex. I reviewed and refactored the code + checked behavior.

## Test Plan

(New test + other tests)

  ```bash
  pytest tests/entrypoints/openai/responses/test_serving_responses.py -q -k test_simple_streaming_omits_preamble_message_before_tool_call


  pytest tests/entrypoints/openai/responses/test_serving_responses.py -q

  pytest \
    tests/entrypoints/openai/responses/test_function_call.py \
    tests/entrypoints/openai/responses/test_harmony.py \
    tests/entrypoints/openai/responses/test_mcp_tools.py \
    -q
  ```

  ## Test Result

  1 passed, 20 deselected
  21 passed
  50 passed, 2 skipped, 1 xpassed
