### PR TITLE
[Bugfix] Fix DeepSeek V3 byte-level tokenizer override

### DIFF
--- a/tests/tokenizers_/test_basic.py
+++ b/tests/tokenizers_/test_basic.py
@@ -1,17 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from pathlib import Path
 from typing import _get_protocol_attrs  # type: ignore
 
 import pytest
+from tokenizers import Tokenizer
+from tokenizers import decoders as tokenizers_decoders
+from tokenizers import models as tokenizers_models
+from tokenizers import pre_tokenizers as tokenizers_pre_tokenizers
 from transformers import (
     PreTrainedTokenizerBase,
     PreTrainedTokenizerFast,
 )
+from transformers.tokenization_utils_tokenizers import TokenizersBackend
 
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.grok2 import Grok2Tokenizer
-from vllm.tokenizers.hf import HfTokenizer
+from vllm.tokenizers.hf import CachedHfTokenizer, HfTokenizer
 from vllm.tokenizers.mistral import MistralTokenizer
+
+BYTELEVEL_SPACE = "\u0120"
+BYTELEVEL_NEWLINE = "\u010a"
 
 
 def _get_missing_attrs(obj: object, target: type):
@@ -54,6 +64,68 @@ def test_tokenizer_like_protocol():
     )
     assert isinstance(tokenizer, HfTokenizer)
     assert "WithoutImagePad" in tokenizer.__class__.__name__
+
+
+def test_deepseek_v3_ignores_bad_tokenizer_class(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    tokenizer = Tokenizer(
+        tokenizers_models.BPE(
+            vocab={
+                "<unk>": 0,
+                "According": 1,
+                f"{BYTELEVEL_SPACE}to": 2,
+                BYTELEVEL_NEWLINE: 3,
+                f"{BYTELEVEL_SPACE}US": 4,
+            },
+            merges=[],
+            unk_token="<unk>",
+        )
+    )
+    tokenizer.pre_tokenizer = tokenizers_pre_tokenizers.ByteLevel(
+        add_prefix_space=False
+    )
+    tokenizer.decoder = tokenizers_decoders.ByteLevel()
+    tokenizer.save(str(tmp_path / "tokenizer.json"))
+
+    # This metadata is inconsistent with the byte-level tokenizer JSON. Loading
+    # through LlamaTokenizerFast can surface byte-level marker glyphs in
+    # decoded text.
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "LlamaTokenizerFast",
+                "unk_token": "<unk>",
+            }
+        )
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v3",
+                "architectures": ["DeepseekV3ForCausalLM"],
+            }
+        )
+    )
+
+    def fail_if_hf_tokenizer_is_used(*args, **kwargs):
+        raise AssertionError("deepseek_v3 should bypass tokenizer_class metadata")
+
+    monkeypatch.setattr(
+        CachedHfTokenizer, "from_pretrained", fail_if_hf_tokenizer_is_used
+    )
+
+    tokenizer = get_tokenizer(str(tmp_path), trust_remote_code=True)
+
+    assert isinstance(tokenizer, TokenizersBackend)
+    assert tokenizer.convert_ids_to_tokens([1, 2, 3, 4]) == [
+        "According",
+        f"{BYTELEVEL_SPACE}to",
+        BYTELEVEL_NEWLINE,
+        f"{BYTELEVEL_SPACE}US",
+    ]
+    assert tokenizer.decode([1, 2, 3, 4]) == "According to\n US"
 
 
 @pytest.mark.parametrize("tokenizer_name", ["facebook/opt-125m", "gpt2"])

--- a/tests/tokenizers_/test_basic.py
+++ b/tests/tokenizers_/test_basic.py
@@ -19,6 +19,7 @@ from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.grok2 import Grok2Tokenizer
 from vllm.tokenizers.hf import CachedHfTokenizer, HfTokenizer
 from vllm.tokenizers.mistral import MistralTokenizer
+from vllm.tokenizers.registry import TokenizerRegistry
 
 BYTELEVEL_SPACE = "\u0120"
 BYTELEVEL_NEWLINE = "\u010a"
@@ -126,6 +127,49 @@ def test_deepseek_v3_ignores_bad_tokenizer_class(
         f"{BYTELEVEL_SPACE}US",
     ]
     assert tokenizer.decode([1, 2, 3, 4]) == "According to\n US"
+
+
+def test_deepseek_v3_respects_explicit_tokenizer_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v3",
+                "architectures": ["DeepseekV3ForCausalLM"],
+            }
+        )
+    )
+
+    class ExplicitModeTokenizer:
+        is_fast = True
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    def load_tokenizer_cls(tokenizer_mode: str):
+        assert tokenizer_mode == "deepseek_v32"
+        return ExplicitModeTokenizer
+
+    def fail_if_tokenizers_backend_is_used(*args, **kwargs):
+        raise AssertionError(
+            "explicit tokenizer modes should not use TokenizersBackend override"
+        )
+
+    monkeypatch.setattr(TokenizerRegistry, "load_tokenizer_cls", load_tokenizer_cls)
+    monkeypatch.setattr(
+        TokenizersBackend, "from_pretrained", fail_if_tokenizers_backend_is_used
+    )
+
+    tokenizer = get_tokenizer(
+        str(tmp_path),
+        tokenizer_mode="deepseek_v32",
+        trust_remote_code=True,
+    )
+
+    assert isinstance(tokenizer, ExplicitModeTokenizer)
 
 
 @pytest.mark.parametrize("tokenizer_name", ["facebook/opt-125m", "gpt2"])

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -38,7 +38,10 @@ logger = init_logger(__name__)
 # temporary workaround and better long term solutions are:
 # - Add model type to MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS in transformers (better)
 # - Fix tokenizer_class on the hub for the affected models (best)
-_MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {"step3_vl"}
+_MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {
+    "deepseek_v3",
+    "step3_vl",
+}
 
 _VLLM_TOKENIZERS = {
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Tokenizer"),

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -232,7 +232,10 @@ def get_tokenizer(
     # Some models have an incorrect tokenizer_class on the hub.
     # For these model types, bypass AutoTokenizer and use TokenizersBackend directly.
     model_type = getattr(config, "model_type", None) if config else None
-    if model_type in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS:
+    if (
+        tokenizer_mode == "hf"
+        and model_type in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS
+    ):
         from transformers.tokenization_utils_tokenizers import TokenizersBackend
 
         logger.debug(


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fix decoding for DeepSeek V3 fine-tuned checkpoints when their tokenizer
metadata is internally inconsistent: `config.json` identifies the checkpoint as
`model_type: "deepseek_v3"`, `tokenizer_config.json` advertises
`tokenizer_class: "LlamaTokenizerFast"`, but the serialized `tokenizer.json`
uses a ByteLevel decoder.

This can happen when a fine-tuned checkpoint is exported or repackaged with
generic Llama tokenizer metadata while preserving the original byte-level
tokenizer JSON. The model weights and tokenizer files may still load, but the
advertised tokenizer class does not match the decoder encoded in
`tokenizer.json`. When vLLM follows that incorrect `tokenizer_class` metadata,
decoded responses can expose byte-level marker glyphs such as `\u0120` and
`\u010a` in user-visible text.

This PR:

- Adds `deepseek_v3` to
  `_MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS` in
  `vllm/tokenizers/registry.py`.
- Reuses the existing vLLM workaround path that bypasses incorrect
  `tokenizer_class` metadata and loads `TokenizersBackend` directly.
- Adds a regression test that creates a synthetic DeepSeek V3 tokenizer repo
  with bad `LlamaTokenizerFast` metadata and a ByteLevel tokenizer JSON, then
  verifies vLLM decodes the ByteLevel tokens correctly.

The issue is not caused by fine-tuning itself. It appears when the published or
local checkpoint has this specific tokenizer metadata mismatch:

```text
config.json:
  "model_type": "deepseek_v3"

tokenizer_config.json:
  "tokenizer_class": "LlamaTokenizerFast"

tokenizer.json:
  "decoder": {"type": "ByteLevel", ...}
```

Code path without this PR:

```text
get_tokenizer(...)
  -> cached_resolve_tokenizer_args(..., tokenizer_mode="auto")
  -> tokenizer_mode becomes "hf"
  -> get_config(...) returns model_type="deepseek_v3"
  -> deepseek_v3 is not in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS
  -> TokenizerRegistry.load_tokenizer_cls("hf")
  -> CachedHfTokenizer.from_pretrained(...)
  -> AutoTokenizer honors tokenizer_config.json tokenizer_class="LlamaTokenizerFast"
  -> decoded text can expose ByteLevel marker glyphs such as \u0120 and \u010a
```

Code path with this PR:

```text
get_tokenizer(...)
  -> get_config(...) returns model_type="deepseek_v3"
  -> deepseek_v3 is in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS
  -> TokenizersBackend.from_pretrained(...)
  -> tokenizer.json ByteLevel decoder is used
  -> decoded text renders normal spaces/newlines instead of marker glyphs
```

## Test Plan

```bash
python -m pytest tests/tokenizers_/test_basic.py::test_deepseek_v3_ignores_bad_tokenizer_class -q
python -m ruff check vllm/tokenizers/registry.py tests/tokenizers_/test_basic.py
python -m ruff format --check vllm/tokenizers/registry.py tests/tokenizers_/test_basic.py
```

I also ran a local smoke check with a representative DeepSeek V3 fine-tuned
tokenizer:

```bash
python - <<'PY'
from vllm.tokenizers import get_tokenizer

p = "/path/to/deepseek-v3-finetuned-checkpoint"
tok = get_tokenizer(p, trust_remote_code=True)
text = tok.decode(tok.encode("According to the US.\n", add_special_tokens=False))
print(type(tok).__name__)
print(repr(text))
print("contains_markers", "\u0120" in text, "\u010a" in text)
PY
```

## Test Result

Targeted regression test:

```text
.                                                                        [100%]
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/tokenizers_/test_basic.py: 14 warnings
  .../site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1 passed, 16 warnings in 0.70s
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

Ruff:

```text
All checks passed!
2 files already formatted
```

Local DeepSeek V3 fine-tuned tokenizer smoke result:

```text
TokenizersBackend
'According to the US.\n'
contains_markers False False
```

Before this fix, deployments serving such fine-tuned checkpoints could produce
decoded content containing literal ByteLevel marker glyphs, for example text
fragments like:

```text
According\u0120to\u0120the ... \u010a\u010a
```

After this fix, the same tokenizer path decodes those tokens through
`TokenizersBackend`, so spaces and newlines are rendered normally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Considered; no documentation update is needed because this is a tokenizer selection bug fix for an existing model type.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
