### PR TITLE
[Model] Nemotron-H 3.5: quantized LM head and MTP compressed-tensors fix

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -875,6 +875,7 @@ class NemotronHForCausalLM(
         self.lm_head = ParallelLMHead(
             config.vocab_size,
             config.hidden_size,
+            quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
 

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.parallel import ParallelConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
@@ -35,6 +36,8 @@ from .nemotron_h import (
     NemotronHAttentionDecoderLayer,
     NemotronHMoEDecoderLayer,
 )
+
+logger = init_logger(__name__)
 
 
 class NemotronHMTPAttentionDecoderLayer(NemotronHAttentionDecoderLayer):
@@ -242,6 +245,35 @@ class NemotronHMultiTokenPredictor(nn.Module):
 
         # Total number of physical layers = num_steps * pattern_len
         total_layers = self.num_mtp_layers * self.pattern_len
+
+        quant_config = vllm_config.quant_config
+        if (
+            quant_config is not None
+            and quant_config.get_name() == "compressed-tensors"
+            and hasattr(quant_config, "ignore")
+        ):
+            num_experts = getattr(config, "n_routed_experts", None)
+            if getattr(config, "model_type", None) == "nemotron_h_puzzle":
+                num_experts = getattr(config, "mtp_n_routed_experts", num_experts)
+            if num_experts:
+                extra: list[str] = []
+                for i in range(total_layers):
+                    if self.pattern_str[i % self.pattern_len] != "E":
+                        continue
+                    for eid in range(num_experts):
+                        for proj in ("gate_proj", "up_proj", "down_proj"):
+                            extra.append(
+                                f"{prefix}.layers.{i}.mixer.experts.{eid}.{proj}"
+                            )
+                new_entries = [n for n in extra if n not in quant_config.ignore]
+                quant_config.ignore.extend(new_entries)
+                if new_entries:
+                    logger.info(
+                        "NemotronH-MTP: extended compressed-tensors ignore "
+                        "with %d per-expert MTP linears (BF16 in the checkpoint)",
+                        len(new_entries),
+                    )
+
         for i in range(total_layers):
             step_rel_idx = i % self.pattern_len
 
@@ -346,6 +378,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
         self.lm_head = ParallelLMHead(
             self.config.vocab_size,
             self.config.hidden_size,
+            quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
 


### PR DESCRIPTION
## Purpose

Two model-side fixes needed to run **Nemotron-H 3.5** on the released NVFP4 checkpoints.

**Part 2/3 of splitting #43333** (the combined B12x + Nemotron-3.5 + Qwen3.5 PR). Logically depends on the LM-head quant routing in part 1/3 (#43341) — once that routing exists, `quant_config=self.quant_config` on `ParallelLMHead` actually does something useful.

## Changes

- **`NemotronHForCausalLM`, `NemotronHMTP`**: pass `quant_config` to `ParallelLMHead` so quantized LM heads load correctly.
- **`NemotronHMTP`**: extend `compressed_tensors_config.ignore` with the per-expert MTP linears (`gate_proj` / `up_proj` / `down_proj`) before constructing `self.layers`. Those linears are BF16 in the released `nvidia/Nemotron-H-3.5-*` compressed-tensors checkpoints; without this, the FusedMoE quant-method dispatch fails with `KeyError` during weight load (same failure mode as #41994 for Qwen3.5 MTP, different model).

## Relation to existing open PRs (overlap disclosure)

- **#42124 (`Add LM head quantization support for ModelOpt`)** already includes the one-line `quant_config=self.quant_config` for `NemotronHForCausalLM.lm_head`. My PR includes the same one-liner plus the matching one for `NemotronHMTP.lm_head`. If #42124 lands first, drop the `NemotronHForCausalLM` hunk on rebase.

**Unique to this PR**:
- `NemotronHMTP` `quant_config` plumbing for `lm_head` (#42124 does not touch `nemotron_h_mtp.py`).
- `NemotronHMTP` compressed-tensors `ignore` extension for per-expert MTP linears — analogous to #41994 but for Nemotron-H. No open PR I found covers this for Nemotron.

## Test Plan

- [ ] End-to-end serve Nemotron-H 3.5 (modelopt NVFP4 W4A4) — exercises quantized LM head + MTP.
- [ ] End-to-end serve Nemotron-H 3.5 (compressed-tensors `nvfp4-pack-quantized` W4A16) — exercises MTP ignore-list extension.

> Fill in actual test results before review per AGENTS.md.

## AI assistance

This change was developed with AI assistance (Claude). Every changed line was reviewed locally by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)