### PR TITLE
[Model] Qwen3.5: quantized LM head, VLM prefix fallbacks, MTP fix

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -2306,6 +2306,24 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         if prefix in self.quantized_layers:
             return self.quantized_layers[prefix]["quant_algo"].upper()
 
+        # Qwen VLM wrappers can construct the LM head under a nested vLLM
+        # prefix while ModelOpt exports the tensor names as top-level lm_head.*.
+        if prefix.endswith(".lm_head") and "lm_head" in self.quantized_layers:
+            return self.quantized_layers["lm_head"]["quant_algo"].upper()
+
+        # Qwen3.5/3.6-MoE VLM: vLLM's internal naming can be
+        # language_model.model.layers.X... while ModelOpt exports keys as
+        # model.language_model.layers.X... (swapped wrapper order). Try the
+        # swap as a direct fallback for any prefix that does not match.
+        if prefix.startswith("language_model.model."):
+            swapped = "model.language_model." + prefix[len("language_model.model.") :]
+            if swapped in self.quantized_layers:
+                return self.quantized_layers[swapped]["quant_algo"].upper()
+        elif prefix.startswith("model.language_model."):
+            swapped = "language_model.model." + prefix[len("model.language_model.") :]
+            if swapped in self.quantized_layers:
+                return self.quantized_layers[swapped]["quant_algo"].upper()
+
         # 2. Packed / fused layer lookup
         proj_name = prefix.rsplit(".", 1)[-1]
         if self.packed_modules_mapping and proj_name in self.packed_modules_mapping:

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -475,6 +475,7 @@ class Qwen3_5ForCausalLMBase(
                 self.lm_head = ParallelLMHead(
                     config.vocab_size,
                     config.hidden_size,
+                    quant_config=self.quant_config,
                     prefix=maybe_prefix(prefix, "lm_head"),
                 )
         else:

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -96,6 +96,26 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             prefix=f"{prefix}.fc",
         )
 
+        if (
+            quant_config is not None
+            and quant_config.get_name() == "compressed-tensors"
+            and hasattr(quant_config, "ignore")
+        ):
+            num_experts = getattr(config, "num_experts", 0)
+            extra: list[str] = []
+            for idx in range(self.num_mtp_layers):
+                for eid in range(num_experts):
+                    for proj in ("gate_proj", "up_proj", "down_proj"):
+                        extra.append(f"{prefix}.layers.{idx}.mlp.experts.{eid}.{proj}")
+            new_entries = [n for n in extra if n not in quant_config.ignore]
+            quant_config.ignore.extend(new_entries)
+            if new_entries:
+                logger.info(
+                    "Qwen3_5MTP: extended compressed-tensors ignore with "
+                    "%d per-expert MTP linears (BF16 in the checkpoint)",
+                    len(new_entries),
+                )
+
         self.layers = torch.nn.ModuleList(
             Qwen3_5DecoderLayer(
                 vllm_config,
@@ -381,6 +401,7 @@ class Qwen3_5MTP(nn.Module, SupportsMultiModal):
                 self.lm_head = ParallelLMHead(
                     config.vocab_size,
                     config.hidden_size,
+                    quant_config=self.quant_config,
                     prefix=maybe_prefix(prefix, "lm_head"),
                 )
         else:


### PR DESCRIPTION
## Purpose

Model-side fixes for **Qwen3.5** under quantized checkpoints, including Qwen3.5/3.6 VLM wrapper-prefix handling.

**Part 3/3 of splitting #43333** (the combined B12x + Nemotron-3.5 + Qwen3.5 PR).

## ⚠️ Heavy overlap with existing open PRs

**Every hunk in this PR is also present in at least one open PR.** I'm filing it as part of the #43333 split for completeness, but **reviewers may prefer to close this in favor of**:

- **#42124 (`Add LM head quantization support for ModelOpt`)** — already passes `quant_config` to `Qwen3_5ForCausalLMBase.lm_head` and `Qwen3_5MTP.lm_head` (same one-line changes as here).
- **#42546 (`Support Qwen3.5/3.6 VLM quantized prefix mapping`)** — already adds the `endswith('.lm_head')` and `language_model.model.` ↔ `model.language_model.` swap logic in `ModelOptMixedPrecisionConfig.get_quant_method`.
- **#41994 (`Extend compressed-tensors ignore for Qwen3.5 MTP experts`)** — already extends `compressed_tensors_config.ignore` with per-expert MTP linears for `Qwen3_5MTP`.

Together, those three PRs cover everything in this PR. **No part of this PR is materially novel.** It is preserved as a standalone split only so that #43333 can be cleanly retired into three focused branches — if any of the above land first, this PR should be closed.

## Changes (for reference)

- **`Qwen3_5ForCausalLMBase`, `Qwen3_5MTP`**: pass `quant_config` to `ParallelLMHead`.
- **`ModelOptMixedPrecisionConfig.get_quant_method`**: Qwen VLM wrapper-prefix handling (`endswith('.lm_head')` + `language_model.model.` ↔ `model.language_model.` swap).
- **`Qwen3_5MTP`**: extend `compressed_tensors_config.ignore` with per-expert MTP linears.

## Test Plan

- [ ] End-to-end serve Qwen3.5-MoE VLM (modelopt) — exercises the nested-prefix / wrapper-swap lookups.
- [ ] Confirm `lm_head` is dispatched to `ModelOptNvFp4LinearMethod` (not `UnquantizedLinearMethod`) via debug logging on a Qwen VLM checkpoint.

> Fill in actual test results before review per AGENTS.md.

## AI assistance

This change was developed with AI assistance (Claude). Every changed line was reviewed locally by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)