### PR TITLE
[Bugfix] Add GELU_TANH activation support to CPU fused MoE

### DIFF
--- a/csrc/cpu/cpu_fused_moe.cpp
+++ b/csrc/cpu/cpu_fused_moe.cpp
@@ -30,7 +30,7 @@
   }()
 
 namespace {
-enum class FusedMOEAct { SiluAndMul, SwigluOAIAndMul, GeluAndMul };
+enum class FusedMOEAct { SiluAndMul, SwigluOAIAndMul, GeluAndMul, GeluTanhAndMul };
 
 FusedMOEAct get_act_type(const std::string& act) {
   if (act == "silu") {
@@ -39,6 +39,8 @@ FusedMOEAct get_act_type(const std::string& act) {
     return FusedMOEAct::SwigluOAIAndMul;
   } else if (act == "gelu") {
     return FusedMOEAct::GeluAndMul;
+  } else if (act == "gelu_tanh") {
+    return FusedMOEAct::GeluTanhAndMul;
   } else {
     TORCH_CHECK(false, "Invalid act type: " + act);
   }
@@ -144,6 +146,46 @@ void gelu_and_mul(float* __restrict__ input, scalar_t* __restrict__ output,
 }
 
 template <typename scalar_t>
+void gelu_tanh_and_mul(float* __restrict__ input, scalar_t* __restrict__ output,
+                       const int32_t m_size, const int32_t n_size,
+                       const int32_t input_stride, const int32_t output_stride) {
+  using scalar_vec_t = typename cpu_utils::VecTypeTrait<scalar_t>::vec_t;
+  const int32_t dim = n_size / 2;
+  float* __restrict__ gate = input;
+  float* __restrict__ up = input + dim;
+  vec_op::FP32Vec16 one_vec(1.0);
+  vec_op::FP32Vec16 w1_vec(0.5);
+  vec_op::FP32Vec16 sqrt_2_over_pi(0.7978845608);  // sqrt(2/pi)
+  vec_op::FP32Vec16 coeff(0.044715);
+  alignas(64) float temp[16];
+
+  DEFINE_FAST_EXP
+
+  for (int32_t m = 0; m < m_size; ++m) {
+    for (int32_t n = 0; n < dim; n += 16) {
+      vec_op::FP32Vec16 gate_vec(gate + n);
+      vec_op::FP32Vec16 up_vec(up + n);
+      // Compute 0.044715 * x^3
+      auto gate_cubed = gate_vec * gate_vec * gate_vec;
+      auto tanh_input = sqrt_2_over_pi * (gate_vec + coeff * gate_cubed);
+
+      tanh_input.save(temp);
+      for (int32_t i = 0; i < 16; ++i) {
+        temp[i] = std::tanh(temp[i]);
+      }
+      vec_op::FP32Vec16 tanh_vec(temp);
+      auto gelu = w1_vec * gate_vec * (one_vec + tanh_vec);
+      auto gated_output_fp32 = up_vec * gelu;
+      scalar_vec_t gated_output = scalar_vec_t(gated_output_fp32);
+      gated_output.save(output + n);
+    }
+    gate += input_stride;
+    up += input_stride;
+    output += output_stride;
+  }
+}
+
+template <typename scalar_t>
 FORCE_INLINE void apply_gated_act(const FusedMOEAct act,
                                   float* __restrict__ input,
                                   scalar_t* __restrict__ output,
@@ -159,6 +201,9 @@ FORCE_INLINE void apply_gated_act(const FusedMOEAct act,
       return;
     case FusedMOEAct::GeluAndMul:
       gelu_and_mul(input, output, m, n, input_stride, output_stride);
+      return;
+    case FusedMOEAct::GeluTanhAndMul:
+      gelu_tanh_and_mul(input, output, m, n, input_stride, output_stride);
       return;
     default:
       TORCH_CHECK(false, "Unsupported act type.");

--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -20,7 +20,12 @@ EXPERT_NUM = [
 HIDDEN_DIM = [128, 2880]
 INTERMEDIATE_DIM = [128, 2880]
 BATCH_SIZE = [1, 64, 256]
-ACT = [MoEActivation.SILU, MoEActivation.SWIGLUOAI, MoEActivation.GELU]
+ACT = [
+    MoEActivation.SILU,
+    MoEActivation.SWIGLUOAI,
+    MoEActivation.GELU,
+    MoEActivation.GELU_TANH,
+]
 USE_BIAS = [True, False]
 ISA = ["amx", "vec"] if torch.cpu._is_amx_tile_supported() else ["vec"]
 DTYPE = [torch.bfloat16]

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -46,6 +46,13 @@ def _gelu_and_mul(
     return F.gelu(x[..., :d], approximate="none") * x[..., d:]
 
 
+def _gelu_tanh_and_mul(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    return F.gelu(x[..., :d], approximate="tanh") * x[..., d:]
+
+
 # Map activation names to their native forward functions.
 # Uses static methods or standalone functions to avoid instantiating CustomOp
 # classes, which would call get_current_vllm_config() before config is set.
@@ -53,6 +60,7 @@ _CPU_MOE_ACT_FN: dict[MoEActivation, Callable[[torch.Tensor], torch.Tensor]] = {
     MoEActivation.SILU: lambda x: SiluAndMul(compile_native=False).forward_native(x),
     MoEActivation.SWIGLUOAI: _swigluoai_forward_native,
     MoEActivation.GELU: _gelu_and_mul,
+    MoEActivation.GELU_TANH: _gelu_tanh_and_mul,
 }
 
 


### PR DESCRIPTION
This PR adds GELU_TANH activation function support to the CPU fused MoE backend.

The `_CPU_MOE_ACT_FN` dictionary in `cpu_fused_moe.py` was missing an entry for `MoEActivation.GELU_TANH`, causing models like Gemma4 26B-A4B to fail with an assertion error when running on CPU. While GELU_TANH is defined in the activation enum and supported in GPU paths, the CPU backend had incomplete coverage.

The fix adds a `_gelu_tanh_and_mul` function that applies `torch.nn.functional.gelu` with `approximate='tanh'` and registers it in the activation function dictionary. This implementation matches the GPU path behavior and follows the same pattern as the existing `_gelu_and_mul` function.

A test case for GELU_TANH has been added to the existing CPU fused MoE test suite to ensure correctness.

Fixes #43326
