### PR TITLE
[Model][Whisper] Batch encoder forward for prefill

### DIFF
--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -5,7 +5,8 @@ from collections.abc import Sequence
 from typing import Any
 
 import pytest
-from transformers import AutoModelForSpeechSeq2Seq
+import torch
+from transformers import AutoModelForSpeechSeq2Seq, WhisperConfig
 
 from vllm.assets.audio import AudioAsset
 from vllm.multimodal.audio import AudioResampler
@@ -123,6 +124,48 @@ def check_model_available(model: str) -> None:
     model_info = HF_EXAMPLE_MODELS.find_hf_info(model)
     model_info.check_available_online(on_fail="skip")
     model_info.check_transformers_version(on_fail="skip")
+
+
+def test_whisper_encoder_batches_list_inputs(monkeypatch):
+    import vllm.model_executor.models.whisper as whisper
+
+    class FakeVllmConfig:
+        def __init__(self, hf_config):
+            self.model_config = type("ModelConfig", (), {"hf_config": hf_config})()
+
+    torch.manual_seed(0)
+    config = WhisperConfig(
+        d_model=16,
+        encoder_attention_heads=2,
+        encoder_layers=0,
+        encoder_ffn_dim=64,
+        num_mel_bins=8,
+        max_source_positions=4,
+    )
+    monkeypatch.setattr(
+        whisper,
+        "make_layers",
+        lambda *args, **kwargs: (0, 0, torch.nn.ModuleList()),
+    )
+    encoder = whisper.WhisperEncoder(vllm_config=FakeVllmConfig(config))
+    features = [
+        torch.randn(config.num_mel_bins, config.max_source_positions * 2)
+        for _ in range(3)
+    ]
+
+    conv1_call_count = 0
+    conv1_forward = encoder.conv1.forward
+
+    def counted_conv1_forward(input_features):
+        nonlocal conv1_call_count
+        conv1_call_count += 1
+        return conv1_forward(input_features)
+
+    monkeypatch.setattr(encoder.conv1, "forward", counted_conv1_forward)
+    list_output = encoder(features)
+
+    assert conv1_call_count == 1
+    torch.testing.assert_close(list_output, encoder(torch.stack(features, dim=0)))
 
 
 @pytest.mark.parametrize("dtype", ["half"])

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -509,25 +509,20 @@ class WhisperEncoder(nn.Module):
     def forward(
         self, input_features: torch.Tensor | list[torch.Tensor]
     ) -> torch.Tensor:
-        hidden_states = []
-        input_is_batched = False
-        for features in input_features:
-            embeds = nn.functional.gelu(self.conv1(features))
-            embeds = nn.functional.gelu(self.conv2(embeds))
-
-            embeds = embeds.transpose(-1, -2)
-            embeds = (embeds + self.embed_positions.weight[: embeds.size(-2), :]).to(
-                embeds.dtype
+        if isinstance(input_features, torch.Tensor) and input_features.ndim == 3:
+            features_batch = input_features
+        else:
+            features_batch = torch.stack(
+                [f if f.ndim == 2 else f.squeeze(0) for f in input_features],
+                dim=0,
             )
 
-            hidden_states.append(embeds)
-            input_is_batched = embeds.ndim > 2
-        # Input to MHA must be B x T x D
-        if input_is_batched:
-            # Models using WhisperEncoder may handle batching internally.
-            hidden_states = torch.cat(hidden_states)
-        else:
-            hidden_states = torch.stack(hidden_states, dim=0)
+        hidden_states = nn.functional.gelu(self.conv1(features_batch))
+        hidden_states = nn.functional.gelu(self.conv2(hidden_states))
+        hidden_states = hidden_states.transpose(-1, -2)
+        hidden_states = (
+            hidden_states + self.embed_positions.weight[: hidden_states.size(-2), :]
+        ).to(hidden_states.dtype)
 
         for encoder_layer in self.layers:
             hidden_states = encoder_layer(hidden_states)


### PR DESCRIPTION
## Purpose

Batch Whisper encoder inputs before running the conv stack. The previous `WhisperEncoder.forward()` loop ran `conv1`/`conv2` per request; when concurrent prefills are batched, those conv launches can run once over an `(N, C, T)` tensor instead.

The single-request path remains equivalent, and the encoder still returns batched hidden states for the existing downstream transformer/layer norm flow.

## Test Plan

- `pre-commit run --files vllm/model_executor/models/whisper.py tests/models/multimodal/generation/test_whisper.py`
- `python -m pytest tests/models/multimodal/generation/test_whisper.py::test_whisper_encoder_batches_list_inputs -q`

## Test Result

- `pre-commit run --files vllm/model_executor/models/whisper.py tests/models/multimodal/generation/test_whisper.py`: passed
- `python -m pytest tests/models/multimodal/generation/test_whisper.py::test_whisper_encoder_batches_list_inputs -q`: passed (`1 passed, 17 warnings`)

The local test environment was installed with `requirements/test/cuda.txt`, `requirements/common.txt`, and `VLLM_USE_PRECOMPILED=1 uv pip install -e .`.