### PR TITLE
Add QK-Norm+RoPE fusion with auto-enable via AITER for ROCm

### DIFF
--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -239,6 +239,13 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
         self.matched_count = self.patterns.apply(graph)
+        if self.matched_count > 0:
+            logger.info_once(
+                "QK-Norm+RoPE fusion: Fused %d attention layer(s) "
+                "(RMSNorm+RoPE operations combined into single kernel)",
+                self.matched_count,
+                scope="global",
+            )
         logger.debug("Fused QK Norm+RoPE on %s sites", self.matched_count)
 
     def uuid(self) -> str:

--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -241,8 +241,7 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
         self.matched_count = self.patterns.apply(graph)
         if self.matched_count > 0:
             logger.info_once(
-                "QK-Norm+RoPE fusion: Fused %d attention layer(s) "
-                "(RMSNorm+RoPE operations combined into single kernel)",
+                "QK-Norm+RoPE fusion: Fused %d attention layer(s)",
                 self.matched_count,
                 scope="global",
             )

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -251,18 +251,19 @@ class PassConfig:
 
             import vllm.envs as envs
 
-            fusion_env_set = os.getenv("VLLM_ENABLE_QKNORM_ROPE_FUSION") is not None
+            fusion_explicitly_disabled = os.getenv(
+                "VLLM_ENABLE_QKNORM_ROPE_FUSION", ""
+            ).lower() in ("0", "false")
 
-            # Fusion requires AITER on ROCm
-            if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER:
-                # AITER enabled: fusion auto-enabled unless explicitly disabled
-                if fusion_env_set and not envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
-                    self.enable_qk_norm_rope_fusion = False
-                else:
-                    self.enable_qk_norm_rope_fusion = True
-                    logger.info_once("QK-Norm+RoPE fusion enabled", scope="global")
+            # Enable if AITER is on (ROCm) and fusion not explicitly disabled
+            if (
+                current_platform.is_rocm()
+                and envs.VLLM_ROCM_USE_AITER
+                and not fusion_explicitly_disabled
+            ):
+                self.enable_qk_norm_rope_fusion = True
+                logger.info_once("QK-Norm+RoPE fusion enabled", scope="global")
             else:
-                # AITER not enabled: fusion disabled
                 self.enable_qk_norm_rope_fusion = False
 
         if not self.eliminate_noops:

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -253,25 +253,25 @@ class PassConfig:
 
             fusion_env_set = os.getenv("VLLM_ENABLE_QKNORM_ROPE_FUSION") is not None
 
-            # If fusion explicitly disabled via env var, respect it
-            if fusion_env_set and not envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
-                self.enable_qk_norm_rope_fusion = False
-            # Auto-enable on ROCm if AITER is enabled or fusion env var is set
-            elif current_platform.is_rocm() and (
-                envs.VLLM_ENABLE_QKNORM_ROPE_FUSION or envs.VLLM_ROCM_USE_AITER
-            ):
-                self.enable_qk_norm_rope_fusion = True
-                if envs.VLLM_ROCM_USE_AITER and not fusion_env_set:
-                    logger.info_once(
-                        "QK-Norm+RoPE fusion auto-enabled via AITER",
-                        scope="global",
-                    )
+            # Fusion requires AITER on ROCm
+            if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER:
+                # AITER enabled: fusion auto-enabled unless explicitly disabled
+                if fusion_env_set and not envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
+                    self.enable_qk_norm_rope_fusion = False
                 else:
-                    logger.info_once(
-                        "QK-Norm+RoPE fusion enabled",
-                        scope="global",
-                    )
+                    self.enable_qk_norm_rope_fusion = True
+                    if not fusion_env_set:
+                        logger.info_once(
+                            "QK-Norm+RoPE fusion auto-enabled via AITER",
+                            scope="global",
+                        )
+                    else:
+                        logger.info_once(
+                            "QK-Norm+RoPE fusion enabled",
+                            scope="global",
+                        )
             else:
+                # AITER not enabled: fusion disabled
                 self.enable_qk_norm_rope_fusion = False
 
         if not self.eliminate_noops:

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -137,7 +137,9 @@ class PassConfig:
     fuse_minimax_qk_norm: bool = None  # type: ignore[assignment]
     """Enable fused allreduce+RMSNorm for MiniMax QK norm."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
-    """Enable fused Q/K RMSNorm + RoPE pass."""
+    """Fuse Q/K RMSNorm + RoPE into single kernel (ROCm-only).
+    Set via VLLM_ENABLE_QKNORM_ROPE_FUSION or auto-enabled with AITER.
+    """
     fuse_rope_kvcache_cat_mla: bool = None  # type: ignore[assignment]
     """Enable fused MLA KV cache update with RoPE."""
 
@@ -243,6 +245,21 @@ class PassConfig:
     def __post_init__(self) -> None:
         # Handle deprecation and defaults
 
+        # Initialize enable_qk_norm_rope_fusion from environment if not explicitly set
+        if self.enable_qk_norm_rope_fusion is None:
+            import vllm.envs as envs
+
+            # Only enable on ROCm if env var is set
+            if current_platform.is_rocm() and envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
+                self.enable_qk_norm_rope_fusion = True
+                logger.info_once(
+                    "QK-Norm+RoPE fusion enabled via VLLM_ENABLE_QKNORM_ROPE_FUSION "
+                    "environment variable (ROCm)",
+                    scope="global",
+                )
+            else:
+                self.enable_qk_norm_rope_fusion = False
+
         if not self.eliminate_noops:
             if self.fuse_norm_quant or self.fuse_act_quant:
                 logger.warning_once(
@@ -264,12 +281,18 @@ class PassConfig:
                     "Fusion enabled but reshape elimination disabled. "
                     "RMSNorm + padding fusion might not work"
                 )
-        if self.enable_qk_norm_rope_fusion and not current_platform.is_cuda_alike():
-            logger.warning_once(
-                "QK Norm + RoPE fusion enabled but the current platform is not "
-                "CUDA or ROCm. The fusion will be disabled."
-            )
-            self.enable_qk_norm_rope_fusion = False
+        # Enforce ROCm-only restriction for QK-Norm+RoPE fusion
+        if self.enable_qk_norm_rope_fusion:
+            if not current_platform.is_rocm():
+                logger.warning_once(
+                    "QK Norm + RoPE fusion is only supported on AMD/ROCm hardware. "
+                    "The fusion will be disabled."
+                )
+                self.enable_qk_norm_rope_fusion = False
+            else:
+                logger.info_once(
+                    "QK-Norm+RoPE fusion enabled for ROCm hardware", scope="global"
+                )
         if self.fuse_act_padding and not current_platform.is_rocm():
             logger.warning_once(
                 "Padding fusion enabled but the current platform is not ROCm. "

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -249,14 +249,23 @@ class PassConfig:
         if self.enable_qk_norm_rope_fusion is None:
             import vllm.envs as envs
 
-            # Only enable on ROCm if env var is set
-            if current_platform.is_rocm() and envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
+            # Auto-enable on ROCm if AITER is enabled or fusion env var is set
+            if current_platform.is_rocm() and (
+                envs.VLLM_ENABLE_QKNORM_ROPE_FUSION or envs.VLLM_ROCM_USE_AITER
+            ):
                 self.enable_qk_norm_rope_fusion = True
-                logger.info_once(
-                    "QK-Norm+RoPE fusion enabled via VLLM_ENABLE_QKNORM_ROPE_FUSION "
-                    "environment variable (ROCm)",
-                    scope="global",
-                )
+                if envs.VLLM_ROCM_USE_AITER and not envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
+                    logger.info_once(
+                        "QK-Norm+RoPE fusion auto-enabled via "
+                        "VLLM_ROCM_USE_AITER (ROCm)",
+                        scope="global",
+                    )
+                else:
+                    logger.info_once(
+                        "QK-Norm+RoPE fusion enabled via "
+                        "VLLM_ENABLE_QKNORM_ROPE_FUSION env var (ROCm)",
+                        scope="global",
+                    )
             else:
                 self.enable_qk_norm_rope_fusion = False
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -247,23 +247,28 @@ class PassConfig:
 
         # Initialize enable_qk_norm_rope_fusion from environment if not explicitly set
         if self.enable_qk_norm_rope_fusion is None:
+            import os
+
             import vllm.envs as envs
 
+            fusion_env_set = os.getenv("VLLM_ENABLE_QKNORM_ROPE_FUSION") is not None
+
+            # If fusion explicitly disabled via env var, respect it
+            if fusion_env_set and not envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
+                self.enable_qk_norm_rope_fusion = False
             # Auto-enable on ROCm if AITER is enabled or fusion env var is set
-            if current_platform.is_rocm() and (
+            elif current_platform.is_rocm() and (
                 envs.VLLM_ENABLE_QKNORM_ROPE_FUSION or envs.VLLM_ROCM_USE_AITER
             ):
                 self.enable_qk_norm_rope_fusion = True
-                if envs.VLLM_ROCM_USE_AITER and not envs.VLLM_ENABLE_QKNORM_ROPE_FUSION:
+                if envs.VLLM_ROCM_USE_AITER and not fusion_env_set:
                     logger.info_once(
-                        "QK-Norm+RoPE fusion auto-enabled via "
-                        "VLLM_ROCM_USE_AITER (ROCm)",
+                        "QK-Norm+RoPE fusion auto-enabled via AITER",
                         scope="global",
                     )
                 else:
                     logger.info_once(
-                        "QK-Norm+RoPE fusion enabled via "
-                        "VLLM_ENABLE_QKNORM_ROPE_FUSION env var (ROCm)",
+                        "QK-Norm+RoPE fusion enabled",
                         scope="global",
                     )
             else:
@@ -291,17 +296,9 @@ class PassConfig:
                     "RMSNorm + padding fusion might not work"
                 )
         # Enforce ROCm-only restriction for QK-Norm+RoPE fusion
-        if self.enable_qk_norm_rope_fusion:
-            if not current_platform.is_rocm():
-                logger.warning_once(
-                    "QK Norm + RoPE fusion is only supported on AMD/ROCm hardware. "
-                    "The fusion will be disabled."
-                )
-                self.enable_qk_norm_rope_fusion = False
-            else:
-                logger.info_once(
-                    "QK-Norm+RoPE fusion enabled for ROCm hardware", scope="global"
-                )
+        if self.enable_qk_norm_rope_fusion and not current_platform.is_rocm():
+            logger.warning_once("QK-Norm+RoPE fusion requires ROCm. Disabling.")
+            self.enable_qk_norm_rope_fusion = False
         if self.fuse_act_padding and not current_platform.is_rocm():
             logger.warning_once(
                 "Padding fusion enabled but the current platform is not ROCm. "

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -251,6 +251,9 @@ class PassConfig:
 
             import vllm.envs as envs
 
+            # Default to disabled
+            self.enable_qk_norm_rope_fusion = False
+
             fusion_explicitly_disabled = os.getenv(
                 "VLLM_ENABLE_QKNORM_ROPE_FUSION", ""
             ).lower() in ("0", "false")
@@ -263,8 +266,6 @@ class PassConfig:
             ):
                 self.enable_qk_norm_rope_fusion = True
                 logger.info_once("QK-Norm+RoPE fusion enabled", scope="global")
-            else:
-                self.enable_qk_norm_rope_fusion = False
 
         if not self.eliminate_noops:
             if self.fuse_norm_quant or self.fuse_act_quant:

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -260,16 +260,7 @@ class PassConfig:
                     self.enable_qk_norm_rope_fusion = False
                 else:
                     self.enable_qk_norm_rope_fusion = True
-                    if not fusion_env_set:
-                        logger.info_once(
-                            "QK-Norm+RoPE fusion auto-enabled via AITER",
-                            scope="global",
-                        )
-                    else:
-                        logger.info_once(
-                            "QK-Norm+RoPE fusion enabled",
-                            scope="global",
-                        )
+                    logger.info_once("QK-Norm+RoPE fusion enabled", scope="global")
             else:
                 # AITER not enabled: fusion disabled
                 self.enable_qk_norm_rope_fusion = False

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1151,12 +1151,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
     ),
-    # Whether to enable QK-Norm+RoPE fusion for AMD/ROCm hardware.
-    # This fuses Q/K RMSNorm and RoPE operations into a single kernel,
-    # reducing memory bandwidth and kernel launch overhead.
-    # By default is disabled.
-    # Note: This flag is ROCm-only and will be automatically disabled on
-    # CUDA/other platforms.
+    # Enable QK-Norm+RoPE fusion (ROCm-only). Fuses Q/K RMSNorm and RoPE
+    # into a single kernel. Disabled by default.
     "VLLM_ENABLE_QKNORM_ROPE_FUSION": lambda: (
         os.getenv("VLLM_ENABLE_QKNORM_ROPE_FUSION", "False").lower() in ("true", "1")
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
+    VLLM_ENABLE_QKNORM_ROPE_FUSION: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -1149,6 +1150,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
+    ),
+    # Whether to enable QK-Norm+RoPE fusion for AMD/ROCm hardware.
+    # This fuses Q/K RMSNorm and RoPE operations into a single kernel,
+    # reducing memory bandwidth and kernel launch overhead.
+    # By default is disabled.
+    # Note: This flag is ROCm-only and will be automatically disabled on
+    # CUDA/other platforms.
+    "VLLM_ENABLE_QKNORM_ROPE_FUSION": lambda: (
+        os.getenv("VLLM_ENABLE_QKNORM_ROPE_FUSION", "False").lower() in ("true", "1")
     ),
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM": lambda: (


### PR DESCRIPTION
## Summary

This PR adds QK-Norm+RoPE fusion optimization for Qwen models on AMD/ROCm hardware with convenient auto-enable via AITER.

## Changes

1. **Auto-Enable with AITER**: Fusion automatically enables when `VLLM_ROCM_USE_AITER=1`
2. **New Environment Variable**: `VLLM_ENABLE_QKNORM_ROPE_FUSION`
   - Explicitly enable/disable QK-Norm+RoPE fusion
  
## Usage

### Option 1: Auto-enable with AITER (Recommended)
```bash
export VLLM_ROCM_USE_AITER=1
python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
```
### Option 2: Explicit disable (overrides AITER)
```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ENABLE_QKNORM_ROPE_FUSION=0
```

## Testing
```bash
VLLM_ROCM_USE_AITER=1 VLLM_ENABLE_QKNORM_ROPE_FUSION=1 python -m vllm.entrypoints.openai.api_server         --model Qwen/Qwen3-235B-A22B-Instruct-2507-FP8         --port 8000    --trust-remote-code --max-model-len 8192 --tensor-parallel-size 4 --no-enable-prefix-caching --max_num_seqs 1024 --mm-encoder-tp-mode "data" --gpu-memory-utilization 0.90 --trust-remote-code --performance-mode throughput --optimization-level 3

python -m atom.benchmarks.benchmark_serving --backend openai --host localhost --port 8000 --endpoint /v1/completions --model Qwen/Qwen3-235B-A22B-Instruct-2507-FP8   --dataset-name random --random-input-len 1024 --random-output-len 1024 --num-prompts 1024  --max-concurrency=32  --request-rate inf --ignore-eos
```
## correctness:
```bash
lm_eval --model vllm \
    --model_args pretrained=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8,\
                 tensor_parallel_size=4,\
                 dtype=auto,\
                 gpu_memory_utilization=0.95,\
                 max_model_len=8192,\
                 trust_remote_code=True \
    --tasks gsm8k \
    --num_fewshot 8 \
    --batch_size 8 \
    --output_path /mnt/nvme5n1p1/khairulkabir1661/Qwen_model_analysis/eval_results/ \
    --log_samples \
    --show_config
```

vllm ({'pretrained': 'Qwen/Qwen3-235B-A22B-Instruct-2507-FP8', 'tensor_parallel_size': 4, 'dtype': 'auto', 'gpu_memory_utilization': 0.95, 'max_model_len': 8192}), gen_kwargs: ({}), limit: None, num_fewshot: 8, batch_size: 8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9272|±  |0.0072|
|     |       |strict-match    |     8|exact_match|↑  |0.9212|±  |0.0074|

## Performance


```
==========================================================================================================================================================
 Conc |       Total Throughput (tok/s)     |         Output Throughput (tok/s)  |            Mean TPOT (ms)          |         Mean TTFT (ms)             |
      |      Baseline         Fused     Δ% |      Baseline         Fused     Δ% |      Baseline         Fused     Δ% |      Baseline         Fused     Δ% |
----------------------------------------------------------------------------------------------------------------------------------------------------------|
   32 |       3063.97       3227.93   5.4% |       1531.98       1613.97   5.4% |         19.39         18.42  -5.0% |       1554.85       1460.80  -6.0% |
   64 |       4354.64       4537.58   4.2% |       2177.32       2268.79   4.2% |         27.21         26.09  -4.1% |       2255.85       2192.09  -2.8% |
   96 |       5458.56       5594.52   2.5% |       2729.28       2797.26   2.5% |         31.98         31.18  -2.5% |       2454.18       2426.47  -1.1% |
  128 |       6464.84       6689.83   3.5% |       3232.42       3344.91   3.5% |         36.92         35.61  -3.5% |       2758.62       2727.67  -1.1% |
  192 |       7256.08       7450.30   2.7% |       3628.04       3725.15   2.7% |         46.30         45.15  -2.5% |       3589.03       3560.54  -0.8% |
  256 |       8410.00       8730.61   3.8% |       4205.00       4365.31   3.8% |         56.53         54.20  -4.1% |       4446.42       4541.04   2.1% |
  320 |       8298.92       8370.91   0.9% |       4149.46       4185.45   0.9% |         65.81         65.18  -1.0% |       5377.59       5396.67   0.4% |
  384 |       9118.49       9288.03   1.9% |       4559.25       4644.01   1.9% |         72.10         70.73  -1.9% |       6777.47       6748.38  -0.4% |
  512 |      10151.10      10287.47   1.3% |       5075.55       5143.74   1.3% |         90.60         88.97  -1.8% |      10287.11      10599.62   3.0% |
  640 |       7932.57       8192.07   3.3% |       3966.28       4096.03   3.3% |        132.49        127.80  -3.5% |      14897.88      14586.71  -2.1% |
----------------------------------------------------------------------------------------------------------------------------------------------------------|
```
