### PR TITLE
Fix the docker build failure in tpu-inference

### DIFF
--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -10,5 +10,6 @@ jinja2>=3.1.6
 ray[default]
 ray[data]
 setuptools==78.1.0
+setuptools-rust>=1.9.0
 nixl==0.3.0
 tpu-inference==0.19.0


### PR DESCRIPTION



## Purpose
This is the follow up fix for PR https://github.com/vllm-project/vllm/pull/40848 
as it missed to add the 
setuptools-rust>=1.9.0
into vllm/requirements/tpu.txt, which leads tpu-inference fail to build docker.

## Test Plan
after the fix, docker build succeeded.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

