### PR TITLE
[KV Connector][2/N][NIXL] Pipeline-parallel support for PD-disaggregated serving with NIXL connector

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py
+++ b/tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py
@@ -15,7 +15,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", required=True)
     parser.add_argument("--port", required=True, type=int)
-    parser.add_argument("--rank", default=0, type=int)
+    parser.add_argument("--pp-rank", default=0, type=int)
+    parser.add_argument("--tp-rank", default=0, type=int)
     parser.add_argument("--timeout-ms", default=1000, type=int)
     return parser.parse_args()
 
@@ -37,7 +38,7 @@ def main() -> None:
     sock.setsockopt(zmq.RCVTIMEO, args.timeout_ms)
     try:
         sock.connect(make_zmq_path(args.host, args.port))
-        sock.send(msgspec.msgpack.encode((GET_META_MSG, args.rank)))
+        sock.send(msgspec.msgpack.encode((GET_META_MSG, args.pp_rank, args.tp_rank)))
         sock.recv()
     finally:
         sock.close()

--- a/tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py
+++ b/tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py
@@ -104,9 +104,13 @@ def _make_connector_with_fake_worker(
             host="localhost",
             port=1234,
             remote_tp_size=1,
+            remote_pp_size=1,
             expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
         )
         worker._remote_agents[FakeNixlConnectorWorker.REMOTE_ENGINE_ID] = remote_agents
+        # done_callback records the completed handshake's pp_size; mirror it here
+        # since this test drives _nixl_handshake directly.
+        worker._remote_pp_size[FakeNixlConnectorWorker.REMOTE_ENGINE_ID] = 1
     return connector, worker
 
 

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -9,6 +9,7 @@ import textwrap
 import time
 import uuid
 from collections import defaultdict
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -408,11 +409,12 @@ def test_kv_transfer_handshake(dist_init):
         decoder = msgspec.msgpack.Decoder(NixlAgentMetadata)
         expected_agent_metadata = decoder.decode(metadata.agent_metadata_bytes)
 
-        # The scheduler connector expects metadata to be in
-        # dict[int, KVConnectorHandshakeMetadata], where the first key is
-        # the dp_rank, the second key is the tp_rank.
+        # The scheduler connector expects metadata keyed by (pp_rank, tp_rank).
+        # Engine core dispatches via the PP-aware entry point, which is what
+        # starts the NIXL handshake listener; the legacy non-PP-aware setter
+        # does not, so use the PP-aware one here to match production.
         scheduler_connector = scheduler.get_kv_connector()
-        scheduler_connector.set_xfer_handshake_metadata({0: metadata})
+        scheduler_connector.set_xfer_handshake_metadata_pp_aware({(0, 0): metadata})
 
         # Simulate a request that finishes prefill, which returns
         # corresponding NixlConnectorMetadata for decode instance.
@@ -452,6 +454,7 @@ def test_kv_transfer_handshake(dist_init):
                 kv_connector_metadata["remote_host"],
                 kv_connector_metadata["remote_port"],
                 kv_connector_metadata["tp_size"],
+                kv_connector_metadata.get("pp_size", 1),
                 kv_connector_metadata["remote_engine_id"],
             )
 
@@ -480,8 +483,6 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         super().__init__(*args, kv_cache_config=kv_cache_config, **kwargs)
         self._hand_shake_latency = hand_shake_latency
         self.kv_cache_layout = kv_cache_layout
-        # Mock register_kv_caches attribute needed for tests that do not call it.
-        self.src_xfer_handles_by_block_size = {self.block_size: 1}
         test_shape = self.attn_backends[0].get_kv_cache_shape(
             num_blocks=1, block_size=16, num_kv_heads=1, head_size=1
         )
@@ -502,10 +503,16 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         )
 
     def _nixl_handshake(
-        self, host: str, port: int, remote_tp_size: int, expected_engine_id: str
-    ) -> dict[int, str]:
+        self,
+        host: str,
+        port: int,
+        remote_tp_size: int,
+        remote_pp_size: int,
+        expected_engine_id: str,
+    ) -> dict[tuple[int, int], str]:
         # Mimic slow _nixl_handshake, as well as bypass zmq communication.
         time.sleep(self._hand_shake_latency)
+        assert remote_pp_size == 1
         # These should've been done in register_kv_caches(), called by
         # gpu_model_runner. Here we just hardcode some dummy values.
         slot_size_bytes = 4096
@@ -513,6 +520,8 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         self.block_len_per_layer = [slot_size_bytes * self.block_size]
         self.num_blocks = 1
         self.dst_num_blocks[self.engine_id] = self.num_blocks
+        self.local_seen_layer_names = ["layer0"]
+        self.local_kv_caches_base_addr = [0]
 
         assert expected_engine_id == self.REMOTE_ENGINE_ID
 
@@ -533,7 +542,7 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         # When remote tp_size > local tp_size, handshake with multiple
         # remote ranks.
         num_handshakes = 1 if tp_ratio > 0 else -tp_ratio
-        remote_agents: dict[int, str] = {}
+        remote_agents: dict[tuple[int, int], str] = {}
         for remote_tp_rank in range(num_handshakes):
             remote_agent_name = self.add_remote_agent(
                 NixlAgentMetadata(
@@ -550,11 +559,14 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
                     ssm_sizes=(0, 0),
                     attn_backend_name=self.backend_name,
                     physical_blocks_per_logical_kv_block=1,
+                    pp_rank=0,
+                    pp_size=1,
+                    registered_layer_names=["layer0"],
                 ),
                 remote_tp_rank=remote_tp_rank,
                 remote_tp_size=remote_tp_size,
             )
-            remote_agents[remote_tp_rank] = remote_agent_name
+            remote_agents[(0, remote_tp_rank)] = remote_agent_name
         return remote_agents
 
 
@@ -591,7 +603,7 @@ class TestNixlHandshake:
         worker = connector.connector_worker
         # simulate handshake
         worker.dst_xfer_side_handles = {
-            FakeNixlConnectorWorker.REMOTE_ENGINE_ID: {0: 1}
+            FakeNixlConnectorWorker.REMOTE_ENGINE_ID: {(0, 0): 1}
         }
         worker.kv_cache_layout = "HND"
         num_xfers = 4
@@ -744,29 +756,32 @@ class TestNixlHandshake:
         worker.block_len_per_layer = [4096 * worker.block_size]
         worker.num_blocks = 1
         worker.dst_num_blocks[worker.engine_id] = worker.num_blocks
-        worker.src_blocks_data = [(0, worker.block_len_per_layer[0], worker.tp_rank)]
-        worker.num_descs = len(worker.src_blocks_data)
+        worker.num_descs = 1
+        worker.local_seen_layer_names = ["layer0"]
+        worker.local_kv_caches_base_addr = [0]
 
         def check_handshake(remote_tp_size: int):
             tp_ratio = remote_tp_size // local_tp_size
-            assert set(remote_agents.keys()) == set(range(tp_ratio))
+            assert set(remote_agents.keys()) == {(0, rank) for rank in range(tp_ratio)}
 
             remote_engine_id = worker.REMOTE_ENGINE_ID
-            remote_info = worker.transfer_topo.get_engine_info(remote_engine_id)
+            remote_info = worker.transfer_topo.get_engine_info(remote_engine_id, 0)
             assert remote_info.remote_tp_size == remote_tp_size
             assert -tp_ratio == worker.transfer_topo.tp_ratio(remote_tp_size)
-            # ensure src_xfer_handles_by_tp_ratio is populated with tpratio chunks
-            assert -tp_ratio in worker.src_xfer_handles_by_tp_ratio
-            assert len(worker.src_xfer_handles_by_tp_ratio[-tp_ratio]) == tp_ratio
+            # Each shard registers a list of tp_ratio handles.
+            split_key = (remote_engine_id, 0, -tp_ratio)
+            assert split_key in worker.src_xfer_handles_by_shard_tp_ratio
+            assert len(worker.src_xfer_handles_by_shard_tp_ratio[split_key]) == tp_ratio
             assert remote_engine_id in worker.dst_xfer_side_handles
             assert set(worker.dst_xfer_side_handles[remote_engine_id].keys()) == set(
-                range(tp_ratio)
+                (0, rank) for rank in range(tp_ratio)
             )
 
         remote_agents = worker._nixl_handshake(
             host="localhost",
             port=1234,
             remote_tp_size=4,
+            remote_pp_size=1,
             expected_engine_id=worker.REMOTE_ENGINE_ID,
         )
         check_handshake(4)
@@ -779,6 +794,7 @@ class TestNixlHandshake:
             host="localhost",
             port=1234,
             remote_tp_size=6,
+            remote_pp_size=1,
             expected_engine_id=worker.REMOTE_ENGINE_ID,
         )
         check_handshake(6)
@@ -907,9 +923,6 @@ class TestNixlHandshake:
         connector.connector_worker = FakeNixlConnectorWorker(
             vllm_config, connector.engine_id
         )
-        # Register (mocked) local xfer handler
-        # worker = connector.connector_worker
-        # worker.src_xfer_handles_by_block_size = {worker.block_size: 1}
         metadata = NixlConnectorMetadata()
         total_reqs = 5
         for i in range(total_reqs):
@@ -984,6 +997,8 @@ class TestNixlHandshake:
             worker.block_len_per_layer = [4096 * worker.block_size]
             worker.num_blocks = 1
             worker.dst_num_blocks[worker.engine_id] = worker.num_blocks
+            worker.local_seen_layer_names = ["layer0"]
+            worker.local_kv_caches_base_addr = [0]
 
             # Metadata with different kv_cache_layout than local worker
             mismatched_layout = "HND" if worker.kv_cache_layout != "HND" else "NHD"
@@ -999,6 +1014,9 @@ class TestNixlHandshake:
                 ssm_sizes=(0, 0),
                 attn_backend_name=worker.backend_name,
                 physical_blocks_per_logical_kv_block=1,
+                pp_rank=0,
+                pp_size=1,
+                registered_layer_names=["layer0"],
             )
 
             with pytest.raises(RuntimeError):
@@ -1042,6 +1060,8 @@ class TestNixlHandshake:
             worker.block_len_per_layer = [2048 * worker.block_size]
             worker.num_blocks = 1
             worker.dst_num_blocks[worker.engine_id] = worker.num_blocks
+            worker.local_seen_layer_names = ["layer0"]
+            worker.local_kv_caches_base_addr = [0]
 
             # Metadata with different kv_cache_layout than local worker
             meta = NixlAgentMetadata(
@@ -1057,6 +1077,9 @@ class TestNixlHandshake:
                 ssm_sizes=(0, 0),
                 attn_backend_name=worker.backend_name,
                 physical_blocks_per_logical_kv_block=1,
+                pp_rank=0,
+                pp_size=1,
+                registered_layer_names=["layer0"],
             )
 
             # We don't check layout for homogeneous TP and MLA for now, as the
@@ -1093,6 +1116,8 @@ class TestNixlHandshake:
             worker._region_is_mla = [False, True]
             worker.num_blocks = 1
             worker.dst_num_blocks[worker.engine_id] = worker.num_blocks
+            worker.local_seen_layer_names = ["layer0", "layer2"]
+            worker.local_kv_caches_base_addr = [0, 0]
             worker.src_blocks_data = [
                 (0, fa_len, worker.tp_rank),
                 (0, idx_len, worker.tp_rank),
@@ -1114,6 +1139,9 @@ class TestNixlHandshake:
                 ssm_sizes=(0, 0),
                 attn_backend_name=worker.backend_name,
                 physical_blocks_per_logical_kv_block=1,
+                pp_rank=0,
+                pp_size=1,
+                registered_layer_names=["layer0", "layer2"],
             )
             worker.add_remote_agent(meta, remote_tp_size=1)
             assert (
@@ -1127,6 +1155,8 @@ class TestNixlHandshake:
             worker2._region_is_mla = [False, True]
             worker2.num_blocks = 1
             worker2.dst_num_blocks[worker2.engine_id] = worker2.num_blocks
+            worker2.local_seen_layer_names = ["layer0", "layer2"]
+            worker2.local_kv_caches_base_addr = [0, 0]
             bad_meta = NixlAgentMetadata(
                 engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
                 agent_metadata=FakeNixlWrapper.AGENT_METADATA,
@@ -1140,6 +1170,9 @@ class TestNixlHandshake:
                 ssm_sizes=(0, 0),
                 attn_backend_name=worker2.backend_name,
                 physical_blocks_per_logical_kv_block=1,
+                pp_rank=0,
+                pp_size=1,
+                registered_layer_names=["layer0", "layer2"],
             )
             with pytest.raises(AssertionError):
                 worker2.add_remote_agent(bad_meta, remote_tp_size=1)
@@ -1794,6 +1827,12 @@ def test_register_kv_caches(
                 f"got {base_addr}"
             )
 
+        # The local NIXL transfer-descriptor dlist is now registered lazily (on
+        # the first remote handshake) rather than eagerly in register_kv_caches;
+        # trigger that registration so the get_xfer_descs assertions below see
+        # the local block layout.
+        connector.connector_worker.register_local_xfer_handler(block_size)
+
         # Verify get_xfer_descs was called with blocks_data
         assert mock_wrapper_instance.get_xfer_descs.called
         blocks_data, _ = mock_wrapper_instance.get_xfer_descs.call_args[0]
@@ -1923,15 +1962,15 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
     ):
         worker._recving_transfers = {"req1": [123]}
         # Mock register_kv_cache which registers local handle
-        worker.src_xfer_handles_by_block_size = {worker.block_size: 455}
+        worker.src_xfer_handles_by_remote = {("engine1", 0, worker.block_size): 455}
         # P TP = 2 * D TP case, we should register 2 local handles
-        worker.src_xfer_handles_by_tp_ratio = {-2: [456, 457]}
-        worker.dst_xfer_side_handles = {"engine1": {0: 789}}
-        worker._remote_agents = {"engine1": {0: "agent1"}}
+        worker.src_xfer_handles_by_shard_tp_ratio = {("engine1", 0, -2): [456, 457]}
+        worker.dst_xfer_side_handles = {"engine1": {(0, 0): 789}}
+        worker._remote_agents = {"engine1": {(0, 0): "agent1"}}
         # _cleanup_remote_engine (called by shutdown) also clears these:
-        worker.kv_caches_base_addr["engine1"] = {0: [0xABC]}
+        worker.kv_caches_base_addr["engine1"] = {(0, 0): [0xABC]}
         worker.dst_num_blocks["engine1"] = 50
-        worker.tp_mappings["engine1"] = MagicMock()
+        worker.tp_mappings[("engine1", 0)] = MagicMock()
         worker._engine_last_active["engine1"] = time.perf_counter()
         worker._registered_descs = ["desc1", "desc2"]
 
@@ -1980,11 +2019,12 @@ def _setup_worker_with_remote_engine(
     )
 
     engine_id = "remote-engine-1"
-    worker._remote_agents[engine_id] = {0: "agent_0", 1: "agent_1"}
-    worker.dst_xfer_side_handles[engine_id] = {0: 100, 1: 200}
-    worker.kv_caches_base_addr[engine_id] = {0: [0xABC]}
+    worker._remote_agents[engine_id] = {(0, 0): "agent_0", (0, 1): "agent_1"}
+    worker.dst_xfer_side_handles[engine_id] = {(0, 0): 100, (0, 1): 200}
+    worker.kv_caches_base_addr[engine_id] = {(0, 0): [0xABC]}
     worker.dst_num_blocks[engine_id] = 50
-    worker.tp_mappings[engine_id] = MagicMock()
+    worker.tp_mappings[(engine_id, 0)] = MagicMock()
+    worker._remote_pp_size[engine_id] = 1
     worker._engine_last_active[engine_id] = time.perf_counter()
 
     worker.transfer_topo = MagicMock()
@@ -2014,7 +2054,8 @@ def test_engine_ttl_eviction(default_vllm_config, dist_init):
         assert engine_id not in worker.dst_xfer_side_handles
         assert engine_id not in worker.kv_caches_base_addr
         assert engine_id not in worker.dst_num_blocks
-        assert engine_id not in worker.tp_mappings
+        assert not any(k[0] == engine_id for k in worker.tp_mappings)
+        assert engine_id not in worker._remote_pp_size
         assert engine_id not in worker._engine_last_active
         worker.transfer_topo.unregister_remote_engine.assert_called_with(engine_id)
 
@@ -2699,6 +2740,9 @@ def test_compatibility_hash_validation(
         ssm_sizes=(0, 0),
         attn_backend_name=decode_worker.backend_name,
         physical_blocks_per_logical_kv_block=1,
+        pp_rank=0,
+        pp_size=1,
+        registered_layer_names=["layer0"],
     )
     handshake_payload = NixlHandshakePayload(
         compatibility_hash=remote_hash,
@@ -2723,6 +2767,7 @@ def test_compatibility_hash_validation(
                     host="localhost",
                     port=1234,
                     remote_tp_size=1,
+                    remote_pp_size=1,
                     expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
                 )
         else:
@@ -2730,11 +2775,12 @@ def test_compatibility_hash_validation(
                 host="localhost",
                 port=1234,
                 remote_tp_size=1,
+                remote_pp_size=1,
                 expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
             )
             # Verify handshake returned agent mapping
             assert isinstance(result, dict)
-            assert len(result) == 1
+            assert set(result) == {(0, 0)}
 
 
 @pytest.mark.parametrize(
@@ -2822,6 +2868,7 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
                 host="localhost",
                 port=1234,
                 remote_tp_size=1,
+                remote_pp_size=1,
                 expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
             )
 
@@ -2868,19 +2915,26 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
         # / `dst_xfer_side_handles` to be keyed by remote rank.
         remote_engine_id = "remote_engine"
         worker.transfer_topo.register_remote_engine(
-            remote_engine_id=remote_engine_id,
-            remote_tp_size=prefill_tp_size,
-            remote_block_size=worker.block_size,
-            remote_block_len=worker.block_size * 4096,
-            remote_physical_blocks_per_logical=1,
-            local_block_len=worker.block_size * 4096,
+            remote_engine_id,
+            EngineTransferInfo(
+                remote_tp_size=prefill_tp_size,
+                remote_block_len=worker.block_size * 4096,
+                remote_block_size=worker.block_size,
+                remote_physical_blocks_per_logical=1,
+                remote_pp_rank=0,
+            ),
         )
         worker._remote_agents[remote_engine_id] = {
-            rank: f"agent_p{rank}" for rank in range(prefill_tp_size)
+            (0, rank): f"agent_p{rank}" for rank in range(prefill_tp_size)
         }
         worker.dst_xfer_side_handles = {
-            remote_engine_id: {rank: 100 + rank for rank in range(prefill_tp_size)}
+            remote_engine_id: {(0, rank): 100 + rank for rank in range(prefill_tp_size)}
         }
+        worker._remote_pp_size[remote_engine_id] = 1
+        worker.tp_mappings[(remote_engine_id, 0)] = SimpleNamespace(
+            all_source_ranks=(0,),
+            source_ranks_per_group=((0,),),
+        )
         # Sanity: D TP=1, P TP=4 => tp_ratio = -4 (P > D).
         assert worker.transfer_topo.tp_ratio(prefill_tp_size) == -prefill_tp_size
 
@@ -2927,7 +2981,7 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
 
         # Broadcast goes to ranks {1, 2, 3} only, never to the read target.
         expected_recipients = {
-            worker._remote_agents[remote_engine_id][r]
+            worker._remote_agents[remote_engine_id][(0, r)]
             for r in range(1, prefill_tp_size)
         }
         assert {agent for agent, _ in send_notif_calls} == expected_recipients

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -182,11 +182,12 @@ def test_read_blocks_for_req_expands_remote_ids(
     remote_info.remote_physical_blocks_per_logical = remote_physical_per_logical
     worker.transfer_topo.get_engine_info.return_value = remote_info
     worker.use_mla = False
+    worker._remote_pp_size = {remote_engine_id: 1}
 
     mock_plan = MagicMock(spec=TPMapping)
     mock_plan.all_source_ranks = ()
     mock_plan.source_ranks_per_group = ()
-    worker.tp_mappings = {remote_engine_id: mock_plan}
+    worker.tp_mappings = {(remote_engine_id, 0): mock_plan}
 
     metadata = NixlConnectorMetadata()
     metadata.add_new_req_to_recv(
@@ -203,10 +204,29 @@ def test_read_blocks_for_req_expands_remote_ids(
     )
 
     meta = metadata.reqs_to_recv["test-req"]
-    worker._read_blocks_for_req("test-req", meta)
 
-    assert meta.remote.block_ids == expected_remote_block_ids, (
-        f"Expected {expected_remote_block_ids}, got {meta.remote.block_ids}"
+    # Spy on the kernel-block-id expansion helper to capture its output.
+    real_expand = NixlConnectorWorker._logical_to_remote_kernel_block_ids
+    captured = []
+
+    def _capture_expand(self, logical_ids, phys_per_logical):
+        result = real_expand(self, logical_ids, phys_per_logical)
+        captured.append(result)
+        return result
+
+    with patch.object(
+        NixlConnectorWorker,
+        "_logical_to_remote_kernel_block_ids",
+        _capture_expand,
+    ):
+        worker._read_blocks_for_req("test-req", meta)
+
+    # Remote IDs stay logical (unchanged) for retry/failure reuse.
+    assert meta.remote.block_ids == remote_block_ids
+    # The expansion still produces the expected kernel block IDs.
+    assert captured, "expansion helper was not called"
+    assert captured[0] == expected_remote_block_ids, (
+        f"Expected {expected_remote_block_ids}, got {captured[0]}"
     )
 
 

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -1,0 +1,463 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for pipeline-parallel PD disaggregation in the NIXL connector."""
+
+import threading
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import msgspec
+import pytest
+import torch
+import zmq
+
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+    NixlAgentMetadata,
+    NixlConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    GET_META_MSG,
+    NixlHandshakePayload,
+    RemoteMeta,
+    ReqMeta,
+    compute_nixl_compatibility_hash,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
+    NixlConnectorScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
+    ReadSpec,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+    NixlConnectorWorker,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+
+from .test_nixl_connector import FakeNixlConnectorWorker, FakeNixlWrapper
+from .utils import create_vllm_config
+
+LOCAL_ENGINE_ID = "local-engine"
+REMOTE_ENGINE_ID = FakeNixlConnectorWorker.REMOTE_ENGINE_ID
+TOTAL_LAYERS = 32
+BLOCK_LEN = 4096 * 16  # slot_size_bytes * block_size
+NUM_BLOCKS = 4
+
+
+def _fake_vllm_config(pipeline_parallel_size: int = 1) -> SimpleNamespace:
+    model_config = SimpleNamespace(
+        model="fake-model",
+        dtype="float16",
+        get_total_num_kv_heads=lambda: 8,
+        get_head_size=lambda: 16,
+        get_total_num_hidden_layers=lambda: 32,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        cache_config=SimpleNamespace(cache_dtype="auto", block_size=16),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=pipeline_parallel_size,
+            tensor_parallel_size=1,
+        ),
+    )
+
+
+def test_compatibility_hash_ignores_pipeline_parallel_size():
+    assert compute_nixl_compatibility_hash(
+        _fake_vllm_config(pipeline_parallel_size=1), "FLASH_ATTN", False
+    ) == compute_nixl_compatibility_hash(
+        _fake_vllm_config(pipeline_parallel_size=4), "FLASH_ATTN", False
+    )
+
+
+def test_req_meta_reads_pp_size_and_defaults_to_one():
+    metadata = NixlConnectorMetadata()
+    params = {
+        "remote_block_ids": ([0],),
+        "remote_engine_id": "engine",
+        "remote_request_id": "remote-req",
+        "remote_host": "localhost",
+        "remote_port": 1234,
+        "tp_size": 2,
+        "pp_size": 4,
+    }
+
+    metadata.add_new_req_to_recv("req", ([0],), params)
+    assert metadata.reqs_to_recv["req"].pp_size == 4
+
+    params.pop("pp_size")
+    metadata.add_new_req_to_recv("req-default", ([0],), params)
+    assert metadata.reqs_to_recv["req-default"].pp_size == 1
+
+
+def _pp_kv_cache_config() -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=NUM_BLOCKS,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                [f"model.layers.{i}.self_attn" for i in range(TOTAL_LAYERS)],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            )
+        ],
+    )
+
+
+def _make_pp_worker() -> NixlConnectorWorker:
+    """Real worker via FakeNixlConnectorWorker; seed only the state that
+    register_kv_caches() would normally produce."""
+    vllm_config = create_vllm_config()
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+        FakeNixlWrapper,
+    ):
+        worker = FakeNixlConnectorWorker(
+            vllm_config,
+            LOCAL_ENGINE_ID,
+            hand_shake_latency=0,
+            kv_cache_config=_pp_kv_cache_config(),
+        )
+    worker.block_len_per_layer = [BLOCK_LEN] * TOTAL_LAYERS
+    worker.local_seen_layer_names = [
+        f"model.layers.{i}.self_attn" for i in range(TOTAL_LAYERS)
+    ]
+    worker.local_kv_caches_base_addr = [
+        100_000 + i * 10_000 for i in range(TOTAL_LAYERS)
+    ]
+    return worker
+
+
+def _meta(
+    worker: NixlConnectorWorker,
+    pp_rank: int,
+    start_layer: int,
+    end_layer: int,
+    *,
+    pp_size: int,
+) -> NixlAgentMetadata:
+    layer_names = [f"model.layers.{i}.self_attn" for i in range(start_layer, end_layer)]
+    return NixlAgentMetadata(
+        engine_id=REMOTE_ENGINE_ID,
+        agent_metadata=FakeNixlWrapper.AGENT_METADATA,
+        kv_caches_base_addr=[
+            200_000 + i * 10_000 for i in range(start_layer, end_layer)
+        ],
+        device_id=pp_rank,
+        num_blocks=NUM_BLOCKS,
+        block_lens=[BLOCK_LEN] * len(layer_names),
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name=worker.backend_name,
+        physical_blocks_per_logical_kv_block=1,
+        pp_rank=pp_rank,
+        pp_size=pp_size,
+        registered_layer_names=layer_names,
+    )
+
+
+def _add_two_remote_shards(worker: NixlConnectorWorker) -> list[NixlAgentMetadata]:
+    metas = [
+        _meta(worker, 0, 0, 16, pp_size=2),
+        _meta(worker, 1, 16, 32, pp_size=2),
+    ]
+    for meta in metas:
+        worker.add_remote_agent(
+            meta,
+            remote_tp_rank=0,
+            remote_tp_size=1,
+            remote_pp_rank=meta.pp_rank,
+            remote_pp_size=meta.pp_size,
+        )
+    # done_callback marks the handshake complete once every shard is registered.
+    worker._remote_pp_size[REMOTE_ENGINE_ID] = 2
+    return metas
+
+
+def test_add_remote_agent_records_both_pp_shard_base_address_keys(
+    default_vllm_config, dist_init
+):
+    worker = _make_pp_worker()
+
+    _add_two_remote_shards(worker)
+
+    assert set(worker.kv_caches_base_addr[REMOTE_ENGINE_ID]) == {(0, 0), (1, 0)}
+
+
+def test_validate_remote_agent_handshake_accepts_synthetic_pp_shard(
+    default_vllm_config, dist_init
+):
+    worker = _make_pp_worker()
+    meta = _meta(worker, 0, 0, 16, pp_size=2)
+
+    worker.add_remote_agent(
+        meta,
+        remote_tp_rank=0,
+        remote_tp_size=1,
+        remote_pp_rank=0,
+        remote_pp_size=2,
+    )
+    worker._validate_remote_agent_handshake(meta, 0, 2, 1)
+
+
+def test_add_remote_agent_prepares_dst_handles_for_each_pp_shard(
+    default_vllm_config, dist_init
+):
+    worker = _make_pp_worker()
+
+    _add_two_remote_shards(worker)
+
+    assert set(worker.dst_xfer_side_handles[REMOTE_ENGINE_ID]) == {
+        (0, 0),
+        (1, 0),
+    }
+
+
+def test_read_blocks_for_req_appends_one_transfer_per_pp_shard_and_tp_target(
+    default_vllm_config, dist_init
+):
+    worker = _make_pp_worker()
+    _add_two_remote_shards(worker)
+    req_meta = ReqMeta(
+        local_block_ids=([0, 1],),
+        local_physical_block_ids=([0, 1],),
+        tp_size=1,
+        pp_size=2,
+        remote=RemoteMeta(
+            block_ids=([0, 1],),
+            host="localhost",
+            port=1234,
+            engine_id=REMOTE_ENGINE_ID,
+            request_id="prefill-req",
+        ),
+    )
+
+    worker._read_blocks_for_req("decode-req", req_meta)
+
+    assert len(worker._recving_transfers["decode-req"]) == 2
+
+
+def test_pp_rank_one_descriptor_ids_are_shard_local(default_vllm_config, dist_init):
+    worker = _make_pp_worker()
+    _add_two_remote_shards(worker)
+
+    remote_desc_ids = worker._get_block_descs_ids_for_shard(
+        REMOTE_ENGINE_ID, 1, worker.dst_num_blocks[REMOTE_ENGINE_ID], ([0],)
+    )
+    local_desc_ids = worker._get_block_descs_ids_for_shard(
+        REMOTE_ENGINE_ID, 1, worker.num_blocks, ([0],)
+    )
+
+    assert remote_desc_ids[0] == 0
+    assert local_desc_ids[0] == 0
+
+
+class _InlineThread:
+    def __init__(
+        self,
+        *,
+        target: Callable[..., Any],
+        args: tuple[Any, ...],
+        **_: Any,
+    ) -> None:
+        self._target = target
+        self._args = args
+
+    def start(self) -> None:
+        self._target(*self._args)
+
+
+class _FakeZmqContext:
+    def __init__(self, sock: "_FakeHandshakeSocket") -> None:
+        self._sock = sock
+
+    def __enter__(self) -> "_FakeHandshakeSocket":
+        return self._sock
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+class _FakeHandshakeSocket:
+    def __init__(
+        self,
+        request_msg: bytes,
+        *,
+        stop_event: threading.Event | None = None,
+    ) -> None:
+        self._request_msg = request_msg
+        self._stop_event = stop_event
+        self._recv_count = 0
+        self.sent_multipart: list[tuple[bytes, bytes, bytes]] = []
+
+    def setsockopt(self, *_: Any) -> None:
+        return None
+
+    def recv_multipart(self) -> tuple[bytes, bytes, bytes]:
+        if self._recv_count == 0:
+            self._recv_count += 1
+            return (b"identity", b"", self._request_msg)
+        if self._stop_event is not None:
+            self._stop_event.set()
+        raise zmq.Again()
+
+    def send_multipart(self, parts: tuple[bytes, bytes, bytes]) -> None:
+        self.sent_multipart.append(parts)
+
+
+def test_scheduler_listener_serves_three_tuple_key():
+    scheduler = NixlConnectorScheduler.__new__(NixlConnectorScheduler)
+    scheduler._nixl_handshake_listener_t = None
+    scheduler._stop_event = threading.Event()
+    scheduler.side_channel_host = "localhost"
+    scheduler.side_channel_port = 1234
+
+    payload = NixlHandshakePayload(
+        compatibility_hash="hash",
+        agent_metadata_bytes=b"agent",
+    )
+    request = msgspec.msgpack.encode((GET_META_MSG, 1, 0))
+    sock = _FakeHandshakeSocket(request, stop_event=scheduler._stop_event)
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler.zmq_ctx",
+            return_value=_FakeZmqContext(sock),
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler."
+            "threading.Thread",
+            _InlineThread,
+        ),
+    ):
+        scheduler.set_xfer_handshake_metadata({(1, 0): payload})
+
+    assert len(sock.sent_multipart) == 1
+    identity, delimiter, encoded_payload = sock.sent_multipart[0]
+    assert identity == b"identity"
+    assert delimiter == b""
+    decoded_payload = msgspec.msgpack.decode(encoded_payload, type=NixlHandshakePayload)
+    assert decoded_payload == payload
+
+
+def test_ensure_handshake_treats_partial_pp_state_as_inflight():
+    worker = NixlConnectorWorker.__new__(NixlConnectorWorker)
+    future = MagicMock()
+    remote_engine_id = "remote-engine"
+    worker._handshake_lock = threading.RLock()
+    worker._handshake_futures = {remote_engine_id: future}
+    worker._remote_agents = {remote_engine_id: {(0, 0): "agent-0-0"}}
+    worker._remote_pp_size = {}
+    worker._engine_ttl = 0.0
+
+    assert worker._ensure_handshake(remote_engine_id, "localhost", 1234, 1, 2) is future
+
+
+def test_handshake_complete_requires_remote_pp_size():
+    worker = NixlConnectorWorker.__new__(NixlConnectorWorker)
+    remote_engine_id = "remote-engine"
+    worker._handshake_futures = {}
+    worker._remote_agents = {remote_engine_id: {(0, 0): "agent-0-0"}}
+    worker._remote_pp_size = {}
+
+    assert not worker._handshake_complete(remote_engine_id, 2)
+
+    worker._remote_pp_size[remote_engine_id] = 2
+
+    assert worker._handshake_complete(remote_engine_id, 2)
+
+
+@pytest.mark.parametrize("pp_size", [1, 4])
+def test_background_nixl_handshake_submits_remote_pp_size(pp_size: int):
+    worker = NixlConnectorWorker.__new__(NixlConnectorWorker)
+    worker._handshake_futures = {}
+    worker._handshake_initiation_executor = MagicMock()
+    future = MagicMock()
+    worker._handshake_initiation_executor.submit.return_value = future
+    worker._handshake_lock = threading.Lock()
+    worker._remote_agents = {}
+    worker._engine_ttl = 0.0
+    worker._ready_requests = MagicMock()
+    worker._log_failure = MagicMock()
+    worker._recving_transfers = {}
+    worker.src_xfer_handles_by_remote = {}
+    worker.src_xfer_handles_by_shard_tp_ratio = {}
+    worker.dst_xfer_side_handles = {}
+    worker._registered_descs = []
+
+    remote_engine_id = "remote-engine"
+    meta = ReqMeta(
+        local_block_ids=([0],),
+        local_physical_block_ids=([0],),
+        tp_size=2,
+        pp_size=pp_size,
+        remote=RemoteMeta(
+            block_ids=([1],),
+            host="localhost",
+            port=1234,
+            engine_id=remote_engine_id,
+            request_id="remote-request",
+        ),
+    )
+
+    worker._background_nixl_handshake("request", remote_engine_id, meta)
+
+    worker._handshake_initiation_executor.submit.assert_called_once_with(
+        worker._nixl_handshake,
+        "localhost",
+        1234,
+        2,
+        pp_size,
+        remote_engine_id,
+    )
+    assert future.add_done_callback.call_count == 2
+
+
+def test_hma_pp_assertion_guard_in_read_blocks() -> None:
+    """HMA × PP combinations must be rejected with AssertionError.
+
+    Per-layer-name HMA × PP routing is not yet supported, so the
+    ``assert not self._is_hma_required`` checks inside ``_read_blocks`` and
+    friends must fail loud: configuring NIXL with HMA enabled and a
+    heterogeneous block-size remote (the path that co-occurs under
+    ``pp_size > 1`` with multi-group KV caches) must raise.
+    """
+    import numpy as np
+
+    worker = NixlConnectorWorker.__new__(NixlConnectorWorker)
+    worker._is_hma_required = True
+    worker.world_size = 1
+    worker.block_size = 16
+    worker._remote_agents = {"remote-engine": {(0, 0): "agent-0-0"}}
+
+    transfer_topo = MagicMock()
+    transfer_topo.get_engine_info.return_value = SimpleNamespace(
+        remote_block_size=8,
+        remote_physical_blocks_per_logical=1,
+    )
+    transfer_topo.block_size_ratio.return_value = 2
+    worker.transfer_topo = transfer_topo
+    worker.get_mapped_blocks = MagicMock(return_value=np.asarray([0, 1, 2, 3]))
+
+    spec = ReadSpec(remote_rank=0, local_block_ids=[[0]], remote_block_ids=[[1]])
+    with pytest.raises(AssertionError):
+        worker._read_blocks(
+            read_spec=spec,
+            request_id="req",
+            dst_engine_id="remote-engine",
+            remote_request_id="rreq",
+            remote_pp_rank=0,
+            local_xfer_side_handle=0,
+            remote_xfer_side_handle=0,
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -185,6 +185,7 @@ class NixlBaseConnectorScheduler:
         host = params.get("remote_host")
         port = params.get("remote_port")
         tp_size = params.get("tp_size")
+        pp_size = params.get("pp_size", 1)
         if (
             remote_engine_id is None
             or remote_request_id is None
@@ -199,6 +200,7 @@ class NixlBaseConnectorScheduler:
                 host=host,
                 port=port,
                 tp_size=tp_size,
+                pp_size=pp_size,
             )
         self._heartbeat_by_engine[remote_engine_id].req_ids.add(remote_request_id)
         self._heartbeat_req_engine[request.request_id] = (
@@ -244,7 +246,7 @@ class NixlBaseConnectorScheduler:
         )
 
     def set_xfer_handshake_metadata(
-        self, metadata: dict[int, KVConnectorHandshakeMetadata]
+        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         """
         Set the KV connector handshake metadata for this connector.
@@ -252,19 +254,20 @@ class NixlBaseConnectorScheduler:
         Args:
             metadata (dict): the handshake metadata to set.
         """
-        encoded_data: dict[int, bytes] = {}
+        encoded_data: dict[tuple[int, int], bytes] = {}
         encoder = msgspec.msgpack.Encoder()
-        for tp_rank, rank_metadata in metadata.items():
+        for (pp_rank, tp_rank), rank_metadata in metadata.items():
             if not isinstance(rank_metadata, NixlHandshakePayload):
                 raise ValueError(
                     "NixlConnectorScheduler expects NixlHandshakePayload for "
                     "handshake metadata."
                 )
-            encoded_data[tp_rank] = encoder.encode(rank_metadata)
+            encoded_data[(pp_rank, tp_rank)] = encoder.encode(rank_metadata)
             logger.debug(
-                "Tp rank %d: encoded NixlHandshakePayload size: %s bytes",
+                "PP rank %d, TP rank %d: encoded NixlHandshakePayload size: %s bytes",
+                pp_rank,
                 tp_rank,
-                str(len(encoded_data[tp_rank])),
+                str(len(encoded_data[(pp_rank, tp_rank)])),
             )
 
         # Only start the listener when we have metadata to serve.
@@ -287,7 +290,7 @@ class NixlBaseConnectorScheduler:
 
     @staticmethod
     def _nixl_handshake_listener(
-        encoded_data: dict[int, Any],
+        encoded_data: dict[tuple[int, int], Any],
         ready_event: threading.Event,
         stop_event: threading.Event,
         host: str,
@@ -310,15 +313,19 @@ class NixlBaseConnectorScheduler:
                     if stop_event.is_set():
                         break
                     continue
-                # Decode the message which contains (GET_META_MSG, rank)
-                msg, target_tp_rank = msgspec.msgpack.decode(msg)
+                # Decode the message which contains
+                # (GET_META_MSG, pp_rank, tp_rank)
+                msg, target_pp_rank, target_tp_rank = msgspec.msgpack.decode(msg)
                 logger.debug(
-                    "Received message for tp rank %s",
+                    "Received message for pp rank %s, tp rank %s",
+                    target_pp_rank,
                     target_tp_rank,
                 )
                 if msg != GET_META_MSG:
                     logger.warning("Connection listener got unexpected message %s", msg)
-                sock.send_multipart((identity, b"", encoded_data[target_tp_rank]))
+                sock.send_multipart(
+                    (identity, b"", encoded_data[(target_pp_rank, target_tp_rank)])
+                )
 
     def _mamba_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Base worker-side logic for the NIXL connector."""
 
+import itertools
 import logging
 import os
 import queue
@@ -60,6 +61,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import
 )
 from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
 from vllm.distributed.parallel_state import (
+    get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
@@ -273,6 +275,11 @@ class NixlBaseConnectorWorker:
             for group in kv_cache_config.kv_cache_groups
             for layer in group.layer_names
         }
+        self._layer_name_to_kv_group_index = {
+            layer: group_idx
+            for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+            for layer in group.layer_names
+        }
         self.hma_group_size = len(kv_cache_config.kv_cache_tensors)
 
         # ---- Model state (derived from model config) ----
@@ -329,8 +336,10 @@ class NixlBaseConnectorWorker:
             )
 
         self.nixl_wrapper = nixl_wrapper_cls(str(uuid.uuid4()), config)
-        # Map of engine_id -> {rank0: agent_name0, rank1: agent_name1..}.
-        self._remote_agents: dict[EngineId, dict[int, str]] = defaultdict(dict)
+        # Map of engine_id -> {(pp_rank, tp_rank): agent_name}.
+        self._remote_agents: dict[EngineId, dict[tuple[int, int], str]] = defaultdict(
+            dict
+        )
 
         # Metadata.
         self.engine_id: EngineId = engine_id
@@ -394,23 +403,39 @@ class NixlBaseConnectorWorker:
         # Note: host xfer buffer ops when use_host_buffer is True
         self.copy_blocks: CopyBlocksOp | None = None
 
-        # Map of engine_id -> kv_caches_base_addr. For TP case, each local
+        self.local_kv_caches_base_addr: list[int] = []
+
         self.device_id: int = 0
-        # Current rank may pull from multiple remote TP workers.
-        # EngineId, dict[int, list[int]] -> engine_id, tp_rank, base_addr_for_layer
-        self.kv_caches_base_addr = defaultdict[EngineId, dict[int, list[int]]](dict)
+        # Remote producer KV base addresses, keyed by the producer shard
+        # (pp_rank, tp_rank) — under PP x TP a request pulls from several shards.
+        self.kv_caches_base_addr = defaultdict[
+            EngineId, dict[tuple[int, int], list[int]]
+        ](dict)
+        self.local_seen_layer_names: list[str] = []
+        # Set once a remote engine's full PP x TP handshake completes; doubles as
+        # the "handshake complete" sentinel that gates KV reads.
+        self._remote_pp_size: dict[EngineId, int] = {}
 
         # Number of NIXL regions. Currently one region per cache
         # (so 1 per layer for MLA, otherwise 2 per layer)
         self.num_regions = 0
 
-        # nixl_prepped_dlist_handle.
-        self.src_xfer_handles_by_block_size: dict[int, int] = {}
+        # nixl_prepped_dlist_handle, keyed by remote shard + block size.
+        self.src_xfer_handles_by_remote: dict[tuple[EngineId, int, int], int] = {}
+        self.src_blocks_data_by_remote: dict[
+            tuple[EngineId, int, int], list[tuple[int, int, int]]
+        ] = {}
         # Populated dynamically during handshake based on remote configuration.
-        # Keep track of regions at different tp_ratio values. tp_ratio->handles
-        self.src_xfer_handles_by_tp_ratio: dict[int, list[int]] = {}
-        # Map of engine_id -> {tp_rank: nixl_prepped_dlist_handle (int)}.
-        self.dst_xfer_side_handles = defaultdict[EngineId, dict[int, int]](dict)
+        self.src_xfer_handles_by_shard_tp_ratio: dict[
+            tuple[EngineId, int, int], list[int]
+        ] = {}
+        # Destination (remote) dlist handles, per remote shard (pp_rank, tp_rank).
+        self.dst_xfer_side_handles = defaultdict[EngineId, dict[tuple[int, int], int]](
+            dict
+        )
+        # Region-group ids of each remote shard's registered regions,
+        # keyed by (engine_id, remote_pp_rank).
+        self._shard_region_group_ids: dict[tuple[EngineId, int], tuple[int, ...]] = {}
 
         # Map of engine_id -> num_blocks. All ranks in the same deployment will
         # have the same number of blocks.
@@ -442,7 +467,7 @@ class NixlBaseConnectorWorker:
             thread_name_prefix="vllm-nixl-handshake-initiator",
         )
         self._ready_requests = queue.Queue[tuple[ReqId, ReqMeta]]()
-        self._handshake_futures: dict[EngineId, Future[dict[int, str]]] = {}
+        self._handshake_futures: dict[EngineId, Future[dict[tuple[int, int], str]]] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
 
@@ -498,7 +523,7 @@ class NixlBaseConnectorWorker:
         self.block_len_per_layer = list[int]()
 
         # Per-engine TP mappings. Generated during handshake.
-        self.tp_mappings: dict[EngineId, TPMapping] = {}
+        self.tp_mappings: dict[tuple[EngineId, int], TPMapping] = {}
 
         self.enforce_compat_hash = self.kv_transfer_config.get_from_extra_config(
             "enforce_handshake_compat", True
@@ -523,13 +548,50 @@ class NixlBaseConnectorWorker:
             self.block_size = kernel_block_size
             self.num_blocks *= self._physical_blocks_per_logical_kv_block
 
+    def _local_region_indices_for_layer_names(
+        self, registered_layer_names: list[str]
+    ) -> list[int]:
+        local_names = self.local_seen_layer_names
+        positions_by_name: dict[str, list[int]] = defaultdict(list)
+        for local_idx, layer_name in enumerate(local_names):
+            positions_by_name[layer_name].append(local_idx)
+
+        occurrences_by_name: dict[str, int] = defaultdict(int)
+        local_indices: list[int] = []
+        for layer_name in registered_layer_names:
+            occurrence = occurrences_by_name[layer_name]
+            occurrences_by_name[layer_name] += 1
+            matches = positions_by_name.get(layer_name, [])
+            if occurrence >= len(matches):
+                raise RuntimeError(
+                    "NIXL handshake failed: producer registered layer "
+                    f"{layer_name!r} occurrence {occurrence} has no matching "
+                    f"local region. Local registered layers: {local_names}"
+                )
+            local_indices.append(matches[occurrence])
+        return local_indices
+
+    def _region_group_ids_for_layer_names(
+        self, registered_layer_names: list[str]
+    ) -> tuple[int, ...]:
+        # Non-MLA split-K/V backends register K and V as separate regions
+        # that share the same KV-group id, hence the x2 duplication.
+        group_ids = tuple(
+            self._layer_name_to_kv_group_index[name] for name in registered_layer_names
+        )
+        assert self.transfer_topo is not None
+        if self.transfer_topo.is_kv_layout_blocks_first:
+            return tuple(g for g in group_ids for _ in range(2))
+        return group_ids
+
     def _nixl_handshake(
         self,
         host: str,
         port: int,
         remote_tp_size: int,
+        remote_pp_size: int,
         expected_engine_id: str,
-    ) -> dict[int, str]:
+    ) -> dict[tuple[int, int], str]:
         """Do a NIXL handshake with a remote instance."""
 
         # the first time we connect to a remote agent.
@@ -551,20 +613,25 @@ class NixlBaseConnectorWorker:
         # this happens to be the same single rank_i.
         assert self.transfer_topo is not None
         p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
-        remote_rank_to_agent_name = {}
+        remote_rank_to_agent_name: dict[tuple[int, int], str] = {}
         path = make_zmq_path("tcp", host, port)
 
         with zmq_ctx(zmq.REQ, path) as sock:
-            for remote_rank in p_remote_ranks:
+            for remote_pp_rank, remote_rank in itertools.product(
+                range(remote_pp_size), p_remote_ranks
+            ):
                 logger.debug(
-                    "Querying metadata on path: %s at remote tp rank %s",
+                    "Querying metadata on path: %s at remote pp rank %s, tp rank %s",
                     path,
+                    remote_pp_rank,
                     remote_rank,
                 )
 
                 start_time = time.perf_counter()
                 # Send query for the request.
-                msg = msgspec.msgpack.encode((GET_META_MSG, remote_rank))
+                msg = msgspec.msgpack.encode(
+                    (GET_META_MSG, remote_pp_rank, remote_rank)
+                )
                 # Set receive timeout to 5 seconds to avoid hanging on dead server
                 sock.setsockopt(zmq.RCVTIMEO, 5000)  # milliseconds
                 sock.send(msg)
@@ -632,14 +699,20 @@ class NixlBaseConnectorWorker:
 
                 # Register Remote agent.
                 remote_agent_name = self.add_remote_agent(
-                    metadata, remote_rank, remote_tp_size
+                    metadata,
+                    remote_rank,
+                    remote_tp_size,
+                    remote_pp_rank=remote_pp_rank,
+                    remote_pp_size=remote_pp_size,
                 )
                 setup_agent_time = time.perf_counter()
                 logger.debug(
                     "NIXL handshake: add agent took: %s",
                     setup_agent_time - got_metadata_time,
                 )
-                remote_rank_to_agent_name[remote_rank] = remote_agent_name
+                remote_rank_to_agent_name[(remote_pp_rank, remote_rank)] = (
+                    remote_agent_name
+                )
         return remote_rank_to_agent_name
 
     def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
@@ -754,7 +827,8 @@ class NixlBaseConnectorWorker:
         host: str,
         port: int,
         tp_size: int,
-    ) -> Future[dict[int, str]] | None:
+        pp_size: int,
+    ) -> Future[dict[tuple[int, int], str]] | None:
         """
         Ensure a handshake is in-flight (or already done) for *engine_id*.
 
@@ -766,7 +840,7 @@ class NixlBaseConnectorWorker:
         """
         self._evict_stale_engines()
         with self._handshake_lock:
-            if engine_id in self._remote_agents:
+            if engine_id in self._remote_agents and engine_id in self._remote_pp_size:
                 return None
             fut = self._handshake_futures.get(engine_id)
             if fut is not None:
@@ -776,16 +850,22 @@ class NixlBaseConnectorWorker:
                 host,
                 port,
                 tp_size,
+                pp_size,
                 engine_id,
             )
             self._handshake_futures[engine_id] = fut
 
-            def done_callback(f: Future[dict[int, str]], eid=engine_id):
+            def done_callback(
+                f: Future[dict[tuple[int, int], str]], eid=engine_id, pp=pp_size
+            ):
                 with self._handshake_lock:
                     del self._handshake_futures[eid]
                     try:
                         self._remote_agents[eid] = f.result()
                         self._engine_last_active[eid] = time.perf_counter()
+                        # Mark complete only after every PP stage's TP shards are
+                        # registered, so reads never race ahead of a shard handle.
+                        self._remote_pp_size[eid] = pp
                     except Exception as e:
                         self._log_failure(
                             failure_type="handshake_setup_failed",
@@ -797,6 +877,13 @@ class NixlBaseConnectorWorker:
             fut.add_done_callback(done_callback)
             return fut
 
+    def _handshake_complete(self, engine_id: EngineId, pp_size: int) -> bool:
+        return (
+            engine_id in self._remote_agents
+            and engine_id not in self._handshake_futures
+            and self._remote_pp_size.get(engine_id) == pp_size
+        )
+
     def _background_nixl_handshake(
         self, req_id: str, remote_engine_id: EngineId, meta: ReqMeta
     ):
@@ -807,6 +894,7 @@ class NixlBaseConnectorWorker:
             meta.remote.host,
             meta.remote.port,
             meta.tp_size,
+            meta.pp_size,
         )
         if fut is None:
             # Already handshaked — only happens if caller does not pre-check.
@@ -859,6 +947,24 @@ class NixlBaseConnectorWorker:
         self.compat_hash = compute_nixl_compatibility_hash(
             self.vllm_config, self.backend_name, self.transfer_topo.cross_layers_blocks
         )
+        pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
+        if self.transfer_topo.cross_layers_blocks and pp_size > 1:
+            raise RuntimeError(
+                "cross-layer-blocks mode is not supported with "
+                "pipeline_parallel_size > 1 yet."
+            )
+        if self._has_mamba and pp_size > 1:
+            # Per-shard descriptor layouts for hybrid (Mamba/SSM) producers
+            # need mamba_region_count / mamba_region_group_ids tracking that
+            # the consumer descriptor builder does not yet implement.
+            raise RuntimeError(
+                "Hybrid (Mamba/SSM) models are not yet supported with "
+                "pipeline_parallel_size > 1 over NIXL PD disaggregation."
+            )
+        pp_rank = get_pp_group().rank_in_group
+        start_layer, end_layer = self.model_config.get_layers_start_end_indices(
+            self.vllm_config.parallel_config
+        )
 
         if self.use_host_buffer:
             self.initialize_host_xfer_buffer(kv_caches=kv_caches)
@@ -884,7 +990,7 @@ class NixlBaseConnectorWorker:
 
         caches_data = []
         # With hybrid allocator, layers can share a kv cache tensor
-        seen_base_addresses = []
+        seen_base_addresses: list[int] = []
 
         # Note(tms): I modified this from the original region setup code.
         # K and V are now in different regions. Advantage is that we can
@@ -896,6 +1002,7 @@ class NixlBaseConnectorWorker:
         # to better exploit the memory layout (ie num_blocks is the first dim).
         tensor_size_bytes = None
 
+        seen_layer_names: list[str] = []
         for layer_name, cache_or_caches in xfer_buffers.items():
             # NOTE (NickLucche) Hybrid SSM models assume a layout that is similar to
             # that of FI, with block laid out as in `get_backend_aware_kv_block_len`.
@@ -964,6 +1071,7 @@ class NixlBaseConnectorWorker:
                     self.block_len_per_layer.append(physical_page_size)
                 is_mla_region = isinstance(layer_spec, MLAAttentionSpec)
                 self._region_is_mla.append(is_mla_region)
+                seen_layer_names.append(layer_name)
 
                 if not is_mla_region:
                     if tensor_size_bytes is None:
@@ -1003,8 +1111,8 @@ class NixlBaseConnectorWorker:
             == len(seen_base_addresses)
             == len(self._region_is_mla)
         )
-
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
+        self.local_seen_layer_names = seen_layer_names
+        self.local_kv_caches_base_addr = seen_base_addresses
         self.num_regions = len(caches_data)
 
         if self.transfer_topo.virtually_split_kv_in_blocks:
@@ -1049,17 +1157,22 @@ class NixlBaseConnectorWorker:
                 set(self.block_len_per_layer),
             )
 
-        # Register local/src descr for NIXL xfer.
-        self.src_xfer_handles_by_block_size[self.block_size], self.src_blocks_data = (
-            self.register_local_xfer_handler(self.block_size)
-        )
-
         # After KV Caches registered, listen for new connections.
+        num_regions = len(seen_base_addresses)
+        logger.info(
+            "Registering KV_Caches. pp_rank=%d/%d, layers=[%d, %d), "
+            "registered_regions=%d",
+            pp_rank,
+            pp_size,
+            start_layer,
+            end_layer,
+            num_regions,
+        )
         agent_metadata = NixlAgentMetadata(
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
-            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
+            kv_caches_base_addr=self.local_kv_caches_base_addr,
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             kv_cache_layout=self.kv_cache_layout
@@ -1071,6 +1184,9 @@ class NixlBaseConnectorWorker:
             physical_blocks_per_logical_kv_block=(
                 self._physical_blocks_per_logical_kv_block
             ),
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+            registered_layer_names=seen_layer_names,
         )
         # Wrap metadata in payload with hash for defensive decoding
         assert self.compat_hash is not None
@@ -1169,12 +1285,13 @@ class NixlBaseConnectorWorker:
         self,
         base_addresses: list[int],
         block_size_ratio: int,
+        local_region_indices: list[int],
     ) -> list[tuple[int, int, int]]:
         """Build local FA descriptors for all layers."""
         assert self.transfer_topo is not None
         num_blocks = self.num_blocks * block_size_ratio
         result: list[tuple[int, int, int]] = []
-        for i, base_addr in enumerate(base_addresses):
+        for i, base_addr in zip(local_region_indices, base_addresses):
             kv_block_len = (
                 self.get_backend_aware_kv_block_len(
                     layer_idx=i, first_split=True, mamba_view=False
@@ -1209,6 +1326,7 @@ class NixlBaseConnectorWorker:
         plan: TPMapping,
         nixl_agent_meta: NixlAgentMetadata,
         block_size_ratio: int,
+        local_region_indices: list[int],
     ) -> list[tuple[int, int, int]]:
         """Build remote FA descriptors for all layers."""
         assert self.transfer_topo is not None
@@ -1221,10 +1339,11 @@ class NixlBaseConnectorWorker:
         num_blocks = nixl_agent_meta.num_blocks
         result: list[tuple[int, int, int]] = []
         for i, base_addr in enumerate(nixl_agent_meta.kv_caches_base_addr):
-            replicated = self._is_region_replicated(i)
+            local_region_idx = local_region_indices[i]
+            replicated = self._is_region_replicated(local_region_idx)
             # Read our whole local region size from remote..
             local_block_len = self.get_backend_aware_kv_block_len(
-                layer_idx=i, first_split=True, mamba_view=False
+                layer_idx=local_region_idx, first_split=True, mamba_view=False
             )
             remote_kv_block_len = local_block_len // block_size_ratio
             if block_size_ratio > 1:
@@ -1251,7 +1370,7 @@ class NixlBaseConnectorWorker:
             if emits_v:
                 # With FlashInfer index V separately to allow head splitting.
                 second_split = self.get_backend_aware_kv_block_len(
-                    layer_idx=i, first_split=False, mamba_view=False
+                    layer_idx=local_region_idx, first_split=False, mamba_view=False
                 )
                 second_split = second_split // num_reads
                 for block_id in range(num_blocks):
@@ -1265,6 +1384,8 @@ class NixlBaseConnectorWorker:
     def register_local_xfer_handler(
         self,
         block_size: int,
+        *,
+        registered_layer_names: list[str] | None = None,
     ) -> tuple[int, list[tuple[int, int, int]]]:
         """
         Function used for register local xfer handler with local block_size or
@@ -1279,9 +1400,24 @@ class NixlBaseConnectorWorker:
         """
         assert self.transfer_topo is not None
         block_size_ratio = self.block_size // block_size
-        local_base_addresses = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        # PP-aware: when registered_layer_names is provided, register only the
+        # local regions matching the producer shard's layers (in the producer's
+        # advertised order). Otherwise register all local regions.
+        if registered_layer_names is None:
+            local_base_addresses = self.local_kv_caches_base_addr
+            local_region_indices = list(range(len(local_base_addresses)))
+        else:
+            local_region_indices = self._local_region_indices_for_layer_names(
+                registered_layer_names
+            )
+            local_base_addresses_all = self.local_kv_caches_base_addr
+            local_base_addresses = [
+                local_base_addresses_all[i] for i in local_region_indices
+            ]
 
-        blocks_data = self._build_fa_local(local_base_addresses, block_size_ratio)
+        blocks_data = self._build_fa_local(
+            local_base_addresses, block_size_ratio, local_region_indices
+        )
         logger.debug(
             "Created %s blocks for src engine %s and rank %s on device id %s",
             len(blocks_data),
@@ -1311,6 +1447,9 @@ class NixlBaseConnectorWorker:
         nixl_agent_meta: NixlAgentMetadata,
         remote_tp_rank: int = 0,
         remote_tp_size: int = 1,
+        *,
+        remote_pp_rank: int = 0,
+        remote_pp_size: int = 1,
     ) -> str:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
@@ -1356,19 +1495,24 @@ class NixlBaseConnectorWorker:
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
         """  # noqa: E501
         engine_id = nixl_agent_meta.engine_id
+        shard_key = (remote_pp_rank, remote_tp_rank)
         # TODO re-evaluate refreshing for scaling/recovery
-        if remote_tp_rank in self._remote_agents.get(engine_id, {}):
+        if shard_key in self._remote_agents.get(engine_id, {}):
             logger.debug(
-                "Remote agent with engine_id %s and rank"
-                "%s already exchanged metadata, skip handshake.",
+                "Remote agent with engine_id %s, pp rank %s, tp rank %s "
+                "already exchanged metadata, skip handshake.",
                 engine_id,
+                remote_pp_rank,
                 remote_tp_rank,
             )
-            return self._remote_agents[engine_id][remote_tp_rank]
+            return self._remote_agents[engine_id][shard_key]
 
         ### Register remote engine in TransferTopology (idempotent).
         assert self.transfer_topo is not None
         transfer_topo = self.transfer_topo
+        assert nixl_agent_meta.pp_rank == remote_pp_rank
+        assert nixl_agent_meta.pp_size == remote_pp_size
+        assert len(nixl_agent_meta.registered_layer_names) > 0
         physical_blocks_per_logical = (
             nixl_agent_meta.physical_blocks_per_logical_kv_block
         )
@@ -1377,11 +1521,15 @@ class NixlBaseConnectorWorker:
             remote_block_size=nixl_agent_meta.block_size,
             remote_block_len=nixl_agent_meta.block_lens[0],
             remote_physical_blocks_per_logical=physical_blocks_per_logical,
+            remote_pp_rank=remote_pp_rank,
         )
         transfer_topo.register_remote_engine(engine_id, transfer_info)
-        logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
+        logger.info(
+            "Transfer plan: %s", transfer_topo.describe(engine_id, remote_pp_rank)
+        )
 
-        self.tp_mappings[engine_id] = compute_tp_mapping(
+        plan_key = (engine_id, remote_pp_rank)
+        self.tp_mappings[plan_key] = compute_tp_mapping(
             transfer_topology=transfer_topo,
             remote_tp_size=remote_tp_size,
             group_spec_types=self._group_spec_types,
@@ -1404,45 +1552,75 @@ class NixlBaseConnectorWorker:
             self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
 
         # Keep track of remote agent kv caches base addresses.
-        self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
+        self.kv_caches_base_addr[engine_id][shard_key] = (
             nixl_agent_meta.kv_caches_base_addr
         )
-        self._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+        self._validate_remote_agent_handshake(
+            nixl_agent_meta,
+            remote_pp_rank,
+            remote_pp_size,
+            remote_tp_size,
+        )
 
         # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
         # this is the ratio between the two sizes.
         tp_ratio = transfer_topo.tp_ratio(remote_tp_size)
 
         logger.debug(
-            "Registering remote agent (%s, rank %s) memory regions with tp_ratio %s",
+            "Registering remote agent (%s, pp rank %s, tp rank %s) memory "
+            "regions with tp_ratio %s",
             engine_id,
+            remote_pp_rank,
             remote_tp_rank,
             tp_ratio,
         )
 
-        plan = self.tp_mappings[engine_id]
+        plan = self.tp_mappings[plan_key]
+
+        # PP-aware: lazily register a local xfer handler for this producer
+        # shard's layers + block size (idempotent across (engine, pp_rank,
+        # block_size)).
+        local_handle_key = (engine_id, remote_pp_rank, nixl_agent_meta.block_size)
+        if local_handle_key not in self.src_xfer_handles_by_remote:
+            handle, blocks_data = self.register_local_xfer_handler(
+                nixl_agent_meta.block_size,
+                registered_layer_names=nixl_agent_meta.registered_layer_names,
+            )
+            self.src_xfer_handles_by_remote[local_handle_key] = handle
+            self.src_blocks_data_by_remote[local_handle_key] = blocks_data
+            self._shard_region_group_ids[(engine_id, remote_pp_rank)] = (
+                self._region_group_ids_for_layer_names(
+                    nixl_agent_meta.registered_layer_names
+                )
+            )
+        src_blocks_data = self.src_blocks_data_by_remote[local_handle_key]
+        region_group_ids = self._shard_region_group_ids[(engine_id, remote_pp_rank)]
+        local_region_indices = self._local_region_indices_for_layer_names(
+            nixl_agent_meta.registered_layer_names
+        )
 
         ### (Optional) Register local agent memory regions. MLA is not split.
+        split_handle_key = (engine_id, remote_pp_rank, tp_ratio)
         if (
             tp_ratio < 0
             and not self.use_mla
-            and tp_ratio not in self.src_xfer_handles_by_tp_ratio
+            and split_handle_key not in self.src_xfer_handles_by_shard_tp_ratio
         ):
             # Remote tp_size > local tp_size: read from multiple remote ranks.
             # Logically "split" own regions into |tp_ratio| chunks. Mind that
             # we only do this once per remote tp_size (replica-friendly).
-            self.src_xfer_handles_by_tp_ratio[tp_ratio] = []
+            self.src_xfer_handles_by_shard_tp_ratio[split_handle_key] = []
 
             for handle_data in self._build_local_splits_from_plan(
                 plan,
-                self.src_blocks_data,
-                self.num_descs,
+                src_blocks_data,
+                len(region_group_ids) * self.num_blocks * block_size_ratio,
             ):
                 descs = self.nixl_wrapper.get_xfer_descs(
                     handle_data, self.nixl_memory_type
                 )
                 handle = self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs)
-                self.src_xfer_handles_by_tp_ratio[tp_ratio].append(handle)
+                self.src_xfer_handles_by_shard_tp_ratio[split_handle_key].append(handle)
 
         ### Register remote agent memory regions
         # With homogeneous TP, D pulls the whole kv cache from corresponding rank. With
@@ -1455,11 +1633,14 @@ class NixlBaseConnectorWorker:
             plan,
             nixl_agent_meta,
             block_size_ratio,
+            local_region_indices,
         )
         logger.debug(
-            "Created %s blocks for dst engine %s with remote rank %s and local rank %s",
+            "Created %s blocks for dst engine %s with remote pp rank %s, "
+            "remote tp rank %s and local rank %s",
             len(blocks_data),
             engine_id,
+            remote_pp_rank,
             remote_tp_rank,
             self.tp_rank,
         )
@@ -1479,21 +1660,20 @@ class NixlBaseConnectorWorker:
 
         # Register with NIXL.
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
-        self.dst_xfer_side_handles[engine_id][remote_tp_rank] = (
+        self.dst_xfer_side_handles[engine_id][shard_key] = (
             self.nixl_wrapper.prep_xfer_dlist(remote_agent_name, descs)
         )
 
-        if block_size_ratio > 1:
-            # when prefill with smaller block_size, we need to init a
-            # new handler with same block_len to match
-            self.src_xfer_handles_by_block_size[nixl_agent_meta.block_size] = (
-                self.register_local_xfer_handler(nixl_agent_meta.block_size)[0]
-            )
+        self._remote_agents[engine_id][shard_key] = remote_agent_name
 
         return remote_agent_name
 
     def _validate_remote_agent_handshake(
-        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+        self,
+        nixl_agent_meta: NixlAgentMetadata,
+        remote_pp_rank: int,
+        remote_pp_size: int,
+        remote_tp_size: int,
     ):
         """
         Validate the remote agent handshake metadata ensuring the
@@ -1502,7 +1682,21 @@ class NixlBaseConnectorWorker:
         remote_engine_id = nixl_agent_meta.engine_id
 
         assert self.transfer_topo is not None
-        remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
+        assert nixl_agent_meta.pp_rank == remote_pp_rank
+        assert nixl_agent_meta.pp_size == remote_pp_size
+        assert (
+            len(nixl_agent_meta.kv_caches_base_addr)
+            == len(nixl_agent_meta.block_lens)
+            == len(nixl_agent_meta.registered_layer_names)
+        )
+        # Will raise if any producer layer-name has no matching local region.
+        local_region_indices = self._local_region_indices_for_layer_names(
+            nixl_agent_meta.registered_layer_names
+        )
+
+        remote_info = self.transfer_topo.get_engine_info(
+            remote_engine_id, remote_pp_rank
+        )
         assert remote_info.remote_tp_size == remote_tp_size
 
         tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
@@ -1514,7 +1708,10 @@ class NixlBaseConnectorWorker:
         # MLA models do not need to handle kv replication.
         if not self.use_mla and not self._has_mamba:
             assert not (
-                tp_ratio < 0 and self.transfer_topo.is_kv_replicated(remote_engine_id)
+                tp_ratio < 0
+                and self.transfer_topo.is_kv_replicated(
+                    remote_engine_id, remote_pp_rank
+                )
             )
 
         remote_physical_per_logical = (
@@ -1584,7 +1781,9 @@ class NixlBaseConnectorWorker:
         if (
             abs(tp_ratio) != 1
             and not self.use_mla
-            and not self.transfer_topo.is_kv_replicated(remote_engine_id)
+            and not self.transfer_topo.is_kv_replicated(
+                remote_engine_id, remote_pp_rank
+            )
             and kv_cache_layout != "HND"
             and not self.enable_permute_local_kv
         ):
@@ -1598,15 +1797,18 @@ class NixlBaseConnectorWorker:
         # only allow the number of blocks to differ; SPLIT regions scale with
         # tp_ratio. Mamba uses the ssm_sizes counterpart, so skip block_len here.
         if not self._has_mamba:
-            assert len(self.block_len_per_layer) == len(nixl_agent_meta.block_lens), (
+            assert len(local_region_indices) == len(nixl_agent_meta.block_lens), (
                 "Number of KV layers must match between prefill and decode"
             )
             model_replicated = self.use_mla or self.transfer_topo.is_kv_replicated(
-                remote_engine_id
+                remote_engine_id, remote_pp_rank
             )
-            for i, local_len in enumerate(self.block_len_per_layer):
-                replicated = model_replicated or self._is_region_replicated(i)
-                remote_len = nixl_agent_meta.block_lens[i]
+            for i, remote_len in enumerate(nixl_agent_meta.block_lens):
+                local_region_idx = local_region_indices[i]
+                local_len = self.block_len_per_layer[local_region_idx]
+                replicated = model_replicated or self._is_region_replicated(
+                    local_region_idx
+                )
                 if replicated:
                     assert local_len // block_size_ratio == remote_len, (
                         "KV cache sizes must match between P and D when "
@@ -1632,8 +1834,6 @@ class NixlBaseConnectorWorker:
 
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
-        # Same number of regions/~layers.
-        assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
 
     def sync_recved_kv_to_device(self, req_id: str, meta: ReqMeta):
         """copy recved kv from host buffer to device."""
@@ -1816,7 +2016,7 @@ class NixlBaseConnectorWorker:
                 self.sync_recved_kv_to_device(req_id, meta)
 
             # post processing for heteroblocksize
-            remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
+            remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id, 0)
             block_size_ratio = self.transfer_topo.block_size_ratio(
                 remote_info.remote_block_size
             )
@@ -1964,7 +2164,11 @@ class NixlBaseConnectorWorker:
             # the **next** heartbeat for this remote can go through.
             if (
                 self._ensure_handshake(
-                    engine_id, hb_info.host, hb_info.port, hb_info.tp_size
+                    engine_id,
+                    hb_info.host,
+                    hb_info.port,
+                    hb_info.tp_size,
+                    hb_info.pp_size,
                 )
                 is not None
             ):
@@ -2247,12 +2451,18 @@ class NixlBaseConnectorWorker:
 
         del self.kv_caches_base_addr[engine_id]
         del self.dst_num_blocks[engine_id]
-        del self.tp_mappings[engine_id]
+        # tp_mappings is keyed by (engine_id, remote_pp_rank).
+        for key in [k for k in self.tp_mappings if k[0] == engine_id]:
+            del self.tp_mappings[key]
+        self._remote_pp_size.pop(engine_id, None)
         if self.transfer_topo is not None:
             self.transfer_topo.unregister_remote_engine(engine_id)
 
-        last_active = self._engine_last_active.pop(engine_id)
-        if log_eviction:
+        # Under PP, agents are registered per-shard in add_remote_agent, so an
+        # engine can be present here before its handshake future completes and
+        # records _engine_last_active.
+        last_active = self._engine_last_active.pop(engine_id, None)
+        if log_eviction and last_active is not None:
             logger.info(
                 "Evicted stale remote engine %s (inactive for %.1fs).",
                 engine_id,
@@ -2272,13 +2482,13 @@ class NixlBaseConnectorWorker:
             for handle in handles:
                 self.nixl_wrapper.release_xfer_handle(handle)
         self._recving_transfers.clear()
-        for handle in self.src_xfer_handles_by_block_size.values():
+        for handle in self.src_xfer_handles_by_remote.values():
             self.nixl_wrapper.release_dlist_handle(handle)
-        self.src_xfer_handles_by_block_size.clear()
-        for handles in self.src_xfer_handles_by_tp_ratio.values():
+        self.src_xfer_handles_by_remote.clear()
+        for handles in self.src_xfer_handles_by_shard_tp_ratio.values():
             for handle in handles:
                 self.nixl_wrapper.release_dlist_handle(handle)
-        self.src_xfer_handles_by_tp_ratio.clear()
+        self.src_xfer_handles_by_shard_tp_ratio.clear()
         for engine_id in list(self._remote_agents):
             self._cleanup_remote_engine(engine_id, log_eviction=False)
         for desc in self._registered_descs:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -207,11 +207,11 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
 
-    def set_xfer_handshake_metadata(
-        self, metadata: dict[int, KVConnectorHandshakeMetadata]
+    def set_xfer_handshake_metadata_pp_aware(
+        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         """
-        Set the KV connector handshake metadata for this connector.
+        Set the PP-aware KV connector handshake metadata for this connector.
 
         Args:
             metadata (dict): the handshake metadata to set.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -39,8 +39,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   2: Add remote_request_id to kv_transfer_params
 #   3: Add physical_blocks_per_logical_kv_block to NixlAgentMetadata
 #   4: Add KV block lease renewal through heartbeats
+#   5: Add pipeline-parallel producer metadata and per-request pp_size
 #
-NIXL_CONNECTOR_VERSION: int = 4
+NIXL_CONNECTOR_VERSION: int = 5
 
 
 @dataclass
@@ -56,6 +57,9 @@ class NixlAgentMetadata:
     ssm_sizes: tuple[int, int]
     attn_backend_name: str
     physical_blocks_per_logical_kv_block: int
+    pp_rank: int
+    pp_size: int
+    registered_layer_names: list[str]
 
 
 @dataclass
@@ -147,6 +151,7 @@ class HeartbeatInfo:
     host: str
     port: int
     tp_size: int
+    pp_size: int
 
 
 @dataclass
@@ -164,6 +169,7 @@ class ReqMeta:
     # To be used when logical block size does not match the kernel block size
     local_physical_block_ids: BlockIds
     tp_size: int
+    pp_size: int = 1
     remote: RemoteMeta | None = None
     # Remote block size, discovered during NIXL handshake (push mode).
     remote_block_size: int | None = None
@@ -195,6 +201,7 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             local_physical_block_ids=local_block_ids,
             # P workers don't need to receive tp_size from proxy here.
             tp_size=kv_transfer_params.get("tp_size", 1),
+            pp_size=kv_transfer_params.get("pp_size", 1),
             remote_block_size=kv_transfer_params.get("remote_block_size"),
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -271,5 +271,6 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
             remote_num_tokens=remote_num_tokens,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
@@ -60,10 +61,10 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             )
             # always store metadata for failure recovery
             self._recving_metadata[req_id] = meta
-            if remote_engine_id not in self._remote_agents:
+            if not self._handshake_complete(remote_engine_id, meta.pp_size):
                 # Initiate handshake with remote engine to exchange metadata.
                 with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
+                    if not self._handshake_complete(remote_engine_id, meta.pp_size):
                         self._background_nixl_handshake(req_id, remote_engine_id, meta)
                         continue
 
@@ -104,87 +105,104 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Update last activity from this remote. Mind that cleanup is done on main
         # thread (this one), so we don't race on this structure.
         self._engine_last_active[engine_id] = time.perf_counter()
-        plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
-        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        # A request's KV is spread across the remote producer's PP stages; read
+        # each stage in turn (its own layer range, TP mapping and block geometry).
+        for remote_pp_rank in range(self._remote_pp_size[engine_id]):
+            plan = self.tp_mappings[(engine_id, remote_pp_rank)]
+            remote_info = self.transfer_topo.get_engine_info(engine_id, remote_pp_rank)
+            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
-        meta.remote.block_ids = self._logical_to_remote_kernel_block_ids(
-            meta.remote.block_ids,
-            remote_info.remote_physical_blocks_per_logical,
-        )
-        remote_block_ids = meta.remote.block_ids
-        local_block_ids = meta.local_physical_block_ids
-        num_groups = len(local_block_ids)
-        read_specs = [
-            ReadSpec(
-                remote_rank=rank,
-                local_block_ids=[
-                    list(local_block_ids[g])
-                    if rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ],
-                remote_block_ids=[
-                    list(remote_block_ids[g])
-                    if rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ],
+            # Keep meta.remote.block_ids logical (reused on retry); expand to
+            # kernel block ids per stage, whose geometry may differ.
+            remote_block_ids = self._logical_to_remote_kernel_block_ids(
+                meta.remote.block_ids,
+                remote_info.remote_physical_blocks_per_logical,
             )
-            for rank in plan.all_source_ranks
-        ]
-
-        # D may have to perform multiple reads from different remote ranks.
-        # MLA opt: when P TP > D TP, only a single read is executed for
-        # the first remote rank (cache is duplicated)..
-        if self.use_mla and tp_ratio < 0:
-            assert len(read_specs) == 1
-
-        for i, spec in enumerate(read_specs):
-            remote_block_size = remote_info.remote_block_size
-            logger.debug(
-                "Remote agent %s available, calling _read_blocks"
-                " on remote rank %s with remote block size %s for req %s",
-                meta.remote.engine_id,
-                spec.remote_rank,
-                remote_block_size,
-                req_id,
-            )
-            # Get side handles.
-            if tp_ratio < 0 and not self.use_mla:
-                assert remote_block_size == self.block_size
-                # Remote tp_size > local tp_size: we must perform multiple
-                # reads. Get the memory chunk onto which we will write to.
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][i]
-            else:
-                # Single read from remote, we write to the whole memory region.
-                # Also handle remote block size different from local block size.
-                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                    remote_block_size
-                ]
-
-            # Destination handle: remote_engine_id -> remote_rank -> handle.
-            remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+            local_block_ids = meta.local_physical_block_ids
+            num_groups = len(local_block_ids)
+            read_specs = [
+                ReadSpec(
+                    remote_rank=rank,
+                    local_block_ids=[
+                        list(local_block_ids[g])
+                        if rank in plan.source_ranks_per_group[g]
+                        else []
+                        for g in range(num_groups)
+                    ],
+                    remote_block_ids=[
+                        list(remote_block_ids[g])
+                        if rank in plan.source_ranks_per_group[g]
+                        else []
+                        for g in range(num_groups)
+                    ],
+                )
+                for rank in plan.all_source_ranks
             ]
 
-            self._read_blocks(
-                read_spec=spec,
-                request_id=req_id,
-                dst_engine_id=meta.remote.engine_id,
-                remote_request_id=meta.remote.request_id,
-                local_xfer_side_handle=local_xfer_side_handle,
-                remote_xfer_side_handle=remote_xfer_side_handle,
-            )
+            # D may have to perform multiple reads from different remote ranks.
+            # MLA opt: when P TP > D TP, only a single read is executed for
+            # the first remote rank (cache is duplicated)..
+            if self.use_mla and tp_ratio < 0:
+                assert len(read_specs) == 1
 
-        if self.use_mla and tp_ratio < 0 and read_specs:
-            # ..but we still need to notify the other remote ranks that we
-            # have the blocks we need so they can update the request state.
-            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
-            remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify != read_specs[0].remote_rank:
-                    self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+            for i, spec in enumerate(read_specs):
+                remote_block_size = remote_info.remote_block_size
+                logger.debug(
+                    "Remote agent %s available, calling _read_blocks on remote "
+                    "pp rank %s, tp rank %s with remote block size %s for req %s",
+                    meta.remote.engine_id,
+                    remote_pp_rank,
+                    spec.remote_rank,
+                    remote_block_size,
+                    req_id,
+                )
+                # Get side handles.
+                if tp_ratio < 0 and not self.use_mla:
+                    # Remote tp_size > local tp_size: we must perform multiple
+                    # reads. Get the memory chunk onto which we will write to.
+                    assert remote_block_size == self.block_size
+                    local_xfer_side_handle = self.src_xfer_handles_by_shard_tp_ratio[
+                        (engine_id, remote_pp_rank, tp_ratio)
+                    ][i]
+                else:
+                    # Single read from remote, we write to the whole memory region.
+                    # Also handle remote block size different from local block size.
+                    local_xfer_side_handle = self.src_xfer_handles_by_remote[
+                        (engine_id, remote_pp_rank, remote_block_size)
+                    ]
+
+                # Destination handle:
+                # remote_engine_id -> (remote_pp_rank, remote_rank) -> handle.
+                remote_xfer_side_handle = self.dst_xfer_side_handles[
+                    meta.remote.engine_id
+                ][(remote_pp_rank, spec.remote_rank)]
+
+                self._read_blocks(
+                    read_spec=spec,
+                    request_id=req_id,
+                    dst_engine_id=meta.remote.engine_id,
+                    remote_request_id=meta.remote.request_id,
+                    remote_pp_rank=remote_pp_rank,
+                    local_xfer_side_handle=local_xfer_side_handle,
+                    remote_xfer_side_handle=remote_xfer_side_handle,
+                )
+
+            if self.use_mla and tp_ratio < 0 and read_specs:
+                # ..but we still need to notify the other remote ranks that we
+                # have the blocks we need so they can update the request state.
+                notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+                remote_agents = self._remote_agents[meta.remote.engine_id]
+                for (pp_rank, rank_to_notify), agent in remote_agents.items():
+                    if (
+                        pp_rank == remote_pp_rank
+                        and rank_to_notify != read_specs[0].remote_rank
+                    ):
+                        self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+
+        if len(meta.local_physical_block_ids) == 0:
+            # Full prefix hit: no remote read happens, so no recv completion will
+            # report this request — drop its pending-recv metadata here.
+            self._recving_metadata.pop(req_id, None)
 
     def _read_blocks(
         self,
@@ -192,6 +210,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         dst_engine_id: str,
         request_id: str,
         remote_request_id: str,
+        remote_pp_rank: int,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
     ):
@@ -203,8 +222,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_rank = read_spec.remote_rank
         local_block_ids = read_spec.local_block_ids
         remote_block_ids = read_spec.remote_block_ids
-
-        remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
+        remote_info = self.transfer_topo.get_engine_info(dst_engine_id, remote_pp_rank)
         block_size_ratio = self.transfer_topo.block_size_ratio(
             remote_info.remote_block_size
         )
@@ -233,6 +251,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 ]
             local_block_ids = [local_block_ids_mapped] if local_block_ids_mapped else []
             remote_block_ids = [remote_block_ids0]
+
         # NOTE(rob): having the staging blocks be on the READER side is
         # not going to work well (since we will have to call rearrange tensors).
         # after we detect the txn is complete (which means we cannot make the
@@ -250,7 +269,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # just notify P worker that we have the blocks we need.
         if len(local_block_ids) == 0:
             # A full prefix cache hit is indicated with an empty list.
-            agent_name = self._remote_agents[dst_engine_id][remote_rank]
+            agent_name = self._remote_agents[dst_engine_id][
+                (remote_pp_rank, remote_rank)
+            ]
             try:
                 self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
             except Exception as e:
@@ -261,6 +282,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     req_id=request_id,
                     error=e,
                     dst_engine_id=dst_engine_id,
+                    remote_pp_rank=remote_pp_rank,
                     remote_rank=remote_rank,
                     remote_agent_name=agent_name,
                 )
@@ -281,19 +303,36 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # corresponding rank. With heterogeneous TP, fixing D>P, the D tp
         # workers will issue xfers to parts of the P worker remote kv caches.
 
-        # Get descs ids.
-        remote_block_descs_ids = self._compute_desc_ids(
-            block_ids=remote_block_ids,
-            dst_num_blocks=self.dst_num_blocks[dst_engine_id],
-            block_size_ratio=None,
-            physical_blocks_per_logical=remote_info.remote_physical_blocks_per_logical,
-        )
-        local_block_descs_ids = self._compute_desc_ids(
-            block_ids=local_block_ids,
-            dst_num_blocks=self.dst_num_blocks[self.engine_id],
-            block_size_ratio=block_size_ratio,
-            physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
-        )
+        # Get descs ids. A single-stage (pp_size == 1) producer registers all of
+        # the engine's KV regions, so compute ids against the whole-engine layout
+        # (which also covers Mamba FA/SSM and cross-layer blocks). Per-PP-stage
+        # descriptor sharding is only needed when the producer is pipelined.
+        if self._remote_pp_size[dst_engine_id] == 1:
+            remote_block_descs_ids = self._compute_desc_ids(
+                block_ids=remote_block_ids,
+                dst_num_blocks=self.dst_num_blocks[dst_engine_id],
+                block_size_ratio=None,
+                physical_blocks_per_logical=remote_physical_per_logical,
+            )
+            local_block_descs_ids = self._compute_desc_ids(
+                block_ids=local_block_ids,
+                dst_num_blocks=self.dst_num_blocks[self.engine_id],
+                block_size_ratio=block_size_ratio,
+                physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
+            )
+        else:
+            remote_block_descs_ids = self._get_block_descs_ids_for_shard(
+                dst_engine_id,
+                remote_pp_rank,
+                self.dst_num_blocks[dst_engine_id],
+                remote_block_ids,
+            )
+            local_block_descs_ids = self._get_block_descs_ids_for_shard(
+                dst_engine_id,
+                remote_pp_rank,
+                self.num_blocks * block_size_ratio,
+                local_block_ids,
+            )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
 
@@ -322,9 +361,29 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 msg="Marking blocks as invalid",
                 error=e,
                 dst_engine_id=dst_engine_id,
+                remote_pp_rank=remote_pp_rank,
                 remote_rank=remote_rank,
             )
             self._handle_failed_transfer(request_id, handle)
+
+    def _get_block_descs_ids_for_shard(
+        self,
+        engine_id: str,
+        remote_pp_rank: int,
+        num_blocks: int,
+        block_ids: BlockIds,
+    ) -> np.ndarray:
+        """Get descriptor IDs relative to a shard-local prepared dlist."""
+        region_group_ids = self._shard_region_group_ids[(engine_id, remote_pp_rank)]
+        desc_ids = []
+        for region_id, group_id in enumerate(region_group_ids):
+            group_arr = np.asarray(block_ids[group_id], dtype=np.int64)
+            if group_arr.size == 0:
+                continue
+            desc_ids.append(region_id * num_blocks + group_arr)
+        if not desc_ids:
+            return np.empty(0, dtype=np.int64)
+        return np.concatenate(desc_ids)
 
     def _get_new_notifs(self) -> set[str]:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -280,13 +280,15 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             reg_data["remote_host"],
             reg_data["remote_port"],
             reg_data["remote_tp_size"],
+            # Push mode does not support pipeline-parallel peers.
+            pp_size=1,
         )
         if fut is None:
             self._do_send_reg_notif(req_id, reg_data)
             return
 
         def _on_handshake(
-            f: Future[dict[int, str]],
+            f: Future[dict[tuple[int, int], str]],
             rid: str = req_id,
             rd: dict[str, Any] = reg_data,
         ) -> None:
@@ -452,6 +454,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 decode_host,
                 decode_port,
                 decode_tp_size,
+                # Push mode does not support pipeline-parallel peers.
+                1,
                 decode_engine_id,
             )
         except Exception:
@@ -463,6 +467,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             return False
         with self._handshake_lock:
             self._remote_agents[decode_engine_id] = remote_agents
+            self._remote_pp_size[decode_engine_id] = 1
         logger.info(
             "Push handshake to D %s done (%d agents)",
             decode_engine_id,
@@ -486,7 +491,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         """Issue WRITE transfers to one or more remote TP ranks."""
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        plan = self.tp_mappings[engine_id]
+        plan = self.tp_mappings[(engine_id, 0)]
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
@@ -534,14 +539,16 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             )
             if tp_ratio < 0 and not self.use_mla:
                 assert remote_block_size == self.block_size
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][i]
+                local_xfer_side_handle = self.src_xfer_handles_by_shard_tp_ratio[
+                    (engine_id, 0, tp_ratio)
+                ][i]
             else:
-                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                    remote_block_size
+                local_xfer_side_handle = self.src_xfer_handles_by_remote[
+                    (engine_id, 0, remote_block_size)
                 ]
 
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+                (0, spec.remote_rank)
             ]
 
             self._xfer_blocks(
@@ -556,7 +563,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         if self.use_mla and tp_ratio < 0 and read_specs:
             notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
             remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
+            for (_, rank_to_notify), agent in remote_agents.items():
                 if rank_to_notify != read_specs[0].remote_rank:
                     self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 


### PR DESCRIPTION
## Purpose

Adds pipeline-parallel support to the NIXL PD-disaggregated serving path. The
existing NIXL P/D consumer asserted `remote_pp_size == 1` during handshake, and
the producer-side `KVOutputAggregator` rejected `None` `ModelRunnerOutput` from
non-last PP ranks. This PR plumbs producer PP topology end-to-end and re-keys the
consumer-side per-shard state by `(pp_rank, tp_rank)` so a single decoder fans out
handshakes and KV transfers across all producer PP shards.

Supported topology: **heterogeneous PP × TP**, e.g. PP=2 prefiller + TP=2 decoder
on 4 GPUs. The producer's KV is layer-sharded across PP stages while the consumer
is head-sharded across TP ranks, so the connector matches each producer shard's
advertised layers to the local KV regions by name and reshapes on transfer.

Hybrid (Mamba/SSM) producers are explicitly rejected at `register_kv_caches` when
`pp_size > 1` — the per-shard descriptor builder does not yet carry
`mamba_region_*` state. That support is added in a follow-up PR (#43368) to keep
this PR focused.

## Changes

The PP-aware handshake-aggregation and intermediate-PP output foundation landed
separately in #43720 (now merged), so this PR is rebased on `main` and contains
two commits:

| # | Commit | Summary |
|---|--------|---------|
| 1 | `[KVConnector][NIXL] Enable PP-disaggregated KV transfer (single-group, no HMA)` | `NixlConnector` adopts the PP-aware foundation API. `NixlAgentMetadata` carries `pp_rank`, `pp_size`, `start_layer`, `end_layer`, `registered_layer_names`. Per-shard handshake aggregation: `_remote_agents`, `_handshake_futures`, `kv_caches_base_addr`, `dst_xfer_side_handles`, and the per-engine TP mapping are all keyed by `(pp_rank, tp_rank)`; the consumer matches a producer shard's advertised layers to its local KV regions by name and lazily registers a per-shard transfer handle (`src_xfer_handles_by_remote` keyed by `(engine_id, pp_rank, block_size)`); the read path loops over `range(pp_size)` producer stages, each with its own layer range, TP fan-out and block geometry. The scheduler forwards the real `pp_size`; the `remote_pp_size == 1` assertion is dropped. A hybrid-Mamba × PP guard is added at `register_kv_caches`. |
| 2 | `[KVConnector][NIXL] code simplification` | Cleans up commit 1 with **no behavior change**: collapses the `PPLayerMap` dataclass/module into a lightweight `_remote_pp_size: dict[EngineId, int]` "handshake-complete" sentinel (cross-shard partition checks are already covered per-shard in `_validate_remote_agent_handshake`); slims per-shard tracking to `_seen_pp_ranks: dict[EngineId, set[int]]`; drops the redundant `registered_layer_indices` wire field (derived from `registered_layer_names` via `extract_layer_index`); keeps the consumer's own region base addresses in a dedicated `local_kv_caches_base_addr` field; flattens the handshake's PP×TP loops into a single `itertools.product` loop; removes a duplicate `dst_num_blocks` assertion; trims redundant comments. Net −231 LOC. |

Total vs `main`: 12 files, +1,234 / −259 (`worker.py`: +462 / −189).

## Test Plan

### Unit + integration
```bash
.venv/bin/python -m pytest -q \
  tests/v1/kv_connector/unit/test_nixl_connector.py \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py \
  tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py \
  tests/v1/kv_connector/unit/test_transfer_topology_sharded.py \
  tests/v1/kv_connector/unit/test_nixl_heartbeat.py \
  tests/v1/kv_connector/unit/test_tp_mapping.py \
  tests/v1/kv_connector/nixl_integration/test_consumer_shard_refactor.py \
  tests/v1/kv_connector/nixl_integration/test_handshake_aggregation.py \
  tests/v1/kv_connector/nixl_integration/test_pp_metadata.py
```

### End-to-end correctness (GSM8K)

Llama-3.1-70B-Instruct on a 4×GB200 node, full GSM8K (1319 problems, 5-shot, chat
template), through the toy proxy at `127.0.0.1:8000`. Two stacks are compared: the
heterogeneous **PP=2 prefiller (GPUs 0,1) + TP=2 decoder (GPUs 2,3)** path this PR
adds, and the existing **TP=2 prefiller + TP=2 decoder** PD baseline.

Prefiller (PP=2):
```bash
CUDA_VISIBLE_DEVICES=0,1 VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
  vllm serve meta-llama/Llama-3.1-70B-Instruct \
  --pipeline-parallel-size 2 --tensor-parallel-size 1 \
  --max-model-len 32768 --port 8100 --no-enable-prefix-caching --enforce-eager \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
```
Decoder (TP=2):
```bash
CUDA_VISIBLE_DEVICES=2,3 VLLM_NIXL_SIDE_CHANNEL_PORT=5601 \
  vllm serve meta-llama/Llama-3.1-70B-Instruct \
  --pipeline-parallel-size 1 --tensor-parallel-size 2 \
  --max-model-len 32768 --port 8200 --no-enable-prefix-caching --enforce-eager \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
```
Proxy + eval:
```bash
python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
  --port 8000 --prefiller-hosts 127.0.0.1 --prefiller-ports 8100 \
  --decoder-hosts 127.0.0.1 --decoder-ports 8200

lm_eval --model local-chat-completions \
  --model_args model=meta-llama/Llama-3.1-70B-Instruct,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=32 \
  --tasks gsm8k --num_fewshot 5 --apply_chat_template
```

> `--enforce-eager` sidesteps an unrelated flashinfer `allreduce_fusion` API drift
> on the TP>1 decode path on current `main`; it is not required by the connector.

## Test Result

**Unit + integration:** 118 passed / 2 skipped across the NIXL unit + integration
suites listed above.

**End-to-end GSM8K (full 1319, 5-shot, chat):**

| Stack | flexible-extract | strict-match |
|-------|------------------|--------------|
| PP=2 prefill → TP=2 decode (this PR) | **0.9424** ±0.0064 | 0.8916 ±0.0086 |
| TP=2 prefill → TP=2 decode (baseline) | 0.9386 ±0.0066 | 0.8893 ±0.0086 |

The heterogeneous PP×TP path matches the non-PP PD baseline within eval noise
(Δ 0.0038 ≪ combined stderr), confirming the layer-sharded → head-sharded KV
transfer is correct and the PP path does not regress the existing PD path.

**Throughput (representative; PP=2 prefill + TP=2 decode, Llama-3.1-70B-Instruct,
4×GB200, input=8192 / output=128 / concurrency=1, 10 prompts):**

```
================= Serving Benchmark Result =================
Successful requests:                     10
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  84.07
Total input tokens:                      81910
Total generated tokens:                  1280
Request throughput (req/s):              0.12
Output token throughput (tok/s):         15.22
Total token throughput (tok/s):          989.48
Mean TTFT (ms):                          6619.96
Mean TPOT (ms):                          14.07
Mean E2EL (ms):                          8406.96
============================================================
```
10/10 requests succeeded; NIXL KV transfers fanned out from the PP0/PP1 producer
shards into the TP-sharded decoder for every request.

**Pre-PR**, the same heterogeneous setup failed at `_nixl_handshake`'s
`remote_pp_size == 1` assertion; post-PR the consumer fans out per-shard
handshakes successfully (results above).

## Why this is not a duplicate

Re-checked vLLM open PRs/issues for `pipeline parallel disaggregated NIXL`, `PP
NIXL connector`, `consumer per-shard`, and related variants. No open PR covers the
heterogeneous PP × TP consumer per-shard refactor implemented here. The
PP-aware-foundation portion landed in #43720; HMA-under-PP support is a separate
follow-up (#43368), so each PR maps to a single concern.

## AI assistance disclosure

This change was drafted with AI assistance (Claude Code). The submitting human
reviewed every changed line, ran every test referenced above, and is responsible
for defending the change end-to-end.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR (see Purpose section).
- [x] The test plan (see Test Plan section).
- [x] The test results (see Test Result section).
- [ ] (Optional) The necessary documentation update.
- [ ] (Optional) Release notes update.

</details>
