### PR TITLE
[Bugfix][Spec Decode] Fix vocab size validation for eagle/eagle3

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pydantic
 import pytest
@@ -1467,3 +1467,43 @@ def test_ir_op_priority_ctx():
         # context restored even after exception
         assert ir.ops.rms_norm.get_priority() == ["vllm_c", "native"]
         assert ir.ops.fused_add_rms_norm.get_priority() == ["native"]
+
+
+@pytest.mark.parametrize("method", ["eagle", "eagle3"])
+def test_verify_vocab_size_raises_for_eagle_mismatch(method):
+    """eagle and eagle3 must enforce vocab-size parity like draft_model does."""
+    spec_cfg = SpeculativeConfig.__new__(SpeculativeConfig)
+    spec_cfg.method = method
+
+    target_mock = Mock()
+    target_mock.get_vocab_size.return_value = 128000
+
+    draft_mock = Mock()
+    draft_mock.get_vocab_size.return_value = 99999
+    draft_mock.hf_config = Mock(spec=[])  # no auto-attrs → draft_vocab_size absent
+
+    spec_cfg.target_model_config = target_mock
+    spec_cfg.draft_model_config = draft_mock
+
+    with pytest.raises(ValueError, match="same vocabulary size"):
+        spec_cfg.verify_equal_vocab_size_if_draft_model()
+
+
+def test_verify_vocab_size_allows_eagle3_pruned_vocab():
+    """eagle3 with draft_vocab_size on hf_config signals intentional pruning."""
+    spec_cfg = SpeculativeConfig.__new__(SpeculativeConfig)
+    spec_cfg.method = "eagle3"
+
+    target_mock = Mock()
+    target_mock.get_vocab_size.return_value = 128000
+
+    draft_mock = Mock()
+    draft_mock.get_vocab_size.return_value = 8000
+    draft_mock.hf_config = Mock(spec=["draft_vocab_size"])
+    draft_mock.hf_config.draft_vocab_size = 8000
+
+    spec_cfg.target_model_config = target_mock
+    spec_cfg.draft_model_config = draft_mock
+
+    # must not raise
+    spec_cfg.verify_equal_vocab_size_if_draft_model()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1469,7 +1469,7 @@ def test_ir_op_priority_ctx():
         assert ir.ops.fused_add_rms_norm.get_priority() == ["native"]
 
 
-@pytest.mark.parametrize("method", ["eagle", "eagle3"])
+@pytest.mark.parametrize("method", ["eagle", "eagle3", "dflash", "mtp"])
 def test_verify_vocab_size_raises_for_eagle_mismatch(method):
     """eagle and eagle3 must enforce vocab-size parity like draft_model does."""
     spec_cfg = SpeculativeConfig.__new__(SpeculativeConfig)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1017,7 +1017,7 @@ class SpeculativeConfig:
 
     def verify_equal_vocab_size_if_draft_model(self):
         if (
-            self.method in ("draft_model", "eagle", "eagle3")
+            (self.method == "draft_model" or self.use_eagle())
             and self.target_model_config is not None
             and self.draft_model_config is not None
         ):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1017,13 +1017,17 @@ class SpeculativeConfig:
 
     def verify_equal_vocab_size_if_draft_model(self):
         if (
-            self.method == "draft_model"
+            self.method in ("draft_model", "eagle", "eagle3")
             and self.target_model_config is not None
             and self.draft_model_config is not None
         ):
             target_vocab_size = self.target_model_config.get_vocab_size()
             draft_vocab_size = self.draft_model_config.get_vocab_size()
-            if target_vocab_size != draft_vocab_size:
+            if (
+                target_vocab_size != draft_vocab_size
+                and getattr(self.draft_model_config.hf_config, "draft_vocab_size", None)
+                is None
+            ):
                 raise ValueError(
                     f"Target and draft model should have the same vocabulary size. "
                     f"Target model vocab_size={target_vocab_size}. "


### PR DESCRIPTION
## Purpose
`verify_equal_vocab_size_if_draft_model()` only enforced vocabulary parity when `method == "draft_model"`, silently skipping `eagle` and `eagle3`.  A mismatched vocabulary between target and draft model causes out-of-bounds GPU memory access during speculative decoding.

Fixes #34583.

This continues the work started in #34722 (closed without merge), using a minimal patch to the existing method rather than introducing a new one.

## Test Plan                                                                                                                                                                                                             
`.venv/bin/python -m pytest tests/test_config.py::test_verify_vocab_size_raises_for_eagle_mismatch tests/test_config.py::test_verify_vocab_size_allows_eagle3_pruned_vocab -v`

## Test Result
```
test_verify_vocab_size_raises_for_eagle_mismatch[eagle] PASSED
test_verify_vocab_size_raises_for_eagle_mismatch[eagle3] PASSED 
test_verify_vocab_size_allows_eagle3_pruned_vocab PASSED
3 passed in 1.82s
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

