### PR TITLE
[Core] AsyncLLM.truncate_session: per-session KV cache truncation API

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -401,6 +401,44 @@ def test_evictable_cached_blocks_not_double_allocated():
     assert len(manager.req_to_blocks[request_id]) == 2
 
 
+def test_truncate_to_tokens():
+    """SlidingWindowManager.truncate_to_tokens frees tail blocks."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=8,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    # Allocate 5 blocks for a 20-token request.
+    blocks = [block_pool.blocks[i] for i in range(5)]
+    for b in blocks:
+        b.ref_cnt = 1
+    manager.req_to_blocks["req"] = list(blocks)
+
+    # Truncate to 12 tokens -> keep ceil(12/4)=3 blocks, free 2.
+    manager.truncate_to_tokens("req", 12)
+    assert len(manager.req_to_blocks["req"]) == 3
+    assert [b.block_id for b in manager.req_to_blocks["req"]] == [0, 1, 2]
+
+    # Truncate to 5 tokens -> keep ceil(5/4)=2 blocks, free 1.
+    manager.truncate_to_tokens("req", 5)
+    assert len(manager.req_to_blocks["req"]) == 2
+
+    # Target larger than current length -> no-op.
+    manager.truncate_to_tokens("req", 100)
+    assert len(manager.req_to_blocks["req"]) == 2
+
+    # Unknown request -> no-op (no exception).
+    manager.truncate_to_tokens("nonexistent", 5)
+
+
 def test_chunked_local_attention_get_num_blocks_to_allocate():
     block_size = 2
     attention_spec = ChunkedLocalAttentionSpec(

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -573,3 +573,104 @@ class TestStreamingScheduler(unittest.TestCase):
             cached_state_cycle1["prompt_token_ids"]
             is not cached_state_cycle3["prompt_token_ids"]
         ), "Cached states from different cycles should be independent objects."
+
+
+class TestTruncateRequest(unittest.TestCase):
+    """Unit tests for Scheduler.truncate_request."""
+
+    def _make_waiting_streaming_request(
+        self,
+        scheduler: Scheduler,
+        prompt_len: int,
+        num_computed: int,
+        output_tokens: list[int] | None = None,
+    ) -> Request:
+        """Construct a Request directly in WAITING_FOR_STREAMING_REQ
+        and register it with the scheduler. Bypasses the prefill path
+        so we can control internal state precisely. Also installs a
+        mock on ``kv_cache_manager.truncate_to_tokens`` so call args
+        can be asserted."""
+        req = DummyRequest(
+            request_id="req",
+            prompt_token_ids=list(range(prompt_len)),
+        )
+        req.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        req.num_computed_tokens = num_computed
+        if output_tokens:
+            req._output_token_ids.extend(output_tokens)
+            req._all_token_ids.extend(output_tokens)
+        req.block_hashes = [object()]  # sentinel; truncate should clear
+        scheduler.requests[req.request_id] = req
+        scheduler.kv_cache_manager.truncate_to_tokens = MagicMock(return_value=None)
+        return req
+
+    def test_truncate_request_basic(self):
+        """Happy path: truncates _all_token_ids, refreshes
+        prompt_token_ids, clears _output_token_ids, clamps
+        num_computed_tokens, clears block_hashes, and calls the
+        kv_cache_manager with the right args."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler,
+            prompt_len=10,
+            num_computed=20,
+            output_tokens=[100, 101, 102, 103, 104],
+        )
+        assert len(req._all_token_ids) == 15
+
+        scheduler.truncate_request(req.request_id, target_num_tokens=8)
+
+        assert req._all_token_ids == [0, 1, 2, 3, 4, 5, 6, 7]
+        assert req.prompt_token_ids == [0, 1, 2, 3, 4, 5, 6, 7]
+        assert req.prompt_token_ids is not req._all_token_ids
+        assert list(req._output_token_ids) == []
+        assert req.num_computed_tokens == 8
+        assert req.block_hashes == []
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_called_once_with(
+            req.request_id, 8
+        )
+
+    def test_truncate_request_clamps_num_computed_only_when_higher(self):
+        """If num_computed_tokens is already below target, it stays put."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=10, num_computed=5
+        )
+        scheduler.truncate_request(req.request_id, target_num_tokens=8)
+        assert req.num_computed_tokens == 5
+
+    def test_truncate_request_noop_for_wrong_status(self):
+        """Request in any state other than WAITING_FOR_STREAMING_REQ is
+        left untouched and the kv_cache_manager is not called."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=10, num_computed=8
+        )
+        req.status = RequestStatus.WAITING
+        pre_tokens = list(req._all_token_ids)
+        scheduler.truncate_request(req.request_id, target_num_tokens=3)
+        assert req._all_token_ids == pre_tokens
+        assert req.num_computed_tokens == 8
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()
+
+    def test_truncate_request_noop_for_unknown_id(self):
+        """An unknown request_id is silently ignored."""
+        scheduler = create_scheduler()
+        scheduler.kv_cache_manager.truncate_to_tokens = MagicMock(return_value=None)
+        scheduler.truncate_request("nonexistent", target_num_tokens=3)
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()
+
+    def test_truncate_request_noop_for_out_of_range_target(self):
+        """target_num_tokens that is negative or >= current length is a no-op."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=10, num_computed=10
+        )
+        pre_tokens = list(req._all_token_ids)
+        scheduler.truncate_request(req.request_id, target_num_tokens=10)
+        assert req._all_token_ids == pre_tokens
+        scheduler.truncate_request(req.request_id, target_num_tokens=100)
+        assert req._all_token_ids == pre_tokens
+        scheduler.truncate_request(req.request_id, target_num_tokens=-1)
+        assert req._all_token_ids == pre_tokens
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -218,6 +218,11 @@ class KVCacheCoordinator(ABC):
         for manager in self.single_type_managers:
             manager.free(request_id)
 
+    def truncate_to_tokens(self, request_id: str, num_tokens: int) -> None:
+        """Free KV cache blocks beyond ``num_tokens`` for a request."""
+        for manager in self.single_type_managers:
+            manager.truncate_to_tokens(request_id, num_tokens)
+
     def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
         """
         Get the number of common prefix blocks for all requests with allocated

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -457,6 +457,14 @@ class KVCacheManager:
         """
         self.block_pool.evict_blocks(block_ids)
 
+    def truncate_to_tokens(self, request_id: str, num_tokens: int) -> None:
+        """Free KV cache blocks for a request beyond ``num_tokens``.
+
+        Used by streaming sessions to shrink a session's KV cache in place
+        when the caller decides to drop a generated suffix.
+        """
+        self.coordinator.truncate_to_tokens(request_id, num_tokens)
+
     def reset_prefix_cache(self) -> bool:
         """Reset prefix cache. This function may be used in RLHF
         flows to invalidate prefix caching after the weights are updated,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -996,6 +996,39 @@ class Scheduler(SchedulerInterface):
         if self.log_stats:
             session.record_event(EngineCoreEventType.QUEUED)
 
+    def truncate_request(
+        self,
+        request_id: str,
+        target_num_tokens: int,
+    ) -> None:
+        """Truncate a streaming session's token count and free KV blocks
+        beyond ``target_num_tokens``.
+
+        Only acts on requests in ``WAITING_FOR_STREAMING_REQ`` state.
+        No-op if the request is unknown, not in that state, or
+        ``target_num_tokens`` is out of range (negative or >= current
+        length).
+        """
+        request = self.requests.get(request_id)
+        if request is None or (
+            request.status != RequestStatus.WAITING_FOR_STREAMING_REQ
+        ):
+            return
+        if target_num_tokens < 0 or target_num_tokens >= request.num_tokens:
+            return
+        del request._all_token_ids[target_num_tokens:]
+        request.prompt_token_ids = request._all_token_ids.copy()
+        request._output_token_ids.clear()
+        request.num_computed_tokens = min(
+            request.num_computed_tokens, target_num_tokens
+        )
+        self.kv_cache_manager.truncate_to_tokens(request_id, target_num_tokens)
+        # Invalidate cached block hashes: freed tail blocks no longer back
+        # any hash, and the surviving boundary block may now have partial
+        # content that does not match its previously-computed hash. The
+        # scheduler will recompute hashes on the next allocation.
+        request.block_hashes = []
+
     def _make_cached_request_data(
         self,
         running_reqs: list[Request],

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -318,6 +318,28 @@ class SingleTypeKVCacheManager(ABC):
         self.block_pool.free_blocks(ordered_blocks)
         self.num_cached_block.pop(request_id, None)
 
+    def truncate_to_tokens(self, request_id: str, num_tokens: int) -> None:
+        """Free KV cache blocks for ``request_id`` beyond ``num_tokens``.
+
+        Keeps the first ``ceil(num_tokens / block_size)`` blocks and frees
+        the tail in reverse order (matching the discipline of ``free``).
+        Drops the cached block count for the request so subsequent
+        re-allocations do not stale-reuse prior accounting. No-op if the
+        request is unknown or no tail blocks would be freed.
+        """
+        req_blocks = self.req_to_blocks.get(request_id)
+        if not req_blocks:
+            return
+        num_blocks_to_keep = cdiv(num_tokens, self.block_size)
+        if num_blocks_to_keep >= len(req_blocks):
+            return
+        blocks_to_free = req_blocks[num_blocks_to_keep:]
+        self.block_pool.free_blocks(reversed(blocks_to_free))
+        self.req_to_blocks[request_id] = req_blocks[:num_blocks_to_keep]
+        # Reset the cached-block count: prior count covered the now-freed
+        # tail. allocate_new_blocks will recompute it on next allocation.
+        self.num_cached_block.pop(request_id, None)
+
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -254,6 +254,7 @@ class EngineCoreRequestType(enum.Enum):
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
+    TRUNCATE = b"\x06"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -900,6 +900,24 @@ class AsyncLLM(EngineClient):
         if self.errored:
             raise self.dead_error
 
+    async def truncate_session(
+        self,
+        request_id: str,
+        target_num_tokens: int,
+    ) -> None:
+        """Shrink a streaming session's KV cache to target_num_tokens.
+
+        For use with resumable streaming sessions
+        (``RequestStatus.WAITING_FOR_STREAMING_REQ``). Frees KV cache blocks
+        beyond ``target_num_tokens`` and clears any generated output tokens
+        past that point. Surviving tokens keep their original positions, so
+        this is safe for all attention/positional-encoding schemes.
+
+        No-op if the request is not in a streaming-waiting state, or if
+        ``target_num_tokens`` is out of range.
+        """
+        await self.engine_core.truncate_request_async(request_id, target_num_tokens)
+
     async def start_profile(self, profile_prefix: str | None = None) -> None:
         coros = [self.engine_core.profile_async(True, profile_prefix)]
         if self.profiler is not None:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1314,6 +1314,9 @@ class EngineCoreProc(EngineCore):
                 (client_idx, EngineCoreOutputs(utility_output=out))
             )
             self._invoke_utility_method(method_name, get_result, output, enqueue_output)
+        elif request_type == EngineCoreRequestType.TRUNCATE:
+            request_id, target_num_tokens = request
+            self.scheduler.truncate_request(request_id, target_num_tokens)
         elif request_type == EngineCoreRequestType.EXECUTOR_FAILED:
             raise RuntimeError("Executor failed.")
         else:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -207,6 +207,16 @@ class EngineCoreClient(ABC):
     async def scale_elastic_ep(self, new_data_parallel_size: int) -> None:
         raise NotImplementedError
 
+    async def truncate_request_async(
+        self, request_id: str, target_num_tokens: int
+    ) -> None:
+        """Truncate a streaming session's KV cache to target_num_tokens."""
+        if not self.resources.engine_dead:
+            await self._send_input(
+                EngineCoreRequestType.TRUNCATE,
+                (request_id, target_num_tokens),
+            )
+
     async def get_output_async(self) -> EngineCoreOutputs:
         raise NotImplementedError
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1405,6 +1405,10 @@ class GPUModelRunner(
             self.input_batch.add_request(request)
             self.input_batch.update_req_spec_token_ids(request, scheduled_spec_tokens)
 
+        # Hook for subclasses to act on the just-added requests (e.g.,
+        # streaming-eviction RoPE re-rotation). No-op in the base runner.
+        self._post_add_requests(reqs_to_add)
+
         # Condense the batched states if there are gaps left by removed requests
         self.input_batch.condense()
         # Allow attention backend to reorder the batch, potentially
@@ -1457,6 +1461,17 @@ class GPUModelRunner(
             return correct_spec_decode_token_counts
         else:
             return None
+
+    def _post_add_requests(self, reqs_to_add: list[CachedRequestState]) -> None:
+        """Hook for subclasses to act on newly-added requests.
+
+        Called after newly-added requests are inserted into ``input_batch``
+        and their per-request spec token ids are recorded, but before the
+        batch is condensed and attention backends reorder it. Subclasses
+        may override this to perform per-request GPU-side work tied to
+        request setup (for example, re-rotating KV cache after streaming
+        eviction). Default implementation is a no-op.
+        """
 
     def _update_states_after_model_execute(
         self, output_token_ids: torch.Tensor, scheduler_output: "SchedulerOutput"


### PR DESCRIPTION

## Purpose

Adds `AsyncLLM.truncate_session(request_id, target_num_tokens)` — a public API
to shrink a live streaming session's token count and free the corresponding KV
cache blocks. Plumbing flows AsyncLLM → EngineCoreClient → EngineCore →
Scheduler → KVCacheManager → KVCacheCoordinator → SingleTypeKVCacheManager.

vLLM already has the resumable streaming-session machinery
(`RequestStatus.WAITING_FOR_STREAMING_REQ`, `StreamingUpdate`,
`Scheduler._update_request_as_session`); the missing piece is a way to
*mutate* a session's KV cache mid-flight rather than only append. The
motivating workload is sliding-window video/audio inference: long-running
sessions that periodically drop a stale generation suffix without tearing
down the whole session. Suffix truncation has no RoPE consequences —
surviving tokens keep their original positions.

Also lands a no-op `GPUModelRunner._post_add_requests(reqs_to_add)` hook,
called from `_update_states` after newly-added requests are inserted into
`input_batch`. A follow-up PR introduces middle-range eviction
(StreamingLLM-style) which needs a GPU-side action on RoPE models; that PR
uses this hook as its extension point.

The new API uses a `_session` suffix to disambiguate from the existing
`SamplingParams.truncate_prompt_tokens` (an input-side option), per vLLM's
naming convention of explicit scope qualifiers
(cf. `_update_request_as_session`).

## Test Plan

- New unit tests in `tests/v1/core/test_single_type_kv_cache_manager.py`:
  - `test_truncate_to_tokens` — block-aligned truncation, sub-block
    truncation, over-target no-op, unknown-request no-op.
- Run with:
  ```
  pytest -sv tests/v1/core/test_single_type_kv_cache_manager.py::test_truncate_to_tokens
  ```

## Test Result

```
tests/v1/core/test_single_type_kv_cache_manager.py::test_truncate_to_tokens PASSED
```
(Local run with PR's changes — please let me know if any additional CI run
is needed.)
