### PR TITLE
[Core] Experimental session KV eviction with attention sinks

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -401,6 +401,44 @@ def test_evictable_cached_blocks_not_double_allocated():
     assert len(manager.req_to_blocks[request_id]) == 2
 
 
+def test_truncate_to_tokens():
+    """SlidingWindowManager.truncate_to_tokens frees tail blocks."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=8,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    # Allocate 5 blocks for a 20-token request.
+    blocks = [block_pool.blocks[i] for i in range(5)]
+    for b in blocks:
+        b.ref_cnt = 1
+    manager.req_to_blocks["req"] = list(blocks)
+
+    # Truncate to 12 tokens -> keep ceil(12/4)=3 blocks, free 2.
+    manager.truncate_to_tokens("req", 12)
+    assert len(manager.req_to_blocks["req"]) == 3
+    assert [b.block_id for b in manager.req_to_blocks["req"]] == [0, 1, 2]
+
+    # Truncate to 5 tokens -> keep ceil(5/4)=2 blocks, free 1.
+    manager.truncate_to_tokens("req", 5)
+    assert len(manager.req_to_blocks["req"]) == 2
+
+    # Target larger than current length -> no-op.
+    manager.truncate_to_tokens("req", 100)
+    assert len(manager.req_to_blocks["req"]) == 2
+
+    # Unknown request -> no-op (no exception).
+    manager.truncate_to_tokens("nonexistent", 5)
+
+
 def test_chunked_local_attention_get_num_blocks_to_allocate():
     block_size = 2
     attention_spec = ChunkedLocalAttentionSpec(

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -439,6 +439,164 @@ def test_truncate_to_tokens():
     manager.truncate_to_tokens("nonexistent", 5)
 
 
+def test_evict_and_compact_aligned():
+    """Eviction where start and end are block-aligned."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=16,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    # 6 blocks: [0..3] [4..7] [8..11] [12..15] [16..19] [20..23]
+    blocks = [block_pool.blocks[i] for i in range(6)]
+    for b in blocks:
+        b.ref_cnt = 1
+    manager.req_to_blocks["req"] = list(blocks)
+
+    # Evict tokens [4, 12) — blocks 1 and 2 are fully covered.
+    # start_block = ceil(4/4) = 1, end_block = floor(12/4) = 3.
+    # new_blocks = [0] + [3, 4, 5] = [0, 3, 4, 5].
+    manager.evict_and_compact("req", 4, 12)
+    result = [b.block_id for b in manager.req_to_blocks["req"]]
+    assert result == [0, 3, 4, 5]
+
+
+def test_evict_and_compact_non_aligned():
+    """Eviction where start is not block-aligned (boundary block stays)."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=16,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    blocks = [block_pool.blocks[i] for i in range(6)]
+    for b in blocks:
+        b.ref_cnt = 1
+    manager.req_to_blocks["req"] = list(blocks)
+
+    # Evict tokens [2, 12) — start_token=2 is mid-block.
+    # start_block = ceil(2/4) = 1, end_block = floor(12/4) = 3.
+    # Blocks 1, 2 freed. Boundary block 0 (containing tokens [0, 4)) stays.
+    manager.evict_and_compact("req", 2, 12)
+    result = [b.block_id for b in manager.req_to_blocks["req"]]
+    assert result == [0, 3, 4, 5]
+
+
+def test_evict_and_compact_shared_block_guard():
+    """Surviving shared blocks (ref_cnt > 1) must raise before mutating."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=16,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    blocks = [block_pool.blocks[i] for i in range(4)]
+    for b in blocks:
+        b.ref_cnt = 1
+    # Block 3 is shared (simulates prefix caching reuse).
+    blocks[3].ref_cnt = 2
+    manager.req_to_blocks["req"] = list(blocks)
+    original = list(manager.req_to_blocks["req"])
+
+    # Block 3 survives this eviction but is shared, so must raise.
+    with pytest.raises(RuntimeError, match="shared"):
+        manager.evict_and_compact("req", 4, 8)
+    # Preflight contract: request state unchanged after a raise.
+    assert manager.req_to_blocks["req"] == original
+
+
+def test_evict_and_compact_no_op():
+    """Degenerate ranges and unknown requests are no-ops."""
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=16,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    blocks = [block_pool.blocks[i] for i in range(4)]
+    for b in blocks:
+        b.ref_cnt = 1
+    manager.req_to_blocks["req"] = list(blocks)
+
+    # Range smaller than one block (start_block >= end_block) -> no-op.
+    manager.evict_and_compact("req", 1, 3)
+    assert len(manager.req_to_blocks["req"]) == 4
+
+    # Unknown request -> no-op (no exception).
+    manager.evict_and_compact("nonexistent", 0, 8)
+
+
+def test_evict_and_compact_evicts_all_blocks_from_start():
+    """Regression: evicting the entire request (start_token=0, end_token
+    block-aligned to the last block) must still free all blocks and
+    clear req_to_blocks. Previously the early-return guard on empty
+    modified_blocks skipped the cleanup, leaking blocks and leaving
+    req_to_blocks stale.
+
+    See: https://github.com/vllm-project/vllm/pull/43374#... (review
+    comment on evict_and_compact).
+    """
+    block_size = 4
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=16,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    blocks = [block_pool.blocks[i] for i in range(3)]
+    for b in blocks:
+        b.ref_cnt = 1
+    manager.req_to_blocks["req"] = list(blocks)
+    manager.num_cached_block["req"] = 3
+
+    # Evict tokens [0, 12) on 3 blocks of 4 tokens each -> all blocks
+    # are in the evicted range and no surviving blocks remain at or
+    # after the eviction position.
+    manager.evict_and_compact("req", 0, 12)
+
+    # req_to_blocks must be updated to the empty list (block leak guard).
+    assert manager.req_to_blocks["req"] == []
+    # num_cached_block must be cleared so future allocations re-account.
+    assert "req" not in manager.num_cached_block
+    # Each freed block's ref_cnt was decremented back to 0.
+    for b in blocks:
+        assert b.ref_cnt == 0, f"block {b.block_id} not freed (ref_cnt={b.ref_cnt})"
+
+
 def test_chunked_local_attention_get_num_blocks_to_allocate():
     block_size = 2
     attention_spec = ChunkedLocalAttentionSpec(

--- a/tests/v1/streaming_input/test_async_llm_eviction.py
+++ b/tests/v1/streaming_input/test_async_llm_eviction.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit-level tests for AsyncLLM.evict_session_token_range.
+
+Round-trip end-to-end behaviour (stream -> evict -> resume against a real
+model) lives in CI integration suites. These tests cover the experimental
+guard, request-state preflight, and the engine-core RPC wiring.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm.v1.core.sched.scheduler import _reindex_mm_features
+from vllm.v1.engine.async_llm import AsyncLLM
+
+
+@pytest.fixture
+def mock_async_llm():
+    """Minimal AsyncLLM mock with engine_core stubbed out."""
+    llm = MagicMock(spec=AsyncLLM)
+    llm.engine_core = MagicMock()
+    llm.engine_core.evict_token_range_async = AsyncMock()
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_evict_session_token_range_requires_env_var(mock_async_llm):
+    """Without VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION, the API must
+    refuse to call into engine_core."""
+    with (
+        patch("vllm.envs.VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION", False),
+        pytest.raises(RuntimeError, match="experimental"),
+    ):
+        await AsyncLLM.evict_session_token_range(
+            mock_async_llm,
+            request_id="req-1",
+            num_tokens_to_evict=4,
+            num_sink_tokens=2,
+        )
+    mock_async_llm.engine_core.evict_token_range_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_evict_session_token_range_passes_args_when_enabled(
+    mock_async_llm,
+):
+    """With the env var set, the API forwards (request_id,
+    num_tokens_to_evict, num_sink_tokens) to engine_core."""
+    with patch("vllm.envs.VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION", True):
+        await AsyncLLM.evict_session_token_range(
+            mock_async_llm,
+            request_id="req-1",
+            num_tokens_to_evict=4,
+            num_sink_tokens=2,
+        )
+    mock_async_llm.engine_core.evict_token_range_async.assert_awaited_once_with(
+        "req-1", 4, 2
+    )
+
+
+# ----------------------------------------------------------------------
+# _reindex_mm_features unit tests
+# ----------------------------------------------------------------------
+
+
+def _mm(offset: int, length: int, identifier: str = "x") -> MultiModalFeatureSpec:
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+def test_reindex_mm_features_fully_before_cut_unchanged():
+    """A mm item that ends at or before the eviction start keeps its offset."""
+    features = [_mm(offset=0, length=10, identifier="sink_img")]
+    out = _reindex_mm_features(features, evict_start=20, evict_end=40)
+    assert len(out) == 1
+    assert out[0].identifier == "sink_img"
+    assert out[0].mm_position.offset == 0
+    assert out[0].mm_position.length == 10
+
+
+def test_reindex_mm_features_fully_after_cut_shifted():
+    """A mm item that starts at or after the eviction end shifts back."""
+    features = [_mm(offset=50, length=10, identifier="tail_img")]
+    out = _reindex_mm_features(features, evict_start=20, evict_end=40)
+    assert len(out) == 1
+    assert out[0].mm_position.offset == 30  # 50 - (40 - 20)
+    assert out[0].mm_position.length == 10
+
+
+def test_reindex_mm_features_fully_inside_cut_dropped():
+    """A mm item entirely within the eviction range is removed."""
+    features = [_mm(offset=22, length=10, identifier="evicted_img")]
+    out = _reindex_mm_features(features, evict_start=20, evict_end=40)
+    assert out == []
+
+
+def test_reindex_mm_features_partial_overlap_raises():
+    """An mm item that straddles the eviction boundary raises ValueError."""
+    # Item [30, 50) overlaps evict [20, 40) at the trailing edge.
+    features = [_mm(offset=30, length=20, identifier="bad_img")]
+    with pytest.raises(ValueError, match="partially overlaps"):
+        _reindex_mm_features(features, evict_start=20, evict_end=40)
+
+
+def test_reindex_mm_features_multi_image_middle_evicted():
+    """Sink image + middle frame (evicted) + trailing image:
+    the trailing image's offset must shift back by exactly the
+    eviction width so M-RoPE rebuilds with the correct grid offsets
+    on the next streaming resume."""
+    features = [
+        _mm(offset=0, length=10, identifier="sink_img"),  # before cut
+        _mm(offset=20, length=15, identifier="evicted_img"),  # inside cut [20,35)
+        _mm(offset=50, length=8, identifier="tail_img"),  # after cut
+    ]
+    out = _reindex_mm_features(features, evict_start=20, evict_end=35)
+    assert [f.identifier for f in out] == ["sink_img", "tail_img"]
+    assert out[0].mm_position.offset == 0  # sink unchanged
+    assert out[1].mm_position.offset == 35  # 50 - (35 - 20)
+    assert out[1].mm_position.length == 8
+
+
+def test_reindex_mm_features_empty_input():
+    """Reindex on an empty mm_features list is a no-op."""
+    assert _reindex_mm_features([], evict_start=10, evict_end=20) == []

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -573,3 +573,104 @@ class TestStreamingScheduler(unittest.TestCase):
             cached_state_cycle1["prompt_token_ids"]
             is not cached_state_cycle3["prompt_token_ids"]
         ), "Cached states from different cycles should be independent objects."
+
+
+class TestTruncateRequest(unittest.TestCase):
+    """Unit tests for Scheduler.truncate_request."""
+
+    def _make_waiting_streaming_request(
+        self,
+        scheduler: Scheduler,
+        prompt_len: int,
+        num_computed: int,
+        output_tokens: list[int] | None = None,
+    ) -> Request:
+        """Construct a Request directly in WAITING_FOR_STREAMING_REQ
+        and register it with the scheduler. Bypasses the prefill path
+        so we can control internal state precisely. Also installs a
+        mock on ``kv_cache_manager.truncate_to_tokens`` so call args
+        can be asserted."""
+        req = DummyRequest(
+            request_id="req",
+            prompt_token_ids=list(range(prompt_len)),
+        )
+        req.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        req.num_computed_tokens = num_computed
+        if output_tokens:
+            req._output_token_ids.extend(output_tokens)
+            req._all_token_ids.extend(output_tokens)
+        req.block_hashes = [object()]  # sentinel; truncate should clear
+        scheduler.requests[req.request_id] = req
+        scheduler.kv_cache_manager.truncate_to_tokens = MagicMock(return_value=None)
+        return req
+
+    def test_truncate_request_basic(self):
+        """Happy path: truncates _all_token_ids, refreshes
+        prompt_token_ids, clears _output_token_ids, clamps
+        num_computed_tokens, clears block_hashes, and calls the
+        kv_cache_manager with the right args."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler,
+            prompt_len=10,
+            num_computed=20,
+            output_tokens=[100, 101, 102, 103, 104],
+        )
+        assert len(req._all_token_ids) == 15
+
+        scheduler.truncate_request(req.request_id, target_num_tokens=8)
+
+        assert req._all_token_ids == [0, 1, 2, 3, 4, 5, 6, 7]
+        assert req.prompt_token_ids == [0, 1, 2, 3, 4, 5, 6, 7]
+        assert req.prompt_token_ids is not req._all_token_ids
+        assert list(req._output_token_ids) == []
+        assert req.num_computed_tokens == 8
+        assert req.block_hashes == []
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_called_once_with(
+            req.request_id, 8
+        )
+
+    def test_truncate_request_clamps_num_computed_only_when_higher(self):
+        """If num_computed_tokens is already below target, it stays put."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=10, num_computed=5
+        )
+        scheduler.truncate_request(req.request_id, target_num_tokens=8)
+        assert req.num_computed_tokens == 5
+
+    def test_truncate_request_noop_for_wrong_status(self):
+        """Request in any state other than WAITING_FOR_STREAMING_REQ is
+        left untouched and the kv_cache_manager is not called."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=10, num_computed=8
+        )
+        req.status = RequestStatus.WAITING
+        pre_tokens = list(req._all_token_ids)
+        scheduler.truncate_request(req.request_id, target_num_tokens=3)
+        assert req._all_token_ids == pre_tokens
+        assert req.num_computed_tokens == 8
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()
+
+    def test_truncate_request_noop_for_unknown_id(self):
+        """An unknown request_id is silently ignored."""
+        scheduler = create_scheduler()
+        scheduler.kv_cache_manager.truncate_to_tokens = MagicMock(return_value=None)
+        scheduler.truncate_request("nonexistent", target_num_tokens=3)
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()
+
+    def test_truncate_request_noop_for_out_of_range_target(self):
+        """target_num_tokens that is negative or >= current length is a no-op."""
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=10, num_computed=10
+        )
+        pre_tokens = list(req._all_token_ids)
+        scheduler.truncate_request(req.request_id, target_num_tokens=10)
+        assert req._all_token_ids == pre_tokens
+        scheduler.truncate_request(req.request_id, target_num_tokens=100)
+        assert req._all_token_ids == pre_tokens
+        scheduler.truncate_request(req.request_id, target_num_tokens=-1)
+        assert req._all_token_ids == pre_tokens
+        scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -674,3 +674,82 @@ class TestTruncateRequest(unittest.TestCase):
         scheduler.truncate_request(req.request_id, target_num_tokens=-1)
         assert req._all_token_ids == pre_tokens
         scheduler.kv_cache_manager.truncate_to_tokens.assert_not_called()
+
+
+class TestEvictTokenRangeRegressions(unittest.TestCase):
+    """Regression tests for Scheduler.evict_token_range bugs caught in
+    review of the experimental session-eviction PR."""
+
+    def _make_waiting_streaming_request(
+        self,
+        scheduler: Scheduler,
+        prompt_len: int,
+        num_computed: int,
+    ) -> Request:
+        """Create a Request directly in WAITING_FOR_STREAMING_REQ state,
+        bypassing the prefill path. Used only for evict_token_range
+        unit tests that need control over ``num_computed_tokens``."""
+        req = DummyRequest(
+            request_id="req",
+            prompt_token_ids=list(range(prompt_len)),
+        )
+        req.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        req.num_computed_tokens = num_computed
+        # Pretend the request is in the scheduler's tracking so that
+        # evict_token_range can find it.
+        scheduler.requests[req.request_id] = req
+        # Provide a no-op kv_cache_manager.evict_and_compact so we can
+        # exercise scheduler-side bookkeeping in isolation.
+        scheduler.kv_cache_manager.evict_and_compact = MagicMock(return_value=None)
+        return req
+
+    def test_evict_with_num_computed_below_sink_does_not_inflate(self):
+        """Regression: if num_computed_tokens < evict_start (= num_sink_tokens),
+        none of the computed tokens are evicted and num_computed_tokens
+        must stay unchanged. Previously the ``max(num_sink_tokens, ...)``
+        formula incorrectly bumped num_computed_tokens UP to the sink
+        boundary, falsely claiming tokens were computed.
+
+        See: https://github.com/vllm-project/vllm/pull/43374#... (review
+        comment on `Scheduler.evict_token_range`).
+        """
+        scheduler = create_scheduler()
+        req = self._make_waiting_streaming_request(
+            scheduler, prompt_len=100, num_computed=5
+        )
+        # num_computed=5 is below evict_start (= num_sink_tokens=10).
+        scheduler.evict_token_range(
+            req.request_id, num_tokens_to_evict=20, num_sink_tokens=10
+        )
+        assert req.num_computed_tokens == 5, (
+            f"num_computed_tokens should stay at 5 (none of the computed "
+            f"tokens were evicted), got {req.num_computed_tokens}"
+        )
+
+    def test_evict_clears_one_shot_state_after_scheduling(self):
+        """Regression: after Scheduler.schedule() serializes the eviction
+        signal into NewRequestData, scheduler-side
+        ``Request.num_tokens_evicted`` / ``num_sink_tokens`` must be
+        cleared. Otherwise a preemption+resume would re-deliver the
+        same delta and cause the runner to apply compensation twice."""
+        scheduler = create_scheduler()
+        # Build a request whose eviction state is set (as
+        # evict_token_range would leave it). We poke the fields directly
+        # because doing a full evict here would require a real
+        # kv_cache_manager.
+        req = DummyRequest(
+            request_id="req",
+            prompt_token_ids=list(range(8)),
+        )
+        req.num_tokens_evicted = 4
+        req.num_sink_tokens = 2
+        scheduler.add_request(req)
+        scheduler.schedule()
+        assert req.num_tokens_evicted == 0, (
+            f"num_tokens_evicted should be cleared after scheduling, "
+            f"got {req.num_tokens_evicted}"
+        )
+        assert req.num_sink_tokens == 0, (
+            f"num_sink_tokens should be cleared after scheduling, "
+            f"got {req.num_sink_tokens}"
+        )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -212,6 +212,7 @@ if TYPE_CHECKING:
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
     VLLM_ENABLE_RESPONSES_API_STORE: bool = False
+    VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION: bool = False
     VLLM_NVFP4_GEMM_BACKEND: str | None = None
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
@@ -1553,6 +1554,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #    never removed from memory until the server terminates.
     "VLLM_ENABLE_RESPONSES_API_STORE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))
+    ),
+    # EXPERIMENTAL. Gate for `AsyncLLM.evict_session_token_range`, which
+    # evicts a middle range of tokens from a live streaming session while
+    # preserving sink tokens at the front (StreamingLLM-style). The default
+    # OSS implementation provides only the engine plumbing; correct attention
+    # on RoPE-based models additionally requires a runner that re-rotates
+    # surviving KV (see `GPUModelRunner._post_add_requests`). Enabling this
+    # flag means the caller accepts responsibility for that.
+    "VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION", "0"))
     ),
     # If set, use the fp8 mfma in rocm paged attention.
     "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": lambda: bool(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -218,6 +218,11 @@ class KVCacheCoordinator(ABC):
         for manager in self.single_type_managers:
             manager.free(request_id)
 
+    def truncate_to_tokens(self, request_id: str, num_tokens: int) -> None:
+        """Free KV cache blocks beyond ``num_tokens`` for a request."""
+        for manager in self.single_type_managers:
+            manager.truncate_to_tokens(request_id, num_tokens)
+
     def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
         """
         Get the number of common prefix blocks for all requests with allocated

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -223,6 +223,13 @@ class KVCacheCoordinator(ABC):
         for manager in self.single_type_managers:
             manager.truncate_to_tokens(request_id, num_tokens)
 
+    def evict_and_compact(
+        self, request_id: str, start_token: int, end_token: int
+    ) -> None:
+        """Evict tokens ``[start_token, end_token)`` and compact blocks."""
+        for manager in self.single_type_managers:
+            manager.evict_and_compact(request_id, start_token, end_token)
+
     def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
         """
         Get the number of common prefix blocks for all requests with allocated

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -457,6 +457,14 @@ class KVCacheManager:
         """
         self.block_pool.evict_blocks(block_ids)
 
+    def truncate_to_tokens(self, request_id: str, num_tokens: int) -> None:
+        """Free KV cache blocks for a request beyond ``num_tokens``.
+
+        Used by streaming sessions to shrink a session's KV cache in place
+        when the caller decides to drop a generated suffix.
+        """
+        self.coordinator.truncate_to_tokens(request_id, num_tokens)
+
     def reset_prefix_cache(self) -> bool:
         """Reset prefix cache. This function may be used in RLHF
         flows to invalidate prefix caching after the weights are updated,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -465,6 +465,18 @@ class KVCacheManager:
         """
         self.coordinator.truncate_to_tokens(request_id, num_tokens)
 
+    def evict_and_compact(
+        self, request_id: str, start_token: int, end_token: int
+    ) -> None:
+        """Evict tokens ``[start_token, end_token)`` from a request's KV
+        cache and compact the block list.
+
+        Raises ``RuntimeError`` if any surviving block past the eviction
+        point is shared via prefix caching (``ref_cnt > 1``); see
+        :meth:`SingleTypeKVCacheManager.evict_and_compact`.
+        """
+        self.coordinator.evict_and_compact(request_id, start_token, end_token)
+
     def reset_prefix_cache(self) -> bool:
         """Reset prefix cache. This function may be used in RLHF
         flows to invalidate prefix caching after the weights are updated,

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -43,6 +43,13 @@ class NewRequestData:
     # Only used for v2 model runner.
     prefill_token_ids: list[int] | None = None
 
+    # Experimental streaming-eviction state. See ``Request.num_sink_tokens``
+    # / ``Request.num_tokens_evicted``. Both 0 for requests that never use
+    # eviction. Propagated to the worker so a runner subclass can drive
+    # GPU-side compensation (e.g., RoPE re-rotation).
+    num_sink_tokens: int = 0
+    num_tokens_evicted: int = 0
+
     @classmethod
     def from_request(
         cls,
@@ -62,6 +69,8 @@ class NewRequestData:
             prompt_embeds=request.prompt_embeds,
             prompt_is_token_ids=request.prompt_is_token_ids,
             prefill_token_ids=prefill_token_ids,
+            num_sink_tokens=request.num_sink_tokens,
+            num_tokens_evicted=request.num_tokens_evicted,
         )
 
     def __repr__(self) -> str:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -996,6 +996,39 @@ class Scheduler(SchedulerInterface):
         if self.log_stats:
             session.record_event(EngineCoreEventType.QUEUED)
 
+    def truncate_request(
+        self,
+        request_id: str,
+        target_num_tokens: int,
+    ) -> None:
+        """Truncate a streaming session's token count and free KV blocks
+        beyond ``target_num_tokens``.
+
+        Only acts on requests in ``WAITING_FOR_STREAMING_REQ`` state.
+        No-op if the request is unknown, not in that state, or
+        ``target_num_tokens`` is out of range (negative or >= current
+        length).
+        """
+        request = self.requests.get(request_id)
+        if request is None or (
+            request.status != RequestStatus.WAITING_FOR_STREAMING_REQ
+        ):
+            return
+        if target_num_tokens < 0 or target_num_tokens >= request.num_tokens:
+            return
+        del request._all_token_ids[target_num_tokens:]
+        request.prompt_token_ids = request._all_token_ids.copy()
+        request._output_token_ids.clear()
+        request.num_computed_tokens = min(
+            request.num_computed_tokens, target_num_tokens
+        )
+        self.kv_cache_manager.truncate_to_tokens(request_id, target_num_tokens)
+        # Invalidate cached block hashes: freed tail blocks no longer back
+        # any hash, and the surviving boundary block may now have partial
+        # content that does not match its previously-computed hash. The
+        # scheduler will recompute hashes on the next allocation.
+        request.block_hashes = []
+
     def _make_cached_request_data(
         self,
         running_reqs: list[Request],

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -27,6 +27,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStat
 from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
@@ -57,6 +58,53 @@ from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
+
+
+def _reindex_mm_features(
+    mm_features: list[MultiModalFeatureSpec],
+    evict_start: int,
+    evict_end: int,
+) -> list[MultiModalFeatureSpec]:
+    """Reindex multimodal features for a token-range eviction.
+
+    Assumes atomic multimodal-item eviction: every mm item must be
+    fully before, fully after, or fully inside ``[evict_start, evict_end)``.
+    Items fully before keep their offset; items fully after shift offset
+    back by ``evict_end - evict_start``; items fully inside are dropped.
+    An item that partially overlaps the eviction range raises
+    ``ValueError`` (caller is expected to align eviction boundaries with
+    whole multimodal items, e.g., evict a whole video frame).
+
+    Pure function: returns a new list, does not mutate the input. The
+    caller assigns the result to ``request.mm_features`` only after all
+    other preflight checks pass.
+    """
+    delta = evict_end - evict_start
+    new_features: list[MultiModalFeatureSpec] = []
+    for f in mm_features:
+        start = f.mm_position.offset
+        end = start + f.mm_position.length
+        if end <= evict_start:
+            # Fully before the cut -- positions unchanged.
+            new_features.append(f)
+        elif start >= evict_end:
+            # Fully after the cut -- shift offset back by the cut width.
+            shifted_pos = replace(f.mm_position, offset=start - delta)
+            new_features.append(replace(f, mm_position=shifted_pos))
+        elif evict_start <= start and end <= evict_end:
+            # Fully inside the cut -- drop (its tokens are gone).
+            continue
+        else:
+            # Straddles a boundary -- violates atomic-item contract.
+            raise ValueError(
+                f"evict_token_range: multimodal item at "
+                f"[{start}, {end}) partially overlaps eviction range "
+                f"[{evict_start}, {evict_end}). Eviction must atomically "
+                f"remove whole multimodal items; align the eviction "
+                f"range to mm-item boundaries (e.g., evict a whole "
+                f"video frame)."
+            )
+    return new_features
 
 
 class Scheduler(SchedulerInterface):
@@ -844,6 +892,16 @@ class Scheduler(SchedulerInterface):
                 for req in scheduled_new_reqs
             ]
 
+        # Eviction state is one-shot: now that it has been serialized into
+        # NewRequestData and will reach the worker on this round, clear
+        # it on the scheduler-side Request so a future preemption + resume
+        # does not re-deliver the same delta and cause the runner to
+        # re-apply compensation (e.g., re-rotate the K cache twice).
+        for req in scheduled_new_reqs:
+            if req.num_tokens_evicted or req.num_sink_tokens:
+                req.num_tokens_evicted = 0
+                req.num_sink_tokens = 0
+
         with record_function_or_nullcontext("schedule: make_cached_request_data"):
             cached_reqs_data = self._make_cached_request_data(
                 scheduled_running_reqs,
@@ -1028,6 +1086,84 @@ class Scheduler(SchedulerInterface):
         # content that does not match its previously-computed hash. The
         # scheduler will recompute hashes on the next allocation.
         request.block_hashes = []
+
+    def evict_token_range(
+        self,
+        request_id: str,
+        num_tokens_to_evict: int,
+        num_sink_tokens: int = 0,
+    ) -> None:
+        """Evict tokens ``[num_sink_tokens, num_sink_tokens + num_tokens_to_evict)``
+        from a streaming session and compact KV cache blocks.
+
+        Preflights all checks (request state, range bounds, KV-cache block
+        sharing, multimodal-item atomicity) *before* mutating any request
+        state. If any preflight fails (e.g. a surviving KV block is shared
+        via prefix caching, or the eviction range straddles a multimodal
+        item), no request-side mutation is performed. See
+        :meth:`SingleTypeKVCacheManager.evict_and_compact` for the
+        cache-side guard and :func:`_reindex_mm_features` for the
+        multimodal-atomicity guard.
+
+        No-op for an unknown request, a request not in
+        ``WAITING_FOR_STREAMING_REQ``, or an out-of-range eviction.
+        """
+        request = self.requests.get(request_id)
+        if request is None:
+            return
+        if request.status != RequestStatus.WAITING_FOR_STREAMING_REQ:
+            return
+        if num_tokens_to_evict <= 0 or num_sink_tokens < 0:
+            return
+        evict_start = num_sink_tokens
+        evict_end = num_sink_tokens + num_tokens_to_evict
+        if evict_end > request.num_tokens:
+            return
+
+        # Preflight 1: validate multimodal-item atomicity before touching
+        # anything else. Raises ValueError if the eviction range straddles
+        # a multimodal item. Done in two phases so we can keep request
+        # state intact if it fails.
+        new_mm_features = _reindex_mm_features(
+            request.mm_features, evict_start, evict_end
+        )
+
+        # Preflight 2 + mutation: compact KV-cache blocks. If a surviving
+        # block is shared (ref_cnt > 1) this raises RuntimeError before
+        # freeing anything, and we leave request state untouched.
+        self.kv_cache_manager.evict_and_compact(request_id, evict_start, evict_end)
+
+        # All preflight checks passed; commit request bookkeeping.
+        del request._all_token_ids[evict_start:evict_end]
+        request.prompt_token_ids = request._all_token_ids.copy()
+        request._output_token_ids.clear()
+        request.num_tokens_evicted = num_tokens_to_evict
+        request.num_sink_tokens = num_sink_tokens
+        # Only adjust num_computed_tokens when the evicted range overlaps
+        # tokens that were already computed. If num_computed_tokens is
+        # already <= evict_start (sink boundary), none of the evicted
+        # tokens were computed and the surviving computed tokens keep
+        # their positions; no adjustment needed.
+        if request.num_computed_tokens > evict_start:
+            request.num_computed_tokens = max(
+                num_sink_tokens,
+                request.num_computed_tokens - num_tokens_to_evict,
+            )
+        request.mm_features = new_mm_features
+        # Invalidate block hashes; surviving block contents will be
+        # rewritten by the runner (RoPE re-rotation, cascade shift).
+        request.block_hashes = []
+
+        logger.debug(
+            "evict_token_range: req=%s evicted %d tokens [%d, %d), "
+            "num_tokens=%d num_computed=%d",
+            request_id,
+            num_tokens_to_evict,
+            evict_start,
+            evict_end,
+            request.num_tokens,
+            request.num_computed_tokens,
+        )
 
     def _make_cached_request_data(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -318,6 +318,28 @@ class SingleTypeKVCacheManager(ABC):
         self.block_pool.free_blocks(ordered_blocks)
         self.num_cached_block.pop(request_id, None)
 
+    def truncate_to_tokens(self, request_id: str, num_tokens: int) -> None:
+        """Free KV cache blocks for ``request_id`` beyond ``num_tokens``.
+
+        Keeps the first ``ceil(num_tokens / block_size)`` blocks and frees
+        the tail in reverse order (matching the discipline of ``free``).
+        Drops the cached block count for the request so subsequent
+        re-allocations do not stale-reuse prior accounting. No-op if the
+        request is unknown or no tail blocks would be freed.
+        """
+        req_blocks = self.req_to_blocks.get(request_id)
+        if not req_blocks:
+            return
+        num_blocks_to_keep = cdiv(num_tokens, self.block_size)
+        if num_blocks_to_keep >= len(req_blocks):
+            return
+        blocks_to_free = req_blocks[num_blocks_to_keep:]
+        self.block_pool.free_blocks(reversed(blocks_to_free))
+        self.req_to_blocks[request_id] = req_blocks[:num_blocks_to_keep]
+        # Reset the cached-block count: prior count covered the now-freed
+        # tail. allocate_new_blocks will recompute it on next allocation.
+        self.num_cached_block.pop(request_id, None)
+
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -340,6 +340,91 @@ class SingleTypeKVCacheManager(ABC):
         # tail. allocate_new_blocks will recompute it on next allocation.
         self.num_cached_block.pop(request_id, None)
 
+    def evict_and_compact(
+        self, request_id: str, start_token: int, end_token: int
+    ) -> None:
+        """Evict tokens in ``[start_token, end_token)`` from this request's
+        KV cache and compact its block list.
+
+        Fully-covered blocks within the evicted range are freed. The
+        surviving blocks at and past the eviction point will see their
+        K data modified by RoPE re-rotation (their tokens shift to
+        earlier positions); we therefore:
+
+        1. **Preflight**: raise ``RuntimeError`` if any modified block
+           is shared (``ref_cnt > 1``). Re-rotating a shared block would
+           corrupt the other request that holds it. The error message
+           instructs the caller to disable prefix caching for sessions
+           that use eviction. Performed *before* freeing anything, so a
+           failing call leaves both KV cache and request state intact.
+        2. Free the fully-covered evicted blocks.
+        3. Invalidate prefix-cache hashes on modified blocks via
+           ``BlockPool._maybe_evict_cached_block`` so future requests do
+           not match stale content.
+
+        No-op if the request is unknown or the range is degenerate.
+        """
+        req_blocks = self.req_to_blocks.get(request_id)
+        if not req_blocks:
+            return
+
+        # First fully-covered evicted block (ceil division).
+        start_block = cdiv(start_token, self.block_size)
+        # Last fully-covered evicted block (floor division).
+        end_block = min(end_token // self.block_size, len(req_blocks))
+
+        # Build the compacted block list and capture blocks to free.
+        if start_block < end_block:
+            blocks_to_free = req_blocks[start_block:end_block]
+            new_blocks = req_blocks[:start_block] + req_blocks[end_block:]
+        else:
+            blocks_to_free = []
+            new_blocks = list(req_blocks)
+
+        # Surviving blocks that will be modified by cascade shift / RoPE
+        # re-rotation. Includes the boundary block (floor div) which
+        # contains both preserved sink tokens and evicted tokens.
+        # Empty when the eviction covers every block at or past the
+        # eviction position (e.g., evicting the entire request from
+        # start_token=0); in that case there is nothing to re-rotate
+        # but we still must free blocks_to_free and update req_to_blocks
+        # below.
+        modified_start = start_token // self.block_size
+        modified_blocks = new_blocks[modified_start:]
+
+        # Preflight (only meaningful when there are blocks to re-rotate):
+        # refuse before any mutation if a modified block is shared.
+        # This keeps the operation atomic from the caller's view.
+        for block in modified_blocks:
+            if block.ref_cnt > 1:
+                raise RuntimeError(
+                    f"Cannot evict tokens [{start_token}, {end_token}) "
+                    f"for request {request_id!r}: surviving block "
+                    f"{block.block_id} is shared via prefix caching "
+                    f"(ref_cnt={block.ref_cnt}). RoPE re-rotation on a "
+                    "shared block would corrupt the other request "
+                    "holding it. Disable prefix caching "
+                    "(--no-enable-prefix-caching) for sessions that use "
+                    "evict_session_token_range."
+                )
+
+        # Free fully-covered evicted blocks. Always runs (including the
+        # "evicted everything" case where modified_blocks is empty),
+        # otherwise we leak the freed blocks.
+        if blocks_to_free:
+            self.block_pool.free_blocks(reversed(blocks_to_free))
+
+        # Invalidate hashes on surviving blocks whose content will change.
+        # No-op when modified_blocks is empty.
+        for block in modified_blocks:
+            self.block_pool._maybe_evict_cached_block(block)
+
+        # Always commit the compacted block list and reset the cached
+        # block count -- block content has changed (or, in the
+        # evict-everything case, the request now holds no blocks).
+        self.req_to_blocks[request_id] = new_blocks
+        self.num_cached_block.pop(request_id, None)
+
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -254,6 +254,7 @@ class EngineCoreRequestType(enum.Enum):
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
+    TRUNCATE = b"\x06"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -255,6 +255,7 @@ class EngineCoreRequestType(enum.Enum):
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
     TRUNCATE = b"\x06"
+    EVICT_TOKEN_RANGE = b"\x07"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -900,6 +900,24 @@ class AsyncLLM(EngineClient):
         if self.errored:
             raise self.dead_error
 
+    async def truncate_session(
+        self,
+        request_id: str,
+        target_num_tokens: int,
+    ) -> None:
+        """Shrink a streaming session's KV cache to target_num_tokens.
+
+        For use with resumable streaming sessions
+        (``RequestStatus.WAITING_FOR_STREAMING_REQ``). Frees KV cache blocks
+        beyond ``target_num_tokens`` and clears any generated output tokens
+        past that point. Surviving tokens keep their original positions, so
+        this is safe for all attention/positional-encoding schemes.
+
+        No-op if the request is not in a streaming-waiting state, or if
+        ``target_num_tokens`` is out of range.
+        """
+        await self.engine_core.truncate_request_async(request_id, target_num_tokens)
+
     async def start_profile(self, profile_prefix: str | None = None) -> None:
         coros = [self.engine_core.profile_async(True, profile_prefix)]
         if self.profiler is not None:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -918,6 +918,56 @@ class AsyncLLM(EngineClient):
         """
         await self.engine_core.truncate_request_async(request_id, target_num_tokens)
 
+    async def evict_session_token_range(
+        self,
+        request_id: str,
+        num_tokens_to_evict: int,
+        num_sink_tokens: int = 0,
+    ) -> None:
+        """Evict ``num_tokens_to_evict`` tokens starting at ``num_sink_tokens``
+        from a streaming session's KV cache (StreamingLLM-style sink + slide).
+
+        EXPERIMENTAL. Requires environment variable
+        ``VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION=1``.
+
+        After eviction, surviving suffix tokens shift to earlier positions
+        (token previously at ``p`` is now at ``p - num_tokens_to_evict``).
+        Their cached K still carries the old rotation. For RoPE-based models
+        (LLaMA / Mistral / Qwen / Gemma / DeepSeek / Phi-3 / …) this means
+        attention against post-eviction queries is numerically incorrect
+        unless a runner subclass implements
+        ``GPUModelRunner._post_add_requests`` to re-rotate the surviving K
+        by the per-token delta ``-num_tokens_evicted``. OSS vLLM does not
+        ship such a runner today; enabling the env var is an explicit
+        opt-in to that responsibility.
+
+        Multimodal contract: the eviction range must atomically cover
+        whole multimodal items. Every mm item the request holds must be
+        fully before, fully after, or fully inside
+        ``[num_sink_tokens, num_sink_tokens + num_tokens_to_evict)``.
+        A range that straddles a multimodal item raises ``ValueError``
+        (no state mutated). Items fully inside are dropped; items fully
+        after have their positions shifted back by ``num_tokens_to_evict``
+        so M-RoPE grid metadata is rebuilt correctly on the next
+        streaming resume.
+
+        No-op if the request is not in
+        ``RequestStatus.WAITING_FOR_STREAMING_REQ``. Raises
+        ``RuntimeError`` from the KV cache manager if any surviving block
+        is shared via prefix caching (the only safe response is to disable
+        prefix caching for sessions that use eviction).
+        """
+        if not envs.VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION:
+            raise RuntimeError(
+                "AsyncLLM.evict_session_token_range is experimental. "
+                "Set VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION=1 to opt in. "
+                "See the method docstring for correctness caveats on "
+                "RoPE-based models."
+            )
+        await self.engine_core.evict_token_range_async(
+            request_id, num_tokens_to_evict, num_sink_tokens
+        )
+
     async def start_profile(self, profile_prefix: str | None = None) -> None:
         coros = [self.engine_core.profile_async(True, profile_prefix)]
         if self.profiler is not None:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1314,6 +1314,9 @@ class EngineCoreProc(EngineCore):
                 (client_idx, EngineCoreOutputs(utility_output=out))
             )
             self._invoke_utility_method(method_name, get_result, output, enqueue_output)
+        elif request_type == EngineCoreRequestType.TRUNCATE:
+            request_id, target_num_tokens = request
+            self.scheduler.truncate_request(request_id, target_num_tokens)
         elif request_type == EngineCoreRequestType.EXECUTOR_FAILED:
             raise RuntimeError("Executor failed.")
         else:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -114,6 +114,24 @@ class EngineCore:
 
         self.log_stats = log_stats
 
+        # Warn early when experimental session eviction is enabled together
+        # with prefix caching. The KV-cache manager will refuse to evict
+        # any surviving block that is shared via prefix caching (ref_cnt>1),
+        # which surfaces as a RuntimeError mid-session. Surfacing on init
+        # gives operators a chance to disable one or the other up front.
+        if (
+            envs.VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION
+            and vllm_config.cache_config.enable_prefix_caching
+        ):
+            logger.warning(
+                "VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION=1 with "
+                "enable_prefix_caching=True. Sessions that call "
+                "evict_session_token_range will raise RuntimeError if "
+                "any surviving KV-cache block is shared via prefix "
+                "caching. Disable prefix caching for sessions that use "
+                "eviction (--no-enable-prefix-caching)."
+            )
+
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
         if executor_fail_callback is not None:
@@ -1317,6 +1335,11 @@ class EngineCoreProc(EngineCore):
         elif request_type == EngineCoreRequestType.TRUNCATE:
             request_id, target_num_tokens = request
             self.scheduler.truncate_request(request_id, target_num_tokens)
+        elif request_type == EngineCoreRequestType.EVICT_TOKEN_RANGE:
+            request_id, num_tokens_to_evict, num_sink_tokens = request
+            self.scheduler.evict_token_range(
+                request_id, num_tokens_to_evict, num_sink_tokens
+            )
         elif request_type == EngineCoreRequestType.EXECUTOR_FAILED:
             raise RuntimeError("Executor failed.")
         else:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -207,6 +207,16 @@ class EngineCoreClient(ABC):
     async def scale_elastic_ep(self, new_data_parallel_size: int) -> None:
         raise NotImplementedError
 
+    async def truncate_request_async(
+        self, request_id: str, target_num_tokens: int
+    ) -> None:
+        """Truncate a streaming session's KV cache to target_num_tokens."""
+        if not self.resources.engine_dead:
+            await self._send_input(
+                EngineCoreRequestType.TRUNCATE,
+                (request_id, target_num_tokens),
+            )
+
     async def get_output_async(self) -> EngineCoreOutputs:
         raise NotImplementedError
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -217,6 +217,19 @@ class EngineCoreClient(ABC):
                 (request_id, target_num_tokens),
             )
 
+    async def evict_token_range_async(
+        self,
+        request_id: str,
+        num_tokens_to_evict: int,
+        num_sink_tokens: int = 0,
+    ) -> None:
+        """Evict a token range from a streaming session's KV cache."""
+        if not self.resources.engine_dead:
+            await self._send_input(
+                EngineCoreRequestType.EVICT_TOKEN_RANGE,
+                (request_id, num_tokens_to_evict, num_sink_tokens),
+            )
+
     async def get_output_async(self) -> EngineCoreOutputs:
         raise NotImplementedError
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -183,6 +183,23 @@ class Request:
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
 
+        # Experimental streaming-eviction state. Set by
+        # ``Scheduler.evict_token_range`` and consumed by a runner subclass
+        # via ``GPUModelRunner._post_add_requests`` for GPU-side
+        # compensation (e.g., RoPE re-rotation on surviving KV).
+        #
+        # Lifecycle: one-shot signal from scheduler to worker.
+        # ``num_tokens_evicted`` reflects the most recent eviction call
+        # only (overwritten on each call), not a cumulative count.
+        # ``num_sink_tokens`` records the sink boundary used by that
+        # same call. The scheduler clears both back to 0 immediately
+        # after serializing them into ``NewRequestData`` so a future
+        # preemption + resume does not re-deliver the same delta and
+        # cause the runner to apply compensation twice. Both default
+        # to 0 for requests that never use eviction.
+        self.num_sink_tokens: int = 0
+        self.num_tokens_evicted: int = 0
+
         # If True, request should be aborted immediately after being added to
         # the scheduler so the connector's request_finished hook runs.
         self.abort_immediately = abort_immediately

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -49,6 +49,15 @@ class CachedRequestState:
 
     lora_request: LoRARequest | None = None
     prompt_embeds: torch.Tensor | None = None
+
+    # Experimental streaming-eviction state, mirrored from
+    # ``Request`` / ``NewRequestData``. Read by runner subclasses that
+    # override ``GPUModelRunner._post_add_requests`` to perform GPU-side
+    # compensation (e.g., RoPE re-rotation). 0 for requests that never
+    # use eviction.
+    num_sink_tokens: int = 0
+    num_tokens_evicted: int = 0
+
     # To accumulate prompt logprobs tensor chunks across prefill steps.
     in_progress_prompt_logprobs_cpu: LogprobsTensors | None = None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1405,6 +1405,10 @@ class GPUModelRunner(
             self.input_batch.add_request(request)
             self.input_batch.update_req_spec_token_ids(request, scheduled_spec_tokens)
 
+        # Hook for subclasses to act on the just-added requests (e.g.,
+        # streaming-eviction RoPE re-rotation). No-op in the base runner.
+        self._post_add_requests(reqs_to_add)
+
         # Condense the batched states if there are gaps left by removed requests
         self.input_batch.condense()
         # Allow attention backend to reorder the batch, potentially
@@ -1457,6 +1461,17 @@ class GPUModelRunner(
             return correct_spec_decode_token_counts
         else:
             return None
+
+    def _post_add_requests(self, reqs_to_add: list[CachedRequestState]) -> None:
+        """Hook for subclasses to act on newly-added requests.
+
+        Called after newly-added requests are inserted into ``input_batch``
+        and their per-request spec token ids are recorded, but before the
+        batch is condensed and attention backends reorder it. Subclasses
+        may override this to perform per-request GPU-side work tied to
+        request setup (for example, re-rotating KV cache after streaming
+        eviction). Default implementation is a no-op.
+        """
 
     def _update_states_after_model_execute(
         self, output_token_ids: torch.Tensor, scheduler_output: "SchedulerOutput"

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1196,6 +1196,8 @@ class GPUModelRunner(
                 generator=generator,
                 block_ids=new_req_data.block_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,
+                num_sink_tokens=new_req_data.num_sink_tokens,
+                num_tokens_evicted=new_req_data.num_tokens_evicted,
                 output_token_ids=[],
                 lora_request=new_req_data.lora_request,
             )
@@ -1540,6 +1542,12 @@ class GPUModelRunner(
         self.late_interaction_runner.register_request(req_id, req_state.pooling_params)
         req_state.block_ids = new_req_data.block_ids
         req_state.num_computed_tokens = new_req_data.num_computed_tokens
+        # Streaming-eviction state must propagate on the streaming-resume
+        # path too, otherwise a runner subclass overriding
+        # `_post_add_requests` would see stale values when an eviction
+        # happens between streaming chunks of the same session.
+        req_state.num_sink_tokens = new_req_data.num_sink_tokens
+        req_state.num_tokens_evicted = new_req_data.num_tokens_evicted
         req_state.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
             req_state.prompt_token_ids, req_state.prompt_embeds
         )


### PR DESCRIPTION

## Purpose

Adds `AsyncLLM.evict_session_token_range(request_id, num_tokens_to_evict,
num_sink_tokens=0)` — an **experimental** API to evict a middle range of
tokens from a live streaming session while preserving "sink" tokens at the
front (StreamingLLM, Xiao et al. 2023, arXiv:2309.17453).

Gated behind `VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION=1`. Builds on the
`truncate_session` plumbing and the `_post_add_requests()` hook from
#43372. This is the dynamic, per-session complement to the existing
static `SinkFullAttentionManager` (model-load-time sink reservation).

**Motivating workload:** sliding-window video inference. As new frames
arrive, the oldest frame's tokens are evicted from the middle of the
session while the system prompt / attention sinks at positions 0…N stay
pinned. This bounds memory per session and avoids rebuilding the prefix
every step.

### Why experimental?

After evicting positions `[s, e)`, surviving tokens shift from position
`p` to `p - (e - s)`. Their cached K still carries the *old* RoPE
rotation. Without re-rotation, attention against post-eviction queries is
numerically wrong on every RoPE model (LLaMA / Mistral / Qwen / Gemma /
DeepSeek / Phi-3 / …).

This PR ships the engine plumbing + extension hook. A downstream runner
(or a future in-tree kernel) implements `GPUModelRunner._post_add_requests`
(landed in #43372) to re-rotate the surviving K cache by
`-num_tokens_evicted`.

The `VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION` env var makes the
trade-off explicit. Users opting in accept that correctness depends on
having a runner that handles the position shift. Once an in-tree RoPE
re-rotation kernel lands, the env var can be removed.

### Implementation notes

- New `EngineCoreRequestType.EVICT_TOKEN_RANGE = b"\x07"` (next free slot
  after `TRUNCATE = b"\x06"` from #43372).
- `Scheduler.evict_token_range()` runs three preflights — request state,
  multimodal-item atomicity (`_reindex_mm_features`), and KV-cache
  shared-block check (`SingleTypeKVCacheManager.evict_and_compact`) —
  *before* mutating any request state. If any preflight raises, the
  request is left untouched.
- `SingleTypeKVCacheManager.evict_and_compact()`:
  - Frees fully-covered blocks in `[start_token, end_token)`.
  - **Preflight guard**: raises `RuntimeError` if any surviving block
    past the eviction point has `ref_cnt > 1` (sharing via prefix
    caching would corrupt the other request when we re-rotate this
    block's K). Error message instructs the user to disable prefix
    caching for eviction sessions. Copy-on-write is a future improvement.
  - Invalidates prefix-cache hashes on modified blocks via
    `BlockPool._maybe_evict_cached_block`.
- `_reindex_mm_features()` reindexes `request.mm_features` for the
  eviction. Asserts **atomic multimodal-item eviction**: every mm item
  must be fully before, fully after, or fully inside the eviction range.
  A range that straddles a multimodal item raises `ValueError`. This
  keeps M-RoPE position math correct on the next streaming resume even
  for sessions with a persistent multimodal sink (e.g., a reference
  image in the prompt + video frames evicted from the middle).
- Boot-time warning if `VLLM_ENABLE_EXPERIMENTAL_SESSION_EVICTION=1`
  with `enable_prefix_caching=True` — operators get an early heads-up
  before they hit the `RuntimeError` mid-session.
- New per-request fields `Request.num_sink_tokens` /
  `Request.num_tokens_evicted` propagated through `NewRequestData` to
  `CachedRequestState` so the `_post_add_requests` extension hook can
  read them. Lifecycle is documented as "overwritten per call; runner
  must reset to 0 after consuming".

## Test Plan

- Unit tests in `tests/v1/core/test_single_type_kv_cache_manager.py`:
  - `test_evict_and_compact_aligned`
  - `test_evict_and_compact_non_aligned`
  - `test_evict_and_compact_shared_block_guard` (asserts request state
    unchanged after the raise)
  - `test_evict_and_compact_no_op`
- Tests in `tests/v1/streaming_input/test_async_llm_eviction.py`:
  - Env-var gating: API raises without the env var, forwards args with it.
  - `_reindex_mm_features` correctness: before-cut, after-cut, inside-cut,
    partial-overlap-raises, multi-image-middle-evicted, empty-input.
- Run with:
  ```
  pytest -sv tests/v1/core/test_single_type_kv_cache_manager.py \
              tests/v1/streaming_input/test_async_llm_eviction.py
  ```

## Test Result

```
tests/v1/core/test_single_type_kv_cache_manager.py::test_evict_and_compact_aligned PASSED
tests/v1/core/test_single_type_kv_cache_manager.py::test_evict_and_compact_non_aligned PASSED
tests/v1/core/test_single_type_kv_cache_manager.py::test_evict_and_compact_shared_block_guard PASSED
tests/v1/core/test_single_type_kv_cache_manager.py::test_evict_and_compact_no_op PASSED
tests/v1/streaming_input/test_async_llm_eviction.py (8 tests) PASSED
```
(Local run with PR's changes — please let me know if any additional CI run
is needed.)

## Future work

- In-tree RoPE re-rotation kernel + a default `_post_add_requests`
  implementation, after which the experimental env var can be removed.
- Copy-on-write path for the shared-block case (instead of raising).

---

Stacked on #43372. Please review that one first.
