### PR TITLE
[WIP] Add FlashInfer NVFP4 GEMM + reduce-scatter fusion

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -115,6 +115,9 @@ void scaled_fp4_quant_out(torch::stable::Tensor const& input,
                           torch::stable::Tensor& output,
                           torch::stable::Tensor& output_scale);
 
+torch::stable::Tensor repack_nvfp4_scale(
+    torch::stable::Tensor const& row_major_scale);
+
 void scaled_fp4_experts_quant(
     torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
     torch::stable::Tensor const& input,

--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu
@@ -28,6 +28,9 @@ void scaled_fp4_quant_sm1xxa(torch::stable::Tensor const& output,
                              torch::stable::Tensor const& output_sf,
                              torch::stable::Tensor const& input_sf,
                              bool is_sf_swizzled_layout);
+
+void repack_nvfp4_scale_sm1xxa(torch::stable::Tensor const& row_major_scale,
+                               torch::stable::Tensor& output_scale);
 #endif
 
 #if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
@@ -115,6 +118,32 @@ std::tuple<torch::stable::Tensor, torch::stable::Tensor> scaled_fp4_quant_func(
   scaled_fp4_quant_out(input, input_sf, is_sf_swizzled_layout, output,
                        output_sf);
   return {output, output_sf};
+}
+
+torch::stable::Tensor repack_nvfp4_scale(
+    torch::stable::Tensor const& row_major_scale) {
+#if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+    (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
+  STD_TORCH_CHECK(nvfp4_quant_sm_supported(),
+                  "No compiled nvfp4 scale repack kernel for SM ",
+                  get_sm_version_num(),
+                  ". Recompile with the appropriate CUDA arch.");
+  STD_TORCH_CHECK(row_major_scale.dim() == 2,
+                  "row_major_scale must be a matrix");
+  STD_TORCH_CHECK(
+      row_major_scale.scalar_type() == torch::headeronly::ScalarType::Byte,
+      "row_major_scale must be uint8");
+
+  auto [sf_m, sf_n] = vllm::computeSwizzledSFShape(
+      row_major_scale.size(0), row_major_scale.size(1) * CVT_FP4_SF_VEC_SIZE);
+  auto output_scale =
+      torch::stable::empty({sf_m, sf_n}, torch::headeronly::ScalarType::Int,
+                           std::nullopt, row_major_scale.device());
+  repack_nvfp4_scale_sm1xxa(row_major_scale, output_scale);
+  return output_scale;
+#endif
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(false,
+                                  "No compiled nvfp4 scale repack kernel");
 }
 
 void scaled_fp4_experts_quant(

--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_kernels.cu
@@ -173,6 +173,37 @@ __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
   }
 }
 
+__global__ void repack_nvfp4_scale_kernel(int32_t numRows, int32_t sfCols,
+                                          int32_t roundedRows,
+                                          int32_t roundedSfCols,
+                                          uint8_t const* __restrict__ in,
+                                          uint8_t* __restrict__ out) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t total = static_cast<int64_t>(roundedRows) * roundedSfCols;
+  if (idx >= total) {
+    return;
+  }
+
+  int32_t row = idx / roundedSfCols;
+  int32_t sfCol = idx - static_cast<int64_t>(row) * roundedSfCols;
+  uint8_t value = 0;
+  if (row < numRows && sfCol < sfCols) {
+    value = in[static_cast<int64_t>(row) * sfCols + sfCol];
+  }
+
+  int32_t numKTiles = roundedSfCols >> 2;
+  int32_t mTileIdx = row >> 7;
+  int32_t outerMIdx = row & 31;
+  int32_t innerMIdx = (row >> 5) & 3;
+  int32_t kTileIdx = sfCol >> 2;
+  int32_t innerKIdx = sfCol & 3;
+
+  int64_t outOffset = (static_cast<int64_t>(mTileIdx) * numKTiles + kTileIdx)
+                          << 9 |
+                      (outerMIdx << 4) | (innerMIdx << 2) | innerKIdx;
+  out[outOffset] = value;
+}
+
 }  // namespace vllm
 
 void scaled_fp4_quant_sm1xxa(torch::stable::Tensor const& output,
@@ -248,4 +279,30 @@ void scaled_fp4_quant_sm1xxa(torch::stable::Tensor const& output,
                   reinterpret_cast<uint32_t*>(sf_out));
         });
   }
+}
+
+void repack_nvfp4_scale_sm1xxa(torch::stable::Tensor const& row_major_scale,
+                               torch::stable::Tensor& output_scale) {
+  int32_t m = row_major_scale.size(0);
+  int32_t sf_n = row_major_scale.size(1);
+  int32_t rounded_m = vllm::round_up(m, 128);
+  int32_t rounded_sf_n = vllm::round_up(sf_n, 4);
+
+  STD_TORCH_CHECK(output_scale.size(0) == rounded_m &&
+                      output_scale.size(1) == rounded_sf_n / 4,
+                  "output_scale must be padded and swizzled to a shape (",
+                  rounded_m, "x", rounded_sf_n / 4, "), but got a shape (",
+                  output_scale.size(0), "x", output_scale.size(1), ")");
+
+  auto input_ptr = static_cast<uint8_t const*>(row_major_scale.data_ptr());
+  auto output_ptr = static_cast<uint8_t*>(output_scale.data_ptr());
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      row_major_scale.get_device_index());
+  auto stream = get_current_cuda_stream(row_major_scale.get_device_index());
+
+  constexpr int block = 256;
+  int64_t total = static_cast<int64_t>(rounded_m) * rounded_sf_n;
+  int grid = vllm::div_round_up(total, static_cast<int64_t>(block));
+  vllm::repack_nvfp4_scale_kernel<<<grid, block, 0, stream>>>(
+      m, sf_n, rounded_m, rounded_sf_n, input_ptr, output_ptr);
 }

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -142,6 +142,8 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "is_sf_swizzled_layout, *, Tensor(a!) output, Tensor(b!) output_scale) "
       "-> ()");
 
+  ops.def("repack_nvfp4_scale(Tensor row_major_scale) -> Tensor");
+
   // Compute NVFP4 experts quantization.
   ops.def(
       "scaled_fp4_experts_quant(Tensor! output, Tensor! output_scale,"
@@ -398,6 +400,7 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("cutlass_scaled_fp4_mm", TORCH_BOX(&cutlass_scaled_fp4_mm));
   ops.impl("scaled_fp4_quant", TORCH_BOX(&scaled_fp4_quant_func));
   ops.impl("scaled_fp4_quant.out", TORCH_BOX(&scaled_fp4_quant_out));
+  ops.impl("repack_nvfp4_scale", TORCH_BOX(&repack_nvfp4_scale));
   ops.impl("scaled_fp4_experts_quant", TORCH_BOX(&scaled_fp4_experts_quant));
   ops.impl("silu_and_mul_scaled_fp4_experts_quant",
            TORCH_BOX(&silu_and_mul_scaled_fp4_experts_quant));

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -109,6 +109,18 @@ if hasattr(torch.ops, "_C") and hasattr(torch.ops._C, "scaled_fp4_quant"):
     ) -> None:
         return None
 
+    if hasattr(torch.ops._C, "repack_nvfp4_scale"):
+
+        @register_fake("_C::repack_nvfp4_scale")
+        def _repack_nvfp4_scale_fake(row_major_scale: torch.Tensor) -> torch.Tensor:
+            rounded_m = cdiv(row_major_scale.shape[0], 128) * 128
+            rounded_n = cdiv(row_major_scale.shape[1], 4) * 4
+            return torch.empty(
+                (rounded_m, rounded_n // 4),
+                dtype=torch.int32,
+                device=row_major_scale.device,
+            )
+
 
 # page attention ops
 def paged_attention_v1(

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -1,15 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from collections.abc import Callable
 from contextlib import suppress
+from typing import Any
 
 import torch
 import torch._inductor.pattern_matcher as pm
 import torch.distributed.distributed_c10d as c10d
 import torch.fx as fx
 from torch._inductor.pattern_matcher import PatternMatcherPass
-from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+from torch.distributed._symmetric_memory import (
+    enable_symm_mem_for_group,
+    get_symm_mem_workspace,
+)
 
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
@@ -19,7 +24,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.utils.torch_utils import current_stream, direct_register_custom_op
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import (
@@ -32,6 +37,38 @@ from ..vllm_inductor_pass import (
 FP8_DTYPE = current_platform.fp8_dtype()
 
 logger = init_logger(__name__)
+
+_fp4_rs_streams: dict[int, Any] = {}
+
+
+def _cuda_module() -> Any:
+    return vars(torch)["cuda"]
+
+
+def _get_fp4_rs_stream(device: torch.device) -> Any:
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    if device_index not in _fp4_rs_streams:
+        _fp4_rs_streams[device_index] = _cuda_module().Stream(device=device_index)
+    return _fp4_rs_streams[device_index]
+
+
+def _align_bytes(size: int, alignment: int = 256) -> int:
+    return ((size + alignment - 1) // alignment) * alignment
+
+
+def _storage_offset(byte_offset: int, dtype: torch.dtype) -> int:
+    return byte_offset // torch.empty((), dtype=dtype).element_size()
+
+
+def _fp4_rs_stripe_sizes(chunk_m: int) -> list[int]:
+    if chunk_m < 8192:
+        return [chunk_m]
+    first = (chunk_m // 2 // 128) * 128
+    if first == 0 or first == chunk_m:
+        return [chunk_m]
+    return [first, chunk_m - first]
 
 
 def _flashinfer_scaled_mm_out(
@@ -311,6 +348,247 @@ def fused_all_gather_flashinfer_fp4_matmul(
     return output
 
 
+def fused_flashinfer_fp4_matmul_reduce_scatter_fake(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    reduce_op: str,
+    scatter_dim: int,
+    world_size: int,
+    vllm_group_name: str,
+    c10d_group_name: str,
+    out_dtype: torch.dtype | None = None,
+    use_8x4_sf_layout: bool = False,
+    backend: str = "cutlass",
+) -> torch.Tensor:
+    del A_scale, B_scale, alpha, reduce_op, vllm_group_name, c10d_group_name
+    del use_8x4_sf_layout, backend
+    result_shape = list(A.shape)
+    result_shape[scatter_dim] //= world_size
+    result_shape[-1] = B.shape[1]
+    return torch.empty(result_shape, dtype=out_dtype or torch.bfloat16, device=A.device)
+
+
+def _get_vllm_pynccl_comm(vllm_group_name: str):
+    from vllm.distributed.parallel_state import _groups
+
+    if vllm_group_name not in _groups:
+        raise RuntimeError(f"vLLM group {vllm_group_name} is not found")
+    group = _groups[vllm_group_name]()
+    if group is None:
+        raise RuntimeError(f"vLLM group {vllm_group_name} is destroyed")
+    pynccl_comm = getattr(group.device_communicator, "pynccl_comm", None)
+    if pynccl_comm is None:
+        raise RuntimeError("FP4 GEMM reduce-scatter requires vLLM PyNCCL")
+    return pynccl_comm
+
+
+def _fp4_rs_workspace_buffers(
+    c10d_group_name: str,
+    *,
+    world_size: int,
+    max_stripe_m: int,
+    k_fp4: int,
+    n: int,
+    A_dtype: torch.dtype,
+    A_scale_shape: torch.Size,
+    A_scale_dtype: torch.dtype,
+    out_dtype: torch.dtype,
+) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+    a_shape = (world_size * max_stripe_m, k_fp4)
+    scale_shape = (world_size * max_stripe_m, A_scale_shape[1])
+    partial_shape = (world_size * max_stripe_m, n)
+
+    a_nbytes = torch.empty((), dtype=A_dtype).element_size()
+    a_nbytes *= a_shape[0] * a_shape[1]
+    scale_nbytes = torch.empty((), dtype=A_scale_dtype).element_size()
+    scale_nbytes *= scale_shape[0] * scale_shape[1]
+    partial_nbytes = torch.empty((), dtype=out_dtype).element_size()
+    partial_nbytes *= partial_shape[0] * partial_shape[1]
+
+    offsets: list[tuple[int, torch.Size | tuple[int, ...], torch.dtype]] = []
+    offset = 0
+    for _ in range(2):
+        offset = _align_bytes(offset)
+        offsets.append((offset, a_shape, A_dtype))
+        offset += a_nbytes
+        offset = _align_bytes(offset)
+        offsets.append((offset, scale_shape, A_scale_dtype))
+        offset += scale_nbytes
+        offset = _align_bytes(offset)
+        offsets.append((offset, partial_shape, out_dtype))
+        offset += partial_nbytes
+
+    workspace = get_symm_mem_workspace(c10d_group_name, _align_bytes(offset))
+    rank = workspace.rank
+    buffers = [
+        workspace.get_buffer(
+            rank,
+            shape,
+            dtype,
+            _storage_offset(byte_offset, dtype),
+        )
+        for byte_offset, shape, dtype in offsets
+    ]
+    a_workspaces = [buffers[0], buffers[3]]
+    scale_workspaces = [buffers[1], buffers[4]]
+    partial_workspaces = [buffers[2], buffers[5]]
+    return a_workspaces, scale_workspaces, partial_workspaces
+
+
+def _run_fp4_full_gemm_nccl_rs(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    *,
+    pynccl_comm,
+    c10d_group_name: str,
+    world_size: int,
+    out_dtype: torch.dtype,
+    use_8x4_sf_layout: bool,
+    backend: str,
+) -> torch.Tensor:
+    partial_nbytes = (
+        A.shape[0] * B.shape[1] * torch.empty((), dtype=out_dtype).element_size()
+    )
+    workspace = get_symm_mem_workspace(c10d_group_name, _align_bytes(partial_nbytes))
+    partial = workspace.get_buffer(
+        workspace.rank,
+        (A.shape[0], B.shape[1]),
+        out_dtype,
+    )
+    _flashinfer_fp4_mm_out(
+        A,
+        B,
+        scale_a=A_scale,
+        scale_b=B_scale,
+        alpha=alpha,
+        out=partial,
+        out_dtype=out_dtype,
+        use_8x4_sf_layout=use_8x4_sf_layout,
+        backend=backend,
+    )
+    out = torch.empty(
+        (A.shape[0] // world_size, B.shape[1]), dtype=out_dtype, device=A.device
+    )
+    pynccl_comm.reduce_scatter(out, partial)
+    return out
+
+
+def fused_flashinfer_fp4_matmul_reduce_scatter(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    reduce_op: str,
+    scatter_dim: int,
+    world_size: int,
+    vllm_group_name: str,
+    c10d_group_name: str,
+    out_dtype: torch.dtype | None = None,
+    use_8x4_sf_layout: bool = False,
+    backend: str = "cutlass",
+) -> torch.Tensor:
+    if reduce_op != "sum" or scatter_dim != 0:
+        raise RuntimeError("FP4 GEMM reduce-scatter currently supports sum on dim 0")
+    if A.shape[0] % world_size != 0:
+        raise RuntimeError("FP4 GEMM reduce-scatter requires equal NCCL chunks")
+
+    out_dtype = out_dtype or torch.bfloat16
+    pynccl_comm = _get_vllm_pynccl_comm(vllm_group_name)
+    chunk_m = A.shape[0] // world_size
+    n = B.shape[1]
+
+    overlap_enabled = os.getenv("VLLM_NVFP4_RS_OVERLAP", "1") != "0"
+    can_overlap = (
+        overlap_enabled
+        and backend in ("cutlass", "cudnn")
+        and not use_8x4_sf_layout
+        and A.is_contiguous()
+        and A_scale.ndim == 2
+        and A_scale.shape[0] >= A.shape[0]
+        and chunk_m % 128 == 0
+    )
+    stripe_ms = _fp4_rs_stripe_sizes(chunk_m) if can_overlap else [chunk_m]
+    if len(stripe_ms) == 1:
+        return _run_fp4_full_gemm_nccl_rs(
+            A,
+            B,
+            A_scale,
+            B_scale,
+            alpha,
+            pynccl_comm=pynccl_comm,
+            c10d_group_name=c10d_group_name,
+            world_size=world_size,
+            out_dtype=out_dtype,
+            use_8x4_sf_layout=use_8x4_sf_layout,
+            backend=backend,
+        )
+
+    a_workspaces, scale_workspaces, partial_workspaces = _fp4_rs_workspace_buffers(
+        c10d_group_name,
+        world_size=world_size,
+        max_stripe_m=max(stripe_ms),
+        k_fp4=A.shape[1],
+        n=n,
+        A_dtype=A.dtype,
+        A_scale_shape=A_scale.shape,
+        A_scale_dtype=A_scale.dtype,
+        out_dtype=out_dtype,
+    )
+    out = torch.empty((chunk_m, n), dtype=out_dtype, device=A.device)
+
+    producer_stream = current_stream()
+    comm_stream = _get_fp4_rs_stream(A.device)
+    producer_events = [_cuda_module().Event() for _ in range(2)]
+    comm_events = [_cuda_module().Event() for _ in range(2)]
+
+    stripe_start = 0
+    for stripe_idx, stripe_m in enumerate(stripe_ms):
+        slot = stripe_idx % 2
+        if stripe_idx >= 2:
+            producer_stream.wait_event(comm_events[slot])
+
+        a_workspace = a_workspaces[slot][: world_size * stripe_m]
+        scale_workspace = scale_workspaces[slot][: world_size * stripe_m]
+        partial_workspace = partial_workspaces[slot][: world_size * stripe_m]
+        for rank in range(world_size):
+            src_start = rank * chunk_m + stripe_start
+            src_stop = src_start + stripe_m
+            dst_start = rank * stripe_m
+            dst_stop = dst_start + stripe_m
+            a_workspace[dst_start:dst_stop].copy_(A[src_start:src_stop])
+            scale_workspace[dst_start:dst_stop].copy_(A_scale[src_start:src_stop])
+
+        _flashinfer_fp4_mm_out(
+            a_workspace,
+            B,
+            scale_a=scale_workspace,
+            scale_b=B_scale,
+            alpha=alpha,
+            out=partial_workspace,
+            out_dtype=out_dtype,
+            use_8x4_sf_layout=use_8x4_sf_layout,
+            backend=backend,
+        )
+        producer_events[slot].record(producer_stream)
+
+        with _cuda_module().stream(comm_stream):
+            comm_stream.wait_event(producer_events[slot])
+            out_slice = out[stripe_start : stripe_start + stripe_m]
+            pynccl_comm.reduce_scatter(out_slice, partial_workspace, stream=comm_stream)
+            comm_events[slot].record(comm_stream)
+        stripe_start += stripe_m
+
+    producer_stream.wait_stream(comm_stream)
+    return out
+
+
 direct_register_custom_op(
     op_name="fused_flashinfer_scaled_matmul_reduce_scatter",
     op_func=fused_flashinfer_scaled_matmul_reduce_scatter,
@@ -327,6 +605,12 @@ direct_register_custom_op(
     op_name="fused_all_gather_flashinfer_fp4_matmul",
     op_func=fused_all_gather_flashinfer_fp4_matmul,
     fake_impl=fused_all_gather_flashinfer_fp4_matmul_fake,
+)
+
+direct_register_custom_op(
+    op_name="fused_flashinfer_fp4_matmul_reduce_scatter",
+    op_func=fused_flashinfer_fp4_matmul_reduce_scatter,
+    fake_impl=fused_flashinfer_fp4_matmul_reduce_scatter_fake,
 )
 
 
@@ -897,6 +1181,84 @@ class FlashInferAllGatherFP4Pattern(
         return _replacement
 
 
+class FlashInferFP4ReduceScatterPattern(
+    BasePattern, VllmPatternReplacement[..., torch.Tensor]
+):
+    def __init__(
+        self,
+        dtype: torch.dtype,
+        device: str | None,
+        backend: str,
+        use_8x4_sf_layout: bool,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.backend = backend
+        self.use_8x4_sf_layout = use_8x4_sf_layout
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        a_2d = torch.empty([16, 8], device=self.device, dtype=torch.uint8)
+        b_2d = torch.empty([8, 16], device=self.device, dtype=torch.uint8)
+        a_scale = torch.empty([128, 4], device=self.device, dtype=torch.uint8)
+        b_scale = torch.empty([4, 16], device=self.device, dtype=torch.uint8)
+        alpha = torch.empty([], device=self.device, dtype=torch.float32)
+        return [a_2d, b_2d, a_scale, b_scale, alpha]
+
+    @property
+    def pattern(self) -> Callable[..., torch.Tensor]:
+        def _pattern(
+            a_2d: torch.Tensor,
+            b_2d: torch.Tensor,
+            a_scale: torch.Tensor,
+            b_scale: torch.Tensor,
+            alpha: torch.Tensor,
+        ) -> torch.Tensor:
+            mm = torch.ops.vllm.flashinfer_mm_fp4.default(
+                a_2d,
+                b_2d,
+                a_scale,
+                b_scale,
+                alpha,
+                self.dtype,
+                self.use_8x4_sf_layout,
+                self.backend,
+            )
+            return torch.ops.vllm.reduce_scatter.default(
+                mm,
+                dim=0,
+                world_size=self.tp_size,
+                group_name=self.tp.unique_name,
+            )
+
+        return _pattern
+
+    @property
+    def replacement(self) -> Callable[..., torch.Tensor]:
+        def _replacement(
+            a_2d: torch.Tensor,
+            b_2d: torch.Tensor,
+            a_scale: torch.Tensor,
+            b_scale: torch.Tensor,
+            alpha: torch.Tensor,
+        ) -> torch.Tensor:
+            return torch.ops.vllm.fused_flashinfer_fp4_matmul_reduce_scatter.default(
+                a_2d,
+                b_2d,
+                a_scale,
+                b_scale,
+                alpha,
+                "sum",
+                0,
+                self.tp_size,
+                self.tp.unique_name,
+                self.tp.device_group.group_name,
+                self.dtype,
+                self.use_8x4_sf_layout,
+                self.backend,
+            )
+
+        return _replacement
+
+
 class AsyncTPPass(VllmFusionPatternMatcherPass):
     @enable_fake_mode
     def __init__(self, config: VllmConfig) -> None:
@@ -934,6 +1296,26 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
                     FlashInferBMMFP8ReduceScatterPattern(self.model_dtype, self.device)
                 )
             if hasattr(torch.ops.vllm, "flashinfer_mm_fp4"):
+                fp4_rs_enabled = os.getenv("VLLM_NVFP4_RS_FUSION", "1") != "0"
+                if fp4_rs_enabled:
+                    for backend in ("cutlass", "cudnn"):
+                        self.register(
+                            FlashInferFP4ReduceScatterPattern(
+                                self.model_dtype,
+                                self.device,
+                                backend,
+                                use_8x4_sf_layout=False,
+                            )
+                        )
+                    for use_8x4_sf_layout in (False, True):
+                        self.register(
+                            FlashInferFP4ReduceScatterPattern(
+                                self.model_dtype,
+                                self.device,
+                                "trtllm",
+                                use_8x4_sf_layout=use_8x4_sf_layout,
+                            )
+                        )
                 for backend in ("cutlass", "cudnn"):
                     for a_scale_view in ("float8_uint8", "uint8"):
                         self.register(
@@ -956,11 +1338,6 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
                                 a_scale_view=a_scale_view,
                             )
                         )
-                # NVFP4 reduce-scatter does not need scale communication: FP4
-                # scales are consumed by the local GEMM and only BF16 partial
-                # outputs are reduced. Keep this PR scoped to the all-gather
-                # path; reduce-scatter needs a dedicated FP4 producer rather
-                # than the existing FP8-style helper.
 
         self.dump_patterns(config, self.pm_pass)
 

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -4,17 +4,13 @@
 import os
 from collections.abc import Callable
 from contextlib import suppress
-from typing import Any
 
 import torch
 import torch._inductor.pattern_matcher as pm
 import torch.distributed.distributed_c10d as c10d
 import torch.fx as fx
 from torch._inductor.pattern_matcher import PatternMatcherPass
-from torch.distributed._symmetric_memory import (
-    enable_symm_mem_for_group,
-    get_symm_mem_workspace,
-)
+from torch.distributed._symmetric_memory import enable_symm_mem_for_group
 
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
@@ -24,7 +20,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.utils.torch_utils import current_stream, direct_register_custom_op
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import (
@@ -37,38 +33,6 @@ from ..vllm_inductor_pass import (
 FP8_DTYPE = current_platform.fp8_dtype()
 
 logger = init_logger(__name__)
-
-_fp4_rs_streams: dict[int, Any] = {}
-
-
-def _cuda_module() -> Any:
-    return vars(torch)["cuda"]
-
-
-def _get_fp4_rs_stream(device: torch.device) -> Any:
-    device_index = device.index
-    if device_index is None:
-        device_index = torch.accelerator.current_device_index()
-    if device_index not in _fp4_rs_streams:
-        _fp4_rs_streams[device_index] = _cuda_module().Stream(device=device_index)
-    return _fp4_rs_streams[device_index]
-
-
-def _align_bytes(size: int, alignment: int = 256) -> int:
-    return ((size + alignment - 1) // alignment) * alignment
-
-
-def _storage_offset(byte_offset: int, dtype: torch.dtype) -> int:
-    return byte_offset // torch.empty((), dtype=dtype).element_size()
-
-
-def _fp4_rs_stripe_sizes(chunk_m: int) -> list[int]:
-    if chunk_m < 8192:
-        return [chunk_m]
-    first = (chunk_m // 2 // 128) * 128
-    if first == 0 or first == chunk_m:
-        return [chunk_m]
-    return [first, chunk_m - first]
 
 
 def _flashinfer_scaled_mm_out(
@@ -348,247 +312,6 @@ def fused_all_gather_flashinfer_fp4_matmul(
     return output
 
 
-def fused_flashinfer_fp4_matmul_reduce_scatter_fake(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    A_scale: torch.Tensor,
-    B_scale: torch.Tensor,
-    alpha: torch.Tensor,
-    reduce_op: str,
-    scatter_dim: int,
-    world_size: int,
-    vllm_group_name: str,
-    c10d_group_name: str,
-    out_dtype: torch.dtype | None = None,
-    use_8x4_sf_layout: bool = False,
-    backend: str = "cutlass",
-) -> torch.Tensor:
-    del A_scale, B_scale, alpha, reduce_op, vllm_group_name, c10d_group_name
-    del use_8x4_sf_layout, backend
-    result_shape = list(A.shape)
-    result_shape[scatter_dim] //= world_size
-    result_shape[-1] = B.shape[1]
-    return torch.empty(result_shape, dtype=out_dtype or torch.bfloat16, device=A.device)
-
-
-def _get_vllm_pynccl_comm(vllm_group_name: str):
-    from vllm.distributed.parallel_state import _groups
-
-    if vllm_group_name not in _groups:
-        raise RuntimeError(f"vLLM group {vllm_group_name} is not found")
-    group = _groups[vllm_group_name]()
-    if group is None:
-        raise RuntimeError(f"vLLM group {vllm_group_name} is destroyed")
-    pynccl_comm = getattr(group.device_communicator, "pynccl_comm", None)
-    if pynccl_comm is None:
-        raise RuntimeError("FP4 GEMM reduce-scatter requires vLLM PyNCCL")
-    return pynccl_comm
-
-
-def _fp4_rs_workspace_buffers(
-    c10d_group_name: str,
-    *,
-    world_size: int,
-    max_stripe_m: int,
-    k_fp4: int,
-    n: int,
-    A_dtype: torch.dtype,
-    A_scale_shape: torch.Size,
-    A_scale_dtype: torch.dtype,
-    out_dtype: torch.dtype,
-) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
-    a_shape = (world_size * max_stripe_m, k_fp4)
-    scale_shape = (world_size * max_stripe_m, A_scale_shape[1])
-    partial_shape = (world_size * max_stripe_m, n)
-
-    a_nbytes = torch.empty((), dtype=A_dtype).element_size()
-    a_nbytes *= a_shape[0] * a_shape[1]
-    scale_nbytes = torch.empty((), dtype=A_scale_dtype).element_size()
-    scale_nbytes *= scale_shape[0] * scale_shape[1]
-    partial_nbytes = torch.empty((), dtype=out_dtype).element_size()
-    partial_nbytes *= partial_shape[0] * partial_shape[1]
-
-    offsets: list[tuple[int, torch.Size | tuple[int, ...], torch.dtype]] = []
-    offset = 0
-    for _ in range(2):
-        offset = _align_bytes(offset)
-        offsets.append((offset, a_shape, A_dtype))
-        offset += a_nbytes
-        offset = _align_bytes(offset)
-        offsets.append((offset, scale_shape, A_scale_dtype))
-        offset += scale_nbytes
-        offset = _align_bytes(offset)
-        offsets.append((offset, partial_shape, out_dtype))
-        offset += partial_nbytes
-
-    workspace = get_symm_mem_workspace(c10d_group_name, _align_bytes(offset))
-    rank = workspace.rank
-    buffers = [
-        workspace.get_buffer(
-            rank,
-            shape,
-            dtype,
-            _storage_offset(byte_offset, dtype),
-        )
-        for byte_offset, shape, dtype in offsets
-    ]
-    a_workspaces = [buffers[0], buffers[3]]
-    scale_workspaces = [buffers[1], buffers[4]]
-    partial_workspaces = [buffers[2], buffers[5]]
-    return a_workspaces, scale_workspaces, partial_workspaces
-
-
-def _run_fp4_full_gemm_nccl_rs(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    A_scale: torch.Tensor,
-    B_scale: torch.Tensor,
-    alpha: torch.Tensor,
-    *,
-    pynccl_comm,
-    c10d_group_name: str,
-    world_size: int,
-    out_dtype: torch.dtype,
-    use_8x4_sf_layout: bool,
-    backend: str,
-) -> torch.Tensor:
-    partial_nbytes = (
-        A.shape[0] * B.shape[1] * torch.empty((), dtype=out_dtype).element_size()
-    )
-    workspace = get_symm_mem_workspace(c10d_group_name, _align_bytes(partial_nbytes))
-    partial = workspace.get_buffer(
-        workspace.rank,
-        (A.shape[0], B.shape[1]),
-        out_dtype,
-    )
-    _flashinfer_fp4_mm_out(
-        A,
-        B,
-        scale_a=A_scale,
-        scale_b=B_scale,
-        alpha=alpha,
-        out=partial,
-        out_dtype=out_dtype,
-        use_8x4_sf_layout=use_8x4_sf_layout,
-        backend=backend,
-    )
-    out = torch.empty(
-        (A.shape[0] // world_size, B.shape[1]), dtype=out_dtype, device=A.device
-    )
-    pynccl_comm.reduce_scatter(out, partial)
-    return out
-
-
-def fused_flashinfer_fp4_matmul_reduce_scatter(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    A_scale: torch.Tensor,
-    B_scale: torch.Tensor,
-    alpha: torch.Tensor,
-    reduce_op: str,
-    scatter_dim: int,
-    world_size: int,
-    vllm_group_name: str,
-    c10d_group_name: str,
-    out_dtype: torch.dtype | None = None,
-    use_8x4_sf_layout: bool = False,
-    backend: str = "cutlass",
-) -> torch.Tensor:
-    if reduce_op != "sum" or scatter_dim != 0:
-        raise RuntimeError("FP4 GEMM reduce-scatter currently supports sum on dim 0")
-    if A.shape[0] % world_size != 0:
-        raise RuntimeError("FP4 GEMM reduce-scatter requires equal NCCL chunks")
-
-    out_dtype = out_dtype or torch.bfloat16
-    pynccl_comm = _get_vllm_pynccl_comm(vllm_group_name)
-    chunk_m = A.shape[0] // world_size
-    n = B.shape[1]
-
-    overlap_enabled = os.getenv("VLLM_NVFP4_RS_OVERLAP", "1") != "0"
-    can_overlap = (
-        overlap_enabled
-        and backend in ("cutlass", "cudnn")
-        and not use_8x4_sf_layout
-        and A.is_contiguous()
-        and A_scale.ndim == 2
-        and A_scale.shape[0] >= A.shape[0]
-        and chunk_m % 128 == 0
-    )
-    stripe_ms = _fp4_rs_stripe_sizes(chunk_m) if can_overlap else [chunk_m]
-    if len(stripe_ms) == 1:
-        return _run_fp4_full_gemm_nccl_rs(
-            A,
-            B,
-            A_scale,
-            B_scale,
-            alpha,
-            pynccl_comm=pynccl_comm,
-            c10d_group_name=c10d_group_name,
-            world_size=world_size,
-            out_dtype=out_dtype,
-            use_8x4_sf_layout=use_8x4_sf_layout,
-            backend=backend,
-        )
-
-    a_workspaces, scale_workspaces, partial_workspaces = _fp4_rs_workspace_buffers(
-        c10d_group_name,
-        world_size=world_size,
-        max_stripe_m=max(stripe_ms),
-        k_fp4=A.shape[1],
-        n=n,
-        A_dtype=A.dtype,
-        A_scale_shape=A_scale.shape,
-        A_scale_dtype=A_scale.dtype,
-        out_dtype=out_dtype,
-    )
-    out = torch.empty((chunk_m, n), dtype=out_dtype, device=A.device)
-
-    producer_stream = current_stream()
-    comm_stream = _get_fp4_rs_stream(A.device)
-    producer_events = [_cuda_module().Event() for _ in range(2)]
-    comm_events = [_cuda_module().Event() for _ in range(2)]
-
-    stripe_start = 0
-    for stripe_idx, stripe_m in enumerate(stripe_ms):
-        slot = stripe_idx % 2
-        if stripe_idx >= 2:
-            producer_stream.wait_event(comm_events[slot])
-
-        a_workspace = a_workspaces[slot][: world_size * stripe_m]
-        scale_workspace = scale_workspaces[slot][: world_size * stripe_m]
-        partial_workspace = partial_workspaces[slot][: world_size * stripe_m]
-        for rank in range(world_size):
-            src_start = rank * chunk_m + stripe_start
-            src_stop = src_start + stripe_m
-            dst_start = rank * stripe_m
-            dst_stop = dst_start + stripe_m
-            a_workspace[dst_start:dst_stop].copy_(A[src_start:src_stop])
-            scale_workspace[dst_start:dst_stop].copy_(A_scale[src_start:src_stop])
-
-        _flashinfer_fp4_mm_out(
-            a_workspace,
-            B,
-            scale_a=scale_workspace,
-            scale_b=B_scale,
-            alpha=alpha,
-            out=partial_workspace,
-            out_dtype=out_dtype,
-            use_8x4_sf_layout=use_8x4_sf_layout,
-            backend=backend,
-        )
-        producer_events[slot].record(producer_stream)
-
-        with _cuda_module().stream(comm_stream):
-            comm_stream.wait_event(producer_events[slot])
-            out_slice = out[stripe_start : stripe_start + stripe_m]
-            pynccl_comm.reduce_scatter(out_slice, partial_workspace, stream=comm_stream)
-            comm_events[slot].record(comm_stream)
-        stripe_start += stripe_m
-
-    producer_stream.wait_stream(comm_stream)
-    return out
-
-
 direct_register_custom_op(
     op_name="fused_flashinfer_scaled_matmul_reduce_scatter",
     op_func=fused_flashinfer_scaled_matmul_reduce_scatter,
@@ -605,12 +328,6 @@ direct_register_custom_op(
     op_name="fused_all_gather_flashinfer_fp4_matmul",
     op_func=fused_all_gather_flashinfer_fp4_matmul,
     fake_impl=fused_all_gather_flashinfer_fp4_matmul_fake,
-)
-
-direct_register_custom_op(
-    op_name="fused_flashinfer_fp4_matmul_reduce_scatter",
-    op_func=fused_flashinfer_fp4_matmul_reduce_scatter,
-    fake_impl=fused_flashinfer_fp4_matmul_reduce_scatter_fake,
 )
 
 

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -34,6 +34,8 @@ logger = init_logger(__name__)
 if hasattr(torch.ops._C, "scaled_fp4_quant"):
     SCALED_FP4_QUANT_OUT_OVERLOAD = torch.ops._C.scaled_fp4_quant.out
     SCALED_FP4_QUANT_DEFAULT_OVERLOAD = torch.ops._C.scaled_fp4_quant.default
+if hasattr(torch.ops._C, "repack_nvfp4_scale"):
+    REPACK_NVFP4_SCALE_OVERLOAD = torch.ops._C.repack_nvfp4_scale.default
 
 # Min hidden size per device capability for sequence parallelism
 # Only apply sequence parallelism for models with hidden_size >= threshold
@@ -411,12 +413,13 @@ class FirstAllReduceRMSNormStaticNVFP4Pattern(_SequenceParallelPatternHelper):
             quant = SCALED_FP4_QUANT_DEFAULT_OVERLOAD(
                 rms,
                 input_global_scale,
-                True,
+                False,
             )
+            gathered_scale = self._all_gather(quant[1])
             return (
                 self._all_gather(quant[0]),
                 reduce_scatter,
-                self._all_gather(quant[1]),
+                REPACK_NVFP4_SCALE_OVERLOAD(gathered_scale),
             )
 
         pm.register_replacement(
@@ -483,9 +486,14 @@ class MiddleAllReduceRMSNormStaticNVFP4Pattern(_SequenceParallelPatternHelper):
             quant = SCALED_FP4_QUANT_DEFAULT_OVERLOAD(
                 rms,
                 input_global_scale,
-                True,
+                False,
             )
-            return self._all_gather(quant[0]), residual_out, self._all_gather(quant[1])
+            gathered_scale = self._all_gather(quant[1])
+            return (
+                self._all_gather(quant[0]),
+                residual_out,
+                REPACK_NVFP4_SCALE_OVERLOAD(gathered_scale),
+            )
 
         pm.register_replacement(
             pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
@@ -567,7 +575,10 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                 epsilon, self.model_dtype, self.device
             ).register(self.patterns)
 
-            if "SCALED_FP4_QUANT_OUT_OVERLOAD" in globals():
+            if (
+                "SCALED_FP4_QUANT_OUT_OVERLOAD" in globals()
+                and "REPACK_NVFP4_SCALE_OVERLOAD" in globals()
+            ):
                 FirstAllReduceRMSNormStaticNVFP4Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -247,6 +247,14 @@ class DeviceCommunicatorBase:
         # Reshape before returning
         return output_tensor.movedim(0, dim).contiguous()
 
+    def reduce_scatter_out(
+        self,
+        output: torch.Tensor,
+        input_: torch.Tensor,
+        stream: object | None = None,
+    ) -> None:
+        raise NotImplementedError
+
     def reduce_scatterv(
         self, input_: torch.Tensor, dim: int = -1, sizes: list[int] | None = None
     ) -> torch.Tensor:

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -322,6 +322,16 @@ class CudaCommunicator(DeviceCommunicatorBase):
         # Reshape before returning
         return output.movedim(0, dim).contiguous()
 
+    def reduce_scatter_out(
+        self,
+        output: torch.Tensor,
+        input_: torch.Tensor,
+        stream: object | None = None,
+    ) -> None:
+        pynccl_comm = self.pynccl_comm
+        assert pynccl_comm is not None
+        pynccl_comm.reduce_scatter(output, input_, stream=stream)
+
     def reduce_scatterv(
         self, input_: torch.Tensor, dim: int = -1, sizes: list[int] | None = None
     ):

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -127,6 +127,15 @@ def _register_group(group: "GroupCoordinator") -> None:
     _groups[group.unique_name] = weakref.ref(group)
 
 
+def get_group_by_name(group_name: str) -> "GroupCoordinator":
+    if group_name not in _groups:
+        raise RuntimeError(f"Group {group_name} is not found.")
+    group = _groups[group_name]()
+    if group is None:
+        raise RuntimeError(f"Group {group_name} is destroyed.")
+    return group
+
+
 def all_reduce(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
     assert group_name in _groups, f"Group {group_name} is not found."
     group = _groups[group_name]()

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -454,7 +454,7 @@ def use_trtllm_attention(
 
 
 if has_flashinfer():
-    from vllm.utils.torch_utils import direct_register_custom_op
+    from vllm.utils.torch_utils import current_stream, direct_register_custom_op
 
     def _flashinfer_concat_mla_k(
         k: torch.Tensor,
@@ -550,6 +550,314 @@ if has_flashinfer():
         use_nvfp4: bool = True,
     ) -> torch.Tensor:
         return torch.empty(A.shape[0], B.shape[1], dtype=dtype, device=A.device)
+
+    _fp4_rs_streams: dict[int, Any] = {}
+
+    def _cuda_module() -> Any:
+        return vars(torch)["cuda"]
+
+    def _get_fp4_rs_stream(device: torch.device) -> Any:
+        device_index = device.index
+        if device_index is None:
+            device_index = torch.accelerator.current_device_index()
+        if device_index not in _fp4_rs_streams:
+            _fp4_rs_streams[device_index] = _cuda_module().Stream(device=device_index)
+        return _fp4_rs_streams[device_index]
+
+    def _align_bytes(size: int, alignment: int = 256) -> int:
+        return ((size + alignment - 1) // alignment) * alignment
+
+    def _storage_offset(byte_offset: int, dtype: torch.dtype) -> int:
+        return byte_offset // torch.empty((), dtype=dtype).element_size()
+
+    def _fp4_rs_stripe_sizes(chunk_m: int) -> list[int]:
+        if chunk_m < 8192:
+            return [chunk_m]
+        # Keep the first stripe 128-row aligned and let the second stripe carry
+        # any tail rows. This lets us probe non-128 chunk sizes without changing
+        # the FlashInfer FP4 GEMM scale-offset API.
+        first = (chunk_m // 2 // 128) * 128
+        if first == 0 or first == chunk_m:
+            return [chunk_m]
+        return [first, chunk_m - first]
+
+    def _flashinfer_fp4_mm_out(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        *,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        alpha: torch.Tensor,
+        out: torch.Tensor,
+        out_dtype: torch.dtype,
+        use_8x4_sf_layout: bool,
+        backend: str,
+    ) -> None:
+        from flashinfer import mm_fp4 as flashinfer_mm_fp4_
+
+        res = flashinfer_mm_fp4_(
+            A,
+            B,
+            scale_a,
+            scale_b,
+            alpha,
+            out_dtype,
+            block_size=16,
+            use_8x4_sf_layout=use_8x4_sf_layout,
+            use_nvfp4=True,
+            backend=backend,
+            out=out,
+        )
+        assert res is out or res.data_ptr() == out.data_ptr()
+
+    def fused_flashinfer_fp4_matmul_reduce_scatter_fake(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        reduce_op: str,
+        scatter_dim: int,
+        world_size: int,
+        vllm_group_name: str,
+        c10d_group_name: str,
+        out_dtype: torch.dtype | None = None,
+        use_8x4_sf_layout: bool = False,
+        backend: str = "cutlass",
+    ) -> torch.Tensor:
+        del A_scale, B_scale, alpha, reduce_op, vllm_group_name, c10d_group_name
+        del use_8x4_sf_layout, backend
+        result_shape = list(A.shape)
+        result_shape[scatter_dim] //= world_size
+        result_shape[-1] = B.shape[1]
+        return torch.empty(
+            result_shape, dtype=out_dtype or torch.bfloat16, device=A.device
+        )
+
+    def _get_vllm_device_communicator(vllm_group_name: str) -> Any:
+        from vllm.distributed.parallel_state import get_group_by_name
+
+        group = get_group_by_name(vllm_group_name)
+        device_communicator = group.device_communicator
+        if device_communicator is None:
+            raise RuntimeError("FP4 GEMM reduce-scatter requires a device communicator")
+        return device_communicator
+
+    def _fp4_rs_workspace_buffers(
+        c10d_group_name: str,
+        *,
+        world_size: int,
+        max_stripe_m: int,
+        k_fp4: int,
+        n: int,
+        A_dtype: torch.dtype,
+        A_scale_shape: torch.Size,
+        A_scale_dtype: torch.dtype,
+        out_dtype: torch.dtype,
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+        from torch.distributed._symmetric_memory import get_symm_mem_workspace
+
+        a_shape = (world_size * max_stripe_m, k_fp4)
+        scale_shape = (world_size * max_stripe_m, A_scale_shape[1])
+        partial_shape = (world_size * max_stripe_m, n)
+
+        a_nbytes = torch.empty((), dtype=A_dtype).element_size()
+        a_nbytes *= a_shape[0] * a_shape[1]
+        scale_nbytes = torch.empty((), dtype=A_scale_dtype).element_size()
+        scale_nbytes *= scale_shape[0] * scale_shape[1]
+        partial_nbytes = torch.empty((), dtype=out_dtype).element_size()
+        partial_nbytes *= partial_shape[0] * partial_shape[1]
+
+        offsets: list[tuple[int, torch.Size | tuple[int, ...], torch.dtype]] = []
+        offset = 0
+        for _ in range(2):
+            offset = _align_bytes(offset)
+            offsets.append((offset, a_shape, A_dtype))
+            offset += a_nbytes
+            offset = _align_bytes(offset)
+            offsets.append((offset, scale_shape, A_scale_dtype))
+            offset += scale_nbytes
+            offset = _align_bytes(offset)
+            offsets.append((offset, partial_shape, out_dtype))
+            offset += partial_nbytes
+
+        workspace = get_symm_mem_workspace(c10d_group_name, _align_bytes(offset))
+        rank = workspace.rank
+        buffers = [
+            workspace.get_buffer(
+                rank,
+                shape,
+                dtype,
+                _storage_offset(byte_offset, dtype),
+            )
+            for byte_offset, shape, dtype in offsets
+        ]
+        a_workspaces = [buffers[0], buffers[3]]
+        scale_workspaces = [buffers[1], buffers[4]]
+        partial_workspaces = [buffers[2], buffers[5]]
+        return a_workspaces, scale_workspaces, partial_workspaces
+
+    def _run_fp4_full_gemm_nccl_rs(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        *,
+        device_communicator: Any,
+        c10d_group_name: str,
+        world_size: int,
+        out_dtype: torch.dtype,
+        use_8x4_sf_layout: bool,
+        backend: str,
+    ) -> torch.Tensor:
+        from torch.distributed._symmetric_memory import get_symm_mem_workspace
+
+        partial_nbytes = (
+            A.shape[0] * B.shape[1] * torch.empty((), dtype=out_dtype).element_size()
+        )
+        workspace = get_symm_mem_workspace(
+            c10d_group_name, _align_bytes(partial_nbytes)
+        )
+        partial = workspace.get_buffer(
+            workspace.rank,
+            (A.shape[0], B.shape[1]),
+            out_dtype,
+        )
+        _flashinfer_fp4_mm_out(
+            A,
+            B,
+            scale_a=A_scale,
+            scale_b=B_scale,
+            alpha=alpha,
+            out=partial,
+            out_dtype=out_dtype,
+            use_8x4_sf_layout=use_8x4_sf_layout,
+            backend=backend,
+        )
+        out = torch.empty(
+            (A.shape[0] // world_size, B.shape[1]), dtype=out_dtype, device=A.device
+        )
+        device_communicator.reduce_scatter_out(out, partial)
+        return out
+
+    def fused_flashinfer_fp4_matmul_reduce_scatter(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        A_scale: torch.Tensor,
+        B_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        reduce_op: str,
+        scatter_dim: int,
+        world_size: int,
+        vllm_group_name: str,
+        c10d_group_name: str,
+        out_dtype: torch.dtype | None = None,
+        use_8x4_sf_layout: bool = False,
+        backend: str = "cutlass",
+    ) -> torch.Tensor:
+        if reduce_op != "sum" or scatter_dim != 0:
+            raise RuntimeError(
+                "FP4 GEMM reduce-scatter currently supports sum on dim 0"
+            )
+        if A.shape[0] % world_size != 0:
+            raise RuntimeError("FP4 GEMM reduce-scatter requires equal NCCL chunks")
+
+        out_dtype = out_dtype or torch.bfloat16
+        device_communicator = _get_vllm_device_communicator(vllm_group_name)
+        chunk_m = A.shape[0] // world_size
+        n = B.shape[1]
+
+        overlap_enabled = os.getenv("VLLM_NVFP4_RS_OVERLAP", "1") != "0"
+        can_overlap = (
+            overlap_enabled
+            and backend in ("cutlass", "cudnn")
+            and not use_8x4_sf_layout
+            and A.is_contiguous()
+            and A_scale.ndim == 2
+            and A_scale.shape[0] >= A.shape[0]
+        )
+        stripe_ms = _fp4_rs_stripe_sizes(chunk_m) if can_overlap else [chunk_m]
+        if len(stripe_ms) == 1:
+            return _run_fp4_full_gemm_nccl_rs(
+                A,
+                B,
+                A_scale,
+                B_scale,
+                alpha,
+                device_communicator=device_communicator,
+                c10d_group_name=c10d_group_name,
+                world_size=world_size,
+                out_dtype=out_dtype,
+                use_8x4_sf_layout=use_8x4_sf_layout,
+                backend=backend,
+            )
+
+        a_workspaces, scale_workspaces, partial_workspaces = _fp4_rs_workspace_buffers(
+            c10d_group_name,
+            world_size=world_size,
+            max_stripe_m=max(stripe_ms),
+            k_fp4=A.shape[1],
+            n=n,
+            A_dtype=A.dtype,
+            A_scale_shape=A_scale.shape,
+            A_scale_dtype=A_scale.dtype,
+            out_dtype=out_dtype,
+        )
+        out = torch.empty((chunk_m, n), dtype=out_dtype, device=A.device)
+
+        producer_stream = current_stream()
+        comm_stream = _get_fp4_rs_stream(A.device)
+        producer_events = [_cuda_module().Event() for _ in range(2)]
+        comm_events = [_cuda_module().Event() for _ in range(2)]
+
+        stripe_start = 0
+        for stripe_idx, stripe_m in enumerate(stripe_ms):
+            slot = stripe_idx % 2
+            if stripe_idx >= 2:
+                producer_stream.wait_event(comm_events[slot])
+
+            a_workspace = a_workspaces[slot][: world_size * stripe_m]
+            scale_workspace = scale_workspaces[slot][: world_size * stripe_m]
+            partial_workspace = partial_workspaces[slot][: world_size * stripe_m]
+            for rank in range(world_size):
+                src_start = rank * chunk_m + stripe_start
+                src_stop = src_start + stripe_m
+                dst_start = rank * stripe_m
+                dst_stop = dst_start + stripe_m
+                a_workspace[dst_start:dst_stop].copy_(A[src_start:src_stop])
+                scale_workspace[dst_start:dst_stop].copy_(A_scale[src_start:src_stop])
+
+            _flashinfer_fp4_mm_out(
+                a_workspace,
+                B,
+                scale_a=scale_workspace,
+                scale_b=B_scale,
+                alpha=alpha,
+                out=partial_workspace,
+                out_dtype=out_dtype,
+                use_8x4_sf_layout=use_8x4_sf_layout,
+                backend=backend,
+            )
+            producer_events[slot].record(producer_stream)
+
+            with _cuda_module().stream(comm_stream):
+                comm_stream.wait_event(producer_events[slot])
+                out_slice = out[stripe_start : stripe_start + stripe_m]
+                device_communicator.reduce_scatter_out(
+                    out_slice, partial_workspace, stream=comm_stream
+                )
+                comm_events[slot].record(comm_stream)
+            stripe_start += stripe_m
+
+        producer_stream.wait_stream(comm_stream)
+        return out
+
+    direct_register_custom_op(
+        op_name="fused_flashinfer_fp4_matmul_reduce_scatter",
+        op_func=fused_flashinfer_fp4_matmul_reduce_scatter,
+        fake_impl=fused_flashinfer_fp4_matmul_reduce_scatter_fake,
+    )
 
     @torch.library.custom_op(
         "vllm::flashinfer_mxfp4_quantize",


### PR DESCRIPTION



## Purpose
Communication still uses NCCL/PyNCCL reduce-scatter. Symmetric memory is used only as workspace/staging for the GEMM output and overlap pipeline.

Attempts and Results
Symmetric-memory RS only: correct, but slower than NCCL RS, especially at large M.
Custom tile RS / multimem-style RS: correctness was possible, but performance was worse than NCCL for this NVFP4 workload, so we dropped it.
NCCL + symmetric workspace + chunk overlap: best direction so far. Keeps NCCL for communication and uses symmetric workspace for staging/pipelining.
FlashInfer PDL / stream overlap probe: did not solve the issue. Without earlier producer visibility, it still behaved like chunked launch overlap and hit the same overhead limits.
FlashInfer epilogue/tile-ready signaling: we prototyped ready-flag signaling in the FlashInfer NVFP4 GEMM path. Nsight showed some actual overlap, but the modified GEMM path added too much overhead, so E2E did not improve.
FlashInfer #2007-style in-kernel reduce idea: useful as a reference, but replacing NCCL with in-kernel/multimem reduce was not competitive for this workload because NVFP4 GEMM is very fast and the custom reduce path became the bottleneck.
Current vLLM fused op: modest E2E gains for large inputs, roughly flat or slightly negative for smaller inputs.


## Test  
```
CUDA_VISIBLE_DEVICES=4,5,6,7 \
PYTHONPATH=/root/zdj/vllm \
FLASHINFER_WORKSPACE_BASE=/tmp \
VLLM_DISABLE_COMPILE_CACHE=1 \
VLLM_NVFP4_RS_FUSION=1 \
VLLM_NVFP4_RS_OVERLAP=1 \
VLLM_NVFP4_GEMM_BACKEND=cutlass \
VLLM_LOGGING_LEVEL=INFO \
VLLM_DEBUG_DUMP_PATH=/tmp/vllm_nvfp4_cutlass_rs_on_debug_dump \
/root/zdj/vllm/.venv/bin/python -m vllm.entrypoints.cli.main serve \
  /root/zdj/models/Llama-3.3-70B-Instruct-NVFP4 \
  --tokenizer /root/zdj/models/Llama-3.3-70B-Instruct-NVFP4 \
  --tensor-parallel-size 4 \
  --host 127.0.0.1 \
  --port 8000 \
  --max-num-seqs 64 \
  --max-num-batched-tokens 32768 \
  --gpu-memory-utilization 0.90 \
  --attention-backend flashinfer \
  --kernel-config '{"enable_flashinfer_autotune": false}' \
  --compilation-config '{"pass_config":{"enable_sp":true,"fuse_gemm_comms":true}}'
```
 
```
/root/zdj/vllm/.venv/bin/python -m lm_eval \
  --model local-completions \
  --tasks gsm8k \
  --num_fewshot 5 \
  --limit 250 \
  --batch_size 32 \
  --model_args model=/root/zdj/models/Llama-3.3-70B-Instruct-NVFP4,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=32,max_retries=3,tokenized_requests=False,timeout=900 \
  --gen_kwargs max_gen_toks=512,temperature=0 \
  --output_path /tmp/lmeval_nvfp4_cutlass_rs_on_gsm8k_250

```
```
al-completions ({'model': '/root/zdj/models/Llama-3.3-70B-Instruct-NVFP4', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'num_concurrent': 32, 'max_retries': 3, 'tokenized_requests': False, 'timeout': 900}), gen_kwargs: ({'max_gen_toks': 512, 'temperature': 0}), limit: 250.0, num_fewshot: 5, batch_size: 32
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.944|±  |0.0146|
|     |       |strict-match    |     5|exact_match|↑  |0.644|±  |0.0303|
```

```
input_len | fused_single | fused_overlap
-- | -- | --
6144 | -0.17% | +0.08%
8192 | -0.41% | -0.73%
12288 | +0.18% | +1.57%
16384 | -1.22% | -0.01%
24576 | -0.54% | -2.94%
32768 | -0.18% | -0.23%
49152 | +0.48% | +0.54%
65536 | +2.07% | +2.33%
98304 | +0.27% | +0.94%
```

 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

