### PR TITLE
[BugFix] Fix setuptools-rust dep in requirements files

### DIFF
--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -11,6 +11,7 @@ cmake>=3.26.1,<4
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
+setuptools-rust>=1.9.0
 wheel
 jinja2>=3.1.6
 amdsmi==7.0.2

--- a/requirements/build/tpu.txt
+++ b/requirements/build/tpu.txt
@@ -3,5 +3,6 @@ cmake>=3.26.1
 ninja
 setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
+setuptools-rust>=1.9.0
 torch==2.11.0+cpu
 wheel

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -15,6 +15,7 @@ tensorizer==2.10.1
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
+setuptools-rust>=1.9.0
 runai-model-streamer[s3,gcs,azure]==0.15.7
 conch-triton-kernels==1.2.1
 timm>=1.0.17

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -15,7 +15,6 @@ tensorizer==2.10.1
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-setuptools-rust>=1.9.0
 runai-model-streamer[s3,gcs,azure]==0.15.7
 conch-triton-kernels==1.2.1
 timm>=1.0.17

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -7,7 +7,6 @@ packaging>=24.2
 setuptools-scm>=8
 setuptools-rust>=1.9.0
 setuptools>=77.0.3,<81.0.0
-setuptools-rust>=1.9.0
 wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts


### PR DESCRIPTION
It was missing from tpu, in wrong place for rocm, duplicated for xpu