### PR TITLE
[Frontend] use BAD_REQUEST for VLLMValidationError

### DIFF
--- a/vllm/entrypoints/anthropic/api_router.py
+++ b/vllm/entrypoints/anthropic/api_router.py
@@ -22,6 +22,7 @@ from vllm.entrypoints.utils import (
     load_aware_call,
     with_cancellation,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -68,6 +69,17 @@ async def create_messages(request: AnthropicMessagesRequest, raw_request: Reques
 
     try:
         generator = await handler.create_messages(request, raw_request)
+    except VLLMValidationError as e:
+        logger.exception("Error in create_messages: %s", e)
+        return JSONResponse(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            content=AnthropicErrorResponse(
+                error=AnthropicError(
+                    type="invalid_request_error",
+                    message=str(e),
+                )
+            ).model_dump(),
+        )
     except Exception as e:
         logger.exception("Error in create_messages: %s", e)
         return JSONResponse(
@@ -114,6 +126,17 @@ async def count_tokens(request: AnthropicCountTokensRequest, raw_request: Reques
 
     try:
         response = await handler.count_tokens(request, raw_request)
+    except VLLMValidationError as e:
+        logger.exception("Error in count_tokens: %s", e)
+        return JSONResponse(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            content=AnthropicErrorResponse(
+                error=AnthropicError(
+                    type="invalid_request_error",
+                    message=str(e),
+                )
+            ).model_dump(),
+        )
     except Exception as e:
         logger.exception("Error in count_tokens: %s", e)
         return JSONResponse(


### PR DESCRIPTION



## Purpose
Return proper HTTP status codes based on error type in the Anthropic Messages API. Currently, all exceptions in create_messages and count_tokens endpoints return 500 INTERNAL_SERVER_ERROR. With this change, VLLMValidationError returns 400 BAD_REQUEST with error type "invalid_request_error", while other exceptions continue to return 500 INTERNAL_SERVER_ERROR with error type "internal_error". This aligns with the Anthropic API error conventions, where invalid request errors should return 400 rather than 500.

## Test Plan
Send a request that triggers a VLLMValidationError (e.g., invalid model parameter) and verify the response has status code 400 with "type": "invalid_request_error".
Send a request that triggers an unexpected exception and verify the response still has status code 500 with "type": "internal_error".

# Test VLLMValidationError returns 400
curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/v1/messages \
  -H "x-api-key: ..." -H "content-type: application/json" \
  -d '{"model": "invalid-model", "max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]}'
# Expected: 400

# Test normal request returns 200
curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/v1/messages \
  -H "x-api-key: ..." -H "content-type: application/json" \
  -d '{"model": "valid-model", "max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]}'
# Expected: 200
## Test Result
Scenario	Before	After
VLLMValidationError	500 internal_error	400 invalid_request_error
Other Exception	500 internal_error	500 internal_error (unchanged)
<details> <summary> Essential Elements of an Effective PR Description Checklist </summary>
 The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
 The test plan, such as providing test command.
 The test results, such as pasting the results comparison before and after, or e2e results
 (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.
</details>

