### PR TITLE
[CI] De-flake eagle correctness spec decode tests

### DIFF
--- a/tests/v1/e2e/spec_decode/test_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/test_spec_decode.py
@@ -464,6 +464,9 @@ def _run_eagle_correctness(
             enable_chunked_prefill=enable_chunked_prefill,
             model_impl=model_impl,
             attention_config=attention_config,
+            # Leave headroom for the eagle draft model's CUDA graphs and
+            # warmup-time allocations on smaller MIG slices (~33 GiB).
+            gpu_memory_utilization=0.7,
         )
         # EAGLE/EAGLE3 supports async scheduling; assert it is active by default.
         assert spec_llm.llm_engine.vllm_config.scheduler_config.async_scheduling


### PR DESCRIPTION
## Purpose

`test_eagle_correctness_light[FLASH_ATTN-deepseek_eagle]` has been flaking on H200 MIG slices (~33 GiB) during warmup with:

```
RuntimeError: NVML_SUCCESS == r INTERNAL ASSERT FAILED at
"/pytorch/c10/cuda/CUDACachingAllocator.cpp":1165
```

At default `gpu_memory_utilization=0.9`, model (6.92 GiB) + KV cache (21.98 GiB) + eagle CUDA graphs (1.69 GiB) ~= 30.6 / 32.5 GiB on the slice, leaving no headroom for the warmup-time FP32 logits allocation in `Sampler.apply_sampling_params`. The OOM surfaces as an NVML internal assert because PyTorch's allocator cannot query full-device NVML stats on MIG.

Lower the spec LLM's `gpu_memory_utilization` to 0.7 so warmup-time allocations have headroom.

Observed failures:
- [Build #67533](https://buildkite.com/vllm/ci/builds/67533/canvas?sid=019e4d10-8c9f-48dc-9d05-36d2722d0b42&tab=output)
- [Build #67037](https://buildkite.com/vllm/ci/builds/67037/canvas?sid=019e4363-2ef2-42e0-9b30-484f5020b879&tab=output)

## Test Plan

## Test Result