### PR TITLE
[Kernel] Add fused CUDA kernels for MoE non-gated activations

### DIFF
--- a/csrc/libtorch_stable/activation_kernels.cu
+++ b/csrc/libtorch_stable/activation_kernels.cu
@@ -636,6 +636,7 @@ __device__ __forceinline__ T gelu_quick_kernel(const T& x) {
 template <typename T>
 __device__ __forceinline__ T relu2_kernel(const T& x) {
   const float f = (float)x;
+  if (isnan(f)) return x;
   const float r = f > 0.0f ? f : 0.0f;
   return (T)(r * r);
 }

--- a/csrc/libtorch_stable/activation_kernels.cu
+++ b/csrc/libtorch_stable/activation_kernels.cu
@@ -633,6 +633,13 @@ __device__ __forceinline__ T gelu_quick_kernel(const T& x) {
   return (T)(((float)x) / (1.0f + expf(-1.702f * (float)x)));
 }
 
+template <typename T>
+__device__ __forceinline__ T relu2_kernel(const T& x) {
+  const float f = (float)x;
+  const float r = f > 0.0f ? f : 0.0f;
+  return (T)(r * r);
+}
+
 }  // namespace vllm
 
 void gelu_new(torch::stable::Tensor& out,    // [..., d]
@@ -651,4 +658,28 @@ void gelu_quick(torch::stable::Tensor& out,    // [..., d]
                 torch::stable::Tensor& input)  // [..., d]
 {
   LAUNCH_ACTIVATION_KERNEL(vllm::gelu_quick_kernel);
+}
+
+void silu_only(torch::stable::Tensor& out,    // [..., d]
+               torch::stable::Tensor& input)  // [..., d]
+{
+  LAUNCH_ACTIVATION_KERNEL(vllm::silu_kernel);
+}
+
+void gelu_only(torch::stable::Tensor& out,    // [..., d]
+               torch::stable::Tensor& input)  // [..., d]
+{
+  LAUNCH_ACTIVATION_KERNEL(vllm::gelu_kernel);
+}
+
+void gelu_tanh_only(torch::stable::Tensor& out,    // [..., d]
+                    torch::stable::Tensor& input)  // [..., d]
+{
+  LAUNCH_ACTIVATION_KERNEL(vllm::gelu_tanh_kernel);
+}
+
+void relu2_only(torch::stable::Tensor& out,    // [..., d]
+                torch::stable::Tensor& input)  // [..., d]
+{
+  LAUNCH_ACTIVATION_KERNEL(vllm::relu2_kernel);
 }

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -175,6 +175,10 @@ void mul_and_silu(torch::stable::Tensor& out, torch::stable::Tensor& input);
 void gelu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input);
 void gelu_tanh_and_mul(torch::stable::Tensor& out,
                        torch::stable::Tensor& input);
+void silu_only(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void gelu_only(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void gelu_tanh_only(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void relu2_only(torch::stable::Tensor& out, torch::stable::Tensor& input);
 void fatrelu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
                      double threshold);
 void swigluoai_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -283,6 +283,11 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
   // Activation function used in GeGLU with `tanh` approximation.
   ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
 
+  ops.def("silu_only(Tensor! out, Tensor input) -> ()");
+  ops.def("gelu_only(Tensor! out, Tensor input) -> ()");
+  ops.def("gelu_tanh_only(Tensor! out, Tensor input) -> ()");
+  ops.def("relu2_only(Tensor! out, Tensor input) -> ()");
+
   // FATReLU implementation.
   ops.def("fatrelu_and_mul(Tensor! out, Tensor input, float threshold) -> ()");
 
@@ -421,6 +426,10 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("mul_and_silu", TORCH_BOX(&mul_and_silu));
   ops.impl("gelu_and_mul", TORCH_BOX(&gelu_and_mul));
   ops.impl("gelu_tanh_and_mul", TORCH_BOX(&gelu_tanh_and_mul));
+  ops.impl("silu_only", TORCH_BOX(&silu_only));
+  ops.impl("gelu_only", TORCH_BOX(&gelu_only));
+  ops.impl("gelu_tanh_only", TORCH_BOX(&gelu_tanh_only));
+  ops.impl("relu2_only", TORCH_BOX(&relu2_only));
   ops.impl("fatrelu_and_mul", TORCH_BOX(&fatrelu_and_mul));
   ops.impl("swigluoai_and_mul", TORCH_BOX(&swigluoai_and_mul));
   ops.impl("gelu_new", TORCH_BOX(&gelu_new));

--- a/vllm/model_executor/layers/fused_moe/activation.py
+++ b/vllm/model_executor/layers/fused_moe/activation.py
@@ -5,7 +5,6 @@
 from enum import Enum
 
 import torch
-import torch.nn.functional as F
 
 
 class MoEActivation(Enum):
@@ -136,14 +135,13 @@ def apply_moe_activation(
 
     # Activations without gated multiplication
     elif activation == MoEActivation.SILU_NO_MUL:
-        output.copy_(F.silu(input))
+        torch.ops._C.silu_only(output, input)
     elif activation == MoEActivation.GELU_NO_MUL:
-        output.copy_(F.gelu(input))
+        torch.ops._C.gelu_only(output, input)
     elif activation == MoEActivation.GELU_TANH_NO_MUL:
-        output.copy_(F.gelu(input, approximate="tanh"))
+        torch.ops._C.gelu_tanh_only(output, input)
     elif activation == MoEActivation.RELU2_NO_MUL:
-        F.relu(input, inplace=True)
-        torch.square(input, out=output)
+        torch.ops._C.relu2_only(output, input)
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}")
 


### PR DESCRIPTION
## Purpose

The `*_NO_MUL` activation variants (`SILU_NO_MUL`, `GELU_NO_MUL`, `GELU_TANH_NO_MUL`, `RELU2_NO_MUL`) in `apply_moe_activation` previously used Python fallbacks: two separate kernel launches plus a temporary tensor allocation. For `RELU2_NO_MUL` specifically, the old code also mutated the input tensor in-place as a side effect.

This PR adds four fused CUDA kernels (`silu_only`, `gelu_only`, `gelu_tanh_only`, `relu2_only`) to the `_C_stable_libtorch` stable ABI extension, and wires them into the four `_NO_MUL` branches. Each kernel reuses the existing `activation_kernel` template and `LAUNCH_ACTIVATION_KERNEL` macro already used by `gelu_new`, `gelu_fast`, and `gelu_quick`.

The main beneficiary is the Nemotron-H family (`NemotronHForCausalLM`), which sets `is_act_and_mul=False` and uses `relu2_no_mul` for its MoE experts. This code path is taken when the activation is computed outside of a fully-fused GEMM kernel, such as with marlin/AWQ/GPTQ quantized variants. On this path the change reduces activation step latency by ~1.9x on decode and up to 4x on large prefill (see Test Result).

## Test Plan

Run existing activation kernel tests to verify nothing is broken:

```
pytest tests/kernels/core/test_activation.py -v
```

Manual correctness check for the new ops (bf16, shape [32, 2816]):

```python
import torch, torch.nn.functional as F
import vllm._C, vllm._C_stable_libtorch

cases = [
    ("silu_only",      torch.ops._C.silu_only,      F.silu),
    ("gelu_only",      torch.ops._C.gelu_only,      F.gelu),
    ("gelu_tanh_only", torch.ops._C.gelu_tanh_only, lambda x: F.gelu(x, approximate="tanh")),
    ("relu2_only",     torch.ops._C.relu2_only,     lambda x: x.clamp(min=0).pow(2)),
]
for name, op, ref in cases:
    inp = torch.randn(32, 2816, device="cuda", dtype=torch.bfloat16)
    out = torch.empty_like(inp)
    op(out, inp)
    print(name, (out - ref(inp)).abs().max().item())
```

## Test Result


```
silu_only      0.0
gelu_only      1.52587890625e-05
gelu_tanh_only 0.0
relu2_only     0.0
```

Microbenchmark on RTX 5070, bf16, DSv3 hidden size (7168), 2000 iterations:

| Config | Before (us) | After (us) | Speedup |
|---|---|---|---|
| decode 1-tok | 5.92 | 3.13 | 1.9x |
| decode 8-tok | 5.88 | 3.09 | 1.9x |
| prefill 1k | 10.28 | 7.56 | 1.4x |
| prefill 4k | 107.49 | 26.62 | 4.0x |

Gated ops (`silu_and_mul`, `gelu_and_mul`) are unchanged in the same benchmark, confirming the change is isolated.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>