### PR TITLE
[Perf][ROCm] MoE int4 weight repacking for GPTQ/AWQ Triton kernel

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -181,6 +181,25 @@ def benchmark_config(
             (num_experts, hidden_size, intermediate_size // group_size),
             dtype=dtype,
         )
+        # On AMD RDNA the fused MoE kernel unpacks int4 weights with
+        # tl.interleave, which needs N-packed int32 weights and per-N scales.
+        # Mirror the runtime repack so tuning targets the kernel that runs.
+        # w1 and w2 feed separate kernel launches, so each is repacked
+        # independently and only when its N % 8 == 0.
+        if current_platform.is_rocm():
+            from vllm.platforms.rocm import on_rdna
+
+            if on_rdna():
+                from vllm.model_executor.layers.quantization.utils.moe_wna16_utils import (  # noqa: E501
+                    repack_int4_to_int32,
+                )
+
+                if w1.shape[1] % 8 == 0:
+                    w1 = repack_int4_to_int32(w1)
+                    w1_scale = w1_scale.permute(0, 2, 1).contiguous()
+                if w2.shape[1] % 8 == 0:
+                    w2 = repack_int4_to_int32(w2)
+                    w2_scale = w2_scale.permute(0, 2, 1).contiguous()
     elif use_int8_w8a16:
         w1_scale = torch.randn(
             (num_experts, 2 * shard_intermediate_size), dtype=torch.float32

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -182,10 +182,7 @@ def benchmark_config(
             dtype=dtype,
         )
         # On AMD RDNA the fused MoE kernel unpacks int4 weights with
-        # tl.interleave, which needs N-packed int32 weights and per-N scales.
-        # Mirror the runtime repack so tuning targets the kernel that runs.
-        # w1 and w2 feed separate kernel launches, so each is repacked
-        # independently and only when its N % 8 == 0.
+        # tl.interleave, which needs the input packed differently.
         if current_platform.is_rocm():
             from vllm.platforms.rocm import on_rdna
 

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -646,6 +646,26 @@ def test_fused_moe_wn16(
         if has_zp:
             w_qzeros[expert_id] = qzeros
 
+    if weight_bits == 4 and current_platform.is_rocm():
+        from vllm.platforms.rocm import on_rdna
+
+        if on_rdna():
+            from vllm.model_executor.layers.quantization.utils.moe_wna16_utils import (
+                repack_int4_to_int32,
+                unpack_zp_int4_to_fp16,
+            )
+
+            if w1_qweight.shape[1] % 8 == 0:
+                w1_qweight = repack_int4_to_int32(w1_qweight)
+                w1_scales = w1_scales.permute(0, 2, 1).contiguous()
+                if has_zp:
+                    w1_qzeros = unpack_zp_int4_to_fp16(w1_qzeros)
+            if w2_qweight.shape[1] % 8 == 0:
+                w2_qweight = repack_int4_to_int32(w2_qweight)
+                w2_scales = w2_scales.permute(0, 2, 1).contiguous()
+                if has_zp:
+                    w2_qzeros = unpack_zp_int4_to_fp16(w2_qzeros)
+
     if ep_size > 1:
         local_e = e // ep_size
         e_ids = torch.randint(0, e, (local_e,), device="cuda", dtype=torch.int32)

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -395,6 +395,10 @@ class FusedMoEQuantConfig:
     def use_int4_w4a16(self) -> bool:
         return self._a1.dtype is None and self._w1.dtype == "int4"
 
+    def is_int4_w4a16_interleaved(self, w: torch.Tensor) -> bool:
+        # AMD RDNA repacks int4 weights into int32 for interleaved unpacking
+        return self.use_int4_w4a16 and w.dtype == torch.int32
+
     @property
     def use_nvfp4_w4a16(self) -> bool:
         return self._a1.dtype is None and self._w1.dtype == "nvfp4"

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -598,6 +598,21 @@ class TritonWNA16Experts(TritonExperts):
             or moe_parallel_config.use_fi_nvl_one_sided_kernels
         )
 
+    def moe_problem_size(
+        self,
+        a1: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> tuple[int, int, int, int, int]:
+        E, M, N, K, topk = super().moe_problem_size(a1, w1, w2, topk_ids)
+        # Interleave-repacked int4: w1 is [E, K, N//8] int32, so N can't
+        # be read from w1.shape[1].  Derive it from the scale tensor.
+        if self.quant_config.is_int4_w4a16_interleaved(w1):
+            assert self.w1_scale is not None
+            N = self.w1_scale.size(2)
+        return E, M, N, K, topk
+
     def apply(
         self,
         output: torch.Tensor,
@@ -617,7 +632,12 @@ class TritonWNA16Experts(TritonExperts):
         apply_router_weight_on_input: bool,
     ):
         # Check constraints.
-        if self.quant_config.use_int4_w4a16:
+        _interleave = self.quant_config.is_int4_w4a16_interleaved(w1)
+        if _interleave:
+            assert hidden_states.size(-1) == w1.size(1), (
+                f"Hidden size mismatch {hidden_states.size(-1)} != {w1.size(1)}"
+            )
+        elif self.quant_config.use_int4_w4a16:
             assert hidden_states.size(-1) // 2 == w1.size(2), (
                 f"Hidden size mismatch {hidden_states.size(-1) // 2} == {w1.size(2)}"
             )
@@ -652,6 +672,7 @@ class TritonWNA16Experts(TritonExperts):
             self.quant_config.config_name(hidden_states.dtype),
             num_tokens,
             block_shape=self.block_shape,
+            int4_packed_as_int32=_interleave,
         )
 
         if hidden_states.dtype == torch.bfloat16:

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -109,6 +109,7 @@ def fused_moe_kernel_gptq_awq(
     has_zp: tl.constexpr,
     use_int4_w4a16: tl.constexpr,
     use_int8_w8a16: tl.constexpr,
+    use_int4_interleave: tl.constexpr = False,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -135,6 +136,11 @@ def fused_moe_kernel_gptq_awq(
     `sorted_token_ids` by expert index and padding ensures divisibility by
     BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
     multiplication across different blocks processed by the same expert.
+
+    When use_int4_interleave=True (int4 with N-packed int32 weights [E, K, N//8]):
+    Uses tl.interleave for weight unpacking for efficient global memory access.
+    Scales are [E, K_groups, N] and zeros are [E, K_groups, N] fp16.
+    See vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
     """
     # -----------------------------------------------------------
     # Map program ids `pid` to the block of C it should compute.
@@ -189,13 +195,37 @@ def fused_moe_kernel_gptq_awq(
     )
 
     if use_int4_w4a16:
-        b_ptrs = (
-            b_ptr
-            + off_experts * stride_be
-            + (offs_k[:, None] // 2) * stride_bk
-            + offs_bn[None, :] * stride_bn
-        )
-        b_shifter = (offs_k[:, None] % 2) * 4
+        if use_int4_interleave:
+            # B: [E, K, N//8] int32 — N-packed, 8 int4 per int32
+            offs_bn_packed = (
+                pid_n * (BLOCK_SIZE_N // 8)
+                + tl.arange(0, BLOCK_SIZE_N // 8).to(tl.int64)
+            ) % (N // 8)
+            b_ptrs = (
+                b_ptr
+                + off_experts * stride_be
+                + offs_k[:, None] * stride_bk
+                + offs_bn_packed[None, :] * stride_bn
+            )
+            # GPTQ sequential shifts tiled across BLOCK_N:
+            # [0,4,8,...,28] repeating for every group of 8 N-values.
+            # Build 1D shifts_1d of length BLOCK_N: column j gets shift (j % 8) * 4
+            shifts_row = tl.arange(0, 8) * 4
+            shifts_1d_2d = tl.broadcast_to(shifts_row[None, :], (BLOCK_SIZE_N // 8, 8))
+            shifts_1d = tl.reshape(shifts_1d_2d, (BLOCK_SIZE_N,))
+            # Broadcast to [BLOCK_K, BLOCK_N] for weight unpacking
+            b_shifter = tl.broadcast_to(
+                shifts_1d[None, :], (BLOCK_SIZE_K, BLOCK_SIZE_N)
+            )
+        else:
+            # B: [E, N, K//2] uint8 — K-packed, 2 int4 per byte
+            b_ptrs = (
+                b_ptr
+                + off_experts * stride_be
+                + (offs_k[:, None] // 2) * stride_bk
+                + offs_bn[None, :] * stride_bn
+            )
+            b_shifter = (offs_k[:, None] % 2) * 4
     elif use_int8_w8a16:
         b_ptrs = (
             b_ptr
@@ -204,11 +234,7 @@ def fused_moe_kernel_gptq_awq(
             + offs_bn[None, :] * stride_bn
         )
 
-    if not has_zp and use_int4_w4a16:
-        b_zp_num = 8
-    if not has_zp and use_int8_w8a16:
-        b_zp_num = 128
-    elif has_zp and use_int4_w4a16:
+    if has_zp and use_int4_w4a16 and not use_int4_interleave:
         b_zp_shifter = (offs_bn[None, :] % 2) * 4
 
     # -----------------------------------------------------------
@@ -233,51 +259,62 @@ def fused_moe_kernel_gptq_awq(
             mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
+
         b = tl.load(b_ptrs)
         if use_int4_w4a16:
+            if use_int4_interleave:
+                # Expand int32 to 8 int4 values via interleave,
+                # reducing register pressure vs per-element shifts.
+                b = tl.interleave(b, b)
+                b = tl.interleave(b, b)
+                b = tl.interleave(b, b)
             b = (b >> b_shifter) & 0xF
+
+        g_idx = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
 
         b_scale_ptrs = (
             b_scale_ptr
             + off_experts * stride_bse
+            + g_idx * stride_bsk
             + offs_bn[None, :] * stride_bsn
-            + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
         )
         b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
         b_scale = b_scale.to(tl.float32)
 
-        if has_zp and use_int4_w4a16:
-            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
-            b_zp_ptrs = (
-                b_zp_ptr
-                + off_experts * stride_bze
-                + (offs_bn[None, :] // 2) * stride_bzn
-                + offs_k_true * stride_bzk
-            )
-            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
-            b_zp = (b_zp >> b_zp_shifter) & 0xF
-            b_zp = b_zp.to(tl.float32)
-        elif has_zp and use_int8_w8a16:
-            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
-            b_zp_ptrs = (
-                b_zp_ptr
-                + off_experts * stride_bze
-                + offs_bn[None, :] * stride_bzn
-                + offs_k_true * stride_bzk
-            )
-            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
-            b_zp = b_zp.to(tl.float32)
-
-        # We accumulate along the K dimension.
+        # Load or set zero points
         if has_zp:
-            b = ((b.to(tl.float32) - b_zp) * b_scale).to(compute_type)
+            if use_int4_w4a16 and not use_int4_interleave:
+                # zeros: [E, N//2, K_groups] uint8, packed 2 per byte
+                b_zp_ptrs = (
+                    b_zp_ptr
+                    + off_experts * stride_bze
+                    + (offs_bn[None, :] // 2) * stride_bzn
+                    + g_idx * stride_bzk
+                )
+                b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+                b_zp = (b_zp >> b_zp_shifter) & 0xF
+            else:
+                b_zp_ptrs = (
+                    b_zp_ptr
+                    + off_experts * stride_bze
+                    + offs_bn[None, :] * stride_bzn
+                    + g_idx * stride_bzk
+                )
+                b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
         else:
-            b = ((b.to(tl.float32) - b_zp_num) * b_scale).to(compute_type)
+            # Symmetric quantization
+            if use_int4_w4a16:
+                b_zp = 8
+            elif use_int8_w8a16:
+                b_zp = 128
+
+        # Dequantize: (weight - zero_point) * scale
+        b = ((b.to(tl.float32) - b_zp) * b_scale).to(compute_type)
         accumulator = tl.dot(a, b, acc=accumulator)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak
-        if use_int4_w4a16:
+        if use_int4_w4a16 and not use_int4_interleave:
             b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
         else:
             b_ptrs += BLOCK_SIZE_K * stride_bk
@@ -695,6 +732,30 @@ def invoke_fused_moe_wna16_triton_kernel(
     M = A.size(0)
     num_tokens = M * top_k
 
+    use_int4_interleave = use_int4_w4a16 and B.dtype == torch.int32
+
+    if use_int4_interleave:
+        N_out = B_scale.size(2)
+        k_dim, n_dim = 1, 2
+    else:
+        N_out = B.size(1)
+        k_dim, n_dim = 2, 1
+
+    stride_be, stride_bk, stride_bn = (B.stride(0), B.stride(k_dim), B.stride(n_dim))
+    stride_bse, stride_bsk, stride_bsn = (
+        B_scale.stride(0),
+        B_scale.stride(k_dim),
+        B_scale.stride(n_dim),
+    )
+    if B_zp is not None:
+        stride_bze, stride_bzk, stride_bzn = (
+            B_zp.stride(0),
+            B_zp.stride(k_dim),
+            B_zp.stride(n_dim),
+        )
+    else:
+        stride_bze, stride_bzk, stride_bzn = 0, 0, 0
+
     EM = sorted_token_ids.size(0)
     if A.size(0) < config["BLOCK_SIZE_M"]:
         # optimize for small batch_size.
@@ -704,7 +765,7 @@ def invoke_fused_moe_wna16_triton_kernel(
         EM = min(sorted_token_ids.size(0), A.size(0) * top_k * config["BLOCK_SIZE_M"])
     grid = lambda META: (
         triton.cdiv(EM, META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.size(1), META["BLOCK_SIZE_N"]),
+        * triton.cdiv(N_out, META["BLOCK_SIZE_N"]),
     )
     config = config.copy()
     config.update(
@@ -713,41 +774,47 @@ def invoke_fused_moe_wna16_triton_kernel(
             use_moe_wna16_cuda=False,
             num_valid_tokens=num_tokens,
             size_k=A.size(1),
-            size_n=B.size(1),
-            num_experts=B.size(1),
+            size_n=N_out,
+            num_experts=B.size(0),
             group_size=block_shape[1],
             real_top_k=top_k,
             block_size_m=config["BLOCK_SIZE_M"],
         )
     )
 
+    if use_int4_interleave:
+        assert config["BLOCK_SIZE_N"] % 8 == 0, (
+            "Interleave path requires BLOCK_SIZE_N divisible by 8, "
+            f"got {config['BLOCK_SIZE_N']}"
+        )
+
     fused_moe_kernel_gptq_awq[grid](
         A,
         B,
         C,
         B_scale,
-        B_zp,
+        B_zp if B_zp is not None else B,
         topk_weights,
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        B.size(1),
+        N_out,
         A.size(1),
         EM,
         num_tokens,
         A.stride(0),
         A.stride(1),
-        B.stride(0),
-        B.stride(2),
-        B.stride(1),
+        stride_be,
+        stride_bk,
+        stride_bn,
         C.stride(1),
         C.stride(2),
-        B_scale.stride(0),
-        B_scale.stride(2),
-        B_scale.stride(1),
-        B_zp.stride(0) if B_zp is not None else 0,
-        B_zp.stride(2) if B_zp is not None else 0,
-        B_zp.stride(1) if B_zp is not None else 0,
+        stride_bse,
+        stride_bsk,
+        stride_bsn,
+        stride_bze,
+        stride_bzk,
+        stride_bzn,
         block_k_diviable=A.size(1) % config["BLOCK_SIZE_K"] == 0,
         group_size=block_shape[1],
         MUL_ROUTED_WEIGHT=mul_routed_weight,
@@ -756,6 +823,7 @@ def invoke_fused_moe_wna16_triton_kernel(
         has_zp=B_zp is not None,
         use_int4_w4a16=use_int4_w4a16,
         use_int8_w8a16=use_int8_w8a16,
+        use_int4_interleave=use_int4_interleave,
         **config,
     )
 
@@ -1420,6 +1488,7 @@ def try_get_optimal_moe_config(
     dtype: str | None,
     M: int,
     block_shape: list[int] | None = None,
+    int4_packed_as_int32: bool = False,
 ) -> dict[str, int]:
     from vllm.model_executor.layers.fused_moe import get_config
 
@@ -1428,9 +1497,14 @@ def try_get_optimal_moe_config(
         config = override_config
     else:
         # First try to load optimal config from the file
-        E, _, N = w2_shape
-        if dtype == "int4_w4a16":
-            N = N * 2
+        if int4_packed_as_int32:
+            # w2 is [E, intermediate, hidden//8] int32
+            E = w2_shape[0]
+            N = w2_shape[1]
+        else:
+            E, _, N = w2_shape
+            if dtype == "int4_w4a16":
+                N = N * 2
         block_n = block_shape[0] if block_shape else 0
         block_k = block_shape[1] if block_shape else 0
         configs = get_moe_configs(E, N, dtype, block_n, block_k)
@@ -1683,7 +1757,13 @@ def fused_experts_impl(
     activation_enum = MoEActivation.from_str(activation)
 
     # Check constraints.
-    if use_int4_w4a16:
+    # Detect ROCm int4 interleave layout: w1 is [E, K, N//8] int32
+    _rocm_interleave = use_int4_w4a16 and w1.dtype == torch.int32
+    if _rocm_interleave:
+        assert hidden_states.size(1) == w1.size(1), (
+            f"Hidden size mismatch {hidden_states.size(1)} != {w1.size(1)}"
+        )
+    elif use_int4_w4a16:
         assert hidden_states.size(1) // 2 == w1.size(2), "Hidden size mismatch"
     else:
         assert hidden_states.size(1) == w1.size(2), (
@@ -1697,8 +1777,13 @@ def fused_experts_impl(
     assert hidden_states.dtype in [torch.float32, torch.float16, torch.bfloat16]
 
     num_tokens = hidden_states.size(0)
-    E, N, _ = w1.size()
-    K = w2.size(1)
+    if _rocm_interleave:
+        E, K, _ = w1.size()
+        assert w1_scale is not None
+        N = w1_scale.size(2)
+    else:
+        E, N, _ = w1.size()
+        K = w2.size(1)
     if global_num_experts == -1:
         global_num_experts = E
     top_k_num = topk_ids.size(1)
@@ -1726,6 +1811,7 @@ def fused_experts_impl(
         top_k_num,
         config_dtype,
         block_shape=block_shape,
+        int4_packed_as_int32=_rocm_interleave,
     )
 
     config = get_config_func(M)

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -1645,6 +1645,7 @@ def convert_to_wna16_moe_kernel_format(
         from vllm.model_executor.layers.quantization.auto_gptq import (
             AutoGPTQConfig,
         )
+        from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
         if isinstance(quant_config, (AutoGPTQConfig, QuantizationArgs)):
             # These integrations build in K-first format even when the Triton
@@ -1657,6 +1658,42 @@ def convert_to_wna16_moe_kernel_format(
             # MoeWNA16 uses N-first uint8 weights and scales.
             w13_uint8 = w13.view(torch.uint8)
             w2_uint8 = w2.view(torch.uint8)
+
+        # On RDNA (gfx11/gfx12), repack int4 weights from N-first uint8
+        # [E, N, K//2] to N-packed int32 [E, K, N//8] so the Triton kernel
+        # unpacks them with tl.interleave (far fewer VGPRs than per-element
+        # shifts). Only the MoeWNA16 (AWQ/GPTQ) and compressed-tensors sources
+        # are handled; AutoGPTQ keeps its scalar-shift path. w13 and w2 feed
+        # separate kernel launches and dispatch per-tensor on dtype, so each is
+        # repacked independently and only when its N % 8 == 0 (else that weight
+        # keeps the uint8 layout and the kernel falls back to scalar shifts).
+        if isinstance(quant_config, MoeWNA16Config):
+            num_bits = quant_config.weight_bits
+        elif isinstance(quant_config, QuantizationArgs):
+            num_bits = quant_config.num_bits
+        else:
+            num_bits = None
+
+        from vllm.platforms.rocm import on_rdna
+
+        if num_bits == 4 and on_rdna():
+            from vllm.model_executor.layers.quantization.utils.moe_wna16_utils import (
+                repack_int4_to_int32,
+                unpack_zp_int4_to_fp16,
+            )
+
+            # Zero points exist only for AWQ (compressed-tensors int4 is
+            # symmetric); unpack the uint8 [E, N//2, Kg] layout to fp16.
+            if w13_uint8.shape[1] % 8 == 0:
+                w13_uint8 = repack_int4_to_int32(w13_uint8)
+                w13_scale = w13_scale.permute(0, 2, 1).contiguous()
+                if w13_qzeros is not None:
+                    w13_qzeros = unpack_zp_int4_to_fp16(w13_qzeros)
+            if w2_uint8.shape[1] % 8 == 0:
+                w2_uint8 = repack_int4_to_int32(w2_uint8)
+                w2_scale = w2_scale.permute(0, 2, 1).contiguous()
+                if w2_qzeros is not None:
+                    w2_qzeros = unpack_zp_int4_to_fp16(w2_qzeros)
         return (
             w13_uint8,
             w2_uint8,

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -1659,14 +1659,12 @@ def convert_to_wna16_moe_kernel_format(
             w13_uint8 = w13.view(torch.uint8)
             w2_uint8 = w2.view(torch.uint8)
 
-        # On RDNA (gfx11/gfx12), repack int4 weights from N-first uint8
+        # On AMD RDNA, repack int4 weights from N-first uint8
         # [E, N, K//2] to N-packed int32 [E, K, N//8] so the Triton kernel
         # unpacks them with tl.interleave (far fewer VGPRs than per-element
-        # shifts). Only the MoeWNA16 (AWQ/GPTQ) and compressed-tensors sources
-        # are handled; AutoGPTQ keeps its scalar-shift path. w13 and w2 feed
-        # separate kernel launches and dispatch per-tensor on dtype, so each is
-        # repacked independently and only when its N % 8 == 0 (else that weight
-        # keeps the uint8 layout and the kernel falls back to scalar shifts).
+        # shifts); AutoGPTQ keeps its scalar-shift path as fallback. w13 and w2
+        # feed separate kernel launches and dispatch per-tensor on dtype, so
+        # each is repacked independently and only when its N % 8 == 0.
         if isinstance(quant_config, MoeWNA16Config):
             num_bits = quant_config.weight_bits
         elif isinstance(quant_config, QuantizationArgs):
@@ -1682,8 +1680,6 @@ def convert_to_wna16_moe_kernel_format(
                 unpack_zp_int4_to_fp16,
             )
 
-            # Zero points exist only for AWQ (compressed-tensors int4 is
-            # symmetric); unpack the uint8 [E, N//2, Kg] layout to fp16.
             if w13_uint8.shape[1] % 8 == 0:
                 w13_uint8 = repack_int4_to_int32(w13_uint8)
                 w13_scale = w13_scale.permute(0, 2, 1).contiguous()

--- a/vllm/model_executor/layers/quantization/utils/moe_wna16_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/moe_wna16_utils.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+
+def repack_int4_to_int32(w: torch.Tensor) -> torch.Tensor:
+    """Repack [E, N, K//2] uint8 → [E, K, N//8] int32.
+
+    Input: K-packed uint8 (2 int4 per byte, low nibble first).
+    Output: N-packed int32 (8 int4 per int32, GPTQ sequential shifts
+            [0,4,...,28]).
+    """
+    E, N, K_half = w.shape
+    assert N % 8 == 0, f"N must be divisible by 8 for int32 repacking, got {N}"
+    K = K_half * 2
+    lo = (w & 0xF).to(torch.int32)
+    hi = ((w >> 4) & 0xF).to(torch.int32)
+    unpacked = torch.stack([lo, hi], dim=-1).reshape(E, N, K)
+    transposed = unpacked.permute(0, 2, 1).contiguous()
+    N8 = N // 8
+    shifts = torch.arange(8, device=w.device, dtype=torch.int32) * 4
+    packed = (transposed.view(E, K, N8, 8) << shifts).sum(dim=-1, dtype=torch.int32)
+    return packed.contiguous()
+
+
+def unpack_zp_int4_to_fp16(zp: torch.Tensor) -> torch.Tensor:
+    """Unpack [E, N//2, K_groups] uint8 → [E, K_groups, N] fp16."""
+    E, N_half, K_groups = zp.shape
+    lo = (zp & 0xF).to(torch.int32)
+    hi = ((zp >> 4) & 0xF).to(torch.int32)
+    unpacked = torch.stack([lo, hi], dim=2).reshape(E, N_half * 2, K_groups)
+    return unpacked.permute(0, 2, 1).contiguous().to(torch.float16)


### PR DESCRIPTION
## [Perf][ROCm] MoE int4 interleave unpacking for GPTQ/AWQ Triton kernel

Optimizes the MoE int4 Triton kernel (`fused_moe_kernel_gptq_awq`) on ROCm by changing the memory packing scheme, mainly benefiting FP16 models.

The current kernel loads each packed int4 byte twice (once per nibble) and uses per-element variable shifts. This PR repacks weights at load time from K-packed `[E, N, K//2]` uint8 to N-packed `[E, K, N//8]` int32, then unpacks in-kernel via 3× `tl.interleave` with constant GPTQ sequential shifts. Zero points are also unpacked to fp16 during load time to avoid on-the-flay unpacking.

**The goal of this GPTQ-style packed memory is to achieve overall better performance with an unified Triton kernel for Prefill + Decode. More compute-intensive Prefill benefit better from Exllama way of packing(refer to [hybrid W4A16](https://github.com/vllm-project/vllm/pull/40977), and optimal skinny decode needs native HIP kernel. Leaving these to future work.**

**Inspiration:**

- The dense [`triton_w4a16.py`](vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py) kernel (upstream)
- Matthias Gehre's [hybrid W4A16 work](https://github.com/vllm-project/vllm/pull/40977)

ROCm only. CUDA path is unchanged — interleave activates when `use_int4_w4a16 and B.dtype == torch.int32`, which only occurs after ROCm-gated weight repacking. The core idea technically extends to CUDA as well — but the CUDA kernel expects uint8 packed weights as input, so guarding this to prevent impacting CUDA paths.

### What changes

- **`MoeWNA16Method.process_weights_after_loading()`** (`vllm/model_executor/layers/quantization/moe_wna16.py`): On ROCm + int4, repacks weights from K-packed uint8 to N-packed int32, transposes scales, and repacks zero points (if asymmetric).
- **`CompressedTensorsWNA16MoEMethod.process_weights_after_loading()`**: Same repacking for compressed-tensors models.
- **`fused_moe_kernel_gptq_awq`** (`vllm/model_executor/layers/fused_moe/fused_moe.py`): New `use_int4_interleave` constexpr path. When `B.dtype == torch.int32` (repacked weights detected), uses `tl.interleave to unpack at register level. Supports both symmetric and asymmetric quantization.
- **`moe_problem_size` override**: Corrects the N dimension for the repacked layout.

### Why fp16 is hit hardest on gfx1100

The dequantization path does `int4 → f32 (dequant) → fp16/bf16 (truncate) → WMMA`. Inspecting LLIR and AMDGCN reveals a type conversion cost asymmetry:

- **bf16→f32**: trivial bit-shift (same 8-bit exponent range). LLVM lowers `fptrunc float→bfloat` to integer `v_lshrrev`/`v_lshlrev` ops. The WMMA intrinsic accepts `<16 x i16>` for bf16, so no float conversion pipeline is needed. **0 fptrunc/fpext instructions** in the LLIR.
- **fp16→f32**: real conversion (5-bit vs 8-bit exponent, needs rounding). LLVM emits `v_cvt_f16_f32`/`v_cvt_f32_f16`, each keeping both f32 source and fp16 result live simultaneously. **265 fptrunc/fpext instructions** (136 trunc + 129 ext) inflate register pressure past the 256 VGPR budget.

The interleave path avoids this entirely by reducing the number of intermediate values in the inner loop regardless of dtype.

### VGPR example analysis (`fused_moe_kernel_gptq_awq`, gfx1100)

| Variant | VGPRs | VGPR Spills | Scratch (B) | Occupancy |
|---------|-------|-------------|-------------|-----------|
| **PR fp16** | **144** | 0 | 0 | **10** |
| **PR bf16** | **163** | 0 | 0 | **9** |
| Original fp16 | 256 | 219 | 880 | 5 |
| Original bf16 | 256 | 133 | 416 | 5 |

Interleave eliminates all register spilling and doubles occupancy on gfx1100.

### Benchmark results

#### AWQ: Qwen3-30B-A3B-AWQ (batched serve, ShareGPT 500 prompts)

**fp16 → fp16 (AWQ default):**

| Metric | gfx1100 Main | gfx1100 PR | gfx1100 Δ | gfx1201 Main | gfx1201 PR | gfx1201 Δ |
|--------|-------------:|-------------------:|----------:|-------------:|-------------------:|----------:|
| Output tok/s | 392 | **957** | **+144%** | 685 | **928** | **+35%** |
| Median TPOT (ms) | 439 | **159** | **−64%** | 233 | **164** | **−30%** |
| Median ITL (ms) | 381 | **127** | **−67%** | 199 | **139** | **−30%** |
| Median TTFT (ms) | 29,166 | **19,259** | **−34%** | 21,263 | **18,093** | **−15%** |

**bf16 → bf16 (`--dtype bfloat16`):**

| Metric | gfx1100 Main | gfx1100 PR | gfx1100 Δ | gfx1201 Main | gfx1201 PR | gfx1201 Δ |
|--------|-------------:|-------------------:|----------:|-------------:|-------------------:|----------:|
| Output tok/s | 863 | **897** | **+4%** | 875 | **892** | **+2%** |
| Median TPOT (ms) | 181 | **166** | **−8%** | 172 | **167** | **−3%** |
| Median ITL (ms) | 147 | **134** | **−9%** | 145 | **141** | **−3%** |
| Median TTFT (ms) | 13,875 | 20,388 | +47% | 17,861 | 17,713 | −1%  |

The fp16 improvement (+144% on gfx1100, +35% on gfx1201) comes from eliminating VGPR spilling. The bf16 improvement (+2–4%) is the pure algorithmic gain. The gfx1100 bf16 TTFT regression is not observed on gfx1201. This compute-bound regression will be solved by the optimized Exllama packing Triton kernel in the future.

#### AWQ: Qwen3-30B-A3B-AWQ (single-batch decode, `max_num_seqs=1`, 100 prompts)

**fp16 → fp16:**

| Metric | Main | this PR | Delta |
|--------|------|-----------|-------|
| Output tok/s | 40.19 | **54.22** | **+35%** |
| Median TPOT (ms) | 24.14 | **17.95** | **−26%** |

**bf16 → bf16:**

| Metric | Main | this PR | Delta |
|--------|------|-----------|-------|
| Output tok/s | 50.15 | **51.64** | +3% |
| Median TPOT (ms) | 19.31 | **18.82** | −3% |

#### Compressed-Tensors: RedHatAI/Qwen3-30B-A3B-quantized.w4a16 (bf16 → bf16, batched serve, 500 prompts, warm avg)

| Metric | Main | this PR | Delta |
|--------|------|-----------|-------|
| Output tok/s | 1095 | **1245** | **+14%** |
| Median TPOT (ms) | 139.0 | **130.9** | **−6%** |
| Median ITL (ms) | 128.4 | **121.3** | **−6%** |
| Median TTFT (ms) | 1635 | 1598 | −2%  |

#### GPTQ: Qwen3.5-35B-A3B-GPTQ-Int4 (fp16 → fp16, 256 experts, batched serve, 500 prompts, warm avg)

| Metric | Main | this PR | Delta |
|--------|------|-----------|-------|
| Output tok/s | 517 | **556** | **+7%** |
| Total tok/s | 1013 | **1097** | **+8%** |
| Median TTFT (ms) | 20,073 | **18,624** | −7% |
| Median ITL (ms) | 189 | **179** | **−5%** |

### Accuracy (lm_eval gsm8k, 5-shot, 200 samples, gfx1100)

| Model | Branch | strict-match | flexible-extract |
|-------|--------|-------------|-----------------|
| Qwen3-30B-A3B-AWQ | main | 0.920 ± 0.019 | 0.890 ± 0.022 |
| Qwen3-30B-A3B-AWQ | PR | 0.915 ± 0.020 | 0.885 ± 0.023 |
| RedHatAI/Qwen3-30B-A3B-quantized.w4a16 | main | 0.900 ± 0.021 | 0.910 ± 0.020 |
| RedHatAI/Qwen3-30B-A3B-quantized.w4a16 | PR | 0.895 ± 0.022 | 0.890 ± 0.022 |

No accuracy regression — all deltas are within stderr.

### Test plan

- [x] `lm_eval` gsm8k 5-shot accuracy (AWQ + CompressedTensors)
- [x] End-to-end serving benchmark (AWQ fp16/bf16, CT bf16, GPTQ fp16)
- [x] Single-batch decode latency (AWQ fp16/bf16)
- [x] VGPR spilling analysis (`.amdgcn` dump inspection)