### PR TITLE
[MM][CG] ViT CudaGraph Video inference fall back to eager when input T > frames_per_item

### DIFF
--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -2136,6 +2136,44 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
     )
 
 
+# Test ViT CG video inference fall back to eager when T > frames_per_item
+# python examples/generate/multimodal/vision_language_offline.py \
+#   -m qwen3_vl_autoinfer --enable_vit_cuda_graph --modality video
+def run_qwen3_vl_autoinfer(questions: list[str], modality: str) -> ModelRequestData:
+    model_name = "Qwen/Qwen3-VL-2B-Instruct"
+
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
+    engine_args = EngineArgs(
+        model=model_name,
+        limit_mm_per_prompt=mm_limit,
+    )
+
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
+    if modality == "image":
+        placeholder = image_placeholder
+    elif modality == "video":
+        placeholder = video_placeholder
+    elif modality == "image+video":
+        placeholder = image_placeholder + video_placeholder
+
+    prompts = [
+        (
+            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+            f"<|im_start|>user\n{placeholder}"
+            f"{question}<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        for question in questions
+    ]
+
+    return ModelRequestData(
+        engine_args=engine_args,
+        prompts=prompts,
+    )
+
+
 # Qwen3-VL-MOE
 def run_qwen3_vl_moe(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "Qwen/Qwen3-VL-30B-A3B-Instruct"
@@ -2528,6 +2566,7 @@ model_example_map = {
     "qwen2_5_omni": run_qwen2_5_omni,
     "qwen3_vl": run_qwen3_vl,
     "qwen3_vl_moe": run_qwen3_vl_moe,
+    "qwen3_vl_autoinfer": run_qwen3_vl_autoinfer,
     "qwen3_5": run_qwen3_5,
     "qwen3_5_moe": run_qwen3_5_moe,
     "rvl": run_r_vl,
@@ -2547,6 +2586,7 @@ MODELS_NEED_VIDEO_METADATA = [
     "glm4_5v_fp8",
     "molmo2",
     "qwen3_vl",
+    "qwen3_vl_autoinfer",
     "qwen3_vl_moe",
     "qwen3_5",
     "qwen3_5_moe",
@@ -2556,6 +2596,7 @@ MODELS_NEED_VIDEO_METADATA = [
 MODELS_SUPPORT_VIT_CUDA_GRAPH = [
     "qwen2_5_vl",
     "qwen3_vl",
+    "qwen3_vl_autoinfer",
     "qwen3_vl_moe",
     "qwen2_vl",
     "qwen3_5",

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -2138,13 +2138,17 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
 
 # Test ViT CG video inference fall back to eager when T > frames_per_item
 # python examples/generate/multimodal/vision_language_offline.py \
-#   -m qwen3_vl_autoinfer --enable_vit_cuda_graph --modality video
-def run_qwen3_vl_autoinfer(questions: list[str], modality: str) -> ModelRequestData:
+#   -m qwen3_vl_vit_cg_fallback --enable_vit_cuda_graph --modality video
+def run_qwen3_vl_vit_cg_fallback(
+    questions: list[str], modality: str
+) -> ModelRequestData:
     model_name = "Qwen/Qwen3-VL-2B-Instruct"
 
     mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
+        max_model_len=4096,
+        max_num_seqs=5,
         limit_mm_per_prompt=mm_limit,
     )
 
@@ -2566,7 +2570,7 @@ model_example_map = {
     "qwen2_5_omni": run_qwen2_5_omni,
     "qwen3_vl": run_qwen3_vl,
     "qwen3_vl_moe": run_qwen3_vl_moe,
-    "qwen3_vl_autoinfer": run_qwen3_vl_autoinfer,
+    "qwen3_vl_vit_cg_fallback": run_qwen3_vl_vit_cg_fallback,
     "qwen3_5": run_qwen3_5,
     "qwen3_5_moe": run_qwen3_5_moe,
     "rvl": run_r_vl,
@@ -2586,7 +2590,7 @@ MODELS_NEED_VIDEO_METADATA = [
     "glm4_5v_fp8",
     "molmo2",
     "qwen3_vl",
-    "qwen3_vl_autoinfer",
+    "qwen3_vl_vit_cg_fallback",
     "qwen3_vl_moe",
     "qwen3_5",
     "qwen3_5_moe",
@@ -2596,7 +2600,7 @@ MODELS_NEED_VIDEO_METADATA = [
 MODELS_SUPPORT_VIT_CUDA_GRAPH = [
     "qwen2_5_vl",
     "qwen3_vl",
-    "qwen3_vl_autoinfer",
+    "qwen3_vl_vit_cg_fallback",
     "qwen3_vl_moe",
     "qwen2_vl",
     "qwen3_5",

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -409,7 +409,7 @@ class EncoderCudaGraphManager:
                     token_budget = None
                     logger.warning(
                         "Input video frames %s exceeds capture capacity %s, "
-                        "fallback to eagar, please manually set "
+                        "fallback to eager, please manually set "
                         "'encoder_cudagraph_max_vision_items_per_batch "
                         "and 'encoder_cudagraph_max_frames_per_batch' "
                         "in 'compilation-config'",

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -402,7 +402,8 @@ class EncoderCudaGraphManager:
                 batch_max_frames = max(
                     actual_frames_per_item[i] for i in batch_orig_indices
                 )
-                if batch_max_frames > self.max_frames_per_batch // self.max_batch_size:
+                frames_per_item = self.max_frames_per_batch // self.max_batch_size
+                if batch_max_frames > frames_per_item:
                     # Check if actual frames per item exceeds capture capacity.
                     # If so, fallback to eager to avoid shape mismatch.
                     token_budget = None
@@ -413,7 +414,7 @@ class EncoderCudaGraphManager:
                         "and 'encoder_cudagraph_max_frames_per_batch' "
                         "in 'compilation-config'",
                         batch_max_frames,
-                        self.max_frames_per_batch // self.max_batch_size,
+                        frames_per_item,
                     )
 
             if token_budget is None:

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -407,11 +407,13 @@ class EncoderCudaGraphManager:
                     # If so, fallback to eager to avoid shape mismatch.
                     token_budget = None
                     logger.warning(
-                        "Input video frames exceeds capture capacity, "
+                        "Input video frames %s exceeds capture capacity %s, "
                         "fallback to eagar, please manually set "
                         "'encoder_cudagraph_max_vision_items_per_batch "
                         "and 'encoder_cudagraph_max_frames_per_batch' "
-                        "in 'compilation-config'"
+                        "in 'compilation-config'",
+                        batch_max_frames,
+                        self.max_frames_per_batch // self.max_batch_size,
                     )
 
             if token_budget is None:

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -337,36 +337,6 @@ class EncoderCudaGraphManager:
 
         per_item_out_tokens = self._get_per_item_out_tokens(mm_kwargs)
 
-        # Check if actual frames per item exceeds capture capacity.
-        # If so, fallback to eager to avoid shape mismatch.
-        if self.max_frames_per_batch > 0:
-            grid_thw_key = f"{self.model.get_input_modality(mm_kwargs)}_grid_thw"
-            grid_thw = mm_kwargs[grid_thw_key]
-            if not isinstance(grid_thw, list):
-                grid_thw = grid_thw.tolist()
-
-            max_replay_frames = max(t for t, h, w in grid_thw)
-            frames_per_item = self.max_frames_per_batch // self.max_batch_size
-            if max_replay_frames > frames_per_item:
-                logger.warning(
-                    "Input video frames exceeds capture capacity, fallback to eagar,"
-                    "please manually set "
-                    "'encoder_cudagraph_max_vision_items_per_batch "
-                    "and 'encoder_cudagraph_max_frames_per_batch' "
-                    "in 'compilation-config'"
-                )
-                self.graph_misses += num_items
-                eager_outputs: dict[int, torch.Tensor] = {}
-                with torch.inference_mode():
-                    raw = self.model.encoder_eager_forward(mm_kwargs)
-                scatter_output_slices(
-                    raw,
-                    list(range(num_items)),
-                    per_item_out_tokens,
-                    eager_outputs,
-                )
-                return [eager_outputs[i] for i in range(num_items)]
-
         # Sort ascending by output token count (smallest first)
         sorted_indices = sorted(range(num_items), key=lambda i: per_item_out_tokens[i])
 
@@ -408,6 +378,15 @@ class EncoderCudaGraphManager:
                 )
             )
 
+        # extract actual frames per item
+        actual_frames_per_item = None
+        if self.max_frames_per_batch > 0:
+            grid_thw_key = f"{self.model.get_input_modality(mm_kwargs)}_grid_thw"
+            grid_thw = mm_kwargs[grid_thw_key]
+            if not isinstance(grid_thw, list):
+                grid_thw = grid_thw.tolist()
+            actual_frames_per_item = [t for t, h, w in grid_thw]
+
         # outputs_by_orig_idx maps each original image index to its output
         # tensor. Needed because greedy packing reorders images; we restore
         # the original order before returning.
@@ -418,6 +397,22 @@ class EncoderCudaGraphManager:
                 mm_kwargs, batch_orig_indices
             )
             batch_out_tokens = sum(per_item_out_tokens[i] for i in batch_orig_indices)
+
+            if actual_frames_per_item is not None:
+                batch_max_frames = max(
+                    actual_frames_per_item[i] for i in batch_orig_indices
+                )
+                if batch_max_frames > self.max_frames_per_batch // self.max_batch_size:
+                    # Check if actual frames per item exceeds capture capacity.
+                    # If so, fallback to eager to avoid shape mismatch.
+                    token_budget = None
+                    logger.warning(
+                        "Input video frames exceeds capture capacity, "
+                        "fallback to eagar, please manually set "
+                        "'encoder_cudagraph_max_vision_items_per_batch "
+                        "and 'encoder_cudagraph_max_frames_per_batch' "
+                        "in 'compilation-config'"
+                    )
 
             if token_budget is None:
                 # Single oversized image: item_tokens > max_budget.

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -380,12 +380,13 @@ class EncoderCudaGraphManager:
 
         # extract actual frames per item
         actual_frames_per_item = None
-        if self.max_frames_per_batch > 0:
+        if num_items > 0 and self.max_frames_per_batch > 0:
             grid_thw_key = f"{self.model.get_input_modality(mm_kwargs)}_grid_thw"
-            grid_thw = mm_kwargs[grid_thw_key]
-            if not isinstance(grid_thw, list):
-                grid_thw = grid_thw.tolist()
-            actual_frames_per_item = [t for t, h, w in grid_thw]
+            grid_thw = mm_kwargs.get(grid_thw_key)
+            if grid_thw is not None:
+                if not isinstance(grid_thw, list):
+                    grid_thw = grid_thw.tolist()
+                actual_frames_per_item = [t for t, h, w in grid_thw]
 
         # outputs_by_orig_idx maps each original image index to its output
         # tensor. Needed because greedy packing reorders images; we restore

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -337,6 +337,36 @@ class EncoderCudaGraphManager:
 
         per_item_out_tokens = self._get_per_item_out_tokens(mm_kwargs)
 
+        # Check if actual frames per item exceeds capture capacity.
+        # If so, fallback to eager to avoid shape mismatch.
+        if self.max_frames_per_batch > 0:
+            grid_thw_key = f"{self.model.get_input_modality(mm_kwargs)}_grid_thw"
+            grid_thw = mm_kwargs[grid_thw_key]
+            if not isinstance(grid_thw, list):
+                grid_thw = grid_thw.tolist()
+
+            max_replay_frames = max(t for t, h, w in grid_thw)
+            frames_per_item = self.max_frames_per_batch // self.max_batch_size
+            if max_replay_frames > frames_per_item:
+                logger.warning(
+                    "Input video frames exceeds capture capacity, fallback to eagar,"
+                    "please manually set "
+                    "'encoder_cudagraph_max_vision_items_per_batch "
+                    "and 'encoder_cudagraph_max_frames_per_batch' "
+                    "in 'compilation-config'"
+                )
+                self.graph_misses += num_items
+                eager_outputs: dict[int, torch.Tensor] = {}
+                with torch.inference_mode():
+                    raw = self.model.encoder_eager_forward(mm_kwargs)
+                scatter_output_slices(
+                    raw,
+                    list(range(num_items)),
+                    per_item_out_tokens,
+                    eager_outputs,
+                )
+                return [eager_outputs[i] for i in range(num_items)]
+
         # Sort ascending by output token count (smallest first)
         sorted_indices = sorted(range(num_items), key=lambda i: per_item_out_tokens[i])
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
In `prepare_encoder_cudagraph_capture_inputs`, the CUDA graph's `T` dimension is set to `frames_per_item = max_frames_per_batch // max_batch_size`. When the actual input video has more frames than this pre-allocated `T`, replaying the graph causes a shape mismatch:
```(EngineCore pid=26802) ERROR 05-22 04:47:15 [v1/engine/core.py:1161] RuntimeError: The size of tensor a (3) must match the size of tensor b (9) at non-singleton dimension 0```

## Reproduction
In `examples/generate/multimodal/vision_language_offline.py`, the `run_qwen3_vl` with EngineArgs  
```
mm_processor_kwargs={
      "min_pixels": 28 * 28,
      "max_pixels": 1280 * 28 * 28,
      "fps": 1,
  },
```
If I remove this config and run
`python examples/generate/multimodal/vision_language_offline.py -m qwen3_vl --enable_vit_cuda_graph --modality video` 

```
Error
(EngineCore pid=26802) ERROR 05-22 04:47:15 [v1/engine/core.py:1161] RuntimeError: The size of tensor a (3) must match the size of tensor b (9) at non-singleton dimension 0
Config
EncoderCudaGraphManager initialized with budgets=[64, 128, 256, 512, 1024, 2048, 4096], max_batch_size=1, max_frames_per_batch=2, use_dp=False
```

## Solution
The auto-infer parameters are diverse and uncontrollable. So we need to make it safe. 

- Add a per-batch check in _execute_local: before dispatching a batch, if any item's frame count exceeds frames_per_item, fall back to eager execution for that batch only. Other batches that satisfy the constraint still benefit from CUDA graph acceleration.
- Issue warning when the fallback happens, advising users to set
```
encoder_cudagraph_max_vision_items_per_batch 
encoder_cudagraph_max_frames_per_batch 
```
to avoid repeated eager fallbacks.

## Test Plan
`python examples/generate/multimodal/vision_language_offline.py -m qwen3_vl_vit_cg_fallback --enable_vit_cuda_graph --modality video`
## Test Result
Test passed and prompted the user to manually set parameters

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
