### PR TITLE
[WIP][CI][ROCm] Isolate test_sleep_mode in its own subprocess

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_sleep.py
+++ b/tests/entrypoints/serve/instrumentator/test_sleep.py
@@ -4,11 +4,12 @@
 import requests
 from prometheus_client.parser import text_string_to_metric_families
 
-from tests.utils import RemoteOpenAIServer
+from tests.utils import RemoteOpenAIServer, create_new_process_for_each_test
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B"
 
 
+@create_new_process_for_each_test()
 def test_sleep_mode():
     # dtype, max-len etc set so that this can run in CI
     args = [


### PR DESCRIPTION
## Purpose

[`test_sleep_mode` on MI300/MI355](https://buildkite.com/vllm/ci/builds/67626/canvas?sid=019e4e47-0a4b-4e9d-a2ec-48422f350b1e&tab=output) fails with `cuMemAddressReserve` HIP OOM on its first cumem allocation because the pytest parent has accumulated HIP/KFD state from ~34 prior `RemoteOpenAIServer` subprocesses in the same session. Wrap the test with `create_new_process_for_each_test()` so it runs in a fresh spawned interpreter, matching the pattern at `tests/distributed/test_context_parallel.py:265`.

## Test Plan

## Test Result