### PR TITLE
[CI] Fix recurring NCCL workspace leak on subprocess engine shutdown

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1076,6 +1076,16 @@ class GroupCoordinator:
 
     def destroy(self):
         if hasattr(self, "device_group"):
+            # NCCL/RCCL: abort any in-flight collective so the destroy below
+            # doesn't block, otherwise the outer shutdown timeout SIGKILLs
+            # the worker mid-cleanup. destroy_process_group() handles the
+            # graceful pg.shutdown() itself.
+            try:
+                backend = self.device_group._get_backend(self.device)
+                if hasattr(backend, "abort"):
+                    backend.abort()
+            except Exception as e:
+                logger.warning_once("Backend abort failed during destroy: %s", str(e))
             torch.distributed.destroy_process_group(self.device_group)
             del self.device_group
         if hasattr(self, "cpu_group"):

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -43,6 +43,15 @@ logger = init_logger(__name__)
 
 T = TypeVar("T")
 
+# Floor on the wall-clock budget shutdown() waits for child procs to exit
+# before falling back to SIGKILL. MultiprocExecutor's inner
+# _ensure_worker_termination takes up to 4s graceful + 4s post-SIGTERM = 8s
+# (with NCCL destroy_process_group running inside that window), followed
+# by MQ / zmq / asyncio teardown in BackgroundResources. 20s leaves headroom
+# for variance under load; below that we SIGKILL the engine mid-cleanup
+# and leak the NCCL workspace.
+_PROC_SHUTDOWN_GRACE_S = 20.0
+
 
 class ConstantList(Generic[T], Sequence):
     def __init__(self, x: list[T]) -> None:
@@ -475,9 +484,7 @@ def shutdown(procs: list[BaseProcess], timeout: float | None = None) -> None:
     """
     if timeout is None:
         timeout = 0.0
-
-    # Allow at least 5 seconds for remaining procs to terminate.
-    timeout = max(timeout, 5.0)
+    timeout = max(timeout, _PROC_SHUTDOWN_GRACE_S)
 
     # Shutdown the process.
     for proc in procs:


### PR DESCRIPTION
## Purpose

Several CI shards intermittently fail with the next test seeing only ~10/22 GiB free per GPU. The previous test's stderr shows `WorkerProc was terminated` + `destroy_process_group() was not called before program exit`, then the next test OOMs at worker init.

Two timing bugs:

1. `vllm/v1/utils.py:shutdown(procs)` only waits 5s after SIGTERM before `kill_process_tree(pid)`. EngineCore's own `_ensure_worker_termination` has its own 4s+4s budget plus NCCL `destroy_process_group()`; with TP+EP+DP this routinely tips past 5s and the client SIGKILLs the engine mid-cleanup, leaking the NCCL workspace into the next test.
2. `destroy_process_group()` blocks on in-flight NCCL collectives unless we call `backend.abort()` first.

Fix:
- `GroupCoordinator.destroy()`: call `backend.abort()` (best-effort) before `torch.distributed.destroy_process_group()`. `destroy_process_group` already handles the graceful `pg.shutdown()` itself.
- `vllm/v1/utils.py`: hoist the client-side shutdown floor into `_PROC_SHUTDOWN_GRACE_S` and raise it 5s -> 20s.

Two CI shards directly exhibit the SIGKILL-mid-cleanup pattern (workers logged `WorkerProc was terminated` or PyTorch's `destroy_process_group() was not called` warning, followed by OOM in the next test):

- [#67626 LoRA TP (Distributed)](https://buildkite.com/vllm/ci/builds/67626/canvas?sid=019e4e47-0a7a-4cd0-b8f3-e83489e26539&tab=output) — gpt-oss-20b TP=2 + LoRA + EP, `[True-True]` worker SIGTERM'd, next test sees 10.17/22.05 GiB free
- [#67615 Model Executor](https://buildkite.com/vllm/ci/builds/67615/canvas?sid=019e4e29-bcd5-40ce-83b3-c916c06c938c&tab=output) — 63 passing tests accumulate 23 `destroy_process_group() was not called` warnings, eventually only 0.83/22.05 GiB free

90 of 189 recently archived CI logs contain the `destroy_process_group() was not called` warning, indicating the cleanup miss is widespread; the OOMs above are the visible tip.

`LoRA TP (Distributed)` retriggered on this branch 4 times and passed every run: [#67686](https://buildkite.com/vllm/ci/builds/67686) / [#67700](https://buildkite.com/vllm/ci/builds/67700) / [#67704](https://buildkite.com/vllm/ci/builds/67704) / [#67710](https://buildkite.com/vllm/ci/builds/67710).

## Test Plan

## Test Result