### PR TITLE
[Bugfix][Frontend] Fix input_audio parsing when uuid is present 

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1517,7 +1517,7 @@ def _parse_chat_message_content_mm_part(
                 audio_url = audio_url.get("url", None)
             return "audio_url", audio_url
         if part.get("input_audio") is not None:
-            input_audio_params = cast(dict[str, str], part)
+            input_audio_params = _InputAudioParser(part).get("input_audio", None)
             return "input_audio", input_audio_params
         if "video_url" in part:
             video_params = cast(CustomChatCompletionContentSimpleVideoParam, part)


### PR DESCRIPTION



## Purpose
Fixes #43415.

Fix `input_audio` chat content parsing when the content part carries a `uuid`.

The compatibility parsing path currently passes the whole content part to `parse_input_audio()`. When `uuid` is present, the full part contains `input_audio` as a nested object, so the downstream parser cannot read `data` and `format` from the top level.

This PR makes the `uuid` path return `part["input_audio"]`, matching the existing non-uuid path.

## Test Plan
- Verify `input_audio + uuid` request no longer reaches the unreachable `None`
  audio parsing path.
- Verify regular `input_audio` without `uuid` is unchanged.
- Verify unrelated multimodal paths, such as `video_url`, are unchanged.
- 
## Test Result
Before the fix, `input_audio + uuid` returned HTTP 500:

```text
AssertionError: Expected code to be unreachable, but got: None
```

After the fix, the same request no longer triggers the parser assertion and
continues into the normal audio loading path.