### PR TITLE
Fix OLMo3 sliding attention RoPE parameters

### DIFF
--- a/tests/models/test_olmo2.py
+++ b/tests/models/test_olmo2.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from transformers import Olmo2Config, Olmo3Config
+
+from vllm.model_executor.models.olmo2 import _get_rope_parameters
+
+
+def test_olmo2_sliding_attention_uses_default_rope() -> None:
+    config = Olmo2Config(
+        rope_parameters={
+            "rope_type": "yarn",
+            "rope_theta": 500000,
+            "factor": 8.0,
+        },
+    )
+
+    assert _get_rope_parameters(config, sliding_window=4096) == {
+        "rope_type": "default",
+        "rope_theta": 500000,
+    }
+
+
+def test_olmo3_sliding_attention_preserves_configured_rope() -> None:
+    rope_parameters = {
+        "rope_type": "yarn",
+        "rope_theta": 500000,
+        "factor": 8.0,
+        "attention_factor": 1.2079,
+    }
+    config = Olmo3Config(rope_parameters=rope_parameters)
+
+    actual = _get_rope_parameters(config, sliding_window=4096)
+
+    assert actual == config.rope_parameters
+    assert actual["rope_type"] == "yarn"
+    assert actual["factor"] == 8.0
+    assert actual["attention_factor"] == 1.2079

--- a/vllm/model_executor/models/olmo2.py
+++ b/vllm/model_executor/models/olmo2.py
@@ -27,6 +27,7 @@
 from collections.abc import Iterable
 from functools import partial
 from itertools import islice
+from typing import Any
 
 import torch
 from torch import nn
@@ -63,6 +64,19 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.sequence import IntermediateTensors
+
+
+def _get_rope_parameters(
+    config: Olmo2Config | Olmo3Config,
+    sliding_window: int | None,
+) -> dict[str, Any]:
+    if sliding_window is None or isinstance(config, Olmo3Config):
+        return config.rope_parameters
+
+    return {
+        "rope_type": "default",
+        "rope_theta": config.rope_parameters["rope_theta"],
+    }
 
 
 class Olmo2Attention(nn.Module):
@@ -137,12 +151,9 @@ class Olmo2Attention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
-        # Rotary embeddings. Rope scaling is only applied on full attention layers.
-        if sliding_window is None:
-            rope_parameters = self.config.rope_parameters
-        else:
-            rope_theta = self.config.rope_parameters["rope_theta"]
-            rope_parameters = {"rope_type": "default", "rope_theta": rope_theta}
+        # OLMo2 applies RoPE scaling only on full attention layers; OLMo3 uses
+        # its configured RoPE parameters for both full and sliding layers.
+        rope_parameters = _get_rope_parameters(self.config, sliding_window)
         self.rotary_emb = get_rope(
             self.head_dim,
             max_position=self.max_position_embeddings,


### PR DESCRIPTION
Summary:
- preserve configured OLMo3 RoPE parameters for sliding-attention layers
- keep existing OLMo2 behavior where sliding layers use default RoPE
- add unit coverage for the OLMo2/OLMo3 split

Why:
- OLMo3 configs use YaRN RoPE parameters for both full and sliding attention layers; the attention mask/window controls the local attention behavior
- the previous OLMo2-shared path replaced sliding-layer RoPE with default RoPE, causing vLLM logprobs to diverge from Transformers/PrimeRL for identical OLMo3 weights and tokens

Validation:
- `python3 -m py_compile vllm/model_executor/models/olmo2.py tests/models/test_olmo2.py`
- external long-sequence check in PrimeRL with vLLM TP=4, no eager execution: patched fp16 vLLM-vs-HF mean_abs logprob error dropped from 0.003227 to 0.000054 over 15,360 completion tokens

Note:
- I could not run the full vLLM pytest locally from the sparse checkout because importing source vLLM requires the compiled `vllm._C` extension; draft PR for CI + maintainer review.