### PR TITLE
[V1][Bugfix] structured_output × spec-decode: pre-commit grammar filter for boundary-step bonus tokens

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1805,6 +1805,32 @@ class Scheduler(SchedulerInterface):
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
 
+            # Pre-commit grammar filter: when spec-decode × reasoning
+            # produces post-boundary bonus tokens that the verifier
+            # sampled WITHOUT the grammar mask engaged (the mask is
+            # gated on reasoning_ended, which is False until the
+            # boundary is observed — i.e. until *after* this step's
+            # tokens are sampled), drop the rejected trailing tokens
+            # before they are committed and fed to accept_tokens below.
+            # Mirrors the verifier-rejected-spec-token bookkeeping
+            # above: we decrement num_computed_tokens /
+            # num_output_placeholders by the rejection count, so the
+            # next step re-runs from the truncated position with the
+            # mask now correctly engaged. Stale outputs are skipped for
+            # the same reason as above: a stale rejection count
+            # predates the preemption rollback and must not apply.
+            if new_token_ids and not output_is_stale:
+                new_token_ids, num_grammar_rejected = (
+                    self.structured_output_manager.precommit_filter_tokens(
+                        request, new_token_ids
+                    )
+                )
+                if num_grammar_rejected > 0:
+                    if request.num_computed_tokens > 0:
+                        request.num_computed_tokens -= num_grammar_rejected
+                    if request.num_output_placeholders > 0:
+                        request.num_output_placeholders -= num_grammar_rejected
+
             # Check for stop and update request status.
             if new_token_ids:
                 new_token_ids, stopped = self._update_request_with_output(

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -485,6 +485,121 @@ class StructuredOutputManager:
             return new_token_ids
         return new_token_ids[num_reasoning:]
 
+    def _find_reasoning_end_in_tokens(
+        self,
+        reasoner: "ReasoningParser",
+        token_ids: list[int],
+        prior_token_ids: list[int],
+    ) -> int | None:
+        """Return the index in ``token_ids`` at which the reasoning-end
+        marker completes, or ``None`` if it does not complete inside this
+        batch.
+
+        Scans progressively longer prefixes via the reasoner's
+        ``is_reasoning_end_streaming`` so that multi-token markers
+        (e.g. gpt-oss's ``<|channel|>final<|message|>``) which can
+        straddle the prior-context / current-batch line are still
+        detected. ``prior_token_ids`` are tokens already committed to
+        the request (passed by the caller from ``request.all_token_ids``).
+
+        Unlike :meth:`_find_reasoning_end_index`, which conservatively
+        falls back to the final index, this returns ``None`` when the
+        marker does not complete in the batch — the pre-commit filter
+        must only act when the boundary is unambiguously inside
+        ``token_ids``.
+        """
+        # Mutate a single growing buffer instead of rebuilding the prefix
+        # list each iteration: avoids O(L * N) allocation for long prior
+        # contexts and large speculative batches.
+        buf = list(prior_token_ids)
+        for i, token in enumerate(token_ids):
+            buf.append(token)
+            if reasoner.is_reasoning_end_streaming(buf, [token]):
+                return i
+        return None
+
+    def precommit_filter_tokens(
+        self,
+        request: "Request",
+        new_token_ids: list[int],
+    ) -> tuple[list[int], int]:
+        """Pre-commit grammar filter for the reasoning-end boundary step.
+
+        When reasoning ends mid-batch (i.e. the boundary marker
+        completes inside ``new_token_ids``), the verifier may have
+        sampled bonus tokens for positions past the boundary *without*
+        the grammar mask engaged: the mask is gated on
+        ``reasoning_ended`` (see :meth:`should_fill_bitmask`), and that
+        flag is only flipped to ``True`` after the boundary has been
+        observed — i.e. after this step's tokens were sampled.
+
+        Without this filter, those grammar-invalid post-boundary bonus
+        tokens are committed to the request and then fed to
+        ``accept_tokens`` by the ``should_advance`` →
+        :meth:`trim_reasoning_for_advance` path in
+        ``Scheduler.update_from_output``, which terminates the request
+        with ``FINISHED_ERROR`` — a spec-decode-only failure mode that
+        grows with the speculative batch size and shows up most
+        prominently on reasoning models whose reasoning-end marker
+        spans multiple tokens (gpt-oss with the Harmony
+        ``openai_gptoss`` parser).
+
+        Mechanism: dry-run grammar validation
+        (:meth:`StructuredOutputGrammar.validate_tokens` — stateless,
+        never advances the matcher) on the post-boundary slice, and
+        report the count of rejected trailing tokens. The caller
+        truncates ``new_token_ids`` and adjusts
+        ``num_computed_tokens`` / ``num_output_placeholders`` by the
+        rejected count (mirroring the existing verifier-rejected
+        spec-token bookkeeping), so the next step re-samples from the
+        boundary with the mask correctly engaged. The surviving tokens
+        are accepted into the matcher afterwards by the existing
+        post-commit advance path; this method never advances it.
+
+        Returns ``(filtered_new_token_ids, num_rejected)``. When no
+        truncation is needed (no spec decode, no boundary in batch, or
+        all post-boundary tokens are grammar-valid), the original list
+        and ``0`` are returned.
+        """
+        if self.vllm_config.speculative_config is None:
+            # Without spec decode there is at most one sampled token per
+            # step, so there are never post-boundary bonus tokens.
+            return new_token_ids, 0
+        if not request.use_structured_output:
+            return new_token_ids, 0
+        reasoner = self._get_reasoner(request)
+        if reasoner is None or self.enable_in_reasoning:
+            return new_token_ids, 0
+        structured_req = request.structured_output_request
+        if structured_req is None or structured_req.grammar is None:
+            return new_token_ids, 0
+        # Only act on the boundary step. Once reasoning has ended in a
+        # prior step the mask was correctly applied at sample time, and
+        # the post-commit accept path already handles validation.
+        if structured_req.reasoning_ended:
+            return new_token_ids, 0
+
+        # Pre-commit: request.all_token_ids does NOT yet include
+        # new_token_ids (we run before _update_request_with_output), so
+        # all_token_ids IS the prior context.
+        prior_token_ids = list(request.all_token_ids or [])
+        split_idx = self._find_reasoning_end_in_tokens(
+            reasoner, new_token_ids, prior_token_ids
+        )
+        if split_idx is None:
+            return new_token_ids, 0
+
+        post_boundary = new_token_ids[split_idx + 1 :]
+        if not post_boundary:
+            return new_token_ids, 0
+
+        grammar = structured_req.grammar
+        validated = grammar.validate_tokens(post_boundary)
+        num_rejected = len(post_boundary) - len(validated)
+        if num_rejected == 0:
+            return new_token_ids, 0
+        return new_token_ids[: split_idx + 1] + list(validated), num_rejected
+
     def clear_backend(self) -> None:
         if self.backend is not None:
             self.backend.destroy()


### PR DESCRIPTION
## Summary

In speculative decoding with a reasoning parser + structured output, post-boundary bonus tokens leak into the response stream as garbage prefixes before the valid JSON (e.g. `chunk_0{"...": ...}`, `**{"...": ...}`). This PR adds a pre-commit grammar filter so those tokens never enter request output.

Generalizes the fix direction in #36138 (single-token boundary, post-commit `accept_tokens`) to:
- **multi-token reasoning markers** (e.g. gpt-oss's Harmony `<|channel|>final<|message|>`, which is 3 tokens after tokenization and almost never lands fully inside a 2-5 token speculative batch); and
- **the post-commit-vs-output-stream ordering** — the existing `should_advance` deferral correctly suppresses the post-commit `accept_tokens` call on the boundary step (avoiding spurious `FINISHED_ERROR`), but the bonus tokens are already in `_output_token_ids` by then.

Credit to @sfbemerk for the original analysis in #36138; this lands the same fix idea via a pre-commit path so it composes with the existing `should_advance` deferral instead of replacing it. Closes #43338.

## Root cause

The grammar bitmask is gated on `reasoning_ended` (see `StructuredOutputManager.should_fill_bitmask`). The boundary step's bonus tokens are sampled **without** the mask engaged — `reasoning_ended` is `False` at sample time and only flips `True` after the boundary is observed (i.e. after this step's tokens are sampled). So the bonus token at the post-boundary position can be any free-text continuation the verifier's logits prefer (`chunk`, `**`, `(no`, etc.).

The existing `should_advance` deferral logic (lines 348-368 on `main`) correctly handles the matcher state — it defers FSM advance to the next step so the matcher doesn't try to accept the boundary-step's pre-boundary reasoning tokens. But it does nothing about the post-boundary bonus tokens that are already in the response stream.

## Mechanism

`precommit_filter_tokens(request, new_token_ids) -> (filtered_new_token_ids, num_rejected)`:

1. Returns early unless the request uses structured output, has a reasoner, and `reasoning_ended` is still `False` (this only fires on the boundary step).
2. Calls `_find_reasoning_end_in_tokens(new_token_ids, prior_token_ids=request.all_token_ids)` to locate the boundary index. The detector uses `reasoner.is_reasoning_end_streaming` with progressively longer cumulative prefixes, so multi-token markers spanning the prior-context / batch line are detected (same approach as `should_advance`).
3. If a boundary is found, splits `new_token_ids` into `(pre_boundary, post_boundary)` and dry-runs `grammar.validate_tokens(post_boundary)` (the matcher state is unchanged on return; only the accepted prefix is reported).
4. Calls `grammar.accept_tokens(req_id, validated)` on the validated prefix so the matcher reflects the committed JSON head when the next step runs.
5. Returns `(pre_boundary + validated, len(post_boundary) - len(validated))`.

Scheduler wiring (24-line insert before `_update_request_with_output`):

```python
if new_token_ids:
    new_token_ids, num_grammar_rejected = (
        self.structured_output_manager.precommit_filter_tokens(
            request, new_token_ids
        )
    )
    if num_grammar_rejected > 0:
        if request.num_computed_tokens > 0:
            request.num_computed_tokens -= num_grammar_rejected
        if request.num_output_placeholders > 0:
            request.num_output_placeholders -= num_grammar_rejected
```

The `num_computed_tokens` / `num_output_placeholders` decrement mirrors the existing verifier-rejected-spec-token bookkeeping in `Scheduler.update_from_output` (lines 1361-1373), so the next step re-runs from the truncated position with the grammar mask now correctly engaged.

## Test results

Reproducer: gpt-oss-120b on 2× H100 with `--reasoning-parser openai_gptoss` + `--speculative-config '{"method":"eagle3", "num_speculative_tokens":3, ...}'` + `response_format: {"type":"json_schema","strict":true,...}`. 300 real production prompts.

| Variant | clean | prefix_bled | malformed | HTTP 500 |
|---|---:|---:|---:|---:|
| vLLM `main` HEAD (this PR's base, unpatched) | 64 (21%) | 163 (54%) | 73 (24%) | 0 |
| vLLM 0.20.1 (pre-PR baseline) | ~140 (47%) | ~156 (52%) | — | 0 |
| #36138 HEAD (sfbemerk fork) | 184 (61%) | 0 | 0 | **116 (38%)** |
| **This PR** | **285 (95%)** | **0** | 15 | **0** |

This PR is running in our production cluster on top of `v0.21.0` for ~3 hours, ~5K live requests, no regressions observed. The 15 malformed in the 300-trace shadow are not bleed — they're long responses hitting `max_tokens=2000` mid-JSON (unchanged from baseline).

The `#36138` row above shows the post-commit `accept_tokens` path: when the matcher rejects the boundary-step's free-text bonus tokens, it sets `FINISHED_ERROR` → HTTP 500. By moving validation pre-commit and truncating instead of failing, this PR avoids both the 500s and the bleeds.

## Scope of change

`vllm/v1/structured_output/__init__.py`: +120 lines (two new methods, additive).
`vllm/v1/core/sched/scheduler.py`: +24 lines (one block inserted before `_update_request_with_output`).
Total: +144 lines, 0 deletions. No existing API changed. No behavior change when `speculative_config is None` (the boundary detector returns `None`, the filter returns inputs unchanged).

## Notes for review

- Same-step `accept_tokens` in `precommit_filter_tokens` and the existing post-commit `accept_tokens` in `update_from_output` are mutually exclusive: pre-commit fires only when `reasoning_ended` is still `False` and a boundary is found in-batch; post-commit fires (via `should_advance`) only when `reasoning_ended` is already `True`. No double-advance.
- The `should_advance` deferral (`Defer FSM advance until the next pass`, lines 356-365) is preserved and still correct: pre-commit handles the boundary step's post-boundary slice; deferred post-commit handles all subsequent steps with the mask engaged.
- Happy to add a unit test exercising the boundary-mid-batch + grammar-rejection path against a `MockReasoner` + `MockGrammar` if the maintainers prefer that before merge.

## Test plan
- [ ] CI passes
- [ ] Unit test added (will follow if reviewers want one — let me know)
- [ ] Re-test against `main` post-merge to confirm
