### PR TITLE
[Bugfix] Fix hash topk dtype mismatch

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2444,6 +2444,13 @@ def topk_hash_softplus_sqrt(
     input_tokens: torch.Tensor | None = None,
     hash_indices_table: torch.Tensor | None = None,
 ) -> None:
+    if hash_indices_table is not None:
+        assert input_tokens is not None
+        if input_tokens.dtype != topk_indices.dtype:
+            input_tokens = input_tokens.to(dtype=topk_indices.dtype)
+        if hash_indices_table.dtype != topk_indices.dtype:
+            hash_indices_table = hash_indices_table.to(dtype=topk_indices.dtype)
+
     torch.ops._moe_C.topk_softplus_sqrt(
         topk_weights,
         topk_indices,


### PR DESCRIPTION
## Purpose

This PR fixes a dtype mismatch in the DeepSeek V4 hash MoE sqrt-softplus top-k path.

We observed this issue on H20 servers using PD disaggregation and DeepEP during DeepSeek V4 Flash startup:

```text
expected scalar type Long but found Int
```

The issue happens because DeepEP's prepare/finalize path can request `topk_indices` with `torch.int64`, while DeepSeek V4 non-MegaMoE hash routing metadata (`input_tokens` and `hash_indices_table`) can remain `torch.int32`.

The CUDA op dispatch currently chooses the pointer type for hash metadata from `topk_indices.scalar_type()`. As a result, when `topk_indices` is int64 but the hash metadata is int32, the op may try to read int32 tensors as int64 before kernel launch.

This PR aligns only the hash metadata tensors (`input_tokens` and `hash_indices_table`) to `topk_indices.dtype` before invoking `_moe_C.topk_softplus_sqrt`.

`token_expert_indices` is intentionally unchanged because the CUDA op reads it as `int*`.

This may also fix the same dtype mismatch reported in https://github.com/vllm-project/vllm/issues/40862.

## Test

Verified on Volcengine servers with:
- vLLM: 0.21.0
- Model: DeepSeek V4 Flash
- Hardware: 8x H20
- Deployment mode: PD disaggregation
- Expert parallel: enabled
- DeepEP: enabled
  - Prefill backend: `deepep_high_throughput`
  - Decode backend: `deepep_low_latency`

After applying this fix:

- The previous `expected scalar type Long but found Int` error is no longer reproduced.
- The service can start successfully and run inference normally.