### PR TITLE
[Frontend] Simplify AuthenticationMiddleware path extraction

### DIFF
--- a/vllm/entrypoints/openai/server_utils.py
+++ b/vllm/entrypoints/openai/server_utils.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.concurrency import iterate_in_threadpool
-from starlette.datastructures import URL, Headers, MutableHeaders
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from vllm import envs
@@ -80,7 +80,7 @@ class AuthenticationMiddleware:
             # in which case we don't need to do anything
             return self.app(scope, receive, send)
         root_path = scope.get("root_path", "")
-        url_path = URL(scope=scope).path.removeprefix(root_path)
+        url_path = scope["path"].removeprefix(root_path)
         headers = Headers(scope=scope)
         # Type narrow to satisfy mypy.
         if url_path.startswith(GUARDED_PREFIX) and not self.verify_token(headers):


### PR DESCRIPTION
Use scope["path"] directly instead of reconstructing a full URL via
URL(scope=scope).path. The scope path is already available and avoids
an unnecessary round-trip through URL parsing.

Fixes GHSA-94f4-hr76-p5j6

Signed-off-by: Russell Bryant <rbryant@redhat.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
