### PR TITLE
[Bugfix] Detect wrong libcute_dsl_runtime.so variant in FlashInfer GDN

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -82,6 +82,11 @@ if GDN_AITER_TRITON_AVAILABLE:
 logger = init_logger(__name__)
 
 
+# TODO(arpera): remove ``_is_libs_cu13_install_intact`` and its caller in
+# ``_should_use_flashinfer_gdn_prefill`` once the upstream packaging bug is
+# fixed and the broken wheels are yanked / superseded on PyPI:
+#   https://github.com/NVIDIA/cutlass/issues/3170
+#   https://github.com/NVIDIA/cutlass/issues/3259
 @functools.cache
 def _is_libs_cu13_install_intact() -> bool:
     """Return True if every file installed by ``nvidia-cutlass-dsl-libs-cu13``
@@ -97,8 +102,10 @@ def _is_libs_cu13_install_intact() -> bool:
     ``-libs-base`` variant fails MLIR legalization when JIT-compiling
     the FlashInfer Blackwell GDN prefill kernel, and any other
     cuTe-DSL-based kernel can break too if on-disk files diverge from
-    what ``-libs-cu13``'s wheel expects. Tracked upstream at
-    https://github.com/NVIDIA/cutlass/issues/3259.
+    what ``-libs-cu13``'s wheel expects. Tracked upstream at:
+
+      * https://github.com/NVIDIA/cutlass/issues/3170
+      * https://github.com/NVIDIA/cutlass/issues/3259
 
     This helper re-hashes every file the ``-libs-cu13`` wheel claims to
     own and compares against its declared SHA-256. Returns False on any
@@ -170,6 +177,7 @@ def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> 
             "-libs-cu13 install, but some on-disk files do not match the "
             "SHA-256 declared in its RECORD (install-order race in "
             "nvidia-cutlass-dsl packaging — see "
+            "https://github.com/NVIDIA/cutlass/issues/3170 and "
             "https://github.com/NVIDIA/cutlass/issues/3259). Falling back "
             "to Triton/FLA. Repair with: pip install --force-reinstall "
             "--no-deps nvidia-cutlass-dsl-libs-cu13"

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3-Next/Qwen3.5 model."""
 
+import functools
+
 import torch
 from einops import rearrange
 from torch import nn
@@ -80,6 +82,69 @@ if GDN_AITER_TRITON_AVAILABLE:
 logger = init_logger(__name__)
 
 
+@functools.cache
+def _is_cu13_libcute_dsl_runtime() -> bool:
+    """Return True if ``nvidia_cutlass_dsl/lib/libcute_dsl_runtime.so`` on
+    disk matches the SHA-256 declared by the ``nvidia-cutlass-dsl-libs-cu13``
+    wheel's ``RECORD``.
+
+    ``nvidia-cutlass-dsl-libs-base`` and ``nvidia-cutlass-dsl-libs-cu13``
+    both ship that file at the same on-disk path but with different
+    content. Whichever wheel extracts last wins; with parallel installers
+    (e.g. ``uv``) the order is racy and the ``-libs-base`` variant can
+    land, which then fails MLIR legalization when JIT-compiling the
+    FlashInfer Blackwell GDN prefill kernel. See
+    https://github.com/NVIDIA/cutlass/issues/3259.
+
+    Returns False on any error (uninstalled, missing RECORD entry,
+    missing file, hash mismatch); the caller should fall back to the
+    Triton/FLA path.
+    """
+    import base64
+    import csv
+    import hashlib
+    import importlib.metadata
+    import os
+
+    target_rel = "nvidia_cutlass_dsl/lib/libcute_dsl_runtime.so"
+
+    try:
+        record_text = (
+            importlib.metadata.distribution("nvidia-cutlass-dsl-libs-cu13").read_text(
+                "RECORD"
+            )
+            or ""
+        )
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+    expected = ""
+    for row in csv.reader(record_text.splitlines()):
+        if row and row[0] == target_rel and len(row) >= 2:
+            expected = row[1]
+            break
+    if not expected:
+        return False
+
+    try:
+        import nvidia_cutlass_dsl
+    except ImportError:
+        return False
+    so_path = os.path.join(
+        os.path.dirname(nvidia_cutlass_dsl.__file__),
+        "lib",
+        "libcute_dsl_runtime.so",
+    )
+    try:
+        with open(so_path, "rb") as f:
+            digest = hashlib.sha256(f.read()).digest()
+    except OSError:
+        return False
+
+    actual = "sha256=" + base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return actual == expected
+
+
 def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> bool:
     """Whether to use FlashInfer's GDN prefill kernel instead of the
     Triton/FLA fallback.
@@ -89,7 +154,10 @@ def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> 
     * ``platform == cuda``;
     * one of the following:
       - Hopper (SM90) — no further constraints;
-      - Blackwell (SM10.x) with ``head_k_dim == 128`` and ``cuda_runtime >= 13``.
+      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``,
+        and the ``nvidia-cutlass-dsl-libs-cu13`` variant of
+        ``libcute_dsl_runtime.so`` actually on disk (see
+        :func:`_is_cu13_libcute_dsl_runtime`).
     """
     if backend not in ["flashinfer", "auto"]:
         return False
@@ -101,7 +169,19 @@ def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> 
         return False  # Neither Hopper nor Blackwell.
     if head_k_dim != 128:
         return False
-    return current_platform.get_cuda_runtime_major() >= 13
+    if current_platform.get_cuda_runtime_major() < 13:
+        return False
+    if not _is_cu13_libcute_dsl_runtime():
+        logger.warning_once(
+            "FlashInfer Blackwell GDN requires the cu13 variant of "
+            "libcute_dsl_runtime.so, but a different variant is installed "
+            "(install-order race in nvidia-cutlass-dsl packaging — see "
+            "https://github.com/NVIDIA/cutlass/issues/3259). Falling back "
+            "to Triton/FLA. Repair with: pip install --force-reinstall "
+            "--no-deps nvidia-cutlass-dsl-libs-cu13"
+        )
+        return False
+    return True
 
 
 def _log_gdn_backend_decision(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -83,67 +83,60 @@ logger = init_logger(__name__)
 
 
 @functools.cache
-def _is_cu13_libcute_dsl_runtime() -> bool:
-    """Return True if ``nvidia_cutlass_dsl/lib/libcute_dsl_runtime.so`` on
-    disk matches the SHA-256 declared by the ``nvidia-cutlass-dsl-libs-cu13``
-    wheel's ``RECORD``.
+def _is_libs_cu13_install_intact() -> bool:
+    """Return True if every file installed by ``nvidia-cutlass-dsl-libs-cu13``
+    matches the SHA-256 declared in its wheel ``RECORD``.
 
     ``nvidia-cutlass-dsl-libs-base`` and ``nvidia-cutlass-dsl-libs-cu13``
-    both ship that file at the same on-disk path but with different
-    content. Whichever wheel extracts last wins; with parallel installers
-    (e.g. ``uv``) the order is racy and the ``-libs-base`` variant can
-    land, which then fails MLIR legalization when JIT-compiling the
-    FlashInfer Blackwell GDN prefill kernel. See
+    both ship into the shared ``nvidia_cutlass_dsl/`` namespace and
+    write many of the same on-disk paths (the runtime ``.so``, the MLIR
+    Python bindings, cuTe-DSL Python sources, ...) with different
+    content. Whichever wheel extracts last wins; with a parallel
+    installer (e.g. ``uv``) the order is racy and the resulting venv
+    can end up with a mix of files from both variants. The
+    ``-libs-base`` variant fails MLIR legalization when JIT-compiling
+    the FlashInfer Blackwell GDN prefill kernel, and any other
+    cuTe-DSL-based kernel can break too if on-disk files diverge from
+    what ``-libs-cu13``'s wheel expects. Tracked upstream at
     https://github.com/NVIDIA/cutlass/issues/3259.
 
-    Returns False on any error (uninstalled, missing RECORD entry,
-    missing file, hash mismatch); the caller should fall back to the
-    Triton/FLA path.
+    This helper re-hashes every file the ``-libs-cu13`` wheel claims to
+    own and compares against its declared SHA-256. Returns False on any
+    error (uninstalled, missing RECORD, missing file, hash mismatch).
+    Result is cached per-process.
     """
-    import csv
     import hashlib
     import importlib.metadata
-    import os
 
     import pybase64 as base64
 
-    target_rel = "nvidia_cutlass_dsl/lib/libcute_dsl_runtime.so"
-
     try:
-        record_text = (
-            importlib.metadata.distribution("nvidia-cutlass-dsl-libs-cu13").read_text(
-                "RECORD"
-            )
-            or ""
-        )
+        dist = importlib.metadata.distribution("nvidia-cutlass-dsl-libs-cu13")
     except importlib.metadata.PackageNotFoundError:
         return False
 
-    expected = ""
-    for row in csv.reader(record_text.splitlines()):
-        if row and row[0] == target_rel and len(row) >= 2:
-            expected = row[1]
-            break
-    if not expected:
+    files = dist.files
+    if not files:
         return False
 
-    try:
-        import nvidia_cutlass_dsl
-    except ImportError:
-        return False
-    so_path = os.path.join(
-        os.path.dirname(nvidia_cutlass_dsl.__file__),
-        "lib",
-        "libcute_dsl_runtime.so",
-    )
-    try:
-        with open(so_path, "rb") as f:
-            digest = hashlib.sha256(f.read()).digest()
-    except OSError:
-        return False
+    for pkg_path in files:
+        file_hash = pkg_path.hash
+        # Skip RECORD rows without a hash (RECORD itself, generated
+        # ``.pyc`` files, ...) and any non-SHA-256 hash modes.
+        if file_hash is None or not file_hash.value:
+            continue
+        if file_hash.mode != "sha256":
+            continue
+        try:
+            with open(pkg_path.locate(), "rb") as f:
+                digest = hashlib.sha256(f.read()).digest()
+        except OSError:
+            return False
+        actual = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+        if actual != file_hash.value:
+            return False
 
-    actual = "sha256=" + base64.urlsafe_b64encode(digest).decode().rstrip("=")
-    return actual == expected
+    return True
 
 
 def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> bool:
@@ -156,9 +149,8 @@ def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> 
     * one of the following:
       - Hopper (SM90) — no further constraints;
       - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``,
-        and the ``nvidia-cutlass-dsl-libs-cu13`` variant of
-        ``libcute_dsl_runtime.so`` actually on disk (see
-        :func:`_is_cu13_libcute_dsl_runtime`).
+        and an intact ``nvidia-cutlass-dsl-libs-cu13`` install on disk
+        (see :func:`_is_libs_cu13_install_intact`).
     """
     if backend not in ["flashinfer", "auto"]:
         return False
@@ -172,11 +164,12 @@ def _should_use_flashinfer_gdn_prefill(backend: str, head_k_dim: int | None) -> 
         return False
     if current_platform.get_cuda_runtime_major() < 13:
         return False
-    if not _is_cu13_libcute_dsl_runtime():
+    if not _is_libs_cu13_install_intact():
         logger.warning_once(
-            "FlashInfer Blackwell GDN requires the cu13 variant of "
-            "libcute_dsl_runtime.so, but a different variant is installed "
-            "(install-order race in nvidia-cutlass-dsl packaging — see "
+            "FlashInfer Blackwell GDN requires an intact nvidia-cutlass-dsl"
+            "-libs-cu13 install, but some on-disk files do not match the "
+            "SHA-256 declared in its RECORD (install-order race in "
+            "nvidia-cutlass-dsl packaging — see "
             "https://github.com/NVIDIA/cutlass/issues/3259). Falling back "
             "to Triton/FLA. Repair with: pip install --force-reinstall "
             "--no-deps nvidia-cutlass-dsl-libs-cu13"

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -100,11 +100,12 @@ def _is_cu13_libcute_dsl_runtime() -> bool:
     missing file, hash mismatch); the caller should fall back to the
     Triton/FLA path.
     """
-    import base64
     import csv
     import hashlib
     import importlib.metadata
     import os
+
+    import pybase64 as base64
 
     target_rel = "nvidia_cutlass_dsl/lib/libcute_dsl_runtime.so"
 


### PR DESCRIPTION
## Purpose

Detect a packaging conflict in `nvidia-cutlass-dsl[cu13]` that silently breaks FlashInfer's Blackwell GDN prefill kernel — and, by extension, any other cuTe-DSL-based kernel.

`nvidia-cutlass-dsl-libs-base` and `nvidia-cutlass-dsl-libs-cu13` both ship into the shared `nvidia_cutlass_dsl/` namespace and write many of the same on-disk paths (the runtime `.so`, MLIR Python bindings, cuTe-DSL Python sources) with different content. Whichever wheel extracts last wins; with a parallel installer (`uv pip install`) the order is racy, and the resulting venv can end up with a mix of files from both variants. The `-libs-base` variant fails MLIR legalization for `tcgen05.make_tmem_copy` and crashes the server when the FlashInfer Blackwell GDN kernel (#40717) JIT-compiles. The same install command on the same host can produce a working or broken venv depending on extraction order. Affects every `nvidia-cutlass-dsl` 4.5.x release we have looked at. Tracked upstream at [NVIDIA/cutlass#3259](https://github.com/NVIDIA/cutlass/issues/3259).

This PR adds a runtime check in `_should_use_flashinfer_gdn_prefill` that walks every file declared in `nvidia-cutlass-dsl-libs-cu13`'s wheel `RECORD`, re-hashes it on disk, and compares against the SHA-256 the wheel itself declares. The check is version-agnostic — it asks `importlib.metadata` for whatever `-libs-cu13` is installed and reads that wheel's own `RECORD`. On any mismatch we log a `warning_once` with the repair command and fall back to Triton/FLA instead of crashing. Result is cached per-process; returns False on any error (uninstalled, missing RECORD, missing file) so older / non-Blackwell setups are unaffected.

## Test Result

TODO

```
# Server
vllm serve <model> --tensor-parallel-size <TP>
```

| `nvidia-cutlass-dsl-libs-cu13` install state | Before this PR | After this PR |
| --- | --- | --- |
| intact (every on-disk file matches RECORD) | server starts, FI GDN used | server starts, FI GDN used |
| contaminated (one or more files come from `-libs-base`) | server crashes with MLIR ICE in `tcgen05.make_tmem_copy` legalization | warning logged, falls back to Triton/FLA, server starts |

The contaminated state is reproduced by running `pip install --force-reinstall --no-deps nvidia-cutlass-dsl-libs-base` after a normal install (or by losing the `uv` install race). The intact state is restored by `pip install --force-reinstall --no-deps nvidia-cutlass-dsl-libs-cu13`.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
