### PR TITLE
[Model] Add hotwords support for model Qwen3-ASR

### DIFF
--- a/examples/speech_to_text/openai/openai_transcription_client.py
+++ b/examples/speech_to_text/openai/openai_transcription_client.py
@@ -84,7 +84,9 @@ async def stream_openai_response(
     print()  # Final newline after stream ends
 
 
-def stream_api_response(audio_path: str, model: str, openai_api_base: str):
+def stream_api_response(
+    audio_path: str, model: str, openai_api_base: str, hotwords: str = None
+):
     """
     Perform streaming transcription using raw HTTP requests to the vLLM API server.
     """
@@ -103,6 +105,8 @@ def stream_api_response(audio_path: str, model: str, openai_api_base: str):
             "language": "en",
             "response_format": "json",
         }
+        if hotwords is not None:
+            data["hotwords"] = hotwords
 
         print("\ntranscription result [stream]:", end=" ")
         response = requests.post(
@@ -167,6 +171,7 @@ def main(args):
             args.audio_path if args.audio_path else winning_call,
             model,
             openai_api_base,
+            hotwords=args.hotwords,
         )
 
 

--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_validation.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_validation.py
@@ -25,6 +25,7 @@ async def transcribe_and_check(
     file,
     *,
     language: str,
+    extra_body: dict | None = None,
     expected_text: str,
     expected_seconds: int | None = None,
     case_sensitive: bool = False,
@@ -38,6 +39,7 @@ async def transcribe_and_check(
         model=model_name,
         file=file,
         language=language,
+        extra_body=extra_body,
         response_format="text",
         temperature=0.0,
     )
@@ -153,4 +155,29 @@ async def test_basic_audio_foscolo(foscolo, rocm_aiter_fa_attention, model_name)
             foscolo,
             language="it",
             expected_text="ove il mio corpo fanciulletto",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen3-ASR-0.6B"])
+async def test_basic_audio_with_hotwords(
+    mary_had_lamb, model_name, rocm_aiter_fa_attention
+):
+    server_args = ["--enforce-eager", *ROCM_EXTRA_ARGS]
+
+    add_attention_backend(server_args, rocm_aiter_fa_attention)
+
+    # Based on https://github.com/openai/openai-cookbook/blob/main/examples/Whisper_prompting_guide.ipynb.
+    with RemoteOpenAIServer(
+        model_name, server_args, env_dict=ROCM_ENV_OVERRIDES
+    ) as remote_server:
+        client = remote_server.get_async_client()
+        await transcribe_and_check(
+            client,
+            model_name,
+            mary_had_lamb,
+            language="en",
+            extra_body={"hotwords": "lamb sheep"},
+            expected_text="Mary had a little lamb",
+            expected_seconds=16,
         )

--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -555,6 +555,7 @@ class Qwen3ASRForConditionalGeneration(
         model_config = stt_params.model_config
         task_type = stt_params.task_type
         to_language = stt_params.to_language
+        hotwords = stt_params.hotwords
         tokenizer = cached_tokenizer_from_config(model_config)
         audio_placeholder = cls.get_placeholder_str("audio", 0)
 
@@ -563,14 +564,19 @@ class Qwen3ASRForConditionalGeneration(
                 f"Unsupported task_type '{task_type}'. "
                 "Supported task types are 'transcribe' and 'translate'."
             )
+        system_prompt_block = (
+            f"<|im_start|>system\n{hotwords}<|im_end|>\n" if hotwords else ""
+        )
         full_lang_name_to = cls.supported_languages.get(to_language, to_language)
         if to_language is None:
             prompt = (
+                f"{system_prompt_block}"
                 f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n"
                 f"<|im_start|>assistant\n"
             )
         else:
             prompt = (
+                f"{system_prompt_block}"
                 f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n"
                 f"<|im_start|>assistant\nlanguage {full_lang_name_to}{_ASR_TEXT_TAG}"
             )


### PR DESCRIPTION



## Purpose
Add hotwords support for model Qwen3-ASR in Transcriptions API.


1. [support hotwords for FunASR model](https://github.com/vllm-project/vllm/pull/39674) had add the "hotwords" parameter for Transcriptions API (POST /v1/audio/transcriptions), but only model "allendou/Fun-ASR-Nano-2512-vllm" uses that parameter.

2. Qwen3-ASR supports hotwords (see [Qwen3-ASR example](https://github.com/QwenLM/Qwen3-ASR/blob/main/examples/example_qwen3_asr_vllm.py)), by setting the context parameter in line 95 to 100. That makes the system prompt like "hotword1 hotword2 hotword3". But in vLLM it does not support hotwords for model Qwen3-ASR yet.

```
<|im_start|>system
hotword1 hotword2 hotword3<|im_end|>
<|im_start|>user
<|audio_start|><|audio_pad|><|audio_end|><|im_end|>
<|im_start|>assistant
```




## Test Plan

### 1. pytest
`pytest -sv tests/entrypoints/speech_to_text/transcription/test_transcription_validation.py -k "Qwen3-ASR"`

### 2. example and curl
#### 2.1. server
`VLLM_LOGGING_LEVEL=INFO vllm serve Qwen/Qwen3-ASR-0.6B --enable-log-requests`

#### 2.2. example (client) 

examples/speech_to_text/openai/openai_transcription_client.py
```
python3 examples/speech_to_text/openai/openai_transcription_client.py  \
    --audio_path /root/shared-nvme/asset/mary_had_lamb.ogg  \ 
    --hotwords "lamb photograph"
```


#### 2.3. curl
```
curl -X POST "http://localhost:8000/v1/audio/transcriptions" \
      -H "Authorization: Bearer token-abc123" \
      -F "file=@/root/shared-nvme/asset/mary_had_lamb.ogg" \
      -F "model=Qwen/Qwen3-ASR-0.6B" \
      -F "language=en" \
      -F "response_format=json" \
      -F "hotwords=lamb photograph" 
```


## Test Result
### 1. pytest
```
=============================================================================== warnings summary ===============================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../.conda/envs/vllm/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /root/.conda/envs/vllm/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/entrypoints/speech_to_text/transcription/test_transcription_validation.py::test_basic_audio[Qwen/Qwen3-ASR-0.6B]
tests/entrypoints/speech_to_text/transcription/test_transcription_validation.py::test_basic_audio_foscolo[Qwen/Qwen3-ASR-0.6B]
tests/entrypoints/speech_to_text/transcription/test_transcription_validation.py::test_basic_audio_with_hotwords[Qwen/Qwen3-ASR-0.6B]
  /root/.conda/envs/vllm/lib/python3.12/site-packages/transformers/modeling_rope_utils.py:1034: FutureWarning: `rope_config_validation` is deprecated and has been removed. Its functionality has been moved to RotaryEmbeddingConfigMixin.validate_rope method. PreTrainedConfig inherits this class, so please call self.validate_rope() instead. Also, make sure to use the new rope_parameters syntax. You can call self.standardize_rope_params() in the meantime.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 3 passed, 3 deselected, 19 warnings in 311.03s (0:05:11) ===========================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

### 2. example and curl
####  2.2. example (client) 
examples/speech_to_text/openai/openai_transcription_client.py 
```
Using model: Qwen/Qwen3-ASR-0.6B
transcription result [sync]: The first words I spoke in the original photographs—a little piece of practical poetry: "Mary had a little lamb; it slept quite as slow, and everywhere that Mary went—the Lamb was sure to go."

transcription result [stream]: language English<asr_text>The first words I spoke in the original photograph: a little piece of practical poetry. Mary had a little lamb; it slept quite as slow, and everywhere that Mary went, the lamb was sure to go.
[Stream finished reason: stop]
```

####  2.3. curl
`{"text":"The first words I spoke in the original photograph: a little piece of practical poetry. Mary had a little lamb; it slept quite as slow, and everywhere that Mary went, the lamb was sure to go.","usage":{"type":"duration","seconds":16}}`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

