### PR TITLE
[Bugfix][Async][SpecDecode] Fix async MTP placeholder draft token handling

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -301,6 +301,97 @@ def test_sample_tokens_skips_pp_group_lookup_without_async_scheduling(
     assert GPUModelRunner.sample_tokens(runner, None) is None
 
 
+class _FakeCpuGpuBuffer:
+    def __init__(self, cpu: torch.Tensor):
+        self.cpu = cpu
+        self.gpu = torch.full_like(cpu, -99)
+        self.copy_count = 0
+
+    def copy_to_gpu(self, num_tokens: int) -> None:
+        self.copy_count += 1
+        self.gpu[:num_tokens].copy_(self.cpu[:num_tokens])
+
+
+def _make_async_spec_prepare_runner(
+    prev_draft_token_ids: torch.Tensor | None,
+) -> GPUModelRunner:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.input_batch = SimpleNamespace(
+        prev_sampled_token_ids=torch.tensor([[101]], dtype=torch.int32),
+        prev_draft_token_ids=prev_draft_token_ids,
+        req_ids=["req-1"],
+    )
+    runner.prev_positions = SimpleNamespace(np=np.array([0], dtype=np.int32))
+    runner.input_ids = _FakeCpuGpuBuffer(
+        torch.tensor([0, -1, -1, -1, -1], dtype=torch.int32)
+    )
+    runner.enable_prompt_embeds = False
+    runner.use_async_spec_decode = True
+    runner.pin_memory = False
+    runner.device = torch.device("cpu")
+    runner.num_spec_tokens = 4
+    runner._draft_token_ids = None
+    return runner
+
+
+def test_prepare_input_ids_replaces_async_spec_placeholders():
+    runner = _make_async_spec_prepare_runner(
+        torch.tensor([[201, 202, 203, 204]], dtype=torch.int64)
+    )
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={"req-1": [-1, -1, -1, -1]}
+    )
+
+    GPUModelRunner._prepare_input_ids(
+        runner,
+        scheduler_output,
+        num_reqs=1,
+        total_num_scheduled_tokens=5,
+        cu_num_tokens=np.array([5], dtype=np.int32),
+    )
+
+    assert runner.input_ids.copy_count == 0
+    torch.testing.assert_close(
+        runner.input_ids.gpu[:5],
+        torch.tensor([101, 201, 202, 203, 204], dtype=torch.int32),
+    )
+
+
+def test_prepare_input_ids_rejects_async_spec_placeholders_without_sample_cache():
+    runner = _make_async_spec_prepare_runner(
+        torch.tensor([[201, 202, 203, 204]], dtype=torch.int64)
+    )
+    runner.input_batch.prev_sampled_token_ids = None
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={"req-1": [-1, -1, -1, -1]}
+    )
+
+    with pytest.raises(RuntimeError, match="no cached sampled token IDs"):
+        GPUModelRunner._prepare_input_ids(
+            runner,
+            scheduler_output,
+            num_reqs=1,
+            total_num_scheduled_tokens=5,
+            cu_num_tokens=np.array([5], dtype=np.int32),
+        )
+
+
+def test_prepare_input_ids_rejects_async_spec_placeholders_without_draft_cache():
+    runner = _make_async_spec_prepare_runner(None)
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={"req-1": [-1, -1, -1, -1]}
+    )
+
+    with pytest.raises(RuntimeError, match="no cached draft token IDs"):
+        GPUModelRunner._prepare_input_ids(
+            runner,
+            scheduler_output,
+            num_reqs=1,
+            total_num_scheduled_tokens=5,
+            cu_num_tokens=np.array([5], dtype=np.int32),
+        )
+
+
 def test_select_common_block_size_no_valid_option():
     backend_a = _make_mock_backend_for_kernel_block_size([64])
     backend_b = _make_mock_backend_for_kernel_block_size([MultipleOf(16)])

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -357,6 +357,40 @@ def test_prepare_input_ids_replaces_async_spec_placeholders():
     )
 
 
+def test_prepare_input_ids_allows_new_req_with_real_spec_tokens():
+    runner = _make_async_spec_prepare_runner(
+        torch.tensor([[201, 202, 203, 204]], dtype=torch.int64)
+    )
+    runner.input_batch.prev_sampled_token_ids = torch.tensor(
+        [[101], [102]], dtype=torch.int32
+    )
+    runner.input_batch.req_ids = ["cached-req", "new-req"]
+    runner.prev_positions = SimpleNamespace(np=np.array([0, -1], dtype=np.int32))
+    runner.input_ids = _FakeCpuGpuBuffer(
+        torch.tensor([0, -1, -1, -1, -1, 301, 302], dtype=torch.int32)
+    )
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={
+            "cached-req": [-1, -1, -1, -1],
+            "new-req": [301, 302],
+        }
+    )
+
+    GPUModelRunner._prepare_input_ids(
+        runner,
+        scheduler_output,
+        num_reqs=2,
+        total_num_scheduled_tokens=7,
+        cu_num_tokens=np.array([5, 7], dtype=np.int32),
+    )
+
+    assert runner.input_ids.copy_count == 1
+    torch.testing.assert_close(
+        runner.input_ids.gpu[:7],
+        torch.tensor([101, 201, 202, 203, 204, 301, 302], dtype=torch.int32),
+    )
+
+
 def test_prepare_input_ids_rejects_async_spec_placeholders_without_sample_cache():
     runner = _make_async_spec_prepare_runner(
         torch.tensor([[201, 202, 203, 204]], dtype=torch.int64)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -293,6 +293,7 @@ class InputBatch:
 
         # Cached reference to the GPU tensor of previously sampled tokens
         self.prev_sampled_token_ids: torch.Tensor | None = None
+        self.prev_draft_token_ids: torch.Tensor | None = None
         self.prev_req_id_to_index: dict[str, int] | None = None
         # These are used to update output_token_ids with real sampled
         # ids from prior step, if required by current sampling params

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1705,7 +1705,20 @@ class GPUModelRunner(
         (-1 for new requests).
         """
 
+        scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+        has_async_spec_placeholders = self.use_async_spec_decode and any(
+            token_id < 0
+            for spec_token_ids in scheduled_spec_tokens.values()
+            for token_id in spec_token_ids
+        )
         if self.input_batch.prev_sampled_token_ids is None:
+            if has_async_spec_placeholders:
+                raise RuntimeError(
+                    "Async speculative decoding scheduled placeholder draft "
+                    "tokens, but the worker has no cached sampled token IDs "
+                    "from the previous step to replace them before model "
+                    "execution."
+                )
             # Normal scheduling case
             self.input_ids.copy_to_gpu(total_num_scheduled_tokens)
             if self.enable_prompt_embeds:
@@ -1717,7 +1730,6 @@ class GPUModelRunner(
         # iteration won't have entries in input_ids_cpu and need to be copied
         # on the GPU from prev_sampled_token_ids.
         prev_positions = self.prev_positions.np[:num_reqs]
-        scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
         sample_flattened_indices: list[int] = []
         spec_flattened_indices: list[int] = []
         prev_draft_token_indices: list[int] = []
@@ -1725,13 +1737,16 @@ class GPUModelRunner(
         common_indices_match = True
         max_flattened_index = -1
         total_num_spec_tokens = 0
+        req_ids_with_spec_without_prev: list[str] = []
 
         for cur_index in range(num_reqs):
             prev_index = prev_positions[cur_index]
+            req_id = self.input_batch.req_ids[cur_index]
             if prev_index < 0:
+                if req_id in scheduled_spec_tokens:
+                    req_ids_with_spec_without_prev.append(req_id)
                 continue
             prev_indices.append(prev_index)
-            req_id = self.input_batch.req_ids[cur_index]
             # We need to compute the flattened input_ids index of the
             # last token in each common request.
             draft_len = len(scheduled_spec_tokens.get(req_id, ()))
@@ -1754,6 +1769,31 @@ class GPUModelRunner(
             prev_draft_token_indices.extend(range(start, start + draft_len))
             common_indices_match &= prev_index == flattened_index
             max_flattened_index = max(max_flattened_index, flattened_index)
+
+        if req_ids_with_spec_without_prev and has_async_spec_placeholders:
+            raise RuntimeError(
+                "Async speculative decoding scheduled placeholder draft "
+                "tokens for requests that are not present in the previous "
+                f"worker batch: {req_ids_with_spec_without_prev}."
+            )
+
+        prev_draft_token_ids = self.input_batch.prev_draft_token_ids
+        if prev_draft_token_ids is None and torch.is_tensor(self._draft_token_ids):
+            prev_draft_token_ids = self._draft_token_ids
+        if spec_flattened_indices:
+            if prev_draft_token_ids is None:
+                raise RuntimeError(
+                    "Async speculative decoding scheduled draft tokens, but "
+                    "the worker has no cached draft token IDs to replace the "
+                    "scheduler placeholders before model execution."
+                )
+            if max(prev_draft_token_indices) >= prev_draft_token_ids.numel():
+                raise RuntimeError(
+                    "Async speculative decoding scheduled draft tokens that "
+                    "do not fit the cached draft token tensor. "
+                    f"max index: {max(prev_draft_token_indices)}, "
+                    f"cached tokens: {prev_draft_token_ids.numel()}."
+                )
 
         num_common_tokens = len(sample_flattened_indices)
         total_without_spec = total_num_scheduled_tokens - total_num_spec_tokens
@@ -1794,10 +1834,10 @@ class GPUModelRunner(
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
-        if self._draft_token_ids is None or not spec_flattened_indices:
+        if not spec_flattened_indices:
             return
 
-        assert isinstance(self._draft_token_ids, torch.Tensor)
+        assert prev_draft_token_ids is not None
         draft_tokens_index_tensor = torch.tensor(
             spec_flattened_indices, dtype=torch.int64, pin_memory=self.pin_memory
         ).to(self.device, non_blocking=True)
@@ -1807,7 +1847,7 @@ class GPUModelRunner(
 
         # because input_ids dtype is torch.int32,
         # so convert draft_token_ids to torch.int32 here.
-        draft_token_ids = self._draft_token_ids.to(dtype=torch.int32)
+        draft_token_ids = prev_draft_token_ids.to(dtype=torch.int32)
 
         self.input_ids.gpu.scatter_(
             dim=0,
@@ -4382,6 +4422,7 @@ class GPUModelRunner(
         self._draft_token_req_ids = None
         self.valid_sampled_token_count_gpu = None
         self.input_batch.prev_sampled_token_ids = None
+        self.input_batch.prev_draft_token_ids = None
 
         def propose_draft_token_ids(sampled_token_ids):
             assert spec_decode_common_attn_metadata is not None
@@ -4397,6 +4438,10 @@ class GPUModelRunner(
                     spec_decode_common_attn_metadata,
                     slot_mappings,
                 )
+                if self.use_async_spec_decode and torch.is_tensor(
+                    self._draft_token_ids
+                ):
+                    self.input_batch.prev_draft_token_ids = self._draft_token_ids
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         spec_config = self.speculative_config
@@ -4475,6 +4520,8 @@ class GPUModelRunner(
                 ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
                 self._draft_probs = None
                 self._draft_prob_req_ids = None
+                if self.use_async_spec_decode:
+                    self.input_batch.prev_draft_token_ids = self._draft_token_ids
                 self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
 
         with record_function_or_nullcontext("gpu_model_runner: bookkeep"):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1737,14 +1737,15 @@ class GPUModelRunner(
         common_indices_match = True
         max_flattened_index = -1
         total_num_spec_tokens = 0
-        req_ids_with_spec_without_prev: list[str] = []
+        req_ids_with_placeholder_spec_without_prev: list[str] = []
 
         for cur_index in range(num_reqs):
             prev_index = prev_positions[cur_index]
             req_id = self.input_batch.req_ids[cur_index]
             if prev_index < 0:
-                if req_id in scheduled_spec_tokens:
-                    req_ids_with_spec_without_prev.append(req_id)
+                spec_token_ids = scheduled_spec_tokens.get(req_id, ())
+                if any(token_id < 0 for token_id in spec_token_ids):
+                    req_ids_with_placeholder_spec_without_prev.append(req_id)
                 continue
             prev_indices.append(prev_index)
             # We need to compute the flattened input_ids index of the
@@ -1770,11 +1771,11 @@ class GPUModelRunner(
             common_indices_match &= prev_index == flattened_index
             max_flattened_index = max(max_flattened_index, flattened_index)
 
-        if req_ids_with_spec_without_prev and has_async_spec_placeholders:
+        if req_ids_with_placeholder_spec_without_prev:
             raise RuntimeError(
                 "Async speculative decoding scheduled placeholder draft "
                 "tokens for requests that are not present in the previous "
-                f"worker batch: {req_ids_with_spec_without_prev}."
+                f"worker batch: {req_ids_with_placeholder_spec_without_prev}."
             )
 
         prev_draft_token_ids = self.input_batch.prev_draft_token_ids


### PR DESCRIPTION

## Purpose

Async scheduling keeps GPU input preparation one step ahead of sampling. For cached decode requests, the CPU-side input_ids for the next step can contain placeholder values, and GPUModelRunner patches those placeholders from previous-step GPU state before launching the model.

The existing async path handled the previously sampled token via prev_sampled_token_ids, but async MTP/spec-decode can also schedule draft-token placeholders in scheduled_spec_decode_tokens. Those placeholders need the draft tokens produced by the previous step, in the previous batch ordering. The code instead looked at self._draft_token_ids from the current runner state and returned early when it was None. In that case the scheduled speculative slots could keep their -1 placeholders and reach model execution. If a stale or misaligned draft tensor was present, the wrong draft ids could be scattered for requests reordered by async scheduling.

This can surface as CUDA device-side asserts or out-of-bounds gather failures instead of a Python-side scheduling error, especially when async scheduling, MTP/speculative decoding, and request reordering/chunked work are combined.

## Test Plan

Fix this by carrying the previous-step draft-token tensor through InputBatch in the same way we already carry the previous sampled-token tensor:

- Add InputBatch.prev_draft_token_ids.
- Cache the tensor returned by propose_draft_token_ids when async spec decode is enabled.
- Cache the zero draft-token tensor used when the drafter input would exceed the drafter max model length, so async scheduling does not reuse stale draft state in that path.
- Clear prev_draft_token_ids together with prev_sampled_token_ids before producing the next sampled/draft outputs.
- In _prepare_input_ids, detect async speculative placeholders before the normal no-cache fast path.
- Fail fast if placeholder draft tokens are scheduled without a previous sampled-token cache.
- Fail fast if placeholder draft tokens are scheduled for a request that is not present in the previous worker batch.
- Scatter scheduled draft-token placeholders from the cached previous draft tensor, not from the current self._draft_token_ids field.
- Validate the computed flattened draft-token indices against the cached draft tensor size before launching the scatter.

The request id lookup in the _prepare_input_ids loop now happens before the prev_index < 0 check so that requests with scheduled spec tokens but no previous batch position can be reported explicitly instead of silently skipping them.

## Test Result
Tests:

- Add a focused _prepare_input_ids test that replaces async speculative -1 placeholders with previous-step draft ids and verifies no CPU input copy is used for the unchanged async decode batch.
- Add a missing previous sampled-token cache test, which should now raise a RuntimeError before model execution.
- Add a missing previous draft-token cache test, which should now raise a RuntimeError before model execution.
- Ran: python -m pytest --confcutdir=tests/v1/worker \ tests/v1/worker/test_gpu_model_runner.py \ -k "prepare_input_ids or sample_tokens_skips_pp_group_lookup_without_async_scheduling"

  Result: 4 passed, 31 deselected.

## Crash logs
I have included 3 log crash
[log_cleaned.txt](https://github.com/user-attachments/files/28153029/log_cleaned.txt)
[log2_cleaned.txt](https://github.com/user-attachments/files/28153032/log2_cleaned.txt)
[log3_cleaned.txt](https://github.com/user-attachments/files/28153033/log3_cleaned.txt)

Sadly, I have not been able to reproduce this bug on demand, this only happen on production server. Logs show vLLM 0.20.2 but it also happened with v0.21.0

Platform: GH200 with base Docker image vllm/vllm-openai
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

