### PR TITLE
[Docs] Fix incorrect docstring for `all_non_structural_tag_constraints_none`

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -97,7 +97,8 @@ class StructuredOutputsParams:
 
     def all_non_structural_tag_constraints_none(self) -> bool:
         """
-        Returns True if all structured-output constraint fields are None.
+        Returns True if all structured-output constraint fields except
+        ``structural_tag`` are None.
         """
         return all(
             getattr(self, field) is None


### PR DESCRIPTION
## Purpose

Fix a copy-paste docstring error in `StructuredOutputsParams`.

`all_non_structural_tag_constraints_none` and `all_constraints_none` had identical docstrings, but their implementations differ:

- `all_constraints_none` checks all 6 fields including `structural_tag`
- `all_non_structural_tag_constraints_none` checks only 5 fields and **intentionally excludes `structural_tag`**

The docstring for the second method said *"Returns True if all structured-output constraint fields are None"* — which is what `all_constraints_none` does, not this method.

The call site in `serving.py:498` confirms the intent: it calls `all_non_structural_tag_constraints_none()` specifically because it needs `structural_tag` to remain non-None (the block immediately after sets it via `reasoning_parser.prepare_structured_tag`).

**Before:**
```python
def all_non_structural_tag_constraints_none(self) -> bool:
    """
    Returns True if all structured-output constraint fields are None.
    """
```

**After:**
```python
def all_non_structural_tag_constraints_none(self) -> bool:
    """
    Returns True if all structured-output constraint fields except
    ``structural_tag`` are None.
    """
```

## Test Plan

Docstring-only change — no behavioral change. Verified via AST parse:

```python
import ast
tree = ast.parse(open('vllm/sampling_params.py').read())
for node in ast.walk(tree):
    if isinstance(node, ast.ClassDef) and node.name == 'StructuredOutputsParams':
        for item in node.body:
            if isinstance(item, ast.FunctionDef) and 'constraints_none' in item.name:
                print(f'{item.name}: {repr(ast.get_docstring(item))}')
```

## Test Result

```
all_constraints_none: 'Returns True if all structured-output constraint fields are None.'
all_non_structural_tag_constraints_none: 'Returns True if all structured-output constraint fields except\n``structural_tag`` are None.'
Syntax OK
```