### PR TITLE
[Bugfix][DeepseekV4] Gate expert weight load on success

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1151,6 +1151,8 @@ class DeepseekV4Model(nn.Module):
                         and loaded_weight.dtype == torch.float8_e8m0fnu
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
+                    name_mapped = None
+                    success = False
                     for mapping in expert_mapping:
                         param_name, weight_name, expert_id, expert_shard_id = mapping
                         if weight_name not in name:
@@ -1176,7 +1178,16 @@ class DeepseekV4Model(nn.Module):
                         if success:
                             name = name_mapped
                             break
-                    loaded_params.add(name_mapped)
+                    if not success:
+                        # No expert mapping matched, or the loader did not
+                        # load this weight for the current rank (e.g. a
+                        # non-canonical checkpoint, or this rank holds no
+                        # replica). Skip it instead of marking it loaded or
+                        # raising UnboundLocalError.
+                        continue
+                    # On the success path the loop sets name = name_mapped
+                    # before breaking, so name is the resolved (non-None) str.
+                    loaded_params.add(name)
                     continue
                 elif "attn_sink" in name:
                     if is_pp_missing_parameter(name, self):


### PR DESCRIPTION
Supersedes #42835. Rebased on top of the post-#43004 DeepSeek V4 restructure. Fixes #42769.

## Background

#43004 ("Migrate DeepSeek V4 to vllm/models/ [1/N]") deleted `vllm/model_executor/models/deepseek_v4.py`, so #42835's patch no longer applies. The bug from #42769 / #42835 survived the migration and is now in `vllm/models/deepseek_v4/nvidia/model.py:1434-1459`, structurally identical to the pre-migration form.

## The bug

In the expert-mapping loop, `name_mapped` is only bound inside the loop body (after the `if weight_name not in name: continue` guard). Two failure modes:

1. If the loop never assigns `name_mapped` (no mapping matched), the post-loop `loaded_params.add(name_mapped)` raises `UnboundLocalError`.
2. If the loop runs but every `weight_loader(..., return_success=True)` call returns `False` for this rank, `name_mapped` is bound to the last attempt and `success` is `False`, but `loaded_params.add(name_mapped)` still runs unconditionally and records a weight that was never actually applied.

## The fix

Initialize `name_mapped = None` and `success = False` before the loop. Gate `loaded_params.add(name_mapped)` on `if not success: continue`. Successful canonical loads are unchanged; this only hardens the unsuccessful-mapping / non-local-expert path so `loaded_params` remains accurate.

The affected path is `load_weights`, which requires a fully instantiated model plus distributed init to exercise, so there is no unit-test seam beyond the CUDA-gated DSV4 tests. The change is self-contained; happy to add a CUDA integration test if a maintainer prefers.

Closes #42769
