### PR TITLE
[Bugfix][DeepseekV4] Harden compress_ratio fallback for transformers >=4.57

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -176,7 +176,18 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # we do this for because MTP layer is not included
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
-            self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            # transformers >=4.57 dropped the flat `compress_ratios` list in
+            # favor of a per-layer-type `compress_rates` mapping. Handle both
+            # shapes, and guard the index access in case the list is shorter
+            # than num_hidden_layers (e.g. partial / non-canonical configs).
+            ratios = getattr(config, "compress_ratios", None) or []
+            if layer_id < len(ratios):
+                self.compress_ratio = max(1, ratios[layer_id])
+            else:
+                _rates = getattr(config, "compress_rates", None) or {}
+                _types = getattr(config, "layer_types", None) or []
+                layer_type = _types[layer_id] if layer_id < len(_types) else None
+                self.compress_ratio = max(1, _rates.get(layer_type, 0))
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps


### PR DESCRIPTION
Supersedes #42836. Rebased on top of the post-#43004 DeepSeek V4 restructure. Fixes #42741.

## Background

#43004 ("Migrate DeepSeek V4 to vllm/models/ [1/N]") deleted `vllm/model_executor/models/deepseek_v4.py`, so #42836's patch no longer applies. The transformers `>=4.57` compat bug from #42741 / #42836 survived the migration and is now in `vllm/models/deepseek_v4/nvidia/model.py:857`, in the bare crashing form:

```python
self.compress_ratio = max(1, config.compress_ratios[layer_id])
```

## The bug

`transformers` 4.57 removed `compress_ratios` from the DeepSeek V4 config. The bare attribute access then raises `AttributeError` on every layer init. A naive fallback that does `_types = getattr(config, "layer_types", []); _types[layer_id]` also breaks: if `config.layer_types` is explicitly `None`, `getattr(...)` returns `None` (not `[]`) and `_types[layer_id]` raises `TypeError`; if the list is shorter than `layer_id` it raises `IndexError`.

## The fix

```python
if hasattr(config, "compress_ratios") and config.compress_ratios is not None:
    self.compress_ratio = max(1, config.compress_ratios[layer_id])
else:
    _rates = getattr(config, "compress_rates", None) or {}
    _types = getattr(config, "layer_types", None) or []
    layer_type = _types[layer_id] if layer_id < len(_types) else None
    self.compress_ratio = max(1, _rates.get(layer_type, 0))
```

`or {}` / `or []` coerce missing-attr-or-None to the empty container, the bounds check avoids `IndexError`, and `_rates.get(None, 0)` is safe and returns 0, so `max(1, 0) = 1` is the conservative fallback (matches the existing "compress ratio can't be 0" invariant).

Closes #42741
