### PR TITLE
[Bugfix] Make openai_serving_render optional in OpenAIServingChat and OpenAIServingCompletion

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -626,6 +626,35 @@ def test_async_serving_chat_init():
     assert serving_completion.chat_template == CHAT_TEMPLATE
 
 
+def test_serving_chat_optional_render():
+    # openai_serving_render should be optional, downstream users constructing
+    # OpenAIServingChat directly (e.g. KubeRay, Ray Serve) must not get a
+    # TypeError just because they don't pass this argument.
+    engine = MockEngine()
+    models = OpenAIServingModels(engine, BASE_MODEL_PATHS)
+
+    # Instantiation without openai_serving_render must not raise
+    chat = OpenAIServingChat(
+        engine,
+        models,
+        response_role="assistant",
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+    )
+    assert chat.openai_serving_render is None
+
+    # Calling render_chat_request with no render object must raise RuntimeError,
+    # not AttributeError
+    async def _call_render():
+        engine.errored = False
+        chat._check_model = AsyncMock(return_value=None)
+        await chat.render_chat_request(MagicMock())
+
+    with pytest.raises(RuntimeError, match="openai_serving_render was not provided"):
+        asyncio.run(_call_render())
+
+
 @pytest.mark.asyncio
 async def test_serving_chat_returns_correct_model_name():
     mock_engine = MagicMock(spec=AsyncLLM)

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -289,6 +289,41 @@ async def test_completion_error_stream():
     assert chunks[-1] == "data: [DONE]\n\n"
 
 
+def test_serving_completion_optional_render():
+    # openai_serving_render should be optional, downstream users constructing
+    # OpenAIServingCompletion directly must not get a TypeError.
+    import asyncio
+
+    engine = MagicMock(spec=AsyncLLM)
+    engine.errored = False
+    engine.model_config = MockModelConfig()
+    engine.input_processor = MagicMock()
+    engine.renderer = MagicMock()
+    models = OpenAIServingModels(
+        engine_client=engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+
+    # Instantiation without openai_serving_render must not raise
+    completion = OpenAIServingCompletion(
+        engine,
+        models,
+        request_logger=None,
+    )
+    assert completion.openai_serving_render is None
+
+    # Calling render_completion_request must raise RuntimeError, not AttributeError
+    async def _call_render():
+        completion._check_model = AsyncMock(return_value=None)
+        from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+
+        req = CompletionRequest(model=MODEL_NAME, prompt="hi")
+        await completion.render_completion_request(req)
+
+    with pytest.raises(RuntimeError, match="openai_serving_render was not provided"):
+        asyncio.run(_call_render())
+
+
 def test_json_schema_response_format_missing_schema():
     """When response_format type is 'json_schema' but the json_schema field
     is not provided, request construction should raise a validation error

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -89,7 +89,7 @@ class OpenAIServingChat(OpenAIServing):
         models: OpenAIServingModels,
         response_role: str,
         *,
-        openai_serving_render: "OpenAIServingRender",
+        openai_serving_render: "OpenAIServingRender | None" = None,
         request_logger: RequestLogger | None,
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
@@ -223,6 +223,11 @@ class OpenAIServingChat(OpenAIServing):
         if self.engine_client.errored:
             raise self.engine_client.dead_error
 
+        if self.openai_serving_render is None:
+            raise RuntimeError(
+                "openai_serving_render was not provided to OpenAIServingChat; "
+                "pass it at construction time to use render_chat"
+            )
         return await self.openai_serving_render.render_chat(request)
 
     async def create_chat_completion(

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -57,7 +57,7 @@ class OpenAIServingCompletion(OpenAIServing):
         engine_client: EngineClient,
         models: OpenAIServingModels,
         *,
-        openai_serving_render: "OpenAIServingRender",
+        openai_serving_render: "OpenAIServingRender | None" = None,
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
@@ -105,6 +105,11 @@ class OpenAIServingCompletion(OpenAIServing):
         if self.engine_client.errored:
             raise self.engine_client.dead_error
 
+        if self.openai_serving_render is None:
+            raise RuntimeError(
+                "openai_serving_render was not provided to OpenAIServingCompletion; "
+                "pass it at construction time to use render_completion"
+            )
         return await self.openai_serving_render.render_completion(request)
 
     async def create_completion(


### PR DESCRIPTION
## Purpose

`OpenAIServingChat` and `OpenAIServingCompletion` started requiring `openai_serving_render` as a mandatory keyword argument in v0.18 (#36483). Any downstream code that constructs these classes directly (KubeRay, Ray Serve, custom deployments) breaks with a `TypeError` on startup even though the rest of the setup is valid.

This makes the argument optional with a `None` default. If someone skips it and later hits the render path, they get a clear `RuntimeError` pointing them at what to pass instead of a cryptic `AttributeError`.

Fixes #43411.

## Test Plan

```
.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_serving_chat_optional_render tests/entrypoints/openai/completion/test_completion_error.py::test_serving_completion_optional_render -v
```

## Test Results

```
tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_serving_chat_optional_render PASSED
tests/entrypoints/openai/completion/test_completion_error.py::test_serving_completion_optional_render PASSED
2 passed in 1.45s
```

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
