### PR TITLE
fix: parse input_audio payloads with uuid

### DIFF
--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -2180,6 +2180,47 @@ def test_parse_chat_messages_single_empty_audio_with_uuid(
     _assert_mm_uuids(mm_uuids, 1, modality="audio", expected_uuids=[audio_uuid])
 
 
+def test_parse_chat_messages_input_audio_with_uuid_uses_nested_payload(
+    qwen2_audio_model_config,
+    audio_url,
+):
+    audio_uuid = "abcd"
+    audio_data = audio_url.split(",", 1)[1]
+
+    conversation, mm_data, mm_uuids = parse_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": audio_data,
+                            "format": "wav",
+                        },
+                        "uuid": audio_uuid,
+                    },
+                    {"type": "text", "text": "What does the audio say?"},
+                ],
+            }
+        ],
+        qwen2_audio_model_config,
+        content_format="string",
+    )
+
+    assert conversation == [
+        {
+            "role": "user",
+            "content": "Audio 1: <|audio_bos|><|AUDIO|><|audio_eos|>\nWhat does the "
+            "audio say?",
+        }
+    ]
+    _assert_mm_data_inputs(mm_data, {"audio": 1})
+    assert mm_data is not None
+    assert mm_data["audio"][0] is not None
+    _assert_mm_uuids(mm_uuids, 1, modality="audio", expected_uuids=[audio_uuid])
+
+
 @pytest.mark.asyncio
 async def test_parse_chat_messages_single_empty_audio_with_uuid_async(
     qwen2_audio_model_config,

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import cached_property, lru_cache, partial
 from itertools import accumulate
@@ -1516,8 +1516,9 @@ def _parse_chat_message_content_mm_part(
                 # with url as a dict of {"url": url}
                 audio_url = audio_url.get("url", None)
             return "audio_url", audio_url
-        if part.get("input_audio") is not None:
-            input_audio_params = cast(dict[str, str], part)
+        input_audio = cast(Mapping[str, object], part).get("input_audio")
+        if input_audio is not None:
+            input_audio_params = cast(InputAudio, input_audio)
             return "input_audio", input_audio_params
         if "video_url" in part:
             video_params = cast(CustomChatCompletionContentSimpleVideoParam, part)


### PR DESCRIPTION
﻿## Summary

- fix `input_audio` content parts with `uuid` so the nested `input_audio` payload is passed to the audio parser
- add a regression test that verifies non-empty base64 audio is still decoded when a UUID is present

Fixes #43415.

## To verify

- `python -m ruff check vllm\entrypoints\chat_utils.py tests\entrypoints\test_chat_utils.py`
- `python -m compileall -q vllm\entrypoints\chat_utils.py tests\entrypoints\test_chat_utils.py`
- `python -c "from vllm.entrypoints.chat_utils import _parse_chat_message_content_mm_part; part={'type':'input_audio','input_audio':{'data':'abc','format':'wav'},'uuid':'u1'}; print(_parse_chat_message_content_mm_part(part))"`

I could not run the focused pytest module on Windows because `tests/conftest.py` imports `uvloop`, and `uvloop` does not support Windows. The import-level check above verifies the exact parser branch changed here.
