### PR TITLE
[deepseek_v4] Route top-level head.weight + embed.weight to MTP shared_head/embed_tokens

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -358,6 +358,36 @@ class DeepSeekV4MTP(nn.Module):
             else ".weight_scale_inv"
         )
 
+        # Top-level ``head.weight`` and ``embed.weight`` keys (as written by
+        # ``transformers.save_pretrained`` for DSv4-Flash) need to be routed
+        # to each MTP layer's ``shared_head.head`` and ``embed_tokens`` slots.
+        # Without this, the rename loop below leaves these keys with
+        # ``spec_layer is None`` and they hit the ``continue`` on line below,
+        # leaving the MTP draft head's lm-head and embedding uninitialized at
+        # serve time. Symptom: speculative decoding produces draft tokens but
+        # acceptance rate is exactly 0% with no load-time error.
+        #
+        # The fix: synthesize ``mtp.{layer}.head.weight`` and
+        # ``mtp.{layer}.emb.tok_emb.weight`` entries (which DO match the
+        # mtp.{i}. -> model.layers.{N+i}. rename and then route correctly via
+        # _remap_weight_name) for each MTP layer the model has.
+        weights = list(weights)
+        extras: list[tuple[str, torch.Tensor]] = []
+        toplevel_aliases = {
+            "head.weight": "head.weight",
+            "embed.weight": "emb.tok_emb.weight",
+        }
+        for raw_name, loaded_weight in weights:
+            if raw_name in toplevel_aliases:
+                for layer_off in range(self.config.num_nextn_predict_layers):
+                    extras.append(
+                        (
+                            f"mtp.{layer_off}.{toplevel_aliases[raw_name]}",
+                            loaded_weight,
+                        )
+                    )
+        weights = list(weights) + extras
+
         for name, loaded_weight in weights:
             mtp_layer_idx = _find_mtp_layer_idx(name)
             # V4 checkpoints store MTP weights as `mtp.{i}.*`; remap to


### PR DESCRIPTION
## Summary

Fixes silent 0% MTP draft acceptance for DSv4-Flash artifacts that store `head.weight` and `embed.weight` at the top level (which is the canonical layout produced by `transformers.save_pretrained` for DSv4-Flash).

Closes #43456.

## The bug

`DeepSeekV4MTP.load_weights` (`vllm/models/deepseek_v4/nvidia/mtp.py`) iterates `weights` and does:

```python
for name, loaded_weight in weights:
    mtp_layer_idx = _find_mtp_layer_idx(name)
    name = name.replace(f"mtp.{mtp_layer_idx}.", f"model.layers.{N+i}.")
    spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
    if spec_layer is None:
        continue
```

For top-level keys like `head.weight` and `embed.weight` (without a `mtp.` prefix), the `name.replace(f"mtp.{i}.", ...)` is a no-op. `get_spec_layer_idx_from_weight_name` then returns `None`. The loop hits `continue` and the weight is silently skipped. The MTP layer's `shared_head.head` (ParallelLMHead) and `embed_tokens` (VocabParallelEmbedding) stay uninitialized → MTP draft head emits garbage logits → speculative decoding produces draft tokens that get 100% rejected by the verifier.

No load-time error.

## Repro

Serve any DSv4-Flash artifact produced via the canonical `transformers.save_pretrained` path with `--speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":1}'` and watch `vllm:spec_decode_num_accepted_tokens_total / vllm:spec_decode_num_draft_tokens_total`: drafts produced, accepted = 0.

Reproducible against:
- https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP (this PR author's W4A16 build, public)
- https://huggingface.co/canada-quant/DeepSeek-V4-Flash-NVFP4-FP8-MTP (sibling NVFP4 build, also public)

Both ship a postprocess that injects `mtp.0.head.weight` + `mtp.0.emb.tok_emb.weight` as full duplicates of the top-level keys, working around this bug at save time. With this PR, that postprocess workaround is no longer needed.

## The fix

Before the existing rename loop, synthesize per-MTP-layer aliases for the two top-level keys. The MTP rename + `_remap_weight_name` chain then routes them correctly:
- `mtp.{N}.head.weight` → (via mtp rename) → `model.layers.{X+N}.head.weight` → (via _remap_weight_name) → `model.layers.{X+N}.shared_head.head.weight`
- `mtp.{N}.emb.tok_emb.weight` → ... → `model.layers.{X+N}.embed_tokens.weight`

```diff
+ weights = list(weights)
+ extras: list[tuple[str, torch.Tensor]] = []
+ toplevel_aliases = {
+     \"head.weight\": \"head.weight\",
+     \"embed.weight\": \"emb.tok_emb.weight\",
+ }
+ for raw_name, loaded_weight in weights:
+     if raw_name in toplevel_aliases:
+         for layer_off in range(self.config.num_nextn_predict_layers):
+             extras.append(
+                 (
+                     f\"mtp.{layer_off}.{toplevel_aliases[raw_name]}\",
+                     loaded_weight,
+                 )
+             )
+ weights = list(weights) + extras
+
  for name, loaded_weight in weights:
      mtp_layer_idx = _find_mtp_layer_idx(name)
      ...
```

## Validation

Tested with the canada-quant W4A16-FP8-MTP artifact on H200 (Hopper, sm_90a, TP=2). Before this fix: 0% MTP draft acceptance (silent). After this fix: 69.94% acceptance over 200 random prompts at k=1 (raw data: https://github.com/canada-quant/dsv4-flash-w4a16-fp8-mtp/blob/main/benchmarks/phase2/acc_2026-05-22T200425Z_metrics.txt).

Decode speedup with the fix (vs same artifact served without spec-decode): **1.49× at bs=1 (TPOT median 6.02ms with MTP vs 8.93ms without)**. Full raw data: https://github.com/canada-quant/dsv4-flash-w4a16-fp8-mtp/tree/main/benchmarks/phase2

The sibling NVFP4 artifact on B300 (sm_103a) hits the same issue with the same workaround; this fix applies cleanly there too (we share the loader code).

## Risk

- Diff size: 30 lines, no behavior change for artifacts that already include `mtp.0.head.weight` / `mtp.0.emb.tok_emb.weight` (the synthesized aliases just become duplicates of the explicit keys and the duplicate is harmless).
- No new dependencies.
- Self-contained to `DeepSeekV4MTP.load_weights`.

## Why not just require the postprocess?

The current behavior is **silent 0% MTP acceptance with no error** — the worst possible failure mode for speculative decoding because the model still functions, just without the speedup. Anyone who quantizes DSv4-Flash without knowing about the sibling-discovered workaround will hit this. Both shipping MTP-preserving DSv4-Flash artifacts (canada-quant W4A16 and canada-quant NVFP4) have the postprocess; future ones will hit this issue independently unless this loader-side fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)