### PR TITLE
[Bugfix] Fix cached_tokens over-reporting in disaggregated prefill/decode mode

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -244,3 +244,24 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.external_kv_transfer == 999
     assert stats.cached_tokens == 999
     assert stats.total == 1000
+
+
+def test_prompt_token_stats_disagg_transfer_not_cached():
+    """Disagg transfer tokens are excluded from cached_tokens."""
+    stats = PromptTokenStats()
+
+    prefill_stats = PrefillStats()
+    prefill_stats.set(
+        num_prompt_tokens=100,
+        num_local_cached_tokens=0,
+        num_external_cached_tokens=0,
+        num_disagg_transfer_tokens=99,
+    )
+    stats.update_from_output(prefill_stats)
+
+    assert stats.cached_tokens == 0
+    assert stats.local_cache_hit == 0
+    assert stats.external_kv_transfer == 99
+    assert stats.disagg_transfer == 99
+    assert stats.computed == 1
+    assert stats.total == 100

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -181,6 +181,15 @@ class KVConnectorBase_V1(ABC):
         """
         return False
 
+    @property
+    def is_disagg_prefill_transfer(self) -> bool:
+        """
+        True on the consumer side of a disaggregated prefill/decode connector.
+        Disagg-transferred tokens were computed on the prefill worker and must
+        not be counted as cached_tokens in the API response. Defaults to False.
+        """
+        return False
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -104,6 +104,10 @@ class P2pNcclConnector(KVConnectorBase_V1):
             else None
         )
 
+    @property
+    def is_disagg_prefill_transfer(self) -> bool:
+        return not self.is_producer
+
     # ==============================
     # Worker-side methods
     # ==============================

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -626,11 +626,22 @@ class Scheduler(SchedulerInterface):
                     # Track first scheduled prefill, not post-preemption repeat prefills
                     if request.prefill_stats is not None:
                         assert num_computed_tokens <= request.num_prompt_tokens
-                        request.prefill_stats.set(
-                            num_prompt_tokens=request.num_prompt_tokens,
-                            num_local_cached_tokens=num_new_local_computed_tokens,
-                            num_external_cached_tokens=num_external_computed_tokens,
-                        )
+                        if (
+                            self.connector is not None
+                            and self.connector.is_disagg_prefill_transfer
+                        ):
+                            request.prefill_stats.set(
+                                num_prompt_tokens=request.num_prompt_tokens,
+                                num_local_cached_tokens=num_new_local_computed_tokens,
+                                num_external_cached_tokens=0,
+                                num_disagg_transfer_tokens=num_external_computed_tokens,
+                            )
+                        else:
+                            request.prefill_stats.set(
+                                num_prompt_tokens=request.num_prompt_tokens,
+                                num_local_cached_tokens=num_new_local_computed_tokens,
+                                num_external_cached_tokens=num_external_computed_tokens,
+                            )
                 else:
                     # KVTransfer: WAITING reqs have num_computed_tokens > 0
                     # after async KV recvs are completed.

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -246,9 +246,12 @@ class PrefillStats:
     Fields:
         num_prompt_tokens: Total number of tokens to be prefilled.
         num_computed_tokens: Tokens to be prefilled locally (actual compute work).
-        num_cached_tokens: Tokens to be prefilled without actual compute work.
-        num_local_cached_tokens: Tokens to be prefilled from local prefix cache.
-        num_external_cached_tokens: Tokens to be prefilled from external KV transfer.
+        num_cached_tokens: APC cache hits (local + external); reported as
+            cached_tokens in the API response.
+        num_local_cached_tokens: Tokens from the local prefix cache.
+        num_external_cached_tokens: Tokens from an external KV cache store.
+        num_disagg_transfer_tokens: Tokens transferred from a disagg prefill
+            worker; not a cache hit, excluded from num_cached_tokens.
     """
 
     num_prompt_tokens: int = 0
@@ -256,21 +259,26 @@ class PrefillStats:
     num_cached_tokens: int = 0
     num_local_cached_tokens: int = 0
     num_external_cached_tokens: int = 0
+    num_disagg_transfer_tokens: int = 0
 
     def set(
         self,
         num_prompt_tokens: int,
         num_local_cached_tokens: int,
         num_external_cached_tokens: int,
+        num_disagg_transfer_tokens: int = 0,
     ):
         num_cached_tokens = num_local_cached_tokens + num_external_cached_tokens
-        assert num_cached_tokens <= num_prompt_tokens
+        assert num_cached_tokens + num_disagg_transfer_tokens <= num_prompt_tokens
 
         self.num_prompt_tokens = num_prompt_tokens
-        self.num_computed_tokens = num_prompt_tokens - num_cached_tokens
+        self.num_computed_tokens = (
+            num_prompt_tokens - num_cached_tokens - num_disagg_transfer_tokens
+        )
         self.num_cached_tokens = num_cached_tokens
         self.num_local_cached_tokens = num_local_cached_tokens
         self.num_external_cached_tokens = num_external_cached_tokens
+        self.num_disagg_transfer_tokens = num_disagg_transfer_tokens
 
 
 @dataclass
@@ -280,13 +288,16 @@ class PromptTokenStats:
     Fields:
         computed: Tokens prefilled locally (actual compute work).
         local_cache_hit: Tokens from local prefix cache.
-        external_kv_transfer: Tokens from external KV transfer.
+        external_kv_transfer: Tokens from external KV transfer (cache store or
+            disagg prefill worker). Preserved for Prometheus metric continuity.
+        disagg_transfer: Tokens transferred from a disagg prefill worker;
+            subset of external_kv_transfer, excluded from cached_tokens.
         cached_tokens: Tokens skipped during prefill (from scheduler).
         total: Total prompt tokens.
 
     Invariants:
         computed + local_cache_hit + external_kv_transfer = total
-        local_cache_hit + external_kv_transfer = cached_tokens
+        local_cache_hit + (external_kv_transfer - disagg_transfer) = cached_tokens
     """
 
     ALL_SOURCES: tuple[str, ...] = (
@@ -298,6 +309,7 @@ class PromptTokenStats:
     computed: int = 0
     local_cache_hit: int = 0
     external_kv_transfer: int = 0
+    disagg_transfer: int = 0
     cached_tokens: int = 0
     total: int = 0
 
@@ -308,7 +320,11 @@ class PromptTokenStats:
         self.total += prefill_stats.num_prompt_tokens
 
         self.local_cache_hit += prefill_stats.num_local_cached_tokens
-        self.external_kv_transfer += prefill_stats.num_external_cached_tokens
+        self.external_kv_transfer += (
+            prefill_stats.num_external_cached_tokens
+            + prefill_stats.num_disagg_transfer_tokens
+        )
+        self.disagg_transfer += prefill_stats.num_disagg_transfer_tokens
 
     def get_by_source(self, source: str) -> int:
         """Get token count by source label."""


### PR DESCRIPTION
## Purpose

Fix #43370: In disaggregated prefill/decode mode, `usage.prompt_tokens_details.cached_tokens` is inflated to nearly `prompt_tokens - 1` for every request, even cold ones with no actual prefix-cache hits.

**Root cause:** The decode worker's scheduler calls `connector.get_num_new_matched_tokens()`, which on the `P2pNcclConnector` consumer side returns `prompt_len - 1` (the number of KV blocks to receive via transfer). This value was passed as `num_external_cached_tokens` into `PrefillStats.set()`, making it flow into `cached_tokens` in the OpenAI API response. KV *transfer* tokens (computed on the prefill worker) were conflated with KV *cache hit* tokens (true APC prefix-cache hits).

**Fix:**
- Add `PrefillStats.num_disagg_transfer_tokens` to track P/D transfer tokens separately from APC cache hits.
- Add `KVConnectorBase_V1.is_disagg_prefill_transfer` property (default `False`); override to `True` in `P2pNcclConnector` for the consumer/decode side.
- In `Scheduler`, when the connector is a disagg transfer connector, route external tokens into `num_disagg_transfer_tokens` (not `num_external_cached_tokens`), so they are excluded from the API `cached_tokens` field.
- `PromptTokenStats.external_kv_transfer` continues to accumulate both external cache hits and disagg transfer tokens to preserve existing Prometheus metric values. A new `disagg_transfer` sub-field makes the breakdown available for future observability work.

## Test Plan

Unit tests:
```bash
pytest tests/v1/metrics/test_stats.py -v
```

E2E repro (single-GPU, decode-only server with `P2pNcclConnector` in consumer role):
```bash
# Start decode worker
python -m vllm.entrypoints.openai.api_server \
  --model <model> \
  --kv-transfer-config '{"kv_connector":"P2pNcclConnector","kv_role":"kv_consumer","kv_ip":"127.0.0.1","kv_port":14580}' \
  --enable-prompt-tokens-details --port 8200

# Send a cold request directly to the decode worker
curl http://localhost:8200/v1/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"<model>","prompt":"<unique cold prompt>","max_tokens":5}'
```

## Test Result

Unit tests: all pass (`tests/v1/metrics/test_stats.py`).

E2E on vllm 0.21.0 with `Qwen2.5-1.5B-Instruct`, cold request sent directly to decode worker with `--enable-prompt-tokens-details`:

**Before fix:**
```json
"usage": {
  "prompt_tokens": 17,
  "prompt_tokens_details": {"cached_tokens": 16}
}
```

**After fix:**
```json
"usage": {
  "prompt_tokens": 17,
  "prompt_tokens_details": null
}
```
(`null` = 0 cached tokens — correct for a cold request. Real local APC hits are still reported correctly on warm requests.)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

