### PR TITLE
bugfix: add cu129 suffix to the cuda 12.9 wheel (#43435)

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -27,7 +27,7 @@ steps:
         agents:
           queue: arm64_cpu_queue_release
         commands:
-          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_AARCH64_CU129}\" --build-arg BUILD_OS=manylinux --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda12.9 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
+          - "RELEASE_VERSION=$$(buildkite-agent meta-data get release-version | sed 's/^v//') && DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg VLLM_VERSION_OVERRIDE=$${RELEASE_VERSION}+cu129 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_AARCH64_CU129}\" --build-arg BUILD_OS=manylinux --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda12.9 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
           - "bash .buildkite/scripts/upload-nightly-wheels.sh"
@@ -69,7 +69,7 @@ steps:
         agents:
           queue: cpu_queue_release
         commands:
-          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_X86_CU129}\" --build-arg BUILD_OS=manylinux --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda12.9 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
+          - "RELEASE_VERSION=$$(buildkite-agent meta-data get release-version | sed 's/^v//') && DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg VLLM_VERSION_OVERRIDE=$${RELEASE_VERSION}+cu129 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_X86_CU129}\" --build-arg BUILD_OS=manylinux --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda12.9 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
           - "bash .buildkite/scripts/upload-nightly-wheels.sh"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -444,6 +444,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 #################### WHEEL BUILD IMAGE ####################
 FROM base AS build
+ARG VLLM_VERSION_OVERRIDE=""
 ARG TARGETPLATFORM
 
 ARG PIP_INDEX_URL UV_INDEX_URL
@@ -512,6 +513,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         export VLLM_USE_PRECOMPILED=1; \
         export VLLM_PRECOMPILED_WHEEL_LOCATION=$(ls /precompiled-wheels/*.whl); \
     fi && \
+    export VLLM_VERSION_OVERRIDE="${VLLM_VERSION_OVERRIDE}" && \
     python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
 
 # Copy extension wheels from extensions-build stage for later use


### PR DESCRIPTION
this commit tries to fix the #43435 bug which is currently breaking vLLM on cu129 setups

the release pipeline already has separate wheel builds for cuda 12.9 and cuda 13. but the cuda 12.9 wheel needs a distinct local version suffix so it can be distinguished from the default cuda 13 wheel

without this suffix, vLLM installs the cuda 13 wheel, even if you precise --torch-backend=cu129

this commit makes cuda 12.9 release pipeline build wheels with the cu129 suffix by passing VLLM_VERSION_OVERRIDE=${RELEASE_VERSION}+cu129 to the Dockerfile

i also added the VLLM_VERSION_OVERRIDE argument to the Dockerfile so it is visible when setup.py bdist_wheel runs



## Purpose

fixing #43435 by making the cuda 12.9 release wheel distinguishable from the default cuda 13 wheel

## Test Plan

I checked that the version override gives the expected wheel version

```bash
VLLM_VERSION_OVERRIDE=0.21.0+cu129 python setup.py --version
0.21.0+cu129

VLLM_VERSION_OVERRIDE=0.21.0 python setup.py --version
0.21.0
```
i also run pre-commit on the modified files which passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

