### PR TITLE
Revert "Add `model` to `WeightTransferEngine.__init__`" (#42922)

### DIFF
--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -100,9 +100,7 @@ class TestNCCLEngineParsing:
         """Test parsing valid init info dict."""
         config = WeightTransferConfig(backend="nccl")
         parallel_config = create_mock_parallel_config()
-        engine = NCCLWeightTransferEngine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = NCCLWeightTransferEngine(config, parallel_config)
 
         init_info = engine.parse_init_info(
             {
@@ -123,9 +121,7 @@ class TestNCCLEngineParsing:
         """Test parsing init info with missing required field."""
         config = WeightTransferConfig(backend="nccl")
         parallel_config = create_mock_parallel_config()
-        engine = NCCLWeightTransferEngine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = NCCLWeightTransferEngine(config, parallel_config)
 
         with pytest.raises(ValueError, match="Invalid init_info"):
             engine.parse_init_info(
@@ -139,9 +135,7 @@ class TestNCCLEngineParsing:
         """Test parsing valid update info dict."""
         config = WeightTransferConfig(backend="nccl")
         parallel_config = create_mock_parallel_config()
-        engine = NCCLWeightTransferEngine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = NCCLWeightTransferEngine(config, parallel_config)
 
         update_info = engine.parse_update_info(
             {
@@ -167,18 +161,14 @@ class TestEngineRegistry:
         """Test factory creates NCCL engine."""
         config = WeightTransferConfig(backend="nccl")
         parallel_config = create_mock_parallel_config()
-        engine = WeightTransferEngineFactory.create_engine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = WeightTransferEngineFactory.create_engine(config, parallel_config)
         assert isinstance(engine, NCCLWeightTransferEngine)
 
     def test_create_engine_ipc(self):
         """Test factory creates IPC engine."""
         config = WeightTransferConfig(backend="ipc")
         parallel_config = create_mock_parallel_config()
-        engine = WeightTransferEngineFactory.create_engine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = WeightTransferEngineFactory.create_engine(config, parallel_config)
         assert isinstance(engine, IPCWeightTransferEngine)
 
     def test_create_engine_invalid_backend(self):
@@ -186,9 +176,7 @@ class TestEngineRegistry:
         config = WeightTransferConfig(backend="invalid")
         parallel_config = create_mock_parallel_config()
         with pytest.raises(ValueError, match="Invalid weight transfer backend"):
-            WeightTransferEngineFactory.create_engine(
-                config, parallel_config, MagicMock(spec=torch.nn.Module)
-            )
+            WeightTransferEngineFactory.create_engine(config, parallel_config)
 
     def test_register_duplicate_raises(self):
         """Test registering duplicate engine name raises."""
@@ -208,9 +196,7 @@ def test_nccl_receive_weights_without_init_raises():
 
     config = WeightTransferConfig(backend="nccl")
     parallel_config = create_mock_parallel_config()
-    engine = NCCLWeightTransferEngine(
-        config, parallel_config, MagicMock(spec=torch.nn.Module)
-    )
+    engine = NCCLWeightTransferEngine(config, parallel_config)
 
     update_info = NCCLWeightTransferUpdateInfo(
         names=["w"],
@@ -287,9 +273,7 @@ def inference_receive_tensor(
     parallel_config.data_parallel_rank = 0
     parallel_config.data_parallel_index = 0
 
-    engine = NCCLWeightTransferEngine(
-        config, parallel_config, MagicMock(spec=torch.nn.Module)
-    )
+    engine = NCCLWeightTransferEngine(config, parallel_config)
 
     # Initialize the engine (joins as rank 1)
     init_info = NCCLWeightTransferInitInfo(
@@ -494,9 +478,7 @@ class TestIPCEngineParsing:
 
         config = WeightTransferConfig(backend="ipc")
         parallel_config = create_mock_parallel_config()
-        engine = IPCWeightTransferEngine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = IPCWeightTransferEngine(config, parallel_config)
 
         # Create dummy IPC handles
         dummy_tensor1 = torch.ones(100, 100, device="cuda:0")
@@ -530,9 +512,7 @@ class TestIPCEngineParsing:
 
         config = WeightTransferConfig(backend="ipc")
         parallel_config = create_mock_parallel_config()
-        engine = IPCWeightTransferEngine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = IPCWeightTransferEngine(config, parallel_config)
 
         dummy_tensor1 = torch.ones(100, 100, device="cuda:0")
         dummy_tensor2 = torch.ones(50, device="cuda:0")
@@ -565,9 +545,7 @@ class TestIPCEngineParsing:
 
         config = WeightTransferConfig(backend="ipc")
         parallel_config = create_mock_parallel_config()
-        engine = IPCWeightTransferEngine(
-            config, parallel_config, MagicMock(spec=torch.nn.Module)
-        )
+        engine = IPCWeightTransferEngine(config, parallel_config)
 
         dummy_tensor = torch.ones(10, 10, device="cuda:0")
         _, ipc_handle = reduce_tensor(dummy_tensor)
@@ -657,9 +635,7 @@ def inference_receive_ipc_tensor(
     parallel_config.data_parallel_rank = 0
     parallel_config.data_parallel_index = 0
 
-    engine = IPCWeightTransferEngine(
-        config, parallel_config, MagicMock(spec=torch.nn.Module)
-    )
+    engine = IPCWeightTransferEngine(config, parallel_config)
 
     # Initialize the engine (no-op for IPC)
     init_info = IPCWeightTransferInitInfo()
@@ -787,9 +763,7 @@ def test_ipc_receive_weights_missing_gpu_uuid_raises():
 
     config = WeightTransferConfig(backend="ipc")
     parallel_config = create_mock_parallel_config()
-    engine = IPCWeightTransferEngine(
-        config, parallel_config, MagicMock(spec=torch.nn.Module)
-    )
+    engine = IPCWeightTransferEngine(config, parallel_config)
 
     # Create IPC handle with wrong GPU UUID
     dummy_tensor = torch.ones(10, 10, device="cuda:0")

--- a/vllm/distributed/weight_transfer/__init__.py
+++ b/vllm/distributed/weight_transfer/__init__.py
@@ -5,10 +5,8 @@ Weight transfer engines for syncing model weights from trainers
 to inference workers.
 """
 
-from vllm.distributed.weight_transfer.base import WeightTransferEngine
 from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 
 __all__ = [
-    "WeightTransferEngine",
     "WeightTransferEngineFactory",
 ]

--- a/vllm/distributed/weight_transfer/base.py
+++ b/vllm/distributed/weight_transfer/base.py
@@ -65,10 +65,7 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
     update_info_cls: type[TUpdateInfo]
 
     def __init__(
-        self,
-        config: WeightTransferConfig,
-        parallel_config: ParallelConfig,
-        model: torch.nn.Module,
+        self, config: WeightTransferConfig, parallel_config: ParallelConfig
     ) -> None:
         """
         Initialize the weight transfer engine.
@@ -76,11 +73,9 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         Args:
             config: The configuration for the weight transfer engine
             parallel_config: The configuration for the parallel setup
-            model: The local model instance which will receive the weights
         """
         self.config = config
         self.parallel_config = parallel_config
-        self.model = model
 
     def parse_init_info(self, init_dict: dict[str, Any]) -> TInitInfo:
         """

--- a/vllm/distributed/weight_transfer/factory.py
+++ b/vllm/distributed/weight_transfer/factory.py
@@ -10,8 +10,6 @@ from vllm.distributed.weight_transfer.base import WeightTransferEngine
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
-    import torch
-
     from vllm.config.parallel import ParallelConfig
     from vllm.config.weight_transfer import WeightTransferConfig
 
@@ -77,14 +75,12 @@ class WeightTransferEngineFactory:
         cls,
         config: "WeightTransferConfig",
         parallel_config: "ParallelConfig",
-        model: "torch.nn.Module",
     ) -> WeightTransferEngine:
         """Create a weight transfer engine instance.
 
         Args:
             config: Weight transfer configuration containing the backend name
             parallel_config: Parallel configuration for the engine
-            model: The local model instance which will receive the weights
 
         Returns:
             An initialized weight transfer engine instance
@@ -106,7 +102,7 @@ class WeightTransferEngineFactory:
             engine_cls.__name__,
         )
 
-        return engine_cls(config, parallel_config, model)
+        return engine_cls(config, parallel_config)
 
 
 # Register built-in weight transfer engines here.

--- a/vllm/distributed/weight_transfer/ipc_engine.py
+++ b/vllm/distributed/weight_transfer/ipc_engine.py
@@ -125,10 +125,7 @@ class IPCWeightTransferEngine(
     update_info_cls = IPCWeightTransferUpdateInfo
 
     def __init__(
-        self,
-        config: WeightTransferConfig,
-        parallel_config: ParallelConfig,
-        model: torch.nn.Module,
+        self, config: WeightTransferConfig, parallel_config: ParallelConfig
     ) -> None:
         """
         Initialize the IPC weight transfer engine.
@@ -136,9 +133,8 @@ class IPCWeightTransferEngine(
         Args:
             config: The configuration for the weight transfer engine
             parallel_config: The configuration for the parallel setup
-            model: The local model instance which will receive the weights
         """
-        super().__init__(config, parallel_config, model)
+        super().__init__(config, parallel_config)
 
     def parse_update_info(
         self, update_dict: dict[str, Any]

--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -109,10 +109,7 @@ class NCCLWeightTransferEngine(
     update_info_cls = NCCLWeightTransferUpdateInfo
 
     def __init__(
-        self,
-        config: WeightTransferConfig,
-        parallel_config: ParallelConfig,
-        model: torch.nn.Module,
+        self, config: WeightTransferConfig, parallel_config: ParallelConfig
     ) -> None:
         """
         Initialize the NCCL weight transfer engine.
@@ -120,9 +117,8 @@ class NCCLWeightTransferEngine(
         Args:
             config: The configuration for the weight transfer engine
             parallel_config: The configuration for the parallel setup
-            model: The local model instance which will receive the weights
         """
-        super().__init__(config, parallel_config, model)
+        super().__init__(config, parallel_config)
         self.model_update_group: PyNcclCommunicator | None = None
 
     def init_transfer_engine(self, init_info: NCCLWeightTransferInitInfo) -> None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -36,10 +36,7 @@ from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
 )
-from vllm.distributed.weight_transfer import (
-    WeightTransferEngine,
-    WeightTransferEngineFactory,
-)
+from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
@@ -134,9 +131,15 @@ class Worker(WorkerBase):
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
 
-        # Weight transfer engine is created in `load_model` once the model
-        # is available, since the engine needs a reference to the model.
-        self.weight_transfer_engine: WeightTransferEngine | None = None
+        # Weight transfer engine (initialized on-demand)
+        self.weight_transfer_engine = (
+            WeightTransferEngineFactory.create_engine(
+                self.vllm_config.weight_transfer_config,
+                self.vllm_config.parallel_config,
+            )
+            if self.vllm_config.weight_transfer_config is not None
+            else None
+        )
         self._weight_update_active = False
         self._is_checkpoint_format = True
 
@@ -340,13 +343,6 @@ class Worker(WorkerBase):
             self._scoped_allocator_max_split(max_split_size_mb=20),
         ):
             self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
-
-        if self.vllm_config.weight_transfer_config is not None:
-            self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
-                self.vllm_config.weight_transfer_config,
-                self.vllm_config.parallel_config,
-                self.model_runner.get_model(),
-            )
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)


### PR DESCRIPTION
## Revert of #42922

This reverts commit 3cb83c95922f34d0a3dc5d7795ab7b4c6ef6e54b (PR https://github.com/vllm-project/vllm/pull/42922).

### Reason
PR #42922 added a `model` parameter to `WeightTransferEngine.__init__` and updated the call in `gpu_worker.py:345`, but the test mock in `test_weight_transfer_llm.py` was not updated to accept the new argument. This caused **1 new test failure** in the nightly CI (build [#67842](https://buildkite.com/vllm/ci/builds/67842)):

- **Entrypoints Unit Tests** — `TypeError: mock_create_engine() takes 2 positional arguments but 3 were given`

### Auto-generated
This revert PR was auto-generated by the CI failure analyzer bot. Please review before merging.