### PR TITLE
[Core] Add prefix-cache-aware routing for internal DP load balancing

### DIFF
--- a/tests/v1/engine/test_dp_prefix_cache_router.py
+++ b/tests/v1/engine/test_dp_prefix_cache_router.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import msgspec
+import pytest
+
+from vllm.config import CacheConfig, ParallelConfig, VllmConfig
+from vllm.config.device import DeviceConfig
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import get_hash_fn_by_name
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.engine import EngineCoreReadyResponse, EngineCoreRequest
+from vllm.v1.engine.core_client import AsyncMPClient, DPLBAsyncMPClient
+from vllm.v1.engine.dp_prefix_cache_router import DPPrefixCacheRouter
+from vllm.v1.request import Request
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    return False
+
+
+def _make_engine_request(
+    token_ids: list[int],
+    *,
+    request_id: str = "request",
+    cache_salt: str | None = None,
+) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=token_ids,
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=cache_salt,
+        data_parallel_rank=None,
+    )
+
+
+def _make_router(
+    *,
+    n_ranks: int = 2,
+    block_size: int = 4,
+    shallow_depth: int = 1,
+    deep_depth: int = 2,
+    warm_threshold: int = 1,
+    max_prefixes: int = 100_000,
+) -> DPPrefixCacheRouter:
+    parallel_config = ParallelConfig(
+        data_parallel_size=n_ranks,
+        data_parallel_prefix_cache_lb=True,
+        data_parallel_prefix_cache_lb_shallow_depth=shallow_depth,
+        data_parallel_prefix_cache_lb_deep_depth=deep_depth,
+        data_parallel_prefix_cache_lb_warm_threshold=warm_threshold,
+        data_parallel_prefix_cache_lb_max_prefixes=max_prefixes,
+    )
+    return DPPrefixCacheRouter(
+        parallel_config,
+        block_size=block_size,
+        hash_algo="sha256",
+        n_ranks=n_ranks,
+    )
+
+
+def _least_loaded(counts: list[list[int]]) -> int:
+    return min(range(len(counts)), key=lambda r: (counts[r][0] * 4 + counts[r][1], r))
+
+
+def test_router_hashes_match_request_block_hashes():
+    token_ids = list(range(12))
+    cache_salt = "tenant-a"
+    hash_fn = get_hash_fn_by_name("sha256")
+    init_none_hash(hash_fn)
+    block_hasher = get_request_block_hasher(4, hash_fn)
+
+    request = Request(
+        request_id="request",
+        prompt_token_ids=token_ids,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        cache_salt=cache_salt,
+        block_hasher=block_hasher,
+    )
+    router = _make_router(block_size=4)
+    engine_request = _make_engine_request(token_ids, cache_salt=cache_salt)
+
+    assert router._prompt_signatures(engine_request) == request.block_hashes
+
+
+def test_router_reuses_sticky_prefix_and_sets_branch_hint():
+    router = _make_router(block_size=2)
+    first = _make_engine_request([1, 2, 3, 4, 5, 6], request_id="first")
+    second = _make_engine_request([1, 2, 3, 4, 5, 6, 7, 8], request_id="second")
+    counts = [[0, 0], [0, 0]]
+
+    first_decision = router.route(first, counts, _least_loaded)
+    second_decision = router.route(second, counts, _least_loaded)
+
+    assert second_decision.rank == first_decision.rank
+    assert second_decision.dp_prefix_cache_prefix_len == 4
+    assert second.dp_prefix_cache_prefix_len is None
+
+
+def test_dp_lb_client_attaches_branch_hint_to_request():
+    client = object.__new__(DPLBAsyncMPClient)
+    client.core_engines = [b"\x00\x00", b"\x01\x00"]
+    client.lb_engines = [[0, 0], [0, 0]]
+    client.dp_prefix_cache_router = _make_router(block_size=2)
+    client.client_count = 1
+    client.eng_start_index = 0
+    client.reqs_in_flight = {}
+
+    first = _make_engine_request([1, 2, 3, 4, 5, 6], request_id="first")
+    second = _make_engine_request([1, 2, 3, 4, 5, 6, 7, 8], request_id="second")
+
+    DPLBAsyncMPClient.get_core_engine_for_request(client, first)
+    DPLBAsyncMPClient.get_core_engine_for_request(client, second)
+
+    assert second.dp_prefix_cache_prefix_len == 4
+
+
+def test_router_does_not_set_branch_hint_for_different_final_rank():
+    router = _make_router(block_size=2)
+    first = _make_engine_request([1, 2, 3, 4], request_id="first")
+    second = _make_engine_request([1, 2, 3, 4, 5, 6], request_id="second")
+    counts = [[0, 0], [0, 0]]
+
+    first_decision = router.route(first, counts, _least_loaded)
+    signatures = router._prompt_signatures(second)
+    session_key = router._session_key(signatures)
+    router.session_rank[session_key] = 1 - first_decision.rank
+
+    second_decision = router.route(second, counts, _least_loaded)
+
+    assert second_decision.rank != first_decision.rank
+    assert second_decision.dp_prefix_cache_prefix_len is None
+
+
+def test_router_caps_branch_hint_at_deep_depth():
+    router = _make_router(block_size=2, shallow_depth=2, deep_depth=4)
+    counts = [[0, 0], [0, 0]]
+
+    three_block = _make_engine_request([1, 2, 3, 4, 5, 6], request_id="three")
+    four_block = _make_engine_request([1, 2, 3, 4, 5, 6, 7, 8], request_id="four")
+    router.route(three_block, counts, _least_loaded)
+    decision = router.route(four_block, counts, _least_loaded)
+    assert decision.dp_prefix_cache_prefix_len == 6
+
+    known = _make_engine_request(
+        list(range(20)),
+        request_id="known",
+    )
+    sibling = _make_engine_request(
+        list(range(22)),
+        request_id="sibling",
+    )
+    router.route(known, counts, _least_loaded)
+    decision = router.route(sibling, counts, _least_loaded)
+    assert decision.dp_prefix_cache_prefix_len == 8
+    assert max(len(prefix) for prefix in router.prefix_stats) <= 4
+
+
+def test_router_bounds_prefix_tracking_state():
+    router = _make_router(block_size=1, max_prefixes=3)
+    counts = [[0, 0], [0, 0]]
+
+    for i in range(8):
+        router.route(_make_engine_request([i, i + 100]), counts, _least_loaded)
+
+    assert len(router.session_rank) <= 3
+    assert len(router.prefix_stats) <= 3
+
+
+def test_router_reroutes_cold_miss_to_less_loaded_rank():
+    router = _make_router(block_size=2)
+    request = _make_engine_request([10, 11, 12, 13], request_id="cold")
+    signatures = router._prompt_signatures(request)
+    base_rank = router._hash_rank(router._session_key(signatures))
+    other_rank = 1 - base_rank
+    counts = [[0, 0], [0, 0]]
+    counts[base_rank] = [10, 0]
+
+    decision = router.route(request, counts, _least_loaded)
+
+    assert decision.rank == other_rank
+    assert decision.miss_rerouted
+
+
+def test_router_updates_sticky_rank_after_miss_reroute():
+    router = _make_router(block_size=2)
+    first = _make_engine_request([10, 11, 12, 13], request_id="first")
+    signatures = router._prompt_signatures(first)
+    session_key = router._session_key(signatures)
+    base_rank = router._hash_rank(session_key)
+    other_rank = 1 - base_rank
+    counts = [[0, 0], [0, 0]]
+    counts[base_rank] = [10, 0]
+
+    first_decision = router.route(first, counts, _least_loaded)
+    second_decision = router.route(
+        _make_engine_request([10, 11, 12, 13], request_id="second"),
+        [[0, 0], [0, 0]],
+        _least_loaded,
+    )
+
+    assert first_decision.rank == other_rank
+    assert second_decision.rank == other_rank
+
+
+def test_parallel_config_validates_dp_prefix_cache_lb():
+    with pytest.raises(ValueError, match="data_parallel_size > 1"):
+        ParallelConfig(data_parallel_prefix_cache_lb=True)
+
+    with pytest.raises(ValueError, match="External DP"):
+        ParallelConfig(
+            data_parallel_size=2,
+            data_parallel_external_lb=True,
+            data_parallel_prefix_cache_lb=True,
+        )
+
+    with pytest.raises(ValueError, match="enable_elastic_ep"):
+        ParallelConfig(
+            data_parallel_size=2,
+            data_parallel_prefix_cache_lb=True,
+            enable_elastic_ep=True,
+        )
+
+    with pytest.raises(ValueError, match="deep_depth"):
+        ParallelConfig(
+            data_parallel_size=2,
+            data_parallel_prefix_cache_lb=True,
+            data_parallel_prefix_cache_lb_shallow_depth=2,
+            data_parallel_prefix_cache_lb_deep_depth=2,
+        )
+
+
+def test_vllm_config_requires_prefix_caching_for_dp_prefix_cache_lb():
+    with pytest.raises(ValueError, match="requires prefix caching"):
+        VllmConfig(
+            cache_config=CacheConfig(enable_prefix_caching=False),
+            device_config=DeviceConfig("cpu"),
+            parallel_config=ParallelConfig(
+                data_parallel_size=2,
+                data_parallel_prefix_cache_lb=True,
+            ),
+        )
+
+
+def test_ready_response_sets_resolved_hash_block_size():
+    vllm_config = SimpleNamespace(
+        cache_config=CacheConfig(hash_block_size=None),
+        model_config=SimpleNamespace(max_model_len=2048),
+    )
+    client = SimpleNamespace(vllm_config=vllm_config, stats_update_address=None)
+    payload = msgspec.msgpack.encode(
+        EngineCoreReadyResponse(
+            max_model_len=1024,
+            num_gpu_blocks=1,
+            block_size=16,
+            dp_stats_address=None,
+            dtype="float16",
+            vllm_version="test",
+            world_size=1,
+            data_parallel_size=1,
+            hash_block_size=8,
+        )
+    )
+
+    AsyncMPClient._apply_ready_response(client, payload)  # type: ignore[arg-type]
+
+    assert vllm_config.cache_config.hash_block_size == 8
+
+
+def test_ready_response_rejects_hash_block_size_mismatch():
+    vllm_config = SimpleNamespace(
+        cache_config=CacheConfig(hash_block_size=4),
+        model_config=SimpleNamespace(max_model_len=2048),
+    )
+    client = SimpleNamespace(vllm_config=vllm_config, stats_update_address=None)
+    payload = msgspec.msgpack.encode(
+        EngineCoreReadyResponse(
+            max_model_len=1024,
+            num_gpu_blocks=1,
+            block_size=16,
+            dp_stats_address=None,
+            dtype="float16",
+            vllm_version="test",
+            world_size=1,
+            data_parallel_size=1,
+            hash_block_size=8,
+        )
+    )
+
+    with pytest.raises(ValueError, match="hash_block_size"):
+        AsyncMPClient._apply_ready_response(client, payload)  # type: ignore[arg-type]
+
+
+def test_mamba_aligned_split_stops_at_dp_prefix_branch_point():
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=4),
+        use_eagle=False,
+    )
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=16,
+        num_tokens=16,
+        dp_prefix_cache_prefix_len=8,
+    )
+
+    num_tokens = Scheduler._mamba_block_aligned_split(
+        scheduler,  # type: ignore[arg-type]
+        request,  # type: ignore[arg-type]
+        num_new_tokens=12,
+    )
+
+    assert num_tokens == 8
+
+
+def test_mamba_aligned_split_counts_external_tokens_as_computed():
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=4),
+        use_eagle=False,
+    )
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=16,
+        num_tokens=16,
+        dp_prefix_cache_prefix_len=8,
+    )
+
+    num_tokens = Scheduler._mamba_block_aligned_split(
+        scheduler,  # type: ignore[arg-type]
+        request,  # type: ignore[arg-type]
+        num_new_tokens=8,
+        num_external_computed_tokens=4,
+    )
+
+    assert num_tokens == 4

--- a/tests/v1/engine/test_dp_prefix_cache_router.py
+++ b/tests/v1/engine/test_dp_prefix_cache_router.py
@@ -46,6 +46,7 @@ def _make_router(
     *,
     n_ranks: int = 2,
     block_size: int = 4,
+    branch_block_size: int | None = None,
     shallow_depth: int = 1,
     deep_depth: int = 2,
     warm_threshold: int = 1,
@@ -61,7 +62,8 @@ def _make_router(
     )
     return DPPrefixCacheRouter(
         parallel_config,
-        block_size=block_size,
+        hash_block_size=block_size,
+        branch_block_size=branch_block_size,
         hash_algo="sha256",
         n_ranks=n_ranks,
     )
@@ -104,6 +106,18 @@ def test_router_reuses_sticky_prefix_and_sets_branch_hint():
     assert second_decision.rank == first_decision.rank
     assert second_decision.dp_prefix_cache_prefix_len == 4
     assert second.dp_prefix_cache_prefix_len is None
+
+
+def test_router_rounds_branch_hint_to_scheduler_block_size():
+    router = _make_router(block_size=2, branch_block_size=4, deep_depth=4)
+    first = _make_engine_request([1, 2, 3, 4, 5, 6], request_id="first")
+    second = _make_engine_request([1, 2, 3, 4, 5, 6, 7, 8], request_id="second")
+    counts = [[0, 0], [0, 0]]
+
+    router.route(first, counts, _least_loaded)
+    second_decision = router.route(second, counts, _least_loaded)
+
+    assert second_decision.dp_prefix_cache_prefix_len == 4
 
 
 def test_dp_lb_client_attaches_branch_hint_to_request():
@@ -251,6 +265,20 @@ def test_vllm_config_requires_prefix_caching_for_dp_prefix_cache_lb():
         )
 
 
+def test_vllm_config_requires_pythonhashseed_for_dp_prefix_cache_lb(monkeypatch):
+    monkeypatch.delenv("PYTHONHASHSEED", raising=False)
+
+    with pytest.raises(ValueError, match="PYTHONHASHSEED"):
+        VllmConfig(
+            cache_config=CacheConfig(enable_prefix_caching=True),
+            device_config=DeviceConfig("cpu"),
+            parallel_config=ParallelConfig(
+                data_parallel_size=2,
+                data_parallel_prefix_cache_lb=True,
+            ),
+        )
+
+
 def test_ready_response_sets_resolved_hash_block_size():
     vllm_config = SimpleNamespace(
         cache_config=CacheConfig(hash_block_size=None),
@@ -274,6 +302,7 @@ def test_ready_response_sets_resolved_hash_block_size():
     AsyncMPClient._apply_ready_response(client, payload)  # type: ignore[arg-type]
 
     assert vllm_config.cache_config.hash_block_size == 8
+    assert vllm_config.cache_config.block_size == 16
 
 
 def test_ready_response_rejects_hash_block_size_mismatch():

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -157,6 +157,22 @@ class ParallelConfig:
     between local data parallel ranks, but an external LB balances
     between vLLM nodes/replicas. Set explicitly in conjunction with
     --data-parallel-start-rank."""
+    data_parallel_prefix_cache_lb: bool = False
+    """Enable prefix-cache-aware routing for internal data-parallel serving.
+    When enabled, the frontend routes requests using prompt prefix signatures
+    and local DP load before falling back to regular queue-depth balancing."""
+    data_parallel_prefix_cache_lb_shallow_depth: int = Field(default=2, gt=0)
+    """Number of prompt blocks used as the shallow sticky-routing key."""
+    data_parallel_prefix_cache_lb_deep_depth: int = Field(default=4, gt=0)
+    """Maximum prompt block depth tracked for deep prefix ownership."""
+    data_parallel_prefix_cache_lb_warm_threshold: int = Field(default=3, gt=0)
+    """Observation threshold before a prefix is treated as warm routing state."""
+    data_parallel_prefix_cache_lb_load_imbalance_ratio: float = Field(
+        default=2.0, gt=1.0
+    )
+    """Load ratio at which cache-miss routing may prefer a less-loaded rank."""
+    data_parallel_prefix_cache_lb_max_prefixes: int = Field(default=100_000, gt=0)
+    """Maximum number of prefix signatures tracked by prefix-cache-aware DP LB."""
     is_moe_model: bool | None = None
     """Whether the deployed model is MoE (if known)."""
     enable_expert_parallel: bool = False
@@ -465,6 +481,27 @@ class ParallelConfig:
                 "data_parallel_external_lb can only be set when data_parallel_size > 1"
             )
 
+        if self.data_parallel_prefix_cache_lb:
+            if self.data_parallel_size <= 1:
+                raise ValueError(
+                    "data_parallel_prefix_cache_lb can only be set when "
+                    "data_parallel_size > 1"
+                )
+            if self.data_parallel_external_lb:
+                raise ValueError(
+                    "data_parallel_prefix_cache_lb is only supported when vLLM "
+                    "can route among local data-parallel engines. External DP "
+                    "load-balancer mode must route outside vLLM."
+                )
+            if (
+                self.data_parallel_prefix_cache_lb_deep_depth
+                <= self.data_parallel_prefix_cache_lb_shallow_depth
+            ):
+                raise ValueError(
+                    "data_parallel_prefix_cache_lb_deep_depth must be greater "
+                    "than data_parallel_prefix_cache_lb_shallow_depth"
+                )
+
         if not self.numa_bind and (
             self.numa_bind_nodes is not None or self.numa_bind_cpus is not None
         ):
@@ -752,6 +789,12 @@ class ParallelConfig:
             "data_parallel_backend",
             "data_parallel_external_lb",
             "data_parallel_hybrid_lb",
+            "data_parallel_prefix_cache_lb",
+            "data_parallel_prefix_cache_lb_shallow_depth",
+            "data_parallel_prefix_cache_lb_deep_depth",
+            "data_parallel_prefix_cache_lb_warm_threshold",
+            "data_parallel_prefix_cache_lb_load_imbalance_ratio",
+            "data_parallel_prefix_cache_lb_max_prefixes",
             "data_parallel_master_ip",
             "data_parallel_master_port",
             "_data_parallel_master_port_list",
@@ -799,6 +842,13 @@ class ParallelConfig:
         if self.distributed_executor_backend == "external_launcher":
             logger.info("Using external launcher for distributed inference.")
             self.world_size *= self.data_parallel_size
+
+        if self.data_parallel_prefix_cache_lb and self.enable_elastic_ep:
+            raise ValueError(
+                "data_parallel_prefix_cache_lb is not compatible with "
+                "enable_elastic_ep because elastic scaling changes the DP "
+                "rank set at runtime."
+            )
 
         if self.enable_elastic_ep:
             if not self.enable_eplb:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -869,6 +869,16 @@ class VllmConfig:
             self.parallel_config.is_moe_model = self.model_config.is_moe
 
         if (
+            self.parallel_config.data_parallel_prefix_cache_lb
+            and not self.cache_config.enable_prefix_caching
+        ):
+            raise ValueError(
+                "data_parallel_prefix_cache_lb requires prefix caching. "
+                "Enable prefix caching or disable data-parallel prefix-cache "
+                "load balancing."
+            )
+
+        if (
             self.model_config is not None
             and self.model_config.enable_return_routed_experts
         ):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -877,6 +877,15 @@ class VllmConfig:
                 "Enable prefix caching or disable data-parallel prefix-cache "
                 "load balancing."
             )
+        if (
+            self.parallel_config.data_parallel_prefix_cache_lb
+            and os.getenv("PYTHONHASHSEED") is None
+        ):
+            raise ValueError(
+                "data_parallel_prefix_cache_lb requires PYTHONHASHSEED to be "
+                "set so frontend routing and engine prefix-cache hashes are "
+                "deterministic across processes."
+            )
 
         if (
             self.model_config is not None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -482,6 +482,24 @@ class EngineArgs:
     data_parallel_hybrid_lb: bool = False
     data_parallel_external_lb: bool = False
     data_parallel_multi_port_external_lb: bool = False
+    data_parallel_prefix_cache_lb: bool = (
+        ParallelConfig.data_parallel_prefix_cache_lb
+    )
+    data_parallel_prefix_cache_lb_shallow_depth: int = (
+        ParallelConfig.data_parallel_prefix_cache_lb_shallow_depth
+    )
+    data_parallel_prefix_cache_lb_deep_depth: int = (
+        ParallelConfig.data_parallel_prefix_cache_lb_deep_depth
+    )
+    data_parallel_prefix_cache_lb_warm_threshold: int = (
+        ParallelConfig.data_parallel_prefix_cache_lb_warm_threshold
+    )
+    data_parallel_prefix_cache_lb_load_imbalance_ratio: float = (
+        ParallelConfig.data_parallel_prefix_cache_lb_load_imbalance_ratio
+    )
+    data_parallel_prefix_cache_lb_max_prefixes: int = (
+        ParallelConfig.data_parallel_prefix_cache_lb_max_prefixes
+    )
     data_parallel_backend: DataParallelBackend = ParallelConfig.data_parallel_backend
     enable_expert_parallel: bool = ParallelConfig.enable_expert_parallel
     enable_ep_weight_filter: bool = ParallelConfig.enable_ep_weight_filter
@@ -1074,6 +1092,32 @@ class EngineArgs:
             "--data-parallel-external-lb",
             "-dpe",
             **parallel_kwargs["data_parallel_external_lb"],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-prefix-cache-lb",
+            **parallel_kwargs["data_parallel_prefix_cache_lb"],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-prefix-cache-lb-shallow-depth",
+            **parallel_kwargs["data_parallel_prefix_cache_lb_shallow_depth"],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-prefix-cache-lb-deep-depth",
+            **parallel_kwargs["data_parallel_prefix_cache_lb_deep_depth"],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-prefix-cache-lb-warm-threshold",
+            **parallel_kwargs["data_parallel_prefix_cache_lb_warm_threshold"],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-prefix-cache-lb-load-imbalance-ratio",
+            **parallel_kwargs[
+                "data_parallel_prefix_cache_lb_load_imbalance_ratio"
+            ],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-prefix-cache-lb-max-prefixes",
+            **parallel_kwargs["data_parallel_prefix_cache_lb_max_prefixes"],
         )
         parallel_group.add_argument(
             "--data-parallel-multi-port-external-lb",
@@ -2076,6 +2120,22 @@ class EngineArgs:
             data_parallel_rank=self.data_parallel_rank or 0,
             data_parallel_external_lb=data_parallel_external_lb,
             data_parallel_size_local=data_parallel_size_local,
+            data_parallel_prefix_cache_lb=self.data_parallel_prefix_cache_lb,
+            data_parallel_prefix_cache_lb_shallow_depth=(
+                self.data_parallel_prefix_cache_lb_shallow_depth
+            ),
+            data_parallel_prefix_cache_lb_deep_depth=(
+                self.data_parallel_prefix_cache_lb_deep_depth
+            ),
+            data_parallel_prefix_cache_lb_warm_threshold=(
+                self.data_parallel_prefix_cache_lb_warm_threshold
+            ),
+            data_parallel_prefix_cache_lb_load_imbalance_ratio=(
+                self.data_parallel_prefix_cache_lb_load_imbalance_ratio
+            ),
+            data_parallel_prefix_cache_lb_max_prefixes=(
+                self.data_parallel_prefix_cache_lb_max_prefixes
+            ),
             master_addr=self.master_addr,
             master_port=self.master_port,
             nnodes=self.nnodes,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -114,6 +114,12 @@ def init_none_hash(hash_fn: Callable[[Any], bytes]):
         NONE_HASH = BlockHash(hash_fn(hash_seed))
 
 
+def ensure_none_hash_initialized(hash_fn: Callable[[Any], bytes]) -> None:
+    """Initialize NONE_HASH if the process has not initialized it yet."""
+    if "NONE_HASH" not in globals():
+        init_none_hash(hash_fn)
+
+
 @dataclass(slots=True)
 class KVCacheBlock:
     """KV-cache block metadata."""
@@ -429,7 +435,10 @@ def need_extra_keys(request: Request) -> bool:
 
 
 def _gen_mm_extra_hash_keys(
-    request: Request, start_token_idx: int, end_token_idx: int, start_mm_idx: int
+    mm_features: Sequence[Any],
+    start_token_idx: int,
+    end_token_idx: int,
+    start_mm_idx: int,
 ) -> tuple[list[Any], int]:
     """Generate extra keys related to MultiModal request for block hash
     computation. For multi-modal inputs, the extra keys are
@@ -437,7 +446,7 @@ def _gen_mm_extra_hash_keys(
     block and its starting offset in the block tokens.
 
     Args:
-        request: The request object.
+        mm_features: Multi-modal features sorted by position.
         start_token_idx: The start token index of the block.
         end_token_idx: The end token index of the block.
         start_mm_idx: The start multi-modal index of the block.
@@ -447,7 +456,6 @@ def _gen_mm_extra_hash_keys(
     """
     extra_keys: list[Any] = []
 
-    mm_features = request.mm_features
     if not mm_features:
         return extra_keys, start_mm_idx
 
@@ -495,28 +503,32 @@ def _gen_mm_extra_hash_keys(
     return extra_keys, curr_mm_idx
 
 
-def _gen_lora_extra_hash_keys(request: Request) -> list[str]:
+def _gen_lora_extra_hash_keys(lora_request: Any | None) -> list[str]:
     """Generate extra keys related to LoRA for block hash computation.
 
     Args:
-        request: The request object.
+        lora_request: The LoRA request, if any.
 
     Returns:
         Return LoRA name of the request if it is a LoRA request. Return empty
         list otherwise.
     """
-    if not request.lora_request:
+    if not lora_request:
         return []
-    return [request.lora_request.lora_name]
+    return [lora_request.lora_name]
 
 
 def _gen_prompt_embeds_extra_hash_keys(
-    request: Request, start_token_idx: int, end_token_idx: int
+    prompt_embeds: Any | None,
+    prompt_embeds_per_block_hashes: dict[tuple[int, int], bytes],
+    start_token_idx: int,
+    end_token_idx: int,
 ) -> list[bytes]:
     """Generate extra keys related to prompt embeds for block hash computation.
 
     Args:
-        request: The request object.
+        prompt_embeds: Prompt embedding tensor, if any.
+        prompt_embeds_per_block_hashes: Per-block prompt embedding hash cache.
         start_token_idx: The start token index of the block.
         end_token_idx: The end token index of the block.
 
@@ -524,15 +536,15 @@ def _gen_prompt_embeds_extra_hash_keys(
         Return a stable hash of the block prompt embeddings if prompt embeds
         are present. Return empty list otherwise.
     """
-    if request.prompt_embeds is None:
+    if prompt_embeds is None:
         return []
     block_range = (start_token_idx, end_token_idx)
-    embeds_hash = request._prompt_embeds_per_block_hashes.get(block_range)
+    embeds_hash = prompt_embeds_per_block_hashes.get(block_range)
     if embeds_hash is None:
-        block_prompt_embeds = request.prompt_embeds[start_token_idx:end_token_idx]
+        block_prompt_embeds = prompt_embeds[start_token_idx:end_token_idx]
         # Hash prompt embeds once per block and cache on request
         embeds_hash = hashlib.sha256(tensor_data(block_prompt_embeds)).digest()
-        request._prompt_embeds_per_block_hashes[block_range] = embeds_hash
+        prompt_embeds_per_block_hashes[block_range] = embeds_hash
     return [embeds_hash]
 
 
@@ -552,16 +564,57 @@ def generate_block_hash_extra_keys(
     Returns:
         A tuple of extra keys and the next multi-modal index.
     """
-    mm_extra_keys: list[Any]
-    mm_extra_keys, new_start_mm_idx = _gen_mm_extra_hash_keys(
-        request, start_token_idx, end_token_idx, start_mm_idx
+    return generate_block_hash_extra_keys_from_components(
+        mm_features=request.mm_features,
+        lora_request=request.lora_request,
+        cache_salt=request.cache_salt,
+        prompt_embeds=request.prompt_embeds,
+        prompt_embeds_per_block_hashes=request._prompt_embeds_per_block_hashes,
+        start_token_idx=start_token_idx,
+        end_token_idx=end_token_idx,
+        start_mm_idx=start_mm_idx,
     )
-    lora_extra_keys: list[str] = _gen_lora_extra_hash_keys(request)
+
+
+def generate_block_hash_extra_keys_from_components(
+    *,
+    mm_features: Sequence[Any],
+    lora_request: Any | None,
+    cache_salt: str | None,
+    prompt_embeds: Any | None,
+    prompt_embeds_per_block_hashes: dict[tuple[int, int], bytes],
+    start_token_idx: int,
+    end_token_idx: int,
+    start_mm_idx: int,
+) -> tuple[tuple[Any, ...] | None, int]:
+    """Generate block hash extra keys from request-like components.
+
+    Args:
+        mm_features: Multi-modal features sorted by position.
+        lora_request: LoRA request metadata, if any.
+        cache_salt: Optional salt mixed into the first block.
+        prompt_embeds: Prompt embedding tensor, if any.
+        prompt_embeds_per_block_hashes: Per-block prompt embedding hash cache.
+        start_token_idx: The start token index of the block.
+        end_token_idx: The end token index of the block.
+        start_mm_idx: The start multi-modal index of the block.
+
+    Returns:
+        A tuple of extra keys and the next multi-modal index.
+    """
+
+    mm_extra_keys, new_start_mm_idx = _gen_mm_extra_hash_keys(
+        mm_features, start_token_idx, end_token_idx, start_mm_idx
+    )
+    lora_extra_keys = _gen_lora_extra_hash_keys(lora_request)
     cache_salt_keys: list[str] = (
-        [request.cache_salt] if (start_token_idx == 0 and request.cache_salt) else []
+        [cache_salt] if (start_token_idx == 0 and cache_salt) else []
     )
     prompt_embeds_keys = _gen_prompt_embeds_extra_hash_keys(
-        request, start_token_idx, end_token_idx
+        prompt_embeds,
+        prompt_embeds_per_block_hashes,
+        start_token_idx,
+        end_token_idx,
     )
 
     extra_keys: list[Any] = (
@@ -685,49 +738,79 @@ def get_request_block_hasher(
     """
 
     def request_block_hasher(request: Request) -> list[BlockHash]:
-        start_token_idx = len(request.block_hashes) * hash_block_size
-        num_tokens = request.num_tokens
-
-        if start_token_idx + hash_block_size > num_tokens:
-            # Early stop when there no new full blocks created.
-            return []
-
-        curr_mm_idx = 0
-        if start_token_idx > 0:
-            # Set curr_mm_idx = -1 to indicate the last mm input.
-            # Note that since we reach to this branch only when the block is
-            # completed with generated tokens, we only need to consider the
-            # last mm input.
-            curr_mm_idx = -1
-
-        prev_block_hash_value = (
-            request.block_hashes[-1] if request.block_hashes else None
+        return compute_block_hashes_from_components(
+            all_token_ids=request.all_token_ids,
+            existing_block_hashes=request.block_hashes,
+            mm_features=request.mm_features,
+            lora_request=request.lora_request,
+            cache_salt=request.cache_salt,
+            prompt_embeds=request.prompt_embeds,
+            prompt_embeds_per_block_hashes=request._prompt_embeds_per_block_hashes,
+            block_size=hash_block_size,
+            caching_hash_fn=caching_hash_fn,
         )
-        new_block_hashes: list[BlockHash] = []
-        while True:
-            end_token_idx = start_token_idx + hash_block_size
-            if end_token_idx > num_tokens:
-                # We only hash full blocks
-                break
-
-            # MM and LoRA requests need extra keys for block-hash computation.
-            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                request, start_token_idx, end_token_idx, curr_mm_idx
-            )
-
-            # Compute the hash of the current block
-            block_tokens = request.all_token_ids[start_token_idx:end_token_idx]
-            block_hash = hash_block_tokens(
-                caching_hash_fn, prev_block_hash_value, block_tokens, extra_keys
-            )
-
-            new_block_hashes.append(block_hash)
-            start_token_idx += hash_block_size
-            prev_block_hash_value = block_hash
-
-        return new_block_hashes
 
     return request_block_hasher
+
+
+def compute_block_hashes_from_components(
+    *,
+    all_token_ids: Sequence[int],
+    existing_block_hashes: Sequence[BlockHash],
+    mm_features: Sequence[Any],
+    lora_request: Any | None,
+    cache_salt: str | None,
+    prompt_embeds: Any | None,
+    prompt_embeds_per_block_hashes: dict[tuple[int, int], bytes],
+    block_size: int,
+    caching_hash_fn: Callable[[Any], bytes],
+) -> list[BlockHash]:
+    """Compute block hashes from request-like components.
+
+    This keeps front-end routing signatures aligned with the scheduler-side
+    prefix cache keys without requiring a full ``Request`` object.
+    """
+    start_token_idx = len(existing_block_hashes) * block_size
+    num_tokens = len(all_token_ids)
+
+    if start_token_idx + block_size > num_tokens:
+        return []
+
+    curr_mm_idx = 0
+    if start_token_idx > 0:
+        # For generated-token hashing we only need to consider the last MM item.
+        curr_mm_idx = -1
+
+    prev_block_hash_value = (
+        existing_block_hashes[-1] if existing_block_hashes else None
+    )
+    new_block_hashes: list[BlockHash] = []
+    while True:
+        end_token_idx = start_token_idx + block_size
+        if end_token_idx > num_tokens:
+            break
+
+        extra_keys, curr_mm_idx = generate_block_hash_extra_keys_from_components(
+            mm_features=mm_features,
+            lora_request=lora_request,
+            cache_salt=cache_salt,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_per_block_hashes=prompt_embeds_per_block_hashes,
+            start_token_idx=start_token_idx,
+            end_token_idx=end_token_idx,
+            start_mm_idx=curr_mm_idx,
+        )
+
+        block_tokens = all_token_ids[start_token_idx:end_token_idx]
+        block_hash = hash_block_tokens(
+            caching_hash_fn, prev_block_hash_value, block_tokens, extra_keys
+        )
+
+        new_block_hashes.append(block_hash)
+        start_token_idx += block_size
+        prev_block_hash_value = block_hash
+
+    return new_block_hashes
 
 
 def _check_enough_kv_cache_memory(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -359,8 +359,24 @@ class Scheduler(SchedulerInterface):
             # eagle prune
             if self.use_eagle:
                 last_cache_position = max(last_cache_position - block_size, 0)
+            branch_cache_position = 0
+            dp_prefix_cache_prefix_len = request.dp_prefix_cache_prefix_len
+            if dp_prefix_cache_prefix_len is not None:
+                branch_cache_position = (
+                    dp_prefix_cache_prefix_len
+                    - dp_prefix_cache_prefix_len % block_size
+                )
+                branch_cache_position = min(branch_cache_position, last_cache_position)
             num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
-            if num_computed_tokens_after_sched < last_cache_position:
+            if (
+                num_computed_tokens
+                < branch_cache_position
+                < num_computed_tokens_after_sched
+            ):
+                # Stop at an observed branch point so align-mode Mamba/GDN can
+                # materialize a reusable state block for later sibling prompts.
+                num_new_tokens = branch_cache_position - num_computed_tokens
+            elif num_computed_tokens_after_sched < last_cache_position:
                 # align to block_size
                 num_new_tokens = num_new_tokens // block_size * block_size
             elif (

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -137,6 +137,11 @@ class EngineCoreRequest(
     # KV-transfer request is rejected on the D node before engine admission.
     abort_immediately: bool = False
 
+    # Internal hint used by DP prefix-cache-aware routing. When set, the
+    # scheduler may stop a prefill chunk at this block-aligned prefix boundary
+    # so hybrid KV cache state can be materialized for later sibling prompts.
+    dp_prefix_cache_prefix_len: int | None = None
+
     @property
     def params(self) -> SamplingParams | PoolingParams:
         """Return the processed params (sampling or pooling)."""

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -83,6 +83,7 @@ class EngineCoreReadyResponse:
     # KV cache capacity (None for encoder-only/attention-free models).
     kv_cache_size_tokens: int | None = None
     kv_cache_max_concurrency: float | None = None
+    hash_block_size: int | None = None
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -146,6 +146,7 @@ class EngineCore:
         scheduler_block_size, hash_block_size = resolve_kv_cache_block_sizes(
             kv_cache_config, vllm_config
         )
+        self.hash_block_size = hash_block_size
 
         self.scheduler: SchedulerInterface = Scheduler(
             vllm_config=vllm_config,
@@ -1537,6 +1538,7 @@ class EngineCoreProc(EngineCore):
                 kv_cache_max_concurrency=(
                     self.vllm_config.cache_config.kv_cache_max_concurrency
                 ),
+                hash_block_size=self.hash_block_size,
             )
             ready_payload = msgspec.msgpack.encode(ready_response)
             for input_socket in input_sockets:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -744,6 +744,17 @@ class MPClient(EngineCoreClient):
             else response.kv_cache_max_concurrency
         )
 
+        if response.hash_block_size is not None:
+            hash_block_size = vllm_config.cache_config.hash_block_size
+            if hash_block_size is None:
+                vllm_config.cache_config.hash_block_size = response.hash_block_size
+            elif hash_block_size != response.hash_block_size:
+                raise ValueError(
+                    "EngineCore resolved hash_block_size="
+                    f"{response.hash_block_size}, but frontend has "
+                    f"hash_block_size={hash_block_size}."
+                )
+
         # In external DP LB mode, the coordinator address that the
         # front-end procs connect to is obtained by each engine via it's
         # initial handshake with the rank 0 front-end.

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1454,6 +1454,9 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                     self._get_least_loaded_engine_index,
                 )
                 eng_index = decision.rank
+                request.dp_prefix_cache_prefix_len = (
+                    decision.dp_prefix_cache_prefix_len
+                )
             # Increment local waiting count for better balancing between stats
             # updates from the coordinator (which happen every 100ms).
             current_counts[eng_index][0] += self.client_count

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -47,6 +47,7 @@ from vllm.v1.engine import (
 )
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.engine.core import EngineCore, EngineCoreProc
+from vllm.v1.engine.dp_prefix_cache_router import DPPrefixCacheRouter
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.engine.tensor_ipc import TensorIpcSender
 from vllm.v1.engine.utils import (
@@ -1420,6 +1421,21 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         self.eng_start_index = (
             len(self.core_engines) * self.client_index
         ) // client_count
+        parallel_config = vllm_config.parallel_config
+        self.dp_prefix_cache_router = (
+            DPPrefixCacheRouter(
+                parallel_config,
+                block_size=(
+                    vllm_config.cache_config.hash_block_size
+                    or vllm_config.cache_config.block_size
+                ),
+                hash_algo=vllm_config.cache_config.prefix_caching_hash_algo,
+                n_ranks=len(self.core_engines),
+                start_index=self.eng_start_index,
+            )
+            if parallel_config.data_parallel_prefix_cache_lb
+            else None
+        )
 
     def get_core_engine_for_request(self, request: EngineCoreRequest) -> EngineIdentity:
         # Engines are in rank order.
@@ -1429,19 +1445,15 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             )
         ) is None:
             current_counts = self.lb_engines
-            # TODO use P2C alg for larger DP sizes
-            num_engines = len(current_counts)
-            min_score = sys.maxsize
-            eng_index = 0
-            for i in range(num_engines):
-                # Start from client_index to help with balancing when engines
-                # are empty.
-                idx = (self.eng_start_index + i) % num_engines
-                waiting, running = current_counts[idx]
-                score = waiting * 4 + running
-                if score < min_score:
-                    min_score = score
-                    eng_index = idx
+            if self.dp_prefix_cache_router is None:
+                eng_index = self._get_least_loaded_engine_index(current_counts)
+            else:
+                decision = self.dp_prefix_cache_router.route(
+                    request,
+                    current_counts,
+                    self._get_least_loaded_engine_index,
+                )
+                eng_index = decision.rank
             # Increment local waiting count for better balancing between stats
             # updates from the coordinator (which happen every 100ms).
             current_counts[eng_index][0] += self.client_count
@@ -1450,6 +1462,24 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         # Record which engine is chosen for this request, to handle aborts.
         self.reqs_in_flight[request.request_id] = chosen_engine
         return chosen_engine
+
+    def _get_least_loaded_engine_index(
+        self, current_counts: Sequence[Sequence[int]]
+    ) -> int:
+        # TODO use P2C alg for larger DP sizes
+        num_engines = len(current_counts)
+        min_score = sys.maxsize
+        eng_index = 0
+        for i in range(num_engines):
+            # Start from client_index to help with balancing when engines
+            # are empty.
+            idx = (self.eng_start_index + i) % num_engines
+            waiting, running = current_counts[idx]
+            score = waiting * 4 + running
+            if score < min_score:
+                min_score = score
+                eng_index = idx
+        return eng_index
 
     async def call_utility_async(self, method: str, *args) -> Any:
         # Only the result from the first engine is returned.

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1425,13 +1425,13 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         self.dp_prefix_cache_router = (
             DPPrefixCacheRouter(
                 parallel_config,
-                block_size=(
+                hash_block_size=(
                     vllm_config.cache_config.hash_block_size
                     or vllm_config.cache_config.block_size
                 ),
+                branch_block_size=vllm_config.cache_config.block_size,
                 hash_algo=vllm_config.cache_config.prefix_caching_hash_algo,
                 n_ranks=len(self.core_engines),
-                start_index=self.eng_start_index,
             )
             if parallel_config.data_parallel_prefix_cache_lb
             else None

--- a/vllm/v1/engine/dp_prefix_cache_router.py
+++ b/vllm/v1/engine/dp_prefix_cache_router.py
@@ -54,13 +54,18 @@ class DPPrefixCacheRouter:
         self,
         parallel_config: ParallelConfig,
         *,
-        block_size: int | None,
+        hash_block_size: int | None,
+        branch_block_size: int | None = None,
         hash_algo: str,
         n_ranks: int,
         start_index: int = 0,
     ) -> None:
         self.n_ranks = n_ranks
-        self.block_size = max(block_size or 1, 1)
+        # Hashes are computed at the engine-resolved hash granularity, while
+        # scheduler branch hints must be aligned to the scheduler's cache block
+        # boundary.
+        self.hash_block_size = max(hash_block_size or 1, 1)
+        self.branch_block_size = max(branch_block_size or self.hash_block_size, 1)
         self.start_index = start_index
         self.shallow_depth = parallel_config.data_parallel_prefix_cache_lb_shallow_depth
         self.deep_depth = parallel_config.data_parallel_prefix_cache_lb_deep_depth
@@ -113,7 +118,7 @@ class DPPrefixCacheRouter:
 
         dp_prefix_cache_prefix_len = None
         if rank == overlap_rank and 0 < overlap_depth < len(full_signatures):
-            dp_prefix_cache_prefix_len = overlap_depth * self.block_size
+            dp_prefix_cache_prefix_len = self._branch_prefix_len(overlap_depth)
 
         self._record_session(session_key, rank)
         self._record_assignment(rank, full_signatures)
@@ -136,7 +141,7 @@ class DPPrefixCacheRouter:
             cache_salt=request.cache_salt,
             prompt_embeds=request.prompt_embeds,
             prompt_embeds_per_block_hashes={},
-            block_size=self.block_size,
+            block_size=self.hash_block_size,
             caching_hash_fn=self.caching_hash_fn,
         )
 
@@ -163,9 +168,14 @@ class DPPrefixCacheRouter:
         return rank
 
     def _hash_rank(self, key: BlockHash) -> int:
-        return (int.from_bytes(bytes(key)[:8], byteorder="big") + self.start_index) % (
+        return (int.from_bytes(key[:8], byteorder="big") + self.start_index) % (
             self.n_ranks
         )
+
+    def _branch_prefix_len(self, depth: int) -> int | None:
+        prefix_len = depth * self.hash_block_size
+        prefix_len -= prefix_len % self.branch_block_size
+        return prefix_len or None
 
     def _would_miss(self, rank: int, signatures: list[BlockHash]) -> bool:
         if rank >= self.n_ranks:

--- a/vllm/v1/engine/dp_prefix_cache_router.py
+++ b/vllm/v1/engine/dp_prefix_cache_router.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Prefix-cache-aware routing helpers for internal data-parallel LB.
+
+This module runs on the frontend side. It only chooses a DP engine and may
+attach a block-aligned prefix boundary hint for the scheduler. Actual KV cache
+hits are still confirmed by the engine-local prefix cache or KV connectors.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import OrderedDict, defaultdict
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from vllm.config import ParallelConfig
+from vllm.utils.hashing import get_hash_fn_by_name
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    compute_block_hashes_from_components,
+    ensure_none_hash_initialized,
+)
+from vllm.v1.engine import EngineCoreRequest
+
+RankSelector = Callable[[Sequence[Sequence[int]]], int]
+
+
+@dataclass(frozen=True)
+class DPPrefixCacheRouteDecision:
+    rank: int
+    reason: str
+    miss_rerouted: bool = False
+    dp_prefix_cache_prefix_len: int | None = None
+
+
+@dataclass
+class _PrefixStats:
+    hits: int = 0
+    rank_hits: defaultdict[int, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+
+    def record(self, rank: int) -> None:
+        self.hits += 1
+        self.rank_hits[rank] += 1
+
+
+class DPPrefixCacheRouter:
+    """Adaptive DP rank router using vLLM block-level prompt hashes."""
+
+    def __init__(
+        self,
+        parallel_config: ParallelConfig,
+        *,
+        block_size: int | None,
+        hash_algo: str,
+        n_ranks: int,
+        start_index: int = 0,
+    ) -> None:
+        self.n_ranks = n_ranks
+        self.block_size = max(block_size or 1, 1)
+        self.start_index = start_index
+        self.shallow_depth = parallel_config.data_parallel_prefix_cache_lb_shallow_depth
+        self.deep_depth = parallel_config.data_parallel_prefix_cache_lb_deep_depth
+        self.warm_threshold = (
+            parallel_config.data_parallel_prefix_cache_lb_warm_threshold
+        )
+        self.load_imbalance_ratio = (
+            parallel_config.data_parallel_prefix_cache_lb_load_imbalance_ratio
+        )
+        self.max_prefixes = parallel_config.data_parallel_prefix_cache_lb_max_prefixes
+        self.caching_hash_fn = get_hash_fn_by_name(hash_algo)
+        ensure_none_hash_initialized(self.caching_hash_fn)
+
+        self.session_rank: OrderedDict[BlockHash, int] = OrderedDict()
+        self.prefix_stats: OrderedDict[tuple[BlockHash, ...], _PrefixStats] = (
+            OrderedDict()
+        )
+
+    def route(
+        self,
+        request: EngineCoreRequest,
+        counts: Sequence[Sequence[int]],
+        fallback_selector: RankSelector,
+    ) -> DPPrefixCacheRouteDecision:
+        full_signatures = self._prompt_signatures(request)
+        if not full_signatures:
+            return DPPrefixCacheRouteDecision(fallback_selector(counts), "no-prefix")
+
+        overlap_depth, overlap_rank = self._longest_known_prefix(
+            full_signatures, counts
+        )
+
+        session_key = self._session_key(full_signatures)
+        rank = self._get_session_rank(session_key)
+        reason = "sticky" if rank is not None else "hash"
+
+        if rank is None and overlap_rank is not None:
+            rank = overlap_rank
+            reason = "overlap-prefix"
+        elif rank is None:
+            rank = self._hash_rank(session_key)
+
+        miss_rerouted = False
+        if self._would_miss(rank, full_signatures):
+            balanced = self._pick_balanced_miss_rank(rank, counts, fallback_selector)
+            if balanced != rank:
+                rank = balanced
+                reason = "miss-reroute"
+                miss_rerouted = True
+
+        dp_prefix_cache_prefix_len = None
+        if rank == overlap_rank and 0 < overlap_depth < len(full_signatures):
+            dp_prefix_cache_prefix_len = overlap_depth * self.block_size
+
+        self._record_session(session_key, rank)
+        self._record_assignment(rank, full_signatures)
+        return DPPrefixCacheRouteDecision(
+            rank,
+            reason,
+            miss_rerouted,
+            dp_prefix_cache_prefix_len,
+        )
+
+    def _prompt_signatures(self, request: EngineCoreRequest) -> list[BlockHash]:
+        all_token_ids = self._all_token_ids(request)
+        if not all_token_ids:
+            return []
+        return compute_block_hashes_from_components(
+            all_token_ids=all_token_ids,
+            existing_block_hashes=[],
+            mm_features=request.mm_features or [],
+            lora_request=request.lora_request,
+            cache_salt=request.cache_salt,
+            prompt_embeds=request.prompt_embeds,
+            prompt_embeds_per_block_hashes={},
+            block_size=self.block_size,
+            caching_hash_fn=self.caching_hash_fn,
+        )
+
+    @staticmethod
+    def _all_token_ids(request: EngineCoreRequest) -> Sequence[int]:
+        if request.prompt_token_ids is not None:
+            return request.prompt_token_ids
+        if request.prompt_embeds is None:
+            return []
+        return [0] * len(request.prompt_embeds)
+
+    def _session_key(self, signatures: list[BlockHash]) -> BlockHash:
+        depth = min(len(signatures), self.shallow_depth)
+        return signatures[depth - 1]
+
+    def _get_session_rank(self, session_key: BlockHash) -> int | None:
+        rank = self.session_rank.get(session_key)
+        if rank is None:
+            return None
+        if rank >= self.n_ranks:
+            del self.session_rank[session_key]
+            return None
+        self.session_rank.move_to_end(session_key)
+        return rank
+
+    def _hash_rank(self, key: BlockHash) -> int:
+        return (int.from_bytes(bytes(key)[:8], byteorder="big") + self.start_index) % (
+            self.n_ranks
+        )
+
+    def _would_miss(self, rank: int, signatures: list[BlockHash]) -> bool:
+        if rank >= self.n_ranks:
+            return True
+        max_depth = min(len(signatures), self.deep_depth)
+        for depth in range(max_depth, 0, -1):
+            prefix = tuple(signatures[:depth])
+            stats = self.prefix_stats.get(prefix)
+            if stats is None:
+                continue
+            self.prefix_stats.move_to_end(prefix)
+            if stats.rank_hits.get(rank, 0) > 0:
+                return False
+        return True
+
+    def _longest_known_prefix(
+        self,
+        signatures: list[BlockHash],
+        counts: Sequence[Sequence[int]],
+    ) -> tuple[int, int | None]:
+        max_depth = min(len(signatures), self.deep_depth)
+        min_depth = min(self.shallow_depth, max_depth)
+        if max_depth == 0:
+            return 0, None
+        for depth in range(max_depth, min_depth - 1, -1):
+            prefix = tuple(signatures[:depth])
+            stats = self.prefix_stats.get(prefix)
+            if stats is None or stats.hits < self.warm_threshold:
+                continue
+            self.prefix_stats.move_to_end(prefix)
+            owners = [
+                rank
+                for rank, hits in stats.rank_hits.items()
+                if rank < self.n_ranks and hits > 0
+            ]
+            if owners:
+                rank = min(owners, key=lambda r: (self._load_score(counts, r), r))
+                return depth, rank
+        return 0, None
+
+    def _pick_balanced_miss_rank(
+        self,
+        current_rank: int,
+        counts: Sequence[Sequence[int]],
+        fallback_selector: RankSelector,
+    ) -> int:
+        balanced = fallback_selector(counts)
+        if balanced == current_rank:
+            return current_rank
+        current_score = self._load_score(counts, current_rank)
+        balanced_score = self._load_score(counts, balanced)
+        if current_score >= max(3, int(balanced_score * self.load_imbalance_ratio)):
+            return balanced
+        return current_rank
+
+    def _record_session(self, session_key: BlockHash, rank: int) -> None:
+        if session_key in self.session_rank:
+            self.session_rank[session_key] = rank
+            self.session_rank.move_to_end(session_key)
+            return
+        self.session_rank[session_key] = rank
+        while len(self.session_rank) > self.max_prefixes:
+            self.session_rank.popitem(last=False)
+
+    def _record_assignment(self, rank: int, signatures: list[BlockHash]) -> None:
+        max_depth = min(len(signatures), self.deep_depth)
+        for depth in range(1, max_depth + 1):
+            prefix = tuple(signatures[:depth])
+            stats = self.prefix_stats.get(prefix)
+            if stats is None:
+                stats = _PrefixStats()
+                self.prefix_stats[prefix] = stats
+            else:
+                self.prefix_stats.move_to_end(prefix)
+            stats.record(rank)
+            while len(self.prefix_stats) > self.max_prefixes:
+                self.prefix_stats.popitem(last=False)
+
+    @staticmethod
+    def _load_score(counts: Sequence[Sequence[int]], rank: int) -> int:
+        if rank >= len(counts):
+            return sys.maxsize
+        waiting, running = counts[rank]
+        return waiting * 4 + running

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -77,6 +77,7 @@ class Request:
         reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
         abort_immediately: bool = False,
+        dp_prefix_cache_prefix_len: int | None = None,
     ) -> None:
         self.request_id = request_id
         self.client_index = client_index
@@ -193,6 +194,7 @@ class Request:
         # If True, request should be aborted immediately after being added to
         # the scheduler so the connector's request_finished hook runs.
         self.abort_immediately = abort_immediately
+        self.dp_prefix_cache_prefix_len = dp_prefix_cache_prefix_len
 
     @classmethod
     def from_engine_core_request(
@@ -219,6 +221,7 @@ class Request:
             reasoning_ended=request.reasoning_ended,
             reasoning_parser_kwargs=request.reasoning_parser_kwargs,
             abort_immediately=request.abort_immediately,
+            dp_prefix_cache_prefix_len=request.dp_prefix_cache_prefix_len,
         )
 
     def append_output_token_ids(


### PR DESCRIPTION
## Purpose

This PR adds an opt-in prefix-cache-aware routing path for V1 internal data-parallel load balancing.

When `--data-parallel-prefix-cache-lb` is enabled, the frontend DP load balancer computes vLLM-compatible prompt block hashes and uses local best-effort prefix ownership state to choose a DP rank. The default behavior is unchanged.

Key points:

- Disabled by default.
- Only supports internal/local DP load balancing.
- Does not implement cross-DP KV import or warmup.
- Does not report external KV hits.
- Reuses vLLM prefix cache block hash semantics for routing signatures.
- Passes the resolved `hash_block_size` from EngineCore back to the frontend.
- Requires `PYTHONHASHSEED` when enabled so routing hashes are deterministic across processes.
- Adds an internal scheduler branch-point hint for align-mode Mamba/GDN prefill splitting.
- The branch-point hint only affects prefill chunk boundaries, not token contents or sampling semantics.

## Test Plan

```bash
python -m pytest tests/v1/engine/test_dp_prefix_cache_router.py -q

python -m ruff check \
  vllm/config/parallel.py \
  vllm/config/vllm.py \
  vllm/engine/arg_utils.py \
  vllm/v1/core/kv_cache_utils.py \
  vllm/v1/core/sched/scheduler.py \
  vllm/v1/engine/__init__.py \
  vllm/v1/engine/core.py \
  vllm/v1/engine/core_client.py \
  vllm/v1/request.py \
  vllm/v1/engine/dp_prefix_cache_router.py \
  tests/v1/engine/test_dp_prefix_cache_router.py

python -m py_compile \
  vllm/config/parallel.py \
  vllm/config/vllm.py \
  vllm/engine/arg_utils.py \
  vllm/v1/core/kv_cache_utils.py \
  vllm/v1/core/sched/scheduler.py \
  vllm/v1/engine/__init__.py \
  vllm/v1/engine/core.py \
  vllm/v1/engine/core_client.py \
  vllm/v1/request.py \
  vllm/v1/engine/dp_prefix_cache_router.py \
  tests/v1/engine/test_dp_prefix_cache_router.py

git diff --check origin/main...HEAD
```

## Test Result

```text
tests/v1/engine/test_dp_prefix_cache_router.py
16 passed

ruff check
All checks passed

py_compile
passed

git diff --check origin/main...HEAD
passed
```

Additional coverage:
- Router hashes match Request block hashes.
- Config validation covers unsupported DP modes and missing prefix caching.
- Routing covers sticky prefix reuse, overlap routing, miss reroute, bounded prefix tracking, deterministic seed requirement, and scheduler branch-hint alignment.
- Scheduler tests cover stopping at DP prefix branch points for align-mode Mamba/GDN splitting.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>

