### PR TITLE
fix: parse JSON literals in qwen3 XML tool args

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 
 import pytest
 
@@ -8,6 +9,11 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.tool_parsers.qwen3xml_tool_parser import Qwen3XMLToolParser
 
 
 class TestQwen3xmlToolParser(ToolParserTests):
@@ -70,3 +76,46 @@ class TestQwen3xmlToolParser(ToolParserTests):
             },
             supports_typed_arguments=False,
         )
+
+
+def test_qwen3xml_parses_json_literals_in_deferred_array_params():
+    tools = [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "AskUserQuestion",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "questions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "question": {"type": "string"},
+                                    "multiSelect": {"type": "boolean"},
+                                    "metadata": {"type": "object"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+    ]
+    model_output = """<tool_call>
+<function=AskUserQuestion>
+<parameter=questions>
+[{"question": "Pick one", "multiSelect": false, "metadata": null}]
+</parameter>
+</function>
+</tool_call>"""
+
+    parser = Qwen3XMLToolParser(tokenizer=None, tools=tools)  # type: ignore[arg-type]
+    request = ChatCompletionRequest(model="test", messages=[], tools=tools)
+    extracted = parser.extract_tool_calls(model_output, request=request)
+
+    args = json.loads(extracted.tool_calls[0].function.arguments)
+    assert args["questions"] == [
+        {"question": "Pick one", "multiSelect": False, "metadata": None}
+    ]

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -513,7 +513,7 @@ class StreamingXMLToolCallParser:
             if processed.startswith("</parameter>"):
                 body_text = self._pre_param_buffer
                 # Trigger deferred parsing mode
-                # literal_eval+json output in end_element
+                # JSON/Python literal parsing happens in end_element
                 self.defer_current_parameter = True
                 self.deferred_param_raw_value = body_text
                 # Clean up state
@@ -821,7 +821,10 @@ class StreamingXMLToolCallParser:
                         raw_for_parse = raw_text + "\n"
                     else:
                         raw_for_parse = raw_text
-                    parsed_value = ast.literal_eval(raw_for_parse)
+                    try:
+                        parsed_value = json.loads(raw_for_parse.strip())
+                    except json.JSONDecodeError:
+                        parsed_value = ast.literal_eval(raw_for_parse)
                     output_arguments = json.dumps(parsed_value, ensure_ascii=False)
                 except Exception:
                     # Fallback: output as string as-is


### PR DESCRIPTION
## Summary
- Parse deferred qwen3_xml array/object parameters with JSON first, so standard JSON literals such as false and null stay typed.
- Keep ast.literal_eval as a fallback for Python-literal style model output.
- Add a regression test for an array-of-objects parameter containing false and null.

Fixes #43238

## To verify
- python -m py_compile vllm\tool_parsers\qwen3xml_tool_parser.py tests\tool_parsers\test_qwen3xml_tool_parser.py
- python -m ruff check vllm\tool_parsers\qwen3xml_tool_parser.py tests\tool_parsers\test_qwen3xml_tool_parser.py
- python -m pytest --confcutdir=tests\tool_parsers tests\tool_parsers\test_qwen3xml_tool_parser.py::test_qwen3xml_parses_json_literals_in_deferred_array_params -q
- git diff --check

Note: the normal pytest entrypoint imports the repository-level conftest, which pulls uvloop/llguidance through the full vLLM runtime. On Windows, uvloop is not installable, so I ran the focused test with the tool_parser confcutdir instead.