### PR TITLE
[ROCm][Critical] Fix the GDN import bug

### DIFF
--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -521,7 +521,7 @@ class _MockGDNLayer:
         self.head_v_dim = head_v_dim
         self.tp_size = tp_size
 
-        from vllm.model_executor.layers.mamba.gdn_linear_attn import (
+        from vllm.model_executor.layers.mamba.gdn.base import (
             GatedDeltaNetAttention,
         )
 

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -560,11 +560,14 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
 
         # Discover (num_heads, head_dim) pairs for gated RMSNorm patterns
         # from GatedDeltaNetAttention layers in static_forward_context.
-        from vllm.model_executor.layers.mamba.gdn_linear_attn import (
+        from vllm.model_executor.layers.mamba.gdn.base import (
             GatedDeltaNetAttention,
         )
 
-        gdn_layers = get_layers_from_vllm_config(config, GatedDeltaNetAttention)
+        gdn_layers = get_layers_from_vllm_config(
+            config,
+            GatedDeltaNetAttention,  # type: ignore[type-abstract]
+        )
         gated_norm_shapes: set[tuple[int, int]] = set()
         for layer in gdn_layers.values():
             gated_norm_shapes.add(


### PR DESCRIPTION



## Purpose

https://github.com/vllm-project/vllm/pull/41126 changes the import of gdn thus causing import error. However this import error is critical as it will cause the server to crashed when we use `VLLM_ROCM_USE_AITER=1`

```
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     self.aot_compiled_fn = self.aot_compile(*args, **kwargs)
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/wrapper.py", line 167, in aot_compile
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     return self._compiled_callable.aot_compile((args, kwargs))
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 832, in aot_compile
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     return aot_compile_fullgraph(
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/aot_compile.py", line 239, in aot_compile_fullgraph
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     compiled_fn = backend(
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]                   ^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/torch/__init__.py", line 2509, in __call__
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     return self.compiler_fn(model_, inputs_, **self.kwargs)
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/lib/python3.12/contextlib.py", line 81, in inner
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     return func(*args, **kwds)
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/backends.py", line 1163, in __call__
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     self.configure_post_pass()
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/backends.py", line 948, in configure_post_pass
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     self.pass_manager.configure(self.vllm_config)
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/passes/pass_manager.py", line 163, in configure
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     RocmAiterRMSNormQuantFusionPass(config),
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/passes/inductor_pass.py", line 139, in fn_new
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     result = fn(*args, **kwargs)
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]              ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/passes/fusion/rocm_aiter_fusion.py", line 563, in __init__
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165]     from vllm.model_executor.layers.mamba.gdn_linear_attn import (
(EngineCore pid=2818) ERROR 05-23 13:50:24 [core.py:1165] ModuleNotFoundError: No module named 'vllm.model_executor.layers.mamba.gdn_linear_attn'

```


## Test Plan

1. fix unit test `pytest -svvvv tests/compile/passes/test_fusion.py::test_aiter_fusion_rmsnorm_gated_quant`

2. Evaluate that the following command works and model generate correct end to end accuracy

```
#!/bin/bash

rm -rf ~/.cache/vllm
export VLLM_ROCM_USE_AITER=1

vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["-rms_norm","-silu_and_mul","+quant_fp8"],"pass_config":{"fuse_norm_quant":true}}'

```

## Test Result

1. `pytest -svvvv tests/compile/passes/test_fusion.py::test_aiter_fusion_rmsnorm_gated_quant`

```
======================= 2 passed, 21 warnings in 11.54s ========================
```

2. Acc of `Qwen/Qwen3-Next-80B-A3B-Instruct-FP8`

```
local-completions ({'model': 'Qwen/Qwen3-Next-80B-A3B-Instruct-FP8', 'base_url': 'http://0.0.0.0:8000/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 8, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9507|±  |0.0060|
|     |       |strict-match    |     8|exact_match|↑  |0.9431|±  |0.0064|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

