### PR TITLE
[Docs] Update deprecated VLLM_FLASHINFER_MOE_BACKEND reference

### DIFF
--- a/docs/design/moe_kernel_features.md
+++ b/docs/design/moe_kernel_features.md
@@ -42,7 +42,7 @@ th {
     1. All types: mxfp4, nvfp4, int4, int8, fp8
     2. A,T quantization occurs after dispatch.
     3. All quantization happens after dispatch.
-    4. Controlled by different env vars (`VLLM_FLASHINFER_MOE_BACKEND` "throughput" or "latency")
+    4. Controlled via `--moe-backend` CLI arg (e.g., `flashinfer_trtllm`, `flashinfer_cutlass`, `flashinfer_cutedsl`). The `VLLM_FLASHINFER_MOE_BACKEND` env var is deprecated.
     5. This is a no-op dispatcher that can be used to pair with any modular experts to produce a modular kernel that runs without dispatch or combine. These cannot be selected via environment variable. These are generally use for testing or adapting an expert subclass to the `fused_experts` API.
     6. This depends on the experts implementation.
 


### PR DESCRIPTION
## Summary

The documentation in `docs/design/moe_kernel_features.md` references `VLLM_FLASHINFER_MOE_BACKEND` environment variable, which is deprecated in `vllm/envs.py` (scheduled for removal in v0.23). Updated to recommend using `--moe-backend` CLI argument instead.

## Why this is not duplicating an existing PR

- Searched open PRs for "moe_kernel_features", "FLASHINFER_MOE_BACKEND", "deprecated env var" - no matches
- PR #40062 (doc-code mismatches) modifies different files and does not address this issue
- No other open documentation PRs touch this file or this specific env var deprecation

## Test commands run

```bash
# Verified the deprecation in source code:
grep -A 10 "VLLM_FLASHINFER_MOE_BACKEND" vllm/envs.py
# Lines 1546-1557 confirm deprecation with message:
# "Use --moe-backend flashinfer_trtllm, flashinfer_cutlass, or flashinfer_cutedsl."
```

## AI assistance disclosure

This PR was created with AI assistance (Claude). The human submitter has reviewed and verified the change.