### PR TITLE
[Docs] Fix stale version number in token_embed.md

### DIFF
--- a/docs/models/pooling_models/token_embed.md
+++ b/docs/models/pooling_models/token_embed.md
@@ -15,7 +15,7 @@ Many embedding models support both (sequence) embedding and token embedding. For
 
 !!! note
 
-    Pooling multitask support is deprecated and will be removed in v0.20. When the default pooling task (embed) is not 
+    Pooling multitask support has been removed since v0.21. When the default pooling task (embed) is not 
     what you want, you need to manually specify it via `PoolerConfig(task="token_embed")` offline or
     `--pooler-config.task token_embed` online.
 


### PR DESCRIPTION
## Summary

Update outdated deprecation notice in `docs/models/pooling_models/token_embed.md`:
- Changed "will be removed in v0.20" to "has been removed since v0.21"

The pooling multitask support has already been removed, but the documentation still references the future tense.

## Why this is not duplicating an existing PR

- Searched open PRs for "token_embed", "v0.20", "pooling multitask" - no matches
- PR #40062 modifies `docs/models/pooling_models/README.md` but not `token_embed.md`
- PR #43358 handles code-level deprecations, not documentation updates

## Test commands run

```bash
# Documentation-only change, verified by reading the file
cat docs/models/pooling_models/token_embed.md | head -25
```

## AI assistance disclosure

This PR was created with AI assistance (Claude). The human submitter has reviewed and verified the change.