### PR TITLE
[Examples] Fix use_beam_search type in dummy_client.py

### DIFF
--- a/examples/observability/opentelemetry/dummy_client.py
+++ b/examples/observability/opentelemetry/dummy_client.py
@@ -27,7 +27,7 @@ with tracer.start_as_current_span("client-span", kind=SpanKind.CLIENT) as span:
         "prompt": prompt,
         "max_tokens": 10,
         "n": 3,
-        "use_beam_search": "true",
+        "use_beam_search": True,
         "temperature": 0.0,
         # "stream": True,
     }


### PR DESCRIPTION
## Summary

Fix incorrect type in `examples/observability/opentelemetry/dummy_client.py`:
- Changed `"use_beam_search": "true"` (string) to `"use_beam_search": True` (boolean)

The API expects a boolean value, not a string. While Pydantic may coerce the string in some cases, the example should demonstrate correct usage.

## Why this is not duplicating an existing PR

- Searched open PRs for "dummy_client", "use_beam_search", "beam_search boolean" - no matches
- No other open PRs modify this example file

## Test commands run

```bash
# Verified the expected type in the API schema
grep -r "use_beam_search" vllm/entrypoints/openai/protocol.py
# Shows: use_beam_search: bool = False
```

## AI assistance disclosure

This PR was created with AI assistance (Claude). The human submitter has reviewed and verified the change.