### PR TITLE
Revert "[Misc] add humming to dependencies"

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -26,6 +26,3 @@ quack-kernels>=0.3.3
 
 # Tokenspeed_MLA for faster mla with spec decode
 tokenspeed-mla==0.1.2
-
-# Humming kernels for quantization gemm
-humming-kernels[cu13]==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -1017,8 +1017,6 @@ def get_requirements() -> list[str]:
             if "nvidia-cutlass-dsl[cu13]" in req and cuda_major == "12":
                 # [cu13] extra is the default; strip it on CUDA 12 builds.
                 req = req.replace("nvidia-cutlass-dsl[cu13]", "nvidia-cutlass-dsl")
-            if "humming-kernels[cu13]" in req and cuda_major == "12":
-                req = req.replace("humming-kernels[cu13]", "humming-kernels[cu12]")
             modified_requirements.append(req)
         requirements = modified_requirements
     elif _is_hip():

--- a/vllm/model_executor/layers/quantization/humming.py
+++ b/vllm/model_executor/layers/quantization/humming.py
@@ -43,9 +43,12 @@ from vllm.model_executor.parameter import (
     RowvLLMParameter,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.platforms import current_platform
 
-if current_platform.is_cuda():
+if TYPE_CHECKING:
+    from vllm.model_executor.models.utils import WeightsMapper
+
+
+try:
     from humming.dtypes import DataType
     from humming.layer import HummingMethod
     from humming.schema import (
@@ -62,16 +65,15 @@ if current_platform.is_cuda():
         HummingIndexedExperts,
         get_humming_moe_gemm_type,
     )
+except ModuleNotFoundError:
+    HummingMethod = None
 
-if TYPE_CHECKING:
-    from humming.schema import (
-        BaseInputSchema,
-        BaseWeightSchema,
-        HummingInputSchema,
-        HummingWeightSchema,
+
+def assert_humming_available():
+    assert HummingMethod is not None, (
+        "humming is not available, please run "
+        "'pip install git+https://github.com/inclusionAI/humming' to install it."
     )
-
-    from vllm.model_executor.models.utils import WeightsMapper
 
 
 def prepare_padded_shape(shape, x):
@@ -184,6 +186,7 @@ class HummingConfig(QuantizationConfig):
     packed_modules_mapping: dict[str, list[str]] = {}
 
     def __init__(self, full_config: dict[str, Any] | None = None):
+        assert_humming_available()
         self.full_config: dict[str, Any] = full_config or {}
 
     @classmethod


### PR DESCRIPTION
Reverts vllm-project/vllm#42540 while we resolve the packaging issue in https://github.com/vllm-project/vllm/issues/43480

We could resolve the default issue by lazy-importing humming again, but I believe there is the fundamental problem of humming's `register_op` using torch's `_register_fake` which walks the stack and eventually loads cupy's `cupy.testing` module. We need to fix this in the package