### PR TITLE
[Bugfix] Respect CompilationMode.NONE / eager backend in VocabParallelEmbedding.get_masked_input_and_mask

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -4,12 +4,17 @@
 import random
 from copy import deepcopy
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
 import torch.nn.functional as F
 
+from vllm.config import (
+    CompilationMode,
+    set_current_vllm_config,
+)
 from vllm.config.lora import LoRAConfig
 from vllm.lora.layers import (
     BaseLayerWithLoRA,
@@ -31,6 +36,9 @@ from vllm.lora.layers import (
 )
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.lora.punica_wrapper import get_punica_wrapper
+from vllm.model_executor.layers import (
+    vocab_parallel_embedding as vocab_parallel_embedding_module,
+)
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
@@ -1130,7 +1138,13 @@ def test_vocab_parallel_embedding_indices(tp_size, seed, default_vllm_config):
         assert torch.all(reindexed_token_ids[vocab_size:] == -1)
 
 
-def test_get_masked_input_and_mask():
+def test_get_masked_input_and_mask(monkeypatch):
+    monkeypatch.setattr(
+        vocab_parallel_embedding_module,
+        "_get_masked_input_and_mask_compiled",
+        vocab_parallel_embedding_module._get_masked_input_and_mask_eager,
+    )
+
     x = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
 
     # base tp 1 case, no padding
@@ -1296,6 +1310,65 @@ def test_get_masked_input_and_mask():
     assert torch.equal(
         modified_x_rank_3, torch.tensor([0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4])
     )
+
+
+def test_get_masked_input_and_mask_respects_compilation_config(monkeypatch):
+    eager_result = (
+        torch.tensor([11, 12]),
+        torch.tensor([False, True]),
+    )
+    compiled_result = (
+        torch.tensor([21, 22]),
+        torch.tensor([True, False]),
+    )
+
+    monkeypatch.setattr(
+        vocab_parallel_embedding_module,
+        "_get_masked_input_and_mask_eager",
+        lambda *args, **kwargs: eager_result,
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding_module,
+        "_get_masked_input_and_mask_compiled",
+        lambda *args, **kwargs: compiled_result,
+    )
+
+    args = dict(
+        input_=torch.tensor([0, 8]),
+        org_vocab_start_index=0,
+        org_vocab_end_index=4,
+        num_org_vocab_padding=0,
+        added_vocab_start_index=8,
+        added_vocab_end_index=10,
+    )
+
+    masked_input, input_mask = get_masked_input_and_mask(**args)
+    assert torch.equal(masked_input, compiled_result[0])
+    assert torch.equal(input_mask, compiled_result[1])
+
+    with set_current_vllm_config(
+        SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                mode=CompilationMode.NONE,
+                backend="inductor",
+            )
+        )
+    ):
+        masked_input, input_mask = get_masked_input_and_mask(**args)
+    assert torch.equal(masked_input, eager_result[0])
+    assert torch.equal(input_mask, eager_result[1])
+
+    with set_current_vllm_config(
+        SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                mode=CompilationMode.VLLM_COMPILE,
+                backend="eager",
+            )
+        )
+    ):
+        masked_input, input_mask = get_masked_input_and_mask(**args)
+    assert torch.equal(masked_input, eager_result[0])
+    assert torch.equal(input_mask, eager_result[1])
 
 
 def test_variable_slice_lora_class_selection(default_vllm_config, dist_init):

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from torch.nn.parameter import Parameter, UninitializedParameter
 
 import vllm.envs as envs
+from vllm.config import CompilationMode, get_current_vllm_config_or_none
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -26,7 +27,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.layers.utils import dispatch_unquantized_gemm
 from vllm.model_executor.parameter import BasevLLMParameter
-from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.utils import maybe_disable_graph_partition, set_weight_attrs
 from vllm.platforms import current_platform
 
 DEFAULT_VOCAB_PADDING_SIZE = 64
@@ -159,8 +160,7 @@ class VocabParallelEmbeddingShardIndices:
         assert self.num_added_elements <= self.num_added_elements_padded
 
 
-@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
-def get_masked_input_and_mask(
+def _get_masked_input_and_mask_eager(
     input_: torch.Tensor,
     org_vocab_start_index: int,
     org_vocab_end_index: int,
@@ -185,6 +185,48 @@ def get_masked_input_and_mask(
     vocab_mask = org_vocab_mask | added_vocab_mask
     input_ = vocab_mask * (input_ - valid_offset)
     return input_, ~vocab_mask
+
+
+_get_masked_input_and_mask_compiled = torch.compile(
+    _get_masked_input_and_mask_eager,
+    dynamic=True,
+    backend=current_platform.simple_compile_backend,
+    options=maybe_disable_graph_partition(current_platform.simple_compile_backend),
+)
+
+
+def get_masked_input_and_mask(
+    input_: torch.Tensor,
+    org_vocab_start_index: int,
+    org_vocab_end_index: int,
+    num_org_vocab_padding: int,
+    added_vocab_start_index: int,
+    added_vocab_end_index: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    vllm_config = get_current_vllm_config_or_none()
+    if vllm_config is not None:
+        compilation_config = vllm_config.compilation_config
+        if (
+            compilation_config.mode == CompilationMode.NONE
+            or compilation_config.backend == "eager"
+        ):
+            return _get_masked_input_and_mask_eager(
+                input_,
+                org_vocab_start_index,
+                org_vocab_end_index,
+                num_org_vocab_padding,
+                added_vocab_start_index,
+                added_vocab_end_index,
+            )
+
+    return _get_masked_input_and_mask_compiled(
+        input_,
+        org_vocab_start_index,
+        org_vocab_end_index,
+        num_org_vocab_padding,
+        added_vocab_start_index,
+        added_vocab_end_index,
+    )
 
 
 # --8<-- [start:vocab_parallel_embedding]


### PR DESCRIPTION



## Purpose

`get_masked_input_and_mask` in `vllm/model_executor/layers/vocab_parallel_embedding.py` was decorated unconditionally with `@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)`. That forces a Dynamo/Inductor trace on every call, even when the active `VllmConfig` has `compilation_config.mode == CompilationMode.NONE` or `compilation_config.backend == "eager"` — i.e. when the user explicitly opted out of compilation.

This PR:

- Splits the implementation into `_get_masked_input_and_mask_eager` and a `torch.compile`-wrapped `_get_masked_input_and_mask_compiled`.
- Replaces the public `get_masked_input_and_mask` with a thin dispatcher that checks `get_current_vllm_config_or_none()` and routes to the eager path when compilation is disabled or the backend is `"eager"`, and to the compiled path otherwise.
- Threads `maybe_disable_graph_partition(current_platform.simple_compile_backend)` into the compiled wrapper's `options=` to match how other compiled helpers under `vllm/model_executor` are constructed.

AI assistance (Claude Code, Codex) was used while writing this change; I reviewed every changed line. Not a duplicate — `gh pr list --repo vllm-project/vllm --state open --search "get_masked_input_and_mask"` and `... "vocab_parallel_embedding compile"` returned no matching open PRs.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/lora/test_layers.py::test_get_masked_input_and_mask \
  tests/lora/test_layers.py::test_get_masked_input_and_mask_respects_compilation_config \
  -v
```

- The existing test_get_masked_input_and_mask is updated to monkeypatch _get_masked_input_and_mask_compiled to the eager implementation so it keeps exercising the pure-Python logic without invoking Dynamo.
- A new test_get_masked_input_and_mask_respects_compilation_config asserts the dispatcher calls the compiled variant by default, and calls the eager variant when set_current_vllm_config installs a config with CompilationMode.NONE or backend="eager".

## Test Result

```
  tests/lora/test_layers.py::test_get_masked_input_and_mask PASSED         [ 50%]
  tests/lora/test_layers.py::test_get_masked_input_and_mask_respects_compilation_config PASSED [100%]

  ======================== 2 passed, 16 warnings in 2.24s ========================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [X] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

