### PR TITLE
[Bugfix] Reject non-positive block_size in CacheConfig

### DIFF
--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config.cache import CacheConfig
+
+
+def test_block_size_none_uses_default():
+    config = CacheConfig()
+    assert config.block_size == CacheConfig.DEFAULT_BLOCK_SIZE
+    assert config.user_specified_block_size is False
+
+
+def test_block_size_positive_is_accepted():
+    config = CacheConfig(block_size=32)
+    assert config.block_size == 32
+    assert config.user_specified_block_size is True
+
+
+@pytest.mark.parametrize("invalid_block_size", [0, -1, -16])
+def test_block_size_non_positive_raises(invalid_block_size):
+    with pytest.raises(ValueError, match="block_size"):
+        CacheConfig(block_size=invalid_block_size)

--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -22,3 +22,12 @@ def test_block_size_positive_is_accepted():
 def test_block_size_non_positive_raises(invalid_block_size):
     with pytest.raises(ValueError, match="block_size"):
         CacheConfig(block_size=invalid_block_size)
+
+
+@pytest.mark.parametrize("invalid_block_size", [0.5, 1.0, -0.5, True, False])
+def test_block_size_non_int_raises(invalid_block_size):
+    # `block_size` is annotated `SkipValidation[int]`, so Pydantic does not
+    # coerce/reject non-int values; the model validator must catch them.
+    # `bool` is a subclass of `int` but is never a meaningful block size.
+    with pytest.raises(ValueError, match="block_size"):
+        CacheConfig(block_size=invalid_block_size)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -230,6 +230,10 @@ class CacheConfig:
         if self.block_size is None:
             object.__setattr__(self, "block_size", self.DEFAULT_BLOCK_SIZE)
         else:
+            if self.block_size <= 0:
+                raise ValueError(
+                    f"block_size must be a positive integer, got {self.block_size}."
+                )
             object.__setattr__(self, "user_specified_block_size", True)
         if self.mamba_block_size is not None:
             object.__setattr__(self, "user_specified_mamba_block_size", True)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -230,9 +230,13 @@ class CacheConfig:
         if self.block_size is None:
             object.__setattr__(self, "block_size", self.DEFAULT_BLOCK_SIZE)
         else:
-            if self.block_size <= 0:
+            if (
+                not isinstance(self.block_size, int)
+                or isinstance(self.block_size, bool)
+                or self.block_size <= 0
+            ):
                 raise ValueError(
-                    f"block_size must be a positive integer, got {self.block_size}."
+                    f"block_size must be a positive integer, got {self.block_size!r}."
                 )
             object.__setattr__(self, "user_specified_block_size", True)
         if self.mamba_block_size is not None:


### PR DESCRIPTION
## Purpose

Fixes #43496.

`--block-size 0` (and equivalently `LLM(block_size=0)`) silently passed argparse and `CacheConfig` validation, then crashed engine init with a `ZeroDivisionError` inside `cdiv(max_model_len, self.block_size)` at `vllm/v1/kv_cache_interface.py:218`. The existing `vllm_config.validate_block_size()` runs after this point and only checks DCP/Mamba alignment — it never asserts `block_size > 0`.

This PR rejects non-positive `block_size` at config-construction time in `CacheConfig._apply_block_size_default`, mirroring the existing `gt=0` constraint already in place for `mamba_block_size` (`vllm/config/cache.py:120`). The user now sees:

```
ValueError: block_size must be a positive integer, got 0.
```

instead of an internal `ZeroDivisionError` traceback from KV-cache profiling.

The follow-up commit (c188c85) also tightens the check to reject non-int values (e.g. `0.5`, `True`), since `block_size` is annotated `SkipValidation[int]` and Pydantic does not coerce or reject non-int inputs.

This implements option 2 from the issue author's proposed fix list — the smallest, earliest-failure path; does not require lifting `SkipValidation` or reordering `validate_block_size`.

### Duplicate-work check

Per AGENTS.md the following were run:

```
gh issue view 43496 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "43496 in:body"
gh pr list --repo vllm-project/vllm --state open --search "block_size validation"
gh pr list --repo vllm-project/vllm --state open --search "block-size positive"
```

The only adjacent open PR is #42682 ("fix: validate backend block size earlier"), which validates *positive* user-specified block sizes against the attention backend's supported sizes inside `Platform.update_block_size_for_backend`. It addresses a different bug (#42510 — backend compatibility) and does not catch `block_size <= 0` because (a) backend `supports_block_size` checks like `bs % 16 == 0` actually pass for `0`, and (b) the direct `LLM(block_size=0)` path bypasses platform validation entirely. The two PRs are complementary.

## Test Plan

New file `tests/config/test_cache_config.py` adds 10 tests:

- `test_block_size_none_uses_default` — sanity, default behavior unchanged
- `test_block_size_positive_is_accepted` — sanity, positive value still works
- `test_block_size_non_positive_raises[0|-1|-16]` — positivity validation
- `test_block_size_non_int_raises[0.5|1.0|-0.5|True|False]` — type validation (added in follow-up commit after review)

Commands run locally on macOS arm64 (`VLLM_TARGET_DEVICE=empty` editable install, Python 3.12.13, pydantic 2.13.4):

```
.venv/bin/python -m pytest tests/config/test_cache_config.py -v
.venv/bin/python -m pytest tests/config/ -v
.venv/bin/pre-commit run --files vllm/config/cache.py tests/config/test_cache_config.py
```

Also re-ran the smallest end-to-end reproducer from the issue:

```python
from vllm.config.cache import CacheConfig
CacheConfig(block_size=0)
CacheConfig(block_size=0.5)
```

## Test Result

```
tests/config/test_cache_config.py::test_block_size_none_uses_default                  PASSED
tests/config/test_cache_config.py::test_block_size_positive_is_accepted               PASSED
tests/config/test_cache_config.py::test_block_size_non_positive_raises[0]             PASSED
tests/config/test_cache_config.py::test_block_size_non_positive_raises[-1]            PASSED
tests/config/test_cache_config.py::test_block_size_non_positive_raises[-16]           PASSED
tests/config/test_cache_config.py::test_block_size_non_int_raises[0.5]                PASSED
tests/config/test_cache_config.py::test_block_size_non_int_raises[1.0]                PASSED
tests/config/test_cache_config.py::test_block_size_non_int_raises[-0.5]               PASSED
tests/config/test_cache_config.py::test_block_size_non_int_raises[True]               PASSED
tests/config/test_cache_config.py::test_block_size_non_int_raises[False]              PASSED
======================== 10 passed, 2 warnings in 0.61s ========================
```

Full `tests/config/` suite: **55 passed, 4 failed** — all 4 failures are unrelated to this change (1 missing `ray` module; 3 gated Llama HuggingFace models requiring auth).

`pre-commit`: ruff check / ruff format / typos / mypy / SPDX / all other applicable hooks **passed**.

Behavioural check against the issue reproducer (before vs. after):

| Input | Before | After |
|---|---|---|
| `CacheConfig(block_size=0)` | `ZeroDivisionError` deep inside KV-cache profiling | `ValueError: block_size must be a positive integer, got 0.` at config construction |
| `CacheConfig(block_size=0.5)` | Silently accepted; `block_size` survives as `float`, downstream `cdiv` produces nonsense | `ValueError: block_size must be a positive integer, got 0.5.` |

---

## AI assistance disclosure

This change was AI-assisted (Claude). I (the submitter) reviewed every line, ran the test commands above, and stand behind the change end-to-end.