### PR TITLE
[Bugfix][DSV4] Plumb quant_config into compressor.fused_wkv_wgate and indexer.weights_proj

### DIFF
--- a/tests/models/test_deepseek_v4_quant_config_passthrough.py
+++ b/tests/models/test_deepseek_v4_quant_config_passthrough.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Constructor contract for DSv4 compressor/indexer linear sub-modules.
+
+The compressor's ``fused_wkv_wgate`` and the indexer's ``wq_b`` /
+``weights_proj`` are part of the attention path and must honour the
+model's quantization recipe. If they are built as unquantized BF16
+linears while the checkpoint carries quantized weights (e.g. FP8 block
+scales) for those prefixes, weight loading fails with a missing
+``weight_scale`` key. The model-level ``quant_config`` therefore has to
+reach these sub-module constructors so the compressed-tensors scheme
+resolver can match their prefixes against the artifact's target
+patterns and allocate the right parameters.
+
+These tests pin down that contract for both the quantized case (the
+config is propagated unchanged) and the unquantized case (``None`` is
+preserved end-to-end, so non-quantized checkpoints still load via
+``UnquantizedLinearMethod``).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def _vllm_config_ctx():
+    """Set a current VllmConfig so RMSNorm / CustomOp dispatch works."""
+    from vllm.config import VllmConfig, set_current_vllm_config
+
+    with set_current_vllm_config(VllmConfig()) as cfg:
+        yield cfg
+
+
+def _make_compressor_stub_config(quant_config_marker):
+    hf = SimpleNamespace(qk_rope_head_dim=64, rms_norm_eps=1e-6)
+    return SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=hf, max_model_len=1024),
+        scheduler_config=SimpleNamespace(max_num_seqs=8, max_num_batched_tokens=64),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+        quant_config=quant_config_marker,
+    )
+
+
+@pytest.mark.parametrize(
+    "quant_config_marker",
+    ["SENTINEL_QUANT_CFG", None],
+    ids=["quantized", "unquantized"],
+)
+def test_compressor_passes_quant_config_to_fused_wkv_wgate(
+    _vllm_config_ctx, quant_config_marker
+):
+    """``fused_wkv_wgate`` must receive the model-level ``quant_config``
+    from ``vllm_config`` so quantized checkpoints can load its weights."""
+    captured: list[dict] = []
+
+    class FakeMergedLinear:
+        def __init__(self, *args, **kwargs):
+            captured.append(kwargs)
+
+    with patch(
+        "vllm.models.deepseek_v4.compressor.MergedColumnParallelLinear",
+        FakeMergedLinear,
+    ):
+        from vllm.models.deepseek_v4.compressor import DeepseekCompressor
+
+        DeepseekCompressor(
+            vllm_config=_make_compressor_stub_config(quant_config_marker),
+            compress_ratio=128,
+            hidden_size=2048,
+            head_dim=128,
+            prefix="layers.0.attn.compressor",
+        )
+
+    assert len(captured) == 1, "fused_wkv_wgate should be constructed exactly once"
+    kwargs = captured[0]
+    assert kwargs.get("prefix") == "layers.0.attn.compressor.fused_wkv_wgate"
+    assert kwargs.get("quant_config") is quant_config_marker, (
+        "fused_wkv_wgate must be constructed with vllm_config.quant_config; "
+        f"got {kwargs.get('quant_config')!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "quant_config_marker",
+    ["SENTINEL_QUANT_CFG", None],
+    ids=["quantized", "unquantized"],
+)
+def test_indexer_passes_quant_config_to_weights_proj_and_wq_b(
+    _vllm_config_ctx, quant_config_marker
+):
+    """Both ``wq_b`` and ``weights_proj`` must be constructed with the
+    same ``quant_config`` the indexer itself was given, so the indexer's
+    linear sub-modules participate in the same quantization scheme as
+    the surrounding model."""
+    captured: list[dict] = []
+
+    class FakeReplicatedLinear:
+        def __init__(self, *args, **kwargs):
+            captured.append(kwargs)
+
+    attn_mod = "vllm.models.deepseek_v4.nvidia.ops.attention"
+    with (
+        patch(f"{attn_mod}.ReplicatedLinear", FakeReplicatedLinear),
+        patch(f"{attn_mod}.DeepseekV4IndexerCache", MagicMock()),
+        patch(f"{attn_mod}.DeepseekCompressor", MagicMock()),
+        patch(f"{attn_mod}.SparseAttnIndexer", MagicMock()),
+        patch(f"{attn_mod}.get_max_prefill_buffer_size", return_value=4096),
+        patch("torch.cuda.Event", MagicMock()),
+    ):
+        from vllm.models.deepseek_v4.nvidia.ops.attention import (
+            DeepseekV4Indexer,
+        )
+
+        cfg = SimpleNamespace(
+            index_topk=64,
+            index_n_heads=8,
+            index_head_dim=128,
+            qk_rope_head_dim=64,
+        )
+        vllm_cfg = SimpleNamespace(
+            model_config=SimpleNamespace(max_model_len=1024),
+            attention_config=SimpleNamespace(use_fp4_indexer_cache=False),
+        )
+
+        DeepseekV4Indexer(
+            vllm_config=vllm_cfg,
+            config=cfg,
+            hidden_size=2048,
+            q_lora_rank=1536,
+            quant_config=quant_config_marker,
+            cache_config=MagicMock(),
+            topk_indices_buffer=None,
+            compress_ratio=1,
+            prefix="layers.0.attn.indexer",
+        )
+
+    by_prefix = {kw.get("prefix"): kw for kw in captured}
+    assert "layers.0.attn.indexer.wq_b" in by_prefix
+    assert "layers.0.attn.indexer.weights_proj" in by_prefix
+
+    assert by_prefix["layers.0.attn.indexer.wq_b"]["quant_config"] is (
+        quant_config_marker
+    )
+    assert by_prefix["layers.0.attn.indexer.weights_proj"]["quant_config"] is (
+        quant_config_marker
+    ), "weights_proj must be constructed with the indexer's quant_config"

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -217,7 +217,7 @@ class DeepseekCompressor(nn.Module):
             [self.coff * self.head_dim, self.coff * self.head_dim],
             bias=False,
             return_bias=False,
-            quant_config=None,
+            quant_config=getattr(vllm_config, "quant_config", None),
             disable_tp=True,
             prefix=f"{prefix}.fused_wkv_wgate",
         )

--- a/vllm/models/deepseek_v4/nvidia/ops/attention.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/attention.py
@@ -828,7 +828,7 @@ class DeepseekV4Indexer(nn.Module):
             hidden_size,
             self.n_head,
             bias=False,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=f"{prefix}.weights_proj",
         )
         self.softmax_scale = self.head_dim**-0.5


### PR DESCRIPTION
## Summary

Fixes #43512.

`DeepseekCompressor.fused_wkv_wgate` and `DeepseekV4Indexer.weights_proj`
were constructed with a hard-coded `quant_config=None` on the NVIDIA DSv4
path. Any DSv4-Flash artifact whose calibration recipe quantizes those
attention sub-modules — for example
`canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP`, which applies FP8_BLOCK
across the whole attention path — fails to load with:

```
KeyError: 'layers.10.attn.mla_attn.compressor.fused_wkv_wgate.weight_scale'
```

The artifact ships `.weight_scale` keys for those modules, but because
the modules were instantiated as unquantized BF16 linears there is
nowhere for the scale parameters to be placed.

This PR plumbs the actual `quant_config` through:

* `vllm/models/deepseek_v4/compressor.py` — `fused_wkv_wgate` now
  receives `getattr(vllm_config, "quant_config", None)` (matches the
  existing pattern used elsewhere in the codebase, e.g.
  `vllm/model_executor/models/granitemoe.py`).
* `vllm/models/deepseek_v4/nvidia/ops/attention.py` — `weights_proj`
  now uses the same `quant_config` parameter that `wq_b` (immediately
  above it) already uses.

Two-line change, plus a regression test.

### Reverse compatibility

When the artifact does not quantize these modules, the compressed-tensors
scheme resolver does not match the prefix and falls through to
`UnquantizedLinearMethod`, exactly as today. The new
`[unquantized]` test parametrization pins this down.

### Note on the original issue text

The issue also flags `indexer.wq_b` as hard-coded. It is **not** — on
current `main` (commit `33d7cbe02`), `wq_b` already passes
`quant_config=quant_config` correctly. Only the two sites above needed
changing. The test still covers `wq_b` so any future regression there
would be caught too.

## Test plan

* [x] `pre-commit run --files <changed files>` — all hooks pass on
  macOS arm64 / Python 3.12 (ruff, ruff format, typos, mypy, SPDX
  header, forbidden imports, etc.).
* [x] `python -m pytest tests/models/test_deepseek_v4_quant_config_passthrough.py -v` — 4/4 pass.
* [x] Verified the new tests fail on `main` (before the fix): both
  `[quantized]` parametrizations FAIL with
  `AssertionError: ... quant_config must receive ... not None`.
  After the fix all four PASS. The `[unquantized]` parametrizations
  pass in both states, confirming reverse compatibility.
* [ ] **Pending CUDA verification** — load
  `canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP` and confirm the
  `KeyError: '...compressor.fused_wkv_wgate.weight_scale'` is gone
  and inference runs end-to-end. DSv4 attention asserts a CUDA device
  and requires FlashMLA, so this could not be exercised on my dev
  machine (macOS arm64). I will run this on a CUDA host before
  asking for review / will rely on CI to cover the path.

### Duplicate-work checks (per `AGENTS.md`)

```
gh issue view 43512 --repo vllm-project/vllm --comments
  → 0 comments, no in-flight PR linked.
gh pr list --repo vllm-project/vllm --state open --search "43512 in:body"
  → no results.
gh pr list --repo vllm-project/vllm --state open --search "DSV4 weights_proj"
  → no results.
```

The two existing open DSv4 bugfixes do not touch this code path:

* #43319 (`canada-quant`) — MTP draft model BF16 detection (unrelated).
* #41312 (`sigridjineth`) — cross-node TP=16 FP8 serving (unrelated).

### Disclosure

AI assistance was used to draft this change (Claude). I reviewed every
changed line and ran the test commands above on my local machine.
