### PR TITLE
manually fuse norm and rope

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -327,6 +327,24 @@ def fused_add_rms_norm(
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
 
+def can_use_fused_qk_norm_rope(
+    qkv: torch.Tensor,
+    head_dim: int,
+    cos_sin_cache: torch.Tensor | None,
+    is_neox_style: bool | None,
+) -> bool:
+    return (
+        hasattr(torch.ops._C, "fused_qk_norm_rope")
+        and current_platform.is_cuda_alike()
+        and isinstance(cos_sin_cache, torch.Tensor)
+        and isinstance(is_neox_style, bool)
+        and qkv.dtype in (torch.float16, torch.bfloat16)
+        and head_dim in (64, 128, 256)
+        and qkv.is_contiguous()
+        and qkv.dim() == 2
+    )
+
+
 def fused_qk_norm_rope(
     qkv: torch.Tensor,
     num_heads_q: int,

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -22,6 +22,7 @@ import torch
 from torch import nn
 from transformers import Gemma3TextConfig
 
+from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
@@ -210,16 +211,40 @@ class Gemma3Attention(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if ops.can_use_fused_qk_norm_rope(
+            qkv,
+            self.head_dim,
+            getattr(self.rotary_emb, "cos_sin_cache", None),
+            getattr(self.rotary_emb, "is_neox_style", None),
+        ):
+            position_ids = positions.reshape(-1)
+            q_weight = (self.q_norm.weight.data.float() + 1.0).to(qkv.dtype)
+            k_weight = (self.k_norm.weight.data.float() + 1.0).to(qkv.dtype)
+            ops.fused_qk_norm_rope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                q_weight,
+                k_weight,
+                self.rotary_emb.cos_sin_cache,
+                self.rotary_emb.is_neox_style,
+                position_ids,
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        q = q.unflatten(-1, (self.num_heads, self.head_dim))
-        q = self.q_norm(q)
-        q = q.flatten(-2, -1)
-        k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
-        k = self.k_norm(k)
-        k = k.flatten(-2, -1)
+            q = q.unflatten(-1, (self.num_heads, self.head_dim))
+            q = self.q_norm(q)
+            q = q.flatten(-2, -1)
+            k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            k = self.k_norm(k)
+            k = k.flatten(-2, -1)
 
-        q, k = self.rotary_emb(positions, q, k)
+            q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -416,8 +416,8 @@ class Gemma3nAttention(nn.Module):
             getattr(self.rotary_emb, "is_neox_style", None),
         ):
             position_ids = positions.reshape(-1)
-            q_weight = self.q_norm.weight.data
-            k_weight = self.k_norm.weight.data
+            q_weight = self.q_norm.weight.data.to(qkv.dtype)
+            k_weight = self.k_norm.weight.data.to(qkv.dtype)
             ops.fused_qk_norm_rope(
                 qkv,
                 self.num_heads,

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -21,6 +21,7 @@ import torch
 from torch import nn
 from transformers.models.gemma3n.configuration_gemma3n import Gemma3nTextConfig
 
+from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
@@ -408,19 +409,46 @@ class Gemma3nAttention(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if ops.can_use_fused_qk_norm_rope(
+            qkv,
+            self.head_dim,
+            getattr(self.rotary_emb, "cos_sin_cache", None),
+            getattr(self.rotary_emb, "is_neox_style", None),
+        ):
+            position_ids = positions.reshape(-1)
+            q_weight = self.q_norm.weight.data
+            k_weight = self.k_norm.weight.data
+            ops.fused_qk_norm_rope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                q_weight,
+                k_weight,
+                self.rotary_emb.cos_sin_cache,
+                self.rotary_emb.is_neox_style,
+                position_ids,
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            v = self.v_norm(v)
+            v = v.flatten(-2, -1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        q = q.unflatten(-1, (self.num_heads, self.head_dim))
-        q = self.q_norm(q)
-        q = q.flatten(-2, -1)
-        k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
-        k = self.k_norm(k)
-        k = k.flatten(-2, -1)
-        v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
-        v = self.v_norm(v)
-        v = v.flatten(-2, -1)
+            q = q.unflatten(-1, (self.num_heads, self.head_dim))
+            q = self.q_norm(q)
+            q = q.flatten(-2, -1)
+            k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            k = self.k_norm(k)
+            k = k.flatten(-2, -1)
+            v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            v = self.v_norm(v)
+            v = v.flatten(-2, -1)
 
-        q, k = self.rotary_emb(positions, q, k)
+            q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
 
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -307,8 +307,8 @@ class Glm4MoeAttention(nn.Module):
                 getattr(self.rotary_emb, "is_neox_style", None),
             ):
                 position_ids = positions.reshape(-1)
-                q_weight = self.q_norm.weight.data
-                k_weight = self.k_norm.weight.data
+                q_weight = self.q_norm.weight.data.to(qkv.dtype)
+                k_weight = self.k_norm.weight.data.to(qkv.dtype)
                 ops.fused_qk_norm_rope(
                     qkv,
                     self.num_heads,

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -32,6 +32,7 @@ import torch
 from torch import nn
 from transformers.models.glm4_moe import Glm4MoeConfig
 
+from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
@@ -298,16 +299,43 @@ class Glm4MoeAttention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         if self.use_qk_norm:
-            q = self.q_norm(q.reshape(-1, self.num_heads, self.head_dim)).reshape(
-                q.shape
-            )
-            k = self.k_norm(k.reshape(-1, self.num_kv_heads, self.head_dim)).reshape(
-                k.shape
-            )
+            if ops.can_use_fused_qk_norm_rope(
+                qkv,
+                self.head_dim,
+                getattr(self.rotary_emb, "cos_sin_cache", None),
+                getattr(self.rotary_emb, "is_neox_style", None),
+            ):
+                position_ids = positions.reshape(-1)
+                q_weight = self.q_norm.weight.data
+                k_weight = self.k_norm.weight.data
+                ops.fused_qk_norm_rope(
+                    qkv,
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                    self.q_norm.variance_epsilon,
+                    q_weight,
+                    k_weight,
+                    self.rotary_emb.cos_sin_cache,
+                    self.rotary_emb.is_neox_style,
+                    position_ids,
+                )
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            else:
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+                q = self.q_norm(q.reshape(-1, self.num_heads, self.head_dim)).reshape(
+                    q.shape
+                )
+                k = self.k_norm(
+                    k.reshape(-1, self.num_kv_heads, self.head_dim)
+                ).reshape(k.shape)
 
-        q, k = self.rotary_emb(positions, q, k)
+                q, k = self.rotary_emb(positions, q, k)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -149,7 +149,7 @@ class Qwen3Attention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        if ops.can_use_fused_qk_norm_rope(
+        if not self.dual_chunk_attention_config and ops.can_use_fused_qk_norm_rope(
             qkv,
             self.head_dim,
             getattr(self.rotary_emb, "cos_sin_cache", None),

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -30,6 +30,7 @@ import torch
 from torch import nn
 from transformers import Qwen3Config
 
+from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
@@ -148,15 +149,43 @@ class Qwen3Attention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-        q_by_head = self.q_norm(q_by_head)
-        q = q_by_head.view(q.shape)
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-        k_by_head = self.k_norm(k_by_head)
-        k = k_by_head.view(k.shape)
-        q, k = self.rotary_emb(positions, q, k)
+        if ops.can_use_fused_qk_norm_rope(
+            qkv,
+            self.head_dim,
+            getattr(self.rotary_emb, "cos_sin_cache", None),
+            getattr(self.rotary_emb, "is_neox_style", None),
+        ):
+            position_ids = positions.reshape(-1)
+            q_weight = self.q_norm.weight.data
+            k_weight = self.k_norm.weight.data
+            ops.fused_qk_norm_rope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                q_weight,
+                k_weight,
+                self.rotary_emb.cos_sin_cache,
+                self.rotary_emb.is_neox_style,
+                position_ids,
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            # Add qk-norm
+            q_by_head = q.view(
+                *q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim
+            )
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
+            k_by_head = k.view(
+                *k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim
+            )
+            k_by_head = self.k_norm(k_by_head)
+            k = k_by_head.view(k.shape)
+            q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -156,8 +156,8 @@ class Qwen3Attention(nn.Module):
             getattr(self.rotary_emb, "is_neox_style", None),
         ):
             position_ids = positions.reshape(-1)
-            q_weight = self.q_norm.weight.data
-            k_weight = self.k_norm.weight.data
+            q_weight = self.q_norm.weight.data.to(qkv.dtype)
+            k_weight = self.k_norm.weight.data.to(qkv.dtype)
             ops.fused_qk_norm_rope(
                 qkv,
                 self.num_heads,

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -347,7 +347,7 @@ class Qwen3MoeAttention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        if ops.can_use_fused_qk_norm_rope(
+        if not self.dual_chunk_attention_config and ops.can_use_fused_qk_norm_rope(
             qkv,
             self.head_dim,
             getattr(self.rotary_emb, "cos_sin_cache", None),

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -354,8 +354,8 @@ class Qwen3MoeAttention(nn.Module):
             getattr(self.rotary_emb, "is_neox_style", None),
         ):
             position_ids = positions.reshape(-1)
-            q_weight = self.q_norm.weight.data
-            k_weight = self.k_norm.weight.data
+            q_weight = self.q_norm.weight.data.to(qkv.dtype)
+            k_weight = self.k_norm.weight.data.to(qkv.dtype)
             ops.fused_qk_norm_rope(
                 qkv,
                 self.num_heads,

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -32,6 +32,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
@@ -346,16 +347,44 @@ class Qwen3MoeAttention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        # Add qk-norm
-        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-        q_by_head = self.q_norm(q_by_head)
-        q = q_by_head.view(q.shape)
+        if ops.can_use_fused_qk_norm_rope(
+            qkv,
+            self.head_dim,
+            getattr(self.rotary_emb, "cos_sin_cache", None),
+            getattr(self.rotary_emb, "is_neox_style", None),
+        ):
+            position_ids = positions.reshape(-1)
+            q_weight = self.q_norm.weight.data
+            k_weight = self.k_norm.weight.data
+            ops.fused_qk_norm_rope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                q_weight,
+                k_weight,
+                self.rotary_emb.cos_sin_cache,
+                self.rotary_emb.is_neox_style,
+                position_ids,
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            # Add qk-norm
+            q_by_head = q.view(
+                *q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim
+            )
+            q_by_head = self.q_norm(q_by_head)
+            q = q_by_head.view(q.shape)
 
-        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-        k_by_head = self.k_norm(k_by_head)
-        k = k_by_head.view(k.shape)
-        q, k = self.rotary_emb(positions, q, k)
+            k_by_head = k.view(
+                *k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim
+            )
+            k_by_head = self.k_norm(k_by_head)
+            k = k_by_head.view(k.shape)
+            q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -304,7 +304,7 @@ class Qwen3NextAttention(nn.Module):
         else:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        if not self.attn_output_gate and ops.can_use_fused_qk_norm_rope(
+        if not self.attn_output_gate and not self.dual_chunk_attention_config and ops.can_use_fused_qk_norm_rope(
             qkv,
             self.head_dim,
             getattr(self.rotary_emb, "cos_sin_cache", None),

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -8,6 +8,7 @@ from itertools import islice
 import torch
 from torch import nn
 
+from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import (
@@ -303,14 +304,38 @@ class Qwen3NextAttention(nn.Module):
         else:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
-            -1, self.num_heads * self.head_dim
-        )
-        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
-            -1, self.num_kv_heads * self.head_dim
-        )
+        if not self.attn_output_gate and ops.can_use_fused_qk_norm_rope(
+            qkv,
+            self.head_dim,
+            getattr(self.rotary_emb, "cos_sin_cache", None),
+            getattr(self.rotary_emb, "is_neox_style", None),
+        ):  # qkv shape is [q, gate, k, v] when self.attn_output_gate = True
+            position_ids = positions.reshape(-1)
+            q_weight = (self.q_norm.weight.data.float() + 1.0).to(qkv.dtype)
+            k_weight = (self.k_norm.weight.data.float() + 1.0).to(qkv.dtype)
+            ops.fused_qk_norm_rope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                q_weight,
+                k_weight,
+                self.rotary_emb.cos_sin_cache,
+                self.rotary_emb.is_neox_style,
+                position_ids,
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
+                -1, self.num_heads * self.head_dim
+            )
+            k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
+                -1, self.num_kv_heads * self.head_dim
+            )
 
-        q, k = self.rotary_emb(positions, q, k)
+            q, k = self.rotary_emb(positions, q, k)
 
         attn_output = self.attn(q, k, v)
 


### PR DESCRIPTION
## Purpose
#43497 #43224
Enable the `fused_qk_norm_rope kernel` across several models. A new `can_use_fused_qk_norm_rope` helper is used to check if fused kernel can be used, with its conditions based on the kernel code.

## Test Plan
Run gsm8k using Qwen3 MoE on H100, see if accuracy and speed is consistent before/after the pr. Add a print message to see if the fused path is took.
```
vllm serve Qwen/Qwen3-30B-A3B \
  --moe-backend triton

python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 100 \
  --num-shots 10 \
  --max-tokens 256
```

## Test Result
Does take the fused path and performance matches for before and after (both completes in ~5.1s).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

