### PR TITLE
[Core][Spec Decode] Dynamic verification for dflash

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -142,6 +142,25 @@ vllm serve <target-model> \
   }'
 ```
 
+#### DFlash
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `dynamic_verifying` | `float` or `"auto"` | `None` | Dynamically truncates DFlash draft tokens when draft confidence falls below the threshold. A float must be in `(0, 1)`. `"auto"` uses an adaptive per-request threshold. |
+| `dynamic_verifying_min_length` | `0 <= integer <= num_speculative_tokens` | `0` | Minimum number of draft tokens to keep when dynamic verification is enabled. |
+
+Example:
+
+```bash
+vllm serve <target-model> \
+  --speculative-config '{
+    "method": "dflash",
+    "model": "<dflash-draft-model>",
+    "num_speculative_tokens": 15,
+    "dynamic_verifying": "auto"
+  }'
+
+
 ### Notes
 
 - `--speculative-config` expects a JSON object on the CLI. In YAML config

--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -159,7 +159,7 @@ vllm serve <target-model> \
     "num_speculative_tokens": 15,
     "dynamic_verifying": "auto"
   }'
-
+```
 
 ### Notes
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -273,6 +273,8 @@ class SpeculativeConfig:
     verification is enabled. Prevents over-truncation when confidence is
     uniformly low. Only takes effect when dynamic_verifying is not None."""
 
+    dynamic_verifying_min_batch_size: int = 16
+
     draft_sample_method: DraftSampleMethod = "greedy"
     """How the draft model samples tokens. 'greedy' always picks the argmax
     token, and the draft probabilities are treated as one-hot during rejection
@@ -939,6 +941,13 @@ class SpeculativeConfig:
                 f"num_speculative_tokens ({self.num_speculative_tokens})."
             )
 
+        if self.use_local_argmax_reduction:
+            raise ValueError(
+                "dynamic_verifying is incompatible with "
+                "use_local_argmax_reduction (needs full logits "
+                "for confidence scores). Disable one of them."
+            )
+
     @staticmethod
     def _maybe_override_draft_max_model_len(
         speculative_max_model_len: int | None,
@@ -1171,6 +1180,9 @@ class SpeculativeConfig:
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 
+    def use_dynamic_verifying(self) -> bool:
+        return self.dynamic_verifying is not None
+    
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -268,7 +268,7 @@ class SpeculativeConfig:
     literal 'auto'. None disables dynamic verifying.
     Only applies to dflash for now."""
 
-    dynamic_verifying_min_length: int = Field(default=0, ge=0)
+    dynamic_verifying_min_length: int = Field(default=1, ge=1)
     """Minimum number of draft tokens to keep per request when dynamic
     verification is enabled. Prevents over-truncation when confidence is
     uniformly low. Only takes effect when dynamic_verifying is not None."""
@@ -901,10 +901,11 @@ class SpeculativeConfig:
             return
 
         if self.method != "dflash":
-            raise ValueError(
+            logger.warning(
                 f"dynamic_verifying is only supported with dflash for now, "
-                f"got method='{self.method}'."
+                f"got method='{self.method}', dynamic_verifying is set to None and disabled."
             )
+            self.dynamic_verifying = None
 
         if isinstance(self.dynamic_verifying, str):
             if self.dynamic_verifying not in ["auto"]:
@@ -917,7 +918,7 @@ class SpeculativeConfig:
                 if self.dynamic_verifying == 0:
                     logger.warning(
                         "dynamic_verifying=0 is effectively disabling dynamic "
-                        "verification, dynamic_verifying is set to None."
+                        "verification, dynamic_verifying is set to None and disabled."
                     )
                     self.dynamic_verifying = None
                 else:

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -262,6 +262,17 @@ class SpeculativeConfig:
             )
         return SpeculativeConfig._acceptance_length_to_rates(length, n)
 
+    dynamic_verifying: float | str | None = None
+    """Dynamic verification: truncates draft tokens based on
+    confidence. Accepts a float threshold in (0, 1) (e.g. 0.7) or the
+    literal 'auto'. None disables dynamic verifying.
+    Only applies to dflash for now."""
+
+    dynamic_verifying_min_length: int = Field(default=0, ge=0)
+    """Minimum number of draft tokens to keep per request when dynamic
+    verification is enabled. Prevents over-truncation when confidence is
+    uniformly low. Only takes effect when dynamic_verifying is not None."""
+
     draft_sample_method: DraftSampleMethod = "greedy"
     """How the draft model samples tokens. 'greedy' always picks the argmax
     token, and the draft probabilities are treated as one-hot during rejection
@@ -845,6 +856,8 @@ class SpeculativeConfig:
                         self.target_parallel_config, self.draft_tensor_parallel_size
                     )
                 )
+
+        self._validate_dynamic_verifying()
         return self
 
     def _validate_suffix_decoding(self):
@@ -881,6 +894,48 @@ class SpeculativeConfig:
             raise ValueError(
                 f"suffix_decoding_min_token_prob="
                 f"{self.suffix_decoding_min_token_prob} must be in [0, 1]"
+            )
+
+    def _validate_dynamic_verifying(self):
+        if self.dynamic_verifying is None:
+            return
+
+        if self.method != "dflash":
+            raise ValueError(
+                f"dynamic_verifying is only supported with dflash for now, "
+                f"got method='{self.method}'."
+            )
+
+        if isinstance(self.dynamic_verifying, str):
+            if self.dynamic_verifying not in ["auto"]:
+                raise ValueError(
+                    f"dynamic_verifying string must be 'auto', "
+                    f"got '{self.dynamic_verifying}'."
+                )
+        elif isinstance(self.dynamic_verifying, (int, float)):
+            if not 0 < self.dynamic_verifying < 1:
+                if self.dynamic_verifying == 0:
+                    logger.warning(
+                        "dynamic_verifying=0 is effectively disabling dynamic "
+                        "verification, dynamic_verifying is set to None."
+                    )
+                    self.dynamic_verifying = None
+                else:
+                    raise ValueError(
+                        f"dynamic_verifying float must be in (0, 1), "
+                        f"got {self.dynamic_verifying}."
+                    )
+        else:
+            raise ValueError(
+                f"dynamic_verifying must be None, a float in (0, 1), or 'auto', "
+                f"got {self.dynamic_verifying!r}."
+            )
+
+        if self.dynamic_verifying_min_length > self.num_speculative_tokens:
+            raise ValueError(
+                f"dynamic_verifying_min_length "
+                f"({self.dynamic_verifying_min_length}) must be <= "
+                f"num_speculative_tokens ({self.num_speculative_tokens})."
             )
 
     @staticmethod

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -768,15 +768,18 @@ class VllmConfig:
         speculative_config = self.speculative_config
         if (
             speculative_config is None
-            or not speculative_config.uses_dynamic_speculative_decoding()
             or not self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            or not (
+                speculative_config.uses_dynamic_speculative_decoding()
+                or speculative_config.use_dynamic_verifying()
+            )
         ):
             return
 
         logger.warning_once(
-            "Dynamic speculative decoding changes the target verification "
-            "length at runtime. Overriding cudagraph_mode from %s to "
-            "PIECEWISE for reliability.",
+            "Dynamic speculative decoding and dynamic verifying "
+            "change the target verification length at runtime. "
+            "Overriding cudagraph_mode from %s to PIECEWISE for reliability.",
             self.compilation_config.cudagraph_mode.name,
         )
         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
@@ -2034,6 +2037,9 @@ class VllmConfig:
 
             if speculative_config.uses_dynamic_speculative_decoding():
                 unsupported.append("dynamic speculative decoding")
+
+            if speculative_config.use_dynamic_verifying():
+                unsupported.append("dynamic verifying")
 
             # V2 EagleSpeculator does not support parallel_drafting (for P-Eagle)
             # DFlash uses parallel drafting natively in V2 via DFlashSpeculator.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1454,7 +1454,7 @@ class Scheduler(SchedulerInterface):
             self.processed_step_seq += 1
             self._drain_deferred_frees()
 
-        dynamic_truncated_spec_tokens = model_runner_output.dynamic_truncated_spec_tokens
+        num_dyn_trunc_tokens = model_runner_output.dynamic_truncated_spec_tokens
 
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
@@ -1530,8 +1530,8 @@ class Scheduler(SchedulerInterface):
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
                 num_rejected = num_draft_tokens - num_accepted
-                if dynamic_truncated_spec_tokens:
-                    num_draft_tokens -= dynamic_truncated_spec_tokens.get(req_id, 0)
+                if num_dyn_trunc_tokens:
+                    num_draft_tokens -= num_dyn_trunc_tokens.get(req_id, 0)
                 # num_computed_tokens represents the number of tokens
                 # processed in the current step, considering scheduled
                 # tokens and rejections. If some tokens are rejected,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1454,6 +1454,8 @@ class Scheduler(SchedulerInterface):
             self.processed_step_seq += 1
             self._drain_deferred_frees()
 
+        dynamic_truncated_spec_tokens = model_runner_output.dynamic_truncated_spec_tokens
+
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
@@ -1528,6 +1530,8 @@ class Scheduler(SchedulerInterface):
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
                 num_rejected = num_draft_tokens - num_accepted
+                if dynamic_truncated_spec_tokens:
+                    num_draft_tokens -= dynamic_truncated_spec_tokens.get(req_id, 0)
                 # num_computed_tokens represents the number of tokens
                 # processed in the current step, considering scheduled
                 # tokens and rejections. If some tokens are rejected,

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -280,6 +280,9 @@ class ModelRunnerOutput:
     # ``None`` when ``enable_return_routed_experts`` is off.
     routed_experts: RoutedExpertsLists | None = None
 
+    # Invalid speculative token numbers for dynamic verification
+    dynamic_truncated_spec_tokens: dict[str, int] | None = None
+
     @staticmethod
     def with_kv_conn_output_only(
         kv_connector_output: KVConnectorOutput | None,

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -366,9 +366,10 @@ class DFlashProposer(SpecDecodeBaseProposer):
             draft_confidence = draft_confidence.view(-1, self.num_speculative_tokens)
 
             if self.dynamic_verifying_method == "auto":
-                # Per-request adaptive threshold: mean confidence capped
-                # at 0.8 so high-confidence requests still truncate.
-                threshold = draft_confidence.mean(dim=-1, keepdim=True).clamp(max=0.8).expand_as(draft_confidence)
+                # Per-request adaptive threshold: thr_i = clamp(mean(conf_i), 0.1, 0.8).
+                # Kepping high-confidence tokens and filtering out low-confidence ones.
+                threshold = draft_confidence.mean(dim=-1, keepdim=True)\
+                                            .clamp(min=0.1, max=0.8).expand_as(draft_confidence)
             else:
                 threshold = self.dynamic_verifying_method
 

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -68,8 +68,11 @@ class DFlashProposer(SpecDecodeBaseProposer):
         # For DFlash we use the input embeddings to embed the mask token
         self.parallel_drafting_hidden_state_tensor = None
         # For Dflash dynamic verifying
-        self.dynamic_verifying_method = self.vllm_config.speculative_config.dynamic_verifying
-        self.dynamic_verifying_min_length = self.vllm_config.speculative_config.dynamic_verifying_min_length
+        self.dyn_verify_method = self.vllm_config.speculative_config.dynamic_verifying
+        self.dyn_verify_min_length = \
+            self.vllm_config.speculative_config.dynamic_verifying_min_length
+        self.dyn_verify_min_batch_size = \
+            self.vllm_config.speculative_config.dynamic_verifying_min_batch_size
         if self.dynamic_verifying_method == 'auto':
             self.dynamic_verifying_min_length = 1
         self.num_valid_draft_tokens = None
@@ -353,29 +356,53 @@ class DFlashProposer(SpecDecodeBaseProposer):
                                         max=draft_confidence.shape[1])
         return num_draft_tokens.int()
     
+    def _should_dynamic_verify(self, hidden_states: torch.Tensor) -> bool:
+        """Check whether dynamic verifying should be activated this step."""
+        if not self.dynamic_verifying_method:
+            return False
+        if self.num_speculative_tokens <= 3:
+            return False
+        bs = hidden_states.shape[0] // self.num_speculative_tokens
+        return bs > self.dynamic_verifying_min_batch_size
+
+    def _get_dynamic_verifying_threshold(
+        self, draft_confidence: torch.Tensor,
+    ) -> float | torch.Tensor:
+        """Compute the confidence threshold for dynamic verifying."""
+        if self.dynamic_verifying_method == "auto":
+            # Per-request adaptive threshold: thr_i = clamp(mean(conf_i), 0.1, 0.8).
+            # Keeping high-confidence tokens and filtering out low-confidence ones.
+            return (draft_confidence.mean(dim=-1, keepdim=True)
+                    .clamp(min=0.1, max=0.8)
+                    .expand_as(draft_confidence))
+        return self.dynamic_verifying_method
+
     @override
     def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        if self.dynamic_verifying_method:
-            logits = self.model.compute_logits(hidden_states)
-            max_logits, draft_token_ids = logits.max(dim=-1)
-            # Numerically stable max-softmax: exp(max - logsumexp) equals
-            # the max probability from softmax without materializing the
-            # full softmax tensor.
-            log_sum_exp = logits.logsumexp(dim=-1)
-            draft_confidence = (max_logits - log_sum_exp).exp()
-            draft_confidence = draft_confidence.view(-1, self.num_speculative_tokens)
-
-            if self.dynamic_verifying_method == "auto":
-                # Per-request adaptive threshold: thr_i = clamp(mean(conf_i), 0.1, 0.8).
-                # Kepping high-confidence tokens and filtering out low-confidence ones.
-                threshold = draft_confidence.mean(dim=-1, keepdim=True)\
-                                            .clamp(min=0.1, max=0.8).expand_as(draft_confidence)
-            else:
-                threshold = self.dynamic_verifying_method
-
-            self.num_valid_draft_tokens = self._truncate_by_confidence(
-                draft_confidence, threshold, self.dynamic_verifying_min_length
-            )
-            return draft_token_ids
-        else:
+        if not self._should_dynamic_verify(hidden_states):
+            self.num_valid_draft_tokens = None
             return super()._greedy_sample(hidden_states)
+
+        # Dynamic verifying requires full logits for confidence computation,
+        # which is incompatible with the communication-efficient local argmax.
+        assert not self.use_local_argmax_reduction, (
+            "dynamic_verifying is incompatible with "
+            "use_local_argmax_reduction (needs full logits "
+            "for confidence scores). Disable one of them."
+        )
+
+        logits = self.model.compute_logits(hidden_states)
+        max_logits, draft_token_ids = logits.max(dim=-1)
+        # Numerically stable max-softmax: exp(max - logsumexp) equals
+        # the max probability from softmax without materializing the
+        # full softmax tensor.
+        log_sum_exp = logits.logsumexp(dim=-1)
+        draft_confidence = (max_logits - log_sum_exp).exp()
+        draft_confidence = draft_confidence.view(
+            -1, self.num_speculative_tokens)
+
+        threshold = self._get_dynamic_verifying_threshold(draft_confidence)
+        self.num_valid_draft_tokens = self._truncate_by_confidence(
+            draft_confidence, threshold, self.dynamic_verifying_min_length,
+        )
+        return draft_token_ids

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -67,6 +67,12 @@ class DFlashProposer(SpecDecodeBaseProposer):
 
         # For DFlash we use the input embeddings to embed the mask token
         self.parallel_drafting_hidden_state_tensor = None
+        # For Dflash dynamic verifying
+        self.dynamic_verifying_method = self.vllm_config.speculative_config.dynamic_verifying
+        self.dynamic_verifying_min_length = self.vllm_config.speculative_config.dynamic_verifying_min_length
+        if self.dynamic_verifying_method == 'auto':
+            self.dynamic_verifying_min_length = 1
+        self.num_valid_draft_tokens = None
 
         self.dflash_causal = self.dflash_config.get("causal", False)
 
@@ -305,3 +311,70 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @property
     def dflash_config(self):
         return getattr(self.draft_model_config.hf_config, "dflash_config", None) or {}
+    
+    def _truncate_by_confidence(
+        self,
+        draft_confidence: torch.Tensor,
+        threshold: float | torch.Tensor = 0.5,
+        min_length: int = 0,
+    ) -> torch.Tensor:
+        """Truncate draft tokens per request based on confidence threshold.
+
+        Args:
+            draft_confidence: [batch_size, num_speculative_tokens] confidence
+                values for each draft token position.
+            threshold: Confidence threshold (float or per-request tensor).
+                Draft tokens at positions where confidence first drops
+                below this value are truncated.
+            min_length: Minimum number of draft tokens to keep per request.
+
+        Returns:
+            [batch_size] int32 tensor — number of draft tokens to keep per request.
+        """
+        # Mask: True where confidence >= threshold
+        valid = draft_confidence >= threshold  # [batch, num_spec_tokens]
+
+        # For each row, find the first False position.
+        # If all True, keep all tokens.
+        # Trick: flip valid, find first True in flipped = first False in original.
+        first_invalid = (~valid).float().argmax(dim=-1)  # [batch]
+
+        # If a row is all-valid (~valid is all False), argmax returns 0,
+        # but we want num_speculative_tokens. Detect this case.
+        all_valid = valid.all(dim=-1)  # [batch], bool
+
+        num_draft_tokens = torch.where(
+            all_valid,
+            draft_confidence.shape[1],
+            first_invalid,
+        )
+        if min_length:
+            num_draft_tokens = torch.clamp(num_draft_tokens, min=min_length,
+                                        max=draft_confidence.shape[1])
+        return num_draft_tokens.int()
+    
+    @override
+    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.dynamic_verifying_method:
+            logits = self.model.compute_logits(hidden_states)
+            max_logits, draft_token_ids = logits.max(dim=-1)
+            # Numerically stable max-softmax: exp(max - logsumexp) equals
+            # the max probability from softmax without materializing the
+            # full softmax tensor.
+            log_sum_exp = logits.logsumexp(dim=-1)
+            draft_confidence = (max_logits - log_sum_exp).exp()
+            draft_confidence = draft_confidence.view(-1, self.num_speculative_tokens)
+
+            if self.dynamic_verifying_method == "auto":
+                # Per-request adaptive threshold: mean confidence capped
+                # at 0.8 so high-confidence requests still truncate.
+                threshold = draft_confidence.mean(dim=-1, keepdim=True).clamp(max=0.8).expand_as(draft_confidence)
+            else:
+                threshold = self.dynamic_verifying_method
+
+            self.num_valid_draft_tokens = self._truncate_by_confidence(
+                draft_confidence, threshold, self.dynamic_verifying_min_length
+            )
+            return draft_token_ids
+        else:
+            return super()._greedy_sample(hidden_states)

--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -472,7 +472,7 @@ def update_scheduler_for_invalid_drafts(
     num_valid_draft_tokens_cpu: torch.Tensor,
     scheduler_output: "SchedulerOutput",
     req_id_to_index: dict[str, int],
-) -> None:
+) -> dict[str, int]:
     """Trim invalid speculative slots using per-request valid draft counts.
 
     Args:
@@ -480,9 +480,13 @@ def update_scheduler_for_invalid_drafts(
         num_valid_draft_tokens_cpu: CPU buffer of valid draft counts.
         scheduler_output: Scheduler metadata to update in-place.
         req_id_to_index: Request-id to batch-index mapping.
+
+    Returns:
+        Per-request number of trimmed (invalid) speculative tokens.
     """
     req_data = scheduler_output.scheduled_cached_reqs
     num_valid_draft_tokens_event.synchronize()
+    trimmed: dict[str, int] = {}
 
     for req_id in req_data.req_ids:
         req_index = req_id_to_index.get(req_id)
@@ -508,6 +512,11 @@ def update_scheduler_for_invalid_drafts(
             scheduler_output.scheduled_spec_decode_tokens[req_id] = spec_token_ids[
                 :valid_k
             ]
+
+        if tokens_to_trim > 0:
+            trimmed[req_id] = tokens_to_trim
+
+    return trimmed
 
 
 def update_ngram_gpu_tensors_incremental(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1274,7 +1274,7 @@ class GPUModelRunner(
         ):
             for req_id, toks in scheduled_spec_tokens.items():
                 original_num_spec_per_req[req_id] = len(toks)
-            self.dynamic_truncated_spec_tokens = update_scheduler_for_invalid_drafts(
+            self._dynamic_truncated_spec_tokens = update_scheduler_for_invalid_drafts(
                 self._num_valid_draft_tokens_event,
                 self._num_valid_draft_tokens_cpu,
                 scheduler_output,
@@ -4625,7 +4625,7 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts=None,
-                dynamic_truncated_spec_tokens = self.dynamic_truncated_spec_tokens
+                dynamic_truncated_spec_tokens = self._dynamic_truncated_spec_tokens
                 if spec_config is not None
                 and spec_config.dynamic_verifying else None,
             )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -850,7 +850,7 @@ class GPUModelRunner(
             self._num_valid_draft_tokens_event = torch.cuda.Event()
             self._num_valid_draft_tokens_copy_stream = torch.cuda.Stream()
             if self.speculative_config.dynamic_verifying:
-                self._dynamic_truncated_spec_tokens: dict[str, int] = {}
+                self._dynamic_truncated_spec_tokens: dict[str, int] | None = None
 
         self._draft_token_req_ids: list[str] | None = None
         self.transfer_event = torch.Event()
@@ -1268,9 +1268,14 @@ class GPUModelRunner(
         # Save scheduler-allocated spec lengths before trimming so
         # prev_num_draft_len keeps the optimistic count for rejection correction.
         original_num_spec_per_req: dict[str, int] = {}
-        if self.speculative_config is not None and(
-            self.speculative_config.use_ngram_gpu()
-            or self.speculative_config.dynamic_verifying
+        # Reset trimming result so stale data from a prior step never leaks.
+        self._dynamic_truncated_spec_tokens = None
+        if (self.speculative_config is not None
+            and self._num_valid_draft_tokens is not None
+            and (
+                self.speculative_config.use_ngram_gpu()
+                or self.speculative_config.dynamic_verifying
+            )
         ):
             for req_id, toks in scheduled_spec_tokens.items():
                 original_num_spec_per_req[req_id] = len(toks)
@@ -4058,8 +4063,9 @@ class GPUModelRunner(
         if self.routed_experts_initialized:
             self.routed_experts_capturer.clear_buffer()
 
-        # If ngram_gpu/dynamic_verifying is used, we need to copy the scheduler_output to avoid
-        # the modification has influence on the scheduler_output in engine core process.
+        # If ngram_gpu/dynamic_verifying is used, we need to copy the scheduler_output 
+        # to avoid the modification has influence on the scheduler_output in 
+        # engine core process.
         # The replace is much faster than deepcopy.
         if (
             self.speculative_config is not None and(
@@ -4625,9 +4631,7 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts=None,
-                dynamic_truncated_spec_tokens = self._dynamic_truncated_spec_tokens
-                if spec_config is not None
-                and spec_config.dynamic_verifying else None,
+                dynamic_truncated_spec_tokens = self._dynamic_truncated_spec_tokens,
             )
 
         if not self.use_async_scheduling:
@@ -5130,14 +5134,16 @@ class GPUModelRunner(
             )
             # Cache valid draft counts and async D2H copy on a dedicated stream.
             if spec_config.dynamic_verifying:
+                # TODO: Explicit parameter passing
                 self._num_valid_draft_tokens = self.drafter.num_valid_draft_tokens
-                copy_num_valid_draft_tokens(
-                    self._num_valid_draft_tokens_cpu,
-                    self._num_valid_draft_tokens_copy_stream,
-                    self._num_valid_draft_tokens_event,
-                    self._num_valid_draft_tokens,
-                    self.input_batch.num_reqs,
-                )
+                if self._num_valid_draft_tokens is not None:
+                    copy_num_valid_draft_tokens(
+                        self._num_valid_draft_tokens_cpu,
+                        self._num_valid_draft_tokens_copy_stream,
+                        self._num_valid_draft_tokens_event,
+                        self._num_valid_draft_tokens,
+                        self.input_batch.num_reqs,
+                    )
             if hasattr(self.drafter, "take_last_draft_probs"):
                 draft_probs = self.drafter.take_last_draft_probs()
                 if draft_probs is not None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -840,15 +840,17 @@ class GPUModelRunner(
         self._num_valid_draft_tokens_cpu: torch.Tensor | None = None
         self._num_valid_draft_tokens_event: torch.cuda.Event | None = None
         self._num_valid_draft_tokens_copy_stream: torch.cuda.Stream | None = None
-        if (
-            self.speculative_config is not None
-            and self.speculative_config.use_ngram_gpu()
+        if self.speculative_config is not None and(
+            self.speculative_config.use_ngram_gpu()
+            or self.speculative_config.dynamic_verifying
         ):
             self._num_valid_draft_tokens_cpu = torch.empty(
                 self.max_num_reqs, dtype=torch.int32, pin_memory=self.pin_memory
             )
             self._num_valid_draft_tokens_event = torch.cuda.Event()
             self._num_valid_draft_tokens_copy_stream = torch.cuda.Stream()
+            if self.speculative_config.dynamic_verifying:
+                self._dynamic_truncated_spec_tokens: dict[str, int] = {}
 
         self._draft_token_req_ids: list[str] | None = None
         self.transfer_event = torch.Event()
@@ -1266,9 +1268,10 @@ class GPUModelRunner(
         # Save scheduler-allocated spec lengths before trimming so
         # prev_num_draft_len keeps the optimistic count for rejection correction.
         original_num_spec_per_req: dict[str, int] = {}
-        if (
-            self.speculative_config is not None
-            and self.speculative_config.use_ngram_gpu()
+        self.dynamic_truncated_spec_tokens = {}
+        if self.speculative_config is not None and(
+            self.speculative_config.use_ngram_gpu()
+            or self.speculative_config.dynamic_verifying
         ):
             for req_id, toks in scheduled_spec_tokens.items():
                 original_num_spec_per_req[req_id] = len(toks)
@@ -1429,12 +1432,17 @@ class GPUModelRunner(
 
             # Add spec_token_ids to token_ids_cpu.
             self.input_batch.update_req_spec_token_ids(req_state, scheduled_spec_tokens)
-            # Restore scheduler-side draft count after ngram trimming.
+            # Restore scheduler-side draft count after
+            # ngram/dynamic_verifying trimming.
             if original_num_spec_per_req:
                 orig = original_num_spec_per_req.get(req_id, 0)
                 if orig != req_state.prev_num_draft_len:
+                    # Record invalid count for dynamic verifying
+                    if self.speculative_config.dynamic_verifying:
+                        num_invalid_tokens = orig - req_state.prev_num_draft_len
+                        self.dynamic_truncated_spec_tokens[req_id] = num_invalid_tokens
                     req_state.prev_num_draft_len = orig
-
+        
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.
         for request in reqs_to_add:
@@ -4055,12 +4063,14 @@ class GPUModelRunner(
         if self.routed_experts_initialized:
             self.routed_experts_capturer.clear_buffer()
 
-        # If ngram_gpu is used, we need to copy the scheduler_output to avoid
+        # If ngram_gpu/dynamic_verifying is used, we need to copy the scheduler_output to avoid
         # the modification has influence on the scheduler_output in engine core process.
         # The replace is much faster than deepcopy.
         if (
-            self.speculative_config is not None
-            and self.speculative_config.use_ngram_gpu()
+            self.speculative_config is not None and(
+            self.speculative_config.use_ngram_gpu()
+            or self.speculative_config.dynamic_verifying
+            )
         ):
             num_scheduled_tokens_copy = scheduler_output.num_scheduled_tokens.copy()
             spec_decode_tokens_copy = (
@@ -4620,6 +4630,9 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts=None,
+                dynamic_truncated_spec_tokens = self.dynamic_truncated_spec_tokens
+                if spec_config is not None
+                and spec_config.dynamic_verifying else None,
             )
 
         if not self.use_async_scheduling:
@@ -5120,6 +5133,18 @@ class GPUModelRunner(
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
                 slot_mappings=slot_mappings,
             )
+            # Cache valid draft counts for scheduler-side trimming.
+            self._num_valid_draft_tokens = self.drafter.num_valid_draft_tokens
+
+            # Async D2H copy on a dedicated stream.
+            if spec_config.dynamic_verifying:
+                copy_num_valid_draft_tokens(
+                    self._num_valid_draft_tokens_cpu,
+                    self._num_valid_draft_tokens_copy_stream,
+                    self._num_valid_draft_tokens_event,
+                    self._num_valid_draft_tokens,
+                    self.input_batch.num_reqs,
+                )
             if hasattr(self.drafter, "take_last_draft_probs"):
                 draft_probs = self.drafter.take_last_draft_probs()
                 if draft_probs is not None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1268,14 +1268,13 @@ class GPUModelRunner(
         # Save scheduler-allocated spec lengths before trimming so
         # prev_num_draft_len keeps the optimistic count for rejection correction.
         original_num_spec_per_req: dict[str, int] = {}
-        self.dynamic_truncated_spec_tokens = {}
         if self.speculative_config is not None and(
             self.speculative_config.use_ngram_gpu()
             or self.speculative_config.dynamic_verifying
         ):
             for req_id, toks in scheduled_spec_tokens.items():
                 original_num_spec_per_req[req_id] = len(toks)
-            update_scheduler_for_invalid_drafts(
+            self.dynamic_truncated_spec_tokens = update_scheduler_for_invalid_drafts(
                 self._num_valid_draft_tokens_event,
                 self._num_valid_draft_tokens_cpu,
                 scheduler_output,
@@ -1437,10 +1436,6 @@ class GPUModelRunner(
             if original_num_spec_per_req:
                 orig = original_num_spec_per_req.get(req_id, 0)
                 if orig != req_state.prev_num_draft_len:
-                    # Record invalid count for dynamic verifying
-                    if self.speculative_config.dynamic_verifying:
-                        num_invalid_tokens = orig - req_state.prev_num_draft_len
-                        self.dynamic_truncated_spec_tokens[req_id] = num_invalid_tokens
                     req_state.prev_num_draft_len = orig
         
         # Add the new or resumed requests to the persistent batch.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5128,11 +5128,9 @@ class GPUModelRunner(
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
                 slot_mappings=slot_mappings,
             )
-            # Cache valid draft counts for scheduler-side trimming.
-            self._num_valid_draft_tokens = self.drafter.num_valid_draft_tokens
-
-            # Async D2H copy on a dedicated stream.
+            # Cache valid draft counts and async D2H copy on a dedicated stream.
             if spec_config.dynamic_verifying:
+                self._num_valid_draft_tokens = self.drafter.num_valid_draft_tokens
                 copy_num_valid_draft_tokens(
                     self._num_valid_draft_tokens_cpu,
                     self._num_valid_draft_tokens_copy_stream,


### PR DESCRIPTION


## Purpose

DFlash generates multiple speculative tokens in parallel within one step. This can substantially increase the speculative length, leading to longer accepted lengths and better performance. However, a longer verification length also puts computing pressure on the target model. Compared with methods such as MTP, DFlash have a lower acceptance rate, meaning many verified speculative tokens are eventually discarded.

This PR adds a simple dynamic verification mechanism for DFlash. Instead of always verifying the full preconfigured speculative length, we can truncate speculative tokens early based on draft-token confidence. The motivation is that low-confidence draft tokens are unlikely to be accepted, so removing them before target-model verification can reduce wasted compute.

This is especially useful under high-concurrency workloads, where target-model verification is more likely to become compute-bound. In low-concurrency settings, the extra computation, copying and shorter accepted length can hurt performance. For details, please see the test result.

Main changes:

- Add `dynamic_verifying` to `SpeculativeConfig`.
  - `None`: disabled.
  - `float` in `(0, 1)`: confidence threshold.
  - `"auto"`: adaptive per-request `threshold = clamp(mean(conf), 0.1, 0.8)`.
- Add `dynamic_verifying_min_length` to avoid over-truncating every request.
- Compute DFlash draft-token confidence from greedy draft logits.
- Truncate DFlash speculative tokens once confidence drops below the configured threshold.
- Propagate the valid draft-token counts back to the scheduler so speculative decoding stats use the actually verified draft length.
- Document the new DFlash speculative config options.

AI assistance was used in preparing this PR. I reviewed the changed lines and am responsible for the implementation, behavior, and tests.

## Test Plan

GPU: H800

Functional coverage:

- Dynamic verification disabled.
- Dynamic verification enabled with varied thresholds and “auto”.
- Different `dynamic_verifying_min_length` values.
- Async scheduling disabled and enabled.
- Tensor parallelism coverage.
- Model coverage:
  - Qwen3-8B + DFlash.
  - Qwen3.5-9B + DFlash.

Performance coverage:

- Qwen3-8B on GSM8K.
```bash
vllm serve ...\
    --gpu-memory-utilization 0.9 \
    --tensor-parallel-size ${TENSOR_PARALLEL_SIZE:=1} \
    --compilation-config '{"cudagraph_mode":"FULL"}' \
    --attention-backend flash_attn \
    --no-enable-prefix-caching \
    --speculative-config '{"method": "dflash", "model": "...", "num_speculative_tokens": 15, "dynamic_verifying": $method, "dynamic_verifying_min_length": 1}' 

```
- Qwen3.5-9B on longbench.

```bash
vllm serve ...\
    --gpu-memory-utilization 0.9 \
    --tensor-parallel-size ${TENSOR_PARALLEL_SIZE:=2} \
    --compilation-config '{"cudagraph_mode":"PIECEWISE"}' \
    --attention-backend flash_attn \
    --no-enable-prefix-caching \
    --speculative-config '{"method": "dflash", "model": "...", "num_speculative_tokens": 15, "dynamic_verifying": $method, "num_speculative_tokens_per_batch_size": [[1, 32, 15], [33, 96, 7], [97, 128, 3]]}' 

```

## Test Result
Functional completeness testing did not find correctness or stability issues.
#### Qwen3-8B + DFlash on GSM8K

The accepted length and verifying length are stable across different batch sizes under the same confidence threshold. Therefore, the table below reports the mean values across all tested batch sizes (`bs=1,8,16,32,64,128`) to summarize the effect of each threshold. We set the max input tokens to 2048, with an average output length of approximately 300.

| Conf thr | Mean acc length | Mean verifying length |
| --- | ---: | ---: |
| 0 (base) | 4.81 | 16.00 |
| 0.1 | 4.81 | 14.82 |
| 0.3 | 4.73 | 9.79 |
| 0.5 | 4.49 | 7.01 |
| 0.7 | 3.99 | 5.10 |
| auto | 4.25 | 5.88 |

<img width="1925" height="726" alt="image" src="https://github.com/user-attachments/assets/3310bc4a-5f1b-42f6-8f90-4cef96f6c27b" />

#### Qwen3.5-359B on longbench

<img width="3177" height="958" alt="image" src="https://github.com/user-attachments/assets/0bf9553b-e489-4271-ab10-1656181c8f99" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>


