### PR TITLE
[Bugfix] Reject non-positive/non-int hash_block_size in CacheConfig

### DIFF
--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config.cache import CacheConfig
+
+
+def test_hash_block_size_none_is_accepted():
+    # None is the default and means "derive from kv cache groups".
+    config = CacheConfig(hash_block_size=None)
+    assert config.hash_block_size is None
+
+
+def test_hash_block_size_positive_is_accepted():
+    config = CacheConfig(hash_block_size=32)
+    assert config.hash_block_size == 32
+
+
+@pytest.mark.parametrize("invalid_hash_block_size", [0, -1, -16])
+def test_hash_block_size_non_positive_raises(invalid_hash_block_size):
+    with pytest.raises(ValueError, match="hash_block_size"):
+        CacheConfig(hash_block_size=invalid_hash_block_size)
+
+
+@pytest.mark.parametrize("invalid_hash_block_size", [0.5, 1.0, -0.5, True, False])
+def test_hash_block_size_non_int_raises(invalid_hash_block_size):
+    # `hash_block_size` is annotated `SkipValidation[int] | None`, so Pydantic
+    # does not coerce/reject non-int values; the model validator must catch
+    # them. `bool` is a subclass of `int` but is never a meaningful block size.
+    with pytest.raises(ValueError, match="hash_block_size"):
+        CacheConfig(hash_block_size=invalid_hash_block_size)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -231,6 +231,15 @@ class CacheConfig:
             object.__setattr__(self, "block_size", self.DEFAULT_BLOCK_SIZE)
         else:
             object.__setattr__(self, "user_specified_block_size", True)
+        if self.hash_block_size is not None and (
+            not isinstance(self.hash_block_size, int)
+            or isinstance(self.hash_block_size, bool)
+            or self.hash_block_size <= 0
+        ):
+            raise ValueError(
+                f"hash_block_size must be a positive integer, got "
+                f"{self.hash_block_size!r}."
+            )
         if self.mamba_block_size is not None:
             object.__setattr__(self, "user_specified_mamba_block_size", True)
         return self


### PR DESCRIPTION
## Purpose

Fixes #43521.

`--hash-block-size 0` (and equivalently `LLM(hash_block_size=0)`) silently passes argparse and `CacheConfig` validation, then crashes engine init with `ZeroDivisionError` at `vllm/v1/core/kv_cache_utils.py:628` (`bs % hash_block_size`) inside `resolve_kv_cache_block_sizes`. The adjacent `Invalid hash_block_size=...` `ValueError` two lines down is never reached. Reachable for multi-group KV caches (hybrid Mamba + Attention models: Falcon-Mamba, RecurrentGemma, Zamba) with `--enable-prefix-caching` or a KV transfer connector.

This is the same shape as #43496 (block_size=0), reported by the same ESBMC-Python formal-verification harness author. The fix follows the same one-line pattern as #43514: reject non-positive and non-int values (`hash_block_size` is annotated `SkipValidation[int] | None`, so Pydantic does not coerce/reject non-int inputs) at config-construction time. `None` is preserved as the valid default ("derive from KV cache groups").

The user now sees:

```
ValueError: hash_block_size must be a positive integer, got 0.
```

instead of an internal `ZeroDivisionError` traceback from KV-cache block-size resolution.

### Relationship with #43514

This PR adds `tests/config/test_cache_config.py`, which #43514 also creates. If #43514 merges first, the file will already exist and this PR's tests should be appended to it (trivial rebase). If this PR merges first, #43514 will need the same trivial rebase. Both PRs are self-contained — they touch disjoint validation logic.

### Duplicate-work check

```
gh issue view 43521 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state all --search "43521 in:body"
gh pr list --repo vllm-project/vllm --state open --search "hash_block_size validation"
gh pr list --repo vllm-project/vllm --state open --search "hash-block-size positive"
```

No open or closed PR addresses this. Issue is 4 hours old.

## Test Plan

```
.venv/bin/python -m pytest tests/config/test_cache_config.py -v
.venv/bin/pre-commit run --files vllm/config/cache.py tests/config/test_cache_config.py
```

Also re-ran the issue reporter's exact reproducer:

```python
from vllm.config.cache import CacheConfig
CacheConfig(hash_block_size=0)
CacheConfig(hash_block_size=0.5)
```

## Test Result

```
tests/config/test_cache_config.py::test_hash_block_size_none_is_accepted              PASSED
tests/config/test_cache_config.py::test_hash_block_size_positive_is_accepted          PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_positive_raises[0]        PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_positive_raises[-1]       PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_positive_raises[-16]      PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_int_raises[0.5]           PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_int_raises[1.0]           PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_int_raises[-0.5]          PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_int_raises[True]          PASSED
tests/config/test_cache_config.py::test_hash_block_size_non_int_raises[False]         PASSED
======================== 10 passed, 2 warnings in 1.20s ========================
```

All pre-commit hooks pass (ruff check / ruff format / typos / mypy / SPDX / etc.).

Behavioural check against the reporter's reproducer (before vs. after):

| Input | Before | After |
|---|---|---|
| `CacheConfig(hash_block_size=0)` | `ZeroDivisionError` at `kv_cache_utils.py:628` for multi-group KV caches | `ValueError: hash_block_size must be a positive integer, got 0.` at config construction |
| `CacheConfig(hash_block_size=0.5)` | Silently accepted; `hash_block_size` survives as `float`, downstream `bs % 0.5` produces nonsense | `ValueError: hash_block_size must be a positive integer, got 0.5.` |

---

## AI assistance disclosure

This change was AI-assisted (Claude). I (the submitter) reviewed every line, ran the test commands above, and stand behind the change end-to-end.