### PR TITLE
[Bugfix] Fix reasoning end token missed by should_advance under async scheduling + spec decode

### DIFF
--- a/tests/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/entrypoints/llm/test_struct_output_generate.py
@@ -727,6 +727,14 @@ Make the response as short as possible.
         ),
         ("Qwen/Qwen3-1.7B", "xgrammar", "auto", "deepseek_r1", None, False),
         ("Qwen/Qwen3-1.7B", "xgrammar", "auto", "deepseek_r1", None, True),
+        (
+            "Qwen/Qwen3-1.7B",
+            "xgrammar",
+            "auto",
+            "qwen3",
+            NGRAM_SPEC_CONFIG,
+            True,
+        ),
     ],
 )
 def test_structured_output_with_reasoning_matrices(

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -258,3 +258,161 @@ class TestReasoningStructuredOutput:
 
         # Should return True since reasoning has ended
         assert result is True
+
+    def test_should_advance_with_new_token_ids_detects_reasoning_end(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """When new_token_ids is passed containing the end token,
+        reasoning_ended should be set regardless of placeholder arithmetic."""
+        END_TOKEN = 999
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda all_ids, delta: END_TOKEN in delta
+        )
+        structured_req.reasoner = reasoner
+
+        # Simulate async + spec decode where placeholder math would produce
+        # an empty delta window: num_computed_tokens == len(all_token_ids)
+        mock_request_with_structured_output.all_token_ids = [
+            1,
+            2,
+            3,
+            END_TOKEN,
+            10,
+        ]
+        mock_request_with_structured_output.num_computed_tokens = 5
+        mock_request_with_structured_output.num_output_placeholders = 0
+
+        new_token_ids = [9, 198, END_TOKEN, 271]
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output, new_token_ids=new_token_ids
+        )
+
+        assert structured_req.reasoning_ended is True
+        # JSON type defers FSM advance to next step
+        assert result is False
+        # Verify we used new_token_ids, not the placeholder-derived delta
+        reasoner.is_reasoning_end_streaming.assert_called_once()
+
+    def test_should_advance_async_spec_decode_empty_delta_misses_end_token(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Reproduce the bug: without new_token_ids, async + spec decode
+        placeholder arithmetic produces start == len(all_token_ids), yielding
+        an empty delta that misses the reasoning end token.
+
+        This test documents the known limitation of the fallback path."""
+        END_TOKEN = 999
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        actual_deltas_seen = []
+
+        def capture_delta(all_ids, delta):
+            delta_list = list(delta)
+            actual_deltas_seen.append(delta_list)
+            return END_TOKEN in delta_list
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming = Mock(side_effect=capture_delta)
+        structured_req.reasoner = reasoner
+
+        # After async scheduling + spec decode token append:
+        # 4 new tokens appended, num_computed_tokens adjusted to match
+        mock_request_with_structured_output.all_token_ids = [
+            1,
+            2,
+            3,
+            4,
+            5,
+            9,
+            198,
+            END_TOKEN,
+            271,
+        ]
+        mock_request_with_structured_output.num_computed_tokens = 9
+        mock_request_with_structured_output.num_output_placeholders = 0
+
+        # Fallback path (no new_token_ids) computes start = 9 - 0 = 9,
+        # but len(all_token_ids) = 9, so islice yields nothing.
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        assert result is False
+        # The delta was empty, so the end token was missed
+        assert actual_deltas_seen == [[]]
+        assert structured_req.reasoning_ended is False
+
+        # Now try with new_token_ids -- this should find the end token
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[9, 198, END_TOKEN, 271],
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is False  # JSON defers
+
+    def test_should_advance_new_token_ids_structural_tag_spec_decode(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Structural tags with spec decode should return True on the same
+        step, even when detected via new_token_ids."""
+        END_TOKEN = 999
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.STRUCTURAL_TAG,
+            "{}",
+        )
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda all_ids, delta: END_TOKEN in delta
+        )
+        structured_req.reasoner = reasoner
+
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[END_TOKEN, 42],
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is True
+
+    def test_should_advance_new_token_ids_no_end_token(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """When new_token_ids does not contain the end token,
+        reasoning_ended should stay False."""
+        END_TOKEN = 999
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda all_ids, delta: END_TOKEN in delta
+        )
+        structured_req.reasoner = reasoner
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[10, 20, 30],
+        )
+
+        assert structured_req.reasoning_ended is False
+        assert result is False

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1413,7 +1413,9 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids=new_token_ids
+            ):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 assert struct_output_request.grammar is not None

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -319,7 +319,11 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self,
+        request: "Request",
+        new_token_ids: list[int] | None = None,
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -342,15 +346,23 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
+        # Check if reasoning ends in *this* step.
+        # When new_token_ids is provided (token-output path), use it
+        # directly as the delta to avoid fragile placeholder arithmetic
+        # that can miss the end token under async scheduling + spec decode.
         all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
+        if new_token_ids is not None:
+            delta: Iterable[int] = new_token_ids
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = (
+                delta_from
+                if delta_from >= 0
+                else max(len(all_token_ids) + delta_from, 0)
+            )
+            delta = itertools.islice(all_token_ids, start, None)
+
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta):
             structured_req.reasoning_ended = True
 
             # Reasoning just ended this step. Defer FSM advance until the next


### PR DESCRIPTION
## Purpose

Fixes #43388, #34650

When async scheduling and speculative decoding are both enabled, `should_advance()` misses the reasoning end token (e.g. `</think>`) because placeholder arithmetic produces an empty delta window.

## Root Cause

`should_advance()` computes a delta slice of recently-generated tokens via:

```python
delta_from = request.num_computed_tokens - request.num_output_placeholders
delta = all_token_ids[delta_from:]
```

Under async scheduling + spec decode:

1. `num_computed_tokens` is pre-incremented by `_update_after_schedule` (before GPU runs)
2. Adjusted down for rejected spec tokens in `update_from_output`
3. `num_output_placeholders` follows a parallel increment/decrement cycle
4. After token append + placeholder decrement, the arithmetic can produce `delta_from == len(all_token_ids)`, yielding an **empty delta**

The reasoning end token sits in `all_token_ids` but the delta window walks past it. `reasoning_ended` never becomes `True`, and JSON grammar constraints are never applied.

Observed in production (from issue #43388):
```
new_token_ids = [9, 198, 248069, 271]   # 248069 = </think>
start = 5975                              # one past the end token at index 5974
delta = []                                # empty!
```

## Fix

Add an optional `new_token_ids` parameter to `should_advance()`. At the token-output call site in `update_from_output` (the only path where `new_token_ids` is naturally available), pass the actual tokens directly. This bypasses the fragile placeholder arithmetic entirely.

The fallback path (draft-token call sites in `update_draft_token_ids` / `update_draft_token_ids_in_output`) is unchanged — those rely on `reasoning_ended` already being set by the prior `update_from_output` call.

## Changes

| File | Change |
|------|--------|
| `vllm/v1/structured_output/__init__.py` | Add `new_token_ids` param to `should_advance()`; use it as delta when provided |
| `vllm/v1/core/sched/scheduler.py` | Pass `new_token_ids` at the `update_from_output` call site |
| `tests/v1/structured_output/test_reasoning_structured_output.py` | 4 new unit tests covering the bug and fix |
| `tests/entrypoints/llm/test_struct_output_generate.py` | New E2E matrix entry: Qwen3 + spec decode + async scheduling |

## Test Plan

**Unit tests (4 new, all pass locally):**

- `test_should_advance_with_new_token_ids_detects_reasoning_end` — end token found via `new_token_ids` regardless of placeholder state
- `test_should_advance_async_spec_decode_empty_delta_misses_end_token` — **reproduces the exact bug** (empty delta), then shows `new_token_ids` fixes it
- `test_should_advance_new_token_ids_structural_tag_spec_decode` — structural tag + spec decode same-step `True` (no regression)
- `test_should_advance_new_token_ids_no_end_token` — negative case: no end token → `reasoning_ended` stays `False`

**E2E test (new matrix entry):**

- `Qwen/Qwen3-1.7B` + `qwen3` reasoning parser + ngram spec decode + `async_scheduling=True` — the exact combination that triggers the bug

**Existing tests (all 13 pass):**

```
tests/v1/structured_output/test_reasoning_structured_output.py — 13 passed
```

## Related Work

- Issue #34650: identical bug reported for DeepSeek-R1 + MTP (Feb 2026)
- PR #36138: comprehensive fix (open since Mar 2026, `needs-rebase`). That PR adds `identify_constrained_draft_tokens()` / `_find_reasoning_end_in_tokens()` across 3 files (+403/-95). This PR achieves the same detection fix with +25/-11 lines in 2 files.
- Issue #43338: related multi-token boundary variant (gpt-oss). This PR fixes single-token boundaries (Qwen3, DeepSeek-R1); multi-token markers need the prior-context approach from #43424.
- PR #31332: the original async scheduling fix by @njhill that introduced `delta_from = num_computed_tokens - num_output_placeholders`. That formula is correct for async-without-spec-decode but breaks when spec decode rejection adjustments shift the counters.
