### PR TITLE
[Bugfix] Fix KeyError on KV-shared consumer layer in get_attn_backends_for_group

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
@@ -998,6 +999,58 @@ def test_init_kv_cache_with_kv_sharing_valid(default_vllm_config):
     assert len(kv_cache_config_after_init.kv_cache_groups[0].layer_names) == 2
     assert kv_cache_config_after_init.kv_cache_groups[0].layer_names[0] == layer_0
     assert kv_cache_config_after_init.kv_cache_groups[0].layer_names[1] == layer_1
+
+
+def test_init_kv_cache_with_kv_sharing_uniform_type_spec(default_vllm_config):
+    torch.set_default_dtype(torch.float16)
+    layer_0 = "model.layers.0.self_attn.attn"
+    layer_1 = "model.layers.1.self_attn.attn"
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        fwd_context = {
+            layer_0: Attention(
+                num_heads=8,
+                head_size=64,
+                scale=1.0,
+                prefix=layer_0,
+            ),
+            layer_1: Attention(
+                num_heads=8,
+                head_size=64,
+                scale=1.0,
+                prefix=layer_1,
+                kv_sharing_target_layer_name=layer_0,
+            ),
+        }
+        assert fwd_context is not None
+
+    runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
+    kv_cache_spec = runner.get_kv_cache_spec()
+    assert runner.shared_kv_cache_layers[layer_1] == layer_0
+
+    available_memory = 20 * GiB_bytes
+    kv_cache_config = get_kv_cache_configs(
+        vllm_config, [kv_cache_spec], [available_memory]
+    )[0]
+
+    group = kv_cache_config.kv_cache_groups[0]
+    producer_spec = kv_cache_spec[layer_0]
+    kv_cache_config.kv_cache_groups[0] = KVCacheGroupSpec(
+        layer_names=group.layer_names,
+        kv_cache_spec=UniformTypeKVCacheSpecs(
+            block_size=producer_spec.block_size,
+            kv_cache_specs={layer_0: producer_spec},
+        ),
+    )
+
+    kv_cache_config.num_blocks = 1
+    kv_cache_config.kv_cache_tensors[0].size = producer_spec.page_size_bytes
+
+    runner.initialize_kv_cache(kv_cache_config)
+
+    assert len(runner.attn_groups) == 1
+    assert len(runner.attn_groups[0]) == 1
+    assert runner.attn_groups[0][0].layer_names == [layer_0, layer_1]
 
 
 @pytest.mark.skipif(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6585,7 +6585,12 @@ class GPUModelRunner(
                 full_cls_name = attn_backend.full_cls_name()
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
-                    layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
+                    spec_lookup_name = self.shared_kv_cache_layers.get(
+                        layer_name, layer_name
+                    )
+                    layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[
+                        spec_lookup_name
+                    ]
                 key = (full_cls_name, layer_kv_cache_spec)
                 attn_backends[key] = AttentionGroupKey(
                     attn_backend, layer_kv_cache_spec


### PR DESCRIPTION
## Purpose

`get_attn_backends_for_group` raises `KeyError` on the first KV-shared consumer layer when the group's `kv_cache_spec` is a `UniformTypeKVCacheSpecs`:

```
File "vllm/v1/worker/gpu_model_runner.py", line 6588, in get_attn_backends_for_group
    layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
KeyError: 'language_model.model.layers.15.self_attn.attn'
```

The dict only contains real cache owners. Consumer layers get appended to `kv_cache_group_spec.layer_names` by `add_kv_sharing_layers_to_kv_cache_groups`, but `get_kv_cache_spec` skips them when populating `kv_cache_specs` because they reuse the producer's KV cache.

Reproduces on Gemma 4 (E2B and E4B) under any of: `disable_hybrid_kv_cache_manager=True`, a `kv_transfer_config` whose connector lacks `SupportsHMA`, or `speculative_config={"method": "extract_hidden_states", ...}`. All three disable the hybrid manager. Gemma 4's heterogeneous head dimensions (256 sliding, 512 full) then keep the post-unify spec dict from passing `is_kv_cache_spec_uniform` while still satisfying `UniformTypeKVCacheSpecs.from_specs`, so dispatch lands on `UniformTypeKVCacheSpecs`.

The fix routes the consumer's spec lookup through `self.shared_kv_cache_layers` (populated in `get_kv_cache_spec`) so the producer's spec is used. `dict.get(name, name)` makes it a no-op for non-shared layers.

PR #40776 patches the same loop for a pipeline-parallelism bug. Its `if layer_name not in layers` check does not skip consumer layers (they are real `Attention` modules and are present in `layers`), so it does not fix this.

## Test

New `test_init_kv_cache_with_kv_sharing_uniform_type_spec` in `tests/v1/worker/test_gpu_model_runner.py` fails on main with the `KeyError` above and passes with the fix.

```
$ pytest tests/v1/worker/test_gpu_model_runner.py -v
======================= 33 passed, 21 warnings in 43.69s =======================
```

End-to-end on `google/gemma-4-E2B-it`:

```python
LLM(model="google/gemma-4-E2B-it", disable_hybrid_kv_cache_manager=True)
```

Without the fix: `KeyError` at engine init on layer 15 (= 35 − 20). With the fix: engine starts and `llm.chat(...)` returns `"Ok."`.
