### PR TITLE
[Test][V1] Add unit tests for parallel sampling metrics

### DIFF
--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -82,7 +82,6 @@ def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:
         data_parallel_rank=None,
     )
 
-
 def test_observe_finished_request_single() -> None:
     """Non-parallel request (n=1) should record metrics correctly."""
     from vllm.v1.metrics.stats import IterationStats
@@ -105,13 +104,10 @@ def test_observe_finished_request_parallel() -> None:
     iteration_stats = IterationStats()
 
     parent_request = ParentRequest(make_request(SamplingParams(n=3)))
-    # Simulate 3 child requests
-    for i in range(3):
-        child_id, _ = parent_request.get_child_info(i)
+    child_ids = [parent_request.get_child_info(i)[0] for i in range(3)]
 
     # Child 0 finishes with 10 tokens — not all done yet, no metrics recorded
-    child_0_id = "0_parent_id"
-    parent_request.child_requests.discard(child_0_id)
+    parent_request.child_requests.remove(child_ids[0])
     ParentRequest.observe_finished_request(
         parent_req=parent_request,
         iteration_stats=iteration_stats,
@@ -121,8 +117,7 @@ def test_observe_finished_request_parallel() -> None:
     assert iteration_stats.max_num_generation_tokens_iter == []
 
     # Child 1 finishes with 20 tokens — still not all done
-    child_1_id = "1_parent_id"
-    parent_request.child_requests.discard(child_1_id)
+    parent_request.child_requests.remove(child_ids[1])
     ParentRequest.observe_finished_request(
         parent_req=parent_request,
         iteration_stats=iteration_stats,
@@ -132,8 +127,7 @@ def test_observe_finished_request_parallel() -> None:
     assert iteration_stats.max_num_generation_tokens_iter == []
 
     # Child 2 finishes with 15 tokens — all done, metrics should be recorded
-    child_2_id = "2_parent_id"
-    parent_request.child_requests.discard(child_2_id)
+    parent_request.child_requests.remove(child_ids[2])
     ParentRequest.observe_finished_request(
         parent_req=parent_request,
         iteration_stats=iteration_stats,
@@ -150,11 +144,10 @@ def test_observe_finished_request_max_tokens_tracked() -> None:
     iteration_stats = IterationStats()
 
     parent_request = ParentRequest(make_request(SamplingParams(n=2)))
-    for i in range(2):
-        parent_request.get_child_info(i)
+    child_ids = [parent_request.get_child_info(i)[0] for i in range(2)]
 
     # Child 0 finishes with 100 tokens
-    parent_request.child_requests.discard("0_parent_id")
+    parent_request.child_requests.remove(child_ids[0])
     ParentRequest.observe_finished_request(
         parent_req=parent_request,
         iteration_stats=iteration_stats,
@@ -162,7 +155,7 @@ def test_observe_finished_request_max_tokens_tracked() -> None:
     )
 
     # Child 1 finishes with 5 tokens — max should still be 100
-    parent_request.child_requests.discard("1_parent_id")
+    parent_request.child_requests.remove(child_ids[1])
     ParentRequest.observe_finished_request(
         parent_req=parent_request,
         iteration_stats=iteration_stats,

--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -82,6 +82,7 @@ def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:
         data_parallel_rank=None,
     )
 
+
 def test_observe_finished_request_single() -> None:
     """Non-parallel request (n=1) should record metrics correctly."""
     from vllm.v1.metrics.stats import IterationStats

--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -81,3 +81,93 @@ def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:
         cache_salt=None,
         data_parallel_rank=None,
     )
+
+
+def test_observe_finished_request_single() -> None:
+    """Non-parallel request (n=1) should record metrics correctly."""
+    from vllm.v1.metrics.stats import IterationStats
+    iteration_stats = IterationStats()
+
+    # n=1, no parent request
+    ParentRequest.observe_finished_request(
+        parent_req=None,
+        iteration_stats=iteration_stats,
+        num_generation_tokens=42,
+    )
+
+    assert iteration_stats.n_params_iter == [1]
+    assert iteration_stats.max_num_generation_tokens_iter == [42]
+
+
+def test_observe_finished_request_parallel() -> None:
+    """Parallel request (n=3) should only record metrics when all children finish."""
+    from vllm.v1.metrics.stats import IterationStats
+    iteration_stats = IterationStats()
+
+    parent_request = ParentRequest(make_request(SamplingParams(n=3)))
+    # Simulate 3 child requests
+    for i in range(3):
+        child_id, _ = parent_request.get_child_info(i)
+
+    # Child 0 finishes with 10 tokens — not all done yet, no metrics recorded
+    child_0_id = "0_parent_id"
+    parent_request.child_requests.discard(child_0_id)
+    ParentRequest.observe_finished_request(
+        parent_req=parent_request,
+        iteration_stats=iteration_stats,
+        num_generation_tokens=10,
+    )
+    assert iteration_stats.n_params_iter == []
+    assert iteration_stats.max_num_generation_tokens_iter == []
+
+    # Child 1 finishes with 20 tokens — still not all done
+    child_1_id = "1_parent_id"
+    parent_request.child_requests.discard(child_1_id)
+    ParentRequest.observe_finished_request(
+        parent_req=parent_request,
+        iteration_stats=iteration_stats,
+        num_generation_tokens=20,
+    )
+    assert iteration_stats.n_params_iter == []
+    assert iteration_stats.max_num_generation_tokens_iter == []
+
+    # Child 2 finishes with 15 tokens — all done, metrics should be recorded
+    child_2_id = "2_parent_id"
+    parent_request.child_requests.discard(child_2_id)
+    ParentRequest.observe_finished_request(
+        parent_req=parent_request,
+        iteration_stats=iteration_stats,
+        num_generation_tokens=15,
+    )
+    # n=3 recorded once, max tokens = 20 (max across all children)
+    assert iteration_stats.n_params_iter == [3]
+    assert iteration_stats.max_num_generation_tokens_iter == [20]
+
+
+def test_observe_finished_request_max_tokens_tracked() -> None:
+    """Max generation tokens should reflect the highest across all children."""
+    from vllm.v1.metrics.stats import IterationStats
+    iteration_stats = IterationStats()
+
+    parent_request = ParentRequest(make_request(SamplingParams(n=2)))
+    for i in range(2):
+        parent_request.get_child_info(i)
+
+    # Child 0 finishes with 100 tokens
+    parent_request.child_requests.discard("0_parent_id")
+    ParentRequest.observe_finished_request(
+        parent_req=parent_request,
+        iteration_stats=iteration_stats,
+        num_generation_tokens=100,
+    )
+
+    # Child 1 finishes with 5 tokens — max should still be 100
+    parent_request.child_requests.discard("1_parent_id")
+    ParentRequest.observe_finished_request(
+        parent_req=parent_request,
+        iteration_stats=iteration_stats,
+        num_generation_tokens=5,
+    )
+
+    assert iteration_stats.n_params_iter == [2]
+    assert iteration_stats.max_num_generation_tokens_iter == [100]


### PR DESCRIPTION

## Purpose

`ParentRequest.observe_finished_request()` populates two key Prometheus 
metrics for parallel sampling requests:
- `n_params_iter` → feeds `vllm:request_params_n` histogram
- `max_num_generation_tokens_iter` → feeds `vllm:request_max_num_generation_tokens` histogram

This logic was introduced in #10980 but had no test coverage.
This PR adds unit tests to verify correct behavior.

## Test Plan

```bash
pytest tests/v1/engine/test_parallel_sampling.py -v
```

## Test Result
tests/v1/engine/test_parallel_sampling.py::test_parent_request_to_output_stream PASSED
tests/v1/engine/test_parallel_sampling.py::test_parent_request_to_output_final_only PASSED
tests/v1/engine/test_parallel_sampling.py::test_observe_finished_request_single PASSED
tests/v1/engine/test_parallel_sampling.py::test_observe_finished_request_parallel PASSED
tests/v1/engine/test_parallel_sampling.py::test_observe_finished_request_max_tokens_tracked PASSED

