### PR TITLE
[Bugfix] Reject max_model_len=0 at config validation time

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1467,3 +1467,19 @@ def test_ir_op_priority_ctx():
         # context restored even after exception
         assert ir.ops.rms_norm.get_priority() == ["vllm_c", "native"]
         assert ir.ops.fused_add_rms_norm.get_priority() == ["native"]
+
+
+@pytest.mark.parametrize("bad_value", [0, -2, -100])
+def test_max_model_len_rejects_zero_and_negative(bad_value):
+    with pytest.raises((ValueError, ValidationError)):
+        ModelConfig("facebook/opt-125m", max_model_len=bad_value)
+
+
+def test_max_model_len_accepts_auto_sentinel():
+    cfg = ModelConfig("facebook/opt-125m", max_model_len=-1)
+    assert cfg.max_model_len > 0
+
+
+def test_max_model_len_accepts_positive():
+    cfg = ModelConfig("facebook/opt-125m", max_model_len=512)
+    assert cfg.max_model_len == 512

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -771,6 +771,15 @@ class ModelConfig:
             return value
         return handler(value)
 
+    @field_validator("max_model_len", mode="after")
+    @classmethod
+    def _check_max_model_len_positive_or_sentinel(cls, v: int) -> int:
+        if v == 0:
+            raise ValueError(
+                "max_model_len must be a positive integer or -1 (auto), got 0."
+            )
+        return v
+
     @field_validator("tokenizer_mode", mode="after")
     def _lowercase_tokenizer_mode(cls, tokenizer_mode: str) -> str:
         return tokenizer_mode.lower()


### PR DESCRIPTION
## Purpose

Fixes #43532.

`--max-model-len 0` is silently accepted because Pydantic's `ge=-1` admits `0` and `_get_and_verify_max_len` has no branch for it (only `None`/`-1` and `> derived`). The `0` propagates to the scheduler where `min(num_new_tokens, 0 - 1 - 0) = -1`, and `cdiv(-1, block_size) = 0` silently allocates zero KV blocks — the engine appears healthy but every request gets scheduled with negative tokens. This adds a `field_validator` on `ModelConfig.max_model_len` that rejects `0` with a clear `ValueError`, following the existing validator pattern in the same class. The `-1` auto-derive sentinel and all positive values remain accepted.

### AGENTS.md value re-evaluation (per the auto-comment requirement)

Per AGENTS.md, here is my objective self-evaluation. I (the AI agent that authored this PR) commit to closing this PR if any of these answers turns out to be "no":

- Real reproducible bug: YES — `ModelConfig("facebook/opt-125m", max_model_len=0).max_model_len == 0` succeeds without error; downstream scheduler produces `num_new_tokens = -1`
- Fix scope ≤ 100 lines: YES (25 lines including tests)
- Unit-testable without GPU/distributed: YES — `tests/test_config.py::test_max_model_len_rejects_zero_and_negative`
- No duplicate open or recently-merged PR: YES — confirmed via `gh pr list --search "43532 in:body" --state all` and keyword searches returning no matches
- Issue not claimed by reporter/maintainer: YES — zero comments on the issue; reporter offered to PR but has not opened one
- Defensible line-by-line: YES — fix adds a `field_validator` following the existing pattern at `vllm/config/model.py:766` (`_skip_none_validation`)
- Not security-sensitive: YES — pure config validation code path
- Not stylistic: YES — closes a concrete silent-misbehaviour failure mode where the engine accepts requests with negative token counts

## Test Plan

```bash
# New tests
.venv/bin/python -m pytest tests/test_config.py::test_max_model_len_rejects_zero_and_negative -v
.venv/bin/python -m pytest tests/test_config.py::test_max_model_len_accepts_auto_sentinel -v
.venv/bin/python -m pytest tests/test_config.py::test_max_model_len_accepts_positive -v

# Regression: full test_config.py suite
.venv/bin/python -m pytest tests/test_config.py -v

# Lint
pre-commit run --files vllm/config/model.py tests/test_config.py
```

## Test Result

All 5 new tests pass (3 parametrized rejection cases for 0/-2/-100, plus acceptance of -1 and 512). Full `test_config.py` suite: 134 passed, 1 skipped, 11 pre-existing failures (HF auth, compilation config — all unrelated to this change). All pre-commit hooks pass.

## AI assistance disclosure

This PR was produced by an automated nightly triage agent (Claude) running with the user's explicit authorization. The user reviews every opened PR and will close any that does not meet vLLM's value bar.