### PR TITLE
[CI/Perf] Fix malformed serving benchmark config

### DIFF
--- a/.buildkite/performance-benchmarks/tests/serving-tests.json
+++ b/.buildkite/performance-benchmarks/tests/serving-tests.json
@@ -29,11 +29,6 @@
       }
     },
     {
-        "dataset_name": "sharegpt",
-        "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json"
-      }
-    },
-    {
       "test_name": "serving_llama8B_tp1_random_128_128",
       "server_parameters": {
         "tensor_parallel_size": 1


### PR DESCRIPTION
Fixes #43537.

## Summary

This removes a stray duplicate object from `.buildkite/performance-benchmarks/tests/serving-tests.json` that makes the default serving benchmark config invalid JSON.

## Root cause

PR #43262 converted the config to the newer defaults-based format but left an extra `dataset_name` / `dataset_path` object after `serving_llama8B_tp1_sharegpt`.

## Validation

Ran locally:

```bash
.venv/bin/python -m json.tool .buildkite/performance-benchmarks/tests/serving-tests.json
.venv/bin/pre-commit run --files .buildkite/performance-benchmarks/tests/serving-tests.json
```

The JSON parses successfully and all applicable pre-commit hooks pass.

## Duplicate-work check

I did not find another open PR addressing this config parse failure.

## Disclosure

AI assistance was used for part of the investigation. I reviewed the final diff and ran the validation above locally.