### PR TITLE
[Quant] Manual fusion for static FP8 attention output quant

### DIFF
--- a/tests/model_executor/test_attention_quant_fusion.py
+++ b/tests/model_executor/test_attention_quant_fusion.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.layers.attention.attention as attention_module
+from vllm.model_executor.layers.quantization.utils.quant_fusion import (
+    get_static_fp8_attn_output_scale,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8DynamicTokenSym,
+    kFp8StaticTensorSym,
+)
+from vllm.platforms import current_platform
+
+
+class _AttentionImpl:
+    def __init__(self, supported: bool = True) -> None:
+        self.supported = supported
+        self.seen_quant_key = None
+
+    def fused_output_quant_supported(self, quant_key):
+        self.seen_quant_key = quant_key
+        return self.supported
+
+
+def _linear(activation_quant_key=kFp8StaticTensorSym):
+    return SimpleNamespace(
+        input_scale=torch.tensor([0.5]),
+        input_quant_key=activation_quant_key,
+    )
+
+
+def _attention(supported: bool = True, fuse_attn_quant: bool = True):
+    attn = object.__new__(attention_module.Attention)
+    attn.calculate_kv_scales = False
+    attn.query_quant = None
+    attn.num_heads = 2
+    attn.num_kv_heads = 2
+    attn.head_size = 4
+    attn.head_size_v = 4
+    attn.use_direct_call = True
+    attn.attn_backend = SimpleNamespace(forward_includes_kv_cache_update=True)
+    attn.kv_sharing_target_layer_name = None
+    attn.layer_name = "test_attn"
+    attn.impl = _AttentionImpl(supported=supported)
+    attn.use_fused_attn_quant = fuse_attn_quant
+    return attn
+
+
+def test_static_fp8_attn_output_scale_selected_when_supported():
+    attn = _attention()
+    output_proj = _linear()
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is output_proj.input_scale
+    assert attn.impl.seen_quant_key == kFp8StaticTensorSym
+
+
+def test_static_fp8_attn_output_scale_skipped_without_input_quant_key():
+    attn = _attention()
+    output_proj = SimpleNamespace(input_scale=torch.tensor([0.5]))
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is None
+
+
+def test_static_fp8_attn_output_scale_skipped_when_flag_disabled():
+    attn = _attention(fuse_attn_quant=False)
+    output_proj = _linear()
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is None
+    assert attn.impl.seen_quant_key is None
+
+
+def test_static_fp8_attn_output_scale_skipped_when_backend_unsupported():
+    attn = _attention(supported=False)
+    output_proj = _linear()
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is None
+
+
+def test_static_fp8_attn_output_scale_skipped_for_non_static_fp8_linear():
+    attn = _attention()
+    output_proj = _linear(activation_quant_key=kFp8DynamicTokenSym)
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is None
+
+
+def test_attention_forward_uses_fp8_output_when_scale_provided(monkeypatch):
+    captured = {}
+
+    def fake_unified_attention_with_output(
+        query,
+        key,
+        value,
+        output,
+        layer_name,
+        output_scale=None,
+        output_block_scale=None,
+        kv_cache_dummy_dep=None,
+    ):
+        captured["output_dtype"] = output.dtype
+        captured["output_scale"] = output_scale
+
+    monkeypatch.setattr(
+        attention_module,
+        "unified_attention_with_output",
+        fake_unified_attention_with_output,
+    )
+
+    attn = _attention()
+    q = torch.randn(3, 8)
+    k = torch.randn(3, 8)
+    v = torch.randn(3, 8)
+    scale = torch.tensor([0.5])
+
+    result = attention_module.Attention.forward(attn, q, k, v, output_scale=scale)
+
+    assert captured["output_scale"] is scale
+    assert captured["output_dtype"] == current_platform.fp8_dtype()
+    assert result.dtype == current_platform.fp8_dtype()

--- a/tests/model_executor/test_attention_quant_fusion.py
+++ b/tests/model_executor/test_attention_quant_fusion.py
@@ -5,8 +5,25 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
 
 import vllm.model_executor.layers.attention.attention as attention_module
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import (  # noqa: E501
+    CompressedTensorsW8A8Fp8,
+)
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptFp8Config,
+    ModelOptFp8LinearMethod,
+)
+from vllm.model_executor.layers.quantization.quark.schemes.quark_w8a8_fp8 import (  # noqa: E501
+    QuarkW8A8Fp8,
+)
 from vllm.model_executor.layers.quantization.utils.quant_fusion import (
     get_static_fp8_attn_output_scale,
 )
@@ -15,6 +32,24 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
+
+
+def _noop_weight_loader(*args, **kwargs):
+    pass
+
+
+@pytest.fixture
+def current_vllm_config(monkeypatch):
+    import vllm.model_executor.parameter as parameter_module
+
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    vllm_config = VllmConfig()
+    vllm_config.model_config = SimpleNamespace(dtype=torch.float16)
+    with set_current_vllm_config(vllm_config):
+        yield
 
 
 class _AttentionImpl:
@@ -51,6 +86,32 @@ def _attention(supported: bool = True, fuse_attn_quant: bool = True):
     return attn
 
 
+def _create_standard_linear_layer(quant_method):
+    layer = torch.nn.Module()
+    quant_method.create_weights(
+        layer=layer,
+        input_size_per_partition=8,
+        output_partition_sizes=[8],
+        input_size=8,
+        output_size=8,
+        params_dtype=torch.float16,
+        weight_loader=_noop_weight_loader,
+    )
+    return layer
+
+
+def _create_quark_linear_layer(quant_method):
+    layer = torch.nn.Module()
+    quant_method.create_weights(
+        layer=layer,
+        output_partition_sizes=[8],
+        input_size_per_partition=8,
+        params_dtype=torch.float16,
+        weight_loader=_noop_weight_loader,
+    )
+    return layer
+
+
 def test_static_fp8_attn_output_scale_selected_when_supported():
     attn = _attention()
     output_proj = _linear()
@@ -68,6 +129,7 @@ def test_static_fp8_attn_output_scale_skipped_without_input_quant_key():
     scale = get_static_fp8_attn_output_scale(attn, output_proj)
 
     assert scale is None
+    assert attn.impl.seen_quant_key is None
 
 
 def test_static_fp8_attn_output_scale_skipped_when_flag_disabled():
@@ -106,6 +168,114 @@ def test_static_fp8_attn_output_scale_skipped_for_non_static_fp8_linear():
     scale = get_static_fp8_attn_output_scale(attn, output_proj)
 
     assert scale is None
+    assert attn.impl.seen_quant_key is None
+
+
+def test_static_fp8_attn_output_scale_skipped_without_input_scale():
+    attn = _attention()
+    output_proj = SimpleNamespace(input_quant_key=kFp8StaticTensorSym)
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is None
+    assert attn.impl.seen_quant_key is None
+
+
+@pytest.mark.parametrize(
+    "layer_factory",
+    [
+        pytest.param(
+            lambda: _create_standard_linear_layer(
+                CompressedTensorsW8A8Fp8(
+                    QuantizationArgs(
+                        num_bits=8,
+                        type=QuantizationType.FLOAT,
+                        strategy=QuantizationStrategy.TENSOR,
+                    ),
+                    is_static_input_scheme=True,
+                )
+            ),
+            id="compressed_tensors",
+        ),
+        pytest.param(
+            lambda: _create_standard_linear_layer(
+                Fp8LinearMethod(
+                    Fp8Config(
+                        is_checkpoint_fp8_serialized=True,
+                        activation_scheme="static",
+                    )
+                )
+            ),
+            id="native_fp8",
+        ),
+        pytest.param(
+            lambda: _create_standard_linear_layer(
+                ModelOptFp8LinearMethod(
+                    ModelOptFp8Config(
+                        quant_method="FP8",
+                        is_checkpoint_fp8_serialized=True,
+                        kv_cache_quant_method=None,
+                        exclude_modules=[],
+                    )
+                )
+            ),
+            id="modelopt",
+        ),
+        pytest.param(
+            lambda: _create_quark_linear_layer(
+                QuarkW8A8Fp8(
+                    weight_config={"qscheme": "per_tensor"},
+                    input_config={"is_dynamic": False, "qscheme": "per_tensor"},
+                )
+            ),
+            id="quark",
+        ),
+    ],
+)
+def test_static_fp8_linear_schemes_mark_input_quant_key(
+    current_vllm_config, layer_factory
+):
+    layer = layer_factory()
+
+    assert layer.input_quant_key == kFp8StaticTensorSym
+    assert layer.input_scale is not None
+
+
+def test_fp8_attention_output_feeds_static_fp8_linear_without_requant(
+    current_vllm_config, monkeypatch
+):
+    quant_method = Fp8LinearMethod(
+        Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="static",
+        )
+    )
+    output_proj = _create_standard_linear_layer(quant_method)
+    attn = _attention()
+    captured = {}
+
+    class FailingQuant(torch.nn.Module):
+        def forward(self, *args, **kwargs):
+            raise AssertionError("FP8 attention output should not be requantized")
+
+    def fake_apply_scaled_mm(*, A, B, out_dtype, As, Bs, bias, output_shape):
+        captured["input_dtype"] = A.dtype
+        captured["input_scale"] = As
+        return torch.empty(output_shape, dtype=out_dtype, device=A.device)
+
+    monkeypatch.setattr(quant_method.fp8_linear, "quant_fp8", FailingQuant())
+    monkeypatch.setattr(
+        quant_method.fp8_linear, "apply_scaled_mm", fake_apply_scaled_mm
+    )
+
+    output_scale = get_static_fp8_attn_output_scale(attn, output_proj)
+    attn_output = torch.empty(3, 8, dtype=current_platform.fp8_dtype())
+    output = quant_method.apply(output_proj, attn_output)
+
+    assert output_scale is output_proj.input_scale
+    assert captured["input_dtype"] == current_platform.fp8_dtype()
+    assert captured["input_scale"] is output_proj.input_scale
+    assert output.shape == torch.Size([3, 8])
 
 
 def test_attention_forward_uses_fp8_output_when_scale_provided(monkeypatch):
@@ -131,6 +301,42 @@ def test_attention_forward_uses_fp8_output_when_scale_provided(monkeypatch):
     )
 
     attn = _attention()
+    q = torch.randn(3, 8)
+    k = torch.randn(3, 8)
+    v = torch.randn(3, 8)
+    scale = torch.tensor([0.5])
+
+    result = attention_module.Attention.forward(attn, q, k, v, output_scale=scale)
+
+    assert captured["output_scale"] is scale
+    assert captured["output_dtype"] == current_platform.fp8_dtype()
+    assert result.dtype == current_platform.fp8_dtype()
+
+
+def test_attention_forward_uses_fp8_output_with_torch_ops_path(monkeypatch):
+    captured = {}
+
+    def fake_unified_attention_with_output(
+        query,
+        key,
+        value,
+        output,
+        layer_name,
+        output_scale=None,
+        output_block_scale=None,
+        kv_cache_dummy_dep=None,
+    ):
+        captured["output_dtype"] = output.dtype
+        captured["output_scale"] = output_scale
+
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "unified_attention_with_output",
+        fake_unified_attention_with_output,
+    )
+
+    attn = _attention()
+    attn.use_direct_call = False
     q = torch.randn(3, 8)
     k = torch.randn(3, 8)
     v = torch.randn(3, 8)

--- a/tests/model_executor/test_attention_quant_fusion.py
+++ b/tests/model_executor/test_attention_quant_fusion.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 import vllm.model_executor.layers.attention.attention as attention_module
@@ -88,6 +89,16 @@ def test_static_fp8_attn_output_scale_skipped_when_backend_unsupported():
     assert scale is None
 
 
+def test_static_fp8_attn_output_scale_skipped_when_backend_has_no_support_probe():
+    attn = _attention()
+    attn.impl = SimpleNamespace()
+    output_proj = _linear()
+
+    scale = get_static_fp8_attn_output_scale(attn, output_proj)
+
+    assert scale is None
+
+
 def test_static_fp8_attn_output_scale_skipped_for_non_static_fp8_linear():
     attn = _attention()
     output_proj = _linear(activation_quant_key=kFp8DynamicTokenSym)
@@ -130,3 +141,15 @@ def test_attention_forward_uses_fp8_output_when_scale_provided(monkeypatch):
     assert captured["output_scale"] is scale
     assert captured["output_dtype"] == current_platform.fp8_dtype()
     assert result.dtype == current_platform.fp8_dtype()
+
+
+def test_attention_forward_rejects_backend_without_support_probe():
+    attn = _attention()
+    attn.impl = SimpleNamespace()
+    q = torch.randn(3, 8)
+    k = torch.randn(3, 8)
+    v = torch.randn(3, 8)
+    scale = torch.tensor([0.5])
+
+    with pytest.raises(ValueError, match="static FP8 attention output quantization"):
+        attention_module.Attention.forward(attn, q, k, v, output_scale=scale)

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -464,7 +464,8 @@ class Attention(nn.Module, AttentionLayerBase):
             )
         output_dtype = query.dtype
         if output_scale is not None:
-            if not self.impl.fused_output_quant_supported(kFp8StaticTensorSym):
+            fused_supported = getattr(self.impl, "fused_output_quant_supported", None)
+            if fused_supported is None or not fused_supported(kFp8StaticTensorSym):
                 raise ValueError(
                     f"{self.impl.__class__.__name__} does not support "
                     "static FP8 attention output quantization."

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -22,7 +22,10 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
-from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    kFp8StaticTensorSym,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     LayerNameType,
@@ -393,6 +396,7 @@ class Attention(nn.Module, AttentionLayerBase):
         self.use_direct_call = not current_platform.opaque_attention_op()
 
         compilation_config = vllm_config.compilation_config
+        self.use_fused_attn_quant = bool(compilation_config.pass_config.fuse_attn_quant)
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
@@ -443,6 +447,7 @@ class Attention(nn.Module, AttentionLayerBase):
         # shape does not match the query shape, so we optionally let the model
         # definition specify the output tensor shape.
         output_shape: torch.Size | None = None,
+        output_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         The KV cache is stored inside this class and is accessed via
@@ -458,6 +463,13 @@ class Attention(nn.Module, AttentionLayerBase):
                 query, key, value, _encode_layer_name(self.layer_name)
             )
         output_dtype = query.dtype
+        if output_scale is not None:
+            if not self.impl.fused_output_quant_supported(kFp8StaticTensorSym):
+                raise ValueError(
+                    f"{self.impl.__class__.__name__} does not support "
+                    "static FP8 attention output quantization."
+                )
+            output_dtype = current_platform.fp8_dtype()
         if self.query_quant is not None:
             # quantizing with a simple torch operation enables
             # torch.compile to fuse this into previous ops
@@ -504,6 +516,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 value,
                 output,
                 self.layer_name,
+                output_scale=output_scale,
                 kv_cache_dummy_dep=kv_cache_dummy_dep,
             )
         else:
@@ -524,6 +537,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 value,
                 output,
                 encoded,
+                output_scale=output_scale,
                 kv_cache_dummy_dep=kv_cache_dummy_dep,
             )
         return output.view(-1, hidden_size)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -142,6 +142,11 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
             weight_shape=(output_size_per_partition, input_size_per_partition),
             module_name=self.__class__.__name__,
         )
+        if (
+            self.is_static_input_scheme
+            and self.activation_quant_key == kFp8StaticTensorSym
+        ):
+            layer.input_quant_key = kFp8StaticTensorSym
 
     def process_weights_after_loading(self, layer) -> None:
         if self.strategy == QuantizationStrategy.TENSOR:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -377,6 +377,7 @@ class Fp8LinearMethod(LinearMethodBase):
             scale = create_fp8_input_scale(output_partition_sizes, weight_loader)
             set_weight_attrs(scale, {"scale_type": "input_scale"})
             layer.register_parameter("input_scale", scale)
+            layer.input_quant_key = kFp8StaticTensorSym
 
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=self.activation_quant_key,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -499,6 +499,7 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
 
             scale[:] = torch.finfo(torch.float32).min
             layer.register_parameter("input_scale", scale)
+            layer.input_quant_key = kFp8StaticTensorSym
 
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=kFp8StaticTensorSym,

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -175,6 +175,7 @@ class QuarkW8A8Fp8(QuarkScheme):
             )
             input_scale[:] = torch.finfo(torch.float32).min
             layer.register_parameter("input_scale", input_scale)
+            layer.input_quant_key = kFp8StaticTensorSym
 
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=self.activation_quant_key,

--- a/vllm/model_executor/layers/quantization/utils/quant_fusion.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_fusion.py
@@ -17,11 +17,15 @@ def get_static_fp8_attn_output_scale(
     if not getattr(attn, "use_fused_attn_quant", False):
         return None
 
+    if getattr(output_proj, "input_quant_key", None) != kFp8StaticTensorSym:
+        return None
+
+    input_scale = getattr(output_proj, "input_scale", None)
+    if input_scale is None:
+        return None
+
     fused_supported = getattr(attn.impl, "fused_output_quant_supported", None)
     if fused_supported is None or not fused_supported(kFp8StaticTensorSym):
         return None
 
-    if getattr(output_proj, "input_quant_key", None) != kFp8StaticTensorSym:
-        return None
-
-    return getattr(output_proj, "input_scale", None)
+    return input_scale

--- a/vllm/model_executor/layers/quantization/utils/quant_fusion.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_fusion.py
@@ -17,7 +17,8 @@ def get_static_fp8_attn_output_scale(
     if not getattr(attn, "use_fused_attn_quant", False):
         return None
 
-    if not attn.impl.fused_output_quant_supported(kFp8StaticTensorSym):
+    fused_supported = getattr(attn.impl, "fused_output_quant_supported", None)
+    if fused_supported is None or not fused_supported(kFp8StaticTensorSym):
         return None
 
     if getattr(output_proj, "input_quant_key", None) != kFp8StaticTensorSym:

--- a/vllm/model_executor/layers/quantization/utils/quant_fusion.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_fusion.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8StaticTensorSym,
+)
+
+
+def get_static_fp8_attn_output_scale(
+    attn: Any, output_proj: Any
+) -> torch.Tensor | None:
+    """Return the output scale for manual attention + static FP8 quant fusion."""
+    if not getattr(attn, "use_fused_attn_quant", False):
+        return None
+
+    if not attn.impl.fused_output_quant_supported(kFp8StaticTensorSym):
+        return None
+
+    if getattr(output_proj, "input_quant_key", None) != kFp8StaticTensorSym:
+        return None
+
+    return getattr(output_proj, "input_scale", None)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -47,6 +47,9 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_fusion import (
+    get_static_fp8_attn_output_scale,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -228,7 +231,12 @@ class LlamaAttention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v)
+        attn_output = self.attn(
+            q,
+            k,
+            v,
+            output_scale=get_static_fp8_attn_output_scale(self.attn, self.o_proj),
+        )
         output, _ = self.o_proj(attn_output)
         return output
 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -49,6 +49,9 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_fusion import (
+    get_static_fp8_attn_output_scale,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -231,7 +234,12 @@ class Qwen2Attention(nn.Module):
             k = k.view(total_tokens, self.kv_size)
 
         q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v)
+        attn_output = self.attn(
+            q,
+            k,
+            v,
+            output_scale=get_static_fp8_attn_output_scale(self.attn, self.o_proj),
+        )
         output, _ = self.o_proj(attn_output)
         return output
 

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -42,6 +42,9 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_fusion import (
+    get_static_fp8_attn_output_scale,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
@@ -157,7 +160,12 @@ class Qwen3Attention(nn.Module):
         k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
         q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v)
+        attn_output = self.attn(
+            q,
+            k,
+            v,
+            output_scale=get_static_fp8_attn_output_scale(self.attn, self.o_proj),
+        )
         output, _ = self.o_proj(attn_output)
         return output
 


### PR DESCRIPTION



## Purpose
Addresses part of #43502 and #43224

This ports the first scoped chunk of attention-output quant fusion to a manual model-code path: standard attention + static per-tensor FP8 output quant for Llama/Qwen-style models.

This reuses the existing `fuse_attn_quant` pass-config flag, but routes the supported static FP8 case through an explicit model-code path instead of relying on the compiler pass. Other quantization modes, broader model coverage, and NVFP4 are left for follow-up PRs.

## Test Plan
- Unit coverage for the manual static FP8 attention-output-quant helper and `Attention.forward` plumbing.
- Eager old-vs-new path comparison on `RedHatAI/Llama-3.2-1B-FP8`:
  - `fuse_attn_quant=False`
  - `fuse_attn_quant=True`
  - `TRITON_ATTN`
  - `enforce_eager=True`
- Temporary runtime instrumentation to verify the manual helper returns output scales for the Llama attention layers.
- GSM8K smoke eval.
- MRCR long-context smoke eval.

## Test Result

- `tests/model_executor/test_attention_quant_fusion.py`: 8 passed.
- Eager parity check: `fuse_attn_quant=False` and `fuse_attn_quant=True` produced identical generated token IDs for the same prompt with `temperature=0.0` and `seed=42`.
- Runtime path check: temporary instrumentation confirmed the manual static FP8 attention-output-quant helper returned non-None scales for all 16 Llama attention layers.
- GSM8K smoke eval: completed 100 questions, 5-shot, with 0 invalid responses.
- MRCR smoke eval: completed 5/5 long-context requests with 16k-18k prompt tokens.

