### PR TITLE
[Bugfix] Split attention groups by num_heads_q for spec-decode drafts

### DIFF
--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -32,6 +32,7 @@ steps:
   source_file_dependencies:
     - vllm/v1/spec_decode/
     - vllm/v1/worker/gpu/spec_decode/
+    - vllm/v1/attention/backends/
     - vllm/transformers_utils/configs/speculators/
     - tests/v1/e2e/spec_decode/
   commands:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6556,8 +6556,21 @@ class GPUModelRunner(
         assert len(self.attn_groups) == 0, "Attention backends are already initialized"
 
         class AttentionGroupKey(NamedTuple):
+            """Deduplication key for attention groups within a KV cache group.
+
+            Splits on per-rank ``num_heads_q`` in addition to backend + spec
+            so layers with different Q-head counts (e.g. a spec-decode draft
+            with fewer attention heads than its target) get separate metadata
+            builders. The builders' scratch (e.g. ``softmax_segm_*`` in
+            ``triton_attn``, ``num_qo_heads`` in FlashInfer) is sized by
+            ``num_heads_q`` and assumes uniformity within the group; see
+            ``get_num_attention_heads_from_layers`` in
+            ``vllm/v1/attention/backends/utils.py``.
+            """
+
             attn_backend: type[AttentionBackend]
             kv_cache_spec: KVCacheSpec
+            num_heads_q: int
 
         def get_attn_backends_for_group(
             kv_cache_group_spec: KVCacheGroupSpec,
@@ -6586,9 +6599,16 @@ class GPUModelRunner(
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                     layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
-                key = (full_cls_name, layer_kv_cache_spec)
+                # Non-Attention layer types (e.g. Mamba1, ShortConv) do not
+                # expose ``num_heads``; fall back to 0 so they cluster as
+                # before. Such layers never coexist with Attention in a
+                # single KV cache group (different KVCacheSpec), so the
+                # fallback can never spuriously merge them with attention
+                # layers.
+                num_heads_q = getattr(layers[layer_name], "num_heads", 0)
+                key = (full_cls_name, layer_kv_cache_spec, num_heads_q)
                 attn_backends[key] = AttentionGroupKey(
-                    attn_backend, layer_kv_cache_spec
+                    attn_backend, layer_kv_cache_spec, num_heads_q
                 )
                 attn_backend_layers[key].append(layer_name)
             return (
@@ -6601,11 +6621,11 @@ class GPUModelRunner(
             kv_cache_group_id: int,
         ) -> list[AttentionGroup]:
             attn_groups: list[AttentionGroup] = []
-            for (attn_backend, kv_cache_spec), layer_names in attn_backends_map.items():
+            for key, layer_names in attn_backends_map.items():
                 attn_group = AttentionGroup(
-                    attn_backend,
+                    key.attn_backend,
                     layer_names,
-                    kv_cache_spec,
+                    key.kv_cache_spec,
                     kv_cache_group_id,
                 )
 


### PR DESCRIPTION
## Purpose

Fix a hard crash at engine init for any spec-decode setup whose draft layers have a different per-rank `num_heads_q` than the target model. Surfaced today by Gemma4 MTP (target = 8 Q-heads, assistant draft = 4 Q-heads, both 1 KV-head):

```
AssertionError: All layers in one attention group must share num_heads;
got {8, 4} for ['language_model.model.layers.3.self_attn.attn', ...,
                'draft_model.layers.0.self_attn.attn', ...,
                'draft_model.layers.2.self_attn.attn'].
```

The assertion was added by #42650 (`get_num_attention_heads_from_layers`, `vllm/v1/attention/backends/utils.py:158`). The assertion itself is correct — the metadata builder's `softmax_segm_*` (Triton) and `num_qo_heads` (FlashInfer) scratch is sized by a single `num_heads_q` per group. The actual bug is upstream of the assertion: `get_attn_backends_for_group` at `vllm/v1/worker/gpu_model_runner.py:6562` keys `AttentionGroup`s by `(backend_cls_name, per_layer_kv_cache_spec)` only. `KVCacheSpec` captures `num_kv_heads`, `head_size`, `block_size`, `dtype` but **not** `num_heads_q`, so a target layer and a spec-decode draft layer with matching KV layout but different Q-head counts hash to the same key, land in one `AttentionGroup`, and feed mixed Q-head counts into the builder.

Pre-#42650 the same grouping bug existed but was silently safe in the target > draft direction (scratch was sized from `model_config.get_num_attention_heads()` — the model-wide / target value — and draft kernels wrote into a subset of slots). #42650 promotes the latent bug to a hard crash.

### Affected

All four must hold:
1. Spec-decode is active (MTP / EAGLE / standalone draft).
2. Draft `num_heads_q` differs from target's.
3. Target and draft layers share a `KVCacheSpec` (same KV-side layout).
4. Backend reads per-layer heads via `get_num_attention_heads_from_layers`, i.e. `TRITON_ATTN` or `FLASHINFER`.

### Not affected

- EAGLE drafts that reuse the target's layer structure (same `num_heads`).
- DeepSeek v3/v4 MTP — the MTP layer is the last layer of the target model itself, so `num_heads` matches by construction.
- `FLASH_ATTN`, MLA, `FlexAttention`, ROCm backends (none call the new helper).
- Laguna XS.2 (the model #42650 was fixing) — its per-layer head differences correspond to different `KVCacheSpec`s and already split into distinct `KVCacheGroup`s upstream; uniformity within each group is preserved.

### Fix

Local to `get_attn_backends_for_group`. Extend the dedup key and `AttentionGroupKey` `NamedTuple` with `layers[layer_name].num_heads` so mismatched-Q-head layers split into separate `AttentionGroup`s. Each group's metadata builder is then sized correctly for its own `num_heads_q`. `KVCacheGroup` layout and shared KV memory are unchanged; only the metadata-builder boundary moves.

Uses `getattr(..., "num_heads", 0)` for non-Attention layer types (`MambaMixer`, `ShortConv`) that do not expose `num_heads`. Such layers never coexist with Attention in a single `KVCacheGroup` (different `KVCacheSpec`), so the fallback can never spuriously merge them with attention layers.

### CI gap closed

`.buildkite/test_areas/spec_decode.yaml` job "Spec Decode Speculators + MTP" already runs the `gemma4-e4b` MTP e2e case via `-k "mtp_correctness"`, but its `source_file_dependencies` omitted `vllm/v1/attention/backends/`, so #42650 did not trigger it. One added line closes that gap.

Note: the `gemma4-e4b` case itself still skips on CI's pinned `transformers==5.5.3` (`pytest.skip` at `tests/v1/e2e/spec_decode/test_spec_decode.py:794-798` and `min_transformers_version="5.8.0"` at `tests/models/registry.py:1545`). `Gemma4AssistantForCausalLM` / `model_type: "gemma4_assistant"` is a separate transformers module that landed in `v5.8.0` (commit `2c7d385621`, "First model", #45788). Lowering the version gate is not safe here — the assistant module simply does not exist in 5.5.x. The dep edit therefore activates the trigger today (for the `mimo`, `deepseek`, `qwen3_5-hybrid` cases of the same parametrize) and additionally covers `gemma4-e4b` the moment vllm's transformers pin moves to `>=5.8.0`.

## Test Plan

End-to-end on a single host (8x A100 80GB), using the same prompt set, sampling config (`temperature=0`, greedy), `--max-num-seqs=1`, `--max-new-tokens=256`, `--max-model-len=8192` for E2B (`google/gemma-4-E2B-it`) dense model.

Same procedure repeated for 26B MoE (`google/gemma-4-26B-it`) with and without its assistant draft.

Existing in-tree unit test that exercises `initialize_attn_backend` (the function containing the patched code) — re-run after the patch to confirm the uniform-heads path is unchanged:

```bash
pytest -v tests/v1/worker/test_gpu_model_runner.py::test_hybrid_cache_integration
```

Lint / pre-commit (per AGENTS.md):

```bash
pre-commit run --files .buildkite/test_areas/spec_decode.yaml \
                       vllm/v1/worker/gpu_model_runner.py
```

## Test Result

Functional (Gemma4 E2B + assistant, MTP γ=4, c=1) bit-identical to pre-#42650 reference run (greedy / deterministic), confirming the fix doesn't alter token-level decisions:

| Metric              | Pre-#42650 ref | Post-fix | Δ                  |
|---------------------|----------------|----------|--------------------|
| Block Efficiency    | 2.6444         | 2.6444   | exact              |
| Acceptance Rate     | 0.4111         | 0.4111   | exact              |
| Verification Rounds | 10,889         | 10,889   | exact              |
| Accepted Tokens     | 17,906         | 17,906   | exact              |
| Drafted Tokens      | 43,556         | 43,556   | exact              |
| Total Tokens        | 28,738         | 28,738   | exact              |
| Throughput (tok/s)  | 223.10         | 225.06   | +0.9% (jitter)     |
| Elapsed (s)         | 128.81         | 127.69   | -0.9% (jitter)     |

Manually validated combinations on 8x A100:

- E2B (dense) baseline — passes.
- E2B + assistant MTP — passes (this was the failure case).
- 26B (MoE) baseline — passes.
- 26B + assistant MTP — passes.

**Regression / lint**:

- `pytest -v tests/v1/worker/test_gpu_model_runner.py::test_hybrid_cache_integration` — passes (uniform-heads path unchanged).
- `pre-commit run --files .buildkite/test_areas/spec_decode.yaml vllm/v1/worker/gpu_model_runner.py` — all 14 applicable hooks green (`ruff check`, `ruff format`, `typos`, `mypy`, SPDX, etc.).