### PR TITLE
[Docs] Fix the duplicate doc icon issue

### DIFF
--- a/docs/mkdocs/hooks/url_schemes.py
+++ b/docs/mkdocs/hooks/url_schemes.py
@@ -35,7 +35,7 @@ gh_icon = ":octicons-mark-github-16:"
 
 # Regex pieces
 TITLE = r"(?P<title>[^\[\]<>]+?)"
-REPO = r"(?P<repo>.+?/.+?)"
+REPO = r"(?P<repo>[^/\s\]\)<>]+/[^/\s\]\)<>]+)"
 TYPE = r"(?P<type>issues|pull|projects)"
 NUMBER = r"(?P<number>\d+)"
 PATH = r"(?P<path>[^\s]+?)"
@@ -106,8 +106,8 @@ class UrlSchemesPreprocessor(Preprocessor):
             return f"[{gh_icon} {title}]({url})"
 
         markdown = "\n".join(lines)
-        markdown = relative_link.sub(replace_relative_link, markdown)
         markdown = github_link.sub(replace_github_link, markdown)
+        markdown = relative_link.sub(replace_relative_link, markdown)
         return markdown.split("\n")
 
 

--- a/docs/mkdocs/hooks/url_schemes.py
+++ b/docs/mkdocs/hooks/url_schemes.py
@@ -35,7 +35,7 @@ gh_icon = ":octicons-mark-github-16:"
 
 # Regex pieces
 TITLE = r"(?P<title>[^\[\]<>]+?)"
-REPO = r"(?P<repo>[^/\s\]\)<>]+/[^/\s\]\)<>]+)"
+REPO = r"(?P<repo>.+?/.+?)"
 TYPE = r"(?P<type>issues|pull|projects)"
 NUMBER = r"(?P<number>\d+)"
 PATH = r"(?P<path>[^\s]+?)"


### PR DESCRIPTION
## Purpose

Fix duplicate GitHub icons in generated documentation links.

On the stable troubleshooting page, the `Failed to infer device type` section rendered two GitHub icons before `the code`:

https://docs.vllm.ai/en/stable/usage/troubleshooting/#failed-to-infer-device-type

<img width="824" height="264" alt="image" src="https://github.com/user-attachments/assets/5a2c3469-e53f-4e3b-90ce-0ef20f657d58" />

<img width="823" height="263" alt="image" src="https://github.com/user-attachments/assets/aff17b53-a6ce-4c3c-8471-15d6f0f73195" />

The duplicate came from the docs URL preprocessor rewriting relative source-file links before rewriting GitHub links. The generated GitHub URL could then be matched again while scanning forward to the next GitHub PR link.

This change rewrites GitHub links first, then rewrites relative source-file links, so each generated link receives only one GitHub icon.

## Test Plan

- Rebuild the docs page.
- Check the rendered `Failed to infer device type` section.
- Confirm the `the code` link and `this PR` link each show one GitHub icon.

## Test Result

Rebuilt the page and compared the final snapshot.
