### PR TITLE
[Bugfix] Expand YAML config when passed as `--config=<path>`

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -126,6 +126,30 @@ def test_config_args(parser_with_config, cli_config_file):
     assert args.trust_remote_code
 
 
+def test_config_args_with_equals_syntax(parser_with_config, cli_config_file):
+    # `--config=<path>` should expand the YAML config just like the spaced
+    # `--config <path>` form does (see test_config_args). The `=` form was
+    # previously skipped, so the config file was silently ignored.
+    args = parser_with_config.parse_args(
+        ["serve", "mymodel", f"--config={cli_config_file}"]
+    )
+    assert args.tensor_parallel_size == 2
+    assert args.trust_remote_code
+
+    # CLI args still take precedence over config values with the `=` form.
+    args = parser_with_config.parse_args(
+        [
+            "serve",
+            "mymodel",
+            f"--config={cli_config_file}",
+            "--tensor-parallel-size",
+            "3",
+        ]
+    )
+    assert args.tensor_parallel_size == 3
+    assert args.port == 12312
+
+
 def test_config_file(parser_with_config):
     with pytest.raises(FileNotFoundError):
         parser_with_config.parse_args(

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -295,6 +295,19 @@ class FlexibleArgumentParser(ArgumentParser):
                     "using `vllm serve`. i.e. `vllm serve <model> --<arg> <value>`."
                 )
 
+        # Normalize `--config=<path>` to `--config <path>` so that config file
+        # expansion works with both the spaced and the `=` syntax. argparse
+        # treats the two forms as equivalent, but the config pre-processing
+        # below (and `_pull_args_from_config`) recognizes `--config` only as a
+        # standalone token.
+        normalized_args = list[str]()
+        for arg in args:
+            if arg.startswith("--config="):
+                normalized_args.extend(arg.split("=", 1))
+            else:
+                normalized_args.append(arg)
+        args = normalized_args
+
         if "--config" in args:
             args = self._pull_args_from_config(args)
 


### PR DESCRIPTION
## Purpose

`vllm serve --config=path.yaml` is accepted on the command line, but the YAML config is silently ignored: none of the values in the file are applied. The spaced form `vllm serve --config path.yaml` works correctly. This is surprising because argparse normally treats `--opt=value` and `--opt value` as equivalent, and `FlexibleArgumentParser` already recognizes the `--config=` form in its served-model-name check.

Root cause: in `FlexibleArgumentParser.parse_args`, config expansion is gated on `"--config" in args` (an exact-token membership test), and `_pull_args_from_config` then locates the path via `args.index("--config")` and reads the *following* token. When the user writes `--config=path.yaml` it is a single token, so the gate never fires and expansion is skipped entirely.

Fix: normalize `--config=<path>` to `--config <path>` before the expansion step, so both syntaxes flow through the same, already-tested code path. The guard matches the exact prefix `--config=`, so dotted config args like `--config.foo=bar` and unrelated options like `--configuration=...` are left untouched, and a path that itself contains `=` is split only on the first one.

Fixes #43252

## Test Plan

```
pytest tests/utils_/test_argparse_utils.py -k config
```

New test `test_config_args_with_equals_syntax` mirrors the existing `test_config_args` but uses the `--config=<path>` form, and additionally asserts that CLI args still take precedence over config values.

## Test Result

I exercised `FlexibleArgumentParser.parse_args` directly against the patched module using the repo fixture `tests/config/test_config.yaml`:

- Before the fix: `--config=<path>` left `tensor_parallel_size`, `port`, and `trust_remote_code` unset (config ignored), while `--config <path>` applied them.
- After the fix: both forms apply the config identically (`tensor_parallel_size=2`, `port=12312`, `trust_remote_code=True`). `--config=<path> --tensor-parallel-size 3` yields `tensor_parallel_size=3` (CLI wins) with `port=12312` from the config. A path containing `=` is split only on the first `=`, and a duplicate `--config=` still raises `More than one config file specified!`.

`ruff check` and `ruff format --check` pass on the changed files.

Note on environment: a full source build was not run on my machine. The parser logic was verified in isolation (`vllm/utils/argparse_utils.py` has no heavyweight imports beyond the logger), and CI will run the added unit test.

## Notes

- Not a duplicate of an open PR: the only prior attempt for this issue, #43256, was closed by its author, and no open PR currently addresses #43252. This PR adds a regression test alongside the fix.
- AI assistance (Claude) was used to investigate and draft this change. I reviewed every changed line and the results above.