### PR TITLE
[Doc] Mention Ascend NPU in quickstart

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -76,6 +76,13 @@ This guide will help you quickly get started with vLLM to perform:
     !!! note
         For more detailed instructions, including Docker, installing from source, and troubleshooting, please refer to the [vLLM on TPU documentation](https://docs.vllm.ai/projects/tpu/en/latest/).
 
+=== "Ascend NPU"
+
+    To run vLLM on Huawei Ascend NPUs, use [vLLM Ascend](https://github.com/vllm-project/vllm-ascend), the vLLM hardware plugin for Ascend.
+
+    !!! note
+        For installation instructions, including Docker, installing from source, and troubleshooting, please refer to the [vLLM Ascend quick start](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html).
+
 === "Apple Silicon (Mac)"
 
     If you are using Apple Silicon Macs, you can use vLLM-Metal for GPU-accelerated inference via Apple's Metal framework.


### PR DESCRIPTION
## Purpose

Fixes #43549.

Add an Ascend NPU installation tab to the main quickstart so users can discover the vLLM Ascend path from the same place as CUDA, ROCm, TPU, and Apple Silicon.

The entry intentionally links to the vLLM Ascend quick start instead of duplicating the full setup steps, because the Ascend instructions depend on NPU hardware, CANN/driver versions, Docker images, and source-install details that are maintained in the vLLM Ascend docs.

## Test Plan

- `git diff --check`
- `pre-commit run markdownlint-cli2 --files docs/getting_started/quickstart.md`
- `pre-commit run typos --files docs/getting_started/quickstart.md`
- `pre-commit run --files docs/getting_started/quickstart.md` attempted

## Test Result

- `git diff --check`: passed
- `pre-commit run markdownlint-cli2 --files docs/getting_started/quickstart.md`: passed
- `pre-commit run typos --files docs/getting_started/quickstart.md`: passed
- `pre-commit run --files docs/getting_started/quickstart.md`: failed while installing the `actionlint` hook because Go dependencies could not be downloaded from `proxy.golang.org` in my local environment. This PR only changes Markdown, and the Markdown-specific checks above passed.

## Notes

AI assistance was used to prepare this documentation-only change.
