### PR TITLE
[Frontend] Add optional llm_sign response signatures

### DIFF
--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -191,3 +191,48 @@ The following extra parameters in the response object are supported:
     ```python
     --8<-- "vllm/entrypoints/openai/responses/protocol.py:responses-response-extra-params"
     ```
+
+### llm_sign response signatures (experimental)
+
+!!! warning
+    `llm_sign` support is experimental and subject to change. The `llm_sign`
+    protocol is currently in beta; breaking changes may happen at any time,
+    and production use is not recommended.
+
+vLLM can attach `llm_sign` metadata to OpenAI-compatible Chat Completions and
+Responses API responses. The metadata lets downstream clients verify that the
+visible response body was signed by the provider certificate key instead of
+being silently modified by an intermediate relay.
+
+This integration is disabled by default. When it is disabled, vLLM does not add
+the `llm_sign` field.
+
+Install `llm-sign` alongside vLLM and point vLLM at the TLS certificate and
+private key used to identify the provider:
+
+```bash
+pip install llm-sign
+
+export VLLM_LLM_SIGN_ENABLED=1
+export VLLM_LLM_SIGN_CERTFILE=/path/to/fullchain.pem
+export VLLM_LLM_SIGN_KEYFILE=/path/to/privkey.pem
+
+vllm serve meta-llama/Meta-Llama-3-8B-Instruct
+```
+
+When enabled, vLLM signs non-streaming `/v1/chat/completions` responses and
+final `/v1/responses` response objects, then attaches the artifact under the
+`llm_sign` field. vLLM-only request and response extensions are excluded from
+the signed OpenAI-compatible payload.
+
+Clients can verify signed responses with the `llm_sign` client helpers:
+
+```python
+from llm_sign.client import (
+    verify_openai_response,
+    verify_openai_responses_response,
+)
+
+chat_result = verify_openai_response(chat_response)
+responses_result = verify_openai_responses_response(responses_response)
+```

--- a/tests/entrypoints/openai/test_llm_sign.py
+++ b/tests/entrypoints/openai/test_llm_sign.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import builtins
+import sys
+from types import ModuleType
+
+import pytest
+
+from vllm import envs
+from vllm.entrypoints.openai import llm_sign
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.engine.protocol import UsageInfo
+from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
+    ResponsesResponse,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_llm_sign(monkeypatch: pytest.MonkeyPatch):
+    llm_sign.clear_cached_signer()
+    envs.disable_envs_cache()
+    monkeypatch.delenv("VLLM_LLM_SIGN_ENABLED", raising=False)
+    monkeypatch.delenv("VLLM_LLM_SIGN_CERTFILE", raising=False)
+    monkeypatch.delenv("VLLM_LLM_SIGN_KEYFILE", raising=False)
+    yield
+    llm_sign.clear_cached_signer()
+    envs.disable_envs_cache()
+
+
+def test_llm_sign_skips_non_chat_completion_response():
+    """``maybe_sign_chat_completion`` is a no-op for non-chat responses.
+
+    The caller (``OpenAIServingChat.create_chat_completion``) is
+    responsible for gating on ``envs.VLLM_LLM_SIGN_ENABLED`` *before*
+    invoking this helper. The hook's only remaining input check is a
+    type guard against streaming / unexpected payload types, so that
+    ``return maybe_sign_chat_completion(request, response)`` is safe
+    even when the caller passes through a non-``ChatCompletionResponse``
+    value (defensive — should not happen on the gated non-streaming
+    code path, but guarantees the hook never crashes the response).
+
+    The byte-for-byte equivalence with upstream when
+    ``VLLM_LLM_SIGN_ENABLED`` is unset is now a property of the
+    *caller* (the hook is not invoked at all in that case); it is
+    covered by the integration tests that exercise the full
+    ``serving_chat`` path.
+    """
+    request = _request()
+    response = "not-a-chat-completion-response"
+    assert llm_sign.maybe_sign_chat_completion(request, response) is response
+
+
+def test_llm_sign_skips_non_responses_response():
+    """``maybe_sign_responses_response`` is a no-op for non-responses payloads.
+
+    Same contract as ``test_llm_sign_skips_non_chat_completion_response``:
+    the caller (``OpenAIServingResponses.responses_full_generator``)
+    pre-checks ``envs.VLLM_LLM_SIGN_ENABLED``; the hook only retains a
+    defensive type guard.
+    """
+    request = _responses_request()
+    response = "not-a-responses-response"
+    assert llm_sign.maybe_sign_responses_response(request, response) is response
+
+
+def test_llm_sign_filters_vllm_only_request_fields(monkeypatch: pytest.MonkeyPatch):
+    """vLLM-only request knobs (e.g. ``min_tokens``) must not leak into the
+    signed payload, otherwise the strict ``openai.chat-completions.input.v1``
+    profile rejects the artifact with ``unknown fields``.
+    """
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    captured: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, captured)
+
+    # A request that includes a vLLM-only knob plus a standard one
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "ping"}],
+        min_tokens=3,  # vLLM extension
+        temperature=0.0,  # OpenAI standard
+    )
+    llm_sign.maybe_sign_chat_completion(request, _response())
+
+    signed_request = captured[1]["request"]
+    assert "model" in signed_request
+    assert "messages" in signed_request
+    assert "temperature" in signed_request
+    # vLLM-only knobs filtered out
+    assert "min_tokens" not in signed_request
+
+
+def test_llm_sign_filters_vllm_only_response_fields(monkeypatch: pytest.MonkeyPatch):
+    """vLLM-only response fields (``prompt_logprobs``, ``prompt_token_ids``,
+    ``kv_transfer_params``) must not leak into the signed payload, otherwise
+    a verifier re-canonicalizing the HTTP body fails with ``unknown fields``.
+    """
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    captured: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, captured)
+
+    response = _response()
+    response.prompt_logprobs = [None]
+    response.prompt_token_ids = [1, 2, 3]
+    response.kv_transfer_params = {"foo": "bar"}
+
+    llm_sign.maybe_sign_chat_completion(_request(), response)
+
+    signed_response = captured[1]["response"]
+    assert "choices" in signed_response
+    assert "model" in signed_response
+    # vLLM-only response fields filtered out
+    assert "prompt_logprobs" not in signed_response
+    assert "prompt_token_ids" not in signed_response
+    assert "kv_transfer_params" not in signed_response
+    assert "llm_sign" not in signed_response
+
+
+def test_llm_sign_filters_vllm_only_responses_request_fields(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    captured: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, captured)
+
+    request = ResponsesRequest(
+        model="test-model",
+        input="ping",
+        temperature=0.0,
+        kv_transfer_params={"foo": "bar"},
+        prompt_cache_key="cache-key",
+        cache_salt="salt",
+        vllm_xargs={"internal": "value"},
+    )
+    llm_sign.maybe_sign_responses_response(request, _responses_response())
+
+    signed_request = captured[1]["request"]
+    assert signed_request["model"] == "test-model"
+    assert signed_request["input"] == "ping"
+    assert signed_request["temperature"] == 0.0
+    assert "kv_transfer_params" not in signed_request
+    assert "prompt_cache_key" not in signed_request
+    assert "cache_salt" not in signed_request
+    assert "vllm_xargs" not in signed_request
+    assert "request_id" not in signed_request
+
+
+def test_llm_sign_strips_client_supplied_previous_response_hash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    captured: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, captured)
+
+    request = ResponsesRequest(
+        model="test-model",
+        input="ping",
+        previous_response_id="resp-parent",
+        previous_response_hash="client-forged-hash",
+    )
+    llm_sign.maybe_sign_responses_response(
+        request,
+        _responses_response(previous_response_id="resp-parent"),
+        parent_hash="server-observed-parent-hash",
+    )
+
+    signed_request = captured[1]["request"]
+    assert signed_request["previous_response_id"] == "resp-parent"
+    assert "previous_response_hash" not in signed_request
+    assert captured[1]["parent_hash"] == "server-observed-parent-hash"
+
+
+def test_llm_sign_reads_parent_hash_from_saved_response_only():
+    parent = _responses_response()
+    parent.llm_sign = {
+        "artifact_hash": "stored-parent-hash",
+        "artifact": {"chain": [{"block": {"seq": 7}}]},
+    }
+
+    assert llm_sign.responses_parent_signing_context(parent) == (
+        "stored-parent-hash",
+        8,
+    )
+
+
+def test_llm_sign_parent_context_ignores_missing_signature():
+    assert llm_sign.responses_parent_signing_context(_responses_response()) == (None, 0)
+
+
+def test_llm_sign_filters_vllm_only_responses_response_fields(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    captured: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, captured)
+
+    response = _responses_response()
+    response.kv_transfer_params = {"foo": "bar"}
+    response.llm_sign = {"stale": "metadata"}
+
+    llm_sign.maybe_sign_responses_response(_responses_request(), response)
+
+    signed_response = captured[1]["response"]
+    assert signed_response["model"] == "test-model"
+    assert signed_response["status"] == "completed"
+    assert "output" in signed_response
+    assert "kv_transfer_params" not in signed_response
+    assert "llm_sign" not in signed_response
+
+
+def _install_fake_llm_sign(
+    monkeypatch: pytest.MonkeyPatch,
+    captured: list[dict],
+) -> None:
+    """Install a fake ``llm_sign`` package so tests don't need cryptography."""
+
+    fake_pkg = ModuleType("llm_sign")
+    fake_server = ModuleType("llm_sign.server")
+
+    _CHAT_REQUEST_ALLOWED = {
+        "messages",
+        "model",
+        "temperature",
+        "top_p",
+        "stop",
+        "max_tokens",
+        "tools",
+        "tool_choice",
+        "n",
+        "stream",
+        "user",
+        "metadata",
+    }
+    _CHAT_RESPONSE_ALLOWED = {
+        "choices",
+        "model",
+        "response_format",
+        "created",
+        "id",
+        "object",
+        "usage",
+        "system_fingerprint",
+    }
+    _RESPONSES_REQUEST_ALLOWED = {
+        "background",
+        "frequency_penalty",
+        "include",
+        "input",
+        "instructions",
+        "logit_bias",
+        "max_output_tokens",
+        "max_tool_calls",
+        "metadata",
+        "model",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "previous_response_hash",
+        "previous_response_id",
+        "prompt",
+        "reasoning",
+        "service_tier",
+        "store",
+        "stream",
+        "temperature",
+        "text",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p",
+        "truncation",
+        "user",
+    }
+    _RESPONSES_RESPONSE_ALLOWED = {
+        "background",
+        "created_at",
+        "frequency_penalty",
+        "id",
+        "incomplete_details",
+        "instructions",
+        "max_output_tokens",
+        "max_tool_calls",
+        "metadata",
+        "model",
+        "object",
+        "output",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "previous_response_id",
+        "prompt",
+        "reasoning",
+        "service_tier",
+        "status",
+        "temperature",
+        "text",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p",
+        "truncation",
+        "usage",
+        "user",
+    }
+
+    def fake_project_openai_chat_request(payload):
+        return {k: v for k, v in payload.items() if k in _CHAT_REQUEST_ALLOWED}
+
+    def fake_project_openai_chat_response(payload):
+        return {k: v for k, v in payload.items() if k in _CHAT_RESPONSE_ALLOWED}
+
+    def fake_project_openai_responses_request(payload):
+        return {k: v for k, v in payload.items() if k in _RESPONSES_REQUEST_ALLOWED}
+
+    def fake_project_openai_responses_response(payload):
+        return {k: v for k, v in payload.items() if k in _RESPONSES_RESPONSE_ALLOWED}
+
+    fake_pkg.project_openai_chat_request = fake_project_openai_chat_request  # type: ignore[attr-defined]
+    fake_pkg.project_openai_chat_response = fake_project_openai_chat_response  # type: ignore[attr-defined]
+    fake_pkg.project_openai_responses_request = fake_project_openai_responses_request  # type: ignore[attr-defined]
+    fake_pkg.project_openai_responses_response = fake_project_openai_responses_response  # type: ignore[attr-defined]
+
+    class FakeCredential:
+        @classmethod
+        def from_files(cls, **kwargs):
+            captured.append(kwargs)
+            return cls()
+
+        def signer(self):
+            return "signer"
+
+        def certificate_chain_pem(self):
+            return ["cert-chain"]
+
+    def fake_sign_openai_chat_turn(**kwargs):
+        captured.append(kwargs)
+        return {
+            "schema": "llm-sign.artifact.v1",
+            "kind": "chat",
+            "chain": [{"block": {"seq": 0}}, {"block": {"seq": 1}}],
+        }
+
+    def fake_sign_openai_responses_turn(**kwargs):
+        captured.append(kwargs)
+        start_seq = kwargs.get("start_seq", 0)
+        return {
+            "schema": "llm-sign.artifact.v1",
+            "kind": "responses",
+            "chain": [
+                {"block": {"seq": start_seq}},
+                {"block": {"seq": start_seq + 1}},
+            ],
+        }
+
+    def fake_attach(envelope, *, artifact, credential=None, certificate_chain_pem=None):
+        envelope["llm_sign"] = {
+            "artifact": dict(artifact),
+            "artifact_hash": f"fake-{artifact.get('kind', 'artifact')}-hash",
+        }
+        chain = certificate_chain_pem
+        if chain is None and credential is not None:
+            chain = credential.certificate_chain_pem()
+        if chain is not None:
+            envelope["llm_sign"]["certificate_chain"] = list(chain)
+        captured.append({"attached": envelope["llm_sign"]})
+        return envelope
+
+    fake_server.TLSCertificateCredential = FakeCredential  # type: ignore[attr-defined]
+    fake_server.sign_openai_chat_turn = fake_sign_openai_chat_turn  # type: ignore[attr-defined]
+    fake_server.sign_openai_responses_turn = fake_sign_openai_responses_turn  # type: ignore[attr-defined]
+    fake_server.attach_signed_artifact_to_openai_response = fake_attach  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "llm_sign", fake_pkg)
+    monkeypatch.setitem(sys.modules, "llm_sign.server", fake_server)
+
+
+def test_llm_sign_attaches_artifact_when_enabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    calls: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, calls)
+
+    response = llm_sign.maybe_sign_chat_completion(_request(), _response())
+
+    assert response.llm_sign["artifact"]["schema"] == "llm-sign.artifact.v1"
+    assert response.llm_sign["artifact"]["kind"] == "chat"
+    assert response.llm_sign["artifact_hash"] == "fake-chat-hash"
+    assert response.llm_sign["certificate_chain"] == ["cert-chain"]
+    # The issuer (host name) is derived from the certificate by llm_sign;
+    # vLLM forwards only the cert and key paths.
+    assert calls[0] == {
+        "ssl_certfile": "cert.pem",
+        "ssl_keyfile": "key.pem",
+    }
+    assert calls[1]["request"]["model"] == "test-model"
+    assert calls[1]["response"]["choices"][0]["message"]["content"] == "pong"
+    assert calls[1]["signer"] == "signer"
+    # The envelope was produced by llm_sign's official helper, not by
+    # vLLM inlining the dict layout.
+    assert calls[-1] == {"attached": response.llm_sign}
+
+
+def test_llm_sign_responses_attaches_artifact_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+
+    calls: list[dict] = []
+    _install_fake_llm_sign(monkeypatch, calls)
+
+    response = llm_sign.maybe_sign_responses_response(
+        _responses_request(previous_response_id="resp-parent"),
+        _responses_response(previous_response_id="resp-parent"),
+        parent_hash="parent-artifact-hash",
+        start_seq=4,
+    )
+
+    assert response.llm_sign["artifact"]["schema"] == "llm-sign.artifact.v1"
+    assert response.llm_sign["artifact"]["kind"] == "responses"
+    assert response.llm_sign["artifact"]["chain"][0]["block"]["seq"] == 4
+    assert response.llm_sign["artifact_hash"] == "fake-responses-hash"
+    assert response.llm_sign["certificate_chain"] == ["cert-chain"]
+    assert calls[0] == {
+        "ssl_certfile": "cert.pem",
+        "ssl_keyfile": "key.pem",
+    }
+    assert calls[1]["request"]["previous_response_id"] == "resp-parent"
+    assert calls[1]["response"]["previous_response_id"] == "resp-parent"
+    assert calls[1]["signer"] == "signer"
+    assert calls[1]["parent_hash"] == "parent-artifact-hash"
+    assert calls[1]["start_seq"] == 4
+    assert calls[-1] == {"attached": response.llm_sign}
+
+
+def test_llm_sign_requires_cert_and_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+
+    with pytest.raises(ValueError, match="VLLM_LLM_SIGN_CERTFILE"):
+        llm_sign.maybe_sign_chat_completion(_request(), _response())
+
+
+def test_llm_sign_import_is_optional_until_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_LLM_SIGN_ENABLED", "1")
+    monkeypatch.setenv("VLLM_LLM_SIGN_CERTFILE", "cert.pem")
+    monkeypatch.setenv("VLLM_LLM_SIGN_KEYFILE", "key.pem")
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "llm_sign.server":
+            raise ImportError("missing llm_sign")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match="llm_sign must be installed"):
+        llm_sign.maybe_sign_chat_completion(_request(), _response())
+
+
+def _request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "ping"}],
+    )
+
+
+def _response() -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="test-model",
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content="pong"),
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def _responses_request(previous_response_id: str | None = None) -> ResponsesRequest:
+    return ResponsesRequest(
+        model="test-model",
+        input="ping",
+        previous_response_id=previous_response_id,
+        store=False,
+    )
+
+
+def _responses_response(previous_response_id: str | None = None) -> ResponsesResponse:
+    return ResponsesResponse(
+        model="test-model",
+        output=[],
+        parallel_tool_calls=True,
+        temperature=0.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        background=False,
+        max_output_tokens=16,
+        previous_response_id=previous_response_id,
+        service_tier="auto",
+        status="completed",
+        truncation="disabled",
+    )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -14,6 +14,7 @@ import numpy as np
 import pybase64 as base64
 from fastapi import Request
 
+from vllm import envs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
@@ -55,6 +56,7 @@ from vllm.entrypoints.openai.engine.serving import (
     OpenAIServing,
     clamp_prompt_logprobs,
 )
+from vllm.entrypoints.openai.llm_sign import maybe_sign_chat_completion
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_stop_tokens_for_assistant_actions,
@@ -381,7 +383,7 @@ class OpenAIServingChat(OpenAIServing):
                 chat_template_kwargs=chat_template_kwargs,
             )
 
-        return await self.chat_completion_full_generator(
+        response = await self.chat_completion_full_generator(
             request,
             result_generator,
             request_id,
@@ -391,6 +393,9 @@ class OpenAIServingChat(OpenAIServing):
             request_metadata,
             reasoning_parser,
         )
+        if envs.VLLM_LLM_SIGN_ENABLED:
+            return maybe_sign_chat_completion(request, response)
+        return response
 
     def get_chat_request_role(self, request: ChatCompletionRequest) -> str:
         if request.add_generation_prompt:

--- a/vllm/entrypoints/openai/llm_sign.py
+++ b/vllm/entrypoints/openai/llm_sign.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+from typing import Any
+
+import vllm.envs as envs
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionResponse
+from vllm.entrypoints.openai.responses.protocol import ResponsesResponse
+
+
+def responses_parent_signing_context(parent_response: Any) -> tuple[str | None, int]:
+    parent_hash: str | None = None
+    start_seq = 0
+
+    parent_llm_sign = getattr(parent_response, "llm_sign", None)
+    if not isinstance(parent_llm_sign, Mapping):
+        return parent_hash, start_seq
+
+    candidate = parent_llm_sign.get("artifact_hash")
+    if isinstance(candidate, str):
+        parent_hash = candidate
+
+    parent_artifact = parent_llm_sign.get("artifact")
+    if not isinstance(parent_artifact, Mapping):
+        return parent_hash, start_seq
+
+    parent_chain = parent_artifact.get("chain")
+    if not isinstance(parent_chain, list) or not parent_chain:
+        return parent_hash, start_seq
+
+    last_signed = parent_chain[-1]
+    if not isinstance(last_signed, Mapping):
+        return parent_hash, start_seq
+
+    last_block = last_signed.get("block")
+    if not isinstance(last_block, Mapping):
+        return parent_hash, start_seq
+
+    last_seq = last_block.get("seq")
+    if isinstance(last_seq, int):
+        start_seq = last_seq + 1
+
+    return parent_hash, start_seq
+
+
+def maybe_sign_chat_completion(
+    request: Any,
+    response: Any,
+) -> Any:
+    """Attach llm_sign metadata to a Chat Completions response.
+
+    This helper assumes the caller has already gated on
+    ``envs.VLLM_LLM_SIGN_ENABLED``; it does not re-check the env var.
+    When the response is a regular :class:`ChatCompletionResponse`
+    (not a streaming generator), this helper:
+
+    1. Projects the request and response to the OpenAI Chat Completions
+       v1 canonical schemas (vLLM-only knobs such as ``min_tokens``,
+       ``prompt_logprobs`` are dropped; they are not covered by the
+       signing profile).
+    2. Signs the projected turn with the TLS private key loaded from
+       ``VLLM_LLM_SIGN_CERTFILE`` / ``VLLM_LLM_SIGN_KEYFILE``.
+    3. Attaches ``{"artifact": ..., "certificate_chain": [...pem...]}``
+       under the ``llm_sign`` field of the response envelope, using the
+       official :func:`llm_sign.server.attach_signed_artifact_to_openai_response`
+       helper so the wire format stays in lockstep with ``llm_sign``'s
+       spec.
+
+    Downstream clients verify the response with
+    :func:`llm_sign.client.verify_openai_response`, which authenticates
+    the embedded certificate chain under the standard TLS / X.509
+    server-certificate validation rules (using the system TLS trust
+    store by default) and then verifies the transcript under the
+    validated leaf public key.
+    """
+
+    if not isinstance(response, ChatCompletionResponse):
+        return response
+
+    signer = _get_signer()
+    # The request payload uses ``exclude_unset=True``: only the fields the
+    # client *explicitly set* on the wire enter the signed digest. Pydantic
+    # otherwise materializes every schema default (``frequency_penalty=0.0``,
+    # ``n=1``, ``logprobs=False``, ...), and a verifier that re-canonicalizes
+    # the bytes the client actually sent would compute a different digest and
+    # reject a legitimate signature. The response payload uses
+    # ``exclude_none=False`` because that mirrors what FastAPI's default JSON
+    # encoder produces on the wire (null fields kept), and the client reads
+    # exactly those bytes.
+    from llm_sign import project_openai_chat_request, project_openai_chat_response
+
+    request_payload = project_openai_chat_request(
+        request.model_dump(mode="json", exclude_unset=True)
+    )
+    response_payload = project_openai_chat_response(
+        response.model_dump(mode="json", exclude_none=False)
+    )
+    envelope: dict[str, Any] = {}
+    signer.sign_chat_and_attach(envelope, request_payload, response_payload)
+    # ``ChatCompletionResponse`` (via ``OpenAIBaseModel``) sets
+    # ``model_config = ConfigDict(extra="allow")``, so the ``llm_sign`` field
+    # is a valid dynamic attribute at runtime. mypy cannot see that through
+    # pydantic's config, hence the targeted ignore.
+    response.llm_sign = envelope["llm_sign"]  # type: ignore[attr-defined]
+    return response
+
+
+def maybe_sign_responses_response(
+    request: Any,
+    response: Any,
+    parent_hash: str | None = None,
+    start_seq: int = 0,
+) -> Any:
+    """Attach llm_sign metadata to a ``/v1/responses`` response.
+
+    Mirror of :func:`maybe_sign_chat_completion` for the OpenAI
+    Responses API. This helper assumes the caller has already gated on
+    ``envs.VLLM_LLM_SIGN_ENABLED``; it does not re-check the env var.
+
+    Projects the request and response to the Responses canonical
+    schemas (vLLM-only knobs such as ``kv_transfer_params``,
+    ``vllm_xargs``, ``prompt_cache_key``, ``cache_salt`` are dropped;
+    they are not part of the signing whitelist), signs the turn with
+    the shared TLS credential, and attaches the artifact envelope.
+
+    The Responses API is stateful (``previous_response_id`` points at
+    a prior turn held in the server's store), and the
+    ``previous_response_id`` pointer is part of the signed input
+    payload. When ``parent_hash`` is supplied, it is also injected
+    into the signed input payload under ``previous_response_hash`` —
+    this is the server's own record of the parent turn's artifact
+    hash (looked up from the session store, not read from client
+    input), which binds the current turn's signature to that specific
+    prior artifact rather than to whatever content is sitting under
+    the id string at verification time.
+
+    ``start_seq`` lets a multi-turn Responses session continue ``seq``
+    monotonically across turns: turn 1 signs blocks at seq=0,1; turn 2
+    at seq=2,3; etc. The chain-level structure is still independent
+    per turn (``prev_block_digest`` on each turn's first block is
+    ``null``); the seq numbering is the only artifact-level signal
+    of a session's turn ordering. Cross-turn integrity is by
+    ``previous_response_hash`` in the signed input.
+
+    Forking — the same ``previous_response_id`` used on multiple
+    create calls — produces independent artifacts. Each fork starts
+    its first block at the same ``start_seq``; that's intentional and
+    fine, llm_sign does not attempt to detect or prevent forks.
+    """
+
+    if not isinstance(response, ResponsesResponse):
+        return response
+
+    signer = _get_signer()
+    from llm_sign import (
+        project_openai_responses_request,
+        project_openai_responses_response,
+    )
+
+    # See ``maybe_sign_chat_completion`` for the rationale: the request
+    # uses ``exclude_unset=True`` to capture only what the client actually
+    # sent on the wire; the response uses ``exclude_none=False`` because
+    # FastAPI's encoder emits null fields and the client reads exactly
+    # those bytes.
+    raw_request_payload = request.model_dump(mode="json", exclude_unset=True)
+    # ``previous_response_hash`` is a server-injected binding derived from
+    # ``response_store``. Never let a client-supplied extra field choose it.
+    raw_request_payload.pop("previous_response_hash", None)
+    request_payload = project_openai_responses_request(raw_request_payload)
+    response_payload = project_openai_responses_response(
+        response.model_dump(mode="json", exclude_none=False)
+    )
+    envelope: dict[str, Any] = {}
+    signer.sign_responses_and_attach(
+        envelope,
+        request_payload,
+        response_payload,
+        parent_hash=parent_hash,
+        start_seq=start_seq,
+    )
+    # ``ResponsesResponse`` (via ``OpenAIBaseModel``) sets
+    # ``model_config = ConfigDict(extra="allow")``, so the ``llm_sign``
+    # field is a valid dynamic attribute at runtime. mypy cannot see
+    # that through pydantic's config, hence the targeted ignore.
+    response.llm_sign = envelope["llm_sign"]  # type: ignore[attr-defined]
+    return response
+
+
+class _OpenAILLMSigner:
+    def __init__(self) -> None:
+        certfile = envs.VLLM_LLM_SIGN_CERTFILE
+        keyfile = envs.VLLM_LLM_SIGN_KEYFILE
+        if not certfile or not keyfile:
+            raise ValueError(
+                "VLLM_LLM_SIGN_CERTFILE and VLLM_LLM_SIGN_KEYFILE must be set "
+                "when VLLM_LLM_SIGN_ENABLED=1"
+            )
+
+        try:
+            from llm_sign.server import (
+                TLSCertificateCredential,
+                attach_signed_artifact_to_openai_response,
+                sign_openai_chat_turn,
+                sign_openai_responses_turn,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "llm_sign must be installed when VLLM_LLM_SIGN_ENABLED=1"
+            ) from exc
+
+        self._credential = TLSCertificateCredential.from_files(
+            ssl_certfile=certfile,
+            ssl_keyfile=keyfile,
+        )
+        self._signer = self._credential.signer()
+        self._sign_openai_chat_turn = sign_openai_chat_turn
+        self._sign_openai_responses_turn = sign_openai_responses_turn
+        self._attach = attach_signed_artifact_to_openai_response
+
+    def sign_chat_and_attach(
+        self,
+        envelope: dict[str, Any],
+        request: Mapping[str, Any],
+        response: Mapping[str, Any],
+    ) -> None:
+        artifact = self._sign_openai_chat_turn(
+            request=request,
+            response=response,
+            signer=self._signer,
+        )
+        self._attach(envelope, artifact=artifact, credential=self._credential)
+
+    def sign_responses_and_attach(
+        self,
+        envelope: dict[str, Any],
+        request: Mapping[str, Any],
+        response: Mapping[str, Any],
+        *,
+        parent_hash: str | None = None,
+        start_seq: int = 0,
+    ) -> None:
+        artifact = self._sign_openai_responses_turn(
+            request=request,
+            response=response,
+            signer=self._signer,
+            parent_hash=parent_hash,
+            start_seq=start_seq,
+        )
+        self._attach(envelope, artifact=artifact, credential=self._credential)
+
+
+_signer: _OpenAILLMSigner | None = None
+_signer_lock = threading.Lock()
+
+
+def _get_signer() -> _OpenAILLMSigner:
+    global _signer
+    if _signer is None:
+        with _signer_lock:
+            # Double-checked locking: another thread may have
+            # initialized the singleton while we were waiting on
+            # the lock.
+            if _signer is None:
+                _signer = _OpenAILLMSigner()
+    return _signer
+
+
+def clear_cached_signer() -> None:
+    global _signer
+    with _signer_lock:
+        _signer = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -43,6 +43,10 @@ from vllm.entrypoints.openai.engine.serving import (
     GenerationError,
     OpenAIServing,
 )
+from vllm.entrypoints.openai.llm_sign import (
+    maybe_sign_responses_response,
+    responses_parent_signing_context,
+)
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_developer_message,
@@ -913,12 +917,48 @@ class OpenAIServingResponses(OpenAIServing):
             kv_transfer_params=context.kv_transfer_params,
         )
 
+        if envs.VLLM_LLM_SIGN_ENABLED:
+            # Resolve cross-turn signing context (parent_hash from
+            # the prior turn's stored llm_sign envelope, and the
+            # next start_seq for monotone numbering across turns)
+            # only when llm_sign is on. Doing this here keeps the
+            # llm_sign-only state out of the inference function
+            # signatures: the signing-related lookup is fully
+            # localized to the signing call site.
+            #
+            # IMPORTANT: signing must happen *before* persisting the
+            # response in ``response_store``. Otherwise a concurrent
+            # request that follows up via ``previous_response_id``
+            # could observe an unsigned (or partially-signed) parent
+            # and break the cross-turn cryptographic chain — and a
+            # signing failure after storage would leave an unsigned
+            # response cached in the store. Keeping sign-then-store
+            # guarantees the store only ever contains fully signed
+            # responses.
+            parent_hash: str | None = None
+            start_seq = 0
+            prev_id = request.previous_response_id
+            if prev_id is not None:
+                async with self.response_store_lock:
+                    prev_response = self.response_store.get(prev_id)
+                if prev_response is not None:
+                    parent_hash, start_seq = responses_parent_signing_context(
+                        prev_response
+                    )
+            response = maybe_sign_responses_response(
+                request,
+                response,
+                parent_hash=parent_hash,
+                start_seq=start_seq,
+            )
+
         if request.store:
             async with self.response_store_lock:
                 stored_response = self.response_store.get(response.id)
                 # If the response is already cancelled, don't update it.
                 if stored_response is None or stored_response.status != "cancelled":
                     self.response_store[response.id] = response
+
         return response
 
     def _topk_logprobs(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     VLLM_ENGINE_READY_TIMEOUT_S: int = 600
     VLLM_API_KEY: str | None = None
     VLLM_DEBUG_LOG_API_SERVER_RESPONSE: bool = False
+    VLLM_LLM_SIGN_ENABLED: bool = False
+    VLLM_LLM_SIGN_CERTFILE: str | None = None
+    VLLM_LLM_SIGN_KEYFILE: str | None = None
     S3_ACCESS_KEY_ID: str | None = None
     S3_SECRET_ACCESS_KEY: str | None = None
     S3_ENDPOINT_URL: str | None = None
@@ -764,6 +767,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DEBUG_LOG_API_SERVER_RESPONSE": lambda: (
         os.environ.get("VLLM_DEBUG_LOG_API_SERVER_RESPONSE", "False").lower() == "true"
     ),
+    # Whether to attach llm_sign signatures to OpenAI-compatible responses.
+    "VLLM_LLM_SIGN_ENABLED": lambda: bool(
+        int(os.environ.get("VLLM_LLM_SIGN_ENABLED", "0"))
+    ),
+    # TLS certificate and private key used by llm_sign when enabled.
+    # The issuer (host name) is derived from the certificate's SAN/CN,
+    # mirroring TLS server identity; no separate override is needed.
+    "VLLM_LLM_SIGN_CERTFILE": lambda: os.environ.get("VLLM_LLM_SIGN_CERTFILE", None),
+    "VLLM_LLM_SIGN_KEYFILE": lambda: os.environ.get("VLLM_LLM_SIGN_KEYFILE", None),
     # S3 access information, used for tensorizer to load model from S3
     "S3_ACCESS_KEY_ID": lambda: os.environ.get("S3_ACCESS_KEY_ID", None),
     "S3_SECRET_ACCESS_KEY": lambda: os.environ.get("S3_SECRET_ACCESS_KEY", None),
@@ -2092,6 +2104,9 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOGGING_COLOR",
         "VLLM_LOG_STATS_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
+        "VLLM_LLM_SIGN_ENABLED",
+        "VLLM_LLM_SIGN_CERTFILE",
+        "VLLM_LLM_SIGN_KEYFILE",
         "VLLM_TUNED_CONFIG_FOLDER",
         "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR",
         "VLLM_ENGINE_ITERATION_TIMEOUT_S",


### PR DESCRIPTION
Adds optional llm_sign response signatures for OpenAI-compatible Chat Completions and Responses API responses. Disabled by default via VLLM_LLM_SIGN_ENABLED. Includes env vars, signing hooks, docs, and focused tests. Local validation: py_compile passed; llm_sign runtime tests passed (13 passed); pip check passed.