### PR TITLE
[Quantization] Add support for remapping KV cache quantization weight name in the KVCacheMethod.

### DIFF
--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     _merge_multimodal_embeddings,
@@ -11,6 +12,97 @@ from vllm.model_executor.models.utils import (
 from vllm.platforms import current_platform
 
 DEVICE_TYPE = current_platform.device_type
+
+
+class MockKVCacheMethod(BaseKVCacheMethod):
+    """Mock KV cache method for testing remapping logic."""
+
+    def __init__(self, remap_rules: dict[str, str] | None = None):
+        self.remap_rules = remap_rules or {}
+
+    def remap_kv_scale_name(self, name: str, params_dict: dict) -> str | None:
+        for pattern, replacement in self.remap_rules.items():
+            if pattern in name:
+                new_name = name.replace(pattern, replacement)
+                return new_name if new_name in params_dict else None
+        return None
+
+
+class ModuleWithKVCacheMethod(torch.nn.Module):
+    """Module with a mock KV cache method."""
+
+    def __init__(self, remap_rules: dict[str, str] | None = None):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 10)
+        self.attn_k_scale = torch.nn.Parameter(torch.tensor(1.0))
+        self.attn_v_scale = torch.nn.Parameter(torch.tensor(1.0))
+        self.quant_method = MockKVCacheMethod(remap_rules)
+
+
+@pytest.mark.cpu_test
+def test_auto_weights_loader_remaps_kv_scale_names():
+    """Ensure AutoWeightsLoader applies KV scale remapping from quant method."""
+    remap_rules = {
+        "k_proj.k_scale": "attn_k_scale",
+        "v_proj.v_scale": "attn_v_scale",
+    }
+    mod = ModuleWithKVCacheMethod(remap_rules)
+
+    def weight_generator():
+        yield "k_proj.k_scale", torch.tensor(2.0)
+        yield "v_proj.v_scale", torch.tensor(3.0)
+        yield "linear.weight", torch.randn(10, 10)
+
+    loader = AutoWeightsLoader(mod)
+    loaded = loader.load_weights(weight_generator())
+
+    assert "k_proj.k_scale" not in loaded
+    assert "v_proj.v_scale" not in loaded
+    assert "attn_k_scale" in loaded
+    assert "attn_v_scale" in loaded
+    assert torch.allclose(mod.attn_k_scale.data, torch.tensor(2.0))
+    assert torch.allclose(mod.attn_v_scale.data, torch.tensor(3.0))
+
+
+@pytest.mark.cpu_test
+def test_auto_weights_loader_skips_remap_when_target_missing():
+    """Ensure remapped weights are skipped when target param is missing."""
+    remap_rules = {
+        "k_proj.k_scale": "nonexistent_scale",
+    }
+    mod = ModuleWithKVCacheMethod(remap_rules)
+
+    def weight_generator():
+        yield "k_proj.k_scale", torch.tensor(2.0)
+
+    loader = AutoWeightsLoader(mod)
+    loaded = loader.load_weights(weight_generator())
+
+    assert "k_proj.k_scale" not in loaded
+    assert "nonexistent_scale" not in loaded
+
+
+@pytest.mark.cpu_test
+def test_auto_weights_loader_no_remap_without_kv_method():
+    """Ensure weights pass through unchanged when no KV method is present."""
+
+    class ModuleWithoutKVMethod(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 10)
+            self.some_scale = torch.nn.Parameter(torch.tensor(1.0))
+
+    mod = ModuleWithoutKVMethod()
+
+    def weight_generator():
+        yield "some_scale", torch.tensor(2.0)
+        yield "linear.weight", torch.randn(10, 10)
+
+    loader = AutoWeightsLoader(mod)
+    loaded = loader.load_weights(weight_generator())
+
+    assert "some_scale" in loaded
+    assert torch.allclose(mod.some_scale.data, torch.tensor(2.0))
 
 
 class ModuleWithBatchNorm(torch.nn.Module):

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -43,6 +43,23 @@ class BaseKVCacheMethod(QuantizeMethodBase):
         # Initialize P = softmax(QK^T) scales
         layer.prob_scale = torch.nn.Parameter(torch.tensor(-1.0), requires_grad=False)
 
+    def remap_kv_scale_name(self, name: str, params_dict: dict) -> str | None:
+        """
+        Remap checkpoint parameter names to vLLM internal names.
+
+        Subclasses should override this to handle format-specific naming
+        variations (e.g., ModelOpt, QKV-fused, etc.).
+
+        Args:
+            name: The original parameter name from the checkpoint.
+            params_dict: Dictionary of model parameters for validation.
+
+        Returns:
+            The remapped name if successful, None if no remapping is needed
+            or if the remapped name is not found in params_dict.
+        """
+        return None
+
     def apply(self, layer: torch.nn.Module) -> torch.Tensor:
         raise RuntimeError(f"{self.__class__.__name__}.apply should not be called.")
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -22,6 +22,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.model_loader.reload import (
     support_quantized_model_reload_from_hp_weights,
 )
@@ -345,6 +346,28 @@ class AutoWeightsLoader:
         *,
         mapper: WeightsMapper | None = None,
     ) -> set[str]:
+        kv_methods = [
+            mod.quant_method
+            for mod in self.module.modules()
+            if hasattr(mod, "quant_method")
+            and isinstance(mod.quant_method, BaseKVCacheMethod)
+        ]
+
+        if kv_methods:
+            params_dict = dict(self.module.named_parameters())
+
+            def remap_kv_scale_stream(weight_iter):
+                for name, tensor in weight_iter:
+                    new_name = name
+                    for method in kv_methods:
+                        remapped = method.remap_kv_scale_name(name, params_dict)
+                        if remapped is not None:
+                            new_name = remapped
+                            break
+                    yield new_name, tensor
+
+            weights = remap_kv_scale_stream(weights)
+
         if mapper is not None:
             weights = mapper.apply(weights)
         # filter out weights with first-prefix/substr to skip in name


### PR DESCRIPTION



## Purpose
The current `maybe_remap_kv_scale_name` function is introduced to resolve the KV cache  quantization problem, and for now, it has accumulated weight name conversions related to KV cache for various quantization tools. For OOT specific KVCacheMethod such like our vllm-ascend, there is no such way to do this, so this PR introduce a way to extend KV cache remapping by defining remap function in `KVCacheMethod` class.

## Test Plan
This is an extended feature, so it should not impact the upstream vLLM.

## Test Result
Already tested in our vllm-ascend, it works.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

