### PR TITLE
[Model] Add Qwen3.5 multimodal LoRA helper coverage

### DIFF
--- a/tests/models/multimodal/test_qwen3_5_mm_lora.py
+++ b/tests/models/multimodal/test_qwen3_5_mm_lora.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration],
+)
+def test_qwen3_5_mm_lora_helpers(model_cls):
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            vision_config=SimpleNamespace(
+                spatial_merge_size=2,
+            ),
+        ),
+    )
+
+    mapping = model_cls.get_mm_mapping(model)
+    assert mapping.language_model == ["language_model"]
+    assert mapping.connector == ["visual.merger", "visual.deepstack_merger_list"]
+    assert mapping.tower_model == ["visual."]
+
+    assert model_cls.get_num_mm_encoder_tokens(model, 7) == 28
+    assert model_cls.get_num_mm_connector_tokens(model, 28) == 7


### PR DESCRIPTION
## Summary

This PR adds regression coverage showing that Qwen3.5 dense and MoE multimodal models expose the inherited Qwen3-VL LoRA tower/connector helper behavior:

- verify the inherited multimodal module mapping for language model, vision tower, merger connector, and deepstack connector
- verify encoder and connector token-count helpers use the Qwen vision `spatial_merge_size`
- cover both `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`

Refs #31479.

## Duplicate check

I checked the related issue and open PRs before opening this PR:

- `gh issue view 31479 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "31479 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "qwen3.5 qwen3_5 mm lora tower connector"`
- `gh pr list --repo vllm-project/vllm --state open --search "Qwen3.5 LoRA"`

No open PR appears to add Qwen3.5 MM tower/connector LoRA helper coverage. The Qwen3.5 LoRA PRs found are for unrelated LoRA internals, shared experts, fusion/perf, or GGUF support.

## Tests

Passed:

- `.venv/bin/pre-commit run --files vllm/model_executor/models/qwen3_5.py tests/models/multimodal/test_qwen3_5_mm_lora.py`
- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/models/multimodal/test_qwen3_5_mm_lora.py -q`

Attempted but blocked by local environment:

- `.venv/bin/pre-commit run --all-files` failed in the repo-wide `shellcheck` hook on existing shell scripts unrelated to this change.
- `.venv/bin/python -m pytest tests/` with the default precompiled install failed during collection on missing `libcudart.so.12`.
- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/` collected the suite but stopped with environment-wide collection errors, including missing CUDA/custom ops, missing optional dependencies such as `ray`, `pandas`, and `pytest_asyncio`, and distributed tests requiring env vars such as `RANK`.

## AI assistance

This PR includes AI-assisted code changes prepared with OpenAI Codex. The submitting human reviewed the changed lines and the test results above.