### PR TITLE
[Bugfix][Model] Fix GPT2ForSequenceClassification sub-module prefix

### DIFF
--- a/vllm/model_executor/models/gpt2.py
+++ b/vllm/model_executor/models/gpt2.py
@@ -339,7 +339,7 @@ class GPT2ForSequenceClassification(nn.Module, SupportsCrossEncoding):
         super().__init__()
         config = vllm_config.model_config.hf_config
         self.transformer = GPT2Model(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "gpt2")
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "transformer")
         )
         self.score = nn.Linear(
             config.n_embd,
@@ -358,6 +358,7 @@ class GPT2ForSequenceClassification(nn.Module, SupportsCrossEncoding):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         loader = AutoWeightsLoader(self)
+        weights = _add_transformer_prefix(weights)
         return loader.load_weights(weights)
 
     def forward(

--- a/vllm/model_executor/models/gpt2.py
+++ b/vllm/model_executor/models/gpt2.py
@@ -381,6 +381,10 @@ def _add_transformer_prefix(
     weights: Iterable[tuple[str, torch.Tensor]],
 ) -> Iterable[tuple[str, torch.Tensor]]:
     for name, tensor in weights:
-        if not name.startswith("transformer.") and not name.startswith("lm_head"):
+        if (
+            not name.startswith("transformer.")
+            and not name.startswith("lm_head.")
+            and not name.startswith("score.")
+        ):
             name = "transformer." + name
         yield name, tensor


### PR DESCRIPTION
## Purpose

Fix a bug in `GPT2ForSequenceClassification` where the sub-module prefix was incorrectly set to `"gpt2"` instead of `"transformer"`, causing weight loading to fail silently for sequence classification models.

Also fixes a secondary issue in `_add_transformer_prefix` where `score.weight` (the classification head) was incorrectly being prefixed with `transformer.`, which would prevent the classification head weights from loading correctly.

Closes #15697 (partially — for the `GPT2ForSequenceClassification` fix)

## Changes

- Fix `GPT2ForSequenceClassification.__init__` to use `"transformer"` as the sub-module prefix for its `GPT2Model` instance (previously used `"gpt2"`, which is incorrect — the checkpoint key namespace is `transformer.*`).
- Fix `_add_transformer_prefix` to exclude weights starting with `score.` from being prefixed with `transformer.`, since `score` is a direct child of `GPT2ForSequenceClassification`, not part of the `transformer` sub-module.
- Apply `_add_transformer_prefix` in `GPT2ForSequenceClassification.load_weights` to correctly route checkpoint weights.

## Test Plan

- Run pre-commit checks: `pre-commit run --files vllm/model_executor/models/gpt2.py` — all hooks passed (ruff, ruff-format, mypy, typos, SPDX headers).
- The fix aligns the sub-module prefix with the actual checkpoint key namespace (`transformer.*`), consistent with `GPT2LMHeadModel`.
- The `score.` exclusion in `_add_transformer_prefix` ensures the classification head weights are routed correctly.

## Test Result

```
ruff check....Passed
ruff format...Passed
typos.........Passed
Run mypy locally for lowest supported Python version....Passed
Check SPDX headers....Passed
```
