### PR TITLE
[Misc] Print accuracy value for PD tests even on success 

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -64,12 +64,12 @@ def test_accuracy():
     measured_value = results["results"][TASK][FILTER]
     expected_value = EXPECTED_VALUES.get(MODEL_NAME)
 
+    print(f"Measured accuracy value: {measured_value}\n")
     if expected_value is None:
         print(
             f"Warning: No expected value found for {MODEL_NAME}. "
             "Skipping accuracy check."
         )
-        print(f"Measured value: {measured_value}")
         return
 
     assert (


### PR DESCRIPTION
Minor change addressing https://github.com/vllm-project/vllm/pull/43186#issuecomment-4499885734.
We run this test on several combinations of models in disaggregated mode, and some of them have exhibited a higher variance than expected.
Let's log the accuracy value regardless so we can track its change across runs before assertion triggers (as for the PR above)
