### PR TITLE
Fix custom allreduce warmup values

### DIFF
--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -9,6 +9,9 @@ import torch
 import torch.distributed as dist
 
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce  # noqa
+from vllm.distributed.device_communicators.custom_all_reduce import (
+    CustomAllreduce,
+)
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
 
 from ..utils import (
@@ -130,3 +133,25 @@ def test_custom_allreduce(
     if world_size > torch.accelerator.device_count():
         pytest.skip("Not enough GPUs to run the test.")
     multi_process_parallel(monkeypatch, tp_size, pipeline_parallel_size, test_target)
+
+
+def test_custom_all_reduce_warmup_returns_reduced_value(monkeypatch):
+    ca = CustomAllreduce.__new__(CustomAllreduce)
+    ca.disabled = False
+    ca._IS_CAPTURING = True
+    ca.should_custom_ar = lambda _: True
+
+    calls: list[bool] = []
+
+    def fake_all_reduce(inp: torch.Tensor, registered: bool) -> torch.Tensor:
+        calls.append(registered)
+        return inp + 1
+
+    ca.all_reduce = fake_all_reduce
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    inp = torch.tensor([1.0])
+    out = ca.custom_all_reduce(inp)
+
+    assert calls == [False]
+    torch.testing.assert_close(out, torch.tensor([2.0]))

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -272,9 +272,11 @@ class CustomAllreduce:
             if torch.cuda.is_current_stream_capturing():
                 return self.all_reduce(input, registered=True)
             else:
-                # If warm up, mimic the allocation pattern since custom
-                # allreduce is out-of-place.
-                return torch.empty_like(input)
+                # Warmup forwards can still update persistent runtime state
+                # such as KV cache or indexing buffers. Return a numerically
+                # valid result while preserving custom allreduce's
+                # out-of-place allocation behavior.
+                return self.all_reduce(input, registered=False)
         else:
             # Note: outside of cuda graph context, custom allreduce incurs a
             # cost of cudaMemcpy, which should be small (<=1% of overall


### PR DESCRIPTION
# Fix CustomAllreduce warmup to return valid reduced values

## Summary

During CUDA graph setup, `CustomAllreduce.custom_all_reduce()` currently returns
`torch.empty_like(input)` for warmup forwards that run while `_IS_CAPTURING` is
set but the current stream is not actively capturing.

That preserves the out-of-place allocation pattern, but it can return
uninitialized values to the model forward. Some model paths can consume warmup
outputs or update persistent runtime state such as KV cache or indexing buffers
during warmup. In those cases, returning uninitialized data can poison later
hidden states and surface as non-finite logits.

This PR changes the warmup branch to run the normal non-registered allreduce:

```python
return self.all_reduce(input, registered=False)
```

The actual stream-capture path still uses `registered=True`, so the steady-state
CUDA graph replay fast path is unchanged.

## Motivation

Warmup forwards should be allowed to exercise the same numerical data path as
normal forwards. Returning an uninitialized tensor is only safe if the caller
never consumes that value and the forward has no persistent side effects.

That assumption is fragile for graph setup paths where model forwards may
populate runtime state during warmup. In those cases, an uninitialized warmup
output can propagate non-finite values into later execution.

Using a valid allreduce result during warmup fixes the issue while keeping
custom allreduce and CUDA graph replay enabled.

## Duplicate check

I searched open PRs for:

- `custom allreduce warmup`
- `CustomAllreduce empty_like`
- `custom_all_reduce CUDA graph warmup`

I did not find an existing open PR that changes this warmup branch to return a
valid allreduce result.

## Testing

- Added a unit test covering the warmup branch and verifying it calls
  `all_reduce(..., registered=False)` and returns that reduced value.
- Locally ran:

```text
python3 -m compileall -q \
  vllm/distributed/device_communicators/custom_all_reduce.py \
  tests/distributed/test_custom_all_reduce.py
```

`pytest` and `ruff` were not installed in this local environment, so I could not
run the full test suite here.

## AI assistance

This PR was prepared with AI assistance. The changed lines and test coverage
were reviewed before submission.
