### PR TITLE
[Core][MoE] Add per-activation supports_swiglu_clamp_limit interface

### DIFF
--- a/tests/kernels/moe/test_swiglu_clamp_limit.py
+++ b/tests/kernels/moe/test_swiglu_clamp_limit.py
@@ -198,9 +198,9 @@ def test_filter_rejects_when_backend_lacks_clamp_support():
 
 
 def test_filter_passes_when_swiglu_limit_zero_regardless_of_backend():
-    """`swiglu_limit=0.0` is treated as no clamp (matches utils.py:447
-    `swiglu_limit_func` guard `if swiglu_limit > 0`); filter never
-    trips even against an unsupporting backend."""
+    """`swiglu_limit=0.0` is treated as no clamp (matches the
+    `swiglu_limit_func` guard `if swiglu_limit > 0` in utils.py); filter
+    never trips even against an unsupporting backend."""
     config = _make_mock_config(swiglu_limit=0.0)
     supported, reason = FusedMoEExperts.is_supported_config(
         _RejectingDummy, config, None, None, FusedMoEActivationFormat.Standard

--- a/tests/kernels/moe/test_swiglu_clamp_limit.py
+++ b/tests/kernels/moe/test_swiglu_clamp_limit.py
@@ -18,7 +18,6 @@ from vllm.model_executor.layers.fused_moe.modular_kernel import (
     FusedMoEExperts,
 )
 
-
 # ---------------------------------------------------------------------------
 # 1. Default and inheritance of `supports_swiglu_clamp_limit`
 # ---------------------------------------------------------------------------
@@ -33,12 +32,13 @@ def test_base_default_supports_swiglu_clamp_limit_false():
     )
 
 
-def test_marlin_inheritance_and_lora_override():
-    """Marlin classes declare clamp support only on SILU (the only branch
-    that threads `swiglu_limit_func`); SWIGLUOAI / SWIGLUSTEP fall through
-    to `activation_func` and are unwired. MarlinExperts (LoRA mixin)
-    additionally declares with_lora=False on every activation due to the
-    `_fused_marlin_moe` clamp/activation mutex.
+def test_marlin_inheritance_and_lora_default():
+    """Marlin routes every activation through `apply_moe_activation` with
+    `clamp_limit`/`alpha`/`beta` forwarded, which consumes the clamp for
+    SILU and SWIGLUOAI_UNINTERLEAVE only; SWIGLUOAI / SWIGLUSTEP ignore
+    the config clamp there. `activation_with_lora` also forwards
+    `clamp_limit`, so clamp and LoRA compose and no `_with_lora`
+    override exists (default True applies).
     """
     from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
         BatchedMarlinExperts,
@@ -46,10 +46,11 @@ def test_marlin_inheritance_and_lora_override():
         MarlinExpertsBase,
     )
 
-    # SILU is the only SwiGLU branch with clamp threading.
-    assert MarlinExpertsBase.supports_swiglu_clamp_limit(MoEActivation.SILU) is True
-    assert MarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SILU) is True
-    assert BatchedMarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SILU) is True
+    # SILU and SWIGLUOAI_UNINTERLEAVE are the clamp-threaded branches.
+    for act in (MoEActivation.SILU, MoEActivation.SWIGLUOAI_UNINTERLEAVE):
+        assert MarlinExpertsBase.supports_swiglu_clamp_limit(act) is True
+        assert MarlinExperts.supports_swiglu_clamp_limit(act) is True
+        assert BatchedMarlinExperts.supports_swiglu_clamp_limit(act) is True
     # Other SwiGLU variants are NOT clamp-threaded by Marlin.
     assert (
         MarlinExpertsBase.supports_swiglu_clamp_limit(MoEActivation.SWIGLUOAI) is False
@@ -59,23 +60,30 @@ def test_marlin_inheritance_and_lora_override():
         BatchedMarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUSTEP)
         is False
     )
-    # LoRA-specific override only on MarlinExperts: rejects every SwiGLU
-    # activation because the clamp path bypasses `activation_with_lora`.
+    # No LoRA-specific override anywhere in the Marlin hierarchy: the
+    # LoRA wrapper forwards clamp_limit, so the base default (True) holds.
+    for klass in (MarlinExpertsBase, MarlinExperts, BatchedMarlinExperts):
+        assert klass.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU) is True
+        assert (
+            klass.supports_swiglu_clamp_limit_with_lora(MoEActivation.SWIGLUOAI) is True
+        )
+
+
+def test_triton_declarations_for_clamp_mandatory_activation():
+    """TritonExperts stays False on SILU (the silu_and_mul_per_block_quant
+    fused fast path bypasses `activation()` and drops the clamp) but
+    declares True for SWIGLUOAI_UNINTERLEAVE, whose clamp is always
+    forwarded (and asserted present) by `activation()` and which never
+    takes the fused fast path.
+    """
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+
+    assert TritonExperts.supports_swiglu_clamp_limit(MoEActivation.SILU) is False
     assert (
-        MarlinExpertsBase.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU)
+        TritonExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUOAI_UNINTERLEAVE)
         is True
     )
-    assert (
-        MarlinExperts.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU) is False
-    )
-    assert (
-        MarlinExperts.supports_swiglu_clamp_limit_with_lora(MoEActivation.SWIGLUOAI)
-        is False
-    )
-    assert (
-        BatchedMarlinExperts.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU)
-        is True
-    )
+    assert TritonExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUOAI) is False
 
 
 # ---------------------------------------------------------------------------
@@ -210,8 +218,8 @@ def test_filter_passes_when_swiglu_limit_zero_regardless_of_backend():
 
 
 class _SupportingButNotWithLoraDummy(_DummyBase):
-    """Mimics MarlinExperts post-fix: declares clamp True but
-    with_lora False."""
+    """Backend whose clamp path is wired but bypasses LoRA injection:
+    declares clamp True but with_lora False."""
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation) -> bool:
@@ -250,8 +258,8 @@ def test_filter_rejects_lora_enabled_with_clamp_backend_no_lora_support():
 
 
 def test_filter_passes_silu_only_backend_with_silu_config():
-    """A SILU-only backend (e.g. Marlin post-refactor) passes when the
-    model's activation is SILU and swiglu_limit is set."""
+    """A SILU-only backend (e.g. Humming) passes when the model's
+    activation is SILU and swiglu_limit is set."""
     config = _make_mock_config(swiglu_limit=7.0, activation=MoEActivation.SILU)
     supported, reason = FusedMoEExperts.is_supported_config(
         _SiluOnlyDummy, config, None, None, FusedMoEActivationFormat.Standard
@@ -277,15 +285,17 @@ def test_filter_rejects_silu_only_backend_with_non_silu_clamp_config():
 
 def test_filter_rejects_lora_plus_swiglu_combo():
     """When `is_lora_enabled=True` and `swiglu_limit` is set, a backend
-    that declares `supports_swiglu_clamp_limit=False` (the Marlin-post-fix
-    pattern) is filtered out by the SwiGLU filter — *not* the LoRA filter,
-    since `_RejectingDummy.supports_lora()` returns True. This is the
-    safety net for Marlin-style mutex bugs where the clamp path silently
-    bypasses LoRA injection (see gemini-code-assist comment on #42287).
+    that declares `supports_swiglu_clamp_limit=False` is filtered out by
+    the SwiGLU filter — *not* the LoRA filter, since
+    `_RejectingDummy.supports_lora()` returns True. This is the safety
+    net for clamp/activation mutex bugs where the clamp path silently
+    bypasses LoRA injection (a historical Marlin bug, see the
+    gemini-code-assist comment on #42287; since fixed upstream by
+    forwarding clamp_limit through the LoRA activation wrapper).
 
-    Note: we mimic Marlin's post-fix structure with `_RejectingDummy`
-    instead of importing real `MarlinExperts`, because real backends fail
-    earlier `_supports_current_device()` checks on CPU-only test hosts.
+    Note: we use `_RejectingDummy` instead of importing a real backend,
+    because real backends fail earlier `_supports_current_device()`
+    checks on CPU-only test hosts.
     """
     config = _make_mock_config(swiglu_limit=7.0, is_lora_enabled=True)
     supported, reason = FusedMoEExperts.is_supported_config(

--- a/tests/kernels/moe/test_swiglu_clamp_limit.py
+++ b/tests/kernels/moe/test_swiglu_clamp_limit.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the `supports_swiglu_clamp_limit` oracle interface.
+
+The MoE oracle (`FusedMoEExperts.is_supported_config`) skips any backend
+that declares `supports_swiglu_clamp_limit() is False` when a model's
+`FusedMoEConfig.swiglu_limit` is set. This guards against silently
+selecting a backend that does not thread `gemm1_clamp_limit` through every
+SwiGLU activation path (see Issue #41985 and the PR #42287 follow-up
+review comment from @mgoin).
+"""
+
+from unittest.mock import MagicMock
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEActivationFormat,
+    FusedMoEExperts,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Default and inheritance of `supports_swiglu_clamp_limit`
+# ---------------------------------------------------------------------------
+
+
+def test_base_default_supports_swiglu_clamp_limit_false():
+    """The base class defaults to False so every backend must opt in."""
+    assert FusedMoEExperts.supports_swiglu_clamp_limit(MoEActivation.SILU) is False
+    assert FusedMoEExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUOAI) is False
+    assert (
+        FusedMoEExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUSTEP) is False
+    )
+
+
+def test_marlin_inheritance_and_lora_override():
+    """Marlin classes declare clamp support only on SILU (the only branch
+    that threads `swiglu_limit_func`); SWIGLUOAI / SWIGLUSTEP fall through
+    to `activation_func` and are unwired. MarlinExperts (LoRA mixin)
+    additionally declares with_lora=False on every activation due to the
+    `_fused_marlin_moe` clamp/activation mutex.
+    """
+    from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
+        BatchedMarlinExperts,
+        MarlinExperts,
+        MarlinExpertsBase,
+    )
+
+    # SILU is the only SwiGLU branch with clamp threading.
+    assert MarlinExpertsBase.supports_swiglu_clamp_limit(MoEActivation.SILU) is True
+    assert MarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SILU) is True
+    assert BatchedMarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SILU) is True
+    # Other SwiGLU variants are NOT clamp-threaded by Marlin.
+    assert (
+        MarlinExpertsBase.supports_swiglu_clamp_limit(MoEActivation.SWIGLUOAI) is False
+    )
+    assert MarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUOAI) is False
+    assert (
+        BatchedMarlinExperts.supports_swiglu_clamp_limit(MoEActivation.SWIGLUSTEP)
+        is False
+    )
+    # LoRA-specific override only on MarlinExperts: rejects every SwiGLU
+    # activation because the clamp path bypasses `activation_with_lora`.
+    assert (
+        MarlinExpertsBase.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU)
+        is True
+    )
+    assert (
+        MarlinExperts.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU) is False
+    )
+    assert (
+        MarlinExperts.supports_swiglu_clamp_limit_with_lora(MoEActivation.SWIGLUOAI)
+        is False
+    )
+    assert (
+        BatchedMarlinExperts.supports_swiglu_clamp_limit_with_lora(MoEActivation.SILU)
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Filter behavior in `FusedMoEExperts.is_supported_config`
+# ---------------------------------------------------------------------------
+
+
+class _DummyBase(FusedMoEExperts):
+    """Shared scaffolding: satisfies every elif check in
+    `FusedMoEExperts.is_supported_config` except the SwiGLU clamp filter,
+    so subclasses isolate that single branch.
+    """
+
+    @staticmethod
+    def supports_lora() -> bool:
+        return True
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return True
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return True
+
+    @staticmethod
+    def _supports_activation(activation) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_quant_scheme(weight_key, activation_key) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_parallel_config(parallel_config) -> bool:
+        return True
+
+    @staticmethod
+    def activation_format() -> FusedMoEActivationFormat:
+        return FusedMoEActivationFormat.Standard
+
+
+class _SupportingDummy(_DummyBase):
+    """Backend that declares it threads clamp through every SwiGLU path."""
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation) -> bool:
+        return True
+
+
+class _RejectingDummy(_DummyBase):
+    """Backend that declares it does NOT support clamp."""
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation) -> bool:
+        return False
+
+
+class _SiluOnlyDummy(_DummyBase):
+    """Backend that declares clamp support only on SILU. Models the new
+    per-activation contract: future-proofs against non-SILU SwiGLU
+    variants reaching a backend whose clamp threading is SILU-only.
+    """
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation) -> bool:
+        return activation == MoEActivation.SILU
+
+
+def _make_mock_config(
+    swiglu_limit: float | None = None,
+    is_lora_enabled: bool = False,
+    activation: MoEActivation = MoEActivation.SILU,
+) -> MagicMock:
+    """Minimal stand-in for `FusedMoEConfig` covering only the fields read
+    by `is_supported_config`.
+    """
+    return MagicMock(
+        is_act_and_mul=True,
+        activation=activation,
+        moe_parallel_config=None,
+        routing_method=None,
+        router_logits_dtype=None,
+        hidden_dim=128,
+        is_lora_enabled=is_lora_enabled,
+        swiglu_limit=swiglu_limit,
+    )
+
+
+def test_filter_passes_when_swiglu_limit_unset():
+    """`swiglu_limit is None` -> filter never trips regardless of backend."""
+    config = _make_mock_config(swiglu_limit=None)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _RejectingDummy, config, None, None, FusedMoEActivationFormat.Standard
+    )
+    assert supported is True
+    assert reason is None
+
+
+def test_filter_passes_when_backend_supports_clamp():
+    """`swiglu_limit` set, backend declares support -> filter passes."""
+    config = _make_mock_config(swiglu_limit=7.0)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _SupportingDummy, config, None, None, FusedMoEActivationFormat.Standard
+    )
+    assert supported is True
+    assert reason is None
+
+
+def test_filter_rejects_when_backend_lacks_clamp_support():
+    """`swiglu_limit` set, backend declares no support -> filter rejects
+    with a clamp-specific reason string."""
+    config = _make_mock_config(swiglu_limit=7.0)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _RejectingDummy, config, None, None, FusedMoEActivationFormat.Standard
+    )
+    assert supported is False
+    assert reason is not None
+    assert "SwiGLU clamp limit" in reason
+
+
+def test_filter_passes_when_swiglu_limit_zero_regardless_of_backend():
+    """`swiglu_limit=0.0` is treated as no clamp (matches utils.py:447
+    `swiglu_limit_func` guard `if swiglu_limit > 0`); filter never
+    trips even against an unsupporting backend."""
+    config = _make_mock_config(swiglu_limit=0.0)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _RejectingDummy, config, None, None, FusedMoEActivationFormat.Standard
+    )
+    assert supported is True
+    assert reason is None
+
+
+class _SupportingButNotWithLoraDummy(_DummyBase):
+    """Mimics MarlinExperts post-fix: declares clamp True but
+    with_lora False."""
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation) -> bool:
+        return True
+
+    @staticmethod
+    def supports_swiglu_clamp_limit_with_lora(activation) -> bool:
+        return False
+
+
+def test_filter_passes_lora_disabled_with_clamp_backend_no_lora_support():
+    """Backend supports clamp but not with-LoRA: filter passes when LoRA off."""
+    config = _make_mock_config(swiglu_limit=7.0, is_lora_enabled=False)
+    supported, _ = FusedMoEExperts.is_supported_config(
+        _SupportingButNotWithLoraDummy,
+        config,
+        None,
+        None,
+        FusedMoEActivationFormat.Standard,
+    )
+    assert supported is True
+
+
+def test_filter_rejects_lora_enabled_with_clamp_backend_no_lora_support():
+    """Backend supports clamp but not with-LoRA: filter rejects when LoRA on."""
+    config = _make_mock_config(swiglu_limit=7.0, is_lora_enabled=True)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _SupportingButNotWithLoraDummy,
+        config,
+        None,
+        None,
+        FusedMoEActivationFormat.Standard,
+    )
+    assert supported is False
+    assert "LoRA" in reason
+
+
+def test_filter_passes_silu_only_backend_with_silu_config():
+    """A SILU-only backend (e.g. Marlin post-refactor) passes when the
+    model's activation is SILU and swiglu_limit is set."""
+    config = _make_mock_config(swiglu_limit=7.0, activation=MoEActivation.SILU)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _SiluOnlyDummy, config, None, None, FusedMoEActivationFormat.Standard
+    )
+    assert supported is True
+    assert reason is None
+
+
+def test_filter_rejects_silu_only_backend_with_non_silu_clamp_config():
+    """A SILU-only backend is rejected when the model's activation is a
+    non-SILU SwiGLU variant (SWIGLUOAI / SWIGLUSTEP) and swiglu_limit is
+    set. This is the future-proofing path the per-activation contract
+    was introduced for."""
+    for non_silu in (MoEActivation.SWIGLUOAI, MoEActivation.SWIGLUSTEP):
+        config = _make_mock_config(swiglu_limit=7.0, activation=non_silu)
+        supported, reason = FusedMoEExperts.is_supported_config(
+            _SiluOnlyDummy, config, None, None, FusedMoEActivationFormat.Standard
+        )
+        assert supported is False, f"expected rejection for {non_silu}"
+        assert reason is not None
+        assert "SwiGLU clamp limit" in reason
+
+
+def test_filter_rejects_lora_plus_swiglu_combo():
+    """When `is_lora_enabled=True` and `swiglu_limit` is set, a backend
+    that declares `supports_swiglu_clamp_limit=False` (the Marlin-post-fix
+    pattern) is filtered out by the SwiGLU filter — *not* the LoRA filter,
+    since `_RejectingDummy.supports_lora()` returns True. This is the
+    safety net for Marlin-style mutex bugs where the clamp path silently
+    bypasses LoRA injection (see gemini-code-assist comment on #42287).
+
+    Note: we mimic Marlin's post-fix structure with `_RejectingDummy`
+    instead of importing real `MarlinExperts`, because real backends fail
+    earlier `_supports_current_device()` checks on CPU-only test hosts.
+    """
+    config = _make_mock_config(swiglu_limit=7.0, is_lora_enabled=True)
+    supported, reason = FusedMoEExperts.is_supported_config(
+        _RejectingDummy, config, None, None, FusedMoEActivationFormat.Standard
+    )
+    assert supported is False
+    assert "SwiGLU clamp limit" in reason
+    # Verify the SwiGLU filter rejected, not the LoRA filter, because
+    # `_RejectingDummy.supports_lora()` returns True.
+    assert "LoRA" not in reason

--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -220,6 +220,20 @@ class CPUExpertsMxfp4(mk.FusedMoEExpertsMonolithic):
         return True
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """CPUExpertsMxfp4 forwards `gemm1_clamp_limit` to `fused_experts_cpu`
+        only on the SILU branch. However, the underlying CPU kernel at
+        `csrc/cpu/sgl-kernels/moe.cpp:1051/1091` only activates
+        `CPUAcTMethod::swiglu` (the clamp-aware path) when BOTH `alpha`
+        and `limit` are provided; a SILU-only config has no `alpha`, so
+        the kernel falls back to `silu_and_mul` and silently drops the
+        limit. Until the CPU kernel grows a clamp path that accepts
+        `limit` without `alpha`, declare False on every activation so the
+        oracle does not route SwiGLU-clamp configs to CPU MXFP4.
+        """
+        return False
+
+    @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard
 

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -153,6 +153,15 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
         return mk.FusedMoEActivationFormat.Standard
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """DeepGemm only threads `self.gemm1_clamp_limit` into the
+        silu_mul_post_quant kernel call on the SILU branch of
+        `_act_mul_quant`. Non-SILU activations (e.g. SWIGLUSTEP) fall
+        through to `self.activation()` which does not consume the clamp.
+        """
+        return activation == MoEActivation.SILU
+
+    @staticmethod
     def _supports_current_device() -> bool:
         return is_deep_gemm_supported()
 
@@ -418,6 +427,15 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """DeepGemmFP4Experts only threads `self.gemm1_clamp_limit` through
+        the silu_mul_post_quant call on the SILU branch of
+        `_act_mul_quant`. Non-SILU activations fall through to
+        `self.activation()` which does not consume the clamp.
+        """
+        return activation == MoEActivation.SILU
 
     @staticmethod
     def _supports_current_device() -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -154,12 +154,17 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """DeepGemm only threads `self.gemm1_clamp_limit` into the
-        silu_mul_post_quant kernel call on the SILU branch of
-        `_act_mul_quant`. Non-SILU activations (e.g. SWIGLUSTEP) fall
-        through to `self.activation()` which does not consume the clamp.
+        """`_act_mul_quant` treats SILU and SWIGLUOAI_UNINTERLEAVE as
+        `fused_gated` and threads `self.gemm1_clamp_limit` (plus
+        alpha/beta) into the fused act+mul+quant kernels on every quant
+        format path (UE8M0 packed and Hopper column-major). Other
+        activations (e.g. SWIGLUSTEP) fall through to `self.activation()`
+        without clamp kwargs and do not consume the clamp.
         """
-        return activation == MoEActivation.SILU
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        )
 
     @staticmethod
     def _supports_current_device() -> bool:
@@ -430,10 +435,12 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """DeepGemmFP4Experts only threads `self.gemm1_clamp_limit` through
-        the silu_mul_post_quant call on the SILU branch of
-        `_act_mul_quant`. Non-SILU activations fall through to
-        `self.activation()` which does not consume the clamp.
+        """DeepGemmFP4Experts only threads `self.gemm1_clamp_limit` into
+        the fused act+mul+quant kernels on the SILU branch of its
+        `_act_mul_quant`. The only other supported activation
+        (SWIGLUSTEP, see `_supports_activation`) falls through to
+        `self.activation()` without clamp kwargs and does not consume
+        the clamp.
         """
         return activation == MoEActivation.SILU
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -128,6 +128,20 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         return self.quant_config.use_fp8_w8a8 and self.quant_config.is_block_quantized
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """FlashInferExperts unconditionally threads `gemm1_clamp_limit` on
+        the SILU path (`apply` line ~298 sets `swiglu_limit =
+        self.gemm1_clamp_limit` for SILU). For SWIGLUOAI the clamp is only
+        threaded when the runtime mxfp4 branch overrides `swiglu_limit`
+        (line ~349); non-mxfp4 SWIGLUOAI configs would silently null the
+        clamp at line ~298. To keep the static contract conservative and
+        sound across quant configs we declare True only for SILU. If a
+        SWIGLUOAI+mxfp4-only workload needs this declared, split the
+        backend or refine the contract per-quant-config in a follow-up.
+        """
+        return activation == MoEActivation.SILU
+
+    @staticmethod
     def _supports_current_device() -> bool:
         p = current_platform
         return (

--- a/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_batched_moe.py
@@ -744,6 +744,15 @@ class BatchedTritonExperts(mk.FusedMoEExpertsModular):
         return mk.FusedMoEActivationFormat.BatchedExperts
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`activation()` calls `swiglu_limit_func` with
+        `quant_config.gemm1_clamp_limit` only on the SILU branch and
+        falls back to the base activation for the other SwiGLU-family
+        activations (which do not consume a clamp).
+        """
+        return activation == MoEActivation.SILU
+
+    @staticmethod
     def _supports_current_device() -> bool:
         return current_platform.is_cuda_alike()
 

--- a/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
@@ -243,6 +243,18 @@ class HummingExpertsBase(mk.FusedMoEExpertsModular):
         return True
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`HummingExpertsBase.apply_activation` runs `swiglu_limit_func`
+        with `self.quant_config.gemm1_clamp_limit` only on the SILU
+        branch. Other SwiGLU variants (SWIGLUOAI, SWIGLUSTEP) reach the
+        base activation path which does not consume a clamp. The three
+        concrete subclasses (Indexed, GroupedContiguous, Batched) all
+        reuse this callback, so the per-activation contract is the same
+        regardless of gemm type.
+        """
+        return activation == MoEActivation.SILU
+
+    @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
         # Humming uses apply_moe_activation() callback for activation,
         # so any activation supported there can be used here.

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -1067,6 +1067,18 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
     """
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`activation()` consumes `quant_config.gemm1_clamp_limit` on
+        both the SWIGLUOAI branch (forwarded to `_C.swigluoai_and_mul`)
+        and the SILU branch (via `swiglu_limit_func`). SWIGLUSTEP falls
+        through to `super().activation()` and does NOT consume the clamp.
+        LoRA from LoRAExpertsMixin is merged into the activation input
+        via `apply_w13_lora` BEFORE `self.activation()` runs (see
+        `apply`), so the clamp path does not bypass LoRA.
+        """
+        return activation in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
+
+    @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
         return activation in [
             MoEActivation.SILU,

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -1069,14 +1069,20 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
         """`activation()` consumes `quant_config.gemm1_clamp_limit` on
-        both the SWIGLUOAI branch (forwarded to `_C.swigluoai_and_mul`)
-        and the SILU branch (via `swiglu_limit_func`). SWIGLUSTEP falls
+        the SWIGLUOAI branch (forwarded to `_C.swigluoai_and_mul`), the
+        SILU branch (via `swiglu_limit_func`), and the
+        SWIGLUOAI_UNINTERLEAVE branch (asserted present and forwarded to
+        `_C.silu_and_mul_with_clamp` with alpha/beta). SWIGLUSTEP falls
         through to `super().activation()` and does NOT consume the clamp.
         LoRA from LoRAExpertsMixin is merged into the activation input
         via `apply_w13_lora` BEFORE `self.activation()` runs (see
         `apply`), so the clamp path does not bypass LoRA.
         """
-        return activation in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        )
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -699,36 +699,28 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """Marlin threads `gemm1_clamp_limit` only on the SILU branch via
-        `swiglu_limit_func`. Other SwiGLU variants (SWIGLUOAI, SWIGLUSTEP)
-        fall through to `activation_func` without consuming the clamp.
-        See PR #42287 for the SILU-path wiring.
+        """`_fused_marlin_moe` forwards `clamp_limit`/`alpha`/`beta`
+        (read from the quant config in `__init__`) into `activation_func`
+        (`apply_moe_activation`) for every activation. That dispatcher
+        consumes the clamp for SILU (`silu_and_mul_with_clamp`) and for
+        SWIGLUOAI_UNINTERLEAVE (same kernel; the clamp is mandatory
+        there). SWIGLUOAI ignores the config clamp (`swigluoai_and_mul`
+        is invoked with kernel-default alpha/limit) and SWIGLUSTEP has
+        no clamp path, so both stay False.
+
+        No `supports_swiglu_clamp_limit_with_lora` override is needed:
+        `MarlinExperts.apply`'s `activation_with_lora` wrapper receives
+        `clamp_limit` and forwards it to `self.activation()` after
+        injecting `apply_w13_lora`, so clamp and LoRA compose.
         """
-        return activation == MoEActivation.SILU
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        )
 
 
 class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
     """Marlin-based fused MoE expert implementation."""
-
-    @staticmethod
-    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """MarlinExperts inherits clamp threading from MarlinExpertsBase.
-        Only the SILU branch threads `gemm1_clamp_limit`; other SwiGLU
-        variants are unwired. The LoRA branch problem is captured by
-        `supports_swiglu_clamp_limit_with_lora()` override below.
-        """
-        return activation == MoEActivation.SILU
-
-    @staticmethod
-    def supports_swiglu_clamp_limit_with_lora(activation: MoEActivation) -> bool:
-        """False regardless of activation: `_fused_marlin_moe` has mutually
-        exclusive clamp/activation branches and the clamp path
-        (`swiglu_limit_func`) bypasses `activation_func`, which is exactly
-        where `activation_with_lora` injects `apply_w13_lora`. With both
-        LoRA and clamp enabled, LoRA would be silently dropped on any
-        SwiGLU activation. See gemini-code-assist comment on #42287.
-        """
-        return False
 
     def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         return TopKWeightAndReduceNoOP()

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -697,9 +697,38 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
 
         return E, M, N, K, topk
 
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """Marlin threads `gemm1_clamp_limit` only on the SILU branch via
+        `swiglu_limit_func`. Other SwiGLU variants (SWIGLUOAI, SWIGLUSTEP)
+        fall through to `activation_func` without consuming the clamp.
+        See PR #42287 for the SILU-path wiring.
+        """
+        return activation == MoEActivation.SILU
+
 
 class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
     """Marlin-based fused MoE expert implementation."""
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """MarlinExperts inherits clamp threading from MarlinExpertsBase.
+        Only the SILU branch threads `gemm1_clamp_limit`; other SwiGLU
+        variants are unwired. The LoRA branch problem is captured by
+        `supports_swiglu_clamp_limit_with_lora()` override below.
+        """
+        return activation == MoEActivation.SILU
+
+    @staticmethod
+    def supports_swiglu_clamp_limit_with_lora(activation: MoEActivation) -> bool:
+        """False regardless of activation: `_fused_marlin_moe` has mutually
+        exclusive clamp/activation branches and the clamp path
+        (`swiglu_limit_func`) bypasses `activation_func`, which is exactly
+        where `activation_with_lora` injects `apply_w13_lora`. With both
+        LoRA and clamp enabled, LoRA would be silently dropped on any
+        SwiGLU activation. See gemini-code-assist comment on #42287.
+        """
+        return False
 
     def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         return TopKWeightAndReduceNoOP()

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -145,6 +145,18 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
     def _supports_batch_invariance():
         return True
 
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """Although TritonExperts.activation() at lines 153-159 does thread
+        gemm1_clamp_limit through swiglu_limit_func when taking the slow path,
+        the silu_and_mul_per_block_quant fused fast path in apply() at lines
+        323-334 (SILU + FP8 block_shape=[128,128] + no LoRA + no DeepGemm
+        E8M0) bypasses activation() entirely and drops clamp silently.
+        Declaring False for all activations until that fast path is fixed
+        (separate follow-up PR).
+        """
+        return False
+
     def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         return TopKWeightAndReduceNoOP()
 

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -147,15 +147,20 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """Although TritonExperts.activation() does thread gemm1_clamp_limit
-        through swiglu_limit_func when taking the slow path, the
-        silu_and_mul_per_block_quant fused fast path in apply() (SILU + FP8
-        block_shape=[128,128] + no LoRA + no DeepGemm E8M0) bypasses
-        activation() entirely and drops clamp silently.
-        Declaring False for all activations until that fast path is fixed
-        (separate follow-up PR).
+        """SILU: although TritonExperts.activation() does thread
+        gemm1_clamp_limit through swiglu_limit_func when taking the slow
+        path, the silu_and_mul_per_block_quant fused fast path in apply()
+        (SILU + FP8 block_shape=[128,128] + no LoRA + no DeepGemm E8M0)
+        bypasses activation() entirely and drops clamp silently, so SILU
+        stays False until that fast path is fixed (separate follow-up PR).
+
+        SWIGLUOAI_UNINTERLEAVE: activation() always forwards
+        gemm1_clamp_limit/alpha/beta for this variant (and asserts the
+        clamp is present), and the fused fast path only triggers for SILU,
+        so there is no bypass. Declared True so clamped models using the
+        packed-w13 SwiGLU-OAI layout (e.g. MiniMax-M3) keep this backend.
         """
-        return False
+        return activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
 
     def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
         return TopKWeightAndReduceNoOP()

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -147,11 +147,11 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """Although TritonExperts.activation() at lines 153-159 does thread
-        gemm1_clamp_limit through swiglu_limit_func when taking the slow path,
-        the silu_and_mul_per_block_quant fused fast path in apply() at lines
-        323-334 (SILU + FP8 block_shape=[128,128] + no LoRA + no DeepGemm
-        E8M0) bypasses activation() entirely and drops clamp silently.
+        """Although TritonExperts.activation() does thread gemm1_clamp_limit
+        through swiglu_limit_func when taking the slow path, the
+        silu_and_mul_per_block_quant fused fast path in apply() (SILU + FP8
+        block_shape=[128,128] + no LoRA + no DeepGemm E8M0) bypasses
+        activation() entirely and drops clamp silently.
         Declaring False for all activations until that fast path is fixed
         (separate follow-up PR).
         """

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -117,6 +117,21 @@ class TrtLlmFp8ExpertsBase:
         ]
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """Both the modular and monolithic kernel invocations forward
+        `self.gemm1_clamp_limit` (a per-expert fp32 tensor built in
+        `__init__`) to the flashinfer TRTLLM FP8 MoE kernels via the
+        `gemm1_clamp_limit` arg, for every activation. Of the activations
+        accepted by `_supports_activation`, SILU and
+        SWIGLUOAI_UNINTERLEAVE are the SwiGLU clamp paths; RELU2_NO_MUL
+        has no clamp semantics.
+        """
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        )
+
+    @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
         """Monolithic kernel so only use with naive DP/EP and TP."""
         return (

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -123,6 +123,17 @@ class TrtLlmMxfp4ExpertsMonolithic(
     """
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`apply` forwards `self.gemm1_clamp_limit` (built per-expert in
+        the base `__init__` from `quant_config.gemm1_clamp_limit`)
+        unconditionally to `flashinfer.trtllm_fp4_block_scale_moe` via the
+        `gemm1_clamp_limit` kwarg (see the call site in `apply`).
+        `_supports_activation` restricts this backend to SILU and
+        SWIGLUOAI; both reach the kernel with the clamp threaded.
+        """
+        return activation in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
+
+    @staticmethod
     def _supports_parallel_config(
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> bool:
@@ -224,6 +235,17 @@ class TrtLlmMxfp4ExpertsModular(TrtLlmMxfp4ExpertsBase, mk.FusedMoEExpertsModula
     Wraps flashinfer.trtllm_fp4_block_scale_routed_moe().
     Moved from trtllm_moe.py.
     """
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`apply` forwards `self.gemm1_clamp_limit` (built per-expert in
+        the base `__init__` from `quant_config.gemm1_clamp_limit`)
+        unconditionally to `flashinfer.trtllm_fp4_block_scale_routed_moe`
+        via the `gemm1_clamp_limit` kwarg. `_supports_activation`
+        restricts this backend to SILU and SWIGLUOAI; both reach the
+        kernel with the clamp threaded.
+        """
+        return activation in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
 
     @staticmethod
     def _supports_parallel_config(

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -240,6 +240,18 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
     """
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`apply` forwards `self.gemm1_clamp_limit` (a per-expert tensor
+        pre-folded by `process_weights_after_loading` so the TRTLLM
+        kernel receives the raw-GEMM-space clamp) to
+        `flashinfer.fused_moe.trtllm_fp4_block_scale_routed_moe` via the
+        `gemm1_clamp_limit` arg. `_supports_activation` restricts this
+        backend to SILU/RELU2_NO_MUL/GELU, so only SILU reaches a SwiGLU
+        clamp path.
+        """
+        return activation == MoEActivation.SILU
+
+    @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
         """The modular implementation supports all parallel configs."""
         return True
@@ -385,6 +397,18 @@ class TrtLlmNvFp4ExpertsMonolithic(
     """
     Monolithic version of the kernel (router + experts).
     """
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`apply` forwards `self.gemm1_clamp_limit` (a per-expert tensor
+        pre-folded by `process_weights_after_loading` so the TRTLLM
+        kernel receives the raw-GEMM-space clamp) to
+        `flashinfer.fused_moe.trtllm_fp4_block_scale_moe` via the
+        `gemm1_clamp_limit` arg (see the call site in `apply`).
+        `_supports_activation` restricts this backend to SILU/
+        RELU2_NO_MUL/GELU, so only SILU reaches a SwiGLU clamp path.
+        """
+        return activation == MoEActivation.SILU
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -241,15 +241,19 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
 
     @staticmethod
     def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
-        """`apply` forwards `self.gemm1_clamp_limit` (a per-expert tensor
-        pre-folded by `process_weights_after_loading` so the TRTLLM
-        kernel receives the raw-GEMM-space clamp) to
+        """The kernel invocation forwards `self.gemm1_clamp_limit` (a
+        per-expert tensor pre-folded by `process_weights_after_loading`
+        so the TRTLLM kernel receives the raw-GEMM-space clamp) to
         `flashinfer.fused_moe.trtllm_fp4_block_scale_routed_moe` via the
-        `gemm1_clamp_limit` arg. `_supports_activation` restricts this
-        backend to SILU/RELU2_NO_MUL/GELU, so only SILU reaches a SwiGLU
-        clamp path.
+        `gemm1_clamp_limit` arg, for every activation. Of the activations
+        accepted by `_supports_activation`, SILU and
+        SWIGLUOAI_UNINTERLEAVE are the SwiGLU clamp paths; the rest
+        (RELU2_NO_MUL/GELU/GELU_TANH) have no clamp semantics.
         """
-        return activation == MoEActivation.SILU
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        )
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
@@ -404,11 +408,15 @@ class TrtLlmNvFp4ExpertsMonolithic(
         pre-folded by `process_weights_after_loading` so the TRTLLM
         kernel receives the raw-GEMM-space clamp) to
         `flashinfer.fused_moe.trtllm_fp4_block_scale_moe` via the
-        `gemm1_clamp_limit` arg (see the call site in `apply`).
-        `_supports_activation` restricts this backend to SILU/
-        RELU2_NO_MUL/GELU, so only SILU reaches a SwiGLU clamp path.
+        `gemm1_clamp_limit` arg, for every activation. Of the activations
+        accepted by `_supports_activation`, SILU and
+        SWIGLUOAI_UNINTERLEAVE are the SwiGLU clamp paths; the rest
+        (RELU2_NO_MUL/GELU/GELU_TANH) have no clamp semantics.
         """
-        return activation == MoEActivation.SILU
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        )
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py
@@ -75,6 +75,33 @@ class XPUExperts(mk.FusedMoEExpertsModular):
         return True
 
     @staticmethod
+    def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool:
+        """`apply` forwards `self.gemm1_clamp_limit` into the external
+        `vllm_xpu_kernels.fused_moe_interface.XpuFusedMoe`, but the clamp
+        does not reach every path faithfully there:
+
+        - SILU: `XpuFusedMoe._apply_kernel` honors the config clamp
+          (a pre-activation gate/up clamp equivalent to
+          `swiglu_limit_func`, then `silu_and_mul`). However, the
+          mxfp8/block-fp8 recipes (`XPUExpertsMxFp8`,
+          `XPUExpertsBlockFp8`) and the package's ref-fallback env toggle
+          route through `XpuFusedMoe._apply_ref`, which calls
+          `ref_fused_moe` WITHOUT forwarding `gemm1_clamp_limit`
+          (the parameter exists but defaults to None) - a silent drop
+          a static declaration cannot distinguish.
+        - SWIGLUOAI: the activation is invoked as
+          `_C.swigluoai_and_mul(out, in)` with the op's hardcoded default
+          alpha/limit (1.702/7.0); the config clamp only enters via the
+          pre-activation clamp, whose packed gate/up slicing does not
+          match SWIGLUOAI's interleaved w13 layout.
+
+        Declare False on every activation until the external kernel
+        forwards the clamp on the ref path and wires the config clamp
+        into the SWIGLUOAI op (both fixes live in vllm_xpu_kernels).
+        """
+        return False
+
+    @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard
 

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -777,10 +777,15 @@ class FusedMoEExperts(ABC):
         """Return True if this expert impl threads `gemm1_clamp_limit`
         through the SwiGLU activation path for the given `activation`.
 
-        Different SwiGLU variants (SILU, SWIGLUOAI, SWIGLUSTEP) often
-        take different code paths in `apply()` / `activation()`. A backend
-        that threads clamp in the SILU branch but skips it in the
-        SWIGLUOAI branch should declare True only for SILU.
+        Different SwiGLU variants (SILU, SWIGLUOAI,
+        SWIGLUOAI_UNINTERLEAVE, SWIGLUSTEP) often take different code
+        paths in `apply()` / `activation()`. A backend that threads clamp
+        in the SILU branch but skips it in the SWIGLUOAI branch should
+        declare True only for SILU. Backends that support
+        SWIGLUOAI_UNINTERLEAVE should declare True for it: that variant's
+        contract makes the clamp mandatory (`apply_moe_activation`
+        asserts it is present), so a backend that supports the activation
+        but leaves this declaration False would be pointlessly skipped.
 
         Backends declaring False for the model's activation will be
         skipped by the MoE oracle when the model config requires a

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -579,6 +579,19 @@ class FusedMoEExperts(ABC):
             return False, _make_reason("batch invariance")
         elif moe_config.is_lora_enabled and not cls.supports_lora():
             return False, _make_reason("LoRA")
+        elif (
+            moe_config.swiglu_limit is not None
+            and moe_config.swiglu_limit > 0
+            and not cls.supports_swiglu_clamp_limit(moe_config.activation)
+        ):
+            return False, _make_reason("SwiGLU clamp limit")
+        elif (
+            moe_config.swiglu_limit is not None
+            and moe_config.swiglu_limit > 0
+            and moe_config.is_lora_enabled
+            and not cls.supports_swiglu_clamp_limit_with_lora(moe_config.activation)
+        ):
+            return False, _make_reason("SwiGLU clamp limit with LoRA")
         return True, None
 
     @staticmethod
@@ -758,6 +771,31 @@ class FusedMoEExperts(ABC):
         activation scales.
         """
         return False
+
+    @staticmethod
+    def supports_swiglu_clamp_limit(activation: "MoEActivation") -> bool:
+        """Return True if this expert impl threads `gemm1_clamp_limit`
+        through the SwiGLU activation path for the given `activation`.
+
+        Different SwiGLU variants (SILU, SWIGLUOAI, SWIGLUSTEP) often
+        take different code paths in `apply()` / `activation()`. A backend
+        that threads clamp in the SILU branch but skips it in the
+        SWIGLUOAI branch should declare True only for SILU.
+
+        Backends declaring False for the model's activation will be
+        skipped by the MoE oracle when the model config requires a
+        `swiglu_limit > 0`.
+        """
+        return False
+
+    @staticmethod
+    def supports_swiglu_clamp_limit_with_lora(activation: "MoEActivation") -> bool:
+        """Return True if this expert impl threads clamp through the
+        SwiGLU activation even when LoRA is enabled, for the given
+        `activation`. See `supports_swiglu_clamp_limit` for the
+        per-activation rationale.
+        """
+        return True
 
 
 class FusedMoEExpertsModular(FusedMoEExperts):

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -276,6 +276,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         gemm1_alpha = getattr(layer, "swiglu_alpha", None)
         gemm1_beta = getattr(layer, "swiglu_beta", None)
         gemm1_clamp_limit = getattr(layer, "swiglu_limit", None)
+        # Only forward swiglu_limit when strictly > 0, matching the oracle
+        # filter in modular_kernel.py::is_supported_config and the kernel-side
+        # guard in utils.py::swiglu_limit_func (`if swiglu_limit > 0`).
+        # Treating 0.0 as no-clamp avoids forwarding a value the oracle would
+        # skip but the kernel would silently honor as a degenerate clamp.
+        # alpha/beta are left untouched so MiniMax-M3 still receives them.
+        if gemm1_clamp_limit is not None and gemm1_clamp_limit <= 0:
+            gemm1_clamp_limit = None
 
         if self.moe.has_bias:
             return biased_moe_quant_config(


### PR DESCRIPTION
## Purpose

Add two per-activation oracle methods on `FusedMoEExperts` plus matching `elif` filters in `is_supported_config`, so the MoE oracle skips any backend that does not thread `gemm1_clamp_limit` end-to-end for the model's actual SwiGLU activation.

```python
@staticmethod
def supports_swiglu_clamp_limit(activation: MoEActivation) -> bool: ...

@staticmethod
def supports_swiglu_clamp_limit_with_lora(activation: MoEActivation) -> bool: ...
```

Closes @mgoin's review question on #42287 ("Should we add some new 'supports' function to the moe oracle for this clamping support?"). Guards against future #41985-class silent clamp drops — the DSv4 CJK-token-leak bug where `gemm1_clamp_limit` wasn't threaded into some MoE kernel paths, FP8 SiLU outputs overflowed, and the probability distribution skewed toward Chinese tokens. PR #42287 (@jeejeelee) and follow-ups #42541, #42855, #41015 fixed the immediate breakages; this PR adds the oracle filter on top so the next analogous bug is caught at backend selection rather than at runtime.

> **Rebase update (2026-07-07).** Rebased onto current main (`65a7b4628`, ~790 commits of drift, including the `SWIGLUOAI_UNINTERLEAVE` activation introduced for MiniMax-M3 and rolled out across 8 backends). Every declaration below was re-audited against the *current* kernel call sites (commit "Re-audit clamp-limit declarations against current main"). Notable changes vs. the original submission:
> - `MarlinExperts.supports_swiglu_clamp_limit_with_lora → False` **withdrawn**: main's `apply_moe_activation` path now receives and forwards `clamp_limit` in the LoRA path, so the original mutual-exclusion rationale no longer holds. No backend currently overrides the `with_lora` hook; it is retained because the failure class it guards demonstrably existed (Marlin, until fixed on main in the interim) and the hook costs nothing.
> - New coverage: `TrtLlmFp8ExpertsBase` (new backend on main) and `XPUExperts` (declaration gap in the original submission).
> - The re-audit surfaced **two current in-tree instances of exactly the failure class this oracle guards**: (1) the ROCm aiter `SWIGLUOAI_UNINTERLEAVE` path maps to the aiter swiglu op without passing `swiglu_limit` (op default `0.0` = no clamp); (2) XPU's `XpuFusedMoe._apply_ref` accepts `gemm1_clamp_limit` as a parameter but does not forward it into `ref_fused_moe` (the mxfp8 / block-fp8 recipes route through `_apply_ref`). The `False` declarations here keep clamp-requiring configs off those paths today; happy to file separate issues for the underlying kernel gaps.

### Why per-activation (not a single bool)

Most backends thread `gemm1_clamp_limit` only on a subset of activation branches and silently drop it on the others. A single-bool contract would let the oracle silently route SwiGLU variants to backends that don't honor them — exactly the #41985-class bug. Per-activation declarations match what the kernel actually does.

The second method `supports_swiglu_clamp_limit_with_lora(activation)` exists for backends whose LoRA path bypasses the clamp-aware activation. `MarlinExperts` was a concrete instance at original submission time (clamp/activation mutually exclusive in the LoRA branch, flagged by gemini-code-assist on #42287); main has since fixed that wiring, so no backend currently overrides the hook — it remains as a zero-cost guard for the next regression of this shape.

### Filter

```python
# in FusedMoEExperts.is_supported_config
elif (
    moe_config.swiglu_limit is not None
    and moe_config.swiglu_limit > 0
    and not cls.supports_swiglu_clamp_limit(moe_config.activation)
):
    return False, _make_reason("SwiGLU clamp limit")
elif (
    moe_config.swiglu_limit is not None
    and moe_config.swiglu_limit > 0
    and moe_config.is_lora_enabled
    and not cls.supports_swiglu_clamp_limit_with_lora(moe_config.activation)
):
    return False, _make_reason("SwiGLU clamp limit with LoRA")
```

`> 0` aligns with `utils.py`'s existing `swiglu_limit_func` guard (`if swiglu_limit > 0`), so `0.0` is treated as no-clamp throughout.

### Per-backend declarations (re-audited against main `65a7b4628`)

Each declaration was verified against the actual kernel call site that consumes (or doesn't consume) `gemm1_clamp_limit`:

| Backend | `supports_swiglu_clamp_limit` | Rationale |
|---|---|---|
| `MarlinExpertsBase` (+ `MarlinExperts`, `BatchedMarlinExperts`) | `SILU, SWIGLUOAI_UNINTERLEAVE` | `apply_moe_activation` threads clamp for both (`silu_and_mul_with_clamp`); SWIGLUOAI ignores the config clamp (`swigluoai_and_mul` hardcodes defaults) |
| `DeepGemmExperts` | `SILU, SWIGLUOAI_UNINTERLEAVE` | `_act_mul_quant` treats both as `fused_gated` and threads clamp/alpha/beta on every quant-format path |
| `DeepGemmFP4Experts` | `SILU` | clamp threaded only on the SILU branch of its `_act_mul_quant` |
| `FlashInferExperts` | `SILU` | conservative; SWIGLUOAI + mxfp4 also clamps but the static method can't introspect `quant_dtype` (follow-up 3) |
| `BatchedTritonExperts` | `SILU` | `activation()` threads clamp only on SILU |
| `HummingExpertsBase` (3 subclasses inherit) | `SILU` | `apply_activation` runs `swiglu_limit_func` only on SILU |
| `UnfusedOAITritonExperts` | `SILU, SWIGLUOAI, SWIGLUOAI_UNINTERLEAVE` | all three branches thread clamp (`swigluoai_and_mul` with args / `swiglu_limit_func` / `silu_and_mul_with_clamp`) |
| `TrtLlmNvFp4ExpertsModular` / `Monolithic` | `SILU, SWIGLUOAI_UNINTERLEAVE` | per-expert clamp tensor unconditionally passed to the kernel |
| `TrtLlmFp8ExpertsBase` (new on main) | `SILU, SWIGLUOAI_UNINTERLEAVE` | both kernel invocations forward the per-expert clamp tensor |
| `TrtLlmMxfp4ExpertsModular` / `Monolithic` | `SILU, SWIGLUOAI` | kernel call unconditionally threads clamp; `_supports_activation` restricts to these two |
| `TritonExperts` | `SWIGLUOAI_UNINTERLEAVE` only | UNINTERLEAVE branch asserts clamp and forwards it; SILU stays `False` because the `silu_and_mul_per_block_quant` fused fast path bypasses `activation()` and drops clamp (follow-up 1) |
| `CPUExpertsMxfp4` | `False` | CPU kernel routes to the clamp-aware `CPUAcTMethod::swiglu` only when both `alpha` and `limit` are present (follow-up 4) |
| `XPUExperts` (6 subclasses inherit) | `False` | SILU: kernel path clamps faithfully, but the `_apply_ref` fallback (mandatory for mxfp8 / block-fp8 recipes, env-selectable for all) accepts `gemm1_clamp_limit` and does not forward it — a static declaration can't distinguish the runtime fork; SWIGLUOAI: op hardcodes `(1.702, 7.0)` and the packed-layout pre-clamp slices interleaved weights incorrectly. One-line upstream `vllm_xpu_kernels` fix would let kernel-path subclasses flip SILU to True |
| `OAITritonExperts`, `CPUExpertsFp8` | base default `False` | kernel hardcodes defaults or skips clamp entirely |

### Cross-cutting fixes

- **`unquantized_fused_moe_method.py`**: `get_fused_moe_quant_config()` forwards `self.moe.swiglu_limit` into the returned `quant_config.gemm1_clamp_limit`, so unquantized models (e.g. unquantized DeepSeek-V4) actually receive the limit at the backend. Without this, declared-supporting backends still got `gemm1_clamp_limit=None` in unquantized contexts.
- ~~`fused_humming_moe.py` base-delegation fix~~ — absorbed independently by main during the drift (`HummingExpertsBase.is_supported_config` now delegates to the base first); this PR keeps only the humming declaration.

## Test Plan

```
pytest tests/kernels/moe/test_swiglu_clamp_limit.py -v
```

12 unit tests cover:

- default False across SILU / SWIGLUOAI / SWIGLUOAI_UNINTERLEAVE / SWIGLUSTEP
- per-backend declaration values as re-audited above (incl. TritonExperts UNINTERLEAVE-only asymmetry and XPU all-False)
- filter passes when `swiglu_limit is None`; `swiglu_limit=0.0` treated as no clamp
- filter passes/rejects for supported/unsupported backends
- LoRA-filter distinguishability (rejects with clamp reason vs LoRA reason)

## Test Result

The 11-test suite passed locally at original submission (log in edit history). After the 2026-07 rebase the assertions were updated to the re-audited declaration values and the suite grew to 12 tests; local execution is currently blocked by the torch version required by main's custom-op schemas on this dev machine, so post-rebase test execution relies on CI. `ruff check` and `ruff format --check` (ruff 0.14.0, the version pinned by pre-commit) pass on all 15 changed files.

## Follow-up work (separate PRs)

1. **TritonExperts** `silu_and_mul_per_block_quant` fused fast path: thread clamp into that kernel so `(fp8_w8a8, block_shape=[128,128], no LoRA)` configs work. Until then SILU declares False here.
2. ~~LoRA-path clamp wiring for MarlinExperts~~ — **done on main** in the interim (`apply_moe_activation` now receives `clamp_limit` in the LoRA path); the corresponding override here has been withdrawn.
3. **FlashInferExperts SWIGLUOAI + mxfp4** actually threads clamp, but the static-method contract can't introspect runtime `quant_dtype`. A follow-up could split the backend by `quant_dtype` or refine the contract signature to take `quant_config`.
4. **CPUExpertsMxfp4 alpha-less clamp path**: the CPU kernel currently routes to `CPUAcTMethod::swiglu` only when both `alpha` and `limit` are provided.
5. **ROCm aiter UNINTERLEAVE**: pass `swiglu_limit` through to the aiter swiglu op (currently silently defaults to `0.0` = no clamp).
6. **XPU `_apply_ref`**: forward `gemm1_clamp_limit` into `ref_fused_moe` in `vllm_xpu_kernels`; once landed, kernel-path XPU subclasses can flip SILU to True.

---

## AI assistance disclosure

This PR was drafted with AI assistance (Claude Code for design, implementation, and test authoring) and reviewed by multiple AI tools (Claude general-purpose reviewer + Codex gpt-5.5 adversarial review across 3 rounds + Claude Ultrareview cloud multi-agent review) before submission. Twenty findings from those rounds drove the design decisions documented above. The 2026-07 rebase and per-backend re-audit were likewise AI-assisted, with each declaration change traced to a main kernel call site before commit. The contributor (@toffee-desuwa) reviewed and accepted every change before commit; the DCO sign-off is by the human contributor.
