### PR TITLE
[Bugfix] Fix Mamba temporal copy OOB after speculative decoding

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Callable
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -149,6 +150,62 @@ def test_resumed_req_ids_cleared_from_mamba_state_idx():
         )
 
     assert mamba_state_idx == {"keep": 99}
+
+
+def test_preprocess_mamba_temporal_source_oob_falls_back_to_neutral_copy():
+    """Accepted-token bias can outlive the current block table.
+
+    Regression coverage for issue #41884: the temporal copy source used to
+    index ``block_ids[src_block_idx + accepted - 1]`` directly, which raised
+    IndexError before the copy metadata could be staged.
+    """
+    spec = SimpleNamespace(block_size=4, num_speculative_blocks=1)
+    cache_config = MagicMock(enable_prefix_caching=True)
+    sched = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={"req": 1},
+        total_num_scheduled_tokens=1,
+        scheduled_spec_decode_tokens={"req": [1]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+        preempted_req_ids=set(),
+    )
+
+    input_batch = SimpleNamespace(
+        req_ids=["req"],
+        num_accepted_tokens_cpu=np.array([2], dtype=np.int32),
+    )
+    req_state = SimpleNamespace(num_computed_tokens=3, block_ids=[[0, 1]])
+    state = torch.empty((2, 1))
+    copy_bufs = SimpleNamespace(
+        mamba_group_ids=[0],
+        mamba_spec=spec,
+        src_ptrs=SimpleNamespace(np=np.zeros(4, dtype=np.uint64)),
+        dst_ptrs=SimpleNamespace(np=np.zeros(4, dtype=np.uint64)),
+        sizes=SimpleNamespace(np=np.zeros(4, dtype=np.uint64)),
+        offset=0,
+    )
+
+    with patch("vllm.v1.worker.mamba_utils.do_mamba_copy_block"):
+        preprocess_mamba(
+            sched,
+            SimpleNamespace(kv_cache_groups=[SimpleNamespace(layer_names=["layer"])]),
+            cache_config,
+            {"req": 1},
+            input_batch,
+            {"req": req_state},
+            {"layer": SimpleNamespace(kv_cache=[state])},
+            (get_temporal_copy_spec,),
+            copy_bufs,
+        )
+
+    assert input_batch.num_accepted_tokens_cpu[0] == 1
+    assert copy_bufs.offset == 1
+    assert copy_bufs.src_ptrs.np[0] == state[1].data_ptr()
+    assert copy_bufs.dst_ptrs.np[0] == state[0].data_ptr()
 
 
 # -----------------------------------------------------------------------------

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -637,6 +637,29 @@ def cleanup_mamba_state_idx(
         mamba_state_idx.pop(req_id, None)
 
 
+def has_valid_mamba_copy_indices(
+    req_state: CachedRequestState,
+    mamba_group_ids: list[int],
+    src_block_idx: int,
+    dest_block_idx: int,
+    num_accepted_tokens: int,
+    has_temporal_state: bool,
+) -> bool:
+    """Return whether all logical Mamba copy indices exist in block tables."""
+    if src_block_idx < 0 or dest_block_idx < 0:
+        return False
+
+    max_src_block_idx = src_block_idx
+    if has_temporal_state:
+        max_src_block_idx += num_accepted_tokens - 1
+
+    for mamba_group_id in mamba_group_ids:
+        block_ids = req_state.block_ids[mamba_group_id]
+        if dest_block_idx >= len(block_ids) or max_src_block_idx >= len(block_ids):
+            return False
+    return True
+
+
 def preprocess_mamba(
     scheduler_output: SchedulerOutput,
     kv_cache_config: KVCacheConfig,
@@ -659,6 +682,7 @@ def preprocess_mamba(
     assert cache_config.enable_prefix_caching
     block_size = mamba_spec.block_size
     cleanup_mamba_state_idx(scheduler_output, mamba_state_idx)
+    has_temporal_state = get_temporal_copy_spec in mamba_state_copy_funcs
 
     copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
@@ -688,6 +712,32 @@ def preprocess_mamba(
         curr_state_idx = num_blocks - 1 - num_speculative_blocks
         mamba_state_idx[req_id] = curr_state_idx
         if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
+            num_accepted_tokens = int(input_batch.num_accepted_tokens_cpu[i])
+            if not has_valid_mamba_copy_indices(
+                req_state,
+                mamba_group_ids,
+                prev_state_idx,
+                curr_state_idx,
+                num_accepted_tokens,
+                has_temporal_state,
+            ):
+                # The speculative temporal slot from the previous step is no
+                # longer present in the request block table. Fall back to a
+                # neutral copy from the last known running-state block instead
+                # of indexing past block_ids.
+                num_accepted_tokens = 1
+                input_batch.num_accepted_tokens_cpu[i] = 1
+
+            if not has_valid_mamba_copy_indices(
+                req_state,
+                mamba_group_ids,
+                prev_state_idx,
+                curr_state_idx,
+                num_accepted_tokens,
+                has_temporal_state,
+            ):
+                continue
+
             collect_mamba_copy_meta(
                 copy_bufs,
                 kv_cache_config,
@@ -695,7 +745,7 @@ def preprocess_mamba(
                 mamba_group_ids,
                 prev_state_idx,
                 curr_state_idx,
-                input_batch.num_accepted_tokens_cpu[i] - 1,
+                num_accepted_tokens - 1,
                 req_state,
                 forward_context,
             )


### PR DESCRIPTION
Fixes #41884.

This fixes an `IndexError` in Mamba state copy metadata collection when speculative decoding leaves an accepted-token bias that no longer maps to a valid source block in the current request block table.