### PR TITLE
[MRV2][KVCache] Optimize block mapping with np array

### DIFF
--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable
 
+import numpy as np
 import torch
 
 from vllm.triton_utils import tl, triton
@@ -37,6 +38,9 @@ class BlockTables:
 
         self.blocks_per_kv_block = [
             bs // kbs for bs, kbs in zip(block_sizes, kernel_block_sizes)
+        ]
+        self.kernel_block_arange_per_group = [
+            np.arange(bpk, dtype=np.int32) for bpk in self.blocks_per_kv_block
         ]
 
         # num_kv_cache_groups x [max_num_reqs, max_num_blocks]
@@ -95,6 +99,21 @@ class BlockTables:
         )
         self.input_block_table_ptrs = self._make_ptr_tensor(self.input_block_tables)
 
+    def _map_to_kernel_blocks(
+        self,
+        group_id: int,
+        kv_manager_block_ids: list[int],
+    ) -> list[int]:
+        bpk = self.blocks_per_kv_block[group_id]
+        if bpk == 1 or not kv_manager_block_ids:
+            return kv_manager_block_ids
+
+        block_ids = np.asarray(kv_manager_block_ids, dtype=np.int32)
+        kernel_block_arange = self.kernel_block_arange_per_group[group_id]
+        assert kernel_block_arange is not None
+        kernel_block_ids = block_ids.reshape(-1, 1) * bpk + kernel_block_arange
+        return kernel_block_ids.reshape(-1).tolist()
+
     def append_block_ids(
         self,
         req_index: int,
@@ -103,10 +122,7 @@ class BlockTables:
     ) -> None:
         for i in range(self.num_kv_cache_groups):
             start = self.num_blocks.np[i, req_index] if not overwrite else 0
-            block_ids = new_block_ids[i]
-            bpk = self.blocks_per_kv_block[i]
-            if bpk > 1:
-                block_ids = [b * bpk + k for b in block_ids for k in range(bpk)]
+            block_ids = self._map_to_kernel_blocks(i, new_block_ids[i])
             self.block_tables[i].stage_write(req_index, start, block_ids)
             self.num_blocks.np[i, req_index] = start + len(block_ids)
 


### PR DESCRIPTION
## Purpose
addressing https://github.com/vllm-project/vllm/pull/38831#discussion_r3291646199

This pr optimizes the block mapping calculation from for expression to np array. This improves the performance of this operation when the number of blocks is bigger than 32, which is a general case in the production scenario.

## Test Plan
**1. test the accuracy**
```bash
# # Only test ceval-valid-computer_network dataset in this demo
export VLLM_USE_V2_MODEL_RUNNER="1"
export HF_DATASETS_OFFLINE=1
export CUDA_VISIBLE_DEVICES="6,7"
lm_eval \
  --model vllm \
  --model_args pretrained=Qwen/Qwen3.5-35B-A3B,tensor_parallel_size=2,enable_expert_parallel=True\
  --tasks gsm8k \
  --batch_size 8
```

**results**
```
vllm ({'pretrained': 'Qwen/Qwen3.5-35B-A3B', 'tensor_parallel_size': 2, 'enable_expert_parallel': True}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: 8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8560|±  |0.0097|
|     |       |strict-match    |     5|exact_match|↑  |0.8362|±  |0.0102|
```

**2. test the e2e performance**
```bash
CUDA_VISIBLE_DEVICES=6,7 vllm serve Qwen/Qwen3.5-35B-A3B \
  --trust-remote-code \
  --enable-expert-parallel \
  --tensor-parallel-size 2 \

vllm bench serve \
    --model Qwen/Qwen3.5-35B-A3B \
    --input-len 3584 \
    --output-len 1536 \
    --request-rate inf \
    --num-prompts 1000

```

**result**
```
# with this pr:
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  332.62    
Total input tokens:                      3584000   
Total generated tokens:                  1536000   
Request throughput (req/s):              3.01      
Output token throughput (tok/s):         4617.88   
Peak output token throughput (tok/s):    9298.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          15392.92  
---------------Time to First Token----------------
Mean TTFT (ms):                          79526.54  
Median TTFT (ms):                        74463.83  
P99 TTFT (ms):                           176246.44 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          157.39    
Median TPOT (ms):                        162.03    
P99 TPOT (ms):                           195.53    
---------------Inter-token Latency----------------
Mean ITL (ms):                           157.40    
Median ITL (ms):                         115.41    
P99 ITL (ms):                            481.02    
==================================================

# w/o this pr:
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  333.04    
Total input tokens:                      3584000   
Total generated tokens:                  1536000   
Request throughput (req/s):              3.00      
Output token throughput (tok/s):         4612.02   
Peak output token throughput (tok/s):    10000.00  
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          15373.42  
---------------Time to First Token----------------
Mean TTFT (ms):                          79618.51  
Median TTFT (ms):                        74554.84  
P99 TTFT (ms):                           176393.42 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          157.59    
Median TPOT (ms):                        162.22    
P99 TPOT (ms):                           195.74    
---------------Inter-token Latency----------------
Mean ITL (ms):                           157.59    
Median ITL (ms):                         115.66    
P99 ITL (ms):                            482.25   
```

**3. test the performance of single operator**
<details>
<summary> the scripts </summary>

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

import gc
import time
from pathlib import Path

import numpy as np
import pytest

from vllm.v1.worker.gpu.block_table import BlockTables


def _list_map_to_kernel_blocks(
    kv_manager_block_ids: list[int],
    blocks_per_kv_block: int,
) -> list[int]:
    return [
        block_id * blocks_per_kv_block + offset
        for block_id in kv_manager_block_ids
        for offset in range(blocks_per_kv_block)
    ]


def _best_elapsed_ns(func, iterations: int, repeats: int = 7) -> int:
    best = None
    gc_was_enabled = gc.isenabled()
    gc.disable()
    try:
        for _ in range(repeats):
            start_ns = time.perf_counter_ns()
            for _ in range(iterations):
                func()
            elapsed_ns = time.perf_counter_ns() - start_ns
            best = elapsed_ns if best is None else min(best, elapsed_ns)
    finally:
        if gc_was_enabled:
            gc.enable()
    assert best is not None
    return best


def _make_block_table_for_mapping(blocks_per_kv_block: int) -> BlockTables:
    block_table = object.__new__(BlockTables)
    block_table.blocks_per_kv_block = [blocks_per_kv_block]
    block_table.kernel_block_arange_per_group = [
        np.arange(blocks_per_kv_block, dtype=np.int32).reshape(1, -1)
    ]
    return block_table


def _plot_mapping_times(
    plot_path: Path,
    num_blocks_values: list[int],
    list_times_ns: list[float],
    numpy_times_ns: list[float],
) -> None:
    matplotlib = pytest.importorskip("matplotlib")

    matplotlib.use("Agg")
    import matplotlib.pyplot as plt

    fig, ax = plt.subplots(figsize=(8, 5))
    ax.plot(
        num_blocks_values,
        list_times_ns,
        marker="o",
        label="list comprehension",
    )
    ax.plot(num_blocks_values, numpy_times_ns, marker="o", label="numpy + tolist")
    ax.set_xscale("log", base=2)
    ax.set_xlabel("number of KV-manager block IDs")
    ax.set_ylabel("best time per call (ns)")
    ax.set_title("Kernel block ID mapping")
    ax.grid(True, which="both", linestyle="--", alpha=0.4)
    ax.legend()
    fig.tight_layout()
    fig.savefig(plot_path)
    plt.close(fig)


def test_kernel_block_mapping_performance_by_num_blocks() -> None:
    blocks_per_kv_block = 4
    num_blocks_values = (
        list(range(1, 33))
        + list(range(40, 129, 8))
        # + list(range(160, 513, 32))
        # + list(range(640, 4097, 256))
    )

    block_table = _make_block_table_for_mapping(blocks_per_kv_block)
    list_times_ns: list[float] = []
    numpy_times_ns: list[float] = []
    faster_with_numpy: list[int] = []

    for num_blocks in num_blocks_values:
        kv_manager_block_ids = list(range(num_blocks))
        expected = _list_map_to_kernel_blocks(
            kv_manager_block_ids,
            blocks_per_kv_block,
        )
        assert block_table._map_to_kernel_blocks(0, kv_manager_block_ids) == expected

        iterations = max(100, 200000 // num_blocks)
        list_elapsed_ns = _best_elapsed_ns(
            lambda: _list_map_to_kernel_blocks(
                kv_manager_block_ids,
                blocks_per_kv_block,
            ),
            iterations,
        )
        numpy_elapsed_ns = _best_elapsed_ns(
            lambda: block_table._map_to_kernel_blocks(0, kv_manager_block_ids),
            iterations,
        )

        list_time_ns = list_elapsed_ns / iterations
        numpy_time_ns = numpy_elapsed_ns / iterations
        list_times_ns.append(list_time_ns)
        numpy_times_ns.append(numpy_time_ns)
        if numpy_time_ns < list_time_ns:
            faster_with_numpy.append(num_blocks)

    plot_path = Path("./kernel_block_mapping_perf_1.png")
    _plot_mapping_times(
        plot_path,
        num_blocks_values,
        list_times_ns,
        numpy_times_ns,
    )
    assert plot_path.exists()

    print(
        "\nKernel block mapping benchmark plot:",
        plot_path,
        "\nnum_blocks:",
        num_blocks_values,
        "\nlist ns/call:",
        list_times_ns,
        "\nnumpy ns/call:",
        numpy_times_ns,
        "\nnumpy faster at:",
        faster_with_numpy or "no tested size",
    )

```
</details>

**result**
<img width="1586" height="986" alt="image" src="https://github.com/user-attachments/assets/0a5c77e0-0eaa-4304-9b78-0aaa43de6579" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
