### PR TITLE
[Transformers v5] Fix IsaacForConditionalGeneration Siglip2VisionConfig import

### DIFF
--- a/vllm/transformers_utils/configs/isaac.py
+++ b/vllm/transformers_utils/configs/isaac.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from transformers import Qwen3Config
-from transformers.models.siglip2.configuration_siglip2 import Siglip2VisionConfig
+from transformers import Siglip2VisionConfig
 
 
 class PixelShuffleSiglip2VisionConfig(Siglip2VisionConfig):


### PR DESCRIPTION
Purpose
Fix #38389 - Part of the Transformers v5 upgrade tracker #38379
vllm/transformers_utils/configs/isaac.py imported Siglip2VisionConfig from an internal module path that no longer exists in Transformers v5, causing ModuleNotFoundError when initializing IsaacForConditionalGeneration.
Before:
from transformers.models.siglip2.configuration_siglip2 import Siglip2VisionConfig
After:
from transformers import Siglip2VisionConfig
Test Plan
pytest tests/models/test_initialization.py::test_can_initialize_large_subset[IsaacForConditionalGeneration]
Test Result
Before fix:
ModuleNotFoundError: No module named 'transformers.models.siglip2.configuration_siglip2'
After fix:
from transformers import Siglip2VisionConfig — imports successfully in Transformers v5.9.0
Full CI test will confirm pass on GitHub Actions.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

