### PR TITLE
Fix Mamba align prefix cache null block lookup

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1009,6 +1009,69 @@ def test_prefill_hybrid_model_mamba_align():
     manager.free(req0)
 
 
+
+def test_prefill_hybrid_model_mamba_align_incremental_prefix_hit():
+    """Regression test for incremental prefix hits in mamba align mode.
+
+    In align mode the Mamba manager keeps only one real running-state block and
+    pads earlier block positions with null blocks.  Those earlier positions must
+    still be represented in the prefix-cache hash map so hybrid lookup can hit
+    an already-computed attention prefix instead of missing because the Mamba
+    group has no entry for that hash.
+    """
+    block_size = 16
+    num_blocks = 30
+
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        block_size, num_blocks, ["full", "mamba_align"]
+    )
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    hash_fn = sha256
+
+    # Cache a request with three full blocks. The Mamba align group stores only
+    # the latest running state, but the first two block hashes are reusable by an
+    # incremental request below.
+    req0 = make_request(
+        "0",
+        [i for i in range(3) for _ in range(block_size)] + [3] * 7,
+        block_size,
+        hash_fn,
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req0, req0.num_tokens, num_computed_tokens, computed_blocks
+    )
+    assert blocks is not None
+    manager.free(req0)
+
+    # Same first two blocks, changed third block: mirrors incremental multimodal
+    # prompts whose shared first blocks have identical block hashes.
+    req1 = make_request(
+        "1",
+        [0] * block_size + [1] * block_size + [99] * block_size + [4] * 7,
+        block_size,
+        hash_fn,
+    )
+    assert req0.block_hashes[0] == req1.block_hashes[0]
+    assert req0.block_hashes[1] == req1.block_hashes[1]
+    assert req0.block_hashes[2] != req1.block_hashes[2]
+
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+    assert num_computed_tokens == 2 * block_size
+    assert [len(group_blocks) for group_blocks in computed_blocks.blocks] == [2, 2]
+    assert all(
+        block is manager.block_pool.null_block
+        for block in computed_blocks.blocks[1]
+    )
+
 def test_prefill_plp():
     """Test prefill with APC and some prompt logprobs (plp) requests.
 
@@ -2740,6 +2803,24 @@ def test_block_lookup_cache_multi_blocks_per_key():
     assert cache.pop(key1, 11) is block11
     assert cache.get_one_block(key1) is None
     assert cache.pop(key1, 12) is None
+
+
+def test_block_lookup_cache_null_entry():
+    cache = BlockHashToBlockMap()
+    key = BlockHashWithGroupId(b"hash")
+    null_block = KVCacheBlock(0)
+    null_block.is_null = True
+    real_block = KVCacheBlock(1)
+
+    cache.insert_null(key)
+    assert cache.get_one_block(key, null_block) is null_block
+    assert cache.pop(key, 0) is None
+    assert cache.get_one_block(key, null_block) is null_block
+
+    cache.insert(key, real_block)
+    assert cache.get_one_block(key, null_block) is real_block
+    assert cache.pop(key, real_block.block_id) is real_block
+    assert cache.get_one_block(key, null_block) is None
 
 
 def test_can_fit_full_sequence_swa_cap_admits_long_prompt():

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -31,6 +31,15 @@ from vllm.v1.request import Request
 logger = init_logger(__name__)
 
 
+class _NullBlockEntry:
+    """Logical prefix-cache entry without a physical KV cache block."""
+
+    __slots__ = ()
+
+
+_NULL_BLOCK_ENTRY = _NullBlockEntry()
+
+
 class BlockHashToBlockMap:
     """
     Cache of blocks that are used for prefix caching. It caches blocks
@@ -56,17 +65,27 @@ class BlockHashToBlockMap:
 
     def __init__(self):
         self._cache: dict[
-            BlockHashWithGroupId, KVCacheBlock | dict[int, KVCacheBlock]
+            BlockHashWithGroupId,
+            KVCacheBlock | _NullBlockEntry | dict[int, KVCacheBlock],
         ] = {}
 
-    def get_one_block(self, key: BlockHashWithGroupId) -> KVCacheBlock | None:
+    def get_one_block(
+        self, key: BlockHashWithGroupId, null_block: KVCacheBlock | None = None
+    ) -> KVCacheBlock | None:
         """
         Gets any block with the given block hash key.
+
+        If the key maps to a null-block entry, it represents a logical
+        null-block cache entry for Mamba align-mode. In that case, return
+        the caller-provided null block.
         """
         blocks = self._cache.get(key)
         if blocks is not None:
             if isinstance(blocks, KVCacheBlock):
                 return blocks
+            if isinstance(blocks, _NullBlockEntry):
+                assert null_block is not None
+                return null_block
             if isinstance(blocks, dict):
                 return next(iter(blocks.values()))
             self._unexpected_blocks_type(blocks)
@@ -77,8 +96,9 @@ class BlockHashToBlockMap:
         Inserts the KVCacheBlock to the cache
         """
         blocks = self._cache.get(key)
-        if blocks is None:
-            # When key is not found, attach a single block to the key
+        if blocks is None or isinstance(blocks, _NullBlockEntry):
+            # When key is not found, attach a single block to the key. A real
+            # block replaces a logical null entry for the same key.
             self._cache[key] = block
         elif isinstance(blocks, KVCacheBlock):
             # If there's a block with the same key, merge the original block
@@ -89,6 +109,15 @@ class BlockHashToBlockMap:
             blocks[block.block_id] = block
         else:
             self._unexpected_blocks_type(blocks)
+
+    def insert_null(self, key: BlockHashWithGroupId) -> None:
+        """Insert a logical null-block entry for prefix-cache lookup.
+
+        This is used for Mamba align-mode positions that can participate in
+        hybrid prefix-cache matching but do not own a physical Mamba cache
+        block. Real blocks, if present, take precedence.
+        """
+        self._cache.setdefault(key, _NULL_BLOCK_ENTRY)
 
     def pop(self, key: BlockHashWithGroupId, block_id: int) -> KVCacheBlock | None:
         """
@@ -108,6 +137,10 @@ class BlockHashToBlockMap:
                 return blocks
             # If the single block ID doesn't match, we should put the
             # block back (it should happen rarely)
+            self._cache[key] = blocks
+            return None
+        if isinstance(blocks, _NullBlockEntry):
+            # Logical null entries are not tied to a physical block id.
             self._cache[key] = blocks
             return None
         if isinstance(blocks, dict):
@@ -201,9 +234,9 @@ class BlockPool:
                 block_hash, group_id
             )
             block = self.cached_block_hash_to_block.get_one_block(
-                block_hash_with_group_id
+                block_hash_with_group_id, self.null_block
             )
-            if not block:
+            if block is None:
                 return None
             cached_blocks.append(block)
         return cached_blocks
@@ -217,6 +250,7 @@ class BlockPool:
         block_size: int,
         kv_cache_group_id: int,
         block_mask: list[bool] | None = None,
+        cache_null_blocks: bool = False,
     ) -> None:
         """Cache a list of full blocks for prefix caching.
         This function takes a list of blocks that will have their block hash
@@ -241,6 +275,10 @@ class BlockPool:
                 consults a subset of blocks (e.g. SWA tail-window), so blocks
                 that can never serve a hit stay out of the prefix-cache hash
                 map.
+            cache_null_blocks: Whether logical entries should be cached for
+                null blocks. This is needed by Mamba align-mode, where earlier
+                prefix positions may not own physical Mamba blocks but must
+                still participate in hybrid prefix-cache lookup.
         """
         if num_cached_blocks >= num_full_blocks:
             return
@@ -265,20 +303,24 @@ class BlockPool:
             [] if self.enable_kv_cache_events else None
         )
         for i, blk in enumerate(new_full_blocks):
-            # Some blocks may be null or masked out when enabling sparse attention
-            # like sliding window attention, or Mamba models with prefix-caching
-            # in align mode. We skip null blocks here.
-            if blk.is_null or (block_mask is not None and not block_mask[i]):
+            if block_mask is not None and not block_mask[i]:
                 continue
-            assert blk.block_hash is None
             block_hash = new_block_hashes[i]
-
-            # Update and added the full block to the cache.
             block_hash_with_group_id = make_block_hash_with_group_id(
                 block_hash, kv_cache_group_id
             )
-            blk.block_hash = block_hash_with_group_id
-            self.cached_block_hash_to_block.insert(block_hash_with_group_id, blk)
+            if blk.is_null:
+                if cache_null_blocks:
+                    self.cached_block_hash_to_block.insert_null(
+                        block_hash_with_group_id
+                    )
+                continue
+            else:
+                assert blk.block_hash is None
+
+                # Update and added the full block to the cache.
+                blk.block_hash = block_hash_with_group_id
+                self.cached_block_hash_to_block.insert(block_hash_with_group_id, blk)
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -316,6 +316,7 @@ class SingleTypeKVCacheManager(ABC):
             block_size=self.block_size,
             kv_cache_group_id=self.kv_cache_group_id,
             block_mask=block_mask,
+            cache_null_blocks=self._cache_null_blocks(),
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
@@ -334,6 +335,10 @@ class SingleTypeKVCacheManager(ABC):
         length.
         """
         return None
+
+    def _cache_null_blocks(self) -> bool:
+        """Whether null blocks should participate in prefix-cache lookup."""
+        return False
 
     def free(self, request_id: str) -> None:
         """
@@ -1096,6 +1101,9 @@ class MambaManager(SingleTypeKVCacheManager):
         num_computed_tokens - 1.
         """
         return num_computed_tokens - 1
+
+    def _cache_null_blocks(self) -> bool:
+        return self.mamba_cache_mode == "align"
 
     def cache_blocks(
         self,


### PR DESCRIPTION
Fixes #43587.

## Summary
- Add logical prefix-cache entries for Mamba align-mode null blocks so hybrid cache lookup can match prefixes even when early Mamba positions do not have physical blocks.
- Keep logical null entries scoped to Mamba align-mode via `MambaManager._cache_null_blocks()`.
- Add regression coverage for incremental Mamba align prefix hits and the null-entry block lookup behavior.

## Test Plan
- `CUDA_VISIBLE_DEVICES=0 VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONUNBUFFERED=1 .venv/bin/python -m pytest tests/v1/core/test_prefix_caching.py::test_block_lookup_cache_null_entry tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_mamba_align_incremental_prefix_hit tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_mamba_align -q`
- End-to-end GPU reproduction on `28.58.247.12` with Qwen3.5-4B:
  - `4-img attempt 1: cached=0`
  - `4-img attempt 2: cached=1584`
  - `5-img after 4-img: cached=1584`
