### PR TITLE
Fix Qwen3-VL and Qwen3-omni-thinker accuracy degradation from deepstack inputs under torch.compile

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1778,8 +1778,8 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
     ) -> IntermediateTensors | None:
         if not getattr(self, "deepstack_input_embeds", None):
             return None  # If vision tower is skipped
-        if getattr(self, "deepstack_input_embeds_num_tokens", 0) == 0:
-            return None
+        if num_tokens > self.deepstack_input_embeds[0].size(0):
+            self._resize_deepstack_input_embeds(num_tokens)
 
         # get deepstack_input_embeds from buffer, and clear the buffer
         return IntermediateTensors(
@@ -1791,6 +1791,17 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             }
         )
 
+    def _resize_deepstack_input_embeds(self, num_tokens: int) -> None:
+        self.deepstack_input_embeds = [
+            torch.zeros(
+                num_tokens,
+                self.config.text_config.hidden_size,
+                device=self.deepstack_input_embeds[0].device,
+                dtype=self.deepstack_input_embeds[0].dtype,
+            )
+            for _ in range(self.deepstack_num_level)
+        ]
+
     def _set_deepstack_input_embeds(self, deepstack_input_embeds: torch.Tensor) -> None:
         if not getattr(self, "deepstack_input_embeds", None):
             return
@@ -1798,15 +1809,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         # set deepstack_input_embeds to buffer
         num_tokens = deepstack_input_embeds.size(1)
         if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self.deepstack_input_embeds = [
-                torch.zeros(
-                    num_tokens,
-                    self.config.text_config.hidden_size,
-                    device=self.deepstack_input_embeds[0].device,
-                    dtype=self.deepstack_input_embeds[0].dtype,
-                )
-                for _ in range(self.deepstack_num_level)
-            ]
+            self._resize_deepstack_input_embeds(num_tokens)
         for idx in range(self.deepstack_num_level):
             self.deepstack_input_embeds[idx][:num_tokens].copy_(
                 deepstack_input_embeds[idx]

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1715,8 +1715,8 @@ class Qwen3VLForConditionalGeneration(
     ) -> IntermediateTensors | None:
         if not getattr(self, "deepstack_input_embeds", None):
             return None  # If vision tower is skipped
-        if getattr(self, "deepstack_input_embeds_num_tokens", 0) == 0:
-            return None
+        if num_tokens > self.deepstack_input_embeds[0].size(0):
+            self._resize_deepstack_input_embeds(num_tokens)
 
         # get deepstack_input_embeds from buffer, and clear the buffer
         return IntermediateTensors(
@@ -1728,6 +1728,17 @@ class Qwen3VLForConditionalGeneration(
             }
         )
 
+    def _resize_deepstack_input_embeds(self, num_tokens: int) -> None:
+        self.deepstack_input_embeds = [
+            torch.zeros(
+                num_tokens,
+                self.config.text_config.hidden_size,
+                device=self.deepstack_input_embeds[0].device,
+                dtype=self.deepstack_input_embeds[0].dtype,
+            )
+            for _ in range(self.deepstack_num_level)
+        ]
+
     def _set_deepstack_input_embeds(self, deepstack_input_embeds: torch.Tensor) -> None:
         if not getattr(self, "deepstack_input_embeds", None):
             return
@@ -1735,15 +1746,7 @@ class Qwen3VLForConditionalGeneration(
         # set deepstack_input_embeds to buffer
         num_tokens = deepstack_input_embeds.size(1)
         if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self.deepstack_input_embeds = [
-                torch.zeros(
-                    num_tokens,
-                    self.config.text_config.hidden_size,
-                    device=self.deepstack_input_embeds[0].device,
-                    dtype=self.deepstack_input_embeds[0].dtype,
-                )
-                for _ in range(self.deepstack_num_level)
-            ]
+            self._resize_deepstack_input_embeds(num_tokens)
         for idx in range(self.deepstack_num_level):
             self.deepstack_input_embeds[idx][:num_tokens].copy_(
                 deepstack_input_embeds[idx]


### PR DESCRIPTION
## Summary

This PR fixes an accuracy regression for Qwen3-VL models when running with vLLM's default `torch.compile` / CUDA graph path.

Qwen3-VL uses `deepstack_input_embeds` to inject visual features into the decoder. Before this change, `_get_deepstack_input_embeds()` returned `None` when `deepstack_input_embeds_num_tokens == 0`. **During compile warmup / profiling, this can make the decoder graph specialize to the no-deepstack path**. Later real multimodal requests may reuse that compiled graph even though they carry real `deepstack_input_embeds`, causing the visual deepstack additions to be skipped or handled incorrectly.

This PR keeps the decoder input structure stable by **always returning `IntermediateTensors` when the deepstack buffers exist**. For no-vision/dummy paths, the tensors are zero-backed, which is semantically equivalent to no deepstack contribution but avoids changing the compiled graph structure. The resize logic is also factored into a helper to keep `_get_deepstack_input_embeds()` and `_set_deepstack_input_embeds()` consistent.

## Motivation

We observed a large Geo3K eval accuracy drop for Qwen3-VL under the default compiled serving path, while eager/no-compile execution was much closer to expected results. The issue does not reproduce on text-only Qwen3 models, which points to the multimodal deepstack path. see https://github.com/vllm-project/vllm/issues/43602

The root cause is the unstable decoder input contract:

```text
compile/profiling path: deepstack_input_embeds = None
real VL request path:  deepstack_input_embeds = IntermediateTensors(...)
```

After this change:

```text
compile/profiling path: deepstack_input_embeds = IntermediateTensors(zero tensors)
real VL request path:  deepstack_input_embeds = IntermediateTensors(real tensors)
```

This makes the compiled decoder graph see a consistent input structure.

## Eval Results

All runs used:

- Dataset: Geo3K full eval, 601 samples
- Sampling: `temperature=0.0`, `top_p=1.0`, `top_k=-1`, `seed=42`, `max_tokens=4096`
- GPUs: 8x H20
- vLLM base commit: `d4004455d [Kernel] Remove NormGateLinear (#43554)`

### Qwen3-VL-2B-Instruct

| Config | Score | Time |
| --- | ---: | ---: |
| pre-patch default compile + cudagraph | 0.20465890183028287 | 116.751s |
| pre-patch no compile + no cudagraph | 0.2911813643926789 | 310.972s |
| pre-patch no compile + decode cudagraph | 0.2778702163061564 | 106.961s |
| post-patch default compile + cudagraph | 0.28286189683860236 | 102.586s |

We can clearly see that it is the `torch.compile` that causes this issue.

### Qwen3-VL-8B-Instruct

| Config | Score | Time |
| --- | ---: | ---: |
| pre-patch default compile + cudagraph | 0.5224625623960066 | 143.152s |
| pre-patch no compile + no cudagraph | 0.5490848585690515 | 259.145s |
| post-patch default compile + cudagraph | 0.5657237936772047 | 124.998s |

For reference, SGLang on Qwen3-VL-8B-Instruct with comparable sampling and 8 GPUs reached:

| Backend | Score | Time |
| --- | ---: | ---: |
| SGLang | 0.5590682196339434 | 123.258s |

## Notes

The zero-backed deepstack tensors are intended as a semantic no-op for dummy/no-vision paths while preserving the tensor-based input contract needed by compiled execution.

This change only keeps the `deepstack_input_embeds` payload shape/type stable for compiled execution. It does not change the visual encoder output, sampling configuration, chat template, or request preprocessing.

