### PR TITLE
WIP: Add `VLLM_WEIGHTS_ONLY` environment variable for configurable weights_only calls

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1916,9 +1916,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_WEIGHT_OFFLOADING_DISABLE_UVA": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_UVA", "0"))
     ),
-    "VLLM_WEIGHTS_ONLY": lambda: bool(
-        int(os.getenv("VLLM_WEIGHTS_ONLY", "1"))
-    ),
+    "VLLM_WEIGHTS_ONLY": lambda: os.getenv("VLLM_WEIGHTS_ONLY", "1").strip().lower() in ("1", "true", "yes"),
     # Disable logging of vLLM logo at server startup time.
     "VLLM_DISABLE_LOG_LOGO": lambda: bool(int(os.getenv("VLLM_DISABLE_LOG_LOGO", "0"))),
     # Disable PDL for LoRA, as enabling PDL with LoRA on SM100 causes

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -266,6 +266,7 @@ if TYPE_CHECKING:
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
+    VLLM_WEIGHTS_ONLY: bool = True
     VLLM_DISABLE_LOG_LOGO: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
     VLLM_ENABLE_CUDA_COMPATIBILITY: bool = False
@@ -1914,6 +1915,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disable using UVA (Unified Virtual Addressing) for CPU offloading.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_UVA": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_UVA", "0"))
+    ),
+    "VLLM_WEIGHTS_ONLY": lambda: bool(
+        int(os.getenv("VLLM_WEIGHTS_ONLY", "1"))
     ),
     # Disable logging of vLLM logo at server startup time.
     "VLLM_DISABLE_LOG_LOGO": lambda: bool(int(os.getenv("VLLM_DISABLE_LOG_LOGO", "0"))),

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -224,7 +224,7 @@ def convert_bin_to_safetensor_file(
     pt_filename: str,
     sf_filename: str,
 ) -> None:
-    loaded = torch.load(pt_filename, map_location="cpu", weights_only=True)
+    loaded = torch.load(pt_filename, map_location="cpu", weights_only=envs.VLLM_WEIGHTS_ONLY)
     if "state_dict" in loaded:
         loaded = loaded["state_dict"]
     shared = _shared_pointers(loaded)
@@ -732,7 +732,7 @@ def np_cache_weights_iterator(
                 disable=not enable_tqdm(use_tqdm_on_load),
                 bar_format=_BAR_FORMAT,
             ):
-                state = torch.load(bin_file, map_location="cpu", weights_only=True)
+                state = torch.load(bin_file, map_location="cpu", weights_only=envs.VLLM_WEIGHTS_ONLY)
                 for name, param in state.items():
                     param_path = os.path.join(np_folder, name)
                     with open(param_path, "wb") as f:
@@ -1216,7 +1216,7 @@ def pt_weights_iterator(
         bar_format=_BAR_FORMAT,
     ):
         state = torch.load(
-            bin_file, map_location=pt_load_map_location, weights_only=True
+            bin_file, map_location=pt_load_map_location, weights_only=envs.VLLM_WEIGHTS_ONLY
         )
         yield from state.items()
         del state
@@ -1232,7 +1232,7 @@ def multi_thread_pt_weights_iterator(
 
     def _load_file(bin_file: str):
         return torch.load(
-            bin_file, map_location=pt_load_map_location, weights_only=True
+            bin_file, map_location=pt_load_map_location, weights_only=envs.VLLM_WEIGHTS_ONLY
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1174,7 +1174,11 @@ class Gemma4ForConditionalGeneration(
         # pass has already allocated activations we should account for.
         last_hidden_states_map: dict[int, torch.Tensor] = {}
         for patches, items in buckets.items():
-            free, total = current_platform.mem_get_info()
+            if self.is_cpu():
+                free, total = 0, 0
+            else:
+                free, total = current_platform.mem_get_info()
+
             max_batch_size = min(
                 len(items),
                 self._encoder_chunk(
@@ -1281,7 +1285,12 @@ class Gemma4ForConditionalGeneration(
             fc_list = list(frame_counts)
 
         total_frames = pixel_values.shape[0]
-        free, total = current_platform.mem_get_info()
+
+        if self.is_cpu():
+            free, total = 0, 0
+        else:
+            free, total = current_platform.mem_get_info()
+
         max_batch_size = min(
             total_frames,
             self._encoder_chunk(


### PR DESCRIPTION
# Summary
vLLM is not supporting loading of external models with custom tensor format, like `OpenVINO` family. The root cause seems lies in `weight_utils.py` where `weights_only` argument is hardcoded. This is ok for modal with standard weights format however breaks vLLM while using generic formats. For sure, this introduces a potential security issue which should be mitigated as well.

Please see the log attached.

[log.log](https://github.com/user-attachments/files/28232958/log.log)

## Purpose

This PR introduces a new environment variable `VLLM_WEIGHTS_ONLY` which makes  `weights_only` configurable.

## Test Plan

Custom CPU image verification

## Test Result

TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

