### PR TITLE
[Bugfix] Avoid concurrent port allocation collisions

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 import socket
+import subprocess
+import sys
+from contextlib import closing
+from pathlib import Path
 
 import pytest
 import zmq
@@ -17,9 +22,76 @@ from vllm.utils.network_utils import (
 )
 
 
+def _get_unused_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("localhost", 0))
+        return sock.getsockname()[1]
+
+
+def _make_port_subprocess(base_port: int, rpc_base_path: Path, call: str):
+    code = r"""
+import importlib.util
+import logging
+import os
+import sys
+import types
+
+fake_vllm = types.ModuleType("vllm")
+fake_envs = types.ModuleType("vllm.envs")
+fake_envs.VLLM_DP_MASTER_PORT = 0
+fake_envs.VLLM_PORT = int(os.environ["VLLM_PORT"])
+fake_envs.VLLM_RPC_BASE_PATH = os.environ["VLLM_RPC_BASE_PATH"]
+
+fake_logger = types.ModuleType("vllm.logger")
+fake_logger.init_logger = lambda _: logging.getLogger("network_utils_under_test")
+
+sys.modules["vllm"] = fake_vllm
+sys.modules["vllm.envs"] = fake_envs
+sys.modules["vllm.logger"] = fake_logger
+
+spec = importlib.util.spec_from_file_location(
+    "network_utils_under_test", os.environ["NETWORK_UTILS_PATH"]
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+if os.environ["NETWORK_UTILS_CALL"] == "one":
+    print(module.get_open_port())
+else:
+    print(",".join(str(port) for port in module.get_open_ports_list(5)))
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "NETWORK_UTILS_CALL": call,
+            "NETWORK_UTILS_PATH": str(
+                Path(__file__).parents[2] / "vllm" / "utils" / "network_utils.py"
+            ),
+            "VLLM_PORT": str(base_port),
+            "VLLM_RPC_BASE_PATH": str(rpc_base_path),
+        }
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+
+
+def _collect_port_subprocesses(procs: list[subprocess.Popen[str]]) -> list[str]:
+    results: list[str] = []
+    for proc in procs:
+        stdout, stderr = proc.communicate(timeout=30)
+        assert proc.returncode == 0, stderr
+        results.append(stdout.strip())
+    return results
+
+
 def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m:
-        m.setenv("VLLM_PORT", "5678")
+        m.setenv("VLLM_PORT", str(_get_unused_port()))
         # make sure we can get multiple ports, even if the env var is set
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1:
             s1.bind(("localhost", get_open_port()))
@@ -29,9 +101,31 @@ def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
                     s3.bind(("localhost", get_open_port()))
 
 
+def test_get_open_port_with_vllm_port_is_unique_across_processes(tmp_path: Path):
+    base_port = _get_unused_port()
+    procs = [_make_port_subprocess(base_port, tmp_path, "one") for _ in range(8)]
+    ports = [int(port) for port in _collect_port_subprocesses(procs)]
+
+    assert len(ports) == len(set(ports)), ports
+
+
+def test_get_open_ports_list_with_vllm_port_is_unique_across_processes(
+    tmp_path: Path,
+):
+    base_port = _get_unused_port()
+    procs = [_make_port_subprocess(base_port, tmp_path, "list") for _ in range(2)]
+    port_lists = [
+        [int(port) for port in output.split(",")]
+        for output in _collect_port_subprocesses(procs)
+    ]
+    ports = [port for port_list in port_lists for port in port_list]
+
+    assert len(ports) == len(set(ports)), port_lists
+
+
 def test_get_open_ports_list_with_vllm_port(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m:
-        m.setenv("VLLM_PORT", "5678")
+        m.setenv("VLLM_PORT", str(_get_unused_port()))
         ports = get_open_ports_list(5)
         assert len(ports) == 5
         assert len(set(ports)) == 5, "ports must be unique"

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -5,6 +5,7 @@ import ipaddress
 import os
 import socket
 import sys
+import threading
 import warnings
 from collections.abc import (
     Iterator,
@@ -12,6 +13,11 @@ from collections.abc import (
 )
 from typing import Any
 from uuid import uuid4
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 import psutil
 import zmq
@@ -22,6 +28,9 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+_open_port_lock = threading.RLock()
+_next_port_from_env: dict[int, int] = {}
 
 
 def close_sockets(sockets: Sequence[zmq.Socket | zmq.asyncio.Socket]):
@@ -156,14 +165,15 @@ def get_open_port() -> int:
     Right now we reserve 10 ports for the data parallel master
     process. Currently it uses 2 ports.
     """
-    if "VLLM_DP_MASTER_PORT" in os.environ:
-        dp_master_port = envs.VLLM_DP_MASTER_PORT
-        reserved_port_range = range(dp_master_port, dp_master_port + 10)
-        while True:
-            candidate_port = _get_open_port()
-            if candidate_port not in reserved_port_range:
-                return candidate_port
-    return _get_open_port()
+    with _open_port_lock:
+        if "VLLM_DP_MASTER_PORT" in os.environ:
+            dp_master_port = envs.VLLM_DP_MASTER_PORT
+            reserved_port_range = range(dp_master_port, dp_master_port + 10)
+            while True:
+                candidate_port = _get_open_port()
+                if candidate_port not in reserved_port_range:
+                    return candidate_port
+        return _get_open_port()
 
 
 def get_open_ports_list(count: int = 5) -> list[int]:
@@ -172,19 +182,18 @@ def get_open_ports_list(count: int = 5) -> list[int]:
     When VLLM_PORT is set, scans upward from that port, advancing
     the start position after each find so every port is unique.
     """
-    ports_set = set[int]()
-    if envs.VLLM_PORT is not None:
-        next_port = envs.VLLM_PORT
-        for _ in range(count):
-            port = _get_open_port(start_port=next_port, max_attempts=1000)
-            ports_set.add(port)
-            next_port = port + 1
-        return list(ports_set)
-    else:
-        while len(ports_set) < count:
-            ports_set.add(get_open_port())
+    with _open_port_lock:
+        ports: list[int] = []
+        if envs.VLLM_PORT is not None:
+            for _ in range(count):
+                ports.append(_get_open_port(max_attempts=1000))
+        else:
+            while len(ports) < count:
+                port = get_open_port()
+                if port not in ports:
+                    ports.append(port)
 
-    return list(ports_set)
+        return ports
 
 
 def _get_open_port(
@@ -192,6 +201,79 @@ def _get_open_port(
     max_attempts: int | None = None,
 ) -> int:
     start_port = start_port if start_port is not None else envs.VLLM_PORT
+    if start_port is not None:
+        return _get_open_port_from_env(start_port, max_attempts)
+    return _get_open_port_uncached(start_port, max_attempts)
+
+
+def _get_open_port_in_process(
+    start_port: int,
+    max_attempts: int | None = None,
+) -> int:
+    next_port = max(start_port, _next_port_from_env.get(start_port, start_port))
+    port = _get_open_port_uncached(next_port, max_attempts)
+    _next_port_from_env[start_port] = port + 1
+    return port
+
+
+def _get_open_port_from_env(
+    start_port: int,
+    max_attempts: int | None = None,
+) -> int:
+    """Get an open port using a cross-process cursor.
+
+    Multiple independent vLLM processes can scan from the same starting port
+    concurrently, so the scan cursor must be shared across processes; otherwise
+    each process can select the same still-unbound port and race when binding
+    later.
+    """
+    lock_path = os.path.join(envs.VLLM_RPC_BASE_PATH, f"vllm_port_{start_port}.lock")
+    if fcntl is None:
+        return _get_open_port_in_process(start_port, max_attempts)
+
+    try:
+        os.makedirs(envs.VLLM_RPC_BASE_PATH, exist_ok=True)
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(lock_path, flags, 0o600)
+        with os.fdopen(fd, "r+") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+            lock_file.seek(0)
+            content = lock_file.read().strip()
+            try:
+                next_port = int(content) if content else start_port
+            except ValueError:
+                next_port = start_port
+            next_port = max(
+                start_port,
+                _next_port_from_env.get(start_port, start_port),
+                next_port,
+            )
+
+            port = _get_open_port_uncached(next_port, max_attempts)
+            _next_port_from_env[start_port] = port + 1
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.write(str(_next_port_from_env[start_port]))
+            lock_file.flush()
+            os.fsync(lock_file.fileno())
+            return port
+    except OSError as e:
+        logger.warning(
+            "Failed to use port lock file %s: %s. Falling back to uncached "
+            "port allocation.",
+            lock_path,
+            e,
+        )
+        return _get_open_port_in_process(start_port, max_attempts)
+
+
+def _get_open_port_uncached(
+    start_port: int | None = None,
+    max_attempts: int | None = None,
+) -> int:
     port = start_port
     if port is not None:
         attempts = 0


### PR DESCRIPTION
## Summary
- Serialize fixed-start port allocation across threads and local processes.
- Keep `VLLM_PORT`/explicit start ports as scan starts while advancing a shared cursor under `VLLM_RPC_BASE_PATH`.
- Avoid duplicate internal distributed init ports when multiple independent vLLM engines start concurrently from the same port base.
- Add subprocess-based regression tests that exercise separate Python processes sharing the same `VLLM_PORT` and cursor directory.

Fixes #43206

## Test Plan
- `git diff --check`
- `uv tool run ruff@0.14.0 check vllm/utils/network_utils.py tests/utils_/test_network_utils.py`
- `uv tool run ruff@0.14.0 format --check vllm/utils/network_utils.py tests/utils_/test_network_utils.py`
- `.venv/bin/python -m pytest tests/utils_/test_network_utils.py::test_get_open_port tests/utils_/test_network_utils.py::test_get_open_port_with_vllm_port_is_unique_across_processes tests/utils_/test_network_utils.py::test_get_open_ports_list_with_vllm_port_is_unique_across_processes tests/utils_/test_network_utils.py::test_get_open_ports_list_with_vllm_port -q` → `4 passed`

Additional manual validation:
- 8 spawned processes calling `get_open_port()` with the same `VLLM_PORT` returned 8 unique ports.
- 2 spawned processes calling `get_open_ports_list(5)` with the same `VLLM_PORT` returned 10 unique ports.

Note: I also tried a 3x TP=2 GPU repro on a shared 8xH20 node. The selected `distributed_init_method` ports were distinct after this patch, but the run still failed later during worker startup on the busy shared node, so the deterministic coverage here focuses on the isolated network utility race.
