### PR TITLE
[Bugfix] Reject invalid block_size, hash_block_size, and max_model_len

### DIFF
--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config.cache import CacheConfig
+
+
+def test_block_size_none_uses_default():
+    config = CacheConfig()
+    assert config.block_size == CacheConfig.DEFAULT_BLOCK_SIZE
+    assert config.user_specified_block_size is False
+
+
+def test_block_size_positive_is_accepted():
+    config = CacheConfig(block_size=32)
+    assert config.block_size == 32
+    assert config.user_specified_block_size is True
+
+
+@pytest.mark.parametrize("invalid_block_size", [0, -1, -16])
+def test_block_size_non_positive_raises(invalid_block_size):
+    with pytest.raises(ValueError, match="block_size"):
+        CacheConfig(block_size=invalid_block_size)
+
+
+@pytest.mark.parametrize("invalid_block_size", [0.5, 1.0, -0.5, True, False])
+def test_block_size_non_int_raises(invalid_block_size):
+    with pytest.raises(ValueError, match="block_size"):
+        CacheConfig(block_size=invalid_block_size)
+
+
+def test_hash_block_size_none_is_accepted():
+    config = CacheConfig(hash_block_size=None)
+    assert config.hash_block_size is None
+
+
+def test_hash_block_size_positive_is_accepted():
+    config = CacheConfig(hash_block_size=32)
+    assert config.hash_block_size == 32
+
+
+@pytest.mark.parametrize("invalid_hash_block_size", [0, -1, -16])
+def test_hash_block_size_non_positive_raises(invalid_hash_block_size):
+    with pytest.raises(ValueError, match="hash_block_size"):
+        CacheConfig(hash_block_size=invalid_hash_block_size)
+
+
+@pytest.mark.parametrize("invalid_hash_block_size", [0.5, 1.0, -0.5, True, False])
+def test_hash_block_size_non_int_raises(invalid_hash_block_size):
+    with pytest.raises(ValueError, match="hash_block_size"):
+        CacheConfig(hash_block_size=invalid_hash_block_size)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1467,3 +1467,19 @@ def test_ir_op_priority_ctx():
         # context restored even after exception
         assert ir.ops.rms_norm.get_priority() == ["vllm_c", "native"]
         assert ir.ops.fused_add_rms_norm.get_priority() == ["native"]
+
+
+@pytest.mark.parametrize("bad_value", [0, -2, -100])
+def test_max_model_len_rejects_zero_and_negative(bad_value):
+    with pytest.raises((ValueError, ValidationError)):
+        ModelConfig("facebook/opt-125m", max_model_len=bad_value)
+
+
+def test_max_model_len_accepts_auto_sentinel():
+    cfg = ModelConfig("facebook/opt-125m", max_model_len=-1)
+    assert cfg.max_model_len > 0
+
+
+def test_max_model_len_accepts_positive():
+    cfg = ModelConfig("facebook/opt-125m", max_model_len=512)
+    assert cfg.max_model_len == 512

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -230,7 +230,24 @@ class CacheConfig:
         if self.block_size is None:
             object.__setattr__(self, "block_size", self.DEFAULT_BLOCK_SIZE)
         else:
+            if (
+                not isinstance(self.block_size, int)
+                or isinstance(self.block_size, bool)
+                or self.block_size <= 0
+            ):
+                raise ValueError(
+                    f"block_size must be a positive integer, got {self.block_size!r}."
+                )
             object.__setattr__(self, "user_specified_block_size", True)
+        if self.hash_block_size is not None and (
+            not isinstance(self.hash_block_size, int)
+            or isinstance(self.hash_block_size, bool)
+            or self.hash_block_size <= 0
+        ):
+            raise ValueError(
+                f"hash_block_size must be a positive integer, got "
+                f"{self.hash_block_size!r}."
+            )
         if self.mamba_block_size is not None:
             object.__setattr__(self, "user_specified_mamba_block_size", True)
         return self

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -771,6 +771,15 @@ class ModelConfig:
             return value
         return handler(value)
 
+    @field_validator("max_model_len", mode="after")
+    @classmethod
+    def _check_max_model_len_positive_or_sentinel(cls, v: int) -> int:
+        if v == 0:
+            raise ValueError(
+                "max_model_len must be a positive integer or -1 (auto), got 0."
+            )
+        return v
+
     @field_validator("tokenizer_mode", mode="after")
     def _lowercase_tokenizer_mode(cls, tokenizer_mode: str) -> str:
         return tokenizer_mode.lower()


### PR DESCRIPTION
## Summary

Fixes #43496, #43521, and #43532.

- Reject non-positive or non-integer `block_size` and `hash_block_size` in `CacheConfig._apply_block_size_default` so users get a clear `ValueError` instead of a later `ZeroDivisionError` in KV cache setup.
- Reject `max_model_len=0` in `ModelConfig` so the engine does not accept a config that schedules requests with negative `num_new_tokens`.

## Why not duplicate

Checked open PRs before starting:

- #43514 (`block_size`)
- #43524 (`hash_block_size`)
- #43536 (`max_model_len`)

This PR consolidates all three fixes and their regression tests in one reviewable changeset. Happy to close or rebase if maintainers prefer the existing split PRs.

## AI assistance

Used Cursor for issue triage, environment setup, and drafting. I reviewed every changed line and ran the tests below locally.

## Test plan

- [x] `pytest tests/config/test_cache_config.py -v`
- [x] `pytest tests/test_config.py::test_max_model_len_rejects_zero_and_negative tests/test_config.py::test_max_model_len_accepts_auto_sentinel tests/test_config.py::test_max_model_len_accepts_positive -v`
- [x] `pre-commit run --files vllm/config/cache.py vllm/config/model.py tests/config/test_cache_config.py tests/test_config.py` (WSL Ubuntu 24.04)

Reproducers from the issues:

```python
from vllm.config.cache import CacheConfig
CacheConfig(block_size=0)  # ValueError
CacheConfig(hash_block_size=0)  # ValueError

from vllm.config import ModelConfig
ModelConfig(facebook/opt-125m, max_model_len=0)  # ValueError
```