### PR TITLE
[Bugfix] Reject mamba_block_size not divisible by 8

### DIFF
--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.config import CacheConfig
+
+
+@pytest.mark.parametrize("mamba_block_size", [8, 16, 512])
+def test_mamba_block_size_multiple_of_eight_accepted(
+    mamba_block_size: int,
+) -> None:
+    cfg = CacheConfig(mamba_block_size=mamba_block_size)
+    assert cfg.mamba_block_size == mamba_block_size
+    assert cfg.user_specified_mamba_block_size is True
+
+
+def test_mamba_block_size_none_accepted() -> None:
+    cfg = CacheConfig()
+    assert cfg.mamba_block_size is None
+    assert cfg.user_specified_mamba_block_size is False
+
+
+@pytest.mark.parametrize("mamba_block_size", [1, 7, 12, 15])
+def test_mamba_block_size_not_multiple_of_eight_rejected(
+    mamba_block_size: int,
+) -> None:
+    with pytest.raises(ValidationError, match="multiple of 8"):
+        CacheConfig(mamba_block_size=mamba_block_size)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -247,6 +247,16 @@ class CacheConfig:
             )
         return calculate_kv_scales
 
+    @field_validator("mamba_block_size", mode="after")
+    @classmethod
+    def _validate_mamba_block_size(cls, mamba_block_size: int | None) -> int | None:
+        if mamba_block_size is not None and mamba_block_size % 8 != 0:
+            raise ValueError(
+                f"mamba_block_size ({mamba_block_size}) must be a multiple of 8 "
+                "to align with the causal_conv1d kernel."
+            )
+        return mamba_block_size
+
     @field_validator("cache_dtype", mode="after")
     @classmethod
     def _validate_cache_dtype(cls, cache_dtype: CacheDType) -> CacheDType:


### PR DESCRIPTION
## Summary
- Reject `mamba_block_size` values that are not a multiple of 8 in `CacheConfig`, matching the existing field documentation for `causal_conv1d` alignment.
- Add CPU-only regression tests in `tests/config/test_cache_config.py`.

## Why this is not a duplicate
- Searched open PRs for `mamba_block_size validation` / `multiple of 8` — no matches.
- Separate from #43514 / #43524 (non-positive `block_size` / `hash_block_size` validation).

## Test plan
- [x] `pytest tests/config/test_cache_config.py -q` (8 passed)
- [x] `pre-commit run --files vllm/config/cache.py tests/config/test_cache_config.py`

## AI disclosure
AI assistance was used to implement and test this change. I reviewed all changed lines.