### PR TITLE
[KV Connector] MooncakeStore: drop dead discard_partial_chunks parameter

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -223,7 +223,6 @@ class ReqMeta:
         skip_save: bool | None = False,
         block_hashes: list[BlockHash] | None = None,
         is_last_chunk: bool | None = None,
-        discard_partial_chunks: bool = True,
         original_block_size: int | None = None,
     ) -> "ReqMeta | None":
         """Create ReqMeta from a RequestTracker."""
@@ -231,16 +230,8 @@ class ReqMeta:
             block_hashes = []
         input_token_len = tracker.token_len
 
-        chunk_boundary = (
-            cdiv(tracker.num_saved_tokens + 1, block_size) * block_size
-            if discard_partial_chunks
-            else 0
-        )
-        num_tokens_to_save = (
-            (input_token_len // block_size * block_size)
-            if discard_partial_chunks
-            else input_token_len
-        )
+        chunk_boundary = cdiv(tracker.num_saved_tokens + 1, block_size) * block_size
+        num_tokens_to_save = input_token_len // block_size * block_size
 
         skip_save = skip_save or num_tokens_to_save < chunk_boundary
         # A ReqMeta must never carry both a save AND a load.


### PR DESCRIPTION
## Summary

Follow-up to #43494 ("Keep MooncakeStore full hits block-aligned"). That PR
removed the `_discard_partial_chunks` config knob from `MooncakeStoreScheduler`
and all four `discard_partial_chunks=...` kwargs at the call sites of
`ReqMeta.from_request_tracker`. The parameter remained on the function itself
(defaulting to `True`) for minimal-surgery review scoping.

This PR completes the cleanup: removes the now-unreachable `else` branches
and the parameter from `ReqMeta.from_request_tracker` in
`mooncake/store/data.py`. No behavior change.

## Why this is not a duplicate

- `gh pr list --state open --search "discard_partial_chunks"` → 0 results.
- `gh issue list --state open --search "discard_partial_chunks"` → 0 results.
- `lmcache_integration/vllm_v1_adapter.py` has its own
  `ReqMeta.from_request_tracker` with the same parameter name; that copy
  still honors the flag (lmcache defaults to `False`) and is **not**
  affected by this PR — different module, different ReqMeta dataclass.

## Why this is not low-value busywork

Strictly the dead-code removal completion of #43494. Opening as draft so
maintainers can flag if it should instead be held until there is
substantive work in `data.py` to bundle it with, per AGENTS.md
"mechanical cleanups acceptable only when bundled with substantive work."
Happy to close and hold the patch.

## Tests

Ran on the branch:

- `pytest tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py -v` → 12 passed
- `pytest tests/v1/kv_connector/unit/test_mooncake_store_worker.py tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py -v` → 67 passed
- `ruff check`, `ruff format --check` → clean

## AI assistance

AI assistance was used to confirm dup-work checks, prepare the diff, and
run the tests above. The submitter reviewed every changed line.