### PR TITLE
[New Model]: Ovis2_6_NextForCausalLM (AIDC-AI/Ovis2.6-80B-A3B)

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -610,6 +610,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Ovis2_5` | Ovis2.5 | T + I<sup>+</sup> + V | `AIDC-AI/Ovis2.5-9B`, etc. | | |
 | `Ovis2_6ForCausalLM` | Ovis2.6 | T + I<sup>+</sup> + V | `AIDC-AI/Ovis2.6-2B`, etc. | | |
 | `Ovis2_6_MoeForCausalLM` | Ovis2.6 | T + I<sup>+</sup> + V | `AIDC-AI/Ovis2.6-30B-A3B`, etc. | | |
+| `Ovis2_6_NextForCausalLM` | Ovis2.6 | T + I<sup>+</sup> + V | `AIDC-AI/Ovis2.6-80B-A3B`, etc. | | |
 | `PaddleOCRVLForConditionalGeneration` | Paddle-OCR | T + I<sup>+</sup> | `PaddlePaddle/PaddleOCR-VL`, etc. | | |
 | `PaliGemmaForConditionalGeneration` | PaliGemma, PaliGemma 2 | T + I<sup>E</sup> | `google/paligemma-3b-pt-224`, `google/paligemma-3b-mix-224`, `google/paligemma2-3b-ft-docci-448`, etc. | ✅︎ | ✅︎ |
 | `Phi3VForCausalLM` | Phi-3-Vision, Phi-3.5-Vision | T + I<sup>E+</sup> | `microsoft/Phi-3-vision-128k-instruct`, `microsoft/Phi-3.5-vision-instruct`, etc. | | ✅︎ |

--- a/vllm/model_executor/models/ovis2_6_next.py
+++ b/vllm/model_executor/models/ovis2_6_next.py
@@ -117,17 +117,34 @@ class Ovis2_6_Next(Ovis2_5, IsHybrid):
     # parameters and populate cache_config.mamba_block_size. The Ovis
     # wrapper has no Mamba layers of its own — only the inner Qwen3-Next
     # backbone does — so we delegate to that class's existing impl.
+    #
+    # Qwen3NextForCausalLM's classmethods read
+    # ``vllm_config.model_config.hf_text_config`` for the LLM-side
+    # config (linear_num_key_heads, linear_conv_kernel_dim, etc.). For
+    # Ovis 2.6 Next, that inner config lives at
+    # ``hf_config.llm_config``. We substitute it explicitly via
+    # ``vllm_config.with_hf_config(...)`` before delegating, mirroring
+    # the pattern this class uses in ``__init__`` for
+    # ``init_vllm_registered_model``.
+    @classmethod
+    def _vllm_config_with_llm(cls, vllm_config: VllmConfig) -> VllmConfig:
+        return vllm_config.with_hf_config(vllm_config.model_config.hf_config.llm_config)
+
     @classmethod
     def get_mamba_state_shape_from_config(
         cls, vllm_config: VllmConfig
     ) -> tuple[tuple[int, int], tuple[int, int]]:
-        return Qwen3NextForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+        return Qwen3NextForCausalLM.get_mamba_state_shape_from_config(
+            cls._vllm_config_with_llm(vllm_config)
+        )
 
     @classmethod
     def get_mamba_state_dtype_from_config(
         cls, vllm_config: VllmConfig
     ) -> tuple[torch.dtype, torch.dtype]:
-        return Qwen3NextForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+        return Qwen3NextForCausalLM.get_mamba_state_dtype_from_config(
+            cls._vllm_config_with_llm(vllm_config)
+        )
 
     @classmethod
     def get_mamba_state_copy_func(

--- a/vllm/model_executor/models/ovis2_6_next.py
+++ b/vllm/model_executor/models/ovis2_6_next.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PyTorch Ovis 2.6 Next model.
+
+Wraps the existing :class:`Qwen3NextForCausalLM` backbone (hybrid Mamba2 /
+GatedDeltaNet + Attention + MoE) with the same Ovis vision-language adapter
+(SigLIP2-NaViT visual tower + visual tokenizer + visual token embedding)
+that :class:`Ovis2_5` already implements for the Ovis 2.5 and Ovis 2.6 Moe
+variants.
+
+The implementation is structurally identical to :class:`Ovis2_5`; the only
+deltas are:
+
+1. ``__init__`` passes ``config.llm_config`` (the :class:`Qwen3NextConfig`
+   under ``sub_configs``) to :func:`init_vllm_registered_model` rather than
+   ``config.text_config``, which the Ovis 2.6 Next config classes do not
+   define.
+2. The class declares the :class:`IsHybrid` interface so vLLM's
+   ``HybridAttentionMambaModelConfig.verify_and_update_config`` runs during
+   config setup. That hook auto-derives ``cache_config.mamba_block_size``
+   from the LLM's ``max_model_len`` and triggers the Mamba-only cache-config
+   plumbing. The Mamba state classmethods below delegate to the existing
+   :class:`Qwen3NextForCausalLM` implementation — the Ovis wrapper has no
+   Mamba layers of its own; only the inner LLM does, so direct delegation
+   is correct.
+
+Safetensors weight layout matches the Moe sibling — ``llm.model.layers.*``
+for the LLM, ``visual_tokenizer.vit.*`` for SigLIP2,
+``visual_tokenizer.head.*`` for the visual head, and ``vte.weight`` for the
+visual token embedding — so :class:`AutoWeightsLoader` (inherited via
+``Ovis2_5.load_weights``) maps them to the right submodules without
+modification.
+
+Tested with ``AIDC-AI/Ovis2.6-80B-A3B``.
+"""
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+from transformers import PretrainedConfig
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.interfaces import IsHybrid
+from vllm.model_executor.models.ovis import VisualEmbedding
+from vllm.model_executor.models.ovis2_5 import (
+    IMAGE_PAD_TOKEN_ID,
+    Ovis2_5,
+    Ovis2_5DummyInputsBuilder,
+    Ovis2_5MultiModalProcessor,
+    Ovis2_5ProcessingInfo,
+    VisualTokenizer,
+)
+from vllm.model_executor.models.qwen3_next import Qwen3NextForCausalLM
+from vllm.model_executor.models.utils import (
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.mamba.abstract import MambaStateCopyFunc
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Ovis2_5MultiModalProcessor,
+    info=Ovis2_5ProcessingInfo,
+    dummy_inputs=Ovis2_5DummyInputsBuilder,
+)
+class Ovis2_6_Next(Ovis2_5, IsHybrid):
+    """Ovis 2.6 with Qwen3-Next backbone (hybrid Mamba2/GatedDeltaNet +
+    Attention + MoE).
+
+    Inherits all vision processing, prompt-replacement and weight-loading
+    logic from :class:`Ovis2_5`. ``__init__`` is overridden to pass
+    ``config.llm_config`` (rather than the non-existent
+    ``config.text_config``) to :func:`init_vllm_registered_model`; the
+    Mamba state classmethods delegate to :class:`Qwen3NextForCausalLM`.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # Replicates Ovis2_5.__init__ but passes config.llm_config in place
+        # of config.text_config, because Ovis 2.6 Next declares its LLM
+        # backbone under sub_configs.llm_config (Qwen3NextConfig).
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+
+        self.config: PretrainedConfig = config
+
+        with self._mark_language_model(vllm_config):
+            self.llm = init_vllm_registered_model(
+                vllm_config=vllm_config.with_hf_config(config.llm_config),
+                prefix=maybe_prefix(prefix, "llm"),
+            )
+
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.visual_tokenizer = VisualTokenizer(
+                config=config.vit_config,
+                visual_vocab_size=config.visual_vocab_size,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "visual_tokenizer"),
+            )
+            self.vte = VisualEmbedding(
+                config.visual_vocab_size,
+                config.hidden_size,
+            )
+
+        self.image_pad_token_id: int = IMAGE_PAD_TOKEN_ID
+
+        self.make_empty_intermediate_tensors = (
+            self.get_language_model().make_empty_intermediate_tensors
+        )
+
+    # IsHybrid protocol: vLLM's HybridAttentionMambaModelConfig consults
+    # these classmethods at config-setup time to derive Mamba cache-spec
+    # parameters and populate cache_config.mamba_block_size. The Ovis
+    # wrapper has no Mamba layers of its own — only the inner Qwen3-Next
+    # backbone does — so we delegate to that class's existing impl.
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return Qwen3NextForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return Qwen3NextForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple["MambaStateCopyFunc", "MambaStateCopyFunc"]:
+        return Qwen3NextForCausalLM.get_mamba_state_copy_func()

--- a/vllm/model_executor/models/ovis2_6_next.py
+++ b/vllm/model_executor/models/ovis2_6_next.py
@@ -31,7 +31,12 @@ visual token embedding — so :class:`AutoWeightsLoader` (inherited via
 ``Ovis2_5.load_weights``) maps them to the right submodules without
 modification.
 
-Tested with ``AIDC-AI/Ovis2.6-80B-A3B``.
+Tested with ``AIDC-AI/Ovis2.6-80B-A3B``::
+
+    vllm serve AIDC-AI/Ovis2.6-80B-A3B \
+        --trust-remote-code \
+        --tensor-parallel-size 4 \
+        --enforce-eager
 """
 
 from typing import TYPE_CHECKING

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -509,6 +509,7 @@ _MULTIMODAL_MODELS = {
     "Ovis2_5": ("ovis2_5", "Ovis2_5"),
     "Ovis2_6ForCausalLM": ("ovis2_5", "Ovis2_5"),
     "Ovis2_6_MoeForCausalLM": ("ovis2_5", "Ovis2_5"),
+    "Ovis2_6_NextForCausalLM": ("ovis2_6_next", "Ovis2_6_Next"),
     "PaddleOCRVLForConditionalGeneration": (
         "paddleocr_vl",
         "PaddleOCRVLForConditionalGeneration",


### PR DESCRIPTION
## Summary

Adds vLLM-native support for the Ovis 2.6 Next family. The headline
checkpoint is `AIDC-AI/Ovis2.6-80B-A3B` — an 80B-total / 3B-active MoE
that wraps a `Qwen3-Next-80B-A3B-Thinking` backbone (hybrid Mamba2 /
GatedDeltaNet + Attention + MoE) with the same SigLIP2-NaViT visual
adapter that `Ovis2_5` already implements for the Ovis 2.5 / 2.6 Moe
variants.

Before this PR, `vllm serve AIDC-AI/Ovis2.6-80B-A3B --trust-remote-code`
fails arch resolution because the published arch
(`Ovis2_6_NextForCausalLM`) is not registered. After this PR it loads
through the existing Ovis 2.5 vision pipeline and the existing
`Qwen3NextForCausalLM` backbone with no new low-level kernels needed.

## Why this is not duplicating an existing PR/issue

Verified via the search commands listed in AGENTS.md before posting
this disclosure:

```
gh pr list --repo vllm-project/vllm --state open --search "Ovis2.6 in:title"
gh pr list --repo vllm-project/vllm --state open --search "Ovis2_6_Next in:title,body"
gh pr list --repo vllm-project/vllm --state open --search "Ovis2.6-80B in:title,body"
gh issue list --repo vllm-project/vllm --state all --search "AIDC-AI/Ovis2.6-80B-A3B in:title,body"
```

Results: no open PR for `Ovis2_6_Next` / `Ovis2.6-80B-A3B`; no open
issue for this model specifically. Prior Ovis-family PRs (#26308,
#20921, #18958) are all merged and unrelated (general 2.5 compile
fixes, multimodal config consolidation, PP/GPTQ inference fixes).

## Approach

`Ovis2_6_Next` inherits from `Ovis2_5` and reuses all of its
multimodal processing, prompt-replacement, and weight-loading logic.
Only two structural deltas were needed:

1. **Config plumbing** — Ovis 2.6 Next declares its LLM backbone under
   `sub_configs.llm_config` (a `Qwen3NextConfig`) rather than
   `text_config`, which `Ovis2_5.__init__` reads. `Ovis2_6_Next.__init__`
   passes `config.llm_config` to `init_vllm_registered_model`
   explicitly, so the inner LLM resolves to the existing vLLM
   `Qwen3NextForCausalLM` impl. The visual tower setup, `vte`, and
   `image_pad_token_id` mirror `Ovis2_5` unchanged.

2. **`IsHybrid` declaration** — Without `IsHybrid`,
   `HybridAttentionMambaModelConfig.verify_and_update_config` doesn't
   run for this model and `cache_config.mamba_block_size` stays `None`,
   causing `Worker` startup to assert at KV-cache spec construction.
   The three Mamba state classmethods
   (`get_mamba_state_shape_from_config`,
   `get_mamba_state_dtype_from_config`, `get_mamba_state_copy_func`)
   delegate to `Qwen3NextForCausalLM` because the Ovis wrapper has no
   Mamba layers of its own; only the inner LLM does. Each helper
   first substitutes the inner ``llm_config`` via
   ``vllm_config.with_hf_config(...)`` so the inner classmethods read
   the right fields (linear_num_key_heads, linear_conv_kernel_dim,
   etc.) — same pattern ``__init__`` uses for
   ``init_vllm_registered_model``.

Safetensors weight layout matches the Moe sibling
(`llm.model.layers.*`, `visual_tokenizer.vit.*`,
`visual_tokenizer.head.*`, `vte.weight`), so the existing
`AutoWeightsLoader` path from `Ovis2_5.load_weights` is reused without
modification.

## Files

- **new** `vllm/model_executor/models/ovis2_6_next.py`
- `vllm/model_executor/models/registry.py` — `+1` entry alongside the
  other Ovis arches
- `docs/models/supported_models.md` — `+1` row in the multimodal table

## Test plan and results

Commands run on Nibi (Alliance Canada) with 4×H100 80GB BF16,
``def-jcaplan_gpu`` partition. ``venv_vllm_ovis80b`` was built from
vLLM nightly (``0.21.1rc1.dev275+g5c1aec3dc``) plus
``transformers==4.57.0``, ``tokenizers==0.22.1``, ``accelerate>=1.12.0``:

```
# Lint
ruff check  vllm/model_executor/models/ovis2_6_next.py    # All checks passed!
ruff format vllm/model_executor/models/ovis2_6_next.py    # 1 file left unchanged

# Arch registry
python3 -c 'from vllm import ModelRegistry; \
            print("Ovis2_6_NextForCausalLM" in ModelRegistry.get_supported_archs())'
# True

# Programmatic load + generate (vllm.LLM Python API)
python3 -c 'from vllm import LLM, SamplingParams; \
            llm = LLM(model="AIDC-AI/Ovis2.6-80B-A3B", \
                      trust_remote_code=True, tensor_parallel_size=4, \
                      max_model_len=4096, enforce_eager=True, dtype="bfloat16"); \
            print(llm.generate(["What is 2+2?"], SamplingParams(max_tokens=16))[0].outputs[0].text)'
# Server loaded: vllm 0.21.1rc1.dev275+g5c1aec3dc
# Resolved architecture: Ovis2_6_NextForCausalLM
# Loading safetensors checkpoint shards: 100% Completed | 33/33
# GPU KV cache size: 1,568,552 tokens
# Max concurrency for 4,096 tokens per request: 382.95x
# Output: " 4"

# OpenAI-compatible server end-to-end
vllm serve AIDC-AI/Ovis2.6-80B-A3B \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --max-model-len 16384 \
    --enforce-eager
# Server ready in ~14 min (incl. flashinfer autotuning)
# /v1/chat/completions returns clean, parseable text-only output
```

A larger validation against the reference HF Transformers
implementation of the same checkpoint was also done — outputs aligned
on the same prompts within the model's own sampling variance.

## AI-assistance disclosure (per AGENTS.md)

This PR was prepared with assistance from an AI coding agent (Claude
in Claude Code). A human submitter (`@devon7y`) directed every
substantive decision: which model to add, what to test, what to
include or omit, when to push, and how to respond to review. All
diffs were reviewed before commit. The latest commit carries a
``Co-authored-by: Claude`` trailer (the first two commits in this
series predate that bookkeeping fix; the trailer is on the most
recent commit and applies to the PR as a whole).