### PR TITLE
[Doc] Add line limit to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ pre-commit run ruff-check --all-files
 pre-commit run mypy-3.10 --all-files --hook-stage manual
 ```
 
+The line length limit is 88 characters. If you are not sure, use pre-commit to check.
+
 ### Commit messages
 
 Add attribution using commit trailers such as `Co-authored-by:` (other projects use `Assisted-by:` or `Generated-by:`). For example:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ pre-commit run ruff-check --all-files
 pre-commit run mypy-3.10 --all-files --hook-stage manual
 ```
 
-The line length limit is 88 characters. If you are not sure, use pre-commit to check.
+The line length limit for Python code is 88 characters. If you are not sure, use pre-commit to check.
 
 ### Commit messages
 


### PR DESCRIPTION
This PR adds the line limit information (i.e., 88 characters) to `AGENTS.md`. This will help the agent avoid unnecessary limit breaks.