### PR TITLE
[BugFix] Fix Mistral3 multimodal offline example

### DIFF
--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -21,6 +21,7 @@ from vllm.assets.image import ImageAsset
 from vllm.assets.video import VideoAsset
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.image import convert_image_mode
+from vllm.multimodal.utils import encode_image_url
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 
@@ -30,6 +31,7 @@ class ModelRequestData(NamedTuple):
     stop_token_ids: list[int] | None = None
     lora_requests: list[LoRARequest] | None = None
     sampling_params: list[SamplingParams] | None = None
+    use_llm_chat: bool = False
 
 
 # NOTE: The default `max_num_seqs` and `max_model_len` may result in OOM on
@@ -1523,18 +1525,19 @@ def run_mistral3(questions: list[str], modality: str) -> ModelRequestData:
     # NOTE: Need L40 (or equivalent) to avoid OOM
     engine_args = EngineArgs(
         model=model_name,
+        tokenizer_mode="mistral",
+        config_format="mistral",
+        load_format="mistral",
         max_model_len=8192,
         max_num_seqs=2,
         tensor_parallel_size=2,
         limit_mm_per_prompt={modality: 1},
-        ignore_patterns=["consolidated.safetensors"],
     )
-
-    prompts = [f"<s>[INST]{question}\n[IMG][/INST]" for question in questions]
 
     return ModelRequestData(
         engine_args=engine_args,
-        prompts=prompts,
+        prompts=questions,
+        use_llm_chat=True,
     )
 
 
@@ -2911,6 +2914,22 @@ def main(args):
     lora_request = (
         req_data.lora_requests * args.num_prompts if req_data.lora_requests else None
     )
+
+    if req_data.use_llm_chat:
+        messages = [
+            [{"role": "user", "content": [
+                {"type": "text", "text": prompts[i % len(prompts)]},
+                {"type": "image_url", "image_url": {"url": encode_image_url(data)}},
+            ]}]
+            for i in range(args.num_prompts)
+        ]
+
+        with time_counter(args.time_generate):
+            outputs = llm.chat(messages, sampling_params=sampling_params)
+
+        for o in outputs:
+            print(o.outputs[0].text)
+        return
 
     with time_counter(args.time_generate):
         outputs = llm.generate(

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -2916,10 +2916,14 @@ def main(args):
     )
 
     if req_data.use_llm_chat:
+        if args.verify_mm_cache_hit_with_uuids:
+            raise ValueError("verify-mm-cache-hit-with-uuids is not supported when use_llm_chat is True.")
+
+        images = [inputs["multi_modal_data"][modality]] if args.num_prompts == 1 else [inp["multi_modal_data"][modality] for inp in inputs]
         messages = [
             [{"role": "user", "content": [
                 {"type": "text", "text": prompts[i % len(prompts)]},
-                {"type": "image_url", "image_url": {"url": encode_image_url(data)}},
+                {"type": "image_url", "image_url": {"url": encode_image_url(images[i])}},
             ]}]
             for i in range(args.num_prompts)
         ]

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -1528,6 +1528,7 @@ def run_mistral3(questions: list[str], modality: str) -> ModelRequestData:
         tokenizer_mode="mistral",
         config_format="mistral",
         load_format="mistral",
+        ignore_patterns=["consolidated.safetensors", "model*.safetensors"],
         max_model_len=8192,
         max_num_seqs=2,
         tensor_parallel_size=2,

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -2931,8 +2931,11 @@ def main(args):
         with time_counter(args.time_generate):
             outputs = llm.chat(messages, sampling_params=sampling_params)
 
+        print("-" * 50)
         for o in outputs:
-            print(o.outputs[0].text)
+             generated_text = o.outputs[0].text
+             print(generated_text)
+             print("-" * 50)
         return
 
     with time_counter(args.time_generate):

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -2918,14 +2918,29 @@ def main(args):
 
     if req_data.use_llm_chat:
         if args.verify_mm_cache_hit_with_uuids:
-            raise ValueError("verify-mm-cache-hit-with-uuids is not supported when use_llm_chat is True.")
+            raise ValueError(
+                "verify-mm-cache-hit-with-uuids is not supported when "
+                "use_llm_chat is True."
+            )
 
-        images = [inputs["multi_modal_data"][modality]] if args.num_prompts == 1 else [inp["multi_modal_data"][modality] for inp in inputs]
+        images = (
+            [inputs["multi_modal_data"][modality]]
+            if args.num_prompts == 1
+            else [inp["multi_modal_data"][modality] for inp in inputs]
+        )
         messages = [
-            [{"role": "user", "content": [
-                {"type": "text", "text": prompts[i % len(prompts)]},
-                {"type": "image_url", "image_url": {"url": encode_image_url(images[i])}},
-            ]}]
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompts[i % len(prompts)]},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": encode_image_url(images[i])},
+                        },
+                    ],
+                }
+            ]
             for i in range(args.num_prompts)
         ]
 
@@ -2934,9 +2949,9 @@ def main(args):
 
         print("-" * 50)
         for o in outputs:
-             generated_text = o.outputs[0].text
-             print(generated_text)
-             print("-" * 50)
+            generated_text = o.outputs[0].text
+            print(generated_text)
+            print("-" * 50)
         return
 
     with time_counter(args.time_generate):

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -1528,7 +1528,7 @@ def run_mistral3(questions: list[str], modality: str) -> ModelRequestData:
         tokenizer_mode="mistral",
         config_format="mistral",
         load_format="mistral",
-        ignore_patterns=["consolidated.safetensors", "model*.safetensors"],
+        ignore_patterns=["model*.safetensors"],
         max_model_len=8192,
         max_num_seqs=2,
         tensor_parallel_size=2,


### PR DESCRIPTION
## Purpose

Fix #33828.

The `run_mistral3()` example in `vision_language_offline.py` crashes with:
```
RuntimeError: Expected there to be 1 prompt placeholders corresponding to 1 image items, but instead found 0 prompt placeholders!
```

Root cause: `[IMG]` is tokenized into regular subword tokens, not Mistral's special image token (ID 10). Pixtral's processor sets `target=""` + `is_update_applied=True`, meaning it never does placeholder replacement — it assumes image tokens were already inserted by the Mistral tokenizer during chat encoding.

Fix: Following the pattern in `mistral-small_offline.py`, switch to `llm.chat()` + `tokenizer_mode="mistral"` so the native Mistral tokenizer handles image token insertion. No changes to vLLM core — only adds a `use_llm_chat` branch in the example harness. Trade-off: Mistral3 now takes a different path from the other ~70 models in this file.

## Test Plan

Verified preprocessing behavior in Docker (vllm v0.20.0, GPU):
- Raw `[IMG]` + HF tokenizer → RuntimeError (confirms bug exists)
- Mistral tokenizer + chat template → preprocessing succeeds
- `ruff check` passes

## Test Result

```
Test 1: raw [IMG] + HF tokenizer...
  PASS - got expected RuntimeError
Test 2: Mistral tokenizer + chat template...
  PASS - preprocessing succeeded
```

## Notes
- No existing open PR addresses this issue.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update.
- [ ] (Optional) Release notes update.
</details>

cc @DarkLight1337 @patrickvonplaten