### PR TITLE
[XPU] Add W8A8 FP8 linear kernel with multi-granularity quant support

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -155,7 +155,8 @@ from vllm.model_executor.kernels.linear.scaled_mm.triton import (
     TritonInt8ScaledMMLinearKernel,
 )
 from vllm.model_executor.kernels.linear.scaled_mm.xpu import (
-    XPUFP8ScaledMMLinearKernel,
+    XPUW8A8FP8LinearKernel,
+    XPUW8A16FP8LinearKernel,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.platforms import PlatformEnum, current_platform
@@ -284,7 +285,7 @@ _POSSIBLE_FP8_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] =
         ChannelWiseTorchFP8ScaledMMLinearKernel,
     ],
     PlatformEnum.XPU: [
-        XPUFP8ScaledMMLinearKernel,
+        XPUW8A8FP8LinearKernel,
     ],
 }
 
@@ -323,7 +324,7 @@ _POSSIBLE_WFP8A16_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]
         # To be added
     ],
     PlatformEnum.XPU: [
-        XPUFP8ScaledMMLinearKernel,
+        XPUW8A16FP8LinearKernel,
     ],
 }
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -10,20 +10,123 @@ from vllm.model_executor.kernels.linear import (  # noqa: E501
     FP8ScaledMMLinearLayerConfig,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8DynamicTensorSym,
+    kFp8DynamicTokenSym,
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
+    kFp8StaticTokenSym,
 )
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
 
-class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
+class XPUW8A8FP8LinearKernel(FP8ScaledMMLinearKernel):
+    _SUPPORTED_ACT_QUANT_KEYS = {
+        kFp8DynamicTensorSym,
+        kFp8DynamicTokenSym,
+        kFp8StaticTensorSym,
+        kFp8StaticTokenSym,
+    }
+    _SUPPORTED_WEIGHT_QUANT_KEYS = {
+        kFp8StaticChannelSym,
+        kFp8StaticTensorSym,
+    }
+
     @classmethod
     def is_supported(
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
         if not current_platform.is_xpu():
-            return False, "XPUFP8ScaledMM only support on XPU"
+            return False, "XPUW8A8FP8Linear only support on XPU"
+        return True, None
+
+    @classmethod
+    def can_implement(cls, c: FP8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
+        if c.weight_quant_key not in cls._SUPPORTED_WEIGHT_QUANT_KEYS:
+            return (
+                False,
+                "XPUW8A8FP8Linear only support per-channel and per-tensor quantization",
+            )
+        if c.activation_quant_key not in cls._SUPPORTED_ACT_QUANT_KEYS:
+            return (
+                False,
+                "XPUW8A8FP8Linear only support per-tensor and per-token activation "
+                "quantization",
+            )
+        if c.weight_quant_key.dtype not in {torch.float8_e5m2, torch.float8_e4m3fn}:
+            return False, "XPUW8A8FP8Linear only support FP8 weight dtype"
+        if c.activation_quant_key.dtype not in {
+            torch.float8_e5m2,
+            torch.float8_e4m3fn,
+        }:
+            return False, "XPUW8A8FP8Linear only support FP8 activation dtype"
+        return True, None
+
+    def __init__(
+        self, c: FP8ScaledMMLinearLayerConfig, layer_param_names: Sequence[str]
+    ) -> None:
+        super().__init__(c, layer_param_names)
+
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Ensure weight is stored as C-contiguous [K, N] (KN layout).
+
+        Checkpoints store weight as [N, K]; fp8_gemm requires [K, N],
+        C-contiguous.  Three incoming layouts are possible:
+          • [N, K] C-contiguous   ← direct checkpoint   → .t().contiguous()
+          • [K, N] Fortran-order  ← fp8.py's weight.t() → .contiguous()
+          • [K, N] C-contiguous   ← already correct     → no-op
+
+        For square weights (K == N) the shape is ambiguous; contiguity is used
+        as a proxy: C-contiguous ≡ checkpoint [N, K] (needs transpose);
+        Fortran-order ≡ fp8.py already transposed (needs only contiguous).
+        """
+        K = getattr(layer, "input_size_per_partition", self.config.weight_shape[1])
+        N = getattr(layer, "output_size_per_partition", self.config.weight_shape[0])
+        w = layer.weight
+
+        if w.shape not in {(K, N), (N, K)}:
+            raise ValueError(
+                f"XPUFP8ScaledMM expects weight shape ({K},{N}) or ({N},{K}), "
+                f"but got {tuple(w.shape)}"
+            )
+
+        needs_transpose = w.shape == (N, K) if K != N else w.is_contiguous()
+        layer_weight = w.t() if needs_transpose else w
+        replace_parameter(layer, "weight", layer_weight.contiguous())
+        ws = layer.weight_scale
+        if ws.numel() == 1:
+            replace_parameter(layer, "weight_scale", ws.reshape(1))
+
+    def apply_scaled_mm(
+        self,
+        *,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        out_dtype: torch.dtype,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+        bias: torch.Tensor | None,
+        output_shape: list,
+    ) -> torch.Tensor:
+        # B is C-contiguous [K, N] from process_weights_after_loading.
+        # fp8_gemm routes on scale dtype (float32) and numel:
+        #   As [1]   → per-tensor  (numel==1 branch)
+        #   As [M,1] → per-token   (group={1,K} branch, broadcast across K)
+        #   Bs [1]   → per-tensor
+        #   Bs [N]   → per-channel (mask=bit1 branch)
+        # No shape manipulation needed here.
+        output = torch.ops._xpu_C.fp8_gemm(A, B, out_dtype, As, Bs, bias)
+        return output.view(*output_shape)
+
+
+class XPUW8A16FP8LinearKernel(XPUW8A8FP8LinearKernel):
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_xpu():
+            return False, "XPUW8A16FP8Linear only support on XPU"
         return True, None
 
     @classmethod
@@ -31,10 +134,10 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         if c.weight_quant_key not in {kFp8StaticChannelSym, kFp8StaticTensorSym}:
             return (
                 False,
-                "XPUFP8ScaledMM only support per-channel and per-tensor quantization",
+                "XPUW8A16FP8Linear only support per-channel and per-tensor quantization",
             )
         if c.weight_quant_key.dtype not in {torch.float8_e5m2, torch.float8_e4m3fn}:
-            return False, "XPUFP8ScaledMM only support FP8 weight dtype"
+            return False, "XPUW8A16FP8Linear only support FP8 weight dtype"
         return True, None
 
     def __init__(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -656,8 +656,13 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsW4A4Fp4()
 
             if self._is_fp8_w8a8(weight_quant, input_quant):
-                is_fp8_w8a8_supported = self._check_scheme_supported(
-                    CompressedTensorsW8A8Fp8.get_min_capability(), error=False
+                # XPU does not expose a CUDA-style capability, but has its own
+                # W8A8 FP8 kernel path.
+                is_fp8_w8a8_supported = (
+                    self._check_scheme_supported(
+                        CompressedTensorsW8A8Fp8.get_min_capability(), error=False
+                    )
+                    or current_platform.is_xpu()
                 )
                 if is_fp8_w8a8_supported:
                     return CompressedTensorsW8A8Fp8(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -308,7 +308,7 @@ class Fp8LinearMethod(LinearMethodBase):
             # Use per-token quantization for better perf if dynamic and cutlass
             if self.act_q_static:
                 self.activation_quant_key = kFp8StaticTensorSym
-            elif cutlass_fp8_supported():
+            elif cutlass_fp8_supported() or current_platform.is_xpu():
                 self.activation_quant_key = kFp8DynamicTokenSym
             else:
                 self.activation_quant_key = kFp8DynamicTensorSym

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -108,7 +108,7 @@ class Fp8PerTensorOnlineLinearMethod(_Fp8OnlineLinearBase):
 
         self.weight_quant_key = kFp8StaticTensorSym
         # Use per-token quantization for better perf if dynamic and cutlass
-        if cutlass_fp8_supported():
+        if cutlass_fp8_supported() or current_platform.is_xpu():
             self.activation_quant_key = kFp8DynamicTokenSym
         else:
             self.activation_quant_key = kFp8DynamicTensorSym


### PR DESCRIPTION

## Purpose
This PR adds `XPUW8A8FP8LinearKernel` and `XPUW8A16FP8LinearKernel` for XPU,
replacing the previous `XPUFP8ScaledMMLinearKernel` with proper support for
multiple weight/activation quantization granularities.

### Changes

- Add `XPUW8A8FP8LinearKernel` and `XPUW8A16FP8LinearKernel`, replacing `XPUFP8ScaledMMLinearKernel`
- Select W8A8 or W8A16 kernel based on whether activation quantization is present
- Ensure dynamic activation quantization uses per-token granularity (`kFp8DynamicTokenSym`) on XPU

---

## Accuracy Tests

**Benchmark:** gsm8k, 250 samples, 5-shot, eager mode
**Environment:** `ZE_AFFINITY_MASK=4,5`, `VLLM_USE_V1=1`

Test script (`acc.py`):

```python
import argparse
from lm_eval import evaluator
from lm_eval.models.vllm_causallms import VLLM

parser = argparse.ArgumentParser()
parser.add_argument("--model", required=True)
parser.add_argument("--dtype", default="bfloat16")
parser.add_argument("--tp", type=int, default=1)
parser.add_argument("--quantization", default=None)
parser.add_argument("--gpu-memory-util", type=float, default=0.9)
parser.add_argument("--max-model-len", type=int, default=None)
args = parser.parse_args()

model_kwargs = {
    "pretrained": args.model,
    "dtype": args.dtype,
    "tensor_parallel_size": args.tp,
    "gpu_memory_utilization": args.gpu_memory_util,
    "add_bos_token": True,
    "trust_remote_code": True,
    "enforce_eager": True,
}
if args.quantization:
    model_kwargs["quantization"] = args.quantization
if args.max_model_len:
    model_kwargs["max_model_len"] = args.max_model_len

results = evaluator.simple_evaluate(
    model=VLLM(**model_kwargs),
    tasks=["gsm8k"],
    num_fewshot=5,
    limit=250,
    batch_size=20,
)
print(results["results"])
```

---

### Case Definitions

| Case | Weight Quant Key | Act Quant Key | Model | TP | Extra Args |
|------|-----------------|---------------|-------|----|------------|
| static-tensor-weight + static-tensor-act | `kFp8StaticTensorSym` | `kFp8StaticTensorSym` | `RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8` | 2 | — |
| static-channel-weight + dynamic-token-act | `kFp8StaticChannelSym` | `kFp8DynamicTokenSym` | `RedHatAI/Qwen3-32B-FP8-dynamic` | 2 | `--max-model-len 30720` |
| static-tensor-weight + dynamic-token-act | `kFp8StaticTensorSym` | `kFp8DynamicTokenSym` | `neuralmagic/Llama-3.2-1B-Instruct-FP8-dynamic` | 1 | — |
| static-tensor-weight + dynamic-tensor-act | `kFp8StaticTensorSym` | `kFp8DynamicTensorSym` | `meta-llama/Llama-3.2-1B-Instruct` | 1 | `--quantization fp8` |

Each case is run with:

```bash
ZE_AFFINITY_MASK=4,5 VLLM_USE_V1=1 python3 acc.py \
    --model <model> --dtype bfloat16 --tp <tp> \
    --block-size 64 --gpu-memory-util 0.9 --eager [extra args]
```

---

### Results

| Case | exact_match,strict-match | exact_match_stderr,strict-match | exact_match,flexible-extract | exact_match_stderr,flexible-extract |
|------|--------------------------|--------------------------------|------------------------------|-------------------------------------|
| static-tensor-weight + static-tensor-act | 0.724 | 0.0283 | 0.776 | 0.0264 |
| static-channel-weight + dynamic-token-act | 0.764 | 0.0269 | 0.640 | 0.0304 |
| static-tensor-weight + dynamic-token-act | 0.288 | 0.0287 | 0.284 | 0.0286 |
| static-tensor-weight + dynamic-tensor-act | 0.324 | 0.0297 | 0.328 | 0.0298 |
