### PR TITLE
[Bugfix] Fix streaming boundary delta losing content and role fields in DelegatingParser

### DIFF
--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -708,7 +708,13 @@ class DelegatingParser(Parser):
 
             # A boundary delta may carry both reasoning and tool call,
             # save it before the tool parser overwrites delta_message.
-            reasoning = delta_message.reasoning if delta_message else None
+            saved_reasoning = (
+                getattr(delta_message, "reasoning", None) if delta_message else None
+            )
+            saved_content = (
+                getattr(delta_message, "content", None) if delta_message else None
+            )
+            saved_role = getattr(delta_message, "role", None) if delta_message else None
             delta_message, state.function_name_returned = (
                 self._extract_tool_calls_streaming(
                     previous_text=state.previous_text,
@@ -723,10 +729,20 @@ class DelegatingParser(Parser):
                     function_name_returned=state.function_name_returned,
                 )
             )
-            if reasoning:
+            if saved_reasoning or saved_content or saved_role:
                 if not delta_message:
                     delta_message = DeltaMessage()
-                delta_message.reasoning = reasoning
+                if saved_reasoning:
+                    delta_message.reasoning = saved_reasoning
+                if saved_content:
+                    # Merge content if tool parser also returned content
+                    current_content = getattr(delta_message, "content", None)
+                    if current_content:
+                        delta_message.content = saved_content + current_content
+                    else:
+                        delta_message.content = saved_content
+                if saved_role:
+                    delta_message.role = saved_role
 
             if (
                 delta_message


### PR DESCRIPTION
## Purpose

Fixes #43221

When a streaming delta spans the reasoning/tool-call boundary (e.g., contains both `</think>` and `<tool_call>` in the same chunk), `Qwen3ReasoningParser.extract_reasoning_streaming` may return a `DeltaMessage` with **both** `reasoning` and `content` fields set.

Previously in `DelegatingParser.parse_delta`, only `reasoning` was saved before `_extract_tool_calls_streaming` overwrote `delta_message`. The `content` field (e.g., the `<tool_call>` prefix text) and `role` field were **silently discarded**, causing streaming reasoning tokens to be truncated.

## Changes

- In `vllm/parser/abstract_parser.py`, `DelegatingParser.parse_delta`: save all three fields (`reasoning`, `content`, `role`) from the boundary `delta_message` before the tool parser overwrites it.
- After the tool parser returns, merge the saved fields back:
  - If the tool parser also returns `content`, the two strings are concatenated in order (`saved_content + tool_content`).
  - `reasoning` and `role` are restored unconditionally if they were set.

## Test Plan

Manually verified with a mock test that reproduces the bug:
- **Before fix**: `result.content` is `None` (the `<tool_call>` prefix is lost)
- **After fix**: `result.content == "<tool_call>"` and `result.reasoning == "think about this"` are both preserved

The existing `tests/parser/test_streaming.py` suite continues to pass.