### PR TITLE
[Bugfix][Core] MTP + enable prefix caching + mamba accuracy fix

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -878,6 +878,12 @@ class MambaManager(SingleTypeKVCacheManager):
 
         block_size = kv_cache_spec.block_size
         max_num_blocks = max_length // block_size
+        if use_eagle and max_num_blocks > 0:
+            # Full-attention cache hit lookup matches one extra block and then
+            # drops that final block as it's only partially accepted. Mamba/GDN state
+            # blocks are [null, ..., state] so popping after a match removes the state
+            # Instead, we can only search up to the boundary (not include final)
+            max_num_blocks -= 1
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(


### PR DESCRIPTION
## Purpose
#43559
In full attention, with speculative decoding the final block is dropped since it contains only part of accepted tokens. Mamba currently does not drop the final block, which causes accuracy drop due to overreuse. Therefore, we drop the final block in a way specific to mamba state (its structure is different from full attention).

## Test Plan

We test accuracy using gsm8k.
The commands are:

```
VLLM_ENGINE_READY_TIMEOUT_S=3600 \
CUDA_VISIBLE_DEVICES=0 \
vllm serve Qwen/Qwen3.5-35B-A3B-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --tensor-parallel-size 1 \
  --reasoning-parser qwen3 \
  --gpu-memory-utilization 0.95 \
  --max-model-len 32768 \
  --max-num-seqs 256 \
  --served-model-name qwen \
  --language-model-only \
  --default-chat-template-kwargs '{"enable_thinking": false}' \
  --enable-prefix-caching \
  --gdn-prefill-backend triton \
  --moe-backend triton

VLLM_ENGINE_READY_TIMEOUT_S=3600 \
CUDA_VISIBLE_DEVICES=0 \
vllm serve Qwen/Qwen3.5-35B-A3B-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --tensor-parallel-size 1 \
  --reasoning-parser qwen3 \
  --gpu-memory-utilization 0.95 \
  --max-model-len 32768 \
  --max-num-seqs 256 \
  --served-model-name qwen \
  --language-model-only \
  --default-chat-template-kwargs '{"enable_thinking": false}' \
  --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}' \
  --enable-prefix-caching \
  --gdn-prefill-backend triton \
  --moe-backend triton
```

## Test Result

No MTP + prefix caching
Results:
Accuracy: 0.916
Invalid responses: 0.000
Total latency: 38.532 s
Questions per second: 12.976
Total output tokens: 63210
Output tokens per second: 1640.438

old MTP + prefix caching
Results:
Accuracy: 0.900
Invalid responses: 0.000
Total latency: 26.811 s
Questions per second: 18.649
Total output tokens: 66864
Output tokens per second: 2493.929

new MTP + prefix caching
Results:
Accuracy: 0.914
Invalid responses: 0.002
Total latency: 32.317 s
Questions per second: 15.472
Total output tokens: 64070
Output tokens per second: 1982.526


I tested several times, the old MTP + prefix cache has systematic lesser accuracy.
The old MTP has accuracy around 0.9, the new MTP/no MTP has accuracy around 0.915.
The increase in latency is expected as the fix makes MTP prefix-cache lookup
recompute one block at the speculative boundary instead of reusing it, this aligns with the full attention behavior.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

