### PR TITLE
[Bugfix] Add SWIGLUSTEP and RELU2 activation support to CPU fused MoE

### DIFF
--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -25,6 +25,8 @@ ACT = [
     MoEActivation.SWIGLUOAI,
     MoEActivation.GELU,
     MoEActivation.GELU_TANH,
+    MoEActivation.SWIGLUSTEP,
+    MoEActivation.RELU2,
 ]
 USE_BIAS = [True, False]
 ISA = ["amx", "vec"] if torch.cpu._is_amx_tile_supported() else ["vec"]

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -60,7 +60,8 @@ def _swiglustep_and_mul(
 def _relu2_and_mul(
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return torch.square(F.relu(x))
+    d = x.shape[-1] // 2
+    return torch.square(F.relu(x[..., :d])) * x[..., d:]
 
 
 # Map activation names to their native forward functions.

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -46,6 +46,23 @@ def _gelu_and_mul(
     return F.gelu(x[..., :d], approximate="none") * x[..., d:]
 
 
+def _swiglustep_and_mul(
+    x: torch.Tensor,
+    limit: float = 7.0,
+) -> torch.Tensor:
+    gate, up = x.chunk(2, dim=-1)
+    gate = F.silu(gate)
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return gate * up
+
+
+def _relu2_and_mul(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return torch.square(F.relu(x))
+
+
 # Map activation names to their native forward functions.
 # Uses static methods or standalone functions to avoid instantiating CustomOp
 # classes, which would call get_current_vllm_config() before config is set.
@@ -57,6 +74,8 @@ _CPU_MOE_ACT_FN: dict[MoEActivation, Callable[[torch.Tensor], torch.Tensor]] = {
         lambda x: F.gelu(x[..., : x.shape[-1] // 2], approximate="tanh")
         * x[..., x.shape[-1] // 2 :]
     ),
+    MoEActivation.SWIGLUSTEP: _swiglustep_and_mul,
+    MoEActivation.RELU2: _relu2_and_mul,
 }
 
 


### PR DESCRIPTION
## Purpose

Fix missing `SWIGLUSTEP` and `RELU2` activation function support in the CPU fused MoE implementation (`cpu_fused_moe.py`).

The `_CPU_MOE_ACT_FN` mapping was missing entries for `MoEActivation.SWIGLUSTEP` and `MoEActivation.RELU2`. This caused an `AssertionError` at runtime when running models that use these activations on CPU. For example, `step3p5.py` sets `activation = "swiglustep"` when `swiglu_limit` is configured, which triggers:
```
assert activation in _CPU_MOE_ACT_FN, f"{activation} is not supported."
```

Closes #43326

## Changes

- Add `_swiglustep_and_mul()`: implements SwigluStep gated activation — `silu(gate).clamp(max=limit) * up.clamp(-limit, limit)` — consistent with `SwigluStepAndMul.forward_native()` in `activation.py`
- Add `_relu2_and_mul()`: implements relu-squared gated activation — `square(relu(gate)) * up` — following the same `activation(gate) * up` pattern as `SiluAndMul` and `GeluAndMul`
- Register both in `_CPU_MOE_ACT_FN`
- Add `MoEActivation.SWIGLUSTEP` and `MoEActivation.RELU2` to the parametrized test list in `tests/kernels/moe/test_cpu_fused_moe.py`

## Test Plan

```bash
pre-commit run --files vllm/model_executor/layers/fused_moe/cpu_fused_moe.py tests/kernels/moe/test_cpu_fused_moe.py
```

## Test Result

All pre-commit hooks pass locally (`ruff`, `mypy`, `typos`, SPDX headers, forbidden imports, etc.).

The new activation functions are added to the existing parametrized CPU test `test_cpu_fused_moe`, so they will be exercised in the CPU CI pipeline.