### PR TITLE
[XPU] Enable compressed-tensors FP8 block-scaled quantization

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -353,7 +353,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             and self.block_shape == [128, 128]
             and lora_context is None
             and not is_deep_gemm_e8m0_used()
-            and current_platform.is_cuda()
+            and current_platform.is_cuda_alike()
         ):
             qintermediate_cache2, a2q_scale = ops.silu_and_mul_per_block_quant(
                 intermediate_cache1.view(-1, N),

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -353,6 +353,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             and self.block_shape == [128, 128]
             and lora_context is None
             and not is_deep_gemm_e8m0_used()
+            and current_platform.is_cuda()
         ):
             qintermediate_cache2, a2q_scale = ops.silu_and_mul_per_block_quant(
                 intermediate_cache1.view(-1, N),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -656,8 +656,11 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsW4A4Fp4()
 
             if self._is_fp8_w8a8(weight_quant, input_quant):
-                is_fp8_w8a8_supported = self._check_scheme_supported(
-                    CompressedTensorsW8A8Fp8.get_min_capability(), error=False
+                is_fp8_w8a8_supported = (
+                    self._check_scheme_supported(
+                        CompressedTensorsW8A8Fp8.get_min_capability(), error=False
+                    )
+                    or current_platform.is_xpu()
                 )
                 if is_fp8_w8a8_supported:
                     return CompressedTensorsW8A8Fp8(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -333,7 +333,10 @@ class CompressedTensorsConfig(QuantizationConfig):
 
     @staticmethod
     def _check_scheme_supported(
-        min_capability: int, error: bool = True, match_exact: bool = False
+        min_capability: int,
+        error: bool = True,
+        match_exact: bool = False,
+        weight_strategy: "QuantizationStrategy | None" = None,
     ) -> bool:
         capability_tuple = current_platform.get_device_capability()
 
@@ -357,6 +360,11 @@ class CompressedTensorsConfig(QuantizationConfig):
                     )
             return supported
         else:
+            # XPU supports FP8 block-scaled W8A8 via
+            # TritonFp8BlockScaledMMKernel; per-tensor/channel falls
+            # back to W8A16Fp8.
+            if current_platform.is_xpu() and weight_strategy is not None:
+                return weight_strategy == QuantizationStrategy.BLOCK
             return False
 
     @staticmethod
@@ -656,11 +664,10 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsW4A4Fp4()
 
             if self._is_fp8_w8a8(weight_quant, input_quant):
-                is_fp8_w8a8_supported = (
-                    self._check_scheme_supported(
-                        CompressedTensorsW8A8Fp8.get_min_capability(), error=False
-                    )
-                    or current_platform.is_xpu()
+                is_fp8_w8a8_supported = self._check_scheme_supported(
+                    CompressedTensorsW8A8Fp8.get_min_capability(),
+                    error=False,
+                    weight_strategy=weight_quant.strategy,
                 )
                 if is_fp8_w8a8_supported:
                     return CompressedTensorsW8A8Fp8(


### PR DESCRIPTION



## Purpose

Enable FP8 W8A8 block-scaled quantization (compressed-tensors format) to work on Intel XPU.

## Changes
- compressed_tensors.py: Fix FP8 W8A8 scheme selection.
- triton_moe.py: Guard CUDA-only fused activation kernel so XPU falls through to the generic path.


## Test Plan
Verified with RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-block on Intel XPU

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

