### PR TITLE
Fix InternVL2-8B compiled generation with InternLM2 backbone

### DIFF
--- a/tests/models/multimodal/processing/test_internvl.py
+++ b/tests/models/multimodal/processing/test_internvl.py
@@ -3,8 +3,12 @@
 """Tests for InternVL's multimodal preprocessing kwargs."""
 
 from collections.abc import Mapping
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+import torch
+import torch.nn as nn
 from PIL import Image
 from transformers import PretrainedConfig
 
@@ -79,6 +83,73 @@ def _run_check(
 
     assert img_tok_count == 256 * total_expected_num_patches
     assert pixel_shape[0] == total_expected_num_patches
+
+
+def test_internvl_internlm2_backbone_disables_torch_compile():
+    from vllm.model_executor.models.internvl import InternVLChatModel
+
+    class DummyLanguageInner(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.make_empty_intermediate_tensors = object()
+
+        def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+            return torch.empty(input_ids.shape[0], 1)
+
+    class DummyLanguageModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = DummyLanguageInner()
+            self.make_empty_intermediate_tensors = object()
+
+    config = SimpleNamespace(
+        architectures=["InternVLChatModel"],
+        model_type="internvl_chat",
+        force_image_size=14,
+        vision_config=SimpleNamespace(
+            image_size=14,
+            patch_size=14,
+            hidden_size=1,
+            num_hidden_layers=1,
+        ),
+        downsample_ratio=1.0,
+        ps_version="v2",
+        select_layer=-1,
+        text_config=SimpleNamespace(
+            architectures=["InternLM2ForCausalLM"],
+            model_type="internlm2",
+            hidden_size=1,
+        ),
+        get_text_config=lambda: config.text_config,
+    )
+    mm_config = SimpleNamespace(
+        mm_encoder_tp_mode="weights",
+        mm_encoder_only=False,
+        get_limit_per_prompt=lambda modality: 1,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=config,
+            multimodal_config=mm_config,
+        ),
+        quant_config=None,
+    )
+
+    with (
+        patch.object(
+            InternVLChatModel,
+            "_init_vision_model",
+            return_value=nn.Identity(),
+        ),
+        patch.object(InternVLChatModel, "_init_mlp1", return_value=nn.Identity()),
+        patch(
+            "vllm.model_executor.models.internvl.init_vllm_registered_model",
+            return_value=DummyLanguageModel(),
+        ),
+    ):
+        model = InternVLChatModel(vllm_config=vllm_config)
+
+    assert model.language_model.model.do_not_compile is True
 
 
 @pytest.mark.parametrize("model_id", ["OpenGVLab/InternVL2-2B"])

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -594,6 +594,14 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA)
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 
+        # InternVL feeds precomputed text+vision embeddings into the text
+        # backbone. InternLM2 backbones currently produce corrupted logits
+        # under this torch.compile inputs_embeds path.
+        if config.text_config.architectures[0] == "InternLM2ForCausalLM":
+            inner_model = getattr(self.language_model, "model", None)
+            if inner_model is not None:
+                inner_model.do_not_compile = True
+
         self.img_context_token_id = None
         self.video_context_token_id = None
 


### PR DESCRIPTION
Fixes #43631.

InternVL feeds precomputed text+vision embeddings into the text backbone. For InternVL2 models whose text backbone is `InternLM2ForCausalLM`, the compiled internal InternLM2 model can produce corrupted logits on this `inputs_embeds` path while eager execution is correct.

This PR disables torch.compile only for the internal InternLM2 text backbone when used inside `InternVLChatModel`. CUDA graph capture and the rest of the model behavior remain enabled.

Validation run:
- `uv run --no-project --with ruff ruff format --check vllm/model_executor/models/internvl.py tests/models/multimodal/processing/test_internvl.py`
- `uv run --no-project --with ruff ruff check vllm/model_executor/models/internvl.py tests/models/multimodal/processing/test_internvl.py`
- `python -m pytest -q tests/models/multimodal/processing/test_internvl.py::test_internvl_internlm2_backbone_disables_torch_compile`
- E2E on H20 with `OpenGVLab/InternVL2-8B`, default `enforce_eager=False`: `The capital of France is Paris.`
