### PR TITLE
[Bugfix] flashinfer: fail fast when --kv-cache-dtype nvfp4 used on unsupported arch

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -623,6 +623,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
             if self.is_kvcache_nvfp4:
+                # trtllm-gen FP4 FMHA kernels only exist for sm100f (sm_100/sm_103).
+                # Fail fast at init rather than crashing on the first request.
+                if not current_platform.is_device_capability_family(100):
+                    raise ValueError(
+                        "--kv-cache-dtype nvfp4 requires sm100f, "
+                        "please try a different dtype or remove"
+                    )
                 # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
                 # which is passed to FlashInferImpl
                 self.kv_cache_dtype = self.cache_dtype


### PR DESCRIPTION
## Problem

`--kv-cache-dtype nvfp4` is silently accepted on architectures without
a trtllm-gen FP4 FMHA kernel. The engine starts cleanly, captures
graphs, then dies on the first request with either:

- `AttributeError: module 'torch' has no attribute 'nvfp4'` (flashinfer
  dtype resolution), or
- `RuntimeError: Unsupported architecture` deep in trtllm-gen FMHA

The server appears healthy until the first token, making this harder to
diagnose than a startup crash.

Reported in #43562 (sm_120 / RTX PRO 6000 Blackwell).

Root cause: trtllm-gen FP4 FMHA kernels only exist for sm_100/sm_103
(GB200/GB202). vLLM forces `backend = "trtllm-gen"` when
`is_kvcache_nvfp4` is True (flashinfer.py:773) but never checks whether
the current device can actually run those kernels.

## Fix

Add a capability check immediately after `is_kvcache_nvfp4` is set to
`True`. If the detected compute capability is not sm_100 or sm_103,
raise a `ValueError` at engine init with a clear, actionable message
pointing the user to `--kv-cache-dtype fp8`.

`current_platform.get_device_capability()` is already imported and used
in this file.

## Before
NFO: Using max model len 8192
... engine starts, graphs captured ...
first request ->
AttributeError: module 'torch' has no attribute 'nvfp4'
or: RuntimeError: Unsupported architecture

## After
ValueError: --kv-cache-dtype nvfp4 requires sm_100 or sm_103
(GB200/GB202); detected sm_120. Use --kv-cache-dtype fp8 instead.

Fixes #43562