### PR TITLE
[Core] Support opt-in custom logits processors with speculative decoding

### DIFF
--- a/docs/features/custom_logitsprocs.md
+++ b/docs/features/custom_logitsprocs.md
@@ -91,6 +91,46 @@ Notes:
 
 Unlike built-in logits processors, custom logits processors may require configuration arguments that are not hard-coded into `SamplingParams` or the vLLM server REST API. To solve this problem, custom logits processors may leverage vLLM [custom arguments](./custom_arguments.md) support to receive configuration settings from the user (although you are also free to design a custom logits processor which utilizes the pre-existing fields in `SamplingParams`.)
 
+### Using Custom Logits Processors with Speculative Decoding
+
+Custom logits processors are disabled by default when speculative decoding is enabled. A processor must explicitly opt in by overriding:
+
+``` python
+@classmethod
+def supports_spec_decode(cls) -> bool:
+    return True
+```
+
+Processors that do not opt in are rejected during engine initialization instead of being silently ignored.
+
+Every opted-in processor must also implement:
+
+``` python
+def apply_with_spec_decode(
+    self,
+    logits: torch.Tensor,
+    num_draft_tokens: list[int],
+) -> torch.Tensor:
+    ...
+```
+
+`logits` contains the target-model logits for all draft-token positions in the batch. `num_draft_tokens` maps request rows to their corresponding draft-token counts. For example, `num_draft_tokens = [2, 3]` means rows `0..1` belong to request 0 and rows `2..4` belong to request 1.
+
+Processors that are not argmax invariant are applied before temperature, top-k, and top-p processing. Argmax-invariant processors are applied only for non-greedy sampling, after temperature processing and before top-k and top-p processing.
+
+By default, custom processors are applied to target-model logits during the rejection sampling step. If the processor must also affect which tokens the draft model proposes, it can additionally implement:
+
+``` python
+def apply_to_speculative_draft_logits(
+    self,
+    logits: torch.Tensor,
+    num_draft_tokens: list[int] | None = None,
+) -> torch.Tensor:
+    ...
+```
+
+This optional hook is applied to draft-model logits before draft tokens are sampled. Implement it only when the processor's constraints must be visible to the draft-token proposer.
+
 ### Example Custom Logits Processor Implementation
 
 The contrived example below implements a custom logits processor which consumes a `(num\_requests) \times (vocab\_size)` logits tensor and masks out all tokens except for one (`target_token`) with `float(-inf)`. The logits processor is disabled for any request that does not specify `target_token`. To determine whether the logits processor is enabled and which token to leave unmasked, the logits processor checks `SamplingParams.extra_args` for a `target_token` custom argument associated with each request:

--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -209,15 +209,16 @@ def test_rejects_custom_logitsprocs(
     monkeypatch, model_scenario: str, logitproc_source: CustomLogitprocSource
 ):
     """Validate that vLLM engine initialization properly rejects custom
-    logitsprocs when the model is a pooling model or speculative decoding
-    enabled.
+    logitsprocs when the model is a pooling model, and rejects custom
+    logitsprocs without explicit opt-in when speculative decoding is enabled.
 
-    Use `LLM` entrypoint. We expect `LLM` initialization to fail before the
-    logitproc is actually loaded.
+    Use `LLM` entrypoint. For constructor-provided logits processors, we expect
+    `LLM` initialization to fail before model loading.
 
     Scenario 1:
     * Mock a logitproc entrypoint
-    * Validate that `LLM` does not load the logitproc
+    * Pooling: validate that `LLM` does not load the logitproc
+    * Spec decode: validate that `LLM` rejects the unsupported logitproc plugin
 
     Scenario 2:
     * Pass custom logitproc to `LLM` constructor
@@ -259,13 +260,19 @@ def test_rejects_custom_logitsprocs(
     }
 
     if logitproc_source == CustomLogitprocSource.LOGITPROC_SOURCE_ENTRYPOINT:
-        # Scenario: vLLM loads a model and ignores a logitproc that is
-        # available at a preconfigured entrypoint
-
         # Register real dist-info package so spawned workers can
         # discover the entrypoint via PYTHONPATH (spawn-compatible)
         setup_fake_entrypoint(monkeypatch)
 
+        if model_scenario == "spec_dec":
+            with pytest.raises(ValueError, match=config["error_message"]):
+                # Speculative decoding now rejects installed logits processor
+                # plugins unless they explicitly opt in.
+                LLM(**llm_kwargs)
+            return
+
+        # Scenario: vLLM loads a pooling model and ignores a logitproc that is
+        # available at a preconfigured entrypoint.
         llm = LLM(**llm_kwargs)
         # Require that no custom logitsprocs have been loaded
         # (built-in processors may exist: MinTokensLogitsProcessor,

--- a/tests/v1/logits_processors/test_spec_decode_custom.py
+++ b/tests/v1/logits_processors/test_spec_decode_custom.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.sample import rejection_sampler
+from vllm.v1.sample.logits_processor import (
+    LogitsProcessor,
+    LogitsProcessors,
+    build_logitsprocs,
+)
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.rejection_sampler import (
+    RejectionSampler,
+    apply_sampling_constraints,
+)
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+
+class SpecDecodeCapableLogitsProcessor(LogitsProcessor):
+    @classmethod
+    def supports_spec_decode(cls) -> bool:
+        return True
+
+    def __init__(self, vllm_config, device: torch.device, is_pin_memory: bool) -> None:
+        del vllm_config, device, is_pin_memory
+        self.spec_decode_calls: list[list[int]] = []
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        return logits + 1
+
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+    ) -> torch.Tensor:
+        self.spec_decode_calls.append(num_draft_tokens)
+        return logits + 1
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def update_state(self, batch_update):
+        del batch_update
+
+
+class SpecDecodeMissingApplyLogitsProcessor(LogitsProcessor):
+    @classmethod
+    def supports_spec_decode(cls) -> bool:
+        return True
+
+    def __init__(self, vllm_config, device: torch.device, is_pin_memory: bool) -> None:
+        del vllm_config, device, is_pin_memory
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        return logits + 1
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def update_state(self, batch_update):
+        del batch_update
+
+
+class ArgmaxInvariantMissingApplyLogitsProcessor(SpecDecodeMissingApplyLogitsProcessor):
+    def is_argmax_invariant(self) -> bool:
+        return True
+
+
+class ArgmaxInvariantSpecDecodeLogitsProcessor(SpecDecodeCapableLogitsProcessor):
+    def is_argmax_invariant(self) -> bool:
+        return True
+
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+    ) -> torch.Tensor:
+        self.spec_decode_calls.append(num_draft_tokens)
+        logits[:, 0] = 5.0
+        return logits
+
+
+class UnsupportedSpecDecodeLogitsProcessor(SpecDecodeCapableLogitsProcessor):
+    @classmethod
+    def supports_spec_decode(cls) -> bool:
+        return False
+
+
+class DraftLogitsProcessor(SpecDecodeCapableLogitsProcessor):
+    def __init__(self, vllm_config, device: torch.device, is_pin_memory: bool) -> None:
+        super().__init__(vllm_config, device, is_pin_memory)
+        self.draft_calls: list[list[int] | None] = []
+
+    def apply_to_speculative_draft_logits(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int] | None = None,
+    ) -> torch.Tensor:
+        self.draft_calls.append(num_draft_tokens)
+        logits[:, 3] = 100.0
+        return logits
+
+
+class ArgmaxInvariantDraftLogitsProcessor(DraftLogitsProcessor):
+    def is_argmax_invariant(self) -> bool:
+        return True
+
+
+class InvalidDraftTokenLogitsProcessor(DraftLogitsProcessor):
+    def apply_to_speculative_draft_logits(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int] | None = None,
+    ) -> torch.Tensor:
+        self.draft_calls.append(num_draft_tokens)
+        logits[:, 4] = 100.0
+        return logits
+
+
+class DummyDraftModel:
+    def __init__(self):
+        self.compute_logits_called = False
+        self.get_top_tokens_called = False
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        self.compute_logits_called = True
+        return hidden_states.clone()
+
+    def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        del hidden_states
+        self.get_top_tokens_called = True
+        return torch.tensor([0, 0], dtype=torch.long)
+
+
+class DummyVocabMapping:
+    def __init__(self):
+        self.constrain_calls = 0
+
+    def constrain_draft_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        self.constrain_calls += 1
+        logits[:, 4] = float("-inf")
+        return logits
+
+    def map_draft_to_target_ids(self, draft_token_ids: torch.Tensor) -> torch.Tensor:
+        return draft_token_ids + 100
+
+
+def _spec_decode_config():
+    return SimpleNamespace(speculative_config=object())
+
+
+def _sampling_metadata(
+    logitsprocs: LogitsProcessors,
+    *,
+    all_greedy: bool = True,
+    all_random: bool = False,
+    temperature: torch.Tensor | None = None,
+) -> SamplingMetadata:
+    return SamplingMetadata(
+        temperature=temperature,
+        all_greedy=all_greedy,
+        all_random=all_random,
+        top_p=None,
+        top_k=None,
+        generators={},
+        max_num_logprobs=None,
+        no_penalties=True,
+        prompt_token_ids=None,
+        frequency_penalties=torch.tensor([]),
+        presence_penalties=torch.tensor([]),
+        repetition_penalties=torch.tensor([]),
+        output_token_ids=[],
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        logitsprocs=logitsprocs,
+    )
+
+
+def _make_draft_proposer() -> SpecDecodeBaseProposer:
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer.use_local_argmax_reduction = True
+    proposer.use_heterogeneous_vocab = False
+    proposer.vocab_mapping = None
+    proposer._enable_probabilistic_draft_probs = False
+    proposer.model = DummyDraftModel()
+    return proposer
+
+
+def test_build_logitsprocs_allows_opted_in_processors_with_spec_decode():
+    processors = build_logitsprocs(
+        _spec_decode_config(),
+        torch.device("cpu"),
+        is_pin_memory=False,
+        is_pooling_model=False,
+        custom_logitsprocs=[SpecDecodeCapableLogitsProcessor],
+    )
+
+    assert any(
+        isinstance(processor, MinTokensLogitsProcessor)
+        for processor in processors.non_argmax_invariant
+    )
+    assert any(
+        isinstance(processor, SpecDecodeCapableLogitsProcessor)
+        for processor in processors.non_argmax_invariant
+    )
+
+
+def test_build_logitsprocs_rejects_processors_without_spec_decode_opt_in():
+    with pytest.raises(ValueError, match="supports_spec_decode"):
+        build_logitsprocs(
+            _spec_decode_config(),
+            torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+            custom_logitsprocs=[UnsupportedSpecDecodeLogitsProcessor],
+        )
+
+
+@pytest.mark.parametrize(
+    "processor_cls",
+    [
+        SpecDecodeMissingApplyLogitsProcessor,
+        ArgmaxInvariantMissingApplyLogitsProcessor,
+    ],
+)
+def test_build_logitsprocs_requires_spec_decode_apply_for_opted_in_processors(
+    processor_cls,
+):
+    with pytest.raises(ValueError, match="apply_with_spec_decode"):
+        build_logitsprocs(
+            _spec_decode_config(),
+            torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+            custom_logitsprocs=[processor_cls],
+        )
+
+
+def test_rejection_sampler_fails_loudly_for_missing_spec_decode_apply():
+    metadata = _sampling_metadata(
+        LogitsProcessors(
+            [SpecDecodeMissingApplyLogitsProcessor(None, torch.device("cpu"), False)]
+        )
+    )
+    spec_decode_metadata = SimpleNamespace(num_draft_tokens=[2])
+
+    sampler = SimpleNamespace(logprobs_mode="raw_logprobs")
+
+    with pytest.raises(NotImplementedError, match="apply_with_spec_decode"):
+        RejectionSampler(sampler).apply_logits_processors(
+            torch.zeros((2, 5)),
+            metadata,
+            spec_decode_metadata,
+        )
+
+
+def test_argmax_invariant_processors_apply_with_non_greedy_spec_decode(monkeypatch):
+    def fake_expand_batch_to_tokens(
+        x: torch.Tensor,
+        cu_num_tokens: torch.Tensor,
+        num_tokens: int,
+        replace_from: int = 0,
+        replace_to: int = 0,
+    ) -> torch.Tensor:
+        del num_tokens
+        counts = torch.diff(torch.cat([cu_num_tokens.new_zeros(1), cu_num_tokens])).to(
+            torch.long
+        )
+        expanded = torch.repeat_interleave(x, counts)
+        if replace_from != replace_to:
+            expanded = torch.where(
+                expanded == replace_from,
+                torch.full_like(expanded, replace_to),
+                expanded,
+            )
+        return expanded
+
+    monkeypatch.setattr(
+        rejection_sampler, "expand_batch_to_tokens", fake_expand_batch_to_tokens
+    )
+
+    processor = ArgmaxInvariantSpecDecodeLogitsProcessor(
+        None, torch.device("cpu"), False
+    )
+    metadata = _sampling_metadata(
+        LogitsProcessors([processor]),
+        all_greedy=False,
+        all_random=True,
+        temperature=torch.tensor([1.0, 1.0]),
+    )
+
+    logits = torch.zeros((3, 5))
+    logits[:, 4] = 10.0
+    logits = apply_sampling_constraints(
+        logits,
+        num_draft_tokens=[1, 2],
+        cu_num_draft_tokens=torch.tensor([1, 3], dtype=torch.int32),
+        sampling_metadata=metadata,
+    )
+
+    assert processor.spec_decode_calls == [[1, 2]]
+    assert torch.equal(logits[:, 0], torch.full((3,), 5.0))
+    assert torch.equal(logits[:, 4], torch.full((3,), 10.0))
+
+
+def test_argmax_invariant_processors_skip_all_greedy_spec_decode():
+    processor = ArgmaxInvariantSpecDecodeLogitsProcessor(
+        None, torch.device("cpu"), False
+    )
+    metadata = _sampling_metadata(LogitsProcessors([processor]))
+
+    logits = torch.zeros((2, 5))
+    logits[:, 4] = 10.0
+    processed = apply_sampling_constraints(
+        logits,
+        num_draft_tokens=[2],
+        cu_num_draft_tokens=torch.tensor([2], dtype=torch.int32),
+        sampling_metadata=metadata,
+    )
+
+    assert processed is logits
+    assert processor.spec_decode_calls == []
+    assert torch.equal(logits[:, 0], torch.zeros(2))
+
+
+def test_logitsprocs_caches_draft_logits_hooks_from_all_buckets():
+    processor = DraftLogitsProcessor(None, torch.device("cpu"), False)
+    argmax_processor = ArgmaxInvariantDraftLogitsProcessor(
+        None, torch.device("cpu"), False
+    )
+    logitsprocs = LogitsProcessors(
+        [
+            processor,
+            SpecDecodeCapableLogitsProcessor(None, torch.device("cpu"), False),
+            argmax_processor,
+        ]
+    )
+
+    assert len(logitsprocs.spec_decode_draft_logits_hooks) == 2
+
+    logits = torch.zeros((1, 5))
+    for hook in logitsprocs.spec_decode_draft_logits_hooks:
+        hook(logits, [1])
+
+    assert processor.draft_calls == [[1]]
+    assert argmax_processor.draft_calls == [[1]]
+
+
+def test_draft_logits_hook_disables_local_argmax_fast_path():
+    processor = DraftLogitsProcessor(None, torch.device("cpu"), False)
+    metadata = _sampling_metadata(LogitsProcessors([processor]))
+
+    proposer = _make_draft_proposer()
+
+    hidden_states = torch.zeros((2, 5))
+    hidden_states[:, 0] = 10.0
+
+    token_ids, draft_probs = proposer._sample_draft_tokens(
+        hidden_states,
+        metadata,
+        num_draft_tokens=[1, 1],
+    )
+
+    assert draft_probs is None
+    assert torch.equal(token_ids, torch.tensor([3, 3]))
+    assert proposer.model.compute_logits_called
+    assert not proposer.model.get_top_tokens_called
+    assert processor.draft_calls == [[1, 1]]
+
+
+def test_argmax_invariant_draft_logits_hook_disables_local_argmax_fast_path():
+    processor = ArgmaxInvariantDraftLogitsProcessor(None, torch.device("cpu"), False)
+    metadata = _sampling_metadata(LogitsProcessors([processor]))
+
+    proposer = _make_draft_proposer()
+
+    hidden_states = torch.zeros((2, 5))
+    hidden_states[:, 0] = 10.0
+
+    token_ids, draft_probs = proposer._sample_draft_tokens(
+        hidden_states,
+        metadata,
+        num_draft_tokens=[1, 1],
+    )
+
+    assert draft_probs is None
+    assert torch.equal(token_ids, torch.tensor([3, 3]))
+    assert proposer.model.compute_logits_called
+    assert not proposer.model.get_top_tokens_called
+    assert processor.draft_calls == [[1, 1]]
+
+
+def test_draft_logits_hook_preserves_heterogeneous_vocab_constraint():
+    processor = InvalidDraftTokenLogitsProcessor(None, torch.device("cpu"), False)
+    metadata = _sampling_metadata(LogitsProcessors([processor]))
+
+    proposer = _make_draft_proposer()
+    vocab_mapping = DummyVocabMapping()
+    proposer.use_heterogeneous_vocab = True
+    proposer.vocab_mapping = vocab_mapping
+
+    hidden_states = torch.zeros((2, 5))
+    hidden_states[:, 0] = 10.0
+
+    token_ids, draft_probs = proposer._sample_draft_tokens(
+        hidden_states,
+        metadata,
+        num_draft_tokens=[1, 1],
+    )
+
+    assert draft_probs is None
+    assert torch.equal(token_ids, torch.tensor([100, 100]))
+    assert processor.draft_calls == [[1, 1]]
+    assert vocab_mapping.constrain_calls == 2

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -881,6 +881,15 @@ class VllmConfig:
 
             self.parallel_config.is_moe_model = self.model_config.is_moe
 
+            if self.speculative_config is not None:
+                from vllm.v1.sample.logits_processor import (
+                    validate_custom_logitsprocs_with_spec_decode,
+                )
+
+                validate_custom_logitsprocs_with_spec_decode(
+                    self.model_config.logits_processors
+                )
+
         if (
             self.model_config is not None
             and self.model_config.enable_return_routed_experts

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -41,7 +41,7 @@ STR_POOLING_REJECTS_LOGITSPROCS = (
 # Error message when the user tries to initialize vLLM with a speculative
 # decoding enabled and custom logitsproces
 STR_SPEC_DEC_REJECTS_LOGITSPROCS = (
-    "Custom logits processors are not supported when speculative decoding is enabled."
+    "Custom logits processors must explicitly opt in to support speculative decoding."
 )
 
 LOGITSPROCS_GROUP = "vllm.logits_processors"
@@ -181,6 +181,68 @@ def _load_custom_logitsprocs(
     return _load_logitsprocs_plugins() + _load_logitsprocs_by_fqcns(logits_processors)
 
 
+def _get_unsupported_spec_decode_logitsprocs(
+    custom_logitproc_classes: Sequence[type[LogitsProcessor]],
+) -> list[type[LogitsProcessor]]:
+    return [
+        ctor for ctor in custom_logitproc_classes if not ctor.supports_spec_decode()
+    ]
+
+
+def _get_missing_spec_decode_apply_logitsprocs(
+    logitproc_classes: Sequence[type[LogitsProcessor]],
+) -> list[type[LogitsProcessor]]:
+    return [
+        ctor
+        for ctor in logitproc_classes
+        if getattr(ctor, "apply_with_spec_decode", None) is None
+    ]
+
+
+def _spec_decode_unsupported_error(
+    unsupported_logitprocs: Sequence[type[LogitsProcessor]],
+) -> ValueError:
+    return ValueError(
+        f"{STR_SPEC_DEC_REJECTS_LOGITSPROCS} "
+        "Custom logits processors can opt in by overriding "
+        "`supports_spec_decode()` to return True. "
+        "Opted-in processors must also implement "
+        "`apply_with_spec_decode(logits, num_draft_tokens)`. "
+        "Processors that should affect draft-token selection may "
+        "also implement `apply_to_speculative_draft_logits(...)`. "
+        f"Unsupported processors: "
+        f"{[ctor.__name__ for ctor in unsupported_logitprocs]}"
+    )
+
+
+def _spec_decode_missing_apply_error(
+    missing_spec_decode_apply: Sequence[str],
+) -> ValueError:
+    return ValueError(
+        "Custom logits processors used with speculative decoding must implement "
+        "`apply_with_spec_decode(logits, num_draft_tokens)`. "
+        f"Unsupported processors: {list(missing_spec_decode_apply)}"
+    )
+
+
+def validate_custom_logitsprocs_with_spec_decode(
+    logits_processors: Sequence[str | type[LogitsProcessor]] | None,
+) -> None:
+    custom_logitproc_classes = _load_custom_logitsprocs(logits_processors)
+    unsupported_logitprocs = _get_unsupported_spec_decode_logitsprocs(
+        custom_logitproc_classes
+    )
+    if unsupported_logitprocs:
+        raise _spec_decode_unsupported_error(unsupported_logitprocs)
+    missing_spec_decode_apply = _get_missing_spec_decode_apply_logitsprocs(
+        custom_logitproc_classes
+    )
+    if missing_spec_decode_apply:
+        raise _spec_decode_missing_apply_error(
+            [ctor.__name__ for ctor in missing_spec_decode_apply]
+        )
+
+
 def build_logitsprocs(
     vllm_config: "VllmConfig",
     device: torch.device,
@@ -199,14 +261,33 @@ def build_logitsprocs(
 
     # Check if speculative decoding is enabled.
     if vllm_config.speculative_config:
-        if custom_logitsprocs:
-            raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+        custom_logitproc_classes = _load_custom_logitsprocs(custom_logitsprocs)
+        unsupported_logitprocs = _get_unsupported_spec_decode_logitsprocs(
+            custom_logitproc_classes
+        )
+        if unsupported_logitprocs:
+            raise _spec_decode_unsupported_error(unsupported_logitprocs)
+        custom_instances = [
+            ctor(vllm_config, device, is_pin_memory)
+            for ctor in custom_logitproc_classes
+        ]
+        logitsprocs = LogitsProcessors(
+            itertools.chain(
+                (MinTokensLogitsProcessor(vllm_config, device, is_pin_memory),),
+                custom_instances,
+            )
+        )
+        missing_spec_decode_apply = [
+            type(processor).__name__
+            for processor in logitsprocs.all
+            if getattr(processor, "apply_with_spec_decode", None) is None
+        ]
+        if missing_spec_decode_apply:
+            raise _spec_decode_missing_apply_error(missing_spec_decode_apply)
         logger.warning(
             "min_p and logit_bias parameters won't work with speculative decoding."
         )
-        return LogitsProcessors(
-            [MinTokensLogitsProcessor(vllm_config, device, is_pin_memory)]
-        )
+        return logitsprocs
 
     custom_logitsprocs_classes = _load_custom_logitsprocs(custom_logitsprocs)
     return LogitsProcessors(

--- a/vllm/v1/sample/logits_processor/interface.py
+++ b/vllm/v1/sample/logits_processor/interface.py
@@ -66,6 +66,11 @@ class LogitsProcessor(ABC):
         """
         return None
 
+    @classmethod
+    def supports_spec_decode(cls) -> bool:
+        """Whether this logits processor can be used with spec decoding."""
+        return False
+
     @abstractmethod
     def __init__(
         self, vllm_config: "VllmConfig", device: torch.device, is_pin_memory: bool

--- a/vllm/v1/sample/logits_processor/state.py
+++ b/vllm/v1/sample/logits_processor/state.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vllm.v1.sample.logits_processor.interface import (
     AddedRequest,
@@ -151,6 +151,7 @@ class LogitsProcessors:
     def __init__(self, logitsprocs: Iterable["LogitsProcessor"] | None = None) -> None:
         self.argmax_invariant: list[LogitsProcessor] = []
         self.non_argmax_invariant: list[LogitsProcessor] = []
+        self.spec_decode_draft_logits_hooks: list[Callable[..., Any]] = []
         if logitsprocs:
             for logitproc in logitsprocs:
                 (
@@ -158,6 +159,13 @@ class LogitsProcessors:
                     if logitproc.is_argmax_invariant()
                     else self.non_argmax_invariant
                 ).append(logitproc)
+                apply_to_draft_logits = getattr(
+                    logitproc,
+                    "apply_to_speculative_draft_logits",
+                    None,
+                )
+                if callable(apply_to_draft_logits):
+                    self.spec_decode_draft_logits_hooks.append(apply_to_draft_logits)
 
     @property
     def all(self) -> Iterator["LogitsProcessor"]:

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -13,7 +13,6 @@ import torch.nn as nn
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
-from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -162,6 +161,7 @@ class RejectionSampler(nn.Module):
         # `apply_sampling_constraints` function.
         target_logits = apply_sampling_constraints(
             target_logits,
+            metadata.num_draft_tokens,
             metadata.cu_num_draft_tokens,
             sampling_metadata,
         )
@@ -332,11 +332,11 @@ class RejectionSampler(nn.Module):
                 logits, bad_words_token_ids, output_token_ids, metadata.num_draft_tokens
             )
 
-        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
-            if isinstance(processor, MinTokensLogitsProcessor):
-                logits = processor.apply_with_spec_decode(
-                    logits, metadata.num_draft_tokens
-                )
+        logits = apply_logits_processors_with_spec_decode(
+            logits,
+            sampling_metadata.logitsprocs.non_argmax_invariant,
+            metadata.num_draft_tokens,
+        )
         if holder is not None and holder.has_tracked_requests():
             logits = holder.apply_to_logits(
                 logits,
@@ -507,8 +507,25 @@ def rejection_sample(
     return output_token_ids
 
 
+def apply_logits_processors_with_spec_decode(
+    logits: torch.Tensor,
+    processors: Sequence[object],
+    num_draft_tokens: list[int],
+) -> torch.Tensor:
+    for processor in processors:
+        apply_with_spec_decode = getattr(processor, "apply_with_spec_decode", None)
+        if apply_with_spec_decode is None:
+            raise NotImplementedError(
+                f"{type(processor).__name__} was enabled with speculative "
+                "decoding but does not implement apply_with_spec_decode()."
+            )
+        logits = apply_with_spec_decode(logits, num_draft_tokens)
+    return logits
+
+
 def apply_sampling_constraints(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
+    num_draft_tokens: list[int],
     cu_num_draft_tokens: torch.Tensor,  # [batch_size]
     sampling_metadata: SamplingMetadata,
 ) -> torch.Tensor:
@@ -543,6 +560,12 @@ def apply_sampling_constraints(
     )
     # NOTE(woosuk): Update `logits` in place to avoid allocating a new tensor.
     logits.div_(temperature.unsqueeze(-1))
+
+    logits = apply_logits_processors_with_spec_decode(
+        logits,
+        sampling_metadata.logitsprocs.argmax_invariant,
+        num_draft_tokens,
+    )
 
     # Get expanded top_k and top_p tensors.
     top_k = None

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -436,6 +436,29 @@ class SpecDecodeBaseProposer:
             return self.vocab_mapping.map_draft_to_target_ids(draft_token_ids)
         return self.model.compute_logits(hidden_states).argmax(dim=-1)
 
+    @staticmethod
+    def _has_speculative_draft_logits_processors(
+        sampling_metadata: SamplingMetadata | None,
+    ) -> bool:
+        if sampling_metadata is None:
+            return False
+        return bool(sampling_metadata.logitsprocs.spec_decode_draft_logits_hooks)
+
+    @staticmethod
+    def _apply_speculative_draft_logits_processors(
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None,
+        num_draft_tokens: list[int] | None = None,
+    ) -> torch.Tensor:
+        if sampling_metadata is None:
+            return logits
+        draft_logits_hooks = (
+            sampling_metadata.logitsprocs.spec_decode_draft_logits_hooks
+        )
+        for apply_to_draft_logits in draft_logits_hooks:
+            logits = apply_to_draft_logits(logits, num_draft_tokens)
+        return logits
+
     def _sample_from_logits(
         self,
         logits: torch.Tensor,
@@ -468,10 +491,25 @@ class SpecDecodeBaseProposer:
         self,
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        num_draft_tokens: list[int] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if not self._enable_probabilistic_draft_probs or sampling_metadata.all_greedy:
+        has_draft_logits_processors = self._has_speculative_draft_logits_processors(
+            sampling_metadata
+        )
+        if not has_draft_logits_processors and (
+            not self._enable_probabilistic_draft_probs or sampling_metadata.all_greedy
+        ):
             return self._greedy_sample(hidden_states), None
+
         logits = self.model.compute_logits(hidden_states)
+        if self.use_heterogeneous_vocab:
+            assert self.vocab_mapping is not None
+            logits = self.vocab_mapping.constrain_draft_logits(logits)
+        logits = self._apply_speculative_draft_logits_processors(
+            logits,
+            sampling_metadata,
+            num_draft_tokens,
+        )
         if self.use_heterogeneous_vocab:
             assert self.vocab_mapping is not None
             logits = self.vocab_mapping.constrain_draft_logits(logits)
@@ -615,8 +653,13 @@ class SpecDecodeBaseProposer:
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
+            proposer_num_draft_tokens = (
+                [self.num_speculative_tokens] * batch_size
+                if self.parallel_drafting
+                else [1] * batch_size
+            )
             draft_token_ids, draft_probs = self._sample_draft_tokens(
-                sample_hidden_states, sampling_metadata
+                sample_hidden_states, sampling_metadata, proposer_num_draft_tokens
             )
             if draft_probs is not None:
                 self._last_draft_probs = draft_probs.view(
@@ -637,7 +680,7 @@ class SpecDecodeBaseProposer:
             self.positions[:batch_size] = positions
 
         draft_token_ids, draft_probs = self._sample_draft_tokens(
-            sample_hidden_states, sampling_metadata
+            sample_hidden_states, sampling_metadata, [1] * batch_size
         )
         draft_probs_list = None if draft_probs is None else [draft_probs]
 
@@ -751,7 +794,7 @@ class SpecDecodeBaseProposer:
 
             hidden_states = hidden_states[:batch_size]
             draft_token_ids, draft_probs = self._sample_draft_tokens(
-                last_hidden_states[:batch_size], sampling_metadata
+                last_hidden_states[:batch_size], sampling_metadata, [1] * batch_size
             )
             if draft_probs is not None:
                 assert draft_probs_list is not None


### PR DESCRIPTION
## Purpose

This PR allows external/custom V1 logits processors to opt into speculative decoding instead of being rejected unconditionally.

This does not broadly allow arbitrary custom logits processors with speculative decoding. The default remains rejection: processors must explicitly opt in and provide the spec-decode apply hook before they are accepted.

The change adds a small explicit contract:

- `LogitsProcessor.supports_spec_decode()` defaults to `False`.
- Custom processors that opt in must implement `apply_with_spec_decode(logits, num_draft_tokens)`.
- Unsupported custom processors are rejected during config initialization, before model loading.
- Opted-in processors are applied during rejection sampling for speculative target logits.
- The optional `apply_to_speculative_draft_logits(...)` hook lets a processor affect draft-token proposal when needed.
- Optional draft hook callables are cached in `LogitsProcessors` at construction time so draft-token generation does not rediscover them on every step.
- Docs explain the spec-decode contract for custom logits processors.

## Duplicate-Work Check

Before opening this PR, I checked open PRs for `custom logits processors speculative decoding` and `logits processor spec decode`.

Related PRs/issues:

- #17799 tracks custom logits processor extensibility.
- #38467 and #38469 add spec-decode support for the built-in `LogitBiasLogitsProcessor`.
- #42802 adds spec-decode handling for the built-in `MinPLogitsProcessor`.

This PR intentionally does not add built-in `logit_bias` or `min_p` support. It is not a duplicate of those PRs; it adds the generic opt-in contract, validation path, and draft-hook caching for external/custom logits processors.

AI assistance disclosure: this PR includes code, tests, and documentation prepared with OpenAI Codex assistance. I reviewed the changed lines, kept the scope limited, and ran the validation below.

## Test Plan

Validated on DGX Spark Linux/aarch64 CUDA with the vLLM Python 3.12 development environment:

- `pre-commit run --files docs/features/custom_logitsprocs.md tests/v1/logits_processors/test_custom_offline.py tests/v1/logits_processors/test_spec_decode_custom.py vllm/config/vllm.py vllm/v1/sample/logits_processor/__init__.py vllm/v1/sample/logits_processor/interface.py vllm/v1/sample/logits_processor/state.py vllm/v1/sample/rejection_sampler.py vllm/v1/spec_decode/llm_base_proposer.py`
- `python -m pytest tests/v1/logits_processors/test_spec_decode_custom.py -q -p no:cacheprovider`
- `python -m pytest tests/v1/logits_processors/test_custom_offline.py -k 'test_rejects_custom_logitsprocs and spec_dec' -q -p no:cacheprovider`
- GPU smoke with `facebook/opt-125m`, `speculative_config={"model": "ngram", "num_speculative_tokens": 1}`, and an opted-in custom logits processor whose `apply_with_spec_decode(...)` asserts CUDA logits.
- After review-readiness docstring polish: `pre-commit run --files tests/v1/logits_processors/test_custom_offline.py`
- After review-readiness docstring polish: `python -m pytest tests/v1/logits_processors/test_custom_offline.py -k 'test_rejects_custom_logitsprocs and spec_dec' -q -p no:cacheprovider`
- After rebasing onto latest `origin/main` (`445ded18c`): reran the changed-file pre-commit and both targeted pytest commands above.

## Test Result

- `pre-commit run --files ...`: passed
- `test_spec_decode_custom.py`: `10 passed`
- `test_custom_offline.py -k 'test_rejects_custom_logitsprocs and spec_dec'`: `3 passed, 8 deselected`
- GPU smoke: `gpu_smoke_ok [6, 38, 437, 10]`
- Review-readiness docstring polish pre-commit: passed
- Review-readiness docstring polish pytest: `3 passed, 8 deselected`
- After rebase to latest `origin/main`: changed-file pre-commit passed, `test_spec_decode_custom.py` still `10 passed`, and targeted `test_custom_offline.py` still `3 passed, 8 deselected`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>