### PR TITLE
[BugFix] FS Offloading: Fallback from O_DIRECT

### DIFF
--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -5,6 +5,7 @@ import logging
 import os
 import random
 import threading
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +14,10 @@ O_DIRECT = getattr(os, "O_DIRECT", 0)
 
 # Thread-local storage for unique temporary file suffixes
 _thread_local = threading.local()
+
+
+def _is_odirect_supported() -> bool:
+    return O_DIRECT != 0
 
 
 def _get_tmp_suffix() -> str:
@@ -27,6 +32,73 @@ def _get_tmp_suffix() -> str:
 def _ensure_dirs(path: str) -> None:
     """Create parent directories of *path* if they don't exist."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
+
+
+def _file_write(tmp_path: str, view_slice: memoryview, with_odirect: bool) -> None:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC
+    if with_odirect:
+        flags |= O_DIRECT
+
+    fd: int | None = None
+    try:
+        fd = os.open(
+            tmp_path,
+            flags,
+            0o644,
+        )
+        written = os.write(fd, view_slice)
+        if written < len(view_slice):
+            raise OSError(
+                f"Short write: expected {len(view_slice)} bytes, wrote {written}"
+            )
+    except Exception:
+        try:
+            if fd is not None:
+                os.remove(tmp_path)
+        except OSError as cleanup_exc:
+            logger.warning("Failed to remove temp file %s: %s", tmp_path, cleanup_exc)
+        raise
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def _file_read(source_path: str, view_slice: memoryview, with_odirect: bool) -> None:
+    flags = os.O_RDONLY
+    if with_odirect:
+        flags |= O_DIRECT
+
+    fd: int | None = None
+    try:
+        fd = os.open(source_path, flags)
+        bytes_read = os.readv(fd, [view_slice])
+        if bytes_read < len(view_slice):
+            raise OSError(
+                f"Short read: expected {len(view_slice)} bytes, read {bytes_read}"
+            )
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def _run_with_odirect_fallback(
+    op_name: str,
+    path: str,
+    op: Callable[[bool], None],
+) -> None:
+    if _is_odirect_supported():
+        try:
+            op(True)
+            return
+        except OSError as exc:
+            logger.debug(
+                "O_DIRECT %s failed path=%s errno=%s err=%s",
+                op_name,
+                path,
+                exc.errno,
+                exc,
+            )
+    op(False)
 
 
 def store_block(
@@ -49,27 +121,13 @@ def store_block(
     # Write block atomically. Cast to a flat byte view so the slice uses byte
     # indices; the raw memoryview may be multi-dimensional with itemsize > 1.
     view_slice = buffer.cast("B")[offset : offset + block_size]
-    try:
-        fd = os.open(
-            tmp_path,
-            os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC | O_DIRECT,
-            0o644,
-        )
-        try:
-            written = os.write(fd, view_slice)
-            if written < len(view_slice):
-                raise OSError(
-                    f"Short write: expected {len(view_slice)} bytes, wrote {written}"
-                )
-        finally:
-            os.close(fd)
-        os.replace(tmp_path, dest_path)
-    except Exception:
-        try:
-            os.remove(tmp_path)
-        except OSError as cleanup_exc:
-            logger.warning("Failed to remove temp file %s: %s", tmp_path, cleanup_exc)
-        raise
+
+    _run_with_odirect_fallback(
+        op_name="_file_write",
+        path=tmp_path,
+        op=lambda with_odirect: _file_write(tmp_path, view_slice, with_odirect),
+    )
+    os.replace(tmp_path, dest_path)
 
 
 def load_block(
@@ -81,13 +139,14 @@ def load_block(
     """
     Load callback: read one KV block from disk. Remove the file on failure.
     """
-    fd: int | None = None
     view_slice = view.cast("B")[offset : offset + block_size]
+
     try:
-        fd = os.open(source_path, os.O_RDONLY | O_DIRECT)
-        bytes_read = os.readv(fd, [view_slice])
-        if bytes_read < block_size:
-            raise OSError(f"Short read: expected {block_size} bytes, read {bytes_read}")
+        _run_with_odirect_fallback(
+            op_name="_file_read",
+            path=source_path,
+            op=lambda with_odirect: _file_read(source_path, view_slice, with_odirect),
+        )
     except Exception:
         try:
             os.remove(source_path)
@@ -96,6 +155,3 @@ def load_block(
                 "Failed to remove unreadable file %s: %s", source_path, cleanup_exc
             )
         raise
-    finally:
-        if fd is not None:
-            os.close(fd)

--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -46,11 +46,14 @@ def _file_write(tmp_path: str, view_slice: memoryview, with_odirect: bool) -> No
             flags,
             0o644,
         )
-        written = os.write(fd, view_slice)
-        if written < len(view_slice):
-            raise OSError(
-                f"Short write: expected {len(view_slice)} bytes, wrote {written}"
-            )
+        try:
+            written = os.write(fd, view_slice)
+            if written < len(view_slice):
+                raise OSError(
+                    f"Short write: expected {len(view_slice)} bytes, wrote {written}"
+                )
+        finally:
+            os.close(fd)
     except Exception:
         try:
             if fd is not None:
@@ -58,9 +61,6 @@ def _file_write(tmp_path: str, view_slice: memoryview, with_odirect: bool) -> No
         except OSError as cleanup_exc:
             logger.warning("Failed to remove temp file %s: %s", tmp_path, cleanup_exc)
         raise
-    finally:
-        if fd is not None:
-            os.close(fd)
 
 
 def _file_read(source_path: str, view_slice: memoryview, with_odirect: bool) -> None:


### PR DESCRIPTION
## Purpose
`VLLM_LOGGING_LEVEL=DEBUG pytest -s tests/v1/kv_offload/test_fs_tier.py` sometimes fails when running locally.
It fails with 
```
FileSystemTierManagerPython: job 1 block I/O failed: [Errno 22] Invalid argument
```
from `vllm/v1/kv_offload/tiering/fs/io.py`

### Issue
On closer inspection, I see that the error is coming from `os.write` due buffer alignment violations when using O_DIRECT. 

### Fix
Fallback to `os.open` without O_DIRECT when using O_DIRECT fails.

## Test Plan
`VLLM_LOGGING_LEVEL=DEBUG pytest -s tests/v1/kv_offload/test_fs_tier.py` 

## Test Result
Pass reliably
