### PR TITLE
[Perf] Optimize Fp8BlockScaledMMLinearKernel input_scale placeholder …

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
@@ -126,7 +126,7 @@ class Fp8BlockScaledMMLinearKernel(
             # always Tensors. Subclasses with apply_input_quant=False must not
             # use As in apply_block_scaled_mm.
             input_scale = (
-                input_scale if input_scale is not None else input_2d.new_ones(1)
+                input_scale if input_scale is not None else input_2d.new_empty(1)
             )
 
         output = self.apply_block_scaled_mm(


### PR DESCRIPTION
…tensor using new_empty()




## Purpose

During profiling I noticed `at::native::vectorized_elementwise_kernel` was launched before `tensorrt_llm::kernels::fp8_blockscale_gemm::scale_1x128_kernel`, and found it's because `input_scale` tensor is created using `new_ones()` when `apply_input_quant=False` in https://github.com/vllm-project/vllm/blob/v0.21.1rc0/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py#L129.

Since when `apply_input_quant=False`, `input_scale` tensor is placeholder tensor and not used in downstream `apply_block_scaled_mm` [here](https://github.com/vllm-project/vllm/blob/5c1aec3dc0600cb816a0389e55ef1f1c17893380/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py#L126-L139), `input_2d.new_ones(1)` can be replaced with `input_2d.new_empty(1)`.

e2e output token throughput improves 2% on H200.

##Profiling

Main:

<img width="1907" height="745" alt="Screenshot 2026-05-26 at 12 26 11 AM" src="https://github.com/user-attachments/assets/72e83b0a-0508-4c01-9da7-39fe646cbbc2" />

PR:

<img width="1906" height="744" alt="Screenshot 2026-05-26 at 12 26 46 AM" src="https://github.com/user-attachments/assets/67bc3147-112e-4212-8bec-7892b55c8245" />

Main: `at::native::vectorized_elementwise_kernel` was launched.

PR: `at::native::vectorized_elementwise_kernel` not launched.

## Benchmark

```
vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 8 \
  --max-num-seqs 8 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --max-model-len 800000 \
  --gpu-memory-utilization 0.95 \
  --max-num-batched-tokens 512 \
  --no-enable-flashinfer-autotune \
  --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
  --tokenizer-mode deepseek_v4 \
  --no-enable-prefix-caching
```

```
vllm bench serve \
        --model deepseek-ai/DeepSeek-V4-Pro \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency ${concurrency} \
        --num-warmups 50 \
        --ignore-eos \
        --temperature 0
```

Main:

concurrency=1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  231.75    
Total input tokens:                      15873     
Total generated tokens:                  18000     
Request throughput (req/s):              0.26      
Output token throughput (tok/s):         77.67     
Peak output token throughput (tok/s):    86.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          146.16    
---------------Time to First Token----------------
Mean TTFT (ms):                          284.41    
Median TTFT (ms):                        235.47    
P99 TTFT (ms):                           579.61    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.97     
Median TPOT (ms):                        12.00     
P99 TPOT (ms):                           12.03     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.97     
Median ITL (ms):                         11.93     
P99 ITL (ms):                            13.73     
==================================================
```
concurrency=8
```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  408.35    
Total input tokens:                      106703    
Total generated tokens:                  144000    
Request throughput (req/s):              1.18      
Output token throughput (tok/s):         352.64    
Peak output token throughput (tok/s):    472.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          613.94    
---------------Time to First Token----------------
Mean TTFT (ms):                          522.20    
Median TTFT (ms):                        470.77    
P99 TTFT (ms):                           1145.04   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.01     
Median TPOT (ms):                        21.31     
P99 TPOT (ms):                           23.18     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.01     
Median ITL (ms):                         16.96     
P99 ITL (ms):                            221.41    
==================================================
```

PR:

concurrency=1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  227.07    
Total input tokens:                      15873     
Total generated tokens:                  18000     
Request throughput (req/s):              0.26      
Output token throughput (tok/s):         79.27     
Peak output token throughput (tok/s):    88.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          149.17    
---------------Time to First Token----------------
Mean TTFT (ms):                          278.29    
Median TTFT (ms):                        231.15    
P99 TTFT (ms):                           567.84    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.73     
Median TPOT (ms):                        11.76     
P99 TPOT (ms):                           11.80     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.73     
Median ITL (ms):                         11.65     
P99 ITL (ms):                            13.49     
==================================================
```

concurrency=8
```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  400.85    
Total input tokens:                      106703    
Total generated tokens:                  144000    
Request throughput (req/s):              1.20      
Output token throughput (tok/s):         359.24    
Peak output token throughput (tok/s):    488.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          625.43    
---------------Time to First Token----------------
Mean TTFT (ms):                          502.99    
Median TTFT (ms):                        465.11    
P99 TTFT (ms):                           1122.58   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.66     
Median TPOT (ms):                        20.67     
P99 TPOT (ms):                           22.83     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.66     
Median ITL (ms):                         16.72     
P99 ITL (ms):                            217.60    
==================================================
```

e2e output token throughput improves 2% on H200.


## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=deepseek-ai/DeepSeek-V4-Pro,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=8 \
  --tasks gsm8k
```

Main:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9553|±  |0.0057|
|     |       |strict-match    |     5|exact_match|↑  |0.9560|±  |0.0056|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

