### PR TITLE
[perf] [xgrammar] Import structural tag from `xgrammar`'s builtin structural tag templates

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,7 +25,7 @@ outlines_core == 0.2.14
 # required for outlines backend disk cache
 diskcache == 5.6.3
 lark == 1.2.2
-xgrammar >= 0.2.0, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -1366,7 +1366,7 @@ word2number==1.1
     # via lm-eval
 wrapt==2.1.2
     # via smart-open
-xgrammar==0.2.0
+xgrammar==0.2.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -42,14 +42,6 @@ def unsupported_array_schemas():
 
 
 @pytest.fixture
-def unsupported_object_schemas():
-    return [
-        {"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}},
-        {"type": "object", "patternProperties": {"^S": {"type": "string"}}},
-    ]
-
-
-@pytest.fixture
 def supported_schema():
     return {
         "type": "object",
@@ -76,6 +68,15 @@ def supported_schema():
                     "city": {"type": "string"},
                 },
             },
+            "student": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "grade": {"type": "string"},
+                },
+                "required": ["name", "grade"],
+                "patternProperties": {"^grade$": {"type": "string"}},
+            },
         },
         "minProperties": 1,
         "maxProperties": 100,
@@ -89,7 +90,6 @@ def supported_schema():
         "unsupported_integer_schemas",
         "unsupported_number_schemas",
         "unsupported_array_schemas",
-        "unsupported_object_schemas",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -5,45 +5,20 @@
 # builtin structural tag implementations:
 # https://github.com/mlc-ai/xgrammar/blob/main/python/xgrammar/builtin_structural_tag.py
 
-from collections.abc import Callable
-from typing import Any, Literal
+from typing import Literal
 
 from xgrammar import StructuralTag
-from xgrammar.structural_tag import (
-    AnyTextFormat,
-    ConstStringFormat,
-    JSONSchemaFormat,
-    SequenceFormat,
-    TagFormat,
-    TagsWithSeparatorFormat,
-    TriggeredTagsFormat,
-)
+from xgrammar import get_model_structural_tag as _get_model_structural_tag
+from xgrammar.openai_tool_call_schema import FunctionToolParam, NamedToolChoiceParam
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
 )
 
-SimplifiedToolChoice = Literal["auto", "required", "forced"]
 ToolChoice = (
     Literal["none", "auto", "required"] | ChatCompletionNamedToolChoiceParam | None
 )
-StructuralTagBuilder = Callable[
-    [list[ChatCompletionToolsParam], SimplifiedToolChoice, bool],
-    StructuralTag,
-]
-
-_structural_tag_registry: dict[str, StructuralTagBuilder] = {}
-
-
-def register_model_structural_tag(name: str):
-    """Register a vLLM-owned model-specific structural tag builder."""
-
-    def decorator(func: StructuralTagBuilder) -> StructuralTagBuilder:
-        _structural_tag_registry[name] = func
-        return func
-
-    return decorator
 
 
 def get_model_structural_tag(
@@ -52,61 +27,19 @@ def get_model_structural_tag(
     tool_choice: ToolChoice,
     reasoning: bool,
 ) -> StructuralTag | None:
-    """Build a structural tag from vLLM-owned model-specific builders."""
+    """Import a structural tag from xgrammar's built-in structural tag templates."""
+    # Transform vllm's tool schema to xgrammar's tool schema.
+    if tools:
+        tools = [FunctionToolParam.model_validate(tool.model_dump()) for tool in tools]
+    if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
+        tool_choice = NamedToolChoiceParam.model_validate(tool_choice.model_dump())
 
-    builder = _structural_tag_registry.get(model)
-    if builder is None:
-        supported = list(_structural_tag_registry.keys())
-        raise ValueError(f"Unknown format type: {model}, supported types: {supported}")
-
-    normalized_tools, simplified_tool_choice = _normalize_tool_choice(
+    return _get_model_structural_tag(
+        model,
         tools=tools,
         tool_choice=tool_choice,
+        reasoning=reasoning,
     )
-    if not normalized_tools:
-        return None
-
-    return builder(normalized_tools, simplified_tool_choice, reasoning)
-
-
-def _normalize_tool_choice(
-    tools: list[ChatCompletionToolsParam] | None,
-    tool_choice: ToolChoice,
-) -> tuple[list[ChatCompletionToolsParam], SimplifiedToolChoice]:
-    """Normalize vLLM ChatCompletion tool_choice for structural tag builders."""
-
-    if not tools:
-        return [], "auto"
-
-    if tool_choice is None or tool_choice == "none":
-        return [], "auto"
-
-    if tool_choice == "auto":
-        return tools, "auto"
-
-    if tool_choice == "required":
-        return tools, "required"
-
-    if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
-        tool_name = tool_choice.function.name
-        filtered_tools = [tool for tool in tools if tool.function.name == tool_name]
-        if not filtered_tools:
-            raise ValueError(
-                f"The tool with name '{tool_name}' is not found in the tools list."
-            )
-        return filtered_tools, "forced"
-
-    raise ValueError(f"Unsupported tool_choice for structural tag: {tool_choice}")
-
-
-def _get_function_parameters(function: Any) -> dict[str, Any] | bool:
-    """Return the JSON schema used for constrained tool arguments."""
-
-    if getattr(function, "strict", None) is False:
-        return True
-    if function.parameters is None:
-        return True
-    return function.parameters
 
 
 _enable_structured_outputs_in_reasoning: bool = False
@@ -132,199 +65,3 @@ def get_enable_structured_outputs_in_reasoning() -> bool:
     """
 
     return _enable_structured_outputs_in_reasoning
-
-
-@register_model_structural_tag("deepseek_v4")
-def get_deepseek_v4_structural_tag(
-    tools: list[ChatCompletionToolsParam],
-    tool_choice: SimplifiedToolChoice,
-    reasoning: bool,
-) -> StructuralTag:
-    """Build DeepSeek V4 structural tags."""
-
-    invoke_begin_prefix = '<｜DSML｜invoke name="'
-    invoke_begin_suffix = '">\n'
-    invoke_end = "</｜DSML｜invoke>\n"
-    tool_calls_prefix = "\n\n"
-    function_calls_begin = "<｜DSML｜tool_calls>\n"
-    function_calls_end = "</｜DSML｜tool_calls>"
-    function_calls_trigger = "<｜DSML｜tool_calls>"
-    think_tag_end = "</think>"
-    think_exclude_tokens = ["<think>", "</think>"]
-    xml_style = "deepseek_xml"
-
-    if tool_choice == "auto":
-        tags = []
-        for tool in tools:
-            function = tool.function
-            parameters = _get_function_parameters(function)
-            tags.append(
-                TagFormat(
-                    begin=invoke_begin_prefix + function.name + invoke_begin_suffix,
-                    content=JSONSchemaFormat(
-                        json_schema=parameters,
-                        style=xml_style,
-                    ),
-                    end=invoke_end,
-                )
-            )
-
-        if tags:
-            function_calling_tags = TagsWithSeparatorFormat(
-                tags=tags,
-                separator="\n",
-                at_least_one=True,
-            )
-            suffix_tag = TriggeredTagsFormat(
-                triggers=[function_calls_trigger],
-                tags=[
-                    TagFormat(
-                        begin=function_calls_begin,
-                        content=function_calling_tags,
-                        end=function_calls_end,
-                    )
-                ],
-                excludes=think_exclude_tokens,
-            )
-        else:
-            suffix_tag = AnyTextFormat(excludes=think_exclude_tokens)
-
-    elif tool_choice == "forced":
-        if not tools:
-            raise ValueError("Forced tool choice must resolve to exactly one tool.")
-        function = tools[0].function
-        suffix_tag = SequenceFormat(
-            elements=[
-                ConstStringFormat(value=tool_calls_prefix + function_calls_begin),
-                TagFormat(
-                    begin=invoke_begin_prefix + function.name + invoke_begin_suffix,
-                    content=JSONSchemaFormat(
-                        json_schema=_get_function_parameters(function),
-                        style=xml_style,
-                    ),
-                    end=invoke_end,
-                ),
-                ConstStringFormat(value=function_calls_end),
-            ]
-        )
-
-    elif tool_choice == "required":
-        tags = []
-        for tool in tools:
-            function = tool.function
-            parameters = _get_function_parameters(function)
-            tags.append(
-                TagFormat(
-                    begin=invoke_begin_prefix + function.name + invoke_begin_suffix,
-                    content=JSONSchemaFormat(
-                        json_schema=parameters,
-                        style=xml_style,
-                    ),
-                    end=invoke_end,
-                )
-            )
-        assert len(tags) > 0
-        suffix_tag = SequenceFormat(
-            elements=[
-                ConstStringFormat(value=tool_calls_prefix + function_calls_begin),
-                TagsWithSeparatorFormat(
-                    tags=tags,
-                    separator="\n",
-                    at_least_one=True,
-                ),
-                ConstStringFormat(value=function_calls_end),
-            ]
-        )
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=think_tag_end)
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
-
-
-@register_model_structural_tag("qwen_3_5")
-def get_qwen_3_5_structural_tag(
-    tools: list[ChatCompletionToolsParam],
-    tool_choice: SimplifiedToolChoice,
-    reasoning: bool,
-) -> StructuralTag:
-    """Build Qwen XML structural tags.
-
-    This format is used for Qwen3-Coder/Qwen3.5/Qwen3.6 and is compatible with
-    Qwen variants that use the same XML tool-call format.
-    """
-    tool_call_begin_prefix = "<tool_call>\n<function="
-    tool_call_begin_suffix = ">\n"
-    tool_call_end = "\n</function>\n</tool_call>"
-    tool_call_trigger = "<tool_call>\n<function="
-    think_tag_end = "</think>"
-    think_suffix = "\n\n"
-    think_exclude_tokens = ["<think>", "</think>"]
-
-    if tool_choice == "auto":
-        tags = []
-        for tool in tools:
-            function = tool.function
-            parameters = _get_function_parameters(function)
-            tags.append(
-                TagFormat(
-                    begin=f"{tool_call_begin_prefix}{function.name}{tool_call_begin_suffix}",
-                    content=JSONSchemaFormat(json_schema=parameters, style="qwen_xml"),
-                    end=tool_call_end,
-                )
-            )
-
-        if tags:
-            suffix_tag = TriggeredTagsFormat(
-                triggers=[tool_call_trigger],
-                tags=tags,
-                excludes=think_exclude_tokens,
-            )
-        else:
-            suffix_tag = AnyTextFormat(excludes=think_exclude_tokens)
-
-    elif tool_choice == "forced":
-        if not tools:
-            raise ValueError("Forced tool choice must resolve to exactly one tool.")
-        function = tools[0].function
-        suffix_tag = TagFormat(
-            begin=f"{tool_call_begin_prefix}{function.name}{tool_call_begin_suffix}",
-            content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(function),
-                style="qwen_xml",
-            ),
-            end=tool_call_end,
-        )
-
-    elif tool_choice == "required":
-        tags = []
-        for tool in tools:
-            function = tool.function
-            parameters = _get_function_parameters(function)
-            tags.append(
-                TagFormat(
-                    begin=f"{tool_call_begin_prefix}{function.name}{tool_call_begin_suffix}",
-                    content=JSONSchemaFormat(json_schema=parameters, style="qwen_xml"),
-                    end=tool_call_end,
-                )
-            )
-        assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(
-            tags=tags,
-            separator="",
-            at_least_one=True,
-        )
-
-    if not reasoning:
-        result = StructuralTag(format=suffix_tag)
-    else:
-        prefix_tag = SequenceFormat(
-            elements=[
-                TagFormat(begin="", content=AnyTextFormat(), end=think_tag_end),
-                ConstStringFormat(value=think_suffix),
-            ]
-        )
-        result = StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
-
-    return result

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -244,12 +244,6 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         ):
             return True
 
-        # Unsupported keywords for objects
-        if obj.get("type") == "object" and any(
-            key in obj for key in ("patternProperties", "propertyNames")
-        ):
-            return True
-
         # Recursively check all nested objects and arrays
         for value in obj.values():
             if isinstance(value, dict):


### PR DESCRIPTION



## Purpose

Stacked on #42904

- Increase minimum version of `xgrammar` to `0.2.1` to utilize structural tag improvement/bugfixes from xgrammar upstream
  - c.f. mlc-ai/xgrammar#634, mlc-ai/xgrammar#638
- Import the target model's structural tag from `xgrammar` instead of vllm's forked one
  - This make it possible for vllm to always use the up-to-date structural tag managed by `xgrammar` team, let alone reducing the maintenance burden of `vllm` team
  - Moreover, it is now way simpler for vllm developers to add strict tool parser support for models of their interest: one can simply implement a `get_structural_tag` method (one-digit lines diff!) in the corresponding tool parser and you are ready to go.

I'd like this PR to be a migration-only change (no behavioral change / new model support) for the ease of review and to exploit the pre-existing unit tests. Further expanding the supported models is left as a follow-up, but as I mentioned above it is kind of trivial.

## Test Plan

Check that existing unit tests pass.

## Test Result

(To be updated after CI runs)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

