### PR TITLE
[LoRA][Bugfix] register lora_linear_async op unconditionally

### DIFF
--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -27,43 +27,48 @@ from vllm.utils.torch_utils import direct_register_custom_op
 from .base import BaseLayerWithLoRA
 from .utils import _get_lora_aux_cuda_stream, _get_lora_device
 
-if envs.VLLM_LORA_ENABLE_DUAL_STREAM:
+def lora_linear_async(
+    layer_name: str,
+    output_size: int,
+    x: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    forward_context: ForwardContext = get_forward_context()
+    self = forward_context.no_compile_layers[layer_name]
+    return self._apply_async_impl(x, bias)
 
-    def lora_linear_async(
-        layer_name: str,
-        output_size: int,
-        x: torch.Tensor,
-        bias: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        forward_context: ForwardContext = get_forward_context()
-        self = forward_context.no_compile_layers[layer_name]
-        return self._apply_async_impl(x, bias)
 
-    def lora_linear_async_fake(
-        layer_name: str,
-        output_size: int,
-        x: torch.Tensor,
-        bias: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        # The real function reshapes output back to the original 3D shape
-        # when the input has an extra batch dimension (transformers backend).
-        if x.ndim == 3:
-            return torch.empty(
-                (x.size(0), x.size(1), output_size),
-                device=x.device,
-                dtype=x.dtype,
-            )
+def lora_linear_async_fake(
+    layer_name: str,
+    output_size: int,
+    x: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    # The real function reshapes output back to the original 3D shape
+    # when the input has an extra batch dimension (transformers backend).
+    if x.ndim == 3:
         return torch.empty(
-            (x.size(0), output_size),
+            (x.size(0), x.size(1), output_size),
             device=x.device,
             dtype=x.dtype,
         )
-
-    direct_register_custom_op(
-        op_name="lora_linear_async",
-        op_func=lora_linear_async,
-        fake_impl=lora_linear_async_fake,
+    return torch.empty(
+        (x.size(0), output_size),
+        device=x.device,
+        dtype=x.dtype,
     )
+
+
+# Registered unconditionally so the op is always available regardless of the
+# VLLM_LORA_ENABLE_DUAL_STREAM env var value at module import time. The
+# async path is still gated at runtime by self._enable_aux_cuda_stream
+# (set per-instance in BaseLinearLayerWithLoRA.__init__), so this only
+# changes whether the op exists in torch.ops, not whether it runs.
+direct_register_custom_op(
+    op_name="lora_linear_async",
+    op_func=lora_linear_async,
+    fake_impl=lora_linear_async_fake,
+)
 
 
 class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):


### PR DESCRIPTION
## Summary

`lora_linear_async` and its fake impl in [`vllm/lora/layers/base_linear.py`](https://github.com/vllm-project/vllm/blob/main/vllm/lora/layers/base_linear.py) are defined and registered inside `if envs.VLLM_LORA_ENABLE_DUAL_STREAM:` at module import time, while `BaseLinearLayerWithLoRA.__init__` re-reads the same env var at object creation to set `self._enable_aux_cuda_stream`. Since the EngineCore subprocess is launched via `fork` by default, the env var value at fork time can differ from its value when `base_linear.py` was first imported.

If the env var is unset at module import but set by the time the layer is constructed, the op is never registered with `torch.ops`, but `self._enable_aux_cuda_stream` becomes `True` and the forward path invokes the op via `self.layer_name`  failing with an attribute or "unknown op" error.

This is the same shape of bug as #39804 / #39834, but for the op registration rather than the `_get_lora_aux_cuda_stream` function. That function was already moved to `vllm/lora/layers/utils.py` and defined unconditionally as part of the MoE LoRA refactor (#40338). This PR applies the same treatment to the `lora_linear_async` op registration.

## Change

Move the `def lora_linear_async`, `def lora_linear_async_fake`, and the `direct_register_custom_op` call out of the `if envs.VLLM_LORA_ENABLE_DUAL_STREAM:` block. The conditional is removed entirely; the runtime gate stays in the existing per-instance `self._enable_aux_cuda_stream` check, so the async path still only runs when the env var is set at object creation time.

Behavior when the env var is set correctly at both import and creation is unchanged. The diff is +37/-32 in one file, and the new content is the original function bodies de-indented one level.

## Why two PRs

#39834 originally tried to fix both this and the `_get_lora_aux_cuda_stream` NameError in a single change. The MoE LoRA refactor superseded the NameError half but didn't touch the op registration, leaving #39834 with a single still-relevant change buried under merge conflicts. Closing #39834 and re-submitting just the op registration fix as a focused PR.

Related: #39804, supersedes #39834.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('vllm/lora/layers/base_linear.py').read())"`. Syntax OK
- [x] No other call sites assume the conditional registration (grep for `lora_linear_async` registration usage is contained to this file + the `self.layer_name` indirection in `BaseLinearLayerWithLoRA`)
- [ ] CI on this PR confirms existing LoRA tests still pass with the op now always registered