### PR TITLE
[Bugfix] Skip CUDA-graph padded positions in eagle draft step kernel

### DIFF
--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -57,8 +57,17 @@ def eagle_step_slot_mapping_metadata_kernel(
         tl.store(out_slot_mapping_ptr + req_idx, PAD_ID)
         return
 
-    # Load current position and increment
-    position = tl.load(positions_ptr + req_idx)
+    # CUDA-graph padded positions (beyond the actual request count) have
+    # seq_lens == 0 and block_table entries of -1.  Incrementing their
+    # seq_lens from 0 to 1 would cause the attention kernel to read
+    # block_table[-1], triggering an illegal memory access.
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    if seq_len == 0:
+        tl.store(out_slot_mapping_ptr + req_idx, PAD_ID)
+        tl.store(out_clamped_positions_ptr + req_idx, 0)
+        return
+
+    position = tl.load(positions_ptr + req_idx)  # Load current position
     new_position = position + 1
 
     # Check bounds and compute clamped position
@@ -75,7 +84,6 @@ def eagle_step_slot_mapping_metadata_kernel(
     slot_id = tl.where(exceeds_max, PAD_ID, slot_id)
 
     # Update seq_lens: +1 normally, or 1 if exceeded
-    seq_len = tl.load(seq_lens_ptr + req_idx)
     new_seq_len = tl.where(exceeds_max, 1, seq_len + 1)
     new_seq_len = tl.minimum(new_seq_len, max_model_len)
 


### PR DESCRIPTION
## Summary

Fixes `cudaErrorIllegalAddress` / CUDA illegal memory access crash during speculative decoding (Eagle, Eagle3, MTP) under concurrent load with CUDA graphs enabled.

**Root cause:** `eagle_step_slot_mapping_metadata_kernel` increments `seq_lens` for *all* positions in the batch, including CUDA-graph padded positions. Padded positions have `seq_lens == 0` and `block_table` entries filled with `-1`. When their `seq_lens` is incremented from 0 to 1, the attention kernel reads `block_table[-1]`, triggering an out-of-bounds GPU memory access that kills the engine.

**Fix:** Check `seq_lens` at the start of the kernel. If `seq_len == 0` (indicating a CUDA-graph padded position), write `PADDING_SLOT_ID` for `slot_mapping`, zero for `clamped_positions`, and return early — leaving `seq_lens` at 0 so the attention kernel correctly skips these positions.

This is a one-line-logic fix in the Triton kernel with no API changes.

## Reproduction

The crash requires:
1. Speculative decoding enabled (Eagle, Eagle3, or MTP)
2. CUDA graphs enabled (the default, not `--enforce-eager`)
3. Batch size that does not exactly match a CUDA graph capture size (creates padded positions)
4. Multiple concurrent requests (triggers the padding)

Typical error:
```
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

Related issues: #39295, #40756

## Test plan

- [ ] Verify existing spec decode tests pass (`pytest tests/v1/spec_decode/`)
- [ ] Run concurrent load test with Eagle3/MTP + async scheduling to confirm the crash no longer occurs
- [ ] Verify no regression in speculative decoding throughput (the early return only affects padded positions)