### PR TITLE
[Bugfix] Clear stale spec/async state on streaming session rebuild

### DIFF
--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -53,6 +53,7 @@ def create_scheduler() -> Scheduler:
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
+    vllm_config.model_config.is_encoder_decoder = False
     vllm_config.model_config.max_model_len = 1024
     vllm_config.model_config.enable_return_routed_experts = False
     vllm_config.cache_config = MagicMock()
@@ -169,6 +170,65 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session._all_token_ids == [1, 2, 3, 4, 5, 6]
         assert session.sampling_params.max_tokens == 10
         assert session.status == RequestStatus.WAITING
+
+    def test_update_request_as_session_clears_async_spec_state(self):
+        """Regression test for https://github.com/vllm-project/vllm/issues/42655
+
+        When a streaming session is rebuilt via _update_request_as_session,
+        stale async scheduling / speculative decode state must be cleared.
+        Otherwise the scheduler emits scheduled_spec_decode_tokens for the
+        rebuilt request, but the worker's prev_req_id_to_index no longer
+        contains it, causing a KeyError crash.
+        """
+        scheduler = create_scheduler()
+
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[1, 2, 3],
+        )
+        session.append_output_token_ids([10, 11])
+        session.num_computed_tokens = 4
+        # Simulate stale async scheduling state from prior chunk.
+        session.spec_token_ids = [101, 102, 103]
+        session.num_output_placeholders = 4
+
+        new_request = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[4, 5],
+        )
+        update = StreamingUpdate.from_request(new_request)
+
+        scheduler._update_request_as_session(session, update)
+
+        assert session._all_token_ids == [1, 2, 3, 10, 4, 5]
+        assert session.prompt_token_ids == [1, 2, 3, 10, 4, 5]
+        assert session.spec_token_ids == []
+        assert session.async_tokens_to_discard == 4
+        assert session.num_output_placeholders == 0
+        assert session.status == RequestStatus.WAITING
+
+    def test_handle_stopped_request_clears_spec_state(self):
+        """When a resumable request stops and waits for the next streaming
+        chunk, stale spec/async state must be cleared."""
+        scheduler = create_scheduler()
+
+        request = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[1, 2, 3],
+        )
+        request.streaming_queue = __import__("collections").deque()
+        request.spec_token_ids = [101, 102]
+        request.num_output_placeholders = 3
+        request.status = RequestStatus.RUNNING
+        scheduler.requests[request.request_id] = request
+
+        finished = scheduler._handle_stopped_request(request)
+
+        assert not finished
+        assert request.status == RequestStatus.WAITING_FOR_STREAMING_REQ
+        assert request.spec_token_ids == []
+        assert request.async_tokens_to_discard == 3
+        assert request.num_output_placeholders == 0
 
     def test_update_request_as_session_with_multimodal(self):
         scheduler = create_scheduler()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1021,6 +1021,15 @@ class Scheduler(SchedulerInterface):
 
         session._all_token_ids.extend(update.prompt_token_ids or ())
         session.prompt_token_ids.extend(update.prompt_token_ids or ())
+        # Clear stale async scheduling / speculative decode state so that the
+        # rebuilt session is not scheduled with spec tokens from the prior
+        # chunk.  Without this, the worker's prev_req_id_to_index will not
+        # contain the rebuilt request, but the scheduler will still emit
+        # scheduled_spec_decode_tokens for it, causing a KeyError crash.
+        # See: https://github.com/vllm-project/vllm/issues/42655
+        session.spec_token_ids = []
+        session.async_tokens_to_discard += session.num_output_placeholders
+        session.num_output_placeholders = 0
         # Update block hashes for the new tokens.
         session.update_block_hashes()
         session.num_prompt_tokens = len(session.prompt_token_ids)
@@ -1638,10 +1647,17 @@ class Scheduler(SchedulerInterface):
             if update is None:
                 # Streaming request finished.
                 return True
+            # _update_request_as_session clears spec/async state internally.
             self._update_request_as_session(request, update)
         else:
             request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
             self.num_waiting_for_streaming_input += 1
+            # Clear stale async/spec state so it doesn't leak into the
+            # next session chunk when the streaming update arrives later.
+            if request.spec_token_ids:
+                request.spec_token_ids = []
+            request.async_tokens_to_discard += request.num_output_placeholders
+            request.num_output_placeholders = 0
 
         self._enqueue_waiting_request(request)
         return False


### PR DESCRIPTION
## Purpose

Fixes #42655.

This PR resolves a scheduler/worker state mismatch in the v1 engine that
crashes the engine with `KeyError` -> `EngineDeadError` under a specific
combination of features:

1. **Async scheduling** (scheduler runs ahead of the GPU worker)
2. **Speculative decoding** (placeholder spec tokens on requests)
3. **Double streaming_update** (same live request legally resumed twice)

### Root cause

When a streaming session is rebuilt via `_update_request_as_session()`
(triggered by `streaming_update` on a live request), stale async
scheduling and speculative decode state (`spec_token_ids`,
`num_output_placeholders`) was not cleared.

This caused the scheduler to continue emitting
`scheduled_spec_decode_tokens` for the rebuilt request. However, the
rebuilt request was removed from and re-added to the worker's persistent
batch, so the worker's `prev_req_id_to_index` mapping no longer
contained it. When the worker's deferred spec-decode correction tried to
look up the previous batch row for that request, it crashed with a
`KeyError` (on v0.17.1) or silently corrupted state (on current main
where `.get()` is used).

### Crash chain

1. Request is RUNNING with active speculative decode
2. First `streaming_update` arrives → queued on `streaming_queue`
3. Async scheduling continues emitting spec tokens for the request
4. Second `streaming_update` arrives → also queued
5. Request stops → `_handle_stopped_request()` rebuilds session via
   `_update_request_as_session()` **without clearing spec/async state**
6. Rebuilt request is re-scheduled with stale `spec_token_ids`
7. Worker's `prev_req_id_to_index` doesn't contain the rebuilt request
8. `KeyError` → `EngineDeadError`

### Fix

Clear `spec_token_ids` and `num_output_placeholders` in:

- **`_update_request_as_session()`** — the core session rebuild path
- **`_handle_stopped_request()`** — the `WAITING_FOR_STREAMING_REQ` path
  (defensive, prevents stale state from leaking into the next chunk)

This matches the pattern already used by `_preempt_request()` (clears
`spec_token_ids`) and `reset_prefix_cache()` (clears
`num_output_placeholders`).

## Test Plan

Added two regression tests in
`tests/v1/streaming_input/test_scheduler_streaming.py`:

1. **`test_update_request_as_session_clears_async_spec_state`** —
   Verifies that `spec_token_ids` and `num_output_placeholders` are
   cleared after session rebuild with stale async/spec state.

2. **`test_handle_stopped_request_clears_spec_state`** — Verifies that
   stale spec/async state is cleared when a resumable request stops and
   enters `WAITING_FOR_STREAMING_REQ`.

```bash
python -m pytest tests/v1/streaming_input/test_scheduler_streaming.py -v -k "clears"
```

## Test Result

- Both new regression tests pass
- All existing streaming scheduler tests continue to pass (9/9)
- The pre-existing `test_streaming_e2e_lifecycle` failure is unrelated
  (fails on clean upstream main as well)