### PR TITLE
[Model Runner V2] Fix `test_spec_decode_acceptance_length` Acceptance length regression

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -244,6 +244,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # For transferring state from execute_model to subsequent sample_tokens call.
         self.execute_model_state: ExecuteModelState | None = None
+        self._deferred_kv_connector_scheduler_output: SchedulerOutput | None = None
 
         # Expert parallelism load balancer.
         self.eplb = EPLBController(self.parallel_config, self.device)
@@ -1207,7 +1208,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             aux_hidden_states = None
             output_intermediate_tensors = model_output
 
-        kv_connector_output = self.kv_connector.post_forward(scheduler_output)
+        kv_connector_output = None
+        self._deferred_kv_connector_scheduler_output = None
+        if self.is_last_pp_rank and self.speculator is not None and not dummy_run:
+            self._deferred_kv_connector_scheduler_output = scheduler_output
+        else:
+            kv_connector_output = self.kv_connector.post_forward(scheduler_output)
         self.execute_model_state = ExecuteModelState(
             input_batch=input_batch,
             attn_metadata=attn_metadata,
@@ -1343,6 +1349,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
             self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
             self.draft_tokens_handler.set_draft_tokens(input_batch, draft_tokens)
+
+            if kv_connector_output is None:
+                assert self._deferred_kv_connector_scheduler_output is not None
+                # delay KV connector finalization until the drafter has written
+                # its KV cache.
+                kv_connector_output = self.kv_connector.post_forward(
+                    self._deferred_kv_connector_scheduler_output
+                )
+                async_output.model_runner_output.kv_connector_output = (
+                    kv_connector_output
+                )
+                self._deferred_kv_connector_scheduler_output = None
 
         if self.use_async_scheduling:
             return async_output


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/41286

Fixes https://buildkite.com/vllm/ci/builds/67897#019e5781-68a4-4544-a7c6-04ba535ea293

`VLLM_USE_V2_MODEL_RUNNER=1 bash tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh`

Originally

```bash
        # ── Extract metrics from decode server ────────────────────────────
        n_drafts = _fetch_metric("vllm:spec_decode_num_drafts_total")
        n_accepted = _fetch_metric("vllm:spec_decode_num_accepted_tokens_total")
    
        assert n_drafts > 0, "No spec-decode drafts were generated"
    
        acceptance_length = 1 + (n_accepted / n_drafts)
        expected = config.expected_acceptance_length
    
        print(
            f"\n{config.id}: acceptance_length={acceptance_length:.3f} "
            f"(expected={expected:.3f})"
        )
        print(f"  Drafts: {n_drafts:.0f}, Accepted: {n_accepted:.0f}")
    
        # ── Assert acceptance length (all methods) ────────────────────────
        rel_error = abs(acceptance_length - expected) / expected
>       assert rel_error <= rtol, (
            f"Acceptance length regression for {config.id}! "
            f"Expected: {expected:.3f}, "
            f"Got: {acceptance_length:.3f}, "
            f"Relative error: {rel_error:.2%} (tolerance: {rtol:.0%})"
        )
E       AssertionError: Acceptance length regression for llama3-8b-eagle3! Expected: 2.600, Got: 1.961, Relative error: 24.58% (tolerance: 5%)
E       assert 0.24578209894195022 <= 0.05

tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py:183: AssertionError
====================================== warnings summary =======================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/yewentao256/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== short test summary info ===================================
FAILED tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py::test_spec_decode_acceptance_length - AssertionError: Acceptance length regression for llama3-8b-eagle3! Expected: 2.600, Got: 1...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================= 1 failed, 16 warnings in 124.15s (0:02:04) ==========================
```

Now

```bash
================== 1 passed, 16 warnings in 97.33s (0:01:37) ==================
```

This PR fixes the issue (the drafter doesn't get the kv correctly)

For eagle3 + kv connector, we did it in an order like `pre_forward -> target forward -> post_forward -> speculator.propose` This makes the drafter can't get the correct kv.

We now do it in order as `pre_forward -> target forward -> speculator.propose -> post_forward`