### PR TITLE
[Kernel][MoE] Add Sonic-MoE unquantized fused-experts backend

### DIFF
--- a/tests/kernels/moe/test_sonic_moe.py
+++ b/tests/kernels/moe/test_sonic_moe.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the sonic-moe fused-experts backend.
+
+Two tests:
+1. ``test_metadata_is_permutation`` — verifies invariants of the copied
+   ``TC_topk_router_metadata`` Triton kernel (frequency, offsets, and the
+   scatter/reverse-scatter permutations) without touching the GEMM path.
+2. ``test_apply_matches_reference`` — runs the full ``SonicMoEExperts.apply``
+   pipeline (metadata + grouped ``gemm_gated`` + grouped ``gemm`` + inline
+   weighted reduce) and compares against the ``iterative_moe`` reference.
+
+Skip-if guards: Hopper sm_90 or Blackwell sm_100/sm_103.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.platforms import current_platform
+
+
+def _backend_available() -> tuple[bool, str]:
+    if not torch.cuda.is_available():
+        return False, "CUDA not available"
+    if not (
+        current_platform.is_cuda()
+        and (
+            current_platform.is_device_capability(90)
+            or current_platform.is_device_capability_family(100)
+        )
+    ):
+        return False, "sonic-moe requires Hopper sm_90 or Blackwell sm_100/sm_103"
+    try:
+        from vllm.model_executor.layers.fused_moe.experts.sonic_moe import (  # noqa: F401
+            SonicMoEExperts,
+        )
+    except Exception as e:  # pragma: no cover
+        return False, f"import failed: {e}"
+    if not SonicMoEExperts._supports_current_device():
+        return False, "SonicMoEExperts._supports_current_device() returned False"
+    return True, ""
+
+
+_ok, _skip_reason = _backend_available()
+pytestmark = pytest.mark.skipif(not _ok, reason=_skip_reason)
+
+
+_SEED = 0xC0FFEE
+
+
+def _iterative_moe_reference(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Slow, obviously-correct reference for SwiGLU MoE.
+
+    Mirrors ``iterative_moe`` in tests/kernels/moe/test_moe.py but takes
+    pre-computed topk_weights/topk_ids.
+
+    Layouts match vLLM convention:
+        w1: (E_local, 2*I, H)  with rows packed [gate_block | up_block]
+        w2: (E_local, H, I)
+    """
+    num_local_experts = w1.shape[0]
+    intermediate = w2.shape[-1]
+
+    out = torch.zeros_like(hidden_states, dtype=torch.float32)
+    for e_local in range(num_local_experts):
+        mask = topk_ids == e_local  # (T, K_topk)
+        gate_w = (topk_weights * mask).sum(dim=-1, keepdim=True).to(hidden_states.dtype)
+        x = F.linear(hidden_states, w1[e_local])  # (T, 2*I)
+        gate = F.silu(x[:, :intermediate])
+        x = x[:, intermediate:] * gate  # (T, I)
+        x = F.linear(x, w2[e_local])  # (T, H)
+        out = out + (x * gate_w).to(torch.float32)
+    return out.to(hidden_states.dtype)
+
+
+def _build_experts(num_experts: int, top_k: int, hidden: int, intermediate: int):
+    """Construct a SonicMoEExperts instance bound to a minimal MoE config."""
+    from vllm.model_executor.layers.fused_moe.experts.sonic_moe import (
+        SonicMoEExperts,
+    )
+
+    moe_config = make_dummy_moe_config(
+        num_experts=num_experts,
+        experts_per_token=top_k,
+        hidden_dim=hidden,
+        intermediate_size_per_partition=intermediate,
+        in_dtype=torch.bfloat16,
+    )
+    # Ensure the dummy config advertises a single-shard layout.
+    assert moe_config.moe_parallel_config == FusedMoEParallelConfig.make_no_parallel()
+    quant_config = FusedMoEQuantConfig.make(None)
+    return SonicMoEExperts(moe_config=moe_config, quant_config=quant_config)
+
+
+def _run_sonic_moe(
+    experts,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    apply_router_weight_on_input: bool,
+) -> torch.Tensor:
+    """Drive SonicMoEExperts.apply() directly with manual workspace allocation.
+
+    ``apply()`` writes the already-reduced (M, K) result into ``output``;
+    ``finalize_weight_and_reduce_impl`` is a NoOP, so the framework's finalize
+    step is just a copy. We skip the framework here — this is unit-level.
+
+    Inputs use the vLLM weight layout (w1: (E, 2I, H), w2: (E, H, I)); we
+    apply the same interleave + permute that
+    ``convert_to_unquantized_kernel_format`` performs for SONIC_MOE.
+    """
+    E_, two_I, H_in = w1.shape
+    I_ = two_I // 2
+    gate, up = w1[:, :I_, :], w1[:, I_:, :]
+    w1 = (
+        torch.stack([gate, up], dim=2)  # (E, I, 2, H)
+        .reshape(E_, 2 * I_, H_in)  # (E, 2I, H) interleaved
+        .permute(0, 2, 1)  # (E, H, 2I)
+        .contiguous()
+    )
+    w2 = w2.permute(0, 2, 1).contiguous()  # (E, I, H)
+    M, H = hidden_states.shape
+    top_k = topk_ids.size(1)
+    E_local, _, two_I = w1.shape
+    N = two_I  # un-activated w1 dim (gated activations halve to I in apply)
+
+    workspace1_shape, workspace2_shape, output_shape = experts.workspace_shapes(
+        M,
+        N,
+        H,
+        top_k,
+        E_local,
+        E_local,
+        None,
+        MoEActivation.SILU,
+    )
+
+    device = hidden_states.device
+    dtype = hidden_states.dtype
+    workspace13 = torch.empty(workspace1_shape, dtype=dtype, device=device)
+    workspace2 = torch.empty(workspace2_shape, dtype=dtype, device=device)
+    output = torch.empty(output_shape, dtype=dtype, device=device)
+
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=E_local,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    return output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1) routing-metadata kernel sanity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("T,K,E", [(64, 2, 8), (256, 4, 16), (128, 2, 8)])
+def test_metadata_is_permutation(T: int, K: int, E: int) -> None:
+    """Routing metadata kernel must produce inverse permutations + valid offsets."""
+    from vllm.model_executor.layers.fused_moe.experts.sonic_moe.sonic_moe_experts import (  # noqa: E501
+        TC_topk_router_metadata_triton,
+    )
+
+    torch.manual_seed(_SEED)
+    device = torch.device("cuda")
+
+    # Random topk_ids with values in [0, E).
+    topk_ids = torch.randint(0, E, (T, K), dtype=torch.int32, device=device)
+
+    TK = T * K
+    expert_frequency = torch.empty(E, dtype=torch.int32, device=device)
+    expert_frequency_offset = torch.empty(E + 1, dtype=torch.int32, device=device)
+    x_gather_idx = torch.empty(TK, dtype=torch.int32, device=device)
+    s_scatter_idx = torch.empty(TK, dtype=torch.int32, device=device)
+    s_reverse_scatter_idx = torch.empty(TK, dtype=torch.int32, device=device)
+
+    TC_topk_router_metadata_triton(
+        topk_ids,
+        E,
+        expert_frequency,
+        expert_frequency_offset,
+        x_gather_idx,
+        s_scatter_idx,
+        s_reverse_scatter_idx,
+    )
+
+    # frequency totals
+    assert int(expert_frequency.sum().item()) == TK
+    # offsets: monotonic, starts at 0, ends at TK
+    assert int(expert_frequency_offset[0].item()) == 0
+    assert int(expert_frequency_offset[-1].item()) == TK
+    diffs = expert_frequency_offset.diff()
+    torch.testing.assert_close(diffs, expert_frequency)
+
+    # scatter / reverse-scatter must be inverse permutations on [0, TK)
+    arange = torch.arange(TK, dtype=torch.int32, device=device)
+    composed = s_reverse_scatter_idx[s_scatter_idx.long()]
+    torch.testing.assert_close(composed, arange)
+    composed2 = s_scatter_idx[s_reverse_scatter_idx.long()]
+    torch.testing.assert_close(composed2, arange)
+
+    # Each grouped slot must correspond to a (token, k) entry whose expert matches
+    # the slot's expert bucket implied by the offsets.
+    cpu_offs = expert_frequency_offset.cpu().tolist()
+    flat_topk = topk_ids.view(-1)
+    for e in range(E):
+        start, end = cpu_offs[e], cpu_offs[e + 1]
+        if start == end:
+            continue
+        entry_idxs = s_scatter_idx[start:end].long()
+        assert torch.all(flat_topk[entry_idxs] == e), (
+            f"expert {e} grouped slots [{start}, {end}) reference non-matching "
+            f"entries in topk_ids"
+        )
+
+    # x_gather_idx must equal s_scatter_idx // K (token index of the entry).
+    torch.testing.assert_close(x_gather_idx, s_scatter_idx // K)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2) full apply() vs iterative reference
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_SHAPES = [
+    # (T, H, I, E_local, K)
+    (64, 512, 1024, 8, 2),
+    (128, 1024, 1408, 16, 4),
+]
+
+
+def _random_problem(T, H, I, E_local, K, *, dtype=torch.bfloat16, seed=_SEED):  # noqa: E741
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    hidden_states = 0.02 * torch.randn(T, H, dtype=dtype, device=device)
+    w1 = 0.02 * torch.randn(E_local, 2 * I, H, dtype=dtype, device=device)
+    w2 = 0.02 * torch.randn(E_local, H, I, dtype=dtype, device=device)
+    score = torch.randn(T, E_local, dtype=torch.float32, device=device)
+    return hidden_states, w1, w2, score
+
+
+def _topk_route(score: torch.Tensor, K: int, dtype: torch.dtype):
+    topk_w, topk_ids = score.softmax(dim=-1).topk(K, dim=-1)
+    return topk_w.to(dtype).contiguous(), topk_ids.to(torch.int32).contiguous()
+
+
+@pytest.mark.parametrize("T,H,I,E_local,K", _SHAPES)
+def test_apply_matches_reference(T, H, I, E_local, K) -> None:  # noqa: E741
+    """Baseline: weights applied during finalize."""
+    hidden_states, w1, w2, score = _random_problem(T, H, I, E_local, K)
+    topk_w, topk_ids = _topk_route(score, K, hidden_states.dtype)
+
+    experts = _build_experts(E_local, K, H, I)
+    out = _run_sonic_moe(
+        experts,
+        hidden_states,
+        w1,
+        w2,
+        topk_w,
+        topk_ids,
+        apply_router_weight_on_input=False,
+    )
+    ref = _iterative_moe_reference(hidden_states, w1, w2, topk_w, topk_ids)
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
+
+
+def test_apply_router_weight_on_input() -> None:
+    """topk=1 path: router weights are pre-applied to the input."""
+    T, H, I, E_local, K = 64, 512, 1024, 8, 1  # noqa: E741
+    hidden_states, w1, w2, score = _random_problem(T, H, I, E_local, K)
+    topk_w, topk_ids = _topk_route(score, K, hidden_states.dtype)
+
+    # Apply router weights upstream, matching MoEPrepareAndFinalizeNoDPEPModular.
+    pre_weighted = hidden_states * topk_w.to(hidden_states.dtype)
+
+    experts = _build_experts(E_local, K, H, I)
+    out = _run_sonic_moe(
+        experts,
+        pre_weighted,
+        w1,
+        w2,
+        topk_w,
+        topk_ids,
+        apply_router_weight_on_input=True,
+    )
+    # Reference: weight is applied on input, then summed (no second weighting).
+    ones = torch.ones_like(topk_w)
+    ref = _iterative_moe_reference(pre_weighted, w1, w2, ones, topk_ids)
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -133,6 +133,7 @@ MoEBackend = Literal[
     "humming",
     "triton_unfused",
     "aiter",
+    "sonic_moe",
     "emulation",
 ]
 

--- a/vllm/model_executor/layers/fused_moe/experts/sonic_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/experts/sonic_moe/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sonic-MoE fused-experts backend (quack grouped-GEMM + SwiGLU)."""
+
+from .sonic_moe_experts import SonicMoEExperts
+
+__all__ = ["SonicMoEExperts"]

--- a/vllm/model_executor/layers/fused_moe/experts/sonic_moe/sonic_moe_experts.py
+++ b/vllm/model_executor/layers/fused_moe/experts/sonic_moe/sonic_moe_experts.py
@@ -1,0 +1,653 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sonic-MoE fused-experts backend.
+
+A grouped-GEMM-with-fused-SwiGLU MoE forward built on top of the quack kernels
+(``quack.gemm_interface.gemm_gated`` for the gate+up projection, ``gemm`` for
+the down projection). Permutation metadata is built by a small Triton kernel
+adapted from the sonic-moe project; the weighted reduction across the top-K
+axis is performed inline (`finalize_weight_and_reduce_impl` is a NoOP).
+
+Opt-in only via ``--moe-backend sonic_moe``. Requires Hopper sm_90 or
+Blackwell sm_100/sm_103.
+
+This file is fully self-contained: the original sonic-moe Triton helpers
+(``_keyed_add``, the two-stage bitmatrix kernels, ``TC_topk_router_metadata``)
+are inlined verbatim with the upstream attribution preserved. No runtime
+dependency on the ``sonicmoe`` Python package.
+"""
+
+from __future__ import annotations
+
+import torch
+from quack.gemm_interface import gemm, gemm_gated
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Triton routing-metadata kernels.
+#
+# Adapted from sonic-moe v0.1.2:
+#   sonicmoe/functional/triton_kernels/{__init__,bitmatrix}.py
+# Copyright (c) 2026, Wentao Guo, Mayank Mishra, Xinle Cheng, Ion Stoica, Tri Dao
+#
+# Modifications:
+#   - Drops the unused general_routing path (we only need TC top-K).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _keyed_add(x, y):
+    # we keep the key in the upper 16 bits of a uint32:
+    key_mask: tl.constexpr = 0xFFFF0000
+
+    kx = x & key_mask
+    ky = y & key_mask
+    z = tl.where(kx == ky, x + y - kx, y)
+    return z
+
+
+@triton.jit
+def _bitmatrix_metadata_compute_stage1(
+    expert_freq_ptr,
+    expert_freq_offs_ptr,
+    E: tl.constexpr,
+    partial_sum_ptr,
+    n_tiles,
+    TK,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    # Assume grid size == E + 2
+    pid = tl.program_id(0)
+    if pid < E:
+        # Convert partial_sum[e, *] from raw counts to exclusive prefix
+        # sums over tiles. After this kernel, partial_sum[e, t] = number of
+        # entries for expert e in tiles 0..t-1.
+        expert_partial_sum_ptr = partial_sum_ptr + pid * n_tiles
+        curr_sum = 0
+        for start in range(0, n_tiles, BLOCK_M):
+            offs = start + tl.arange(0, BLOCK_M)
+            tile_counts = tl.load(
+                expert_partial_sum_ptr + offs, mask=offs < n_tiles, other=0
+            )
+            excl_cumsum = tl.cumsum(tile_counts, 0) - tile_counts + curr_sum
+            curr_sum += tl.sum(tile_counts, 0)
+            tl.store(expert_partial_sum_ptr + offs, excl_cumsum, mask=offs < n_tiles)
+    elif pid == E:
+        # Exclusive prefix sum of per-expert total counts → expert_offs[e].
+        curr_sum = 0
+        for start in tl.static_range(0, E, BLOCK_N):
+            offs = start + tl.arange(0, BLOCK_N)
+            expert_freq = tl.load(expert_freq_ptr + offs, mask=offs < E, other=0)
+            excl_cumsum = tl.cumsum(expert_freq, 0) - expert_freq + curr_sum
+            curr_sum += tl.sum(expert_freq, 0)
+            tl.store(expert_freq_offs_ptr + offs, excl_cumsum, mask=offs < E)
+    elif pid == E + 1:
+        tl.store(expert_freq_offs_ptr + E, TK)
+
+
+@triton.jit
+def _bitmatrix_metadata_compute_stage2(
+    s_scatter_idx_ptr,
+    s_reverse_scatter_idx_ptr,
+    x_gather_idx_ptr,
+    topk_indices_ptr,
+    T,
+    partial_sum_ptr,
+    n_tiles,
+    expert_offs_ptr,
+    K_POW2: tl.constexpr,
+    K: tl.constexpr,
+    TOKENS_PER_BLOCK: tl.constexpr,
+):
+    BLOCK_SIZE: tl.constexpr = TOKENS_PER_BLOCK * K_POW2
+    IS_POW2_K: tl.constexpr = K == K_POW2
+    tl.static_assert(BLOCK_SIZE <= 32768)
+
+    pid_m = tl.program_id(0)
+    offs_local = tl.arange(0, BLOCK_SIZE)
+    offs_global = pid_m * BLOCK_SIZE + offs_local
+    mask = offs_global < T * K_POW2
+
+    if IS_POW2_K:
+        expert = tl.load(topk_indices_ptr + offs_global, mask=mask, other=-1).to(
+            tl.uint32
+        )
+    else:
+        token_i_local = offs_local // K_POW2
+        k_slot = offs_local % K_POW2
+        token_i_global = pid_m * TOKENS_PER_BLOCK + token_i_local
+        load_mask = mask & (k_slot < K)
+        safe_k = tl.minimum(k_slot, K - 1)
+        expert = tl.load(
+            topk_indices_ptr + token_i_global * K + safe_k,
+            mask=load_mask,
+            other=-1,
+        ).to(tl.uint32)
+
+    kv_pairs = tl.sort(((expert << 16) | offs_local).to(tl.uint32), 0)
+    expert = kv_pairs >> 16
+    mask = expert != 0xFFFF
+
+    scan_input = (kv_pairs & 0xFFFF0000) | 0x00000001
+    inclusive_run_lengths = tl.associative_scan(scan_input, 0, _keyed_add)
+    within_expert_rank = (inclusive_run_lengths - 1) & 0xFFFF
+
+    s_reverse_scatter_idx = tl.load(
+        partial_sum_ptr + pid_m + expert * n_tiles, mask=mask
+    )
+    s_reverse_scatter_idx += tl.load(expert_offs_ptr + expert, mask=mask)
+    s_reverse_scatter_idx += within_expert_rank
+
+    if IS_POW2_K:
+        presort_offs = kv_pairs & 0xFFFF
+        entry_idx = pid_m * BLOCK_SIZE + presort_offs
+        tl.store(
+            s_reverse_scatter_idx_ptr + entry_idx, s_reverse_scatter_idx, mask=mask
+        )
+        tl.store(s_scatter_idx_ptr + s_reverse_scatter_idx, entry_idx, mask=mask)
+        tl.store(
+            x_gather_idx_ptr + s_reverse_scatter_idx, entry_idx // K_POW2, mask=mask
+        )
+    else:
+        presort_offs = kv_pairs & 0xFFFF
+        token_i_global_s = pid_m * TOKENS_PER_BLOCK + presort_offs // K_POW2
+        entry_idx = token_i_global_s * K + presort_offs % K_POW2
+        tl.store(
+            s_reverse_scatter_idx_ptr + entry_idx, s_reverse_scatter_idx, mask=mask
+        )
+        tl.store(s_scatter_idx_ptr + s_reverse_scatter_idx, entry_idx, mask=mask)
+        tl.store(x_gather_idx_ptr + s_reverse_scatter_idx, token_i_global_s, mask=mask)
+
+
+@triton.jit
+def _compute_col_partial_sum_kernel(
+    topk_indices_ptr,
+    partial_sum_ptr,
+    T,
+    E: tl.constexpr,
+    n_tiles,
+    TOKENS_PER_TILE: tl.constexpr,
+    K_POW2: tl.constexpr,
+    K: tl.constexpr,
+    E_POW2: tl.constexpr,
+):
+    tile_id = tl.program_id(0)
+
+    for e_start in tl.static_range(0, E, E_POW2):
+        e_offs = e_start + tl.arange(0, E_POW2)
+        tl.store(
+            partial_sum_ptr + e_offs * n_tiles + tile_id,
+            tl.zeros([E_POW2], tl.int32),
+            mask=e_offs < E,
+        )
+
+    tok_offs = tile_id * TOKENS_PER_TILE + tl.arange(0, TOKENS_PER_TILE)
+    k_offs = tl.arange(0, K_POW2)
+    tok_mask = tok_offs < T
+
+    load_mask = tok_mask[:, None] & (k_offs[None, :] < K)
+    safe_k = tl.minimum(k_offs, K - 1)
+    expert_ids = tl.load(
+        topk_indices_ptr + tok_offs[:, None] * K + safe_k[None, :],
+        mask=load_mask,
+        other=-1,
+    )
+
+    flat_experts = tl.reshape(expert_ids, [TOKENS_PER_TILE * K_POW2])
+    flat_mask = tl.reshape(load_mask, [TOKENS_PER_TILE * K_POW2])
+    safe_experts = tl.where(flat_mask, flat_experts, 0)
+
+    tl.atomic_add(
+        partial_sum_ptr + safe_experts * n_tiles + tile_id,
+        tl.full([TOKENS_PER_TILE * K_POW2], 1, dtype=tl.int32),
+        mask=flat_mask,
+    )
+
+
+def TC_topk_router_metadata_triton(
+    topk_router_indices: torch.Tensor,
+    E: int,
+    expert_frequency: torch.Tensor,
+    expert_frequency_offset: torch.Tensor,
+    x_gather_idx: torch.Tensor,
+    s_scatter_idx: torch.Tensor,
+    s_reverse_scatter_idx: torch.Tensor,
+) -> None:
+    """Compute permutation metadata for grouped-by-expert MoE GEMMs.
+
+    Given top-K-Choice routing indices of shape (T, K) with values in
+    [0, E), produces:
+
+    - expert_frequency[E]            : tokens routed to each expert
+    - expert_frequency_offset[E+1]   : cumulative sum (cu_seqlens for grouped GEMM)
+    - x_gather_idx[TK]               : grouped-slot -> source token index
+    - s_scatter_idx[TK]              : grouped-slot -> original (token, k) entry
+    - s_reverse_scatter_idx[TK]      : original (token, k) entry -> grouped-slot
+    """
+    T, K = topk_router_indices.size()
+    TK = T * K
+    device = topk_router_indices.device
+    E_POW2 = triton.next_power_of_2(E)
+    K_POW2 = triton.next_power_of_2(K)
+    TOKENS_PER_BLOCK = 1024 // K_POW2
+    n_tiles = triton.cdiv(T, TOKENS_PER_BLOCK)
+
+    col_partial_sum_trans = torch.empty(E, n_tiles, dtype=torch.int32, device=device)
+    _compute_col_partial_sum_kernel[(n_tiles,)](
+        topk_router_indices,
+        col_partial_sum_trans,
+        T,
+        E,
+        n_tiles,
+        TOKENS_PER_TILE=TOKENS_PER_BLOCK,
+        K_POW2=K_POW2,
+        K=K,
+        E_POW2=E_POW2,
+    )
+
+    expert_frequency.copy_(col_partial_sum_trans.sum(dim=1, dtype=torch.int32))
+    col_partial_sum = col_partial_sum_trans.T  # [n_tiles, E]
+
+    _bitmatrix_metadata_compute_stage1[(E + 2,)](
+        expert_frequency,
+        expert_frequency_offset,
+        E,
+        col_partial_sum,
+        n_tiles,
+        TK,
+        BLOCK_M=128,
+        BLOCK_N=E_POW2,
+    )
+
+    _bitmatrix_metadata_compute_stage2[(n_tiles,)](
+        s_scatter_idx,
+        s_reverse_scatter_idx,
+        x_gather_idx,
+        topk_router_indices,
+        T,
+        col_partial_sum,
+        n_tiles,
+        expert_frequency_offset[:E],
+        K_POW2=K_POW2,
+        TOKENS_PER_BLOCK=TOKENS_PER_BLOCK,
+        K=K,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Triton token-gather + weighted-sum kernel.
+#
+# Adapted from sonic-moe v0.1.2:
+#   sonicmoe/functional/reduction_over_k_gather.py
+# Copyright (c) 2026, Wentao Guo, Mayank Mishra, Xinle Cheng, Ion Stoica, Tri Dao
+#
+# Computes, for each token t:
+#   output[t] = Σ_{k=0..K-1}  y[M_perm[t*K + k]] * w[t*K + k]
+# where y is the grouped-order down-GEMM output and M_perm = s_reverse_scatter_idx
+# (natural slot -> grouped slot). Fused per-token gather + weighted reduce in
+# one pass, no atomics, no `(M*topk, K)` intermediate.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _gather_sum_autotune_configs() -> list[triton.Config]:
+    configs = []
+    block_h = 256
+    while block_h <= 4096:
+        block_k = 1
+        while block_k <= 128:
+            if block_k * block_h <= 32768:
+                for num_warps in (4, 8):
+                    configs.append(
+                        triton.Config(
+                            {"BLOCK_H": block_h, "BLOCK_K": block_k},
+                            num_warps=num_warps,
+                            num_stages=4,
+                        )
+                    )
+            block_k <<= 1
+        block_h <<= 1
+    return configs
+
+
+def _prune_gather_sum_configs(configs, nargs, **kw):
+    pruned = []
+    for c in configs:
+        block_h = c.kwargs["BLOCK_H"]
+        block_k = c.kwargs["BLOCK_K"]
+        if (
+            block_h <= triton.next_power_of_2(kw["H"])
+            and block_k <= triton.next_power_of_2(kw["MAX_K"])
+            and min(kw["H"] * kw["MAX_K"], 1024) <= (block_h * block_k)
+        ):
+            pruned.append(c)
+    return pruned if pruned else configs
+
+
+@triton.autotune(
+    configs=_gather_sum_autotune_configs(),
+    key=["H", "MAX_K", "w_is_None", "is_varlen_K"],
+    prune_configs_by={"early_config_prune": _prune_gather_sum_configs},
+)
+@triton.jit
+def _token_gather_sum_kernel(
+    x_ptr,  # (Mtotal, H)
+    w_ptr,  # (Mtotal,) or null when w_is_None
+    M_perm_ptr,  # (Mtotal,) int32
+    M_offset_ptr,  # (T+1,) int32, only read when is_varlen_K
+    out_ptr,  # (T, H)
+    T,
+    H: tl.constexpr,
+    MAX_K: tl.constexpr,
+    stride_xM: tl.constexpr,
+    stride_xH: tl.constexpr,
+    stride_outT: tl.constexpr,
+    stride_outH: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    w_is_None: tl.constexpr,
+    is_varlen_K: tl.constexpr,
+):
+    pid_t = tl.program_id(axis=0)
+    t_idx = pid_t.to(tl.int64)
+
+    if is_varlen_K:
+        Ms = tl.load(M_offset_ptr + t_idx).to(tl.int64)
+        Me = tl.load(M_offset_ptr + t_idx + 1).to(tl.int64)
+        K_this_token = Me - Ms
+    else:
+        Ms = MAX_K * t_idx
+        K_this_token = MAX_K  # type: ignore[no-redef]
+
+    for h_tile in tl.static_range(triton.cdiv(H, BLOCK_H)):
+        h_idx = (h_tile * BLOCK_H + tl.arange(0, BLOCK_H)).to(tl.int64)
+        m_h = h_idx < H
+
+        acc = tl.zeros([BLOCK_H], dtype=tl.float32)
+
+        for k_tile in tl.range(tl.cdiv(K_this_token, BLOCK_K)):
+            k_offset = k_tile * BLOCK_K
+            k_idx = (k_offset + tl.arange(0, BLOCK_K)).to(tl.int64)
+            m_k = k_idx < K_this_token
+            m_abs = Ms + k_idx
+
+            perm_idx = tl.load(M_perm_ptr + m_abs, mask=m_k, other=0).to(tl.int64)
+
+            x_ptrs = x_ptr + perm_idx[:, None] * stride_xM + h_idx[None, :] * stride_xH
+            x_mask = m_k[:, None] & m_h[None, :]
+            x_vals = tl.load(x_ptrs, mask=x_mask, other=0.0).to(tl.float32)
+
+            if w_is_None:
+                acc += tl.sum(x_vals, axis=0)
+            else:
+                w_vals = tl.load(w_ptr + m_abs, mask=m_k, other=0.0).to(tl.float32)
+                acc += tl.sum(x_vals * w_vals[:, None], axis=0)
+
+        out_ptrs = out_ptr + t_idx * stride_outT + h_idx * stride_outH
+        tl.store(out_ptrs, acc, mask=m_h)
+
+
+def token_gather_and_sum_varlen_K_triton(
+    x: torch.Tensor,
+    w: torch.Tensor | None,
+    out: torch.Tensor,
+    M_perm: torch.Tensor,
+    M_offset: torch.Tensor | None,
+    T: int,
+    MAX_K: int,
+    H: int,
+    is_varlen_K: bool,
+) -> None:
+    """Per-token gather + weighted sum of grouped-order rows.
+
+        out[t, :] = Σ_{k=0..K[t]-1}  x[M_perm[M_offset[t]+k], :] * w[M_offset[t]+k]
+
+    When ``is_varlen_K=False``, ``K[t] = MAX_K`` for all t and ``M_offset`` is
+    ignored (can be ``None``).
+    """
+    _token_gather_sum_kernel[(T,)](
+        x,
+        w,
+        M_perm,
+        M_offset,
+        out,
+        T=T,
+        H=H,
+        MAX_K=MAX_K,
+        stride_xM=x.stride(0),
+        stride_xH=x.stride(1),
+        stride_outT=out.stride(0),
+        stride_outH=out.stride(1),
+        w_is_None=(w is None),
+        is_varlen_K=is_varlen_K,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fused-experts class
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class SonicMoEExperts(mk.FusedMoEExpertsModular):
+    """Grouped-GEMM + fused-SwiGLU MoE experts using quack kernels."""
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(moe_config, quant_config)
+        self.out_dtype = moe_config.in_dtype
+
+    # ---- capability advertisement ----
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return current_platform.is_cuda() and (
+            current_platform.is_device_capability(90)
+            or current_platform.is_device_capability_family(100)
+        )
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        # quack's gemm_gated requires a gated activation; non-gated MLPs would
+        # need gemm_act + a separate combine path that we do not implement.
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return weight_key is None and activation_key is None
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        # MoEActivation.SILU under is_act_and_mul=True == SwiGLU; quack maps it
+        # to its "swiglu" gated activation in gemm_gated.
+        return activation == MoEActivation.SILU
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        return True
+
+    def supports_expert_map(self) -> bool:
+        return False
+
+    # ---- buffer + finalize plumbing ----
+
+    def moe_problem_size(
+        self,
+        a1: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> tuple[int, int, int, int, int]:
+        # Sonic MoE stores weights in quack's (E, K, N) layout after
+        # convert_to_unquantized_kernel_format:
+        #   w1: (E, H, 2*I)  -> N is the trailing dim
+        #   w2: (E, I, H)
+        # The default implementation extracts N from w1.shape[1], which would
+        # return H (= K) here and cause incorrect workspace allocation.
+        assert w1.dim() == 3 and w2.dim() == 3
+        E, _, N = w1.shape
+        K = a1.size(-1)
+        assert a1.dim() == 2
+        assert topk_ids.size(0) == a1.size(0)
+        return E, a1.size(0), N, K, topk_ids.size(1)
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        # apply() already multiplies by topk_weights and reduces over the topk
+        # axis; the framework's finalize is a no-op.
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        # N is the *unactivated* width of w1, which for a gated activation is
+        # 2 * intermediate. activation_out_dim halves N for gated activations.
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        # workspace13: post-activation buffer `a`        (M*topk, I)
+        # workspace2:  down-projection output buffer `y` (M*topk, K_hidden)
+        # output:      final reduced result              (M, K_hidden)
+        # workspace13 and output share storage in the framework's common
+        # workspace; ordering in apply() makes that safe (see comments there).
+        workspace1 = (M * topk, activation_out_dim)
+        workspace2 = (M * topk, K)
+        output = (M, K)
+        return workspace1, workspace2, output
+
+    # ---- forward ----
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        # ---- shapes ----
+        # After process_weights_after_loading the weights are in quack layout:
+        #   w1: (E_local, H, 2*I)  with [gate | up] packed BLOCK along the last dim
+        #   w2: (E_local, I, H)
+        T, K_topk = topk_ids.shape
+        E_local, H, two_I = w1.shape
+        assert two_I % 2 == 0, (
+            "SonicMoE expects gated w1 with packed gate|up, got shape "
+            f"{tuple(w1.shape)}"
+        )
+        TK = T * K_topk
+        device = hidden_states.device
+
+        assert hidden_states.dim() == 2 and hidden_states.size(-1) == H
+        assert w2.shape == (E_local, two_I // 2, H), (
+            f"SonicMoE expects w2 shape {(E_local, two_I // 2, H)}, got "
+            f"{tuple(w2.shape)}"
+        )
+
+        assert expert_map is None, (
+            "SonicMoE does not support expert_map; supports_expert_map() returns False"
+        )
+        routed_ids = topk_ids.to(torch.int32).contiguous()
+
+        # ---- routing metadata ----
+        expert_frequency = torch.empty(E_local, dtype=torch.int32, device=device)
+        expert_frequency_offset = torch.empty(
+            E_local + 1, dtype=torch.int32, device=device
+        )
+        x_gather_idx = torch.empty(TK, dtype=torch.int32, device=device)
+        s_scatter_idx = torch.empty(TK, dtype=torch.int32, device=device)
+        s_reverse_scatter_idx = torch.empty(TK, dtype=torch.int32, device=device)
+        TC_topk_router_metadata_triton(
+            routed_ids,
+            E_local,
+            expert_frequency,
+            expert_frequency_offset,
+            x_gather_idx,
+            s_scatter_idx,
+            s_reverse_scatter_idx,
+        )
+
+        # ---- up projection: grouped GEMM + fused SwiGLU ----
+        # w1 is (E, H, 2*I) with [gate | up] INTERLEAVED on the last dim
+        # ([g0, u0, g1, u1, ...]); the interleave is materialized in
+        # convert_to_unquantized_kernel_format. quack's varlen_m gemm_gated
+        # ignores concat_layout=("B",) so we must hand it the interleaved
+        # tensor directly.
+        a = workspace13  # (TK, I)
+        gemm_gated(
+            hidden_states,
+            w1,
+            activation="swiglu",
+            cu_seqlens_m=expert_frequency_offset,
+            A_idx=x_gather_idx,
+            postact_out=a,
+            store_preact=False,
+            tuned=False,
+        )
+
+        # ---- down projection: grouped GEMM (no activation) ----
+        y = workspace2  # (TK, H)
+        gemm(a, w2, out=y, cu_seqlens_m=expert_frequency_offset, tuned=False)
+
+        # ---- weighted reduce: y (grouped) -> output (M, H) ----
+        # Per natural slot (t, k), the corresponding grouped-row index in y is
+        # s_reverse_scatter_idx[t*K + k]. The sonic-moe gather-sum kernel does
+        # the natural-order gather + topk-weighted reduce in one pass — no
+        # atomics, no (M*topk, K) intermediate.
+        if apply_router_weight_on_input:
+            flat_w: torch.Tensor | None = None
+        else:
+            flat_w = topk_weights.to(y.dtype).contiguous().view(-1)
+
+        token_gather_and_sum_varlen_K_triton(
+            x=y,
+            w=flat_w,
+            out=output,
+            M_perm=s_reverse_scatter_idx,
+            M_offset=None,
+            T=T,
+            MAX_K=K_topk,
+            H=H,
+            is_varlen_K=False,
+        )

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -35,6 +35,7 @@ class UnquantizedMoeBackend(Enum):
     AITER = "ROCm AITER"
     TRITON = "TRITON"
     BATCHED_TRITON = "BATCHED_TRITON"
+    SONIC_MOE = "Sonic MoE"
     CPU = "CPU"
     XPU = "XPU"
     TPU = "TPU"
@@ -119,6 +120,13 @@ def backend_to_kernel_cls(
 
         return BatchedTritonExperts
 
+    elif backend == UnquantizedMoeBackend.SONIC_MOE:
+        from vllm.model_executor.layers.fused_moe.experts.sonic_moe import (
+            SonicMoEExperts,
+        )
+
+        return SonicMoEExperts
+
     elif backend == UnquantizedMoeBackend.XPU:
         from vllm.model_executor.layers.fused_moe.experts.xpu_moe import XPUExperts
 
@@ -135,6 +143,7 @@ def map_unquantized_backend(runner_backend: MoEBackend) -> UnquantizedMoeBackend
         "flashinfer_trtllm": UnquantizedMoeBackend.FLASHINFER_TRTLLM,
         "flashinfer_cutlass": UnquantizedMoeBackend.FLASHINFER_CUTLASS,
         "aiter": UnquantizedMoeBackend.AITER,
+        "sonic_moe": UnquantizedMoeBackend.SONIC_MOE,
     }
     if backend := mapping.get(runner_backend):
         return backend
@@ -316,6 +325,30 @@ def convert_to_unquantized_kernel_format(
             w13_weight,
             w2_weight,
         )
+
+    elif unquantized_backend == UnquantizedMoeBackend.SONIC_MOE:
+        # quack's grouped GEMM wants `mB: (E, K, N)` with the gate/up split
+        # INTERLEAVED on the N axis ([g0, u0, g1, u1, ...]). vLLM stores w13
+        # as (E, 2*I, H) with [gate | up] BLOCK-concatenated on dim 1:
+        #   w13: (E, 2*I, H)  ->  permute to (E, H, 2*I)  ->  interleave the
+        #        last dim so even cols are gate and odd cols are up
+        #   w2:  (E, H, I)   ->  (E, I, H)  (no interleave needed)
+        # NOTE: quack's `concat_layout=("B",)` is silently a no-op on the
+        # varlen_m (grouped) path, so the interleave must be materialized.
+        E_local = w13_weight.shape[0]
+        intermediate = w13_weight.shape[1] // 2
+        H_dim = w13_weight.shape[2]
+        gate = w13_weight[:, :intermediate, :]
+        up = w13_weight[:, intermediate:, :]
+        # Stack (gate, up) along a new axis and flatten to interleave:
+        #   (E, I, H) + (E, I, H) -> (E, I, 2, H) -> (E, 2I, H)
+        # then permute to (E, H, 2I).
+        w13_weight = (
+            torch.stack([gate, up], dim=2)  # (E, I, 2, H)
+            .reshape(E_local, 2 * intermediate, H_dim)  # (E, 2I, H) interleaved
+            .permute(0, 2, 1)  # (E, H, 2I)
+        )
+        w2_weight = w2_weight.permute(0, 2, 1)
 
     return w13_weight.contiguous(), w2_weight.contiguous()
 


### PR DESCRIPTION
Thanks for @clocksmith for the original implementation! 

## Purpose
See original implementation [here](https://github.com/vllm-project/vllm/pull/31548)
Since there's significantly code structure change from upstream kernels (the core impl has been moved to quack rather than in sonic-moe repo). I am making this new PRs to port it over. 

Adds a new opt-in unquantized MoE backend built on the quack grouped-GEMM kernels (`quack.gemm_interface.gemm_gated` + `gemm`). Routing metadata and the topk-weighted gather-sum reduction are implemented as inlined Triton kernels adapted from the sonic-moe project; no runtime dependency on the `sonicmoe` Python package.

Pipeline:
  routing-metadata -> grouped gemm_gated (fused SwiGLU) -> grouped gemm
  -> sonic-moe gather-sum reduction (no atomics, no `(M*topk, K)` intermediate)

The backend is opt-in only via `--moe-backend sonic_moe`; it is not added to the default backend priority list and only advertises itself on Hopper sm_90 or Blackwell sm_100/sm_103.

Weight repacking:
  `convert_to_unquantized_kernel_format` permutes w13/w2 from vLLM's
  `(E, 2I, H)` / `(E, H, I)` to quack's `(E, K, N)` order and INTERLEAVES
  the gate/up halves on the N axis. quack's `concat_layout=("B",)` flag is
  a no-op on the varlen_m grouped path, so the interleave must be
  materialized at load time.

Verified end-to-end:
  Qwen3-235B-A22B-Instruct-2507 (TP=4) gsm8k 5-shot:
    flexible-extract exact_match = 0.909 (+/- 0.0079)
    strict-match     exact_match = 0.903 (+/- 0.0082)

Tested with `tests/kernels/moe/test_sonic_moe.py` (6 unit tests pass). AI assistance (Claude) was used in writing and debugging this change.

## Test Plan
gsm8k scores on qwen moe. 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

