### PR TITLE
[MoE/b12x] Add cutlass_prefill_threshold hybrid dispatch to FlashInferB12xExperts

### DIFF
--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -8,8 +10,7 @@ from vllm.platforms import current_platform
 
 if not current_platform.is_device_capability_family(120):
     pytest.skip(
-        reason="FlashInfer CuteDSL SM12x MoE requires SM120 "
-        "(RTX Pro 6000 / DGX Spark).",
+        reason="FlashInfer B12x MoE requires SM120 (RTX Pro 6000 / DGX Spark).",
         allow_module_level=True,
     )
 
@@ -18,8 +19,8 @@ from vllm.utils.flashinfer import has_flashinfer_b12x_moe
 if not has_flashinfer_b12x_moe():
     pytest.skip(
         reason=(
-            "FlashInfer cute_dsl_fused_moe_nvfp4 / convert_sf_to_mma_layout "
-            "not available in installed FlashInfer (needs PRs #3051 and #3066)."
+            "FlashInfer B12xMoEWrapper not available in installed "
+            "FlashInfer (needs PR #3080)."
         ),
         allow_module_level=True,
     )
@@ -40,7 +41,6 @@ from vllm.model_executor.layers.fused_moe.config import nvfp4_moe_quant_config
 from vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe import (
     FlashInferB12xExperts,
 )
-from vllm.utils.flashinfer import flashinfer_convert_sf_to_mma_layout
 from vllm.utils.torch_utils import set_random_seed
 
 # Dimensions chosen to satisfy FP4 alignment requirements (k multiple of 256,
@@ -59,7 +59,7 @@ def _reorder_gate_up_to_up_gate(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Swap gate and up-projection halves along dim=1 to [up, gate] order.
 
-    The SM12x kernel expects weights in [up (w3), gate (w1)] order while the
+    The B12x kernel expects weights in [up (w3), gate (w1)] order while the
     BF16 reference uses [gate (w1), up (w3)].  This replicates the reordering
     done at model-load time by ``prepare_nvfp4_moe_layer_for_fi_or_cutlass``.
     """
@@ -68,6 +68,22 @@ def _reorder_gate_up_to_up_gate(
         torch.cat([w[:, n:, :], w[:, :n, :]], dim=1),
         torch.cat([w_s[:, n:, :], w_s[:, :n, :]], dim=1),
     )
+
+
+def _process_b12x_weights(
+    experts: FlashInferB12xExperts,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    w1_scale_2: torch.Tensor,
+    w2_scale_2: torch.Tensor,
+) -> None:
+    layer = SimpleNamespace(
+        w13_weight_scale=w1_scale,
+        w13_weight_scale_2=w1_scale_2,
+        w2_weight_scale=w2_scale,
+        w2_weight_scale_2=w2_scale_2,
+    )
+    experts.process_weights_after_loading(layer)
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
@@ -174,22 +190,12 @@ def test_flashinfer_b12x_moe(
             moe_config=moe_config,
             quant_config=quant_config,
         )
-        # In production, process_weights_after_loading computes these after
-        # normalizing block scales. In the test the scales are already in final
-        # form (global_scale=1.0), so we compute the MMA layouts directly.
-        num_experts_w1, m1, k1_sf = w1_blockscale.shape
-        experts.w1_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            w1_blockscale.reshape(num_experts_w1 * m1, k1_sf),
-            m=m1,
-            k=k1_sf * 16,
-            num_groups=num_experts_w1,
-        )
-        num_experts_w2, m2, k2_sf = w2_blockscale.shape
-        experts.w2_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            w2_blockscale.reshape(num_experts_w2 * m2, k2_sf),
-            m=m2,
-            k=k2_sf * 16,
-            num_groups=num_experts_w2,
+        _process_b12x_weights(
+            experts,
+            w1_blockscale,
+            w2_blockscale,
+            ones_e,
+            ones_e,
         )
 
         kernel = mk.FusedMoEKernel(
@@ -222,6 +228,135 @@ def test_flashinfer_b12x_moe(
         torch_output = torch_moe(a, w1_bf16, w2_bf16, score, topk)
 
         torch.testing.assert_close(sm12x_output, torch_output, atol=2e-1, rtol=2e-1)
+
+
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
+@pytest.mark.parametrize("e", [8, 16])
+@pytest.mark.parametrize("topk", [1, 2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.inference_mode()
+def test_flashinfer_b12x_moe_relu2(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    dtype: torch.dtype,
+    workspace_init,
+):
+    """Test FlashInferB12xExperts with ReLU2 (non-gated) activation.
+
+    ReLU2 is used by Nemotron-H style models.  Unlike the gated SiLU
+    path, w1 has shape [E, N, K] (not [E, 2N, K]) and the activation
+    is relu(x)^2 without a gate/up split.
+    """
+    set_random_seed(7)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+
+        # Non-gated: w1 shape is (e, n, k), not (e, 2n, k).
+        w1_bf16 = torch.randn((e, n, k), device="cuda", dtype=dtype) / 15
+        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
+
+        gs = torch.ones(1, device="cuda", dtype=torch.float32)
+        sf_vec_size = 16
+
+        # W1: no gate/up reordering for non-gated.
+        w1_flat = w1_bf16.reshape(e * n, k)
+        w1_q_flat, w1_sf_flat = fp4_quantize(
+            w1_flat,
+            global_scale=gs,
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w1_q = w1_q_flat.view(e, n, k // 2)
+        w1_blockscale = w1_sf_flat.view(e, n, w1_sf_flat.shape[1])
+
+        w2_flat = w2_bf16.reshape(e * k, n)
+        w2_q_flat, w2_sf_flat = fp4_quantize(
+            w2_flat,
+            global_scale=gs,
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w2_q = w2_q_flat.view(e, k, n // 2)
+        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])
+
+        ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=ones_e,
+            g2_alphas=ones_e,
+            a1_gscale=ones_e,
+            a2_gscale=ones_e,
+            w1_scale=w1_blockscale,
+            w2_scale=w2_blockscale,
+        )
+
+        moe_config = make_dummy_moe_config(
+            num_experts=e,
+            experts_per_token=topk,
+            hidden_dim=k,
+            intermediate_size=n,
+            in_dtype=dtype,
+            activation=MoEActivation.RELU2_NO_MUL,
+        )
+
+        experts = FlashInferB12xExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        )
+        _process_b12x_weights(
+            experts,
+            w1_blockscale,
+            w2_blockscale,
+            ones_e,
+            ones_e,
+        )
+
+        kernel = mk.FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
+            experts,
+            inplace=False,
+        )
+
+        score = torch.randn((m, e), device="cuda", dtype=dtype)
+        topk_weights, topk_ids, _ = fused_topk(a, score, topk, renormalize=False)
+
+        b12x_output = kernel.apply(
+            hidden_states=a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=e,
+            activation=MoEActivation.RELU2_NO_MUL,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+        )
+
+        torch_output = torch_moe(
+            a,
+            w1_bf16,
+            w2_bf16,
+            score,
+            topk,
+            activation=MoEActivation.RELU2_NO_MUL,
+        )
+
+        torch.testing.assert_close(
+            b12x_output,
+            torch_output,
+            atol=2e-1,
+            rtol=2e-1,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -76,12 +77,21 @@ def _process_b12x_weights(
     w2_scale: torch.Tensor,
     w1_scale_2: torch.Tensor,
     w2_scale_2: torch.Tensor,
+    w1_input_scale: torch.Tensor | None = None,
+    w2_input_scale: torch.Tensor | None = None,
 ) -> None:
+    if w1_input_scale is None:
+        w1_input_scale = torch.ones((), device=w1_scale.device, dtype=torch.float32)
+    if w2_input_scale is None:
+        w2_input_scale = torch.ones((), device=w2_scale.device, dtype=torch.float32)
     layer = SimpleNamespace(
+        w13_weight=torch.empty(0, device=w1_scale.device),
         w13_weight_scale=w1_scale,
         w13_weight_scale_2=w1_scale_2,
+        w13_input_scale=w1_input_scale,
         w2_weight_scale=w2_scale,
         w2_weight_scale_2=w2_scale_2,
+        w2_input_scale=w2_input_scale,
     )
     experts.process_weights_after_loading(layer)
 
@@ -324,7 +334,6 @@ def test_flashinfer_b12x_moe_relu2(
                 use_monolithic=False,
             ),
             experts,
-            inplace=False,
         )
 
         score = torch.randn((m, e), device="cuda", dtype=dtype)
@@ -357,6 +366,207 @@ def test_flashinfer_b12x_moe_relu2(
             atol=2e-1,
             rtol=2e-1,
         )
+
+
+def _assert_kernel_parity(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    same_backend: bool,
+) -> None:
+    actual_float = actual.float()
+    expected_float = expected.float()
+    reference_rms = expected_float.square().mean().sqrt().clamp_min(1e-6)
+    nrmse = (
+        (actual_float - expected_float).square().mean().sqrt() / reference_rms
+    ).item()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_float.flatten(), expected_float.flatten(), dim=0
+    ).item()
+    if same_backend:
+        assert nrmse < 0.02
+        assert cosine > 0.9998
+    else:
+        assert nrmse < 0.05
+        assert cosine > 0.999
+
+
+@pytest.mark.parametrize("m", [31, 32, 33])
+@torch.inference_mode()
+def test_flashinfer_b12x_cutlass_hybrid_scale_contract(
+    m: int,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_init,
+):
+    """Hybrid dispatch preserves checkpoint numerics across its threshold.
+
+    Use non-unit activation and weight-global scales so this fails if vLLM
+    folds an activation scale into the B12x block SF, replaces a B12x alpha
+    with one, or builds CUTLASS's dequant multipliers from mutated tensors.
+    """
+    from flashinfer.fused_moe import B12xMoEWrapper
+
+    if (
+        "cutlass_prefill_threshold"
+        not in inspect.signature(B12xMoEWrapper.__init__).parameters
+    ):
+        pytest.skip("FlashInfer B12x/CUTLASS hybrid dispatch is unavailable")
+
+    set_random_seed(11)
+    e, n, k, topk = 8, 128, 256, 2
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    hidden_states = torch.randn((m, k), device=device, dtype=dtype) / 10
+    w1_bf16 = torch.randn((e, n, k), device=device, dtype=dtype) / 15
+    w2_bf16 = torch.randn((e, k, n), device=device, dtype=dtype) / 15
+    unit_global_scale = torch.ones((), device=device, dtype=torch.float32)
+    w1_q_flat, logical_w1_sf_flat = fp4_quantize(
+        w1_bf16.reshape(e * n, k),
+        global_scale=unit_global_scale,
+        sf_vec_size=16,
+        is_sf_swizzled_layout=True,
+    )
+    w2_q_flat, logical_w2_sf_flat = fp4_quantize(
+        w2_bf16.reshape(e * k, n),
+        global_scale=unit_global_scale,
+        sf_vec_size=16,
+        is_sf_swizzled_layout=True,
+    )
+    w1_q = w1_q_flat.view(e, n, k // 2)
+    w2_q = w2_q_flat.view(e, k, n // 2)
+    logical_w1_sf = logical_w1_sf_flat.view(torch.float8_e4m3fn).view(e, n, -1)
+    logical_w2_sf = logical_w2_sf_flat.view(torch.float8_e4m3fn).view(e, k, -1)
+
+    # ModelOpt checkpoint convention: normalized SF plus a separate
+    # per-expert weight multiplier and a small global activation scale.
+    w1_weight_alpha = torch.tensor(
+        [0.5, 0.25], device=device, dtype=torch.float32
+    ).repeat(e // 2)
+    w2_weight_alpha = torch.tensor(
+        [0.25, 0.5], device=device, dtype=torch.float32
+    ).repeat(e // 2)
+    w1_checkpoint_sf = (logical_w1_sf.float() / w1_weight_alpha.view(e, 1, 1)).to(
+        torch.float8_e4m3fn
+    )
+    w2_checkpoint_sf = (logical_w2_sf.float() / w2_weight_alpha.view(e, 1, 1)).to(
+        torch.float8_e4m3fn
+    )
+    w1_input_scale = torch.tensor(1.0 / 16.0, device=device)
+    w2_input_scale = torch.tensor(1.0 / 8.0, device=device)
+
+    moe_config = make_dummy_moe_config(
+        num_experts=e,
+        experts_per_token=topk,
+        hidden_dim=k,
+        intermediate_size=n,
+        in_dtype=dtype,
+        activation=MoEActivation.RELU2_NO_MUL,
+    )
+
+    def build_experts(threshold: int) -> FlashInferB12xExperts:
+        monkeypatch.setenv(
+            "VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", str(threshold)
+        )
+        w1_scale = w1_checkpoint_sf.clone()
+        w2_scale = w2_checkpoint_sf.clone()
+        w1_scale_2 = w1_weight_alpha.clone()
+        w2_scale_2 = w2_weight_alpha.clone()
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=w1_scale_2,
+            g2_alphas=w2_scale_2,
+            a1_gscale=1.0 / w1_input_scale,
+            a2_gscale=1.0 / w2_input_scale,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+        )
+        experts = FlashInferB12xExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        )
+        _process_b12x_weights(
+            experts,
+            w1_scale,
+            w2_scale,
+            w1_scale_2,
+            w2_scale_2,
+            w1_input_scale,
+            w2_input_scale,
+        )
+        return experts
+
+    pure_b12x = build_experts(0)
+    hybrid = build_experts(32)
+
+    # The live B12x tensors recover the unnormalized logical SF and use the
+    # checkpoint's small activation scales as kernel alphas.
+    torch.testing.assert_close(pure_b12x.w1_scale, logical_w1_sf, rtol=0, atol=0)
+    torch.testing.assert_close(pure_b12x.w2_scale, logical_w2_sf, rtol=0, atol=0)
+    torch.testing.assert_close(
+        pure_b12x.g1_alphas,
+        w1_input_scale.expand_as(w1_weight_alpha),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        pure_b12x.g2_alphas,
+        w2_input_scale.expand_as(w2_weight_alpha),
+        rtol=0,
+        atol=0,
+    )
+    assert pure_b12x._fc2_input_scale is w2_input_scale
+
+    # CUTLASS keeps the original normalized SF and combines the independent
+    # weight and activation multipliers in quant_scales[2]/[5].
+    assert hybrid._cutlass_quant_scales is not None
+    cutlass_scales = hybrid._cutlass_quant_scales
+    torch.testing.assert_close(cutlass_scales[0], 1.0 / w1_input_scale)
+    torch.testing.assert_close(cutlass_scales[3], 1.0 / w2_input_scale)
+    assert torch.equal(
+        cutlass_scales[1].view(torch.uint8).flatten(),
+        w1_checkpoint_sf.view(torch.uint8).flatten(),
+    )
+    assert torch.equal(
+        cutlass_scales[4].view(torch.uint8).flatten(),
+        w2_checkpoint_sf.view(torch.uint8).flatten(),
+    )
+    torch.testing.assert_close(cutlass_scales[2], w1_weight_alpha * w1_input_scale)
+    torch.testing.assert_close(cutlass_scales[5], w2_weight_alpha * w2_input_scale)
+
+    topk_ids = torch.randint(0, e, (m, topk), device=device, dtype=torch.int32)
+    topk_weights = torch.rand((m, topk), device=device, dtype=torch.float32)
+    topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+
+    def run(experts: FlashInferB12xExperts) -> torch.Tensor:
+        output = torch.empty((m, k), device=device, dtype=dtype)
+        experts.apply(
+            output=output,
+            hidden_states=hidden_states,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.RELU2_NO_MUL,
+            global_num_experts=e,
+            expert_map=None,
+            a1q_scale=None,
+            a2_scale=None,
+            workspace13=None,
+            workspace2=None,
+            expert_tokens_meta=None,
+            apply_router_weight_on_input=False,
+        )
+        return output.clone()
+
+    pure_output = run(pure_b12x)
+    hybrid_output = run(hybrid)
+    assert hybrid._wrapper is not None
+    assert hybrid._wrapper._should_route_to_cutlass(m) is (m >= 32)
+    _assert_kernel_parity(
+        hybrid_output,
+        pure_output,
+        same_backend=m < 32,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/kernels/moe/utils.py
+++ b/tests/kernels/moe/utils.py
@@ -55,6 +55,7 @@ def make_dummy_moe_config(
     intermediate_size: int = 1,
     in_dtype: torch.dtype = torch.bfloat16,
     max_num_tokens: int = 512,
+    activation: MoEActivation = MoEActivation.SILU,
 ) -> FusedMoEConfig:
     """
     This is a dummy config for the mk constructor interface
@@ -73,7 +74,7 @@ def make_dummy_moe_config(
         else num_experts,
         num_logical_experts=num_experts,
         moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
-        activation=MoEActivation.SILU,
+        activation=activation,
         in_dtype=in_dtype,
         device="cuda",
         routing_method=RoutingMethodType.TopK,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -193,6 +193,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+    VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD: int = 0
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1579,6 +1580,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Control the workspace buffer size for the FlashInfer backend.
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
+    ),
+    # When >0 and num_tokens >= threshold, the B12x SM12x MoE wrapper routes
+    # to cutlass_fused_moe (prefill) instead of the b12x kernels (decode).
+    # 0 (default) keeps pure b12x dispatch. Requires a FlashInfer build that
+    # exposes the `cutlass_prefill_threshold` kwarg on B12xMoEWrapper.
+    "VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD": lambda: int(
+        os.getenv("VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD", "0")
     ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -192,7 +192,9 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
-        return True
+        # B12xMoEWrapper does not yet support expert parallelism: its local
+        # expert count must equal the global expert count.
+        return not moe_parallel_config.use_ep
 
     def supports_expert_map(self) -> bool:
         return False
@@ -275,17 +277,19 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         )
 
         self._ensure_wrapper()
+        wrapper = self._wrapper
+        assert wrapper is not None
 
-        self._wrapper.run(
+        wrapper_output = wrapper.run(
             x=hidden_states,
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,
             w1_alpha=self.g1_alphas,
-            fc2_input_scale=self.a2_gscale,
+            fc2_input_scale=self._fc2_input_scale,
             w2_weight=w2,
             w2_weight_sf=self.w2_sf_mma,
             w2_alpha=self.g2_alphas,
             token_selected_experts=topk_ids.to(torch.int32),
             token_final_scales=topk_weights,
-            out=output,
         )
+        output.copy_(wrapper_output)

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import inspect
 from typing import Any
 
 import torch
 
+import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
@@ -85,12 +87,98 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             )
         self._activation_str = self._ACTIVATION_MAP[activation]
 
+        # Hybrid CUTLASS-prefill / B12x-decode dispatch. When > 0, the
+        # wrapper routes batches with num_tokens >= threshold through
+        # cutlass_fused_moe; see register_cutlass_prefill_weights() in
+        # _ensure_wrapper. Requires a FlashInfer build exposing the
+        # `cutlass_prefill_threshold` kwarg on B12xMoEWrapper.
+        self.cutlass_prefill_threshold = (
+            envs.VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD
+        )
+
         # Lazily created on first apply() call.
         self._wrapper: Any | None = None
+        self._cutlass_registered: bool = False
         self.w1_sf_mma: torch.Tensor | None = None
         self.w2_sf_mma: torch.Tensor | None = None
 
+        # CUTLASS-format scales saved before the in-place B12x rewrite in
+        # process_weights_after_loading. Only populated when
+        # cutlass_prefill_threshold > 0.
+        self._cutlass_w13_scale: torch.Tensor | None = None
+        self._cutlass_w2_scale: torch.Tensor | None = None
+        self._cutlass_a1_gscale: torch.Tensor | None = None
+        self._cutlass_a2_gscale: torch.Tensor | None = None
+        self._cutlass_g1_alphas: torch.Tensor | None = None
+        self._cutlass_g2_alphas: torch.Tensor | None = None
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # When hybrid CUTLASS prefill is enabled, save copies of the
+        # CUTLASS-format scales BEFORE the in-place B12x rewrite below
+        # destroys them. The FP4 weight bytes themselves are reusable —
+        # prepare_nvfp4_moe_layer_for_fi_or_cutlass produces the same
+        # [w3, w1] reorder + swizzled SF for both FLASHINFER_CUTLASS and
+        # FLASHINFER_B12X — so we only need to clone the scales.
+        #
+        # g_alphas: B12x leaves g1_alphas = 1/w_gs (does NOT fold
+        # a_input_scale). CUTLASS wants 1/(a_gs * w_gs) = (1/w_gs) / a_gs,
+        # hence the division.
+        #
+        # The clones are registered as nn.Parameter on the layer so
+        # FusedMoE.get_expert_weights picks them up and EPLB rearranges
+        # them in lockstep with the live b12x scales.
+        if self.cutlass_prefill_threshold > 0:
+            assert layer.w13_weight_scale.dtype == torch.float8_e4m3fn, (
+                "Expected swizzled FP8 SF before B12x rewrite, got "
+                f"{layer.w13_weight_scale.dtype}"
+            )
+            cutlass_w13_scale = layer.w13_weight_scale.clone()
+            cutlass_w2_scale = layer.w2_weight_scale.clone()
+            cutlass_a1_gscale = self.a1_gscale.clone()
+            cutlass_a2_gscale = self.a2_gscale.clone()
+            cutlass_g1_alphas = (
+                self.g1_alphas.float() / self.a1_gscale
+            ).contiguous()
+            cutlass_g2_alphas = (
+                self.g2_alphas.float() / self.a2_gscale
+            ).contiguous()
+
+            layer.register_parameter(
+                "w13_cutlass_weight_scale",
+                torch.nn.Parameter(cutlass_w13_scale, requires_grad=False),
+            )
+            layer.register_parameter(
+                "w2_cutlass_weight_scale",
+                torch.nn.Parameter(cutlass_w2_scale, requires_grad=False),
+            )
+            layer.register_parameter(
+                "w13_cutlass_a_gscale",
+                torch.nn.Parameter(cutlass_a1_gscale, requires_grad=False),
+            )
+            layer.register_parameter(
+                "w2_cutlass_a_gscale",
+                torch.nn.Parameter(cutlass_a2_gscale, requires_grad=False),
+            )
+            layer.register_parameter(
+                "w13_cutlass_g_alphas",
+                torch.nn.Parameter(cutlass_g1_alphas, requires_grad=False),
+            )
+            layer.register_parameter(
+                "w2_cutlass_g_alphas",
+                torch.nn.Parameter(cutlass_g2_alphas, requires_grad=False),
+            )
+
+            # Hold references on the experts class so _ensure_wrapper can
+            # build the quant_scales list without re-fetching from layer.
+            # These alias the registered Parameters' storage, so EPLB
+            # rearrangement of the parameters is observed here too.
+            self._cutlass_w13_scale = layer.w13_cutlass_weight_scale.data
+            self._cutlass_w2_scale = layer.w2_cutlass_weight_scale.data
+            self._cutlass_a1_gscale = layer.w13_cutlass_a_gscale.data
+            self._cutlass_a2_gscale = layer.w2_cutlass_a_gscale.data
+            self._cutlass_g1_alphas = layer.w13_cutlass_g_alphas.data
+            self._cutlass_g2_alphas = layer.w2_cutlass_g_alphas.data
+
         # Normalise block scales to absorb the per-expert weight global scale
         # (w_gs).  vLLM's NVFP4 convention stores:
         #   block_scale = max_abs * w_gs / fp4_max,  g1_alphas = 1/w_gs
@@ -227,23 +315,67 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # from pre-quantizing activations.
         return True
 
-    def _ensure_wrapper(self) -> None:
-        """Lazily create B12xMoEWrapper on first use."""
-        if self._wrapper is not None:
-            return
+    def _ensure_wrapper(self, w1: torch.Tensor, w2: torch.Tensor) -> None:
+        """Lazily create B12xMoEWrapper on first use.
 
-        from flashinfer.fused_moe import B12xMoEWrapper
+        Also registers CUTLASS-format prefill weights when hybrid dispatch
+        is enabled; the FP4 byte tensors are shared with the b12x decode
+        path (only scales differ — saved in process_weights_after_loading).
+        """
+        if self._wrapper is None:
+            from flashinfer.fused_moe import B12xMoEWrapper
 
-        self._wrapper = B12xMoEWrapper(
-            num_experts=self.global_num_experts,
-            top_k=self.topk,
-            hidden_size=self.hidden_dim,
-            intermediate_size=self.intermediate_size_per_partition,
-            use_cuda_graph=True,
-            max_num_tokens=self.max_num_tokens,
-            num_local_experts=self.num_local_experts,
-            activation=self._activation_str,
-        )
+            b12x_kwargs = dict(
+                num_experts=self.global_num_experts,
+                top_k=self.topk,
+                hidden_size=self.hidden_dim,
+                intermediate_size=self.intermediate_size_per_partition,
+                use_cuda_graph=True,
+                max_num_tokens=self.max_num_tokens,
+                num_local_experts=self.num_local_experts,
+                activation=self._activation_str,
+            )
+            # cutlass_prefill_threshold is gated on a FlashInfer build that
+            # exposes the kwarg. Skip silently if absent and threshold is 0;
+            # error cleanly if the user is asking for the hybrid path.
+            if "cutlass_prefill_threshold" in inspect.signature(
+                B12xMoEWrapper.__init__
+            ).parameters:
+                b12x_kwargs["cutlass_prefill_threshold"] = (
+                    self.cutlass_prefill_threshold
+                )
+            elif self.cutlass_prefill_threshold > 0:
+                raise RuntimeError(
+                    "VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD > 0 "
+                    "requires a FlashInfer build that exposes the "
+                    "`cutlass_prefill_threshold` kwarg on B12xMoEWrapper; "
+                    "current FlashInfer does not."
+                )
+            self._wrapper = B12xMoEWrapper(**b12x_kwargs)
+
+        if self.cutlass_prefill_threshold > 0 and not self._cutlass_registered:
+            assert self._cutlass_w13_scale is not None, (
+                "cutlass_prefill_threshold > 0 but CUTLASS scales were "
+                "not saved in process_weights_after_loading"
+            )
+            # quant_scales order matches FlashInferExperts (NVFP4 mode):
+            # [a1_gs, w1_blockscale_int32, 1/(a1_gs*w1_gs),
+            #  a2_gs, w2_blockscale_int32, 1/(a2_gs*w2_gs)].
+            # register_cutlass_prefill_weights does .contiguous().view(long)
+            # on w*_q internally — pass uint8 directly.
+            self._wrapper.register_cutlass_prefill_weights(
+                w1_q=w1,
+                w2_q=w2,
+                quant_scales=[
+                    self._cutlass_a1_gscale,
+                    self._cutlass_w13_scale.view(torch.int32),
+                    self._cutlass_g1_alphas,
+                    self._cutlass_a2_gscale,
+                    self._cutlass_w2_scale.view(torch.int32),
+                    self._cutlass_g2_alphas,
+                ],
+            )
+            self._cutlass_registered = True
 
     def apply(
         self,
@@ -276,7 +408,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             "process_weights_after_loading must run before FlashInferB12xExperts.apply"
         )
 
-        self._ensure_wrapper()
+        self._ensure_wrapper(w1, w2)
         wrapper = self._wrapper
         assert wrapper is not None
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -276,7 +276,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
         self._ensure_wrapper()
 
-        result = self._wrapper.run(
+        self._wrapper.run(
             x=hidden_states,
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -62,10 +62,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.out_dtype = moe_config.in_dtype
         self.num_local_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
-        # FC2 input scale tensor bound in process_weights_after_loading: the
-        # calibrated (now-zeroed) a2_gscale for static-quant checkpoints, or
-        # a synthesized uniform-1.0 tensor for W4A16 checkpoints that lack
-        # one. Holding it on the instance keeps apply() alloc-free.
+        # FC2 input scale tensor bound in process_weights_after_loading. For
+        # W4A4 checkpoints this is the checkpoint's small activation input
+        # scale; W4A16 checkpoints use a synthesized uniform-1.0 tensor.
+        # Holding it on the instance keeps apply() alloc-free.
         self._fc2_input_scale: torch.Tensor | None = None
 
         # Shape params for B12xMoEWrapper construction.
@@ -102,120 +102,73 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.w1_sf_mma: torch.Tensor | None = None
         self.w2_sf_mma: torch.Tensor | None = None
 
-        # CUTLASS-format scales saved before the in-place B12x rewrite in
-        # process_weights_after_loading. Only populated when
-        # cutlass_prefill_threshold > 0.
-        self._cutlass_w13_scale: torch.Tensor | None = None
-        self._cutlass_w2_scale: torch.Tensor | None = None
-        self._cutlass_a1_gscale: torch.Tensor | None = None
-        self._cutlass_a2_gscale: torch.Tensor | None = None
-        self._cutlass_g1_alphas: torch.Tensor | None = None
-        self._cutlass_g2_alphas: torch.Tensor | None = None
+        # Frozen CUTLASS-format scales saved before the live tensors are
+        # converted in-place to B12x's scale convention. Only populated when
+        # hybrid dispatch is enabled.
+        self._cutlass_quant_scales: list[torch.Tensor] | None = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # When hybrid CUTLASS prefill is enabled, save copies of the
-        # CUTLASS-format scales BEFORE the in-place B12x rewrite below
-        # destroys them. The FP4 weight bytes themselves are reusable —
-        # prepare_nvfp4_moe_layer_for_fi_or_cutlass produces the same
-        # [w3, w1] reorder + swizzled SF for both FLASHINFER_CUTLASS and
-        # FLASHINFER_B12X — so we only need to clone the scales.
-        #
-        # g_alphas: B12x leaves g1_alphas = 1/w_gs (does NOT fold
-        # a_input_scale). CUTLASS wants 1/(a_gs * w_gs) = (1/w_gs) / a_gs,
-        # hence the division.
-        #
-        # The clones are registered as nn.Parameter on the layer so
-        # FusedMoE.get_expert_weights picks them up and EPLB rearranges
-        # them in lockstep with the live b12x scales.
+        w13_input_scale = getattr(layer, "w13_input_scale", None)
+        w2_input_scale = getattr(layer, "w2_input_scale", None)
+        has_activation_scales = (
+            w13_input_scale is not None
+            and w2_input_scale is not None
+            and self.a1_gscale is not None
+            and self.a2_gscale is not None
+        )
+
+        # CUTLASS and B12x share the packed FP4 bytes but consume different
+        # scale conventions. Preserve CUTLASS's normalized representation
+        # before rewriting the live tensors for B12x:
+        #   [1/a1, normalized_w1_sf, weight_alpha1*a1,
+        #    1/a2, normalized_w2_sf, weight_alpha2*a2]
+        # where a1/a2 are the checkpoint's small activation input scales.
         if self.cutlass_prefill_threshold > 0:
-            assert layer.w13_weight_scale.dtype == torch.float8_e4m3fn, (
-                "Expected swizzled FP8 SF before B12x rewrite, got "
-                f"{layer.w13_weight_scale.dtype}"
-            )
-            cutlass_w13_scale = layer.w13_weight_scale.clone()
-            cutlass_w2_scale = layer.w2_weight_scale.clone()
-            cutlass_a1_gscale = self.a1_gscale.clone()
-            cutlass_a2_gscale = self.a2_gscale.clone()
-            cutlass_g1_alphas = (
-                self.g1_alphas.float() / self.a1_gscale
-            ).contiguous()
-            cutlass_g2_alphas = (
-                self.g2_alphas.float() / self.a2_gscale
-            ).contiguous()
+            if not has_activation_scales:
+                raise RuntimeError(
+                    "Hybrid B12x/CUTLASS dispatch requires an NVFP4 W4A4 "
+                    "checkpoint with w13_input_scale and w2_input_scale."
+                )
+            assert self.a1_gscale is not None and self.a2_gscale is not None
+            assert w13_input_scale is not None and w2_input_scale is not None
+            self._cutlass_quant_scales = [
+                self.a1_gscale.detach().clone(),
+                layer.w13_weight_scale.detach().clone().view(torch.int32),
+                (layer.w13_weight_scale_2.float() * w13_input_scale.float()).detach(),
+                self.a2_gscale.detach().clone(),
+                layer.w2_weight_scale.detach().clone().view(torch.int32),
+                (layer.w2_weight_scale_2.float() * w2_input_scale.float()).detach(),
+            ]
 
-            layer.register_parameter(
-                "w13_cutlass_weight_scale",
-                torch.nn.Parameter(cutlass_w13_scale, requires_grad=False),
-            )
-            layer.register_parameter(
-                "w2_cutlass_weight_scale",
-                torch.nn.Parameter(cutlass_w2_scale, requires_grad=False),
-            )
-            layer.register_parameter(
-                "w13_cutlass_a_gscale",
-                torch.nn.Parameter(cutlass_a1_gscale, requires_grad=False),
-            )
-            layer.register_parameter(
-                "w2_cutlass_a_gscale",
-                torch.nn.Parameter(cutlass_a2_gscale, requires_grad=False),
-            )
-            layer.register_parameter(
-                "w13_cutlass_g_alphas",
-                torch.nn.Parameter(cutlass_g1_alphas, requires_grad=False),
-            )
-            layer.register_parameter(
-                "w2_cutlass_g_alphas",
-                torch.nn.Parameter(cutlass_g2_alphas, requires_grad=False),
-            )
-
-            # Hold references on the experts class so _ensure_wrapper can
-            # build the quant_scales list without re-fetching from layer.
-            # These alias the registered Parameters' storage, so EPLB
-            # rearrangement of the parameters is observed here too.
-            self._cutlass_w13_scale = layer.w13_cutlass_weight_scale.data
-            self._cutlass_w2_scale = layer.w2_cutlass_weight_scale.data
-            self._cutlass_a1_gscale = layer.w13_cutlass_a_gscale.data
-            self._cutlass_a2_gscale = layer.w2_cutlass_a_gscale.data
-            self._cutlass_g1_alphas = layer.w13_cutlass_g_alphas.data
-            self._cutlass_g2_alphas = layer.w2_cutlass_g_alphas.data
-
-        # Normalise block scales to absorb the per-expert weight global scale
-        # (w_gs).  vLLM's NVFP4 convention stores:
-        #   block_scale = max_abs * w_gs / fp4_max,  g1_alphas = 1/w_gs
-        # The SM12x kernel treats w1_alpha (= g1_alphas) as a per-expert weight
-        # dequant multiplier separate from input_gs (activation scale).  We bake
-        # w_gs into the block scales so that w1_alpha = 1.0 and the kernel sees
-        # the simpler form:
-        #   block_scale = max_abs / fp4_max,  w1_alpha = 1.0
-        # The FP4-packed values and dequantised results are identical in both
-        # representations.  We set scale_2 = 1.0 to signal that the bake-in is
-        # already done.
+        # B12x consumes unnormalized weight SFs and the checkpoint's small
+        # activation scales as w1/w2 alphas. Fold only the per-expert weight
+        # multiplier into each block SF. Folding the activation scale into the
+        # SF as well (or replacing the alpha with 1) changes model numerics.
         layer.w13_weight_scale.data = (
-            layer.w13_weight_scale.float() * layer.w13_weight_scale_2.view(-1, 1, 1)
+            layer.w13_weight_scale.float()
+            * layer.w13_weight_scale_2.float().view(-1, 1, 1)
         ).to(layer.w13_weight_scale.dtype)
-        layer.w13_weight_scale_2.data.fill_(1.0)
-
         layer.w2_weight_scale.data = (
-            layer.w2_weight_scale.float() * layer.w2_weight_scale_2.view(-1, 1, 1)
+            layer.w2_weight_scale.float()
+            * layer.w2_weight_scale_2.float().view(-1, 1, 1)
         ).to(layer.w2_weight_scale.dtype)
-        layer.w2_weight_scale_2.data.fill_(1.0)
 
-        # The SM12x kernel uses dynamic per-block quantization for FC2 input
-        # activations (the SwiGLU output before the down projection).  The
-        # calibrated a2_gscale from the modelopt checkpoint (~tens to hundreds)
-        # is intended for static-quantisation backends (TRTLLM/CUTLASS) and
-        # causes every intermediate activation to saturate at max FP4 when
-        # multiplied by values that large.  Force to 1.0 so the kernel uses
-        # its own per-block dynamic scale.
-        if self.a2_gscale is not None:
-            self.a2_gscale.fill_(1.0)
-            self._fc2_input_scale = self.a2_gscale
+        if has_activation_scales:
+            assert w13_input_scale is not None and w2_input_scale is not None
+            layer.w13_weight_scale_2.data.copy_(
+                w13_input_scale.expand_as(layer.w13_weight_scale_2)
+            )
+            layer.w2_weight_scale_2.data.copy_(
+                w2_input_scale.expand_as(layer.w2_weight_scale_2)
+            )
+            self._fc2_input_scale = w2_input_scale
         else:
             # W4A16 NVFP4 checkpoints have no calibrated a2_gscale; b12x
-            # performs dynamic per-block FC2-input quantization, so a uniform
-            # 1.0 scale per expert is equivalent to the bake-in above for
-            # static-quant checkpoints. Allocate once here so apply() stays
-            # alloc-free.
+            # performs dynamic per-block activation quantization. Keep its
+            # existing unit-alpha behavior and allocate once here so apply()
+            # stays allocation-free.
+            layer.w13_weight_scale_2.data.fill_(1.0)
+            layer.w2_weight_scale_2.data.fill_(1.0)
             self._fc2_input_scale = torch.ones(
                 self.num_local_experts,
                 device=layer.w13_weight.device,
@@ -338,9 +291,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             # cutlass_prefill_threshold is gated on a FlashInfer build that
             # exposes the kwarg. Skip silently if absent and threshold is 0;
             # error cleanly if the user is asking for the hybrid path.
-            if "cutlass_prefill_threshold" in inspect.signature(
-                B12xMoEWrapper.__init__
-            ).parameters:
+            if (
+                "cutlass_prefill_threshold"
+                in inspect.signature(B12xMoEWrapper.__init__).parameters
+            ):
                 b12x_kwargs["cutlass_prefill_threshold"] = (
                     self.cutlass_prefill_threshold
                 )
@@ -354,7 +308,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             self._wrapper = B12xMoEWrapper(**b12x_kwargs)
 
         if self.cutlass_prefill_threshold > 0 and not self._cutlass_registered:
-            assert self._cutlass_w13_scale is not None, (
+            assert self._cutlass_quant_scales is not None, (
                 "cutlass_prefill_threshold > 0 but CUTLASS scales were "
                 "not saved in process_weights_after_loading"
             )
@@ -366,14 +320,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             self._wrapper.register_cutlass_prefill_weights(
                 w1_q=w1,
                 w2_q=w2,
-                quant_scales=[
-                    self._cutlass_a1_gscale,
-                    self._cutlass_w13_scale.view(torch.int32),
-                    self._cutlass_g1_alphas,
-                    self._cutlass_a2_gscale,
-                    self._cutlass_w2_scale.view(torch.int32),
-                    self._cutlass_g2_alphas,
-                ],
+                quant_scales=self._cutlass_quant_scales,
             )
             self._cutlass_registered = True
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -20,7 +22,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
-    flashinfer_b12x_fused_moe,
     flashinfer_convert_sf_to_mma_layout,
     has_flashinfer_b12x_moe,
 )
@@ -42,6 +43,11 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
     Only NVFP4 (kNvfp4Static/kNvfp4Dynamic) quantization is supported.
     """
 
+    _ACTIVATION_MAP: dict[MoEActivation, str] = {
+        MoEActivation.SILU: "silu",
+        MoEActivation.RELU2_NO_MUL: "relu2",
+    }
+
     def __init__(
         self,
         moe_config: FusedMoEConfig,
@@ -59,6 +65,30 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # a synthesized uniform-1.0 tensor for W4A16 checkpoints that lack
         # one. Holding it on the instance keeps apply() alloc-free.
         self._fc2_input_scale: torch.Tensor | None = None
+
+        # Shape params for B12xMoEWrapper construction.
+        self.global_num_experts = moe_config.num_experts
+        self.topk = moe_config.experts_per_token
+        self.hidden_dim = moe_config.hidden_dim
+        self.intermediate_size_per_partition = (
+            moe_config.intermediate_size_per_partition
+        )
+        self.max_num_tokens = moe_config.max_num_tokens
+        self.local_expert_offset = self.ep_rank * self.num_local_experts
+
+        activation = moe_config.activation
+        if activation not in self._ACTIVATION_MAP:
+            raise ValueError(
+                f"FlashInferB12xExperts does not support "
+                f"activation {activation!r}. "
+                f"Supported: {list(self._ACTIVATION_MAP.keys())}"
+            )
+        self._activation_str = self._ACTIVATION_MAP[activation]
+
+        # Lazily created on first apply() call.
+        self._wrapper: Any | None = None
+        self.w1_sf_mma: torch.Tensor | None = None
+        self.w2_sf_mma: torch.Tensor | None = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Normalise block scales to absorb the per-expert weight global scale
@@ -141,7 +171,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
-        return False
+        return True
 
     @staticmethod
     def _supports_quant_scheme(
@@ -158,7 +188,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation == MoEActivation.SILU
+        return activation in (MoEActivation.SILU, MoEActivation.RELU2_NO_MUL)
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
@@ -190,12 +220,28 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @property
     def expects_unquantized_inputs(self) -> bool:
-        # b12x_fused_moe expects BF16 hidden states and performs its own FP4
+        # B12xMoEWrapper expects BF16 hidden states and performs its own FP4
         # quantization internally.  Returning True prevents the modular kernel
-        # from pre-quantizing activations, which would produce an FP4-packed
-        # tensor with size(-1)=k//2 and break the scale-factor conversion that
-        # expects size(-1)=k.
+        # from pre-quantizing activations.
         return True
+
+    def _ensure_wrapper(self) -> None:
+        """Lazily create B12xMoEWrapper on first use."""
+        if self._wrapper is not None:
+            return
+
+        from flashinfer.fused_moe import B12xMoEWrapper
+
+        self._wrapper = B12xMoEWrapper(
+            num_experts=self.global_num_experts,
+            top_k=self.topk,
+            hidden_size=self.hidden_dim,
+            intermediate_size=self.intermediate_size_per_partition,
+            use_cuda_graph=True,
+            max_num_tokens=self.max_num_tokens,
+            num_local_experts=self.num_local_experts,
+            activation=self._activation_str,
+        )
 
     def apply(
         self,
@@ -224,23 +270,22 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         assert self._fc2_input_scale is not None, (
             "_fc2_input_scale must be set by process_weights_after_loading"
         )
+        assert self.w1_sf_mma is not None and self.w2_sf_mma is not None, (
+            "process_weights_after_loading must run before FlashInferB12xExperts.apply"
+        )
 
-        top_k = topk_ids.shape[1]
+        self._ensure_wrapper()
 
-        flashinfer_b12x_fused_moe(
+        result = self._wrapper.run(
             x=hidden_states,
-            token_selected_experts=topk_ids.to(torch.int32),
-            token_final_scales=topk_weights,
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,
             w1_alpha=self.g1_alphas,
-            fc2_input_scale=self._fc2_input_scale,
+            fc2_input_scale=self.a2_gscale,
             w2_weight=w2,
             w2_weight_sf=self.w2_sf_mma,
             w2_alpha=self.g2_alphas,
-            num_experts=global_num_experts,
-            top_k=top_k,
-            num_local_experts=self.num_local_experts,
-            output_dtype=self.out_dtype,
-            output=output,
+            token_selected_experts=topk_ids.to(torch.int32),
+            token_final_scales=topk_weights,
+            out=output,
         )


### PR DESCRIPTION
## Summary

Stacked on top of #43328.

Adds hybrid FlashInfer MoE dispatch to `FlashInferB12xExperts`: token batches at or above `VLLM_FLASHINFER_B12X_CUTLASS_PREFILL_THRESHOLD` use `cutlass_fused_moe`, while smaller decode batches remain on B12x. The default threshold is `0`, which preserves pure-B12x behavior.

## Implementation

- Passes `cutlass_prefill_threshold` to `B12xMoEWrapper` when the installed FlashInfer exposes the hybrid API. Threshold `0` remains compatible with older FlashInfer builds; requesting hybrid dispatch on an older build raises a targeted error.
- Reuses the same packed FP4 weight bytes for both backends and keeps the two required scale representations:
  - CUTLASS retains the checkpoint's normalized E4M3 block scales plus `[1 / a_scale, weight_alpha * a_scale]` global factors.
  - B12x folds only the per-expert weight multiplier into the block scales and consumes the checkpoint's small activation input scales as `w1_alpha`, `w2_alpha`, and `fc2_input_scale`.
- Saves the CUTLASS scale list before rewriting the live tensors to B12x's convention, then registers the CUTLASS weights once when the wrapper is created.
- Rejects hybrid mode for checkpoints without the W4A4 activation-scale metadata it requires.
- Removes the obsolete `inplace=False` test argument after rebasing onto the current modular-kernel API.

The scale separation is required for real ModelOpt checkpoints. Replacing B12x's activation scales with `1.0`, or folding an activation scale into its weight SF, produces incorrect Nemotron output even though dispatch itself succeeds.

## Validation

- `pre-commit run --all-files`: all code, formatting, typing, dependency, config, and Rust checks pass. The unrelated non-root entrypoint test is skipped locally because macOS reports the same temporary path through `/var` and `/private/var`.
- GB10/SM121, CUDA 13:
  - 24 gated-SiLU B12x reference cases passed.
  - 24 ReLU2/Nemotron-style B12x reference cases passed.
  - 3 non-unit-scale hybrid numerical cases passed at 31, 32, and 33 tokens around threshold 32.
  - Below threshold, hybrid matches standalone B12x within its atomic-order tolerance.
  - At and above threshold, hybrid CUTLASS output matches standalone B12x with NRMSE `< 0.05` and cosine similarity `> 0.999`.
- Literal server smoke test on `p4242-0070.ipp2a1.colossus.nvidia.com`:
  - Started `vllm serve ... --moe-backend flashinfer_b12x` with threshold 8 and the model-default `fp8_e4m3` KV cache (without the generic `--kv-cache-dtype fp8` override).
  - `/v1/models` returned `nemotron-3-super`.
  - Deterministic `curl` requests correctly produced Paris, 4, Berlin, and Earth.
  - A control run with the generic `--kv-cache-dtype fp8` override produced substantially worse text. This is recorded as an observation, not attributed to this MoE PR; earlier `fp8_e4m3` runs also exhibited some repetition, so a dedicated KV-cache A/B is still needed.

## Duplicate-work check

Not a duplicate. #43328 supplies the underlying Nemotron/ReLU2 B12x integration; this PR is the stacked hybrid-prefill integration.

## AI assistance disclosure

This PR was prepared with AI assistance. The submitting human reviewed the changes and validation results.
