### PR TITLE
[SpecDec + Reasoning] Fix race condition when <channel|> reasoning-end

### DIFF
--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -60,11 +60,13 @@ class TestReasoningStructuredOutput:
     def mock_request_with_structured_output(self):
         """Create a mock request with structured output."""
         request = Mock(spec=Request)
+        request.request_id = "test-request-123"
         request.structured_output_request = Mock()
         request.structured_output_request.reasoning_ended = None
         request.structured_output_request.grammar = Mock()
         request.structured_output_request.reasoning_parser_kwargs = None
         request.structured_output_request.reasoner = None
+        request.structured_output_request.bonus_requires_grammar = False
         request.structured_output_request.grammar.is_terminated = Mock(
             return_value=False
         )
@@ -258,3 +260,282 @@ class TestReasoningStructuredOutput:
 
         # Should return True since reasoning has ended
         assert result is True
+
+    def _make_detecting_reasoner(self, end_token_id: int = 99):
+        """Return a reasoner whose is_reasoning_end_streaming detects
+        ``end_token_id`` and records every call in ``detected_tokens``."""
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.detected_tokens = []
+
+        def side_effect(input_ids, delta_ids):
+            delta_list = (
+                list(delta_ids) if not isinstance(delta_ids, list) else delta_ids
+            )
+            reasoner.detected_tokens.append(delta_list)
+            return end_token_id in delta_list
+
+        reasoner.is_reasoning_end_streaming = Mock(side_effect=side_effect)
+        return reasoner
+
+    def _make_mock_grammar(self, accept_result: bool = True):
+        grammar = Mock()
+        grammar.is_terminated = Mock(return_value=False)
+        grammar.fill_bitmask = Mock()
+        grammar.accept_tokens = Mock(return_value=accept_result)
+        grammar.rollback = Mock()
+        return grammar
+
+    def _setup_manager_backend(self, manager):
+        import torch
+
+        manager.backend = Mock()
+        manager.backend.allocate_token_bitmask = Mock(
+            return_value=torch.zeros((10, 50000), dtype=torch.int32)
+        )
+        manager._full_mask = torch.tensor(-1, dtype=torch.int32)
+
+    # ------------------------------------------------------------------ #
+    # Test: reasoning ends at the LAST draft token                       #
+    #   Draft:   [10, 20, 30, 99]   ← 99 = reasoning-end                #
+    #   Expect:  bonus slot (idx 4) gets constrained bitmask             #
+    # ------------------------------------------------------------------ #
+
+    def test_grammar_bitmask_reasoning_ends_mid_batch(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Grammar_bitmask constrains bonus token when reasoning-end is
+        the last draft token."""
+
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        reasoner = self._make_detecting_reasoner(end_token_id=99)
+        structured_req.reasoner = reasoner
+
+        grammar = self._make_mock_grammar()
+        structured_req.grammar = grammar
+
+        self._setup_manager_backend(manager_with_reasoner)
+
+        requests = {
+            mock_request_with_structured_output.request_id: mock_request_with_structured_output
+        }
+        scheduled_spec_decode_tokens = {
+            mock_request_with_structured_output.request_id: [10, 20, 30, 99]
+        }
+
+        manager_with_reasoner.grammar_bitmask(
+            requests,
+            [mock_request_with_structured_output.request_id],
+            scheduled_spec_decode_tokens,
+        )
+
+        # --- assertions ---
+
+        # is_reasoning_end_streaming was called per draft token
+        assert reasoner.is_reasoning_end_streaming.called
+
+        # reasoning_ended flag is NOT set by grammar_bitmask — that is
+        # managed by should_advance() post-batch to avoid prematurely
+        # claiming reasoning is done while the current step's output
+        # still contains the reasoning-end token.
+        assert structured_req.reasoning_ended is False
+
+        # bonus_requires_grammar flag IS set — tells update_from_output()
+        # to advance the grammar with the bonus token even though
+        # should_advance() will return False this step.
+        assert structured_req.bonus_requires_grammar is True
+
+        # fill_bitmask should have been called exactly once — for the
+        # bonus token position (index 4).  Positions 0-3 were filled
+        # with the full mask (no constraint).
+        fill_calls = grammar.fill_bitmask.call_args_list
+        assert len(fill_calls) == 1, (
+            f"Expected 1 fill_bitmask (bonus pos), got {len(fill_calls)}"
+        )
+        # The second argument is the index into the bitmask tensor
+        fill_index = fill_calls[0][0][1]
+        assert fill_index == 4, f"Expected bonus position index 4, got {fill_index}"
+
+        # accept_tokens should NOT have been called (only the bonus
+        # position had the bitmask enabled, and its token is the
+        # sentinel -1 which is handled before the accept call).
+        grammar.accept_tokens.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # Test: reasoning ends MID-DRAFT (not at last position)              #
+    #   Draft:   [10, 99, 30, 40]   ← 99 = reasoning-end at pos 1       #
+    #   Expect:  positions 2, 3, and bonus (idx 4) constrained           #
+    #   NOTE: positions 2-3 are draft tokens generated WITHOUT the       #
+    #         constraint; accept_tokens is skipped to avoid xgrammar     #
+    #         state corruption risk.                                     #
+    # ------------------------------------------------------------------ #
+
+    def test_grammar_bitmask_reasoning_ends_mid_draft(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Grammar_bitmask constrains remaining draft + bonus when
+        reasoning-end appears mid-draft (not at the last position)."""
+
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        reasoner = self._make_detecting_reasoner(end_token_id=99)
+        structured_req.reasoner = reasoner
+
+        grammar = self._make_mock_grammar(accept_result=False)
+        structured_req.grammar = grammar
+
+        self._setup_manager_backend(manager_with_reasoner)
+
+        requests = {
+            mock_request_with_structured_output.request_id: mock_request_with_structured_output
+        }
+        # reasoning-end (99) at position 1, two more draft tokens follow
+        scheduled_spec_decode_tokens = {
+            mock_request_with_structured_output.request_id: [10, 99, 30, 40]
+        }
+
+        manager_with_reasoner.grammar_bitmask(
+            requests,
+            [mock_request_with_structured_output.request_id],
+            scheduled_spec_decode_tokens,
+        )
+
+        # --- assertions ---
+
+        assert reasoner.is_reasoning_end_streaming.called
+        # reasoning_ended is NOT set by grammar_bitmask — done by
+        # should_advance() post-batch to avoid feeding reasoning-end
+        # tokens into the grammar FSM in the same step.
+        assert structured_req.reasoning_ended is False
+
+        # bonus_requires_grammar IS set
+        assert structured_req.bonus_requires_grammar is True
+
+        # fill_bitmask for constrained positions: indices 2, 3, 4
+        # (draft after end, last draft after end, bonus)
+        fill_calls = grammar.fill_bitmask.call_args_list
+        fill_indices = sorted(c[0][1] for c in fill_calls)
+        assert fill_indices == [2, 3, 4], (
+            f"Expected constrained indices [2, 3, 4], got {fill_indices}"
+        )
+
+        # accept_tokens is NOT called for any position — draft tokens
+        # after reasoning-end were generated without constraint and
+        # are skipped to avoid xgrammar state corruption risk.
+        grammar.accept_tokens.assert_not_called()
+
+        # rollback is not called (state_advancements stayed at 0)
+        grammar.rollback.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # Test: NO reasoning-end token in the batch                          #
+    #   Draft:   [10, 20, 30, 40]                                        #
+    #   Expect:  everything unconstrained (existing behaviour)           #
+    # ------------------------------------------------------------------ #
+
+    def test_grammar_bitmask_no_reasoning_end(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Grammar_bitmask leaves everything unconstrained when no
+        reasoning-end token appears in the draft tokens."""
+
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        reasoner = self._make_detecting_reasoner(end_token_id=99)
+        structured_req.reasoner = reasoner
+
+        grammar = self._make_mock_grammar()
+        structured_req.grammar = grammar
+
+        self._setup_manager_backend(manager_with_reasoner)
+
+        requests = {
+            mock_request_with_structured_output.request_id: mock_request_with_structured_output
+        }
+        # No reasoning-end token (99) in draft
+        scheduled_spec_decode_tokens = {
+            mock_request_with_structured_output.request_id: [10, 20, 30, 40]
+        }
+
+        manager_with_reasoner.grammar_bitmask(
+            requests,
+            [mock_request_with_structured_output.request_id],
+            scheduled_spec_decode_tokens,
+        )
+
+        # --- assertions ---
+
+        # is_reasoning_end_streaming was called but never returned True
+        assert reasoner.is_reasoning_end_streaming.called
+
+        # reasoning_ended flag is still False
+        assert structured_req.reasoning_ended is False
+
+        # fill_bitmask was never called — all positions stayed
+        # unconstrained (fill with full mask instead)
+        grammar.fill_bitmask.assert_not_called()
+
+        # accept_tokens was never called
+        grammar.accept_tokens.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # Test: reasoning already ended BEFORE this batch                     #
+    #   Draft: [10, 20, 30, 40]  with reasoning_ended=True               #
+    #   Expect: all positions constrained normally                        #
+    # ------------------------------------------------------------------ #
+
+    def test_grammar_bitmask_reasoning_already_ended(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Grammar_bitmask constrains everything when reasoning already
+        ended before this batch."""
+
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = True  # already ended
+
+        grammar = self._make_mock_grammar()
+        structured_req.grammar = grammar
+
+        self._setup_manager_backend(manager_with_reasoner)
+
+        requests = {
+            mock_request_with_structured_output.request_id: mock_request_with_structured_output
+        }
+        scheduled_spec_decode_tokens = {
+            mock_request_with_structured_output.request_id: [10, 20, 30, 40]
+        }
+
+        manager_with_reasoner.grammar_bitmask(
+            requests,
+            [mock_request_with_structured_output.request_id],
+            scheduled_spec_decode_tokens,
+        )
+
+        # --- assertions ---
+
+        # fill_bitmask was called for every position (4 draft + 1 bonus)
+        fill_calls = grammar.fill_bitmask.call_args_list
+        assert len(fill_calls) == 5, (
+            f"Expected 5 fill_bitmask calls, got {len(fill_calls)}"
+        )
+
+        # accept_tokens was called for each draft token only (4).  The
+        # bonus position uses sentinel -1 which sets apply_bitmask=False
+        # before the accept check, so no accept call for the bonus.
+        assert grammar.accept_tokens.call_count == 4, (
+            f"Expected 4 accept_tokens calls, got {grammar.accept_tokens.call_count}"
+        )
+
+        # rollback was called (state_advancements == 4 > 0)
+        grammar.rollback.assert_called_once()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1429,6 +1429,21 @@ class Scheduler(SchedulerInterface):
                     request.status = RequestStatus.FINISHED_ERROR
                     request.resumable = False
                     stopped = True
+            elif (
+                request.structured_output_request is not None
+                and request.structured_output_request.bonus_requires_grammar
+                and generated_token_ids
+            ):
+                struct_req = request.structured_output_request
+                assert struct_req.grammar is not None
+                struct_req.grammar.suppress_accept_errors = True
+                accepted = struct_req.grammar.accept_tokens(
+                    req_id, [generated_token_ids[-1]]
+                )
+                struct_req.grammar.suppress_accept_errors = False
+                struct_req.bonus_requires_grammar = False
+                if accepted:
+                    struct_req.reasoning_ended = True
 
             routed_experts = None
             if (

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -191,9 +191,6 @@ class StructuredOutputManager:
             if apply_bitmask and not grammar.is_terminated():
                 grammar.fill_bitmask(self._grammar_bitmask, index)
             else:
-                # Note that for thinking support, we will need to
-                # reset the relevant part of the bitmask for consequent
-                # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
 
     def _async_submit_fill_bitmask(
@@ -275,17 +272,44 @@ class StructuredOutputManager:
                 grammar = structured_output_request.grammar
                 apply_bitmask = self.should_fill_bitmask(request)
 
+                # Per-token reasoning-end detection: when apply_bitmask is
+                # False because reasoning is active, we need to watch for the
+                # end-of-reasoning token within the draft batch. When found,
+                # flip apply_bitmask so subsequent positions (including the
+                # bonus token) get the constrained bitmask.
+                reasoner = (
+                    self._get_reasoner(request)
+                    if not apply_bitmask and not self.enable_in_reasoning
+                    else None
+                )
+                reasoning_ended_in_batch = False
+
                 state_advancements = 0
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 for token in itertools.chain(req_tokens, (-1,)):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
                     if token == -1:
-                        # Stop advancing the grammar once we hit a padding token.
                         apply_bitmask = False
                     if apply_bitmask and not grammar.is_terminated():
-                        accepted = grammar.accept_tokens(req_id, [token])
-                        assert accepted, (token, req_id, scheduled_spec_decode_tokens)
-                        state_advancements += 1
+                        if not reasoning_ended_in_batch:
+                            accepted = grammar.accept_tokens(req_id, [token])
+                            assert accepted, (
+                                token,
+                                req_id,
+                                scheduled_spec_decode_tokens,
+                            )
+                            state_advancements += 1
+                    elif (
+                        token != -1
+                        and reasoner is not None
+                        and reasoner.is_reasoning_end_streaming(
+                            request.all_token_ids, [token]
+                        )
+                    ):
+                        apply_bitmask = True
+                        reasoning_ended_in_batch = True
+                        reasoner = None
+                        structured_output_request.bonus_requires_grammar = True
                     cumulative_index += 1
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -94,6 +94,14 @@ class StructuredOutputGrammar(ABC):
         Resets the state of the structured output grammar.
         """
 
+    @property
+    def suppress_accept_errors(self) -> bool:
+        return False
+
+    @suppress_accept_errors.setter
+    def suppress_accept_errors(self, value: bool) -> None:
+        pass
+
 
 @dataclass
 class StructuredOutputBackend(ABC):

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -144,6 +144,13 @@ class XgrammarGrammar(StructuredOutputGrammar):
         default_factory=lambda: 0, repr=False, hash=False, init=False
     )
     _is_terminated: bool = field(default=False, repr=False, hash=False)
+    # When True, accept_tokens() will not log errors on rejection.
+    # Used to suppress expected failures e.g. when a bonus token generated
+    # without grammar constraint is force-fed in the bonus_requires_grammar
+    # path after the spec-dec <channel|> draft token was rejected.
+    suppress_accept_errors: bool = field(
+        default=False, repr=False, hash=False, init=False
+    )
 
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
@@ -155,12 +162,13 @@ class XgrammarGrammar(StructuredOutputGrammar):
             return False
         for token in tokens:
             if not self.matcher.accept_token(token):
-                logger.error(
-                    "Failed to advance FSM for request %s "
-                    "for tokens %s. Please file an issue.",
-                    request_id,
-                    token,
-                )
+                if not self.suppress_accept_errors:
+                    logger.error(
+                        "Failed to advance FSM for request %s "
+                        "for tokens %s. Please file an issue.",
+                        request_id,
+                        token,
+                    )
                 return False
             self.num_processed_tokens += 1
         self._is_terminated = self.matcher.is_terminated()

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -27,6 +27,11 @@ class StructuredOutputRequest:
     # Cached per request; do not share reasoning parsers across requests because
     # their behavior can depend on reasoning_parser_kwargs.
     reasoner: "ReasoningParser | None" = None
+    # When reasoning ends mid-draft-batch during speculative decoding, the bonus
+    # token is constrained by the grammar bitmask but should_advance() returns
+    # False in the same step (because reasoning just ended). This flag tells
+    # update_from_output() to advance the grammar with the bonus token anyway.
+    bonus_requires_grammar: bool = False
 
     @staticmethod
     def from_sampling_params(


### PR DESCRIPTION
Hello,

### Setup

I investigated further from my issue #38106. It's actually the combination of speculative decoding, reasoning and tool_choice="required". If either one of these three is disabled the bug doesn't happen. I reproduced this with these two configs:
<details>
<summary>The configs</summary>

```
cyankiwi/gemma-4-31B-it-AWQ-8bit
  --tool-call-parser=gemma4
  --reasoning-parser=gemma4
  --enable-auto-tool-choice
  --speculative-config '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":4}'
lukealonso/Qwen3.5-397B-A17B-NVFP4
    --enable-auto-tool-choice
    --tool-call-parser qwen3_coder
    --reasoning-parser qwen3
    --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}'

```
</details>

And the following request fails in roughly 75% of cases before the bugfix for me:
<details>
<summary>The request</summary>

```text
curl -X POST http://localhost:8001/v1/chat/completions \
                          -H "Content-Type: application/json" \
                          -d '{
                        "messages": [
                            {
                                "role": "user",
                                "content": [
                                    {
                                        "text": "Detect if there is a bunny in this video.",
                                        "type": "text"
                                    },
                                    {
                                        "type": "video_url",
                                        "video_url": {
                                            "url": "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4"
                                        }
                                    }
                                ]
                            }
                        ],
                        "model": "ai_model",
                        "max_completion_tokens": 16000,
                        "presence_penalty": 1.5,
                        "reasoning_effort": "low",
                        "stream": false,
                        "temperature": 1.0,
                        "tool_choice": "required",
                        "tools": [
                            {
                                "type": "function",
                                "function": {
                                    "name": "final_result",
                                    "description": "The final response which ends this conversation",
                                    "parameters": {
                                        "properties": {
                                            "chain_of_thought": {
                                                "description": "The chain of thought that results in the conclusion for any potential bunnies.",
                                                "type": "string"
                                            },
                                            "conclusion": {
                                                "description": "The conclusion based on the occurrences.",
                                                "enum": ["detection", "no detection", "unsure"],
                                                "type": "string"
                                            }
                                        },
                                        "required": ["chain_of_thought", "conclusion"],
                                        "title": "Bunnies",
                                        "type": "object"
                                    }
                                }
                            }
                        ],
                        "top_p": 0.95,
                        "top_k": 20,
                        "priority": 0.0,
                        "chat_template_kwargs": { "enable_thinking": true }
                    }'

```

</details>


### The bug 

When speculative decoding generates the reasoning-end token as a draft token, the old code unconditionally set reasoning_ended=True and force-fed the unconstrained bonus token to the grammar, corrupting its state. All subsequent outputs were then constrained by a corrupted grammar leading to unconstrained generation of the model, which more often than not lead to the model generating native tool calls. This then breaks the tool_choice="required" path in `_parse_tool_calls_from_content`, because it expects the tool calls to be a json of format `list[FunctionDefinition]`. The model generating native tool calls could be fixed by the suggestion I had in the issue above, but since the model could also generate something else afaik, this is not a true fix.
This bug is also stochastic, because if the reasoning-end token gets generated as the bonus token everything works.

### The fix
`grammar_bitmask()` now does per-token reasoning-end detection: when `apply_bitmask=False`, each draft token is checked against the reasoner. If reasoning-end token is found mid-batch, `apply_bitmask` flips to `True` for subsequent positions (draft tokens after the end token + bonus slot), and `bonus_requires_grammar=True` is set. 
`update_from_output()` has a new elif branch for `bonus_requires_grammar`. The bonus token is fed to the grammar:
- Accepted: bonus was generated under constraint → set `reasoning_ended=True`, constrain all future tokens
- Rejected: bonus was generated without constraint (spec decode rejected reasoning-end token draft) → reset `bonus_requires_grammar=False`, leave `reasoning_ended=False`, grammar state untouched. The model continues reasoning naturally and reasoning-end token will appear in a future batch.
`accept_tokens()` has a `suppress_accept_errors` flag to avoid ERROR log spam from expected rejections in this path.

## Test Plan

Four unit tests were added to tests/v1/structured_output/test_reasoning_structured_output.py, using mocked reasoners and grammars to validate the `grammar_bitmask()` per-token reasoning-end detection logic:
1. `test_grammar_bitmask_reasoning_ends_mid_batch` — `<channel|>` is the last draft token ([10, 20, 30, 99]). Verifies: only the bonus slot (idx 4) gets a constrained bitmask, `bonus_requires_grammar=True` is set, reasoning_ended stays False, and no accept_tokens calls are made for draft positions.
2. `test_grammar_bitmask_reasoning_ends_mid_draft` — `<channel|>` is at position 1 ([10, 99, 30, 40]). Verifies: positions 2, 3, and bonus (idx 2-4) get constrained bitmasks, accept_tokens is skipped for all positions (draft tokens after `<channel|>` were generated unconstrained), `bonus_requires_grammar=True`, no rollback called.
3. `test_grammar_bitmask_no_reasoning_end` — No end token in batch ([10, 20, 30, 40]). Verifies: all positions unconstrained, reasoning_ended unchanged, no fill_bitmask calls.
4. `test_grammar_bitmask_reasoning_already_ended` — `reasoning_ended=True` before the batch. Verifies: all 5 positions (4 draft + 1 bonus) constrained, 4 accept_tokens calls made, rollback called — the normal pre-existing path is unchanged.

## Test Result

All tests for `tests/v1/structured_output` are passing.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

