### PR TITLE
[Bugfix][Responses API] Support thinking_token_budget in /v1/responses

### DIFF
--- a/tests/entrypoints/openai/responses/test_sampling_params.py
+++ b/tests/entrypoints/openai/responses/test_sampling_params.py
@@ -154,3 +154,32 @@ class TestResponsesRequestSamplingParams:
         assert "Cannot specify both structured_outputs and text.format" in str(
             exc_info.value
         )
+
+    def test_thinking_token_budget_passed_through(self):
+        """Test that thinking_token_budget is correctly forwarded to SamplingParams.
+
+        Regression test: thinking_token_budget was previously silently ignored
+        because ResponsesRequest had no such field and to_sampling_params() never
+        passed it.  Passing it via vllm_xargs/extra_args does NOT work because
+        SamplingParams.from_optional() does not forward extra_args to named params.
+        """
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+            thinking_token_budget=24576,
+        )
+
+        sampling_params = request.to_sampling_params(default_max_tokens=32768)
+
+        assert sampling_params.thinking_token_budget == 24576
+
+    def test_thinking_token_budget_default_is_none(self):
+        """Test that thinking_token_budget defaults to None."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+        )
+
+        sampling_params = request.to_sampling_params(default_max_tokens=1000)
+
+        assert sampling_params.thinking_token_budget is None

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -68,6 +68,7 @@ from vllm.sampling_params import (
     RequestOutputKind,
     SamplingParams,
     StructuredOutputsParams,
+    ThinkingTokenBudget,
 )
 from vllm.utils import random_uuid
 
@@ -265,6 +266,7 @@ class ResponsesRequest(OpenAIBaseModel):
     seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
     ignore_eos: bool = False
+    thinking_token_budget: ThinkingTokenBudget = None
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(
         default=None,
         description=(
@@ -410,6 +412,7 @@ class ResponsesRequest(OpenAIBaseModel):
             ),
             structured_outputs=structured_outputs,
             logit_bias=self.logit_bias,
+            thinking_token_budget=self.thinking_token_budget,
             extra_args=extra_args,
             skip_clone=True,  # Created fresh per request, safe to skip clone
             skip_special_tokens=self.skip_special_tokens,


### PR DESCRIPTION
## Purpose

Fix `thinking_token_budget` being silently ignored by the `/v1/responses` endpoint.

**The bug:** `thinking_token_budget` is accepted by `/v1/chat/completions` but silently dropped by `/v1/responses`. Both endpoints go through `SamplingParams` under the hood.

**Root cause:**

`ChatCompletionRequest` (and `CompletionRequest`) define the field and forward it:
- `vllm/entrypoints/openai/chat_completion/protocol.py` — field `thinking_token_budget: ThinkingTokenBudget = None`; forwarded via `thinking_token_budget=self.thinking_token_budget` in `to_sampling_params()`

`ResponsesRequest` was missing it entirely:
- `vllm/entrypoints/openai/responses/protocol.py` — no field, `to_sampling_params()` never passes it
- Using `vllm_xargs` as a workaround does **not** work; `extra_args` is not mapped to named `SamplingParams` fields:

```python
# Does NOT work:
SamplingParams.from_optional(extra_args={'thinking_token_budget': 24576}).thinking_token_budget
# → None  ❌

# Works:
SamplingParams.from_optional(thinking_token_budget=24576).thinking_token_budget
# → 24576  ✓
```

**The fix (two lines in one file — `vllm/entrypoints/openai/responses/protocol.py`):**

1. Import `ThinkingTokenBudget` from `vllm.sampling_params`
2. Add `thinking_token_budget: ThinkingTokenBudget = None` field to `ResponsesRequest`
3. Pass `thinking_token_budget=self.thinking_token_budget` in `to_sampling_params()`

This exactly mirrors the pattern used in `ChatCompletionRequest` and `CompletionRequest`.

## Test Plan

Added two unit tests to `tests/entrypoints/openai/responses/test_sampling_params.py`:

- `test_thinking_token_budget_passed_through` — verifies the budget is correctly forwarded to `SamplingParams`
- `test_thinking_token_budget_default_is_none` — verifies the default remains `None`

```bash
pytest tests/entrypoints/openai/responses/test_sampling_params.py -v
```

## Test Result

Both new tests pass. Existing tests in the file are unaffected.