### PR TITLE
[Bugfix] Fix CUTLASS MoE router input weighting for FP8/FP4

### DIFF
--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -81,8 +81,8 @@ void moe_permute(
 
 void moe_unpermute(
     const torch::Tensor& permuted_hidden_states,  // [n_token * topk, hidden]
-    const torch::Tensor& topk_weights,            // [n_token, topk]
-    const torch::Tensor& inv_permuted_idx,        // [n_token, topk]
+    const std::optional<torch::Tensor>& topk_weights,  // [n_token, topk]
+    const torch::Tensor& inv_permuted_idx,             // [n_token, topk]
     const std::optional<torch::Tensor>&
         expert_first_token_offset,  // [n_local_expert+1]
     int64_t topk,
@@ -101,11 +101,15 @@ void moe_unpermute(
     valid_ptr =
         get_ptr<int64_t>(expert_first_token_offset.value()) + n_local_expert;
   }
+  float const* topk_weights_ptr = nullptr;
+  if (topk_weights.has_value()) {
+    topk_weights_ptr = get_ptr<float>(topk_weights.value());
+  }
 
   MOE_DISPATCH(hidden_states.scalar_type(), [&] {
     finalizeMoeRoutingKernelLauncher<scalar_t, scalar_t>(
         get_ptr<scalar_t>(permuted_hidden_states),
-        get_ptr<scalar_t>(hidden_states), get_ptr<float>(topk_weights),
+        get_ptr<scalar_t>(hidden_states), topk_weights_ptr,
         get_ptr<int>(inv_permuted_idx), n_token, n_hidden, topk, valid_ptr,
         stream);
   });
@@ -181,7 +185,8 @@ void moe_permute(const torch::Tensor& input, const torch::Tensor& topk_ids,
 
 void moe_unpermute(
     const torch::Tensor& permuted_hidden_states,
-    const torch::Tensor& topk_weights, const torch::Tensor& inv_permuted_idx,
+    const std::optional<torch::Tensor>& topk_weights,
+    const torch::Tensor& inv_permuted_idx,
     const std::optional<torch::Tensor>& expert_first_token_offset, int64_t topk,
     torch::Tensor& hidden_states) {
   TORCH_CHECK(false, "moe_unpermute is not supported on CUDA < 12.0");

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.inl
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.inl
@@ -127,7 +127,7 @@ __global__ void finalizeMoeRoutingKernel(
           expanded_source_row_to_expanded_dest_row[expanded_original_row];
 
       int64_t const k_offset = original_row * k + k_idx;
-      float const row_scale = scales[k_offset];
+      float const row_scale = scales == nullptr ? 1.0f : scales[k_offset];
 
       if (CHECK_SKIPPED && expanded_permuted_row >= num_valid) {
         continue;

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -101,7 +101,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "permuted_idx)->()");
 
   m.def(
-      "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
+      "moe_unpermute(Tensor permuted_hidden_states, Tensor? topk_weights,"
       "Tensor inv_permuted_idx, Tensor? expert_first_token_offset, "
       "int topk, Tensor! hidden_states)->()");
 

--- a/tests/kernels/moe/test_cutlass_moe.py
+++ b/tests/kernels/moe/test_cutlass_moe.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
     CutlassExpertsFp8,
     run_cutlass_moe_fp8,
 )
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
 from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -228,6 +229,9 @@ def run_8_bit(
     per_act_token: bool,
     per_out_ch: bool,
     num_local_experts: int | None = None,
+    hidden_states: torch.Tensor | None = None,
+    apply_router_weight_on_input: bool = False,
+    experts_cls: type[mk.FusedMoEExpertsModular] = CutlassExpertsFp8,
 ) -> torch.Tensor:
     assert not any(
         [
@@ -252,8 +256,11 @@ def run_8_bit(
         a1_scale=None,
     )
 
+    if hidden_states is None:
+        hidden_states = moe_tensors.a
+
     kwargs = {
-        "hidden_states": moe_tensors.a,
+        "hidden_states": hidden_states,
         "w1": moe_tensors.w1_q,  # type: ignore[union-attr]
         "w2": moe_tensors.w2_q,  # type: ignore[union-attr]
         "topk_weights": topk_weights,
@@ -261,7 +268,7 @@ def run_8_bit(
         "global_num_experts": moe_tensors.w1_q.shape[0],  # type: ignore[union-attr]
         "activation": MoEActivation.SILU,
         "expert_map": None,
-        "apply_router_weight_on_input": False,
+        "apply_router_weight_on_input": apply_router_weight_on_input,
     }
 
     num_experts = moe_tensors.w1.size(0)  # type: ignore[attr-defined]
@@ -271,7 +278,7 @@ def run_8_bit(
             num_experts=moe_tensors.w2_q.shape[0],  # type: ignore[union-attr]
             hidden_dim=moe_tensors.w2_q.shape[1],  # type: ignore[union-attr]
             intermediate_size_per_partition=moe_tensors.w2_q.shape[2],  # type: ignore[union-attr]
-            in_dtype=moe_tensors.a.dtype,
+            in_dtype=hidden_states.dtype,
         )
         kernel = mk.FusedMoEKernel(
             maybe_make_prepare_finalize(
@@ -280,7 +287,7 @@ def run_8_bit(
                 allow_new_interface=True,
                 use_monolithic=False,
             ),
-            CutlassExpertsFp8(
+            experts_cls(
                 moe_config=moe_config,
                 quant_config=quant_config,
             ),
@@ -295,6 +302,48 @@ def run_8_bit(
         quant_config,
         **kwargs,
     )
+
+
+@pytest.mark.skipif(
+    (lambda x: x is None or not ops.cutlass_group_gemm_supported(x.to_int()))(
+        current_platform.get_device_capability()
+    ),
+    reason="Grouped gemm is not supported on this GPU type.",
+)
+@torch.inference_mode()
+def test_cutlass_moe_8_bit_router_weight_on_input(workspace_init):
+    set_random_seed(7)
+    with set_current_vllm_config(vllm_config):
+        m, n, k, e = 4, 1024, 1024, 8
+        per_act_token = False
+        per_out_ch = False
+        mt = MOETensors8Bit.make_moe_tensors_8bit(m, k, n, e, per_act_token, per_out_ch)
+
+        topk_ids = torch.arange(m, device="cuda", dtype=torch.int32).view(m, 1)
+        topk_weights = torch.tensor(
+            [[0.25], [0.5], [0.75], [0.875]], device="cuda", dtype=torch.float32
+        )
+
+        cutlass_output = run_8_bit(
+            mt,
+            topk_weights,
+            topk_ids,
+            per_act_token,
+            per_out_ch,
+            apply_router_weight_on_input=True,
+            experts_cls=CutlassExpertsFp8,
+        )
+        triton_output = run_8_bit(
+            mt,
+            topk_weights,
+            topk_ids,
+            per_act_token,
+            per_out_ch,
+            apply_router_weight_on_input=True,
+            experts_cls=TritonExperts,
+        )
+
+        torch.testing.assert_close(triton_output, cutlass_output, atol=5e-2, rtol=5e-2)
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)

--- a/tests/kernels/moe/test_mxfp4_moe.py
+++ b/tests/kernels/moe/test_mxfp4_moe.py
@@ -8,8 +8,19 @@ import random
 import pytest
 import torch
 
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from tests.kernels.moe.utils import make_dummy_moe_config
 from tests.kernels.utils import torch_moe_single
 from vllm import _custom_ops as ops
+from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import mxfp4_moe_quant_config
+from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+    CutlassExpertsMxfp4,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize import (
+    make_moe_prepare_and_finalize_no_dp_ep,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -58,6 +69,43 @@ def compute_ref_output(
     return torch_moe_single(
         input_tensor, torch.stack(weight_list, dim=0), score, topk=1
     )
+
+
+def make_mxfp4_moe_weights(
+    num_experts: int,
+    n: int,
+    k: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    def quantize_weights(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        e, rows, cols = weight.shape
+        flat_weight = weight.reshape(e * rows, cols)
+        expert_offsets = torch.arange(
+            0, (e + 1) * rows, rows, device="cuda", dtype=torch.int32
+        )
+        blockscale_offsets = torch.arange(
+            0, (e + 1) * align(rows), align(rows), device="cuda", dtype=torch.int32
+        )
+
+        weight_quant, weight_sf = ops.mxfp4_experts_quant(
+            flat_weight,
+            expert_offsets,
+            blockscale_offsets,
+            e,
+            topk=1,
+        )
+
+        weight_quant = weight_quant[: e * rows].view(e, rows, cols // 2)
+        scales_per_row = cols // MXFP4_BLOCK_SIZE
+        weight_sf = weight_sf.view(-1)[: e * rows * scales_per_row]
+        return weight_quant, weight_sf.view(e, rows, scales_per_row)
+
+    w1 = torch.randn((num_experts, 2 * n, k), device="cuda", dtype=dtype) * (k**-0.5)
+    w2 = torch.randn((num_experts, k, n), device="cuda", dtype=dtype) * (n**-0.5)
+
+    w1_q, w1_scale = quantize_weights(w1)
+    w2_q, w2_scale = quantize_weights(w2)
+    return w1_q, w2_q, w1_scale, w2_scale
 
 
 @pytest.mark.skipif(
@@ -242,6 +290,75 @@ def test_mxfp4_experts_quant_basic():
         f"MXFP4 experts quant: output shape={output.shape}, sf shape={output_sf.shape}"
     )
     print("PASSED")
+
+
+@pytest.mark.skipif(
+    not is_sm100_supported(),
+    reason="CutlassExpertsMxfp4 requires CUDA SM100",
+)
+@torch.inference_mode()
+def test_cutlass_mxfp4_moe_router_weight_on_input(workspace_init):
+    set_random_seed(7)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        m, n, k, e = 4, 1024, 1024, 8
+        dtype = torch.bfloat16
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+        w1_q, w2_q, w1_scale, w2_scale = make_mxfp4_moe_weights(e, n, k, dtype)
+
+        topk_ids = torch.arange(m, device="cuda", dtype=torch.int32).view(m, 1)
+        topk_weights = torch.tensor(
+            [[0.25], [0.5], [0.75], [0.875]], device="cuda", dtype=torch.float32
+        )
+        unit_topk_weights = torch.ones_like(topk_weights)
+        preweighted_a = (a * topk_weights.to(a.dtype)).contiguous()
+
+        quant_config = mxfp4_moe_quant_config(
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+        )
+        moe_config = make_dummy_moe_config(
+            num_experts=e,
+            hidden_dim=k,
+            intermediate_size_per_partition=n,
+            in_dtype=dtype,
+        )
+        kernel = mk.FusedMoEKernel(
+            make_moe_prepare_and_finalize_no_dp_ep(use_monolithic=False),
+            CutlassExpertsMxfp4(
+                moe_config=moe_config,
+                quant_config=quant_config,
+            ),
+            inplace=False,
+        )
+
+        output_apply_on_input = kernel.apply(
+            hidden_states=a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=True,
+        )
+        output_preweighted = kernel.apply(
+            hidden_states=preweighted_a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=unit_topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+        torch.testing.assert_close(
+            output_apply_on_input, output_preweighted, atol=1e-1, rtol=1e-1
+        )
 
 
 if __name__ == "__main__":

--- a/tests/kernels/moe/test_nvfp4_moe.py
+++ b/tests/kernels/moe/test_nvfp4_moe.py
@@ -289,5 +289,93 @@ def test_cutlass_fp4_moe_swiglustep(
         torch.testing.assert_close(torch_output, cutlass_output, atol=1e-1, rtol=1e-1)
 
 
+@torch.inference_mode()
+def test_cutlass_fp4_moe_router_weight_on_input(workspace_init):
+    set_random_seed(7)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        m, n, k, e = 4, 1024, 1024, 8
+        dtype = torch.bfloat16
+
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+        (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
+            make_test_weights(
+                e,
+                n,
+                k,
+                in_dtype=dtype,
+                quant_dtype="nvfp4",
+                block_shape=None,
+                per_out_ch_quant=False,
+            )
+        )
+
+        topk_ids = torch.arange(m, device="cuda", dtype=torch.int32).view(m, 1)
+        topk_weights = torch.tensor(
+            [[0.25], [0.5], [0.75], [0.875]], device="cuda", dtype=torch.float32
+        )
+        unit_topk_weights = torch.ones_like(topk_weights)
+        preweighted_a = (a * topk_weights.to(a.dtype)).contiguous()
+
+        a1_gs = torch.ones((e,), device="cuda", dtype=torch.float32)
+        a2_gs = torch.ones((e,), device="cuda", dtype=torch.float32)
+
+        assert w1_gs is not None
+        assert w2_gs is not None
+        assert w1_blockscale is not None
+        assert w2_blockscale is not None
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=(1 / w1_gs),
+            g2_alphas=(1 / w2_gs),
+            a1_gscale=a1_gs,
+            a2_gscale=a2_gs,
+            w1_scale=w1_blockscale,
+            w2_scale=w2_blockscale,
+        )
+        moe_config = make_dummy_moe_config(
+            num_experts=e,
+            hidden_dim=k,
+            intermediate_size_per_partition=n,
+            in_dtype=dtype,
+        )
+        kernel = mk.FusedMoEKernel(
+            make_moe_prepare_and_finalize_no_dp_ep(use_monolithic=False),
+            CutlassExpertsFp4(
+                moe_config=moe_config,
+                quant_config=quant_config,
+            ),
+            inplace=False,
+        )
+
+        output_apply_on_input = kernel.apply(
+            hidden_states=a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=True,
+        )
+        output_preweighted = kernel.apply(
+            hidden_states=preweighted_a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=unit_topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+        torch.testing.assert_close(
+            output_apply_on_input, output_preweighted, atol=1e-1, rtol=1e-1
+        )
+
+
 if __name__ == "__main__":
     test_cutlass_fp4_moe_no_graph((2, 1024, 1024), 40, 1, torch.half)

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -48,6 +48,40 @@ from vllm.scalar_type import scalar_types
 logger = init_logger(__name__)
 
 
+def _check_router_weight_on_input(
+    topk_ids: torch.Tensor,
+    apply_router_weight_on_input: bool,
+) -> None:
+    if apply_router_weight_on_input:
+        topk = topk_ids.size(1)
+        assert topk == 1, "apply_router_weight_on_input is only implemented for topk=1"
+
+
+def _copy_cutlass_moe_output(
+    output: torch.Tensor,
+    expert_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    apply_router_weight_on_input: bool,
+) -> None:
+    m, num_topk = topk_ids.shape
+    k = output.size(1)
+    assert expert_output.shape == (m * num_topk, k)
+    assert output.dtype == expert_output.dtype
+    if apply_router_weight_on_input:
+        _check_router_weight_on_input(topk_ids, apply_router_weight_on_input)
+        output.copy_(expert_output.view(m, k), non_blocking=True)
+        return
+
+    output.copy_(
+        (
+            expert_output.view(m, num_topk, k)
+            * topk_weights.view(m, num_topk, 1).to(output.dtype)
+        ).sum(dim=1),
+        non_blocking=True,
+    )
+
+
 def run_cutlass_moe_fp8(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
@@ -73,6 +107,7 @@ def run_cutlass_moe_fp8(
     per_out_ch: bool,
     use_batched_format: bool,
     topk_weights: torch.Tensor | None,
+    apply_router_weight_on_input: bool = False,
 ):
     a1q = hidden_states
 
@@ -251,14 +286,17 @@ def run_cutlass_moe_fp8(
     if use_batched_format:
         output.copy_(mm2_out.reshape(local_E, padded_M, K), non_blocking=True)
     else:
+        assert topk_weights is not None
+        _check_router_weight_on_input(topk_ids, apply_router_weight_on_input)
         # for non-chunking mode the output is resized from workspace13
         # so we need to make sure mm2_out uses workspace2.
         moe_unpermute(
             out=output,
             permuted_hidden_states=mm2_out,
-            topk_weights=topk_weights,
+            topk_weights=None if apply_router_weight_on_input else topk_weights,
             inv_permuted_idx=inv_perm,
             expert_first_token_offset=expert_first_token_offset,
+            topk=topk_ids.size(1),
         )
 
 
@@ -379,6 +417,7 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
             self.per_out_ch_quant,
             use_batched_format,
             topk_weights,
+            apply_router_weight_on_input,
         )
 
 
@@ -575,12 +614,7 @@ def run_cutlass_moe_fp4(
     a_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
     c_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
 
-    if apply_router_weight_on_input:
-        # TODO: this only works for topK=1, will need to update for topK>1
-        assert num_topk == 1, (
-            "apply_router_weight_on_input is only implemented for topk=1"
-        )
-        a.mul_(topk_weights.to(out_dtype))
+    _check_router_weight_on_input(topk_ids, apply_router_weight_on_input)
 
     # problem shapes should have [m, n, k]
     # Note that problem sizes are based on logical number of elements.
@@ -650,16 +684,9 @@ def run_cutlass_moe_fp4(
     c3 = ops.shuffle_rows(c3, c_map)
 
     assert output.dtype == out_dtype
-    if not apply_router_weight_on_input:
-        output.copy_(
-            (
-                c3.view(m, num_topk, k)
-                * topk_weights.view(m, num_topk, 1).to(out_dtype)
-            ).sum(dim=1),
-            non_blocking=True,
-        )
-    else:
-        output.copy_(c3.view(m, num_topk, k).sum(dim=1), non_blocking=True)
+    _copy_cutlass_moe_output(
+        output, c3, topk_weights, topk_ids, apply_router_weight_on_input
+    )
     return
 
 
@@ -851,11 +878,7 @@ def run_cutlass_moe_mxfp4(
     a_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
     c_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
 
-    if apply_router_weight_on_input:
-        assert num_topk == 1, (
-            "apply_router_weight_on_input is only implemented for topk=1"
-        )
-        a.mul_(topk_weights.to(out_dtype))
+    _check_router_weight_on_input(topk_ids, apply_router_weight_on_input)
 
     ops.get_cutlass_moe_mm_data(
         topk_ids,
@@ -919,16 +942,9 @@ def run_cutlass_moe_mxfp4(
     c3 = ops.shuffle_rows(c3, c_map)
 
     assert output.dtype == out_dtype
-    if not apply_router_weight_on_input:
-        output.copy_(
-            (
-                c3.view(m, num_topk, k)
-                * topk_weights.view(m, num_topk, 1).to(out_dtype)
-            ).sum(dim=1),
-            non_blocking=True,
-        )
-    else:
-        output.copy_(c3.view(m, num_topk, k).sum(dim=1), non_blocking=True)
+    _copy_cutlass_moe_output(
+        output, c3, topk_weights, topk_ids, apply_router_weight_on_input
+    )
     return
 
 
@@ -1120,6 +1136,7 @@ def run_cutlass_moe_w4a8_fp8(
     per_out_ch: bool,
     use_batched_format: bool,
     topk_weights: torch.Tensor | None,
+    apply_router_weight_on_input: bool,
     group_size: int,
 ):
     a1q = hidden_states
@@ -1223,12 +1240,15 @@ def run_cutlass_moe_w4a8_fp8(
 
     # for non-chunking mode the output is resized from workspace13
     # so we need to make sure mm2_out uses workspace2.
+    assert topk_weights is not None
+    _check_router_weight_on_input(topk_ids, apply_router_weight_on_input)
     moe_unpermute(
         out=output,
         permuted_hidden_states=mm2_out,
-        topk_weights=topk_weights,
+        topk_weights=None if apply_router_weight_on_input else topk_weights,
         inv_permuted_idx=inv_perm,
         expert_first_token_offset=expert_first_token_offset,
+        topk=topk_ids.size(1),
     )
 
 
@@ -1408,5 +1428,6 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
             self.per_out_ch_quant,
             use_batched_format,
             topk_weights,
+            apply_router_weight_on_input,
             self.group_size,
         )

--- a/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
+++ b/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
@@ -100,9 +100,10 @@ def moe_permute(
 def moe_unpermute(
     out: torch.Tensor,
     permuted_hidden_states: torch.Tensor,
-    topk_weights: torch.Tensor,
+    topk_weights: torch.Tensor | None,
     inv_permuted_idx: torch.Tensor,
     expert_first_token_offset: torch.Tensor | None = None,
+    topk: int | None = None,
 ) -> None:
     """
     This function expands and permutes activation to gathering uncontinuous
@@ -110,20 +111,28 @@ def moe_unpermute(
     Parameters:
     - out (torch.Tensor): output tensor
     - permuted_hidden_states (torch.Tensor): permuted activation.
-    - topk_weights (torch.Tensor): topk expert route weight for each token.
+    - topk_weights (Optional[torch.Tensor]): topk expert route weight for each
+      token. If None, rows are reduced without output-side weighting.
     - inv_permuted_idx (torch.Tensor): row idx map for moe_unpermute.
     - expert_first_token_offset (Optional[torch.Tensor]): offset of the first
       token of each expert for grouped gemm.
+    - topk (Optional[int]): required when topk_weights is None.
     Returns:
     - hidden_states (torch.Tensor): The reduced and unpermuted activation
       tensor.
     """
-    topk = topk_weights.size(1)
+    if topk_weights is None:
+        assert topk is not None, "topk must be provided when topk_weights is None"
+    else:
+        weights_topk = topk_weights.size(1)
+        assert topk is None or topk == weights_topk
+        topk = weights_topk
     n_hidden = permuted_hidden_states.size(-1)
     assert (n_hidden * permuted_hidden_states.element_size()) % 16 == 0, (
         "unpermue kernel need hidden dim align to 16B"
     )
 
+    assert topk is not None
     torch.ops._moe_C.moe_unpermute(
         permuted_hidden_states,
         topk_weights,


### PR DESCRIPTION
Fix CUTLASS MoE handling of `apply_router_weight_on_input=True` so router weights are applied exactly once.

## Purpose

  The prepare/finalize path already applies router weights to the MoE input before quantization when `apply_router_weight_on_input=True`. Some CUTLASS expert paths still applied the same weights again on the output side, causing double weighting.

  ### What Changed
  - Fixed CUTLASS FP4 and MXFP4 paths to skip output-side router weighting when prepare already applied the weights.
  - Fixed standard CUTLASS FP8 and W4A8-FP8 paths to skip fused unpermute weighting when prepare already applied router weights.
    - `moe_unpermute` now accepts `topk_weights=None`.
    - The CUDA unpermute kernel treats a null weights pointer as scale `1.0`.

  - Preserved normal output-side weighting behavior when `apply_router_weight_on_input=False`.
## Test Plan
```
pytest tests/kernels/moe/test_cutlass_moe.py tests/kernels/moe/test_nvfp4_moe.py tests/kernels/moe/test_mxfp4_moe.py -v -k router_weight_on_input
```
Added focused synthetic CUDA/CUTLASS kernel regressions:
  - FP8 CUTLASS MoE test compares `CutlassExpertsFp8` against the known-safe Triton MoE backend using the same input, weights, routing, and `apply_router_weight_on_input=True`.
  - NVFP4 CUTLASS MoE test checks that apply-on-input matches explicitly pre-weighted input with unit router weights.
  - MXFP4 CUTLASS MoE test checks the same apply-on-input equivalence.
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

