### PR TITLE
Fix test_aot_compile for torch 2.12

### DIFF
--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -465,7 +465,10 @@ def test_standalone_compile_correctness():
         common_args,
         common_args,
         env1={"VLLM_USE_STANDALONE_COMPILE": "1"},
-        env2={"VLLM_USE_STANDALONE_COMPILE": "0"},
+        env2={
+            "VLLM_USE_STANDALONE_COMPILE": "0",
+            "VLLM_USE_MEGA_AOT_ARTIFACT": "0",
+        },
     )
 
 


### PR DESCRIPTION
Fixes test_aot_compile when upgrading to torch 2.12 (https://github.com/pytorch/pytorch/issues/184550)
cc @zou3519 