### PR TITLE
[Docs] Fix MLA prefill backend default docs

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -205,8 +205,9 @@ hardware and configuration.
 | `FLASHINFER` | FlashInfer CUTLASS backend | fp16, bf16 | 10.x | DeepSeek R1 dims only |
 | `TOKENSPEED_MLA` | | fp16, bf16 | 10.x | DeepSeek R1 dims only |
 
-> **‡** TRT-LLM Ragged is the default on Blackwell (SM100).
-> On other GPUs, FlashAttention is used as the default.
+> **‡** Automatic selection tries FlashAttention first. On Blackwell
+> (SM100), the fallback order is TRT-LLM Ragged, FlashInfer, then
+> TokenSpeed MLA. On other GPUs, only FlashAttention is considered.
 
 ### Decode Backends
 

--- a/tools/pre_commit/generate_attention_backend_docs.py
+++ b/tools/pre_commit/generate_attention_backend_docs.py
@@ -508,7 +508,7 @@ def parse_mla_prefill_backends() -> list[dict[str, Any]]:
         metadata = backend_metadata.get(backend_name, {})
         display_name = backend_info.get("name", backend_name)
 
-        # Add marker for default Blackwell backend
+        # Add marker for the highest-priority automatic backend.
         marker = ""
         if backend_name == priority_order[0] and priorities.get("blackwell"):
             marker = "‡"
@@ -1595,8 +1595,9 @@ def generate_mla_section(
     lines.extend(
         [
             "",
-            "> **‡** TRT-LLM Ragged is the default on Blackwell (SM100).",
-            "> On other GPUs, FlashAttention is used as the default.",
+            "> **‡** Automatic selection tries FlashAttention first. On Blackwell",
+            "> (SM100), the fallback order is TRT-LLM Ragged, FlashInfer, then",
+            "> TokenSpeed MLA. On other GPUs, only FlashAttention is considered.",
             "",
             "### Decode Backends",
             "",


### PR DESCRIPTION
## Summary

It seems the MLA prefill backend docs were not aligned with the current auto-selection behavior, so this updates them to say FlashAttention is tried first, with Blackwell falling back to TRT-LLM Ragged, FlashInfer, then TokenSpeed MLA.

https://github.com/vllm-project/vllm/blob/3aea37d28e44f0b8389e2cfa9876c3faa62543f4/vllm/v1/attention/backends/mla/prefill/selector.py#L65-L75