### PR TITLE
[CI] Soft-fail AMD entrypoints mirror tests

### DIFF
--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -29,6 +29,7 @@ steps:
   mirror:
     amd:
       device: mi300_1
+      soft_fail: true
       depends_on:
       - image-build-amd
 
@@ -46,6 +47,7 @@ steps:
   mirror:
     amd:
       device: mi300_1
+      soft_fail: true
       timeout_in_minutes: 80
       depends_on:
       - image-build-amd
@@ -64,6 +66,7 @@ steps:
   mirror:
     amd:
       device: mi300_1
+      soft_fail: true
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd
@@ -83,6 +86,7 @@ steps:
   mirror:
     amd:
       device: mi300_1
+      soft_fail: true
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd
@@ -105,6 +109,7 @@ steps:
   mirror:
     amd:
       device: mi300_1
+      soft_fail: true
       depends_on:
       - image-build-amd
 


### PR DESCRIPTION
## Summary
- Add `soft_fail: true` to all 5 AMD-mirrored entrypoints test steps so failures show as warnings instead of blocking the pipeline
- Affected steps: LLM, API Server openai Part 1/2/3, API Server 2
- NVIDIA-side entrypoints tests are unaffected

**Depends on:** vllm-project/ci-infra#364 (adds `soft_fail` support in AMD mirror blocks — must land first)

## Test plan
- [ ] Verify AMD entrypoints steps show `soft_fail: true` in generated Buildkite pipeline
- [ ] Verify NVIDIA entrypoints steps are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)