### PR TITLE
[Bugfix] qwen3_xml: emit one OpenAI tool_call per <function=...>, fix duplicate close

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -12,6 +12,18 @@ from tests.tool_parsers.common_tests import (
 )
 from tests.tool_parsers.utils import run_tool_extraction
 
+# All current streaming xfails for this parser fail with the same assertion:
+# `StreamingToolReconstructor` in tests/tool_parsers/utils.py requires `id`
+# (and `name`) only on the first delta of each tool_call slot, but the
+# parser sets id=self.current_call_id on every DeltaToolCall it emits,
+# including continuation/args deltas. Fix is localized to the parser's
+# delta-emit sites; once done, remove this constant and these entries.
+_STREAMING_ID_REEMITTED = (
+    "Parser sets id on every delta; OpenAI protocol requires id only on the "
+    "first delta per slot"
+)
+
+
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
     def test_config(self) -> ToolParserTestConfig:
@@ -57,32 +69,22 @@ class TestQwen3xmlToolParser(ToolParserTests):
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "get_time"],
             # xfail markers - Qwen3XML has systematic streaming issues
-            # xfail markers - Qwen3XML has systematic streaming issues
-            xfail_streaming={
-                "test_single_tool_call_simple_args": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_parallel_tool_calls": "Qwen3XML streaming has systematic issues",
-                "test_various_data_types": "Qwen3XML streaming has systematic issues",
-                "test_empty_arguments": "Qwen3XML streaming has systematic issues",
-                "test_surrounding_text": "Qwen3XML streaming has systematic issues",
-                "test_escaped_strings": "Qwen3XML streaming has systematic issues",
-                "test_streaming_reconstruction": (
-                    "Qwen3XML streaming reconstruction has known issues"
-                ),
-                "test_multiple_functions_in_one_tool_call": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_multiple_empty_functions_in_one_tool_call": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_three_functions_in_one_tool_call": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_multi_function_state_resets_between_tool_calls": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-            },
+            xfail_streaming=dict.fromkeys(
+                [
+                    "test_single_tool_call_simple_args",
+                    "test_parallel_tool_calls",
+                    "test_various_data_types",
+                    "test_empty_arguments",
+                    "test_surrounding_text",
+                    "test_escaped_strings",
+                    "test_streaming_reconstruction",
+                    "test_multiple_functions_in_one_tool_call",
+                    "test_multiple_empty_functions_in_one_tool_call",
+                    "test_three_functions_in_one_tool_call",
+                    "test_multi_function_state_resets_between_tool_calls",
+                ],
+                _STREAMING_ID_REEMITTED,
+            ),
             supports_typed_arguments=False,
         )
 

--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -2,13 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
-
+from tests.tool_parsers.utils import run_tool_extraction
 
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
@@ -55,6 +57,7 @@ class TestQwen3xmlToolParser(ToolParserTests):
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "get_time"],
             # xfail markers - Qwen3XML has systematic streaming issues
+            # xfail markers - Qwen3XML has systematic streaming issues
             xfail_streaming={
                 "test_single_tool_call_simple_args": (
                     "Qwen3XML streaming has systematic issues"
@@ -67,6 +70,164 @@ class TestQwen3xmlToolParser(ToolParserTests):
                 "test_streaming_reconstruction": (
                     "Qwen3XML streaming reconstruction has known issues"
                 ),
+                "test_multiple_functions_in_one_tool_call": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
+                "test_multiple_empty_functions_in_one_tool_call": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
+                "test_three_functions_in_one_tool_call": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
+                "test_multi_function_state_resets_between_tool_calls": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
             },
             supports_typed_arguments=False,
         )
+
+    def test_multiple_functions_in_one_tool_call(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Multiple <function=...> in one <tool_call> -> distinct slots."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_multiple_functions_in_one_tool_call",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>README.md</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>AGENTS.md</parameter>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+
+        assert len(tool_calls) == 2, (
+            f"Expected 2 tool calls (one per <function=...>), got {len(tool_calls)}"
+        )
+        for i, tc in enumerate(tool_calls):
+            assert tc.function.name == "read", (
+                f"tool_calls[{i}].name expected 'read', got {tc.function.name!r}"
+            )
+            json.loads(tc.function.arguments)  # must be valid JSON
+        assert json.loads(tool_calls[0].function.arguments) == {"path": "README.md"}
+        assert json.loads(tool_calls[1].function.arguments) == {"path": "AGENTS.md"}
+
+    def test_multiple_empty_functions_in_one_tool_call(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Empty-args variant: pre-fix produced `{}{}` (or `{}{}{}` for N=3)."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_multiple_empty_functions_in_one_tool_call",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=ping>\n</function>\n"
+            "<function=ping>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+
+        assert len(tool_calls) == 2, (
+            f"Expected 2 tool calls, got {len(tool_calls)}"
+        )
+        for tc in tool_calls:
+            assert tc.function.name == "ping"
+            # Empty args render as "{}" or "" depending on path; never `{}{}`.
+            assert tc.function.arguments in ("{}", ""), (
+                f"Expected empty args, got {tc.function.arguments!r}"
+            )
+
+    def test_three_functions_in_one_tool_call(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Guards against an off-by-one that would only break for N>2."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_three_functions_in_one_tool_call",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>A</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>B</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>C</parameter>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+        assert [tc.function.name for tc in tool_calls] == ["read", "read", "read"]
+        assert [json.loads(tc.function.arguments) for tc in tool_calls] == [
+            {"path": "A"},
+            {"path": "B"},
+            {"path": "C"},
+        ]
+
+    def test_multi_function_state_resets_between_tool_calls(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Per-<tool_call> function counter must reset on a new <tool_call>."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_multi_function_state_resets_between_tool_calls",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>A</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>B</parameter>\n</function>\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>C</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>D</parameter>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+        assert [json.loads(tc.function.arguments) for tc in tool_calls] == [
+            {"path": "A"},
+            {"path": "B"},
+            {"path": "C"},
+            {"path": "D"},
+        ]
+
+    def test_malformed_function_close_without_open_does_not_crash(
+        self, tool_parser
+    ):
+        """Out-of-scope contract: parser may return garbage, must not raise."""
+        model_output = (
+            "<tool_call>\n"
+            "<parameter=q>x</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        run_tool_extraction(tool_parser, model_output, streaming=False)

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -621,6 +621,13 @@ class StreamingXMLToolCallParser:
         if incoming_tag == "tool_call" and self.current_call_id:
             self._end_element("tool_call")
 
+    def _mint_new_tool_call_slot(self) -> None:
+        """Bump tool_call index, mint a fresh id, reset per-function state."""
+        self.parameters = {}
+        self.current_call_id = make_tool_call_id()
+        self.current_param_is_first = True
+        self.tool_call_index += 1
+
     def _start_element(self, name: str, attrs: dict[str, str]):
         """Handle XML start element events"""
 
@@ -632,10 +639,7 @@ class StreamingXMLToolCallParser:
             # automatically complete previous unclosed tags
             self._auto_close_open_parameter_if_needed("tool_call")
 
-            self.parameters = {}
-            self.current_call_id = make_tool_call_id()
-            self.current_param_is_first = True
-            self.tool_call_index += 1
+            self._mint_new_tool_call_slot()
             self.functions_in_tool_call = 0
         elif name.startswith("function") or (name == "function"):
             # If missing tool_call, manually complete
@@ -644,10 +648,7 @@ class StreamingXMLToolCallParser:
             # First function reuses <tool_call>'s slot; rest mint fresh.
             self.functions_in_tool_call += 1
             if self.functions_in_tool_call > 1:
-                self.parameters = {}
-                self.current_call_id = make_tool_call_id()
-                self.current_param_is_first = True
-                self.tool_call_index += 1
+                self._mint_new_tool_call_slot()
             # Before opening new function,
             # automatically complete previous unclosed tags (parameter/function)
             self._auto_close_open_parameter_if_needed("function")

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -59,6 +59,9 @@ class StreamingXMLToolCallParser:
         self.last_completed_call_id = None
         self.current_function_name = None
         self.current_function_open = False
+        # Per-<tool_call> counter; each <function=...> maps to one OpenAI
+        # tool_call slot, so the 2nd+ function mints a fresh slot.
+        self.functions_in_tool_call = 0
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""
@@ -633,10 +636,18 @@ class StreamingXMLToolCallParser:
             self.current_call_id = make_tool_call_id()
             self.current_param_is_first = True
             self.tool_call_index += 1
+            self.functions_in_tool_call = 0
         elif name.startswith("function") or (name == "function"):
             # If missing tool_call, manually complete
             if not self.current_call_id:
                 self._start_element("tool_call", {})
+            # First function reuses <tool_call>'s slot; rest mint fresh.
+            self.functions_in_tool_call += 1
+            if self.functions_in_tool_call > 1:
+                self.parameters = {}
+                self.current_call_id = make_tool_call_id()
+                self.current_param_is_first = True
+                self.tool_call_index += 1
             # Before opening new function,
             # automatically complete previous unclosed tags (parameter/function)
             self._auto_close_open_parameter_if_needed("function")
@@ -898,6 +909,13 @@ class StreamingXMLToolCallParser:
             self.start_quote_emitted = False
 
         elif name.startswith("function") or name == "function":
+            # Skip duplicate closes (auto-close paths, `</function></function>`).
+            # Out of scope: `</function>` without a matching `<function=...>`
+            # open -- the resulting tool_call has no name and is
+            # undispatchable; not worth extra state to balance its JSON.
+            # See test_malformed_function_close_without_open_does_not_crash.
+            if not self.current_function_open:
+                return
             # if there are parameters, close JSON object
             if self.parameters:
                 delta = DeltaMessage(
@@ -925,6 +943,10 @@ class StreamingXMLToolCallParser:
                 )
                 self._emit_delta(delta)
             self.current_function_open = False
+            # Clear so next <function=...> starts clean and the
+            # current_function_name-driven auto-close path no-ops.
+            self.parameters = {}
+            self.current_function_name = None
 
         elif name == "tool_call":
             # Before ending tool_call,
@@ -1128,6 +1150,7 @@ class StreamingXMLToolCallParser:
         self.current_call_id = None
         self.current_function_name = None
         self.current_function_open = False
+        self.functions_in_tool_call = 0
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""


### PR DESCRIPTION
## Purpose

Fixes #43713.

The `qwen3_xml` streaming tool-call parser emits invalid JSON in `delta.tool_calls.function.arguments` when the model output contains multiple `<function=...>` blocks inside a single `<tool_call>`. Symptoms:

- `{"path": "README.md"}}, "path": "AGENTS.md"}` (extra close brace, names concatenated into one slot)
- `{}{}{}` (when the functions have no parameters)

Both break OpenAI-compatible clients that `json.loads` the accumulated arguments.

Two interacting causes in `StreamingXMLToolCallParser`:

1. **`_end_element('function')` is not guarded against re-entry, and leaves `self.parameters` / `self.current_function_name` populated.** When the next `<function=...>` opens, `_start_element` calls `_auto_close_open_parameter_if_needed('function')`, which sees `current_function_name` still set and re-fires `_end_element('function')`, emitting another `}` from stale `self.parameters`.
2. **`tool_call_index` is only bumped at `<tool_call>` open**, so multiple `<function=...>` in the same `<tool_call>` all land in the same OpenAI tool_call slot.

## Fix

Minimal, reusing existing state:

- On `</function>`, clear `self.parameters` and `self.current_function_name` (so auto-close paths driven by `current_function_name` no-op) and gate the function-end branch on the existing `self.current_function_open` — a duplicate close becomes a clean no-op.
- Add one integer of state, `self.functions_in_tool_call`, reset at `<tool_call>` open. Increment on `<function=...>` open; if `> 1`, mint a fresh OpenAI tool_call slot. One `<function=...>` block ↔ one OpenAI tool_call.
- Factor `_mint_new_tool_call_slot()` (separate commit) so the `<tool_call>`-open and second+ `<function=...>` paths can't drift.

**Out of scope** (explicit carveout, comment in source + pinning test):
`<tool_call><parameter=q>x</parameter></function>...` — malformed input that hits `</function>` without a matching `<function=...>` open. The resulting OpenAI tool_call would have no `name` and be undispatchable anyway; balancing JSON for it isn't worth the extra state. The parser does not raise on this input (verified by `test_malformed_function_close_without_open_does_not_crash`).

## Tests

Added to `tests/tool_parsers/test_qwen3xml_tool_parser.py`, using the same `streaming` fixture + `apply_xfail_mark` + `xfail_streaming` dict mechanism as every other test in the suite:

- `test_multiple_functions_in_one_tool_call` — two `<function=read>` blocks with `<parameter=path>` each; expects two tool_calls with valid JSON args.
- `test_multiple_empty_functions_in_one_tool_call` — two `<function=ping>` with no parameters; expects two tool_calls with empty args, never `{}{}`.
- `test_three_functions_in_one_tool_call` — exercises the counter past 2 so the fix can't accidentally work only for N=2.
- `test_multi_function_state_resets_between_tool_calls` — regression guard that `functions_in_tool_call` resets on a new `<tool_call>`.
- `test_malformed_function_close_without_open_does_not_crash` — pins the out-of-scope contract (parser must not raise).

All four bug-related non-streaming tests fail on `main` and pass with this patch. Streaming variants are added to the existing `xfail_streaming` dict for the same pre-existing reason all current qwen3_xml streaming tests are xfailed. Direct-probe verification of the parser's all-at-once streaming output confirms the multi-function fix itself is correct (two clean slots, valid JSON, no phantom deltas).

**Separate commit** (`Document the actual cause of qwen3_xml streaming xfails`): the existing entries all shared the reason string `"Qwen3XML streaming has systematic issues"`, which is folklore. Verified all 11 failures hit the same assertion in `StreamingToolReconstructor` on the same parser behavior: the parser sets `id=self.current_call_id` on every `DeltaToolCall` it emits (12 sites), but the OpenAI streaming protocol requires `id` only on the first delta per slot. Replaces the vague string with a specific one + a source comment pointing at the fix site, so whoever picks this up next has a starting point.

## Real-world impact

Observed in production on Qwen3.6-27B served via this stack (vLLM nightly + AutoRound INT4, 2× RTX 3090 TP=2, `qwen3_xml` parser, `qwen3` reasoning parser, sampling temp 0.6, real coding-agent prompts captured on the wire). The model emits multiple `<function=...>` per `<tool_call>` in roughly 6-7% of trials on a 200-trial matrix bench, each producing invalid JSON in the streamed args. Patch brings residual streamed-args garble from ~7% to 0%.

## Compatibility

- No public API change.
- No behavior change for single-`<function=...>`-per-`<tool_call>` outputs (the common case) — verified by existing tests still passing.
- The newly-emitted second/third OpenAI tool_call has a fresh `id` and incremented `index`; OpenAI-compatible clients already expect this for parallel tool calls.
- One new instance attribute, `functions_in_tool_call: int`, initialised in `__init__` and `_reset_xml_parser_after_tool_call`.

## Test Plan

```
pytest tests/tool_parsers/test_qwen3xml_tool_parser.py -v
```

Result: `15 passed, 11 xfailed` (7 pre-existing class-level + 4 new streaming variants xfailed for the same reason).
