### PR TITLE
[Bugfix][Quantization] Refuse block-FP8 in MarlinFP8.can_implement

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -57,6 +57,25 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
 
     @classmethod
     def can_implement(cls, c: FP8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
+        # Marlin's per-channel scale layout cannot serve block-FP8 layers
+        # (weight_scale_inv shape [N_blocks_n, N_blocks_k]).
+        # csrc/quantization/marlin/marlin.cu fires
+        # ``TORCH_CHECK(b_scales.size(1) == size_n, ...)`` for any layer
+        # where the block-quant scales arrive in their raw 2-D layout.
+        # Even when VLLM_TEST_FORCE_FP8_MARLIN=1 is set (which downstream
+        # operators do for NVFP4-MoE on SM 12.0 / RTX PRO 6000 Blackwell),
+        # block-FP8 attention compressor layers like DSv4 fused_wqa_wkv
+        # must fall through to the next supported kernel in
+        # ``_POSSIBLE_FP8_BLOCK_KERNELS[CUDA]`` (typically the Triton
+        # block-FP8 path).
+        try:
+            if c.activation_quant_key.scale.group_shape.is_per_group():
+                return False, (
+                    "MarlinFP8 cannot serve block-FP8 layers; falling "
+                    "through to the next kernel in the priority list."
+                )
+        except Exception:
+            pass
         return True, None
 
     def __init__(


### PR DESCRIPTION
## Summary

Refuse block-FP8 layers in `MarlinFP8ScaledMMLinearKernel.can_implement` so the dispatcher falls through to the next supported kernel (typically `TritonFp8BlockScaledMMKernel`).

## The bug

`csrc/quantization/marlin/marlin.cu` TORCH_CHECKs `b_scales.size(1) == size_n` for the 2-D scales path. Block-quantized FP8 layers ship `weight_scale_inv` of shape `[N_blocks_n, N_blocks_k]` — e.g. DSv4-Flash's `compressor.fused_wqa_wkv` at `[12, 32]` for `(1536, 4096)` weight with block `[128, 128]`. Marlin's per-channel kernel-side expectation is `[K/group, size_n]`. The check fires.

This is reachable in production today because:

1. Consumer-Blackwell operators set `VLLM_TEST_FORCE_FP8_MARLIN=1` to keep NVFP4-MoE alive on SM 12.0 (no other NVFP4 MoE backend currently lights up on RTX PRO 6000).
2. With the env var set, `MarlinFP8ScaledMMLinearKernel.is_supported` returns True for SM ≥ 89.
3. Marlin is at priority 4 in `_POSSIBLE_FP8_BLOCK_KERNELS[CUDA]`, ahead of `TritonFp8BlockScaledMMKernel`.
4. `CompressedTensorsW8A8Fp8.apply_weights` → `Fp8LinearOp` → dispatcher picks MarlinFP8 for block-FP8 layers → `b_scales` shape mismatch.

Symptom: `RuntimeError: b_scales dim 1 = 32 is not size_n = 1536` at `profile_run`. Reproducible with `canada-quant/DeepSeek-V4-Flash-NVFP4-FP8-MTP` on RTX PRO 6000 Blackwell.

## The fix

`can_implement` is the canonical place to refuse layers a kernel can't actually serve. Per-group activation quant scales is the dispatch-side signal for block-quantization (see `init_fp8_linear_kernel` at `vllm/model_executor/kernels/linear/__init__.py:521`).

```python
@classmethod
def can_implement(cls, c) -> tuple[bool, str | None]:
    try:
        if c.activation_quant_key.scale.group_shape.is_per_group():
            return False, "MarlinFP8 cannot serve block-FP8 layers; ..."
    except Exception:
        pass
    return True, None
```

Defensive try/except because the config shape can vary across schemes; if introspection fails, we keep the prior permissive behavior.

## Validation

Verified on `canada-quant/DeepSeek-V4-Flash-NVFP4-FP8-MTP` (RTX PRO 6000 Blackwell, SM 12.0, TP=4) with `VLLM_TEST_FORCE_FP8_MARLIN=1`:

- **Before**: `RuntimeError: b_scales dim 1 = 32 is not size_n = 1536` at `profile_run` (3-frame trace pinned to `attention.py:454 attn_gemm_parallel_execute` → `fused_wqa_wkv` → `compressed_tensors.py:851 scheme.apply_weights` → `marlin_utils_fp8.py:69 apply_fp8_marlin_linear` → `marlin.cu:701`).
- **After**: dispatcher picks `TritonFp8BlockScaledMMKernel`, engine init completes (43.4 GiB / 33.8s weight load, MTP shared embeddings, profile_run + cudagraph capture succeed), `"Application startup complete"` reached, smoke completion `"The capital of France is" → " Paris, which is located in the Île-de"` (10 tokens, coherent).

## Risk

- 19-line change in one file, no behavior change for any layer that isn't per-group-activation-quantized (i.e. tensor / channel / token strategies are unaffected).
- The `try/except` on config introspection means even if a future scheme's quant_key doesn't have `.scale.group_shape`, we keep the prior permissive return.
- The dispatcher's existing fallback chain handles the actual block-FP8 serving — Marlin was never the right kernel for these layers; this just stops it from claiming it can.

## Adjacent

- `vllm/models/deepseek_v4/attention.py:377` directly reads `self.wo_a.weight_scale_inv` — but only `MarlinFP8.process_weights_after_loading` renames `weight_scale` → `weight_scale_inv`. Once this PR routes the layer to a non-Marlin kernel, the bare read AttributeErrors. Follow-up commit / PR adds a `getattr` fallback.
- Closes one strand of #43564 (the load-time crash on consumer Blackwell). The numerical-correctness concern documented in that issue is orthogonal to this PR and remains under investigation.

Disclosure (per [AGENTS.md](https://github.com/vllm-project/vllm/blob/main/AGENTS.md#accountability)): authored with AI assistance; the code path was traced end-to-end from the runtime trace, the fix shape was confirmed by reading the dispatcher (`vllm/model_executor/kernels/linear/__init__.py:502+`) and the kernel selection priority list, and the patch was tested on a downstream venv built from `jasl/vllm@a02a3778f` against the canada-quant artifact. Mainline-build verification is in progress; will report results on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)