### PR TITLE
[Bugfix][DSV4] wo_a scale getattr fallback for non-Marlin kernel paths

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -327,7 +327,13 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         )
 
         wo_a_fp8 = self.wo_a.weight
-        wo_a_scale = self.wo_a.weight_scale_inv
+        # Block-FP8 layers are renamed weight_scale -> weight_scale_inv
+        # by MarlinFP8.process_weights_after_loading. Non-Marlin kernels
+        # (TritonFp8BlockScaledMM, DeepGemm, Cutlass, FlashInfer) leave
+        # the on-disk name. Accept either; math is identical.
+        wo_a_scale = getattr(self.wo_a, "weight_scale_inv", None)
+        if wo_a_scale is None:
+            wo_a_scale = self.wo_a.weight_scale
 
         z = torch.empty(
             (num_tokens, self.n_local_groups, self.o_lora_rank),


### PR DESCRIPTION
## Summary

`vllm/models/deepseek_v4/attention.py:330` reads `self.wo_a.weight_scale_inv` directly. Only `MarlinFP8ScaledMMLinearKernel.process_weights_after_loading` renames the on-disk `weight_scale` → `weight_scale_inv`; non-Marlin kernels (Triton block-FP8, DeepGemm, Cutlass, FlashInfer) preserve the original name. Bare attribute read then `AttributeError`s.

Companion PR to #43722, which corrects the MarlinFP8 block-FP8 dispatch (routing `compressor.fused_wqa_wkv` to `TritonFp8BlockScaledMMKernel` instead). Once #43722 lands, `wo_a` joins it on the Triton path — at which point this PR is required to avoid the `AttributeError` at profile_run.

## The fix

`getattr` with fallback. Math is identical for either name (the storage matches the on-disk layout regardless of attribute name). Primary lookup stays `weight_scale_inv` to preserve existing behavior in the Marlin code path.

```python
wo_a_fp8 = self.wo_a.weight
wo_a_scale = getattr(self.wo_a, "weight_scale_inv", None)
if wo_a_scale is None:
    wo_a_scale = self.wo_a.weight_scale
```

## Validation

Verified on `canada-quant/DeepSeek-V4-Flash-NVFP4-FP8-MTP` (RTX PRO 6000 Blackwell, SM 12.0, TP=4) with `VLLM_TEST_FORCE_FP8_MARLIN=1` + #43722 + this PR:

- Before this PR (with #43722 only): `AttributeError: 'ColumnParallelLinear' object has no attribute 'weight_scale_inv'` at `attention.py:330` during profile_run.
- After this PR: profile_run completes, engine reaches "Application startup complete" (43.4 GiB / 33.8s weight load), serves real completions.

## Risk

- 7-line change in one file, defensive fallback only.
- Marlin code paths unaffected (the primary `getattr` succeeds when Marlin runs).
- Non-Marlin paths previously broken at this read site; the fallback makes them work.

Disclosure (per [AGENTS.md](https://github.com/vllm-project/vllm/blob/main/AGENTS.md#accountability)): authored with AI assistance; the call site was identified from a runtime trace and the math equivalence between `weight_scale` and `weight_scale_inv` for block-FP8 layers (block-scale tensor of shape `[N_blocks_n, N_blocks_k]` is the same data under either name; the `_inv` suffix is a Marlin-internal convention) was verified by reading `MarlinFP8.process_weights_after_loading` and `compressed_tensors_w8a16_fp8.py:120-130`. The human submitter (@pasta-paul / canada-quant) defends every claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)