### PR TITLE
[FileSystemTierManager] Toy Evictors for FS Offloading

### DIFF
--- a/vllm/v1/kv_offload/tiering/fs/evictor.py
+++ b/vllm/v1/kv_offload/tiering/fs/evictor.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Evictors for the fs tier where the storage is not shared between vllm
+instances.
+
+An Evictor controls whether a store job is allowed to proceed and reconciles
+the in-memory view of which keys are resident on disk after each job completes.
+
+Three concrete implementations are provided:
+
+  NoOpEvictor       - Unbounded. Lookup delegates to the filesystem and all
+                      lifecycle hooks are no-ops.  Use when no storage cap is
+                      configured.
+
+  LRUEvictor        - Bounded. Evicts the least-recently-used blocks to make
+                      room for new stores.  May briefly overshoot the cap while
+                      multiple stores are in-flight; eventual consistency is
+                      guaranteed via complete_store.
+
+  FailOnFullEvictor - Bounded. Refuses new store jobs (returns False from
+                      prepare_store) when the cap is exhausted instead of
+                      evicting existing blocks.
+
+Lifecycle hooks called by FileSystemTierManager:
+  prepare_store  - called before enqueueing a store task.
+  complete_store - called after a store task finishes (success or failure).
+  prepare_load   - called before enqueueing a load task.
+  complete_load  - called after a load task finishes.
+"""
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Literal
+
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import OffloadKey
+from vllm.v1.kv_offload.cpu.policies.base import BlockStatus
+from vllm.v1.kv_offload.cpu.policies.lru import LRUCachePolicy
+from vllm.v1.kv_offload.file_mapper import FileMapper
+from vllm.v1.kv_offload.tiering.base import JobMetadata
+
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class EvictorBase(ABC):
+    """
+    Common interface for all fs-tier evictors.
+
+    Every method is called on the scheduler thread and must not block.
+    """
+
+    @abstractmethod
+    def lookup(self, key: OffloadKey) -> bool:
+        """Return True iff key is resident and ready to be loaded."""
+
+    @abstractmethod
+    def prepare_store(self, job_metadata: JobMetadata) -> bool:
+        """
+        Gate a store job before it is enqueued.
+
+        Returns True if the job should proceed; False if it should be skipped
+        (the caller will surface a failed JobResult without touching disk).
+        """
+
+    @abstractmethod
+    def prepare_load(self, job_metadata: JobMetadata) -> None:
+        """
+        Called just before a load job is enqueued.
+
+        May update ref-counts or recency information.
+        """
+
+    @abstractmethod
+    def complete_store(self, job_metadata: JobMetadata) -> None:
+        """
+        Called once after a store job finishes (success or failure).
+
+        Reconciles the in-memory state with what actually landed on disk.
+        """
+
+    @abstractmethod
+    def complete_load(self, job_metadata: JobMetadata) -> None:
+        """Called once after a load job finishes."""
+
+
+# ---------------------------------------------------------------------------
+# No-op evictor (unbounded storage)
+# ---------------------------------------------------------------------------
+
+
+class NoOpEvictor(EvictorBase):
+    """
+    Unbounded evictor used when no storage cap is configured.
+
+    Lookup is delegated to the filesystem.  All lifecycle hooks are no-ops so
+    there is zero overhead for the common uncapped case.
+    """
+
+    def __init__(self, file_mapper: FileMapper) -> None:
+        self.file_mapper = file_mapper
+
+    def lookup(self, key: OffloadKey) -> bool:
+        return os.path.exists(self.file_mapper.get_file_name(key))
+
+    def prepare_store(self, job_metadata: JobMetadata) -> bool:
+        return True
+
+    def prepare_load(self, job_metadata: JobMetadata) -> None:
+        pass
+
+    def complete_store(self, job_metadata: JobMetadata) -> None:
+        pass
+
+    def complete_load(self, job_metadata: JobMetadata) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Shared base for capacity-limited evictors
+# ---------------------------------------------------------------------------
+
+
+class _BoundedEvictor(EvictorBase):
+    """
+    Abstract base for evictors that enforce a storage cap via a CachePolicy.
+
+    Subclasses only need to implement _acquire_slots, which decides how (or
+    whether) to make room for a new set of keys.
+
+    Shared responsibilities handled here:
+      - policy-backed lookup and ref-count tracking for in-flight loads
+      - complete_store reconciliation (file-existence vs. policy state)
+      - prepare_store skeleton (filter already-tracked keys, delegate to
+        _acquire_slots for the remainder)
+    """
+
+    def __init__(
+        self, file_mapper: FileMapper, policy: LRUCachePolicy, max_files: int
+    ) -> None:
+        logger.warning(
+            "%s should only be used for testing, not in production.",
+            type(self).__name__,
+        )
+        self.file_mapper = file_mapper
+        self.policy = policy
+        self.max_files = max_files
+
+    # ------------------------------------------------------------------
+    # Shared factory helper
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def make(
+        cls,
+        file_mapper: FileMapper,
+        file_size_bytes: int,
+        max_storage_size_gb: float,
+    ) -> "_BoundedEvictor":
+        """Construct from a storage budget expressed in gigabytes."""
+        max_storage_bytes = int(max_storage_size_gb * 1024**3)
+        max_files = max_storage_bytes // file_size_bytes
+        assert max_files > 0, (
+            f"Configured {max_storage_size_gb=} GB is too small for "
+            f"{file_size_bytes=}-byte files"
+        )
+        return cls(file_mapper, LRUCachePolicy(max_files), max_files)
+
+    # ------------------------------------------------------------------
+    # EvictorBase interface
+    # ------------------------------------------------------------------
+
+    def lookup(self, key: OffloadKey) -> bool:
+        block = self.policy.get(key)
+        return block is not None and block.is_ready
+
+    def prepare_load(self, job_metadata: JobMetadata) -> None:
+        self.policy.touch(job_metadata.keys)
+        for key in job_metadata.keys:
+            block = self.policy.get(key)
+            assert block is not None, f"Untracked file found for key {key!r}"
+            assert block.is_ready, f"Block for {key!r} not yet ready"
+            block.ref_cnt += 1
+
+    def complete_load(self, job_metadata: JobMetadata) -> None:
+        for key in job_metadata.keys:
+            block = self.policy.get(key)
+            assert block is not None, f"Untracked file found for key {key!r}"
+            assert block.ref_cnt > 0
+            block.ref_cnt -= 1
+
+    def prepare_store(self, job_metadata: JobMetadata) -> bool:
+        keys_to_store = [k for k in job_metadata.keys if self.policy.get(k) is None]
+
+        if not keys_to_store:
+            return True
+
+        return self._acquire_slots(keys_to_store, protected=set(job_metadata.keys))
+
+    def _complete_store(self, key: OffloadKey):
+        # Determine store complete by checking file presence.
+        # We allow multiple in-flight stores reconcile them here.
+
+        def _maybe_materialize_slot(mkey: OffloadKey) -> bool:
+            num_free_slots = self.max_files - len(self.policy.blocks)
+            if num_free_slots > 0:
+                block_status = BlockStatus(block_id=0)
+                block_status.ref_cnt = 0
+                self.policy.insert(mkey, block_status)
+                return True
+            return False
+
+        key_file = self.file_mapper.get_file_name(key)
+        key_file_exists = os.path.exists(key_file)
+        block_meta = self.policy.get(key)
+
+        if key_file_exists:
+            if block_meta is not None:
+                # Protect against multiple in-flight stores.
+                if block_meta.ref_cnt == -1:
+                    # Only the first reported store succeeds.
+                    block_meta.ref_cnt = 0
+            else:
+                # Maybe a previous store-job failed and this job succeeded.
+                # Try updating the self.policy.
+                if not _maybe_materialize_slot(key):
+                    # Cannot materialize. This block was likely evicted and
+                    # a scheduled store job recreated it.
+                    # Remove the file for consistency and to respect the FS size
+                    # requirements.
+                    try:
+                        os.remove(key_file)
+                        logger.warning("Removed a hash_file %s", key_file)
+                    except Exception:
+                        logger.warning("Cannot remove stray hash file %s", key_file)
+            return
+
+        # File does not exist
+        if block_meta is not None:
+            # Failed store job
+            self.policy.remove(key)
+
+    def complete_store(self, job_metadata: JobMetadata):
+        for key in job_metadata.keys:
+            self._complete_store(key)
+
+    @abstractmethod
+    def _acquire_slots(
+        self, keys_to_store: list[OffloadKey], protected: set[OffloadKey]
+    ) -> bool:
+        """
+        Reserve capacity for keys_to_store and insert them into the policy.
+
+        keys_to_store  - keys that are not yet tracked by the policy.
+        protected      - keys that must not be evicted (the full job key set).
+
+        Returns True if the slots were acquired and the keys inserted;
+        False if no space could be made (the store job will be skipped).
+        """
+
+
+# ---------------------------------------------------------------------------
+# LRU evictor
+# ---------------------------------------------------------------------------
+
+
+class LRUEvictor(_BoundedEvictor):
+    """
+    Bounded evictor that evicts the least-recently-used blocks to make room.
+
+    Stores may transiently overshoot the cap when multiple jobs are in-flight;
+    complete_store restores consistency once each job settles.
+    """
+
+    def __init__(
+        self, file_mapper: FileMapper, policy: LRUCachePolicy, max_files: int
+    ) -> None:
+        super().__init__(file_mapper, policy, max_files)
+        logger.warning(
+            "LRUEvictor: storage cap may be briefly exceeded while "
+            "in-flight stores are outstanding; eventual consistency is guaranteed."
+        )
+
+    def _acquire_slots(
+        self, keys_to_store: list[OffloadKey], protected: set[OffloadKey]
+    ) -> bool:
+        need = len(keys_to_store)
+        free = self.max_files - len(self.policy.blocks)
+        num_to_evict = max(0, need - free)
+
+        if num_to_evict > 0:
+            evicted = self.policy.evict(num_to_evict, protected=protected)
+            if evicted is None:
+                return False
+            for evicted_key, _ in evicted:
+                os.remove(self.file_mapper.get_file_name(evicted_key))
+
+        for key in keys_to_store:
+            self.policy.insert(key, BlockStatus(block_id=0))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Fail-on-full evictor
+# ---------------------------------------------------------------------------
+
+
+class FailOnFullEvictor(_BoundedEvictor):
+    """
+    Bounded evictor that rejects new store jobs when the cap is exhausted.
+
+    Unlike LRUEvictor, no existing blocks are ever evicted to make room.
+    Stores for keys that do not fit are skipped immediately with a failed
+    JobResult, leaving all currently resident blocks untouched.
+    """
+
+    def _acquire_slots(
+        self, keys_to_store: list[OffloadKey], protected: set[OffloadKey]
+    ) -> bool:
+        free = self.max_files - len(self.policy.blocks)
+        if len(keys_to_store) > free:
+            return False
+        for key in keys_to_store:
+            self.policy.insert(key, BlockStatus(block_id=0))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+_EVICTOR_CLASSES: dict[str, type[_BoundedEvictor]] = {
+    "lru": LRUEvictor,
+    "fail_on_full": FailOnFullEvictor,
+}
+
+
+def make_evictor(
+    file_mapper: FileMapper,
+    file_size_bytes: int,
+    evictor_args: dict[str, Any] | None,
+) -> EvictorBase:
+    """
+    Construct an evictor from a plain args dict.
+
+    Pass None (or omit evictor_args) to get an unbounded NoOpEvictor.
+
+    Recognised keys in evictor_args:
+      max_storage_size_gb (float) - storage cap in GB.
+      evictor_type        (str)   - "lru" (default) or "fail_on_full".
+
+    Example::
+
+        evictor = make_evictor(
+            file_mapper,
+            block_size,
+            {"max_storage_size_gb": 100.0, "evictor_type": "lru"},
+        )
+    """
+    if evictor_args is None:
+        return NoOpEvictor(file_mapper)
+
+    max_gb = evictor_args.get("max_storage_size_gb")
+    if max_gb is None:
+        return NoOpEvictor(file_mapper)
+
+    evictor_type: Literal["lru", "fail_on_full"] = evictor_args.get(
+        "evictor_type", "lru"
+    )
+    if evictor_type not in _EVICTOR_CLASSES:
+        raise ValueError(
+            f"Unknown evictor_type {evictor_type!r}. "
+            f"Choose from: {list(_EVICTOR_CLASSES)}"
+        )
+    return _EVICTOR_CLASSES[evictor_type].make(
+        file_mapper,
+        file_size_bytes=file_size_bytes,
+        max_storage_size_gb=float(max_gb),
+    )

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -19,17 +19,19 @@ import functools
 import json
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import OffloadKey, ReqContext
 from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.tiering.base import (
+    JobId,
     JobMetadata,
     JobResult,
     RequestOffloadingContext,
     SecondaryTierManager,
 )
+from vllm.v1.kv_offload.tiering.fs.evictor import EvictorBase, make_evictor
 from vllm.v1.kv_offload.tiering.fs.io import load_block, store_block
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
 
@@ -58,6 +60,7 @@ class FileSystemTierManager(SecondaryTierManager):
         primary_kv_view: memoryview,
         tier_type: str,
         root_dir: str,
+        evictor_args: dict[str, Any] | None = None,
         n_read_threads: int = 16,
         n_write_threads: int = 16,
     ):
@@ -68,6 +71,8 @@ class FileSystemTierManager(SecondaryTierManager):
             primary_kv_view: Memoryview of the primary tier's CPU KV cache.
             tier_type: Tier type identifier, set by SecondaryTierFactory.
             root_dir: Root directory for block files.
+            evictor_args: Forwarded to make_evictor().  None → NoOpEvictor
+                (unbounded storage).  See make_evictor() for supported keys.
             n_read_threads: Number of read-priority I/O threads.
             n_write_threads: Number of write-priority I/O threads.
         """
@@ -86,6 +91,12 @@ class FileSystemTierManager(SecondaryTierManager):
             gpu_blocks_per_file=offloading_spec.block_size_factor,
         )
 
+        self._evictor: EvictorBase = make_evictor(
+            self.file_mapper,
+            file_size_bytes=self._block_size,
+            evictor_args=evictor_args,
+        )
+
         # Write config file
         config_path = self.file_mapper.get_config_file_path()
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
@@ -100,6 +111,8 @@ class FileSystemTierManager(SecondaryTierManager):
             n_write_threads,
             thread_name_prefix="vllm_kv_py_fs",
         )
+        self._job_meta: dict[JobId, JobMetadata] = {}
+        self._skipped_jobs: list[JobResult] = []
 
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
         return RequestOffloadingContext()
@@ -107,9 +120,14 @@ class FileSystemTierManager(SecondaryTierManager):
     def lookup(
         self, key: OffloadKey, req_context: ReqContext | None = None
     ) -> bool | None:
-        return os.path.exists(self.file_mapper.get_file_name(key))
+        return self._evictor.lookup(key)
 
     def submit_store(self, job_metadata: JobMetadata) -> None:
+        if not self._evictor.prepare_store(job_metadata):
+            # Skip store. This is drained in get_finished().
+            self._skipped_jobs.append(JobResult(job_metadata.job_id, success=False))
+            return
+
         tasks = (
             functools.partial(
                 store_block,
@@ -121,8 +139,11 @@ class FileSystemTierManager(SecondaryTierManager):
             for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
         )
         self._pool.enqueue_store(job_metadata.job_id, len(job_metadata.keys), tasks)
+        self._job_meta[job_metadata.job_id] = job_metadata
 
     def submit_load(self, job_metadata: JobMetadata) -> None:
+        self._evictor.prepare_load(job_metadata)
+
         tasks = (
             functools.partial(
                 load_block,
@@ -134,15 +155,31 @@ class FileSystemTierManager(SecondaryTierManager):
             for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
         )
         self._pool.enqueue_load(job_metadata.job_id, len(job_metadata.keys), tasks)
+        self._job_meta[job_metadata.job_id] = job_metadata
+
+    def _complete_job(self, job_id: JobId):
+        job_meta = self._job_meta[job_id]
+        if not job_meta.is_promotion:
+            self._evictor.complete_store(job_meta)
+        else:
+            self._evictor.complete_load(job_meta)
 
     def get_finished_jobs(self) -> Iterable[JobResult]:
         """
         Collect completed jobs from the finished-jobs queue.
         """
-        return (
-            JobResult(job_id=job_id, success=success)
-            for job_id, success in self._pool.get_finished()
-        )
+        results: list[JobResult] = []
+        for job_id, success in self._pool.get_finished():
+            results.append(JobResult(job_id=job_id, success=success))
+            self._complete_job(job_id)
+            # book-keeping
+            self._job_meta.pop(job_id)
+
+        # Drain skipped jobs
+        results.extend(self._skipped_jobs)
+        self._skipped_jobs = []
+
+        return results
 
     def shutdown(self) -> None:
         """


### PR DESCRIPTION
## Purpose
on `main` FileSystemTierManager does not have a eviction logic. This makes it hard to debug and test the FS layer for performance. 

Concretely, with a finite amount of disk space we dont want infinite writes.
Workflow for testing correctness:
 - Run vllm server - the fs offloader should stop future stores if it runs out of the specified size.  
 - Trigger lm-eval to seed the FS
 - Trigger lm-eval multiple times and verify lm-eval scores are the same. 
 
Workflow for perfomance testing:
 - Run vllm server - the fs offloader, when it runs out of the specified size, should trigger delete files to make new space.
 - Run benchmarks or get torch profiles. 
 
 To this effect the PR introduces 2 evictors, 
  - fail_on_full evictor for debug and evals 
  - LRU eviction, with hard deletes for perf testing. 
