### PR TITLE
[Bugfix] Fix CUDA illegal memory access in Marlin MoE c_tmp on SM 12.0a (re-file of #36889)

### DIFF
--- a/csrc/moe/marlin_moe_wna16/ops.cu
+++ b/csrc/moe/marlin_moe_wna16/ops.cu
@@ -429,6 +429,7 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
   cudaDeviceGetAttribute(&max_shared_mem,
                          cudaDevAttrMaxSharedMemoryPerBlockOptin, dev);
   TORCH_CHECK(max_shared_mem > 0);
+  int device_max_shared_mem = max_shared_mem;
 
   int major_capability, minor_capability;
   cudaDeviceGetAttribute(&major_capability, cudaDevAttrComputeCapabilityMajor,
@@ -519,10 +520,10 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
   }
 
   cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                       max_shared_mem);
+                       device_max_shared_mem);
   // avoid ">>>" being formatted to "> > >"
   // clang-format off
-  kernel<<<blocks, num_threads, max_shared_mem, stream>>>(
+  kernel<<<blocks, num_threads, sh_cache_size, stream>>>(
       A_ptr, B_ptr, C_ptr, C_tmp_ptr, bias_ptr, a_s_ptr, b_s_ptr, g_s_ptr, zp_ptr, g_idx_ptr,
       sorted_token_ids_ptr, expert_ids_ptr, num_tokens_past_padded_ptr,
       topk_weights_ptr, top_k, mul_topk_weights, num_groups, prob_m,
@@ -691,9 +692,8 @@ torch::Tensor moe_wna16_marlin_gemm(
   torch::Tensor c_tmp;
   if (use_fp32_reduce && !use_atomic_add) {
     // max num of threadblocks is sms * 4
-    long max_c_tmp_size = min(
-        (long)size_n * sorted_token_ids.size(0),
-        (long)sms * 4 * moe_block_size * MARLIN_NAMESPACE_NAME::max_thread_n);
+    long max_c_tmp_size =
+        (long)sms * 4 * moe_block_size * MARLIN_NAMESPACE_NAME::max_thread_n;
     if (moe_block_size == 8) max_c_tmp_size *= 2;
     c_tmp = torch::empty({max_c_tmp_size}, options_fp32);
   } else {

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -1009,6 +1009,119 @@ def test_fused_marlin_moe(
     torch.testing.assert_close(marlin_output, torch_output, atol=4e-2, rtol=0)
 
 
+@pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
+def test_fused_marlin_moe_cuda_graph():
+    """Test that GPTQ Marlin MoE works correctly with CUDA graphs.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/36811
+    The bug was caused by:
+    1. cudaFuncSetAttribute(MaxDynamicSharedMemorySize) being overwritten
+       by later CUDA graph captures with different blocks_per_sm values.
+    2. Batch-dependent c_tmp buffer sizing via sorted_token_ids.size(0).
+    """
+    torch.cuda.manual_seed(42)
+
+    # Use 64 experts like Qwen3.5-35B-A3B to trigger the bug
+    e, topk = 64, 8
+    n, k = 1024, 1024
+    group_size = 128
+    quant_type = scalar_types.uint4b8
+    dtype = torch.half
+
+    # Batch sizes matching vLLM's CUDA graph capture sizes
+    batch_sizes = [1, 2, 4, 8, 16, 24, 32]
+
+    # Create weights (shared across all batch sizes)
+    w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
+
+    w1_data = MarlinMoEWeightData.make(
+        w=w1,
+        quant_type=quant_type,
+        group_size=group_size,
+        act_order=False,
+    )
+    w2_data = MarlinMoEWeightData.make(
+        w=w2,
+        quant_type=quant_type,
+        group_size=group_size,
+        act_order=False,
+    )
+
+    # Capture a CUDA graph for each batch size
+    graphs = {}
+    static_inputs = {}
+    static_outputs = {}
+
+    for m in batch_sizes:
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+        score = torch.randn((m, e), device="cuda", dtype=dtype)
+        topk_weights, topk_ids, _ = fused_topk(a, score, topk, False)
+
+        # Static input tensors for graph replay
+        a_static = a.clone()
+        topk_weights_static = topk_weights.clone()
+        topk_ids_static = topk_ids.clone()
+
+        stream = torch.cuda.Stream()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(stream), torch.cuda.graph(graph):
+            out = fused_marlin_moe(
+                a_static,
+                w1_data.qweight,
+                w2_data.qweight,
+                None,
+                None,
+                w1_data.scales,
+                w2_data.scales,
+                topk_weights_static,
+                topk_ids_static,
+                global_num_experts=e,
+                quant_type_id=quant_type.id,
+                is_k_full=True,
+            )
+
+        graphs[m] = graph
+        static_inputs[m] = (a_static, topk_weights_static, topk_ids_static)
+        static_outputs[m] = out
+
+    torch.accelerator.synchronize()
+
+    # Replay each graph and compare against eager mode.
+    # The bug manifested when replaying small batch size graphs (e.g., M=1)
+    # after larger batch sizes had overwritten cudaFuncSetAttribute.
+    for m in batch_sizes:
+        a_static, topk_weights_static, topk_ids_static = static_inputs[m]
+
+        # Compute eager reference with the same inputs
+        eager_out = fused_marlin_moe(
+            a_static,
+            w1_data.qweight,
+            w2_data.qweight,
+            None,
+            None,
+            w1_data.scales,
+            w2_data.scales,
+            topk_weights_static,
+            topk_ids_static,
+            global_num_experts=e,
+            quant_type_id=quant_type.id,
+            is_k_full=True,
+        )
+
+        # Replay the captured graph
+        static_outputs[m].zero_()
+        graphs[m].replay()
+        torch.accelerator.synchronize()
+
+        torch.testing.assert_close(
+            static_outputs[m],
+            eager_out,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
 @pytest.mark.usefixtures("default_vllm_config")


### PR DESCRIPTION
## Summary

Re-files [@haosdent's](https://github.com/haosdent) closed-without-merge [`#36889`](https://github.com/vllm-project/vllm/pull/36889) with a new deterministic reproducer on RTX PRO 6000 Blackwell Server Edition (SM 12.0, sm_120a). Both commits preserved with original authorship:

1. `d7ff63ba1` — [Bugfix] Drop `min()` clamp on `c_tmp` FP32 reduce buffer (csrc/moe/marlin_moe_wna16/ops.cu, 10 lines)
2. `d79009de6` — Add regression test (tests/kernels/moe/test_moe.py, 113 lines)

## Why re-filing

The original PR was closed because the author couldn't reproduce the failure on A6000 and DGX Spark. We reproduce it deterministically on RTX PRO 6000 Blackwell Server Edition under the workload class [`#43507`](https://github.com/vllm-project/vllm/issues/43507) + [`jasl/vllm#12`](https://github.com/jasl/vllm/issues/12) documents: AIME-2024 c=4 thinking-mode against `canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP` (W4A16 Marlin MoE + BF16 MTP draft head).

Without this fix, after applying [`#40923`](https://github.com/vllm-project/vllm/pull/40923) (sm_120a native cubins), the Marlin MoE decode path on RTX PRO 6000 produces `CUDA error: an illegal memory access was encountered` in 29/30 concurrent thinking-mode requests under that workload. PR #40923 fixed the JIT-PTX-fallback silent corruption that masked this c_tmp OOB; with native cubins active, the OOB shows up as a hard memory fault.

## Reproducer

Full reproducer documented in [`jasl/vllm#12`](https://github.com/jasl/vllm/issues/12) (open) + [canada-quant findings](https://github.com/canada-quant/dsv4-flash-w4a16-fp8-mtp/blob/main/docs/findings/sm12x_token_corruption_2026_05_24.md). Cross-card control on the same hardware confirms it's a Marlin MoE issue specifically — the NVFP4 sibling (`canada-quant/DeepSeek-V4-Flash-NVFP4-FP8-MTP`, FlashInfer TRTLLM MoE backend) running the same workload on the same box has 0/30 errors / 0/30 corruption.

Workload to reproduce:
```bash
VLLM_TEST_FORCE_FP8_MARLIN=1 vllm serve canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP \
    --tensor-parallel-size 4 \
    --speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
    --kv-cache-dtype fp8 --max-model-len 32768 \
    --trust-remote-code
# Then run AIME-2024 at concurrency=4 with thinking-mode prompts
```

## Risk

- 10-line CUDA change to ops.cu (kernel launch parameter); the test commit adds a CUDA-graphs regression test.
- Applies cleanly to current main (`e19b9b104`) — verified via `git cherry-pick`. No conflicts.
- Companion to [`#40923`](https://github.com/vllm-project/vllm/pull/40923) which enables sm_120a native cubins; this PR addresses the OOB that #40923 unmasks.

## Disclosure

> _Per [`AGENTS.md`](https://github.com/vllm-project/vllm/blob/main/AGENTS.md#accountability): re-filing performed with AI assistance using `git cherry-pick`; both commits preserve @haosdent's authorship. The fix in `40668833b` and test in `c43008f40` are unchanged from the closed PR. The empirical reproducer evidence on RTX PRO 6000 is from live benches on canada-quant artifacts; the human submitter (@pasta-paul / canada-quant) defends every empirical claim._

cc @haosdent @mgoin @tlrmchlsmth @pavanimajety @robertgshaw2-redhat @yewentao256 @zyongye @jasl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)