### PR TITLE
[Kernel] Enable TritonW4A16LinearKernel as CUDA fallback for non-Marlin-aligned W4A16 shapes

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -336,6 +336,7 @@ _POSSIBLE_KERNELS: dict[PlatformEnum, list[type[MPLinearKernel]]] = {
         MarlinLinearKernel,
         ConchLinearKernel,
         ExllamaLinearKernel,
+        TritonW4A16LinearKernel,
     ],
     PlatformEnum.ROCM: [
         TritonW4A16LinearKernel,

--- a/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
@@ -288,8 +288,8 @@ class TritonW4A16LinearKernel(MPLinearKernel):
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
-        if not current_platform.is_rocm():
-            return False, "TritonW4A16LinearKernel only targets ROCm"
+        if not (current_platform.is_rocm() or current_platform.is_cuda()):
+            return False, "TritonW4A16LinearKernel requires CUDA or ROCm"
 
         if c.weight_type not in cls.SUPPORTED_QUANT_TYPES:
             return (


### PR DESCRIPTION
## Purpose

Certain W4A16 compressed-tensors models have linear layer dimensions that are not divisible by Marlin's `GPTQ_MARLIN_MIN_THREAD_K=128` (e.g. `intermediate_size=2112`, `moe_intermediate_size=704`). On Ampere (SM80), all available CUDA W4A16 kernels reject these shapes:

- **CutlassW4A8 / Machete**: require SM90 (Hopper)
- **Marlin**: requires `input_size_per_partition % 128 == 0` — fails for 2112 and 704
- **AllSpark**: only supports `group_size=-1` on Ampere
- **Conch**: only supports `group_size` in `[-1, 128]`
- **Exllama**: only supports `float16` activations (not `bfloat16`)

The existing `TritonW4A16LinearKernel` handles these shapes correctly (only requires `N % 8 == 0`) but was gated to ROCm-only despite being pure Triton with no platform-specific ops.

This PR:
- Relaxes the platform gate in `TritonW4A16LinearKernel.can_implement()` from ROCm-only to CUDA+ROCm
- Adds `TritonW4A16LinearKernel` as the **lowest-priority** entry in the CUDA kernel list

**Zero impact on existing models**: higher-priority kernels (Marlin, Machete, etc.) are selected first. The Triton fallback only activates when all other kernels reject the layer shape.

## Test Plan

- Serve a W4A16 `compressed-tensors` MoE model with `intermediate_size=2112` and `moe_intermediate_size=704` on A100 (SM80)
- Verify that the model loads successfully and the Triton kernel is selected only for non-Marlin-aligned layers
- Verify that existing W4A16 models with Marlin-aligned shapes continue to use `MarlinLinearKernel` (no behavior change)

```bash
python -c "
from vllm import LLM, SamplingParams
from transformers import AutoTokenizer

model_path = '<path-to-w4a16-moe-model>'
tokenizer = AutoTokenizer.from_pretrained(model_path)
llm = LLM(model_path, max_model_len=4096, enforce_eager=True)

messages = [{'role': 'user', 'content': 'What is the capital of Brazil?'}]
prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
out = llm.generate([prompt], SamplingParams(max_tokens=100))
print(out[0].outputs[0].text)
"
```

## Test Result

- **Before**: `ValueError: Failed to find a kernel that can implement the WNA16 linear layer`
- **After**: Model loads and generates correctly using `TritonW4A16LinearKernel` for non-aligned layers

```
Processed prompts: 100%|█████| 1/1 [00:05<00:00, 5.81s/it]
The capital of Brazil is **Brasília**.
```

Full e2e test suite on a W4A16 dense model (31B) with Marlin-aligned shapes confirms no regression — all 29/29 tests pass, and `MarlinLinearKernel` is still selected as expected.