### PR TITLE
[Bugfix][DFlash]allocate the proper number of lookahead slots

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -713,6 +713,9 @@ class Scheduler(SchedulerInterface):
                     and kv_transfer_config.kv_role == "kv_producer"
                     and self.use_eagle
                     and request.num_computed_tokens == 0
+                limit_lookahead_tokens = (
+                    and load_kv_async
+                    and self.use_eagle
                 )
                 effective_lookahead_tokens = (
                     0 if limit_lookahead_tokens else self.num_lookahead_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -707,12 +707,6 @@ class Scheduler(SchedulerInterface):
                 # extra block gets allocated which
                 # creates a mismatch between the number
                 # of local and remote blocks.
-                kv_transfer_config = self.vllm_config.kv_transfer_config
-                limit_lookahead_tokens = (
-                    kv_transfer_config is not None
-                    and kv_transfer_config.kv_role == "kv_producer"
-                    and self.use_eagle
-                    and request.num_computed_tokens == 0
                 limit_lookahead_tokens = (
                     and load_kv_async
                     and self.use_eagle

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -218,6 +218,11 @@ class Scheduler(SchedulerInterface):
                 self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
+            if speculative_config.use_dflash():
+                # DFlash requires an extra lookahead slot since it uses in-fill-style
+                # decoding instead of standard next-token sampling, so it has a query
+                # for the last sampled token plus queries for each draft token.
+                self.num_lookahead_tokens = self.num_spec_tokens + 1
 
         # Create the KV cache manager.
         if hash_block_size is None:
@@ -702,8 +707,15 @@ class Scheduler(SchedulerInterface):
                 # extra block gets allocated which
                 # creates a mismatch between the number
                 # of local and remote blocks.
+                kv_transfer_config = self.vllm_config.kv_transfer_config
+                limit_lookahead_tokens = (
+                    kv_transfer_config is not None
+                    and kv_transfer_config.kv_role == "kv_producer"
+                    and self.use_eagle
+                    and request.num_computed_tokens == 0
+                )
                 effective_lookahead_tokens = (
-                    0 if request.num_computed_tokens == 0 else self.num_lookahead_tokens
+                    0 if limit_lookahead_tokens else self.num_lookahead_tokens
                 )
 
                 # Determine if we need to allocate cross-attention blocks.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -707,10 +707,7 @@ class Scheduler(SchedulerInterface):
                 # extra block gets allocated which
                 # creates a mismatch between the number
                 # of local and remote blocks.
-                limit_lookahead_tokens = (
-                    load_kv_async
-                    and self.use_eagle
-                )
+                limit_lookahead_tokens = load_kv_async and self.use_eagle
                 effective_lookahead_tokens = (
                     0 if limit_lookahead_tokens else self.num_lookahead_tokens
                 )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -708,7 +708,7 @@ class Scheduler(SchedulerInterface):
                 # creates a mismatch between the number
                 # of local and remote blocks.
                 limit_lookahead_tokens = (
-                    and load_kv_async
+                    load_kv_async
                     and self.use_eagle
                 )
                 effective_lookahead_tokens = (


### PR DESCRIPTION
## Purpose

Fixes various crashes when running DFlash, due to lookahead slots not being properly allocated.

- DFlash needs an extra lookahead slot
- [This PR](https://github.com/vllm-project/vllm/pull/22317) seems to override the lookahead slots when scheduling prefills, despite that drafters will still expect those lookahead slots when drafting after the target model prefill. Only prefill workers in P/D disagg don't worry about the lookahead slots, and even then I think they might need them?

## Testing

Need to rerun on top of https://github.com/vllm-project/vllm/pull/42095 instead of https://github.com/vllm-project/vllm/pull/41657. Confirmed that with the latter (plus some extra patches needed for hybrid models -- not needed with 42095) it runs well and outputs are sensible.