### PR TITLE
[BugFix] Fix prefix cache hit stats on kv-allocation failure

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1541,6 +1541,81 @@ def test_kv_connector_unable_to_allocate(use_ec_connector, ec_role):
     assert len(scheduler.waiting) == 0
 
 
+def test_prefix_cache_stats_ignore_unscheduled_allocation_failure():
+    """Do not count prefix-cache lookups until allocation succeeds."""
+
+    block_size = 4
+    num_blocks = 4  # 1 null block + 3 usable blocks.
+    num_tokens = 12
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        block_size=block_size,
+        num_blocks=num_blocks,
+    )
+
+    # Fill the prefix cache with a prompt that occupies all usable blocks.
+    (warmup_req,) = create_requests(
+        num_requests=1,
+        num_tokens=num_tokens,
+        max_tokens=1,
+        block_size=block_size,
+        same_prompt=True,
+    )
+    scheduler.add_request(warmup_req)
+    scheduler.schedule()
+    scheduler.finish_requests(warmup_req.request_id, RequestStatus.FINISHED_ABORTED)
+    assert (
+        scheduler.kv_cache_manager.block_pool.get_num_free_blocks() == num_blocks - 1
+    )
+    # Drain warmup stats so the assertion below only covers the retry scenario.
+    scheduler.make_stats()
+
+    # Both requests have the cached prefix. The first one can touch the cached
+    # blocks and allocate the recomputed tail block. The second one can look up
+    # the same prefix but cannot allocate its tail block, so it must not be
+    # counted in prefix-cache stats yet.
+    requests = create_requests(
+        num_requests=2,
+        num_tokens=num_tokens,
+        max_tokens=1,
+        block_size=block_size,
+        same_prompt=True,
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    assert len(scheduler.running) == 1
+    assert len(scheduler.waiting) == 1
+
+    stats = scheduler.make_stats()
+    assert stats is not None
+    prefix_stats = stats.prefix_cache_stats
+    assert prefix_stats.requests == 1
+    assert prefix_stats.queries == num_tokens
+    # max_cache_hit_length is num_tokens - 1, so only two full blocks hit.
+    assert prefix_stats.hits == num_tokens - block_size
+
+    # Once the first request releases its blocks, the waiting request can be
+    # scheduled and should be counted exactly once in the next stats snapshot.
+    scheduler.finish_requests(
+        requests[0].request_id,
+        RequestStatus.FINISHED_ABORTED,
+    )
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    assert len(scheduler.running) == 1
+    assert len(scheduler.waiting) == 0
+
+    stats = scheduler.make_stats()
+    assert stats is not None
+    prefix_stats = stats.prefix_cache_stats
+    assert prefix_stats.requests == 1
+    assert prefix_stats.queries == num_tokens
+    assert prefix_stats.hits == num_tokens - block_size
+
+
 @pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.parametrize(
     "use_ec_connector, ec_role", [(False, None), (True, "ec_consumer")]

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -223,15 +223,27 @@ class KVCacheManager:
             )
         )
 
-        if self.log_stats:
-            assert self.prefix_cache_stats is not None
-            self.prefix_cache_stats.record(
-                num_tokens=request.num_tokens,
-                num_hits=num_new_computed_tokens,
-                preempted=request.num_preemptions > 0,
-            )
-
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
+
+    def record_prefix_cache_stats(
+        self,
+        request: Request,
+        num_new_computed_tokens: int,
+    ) -> None:
+        """Record prefix cache stats after the request is scheduled.
+        """
+        if (
+            not self.log_stats
+            or not self.enable_caching
+            or request.skip_reading_prefix_cache
+        ):
+            return
+        assert self.prefix_cache_stats is not None
+        self.prefix_cache_stats.record(
+            num_tokens=request.num_tokens,
+            num_hits=num_new_computed_tokens,
+            preempted=request.num_preemptions > 0,
+        )
 
     def allocate_slots(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -739,6 +739,11 @@ class Scheduler(SchedulerInterface):
                         self.encoder_cache_manager.free(request)
                     break
 
+                if request.num_computed_tokens == 0:
+                    self.kv_cache_manager.record_prefix_cache_stats(
+                        request, num_new_local_computed_tokens
+                    )
+
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that
                 # This information is used to determine if a load is


### PR DESCRIPTION



## Purpose
Fix issue #43736

Fix local prefix cache hit-rate stats being over-counted when a request hits the prefix cache but fails KV slot allocation and remains waiting.

Previously, KVCacheManager.get_computed_blocks() recorded prefix cache stats immediately after lookup. If Scheduler.allocate_slots() later failed, the same waiting request could retry in a later scheduling step and be counted again. This PR records local prefix cache stats only after KV slot allocation succeeds.

## Test Plan
It constructs a small KV block pool to verify that a prefix-cache lookup followed by allocation failure is not counted, and that the same request is counted exactly once after it later schedules successfully.

Added case:
test_scheduler.py::test_prefix_cache_stats_ignore_unscheduled_allocation_failure

## Test Result
pytest tests/v1/core/test_scheduler.py -v
Result: 97 passed, 1 failed, 17 warnings.
The only failure is unrelated to this change. test_async_scheduling_pp_allows_rescheduling_with_output_placeholders fails while creating ParallelConfig(pipeline_parallel_size=2) because the environment has only 1 available GPU

## Notice
AI assistance was used for analysis and implementation.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

