### PR TITLE
[Bugfix] [ROCm] [DSV4] Bugfix cutlass import DSV4

### DIFF
--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -16,12 +16,14 @@ from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
     _compress_kv_sparse_attn_cutedsl,
     _fused_kv_compress_norm_rope_insert_indexer_attn,
     _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn,
+    _fused_kv_compress_norm_rope_insert_sparse_attn,
     _fused_kv_compress_norm_rope_insert_sparse_attn_cutedsl,
     _norm_rope_insert_sparse_attn_cutedsl,
 )
 from vllm.models.deepseek_v4.common.ops.fused_indexer_q import MXFP4_BLOCK_SIZE
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.utils.import_utils import has_cutedsl
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -242,13 +244,21 @@ class DeepseekCompressor(nn.Module):
             assert not use_fp4_cache, (
                 "MXFP4 cache is only supported for indexer (head=128)"
             )
-            self._use_cutedsl_sparse_compressor = True
-            self._use_cutedsl_fused_sparse_compressor = self.compress_ratio == 4
-            self._compress_kernel = _compress_kv_sparse_attn_cutedsl
-            self._norm_rope_store_kernel = _norm_rope_insert_sparse_attn_cutedsl
-            self._fused_sparse_kernel = (
-                _fused_kv_compress_norm_rope_insert_sparse_attn_cutedsl
-            )
+            self._use_cutedsl_sparse_compressor = has_cutedsl()
+            if self._use_cutedsl_sparse_compressor:
+                self._use_cutedsl_fused_sparse_compressor = self.compress_ratio == 4
+                self._compress_kernel = _compress_kv_sparse_attn_cutedsl
+                self._norm_rope_store_kernel = _norm_rope_insert_sparse_attn_cutedsl
+                self._fused_sparse_kernel = (
+                    _fused_kv_compress_norm_rope_insert_sparse_attn_cutedsl
+                )
+                self._compressed_kv_buffer = self._get_compressed_kv_buffer(
+                    self.device,
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    self.head_dim,
+                )
+            else:
+                self._fused_kernel = _fused_kv_compress_norm_rope_insert_sparse_attn
             self._quant_block = 64
             self._token_stride = self.nope_head_dim + self.rope_head_dim * 2
             self._scale_dim = self.nope_head_dim // 64 + 1  # 7 real + 1 pad


### PR DESCRIPTION



## Purpose

This is a bugfix for import error `cutlass` not found, introduced in this PR https://github.com/vllm-project/vllm/pull/43584

```
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]     return forward_call(*args, **kwargs)
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]   File "/app/dsv4tilelang/bugfixdsv4-2/vllm/models/deepseek_v4/compressor.py", line 383, in forward
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]     self._compress_kernel(
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]   File "/app/dsv4tilelang/bugfixdsv4-2/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py", line 52, in _compress_kv_sparse_attn_cutedsl
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]     return _get_sparse_attn_cutedsl_impls()[0](*args, **kwargs)
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]   File "/app/dsv4tilelang/bugfixdsv4-2/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py", line 37, in _get_sparse_attn_cutedsl_impls
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]     from .sparse_attn_compress_cutedsl import (
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]   File "/app/dsv4tilelang/bugfixdsv4-2/vllm/models/deepseek_v4/common/ops/sparse_attn_compress_cutedsl.py", line 12, in <module>
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962]     import cutlass
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962] ModuleNotFoundError: No module named 'cutlass'
(Worker_TP0 pid=177406) ERROR 05-27 00:12:09 [multiproc_executor.py:962] 
```

## Test Plan

```
#!/bin/bash

rm -rf /root/.cache/vllm

VLLM_ROCM_USE_AITER=1 \
vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --host localhost \
  --port 8001 \
  --dtype auto \
  --tensor-parallel-size 8 \
  --max-num-seqs 256 \
  --distributed-executor-backend mp \
  --trust-remote-code \
  --gpu-memory-utilization 0.6 \
  --moe-backend triton_unfused \
  --tokenizer-mode deepseek_v4 \
  --reasoning-parser deepseek_v4 \
  --kv-cache-dtype fp8_e4m3 \
  --compilation-config '{"mode":3,"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --speculative_config '{"method":"mtp","num_speculative_tokens":2}'
```

## Test Result

```
local-completions ({'model': 'deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://0.0.0.0:8001/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'max_length': 1048576, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 20, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9500|_  | 0.006|
|     |       |strict-match    |    20|exact_match|_  |0.9507|_  | 0.006|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

