### PR TITLE
[bugifix] handle padding situation of all-gather for router experts return

### DIFF
--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -232,6 +232,35 @@ def test_routed_experts_capturer_dp_modular_local_tokens():
     assert torch.equal(capturer.device_buffer[:3, 0, :], topk)
 
 
+@pytest.mark.parametrize(
+    "dp_rank,expected_slice,expected_count",
+    [
+        (0, slice(0, 5), 5),  # dp_rank=0: tokens 0-4 (first 5 tokens)
+        (1, slice(7, 14), 7),  # dp_rank=1: tokens 7-13 (second block, all 7 valid)
+    ],
+)
+def test_routed_experts_capturer_dp_padded_all_gather(
+    dp_rank, expected_slice, expected_count
+):
+    """n == total_with_padding: padded all-gather path for different DP ranks."""
+    # DP0 has 5 tokens, DP1 has 7 tokens, max_tokens=7.
+    # After padding: DP0 has 7 tokens, DP1 has 7 tokens.
+    # After all-gather: total_with_padding = 7 * 2 = 14.
+    capturer = _capturer_with_buffer(dp_rank=dp_rank, max_tokens=7)
+    num_tokens_dp = torch.tensor([5, 7], dtype=torch.int32)
+    ctx = SimpleNamespace(
+        dp_metadata=SimpleNamespace(num_tokens_across_dp_cpu=num_tokens_dp)
+    )
+    topk = torch.arange(28, dtype=torch.int32).view(14, 2)
+    with patch(f"{_REC_MODULE}.get_forward_context", return_value=ctx):
+        capturer.capture(layer_id=0, topk_ids=topk)
+    want = topk[expected_slice]
+    assert torch.equal(capturer.device_buffer[:expected_count, 0, :], want)
+    # For dp_rank=0, remaining buffer slots should remain -1
+    if dp_rank == 0:
+        assert capturer.device_buffer[5, 0, 0].item() == -1
+
+
 def test_routed_experts_capturer_dp_unexpected_batch_raises():
     """Mismatch between topk batch dim and DP layout: fail fast."""
     capturer = _capturer_with_buffer(dp_rank=0)

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -146,6 +146,15 @@ class RoutedExpertsCapturer:
             total = int(num_tokens_dp.sum().item())
             n = topk_ids.shape[0]
 
+            # Calculate total with padding for all-gather scenario.
+            # When tokens are padded to max_tokens before all-gather across DP group,
+            # the total size becomes max_tokens * dp_size.
+            # Example: DP0 has 5 tokens, DP1 has 7 tokens, max_tokens=7.
+            # After padding: DP0 has 7 tokens, DP1 has 7 tokens.
+            # After all-gather: total_with_padding = 7 * 2 = 14.
+            max_tokens = int(num_tokens_dp.max().item())
+            total_with_padding = max_tokens * len(num_tokens_dp)
+
             if n == total:
                 # Naive dispatch: all DP ranks' tokens concatenated
                 # before routing. This rank owns tokens
@@ -159,6 +168,16 @@ class RoutedExpertsCapturer:
                 # rank's tokens, take the whole tensor.
                 start_loc = 0
                 end_loc = token_num_per_dp
+            elif n == total_with_padding:
+                # Padded all-gather path: tokens are padded to max_tokens before
+                # all-gather across DP group. Each DP rank occupies a contiguous
+                # block of size max_tokens. Extract only the actual tokens for
+                # this rank (skip padding).
+                # Example: dp_rank=0, max_tokens=7, token_num_per_dp=5.
+                # start_loc = 0 * 7 = 0
+                # end_loc = 0 + 5 = 5 (only first 5 tokens are valid)
+                start_loc = self.dp_rank * max_tokens
+                end_loc = start_loc + token_num_per_dp
             elif (
                 self.tp_size > 1
                 and n != token_num_per_dp

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -169,6 +169,11 @@ class RoutedExpertsCapturer:
                 start_loc = 0
                 end_loc = token_num_per_dp
             elif n == total_with_padding:
+                # NOTE(Ronald1995): When all DP ranks have equal token counts,
+                # total == total_with_padding, so the first branch (n == total)
+                # fires instead. This overlap is intentional since both branches
+                # produce equivalent results in that case.
+
                 # Padded all-gather path: tokens are padded to max_tokens before
                 # all-gather across DP group. Each DP rank occupies a contiguous
                 # block of size max_tokens. Extract only the actual tokens for
@@ -176,6 +181,7 @@ class RoutedExpertsCapturer:
                 # Example: dp_rank=0, max_tokens=7, token_num_per_dp=5.
                 # start_loc = 0 * 7 = 0
                 # end_loc = 0 + 5 = 5 (only first 5 tokens are valid)
+
                 start_loc = self.dp_rank * max_tokens
                 end_loc = start_loc + token_num_per_dp
             elif (
@@ -210,8 +216,8 @@ class RoutedExpertsCapturer:
                 raise AssertionError(
                     "RoutedExpertsCapturer: unexpected topk_ids batch "
                     f"dim {n} (expected {total}, {token_num_per_dp}, "
-                    f"or {sp_expected} for dp_rank={self.dp_rank}, "
-                    f"tp_size={self.tp_size})"
+                    f"{total_with_padding}, or {sp_expected} for "
+                    f"dp_rank={self.dp_rank}, tp_size={self.tp_size})"
                 )
 
         # Defensive: model may expose more layers than the capture buffer

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -110,7 +110,7 @@ class RoutedExpertsCapturer:
     def capture(self, layer_id: int, topk_ids: torch.Tensor) -> None:
         """Capture expert routing decisions for a specific layer.
 
-        Under data parallelism, ``topk_ids`` may have three different batch
+        Under data parallelism, ``topk_ids`` may have four different batch
         layouts depending on where the DP combine happens and whether
         Sequence Parallelism (SP) is active for the MoE layer:
           - ``n == total`` (naive dispatch): all DP ranks' tokens are
@@ -119,6 +119,12 @@ class RoutedExpertsCapturer:
           - ``n == token_num_per_dp`` (modular-kernel path): DP combine
             happens inside ``quant_method.apply``; ``select_experts`` only
             ever sees this rank's tokens, so we take the whole tensor.
+          - ``n == total_with_padding`` (padded all-gather path): tokens are
+            padded to max_tokens before all-gather across DP group; each
+            DP rank occupies a contiguous block of size max_tokens, and we
+            extract only the actual tokens for this rank (skip padding).
+            When all DP ranks have equal token counts, ``total == total_with_padding``,
+            so the naive dispatch branch fires instead (equivalent result).
           - ``n == ceil(token_num_per_dp / tp_size)`` (SP + modular-kernel
             path): tokens were split along dim=0 across the TP group by
             ``_sequence_parallel_context``


### PR DESCRIPTION



## Purpose
Add support for padded all-gather in RoutedExpertsCapturer

This change extends the RoutedExpertsCapturer.capture() method to handle 
the scenario where tokens are padded to max_tokens before all-gather across 
the DP group. In this case, the topk_ids tensor has a shape of 
[max_tokens * dp_size, ...] instead of [sum(num_tokens_dp), ...], and each 
DP rank occupies a contiguous block of size max_tokens. This layout occurs in vLLM-Ascend where
Ascend NPU communication primitives require consistent tensor shapes acorss ranks.

The fix adds a new branch to detect this layout (n == total_with_padding) 
and correctly computes the slice range to extract only the actual tokens for 
the current rank, skipping the padding tokens. This ensures that expert 
routing information is captured correctly regardless of whether the MoE layer 
uses naive dispatch (concatenated tokens) or padded all-gather (padded to 
max_tokens).

The change is backward compatible and only affects the new padded all-gather 
path, preserving the existing behavior for naive dispatch and modular-kernel 
paths.
## Test Plan

```python
import os
from time import sleep

from vllm import LLM, EngineArgs, SamplingParams
from vllm.platforms import current_platform
from vllm.utils.argparse_utils import FlexibleArgumentParser
from vllm.utils.network_utils import get_open_port


def create_parser():
    parser = FlexibleArgumentParser(description="Data Parallel Inference")

    # Add all engine args
    EngineArgs.add_cli_args(parser)
    parser.set_defaults(
        model="ibm-research/PowerMoE-3b",
        enable_expert_parallel=True,
    )

    # Add DP-specific args (separate from engine args to avoid conflicts)
    parser.add_argument(
        "--dp-num-nodes",
        type=int,
        default=1,
        help="Total number of nodes for data parallel.",
    )
    parser.add_argument(
        "--dp-node-rank",
        type=int,
        default=0,
        help="Rank of the current node for data parallel.",
    )
    parser.add_argument(
        "--dp-master-addr",
        type=str,
        default="",
        help="Master node IP address for DP coordination.",
    )
    parser.add_argument(
        "--dp-master-port",
        type=int,
        default=0,
        help="Master node port for DP coordination.",
    )
    parser.add_argument(
        "--timeout",
        type=int,
        default=300,
        help="Number of seconds before unresponsive process is killed.",
    )

    return parser


def main(
    dp_size,
    local_dp_rank,
    global_dp_rank,
    dp_master_ip,
    dp_master_port,
    engine_args,
):
    os.environ["VLLM_DP_RANK"] = str(global_dp_rank)
    os.environ["VLLM_DP_RANK_LOCAL"] = str(local_dp_rank)
    os.environ["VLLM_DP_SIZE"] = str(dp_size)
    os.environ["VLLM_DP_MASTER_IP"] = dp_master_ip
    os.environ["VLLM_DP_MASTER_PORT"] = str(dp_master_port)

    # CUDA_VISIBLE_DEVICES for each DP rank is set automatically inside the
    # engine processes.

    # Sample prompts.
    prompts = [
        "Hello, my name is",
        "The president of the United States is",
        "The capital of France is",
        "The future of AI is",
    ] * 100

    # with DP, each rank should process different prompts.
    # usually all the DP ranks process a full dataset,
    # and each rank processes a different part of the dataset.
    floor = len(prompts) // dp_size
    remainder = len(prompts) % dp_size

    # Distribute prompts into even groups.
    def start(rank):
        return rank * floor + min(rank, remainder)

    prompts = prompts[start(global_dp_rank) : start(global_dp_rank + 1)]
    if len(prompts) == 0:
        # if any rank has no prompts to process,
        # we need to set a placeholder prompt
        prompts = ["Placeholder"]
    print(f"DP rank {global_dp_rank} needs to process {len(prompts)} prompts")

    # Create a sampling params object.
    # since we are doing data parallel, every rank can have different
    # sampling params. here we set different max_tokens for different
    # ranks for demonstration.
    sampling_params = SamplingParams(
        temperature=0.8, top_p=0.95, max_tokens=[16, 20][global_dp_rank % 2]
    )

    # Create an LLM.
    llm = LLM(model="Qwen3.5-35B-A3B", enforce_eager=True, enable_return_routed_experts=True,tensor_parallel_size=2)
    outputs = llm.generate(prompts, sampling_params)
    # Print the outputs.
    for i, output in enumerate(outputs):
        if i >= 5:
            # print only 5 outputs
            break
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(
            f"DP rank {global_dp_rank}, Prompt: {prompt!r}, "
            f"Generated text: {generated_text!r}"
        )

    # Give engines time to pause their processing loops before exiting.
    sleep(1)


if __name__ == "__main__":
    parser = create_parser()
    args = vars(parser.parse_args())

    # Extract DP-specific args (pop to remove from engine_args)
    dp_size = 2
    dp_num_nodes = args.pop("dp_num_nodes")
    dp_node_rank = args.pop("dp_node_rank")
    dp_master_addr = args.pop("dp_master_addr")
    dp_master_port = args.pop("dp_master_port")
    timeout = args.pop("timeout")

    # Remaining args are engine args

    if dp_num_nodes == 1:
        dp_master_ip = "127.0.0.1"
        dp_master_port_val = get_open_port()
    else:
        dp_master_ip = dp_master_addr
        dp_master_port_val = dp_master_port

    assert dp_size % dp_num_nodes == 0, "dp_size should be divisible by dp_num_nodes"
    dp_per_node = dp_size // dp_num_nodes

    from multiprocessing import Process

    if current_platform.is_rocm():
        from multiprocessing import set_start_method

        set_start_method("spawn", force=True)

    procs = []
    for local_dp_rank, global_dp_rank in enumerate(
        range(dp_node_rank * dp_per_node, (dp_node_rank + 1) * dp_per_node)
    ):
        proc = Process(
            target=main,
            args=(
                dp_size,
                local_dp_rank,
                global_dp_rank,
                dp_master_ip,
                dp_master_port_val,
                engine_args,
            ),
        )
        proc.start()
        procs.append(proc)
    exit_code = 0
    for proc in procs:
        proc.join(timeout=timeout)
        if proc.exitcode is None:
            print(f"Killing process {proc.pid} that didn't stop within 5 minutes.")
            proc.kill()
            exit_code = 1
        elif proc.exitcode:
            exit_code = proc.exitcode

    exit(exit_code)
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

