### PR TITLE
multi-turn support reasoning mode

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -282,24 +282,28 @@ async def send_request(
                     data = json.loads(chunk)
                     message = data["choices"][0]["message"]
                     assert message["role"] == "assistant"
-                    generated_text += message["content"]
+                    if message.get("reasoning", None):
+                        generated_text += message["reasoning"]
+                    if message.get("content", None):
+                        generated_text += message["content"]
                 else:
                     timestamp: int = time.perf_counter_ns()
                     data = json.loads(chunk)
 
                     # Delta is the new content/text/data
                     delta = data["choices"][0]["delta"]
-                    if delta.get("content", None):
-                        if ttft is None:
-                            # First token
-                            first_token_time = time.perf_counter_ns()
-                            ttft = first_token_time - start_time
-                            first_chunk = delta["content"]
-                        else:
-                            # Decoding phase
-                            chunk_delay.append(timestamp - most_recent_timestamp)
+                    for field in ("reasoning", "content"):
+                        if delta.get(field, None):
+                            if ttft is None:
+                                # First token
+                                first_token_time = time.perf_counter_ns()
+                                ttft = first_token_time - start_time
+                                first_chunk = delta[field]
+                            else:
+                                # Decoding phase
+                                chunk_delay.append(timestamp - most_recent_timestamp)
 
-                        generated_text += delta["content"]
+                            generated_text += delta[field]
 
                     most_recent_timestamp = timestamp
         else:


### PR DESCRIPTION



## Purpose
Fix a issue where the multi-turn benchmark tool does not support reasoning mode. 

## Test Plan
Start a model with argument "--reasoning-parser", then use the multi-turn tool to test. 

## Test Result
without my modification, the output number of tokens / TPOT cannot be correctly counted
```
----------------------------------------------------------------------------------------------------
Parameters:
model=/data/GLM-4.7-w8a8/
num_clients=1
num_conversations=1
active_conversations=1
seed=0
Conversations Generation Parameters:
text_files=pg1184.txt
input_num_turns=Constant[4]
input_common_prefix_num_tokens=Constant[0]
input_prefix_num_tokens=Constant[1024]
input_num_tokens=Constant[1024]
output_num_tokens=Constant[1024]
----------------------------------------------------------------------------------------------------
Statistics summary:
runtime_sec = 44.406
requests_per_sec = 0.045
----------------------------------------------------------------------------------------------------
                   count      mean      std      min       25%       50%       75%      90%       max
ttft_ms              2.0  22195.78  1065.29  21442.5  21819.14  22195.78  22572.41  22798.4  22949.05
tpot_ms              2.0      0.00     0.00      0.0      0.00      0.00      0.00      0.0      0.00
latency_ms           2.0  22195.78  1065.29  21442.5  21819.14  22195.78  22572.41  22798.4  22949.05
input_num_turns      2.0      2.00     1.41      1.0      1.50      2.00      2.50      2.8      3.00
input_num_tokens     2.0   2560.00   722.66   2049.0   2304.50   2560.00   2815.50   2968.8   3071.00
output_num_tokens    2.0      0.00     0.00      0.0      0.00      0.00      0.00      0.0      0.00
output_num_chunks    2.0      0.00     0.00      0.0      0.00      0.00      0.00      0.0      0.00
----------------------------------------------------------------------------------------------------
```

with my modification, the output number of tokens / TPOT could be correctly counted
```
----------------------------------------------------------------------------------------------------
Parameters:
model=/data/GLM-4.7-w8a8/
num_clients=1
num_conversations=1
active_conversations=1
seed=0
Conversations Generation Parameters:
text_files=pg1184.txt
input_num_turns=Constant[4]
input_common_prefix_num_tokens=Constant[0]
input_prefix_num_tokens=Constant[1024]
input_num_tokens=Constant[1024]
output_num_tokens=Constant[1024]
----------------------------------------------------------------------------------------------------
Statistics summary:
runtime_sec = 45.536
requests_per_sec = 0.044
----------------------------------------------------------------------------------------------------
                   count      mean      std       min       25%       50%       75%       90%       max
ttft_ms              2.0    889.09   116.31    806.84    847.97    889.09    930.21    954.88    971.33
tpot_ms              2.0     21.38     0.61     20.95     21.16     21.38     21.59     21.72     21.81
latency_ms           2.0  22759.74   741.15  22235.67  22497.71  22759.74  23021.78  23179.00  23283.82
input_num_turns      2.0      2.00     1.41      1.00      1.50      2.00      2.50      2.80      3.00
input_num_tokens     2.0   3072.00  1446.74   2049.00   2560.50   3072.00   3583.50   3890.40   4095.00
output_num_tokens    2.0   1024.00     0.00   1024.00   1024.00   1024.00   1024.00   1024.00   1024.00
output_num_chunks    2.0    435.00    11.31    427.00    431.00    435.00    439.00    441.40    443.00
----------------------------------------------------------------------------------------------------
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

