### PR TITLE
[Frontend] Improve response_format validation errors for OpenAI-compatible chat/completion APIs

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat_error.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_error.py
@@ -438,6 +438,7 @@ def test_system_message_warns_on_video(video_content):
     assert "video_url" in call_args
 
 
+@pytest.mark.skip_global_cleanup
 def test_json_schema_response_format_missing_schema():
     """When response_format type is 'json_schema' but the json_schema field
     is not provided, request construction should raise a validation error
@@ -489,4 +490,48 @@ def test_structured_outputs_structural_tag_invalid(structural_tag):
             model=MODEL_NAME,
             messages=[{"role": "user", "content": "hello"}],
             structured_outputs={"structural_tag": structural_tag},
+        )
+
+
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        {"type": "text"},
+        {"type": "json_object"},
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "schema": {"type": "object"},
+            },
+        },
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_valid_response_format_is_accepted(response_format):
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "hello"}],
+        response_format=response_format,
+    )
+
+    assert request.response_format is not None
+
+
+@pytest.mark.parametrize(
+    ("response_format", "match"),
+    [
+        ("json", "response_format.*object.*type"),
+        ({}, "response_format.*type"),
+        ({"type": "xml"}, "response_format.type.*one of"),
+        ({"type": "json_schema", "json_schema": "schema"}, "json_schema.*object"),
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_invalid_response_format_is_rejected(response_format, match):
+    with pytest.raises(Exception, match=match):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            response_format=response_format,
         )

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -290,6 +290,7 @@ async def test_completion_error_stream():
     assert chunks[-1] == "data: [DONE]\n\n"
 
 
+@pytest.mark.skip_global_cleanup
 def test_json_schema_response_format_missing_schema():
     """When response_format type is 'json_schema' but the json_schema field
     is not provided, request construction should raise a validation error
@@ -330,6 +331,52 @@ def test_structured_outputs_structural_tag_invalid(structural_tag):
             prompt="Test prompt",
             max_tokens=10,
             structured_outputs={"structural_tag": structural_tag},
+        )
+
+
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        {"type": "text"},
+        {"type": "json_object"},
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "schema": {"type": "object"},
+            },
+        },
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_valid_response_format_is_accepted(response_format):
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=10,
+        response_format=response_format,
+    )
+
+    assert request.response_format is not None
+
+
+@pytest.mark.parametrize(
+    ("response_format", "match"),
+    [
+        ("json", "response_format.*object.*type"),
+        ({}, "response_format.*type"),
+        ({"type": "xml"}, "response_format.type.*one of"),
+        ({"type": "json_schema", "json_schema": "schema"}, "json_schema.*object"),
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_invalid_response_format_is_rejected(response_format, match):
+    with pytest.raises(Exception, match=match):
+        CompletionRequest(
+            model=MODEL_NAME,
+            prompt="Test prompt",
+            max_tokens=10,
+            response_format=response_format,
         )
 
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -30,6 +30,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StructuralTagResponseFormat,
     ToolCall,
     UsageInfo,
+    validate_response_format_param,
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
@@ -650,30 +651,19 @@ class ChatCompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_response_format(cls, data):
-        response_format = data.get("response_format")
-        if response_format is None:
+        if not isinstance(data, dict):
             return data
 
+        response_format = data.get("response_format")
+        validate_response_format_param(response_format)
         rf_type = (
             response_format.get("type")
             if isinstance(response_format, dict)
             else getattr(response_format, "type", None)
         )
 
-        if rf_type == "json_schema":
-            json_schema = (
-                response_format.get("json_schema")
-                if isinstance(response_format, dict)
-                else getattr(response_format, "json_schema", None)
-            )
-            if json_schema is None:
-                raise VLLMValidationError(
-                    "When response_format type is 'json_schema', the "
-                    "'json_schema' field must be provided.",
-                    parameter="response_format",
-                )
-
         if rf_type == "structural_tag":
+            assert response_format is not None
             validate_structural_tag_response_format(response_format)
 
         return data

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -18,6 +18,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StreamOptions,
     StructuralTagResponseFormat,
     UsageInfo,
+    validate_response_format_param,
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
@@ -349,30 +350,19 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_response_format(cls, data):
-        response_format = data.get("response_format")
-        if response_format is None:
+        if not isinstance(data, dict):
             return data
 
+        response_format = data.get("response_format")
+        validate_response_format_param(response_format)
         rf_type = (
             response_format.get("type")
             if isinstance(response_format, dict)
             else getattr(response_format, "type", None)
         )
 
-        if rf_type == "json_schema":
-            json_schema = (
-                response_format.get("json_schema")
-                if isinstance(response_format, dict)
-                else getattr(response_format, "json_schema", None)
-            )
-            if json_schema is None:
-                raise VLLMValidationError(
-                    "When response_format type is 'json_schema', the "
-                    "'json_schema' field must be provided.",
-                    parameter="response_format",
-                )
-
         if rf_type == "structural_tag":
+            assert response_format is not None
             validate_structural_tag_response_format(response_format)
 
         return data

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -158,6 +158,54 @@ AnyResponseFormat: TypeAlias = (
     ResponseFormat | StructuralTagResponseFormat | LegacyStructuralTagResponseFormat
 )
 
+_SUPPORTED_RESPONSE_FORMAT_TYPES = frozenset(
+    ("text", "json_object", "json_schema", "structural_tag")
+)
+
+
+def validate_response_format_param(response_format: Any) -> None:
+    if response_format is None:
+        return
+
+    if isinstance(response_format, dict):
+        rf_type = response_format.get("type")
+        json_schema = response_format.get("json_schema")
+    else:
+        rf_type = getattr(response_format, "type", None)
+        json_schema = getattr(response_format, "json_schema", None)
+        if rf_type is None:
+            raise VLLMValidationError(
+                "response_format must be an object with a 'type' field.",
+                parameter="response_format",
+            )
+
+    if rf_type is None:
+        raise VLLMValidationError(
+            "response_format must include a 'type' field.",
+            parameter="response_format",
+        )
+
+    if rf_type not in _SUPPORTED_RESPONSE_FORMAT_TYPES:
+        raise VLLMValidationError(
+            "response_format.type must be one of: 'text', 'json_object', "
+            "'json_schema', or 'structural_tag'.",
+            parameter="response_format",
+        )
+
+    if rf_type == "json_schema":
+        if json_schema is None:
+            raise VLLMValidationError(
+                "When response_format type is 'json_schema', the "
+                "'json_schema' field must be provided.",
+                parameter="response_format",
+            )
+        if not isinstance(json_schema, (dict, JsonSchemaResponseFormat)):
+            raise VLLMValidationError(
+                "When response_format type is 'json_schema', the "
+                "'json_schema' field must be an object.",
+                parameter="response_format",
+            )
+
 
 def validate_structural_tag_response_format(
     response_format: AnyStructuralTagResponseFormat | dict[str, Any],


### PR DESCRIPTION
## Summary
This PR improves validation for invalid OpenAI-compatible `response_format` values in chat and completion requests.

Previously, chat/completion only prevalidated the missing `json_schema` case for `type="json_schema"`. Other invalid shapes, such as non-object `response_format`, missing `type`, unsupported `type`, or non-object `json_schema`, were left to later Pydantic union validation and produced less focused errors.

This PR adds shared early validation so these invalid request shapes fail deterministically with `VLLMValidationError(parameter="response_format")`, which is mapped by the OpenAI server path to HTTP 400.

## Changes
- Added shared `response_format` validation helper.
- Reused the helper in chat and completion request validation.
- Added focused tests for valid and invalid `response_format` cases.
- Preserved existing valid behavior, including existing `structural_tag` handling.

## Tests
```bash
git diff --check
python -m compileall -q vllm/entrypoints/openai tests/entrypoints/openai
pre-commit run --files \
  vllm/entrypoints/openai/engine/protocol.py \
  vllm/entrypoints/openai/chat_completion/protocol.py \
  vllm/entrypoints/openai/completion/protocol.py \
  tests/entrypoints/openai/chat_completion/test_chat_error.py \
  tests/entrypoints/openai/completion/test_completion_error.py
pytest \
  tests/entrypoints/openai/chat_completion/test_chat_error.py::test_valid_response_format_is_accepted \
  tests/entrypoints/openai/chat_completion/test_chat_error.py::test_invalid_response_format_is_rejected \
  tests/entrypoints/openai/chat_completion/test_chat_error.py::test_json_schema_response_format_missing_schema \
  tests/entrypoints/openai/completion/test_completion_error.py::test_valid_response_format_is_accepted \
  tests/entrypoints/openai/completion/test_completion_error.py::test_invalid_response_format_is_rejected \
  tests/entrypoints/openai/completion/test_completion_error.py::test_json_schema_response_format_missing_schema
```

Result:

```text
pre-commit: passed
pytest: 16 passed, 1 warning in 0.05s
```

## AI-assisted contribution
This PR was prepared with assistance from OpenAI Codex. I manually reviewed the changed code, validated the behavior contract, and ran the relevant tests listed above.