### PR TITLE
Fix: Prevent Runtime Crashes in MiniCPM-V/O Multimodal Inference on CUDA and XPU

### DIFF
--- a/tests/model_executor/layers/test_minicpmv_resampler.py
+++ b/tests/model_executor/layers/test_minicpmv_resampler.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.models.minicpmv import Resampler2_5, Resampler4_5
+
+
+@pytest.mark.parametrize("resampler_cls", [Resampler2_5, Resampler4_5])
+def test_minicpmv_resampler_device(resampler_cls):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    num_queries = 8
+    embed_dim = 16
+    num_heads = 2
+    resampler = resampler_cls(
+        num_queries=num_queries,
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+    ).to(device)
+
+    bs = 2
+    h, w = 10, 10
+    x = torch.randn((bs, h * w, embed_dim), device=device)
+    tgt_sizes = torch.tensor([[h, w], [h, w]], device=device)
+
+    if resampler_cls is Resampler4_5:
+        temporal_ids = [[-1], [-1]]
+        out = resampler(x, tgt_sizes, temporal_ids=temporal_ids)
+    else:
+        out = resampler(x, tgt_sizes)
+
+    # Verify output shape and device
+    assert out.device == x.device
+    assert out.shape == (bs, num_queries, embed_dim)
+
+    # Verify that buffers are on the target device
+    assert resampler.pos_embed.device == x.device
+    if resampler_cls is Resampler4_5:
+        assert resampler.temporal_pos_embed.device == x.device

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -217,7 +217,9 @@ class Resampler2_5(BaseResampler):
         for i in range(bs):
             tgt_h, tgt_w = tgt_sizes[i].tolist()
             pos_embed.append(
-                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
+                self.pos_embed[:tgt_h, :tgt_w, :]
+                .reshape((tgt_h * tgt_w, -1))
+                .to(device=device, dtype=dtype)
             )  # patches * D
             key_padding_mask[i, patch_len[i] :] = True
         pos_embed = torch.nn.utils.rnn.pad_sequence(
@@ -374,7 +376,9 @@ class Resampler4_5(Resampler2_5):
                     )
                 else:
                     pos_embed_temporal.append(
-                        self.temporal_pos_embed[temporal_ids_flatten[i]].to(dtype)
+                        self.temporal_pos_embed[temporal_ids_flatten[i]].to(
+                            device=device, dtype=dtype
+                        )
                     )  # D
 
             pos_embed_2d.append(


### PR DESCRIPTION


## Purpose

Trigger Scenario:
  Running MiniCPM-V (2.5/2.6/4.0) or MiniCPM-O (4.5) image/video inference on non-CPU devices (CUDA/XPU) when positional embedding buffers stay on CPU.

  Symptom:
  PyTorch runtime error:  Expected all tensors to be on the same device . Inference fails.

  Expected Behavior:
  Resampler performs tensor operations on same device, executing image/video inference successfully.

  Root Cause:
  Positional embedding buffers registered with  persistent=False  remain on CPU. Original code converted only tensor data type ( .to(dtype) ) without  specifying target device, leading to device mismatch (CPU vs CUDA/XPU) during tensor addition.



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

