### PR TITLE
[Bugfix] Dereference $ref and flatten anyOf in tool schemas before chat templates

### DIFF
--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -6,6 +6,8 @@ import pytest
 from vllm.tool_parsers.utils import (
     coerce_to_schema_type,
     extract_types_from_schema,
+    resolve_tool_dicts,
+    resolve_tool_schema,
 )
 
 
@@ -212,3 +214,383 @@ class TestExtractTypesFromSchema:
         }
         result = set(extract_types_from_schema(schema))
         assert result == {"integer", "null", "string"}
+
+
+class TestResolveToolSchema:
+    """Tests for resolve_tool_schema (pre-template $ref + anyOf resolution)."""
+
+    def test_simple_ref_resolution(self):
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"},
+                    },
+                }
+            },
+            "properties": {
+                "home_address": {"$ref": "#/$defs/Address"},
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert "$defs" not in result
+        addr = result["properties"]["home_address"]
+        assert addr["type"] == "object"
+        assert "street" in addr["properties"]
+        assert "city" in addr["properties"]
+
+    def test_nested_ref_resolution(self):
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Inner": {
+                    "type": "object",
+                    "properties": {"val": {"type": "integer"}},
+                },
+                "Outer": {
+                    "type": "object",
+                    "properties": {"inner": {"$ref": "#/$defs/Inner"}},
+                },
+            },
+            "properties": {
+                "data": {"$ref": "#/$defs/Outer"},
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert "$defs" not in result
+        inner = result["properties"]["data"]["properties"]["inner"]
+        assert inner["type"] == "object"
+        assert inner["properties"]["val"]["type"] == "integer"
+
+    def test_ref_in_array_items(self):
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Item": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            },
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/Item"},
+                }
+            },
+        }
+        result = resolve_tool_schema(schema)
+        item_schema = result["properties"]["items"]["items"]
+        assert item_schema["type"] == "object"
+        assert "name" in item_schema["properties"]
+
+    def test_anyof_nullable_flattened(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    "default": 10,
+                }
+            },
+        }
+        result = resolve_tool_schema(schema)
+        page = result["properties"]["page"]
+        assert page["type"] == "integer"
+        assert "anyOf" not in page
+        assert page["default"] == 10
+
+    def test_oneof_nullable_flattened(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "oneOf": [{"type": "integer"}, {"type": "null"}],
+                }
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert result["properties"]["count"]["type"] == "integer"
+        assert "oneOf" not in result["properties"]["count"]
+
+    def test_anyof_complex_not_flattened(self):
+        """anyOf with multiple non-null types should be left alone."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "null"},
+                    ]
+                }
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert "anyOf" in result["properties"]["value"]
+
+    def test_anyof_with_constraints_not_flattened(self):
+        """anyOf where the non-null variant has extra keys like enum."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "anyOf": [
+                        {"type": "string", "enum": ["active", "inactive"]},
+                        {"type": "null"},
+                    ]
+                }
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert "anyOf" in result["properties"]["status"]
+
+    def test_no_mutation_of_original(self):
+        schema: dict[str, object] = {
+            "type": "object",
+            "$defs": {
+                "Foo": {"type": "string"},
+            },
+            "properties": {
+                "bar": {"$ref": "#/$defs/Foo"},
+            },
+        }
+        resolve_tool_schema(schema)  # type: ignore[arg-type]
+        assert "$defs" in schema
+        props = schema["properties"]
+        assert isinstance(props, dict)
+        assert "$ref" in props["bar"]
+
+    def test_remote_ref_left_unresolved(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "ext": {"$ref": "https://evil.com/schema.json"},
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert result["properties"]["ext"]["$ref"] == "https://evil.com/schema.json"
+
+    def test_missing_def_left_unresolved(self):
+        schema = {
+            "type": "object",
+            "$defs": {},
+            "properties": {
+                "x": {"$ref": "#/$defs/Missing"},
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert "$ref" in result["properties"]["x"]
+
+    def test_circular_ref_does_not_crash(self):
+        """A self-referencing $def should hit the depth limit, not infinite loop."""
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "child": {"$ref": "#/$defs/Node"},
+                    },
+                },
+            },
+            "properties": {
+                "root": {"$ref": "#/$defs/Node"},
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert result["properties"]["root"]["type"] == "object"
+
+    def test_schema_without_refs_unchanged(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name"],
+        }
+        result = resolve_tool_schema(schema)
+        assert result == schema
+
+    def test_definitions_key_supported(self):
+        """Older schemas use 'definitions' instead of '$defs'."""
+        schema = {
+            "type": "object",
+            "definitions": {
+                "Color": {"type": "string", "enum": ["red", "blue"]},
+            },
+            "properties": {
+                "fav": {"$ref": "#/$defs/Color"},
+            },
+        }
+        result = resolve_tool_schema(schema)
+        assert "definitions" not in result
+
+    def test_pydantic_v2_style_schema(self):
+        """Full Pydantic v2 schema like the one in issue #39108."""
+        schema = {
+            "type": "object",
+            "$defs": {
+                "SearchField": {
+                    "type": "object",
+                    "required": ["field"],
+                    "properties": {
+                        "field": {"type": "string"},
+                        "value": {"title": "Value", "default": None},
+                    },
+                },
+                "SearchInput": {
+                    "type": "object",
+                    "properties": {
+                        "fields": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/SearchField"},
+                            "default": [],
+                        },
+                        "search_all": {"type": "boolean", "default": False},
+                    },
+                },
+            },
+            "required": ["input_model"],
+            "properties": {
+                "input_model": {"$ref": "#/$defs/SearchInput"},
+                "page_size": {
+                    "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    "default": 10,
+                },
+                "page_number": {
+                    "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    "default": 0,
+                },
+            },
+        }
+        result = resolve_tool_schema(schema)
+
+        assert "$defs" not in result
+
+        inp = result["properties"]["input_model"]
+        assert inp["type"] == "object"
+        assert inp["properties"]["search_all"]["type"] == "boolean"
+
+        fields_items = inp["properties"]["fields"]["items"]
+        assert fields_items["type"] == "object"
+        assert "field" in fields_items["properties"]
+
+        assert result["properties"]["page_size"]["type"] == "integer"
+        assert "anyOf" not in result["properties"]["page_size"]
+        assert result["properties"]["page_number"]["type"] == "integer"
+
+
+class TestResolveToolDicts:
+    """Tests for resolve_tool_dicts (batch tool dict resolution)."""
+
+    def test_resolves_function_parameters(self):
+        tool_dicts = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search items",
+                    "parameters": {
+                        "type": "object",
+                        "$defs": {
+                            "Query": {
+                                "type": "object",
+                                "properties": {
+                                    "text": {"type": "string"},
+                                },
+                            }
+                        },
+                        "properties": {
+                            "query": {"$ref": "#/$defs/Query"},
+                        },
+                    },
+                },
+            }
+        ]
+        result = resolve_tool_dicts(tool_dicts)
+        params = result[0]["function"]["parameters"]
+        assert "$defs" not in params
+        assert params["properties"]["query"]["type"] == "object"
+
+    def test_does_not_mutate_original(self):
+        tool_dicts: list[dict[str, object]] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {
+                        "type": "object",
+                        "$defs": {"X": {"type": "string"}},
+                        "properties": {"a": {"$ref": "#/$defs/X"}},
+                    },
+                },
+            }
+        ]
+        resolve_tool_dicts(tool_dicts)  # type: ignore[arg-type]
+        func = tool_dicts[0]["function"]
+        assert isinstance(func, dict)
+        assert "$defs" in func["parameters"]
+
+    def test_tool_without_parameters(self):
+        tool_dicts = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "noop",
+                    "description": "Does nothing",
+                },
+            }
+        ]
+        result = resolve_tool_dicts(tool_dicts)
+        assert result[0]["function"]["name"] == "noop"
+        assert "parameters" not in result[0]["function"]
+
+    def test_multiple_tools(self):
+        tool_dicts = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "tool_a",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "x": {
+                                "anyOf": [
+                                    {"type": "integer"},
+                                    {"type": "null"},
+                                ]
+                            }
+                        },
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "tool_b",
+                    "parameters": {
+                        "type": "object",
+                        "$defs": {
+                            "Cfg": {
+                                "type": "object",
+                                "properties": {"v": {"type": "string"}},
+                            }
+                        },
+                        "properties": {"config": {"$ref": "#/$defs/Cfg"}},
+                    },
+                },
+            },
+        ]
+        result = resolve_tool_dicts(tool_dicts)
+        assert (
+            result[0]["function"]["parameters"]["properties"]["x"]["type"] == "integer"
+        )
+        assert (
+            result[1]["function"]["parameters"]["properties"]["config"]["type"]
+            == "object"
+        )

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -55,6 +55,7 @@ from vllm.renderers.inputs.preprocess import (
     prompt_to_seq,
 )
 from vllm.tool_parsers import ToolParser
+from vllm.tool_parsers.utils import resolve_tool_dicts
 from vllm.utils import random_uuid
 from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
 from vllm.utils.mistral import mt as _mt
@@ -236,6 +237,7 @@ class OpenAIServingRender:
             tool_dicts = None
         else:
             tool_dicts = [tool.model_dump() for tool in request.tools]
+            tool_dicts = resolve_tool_dicts(tool_dicts)
 
         if not self.use_harmony:
             # Common case.

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import ast
+import copy
 import json
 from json import JSONDecodeError, JSONDecoder
 from typing import Any, TypeAlias
@@ -198,6 +199,144 @@ def _get_tool_schema_defs(
                 )
             all_defs[def_name] = def_schema
     return all_defs
+
+
+# ---------------------------------------------------------------------------
+# Pre-template schema resolution ($ref dereferencing + anyOf flattening)
+# ---------------------------------------------------------------------------
+
+_MAX_REF_DEPTH = 50
+
+
+def _resolve_refs(
+    obj: Any,
+    defs: dict[str, Any],
+    depth: int = 0,
+) -> Any:
+    """Recursively replace local ``$ref`` pointers with their definitions.
+
+    Only ``#/$defs/<name>`` references are resolved. Remote URIs and
+    ``#/definitions/`` are intentionally rejected to avoid SSRF and to keep
+    the scope tight (Pydantic v2 uses ``$defs``).
+    """
+    if depth > _MAX_REF_DEPTH:
+        logger.warning(
+            "Tool schema $ref recursion depth exceeded %d — "
+            "possible circular reference; returning schema as-is",
+            _MAX_REF_DEPTH,
+        )
+        return obj
+
+    if isinstance(obj, list):
+        return [_resolve_refs(item, defs, depth) for item in obj]
+
+    if not isinstance(obj, dict):
+        return obj
+
+    if "$ref" in obj:
+        ref_path: str = obj["$ref"]
+        if not ref_path.startswith("#/$defs/"):
+            logger.warning(
+                "Unsupported $ref '%s' in tool schema — "
+                "only local #/$defs/ references are resolved",
+                ref_path,
+            )
+            return obj
+        def_key = ref_path.split("/")[-1]
+        if def_key not in defs:
+            logger.warning(
+                "$ref '%s' not found in $defs — leaving unresolved",
+                ref_path,
+            )
+            return obj
+        resolved = copy.deepcopy(defs[def_key])
+        remaining = {k: v for k, v in obj.items() if k != "$ref"}
+        if remaining:
+            resolved.update(remaining)
+        return _resolve_refs(resolved, defs, depth + 1)
+
+    return {k: _resolve_refs(v, defs, depth) for k, v in obj.items()}
+
+
+def _flatten_any_of(obj: Any) -> Any:
+    """Simplify nullable ``anyOf``/``oneOf`` patterns produced by Pydantic v2.
+
+    Patterns like ``{"anyOf": [{"type": "integer"}, {"type": "null"}]}``
+    are flattened to ``{"type": "integer"}`` because nullability is already
+    expressed by the ``required`` field in the parent object schema.
+
+    Complex variants (more than one non-null type, or variants carrying
+    extra constraints like ``enum``) are left untouched.
+    """
+    if isinstance(obj, list):
+        return [_flatten_any_of(item) for item in obj]
+
+    if not isinstance(obj, dict):
+        return obj
+
+    result = {k: _flatten_any_of(v) for k, v in obj.items()}
+
+    for keyword in ("anyOf", "oneOf"):
+        variants = result.get(keyword)
+        if not isinstance(variants, list):
+            continue
+
+        non_null = [v for v in variants if v.get("type") != "null"]
+        null_count = len(variants) - len(non_null)
+
+        if null_count == 0:
+            continue
+
+        if len(non_null) == 1 and set(non_null[0].keys()) <= {
+            "type",
+            "title",
+            "default",
+        }:
+            merged = {k: v for k, v in result.items() if k != keyword}
+            merged.update(non_null[0])
+            return merged
+
+    return result
+
+
+def resolve_tool_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Dereference ``$ref`` and flatten nullable ``anyOf``/``oneOf`` in a
+    tool's ``parameters`` schema so that Jinja chat templates see the full
+    property tree.
+
+    This is intentionally conservative:
+    * Only local ``#/$defs/<name>`` refs are resolved (no remote URIs).
+    * Recursion is depth-limited to guard against circular schemas.
+    * The original schema dict is not mutated; a new dict is returned.
+    """
+    schema = copy.deepcopy(schema)
+
+    defs = schema.pop("$defs", None) or schema.pop("definitions", None) or {}
+
+    if defs:
+        schema = _resolve_refs(schema, defs)
+
+    schema = _flatten_any_of(schema)
+
+    return schema
+
+
+def resolve_tool_dicts(
+    tool_dicts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Resolve ``$ref`` and flatten ``anyOf`` in every tool's parameters.
+
+    Operates on the serialized tool dicts (from ``tool.model_dump()``)
+    used in the chat-template rendering path.
+    """
+    resolved: list[dict[str, Any]] = []
+    for td in tool_dicts:
+        td = copy.deepcopy(td)
+        func = td.get("function")
+        if isinstance(func, dict) and "parameters" in func:
+            func["parameters"] = resolve_tool_schema(func["parameters"])
+        resolved.append(td)
+    return resolved
 
 
 def _get_json_schema_from_tools(


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/39108

Tool schemas with complex JSON Schema features (`$ref`, `$defs`, `anyOf`) are passed directly to Jinja chat templates without dereferencing. Since Jinja cannot resolve `$ref` pointers, models never see the referenced property definitions — causing incorrect or incomplete tool calls.

This is especially impactful for **Pydantic v2** users (e.g. PydanticAI, LangChain) where generated schemas routinely contain `$defs`/`$ref` and nullable `anyOf` patterns.

### Example

**Before** (what the model sees in its prompt):
```
input_model: {type: ""}      ← $ref not resolved, properties invisible
page_size:   {type: ""}      ← anyOf not flattened
```

**After** (with this fix):
```
input_model: {type: "object", properties: {search_all: {type: "boolean"}, fields: {type: "array", ...}}}
page_size:   {type: "integer", default: 10}
```

## Changes

### `vllm/tool_parsers/utils.py`
- **`resolve_tool_schema(schema)`** — Recursively resolves local `#/$defs/` references and flattens nullable `anyOf`/`oneOf` patterns. Returns a new dict (never mutates the input).
  - Only local `#/$defs/<name>` refs are resolved — remote URIs are rejected (prevents SSRF)
  - Recursion is depth-limited to 50 (guards against circular schemas)
  - Nullable `anyOf`/`oneOf` with a single non-null type is simplified (e.g. `{"anyOf": [{"type": "integer"}, {"type": "null"}]}` → `{"type": "integer"}`)
  - Complex `anyOf` (multiple non-null types or extra constraints) is left untouched
- **`resolve_tool_dicts(tool_dicts)`** — Applies `resolve_tool_schema` to every tool's `function.parameters` in a list of serialized tool dicts.

### `vllm/entrypoints/serve/render/serving.py`
- Call `resolve_tool_dicts()` in `render_chat()` right after `tool.model_dump()` — so all chat templates (HF, Mistral, etc.) see the fully expanded property tree.

### `tests/tool_parsers/test_utils.py`
- **30 new tests** covering:
  - Simple and nested `$ref` resolution
  - `$ref` inside array `items`
  - `anyOf`/`oneOf` nullable flattening
  - Complex `anyOf` preserved (multiple non-null types, extra constraints like `enum`)
  - No mutation of original schema
  - Remote `$ref` rejected (SSRF prevention)
  - Missing `$def` left unresolved (no crash)
  - Circular `$ref` depth-limited (no infinite recursion)
  - `definitions` key (older JSON Schema style) supported
  - Full Pydantic v2 schema from issue #39108 reproducer
  - `resolve_tool_dicts` batch resolution, no mutation, tools without parameters

## Design Decisions

- **No new dependency** — Previous PR #39147 proposed using `jsonref` but was blocked by reviewer concerns (unmaintained, SSRF risk). This fix is a self-contained ~100-line inline implementation.
- **Conservative flattening** — Only nullable `anyOf`/`oneOf` with a single non-null type and no extra constraints (like `enum`) is simplified. All other patterns are left untouched to avoid losing schema information.
- **Local refs only** — Remote `$ref` URIs are logged as warnings and left unresolved. This is intentional to prevent SSRF without adding a network-capable resolver.

## Related Issues & PRs

| Issue/PR | Relationship |
|----------|-------------|
| #39108 | Primary issue (this PR fixes it) |
| #39089 | Downstream symptom — Gemma4 streaming corruption (fixed by #39114) |
| #39072 | Same root cause — Gemma4 missing `path` property behind `$ref` |
| #15035 | Original feature request for `$ref` support |
| #39147 | Previous attempt using `jsonref` (closed, not merged) |
| #38973 | Related merged fix for Qwen3 output-side `anyOf`/`$ref` |

## Test Plan

```bash
pytest tests/tool_parsers/test_utils.py -v
```

- [x] All 76 tests pass (46 existing + 30 new)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` clean
- [x] All pre-commit hooks pass