### PR TITLE
[Bugfix] Fix custom compiler backend resolution

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -8,6 +8,8 @@ import pytest
 import torch
 from pydantic import ValidationError
 
+from vllm.compilation.backends import make_compiler
+from vllm.compilation.compiler_interface import CompilerInterface
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.passes.utility.fix_functionalization import (
     FixFunctionalizationPass,
@@ -32,6 +34,10 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from . import silly_attention  # noqa: F401
 
 DEVICE_TYPE = current_platform.device_type
+
+
+class CustomBackendForTest(CompilerInterface):
+    name = "custom_backend_for_test"
 
 
 def test_version():
@@ -86,6 +92,17 @@ def test_custom_op():
 
     with pytest.raises(ValueError, match="Invalid syntax '"):
         _ = CompilationConfig(custom_ops=["quant_fp8"])
+
+
+def test_custom_backend_uses_config_backend_instead_of_platform_default():
+    backend = f"{__name__}.CustomBackendForTest"
+    config = CompilationConfig(backend=backend)
+    config.mode = CompilationMode.VLLM_COMPILE
+
+    with patch.object(current_platform, "get_compile_backend", return_value="inductor"):
+        compiler = make_compiler(config)
+
+    assert isinstance(compiler, CustomBackendForTest)
 
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -116,7 +116,7 @@ def make_compiler(compilation_config: CompilationConfig) -> CompilerInterface:
         return EagerAdaptor()
     else:
         logger.debug("Using custom backend: %s", compilation_config.backend)
-        compiler = resolve_obj_by_qualname(current_platform.get_compile_backend())()
+        compiler = resolve_obj_by_qualname(compilation_config.backend)()
         assert isinstance(compiler, CompilerInterface)
         return compiler
 


### PR DESCRIPTION
Fixes #35084.

Summary:
- Resolve custom vLLM compiler backends from `CompilationConfig.backend` instead of the platform default backend.
- Add a regression test where the platform default is `inductor` but the config asks for a custom `CompilerInterface` implementation.
- Checked for duplicate open PRs by issue number and custom-backend keywords; none matched this fix.

Tests:
- `.venv/bin/python -m pytest tests/compile/test_config.py::test_custom_backend_uses_config_backend_instead_of_platform_default tests/engine/test_arg_utils.py::test_compilation_config -q`
- `uvx ruff==0.15.12 check vllm/compilation/backends.py tests/compile/test_config.py`
- `uvx ruff==0.15.12 format --check vllm/compilation/backends.py tests/compile/test_config.py`
- `git diff --check`

Prepared with AI assistance.