### PR TITLE
[XPU][CPU] fix import error when invoke quant path

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -59,7 +59,6 @@ from vllm.models.deepseek_v4.attention import (
     DeepseekV4MLAModules,
     DeepseekV4MultiHeadLatentAttentionWrapper,
 )
-from vllm.models.deepseek_v4.nvidia.ops import prepare_megamoe_inputs
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -378,6 +377,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         fast_math: bool,
     ) -> None:
         import vllm.third_party.deep_gemm as deep_gemm
+        from vllm.models.deepseek_v4.nvidia.ops import prepare_megamoe_inputs
 
         symm_buffer = self.get_symm_buffer()
         num_tokens = hidden_states.shape[0]


### PR DESCRIPTION



## Purpose
https://github.com/vllm-project/vllm/pull/43710 add dequant_gather_k_cutedsl.py which will `import cutlass` when invoke quant path
this pr make related op lazy import to avoid such issue.

error log on XPU, see https://buildkite.com/vllm/intel-ci/builds/3377#019e6827-eca8-4c7f-9ba1-b50f2cd68bca:

```

2026-05-27 15:03:26 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- | --
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 2224, in create_engine_config
  | 2026-05-27 15:03:26 | config = VllmConfig(
  | 2026-05-27 15:03:26 | ^^^^^^^^^^^
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
  | 2026-05-27 15:03:26 | s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/config/vllm.py", line 882, in __post_init__
  | 2026-05-27 15:03:26 | self.quant_config = VllmConfig._get_quantization_config(
  | 2026-05-27 15:03:26 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/config/vllm.py", line 589, in _get_quantization_config
  | 2026-05-27 15:03:26 | quant_config = get_quant_config(model_config, load_config)
  | 2026-05-27 15:03:26 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/model_loader/weight_utils.py", line 268, in get_quant_config
  | 2026-05-27 15:03:26 | quant_cls = get_quantization_config(model_config.quantization)
  | 2026-05-27 15:03:26 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/__init__.py", line 116, in get_quantization_config
  | 2026-05-27 15:03:26 | from vllm.models.deepseek_v4 import DeepseekV4FP8Config
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/__init__.py", line 20, in <module>
  | 2026-05-27 15:03:26 | from .nvidia.model import DeepseekV4ForCausalLM
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/model.py", line 62, in <module>
  | 2026-05-27 15:03:26 | from vllm.models.deepseek_v4.nvidia.ops import prepare_megamoe_inputs
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/ops/__init__.py", line 10, in <module>
  | 2026-05-27 15:03:26 | from .dequant_gather_k_cutedsl import dequantize_and_gather_k_cache_cutedsl
  | 2026-05-27 15:03:26 | File "/opt/venv/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/ops/dequant_gather_k_cutedsl.py", line 6, in <module>
  | 2026-05-27 15:03:26 | import cutlass
  | 2026-05-27 15:03:26 | ModuleNotFoundError: No module named 'cutlass'
``` 

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

