### PR TITLE
[Frontend] Add Rust frontend router extension hook

### DIFF
--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -12,6 +12,7 @@ mod utils;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::{Context as _, Result};
+use axum::Router;
 use axum::serve::ListenerExt as _;
 pub use config::{Config, CoordinatorMode, HttpListenerMode};
 use tokio::net::TcpListener;
@@ -28,7 +29,7 @@ use vllm_llm::Llm;
 use vllm_text::TextLlm;
 
 use crate::listener::Listener;
-use crate::routes::build_router;
+use crate::routes::build_router_with_extension;
 use crate::state::AppState;
 
 /// Build the shared application state for one configured model and one engine
@@ -95,6 +96,35 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
 /// The server owns one `vllm-chat` facade, which in turn owns the lower
 /// `vllm-text` and `vllm-llm` layers, and shuts them down before returning.
 pub async fn serve(config: Config, shutdown: CancellationToken) -> Result<()> {
+    serve_with_router_extension(config, shutdown, std::convert::identity).await
+}
+
+/// Run the OpenAI-compatible HTTP server with additional same-port routes.
+///
+/// The supplied router is merged into the finalized vLLM router after the
+/// built-in routes, middleware, and state have been configured. This is intended
+/// for endpoint composition; it does not expose the internal [`AppState`].
+pub async fn serve_with_routes(
+    config: Config,
+    shutdown: CancellationToken,
+    extra_routes: Router,
+) -> Result<()> {
+    serve_with_router_extension(config, shutdown, move |router| router.merge(extra_routes)).await
+}
+
+/// Run the OpenAI-compatible HTTP server with a router extension hook.
+///
+/// The extension receives the finalized vLLM router and may merge additional
+/// routes or apply downstream-specific layers. The default [`serve`] path uses
+/// an identity extension and is unchanged.
+pub async fn serve_with_router_extension<F>(
+    config: Config,
+    shutdown: CancellationToken,
+    extend_router: F,
+) -> Result<()>
+where
+    F: FnOnce(Router) -> Router,
+{
     config.validate().context("invalid OpenAI frontend configuration")?;
 
     // Also check shutdown during the (potentially long) startup handshake.
@@ -107,7 +137,7 @@ pub async fn serve(config: Config, shutdown: CancellationToken) -> Result<()> {
         .context("failed to bind listener for OpenAI server")?;
     let bind_address = listener.local_addr()?;
     let model = state.primary_model_name().to_owned();
-    let app = build_router(state.clone());
+    let app = build_router_with_extension(state.clone(), extend_router);
 
     // Optionally bind the gRPC Generate server on a separate port. Bind
     // synchronously here so bind errors (port in use, permission denied, ...)

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -26,10 +26,30 @@ fn server_dev_mode_enabled() -> bool {
 
 /// Build the minimal OpenAI-compatible router for one configured model.
 pub fn build_router(state: Arc<AppState>) -> Router {
-    build_router_with_dev_mode(state, server_dev_mode_enabled())
+    build_router_with_extension(state, |router| router)
+}
+
+/// Build the minimal OpenAI-compatible router, then let the caller compose
+/// additional same-port routes without exposing internal application state.
+pub fn build_router_with_extension<F>(state: Arc<AppState>, extend_router: F) -> Router
+where
+    F: FnOnce(Router) -> Router,
+{
+    build_router_with_dev_mode_and_extension(state, server_dev_mode_enabled(), extend_router)
 }
 
 fn build_router_with_dev_mode(state: Arc<AppState>, dev_mode_enabled: bool) -> Router {
+    build_router_with_dev_mode_and_extension(state, dev_mode_enabled, |router| router)
+}
+
+fn build_router_with_dev_mode_and_extension<F>(
+    state: Arc<AppState>,
+    dev_mode_enabled: bool,
+    extend_router: F,
+) -> Router
+where
+    F: FnOnce(Router) -> Router,
+{
     let mut router = Router::new()
         // Health & monitoring
         .route("/health", get(health::health))
@@ -54,11 +74,13 @@ fn build_router_with_dev_mode(state: Arc<AppState>, dev_mode_enabled: bool) -> R
             .route("/is_sleeping", get(sleep::is_sleeping))
     }
 
-    router
+    let router = router
         .with_state(state.clone())
         .layer(from_fn_with_state(state, middleware::track_server_load))
         .layer(from_fn(middleware::track_http_metrics))
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http());
+
+    extend_router(router)
 }
 
 #[cfg(test)]

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -43,7 +43,7 @@ use vllm_text::{Prompt, TextBackend};
 use zeromq::prelude::{SocketRecv, SocketSend};
 use zeromq::{DealerSocket, PushSocket, ZmqMessage};
 
-use super::{build_router, build_router_with_dev_mode};
+use super::{build_router, build_router_with_dev_mode, build_router_with_extension};
 use crate::routes::openai::chat_completions::convert::prepare_chat_request;
 use crate::state::AppState;
 
@@ -821,6 +821,37 @@ where
 
 async fn test_app_with_engine_handle() -> (axum::Router, MockEngineTask) {
     test_app_with_stream_output_specs(default_stream_output_specs()).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn router_extension_can_mount_same_port_route() {
+    let (_base_app, state, engine_task) =
+        test_health_app_with_engine_script(|_| boxed_test_future(async {})).await;
+    let app = build_router_with_extension(state, |router| {
+        router.merge(axum::Router::new().route(
+            "/extension/health",
+            axum::routing::get(|| async { "extension-ok" }),
+        ))
+    });
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("GET")
+                .uri("/extension/health")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    assert_eq!(&body[..], b"extension-ok");
+
+    drop(app);
+    engine_task.finish().await;
 }
 
 async fn test_app_with_stream_output_specs(


### PR DESCRIPTION


This adds a public Rust frontend router extension hook so embedders can mount same-port Axum routes around the built-in vLLM HTTP routes without copying the server router implementation.

The new APIs are:
- `serve_with_routes(config, shutdown, extra_routes)`
- `serve_with_router_extension(config, shutdown, extend_router)`

The default `serve` path keeps the existing behavior by using an identity extension.

## Test Plan

- Format Rust code.
- Compile `vllm-server` tests.
- Verify a router extension can mount a same-port route.

## Test Result

- `cargo fmt --all --check`
- `cargo check -p vllm-server --tests`
- `cargo test -p vllm-server router_extension_can_mount_same_port_route -- --nocapture`

Not run: `cargo nextest` because `cargo-nextest` is not installed in this environment.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] User-facing changes.
- [x] How the implementation works at a high level.
- [x] How the PR was tested.

</details>