### PR TITLE
[Bugfix] Fail fast for spawn with stdin entrypoint

### DIFF
--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -230,6 +230,12 @@ if __name__ == '__main__':
     llm = vllm.LLM(...)
 ```
 
+Code passed through standard input, such as `python -`, also cannot be used
+with the `spawn` multiprocessing start method because Python cannot re-import
+the `<stdin>` module in worker processes. Put the code in a Python file with an
+`if __name__ == '__main__':` guard, or set `VLLM_ENABLE_V1_MULTIPROCESSING=0`
+for local offline debugging.
+
 ## `torch.compile` Error
 
 vLLM heavily depends on `torch.compile` to optimize the model for better performance, which introduces the dependency on the `torch.compile` functionality and the `triton` library. By default, we use `torch.compile` to [optimize some functions](https://github.com/vllm-project/vllm/pull/10406) in the model. Before running vLLM, you can check if `torch.compile` is working as expected by running the following script:

--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -5,7 +5,15 @@ import os
 import tempfile
 from pathlib import Path
 
-from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
+import pytest
+
+import __main__
+from vllm.utils.system_utils import (
+    _check_spawn_stdin_entrypoint,
+    _maybe_force_spawn,
+    get_mp_context,
+    unique_filepath,
+)
 
 
 def test_unique_filepath():
@@ -25,3 +33,42 @@ def test_numa_bind_forces_spawn(monkeypatch):
     monkeypatch.setattr("sys.argv", ["vllm", "serve", "--numa-bind"])
     _maybe_force_spawn()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+
+def test_spawn_rejects_stdin_main(monkeypatch):
+    monkeypatch.setattr(__main__, "__file__", "<stdin>", raising=False)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _check_spawn_stdin_entrypoint("spawn")
+
+    message = str(exc_info.value)
+    assert "standard input" in message
+    assert "VLLM_ENABLE_V1_MULTIPROCESSING=0" in message
+
+
+def test_get_mp_context_rejects_stdin_with_spawn(monkeypatch):
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    monkeypatch.setattr(__main__, "__file__", "<stdin>", raising=False)
+
+    with pytest.raises(RuntimeError, match="standard input"):
+        get_mp_context()
+
+
+def test_spawn_allows_python_c_without_main_file(monkeypatch):
+    monkeypatch.delattr(__main__, "__file__", raising=False)
+
+    _check_spawn_stdin_entrypoint("spawn")
+
+
+def test_spawn_allows_importable_main_file(monkeypatch, tmp_path):
+    main_file = tmp_path / "main.py"
+    main_file.write_text("pass")
+    monkeypatch.setattr(__main__, "__file__", str(main_file), raising=False)
+
+    _check_spawn_stdin_entrypoint("spawn")
+
+
+def test_fork_allows_stdin_main(monkeypatch):
+    monkeypatch.setattr(__main__, "__file__", "<stdin>", raising=False)
+
+    _check_spawn_stdin_entrypoint("fork")

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -165,6 +165,35 @@ def _maybe_force_spawn():
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
+def _check_spawn_stdin_entrypoint(mp_method: str):
+    """Reject `python -` entrypoints when the spawn start method is used.
+
+    Without this guard, the worker process fails with a confusing
+    ``FileNotFoundError: '<stdin>'`` raised from
+    ``multiprocessing.spawn._fixup_main_from_path`` because ``<stdin>`` is
+    not a re-importable path. Other "main not importable" cases (e.g.
+    interactive REPL with no ``__file__``) are left to Python's own
+    handling.
+    """
+    if mp_method != "spawn":
+        return
+
+    import __main__
+
+    if getattr(__main__, "__file__", None) != "<stdin>":
+        return
+
+    raise RuntimeError(
+        "vLLM is using the 'spawn' multiprocessing start method, but the "
+        "current Python entrypoint was read from standard input (`python -`). "
+        "Spawned worker processes must be able to import the main module, and "
+        "standard input cannot be re-imported. Run the code from a real Python "
+        'file guarded by `if __name__ == "__main__":`, or for local offline '
+        "debugging set `VLLM_ENABLE_V1_MULTIPROCESSING=0` before initializing "
+        "vLLM."
+    )
+
+
 def get_mp_context():
     """Get a multiprocessing context with a particular method (spawn or fork).
     By default we follow the value of the VLLM_WORKER_MULTIPROC_METHOD to
@@ -178,6 +207,7 @@ def get_mp_context():
     # of whether spawn was already set.
     _sync_visible_devices_env_vars()
     mp_method = envs.VLLM_WORKER_MULTIPROC_METHOD
+    _check_spawn_stdin_entrypoint(mp_method)
     return multiprocessing.get_context(mp_method)
 
 


### PR DESCRIPTION
## Purpose

When vLLM uses the `spawn` multiprocessing start method, Python worker processes need to re-import the main module. That breaks when the entrypoint is standard input, for example `python -`, because `__main__.__file__` is the literal string `"<stdin>"` and there is no file for the spawned worker to import.

On macOS CPU this shows up when constructing `vllm.LLM(...)`: the worker fails with `FileNotFoundError: '<stdin>'` inside `multiprocessing.spawn._fixup_main_from_path`, and the parent later reports a generic engine initialization failure.

This PR adds a small guard in `get_mp_context()`. Once the multiprocessing method resolves to `spawn`, vLLM now rejects the `python -` case in the parent process with an actionable error message. The message points users to the two options that work: run the code from a real Python file with the usual `if __name__ == "__main__":` guard, or set `VLLM_ENABLE_V1_MULTIPROCESSING=0` for local offline debugging.

`python -c` is intentionally unaffected because `__main__` has no `__file__` there, and the `fork` path is unaffected.

## Duplicate check

I did not find an open PR or issue covering this exact `python -` / `<stdin>` spawn failure. The closest open PR search results were:

- #38335, which changes a ROCm CI spawn test decorator.
- #41671, which makes the gRPC CLI call `cli_env_setup()`.

Neither handles the standard-input entrypoint failure fixed here.

## Test Plan

- `.venv/bin/python -m pytest tests/utils_/test_system_utils.py -q`
- `.venv/bin/pre-commit run --files vllm/utils/system_utils.py tests/utils_/test_system_utils.py docs/usage/troubleshooting.md`
- Manual macOS CPU stdin smoke check:

```bash
VLLM_CPU_KVCACHE_SPACE=1 .venv/bin/python - <<'PY'
from vllm import LLM

try:
    LLM(
        model="hmellor/tiny-random-LlamaForCausalLM",
        dtype="float16",
        max_model_len=64,
        enforce_eager=True,
    )
except RuntimeError as exc:
    message = str(exc)
    assert "standard input" in message
    assert "VLLM_ENABLE_V1_MULTIPROCESSING=0" in message
    print("caught expected stdin/spawn RuntimeError")
else:
    raise AssertionError("expected stdin/spawn RuntimeError")
PY
```

## Test Result

- `7 passed, 2 warnings in 1.06s`
- File-scoped pre-commit passed.
- The manual stdin smoke check printed `caught expected stdin/spawn RuntimeError`.

## Documentation

`docs/usage/troubleshooting.md` now mentions the `python -` case next to the existing multiprocessing guidance for the `if __name__ == "__main__"` guard.

## AI assistance

AI assistance was used to help prepare this change. I reviewed the diff and ran the validation above.
