### PR TITLE
[Bugfix] qwen3_xml: emit id once per streamed tool_call slot

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -12,6 +12,18 @@ from tests.tool_parsers.common_tests import (
 )
 from tests.tool_parsers.utils import run_tool_extraction
 
+# All current streaming xfails for this parser fail with the same assertion:
+# `StreamingToolReconstructor` in tests/tool_parsers/utils.py requires `id`
+# (and `name`) only on the first delta of each tool_call slot, but the
+# parser sets id=self.current_call_id on every DeltaToolCall it emits,
+# including continuation/args deltas. Fix is localized to the parser's
+# delta-emit sites; once done, remove this constant and these entries.
+_STREAMING_ID_REEMITTED = (
+    "Parser sets id on every delta; OpenAI protocol requires id only on the "
+    "first delta per slot"
+)
+
+
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
     def test_config(self) -> ToolParserTestConfig:
@@ -57,32 +69,22 @@ class TestQwen3xmlToolParser(ToolParserTests):
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "get_time"],
             # xfail markers - Qwen3XML has systematic streaming issues
-            # xfail markers - Qwen3XML has systematic streaming issues
-            xfail_streaming={
-                "test_single_tool_call_simple_args": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_parallel_tool_calls": "Qwen3XML streaming has systematic issues",
-                "test_various_data_types": "Qwen3XML streaming has systematic issues",
-                "test_empty_arguments": "Qwen3XML streaming has systematic issues",
-                "test_surrounding_text": "Qwen3XML streaming has systematic issues",
-                "test_escaped_strings": "Qwen3XML streaming has systematic issues",
-                "test_streaming_reconstruction": (
-                    "Qwen3XML streaming reconstruction has known issues"
-                ),
-                "test_multiple_functions_in_one_tool_call": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_multiple_empty_functions_in_one_tool_call": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_three_functions_in_one_tool_call": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_multi_function_state_resets_between_tool_calls": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-            },
+            xfail_streaming=dict.fromkeys(
+                [
+                    "test_single_tool_call_simple_args",
+                    "test_parallel_tool_calls",
+                    "test_various_data_types",
+                    "test_empty_arguments",
+                    "test_surrounding_text",
+                    "test_escaped_strings",
+                    "test_streaming_reconstruction",
+                    "test_multiple_functions_in_one_tool_call",
+                    "test_multiple_empty_functions_in_one_tool_call",
+                    "test_three_functions_in_one_tool_call",
+                    "test_multi_function_state_resets_between_tool_calls",
+                ],
+                _STREAMING_ID_REEMITTED,
+            ),
             supports_typed_arguments=False,
         )
 

--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -2,13 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
-
+from tests.tool_parsers.utils import run_tool_extraction
 
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
@@ -55,6 +57,7 @@ class TestQwen3xmlToolParser(ToolParserTests):
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "get_time"],
             # xfail markers - Qwen3XML has systematic streaming issues
+            # xfail markers - Qwen3XML has systematic streaming issues
             xfail_streaming={
                 "test_single_tool_call_simple_args": (
                     "Qwen3XML streaming has systematic issues"
@@ -67,6 +70,164 @@ class TestQwen3xmlToolParser(ToolParserTests):
                 "test_streaming_reconstruction": (
                     "Qwen3XML streaming reconstruction has known issues"
                 ),
+                "test_multiple_functions_in_one_tool_call": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
+                "test_multiple_empty_functions_in_one_tool_call": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
+                "test_three_functions_in_one_tool_call": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
+                "test_multi_function_state_resets_between_tool_calls": (
+                    "Qwen3XML streaming has systematic issues"
+                ),
             },
             supports_typed_arguments=False,
         )
+
+    def test_multiple_functions_in_one_tool_call(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Multiple <function=...> in one <tool_call> -> distinct slots."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_multiple_functions_in_one_tool_call",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>README.md</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>AGENTS.md</parameter>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+
+        assert len(tool_calls) == 2, (
+            f"Expected 2 tool calls (one per <function=...>), got {len(tool_calls)}"
+        )
+        for i, tc in enumerate(tool_calls):
+            assert tc.function.name == "read", (
+                f"tool_calls[{i}].name expected 'read', got {tc.function.name!r}"
+            )
+            json.loads(tc.function.arguments)  # must be valid JSON
+        assert json.loads(tool_calls[0].function.arguments) == {"path": "README.md"}
+        assert json.loads(tool_calls[1].function.arguments) == {"path": "AGENTS.md"}
+
+    def test_multiple_empty_functions_in_one_tool_call(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Empty-args variant: pre-fix produced `{}{}` (or `{}{}{}` for N=3)."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_multiple_empty_functions_in_one_tool_call",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=ping>\n</function>\n"
+            "<function=ping>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+
+        assert len(tool_calls) == 2, (
+            f"Expected 2 tool calls, got {len(tool_calls)}"
+        )
+        for tc in tool_calls:
+            assert tc.function.name == "ping"
+            # Empty args render as "{}" or "" depending on path; never `{}{}`.
+            assert tc.function.arguments in ("{}", ""), (
+                f"Expected empty args, got {tc.function.arguments!r}"
+            )
+
+    def test_three_functions_in_one_tool_call(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Guards against an off-by-one that would only break for N>2."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_three_functions_in_one_tool_call",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>A</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>B</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>C</parameter>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+        assert [tc.function.name for tc in tool_calls] == ["read", "read", "read"]
+        assert [json.loads(tc.function.arguments) for tc in tool_calls] == [
+            {"path": "A"},
+            {"path": "B"},
+            {"path": "C"},
+        ]
+
+    def test_multi_function_state_resets_between_tool_calls(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser,
+        test_config: ToolParserTestConfig,
+        streaming: bool,
+    ):
+        """Per-<tool_call> function counter must reset on a new <tool_call>."""
+        self.apply_xfail_mark(
+            request,
+            test_config,
+            "test_multi_function_state_resets_between_tool_calls",
+            streaming,
+        )
+        model_output = (
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>A</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>B</parameter>\n</function>\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            "<function=read>\n<parameter=path>C</parameter>\n</function>\n"
+            "<function=read>\n<parameter=path>D</parameter>\n</function>\n"
+            "</tool_call>"
+        )
+        _, tool_calls = run_tool_extraction(
+            tool_parser, model_output, streaming=streaming
+        )
+        assert [json.loads(tc.function.arguments) for tc in tool_calls] == [
+            {"path": "A"},
+            {"path": "B"},
+            {"path": "C"},
+            {"path": "D"},
+        ]
+
+    def test_malformed_function_close_without_open_does_not_crash(
+        self, tool_parser
+    ):
+        """Out-of-scope contract: parser may return garbage, must not raise."""
+        model_output = (
+            "<tool_call>\n"
+            "<parameter=q>x</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        run_tool_extraction(tool_parser, model_output, streaming=False)

--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -12,17 +12,6 @@ from tests.tool_parsers.common_tests import (
 )
 from tests.tool_parsers.utils import run_tool_extraction
 
-# All current streaming xfails for this parser fail with the same assertion:
-# `StreamingToolReconstructor` in tests/tool_parsers/utils.py requires `id`
-# (and `name`) only on the first delta of each tool_call slot, but the
-# parser sets id=self.current_call_id on every DeltaToolCall it emits,
-# including continuation/args deltas. Fix is localized to the parser's
-# delta-emit sites; once done, remove this constant and these entries.
-_STREAMING_ID_REEMITTED = (
-    "Parser sets id on every delta; OpenAI protocol requires id only on the "
-    "first delta per slot"
-)
-
 
 class TestQwen3xmlToolParser(ToolParserTests):
     @pytest.fixture
@@ -68,23 +57,6 @@ class TestQwen3xmlToolParser(ToolParserTests):
             single_tool_call_expected_args={"city": "Tokyo"},
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "get_time"],
-            # xfail markers - Qwen3XML has systematic streaming issues
-            xfail_streaming=dict.fromkeys(
-                [
-                    "test_single_tool_call_simple_args",
-                    "test_parallel_tool_calls",
-                    "test_various_data_types",
-                    "test_empty_arguments",
-                    "test_surrounding_text",
-                    "test_escaped_strings",
-                    "test_streaming_reconstruction",
-                    "test_multiple_functions_in_one_tool_call",
-                    "test_multiple_empty_functions_in_one_tool_call",
-                    "test_three_functions_in_one_tool_call",
-                    "test_multi_function_state_resets_between_tool_calls",
-                ],
-                _STREAMING_ID_REEMITTED,
-            ),
             supports_typed_arguments=False,
         )
 

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -621,6 +621,13 @@ class StreamingXMLToolCallParser:
         if incoming_tag == "tool_call" and self.current_call_id:
             self._end_element("tool_call")
 
+    def _mint_new_tool_call_slot(self) -> None:
+        """Bump tool_call index, mint a fresh id, reset per-function state."""
+        self.parameters = {}
+        self.current_call_id = make_tool_call_id()
+        self.current_param_is_first = True
+        self.tool_call_index += 1
+
     def _start_element(self, name: str, attrs: dict[str, str]):
         """Handle XML start element events"""
 
@@ -632,10 +639,7 @@ class StreamingXMLToolCallParser:
             # automatically complete previous unclosed tags
             self._auto_close_open_parameter_if_needed("tool_call")
 
-            self.parameters = {}
-            self.current_call_id = make_tool_call_id()
-            self.current_param_is_first = True
-            self.tool_call_index += 1
+            self._mint_new_tool_call_slot()
             self.functions_in_tool_call = 0
         elif name.startswith("function") or (name == "function"):
             # If missing tool_call, manually complete
@@ -644,10 +648,7 @@ class StreamingXMLToolCallParser:
             # First function reuses <tool_call>'s slot; rest mint fresh.
             self.functions_in_tool_call += 1
             if self.functions_in_tool_call > 1:
-                self.parameters = {}
-                self.current_call_id = make_tool_call_id()
-                self.current_param_is_first = True
-                self.tool_call_index += 1
+                self._mint_new_tool_call_slot()
             # Before opening new function,
             # automatically complete previous unclosed tags (parameter/function)
             self._auto_close_open_parameter_if_needed("function")

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -59,6 +59,9 @@ class StreamingXMLToolCallParser:
         self.last_completed_call_id = None
         self.current_function_name = None
         self.current_function_open = False
+        # Per-<tool_call> counter; each <function=...> maps to one OpenAI
+        # tool_call slot, so the 2nd+ function mints a fresh slot.
+        self.functions_in_tool_call = 0
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""
@@ -633,10 +636,18 @@ class StreamingXMLToolCallParser:
             self.current_call_id = make_tool_call_id()
             self.current_param_is_first = True
             self.tool_call_index += 1
+            self.functions_in_tool_call = 0
         elif name.startswith("function") or (name == "function"):
             # If missing tool_call, manually complete
             if not self.current_call_id:
                 self._start_element("tool_call", {})
+            # First function reuses <tool_call>'s slot; rest mint fresh.
+            self.functions_in_tool_call += 1
+            if self.functions_in_tool_call > 1:
+                self.parameters = {}
+                self.current_call_id = make_tool_call_id()
+                self.current_param_is_first = True
+                self.tool_call_index += 1
             # Before opening new function,
             # automatically complete previous unclosed tags (parameter/function)
             self._auto_close_open_parameter_if_needed("function")
@@ -898,6 +909,13 @@ class StreamingXMLToolCallParser:
             self.start_quote_emitted = False
 
         elif name.startswith("function") or name == "function":
+            # Skip duplicate closes (auto-close paths, `</function></function>`).
+            # Out of scope: `</function>` without a matching `<function=...>`
+            # open -- the resulting tool_call has no name and is
+            # undispatchable; not worth extra state to balance its JSON.
+            # See test_malformed_function_close_without_open_does_not_crash.
+            if not self.current_function_open:
+                return
             # if there are parameters, close JSON object
             if self.parameters:
                 delta = DeltaMessage(
@@ -925,6 +943,10 @@ class StreamingXMLToolCallParser:
                 )
                 self._emit_delta(delta)
             self.current_function_open = False
+            # Clear so next <function=...> starts clean and the
+            # current_function_name-driven auto-close path no-ops.
+            self.parameters = {}
+            self.current_function_name = None
 
         elif name == "tool_call":
             # Before ending tool_call,
@@ -1128,6 +1150,7 @@ class StreamingXMLToolCallParser:
         self.current_call_id = None
         self.current_function_name = None
         self.current_function_open = False
+        self.functions_in_tool_call = 0
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -62,6 +62,10 @@ class StreamingXMLToolCallParser:
         # Per-<tool_call> counter; each <function=...> maps to one OpenAI
         # tool_call slot, so the 2nd+ function mints a fresh slot.
         self.functions_in_tool_call = 0
+        # Track slot indices whose first delta (with id+name) has already
+        # been emitted, so _emit_delta can strip id from continuation
+        # deltas (OpenAI streaming protocol: id appears once per slot).
+        self._slots_with_id_emitted: set[int] = set()
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""
@@ -444,10 +448,13 @@ class StreamingXMLToolCallParser:
             if delta.tool_calls:
                 # For tool_calls, we need to intelligently merge arguments
                 for tool_call in delta.tool_calls:
-                    # Find if there's already a tool_call with the same call_id
+                    # Identify the slot by `index` (the OpenAI streaming
+                    # protocol's slot key). Matching by `id` would break
+                    # for continuation deltas, which carry only the
+                    # delta'd args + index and no id.
                     existing_call = None
                     for existing in merged_tool_calls:
-                        if existing.id == tool_call.id:
+                        if existing.index == tool_call.index:
                             existing_call = existing
                             break
 
@@ -593,7 +600,22 @@ class StreamingXMLToolCallParser:
         return processed
 
     def _emit_delta(self, delta: DeltaMessage):
-        """Emit Delta response (streaming output)"""
+        """Emit Delta response (streaming output).
+
+        Strips `id` from continuation deltas. Per the OpenAI streaming
+        protocol, `id` (like `name`) is emitted only on the first delta
+        announcing each tool_call slot; subsequent args/continuation
+        deltas must carry only `index` + `function.arguments`. Callers
+        construct deltas with `id=self.current_call_id` unconditionally;
+        this gateway is the single place that enforces the once-per-slot
+        invariant.
+        """
+        if delta.tool_calls:
+            for tc in delta.tool_calls:
+                if tc.index in self._slots_with_id_emitted:
+                    tc.id = None
+                elif tc.id is not None:
+                    self._slots_with_id_emitted.add(tc.index)
         self.deltas.append(delta)
 
     def _auto_close_open_parameter_if_needed(self, incoming_tag: str | None = None):
@@ -1152,6 +1174,7 @@ class StreamingXMLToolCallParser:
         self.current_function_name = None
         self.current_function_open = False
         self.functions_in_tool_call = 0
+        self._slots_with_id_emitted = set()
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""


### PR DESCRIPTION
## Purpose

Stacked on top of #43714.

Follow-up that fixes the underlying streaming bug that #43714 documented as out-of-scope: the parser sets `id=self.current_call_id` on every `DeltaToolCall` it emits (12 sites), but the OpenAI streaming protocol emits `id` (and `name`) only on the first delta announcing each tool_call slot. Subsequent deltas for the same slot carry only `index` + `function.arguments`.

OpenAI-compatible clients tolerate the redundant `id` in practice, but the invariant matters for two reasons:

1. The test reconstructor (`tests/tool_parsers/utils.py`) enforces it, which is why all 11 streaming tests in `test_qwen3xml_tool_parser.py` were xfailed in the parent PR -- they failed with the same `AssertionError: Streaming tool calls must emit function id only once` against the same parser behavior.
2. `_merge_new_deltas_to_single_response` in the same file identifies slots by `id`, not by `index`. Once `id` is suppressed on continuation deltas (per protocol), the non-streaming path (which goes through the same delta merge) fails to aggregate args into the right slot. So this PR has to fix both.

## Fix

Two localized changes in `vllm/tool_parsers/qwen3xml_tool_parser.py`:

- **Centralize the once-per-slot invariant in `_emit_delta`.** Track slot indices whose first delta has been emitted (set `_slots_with_id_emitted`); on subsequent emits for that index, set `tc.id = None`. The 12 emit call sites continue to construct `DeltaToolCall(id=self.current_call_id, ...)` unconditionally; this gateway is the single enforcement point. Easier to keep correct than auditing 12 call sites.
- **Fix `_merge_new_deltas_to_single_response` to identify slots by `index`** (the OpenAI protocol's slot key) instead of `id`. Without this, the non-streaming path breaks the moment the emit-time fix lands.

## Tests

The parent PR documents this bug and xfails 11 tests for it. This PR removes:

- All 11 entries from the `xfail_streaming` dict.
- The `_STREAMING_ID_REEMITTED` constant + the source comment introduced to document the bug.

All 11 (7 pre-existing + 4 added in the parent PR's multi-function fix) now pass in streaming mode.

Result: **26 passed, 0 xfailed** (was 15 passed, 11 xfailed).

Additionally verified token-by-token streaming directly: each slot's `id` is emitted exactly once, regardless of how the input is chunked across deltas.

## Compatibility

- No public API change.
- Clients that previously received redundant `id` on every delta still work; they now receive the protocol-compliant single emission.
- Internal: `DeltaToolCall.id` is now mutated in `_emit_delta` for continuation deltas. The construction call sites are unchanged.
- New instance attribute `_slots_with_id_emitted: set[int]`, initialised in `reset_streaming_state` and `_reset_xml_parser_after_tool_call`.

## Test Plan

```
pytest tests/tool_parsers/test_qwen3xml_tool_parser.py -v
```

Should report `26 passed`.
