### PR TITLE
[Core][Perf] Add MessagePack prefix block hash algorithms

### DIFF
--- a/benchmarks/benchmark_prefix_block_hash.py
+++ b/benchmarks/benchmark_prefix_block_hash.py
@@ -11,16 +11,33 @@ Example:
 from __future__ import annotations
 
 import argparse
+import os
 import random
 import statistics
 import sys
 import time
 from collections.abc import Callable, Iterable, Sequence
+from typing import NewType
 
-from vllm.utils.hashing import get_hash_fn_by_name
-from vllm.v1.core.kv_cache_utils import BlockHash, hash_block_tokens, init_none_hash
+from vllm.utils.hashing import get_block_hash_fn, get_hash_fn_by_name
 
-SUPPORTED_ALGOS = ("sha256", "sha256_cbor", "xxhash", "xxhash_cbor")
+BlockHash = NewType("BlockHash", bytes)
+
+SUPPORTED_ALGOS = (
+    "sha256",
+    "sha256_cbor",
+    "sha256_msgpack",
+    "xxhash",
+    "xxhash_cbor",
+    "xxhash_msgpack",
+)
+
+
+def _init_none_hash(hash_fn: Callable[[object], bytes]) -> BlockHash:
+    hash_seed = os.getenv("PYTHONHASHSEED")
+    if hash_seed is None:
+        return BlockHash(os.urandom(32))
+    return BlockHash(hash_fn(hash_seed))
 
 
 def _generate_blocks(
@@ -37,10 +54,12 @@ def _hash_all_blocks(
     hash_fn: Callable[[object], bytes],
     blocks: Iterable[Sequence[int]],
 ) -> float:
+    none_hash = _init_none_hash(hash_fn)
+    block_hash_fn = get_block_hash_fn(hash_fn)
     parent_hash: BlockHash | None = None
     start = time.perf_counter()
     for block in blocks:
-        parent_hash = hash_block_tokens(hash_fn, parent_hash, block, extra_keys=None)
+        parent_hash = BlockHash(block_hash_fn(parent_hash or none_hash, block, None))
     end = time.perf_counter()
     return end - start
 
@@ -52,7 +71,6 @@ def _benchmark(
 ) -> tuple[float, float, float] | None:
     try:
         hash_fn = get_hash_fn_by_name(hash_algo)
-        init_none_hash(hash_fn)
         timings = [_hash_all_blocks(hash_fn, blocks) for _ in range(trials)]
     except ModuleNotFoundError as exc:
         print(f"Skipping {hash_algo}: {exc}", file=sys.stderr)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -18,7 +18,14 @@ from vllm.multimodal.inputs import (
     PlaceholderRange,
 )
 from vllm.sampling_params import SamplingParams
-from vllm.utils.hashing import sha256, sha256_cbor
+from vllm.utils.hashing import (
+    _xxhash,
+    hash_block_token_sequence,
+    sha256,
+    sha256_cbor,
+    sha256_msgpack,
+    xxhash_msgpack,
+)
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import (
@@ -625,6 +632,37 @@ def test_hash_block_tokens(hash_fn):
     )
     expected = hash_fn((parent_block_hash, curr_block_token_ids, extra_keys))
     assert block_hash == expected
+
+
+@pytest.mark.parametrize(
+    "hash_fn",
+    [
+        sha256_msgpack,
+        pytest.param(
+            xxhash_msgpack,
+            marks=pytest.mark.skipif(_xxhash is None, reason="xxhash not installed"),
+        ),
+    ],
+)
+def test_hash_block_tokens_msgpack(hash_fn):
+    parent_block_hash = BlockHash(b"123")
+    curr_block_token_ids = (1, 2, 3)
+
+    block_hash = hash_block_tokens(hash_fn, parent_block_hash, curr_block_token_ids)
+    assert block_hash == hash_block_token_sequence(
+        hash_fn, parent_block_hash, curr_block_token_ids
+    )
+    assert block_hash == hash_block_tokens(
+        hash_fn, parent_block_hash, list(curr_block_token_ids)
+    )
+    assert block_hash != hash_block_tokens(
+        hash_fn, parent_block_hash, (1, 2, 4)
+    )
+
+    extra_keys = ("key1", "key2")
+    assert hash_block_tokens(
+        hash_fn, parent_block_hash, curr_block_token_ids, extra_keys
+    ) == hash_fn((parent_block_hash, curr_block_token_ids, extra_keys))
 
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])

--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -43,6 +43,11 @@ def test_prefix_caching_from_cli():
     vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
     assert vllm_config.cache_config.prefix_caching_hash_algo == "sha256"
 
+    # set hash algorithm to sha256_msgpack
+    args = parser.parse_args(["--prefix-caching-hash-algo", "sha256_msgpack"])
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.cache_config.prefix_caching_hash_algo == "sha256_msgpack"
+
     # an invalid hash algorithm raises an error
     parser.exit_on_error = False
     with pytest.raises(ArgumentError):
@@ -62,6 +67,11 @@ def test_prefix_caching_xxhash_from_cli():
     args = parser.parse_args(["--prefix-caching-hash-algo", "xxhash_cbor"])
     vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
     assert vllm_config.cache_config.prefix_caching_hash_algo == "xxhash_cbor"
+
+    # set hash algorithm to xxhash_msgpack
+    args = parser.parse_args(["--prefix-caching-hash-algo", "xxhash_msgpack"])
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.cache_config.prefix_caching_hash_algo == "xxhash_msgpack"
 
 
 def test_defaults_with_usage_context():

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -34,7 +34,14 @@ CacheDType = Literal[
 ]
 MambaDType = Literal["auto", "float32", "float16", "bfloat16"]
 MambaCacheMode = Literal["all", "align", "none"]
-PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
+PrefixCachingHashAlgo = Literal[
+    "sha256",
+    "sha256_cbor",
+    "sha256_msgpack",
+    "xxhash",
+    "xxhash_cbor",
+    "xxhash_msgpack",
+]
 KVOffloadingBackend = Literal["native", "lmcache"]
 
 
@@ -97,6 +104,8 @@ class CacheConfig:
       default, as SHA256 is the most secure choice to avoid potential hash collisions.
     - "sha256_cbor" provides a reproducible, cross-language compatible hash. It
       serializes objects using canonical CBOR and hashes them with SHA-256.
+    - "sha256_msgpack" serializes objects using MessagePack and hashes them
+      with SHA-256.
     - "xxhash" uses Pickle serialization with xxHash (128-bit) for faster,
       non-cryptographic hashing. Requires the optional ``xxhash`` package.
       IMPORTANT: Use of a hashing algorithm that is not considered  cryptographically
@@ -105,7 +114,9 @@ class CacheConfig:
       Even if collisions are still very unlikely, it is important to consider your
       security risk tolerance against the performance benefits before turning this on.
     - "xxhash_cbor" combines canonical CBOR serialization with xxHash for
-      reproducible hashing. Requires the optional ``xxhash`` package."""
+      reproducible hashing. Requires the optional ``xxhash`` package.
+    - "xxhash_msgpack" combines MessagePack serialization with xxHash.
+      Requires the optional ``xxhash`` package."""
     calculate_kv_scales: bool = False
     """Deprecated: This option is deprecated and will be removed in v0.19.
     It enables dynamic calculation of `k_scale` and `v_scale` when

--- a/vllm/utils/hashing.py
+++ b/vllm/utils/hashing.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import hashlib
 import pickle
 from _hashlib import HASH, UnsupportedDigestmodError
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import cbor2
+import msgspec
 
 try:
     # It is important that this remains an optional dependency.
@@ -58,7 +59,16 @@ def sha256_cbor(input: Any) -> bytes:
     return hashlib.sha256(input_bytes).digest()
 
 
-def _xxhash_digest(input_bytes: bytes) -> bytes:
+_MSGPACK_ENCODER = msgspec.msgpack.Encoder()
+
+
+def sha256_msgpack(input: Any) -> bytes:
+    """Hash objects using MessagePack serialization and SHA-256."""
+    input_bytes = _MSGPACK_ENCODER.encode(input)
+    return hashlib.sha256(input_bytes).digest()
+
+
+def _xxhash_digest(input_bytes: bytes | bytearray | memoryview) -> bytes:
     if _xxhash is None:
         raise ModuleNotFoundError(
             "xxhash is required for the 'xxhash' prefix caching hash algorithms. "
@@ -79,6 +89,60 @@ def xxhash_cbor(input: Any) -> bytes:
     return _xxhash_digest(input_bytes)
 
 
+def xxhash_msgpack(input: Any) -> bytes:
+    """Hash objects serialized with MessagePack using xxHash."""
+    input_bytes = _MSGPACK_ENCODER.encode(input)
+    return _xxhash_digest(input_bytes)
+
+
+_MSGPACK_HASH_FUNCTIONS = frozenset({sha256_msgpack, xxhash_msgpack})
+
+
+def hash_block_token_sequence(
+    hash_function: Callable[[Any], bytes],
+    parent_block_hash: bytes,
+    curr_block_token_ids: Sequence[int],
+    extra_keys: tuple[Any, ...] | None = None,
+) -> bytes:
+    """Hash a prefix-cache block and its parent hash.
+
+    Existing algorithms preserve the legacy tuple-based object shape exactly.
+    MessagePack algorithms avoid the tuple conversion because MessagePack
+    encodes tuples and lists as the same array type.
+    """
+    if hash_function in _MSGPACK_HASH_FUNCTIONS:
+        return hash_function((parent_block_hash, curr_block_token_ids, extra_keys))
+
+    return hash_function((parent_block_hash, tuple(curr_block_token_ids), extra_keys))
+
+
+def get_block_hash_fn(
+    hash_function: Callable[[Any], bytes],
+) -> Callable[[bytes, Sequence[int], tuple[Any, ...] | None], bytes]:
+    """Return a block-hash function specialized for ``hash_function``."""
+    if hash_function in _MSGPACK_HASH_FUNCTIONS:
+
+        def msgpack_block_hash(
+            parent_block_hash: bytes,
+            curr_block_token_ids: Sequence[int],
+            extra_keys: tuple[Any, ...] | None = None,
+        ) -> bytes:
+            return hash_function((parent_block_hash, curr_block_token_ids, extra_keys))
+
+        return msgpack_block_hash
+
+    def tuple_block_hash(
+        parent_block_hash: bytes,
+        curr_block_token_ids: Sequence[int],
+        extra_keys: tuple[Any, ...] | None = None,
+    ) -> bytes:
+        return hash_function(
+            (parent_block_hash, tuple(curr_block_token_ids), extra_keys)
+        )
+
+    return tuple_block_hash
+
+
 def get_hash_fn_by_name(hash_fn_name: str) -> Callable[[Any], bytes]:
     """Get a hash function by name, or raise an error if the function is not found.
 
@@ -92,10 +156,14 @@ def get_hash_fn_by_name(hash_fn_name: str) -> Callable[[Any], bytes]:
         return sha256
     if hash_fn_name == "sha256_cbor":
         return sha256_cbor
+    if hash_fn_name == "sha256_msgpack":
+        return sha256_msgpack
     if hash_fn_name == "xxhash":
         return xxhash
     if hash_fn_name == "xxhash_cbor":
         return xxhash_cbor
+    if hash_fn_name == "xxhash_msgpack":
+        return xxhash_msgpack
 
     raise ValueError(f"Unsupported hash function: {hash_fn_name}")
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -15,7 +15,12 @@ from typing import Any, NewType, TypeAlias, cast, overload
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.utils.hashing import sha256_cbor, xxhash_cbor
+from vllm.utils.hashing import (
+    get_block_hash_fn,
+    hash_block_token_sequence,
+    sha256_cbor,
+    xxhash_cbor,
+)
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import get_dtype_size
@@ -562,9 +567,10 @@ def hash_block_tokens(
     if not parent_block_hash:
         parent_block_hash = NONE_HASH
 
-    curr_block_token_ids_tuple = tuple(curr_block_token_ids)
     return BlockHash(
-        hash_function((parent_block_hash, curr_block_token_ids_tuple, extra_keys))
+        hash_block_token_sequence(
+            hash_function, parent_block_hash, curr_block_token_ids, extra_keys
+        )
     )
 
 
@@ -641,6 +647,7 @@ def get_request_block_hasher(
     """
     Returns a function which computes the list of un-computed block hashes
     of a request."""
+    block_hash_fn = get_block_hash_fn(caching_hash_fn)
 
     def request_block_hasher(request: Request) -> list[BlockHash]:
         start_token_idx = len(request.block_hashes) * block_size
@@ -675,8 +682,9 @@ def get_request_block_hasher(
 
             # Compute the hash of the current block
             block_tokens = request.all_token_ids[start_token_idx:end_token_idx]
-            block_hash = hash_block_tokens(
-                caching_hash_fn, prev_block_hash_value, block_tokens, extra_keys
+            parent_hash = prev_block_hash_value or NONE_HASH
+            block_hash = BlockHash(
+                block_hash_fn(parent_hash, block_tokens, extra_keys)
             )
 
             new_block_hashes.append(block_hash)


### PR DESCRIPTION
## Purpose

Prefix-cache block hashing currently serializes every block hash input with Pickle for `sha256`/`xxhash` or canonical CBOR for `*_cbor`. In the hot path this means each block pays for serializing `(parent_block_hash, tuple(curr_block_token_ids), extra_keys)` even when the token block is already available as a sequence.

This PR adds opt-in MessagePack variants for prefix-cache block hashing:

- `sha256_msgpack`
- `xxhash_msgpack`

This PR also specializes block-hash dispatch so MessagePack algorithms can encode the existing token sequence directly. Existing algorithms keep the legacy tuple conversion and hash bytes unchanged.

No default behavior changes: `sha256` remains the default prefix-caching hash algorithm.

## Benchmark

Command:

```bash
python benchmarks/benchmark_prefix_block_hash.py \
  --num-blocks 100000 \
  --block-size 32 \
  --trials 5 \
  --algorithms sha256 xxhash sha256_msgpack xxhash_msgpack
```

Result on local macOS arm64 / Python 3.10:

```text
Benchmarking 4 algorithms on 100000 blocks (block size=32).
sha256         avg: 0.102620s  best: 0.101744s  throughput: 31.45M tokens/s
xxhash         avg: 0.070394s  best: 0.069837s  throughput: 45.82M tokens/s
sha256_msgpack avg: 0.074124s  best: 0.073073s  throughput: 43.79M tokens/s
xxhash_msgpack avg: 0.040289s  best: 0.039997s  throughput: 80.01M tokens/s
```

`xxhash_msgpack` improves the benchmarked prefix-block hashing throughput by ~1.75x versus `xxhash` and ~2.54x versus the default `sha256`.

Additional block-size sweep:

```bash
for bs in 16 32 64; do
  python benchmarks/benchmark_prefix_block_hash.py \
    --num-blocks 20000 \
    --block-size "$bs" \
    --trials 9 \
    --algorithms sha256 xxhash sha256_msgpack xxhash_msgpack
done
```

```text
Benchmarking 4 algorithms on 20000 blocks (block size=16).
sha256         avg: 0.018600s  best: 0.017699s  throughput: 18.08M tokens/s
xxhash         avg: 0.013160s  best: 0.012219s  throughput: 26.19M tokens/s
sha256_msgpack avg: 0.013562s  best: 0.012346s  throughput: 25.92M tokens/s
xxhash_msgpack avg: 0.006740s  best: 0.006573s  throughput: 48.68M tokens/s

Benchmarking 4 algorithms on 20000 blocks (block size=32).
sha256         avg: 0.021410s  best: 0.020603s  throughput: 31.06M tokens/s
xxhash         avg: 0.014445s  best: 0.013992s  throughput: 45.74M tokens/s
sha256_msgpack avg: 0.013908s  best: 0.013674s  throughput: 46.81M tokens/s
xxhash_msgpack avg: 0.007792s  best: 0.007685s  throughput: 83.28M tokens/s

Benchmarking 4 algorithms on 20000 blocks (block size=64).
sha256         avg: 0.029087s  best: 0.028148s  throughput: 45.47M tokens/s
xxhash         avg: 0.022227s  best: 0.020911s  throughput: 61.21M tokens/s
sha256_msgpack avg: 0.017244s  best: 0.015953s  throughput: 80.24M tokens/s
xxhash_msgpack avg: 0.010313s  best: 0.009945s  throughput: 128.71M tokens/s
```

## Test Plan

- Preserve existing `sha256`, `sha256_cbor`, `xxhash`, and `xxhash_cbor` behavior.
- Verify MessagePack block hashing is stable for tuple/list token inputs.
- Verify new hash algorithm names are accepted by config and CLI parsing.
- Run formatting/lint checks on touched files.
- Run the prefix block hash benchmark before/after adding the new algorithms.

## Test Result

```bash
python -m ruff check \
  vllm/utils/hashing.py \
  vllm/v1/core/kv_cache_utils.py \
  vllm/config/cache.py \
  benchmarks/benchmark_prefix_block_hash.py \
  tests/v1/core/test_kv_cache_utils.py \
  tests/v1/engine/test_engine_args.py
```

```text
All checks passed!
```

```bash
python -m py_compile \
  vllm/utils/hashing.py \
  vllm/v1/core/kv_cache_utils.py \
  vllm/config/cache.py \
  benchmarks/benchmark_prefix_block_hash.py \
  tests/v1/core/test_kv_cache_utils.py \
  tests/v1/engine/test_engine_args.py
```

Passed.

Compatibility check script:

```text
hash compatibility checks passed
```

I also attempted focused pytest locally:

```bash
python -m pytest \
  tests/v1/core/test_kv_cache_utils.py::test_hash_block_tokens \
  tests/v1/core/test_kv_cache_utils.py::test_hash_block_tokens_msgpack \
  tests/v1/core/test_kv_cache_utils.py::test_hash_request_tokens_no_mm_inputs \
  tests/v1/engine/test_engine_args.py::test_prefix_caching_from_cli \
  tests/v1/engine/test_engine_args.py::test_prefix_caching_xxhash_from_cli
```

The targeted assertions pass, but this source-tree macOS run exits non-zero during vLLM's global cleanup because `torch.accelerator.empty_cache()` hits an MPS allocator assertion, and the CLI tests also cannot infer a device from the unbuilt source checkout. CI should exercise these normally in the supported vLLM test environment.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>