### PR TITLE
[Bugfix] Fix broken DeepseekV4ForCausalLM import on non-CUDA platform

### DIFF
--- a/vllm/models/deepseek_v4/__init__.py
+++ b/vllm/models/deepseek_v4/__init__.py
@@ -19,9 +19,12 @@ from .quant_config import DeepseekV4FP8Config
 if TYPE_CHECKING or current_platform.is_cuda():
     from .nvidia.model import DeepseekV4ForCausalLM
     from .nvidia.mtp import DeepSeekV4MTP
-else:
+elif current_platform.is_rocm():
     from .amd.model import DeepseekV4ForCausalLM  # type: ignore[assignment]
     from .amd.mtp import DeepSeekV4MTP  # type: ignore[assignment]
+else:
+    DeepseekV4ForCausalLM = object  # type: ignore[assignment]
+    DeepSeekV4MTP = object  # type: ignore[assignment]
 
 __all__ = [
     "DeepSeekV4MTP",

--- a/vllm/models/deepseek_v4/__init__.py
+++ b/vllm/models/deepseek_v4/__init__.py
@@ -16,7 +16,7 @@ from .quant_config import DeepseekV4FP8Config
 # Pick the per-platform implementation. The NVIDIA branch is the static
 # default that mypy sees; the ROCm branch overrides it at runtime and is
 # kept type-compatible via ``# type: ignore[assignment]``.
-if TYPE_CHECKING or not current_platform.is_rocm():
+if TYPE_CHECKING or current_platform.is_cuda():
     from .nvidia.model import DeepseekV4ForCausalLM
     from .nvidia.mtp import DeepSeekV4MTP
 else:


### PR DESCRIPTION



## Purpose
- Fix `ModuleNotFoundError: No module named 'cutlass'` on CPU CI:
```
[2026-05-27T12:17:54Z] FAILED models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-1.0-internlm/Intern-S1-Pro] - ModuleNotFoundError: No module named 'cutlass'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

