### PR TITLE
[Feat][rust-vllm] add log available router

### DIFF
--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -107,9 +107,6 @@ pub async fn serve(config: Config, shutdown: CancellationToken) -> Result<()> {
         .context("failed to bind listener for OpenAI server")?;
     let bind_address = listener.local_addr()?;
     let model = state.primary_model_name().to_owned();
-    let app = build_router_with_routes(state.clone());
-    log_available_routes(&app);
-    let app = app.router;
 
     // Optionally bind the gRPC Generate server on a separate port. Bind
     // synchronously here so bind errors (port in use, permission denied, ...)
@@ -133,7 +130,10 @@ pub async fn serve(config: Config, shutdown: CancellationToken) -> Result<()> {
         None
     };
 
-    info!(%bind_address, %model, "starting OpenAI server");
+    info!(%bind_address, %model, "Starting vLLM API server");
+    let app = build_router_with_routes(state.clone());
+    log_available_routes(&app);
+    let app = app.router;
 
     // Set TCP_NODELAY on accepted connections to reduce latency.
     // By `tap_io` we will do this on every accepted connection.

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -28,7 +28,7 @@ use vllm_llm::Llm;
 use vllm_text::TextLlm;
 
 use crate::listener::Listener;
-use crate::routes::build_router;
+use crate::routes::{build_router_with_routes, log_available_routes};
 use crate::state::AppState;
 
 /// Build the shared application state for one configured model and one engine
@@ -107,7 +107,9 @@ pub async fn serve(config: Config, shutdown: CancellationToken) -> Result<()> {
         .context("failed to bind listener for OpenAI server")?;
     let bind_address = listener.local_addr()?;
     let model = state.primary_model_name().to_owned();
-    let app = build_router(state.clone());
+    let app = build_router_with_routes(state.clone());
+    log_available_routes(&app);
+    let app = app.router;
 
     // Optionally bind the gRPC Generate server on a separate port. Bind
     // synchronously here so bind errors (port in use, permission denied, ...)

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use axum::Router;
 use axum::middleware::{from_fn, from_fn_with_state};
 use axum::routing::{MethodRouter, get, post};
+use itertools::Itertools as _;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
@@ -63,30 +64,21 @@ where
 const GET_HEAD: &[&str] = &["GET", "HEAD"];
 const POST: &[&str] = &["POST"];
 
-fn route_log_lines(routes: &[RouteInfo]) -> Vec<String> {
-    routes
-        .iter()
-        .map(|route| {
-            format!(
-                "Route: {}, Methods: {}",
-                route.path,
-                route.methods.join(", ")
-            )
-        })
-        .collect()
-}
-
 pub(crate) fn log_available_routes(app: &WrapperRouter) {
     info!("Available routes are:");
-    for line in route_log_lines(&app.routes) {
-        info!("{line}");
+    for route in &app.routes {
+        info!(
+            "Route: {}, Methods: {}",
+            route.path,
+            route.methods.iter().format(", ")
+        );
     }
 }
 
 /// Build the minimal OpenAI-compatible router for one configured model.
-#[cfg(test)]
-fn build_router(state: Arc<AppState>) -> Router {
-    build_router_with_dev_mode(state, server_dev_mode_enabled())
+#[allow(dead_code)]
+pub(crate) fn build_router(state: Arc<AppState>) -> Router {
+    build_router_with_dev_mode_and_routes(state, server_dev_mode_enabled()).router
 }
 
 #[cfg(test)]

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -12,8 +12,9 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::middleware::{from_fn, from_fn_with_state};
-use axum::routing::{get, post};
+use axum::routing::{MethodRouter, get, post};
 use tower_http::trace::TraceLayer;
+use tracing::info;
 
 use crate::middleware;
 use crate::state::AppState;
@@ -25,42 +26,127 @@ fn server_dev_mode_enabled() -> bool {
         .is_some_and(|value| value != 0)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RouteInfo {
+    path: &'static str,
+    methods: &'static [&'static str],
+}
+
+pub(crate) struct WrapperRouter<S = ()> {
+    pub(crate) router: Router<S>,
+    routes: Vec<RouteInfo>,
+}
+
+impl<S> WrapperRouter<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    fn new() -> Self {
+        Self {
+            router: Router::new(),
+            routes: Vec::new(),
+        }
+    }
+
+    fn route(
+        mut self,
+        path: &'static str,
+        method_router: MethodRouter<S>,
+        methods: &'static [&'static str],
+    ) -> Self {
+        self.router = self.router.route(path, method_router);
+        self.routes.push(RouteInfo { path, methods });
+        self
+    }
+}
+
+const GET_HEAD: &[&str] = &["GET", "HEAD"];
+const POST: &[&str] = &["POST"];
+
+fn route_log_lines(routes: &[RouteInfo]) -> Vec<String> {
+    routes
+        .iter()
+        .map(|route| {
+            format!(
+                "Route: {}, Methods: {}",
+                route.path,
+                route.methods.join(", ")
+            )
+        })
+        .collect()
+}
+
+pub(crate) fn log_available_routes(app: &WrapperRouter) {
+    info!("Available routes are:");
+    for line in route_log_lines(&app.routes) {
+        info!("{line}");
+    }
+}
+
 /// Build the minimal OpenAI-compatible router for one configured model.
-pub fn build_router(state: Arc<AppState>) -> Router {
+#[cfg(test)]
+fn build_router(state: Arc<AppState>) -> Router {
     build_router_with_dev_mode(state, server_dev_mode_enabled())
 }
 
+#[cfg(test)]
 fn build_router_with_dev_mode(state: Arc<AppState>, dev_mode_enabled: bool) -> Router {
-    let mut router = Router::new()
+    build_router_with_dev_mode_and_routes(state, dev_mode_enabled).router
+}
+
+pub(crate) fn build_router_with_routes(state: Arc<AppState>) -> WrapperRouter {
+    build_router_with_dev_mode_and_routes(state, server_dev_mode_enabled())
+}
+
+fn build_route_registry(dev_mode_enabled: bool) -> WrapperRouter<Arc<AppState>> {
+    let mut tracked = WrapperRouter::<Arc<AppState>>::new()
         // Health & monitoring
-        .route("/health", get(health::health))
-        .route("/metrics", get(metrics::scrape))
-        .route("/load", get(load::load))
-        .route("/version", get(version::version))
+        .route("/health", get(health::health), GET_HEAD)
+        .route("/metrics", get(metrics::scrape), GET_HEAD)
+        .route("/load", get(load::load), GET_HEAD)
+        .route("/version", get(version::version), GET_HEAD)
         // OpenAI-compatible endpoints
-        .route("/v1/models", get(openai::list_models))
-        .route("/v1/completions", post(openai::completions))
-        .route("/v1/chat/completions", post(openai::chat_completions))
+        .route("/v1/models", get(openai::list_models), GET_HEAD)
+        .route("/v1/completions", post(openai::completions), POST)
+        .route("/v1/chat/completions", post(openai::chat_completions), POST)
         // vLLM specific inference endpoints
-        .route("/inference/v1/generate", post(inference::generate));
+        .route("/inference/v1/generate", post(inference::generate), POST);
 
     if dev_mode_enabled {
         // Development-only
-        router = router
-            .route("/reset_prefix_cache", post(cache::reset_prefix_cache))
-            .route("/reset_mm_cache", post(cache::reset_mm_cache))
-            .route("/reset_encoder_cache", post(cache::reset_encoder_cache))
-            .route("/collective_rpc", post(collective_rpc::collective_rpc))
-            .route("/sleep", post(sleep::sleep))
-            .route("/wake_up", post(sleep::wake_up))
-            .route("/is_sleeping", get(sleep::is_sleeping))
+        tracked = tracked
+            .route("/reset_prefix_cache", post(cache::reset_prefix_cache), POST)
+            .route("/reset_mm_cache", post(cache::reset_mm_cache), POST)
+            .route(
+                "/reset_encoder_cache",
+                post(cache::reset_encoder_cache),
+                POST,
+            )
+            .route(
+                "/collective_rpc",
+                post(collective_rpc::collective_rpc),
+                POST,
+            )
+            .route("/sleep", post(sleep::sleep), POST)
+            .route("/wake_up", post(sleep::wake_up), POST)
+            .route("/is_sleeping", get(sleep::is_sleeping), GET_HEAD)
     }
+    tracked
+}
 
-    router
+fn build_router_with_dev_mode_and_routes(
+    state: Arc<AppState>,
+    dev_mode_enabled: bool,
+) -> WrapperRouter {
+    let tracked = build_route_registry(dev_mode_enabled);
+    let WrapperRouter { router, routes } = tracked;
+    let router = router
         .with_state(state.clone())
         .layer(from_fn_with_state(state, middleware::track_server_load))
         .layer(from_fn(middleware::track_http_metrics))
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http());
+
+    WrapperRouter { router, routes }
 }
 
 #[cfg(test)]

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -14,6 +14,7 @@ use std::{fmt, fs};
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode};
 use bytes::Bytes;
+use expect_test::expect;
 use futures::StreamExt as _;
 use rmpv::Value;
 use serde_json::json;
@@ -43,9 +44,48 @@ use vllm_text::{Prompt, TextBackend};
 use zeromq::prelude::{SocketRecv, SocketSend};
 use zeromq::{DealerSocket, PushSocket, ZmqMessage};
 
-use super::{build_router, build_router_with_dev_mode};
+use super::{build_route_registry, build_router, build_router_with_dev_mode, route_log_lines};
 use crate::routes::openai::chat_completions::convert::prepare_chat_request;
 use crate::state::AppState;
+
+#[test]
+fn available_route_log_lines_match_registered_public_routes() {
+    expect![[r#"
+        [
+            "Route: /health, Methods: GET, HEAD",
+            "Route: /metrics, Methods: GET, HEAD",
+            "Route: /load, Methods: GET, HEAD",
+            "Route: /v1/models, Methods: GET, HEAD",
+            "Route: /v1/completions, Methods: POST",
+            "Route: /v1/chat/completions, Methods: POST",
+            "Route: /inference/v1/generate, Methods: POST",
+        ]
+    "#]]
+    .assert_debug_eq(&route_log_lines(&build_route_registry(false).routes));
+}
+
+#[test]
+fn available_route_log_lines_include_dev_routes_when_enabled() {
+    expect![[r#"
+        [
+            "Route: /health, Methods: GET, HEAD",
+            "Route: /metrics, Methods: GET, HEAD",
+            "Route: /load, Methods: GET, HEAD",
+            "Route: /v1/models, Methods: GET, HEAD",
+            "Route: /v1/completions, Methods: POST",
+            "Route: /v1/chat/completions, Methods: POST",
+            "Route: /inference/v1/generate, Methods: POST",
+            "Route: /reset_prefix_cache, Methods: POST",
+            "Route: /reset_mm_cache, Methods: POST",
+            "Route: /reset_encoder_cache, Methods: POST",
+            "Route: /collective_rpc, Methods: POST",
+            "Route: /sleep, Methods: POST",
+            "Route: /wake_up, Methods: POST",
+            "Route: /is_sleeping, Methods: GET, HEAD",
+        ]
+    "#]]
+    .assert_debug_eq(&route_log_lines(&build_route_registry(true).routes));
+}
 
 fn request_output(
     request_id: &str,

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -44,47 +44,175 @@ use vllm_text::{Prompt, TextBackend};
 use zeromq::prelude::{SocketRecv, SocketSend};
 use zeromq::{DealerSocket, PushSocket, ZmqMessage};
 
-use super::{build_route_registry, build_router, build_router_with_dev_mode, route_log_lines};
+use super::{build_route_registry, build_router, build_router_with_dev_mode};
 use crate::routes::openai::chat_completions::convert::prepare_chat_request;
 use crate::state::AppState;
 
 #[test]
-fn available_route_log_lines_match_registered_public_routes() {
+fn available_routes_match_registered_public_routes() {
     expect![[r#"
         [
-            "Route: /health, Methods: GET, HEAD",
-            "Route: /metrics, Methods: GET, HEAD",
-            "Route: /load, Methods: GET, HEAD",
-            "Route: /v1/models, Methods: GET, HEAD",
-            "Route: /v1/completions, Methods: POST",
-            "Route: /v1/chat/completions, Methods: POST",
-            "Route: /inference/v1/generate, Methods: POST",
+            RouteInfo {
+                path: "/health",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/metrics",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/load",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/version",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/v1/models",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/v1/completions",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/v1/chat/completions",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/inference/v1/generate",
+                methods: [
+                    "POST",
+                ],
+            },
         ]
     "#]]
-    .assert_debug_eq(&route_log_lines(&build_route_registry(false).routes));
+    .assert_debug_eq(&build_route_registry(false).routes);
 }
 
 #[test]
-fn available_route_log_lines_include_dev_routes_when_enabled() {
+fn available_routes_include_dev_routes_when_enabled() {
     expect![[r#"
         [
-            "Route: /health, Methods: GET, HEAD",
-            "Route: /metrics, Methods: GET, HEAD",
-            "Route: /load, Methods: GET, HEAD",
-            "Route: /v1/models, Methods: GET, HEAD",
-            "Route: /v1/completions, Methods: POST",
-            "Route: /v1/chat/completions, Methods: POST",
-            "Route: /inference/v1/generate, Methods: POST",
-            "Route: /reset_prefix_cache, Methods: POST",
-            "Route: /reset_mm_cache, Methods: POST",
-            "Route: /reset_encoder_cache, Methods: POST",
-            "Route: /collective_rpc, Methods: POST",
-            "Route: /sleep, Methods: POST",
-            "Route: /wake_up, Methods: POST",
-            "Route: /is_sleeping, Methods: GET, HEAD",
+            RouteInfo {
+                path: "/health",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/metrics",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/load",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/version",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/v1/models",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
+            RouteInfo {
+                path: "/v1/completions",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/v1/chat/completions",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/inference/v1/generate",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/reset_prefix_cache",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/reset_mm_cache",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/reset_encoder_cache",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/collective_rpc",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/sleep",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/wake_up",
+                methods: [
+                    "POST",
+                ],
+            },
+            RouteInfo {
+                path: "/is_sleeping",
+                methods: [
+                    "GET",
+                    "HEAD",
+                ],
+            },
         ]
     "#]]
-    .assert_debug_eq(&route_log_lines(&build_route_registry(true).routes));
+    .assert_debug_eq(&build_route_registry(true).routes);
 }
 
 fn request_output(


### PR DESCRIPTION



## Purpose

Currently, after enabling `rust_vllm` via `VLLM_USE_RUST_FRONTEND=1`, the router registration information is not printed upon service startup.

## Test Plan

```
$ VLLM_USE_RUST_FRONTEND=1 vllm serve /new-model/MiniMax-M2.7 -tp=4
```

## Test Result

Service logs will be printed after startup.
```
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [server/src/lib.rs:133] starting OpenAI server bind_address=0.0.0.0:8000 model=/new-model/MiniMax-M2.7
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:79] Available routes are:
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /health, Methods: GET, HEAD
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /metrics, Methods: GET, HEAD
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /load, Methods: GET, HEAD
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /v1/models, Methods: GET, HEAD
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /v1/completions, Methods: POST
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /v1/chat/completions, Methods: POST
(RustFrontend pid=3638331) INFO 05-27 15:38:24 [routes.rs:81] Route: /inference/v1/generate, Methods: POST
```

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

