### PR TITLE
[Kernel][Hardware][AMD] Fix unsupported fp8 dtype on gfx942

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1194,7 +1194,7 @@ def _sparse_attn_decode_ragged_kernel(
             other=0,
         )
         if IS_FNUZ:
-            x_fp8 = x_uint8.to(tl.float8e4b15, bitcast=True)
+            x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
         else:
             x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
         encoded_scales = tl.load(
@@ -1262,7 +1262,7 @@ def _sparse_attn_decode_ragged_kernel(
                 other=0,
             )
             if IS_FNUZ:
-                x_fp8 = x_uint8.to(tl.float8e4b15, bitcast=True)
+                x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
             else:
                 x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
             encoded_scales = tl.load(


### PR DESCRIPTION

### Summary

Replace unsupported Triton fp8e4b15 dtype usage with fp8e4nv in the ROCm sparse attention ragged decode kernel for gfx942 compatibility.
The issue was observed from AMD CI failures during the sparse attention decode test path.

### Repro Information
Failing test
`pytest tests/kernels/attention/test_rocm_triton_attn_dsv4.py::test_sparse_attn_decode_ragged_kernel -v`
Environment
Architecture: gfx942 / MI300
ROCm CI environment
Triton backend path in:
vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
Relevant error
type fp8e4b15 not supported in this architecture

Triton reported the following supported FP8 dtypes on gfx942:

('fp8e4b8', 'fp8e4nv', 'fp8e5', 'fp8e5b16')

The failing path was:

`x_uint8.to(tl.float8e4b15, bitcast=True)
`
### Changes

Replaced:

`tl.float8e4b15` with `tl.float8e4nv`

in the sparse attention decode ragged kernel.

### Notes

I do not currently have local access to MI300 hardware, so this fix was derived from the AMD CI repro logs and Triton-supported dtype information reported on gfx942.
The failure appears to be isolated to this sparse/ragged decode kernel path.

### AI-assisted contribution disclosure

This PR was developed with assistance from AI tools for log analysis and debugging guidance. All code changes and reasoning were manually reviewed and validated by me before submission.