### PR TITLE
[DeepSeekV4][PCP] Enable context-parallel prefill for hybrid KV and MegaMoE

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1392,6 +1392,10 @@ def get_pcp_group() -> GroupCoordinator:
     return _PCP
 
 
+def maybe_get_pcp_group() -> GroupCoordinator | None:
+    return _PCP
+
+
 @contextmanager
 def graph_capture(device: torch.device):
     """

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1392,10 +1392,6 @@ def get_pcp_group() -> GroupCoordinator:
     return _PCP
 
 
-def maybe_get_pcp_group() -> GroupCoordinator | None:
-    return _PCP
-
-
 @contextmanager
 def graph_capture(device: torch.device):
     """

--- a/vllm/models/deepseek_v4/common/ops/__init__.py
+++ b/vllm/models/deepseek_v4/common/ops/__init__.py
@@ -5,6 +5,7 @@ from .cache_utils import (
     build_flashinfer_mixed_sparse_indices,
     combine_topk_swa_indices,
     compute_global_topk_indices_and_lens,
+    compute_local_topk_indices_and_lens,
     dequantize_and_gather_k_cache,
     quantize_and_insert_k_cache,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "build_flashinfer_mixed_sparse_indices",
     "combine_topk_swa_indices",
     "compute_global_topk_indices_and_lens",
+    "compute_local_topk_indices_and_lens",
     "dequantize_and_gather_k_cache",
     "fused_indexer_q_rope_quant",
     "fused_inv_rope_fp8_quant",

--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -8,8 +8,10 @@ preparation.
   the paged cache.
 - dequantize_and_gather_k_cache: gather and dequantize FP8 K from the paged
   cache for sparse/SWA prefill.
-- compute_global_topk_indices_and_lens: map local topk indices to global KV
-  cache slots and count valid entries.
+- compute_global_topk_indices_and_lens: map CP-global topk positions to local
+  KV cache slots and count valid entries.
+- compute_local_topk_indices_and_lens: map rank-local topk positions to local
+  KV cache slots and count valid entries.
 - combine_topk_swa_indices: concatenate topk compressed indices with SWA
   window indices for sparse prefill.
 """
@@ -18,6 +20,26 @@ import torch
 
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_cutedsl
+
+
+@triton.jit
+def _cp_local_len(length, total_cp_world_size, total_cp_rank, interleave_size):
+    base = length // interleave_size // total_cp_world_size * interleave_size
+    remainder = length - base * total_cp_world_size
+    extra = tl.minimum(
+        tl.maximum(remainder - total_cp_rank * interleave_size, 0),
+        interleave_size,
+    )
+    return base + extra
+
+
+@triton.jit
+def _cp_map_pos(pos, total_cp_world_size, total_cp_rank, interleave_size):
+    owner_rank = (pos // interleave_size) % total_cp_world_size
+    local_pos = (pos // (total_cp_world_size * interleave_size)) * interleave_size + (
+        pos % interleave_size
+    )
+    return owner_rank == total_cp_rank, local_pos
 
 
 @triton.jit
@@ -204,6 +226,9 @@ def _dequantize_and_gather_k_kernel(
     block_table_ptr,
     offset,
     gather_lens_ptr,
+    total_cp_world_size,
+    total_cp_rank,
+    cp_kv_cache_interleave_size,
     # Constants
     max_blocks_per_seq: tl.constexpr,
     fp8_dim: tl.constexpr,  # 448
@@ -228,18 +253,41 @@ def _dequantize_and_gather_k_kernel(
         # Gather all tokens
         gather_len = seq_len
     start_pos = seq_len - gather_len
+    local_start_pos = _cp_local_len(
+        start_pos,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
+    )
 
     for i in range(worker_id, gather_len, num_workers):
         # Calculate the actual token index in the sequence
         pos = start_pos + i
+        is_local, local_pos = _cp_map_pos(
+            pos,
+            total_cp_world_size,
+            total_cp_rank,
+            cp_kv_cache_interleave_size,
+        )
+        output_pos = local_pos - local_start_pos
 
         # Calculate which block and position within block
-        block_in_seq = pos // cache_block_size
-        pos_in_block = pos % cache_block_size
+        virtual_block_size = cache_block_size * total_cp_world_size
+        block_in_seq = pos // virtual_block_size
+        virtual_block_offset = pos - block_in_seq * virtual_block_size
+        pos_in_block = (
+            virtual_block_offset // (total_cp_world_size * cp_kv_cache_interleave_size)
+        ) * cp_kv_cache_interleave_size + (
+            virtual_block_offset % cp_kv_cache_interleave_size
+        )
 
         # Get physical block index from block table
         block_table_row_ptr = block_table_ptr + batch_idx * max_blocks_per_seq
-        physical_block_idx = tl.load(block_table_row_ptr + block_in_seq)  # int32
+        physical_block_idx = tl.load(
+            block_table_row_ptr + block_in_seq,
+            mask=is_local,
+            other=0,
+        )  # int32
 
         # int64: physical_block_idx * block_stride can exceed 2^31 with many
         # KV-cache blocks (e.g. >= 57K at block_stride ~37K).
@@ -260,7 +308,9 @@ def _dequantize_and_gather_k_kernel(
         token_bf16_ptr = token_data_ptr + fp8_dim
 
         # Output pointer for this token (flattened)
-        output_row_ptr = out_ptr + batch_idx * out_stride0 + (offset + i) * out_stride1
+        output_row_ptr = (
+            out_ptr + batch_idx * out_stride0 + (offset + output_pos) * out_stride1
+        )
 
         # ========== Dequantize FP8 portion using UE8M0 ==========
         for qblock_idx in tl.static_range(n_quant_blocks):
@@ -289,7 +339,11 @@ def _dequantize_and_gather_k_kernel(
                 x_dequant = x_float * scale
 
                 # Store as bf16
-                tl.store(output_row_ptr + offsets, x_dequant.to(tl.bfloat16), mask=mask)
+                tl.store(
+                    output_row_ptr + offsets,
+                    x_dequant.to(tl.bfloat16),
+                    mask=mask & is_local,
+                )
 
         # ========== Copy BF16 portion directly ==========
         bf16_output_offset = fp8_dim  # After 448 elements in output
@@ -300,8 +354,16 @@ def _dequantize_and_gather_k_kernel(
         # Process in chunks of 16
         for j in tl.static_range(bf16_dim // 16):
             chunk_offsets = j * 16 + tl.arange(0, 16)
-            bf16_vals = tl.load(bf16_cache_ptr + chunk_offsets)
-            tl.store(output_row_ptr + bf16_output_offset + chunk_offsets, bf16_vals)
+            bf16_vals = tl.load(
+                bf16_cache_ptr + chunk_offsets,
+                mask=is_local,
+                other=0.0,
+            )
+            tl.store(
+                output_row_ptr + bf16_output_offset + chunk_offsets,
+                bf16_vals,
+                mask=is_local,
+            )
 
 
 def dequantize_and_gather_k_cache_triton(
@@ -317,6 +379,9 @@ def dequantize_and_gather_k_cache_triton(
     block_table: torch.Tensor,
     block_size: int,
     offset: int,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> None:
     TOKEN_FP8_DIM = 448
     TOKEN_BF16_DIM = 64
@@ -336,6 +401,9 @@ def dequantize_and_gather_k_cache_triton(
         block_table,
         offset,
         gather_lens,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
         max_blocks_per_seq=block_table.shape[-1],
         fp8_dim=TOKEN_FP8_DIM,
         bf16_dim=TOKEN_BF16_DIM,
@@ -363,8 +431,11 @@ def dequantize_and_gather_k_cache(
     block_table: torch.Tensor,
     block_size: int,
     offset: int,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> None:
-    if has_cutedsl():
+    if has_cutedsl() and total_cp_world_size == 1:
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.dequant_gather_k_cutedsl import (
             dequantize_and_gather_k_cache_cutedsl,
@@ -376,7 +447,16 @@ def dequantize_and_gather_k_cache(
         return
 
     dequantize_and_gather_k_cache_triton(
-        out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
+        out,
+        k_cache,
+        seq_lens,
+        gather_lens,
+        block_table,
+        block_size,
+        offset,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
     )
 
 
@@ -386,6 +466,9 @@ def compute_global_topk_indices_and_lens(
     block_table: torch.Tensor,
     block_size: int,
     is_valid_token: torch.Tensor,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Map local topk indices to global KV cache slots and count valid entries.
 
@@ -409,9 +492,32 @@ def compute_global_topk_indices_and_lens(
         block_table.stride(0),
         block_size,
         is_valid_token,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
         TRITON_BLOCK_SIZE=1024,
     )
     return global_topk_indices, topk_lens
+
+
+def compute_local_topk_indices_and_lens(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map rank-local topk indices to KV cache slots and count valid entries."""
+    return compute_global_topk_indices_and_lens(
+        topk_indices,
+        token_to_req_indices,
+        block_table,
+        block_size,
+        is_valid_token,
+        total_cp_world_size=1,
+        total_cp_rank=0,
+        cp_kv_cache_interleave_size=1,
+    )
 
 
 @triton.jit
@@ -427,6 +533,9 @@ def _compute_global_topk_indices_and_lens_kernel(
     block_table_stride,
     block_size,
     is_valid_token_ptr,
+    total_cp_world_size,
+    total_cp_rank,
+    cp_kv_cache_interleave_size,
     TRITON_BLOCK_SIZE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
@@ -437,6 +546,11 @@ def _compute_global_topk_indices_and_lens_kernel(
     for i in range(0, topk, TRITON_BLOCK_SIZE):
         offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
         mask = offset < topk
+        tl.store(
+            global_topk_indices_ptr + token_idx * global_topk_indices_stride + offset,
+            -1,
+            mask=mask,
+        )
 
         local_idx = tl.load(
             topk_indices_ptr + token_idx * topk_indices_stride + offset,
@@ -445,21 +559,33 @@ def _compute_global_topk_indices_and_lens_kernel(
         )
         is_valid = local_idx >= 0
 
-        block_indices = local_idx // block_size
+        virtual_block_size = block_size * total_cp_world_size
+        block_indices = local_idx // virtual_block_size
         block_numbers = tl.load(
             block_table_ptr + req_idx * block_table_stride + block_indices,
             mask=mask & is_valid,
         )
-        block_offsets = local_idx % block_size
-
-        slot_ids = block_numbers * block_size + block_offsets
-        slot_ids = tl.where(is_valid, slot_ids, -1)
-        tl.store(
-            global_topk_indices_ptr + token_idx * global_topk_indices_stride + offset,
-            slot_ids,
-            mask=mask,
+        virtual_block_offsets = local_idx - block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // cp_kv_cache_interleave_size
+        ) % total_cp_world_size == total_cp_rank
+        local_block_offsets = (
+            virtual_block_offsets // (total_cp_world_size * cp_kv_cache_interleave_size)
+        ) * cp_kv_cache_interleave_size + (
+            virtual_block_offsets % cp_kv_cache_interleave_size
         )
-        count += tl.sum(is_valid.to(tl.int32), axis=0)
+
+        slot_ids = block_numbers * block_size + local_block_offsets
+        is_valid_local = is_valid & is_local
+        local_rank = count + tl.cumsum(is_valid_local.to(tl.int32), 0) - 1
+        tl.store(
+            global_topk_indices_ptr
+            + token_idx * global_topk_indices_stride
+            + local_rank,
+            slot_ids,
+            mask=mask & is_valid_local,
+        )
+        count += tl.sum(is_valid_local.to(tl.int32), axis=0)
 
     # Zero out length for padding tokens.
     tl.store(topk_lens_ptr + token_idx, tl.where(is_valid_token, count, 0))
@@ -483,6 +609,9 @@ def combine_topk_swa_indices(
     topk: int,
     M: int,
     N: int,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     num_tokens = topk_indices.shape[0]
     num_reqs = seq_lens.shape[0]
@@ -517,6 +646,9 @@ def combine_topk_swa_indices(
         COMPRESS_RATIO=compress_ratio,
         WINDOW_SIZE=window_size,
         PADDED_TOP_K=triton.next_power_of_2(topk_indices.shape[-1]),
+        TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+        TOTAL_CP_RANK=total_cp_rank,
+        CP_KV_CACHE_INTERLEAVE_SIZE=cp_kv_cache_interleave_size,
     )
     return combined_indices, combined_lens
 
@@ -537,6 +669,9 @@ def _combine_topk_swa_indices_kernel(
     COMPRESS_RATIO: tl.constexpr,
     WINDOW_SIZE: tl.constexpr,
     PADDED_TOP_K: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     worker_id = tl.program_id(1)
@@ -555,6 +690,12 @@ def _combine_topk_swa_indices_kernel(
     # (seq_len - gather_len), not position 0. We need this offset
     # to correctly index into the gathered buffer.
     gather_start = seq_len - gather_len
+    local_gather_start = _cp_local_len(
+        gather_start,
+        TOTAL_CP_WORLD_SIZE,
+        TOTAL_CP_RANK,
+        CP_KV_CACHE_INTERLEAVE_SIZE,
+    )
 
     for token_idx in range(query_start + worker_id, query_end, num_workers):
         # topk_len is fully determined by the query token's absolute position:
@@ -565,32 +706,45 @@ def _combine_topk_swa_indices_kernel(
         pos = start_pos + token_idx_in_query
         topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, TOP_K)
         swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
+        combined_len = tl.zeros((), dtype=tl.int32)
 
         offset = tl.arange(0, PADDED_TOP_K)
         mask = offset < topk_len
         topk_indices = tl.load(
             topk_indices_ptr + token_idx * topk_indices_stride + offset,
             mask=mask,
+            other=-1,
         )
+        topk_valid = mask & (topk_indices >= 0)
+        topk_rank = combined_len + tl.cumsum(topk_valid.to(tl.int32), 0) - 1
         tl.store(
-            combined_indices_ptr + token_idx * combined_indices_stride + offset,
+            combined_indices_ptr + token_idx * combined_indices_stride + topk_rank,
             topk_indices + M * batch_idx,
-            mask=mask,
+            mask=topk_valid,
         )
+        combined_len += tl.sum(topk_valid.to(tl.int32), axis=0)
+
         offset = tl.arange(0, WINDOW_SIZE)
+        swa_pos = pos - swa_len + 1 + offset
+        is_local, local_pos = _cp_map_pos(
+            swa_pos,
+            TOTAL_CP_WORLD_SIZE,
+            TOTAL_CP_RANK,
+            CP_KV_CACHE_INTERLEAVE_SIZE,
+        )
+        swa_valid = offset < swa_len
+        swa_valid_local = swa_valid & is_local
+        swa_rank = combined_len + tl.cumsum(swa_valid_local.to(tl.int32), 0) - 1
         # Index into gathered buffer: N + (position - gather_start)
         # For positions [pos - swa_len + 1, pos], the buffer indices are:
         # [N + pos - swa_len + 1 - gather_start, N + pos - gather_start]
         tl.store(
-            combined_indices_ptr
-            + token_idx * combined_indices_stride
-            + topk_len
-            + offset,
-            M * batch_idx + N + offset + pos - swa_len + 1 - gather_start,
-            mask=offset < swa_len,
+            combined_indices_ptr + token_idx * combined_indices_stride + swa_rank,
+            M * batch_idx + N + local_pos - local_gather_start,
+            mask=swa_valid_local,
         )
 
-        combined_len = topk_len + swa_len
+        combined_len += tl.sum(swa_valid_local.to(tl.int32), axis=0)
         tl.store(combined_lens_ptr + token_idx, combined_len)
 
 

--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -107,6 +107,496 @@ def compress_norm_rope_store_triton(
 
 
 # =============================================================================
+# DeepseekV4 PCP compressor path
+# =============================================================================
+@triton.jit
+def _dsv4_pcp_compressor_partial_stats_kernel(
+    # ── state cache (compressor internal state) ──
+    state_cache_ptr,
+    state_cache_stride0,
+    state_cache_stride1,
+    # ── metadata ──
+    token_to_req_indices_ptr,
+    positions_ptr,
+    slot_mapping_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    # ── partial softmax stats output ──
+    partial_m_ptr,
+    partial_s_ptr,
+    partial_v_ptr,
+    partial_stride0,
+    # ── constexprs ──
+    HEAD_SIZE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    STATE_WIDTH: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    OVERLAP: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    block = tl.arange(0, TRITON_BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+    out_offsets = token_idx * partial_stride0 + block
+
+    slot_id = tl.load(slot_mapping_ptr + token_idx)
+    if slot_id < 0:
+        tl.store(partial_m_ptr + out_offsets, 0.0, mask=mask)
+        tl.store(partial_s_ptr + out_offsets, 0.0, mask=mask)
+        tl.store(partial_v_ptr + out_offsets, 0.0, mask=mask)
+        return
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % COMPRESS_RATIO != 0:
+        tl.store(partial_m_ptr + out_offsets, 0.0, mask=mask)
+        tl.store(partial_s_ptr + out_offsets, 0.0, mask=mask)
+        tl.store(partial_v_ptr + out_offsets, 0.0, mask=mask)
+        return
+
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx)
+
+    start = position - (1 + OVERLAP) * COMPRESS_RATIO + 1
+    tokens = tl.arange(0, (1 + OVERLAP) * COMPRESS_RATIO)
+    pos = start + tokens
+    mask_pos = pos >= 0
+
+    virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+    block_indices = pos // virtual_block_size
+    block_numbers = tl.load(
+        block_table_ptr + req_idx * block_table_stride + block_indices,
+        mask=mask_pos,
+        other=0,
+    )
+    virtual_block_offsets = pos - block_indices * virtual_block_size
+    is_local = (
+        virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+    ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+    local_block_offsets = (
+        virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+    ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+        virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+    )
+    head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
+
+    row_base = (
+        state_cache_ptr
+        + block_numbers.to(tl.int64) * state_cache_stride0
+        + local_block_offsets * state_cache_stride1
+        + head_offset
+    )
+    combined_mask = mask_pos[:, None] & is_local[:, None] & mask[None, :]
+
+    score = tl.load(
+        row_base[:, None] + STATE_WIDTH + block[None, :],
+        mask=combined_mask,
+        other=float("-inf"),
+    )
+    local_m = tl.max(score, axis=0)
+    has_local = local_m != -float("inf")
+    shifted = tl.where(has_local[None, :], score - local_m[None, :], -float("inf"))
+    weight = tl.exp(shifted)
+    local_s = tl.sum(weight, axis=0)
+
+    kv = tl.load(
+        row_base[:, None] + block[None, :],
+        mask=combined_mask,
+        other=0.0,
+    )
+    local_v = tl.sum(kv * weight, axis=0)
+
+    tl.store(partial_m_ptr + out_offsets, local_m, mask=mask)
+    tl.store(partial_s_ptr + out_offsets, local_s, mask=mask)
+    tl.store(partial_v_ptr + out_offsets, local_v, mask=mask)
+
+
+@triton.jit
+def _dsv4_pcp_rescale_partial_stats_kernel(
+    partial_m_ptr,
+    partial_s_ptr,
+    partial_v_ptr,
+    global_m_ptr,
+    global_s_ptr,
+    global_v_ptr,
+    partial_stride0,
+    HEAD_SIZE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    block = tl.arange(0, TRITON_BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+    offsets = token_idx * partial_stride0 + block
+
+    partial_m = tl.load(partial_m_ptr + offsets, mask=mask, other=-float("inf"))
+    global_m = tl.load(global_m_ptr + offsets, mask=mask, other=-float("inf"))
+    partial_s = tl.load(partial_s_ptr + offsets, mask=mask, other=0.0)
+    partial_v = tl.load(partial_v_ptr + offsets, mask=mask, other=0.0)
+
+    valid = (
+        (partial_m == partial_m)
+        & (partial_m != float("inf"))
+        & (partial_m != -float("inf"))
+        & (global_m == global_m)
+        & (global_m != float("inf"))
+        & (global_m != -float("inf"))
+    )
+    scale = tl.where(valid, tl.exp(partial_m - global_m), 0.0)
+    tl.store(global_s_ptr + offsets, partial_s * scale, mask=mask)
+    tl.store(global_v_ptr + offsets, partial_v * scale, mask=mask)
+
+
+@triton.jit
+def _dsv4_pcp_finalize_sparse_attn_kernel(
+    # ── merged compressor stats ──
+    global_s_ptr,
+    global_v_ptr,
+    global_stride0,
+    # ── metadata ──
+    positions_ptr,
+    # ── RMSNorm ──
+    rms_norm_weight_ptr,
+    rms_norm_eps,
+    # ── RoPE ──
+    cos_sin_cache_ptr,
+    cos_sin_stride,
+    # ── KV cache output ──
+    k_cache_ptr,
+    kv_slot_mapping_ptr,
+    kv_cache_block_size,
+    # ── constexprs ──
+    HEAD_SIZE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    ROPE_HEAD_DIM: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    QUANT_BLOCK: tl.constexpr,
+    TOKEN_STRIDE: tl.constexpr,
+    SCALE_DIM: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % COMPRESS_RATIO != 0:
+        return
+
+    kv_slot_idx = tl.load(kv_slot_mapping_ptr + token_idx)
+    if kv_slot_idx < 0:
+        return
+
+    block = tl.arange(0, TRITON_BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+    stat_offsets = token_idx * global_stride0 + block
+    global_s = tl.load(global_s_ptr + stat_offsets, mask=mask, other=1.0)
+    global_v = tl.load(global_v_ptr + stat_offsets, mask=mask, other=0.0)
+    compressed_kv = global_v / global_s
+
+    rms_w = tl.load(rms_norm_weight_ptr + block, mask=mask, other=0.0)
+    variance = tl.sum(compressed_kv * compressed_kv, axis=0) / HEAD_SIZE
+    rrms = tl.rsqrt(variance + rms_norm_eps)
+    normed = compressed_kv * rrms * rms_w
+
+    kv_block_idx = kv_slot_idx // kv_cache_block_size
+    kv_pos_in_block = kv_slot_idx % kv_cache_block_size
+
+    cache_block_ptr = k_cache_ptr + kv_block_idx.to(tl.int64) * KV_BLOCK_STRIDE
+    fp8_ptr = cache_block_ptr + kv_pos_in_block * TOKEN_STRIDE
+    scale_ptr = (
+        cache_block_ptr
+        + kv_cache_block_size * TOKEN_STRIDE
+        + kv_pos_in_block * SCALE_DIM
+    )
+
+    NOPE_HEAD_DIM: tl.constexpr = HEAD_SIZE - ROPE_HEAD_DIM
+    HALF_ROPE: tl.constexpr = ROPE_HEAD_DIM // 2
+
+    N_QUANT_BLOCKS: tl.constexpr = TRITON_BLOCK_SIZE // QUANT_BLOCK
+    N_NOPE_BLOCKS: tl.constexpr = NOPE_HEAD_DIM // QUANT_BLOCK
+    INV_FP8_MAX: tl.constexpr = 1.0 / FP8_MAX
+
+    quant_input = normed.to(tl.bfloat16).to(tl.float32)
+    quant_2d = tl.reshape(quant_input, (N_QUANT_BLOCKS, QUANT_BLOCK))
+    abs_2d = tl.abs(quant_2d)
+    block_absmax = tl.max(abs_2d, axis=1)
+    block_absmax = tl.maximum(block_absmax, 1e-4)
+
+    raw_scales = block_absmax * INV_FP8_MAX
+    exponents = tl.ceil(tl.log2(raw_scales))
+    inv_scales = tl.exp2(-exponents)
+    inv_scales_col = tl.reshape(inv_scales, (N_QUANT_BLOCKS, 1))
+    x_scaled = quant_2d * inv_scales_col
+    x_clamped = tl.clamp(x_scaled, -FP8_MAX, FP8_MAX)
+    x_fp8 = x_clamped.to(tl.float8e4nv)
+    x_uint8 = x_fp8.to(tl.uint8, bitcast=True)
+    x_uint8_flat = tl.reshape(x_uint8, (TRITON_BLOCK_SIZE,))
+
+    nope_mask = block < NOPE_HEAD_DIM
+    tl.store(fp8_ptr + block, x_uint8_flat, mask=nope_mask)
+
+    scale_idx = tl.arange(0, N_QUANT_BLOCKS)
+    encoded = exponents + 127.0
+    encoded = tl.maximum(tl.minimum(encoded, 255.0), 0.0)
+    tl.store(
+        scale_ptr + scale_idx,
+        encoded.to(tl.uint8),
+        mask=scale_idx < N_NOPE_BLOCKS,
+    )
+    tl.store(scale_ptr + N_NOPE_BLOCKS, tl.zeros((), dtype=tl.uint8))
+
+    NUM_PAIRS: tl.constexpr = TRITON_BLOCK_SIZE // 2
+    NOPE_PAIRS: tl.constexpr = NOPE_HEAD_DIM // 2
+
+    pair_2d = tl.reshape(normed, (NUM_PAIRS, 2))
+    even, odd = tl.split(pair_2d)
+
+    pair_idx = tl.arange(0, NUM_PAIRS)
+    rope_pair_local = pair_idx - NOPE_PAIRS
+    is_rope_pair = rope_pair_local >= 0
+    cs_idx = tl.maximum(rope_pair_local, 0)
+
+    compressed_pos = (position // COMPRESS_RATIO) * COMPRESS_RATIO
+    cache_base = cos_sin_cache_ptr + compressed_pos * cos_sin_stride
+    cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
+    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
+
+    new_even = even * cos_v - odd * sin_v
+    new_odd = odd * cos_v + even * sin_v
+    result = tl.interleave(new_even, new_odd)
+
+    bf16_ptr = (fp8_ptr + NOPE_HEAD_DIM).to(tl.pointer_type(tl.bfloat16))
+    rope_local = block - NOPE_HEAD_DIM
+    is_rope = (block >= NOPE_HEAD_DIM) & mask
+    tl.store(bf16_ptr + rope_local, result.to(tl.bfloat16), mask=is_rope)
+
+
+@triton.jit
+def _dsv4_pcp_finalize_indexer_attn_kernel(
+    # ── merged compressor stats ──
+    global_s_ptr,
+    global_v_ptr,
+    global_stride0,
+    # ── metadata ──
+    positions_ptr,
+    # ── RMSNorm ──
+    rms_norm_weight_ptr,
+    rms_norm_eps,
+    # ── RoPE ──
+    cos_sin_cache_ptr,
+    cos_sin_stride,
+    # ── KV cache output ──
+    k_cache_ptr,
+    kv_slot_mapping_ptr,
+    kv_cache_block_size,
+    # ── constexprs ──
+    HEAD_SIZE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    ROPE_HEAD_DIM: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    QUANT_BLOCK: tl.constexpr,
+    TOKEN_STRIDE: tl.constexpr,
+    SCALE_DIM: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % COMPRESS_RATIO != 0:
+        return
+
+    kv_slot_idx = tl.load(kv_slot_mapping_ptr + token_idx)
+    if kv_slot_idx < 0:
+        return
+
+    block = tl.arange(0, TRITON_BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+    stat_offsets = token_idx * global_stride0 + block
+    global_s = tl.load(global_s_ptr + stat_offsets, mask=mask, other=1.0)
+    global_v = tl.load(global_v_ptr + stat_offsets, mask=mask, other=0.0)
+    compressed_kv = global_v / global_s
+
+    rms_w = tl.load(rms_norm_weight_ptr + block, mask=mask, other=0.0)
+    variance = tl.sum(compressed_kv * compressed_kv, axis=0) / HEAD_SIZE
+    rrms = tl.rsqrt(variance + rms_norm_eps)
+    normed = compressed_kv * rrms * rms_w
+
+    kv_block_idx = kv_slot_idx // kv_cache_block_size
+    kv_pos_in_block = kv_slot_idx % kv_cache_block_size
+
+    cache_block_ptr = k_cache_ptr + kv_block_idx.to(tl.int64) * KV_BLOCK_STRIDE
+    fp8_ptr = cache_block_ptr + kv_pos_in_block * TOKEN_STRIDE
+    scale_ptr = (
+        cache_block_ptr
+        + kv_cache_block_size * TOKEN_STRIDE
+        + kv_pos_in_block * SCALE_DIM
+    )
+
+    NOPE_HEAD_DIM: tl.constexpr = HEAD_SIZE - ROPE_HEAD_DIM
+    HALF_ROPE: tl.constexpr = ROPE_HEAD_DIM // 2
+
+    NUM_PAIRS: tl.constexpr = TRITON_BLOCK_SIZE // 2
+    NOPE_PAIRS: tl.constexpr = NOPE_HEAD_DIM // 2
+
+    normed_2d = tl.reshape(normed, (NUM_PAIRS, 2))
+    even, odd = tl.split(normed_2d)
+
+    pair_idx = tl.arange(0, NUM_PAIRS)
+    rope_pair_local = pair_idx - NOPE_PAIRS
+    is_rope_pair = rope_pair_local >= 0
+    cs_idx = tl.maximum(rope_pair_local, 0)
+
+    compressed_pos = (position // COMPRESS_RATIO) * COMPRESS_RATIO
+    cache_base = cos_sin_cache_ptr + compressed_pos * cos_sin_stride
+    cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
+    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
+
+    new_even = even * cos_v - odd * sin_v
+    new_odd = odd * cos_v + even * sin_v
+    result = tl.interleave(new_even, new_odd)
+
+    tl.static_assert(
+        TRITON_BLOCK_SIZE == QUANT_BLOCK,
+        "Indexer expects one quant block (QUANT_BLOCK == TRITON_BLOCK_SIZE)",
+    )
+    INV_FP8_MAX: tl.constexpr = 1.0 / FP8_MAX
+
+    result_bf16 = result.to(tl.bfloat16).to(tl.float32)
+    absmax = tl.max(tl.abs(result_bf16), axis=0)
+    absmax = tl.maximum(absmax, 1e-4)
+    raw_scale = absmax * INV_FP8_MAX
+    exponent = tl.ceil(tl.log2(raw_scale))
+    inv_scale = tl.exp2(-exponent)
+
+    x_scaled = result_bf16 * inv_scale
+    x_clamped = tl.clamp(x_scaled, -FP8_MAX, FP8_MAX)
+    x_fp8 = x_clamped.to(tl.float8e4nv)
+    x_uint8 = x_fp8.to(tl.uint8, bitcast=True)
+
+    tl.store(fp8_ptr + block, x_uint8, mask=mask)
+
+    scale_val = tl.exp2(exponent)
+    tl.store(scale_ptr.to(tl.pointer_type(tl.float32)), scale_val)
+
+
+@triton.jit
+def _dsv4_pcp_finalize_indexer_mxfp4_attn_kernel(
+    # ── merged compressor stats ──
+    global_s_ptr,
+    global_v_ptr,
+    global_stride0,
+    # ── metadata ──
+    positions_ptr,
+    # ── RMSNorm ──
+    rms_norm_weight_ptr,
+    rms_norm_eps,
+    # ── RoPE ──
+    cos_sin_cache_ptr,
+    cos_sin_stride,
+    # ── KV cache output ──
+    k_cache_ptr,
+    kv_slot_mapping_ptr,
+    kv_cache_block_size,
+    # ── constexprs ──
+    HEAD_SIZE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    ROPE_HEAD_DIM: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    QUANT_BLOCK: tl.constexpr,
+    TOKEN_STRIDE: tl.constexpr,
+    SCALE_DIM: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % COMPRESS_RATIO != 0:
+        return
+
+    kv_slot_idx = tl.load(kv_slot_mapping_ptr + token_idx)
+    if kv_slot_idx < 0:
+        return
+
+    block = tl.arange(0, TRITON_BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+    stat_offsets = token_idx * global_stride0 + block
+    global_s = tl.load(global_s_ptr + stat_offsets, mask=mask, other=1.0)
+    global_v = tl.load(global_v_ptr + stat_offsets, mask=mask, other=0.0)
+    compressed_kv = global_v / global_s
+
+    rms_w = tl.load(rms_norm_weight_ptr + block, mask=mask, other=0.0)
+    variance = tl.sum(compressed_kv * compressed_kv, axis=0) / HEAD_SIZE
+    rrms = tl.rsqrt(variance + rms_norm_eps)
+    normed = compressed_kv * rrms * rms_w
+
+    kv_block_idx = kv_slot_idx // kv_cache_block_size
+    kv_pos_in_block = kv_slot_idx % kv_cache_block_size
+
+    cache_block_ptr = k_cache_ptr + kv_block_idx.to(tl.int64) * KV_BLOCK_STRIDE
+    val_ptr = cache_block_ptr + kv_pos_in_block * TOKEN_STRIDE
+    scale_ptr = (
+        cache_block_ptr
+        + kv_cache_block_size * TOKEN_STRIDE
+        + kv_pos_in_block * SCALE_DIM
+    )
+
+    NOPE_HEAD_DIM: tl.constexpr = HEAD_SIZE - ROPE_HEAD_DIM
+    HALF_ROPE: tl.constexpr = ROPE_HEAD_DIM // 2
+
+    NUM_PAIRS: tl.constexpr = TRITON_BLOCK_SIZE // 2
+    NOPE_PAIRS: tl.constexpr = NOPE_HEAD_DIM // 2
+
+    normed_2d = tl.reshape(normed, (NUM_PAIRS, 2))
+    even, odd = tl.split(normed_2d)
+
+    pair_idx = tl.arange(0, NUM_PAIRS)
+    rope_pair_local = pair_idx - NOPE_PAIRS
+    is_rope_pair = rope_pair_local >= 0
+    cs_idx = tl.maximum(rope_pair_local, 0)
+
+    compressed_pos = (position // COMPRESS_RATIO) * COMPRESS_RATIO
+    cache_base = cos_sin_cache_ptr + compressed_pos * cos_sin_stride
+    cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
+    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
+
+    new_even = even * cos_v - odd * sin_v
+    new_odd = odd * cos_v + even * sin_v
+
+    new_even = new_even.to(tl.bfloat16).to(tl.float32)
+    new_odd = new_odd.to(tl.bfloat16).to(tl.float32)
+
+    N_QUANT_BLOCKS: tl.constexpr = HEAD_SIZE // QUANT_BLOCK
+    HALF_BLOCK: tl.constexpr = QUANT_BLOCK // 2
+    tl.static_assert(TRITON_BLOCK_SIZE == HEAD_SIZE)
+    tl.static_assert(HEAD_SIZE % QUANT_BLOCK == 0)
+    tl.static_assert(TOKEN_STRIDE == HEAD_SIZE // 2)
+    tl.static_assert(SCALE_DIM == N_QUANT_BLOCKS)
+
+    even_2d = tl.reshape(new_even, (N_QUANT_BLOCKS, HALF_BLOCK))
+    odd_2d = tl.reshape(new_odd, (N_QUANT_BLOCKS, HALF_BLOCK))
+
+    amax = tl.maximum(
+        tl.max(tl.abs(even_2d), axis=1),
+        tl.max(tl.abs(odd_2d), axis=1),
+    )
+    amax = tl.maximum(amax, 6.0 * (2**-126))
+
+    log2_ratio = tl.ceil(tl.log2(amax * (1.0 / 6.0)))
+    log2_ratio = tl.minimum(tl.maximum(log2_ratio, -127.0), 127.0)
+    inv_scale = tl.exp2(-log2_ratio)
+    ue8m0 = (log2_ratio + 127.0).to(tl.uint8)
+
+    inv_scale_col = tl.reshape(inv_scale, (N_QUANT_BLOCKS, 1))
+    packed = _fp32x2_to_fp4x2(even_2d * inv_scale_col, odd_2d * inv_scale_col)
+    packed_flat = tl.reshape(packed, (TOKEN_STRIDE,))
+
+    tl.store(val_ptr + tl.arange(0, TOKEN_STRIDE), packed_flat)
+    tl.store(scale_ptr + tl.arange(0, SCALE_DIM), ue8m0)
+
+
+# =============================================================================
 # DeepseekV4 Attention path (head=512, nope=448 FP8 + rope=64 bf16)
 # =============================================================================
 @triton.jit

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -5,14 +5,21 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
 import torch
+import torch.distributed as dist
 from torch import nn
 
 from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
 from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+    _dsv4_pcp_compressor_partial_stats_kernel,
+    _dsv4_pcp_finalize_indexer_attn_kernel,
+    _dsv4_pcp_finalize_indexer_mxfp4_attn_kernel,
+    _dsv4_pcp_finalize_sparse_attn_kernel,
+    _dsv4_pcp_rescale_partial_stats_kernel,
     compress_norm_rope_store_triton,
 )
 from vllm.models.deepseek_v4.common.ops.fused_indexer_q import MXFP4_BLOCK_SIZE
@@ -20,6 +27,7 @@ from vllm.models.deepseek_v4.common.ops.save_partial_states import (
     save_partial_states,
 )
 from vllm.platforms import current_platform
+from vllm.triton_utils import triton
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -32,6 +40,7 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+from vllm.v1.worker.cp_utils import get_total_cp_world_size_and_rank
 
 
 class CompressorBackend(AttentionBackend):
@@ -212,6 +221,9 @@ class DeepseekCompressor(nn.Module):
         self.device = current_platform.device_type
         self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         self.max_model_len = vllm_config.model_config.max_model_len
+        self.cp_kv_cache_interleave_size = (
+            vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
 
         self.overlap = compress_ratio == 4
         self.coff = 1 + self.overlap
@@ -257,15 +269,20 @@ class DeepseekCompressor(nn.Module):
             self._quant_block = 64
             self._token_stride = self.nope_head_dim + self.rope_head_dim * 2
             self._scale_dim = self.nope_head_dim // 64 + 1  # 7 real + 1 pad
+            self._num_warps = 4
+            self._pcp_finalize_kernel = _dsv4_pcp_finalize_sparse_attn_kernel
         elif self.head_dim == 128:
             if use_fp4_cache:
                 self._quant_block = MXFP4_BLOCK_SIZE
                 self._token_stride = self.head_dim // 2
                 self._scale_dim = self.head_dim // MXFP4_BLOCK_SIZE
+                self._pcp_finalize_kernel = _dsv4_pcp_finalize_indexer_mxfp4_attn_kernel
             else:
                 self._quant_block = 128
                 self._token_stride = self.head_dim
                 self._scale_dim = 4  # single float32 scale
+                self._pcp_finalize_kernel = _dsv4_pcp_finalize_indexer_attn_kernel
+            self._num_warps = 1
         else:
             raise ValueError(
                 f"Unsupported head_dim for fused quant+cache: {self.head_dim}"
@@ -350,6 +367,26 @@ class DeepseekCompressor(nn.Module):
             else None
         )
 
+        total_cp_world_size, total_cp_rank = get_total_cp_world_size_and_rank()
+        if total_cp_world_size > 1:
+            self._pcp_compress_and_insert(
+                state_cache=state_cache,
+                token_to_req_indices=token_to_req_indices,
+                positions=positions,
+                state_slot_mapping=slot_mapping,
+                block_table=block_table,
+                block_size=block_size,
+                state_width=state_width,
+                cos_sin_cache=cos_sin_cache,
+                kv_cache=kv_cache,
+                kv_slot_mapping=k_cache_metadata.slot_mapping,
+                num_actual=num_actual,
+                total_cp_world_size=total_cp_world_size,
+                total_cp_rank=total_cp_rank,
+                pdl_kwargs=pdl_kwargs,
+            )
+            return
+
         # cutedsl (head=512) accepts the full-cache flags; triton (indexer/AMD)
         # does not, so the two callables have different signatures.
         compress_norm_rope_store_fn: Any
@@ -396,4 +433,114 @@ class DeepseekCompressor(nn.Module):
             token_stride=self._token_stride,
             scale_dim=self._scale_dim,
             **extra_kwargs,
+        )
+
+    def _pcp_compress_and_insert(
+        self,
+        *,
+        state_cache: torch.Tensor,
+        token_to_req_indices: torch.Tensor,
+        positions: torch.Tensor,
+        state_slot_mapping: torch.Tensor,
+        block_table: torch.Tensor,
+        block_size: int,
+        state_width: int,
+        cos_sin_cache: torch.Tensor,
+        kv_cache: torch.Tensor,
+        kv_slot_mapping: torch.Tensor,
+        num_actual: int,
+        total_cp_world_size: int,
+        total_cp_rank: int,
+        pdl_kwargs: dict[str, Any],
+    ) -> None:
+        pcp_group = get_pcp_group()
+        assert pcp_group.world_size == total_cp_world_size, (
+            "Deepseek V4 PCP compressor currently supports PCP-only CP."
+        )
+
+        shape = (num_actual, self.head_dim)
+        partial_m = torch.empty(shape, device=positions.device, dtype=torch.float32)
+        partial_s = torch.empty_like(partial_m)
+        partial_v = torch.empty_like(partial_m)
+
+        _dsv4_pcp_compressor_partial_stats_kernel[(num_actual,)](
+            # state cache
+            state_cache,
+            state_cache.stride(0),
+            state_cache.stride(1),
+            # metadata
+            token_to_req_indices,
+            positions,
+            state_slot_mapping,
+            block_table,
+            block_table.stride(0),
+            block_size,
+            # partial stats
+            partial_m,
+            partial_s,
+            partial_v,
+            partial_m.stride(0),
+            # constexprs
+            HEAD_SIZE=self.head_dim,
+            TRITON_BLOCK_SIZE=triton.next_power_of_2(self.head_dim),
+            STATE_WIDTH=state_width,
+            COMPRESS_RATIO=self.compress_ratio,
+            OVERLAP=self.overlap,
+            TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+            TOTAL_CP_RANK=total_cp_rank,
+            CP_KV_CACHE_INTERLEAVE_SIZE=self.cp_kv_cache_interleave_size,
+            num_warps=self._num_warps,
+            **pdl_kwargs,
+        )
+
+        global_m = partial_m.clone()
+        dist.all_reduce(global_m, op=dist.ReduceOp.MAX, group=pcp_group.device_group)
+
+        global_s = torch.empty_like(partial_s)
+        global_v = torch.empty_like(partial_v)
+        _dsv4_pcp_rescale_partial_stats_kernel[(num_actual,)](
+            partial_m,
+            partial_s,
+            partial_v,
+            global_m,
+            global_s,
+            global_v,
+            partial_m.stride(0),
+            HEAD_SIZE=self.head_dim,
+            TRITON_BLOCK_SIZE=triton.next_power_of_2(self.head_dim),
+            num_warps=self._num_warps,
+            **pdl_kwargs,
+        )
+        global_s = pcp_group.all_reduce(global_s)
+        global_v = pcp_group.all_reduce(global_v)
+
+        self._pcp_finalize_kernel[(num_actual,)](
+            # merged stats
+            global_s,
+            global_v,
+            global_s.stride(0),
+            # metadata
+            positions,
+            # RMSNorm
+            self.norm.weight,
+            self.rms_norm_eps,
+            # RoPE
+            cos_sin_cache,
+            cos_sin_cache.stride(0),
+            # KV cache
+            kv_cache,
+            kv_slot_mapping,
+            kv_cache.shape[1],
+            # constexprs
+            HEAD_SIZE=self.head_dim,
+            TRITON_BLOCK_SIZE=triton.next_power_of_2(self.head_dim),
+            COMPRESS_RATIO=self.compress_ratio,
+            ROPE_HEAD_DIM=self.rope_head_dim,
+            FP8_MAX=448.0,
+            QUANT_BLOCK=self._quant_block,
+            TOKEN_STRIDE=self._token_stride,
+            SCALE_DIM=self._scale_dim,
+            KV_BLOCK_STRIDE=kv_cache.stride(0),
+            num_warps=self._num_warps,
+            **pdl_kwargs,
         )

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -5,11 +5,12 @@ from typing import TYPE_CHECKING, cast
 
 import torch
 
+from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
 from vllm.models.deepseek_v4.common.ops import (
     combine_topk_swa_indices,
-    compute_global_topk_indices_and_lens,
+    compute_local_topk_indices_and_lens,
     dequantize_and_gather_k_cache,
 )
 from vllm.models.deepseek_v4.nvidia.ops.o_proj import (
@@ -20,6 +21,8 @@ from vllm.models.deepseek_v4.sparse_mla import (
     DeepseekV4FlashMLABackend,
     DeepseekV4FlashMLAMetadata,
 )
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.ops.common import cp_lse_ag_out_ar
 from vllm.v1.attention.ops.flashmla import (
     flash_mla_sparse_fwd,
     flash_mla_with_kvcache,
@@ -28,6 +31,126 @@ from vllm.v1.worker.workspace import current_workspace_manager
 
 if TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
+
+
+def _get_pcp_group_for_merge():
+    try:
+        pcp_group = get_pcp_group()
+    except AssertionError:
+        return None
+    return pcp_group if pcp_group.world_size > 1 else None
+
+
+def _decode_lse_to_2d(lse: torch.Tensor) -> torch.Tensor:
+    if lse.ndim == 3 and lse.shape[-1] == 1:
+        lse = lse.squeeze(-1)
+    if lse.ndim == 3 and lse.shape[1] == 1:
+        lse = lse.squeeze(1)
+    assert lse.ndim == 2, f"expected decode lse [B,H], got {tuple(lse.shape)}"
+    return lse
+
+
+@triton.jit
+def _mask_empty_lse_kernel(
+    lse_ptr,
+    lengths_ptr,
+    lse_stride_t,
+    lse_stride_h,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    head_offsets = tl.arange(0, BLOCK_H)
+    mask = head_offsets < H
+    length = tl.load(lengths_ptr + token_idx)
+    lse_offsets = token_idx * lse_stride_t + head_offsets * lse_stride_h
+    lse = tl.load(lse_ptr + lse_offsets, mask=mask)
+    lse = tl.where(length <= 0, -float("inf"), lse)
+    tl.store(lse_ptr + lse_offsets, lse, mask=mask)
+
+
+@triton.jit
+def _apply_attn_sink_and_copy_kernel(
+    src_ptr,
+    lse_ptr,
+    attn_sink_ptr,
+    dst_ptr,
+    src_stride_t,
+    src_stride_h,
+    src_stride_d,
+    lse_stride_t,
+    lse_stride_h,
+    dst_stride_t,
+    dst_stride_h,
+    dst_stride_d,
+    HEAD_DIM: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    head_idx = tl.program_id(1).to(tl.int64)
+    d_offsets = tl.arange(0, HEAD_DIM)
+
+    lse = tl.load(lse_ptr + token_idx * lse_stride_t + head_idx * lse_stride_h).to(
+        tl.float32
+    )
+    sink = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+    scale = tl.sigmoid(lse - sink)
+
+    src_offsets = (
+        token_idx * src_stride_t + head_idx * src_stride_h + d_offsets * src_stride_d
+    )
+    dst_offsets = (
+        token_idx * dst_stride_t + head_idx * dst_stride_h + d_offsets * dst_stride_d
+    )
+    output = tl.load(src_ptr + src_offsets)
+    tl.store(dst_ptr + dst_offsets, output * scale)
+
+
+def _mask_empty_lse_(lse: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    assert lse.ndim == 2, f"expected lse [T,H], got {tuple(lse.shape)}"
+    assert lengths.ndim == 1, f"expected lengths [T], got {tuple(lengths.shape)}"
+    if lse.numel() == 0:
+        return lse
+    T, H = lse.shape
+    _mask_empty_lse_kernel[(T,)](
+        lse,
+        lengths,
+        lse.stride(0),
+        lse.stride(1),
+        H=H,
+        BLOCK_H=triton.next_power_of_2(H),
+    )
+    return lse
+
+
+def _apply_attn_sink_and_copy(
+    src: torch.Tensor,
+    lse: torch.Tensor,
+    attn_sink: torch.Tensor,
+    dst: torch.Tensor,
+) -> None:
+    assert src.ndim == 3, f"expected src [T,H,D], got {tuple(src.shape)}"
+    assert dst.ndim == 3, f"expected dst [T,H,D], got {tuple(dst.shape)}"
+    assert lse.ndim == 2, f"expected lse [T,H], got {tuple(lse.shape)}"
+    if src.numel() == 0:
+        return
+    T, H, D = src.shape
+    assert dst.shape == src.shape
+    assert lse.shape == (T, H)
+    _apply_attn_sink_and_copy_kernel[(T, H)](
+        src,
+        lse,
+        attn_sink,
+        dst,
+        src.stride(0),
+        src.stride(1),
+        src.stride(2),
+        lse.stride(0),
+        lse.stride(1),
+        dst.stride(0),
+        dst.stride(1),
+        dst.stride(2),
+        HEAD_DIM=triton.next_power_of_2(D),
+    )
 
 
 class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
@@ -164,14 +287,14 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             if self.compress_ratio == 4:
                 # C4A: local indices differ per layer (filled by Indexer).
                 assert self.topk_indices_buffer is not None
-                global_indices, topk_lens = compute_global_topk_indices_and_lens(
+                slot_indices, topk_lens = compute_local_topk_indices_and_lens(
                     self.topk_indices_buffer[:num_decode_tokens],
                     swa_metadata.token_to_req_indices,
                     attn_metadata.block_table[:num_decodes],
                     block_size,
                     is_valid,
                 )
-                topk_indices = global_indices.view(num_decode_tokens, 1, -1)
+                topk_indices = slot_indices.view(num_decode_tokens, 1, -1)
             else:
                 # C128A: pre-computed during metadata build.
                 topk_indices = attn_metadata.c128a_global_decode_topk_indices
@@ -216,7 +339,13 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             "allocate one for this layer type."
         )
 
-        out, _ = flash_mla_with_kvcache(
+        pcp_group = _get_pcp_group_for_merge()
+        out_buffer = (
+            torch.empty_like(output).unsqueeze(1)
+            if pcp_group is not None
+            else output.unsqueeze(1)
+        )
+        out, lse = flash_mla_with_kvcache(
             q=q,
             k_cache=swa_cache,
             block_table=None,
@@ -227,12 +356,25 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             indices=swa_indices,
             topk_length=swa_lens,
             softmax_scale=self.scale,
-            attn_sink=self.attn_sink,
+            attn_sink=None if pcp_group is not None else self.attn_sink,
             extra_k_cache=kv_cache if not swa_only else None,
             extra_indices_in_kvcache=topk_indices,
             extra_topk_length=topk_lens,
-            out=output.unsqueeze(1),
+            out=out_buffer,
         )
+        if pcp_group is not None:
+            lse = _decode_lse_to_2d(lse)
+            local_lens = swa_lens if topk_lens is None else swa_lens + topk_lens
+            lse = _mask_empty_lse_(lse, local_lens)
+            partial_out = out.squeeze(1)
+            merged_out, merged_lse = cp_lse_ag_out_ar(
+                partial_out,
+                lse,
+                pcp_group,
+                return_lse=True,
+                is_lse_base_on_e=True,
+            )
+            _apply_attn_sink_and_copy(merged_out, merged_lse, self.attn_sink, output)
 
     def _forward_prefill(
         self,
@@ -309,6 +451,9 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                     block_table=block_table[chunk_start:chunk_end],
                     block_size=attn_metadata.block_size // self.compress_ratio,
                     offset=0,
+                    total_cp_world_size=attn_metadata.total_cp_world_size,
+                    total_cp_rank=attn_metadata.total_cp_rank,
+                    cp_kv_cache_interleave_size=attn_metadata.cp_kv_cache_interleave_size,
                 )
 
             # Gather SWA KV
@@ -321,6 +466,9 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 block_table=swa_block_table[chunk_start:chunk_end],
                 block_size=swa_metadata.block_size,
                 offset=N,
+                total_cp_world_size=swa_metadata.total_cp_world_size,
+                total_cp_rank=swa_metadata.total_cp_rank,
+                cp_kv_cache_interleave_size=swa_metadata.cp_kv_cache_interleave_size,
             )
 
             # Combine the topk indices and SWA indices for gathered KV cache
@@ -343,13 +491,33 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 top_k,
                 M,
                 N,
+                total_cp_world_size=swa_metadata.total_cp_world_size,
+                total_cp_rank=swa_metadata.total_cp_rank,
+                cp_kv_cache_interleave_size=swa_metadata.cp_kv_cache_interleave_size,
             )
-            flash_mla_sparse_fwd(
+            pcp_group = _get_pcp_group_for_merge()
+            out_slice = output[query_start:query_end]
+            partial_out = (
+                torch.empty_like(out_slice) if pcp_group is not None else out_slice
+            )
+            partial_out, _, partial_lse = flash_mla_sparse_fwd(
                 q=q[query_start:query_end],
                 kv=kv.view(-1, 1, q.shape[-1]),
                 indices=combined_indices.unsqueeze(1),
                 sm_scale=self.scale,
-                attn_sink=self.attn_sink,
+                attn_sink=None if pcp_group is not None else self.attn_sink,
                 topk_length=combined_lens,
-                out=output[query_start:query_end],
+                out=partial_out,
             )
+            if pcp_group is not None:
+                partial_lse = _mask_empty_lse_(partial_lse, combined_lens)
+                merged_out, merged_lse = cp_lse_ag_out_ar(
+                    partial_out,
+                    partial_lse,
+                    pcp_group,
+                    return_lse=True,
+                    is_lse_base_on_e=True,
+                )
+                _apply_attn_sink_and_copy(
+                    merged_out, merged_lse, self.attn_sink, out_slice
+                )

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, cast
 
 import torch
 
-from vllm.distributed import get_pcp_group
+from vllm.distributed import maybe_get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
 from vllm.models.deepseek_v4.common.ops import (
@@ -34,11 +34,8 @@ if TYPE_CHECKING:
 
 
 def _get_pcp_group_for_merge():
-    try:
-        pcp_group = get_pcp_group()
-    except AssertionError:
-        return None
-    return pcp_group if pcp_group.world_size > 1 else None
+    pcp_group = maybe_get_pcp_group()
+    return pcp_group if pcp_group is not None and pcp_group.world_size > 1 else None
 
 
 def _decode_lse_to_2d(lse: torch.Tensor) -> torch.Tensor:

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, cast
 
 import torch
 
-from vllm.distributed import maybe_get_pcp_group
+from vllm.distributed import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
 from vllm.models.deepseek_v4.common.ops import (
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 
 
 def _get_pcp_group_for_merge():
-    pcp_group = maybe_get_pcp_group()
-    return pcp_group if pcp_group is not None and pcp_group.world_size > 1 else None
+    pcp_group = get_pcp_group()
+    return pcp_group if pcp_group.world_size > 1 else None
 
 
 def _decode_lse_to_2d(lse: torch.Tensor) -> torch.Tensor:

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -671,7 +671,14 @@ class DeepseekV4MoE(nn.Module):
             return self._forward_fused_moe(hidden_states, input_ids)
 
         if self.use_mega_moe_pcp_token_shard:
-            return self._forward_mega_moe_pcp_token_shard(hidden_states, input_ids)
+            org_shape = hidden_states.shape
+            final_hidden_states = torch.empty_like(hidden_states, dtype=torch.bfloat16)
+            self._run_mega_moe_pcp_token_shard(
+                hidden_states,
+                input_ids,
+                final_hidden_states,
+            )
+            return final_hidden_states.view(org_shape)
 
         return self._forward_mega_moe(hidden_states, input_ids)
 
@@ -710,17 +717,18 @@ class DeepseekV4MoE(nn.Module):
 
         return final_hidden_states.view(org_shape)
 
-    def _forward_mega_moe_pcp_token_shard(
+    def _run_mega_moe_pcp_token_shard(
         self,
         hidden_states: torch.Tensor,
         input_ids: torch.Tensor | None,
-    ) -> torch.Tensor:
+        out: torch.Tensor,
+    ) -> None:
         assert hidden_states.dim() == 2
-        org_shape = hidden_states.shape
         pcp_group = get_pcp_group()
         pcp_size = pcp_group.world_size
         if pcp_size == 1:
-            return self._forward_mega_moe(hidden_states, input_ids)
+            out.copy_(self._forward_mega_moe(hidden_states, input_ids))
+            return
 
         num_tokens = hidden_states.shape[0]
         shard_size = (num_tokens + pcp_size - 1) // pcp_size
@@ -745,7 +753,7 @@ class DeepseekV4MoE(nn.Module):
         )
         local_output = self._forward_mega_moe(local_hidden_states, local_input_ids)
         output = pcp_group.all_gather(local_output, dim=0)
-        return output[:num_tokens].view(org_shape)
+        out.copy_(output[:num_tokens])
 
     def _forward_fused_moe(
         self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 import typing
 from collections.abc import Callable, Iterable, MutableSequence, Sequence
 from itertools import islice
@@ -11,6 +12,7 @@ import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_ep_group,
+    get_pcp_group,
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -490,6 +492,12 @@ class DeepseekV4MoE(nn.Module):
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
         )
+        token_shard_enabled = os.getenv("DSV4_MEGAMOE_PCP_TOKEN_SHARD", "1") != "0"
+        self.use_mega_moe_pcp_token_shard = (
+            self.use_mega_moe
+            and vllm_config.parallel_config.prefill_context_parallel_size > 1
+            and token_shard_enabled
+        )
         if self.use_mega_moe and not vllm_config.parallel_config.enable_expert_parallel:
             raise NotImplementedError(
                 "DeepSeek V4 MegaMoE currently requires expert parallel. "
@@ -665,6 +673,14 @@ class DeepseekV4MoE(nn.Module):
         if not self.use_mega_moe:
             return self._forward_fused_moe(hidden_states, input_ids)
 
+        if self.use_mega_moe_pcp_token_shard:
+            return self._forward_mega_moe_pcp_token_shard(hidden_states, input_ids)
+
+        return self._forward_mega_moe(hidden_states, input_ids)
+
+    def _forward_mega_moe(
+        self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None
+    ) -> torch.Tensor:
         org_shape = hidden_states.shape
         router_logits, _ = self.gate(hidden_states)
         topk_weights, topk_ids = fused_topk_bias(
@@ -696,6 +712,43 @@ class DeepseekV4MoE(nn.Module):
             final_hidden_states += shared_output
 
         return final_hidden_states.view(org_shape)
+
+    def _forward_mega_moe_pcp_token_shard(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor | None,
+    ) -> torch.Tensor:
+        assert hidden_states.dim() == 2
+        org_shape = hidden_states.shape
+        pcp_group = get_pcp_group()
+        pcp_size = pcp_group.world_size
+        if pcp_size == 1:
+            return self._forward_mega_moe(hidden_states, input_ids)
+
+        num_tokens = hidden_states.shape[0]
+        shard_size = (num_tokens + pcp_size - 1) // pcp_size
+        padded_tokens = shard_size * pcp_size
+        if padded_tokens != num_tokens:
+            hidden_padding = hidden_states.new_zeros(
+                (padded_tokens - num_tokens, hidden_states.shape[1])
+            )
+            hidden_states = torch.cat((hidden_states, hidden_padding), dim=0)
+            if input_ids is not None:
+                input_padding = input_ids.new_zeros(
+                    (padded_tokens - num_tokens, *input_ids.shape[1:])
+                )
+                input_ids = torch.cat((input_ids, input_padding), dim=0)
+
+        pcp_rank = pcp_group.rank_in_group
+        start = pcp_rank * shard_size
+        end = start + shard_size
+        local_hidden_states = hidden_states[start:end].contiguous()
+        local_input_ids = (
+            input_ids[start:end].contiguous() if input_ids is not None else None
+        )
+        local_output = self._forward_mega_moe(local_hidden_states, local_input_ids)
+        output = pcp_group.all_gather(local_output, dim=0)
+        return output[:num_tokens].view(org_shape)
 
     def _forward_fused_moe(
         self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import os
 import typing
 from collections.abc import Callable, Iterable, MutableSequence, Sequence
 from itertools import islice
@@ -492,11 +491,9 @@ class DeepseekV4MoE(nn.Module):
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
         )
-        token_shard_enabled = os.getenv("DSV4_MEGAMOE_PCP_TOKEN_SHARD", "1") != "0"
         self.use_mega_moe_pcp_token_shard = (
             self.use_mega_moe
             and vllm_config.parallel_config.prefill_context_parallel_size > 1
-            and token_shard_enabled
         )
         if self.use_mega_moe and not vllm_config.parallel_config.enable_expert_parallel:
             raise NotImplementedError(

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -24,6 +24,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.worker.cp_utils import get_total_cp_world_size_and_rank
 
 # Pad C128A topk width to this alignment. 128 covers both h_q=64 (B_TOPK=64) and
 # h_q=128 (B_TOPK=128). FlashMLA decode asserts extra_topk % B_TOPK == 0;
@@ -127,6 +128,9 @@ class DeepseekV4FlashMLAMetadata(AttentionMetadata):
     c128a_decode_topk_lens: torch.Tensor | None = None
     # Prefill: local topk indices (used by combine_topk_swa_indices).
     c128a_prefill_topk_indices: torch.Tensor | None = None
+    total_cp_world_size: int = 1
+    total_cp_rank: int = 0
+    cp_kv_cache_interleave_size: int = 1
 
 
 class DeepseekV4FlashMLAMetadataBuilder(
@@ -143,6 +147,11 @@ class DeepseekV4FlashMLAMetadataBuilder(
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         self.model_config = vllm_config.model_config
+        parallel_config = vllm_config.parallel_config
+        self.total_cp_world_size, self.total_cp_rank = (
+            get_total_cp_world_size_and_rank()
+        )
+        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         # Classify single-token queries (plus num_speculative_tokens via
         # supports_spec_as_decode=True) as decodes; longer queries go to prefill.
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
@@ -221,6 +230,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
                 cm.block_table_tensor.clamp(min=0),
                 int(self.kv_cache_spec.storage_block_size),
                 self.compress_ratio,
+                total_cp_world_size=self.total_cp_world_size,
+                total_cp_rank=self.total_cp_rank,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
                 out=self.compressed_slot_mapping_buffer,
             )
 
@@ -244,6 +256,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
             ),
             c128a_decode_topk_lens=c128a_fields.get("c128a_decode_topk_lens"),
             c128a_prefill_topk_indices=c128a_fields.get("c128a_prefill_topk_indices"),
+            total_cp_world_size=self.total_cp_world_size,
+            total_cp_rank=self.total_cp_rank,
+            cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
         )
 
     def _build_c128a_metadata(
@@ -275,6 +290,7 @@ class DeepseekV4FlashMLAMetadataBuilder(
             cm.positions[:num_total],
             self.compress_ratio,
             num_decode_tokens,
+            int(cm.query_start_loc_cpu[cm.num_reqs].item()),
             req_id_per_token,
             cm.block_table_tensor[:num_decodes],
             block_size,
@@ -282,6 +298,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
             self.c128a_global_decode_buffer,
             self.c128a_decode_lens_buffer,
             self.c128a_prefill_buffer,
+            total_cp_world_size=self.total_cp_world_size,
+            total_cp_rank=self.total_cp_rank,
+            cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             max_compressed_tokens=self.c128a_max_compressed,
         )
 
@@ -300,6 +319,7 @@ def build_c128a_topk_metadata(
     positions: torch.Tensor,
     compress_ratio: int,
     num_decode_tokens: int,
+    num_query_tokens: int,
     token_to_req_indices: torch.Tensor,
     block_table: torch.Tensor,
     block_size: int,
@@ -307,6 +327,9 @@ def build_c128a_topk_metadata(
     global_decode_buffer: torch.Tensor,
     decode_lens_buffer: torch.Tensor,
     prefill_buffer: torch.Tensor,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
     max_compressed_tokens: int = 8192,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Single kernel for all C128A tokens (decode + prefill).
@@ -337,11 +360,15 @@ def build_c128a_topk_metadata(
         compress_ratio,
         max_compressed_tokens,
         num_decode_tokens,
+        num_query_tokens,
         token_to_req_indices,
         block_table,
         block_table.stride(0),
         block_size,
         slot_mapping,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
         BLOCK_SIZE=1024,
     )
     return global_decode, decode_lens, prefill_local
@@ -361,11 +388,15 @@ def _build_c128a_topk_metadata_kernel(
     compress_ratio,
     max_compressed_tokens,
     num_decode_tokens,
+    num_query_tokens,
     token_to_req_indices_ptr,
     block_table_ptr,
     block_table_stride,
     block_size,
     slot_mapping_ptr,
+    total_cp_world_size,
+    total_cp_rank,
+    cp_kv_cache_interleave_size,
     BLOCK_SIZE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
@@ -376,7 +407,12 @@ def _build_c128a_topk_metadata_kernel(
 
     if is_decode:
         # --- Decode: block-table lookup → global slot ids + count ---
-        is_valid_token = tl.load(slot_mapping_ptr + token_idx) >= 0
+        slot_is_valid = tl.load(slot_mapping_ptr + token_idx) >= 0
+        is_valid_token = tl.where(
+            total_cp_world_size > 1,
+            token_idx < num_query_tokens,
+            slot_is_valid,
+        )
         req_idx = tl.load(token_to_req_indices_ptr + token_idx)
         count = tl.zeros((), dtype=tl.int32)
         for i in range(0, max_compressed_tokens, BLOCK_SIZE):
@@ -384,20 +420,31 @@ def _build_c128a_topk_metadata_kernel(
             mask = offset < max_compressed_tokens
             is_valid = offset < num_compressed
 
-            block_indices = offset // block_size
+            virtual_block_size = block_size * total_cp_world_size
+            block_indices = offset // virtual_block_size
             block_numbers = tl.load(
                 block_table_ptr + req_idx * block_table_stride + block_indices,
                 mask=mask & is_valid,
             )
-            block_offsets = offset % block_size
-            slot_ids = block_numbers * block_size + block_offsets
-            slot_ids = tl.where(is_valid, slot_ids, -1)
-            tl.store(
-                global_decode_ptr + token_idx * global_decode_stride + offset,
-                slot_ids,
-                mask=mask,
+            virtual_block_offsets = offset - block_indices * virtual_block_size
+            is_local = (
+                virtual_block_offsets // cp_kv_cache_interleave_size
+            ) % total_cp_world_size == total_cp_rank
+            local_block_offsets = (
+                virtual_block_offsets
+                // (total_cp_world_size * cp_kv_cache_interleave_size)
+            ) * cp_kv_cache_interleave_size + (
+                virtual_block_offsets % cp_kv_cache_interleave_size
             )
-            count += tl.sum(is_valid.to(tl.int32), axis=0)
+            slot_ids = block_numbers * block_size + local_block_offsets
+            is_valid_local = is_valid & is_local
+            local_rank = count + tl.cumsum(is_valid_local.to(tl.int32), 0) - 1
+            tl.store(
+                global_decode_ptr + token_idx * global_decode_stride + local_rank,
+                slot_ids,
+                mask=mask & is_valid_local,
+            )
+            count += tl.sum(is_valid_local.to(tl.int32), axis=0)
 
         tl.store(
             decode_lens_ptr + token_idx,
@@ -406,11 +453,27 @@ def _build_c128a_topk_metadata_kernel(
     else:
         # --- Prefill: write local indices ---
         pfx_idx = token_idx - num_decode_tokens
+        count = tl.zeros((), dtype=tl.int32)
         for i in range(0, max_compressed_tokens, BLOCK_SIZE):
             offset = i + tl.arange(0, BLOCK_SIZE)
             mask = offset < max_compressed_tokens
             tl.store(
                 prefill_local_ptr + pfx_idx * prefill_local_stride + offset,
-                tl.where(offset < num_compressed, offset, -1),
+                -1,
                 mask=mask,
             )
+            is_valid = offset < num_compressed
+            is_local = (
+                (offset // cp_kv_cache_interleave_size) % total_cp_world_size
+            ) == total_cp_rank
+            local_offsets = (
+                offset // (total_cp_world_size * cp_kv_cache_interleave_size)
+            ) * cp_kv_cache_interleave_size + (offset % cp_kv_cache_interleave_size)
+            is_valid_local = is_valid & is_local
+            local_rank = count + tl.cumsum(is_valid_local.to(tl.int32), 0) - 1
+            tl.store(
+                prefill_local_ptr + pfx_idx * prefill_local_stride + local_rank,
+                local_offsets,
+                mask=mask & is_valid_local,
+            )
+            count += tl.sum(is_valid_local.to(tl.int32), axis=0)

--- a/vllm/v1/attention/backends/mla/compressor_utils.py
+++ b/vllm/v1/attention/backends/mla/compressor_utils.py
@@ -17,6 +17,9 @@ def _compressed_slot_mapping_kernel(
     block_table_ptr,
     block_table_stride,
     block_size,
+    total_cp_world_size,
+    total_cp_rank,
+    cp_kv_cache_interleave_size,
     COMPRESS_RATIO: tl.constexpr,
     PAD_ID: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
@@ -35,18 +38,27 @@ def _compressed_slot_mapping_kernel(
         mask = offset < query_len
 
         pos = start_pos + i + tl.arange(0, TRITON_BLOCK_SIZE)
-        is_valid = (pos + 1) % COMPRESS_RATIO == 0
+        is_valid = mask & (pos >= 0) & ((pos + 1) % COMPRESS_RATIO == 0)
         pos_after_compress = pos // COMPRESS_RATIO
 
-        block_ids = pos_after_compress // block_size
+        virtual_block_size = block_size * total_cp_world_size
+        block_ids = pos_after_compress // virtual_block_size
         block_numbers = tl.load(
             block_table_ptr + batch_idx * block_table_stride + block_ids,
-            mask=mask & is_valid,
+            mask=is_valid,
         )
-        slot_ids = block_numbers * block_size + pos_after_compress % block_size
+        virtual_block_offsets = pos_after_compress - block_ids * virtual_block_size
+        is_local = (
+            virtual_block_offsets // cp_kv_cache_interleave_size
+        ) % total_cp_world_size == total_cp_rank
+        local_block_offsets = (
+            virtual_block_offsets // (total_cp_world_size * cp_kv_cache_interleave_size)
+        ) * cp_kv_cache_interleave_size + (
+            virtual_block_offsets % cp_kv_cache_interleave_size
+        )
+        slot_ids = block_numbers * block_size + local_block_offsets
 
-        # NOTE
-        slot_ids = tl.where(is_valid, slot_ids, PAD_ID)
+        slot_ids = tl.where(is_valid & is_local, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + query_start + offset, slot_ids, mask=mask)
 
 
@@ -57,6 +69,9 @@ def get_compressed_slot_mapping(
     block_table: torch.Tensor,
     block_size: int,
     compress_ratio: int,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     if out is not None:
@@ -79,6 +94,9 @@ def get_compressed_slot_mapping(
         block_table,
         block_table.stride(0),
         block_size,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
         compress_ratio,
         PAD_ID=-1,
         TRITON_BLOCK_SIZE=1024,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -24,12 +24,40 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
 from vllm.v1.attention.backends.utils import (
+    get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
-from vllm.v1.worker.cp_utils import get_total_cp_world_size
+from vllm.v1.worker.cp_utils import (
+    get_total_cp_world_size,
+    get_total_cp_world_size_and_rank,
+)
 
 logger = init_logger(__name__)
+
+
+@triton.jit
+def _cp_local_len(
+    length,
+    total_cp_world_size: tl.constexpr,
+    total_cp_rank: tl.constexpr,
+    cp_kv_cache_interleave_size: tl.constexpr,
+):
+    base = (
+        length
+        // cp_kv_cache_interleave_size
+        // total_cp_world_size
+        * cp_kv_cache_interleave_size
+    )
+    remainder = length - base * total_cp_world_size
+    extra = tl.minimum(
+        tl.maximum(
+            remainder - total_cp_rank * cp_kv_cache_interleave_size,
+            0,
+        ),
+        cp_kv_cache_interleave_size,
+    )
+    return base + extra
 
 
 @triton.jit
@@ -245,6 +273,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         scheduler_config = self.vllm_config.scheduler_config
+        self.total_cp_world_size, self.total_cp_rank = (
+            get_total_cp_world_size_and_rank()
+        )
+        self.cp_kv_cache_interleave_size = (
+            self.vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
         # NOTE(Chen):an estimated max size of flattened_kv. Need to double check.
         self.max_prefill_buffer_size = get_max_prefill_buffer_size(self.vllm_config)
         self.num_speculative_tokens = (
@@ -499,6 +533,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 block_table,
                 self.kv_cache_spec.storage_block_size,
                 self.compress_ratio,
+                total_cp_world_size=self.total_cp_world_size,
+                total_cp_rank=self.total_cp_rank,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
                 out=self.compressed_slot_mapping_buffer,
             )
             compressed_seq_lens = seq_lens // self.compress_ratio
@@ -515,16 +552,27 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 if self.compress_ratio > 1
                 else seq_lens_cpu
             )
+            local_compressed_seq_lens = compressed_seq_lens
+            local_compressed_seq_lens_cpu = compressed_seq_lens_cpu
+            if self.total_cp_world_size > 1:
+                local_compressed_seq_lens = get_dcp_local_seq_lens(
+                    compressed_seq_lens,
+                    self.total_cp_world_size,
+                    self.total_cp_rank,
+                    self.cp_kv_cache_interleave_size,
+                )
+                local_compressed_seq_lens_cpu = get_dcp_local_seq_lens(
+                    compressed_seq_lens_cpu,
+                    self.total_cp_world_size,
+                    self.total_cp_rank,
+                    self.cp_kv_cache_interleave_size,
+                )
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
-            # Upper bound is exact for prefill rows (the `[num_decodes:]`
-            # slice below).
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             chunk_specs = split_indexer_prefill_chunks(
-                compressed_seq_lens_cpu[num_decodes:],
+                local_compressed_seq_lens_cpu[num_decodes:],
                 prefill_query_lens_cpu,
                 self.max_prefill_buffer_size,
                 max_logits_bytes,
@@ -539,12 +587,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     query_start_loc,
                     query_start_loc_cpu,
                     seq_lens,
-                    compressed_seq_lens,
-                    compressed_seq_lens_cpu,
+                    local_compressed_seq_lens,
+                    local_compressed_seq_lens_cpu,
                     common_attn_metadata.block_table_tensor,
                     self.compress_ratio,
                     query_slice=query_slice,
                     skip_kv_gather=query_slice.start > 0,
+                    total_cp_world_size=self.total_cp_world_size,
+                    total_cp_rank=self.total_cp_rank,
+                    cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
                 )
                 # Skip when total_seq_lens is 0 (i.e., no compressed token).
                 if metadata is not None:
@@ -587,18 +638,24 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # For DeepseekV4 (compress_ratio > 1), the indexer KV cache stores
             # compressed tokens. Convert uncompressed seq_lens to compressed.
             if self.compress_ratio > 1:
+                seq_lens = seq_lens // self.compress_ratio
+                if self.total_cp_world_size > 1:
+                    seq_lens = get_dcp_local_seq_lens(
+                        seq_lens,
+                        self.total_cp_world_size,
+                        self.total_cp_rank,
+                        self.cp_kv_cache_interleave_size,
+                    )
                 # True iff seq_lens aliases decode_seq_lens_buffer (flatten or
                 # native wrote it); False iff it aliases common_attn_metadata.
                 seq_lens_is_local_view = (use_native and next_n > 1) or (
                     not use_native and max_decode_len > 1
                 )
                 if seq_lens_is_local_view:
-                    seq_lens //= self.compress_ratio
+                    pass
                 else:
                     # Copy to avoid mutating shared state; keeps CG address stable.
-                    self.expanded_seq_lens_buffer[:num_decodes] = (
-                        seq_lens // self.compress_ratio
-                    )
+                    self.expanded_seq_lens_buffer[:num_decodes] = seq_lens
                     self.expanded_seq_lens_buffer[num_decodes:num_decode_tokens] = 0
                     seq_lens = self.expanded_seq_lens_buffer[:num_decode_tokens]
 
@@ -651,6 +708,9 @@ def build_prefill_chunk_metadata(
     compress_ratio: int,
     query_slice: slice | None = None,
     skip_kv_gather: bool = False,
+    total_cp_world_size: int = 1,
+    total_cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> DeepseekV32IndexerPrefillChunkMetadata | None:
     total_seq_lens = compressed_seq_lens_cpu[start_idx:end_idx].sum().item()
     if total_seq_lens == 0:
@@ -694,6 +754,9 @@ def build_prefill_chunk_metadata(
         qs_stop,
         BLOCK_SIZE=1024,
         COMPRESS_RATIO=compress_ratio,
+        TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+        TOTAL_CP_RANK=total_cp_rank,
+        CP_KV_CACHE_INTERLEAVE_SIZE=cp_kv_cache_interleave_size,
     )
 
     token_start = query_start_loc_cpu[start_idx].item()
@@ -732,6 +795,9 @@ def _build_prefill_chunk_metadata_kernel(
     query_slice_stop,
     BLOCK_SIZE: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
 
@@ -761,6 +827,12 @@ def _build_prefill_chunk_metadata_kernel(
 
         # Compute cu_seq_len_ke
         seq_len_per_token = (start_pos + 1 + offset) // COMPRESS_RATIO
+        seq_len_per_token = _cp_local_len(
+            seq_len_per_token,
+            TOTAL_CP_WORLD_SIZE,
+            TOTAL_CP_RANK,
+            CP_KV_CACHE_INTERLEAVE_SIZE,
+        )
         tl.store(
             cu_compressed_seq_len_ke_ptr + out_pos,
             seq_start + seq_len_per_token,

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -23,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+from vllm.v1.worker.cp_utils import get_total_cp_world_size_and_rank
 
 # DeepseekV4 decode layer types, keyed by compress_ratio. Each type has a distinct
 # (topk, extra_topk, extra_page_block_size) config, so they cannot share a
@@ -187,6 +188,9 @@ class DeepseekSparseSWAMetadata:
     tile_sched_swaonly: "FlashMLASchedMeta | None" = None
     tile_sched_c4a: "FlashMLASchedMeta | None" = None
     tile_sched_c128a: "FlashMLASchedMeta | None" = None
+    total_cp_world_size: int = 1
+    total_cp_rank: int = 0
+    cp_kv_cache_interleave_size: int = 1
 
 
 class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
@@ -213,6 +217,12 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         self.head_size = mla_spec.head_size  # Already considered quantization.
         self.compress_ratio = mla_spec.compress_ratio
         self.block_size = mla_spec.block_size
+        self.total_cp_world_size, self.total_cp_rank = (
+            get_total_cp_world_size_and_rank()
+        )
+        self.cp_kv_cache_interleave_size = (
+            self.vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
 
         # Handle MTP: adjust decode_threshold like the indexer does
         self.num_speculative_tokens = (
@@ -299,7 +309,14 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         token_to_req_indices.copy_(x, non_blocking=True)
 
         is_valid_token = self.is_valid_token[: slot_mapping.shape[0]]
-        is_valid_token.copy_(slot_mapping >= 0)
+        if self.total_cp_world_size > 1:
+            # In CP, slot_mapping marks the rank that owns the KV write slot.
+            # Query tokens are still valid on every CP rank for partial attention.
+            num_query_tokens = int(query_start_loc_cpu[num_reqs].item())
+            is_valid_token[:num_query_tokens].fill_(True)
+            is_valid_token[num_query_tokens:].fill_(False)
+        else:
+            is_valid_token.copy_(slot_mapping >= 0)
 
         if num_decode_tokens > 0:
             self.decode_swa_lens[num_decode_tokens:] = 0
@@ -315,6 +332,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
                 block_table,
                 block_table.stride(0),
                 self.block_size,
+                TOTAL_CP_WORLD_SIZE=self.total_cp_world_size,
+                TOTAL_CP_RANK=self.total_cp_rank,
+                CP_KV_CACHE_INTERLEAVE_SIZE=self.cp_kv_cache_interleave_size,
                 TRITON_BLOCK_SIZE=1024,
             )
 
@@ -350,6 +370,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             tile_sched_swaonly=tile_sched[_LAYER_TYPE_SWAONLY],
             tile_sched_c4a=tile_sched[_LAYER_TYPE_C4A],
             tile_sched_c128a=tile_sched[_LAYER_TYPE_C128A],
+            total_cp_world_size=self.total_cp_world_size,
+            total_cp_rank=self.total_cp_rank,
+            cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             **deepseek_v4_fields,
         )
 
@@ -464,6 +487,9 @@ def _compute_swa_indices_and_lens_kernel(
     block_table_ptr,
     block_table_stride,
     block_size,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
@@ -486,23 +512,42 @@ def _compute_swa_indices_and_lens_kernel(
     end_pos = pos + 1
 
     swa_len = end_pos - start_pos
-    tl.store(swa_lens_ptr + token_idx, swa_len)
+    count = tl.zeros((), dtype=tl.int32)
 
     for i in range(0, window_size, TRITON_BLOCK_SIZE):
         offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
-
-        pos_offset = start_pos + offset
-        block_indices = pos_offset // block_size
-        block_numbers = tl.load(
-            block_table_ptr + req_idx * block_table_stride + block_indices,
-            mask=pos_offset < end_pos,
-        )
-        block_offsets = pos_offset % block_size
-        slot_ids = block_numbers * block_size + block_offsets
-
-        slot_ids = tl.where(offset < swa_len, slot_ids, -1)
         tl.store(
             swa_indices_ptr + token_idx * swa_indices_stride + offset,
-            slot_ids,
+            -1,
             mask=offset < window_size,
         )
+
+        pos_offset = start_pos + offset
+        is_in_window = offset < swa_len
+        virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+        block_indices = pos_offset // virtual_block_size
+        block_numbers = tl.load(
+            block_table_ptr + req_idx * block_table_stride + block_indices,
+            mask=is_in_window,
+        )
+        virtual_block_offsets = pos_offset - block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        )
+        is_valid_local = is_in_window & is_local
+        local_rank = count + tl.cumsum(is_valid_local.to(tl.int32), 0) - 1
+
+        slot_ids = block_numbers * block_size + local_block_offsets
+        tl.store(
+            swa_indices_ptr + token_idx * swa_indices_stride + local_rank,
+            slot_ids,
+            mask=is_valid_local,
+        )
+        count += tl.sum(is_valid_local.to(tl.int32), axis=0)
+
+    tl.store(swa_lens_ptr + token_idx, count)

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -81,6 +81,9 @@ def _correct_attn_cp_out_kernel(
         lse_idx * lses_stride_N + batch_idx * lses_stride_B + head_idx * lses_stride_H
     )
     lse_tmp = tl.load(lses_ptr + lse_offset)
+    valid_local_lse = (
+        (lse_tmp == lse_tmp) & (lse_tmp != float("inf")) & (lse_tmp != -float("inf"))
+    )
     lse_finally = lse_tmp - lse
     lse_finally = tl.where(
         (lse_finally != lse_finally) | (lse_finally == float("inf")),
@@ -89,7 +92,7 @@ def _correct_attn_cp_out_kernel(
     )
     factor = tl.exp(lse_finally) if IS_BASE_E else tl.exp2(lse_finally)
     output = tl.load(outputs_ptr + output_offsets)
-    output = output * factor
+    output = tl.where(valid_local_lse, output, 0.0) * factor
 
     tl.store(new_output_ptr + output_offsets, output)
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -12,6 +12,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
     BlockHashListWithBlockSize,
     KVCacheBlock,
+    _is_deepseek_v4_hybrid_kv_cache_groups,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -505,8 +506,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             g.kv_cache_spec.block_size % hash_block_size == 0
             for g in kv_cache_config.kv_cache_groups
         ), "block_size must be divisible by hash_block_size"
+        is_dsv4_pcp = (
+            dcp_world_size == 1
+            and pcp_world_size > 1
+            and _is_deepseek_v4_hybrid_kv_cache_groups(kv_cache_config.kv_cache_groups)
+        )
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
-        assert pcp_world_size == 1, "PCP not support hybrid attn now."
+        assert pcp_world_size == 1 or is_dsv4_pcp, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
 
     def verify_and_split_kv_cache_groups(self) -> None:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -113,6 +113,46 @@ def init_none_hash(hash_fn: Callable[[Any], bytes]):
         NONE_HASH = BlockHash(hash_fn(hash_seed))
 
 
+def _iter_kv_cache_group_specs(kv_cache_spec: KVCacheSpec) -> Iterator[KVCacheSpec]:
+    if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+        yield from kv_cache_spec.kv_cache_specs.values()
+    else:
+        yield kv_cache_spec
+
+
+def _is_deepseek_v4_hybrid_kv_cache_groups(
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
+) -> bool:
+    if len(kv_cache_groups) <= 1:
+        return False
+
+    has_deepseek_v4_spec = False
+    for group in kv_cache_groups:
+        for spec in _iter_kv_cache_group_specs(group.kv_cache_spec):
+            if not isinstance(spec, MLAAttentionSpec | SlidingWindowMLASpec):
+                return False
+            has_deepseek_v4_spec = (
+                has_deepseek_v4_spec
+                or getattr(spec, "model_version", None) == "deepseek_v4"
+            )
+
+    return has_deepseek_v4_spec
+
+
+def _is_deepseek_v4_megamoe_pcp(
+    vllm_config: VllmConfig,
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
+) -> bool:
+    parallel_config = vllm_config.parallel_config
+    return (
+        parallel_config.decode_context_parallel_size == 1
+        and parallel_config.prefill_context_parallel_size > 1
+        and parallel_config.enable_expert_parallel
+        and vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
+        and _is_deepseek_v4_hybrid_kv_cache_groups(kv_cache_groups)
+    )
+
+
 @dataclass(slots=True)
 class KVCacheBlock:
     """KV-cache block metadata."""
@@ -617,13 +657,32 @@ def resolve_kv_cache_block_sizes(
         bs = cache_config.block_size * dcp * pcp
         return bs, bs
 
+    group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
+    is_dsv4_pcp = _is_deepseek_v4_megamoe_pcp(vllm_config, groups)
     if dcp != 1 or pcp != 1:
-        raise ValueError(
-            "Hybrid KV cache groups with multiple block sizes do not "
-            "support context parallelism (dcp_world_size/pcp_world_size > 1)."
+        if not is_dsv4_pcp:
+            raise ValueError(
+                "Hybrid KV cache groups with multiple block sizes do not "
+                "support context parallelism "
+                "(dcp_world_size/pcp_world_size > 1)."
+            )
+        logger.warning_once(
+            "Allowing experimental DeepSeek V4 MegaMoE hybrid KV cache groups "
+            "with prefill context parallelism. Prefix caching and KV transfer "
+            "must remain disabled for this experimental path."
         )
 
-    group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
+    if is_dsv4_pcp:
+        connector_enabled = vllm_config.kv_transfer_config is not None
+        if cache_config.enable_prefix_caching or connector_enabled:
+            raise ValueError(
+                "Experimental DeepSeek V4 MegaMoE PCP does not support prefix "
+                "caching or KV transfer yet. Disable prefix caching with "
+                "--no-enable-prefix-caching."
+            )
+        scheduler_block_size = math.lcm(*(bs * pcp for bs in group_block_sizes))
+        return scheduler_block_size, scheduler_block_size
+
     scheduler_block_size = math.lcm(*group_block_sizes)
 
     # Block hashes are only consumed by prefix caching and KV connectors

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -4,17 +4,52 @@ from typing import TYPE_CHECKING, Any, cast
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.distributed import get_dcp_group, get_pcp_group
+from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 else:
     AttentionLayerBase = object
 
+logger = init_logger(__name__)
+
+
+def _is_deepseek_v4_config(vllm_config: VllmConfig) -> bool:
+    hf_config = vllm_config.model_config.hf_config
+    compress_ratios = getattr(hf_config, "compress_ratios", None)
+    return compress_ratios is not None and len(compress_ratios) > 0
+
+
+def _is_deepseek_v4_megamoe_pcp_config(vllm_config: VllmConfig) -> bool:
+    parallel_config = vllm_config.parallel_config
+    return (
+        parallel_config.prefill_context_parallel_size > 1
+        and parallel_config.decode_context_parallel_size == 1
+        and parallel_config.enable_expert_parallel
+        and vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
+        and _is_deepseek_v4_config(vllm_config)
+    )
+
 
 def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
     pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
     dcp_size = vllm_config.parallel_config.decode_context_parallel_size
     interleave_size = vllm_config.parallel_config.cp_kv_cache_interleave_size
+    allow_deepseek_v4_pcp = _is_deepseek_v4_megamoe_pcp_config(vllm_config)
+    if allow_deepseek_v4_pcp:
+        if (
+            vllm_config.cache_config.enable_prefix_caching
+            or vllm_config.kv_transfer_config is not None
+        ):
+            raise ValueError(
+                "Experimental DeepSeek V4 MegaMoE PCP does not support prefix "
+                "caching or KV transfer yet. Disable prefix caching with "
+                "--no-enable-prefix-caching."
+            )
+        logger.warning_once(
+            "Allowing experimental DeepSeek V4 MegaMoE PCP attention path. "
+            "Prefix caching and KV transfer are disabled for this path."
+        )
     if pcp_size * dcp_size > 1:
         layer_type = cast(type[Any], AttentionLayerBase)
         layers = get_layers_from_vllm_config(vllm_config, layer_type)
@@ -37,6 +72,8 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                 )
 
             if pcp_size > 1:
+                if allow_deepseek_v4_pcp:
+                    continue
                 assert layer_impl.supports_pcp, (
                     "PCP requires attention impls' support, "
                     f"but the impl {layer_impl.__class__.__name__} "
@@ -45,14 +82,28 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
 
 
 def get_total_cp_world_size():
+    world_size, _ = get_total_cp_world_size_and_rank()
+    return world_size
+
+
+def get_total_cp_world_size_and_rank() -> tuple[int, int]:
     try:
-        pcp_world_size = get_pcp_group().world_size
+        pcp_group = get_pcp_group()
+        pcp_world_size = pcp_group.world_size
+        pcp_rank = pcp_group.rank_in_group
     except AssertionError:
         # PCP might not be initialized in testing
         pcp_world_size = 1
+        pcp_rank = 0
     try:
-        dcp_world_size = get_dcp_group().world_size
+        dcp_group = get_dcp_group()
+        dcp_world_size = dcp_group.world_size
+        dcp_rank = dcp_group.rank_in_group
     except AssertionError:
         # DCP might not be initialized in testing
         dcp_world_size = 1
-    return dcp_world_size * pcp_world_size
+        dcp_rank = 0
+
+    total_cp_world_size = dcp_world_size * pcp_world_size
+    total_cp_rank = pcp_rank * dcp_world_size + dcp_rank
+    return total_cp_world_size, total_cp_rank

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6939,6 +6939,7 @@ class GPUModelRunner(
                 logitsprocs=self.input_batch.logitsprocs,
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,
+                cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
                 reasoning_config=self.vllm_config.reasoning_config,
             )
 


### PR DESCRIPTION



## Purpose
#40902
Implementation summary:

Added PCP-aware hybrid KV handling for DeepSeekV4, covering MLA / SWA / C4 / C128 block and slot mapping.
Added PCP merge for sparse prefill attention: each PCP rank computes local partial attention, then merges LSE/output globally and applies attn_sink only once.
Added a MegaMoE PCP token-shard path: after attention, each PCP rank runs router / MegaMoE / shared expert only for its local token shard, then all-gathers full hidden states for the next layer.
Main challenges:

DeepSeekV4 uses multiple KV layouts with different block sizes and compression ratios.
C4/C128 compressor states need global PCP merge, not local-only updates.
attn_sink must not be applied independently on each PCP rank.
Naive PCP duplicated MoE work across ranks, causing large overhead.
The MoE token-shard path had to be wrapped as a custom op to work cleanly with CUDA graph / torch compile.


```
Aligned common-length results:

**TTFT**

| Length | TP8+EP+MegaMoE TTFT | PCP2 TTFT | Improvement |
|---|---:|---:|---:|
| 128K | 11.17s | 8.73s | ~21.8% faster |
| 256K | 21.20s | 18.38s | ~13.3% faster |
| 512K | 49.19s | 41.01s | ~16.6% faster |
| 1M | 126.68s | 95.59s | ~24.5% faster |

**Throughput**

| Length | TP8+EP+MegaMoE tok/s | PCP2 tok/s | Improvement |
|---|---:|---:|---:|
| 128K | 11,739 | 15,005 | +27.8% |
| 256K | 12,365 | 14,264 | +15.4% |
| 512K | 10,657 | 12,784 | +20.0% |
| 1M | 8,277 | 10,970 | +32.5% | 
```

tp =8 +maga moe:
start:
```
MODEL=/root/model/DeepSeek-V4-Pro

CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 \
.venv/bin/python -m vllm.entrypoints.cli.main serve "$MODEL" \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name dsv4pro \
  --tensor-parallel-size 8 \
  --decode-context-parallel-size 1 \
  --prefill-context-parallel-size 1 \
  --enable-expert-parallel \
  --tokenizer-mode deepseek_v4 \
  --trust-remote-code \
  --dtype bfloat16 \
  --kv-cache-dtype fp8 \
  --max-model-len 1048576 \
  --max-num-batched-tokens 32768 \
  --enable-chunked-prefill \
  --gpu-memory-utilization 0.90 \
  --moe-backend deep_gemm_mega_moe \
  --no-enable-prefix-caching
```
 res :  https://paste.ubuntu.com/p/mcQrbwqVN3/    
tp =4 pcp =2   maga moe:
MODEL=/root/model/DeepSeek-V4-Pro

```
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 \
.venv/bin/python -m vllm.entrypoints.cli.main serve "$MODEL" \
  --host 0.0.0.0 \
  --port 8000 \
  --served-model-name dsv4pro \
  --tensor-parallel-size 4 \
  --decode-context-parallel-size 1 \
  --prefill-context-parallel-size 2 \
  --enable-expert-parallel \
  --tokenizer-mode deepseek_v4 \
  --trust-remote-code \
  --dtype bfloat16 \
  --kv-cache-dtype fp8 \
  --max-model-len 1048576 \
  --max-num-batched-tokens 32768 \
  --enable-chunked-prefill \
  --gpu-memory-utilization 0.90 \
  --moe-backend deep_gemm_mega_moe \
  --no-enable-prefix-caching
 
```
res:  https://docs.google.com/document/d/1upWKu1zhqfJpRG9n-fdQA8k3RhNeIxIuh9FJNysN_gQ/edit?tab=t.0


tp=4  dp =2 +maga moe : https://paste.ubuntu.com/p/mG2dDQrVKp/
lm eval: 

```
m8k_250/dsv4pro/*.jsonl
local-completions ({'model': 'dsv4pro', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'tokenizer_backend': 'none', 'tokenized_requests': False, 'max_length': 1048576, 'max_gen_toks': 512, 'num_concurrent': 4, 'timeout': 1200}), gen_kwargs: ({}), limit: 250.0, num_fewshot: None, batch_size: 4
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.94|±  |0.0151|
|     |       |strict-match    |     5|exact_match|↑  | 0.94|±  |0.0151

```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

