### PR TITLE
fix(gemma4): handle missing k_norm.weight for KV-shared layers in both base and SFT checkpoints

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -424,12 +424,6 @@ class Gemma4Attention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
-        # Q/K norms: output = norm(x) * weight (learnable per-head scale)
-        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        # V norm: no learnable scale (pure normalization only)
-        self.v_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
-
         # Determine layer type and sliding window
         layer_idx = extract_layer_index(prefix)
         layer_type = config.layer_types[layer_idx]
@@ -481,6 +475,18 @@ class Gemma4Attention(nn.Module):
                         f"{param_name_before_layers}.layers."
                         f"{kv_shared_layer_index}.self_attn.attn"
                     )
+
+        # Q/K norms: output = norm(x) * weight (learnable per-head scale).
+        # Initialised after is_kv_shared_layer is known so that load_weights()
+        # can fill in k_norm.weight with ones for KV-shared layers whose SFT
+        # checkpoint omits that parameter (they never call k_norm in forward).
+        # has_weight=True for k_norm on all layers supports both base-model
+        # checkpoints (which store k_norm.weight everywhere) and SFT checkpoints
+        # (handled in Gemma4Model.load_weights).
+        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        # V norm: no learnable scale (pure normalization only)
+        self.v_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
 
         self.rotary_emb = get_rope(
             self.head_dim,
@@ -1494,6 +1500,17 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+        # SFT checkpoints omit k_norm.weight for KV-shared layers because those
+        # layers reuse the KV cache from an earlier layer and never execute
+        # k_norm in the forward pass.  Fill any such missing parameter with
+        # ones so that it is not flagged as uninitialised.
+        for mod_name, mod in self.named_modules():
+            if isinstance(mod, Gemma4Attention) and mod.is_kv_shared_layer:
+                k_norm_key = f"{mod_name}.k_norm.weight"
+                if k_norm_key in params_dict and k_norm_key not in loaded_params:
+                    params_dict[k_norm_key].fill_(1.0)
+                    loaded_params.add(k_norm_key)
 
         return loaded_params
 

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -85,6 +85,15 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _raise_if_k_norm_called_on_kv_shared_layer(
+    _module: nn.Module, _args: tuple[object, ...]
+) -> None:
+    raise AssertionError(
+        "k_norm must not execute on KV-shared layers; "
+        "k_norm.weight may be 1.0 (SFT checkpoint fallback)"
+    )
+
+
 def _remap_gemma4_expert_weight_name(name: str) -> str:
     return re.sub(r"(?<!\.moe)\.experts\.(\d+)\.", r".moe.experts.\1.", name)
 
@@ -487,6 +496,15 @@ class Gemma4Attention(nn.Module):
         self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
         # V norm: no learnable scale (pure normalization only)
         self.v_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
+
+        if self.is_kv_shared_layer:
+            # k_norm is never executed in forward() for KV-shared layers;
+            # they borrow K/V from an earlier layer. Register a hook so any
+            # future code path that accidentally calls k_norm here raises
+            # immediately rather than silently using wrong weights.
+            self.k_norm.register_forward_pre_hook(
+                _raise_if_k_norm_called_on_kv_shared_layer
+            )
 
         self.rotary_emb = get_rope(
             self.head_dim,
@@ -1509,7 +1527,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             if isinstance(mod, Gemma4Attention) and mod.is_kv_shared_layer:
                 k_norm_key = f"{mod_name}.k_norm.weight"
                 if k_norm_key in params_dict and k_norm_key not in loaded_params:
-                    params_dict[k_norm_key].fill_(1.0)
+                    params_dict[k_norm_key].data.fill_(1.0)
                     loaded_params.add(k_norm_key)
 
         return loaded_params


### PR DESCRIPTION
## Summary

This PR fixes the regression introduced by #41385 while also preserving its original fix for SFT model loading.

## The problem

Gemma4 has KV-shared layers (the last `num_kv_shared_layers` layers). These layers reuse the KV cache from an earlier layer and therefore never execute `k_norm` in their forward pass.

| Checkpoint type | `k_norm.weight` in KV-shared layers | Old code (pre-#41385) | #41385 fix | This PR |
|---|---|---|---|---|
| Base model (e.g. `google/gemma-4b-it`) | Present | loads OK | KeyError (has_weight=False) | loads OK |
| After SFT | Absent | ValueError (uninitialised param) | loads OK | loads OK |

## Root cause

The original code initialised `k_norm` *before* `is_kv_shared_layer` was determined, preventing conditional logic. #41385 solved the SFT case by moving norm init after the layer-type check and using `has_weight=False` for shared layers — but that broke base-model loading because base checkpoints do store `k_norm.weight` for every layer.

## This fix

Two minimal changes to `vllm/model_executor/models/gemma4.py`:

1. **Move norm init after `is_kv_shared_layer`** (same as #41385) — enables the conditional path.
2. **Keep `has_weight=True` for `k_norm` on all layers** — base-model checkpoints load unchanged.
3. **Post-load fallback in `Gemma4Model.load_weights()`** — after the main weight-loading loop, detect any KV-shared layer whose `k_norm.weight` was absent from the checkpoint (SFT case) and fill it with `1.0` (the identity value for RMSNorm). Since `k_norm` is never called for these layers, the value is irrelevant to inference.

## Why `fill_(1.0)` is safe

`RMSNorm(x) * weight` with `weight == 1.0` is equivalent to plain `RMSNorm(x)`. KV-shared layers skip the `k_norm` call entirely in `forward()`, so this weight is never read at inference time.

## Test plan

- [ ] Load `google/gemma-4b-it` (base model) — should load without `KeyError`
- [ ] Load a Gemma4 checkpoint fine-tuned with SFT — should load without `ValueError` about uninitialised weights
- [ ] Run basic inference on both to confirm correctness
