### PR TITLE
[Bug] Fix `tests/distributed/test_elastic_ep.py  - assert False`

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -117,8 +117,12 @@ class CpuGpuBuffer:
         pin_memory: bool,
         with_numpy: bool = True,
     ) -> None:
-        self.cpu = torch.zeros(*size, dtype=dtype, device="cpu", pin_memory=pin_memory)
-        self.gpu = torch.zeros_like(self.cpu, device=device)
+        # these buffers are mutable runtime state, so allocate them as normal
+        with torch.inference_mode(False):
+            self.cpu = torch.zeros(
+                *size, dtype=dtype, device="cpu", pin_memory=pin_memory
+            )
+            self.gpu = torch.zeros_like(self.cpu, device=device)
         self.np: np.ndarray
         # To keep type hints simple (avoiding generics and subclasses), we
         # only conditionally create the numpy array attribute. This can cause


### PR DESCRIPTION
## Purpose

`pytest tests/distributed/test_elastic_ep.py -k test_elastic_ep_scaling -xvs`

```bash
(APIServer pid=2092331) Traceback (most recent call last):
(APIServer pid=2092331)   File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
(APIServer pid=2092331)     self.run()
(APIServer pid=2092331)   File "/usr/lib/python3.12/threading.py", line 1010, in run
(APIServer pid=2092331)     self._target(*self._args, **self._kwargs)
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core_client.py", line 685, in monitor_engine_cores
(APIServer pid=2092331)     engine_manager.monitor_engine_liveness()
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/engine/utils.py", line 940, in monitor_engine_liveness
(APIServer pid=2092331)     ray.get(actor_ref)
(APIServer pid=2092331)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(APIServer pid=2092331)     return fn(*args, **kwargs)
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
(APIServer pid=2092331)     return func(*args, **kwargs)
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/ray/_private/worker.py", line 2858, in get
(APIServer pid=2092331)     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
(APIServer pid=2092331)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/ray/_private/worker.py", line 958, in get_objects
(APIServer pid=2092331)     raise value.as_instanceof_cause()
(APIServer pid=2092331) ray.exceptions.RayTaskError(RuntimeError): ray::DPMoEEngineCoreActor.run() (pid=2107890, ip=10.14.216.12, actor_id=2c3e67435db2c20635c9162501000000, repr=<vllm.v1.engine.core.DPMoEEngineCoreActor object at 0x785d6626bd10>)
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 2136, in run
(APIServer pid=2092331)     self.run_busy_loop()  # type: ignore[attr-defined]
(APIServer pid=2092331)     ^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 1840, in run_busy_loop
(APIServer pid=2092331)     _ = self.eep_scaling_state.progress()
(APIServer pid=2092331)         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/distributed/elastic_ep/elastic_state.py", line 138, in progress
(APIServer pid=2092331)     else self._progress_existing_engine()
(APIServer pid=2092331)          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/distributed/elastic_ep/elastic_state.py", line 281, in _progress_existing_engine
(APIServer pid=2092331)     self._switch_and_prepare()
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/distributed/elastic_ep/elastic_state.py", line 506, in _switch_and_prepare
(APIServer pid=2092331)     self.model_executor.collective_rpc(
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 403, in collective_rpc
(APIServer pid=2092331)     return future if non_block else future.result()
(APIServer pid=2092331)                                     ^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 90, in result
(APIServer pid=2092331)     return super().result()
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(APIServer pid=2092331)     return self.__get_result()
(APIServer pid=2092331)            ^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(APIServer pid=2092331)     raise self._exception
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 94, in _wait_for_response
(APIServer pid=2092331)     response = self.aggregate(self.get_response())
(APIServer pid=2092331)                               ^^^^^^^^^^^^^^^^^^^
(APIServer pid=2092331)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 390, in get_response
(APIServer pid=2092331)     raise RuntimeError(
(APIServer pid=2092331) RuntimeError: Worker failed with error 'Inplace update to inference tensor outside InferenceMode is not allowed.You can make a clone to get a normal tensor before doing inplace update.See https://github.com/pytorch/rfcs/pull/17 for more details.', please check the stack trace above for the root cause
```

This is because we create the tensor in inferrence mode (not mutable) but during the tests we update them, this PR fixes the issue.

Now

```bash
============ 2 passed, 19 warnings in 552.15s (0:09:12) =============
```