### PR TITLE
[Bugfix][SM120] Enable CUTLASS grouped GEMM (MoE) for SM_120/SM_121 consumer Blackwell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,7 +910,8 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
-      "csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu")
+      "csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu"
+      "csrc/libtorch_stable/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm120.cu")
     set_gencode_flags_for_srcs(
       SRCS "${FP4_SM120_SRCS}"
       CUDA_ARCHS "${FP4_SM120_ARCHS}")

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm120.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm120.cu
@@ -1,0 +1,108 @@
+#include <cudaTypedefs.h>
+
+#include "libtorch_stable/torch_utils.h"
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+
+#include "cutlass/cutlass.h"
+#include "grouped_mm_c3x.cuh"
+
+using namespace cute;
+
+namespace {
+
+template <typename InType, typename OutType,
+          template <typename, typename, typename> typename Epilogue>
+struct sm120_fp8_config_default {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  // SM120 / SM121 (consumer Blackwell / DGX Spark) FP8 grouped GEMM with
+  // tensor/token-level FP8 scaling (scaling done in epilogue, not mainloop).
+  // Uses the SM120 dense ptr-array schedule (NOT the Blockwise variant —
+  // Blockwise expects per-block scale factors in the mainloop layout,
+  // which our model does not provide).
+  using KernelSchedule =
+      cutlass::gemm::KernelPtrArrayTmaWarpSpecializedCooperativeSm120<2>;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+  using TileShape = cute::Shape<cute::_128, cute::_128, cute::_128>;
+  using ClusterShape = cute::Shape<cute::_1, cute::_1, cute::_1>;
+  using ArchTag = cutlass::arch::Sm120;
+
+  using Cutlass3xGemm =
+      cutlass_3x_group_gemm<InType, OutType, ArchTag, Epilogue, TileShape,
+                            ClusterShape, KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType>
+void run_cutlass_moe_mm_sm120(torch::stable::Tensor& out_tensors,
+                              torch::stable::Tensor const& a_tensors,
+                              torch::stable::Tensor const& b_tensors,
+                              torch::stable::Tensor const& a_scales,
+                              torch::stable::Tensor const& b_scales,
+                              torch::stable::Tensor const& expert_offsets,
+                              torch::stable::Tensor const& problem_sizes,
+                              torch::stable::Tensor const& a_strides,
+                              torch::stable::Tensor const& b_strides,
+                              torch::stable::Tensor const& c_strides,
+                              bool per_act_token, bool per_out_ch) {
+  STD_TORCH_CHECK(a_tensors.size(0) > 0, "No input A tensors provided.");
+  STD_TORCH_CHECK(b_tensors.size(0) > 0, "No input B tensors provided.");
+  STD_TORCH_CHECK(out_tensors.size(0) > 0, "No output tensors provided.");
+
+  STD_TORCH_CHECK(
+      a_tensors.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn,
+      "A tensors must be of type float8_e4m3fn.");
+  STD_TORCH_CHECK(
+      b_tensors.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn,
+      "B tensors must be of type float8_e4m3fn.");
+
+  // Single-config dispatch for v1: prove the SM120 CUTLASS path runs
+  // correctly before adding M-bucket or N-bucket specializations.
+  using Cutlass3xGemmDefault = typename sm120_fp8_config_default<
+      InType, OutType, vllm::c3x::ScaledEpilogueArray>::Cutlass3xGemm;
+
+  cutlass_group_gemm_caller<Cutlass3xGemmDefault>(
+      out_tensors, a_tensors, b_tensors, a_scales, b_scales, expert_offsets,
+      problem_sizes, a_strides, b_strides, c_strides, per_act_token,
+      per_out_ch);
+}
+}  // namespace
+
+void dispatch_moe_mm_sm120(torch::stable::Tensor& out_tensors,
+                           torch::stable::Tensor const& a_tensors,
+                           torch::stable::Tensor const& b_tensors,
+                           torch::stable::Tensor const& a_scales,
+                           torch::stable::Tensor const& b_scales,
+                           torch::stable::Tensor const& expert_offsets,
+                           torch::stable::Tensor const& problem_sizes,
+                           torch::stable::Tensor const& a_strides,
+                           torch::stable::Tensor const& b_strides,
+                           torch::stable::Tensor const& c_strides,
+                           bool per_act_token, bool per_out_ch) {
+  if (out_tensors.scalar_type() == torch::headeronly::ScalarType::BFloat16) {
+    run_cutlass_moe_mm_sm120<cutlass::float_e4m3_t, cutlass::bfloat16_t>(
+        out_tensors, a_tensors, b_tensors, a_scales, b_scales, expert_offsets,
+        problem_sizes, a_strides, b_strides, c_strides, per_act_token,
+        per_out_ch);
+  } else {
+    run_cutlass_moe_mm_sm120<cutlass::float_e4m3_t, cutlass::half_t>(
+        out_tensors, a_tensors, b_tensors, a_scales, b_scales, expert_offsets,
+        problem_sizes, a_strides, b_strides, c_strides, per_act_token,
+        per_out_ch);
+  }
+}
+
+void cutlass_moe_mm_sm120(torch::stable::Tensor& out_tensors,
+                          torch::stable::Tensor const& a_tensors,
+                          torch::stable::Tensor const& b_tensors,
+                          torch::stable::Tensor const& a_scales,
+                          torch::stable::Tensor const& b_scales,
+                          torch::stable::Tensor const& expert_offsets,
+                          torch::stable::Tensor const& problem_sizes,
+                          torch::stable::Tensor const& a_strides,
+                          torch::stable::Tensor const& b_strides,
+                          torch::stable::Tensor const& c_strides,
+                          bool per_act_token, bool per_out_ch) {
+  dispatch_moe_mm_sm120(out_tensors, a_tensors, b_tensors, a_scales, b_scales,
+                        expert_offsets, problem_sizes, a_strides, b_strides,
+                        c_strides, per_act_token, per_out_ch);
+}

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu
@@ -65,6 +65,20 @@ void cutlass_moe_mm_sm100(torch::stable::Tensor& out_tensors,
                           bool per_act_token, bool per_out_ch);
 #endif
 
+#if defined ENABLE_CUTLASS_MOE_SM120 && ENABLE_CUTLASS_MOE_SM120
+void cutlass_moe_mm_sm120(torch::stable::Tensor& out_tensors,
+                          torch::stable::Tensor const& a_tensors,
+                          torch::stable::Tensor const& b_tensors,
+                          torch::stable::Tensor const& a_scales,
+                          torch::stable::Tensor const& b_scales,
+                          torch::stable::Tensor const& expert_offsets,
+                          torch::stable::Tensor const& problem_sizes,
+                          torch::stable::Tensor const& a_strides,
+                          torch::stable::Tensor const& b_strides,
+                          torch::stable::Tensor const& c_strides,
+                          bool per_act_token, bool per_out_ch);
+#endif
+
 #if defined ENABLE_SCALED_MM_SM120 && ENABLE_SCALED_MM_SM120
 void cutlass_scaled_mm_sm120(torch::stable::Tensor& c,
                              torch::stable::Tensor const& a,
@@ -281,6 +295,14 @@ void cutlass_moe_mm(torch::stable::Tensor& out_tensors,
                     torch::stable::Tensor const& c_strides, bool per_act_token,
                     bool per_out_ch) {
   int32_t version_num = get_sm_version_num();
+#if defined ENABLE_CUTLASS_MOE_SM120 && ENABLE_CUTLASS_MOE_SM120
+  if (version_num >= 120 && version_num < 130) {
+    cutlass_moe_mm_sm120(out_tensors, a_tensors, b_tensors, a_scales, b_scales,
+                         expert_offsets, problem_sizes, a_strides, b_strides,
+                         c_strides, per_act_token, per_out_ch);
+    return;
+  }
+#endif
 #if defined ENABLE_CUTLASS_MOE_SM100 && ENABLE_CUTLASS_MOE_SM100
   if (version_num >= 100 && version_num < 110) {
     cutlass_moe_mm_sm100(out_tensors, a_tensors, b_tensors, a_scales, b_scales,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -892,7 +892,7 @@ def cutlass_scaled_mm_azp(
 
 
 def cutlass_group_gemm_supported(cuda_device_capability: int) -> bool:
-    if cuda_device_capability < 90 or cuda_device_capability >= 110:
+    if cuda_device_capability < 90 or cuda_device_capability >= 130:
         return False
     try:
         return torch.ops._C.cutlass_group_gemm_supported(cuda_device_capability)


### PR DESCRIPTION
## Summary

Fixes two bugs that silently disabled the CUTLASS FP8 grouped GEMM path for all SM_120/SM_121 hardware (RTX 5090/5080/5070, DGX Spark GB10), causing every MoE expert dispatch to fall back to the Triton backend.

Fixes #43507.

---

## What changed

### Bug 1 — Python gate (`vllm/_custom_ops.py`)

\`\`\`python
# Before (wrong):
if cuda_device_capability < 90 or cuda_device_capability >= 110:
    return False

# After (correct):
if cuda_device_capability < 90 or cuda_device_capability >= 130:
    return False
\`\`\`

\`cuda_device_capability\` is an integer: \`121 >= 110\` is \`True\`, so this gate always returned \`False\` for SM121, routing every call through Triton. \`>= 130\` is correct — it reserves the exit clause for genuinely unsupported future architectures beyond SM12x.

### Bug 2 — Missing SM120 grouped GEMM kernel

Added \`csrc/libtorch_stable/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm120.cu\`, the SM120 analog of \`grouped_mm_c3x_sm100.cu\`. Configuration:

- **Schedule**: \`KernelPtrArrayTmaWarpSpecializedCooperativeSm120<2>\` (cooperative, 4×2 UMMA atom layout)
- **Tile shape**: \`128×128×128\` (same as SM100 default)
- **Cluster shape**: \`1×1×1\` (no programmatic multicast on consumer Blackwell)
- **Epilogue**: \`EpilogueScheduleAuto\` (auto-selects per-tensor/per-token scaling in the epilogue, matching the FP8-Dynamic quantization scheme)
- **Arch tag**: \`Sm120\` (runs on SM_121 as well per CUDA arch compatibility)

Added dispatch block in \`scaled_mm_entry.cu\` for \`version_num >= 120 && version_num < 130\`.
Added the \`.cu\` file to the existing SM12x build block in \`CMakeLists.txt\` (under \`FP4_ARCHS\`, which already sets \`ENABLE_CUTLASS_MOE_SM120=1\`).

---

## CUTLASS dependency

\`KernelPtrArrayTmaWarpSpecializedCooperativeSm120<2>\` requires the \`MainloopSm120ArrayTmaWarpSpecialized\` collective specialization, which is **not yet in CUTLASS 4.5**. It has been contributed upstream via [NVIDIA/cutlass#3280](https://github.com/NVIDIA/cutlass/pull/3280) (currently in review). This vLLM PR will compile correctly once vLLM's pinned CUTLASS revision includes that change.

---

## Why not duplicate

- \`gh pr list --repo vllm-project/vllm --state open --search "SM121 cuda_device_capability"\` — no results
- \`gh pr list --repo vllm-project/vllm --state open --search "grouped_mm_c3x_sm120"\` — no results
- Existing SM120 PRs (#43477, #41738, #42856) address different subsystems (FlashInfer, NVFP4, sparse-MLA), not the FP8 grouped GEMM path

---

## Hardware validation

Validated on **SM_121 hardware** (NVIDIA DGX Spark, GB10, 128 GB LPDDR5X unified memory):

- **Container**: vLLM source build, CUDA 13.0.2, \`TORCH_CUDA_ARCH_LIST=12.0a;12.1a;12.1+PTX\`, patched CUTLASS (includes NVIDIA/cutlass#3280 changes)
- **Model**: \`RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic\` (Gemma 4 MoE, 26B total / 4B active, FP8-Dynamic quantization)

**Result**: SM120 CUTLASS grouped GEMM collective activates and produces correct outputs. Previously fell back to Triton for every MoE dispatch.

### Throughput comparison (wall-clock, single-stream, MTP speculative decoding, 3 iterations)

| Prompt size | Baseline (Triton fallback) | This fix (SM120 CUTLASS) | Delta |
|---|---|---|---|
| Short (128 tok output) | 76.3 tok/s | 81.9 tok/s | **+7.3%** |
| Medium (512 tok output) | 89.8 tok/s | 89.8 tok/s | ≈0% (within noise) |
| Long (1024 tok output) | 87.6 tok/s | 85.5 tok/s | -2.4% (within noise) |

Short-sequence improvement is the clearest signal (decode-dominated, grouped GEMM runs every forward pass). Medium/long variance is dominated by speculative decoding accept-rate noise over 3 iterations.

---

## Update — rebased onto main (2026-06-20)

Rebased cleanly onto current \`main\` (post-v0.23.0). No conflicts. The two changed hunks (\`_custom_ops.py\` gate fix and \`scaled_mm_entry.cu\` dispatch block) applied without modification.

**Relevant context from v0.23.0**: #40923 (Marlin MoE SM 12.x native cubins) and #42027 (gelu_tanh CUTLASS/WNA16 MoE) both landed in v0.23.0, covering adjacent SM12x infrastructure. This PR addresses the remaining gap: the FP8 grouped GEMM Python gate and the missing SM120 CUTLASS kernel.

---

## AI assistance disclosure

This fix was developed with Claude (Anthropic) AI assistance, including root cause analysis of the gate condition, derivation of the SM120 kernel configuration from the SM100 analog, and iterative compile debugging (four full Docker builds on real SM_121 hardware). All changed lines have been reviewed by the human submitter (Tyler Merritt). Build and inference validation ran on physical DGX Spark hardware.

Related CUTLASS upstream PR: [NVIDIA/cutlass#3280](https://github.com/NVIDIA/cutlass/pull/3280)