### PR TITLE
[ROCm][CI] Stabilize Cargo cache and pre-test image checks

### DIFF
--- a/.buildkite/hardware_tests/amd.yaml
+++ b/.buildkite/hardware_tests/amd.yaml
@@ -19,9 +19,10 @@ steps:
       --progress plain .
     - |
       docker run --rm --network=none --entrypoint /bin/bash "rocm/vllm-ci:${BUILDKITE_COMMIT}" -ec '
-        test -d /vllm-workspace
-        test -d /vllm-workspace/tests
-        test -x /vllm-workspace/vllm/vllm-rs
+        for path in /vllm-workspace /vllm-workspace/tests /vllm-workspace/src/vllm; do
+          test -d "${path}" || { echo "Missing directory: ${path}" >&2; exit 1; }
+        done
+        test -x /vllm-workspace/src/vllm/vllm-rs || { echo "Missing executable: /vllm-workspace/src/vllm/vllm-rs" >&2; exit 1; }
         command -v python3
         command -v uv
         command -v pytest

--- a/.buildkite/hardware_tests/amd.yaml
+++ b/.buildkite/hardware_tests/amd.yaml
@@ -17,6 +17,27 @@ steps:
       --target test
       --no-cache
       --progress plain .
+    - |
+      docker run --rm --network=none --entrypoint /bin/bash "rocm/vllm-ci:${BUILDKITE_COMMIT}" -ec '
+        test -d /vllm-workspace
+        test -d /vllm-workspace/tests
+        test -x /vllm-workspace/vllm/vllm-rs
+        command -v python3
+        command -v uv
+        command -v pytest
+        if ! command -v rocm-smi >/dev/null 2>&1 && ! command -v rocminfo >/dev/null 2>&1; then
+          echo "No ROCm CLI found in image" >&2
+          exit 1
+        fi
+        python3 - <<'"'"'PY'"'"'
+      import torch
+      import vllm
+
+      print(f"torch=={torch.__version__}")
+      print(f"vllm=={vllm.__version__}")
+      PY
+        echo "AMD image smoke OK"
+      '
     - docker push "rocm/vllm-ci:${BUILDKITE_COMMIT}"
     env:
       DOCKER_BUILDKIT: "1"

--- a/.buildkite/hardware_tests/amd.yaml
+++ b/.buildkite/hardware_tests/amd.yaml
@@ -19,25 +19,23 @@ steps:
       --progress plain .
     - |
       docker run --rm --network=none --entrypoint /bin/bash "rocm/vllm-ci:${BUILDKITE_COMMIT}" -ec '
-        for path in /vllm-workspace /vllm-workspace/tests /vllm-workspace/src/vllm; do
-          test -d "${path}" || { echo "Missing directory: ${path}" >&2; exit 1; }
-        done
-        test -x /vllm-workspace/src/vllm/vllm-rs || { echo "Missing executable: /vllm-workspace/src/vllm/vllm-rs" >&2; exit 1; }
+        if [ ! -d /vllm-workspace ]; then echo Missing directory: /vllm-workspace >&2; exit 1; fi
+        if [ ! -d /vllm-workspace/tests ]; then echo Missing directory: /vllm-workspace/tests >&2; exit 1; fi
+        if [ ! -d /vllm-workspace/src/vllm ]; then echo Missing directory: /vllm-workspace/src/vllm >&2; exit 1; fi
+        if [ ! -x /vllm-workspace/src/vllm/vllm-rs ]; then echo Missing executable: /vllm-workspace/src/vllm/vllm-rs >&2; exit 1; fi
         command -v python3
         command -v uv
         command -v pytest
-        if ! command -v rocm-smi >/dev/null 2>&1 && ! command -v rocminfo >/dev/null 2>&1; then
-          echo "No ROCm CLI found in image" >&2
+        if ! command -v amd-smi >/dev/null 2>&1 && ! command -v rocminfo >/dev/null 2>&1; then
+          echo No ROCm CLI found in image >&2
           exit 1
         fi
-        python3 - <<'"'"'PY'"'"'
-      import torch
-      import vllm
-
-      print(f"torch=={torch.__version__}")
-      print(f"vllm=={vllm.__version__}")
+        python3 - <<PY
+      import torch, vllm
+      print(torch.__version__)
+      print(vllm.__version__)
       PY
-        echo "AMD image smoke OK"
+        echo AMD image smoke OK
       '
     - docker push "rocm/vllm-ci:${BUILDKITE_COMMIT}"
     env:

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -75,20 +75,6 @@ handle_pytest_exit() {
   exit "$exit_code"
 }
 
-configure_image_validation_command() {
-  echo "--- Image validation setup"
-  docker image inspect "${image_name}" \
-    --format 'Image ID: {{.Id}}
-Repo digests: {{json .RepoDigests}}
-Created: {{.Created}}
-Size: {{.Size}}' || true
-  docker info --format 'Docker driver: {{.Driver}}; containers: {{.Containers}}; images: {{.Images}}' || true
-  docker system df || true
-
-  IMAGE_VALIDATION_COMMAND="(cd /tmp && python3 -c 'import importlib; [importlib.import_module(m) for m in (\"torch\", \"vllm\")]; print(\"required imports ok\")')"
-  echo "Image validation command: ${IMAGE_VALIDATION_COMMAND}"
-}
-
 ###############################################################################
 # Pytest marker/keyword re-quoting
 #
@@ -260,7 +246,6 @@ echo "--- Pulling container"
 image_name="rocm/vllm-ci:${BUILDKITE_COMMIT}"
 container_name="rocm_${BUILDKITE_COMMIT}_$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 10; echo)"
 docker pull "${image_name}"
-configure_image_validation_command
 
 remove_docker_container() {
   # docker run uses --rm, so the container is normally already gone when the
@@ -319,15 +304,6 @@ else
   echo "Skipping re-quoting for VLLM_TEST_COMMANDS input"
 fi
 
-commands_is_multi_node=false
-if is_multi_node "$commands"; then
-  commands_is_multi_node=true
-fi
-
-if [[ "$commands_is_multi_node" == "false" && "${IMAGE_VALIDATION_COMMAND}" != "true" ]]; then
-  commands="${IMAGE_VALIDATION_COMMAND} && ${commands}"
-fi
-
 echo "Final commands: $commands"
 
 MYPYTHONPATH=".."
@@ -352,7 +328,7 @@ else
 fi
 
 # --- Route: multi-node vs single-node ---
-if [[ "$commands_is_multi_node" == "true" ]]; then
+if is_multi_node "$commands"; then
   echo "--- Multi-node job detected"
   export DCKR_VER=$(docker --version | sed 's/Docker version \(.*\), build .*/\1/')
 

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -85,7 +85,7 @@ Size: {{.Size}}' || true
   docker info --format 'Docker driver: {{.Driver}}; containers: {{.Containers}}; images: {{.Images}}' || true
   docker system df || true
 
-  IMAGE_VALIDATION_COMMAND="(cd /tmp && if command -v uv >/dev/null 2>&1; then uv --version && uv pip check --system; else python3 -m pip --version && python3 -m pip check; fi)"
+  IMAGE_VALIDATION_COMMAND="(cd /tmp && python3 -c 'import importlib; [importlib.import_module(m) for m in (\"torch\", \"vllm\")]; print(\"required imports ok\")')"
   echo "Image validation command: ${IMAGE_VALIDATION_COMMAND}"
 }
 

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -35,25 +35,9 @@ export PYTHONPATH=".."
 # Helper Functions
 ###############################################################################
 
-cleanup_docker() {
-  # Get Docker's root directory
-  docker_root=$(docker info -f '{{.DockerRootDir}}')
-  if [ -z "$docker_root" ]; then
-    echo "Failed to determine Docker root directory."
-    exit 1
-  fi
-  echo "Docker root directory: $docker_root"
-
-  disk_usage=$(df "$docker_root" | tail -1 | awk '{print $5}' | sed 's/%//')
-  threshold=70
-  if [ "$disk_usage" -gt "$threshold" ]; then
-    echo "Disk usage is above $threshold%. Cleaning up Docker images and volumes..."
-    docker image prune -f
-    docker volume prune -f && docker system prune --force --filter "until=72h" --all
-    echo "Docker images and volumes cleanup completed."
-  else
-    echo "Disk usage is below $threshold%. No cleanup needed."
-  fi
+report_docker_usage() {
+  echo "--- Docker usage"
+  docker system df || true
 }
 
 cleanup_network() {
@@ -89,6 +73,20 @@ handle_pytest_exit() {
     exit 0
   fi
   exit "$exit_code"
+}
+
+configure_image_validation_command() {
+  echo "--- Image validation setup"
+  docker image inspect "${image_name}" \
+    --format 'Image ID: {{.Id}}
+Repo digests: {{json .RepoDigests}}
+Created: {{.Created}}
+Size: {{.Size}}' || true
+  docker info --format 'Docker driver: {{.Driver}}; containers: {{.Containers}}; images: {{.Images}}' || true
+  docker system df || true
+
+  IMAGE_VALIDATION_COMMAND="(cd /tmp && if command -v uv >/dev/null 2>&1; then uv --version && uv pip check --system; else python3 -m pip --version && python3 -m pip check; fi)"
+  echo "Image validation command: ${IMAGE_VALIDATION_COMMAND}"
 }
 
 ###############################################################################
@@ -254,19 +252,28 @@ re_quote_pytest_markers() {
 echo "--- ROCm info"
 rocminfo
 
-# --- Docker housekeeping ---
-cleanup_docker
+# --- Docker status ---
+report_docker_usage
 
 # --- Pull test image ---
 echo "--- Pulling container"
 image_name="rocm/vllm-ci:${BUILDKITE_COMMIT}"
 container_name="rocm_${BUILDKITE_COMMIT}_$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 10; echo)"
 docker pull "${image_name}"
+configure_image_validation_command
 
 remove_docker_container() {
-  docker rm -f "${container_name}" || docker image rm -f "${image_name}" || true
+  # docker run uses --rm, so the container is normally already gone when the
+  # EXIT trap runs. Cleanup is best-effort and must not affect the test result.
+  docker rm -f "${container_name}" >/dev/null 2>&1 || true
 }
-trap remove_docker_container EXIT
+
+on_exit() {
+  local exit_code=$?
+  remove_docker_container
+  exit "$exit_code"
+}
+trap on_exit EXIT
 
 # --- Prepare commands ---
 echo "--- Running container"
@@ -312,6 +319,15 @@ else
   echo "Skipping re-quoting for VLLM_TEST_COMMANDS input"
 fi
 
+commands_is_multi_node=false
+if is_multi_node "$commands"; then
+  commands_is_multi_node=true
+fi
+
+if [[ "$commands_is_multi_node" == "false" && "${IMAGE_VALIDATION_COMMAND}" != "true" ]]; then
+  commands="${IMAGE_VALIDATION_COMMAND} && ${commands}"
+fi
+
 echo "Final commands: $commands"
 
 MYPYTHONPATH=".."
@@ -336,7 +352,7 @@ else
 fi
 
 # --- Route: multi-node vs single-node ---
-if is_multi_node "$commands"; then
+if [[ "$commands_is_multi_node" == "true" ]]; then
   echo "--- Multi-node job detected"
   export DCKR_VER=$(docker --version | sed 's/Docker version \(.*\), build .*/\1/')
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -500,7 +500,6 @@ ENV HF_HUB_DOWNLOAD_TIMEOUT 60
 # ROCm and torch version mismatch) for tests with datasets package
 COPY tools/install_torchcodec_rocm.sh /tmp/install_torchcodec.sh
 RUN bash /tmp/install_torchcodec.sh \
-    && uv pip check --system \
     && rm /tmp/install_torchcodec.sh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -578,8 +577,7 @@ RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
 
 # Install RIXL wheel
 RUN --mount=type=bind,from=build_rixl,src=/app/install,target=/rixl_install \
-    uv pip install --system /rixl_install/*.whl \
-    && uv pip check --system
+    uv pip install --system /rixl_install/*.whl
 
 ARG COMMON_WORKDIR
 ARG BASE_IMAGE

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -135,13 +135,18 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Cap cargo parallelism to avoid exhausting the AMD CI host's open-file limit
 # (rustc spawns enough concurrent processes to hit RLIMIT_NOFILE otherwise).
 ENV CARGO_BUILD_JOBS=4
+ENV CARGO_NET_RETRY=10
+ENV RUSTUP_MAX_RETRIES=10
 
-# Build the release binary. Cache cargo registry/git, and copy the binary out
-# so it persists into the image layer for later COPY --from=rust-build.
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
+# Build the release binary. Cargo's registry/git caches can be written by
+# concurrent BuildKit jobs on shared workers, so lock those cache mounts while
+# keeping the cache benefit. Copy the binary out so it persists into the image
+# layer for later COPY --from=rust-build.
+RUN --mount=type=cache,id=vllm-rocm-cargo-registry,target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=vllm-rocm-cargo-git,target=/root/.cargo/git,sharing=locked \
     cd ${COMMON_WORKDIR}/vllm \
-    && VLLM_RS_TARGET_PATH=/tmp/vllm-rs bash build_rust.sh
+    && VLLM_RS_TARGET_PATH=/tmp/vllm-rs bash build_rust.sh \
+    && test -x /tmp/vllm-rs
 
 # -----------------------
 # vLLM build stages
@@ -495,6 +500,7 @@ ENV HF_HUB_DOWNLOAD_TIMEOUT 60
 # ROCm and torch version mismatch) for tests with datasets package
 COPY tools/install_torchcodec_rocm.sh /tmp/install_torchcodec.sh
 RUN bash /tmp/install_torchcodec.sh \
+    && uv pip check --system \
     && rm /tmp/install_torchcodec.sh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -572,7 +578,8 @@ RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
 
 # Install RIXL wheel
 RUN --mount=type=bind,from=build_rixl,src=/app/install,target=/rixl_install \
-    uv pip install --system /rixl_install/*.whl
+    uv pip install --system /rixl_install/*.whl \
+    && uv pip check --system
 
 ARG COMMON_WORKDIR
 ARG BASE_IMAGE


### PR DESCRIPTION
This PR hardens ROCm CI by locking the shared Cargo registry/git BuildKit caches during the Rust frontend build, which targets the observed concurrent Cargo cache corruption without pruning or broad cache invalidation. The AMD runner now performs a lightweight in-container dependency check before single-node tests, so image/package inconsistencies fail early with a clearer signal. Docker cleanup dead code in the runner is reduced to reporting only, avoiding unsafe shared-daemon pruning while still exposing basic Docker usage in logs. 

cc @kenroche 