### PR TITLE
feat: support to OpenMOSS-Team

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_moss_audio.py
+++ b/tests/entrypoints/openai/chat_completion/test_moss_audio.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import openai
+import pytest
+
+from tests.models.registry import HF_EXAMPLE_MODELS
+from tests.utils import RemoteOpenAIServer
+from vllm.assets.audio import AudioAsset
+from vllm.multimodal.utils import encode_audio_base64, encode_audio_url
+
+MODEL_NAME = "OpenMOSS-Team/MOSS-Audio-4B-Instruct"
+TEST_AUDIO = AudioAsset("winning_call")
+QUESTION = "What is happening in this audio?"
+
+
+@pytest.fixture(scope="module")
+def server():
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(MODEL_NAME)
+    model_info.check_available_online(on_fail="skip")
+    model_info.check_transformers_version(on_fail="skip")
+
+    args = [
+        "--dtype",
+        "half",
+        "--max-model-len",
+        "1024",
+        "--max-num-seqs",
+        "1",
+        "--enforce-eager",
+        "--trust-remote-code",
+        "--limit-mm-per-prompt",
+        json.dumps({"audio": 1}),
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture
+def client(server):
+    return server.get_client()
+
+
+def _messages_from_audio_url(audio_url: str) -> list[dict[str, object]]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio_url", "audio_url": {"url": audio_url}},
+                {"type": "text", "text": QUESTION},
+            ],
+        }
+    ]
+
+
+def _messages_from_input_audio(audio_b64: str) -> list[dict[str, object]]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": audio_b64, "format": "wav"},
+                },
+                {"type": "text", "text": QUESTION},
+            ],
+        }
+    ]
+
+
+def _get_test_audio_data():
+    return TEST_AUDIO.audio_and_sample_rate
+
+
+def test_single_chat_session_audio_url(
+    client: openai.OpenAI,
+):
+    audio_url = encode_audio_url(*_get_test_audio_data())
+    chat_completion = client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=_messages_from_audio_url(audio_url),
+        max_completion_tokens=16,
+        temperature=0.0,
+    )
+
+    assert len(chat_completion.choices) == 1
+    choice = chat_completion.choices[0]
+    assert choice.message.content is not None
+    assert choice.message.content.strip() != ""
+
+
+def test_single_chat_session_input_audio(
+    client: openai.OpenAI,
+):
+    audio_b64 = encode_audio_base64(*_get_test_audio_data())
+    chat_completion = client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=_messages_from_input_audio(audio_b64),
+        max_completion_tokens=16,
+        temperature=0.0,
+    )
+
+    assert len(chat_completion.choices) == 1
+    choice = chat_completion.choices[0]
+    assert choice.message.content is not None
+    assert choice.message.content.strip() != ""

--- a/tests/models/multimodal/processing/test_moss_audio.py
+++ b/tests/models/multimodal/processing/test_moss_audio.py
@@ -2,11 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
+from pathlib import Path
 
 import pytest
 import torch
 from transformers import Qwen3Config
 
+from vllm.config.multimodal import MultiModalConfig
 from vllm.model_executor.models.interfaces import supports_multimodal, supports_pp
 from vllm.model_executor.models.interfaces_base import is_text_generation_model
 from vllm.model_executor.models.moss_audio import (
@@ -21,6 +23,7 @@ from vllm.model_executor.models.moss_audio import (
     MossAudioEncoder,
     MossAudioEncoderConfig,
     MossAudioModel,
+    MOSS_AUDIO_PLACEHOLDER,
     MossAudioMultiModalProcessor,
     MossAudioProcessingInfo,
     MossAudioProcessor,
@@ -60,11 +63,52 @@ class _Info:
 
 
 class _ProcessingContext:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        model: str = ".",
+        revision: str | None = None,
+        mm_processor_kwargs: dict[str, object] | None = None,
+    ) -> None:
         self.tokenizer = _Tokenizer()
+        self.model_config = _ProcessingModelConfig(
+            model=model,
+            revision=revision,
+            multimodal_config=MultiModalConfig(
+                mm_processor_kwargs=mm_processor_kwargs
+            ),
+            hf_config=MossAudioConfig(language_config=Qwen3Config()),
+        )
 
     def get_tokenizer(self) -> _Tokenizer:
         return self.tokenizer
+
+    def get_hf_config(self) -> MossAudioConfig:
+        return self.model_config.hf_config
+
+    def get_merged_mm_kwargs(
+        self,
+        kwargs: dict[str, object],
+    ) -> dict[str, object]:
+        return self.model_config.multimodal_config.merge_mm_processor_kwargs(kwargs)
+
+
+class _ProcessingModelConfig:
+    def __init__(
+        self,
+        *,
+        model: str,
+        revision: str | None,
+        multimodal_config: MultiModalConfig,
+        hf_config: MossAudioConfig,
+    ) -> None:
+        self.model = model
+        self.revision = revision
+        self.multimodal_config = multimodal_config
+        self.hf_config = hf_config
+
+    def get_multimodal_config(self) -> MultiModalConfig:
+        return self.multimodal_config
 
 
 class _OutKwargs:
@@ -126,9 +170,7 @@ def _patch_tensor_parallel_for_linear_layers(
 
 def test_moss_audio_processor_expands_audio_placeholder() -> None:
     processor = MossAudioProcessor(_Tokenizer())
-    prompt = (
-        f"before {MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN} after"
-    )
+    prompt = f"before {MOSS_AUDIO_PLACEHOLDER} after"
     raw_mel_len = 17
     audio = torch.zeros(160 * raw_mel_len)
 
@@ -143,11 +185,27 @@ def test_moss_audio_processor_expands_audio_placeholder() -> None:
     assert processed["audio_data_seqlens"].tolist() == [raw_mel_len]
 
 
-def test_moss_audio_processor_preserves_placeholder_without_audio() -> None:
+def test_moss_audio_processor_expands_multi_token_audio_span() -> None:
     processor = MossAudioProcessor(_Tokenizer())
     prompt = (
-        f"before {MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN} after"
+        f"before {MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}"
+        f"{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN} after"
     )
+    raw_mel_len = 17
+    audio = torch.zeros(160 * raw_mel_len)
+
+    processed = processor(text=prompt, audio=[audio])
+    input_ids = processed["input_ids"][0].tolist()
+    expected_audio_tokens = MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)
+
+    assert input_ids.count(MOSS_AUDIO_BOS_TOKEN_ID) == 1
+    assert input_ids.count(MOSS_AUDIO_EOS_TOKEN_ID) == 1
+    assert input_ids.count(MOSS_AUDIO_TOKEN_ID) == expected_audio_tokens
+
+
+def test_moss_audio_processor_preserves_placeholder_without_audio() -> None:
+    processor = MossAudioProcessor(_Tokenizer())
+    prompt = f"before {MOSS_AUDIO_PLACEHOLDER} after"
 
     processed = processor(text=prompt)
     input_ids = processed["input_ids"][0].tolist()
@@ -161,6 +219,72 @@ def test_moss_audio_processor_preserves_placeholder_without_audio() -> None:
     ]
     assert "audio_data" not in processed
     assert "audio_data_seqlens" not in processed
+
+
+def test_moss_audio_processor_inserts_default_prompt_without_placeholder() -> None:
+    processor = MossAudioProcessor(_Tokenizer())
+    raw_mel_len = 17
+    audio = torch.zeros(160 * raw_mel_len)
+
+    processed = processor(text="Describe this audio.", audio=[audio])
+    input_ids = processed["input_ids"][0].tolist()
+    expected_audio_tokens = MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)
+    expected_prefix = [
+        MOSS_AUDIO_BOS_TOKEN_ID,
+        *([MOSS_AUDIO_TOKEN_ID] * expected_audio_tokens),
+        MOSS_AUDIO_EOS_TOKEN_ID,
+        ord("\n"),
+    ]
+
+    assert input_ids[: len(expected_prefix)] == expected_prefix
+    assert processed["audio_data"].shape == (1, 128, raw_mel_len)
+
+
+def test_moss_audio_processor_uses_custom_mel_config() -> None:
+    processor = MossAudioProcessor(
+        _Tokenizer(),
+        mel_config={
+            "mel_dim": 80,
+            "mel_sr": 8000,
+            "mel_hop_length": 80,
+            "mel_n_fft": 200,
+        },
+    )
+    raw_mel_len = 17
+    audio = torch.zeros(80 * raw_mel_len)
+
+    processed = processor(text=MOSS_AUDIO_PLACEHOLDER, audio=[audio])
+
+    assert processor.mel_config == {
+        "mel_dim": 80,
+        "mel_sr": 8000,
+        "mel_hop_length": 80,
+        "mel_n_fft": 200,
+    }
+    assert processed["audio_data"].shape == (1, 80, raw_mel_len)
+    assert processed["audio_data"].dtype == torch.float32
+
+
+def test_moss_audio_processor_uses_manual_audio_token_ids() -> None:
+    processor = MossAudioProcessor(
+        _Tokenizer(),
+        audio_token_id=901,
+        audio_start_id=902,
+        audio_end_id=903,
+        enable_time_marker=True,
+    )
+    raw_mel_len = 320
+    audio = torch.zeros(160 * raw_mel_len)
+
+    processed = processor(text=MOSS_AUDIO_PLACEHOLDER, audio=[audio])
+    input_ids = processed["input_ids"][0].tolist()
+    audio_token_len = MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)
+
+    assert input_ids[0] == 902
+    assert input_ids[-1] == 903
+    assert input_ids.count(901) == audio_token_len
+    assert MOSS_AUDIO_BOS_TOKEN_ID not in input_ids
+    assert MOSS_AUDIO_EOS_TOKEN_ID not in input_ids
 
 
 def test_moss_audio_time_markers_are_not_embedding_targets() -> None:
@@ -190,9 +314,7 @@ def test_moss_audio_time_markers_are_not_embedding_targets() -> None:
 def test_moss_audio_prompt_updates_match_chat_template_tokenization() -> None:
     class _ChatTemplateTokenizer(_Tokenizer):
         def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
-            placeholder = (
-                f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
-            )
+            placeholder = MOSS_AUDIO_PLACEHOLDER
             if text == placeholder:
                 return [11, 12, 13, 14]
             if text == f"{placeholder}\n":
@@ -258,6 +380,145 @@ def test_moss_audio_processing_info_caches_default_processor() -> None:
     assert time_marker_processor.enable_time_marker
 
 
+def test_moss_audio_processing_info_reads_processor_config(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "processor_config.json").write_text(
+        """
+        {
+          "audio_token_id": 301,
+          "audio_start_id": 302,
+          "audio_end_id": 303,
+          "enable_time_marker": true,
+          "mel_config": {
+            "mel_dim": 80,
+            "mel_sr": 8000,
+            "mel_hop_length": 80,
+            "mel_n_fft": 200
+          },
+          "processor_class": "PalomarProcessor"
+        }
+        """,
+    )
+    info = MossAudioProcessingInfo(_ProcessingContext(model=str(tmp_path)))
+
+    processor = info.get_hf_processor()
+
+    assert processor.audio_token_id == 301
+    assert processor.audio_start_id == 302
+    assert processor.audio_end_id == 303
+    assert processor.enable_time_marker
+    assert processor.mel_config == {
+        "mel_dim": 80,
+        "mel_sr": 8000,
+        "mel_hop_length": 80,
+        "mel_n_fft": 200,
+    }
+
+
+def test_moss_audio_processing_info_reads_preprocessor_config(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "preprocessor_config.json").write_text(
+        """
+        {
+          "audio_token_id": 401,
+          "mel_config": {
+            "sampling_rate": 12000,
+            "feature_size": 64,
+            "hop_length": 120,
+            "n_fft": 240
+          }
+        }
+        """,
+    )
+    info = MossAudioProcessingInfo(_ProcessingContext(model=str(tmp_path)))
+
+    processor = info.get_hf_processor()
+
+    assert processor.audio_token_id == 401
+    assert processor.audio_start_id == MOSS_AUDIO_BOS_TOKEN_ID
+    assert processor.audio_end_id == MOSS_AUDIO_EOS_TOKEN_ID
+    assert not processor.enable_time_marker
+    assert processor.mel_config == {
+        "mel_dim": 64,
+        "mel_sr": 12000,
+        "mel_hop_length": 120,
+        "mel_n_fft": 240,
+    }
+
+
+def test_moss_audio_processing_info_merges_processor_kwargs(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "processor_config.json").write_text(
+        """
+        {
+          "audio_token_id": 501,
+          "audio_start_id": 502,
+          "audio_end_id": 503,
+          "enable_time_marker": false,
+          "mel_config": {
+            "mel_dim": 80,
+            "mel_sr": 8000,
+            "mel_hop_length": 80,
+            "mel_n_fft": 200
+          }
+        }
+        """,
+    )
+    info = MossAudioProcessingInfo(
+        _ProcessingContext(
+            model=str(tmp_path),
+            mm_processor_kwargs={
+                "audio_token_id": 601,
+                "mel_config": {
+                    "mel_dim": 96,
+                    "mel_sr": 12000,
+                },
+            },
+        )
+    )
+
+    processor = info.get_hf_processor(
+        audio_end_id=603,
+        enable_time_marker=True,
+        mel_config={"mel_hop_length": 120},
+    )
+
+    assert processor.audio_token_id == 601
+    assert processor.audio_start_id == 502
+    assert processor.audio_end_id == 603
+    assert processor.enable_time_marker
+    assert processor.mel_config == {
+        "mel_dim": 96,
+        "mel_sr": 12000,
+        "mel_hop_length": 120,
+        "mel_n_fft": 200,
+    }
+
+
+def test_moss_audio_processing_info_cache_key_includes_processor_config() -> None:
+    info = MossAudioProcessingInfo(_ProcessingContext())
+
+    processor = info.get_hf_processor(audio_token_id=701)
+    same_processor = info.get_hf_processor(audio_token_id=701)
+    different_token_processor = info.get_hf_processor(audio_token_id=702)
+    different_time_marker_processor = info.get_hf_processor(
+        audio_token_id=701,
+        enable_time_marker=True,
+    )
+    different_mel_processor = info.get_hf_processor(
+        audio_token_id=701,
+        mel_config={"mel_dim": 80},
+    )
+
+    assert same_processor is processor
+    assert different_token_processor is not processor
+    assert different_time_marker_processor is not processor
+    assert different_mel_processor is not processor
+
+
 def test_moss_audio_encoder_vectorized_mask_matches_token_count() -> None:
     config = MossAudioEncoderConfig(
         output_dim=8,
@@ -310,10 +571,7 @@ def test_moss_audio_field_config_and_interfaces() -> None:
     fields = _moss_audio_field_config({})
 
     assert set(fields) == {"audio_data", "audio_data_seqlens"}
-    assert (
-        MossAudioModel.get_placeholder_str("audio", 0)
-        == f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
-    )
+    assert MossAudioModel.get_placeholder_str("audio", 0) == MOSS_AUDIO_PLACEHOLDER
     assert supports_multimodal(MossAudioModel)
     assert is_text_generation_model(MossAudioModel)
     assert not supports_pp(MossAudioModel)
@@ -360,12 +618,84 @@ def test_moss_audio_arch_config_uses_language_config() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    (
+        "language_config",
+        "expected_hidden_size",
+        "expected_num_heads",
+        "expected_kv_heads",
+        "expected_head_dim",
+        "expected_vocab_size",
+    ),
+    [
+        (
+            Qwen3Config(
+                hidden_size=2560,
+                num_attention_heads=32,
+                num_key_value_heads=8,
+                head_dim=80,
+                num_hidden_layers=36,
+                vocab_size=151936,
+                max_position_embeddings=32768,
+            ),
+            2560,
+            32,
+            8,
+            80,
+            151936,
+        ),
+        (
+            Qwen3Config(
+                hidden_size=4096,
+                num_attention_heads=32,
+                num_key_value_heads=8,
+                head_dim=128,
+                num_hidden_layers=36,
+                vocab_size=151936,
+                max_position_embeddings=32768,
+            ),
+            4096,
+            32,
+            8,
+            128,
+            151936,
+        ),
+    ],
+)
+def test_moss_audio_arch_config_supports_4b_and_8b_language_configs(
+    language_config: Qwen3Config,
+    expected_hidden_size: int,
+    expected_num_heads: int,
+    expected_kv_heads: int,
+    expected_head_dim: int,
+    expected_vocab_size: int,
+) -> None:
+    from vllm.transformers_utils.model_arch_config_convertor import (
+        MODEL_ARCH_CONFIG_CONVERTORS,
+    )
+
+    config = MossAudioConfig(language_config=language_config)
+    convertor = MODEL_ARCH_CONFIG_CONVERTORS["moss_audio"](config, config)
+
+    arch_config = convertor.convert()
+
+    assert config.hidden_size == expected_hidden_size
+    assert arch_config.hidden_size == expected_hidden_size
+    assert arch_config.total_num_attention_heads == expected_num_heads
+    assert arch_config.total_num_kv_heads == expected_kv_heads
+    assert arch_config.head_size == expected_head_dim
+    assert arch_config.vocab_size == expected_vocab_size
+
+
 def test_moss_audio_registry_entries() -> None:
     assert _MULTIMODAL_MODELS["MossAudioModel"] == ("moss_audio", "MossAudioModel")
-    assert (
-        _MULTIMODAL_EXAMPLE_MODELS["MossAudioModel"].default
-        == "OpenMOSS-Team/MOSS-Audio-4B-Instruct"
-    )
+    info = _MULTIMODAL_EXAMPLE_MODELS["MossAudioModel"]
+    assert info.default == "OpenMOSS-Team/MOSS-Audio-4B-Instruct"
+    assert info.extras == {
+        "4b-thinking": "OpenMOSS-Team/MOSS-Audio-4B-Thinking",
+        "8b-instruct": "OpenMOSS-Team/MOSS-Audio-8B-Instruct",
+        "8b-thinking": "OpenMOSS-Team/MOSS-Audio-8B-Thinking",
+    }
 
 
 @pytest.mark.parametrize(
@@ -561,9 +891,24 @@ def test_moss_audio_embed_input_ids_caches_packed_deepstack() -> None:
     )
 
 
+def test_moss_audio_model_load_weights_skips_sinusoid_buffer() -> None:
+    model = object.__new__(MossAudioModel)
+    torch.nn.Module.__init__(model)
+
+    weights = [
+        (
+            "audio_encoder.embed_positions.inv_timescales",
+            torch.empty(1),
+        ),
+    ]
+    loaded = model.load_weights(weights)
+
+    assert loaded == set()
+
+
 def test_moss_audio_rejects_too_short_audio() -> None:
     processor = MossAudioProcessor(_Tokenizer())
-    prompt = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+    prompt = MOSS_AUDIO_PLACEHOLDER
 
     with pytest.raises(ValueError, match="too short"):
         processor(text=prompt, audio=[torch.empty(0)])
@@ -577,7 +922,7 @@ def test_moss_audio_rejects_too_short_audio() -> None:
 
 
 def test_moss_audio_max_tokens_uses_default_30s_limit() -> None:
-    info = object.__new__(MossAudioProcessingInfo)
+    info = MossAudioProcessingInfo(_ProcessingContext())
 
     raw_mel_len = math.ceil((DEFAULT_MAX_AUDIO_SECONDS * 16000) / 160)
     assert info.get_mm_max_tokens_per_item(seq_len=2048, mm_counts={"audio": 1}) == {

--- a/tests/models/multimodal/processing/test_moss_audio.py
+++ b/tests/models/multimodal/processing/test_moss_audio.py
@@ -55,6 +55,9 @@ class _Info:
         del kwargs
         return self.processor
 
+    def get_tokenizer(self) -> object:
+        return self.processor.tokenizer
+
 
 class _ProcessingContext:
     def __init__(self) -> None:
@@ -140,6 +143,26 @@ def test_moss_audio_processor_expands_audio_placeholder() -> None:
     assert processed["audio_data_seqlens"].tolist() == [raw_mel_len]
 
 
+def test_moss_audio_processor_preserves_placeholder_without_audio() -> None:
+    processor = MossAudioProcessor(_Tokenizer())
+    prompt = (
+        f"before {MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN} after"
+    )
+
+    processed = processor(text=prompt)
+    input_ids = processed["input_ids"][0].tolist()
+
+    assert input_ids == [
+        *[ord(char) for char in "before "],
+        MOSS_AUDIO_BOS_TOKEN_ID,
+        MOSS_AUDIO_TOKEN_ID,
+        MOSS_AUDIO_EOS_TOKEN_ID,
+        *[ord(char) for char in " after"],
+    ]
+    assert "audio_data" not in processed
+    assert "audio_data_seqlens" not in processed
+
+
 def test_moss_audio_time_markers_are_not_embedding_targets() -> None:
     processor = MossAudioProcessor(_Tokenizer(), enable_time_marker=True)
     mm_processor = object.__new__(MossAudioMultiModalProcessor)
@@ -162,6 +185,62 @@ def test_moss_audio_time_markers_are_not_embedding_targets() -> None:
     assert full[-1] == MOSS_AUDIO_EOS_TOKEN_ID
     assert is_embed.sum().item() == audio_token_len
     assert len(full) > audio_token_len + 2
+
+
+def test_moss_audio_prompt_updates_match_chat_template_tokenization() -> None:
+    class _ChatTemplateTokenizer(_Tokenizer):
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            placeholder = (
+                f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+            )
+            if text == placeholder:
+                return [11, 12, 13, 14]
+            if text == f"{placeholder}\n":
+                return [11, 12, 13, 99]
+            if text == "\n":
+                return [99]
+            return super().encode(text, add_special_tokens=add_special_tokens)
+
+    processor = MossAudioProcessor(_ChatTemplateTokenizer())
+    mm_processor = object.__new__(MossAudioMultiModalProcessor)
+    mm_processor.info = _Info(processor)
+
+    updates = mm_processor._get_prompt_updates(
+        mm_items=None,
+        hf_processor_mm_kwargs={},
+        out_mm_kwargs=_OutKwargs(
+            {"audio_data_seqlens": torch.tensor([17], dtype=torch.long)}
+        ),
+    )
+    resolved_updates = [update.resolve(0) for update in updates]
+
+    assert [update.target for update in resolved_updates] == [
+        [MOSS_AUDIO_BOS_TOKEN_ID, MOSS_AUDIO_TOKEN_ID, MOSS_AUDIO_EOS_TOKEN_ID],
+        [11, 12, 13, 14],
+        [11, 12, 13, 99],
+    ]
+    assert resolved_updates[1].content.full == resolved_updates[0].content.full
+    assert resolved_updates[2].content.full == [
+        *resolved_updates[0].content.full,
+        99,
+    ]
+
+    mm_prompt_updates = mm_processor._bind_and_group_updates(updates, {"audio": 1})
+    new_token_ids, placeholders = mm_processor._apply_prompt_updates(
+        [1, 11, 12, 13, 99, 2],
+        mm_prompt_updates,
+    )
+
+    assert new_token_ids == [
+        1,
+        *resolved_updates[2].content.full,
+        2,
+    ]
+    assert len(placeholders["audio"]) == 1
+    assert placeholders["audio"][0].start_idx == 1
+    assert placeholders["audio"][0].length == len(resolved_updates[2].content.full)
+    assert placeholders["audio"][0].is_embed is not None
+    assert not bool(placeholders["audio"][0].is_embed[-1])
 
 
 def test_moss_audio_processing_info_caches_default_processor() -> None:
@@ -240,6 +319,47 @@ def test_moss_audio_field_config_and_interfaces() -> None:
     assert not supports_pp(MossAudioModel)
 
 
+def test_moss_audio_config_exposes_language_config() -> None:
+    config = MossAudioConfig(language_config=Qwen3Config(hidden_size=2560))
+
+    assert config.get_text_config() is config.language_config
+    assert config.hidden_size == config.language_config.hidden_size
+    assert config.num_attention_heads == config.language_config.num_attention_heads
+    assert config.num_key_value_heads == config.language_config.num_key_value_heads
+    assert config.head_dim == config.language_config.head_dim
+
+
+def test_moss_audio_arch_config_uses_language_config() -> None:
+    from vllm.transformers_utils.model_arch_config_convertor import (
+        MODEL_ARCH_CONFIG_CONVERTORS,
+    )
+
+    language_config = Qwen3Config(
+        hidden_size=2560,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=80,
+        num_hidden_layers=36,
+        vocab_size=151936,
+        max_position_embeddings=32768,
+    )
+    config = MossAudioConfig(language_config=language_config)
+    convertor = MODEL_ARCH_CONFIG_CONVERTORS["moss_audio"](config, config)
+
+    arch_config = convertor.convert()
+
+    assert arch_config.hidden_size == 2560
+    assert arch_config.total_num_attention_heads == 32
+    assert arch_config.total_num_kv_heads == 8
+    assert arch_config.head_size == 80
+    assert arch_config.total_num_hidden_layers == 36
+    assert arch_config.vocab_size == 151936
+    assert arch_config.derived_max_model_len_and_key == (
+        32768,
+        "language_config.max_position_embeddings",
+    )
+
+
 def test_moss_audio_registry_entries() -> None:
     assert _MULTIMODAL_MODELS["MossAudioModel"] == ("moss_audio", "MossAudioModel")
     assert (
@@ -313,12 +433,132 @@ def test_moss_audio_deepstack_disabled_skips_cache() -> None:
     )
 
     assert audio_encoder.output_deepstack_hidden_states is False
-    assert len(multimodal_embeddings) == 1
-    assert [embeds.shape for embeds in multimodal_embeddings[0]] == [
+    assert [embeds.shape for embeds in multimodal_embeddings] == [
         torch.Size([1, 8]),
         torch.Size([2, 8]),
     ]
     assert model.deepstack_input_embeds is None
+
+
+def test_moss_audio_embed_multimodal_packs_deepstack_per_audio() -> None:
+    class _FakeAudioEncoder:
+        dtype = torch.float32
+
+        def __init__(self) -> None:
+            self.output_deepstack_hidden_states: bool | None = None
+
+        def __call__(
+            self,
+            audio_data: torch.Tensor,
+            *,
+            feature_lens: torch.Tensor,
+            output_deepstack_hidden_states: bool,
+        ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+            del audio_data
+            self.output_deepstack_hidden_states = output_deepstack_hidden_states
+            audio_lengths = MossAudioEncoder._compute_downsampled_length(feature_lens)
+            total_tokens = int(audio_lengths.sum().item())
+            hidden_states = torch.ones(1, total_tokens, 8)
+            return hidden_states, [hidden_states * 2, hidden_states * 3]
+
+    class _ScaleAdapter:
+        def __init__(self, scale: int) -> None:
+            self.scale = scale
+
+        def __call__(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            return hidden_states * self.scale
+
+    model = object.__new__(MossAudioModel)
+    audio_encoder = _FakeAudioEncoder()
+    model.audio_encoder = audio_encoder
+    model.audio_adapter = _ScaleAdapter(5)
+    model.deepstack_audio_merger_list = [_ScaleAdapter(7), _ScaleAdapter(11)]
+    model.deepstack_input_embeds = None
+
+    multimodal_embeddings = model.embed_multimodal(
+        audio_data=torch.zeros(2, 128, 9),
+        audio_data_seqlens=torch.tensor([8, 9], dtype=torch.long),
+    )
+
+    assert audio_encoder.output_deepstack_hidden_states is True
+    assert [embeds.shape for embeds in multimodal_embeddings] == [
+        torch.Size([1, 24]),
+        torch.Size([2, 24]),
+    ]
+    main_embeddings, deepstack_embeddings = model._split_multimodal_embeddings(
+        multimodal_embeddings,
+        hidden_size=8,
+    )
+    assert [embeds.shape for embeds in main_embeddings] == [
+        torch.Size([1, 8]),
+        torch.Size([2, 8]),
+    ]
+    assert [[embeds.shape for embeds in layer] for layer in deepstack_embeddings] == [
+        [torch.Size([1, 8]), torch.Size([2, 8])],
+        [torch.Size([1, 8]), torch.Size([2, 8])],
+    ]
+    assert torch.equal(main_embeddings[0], torch.full((1, 8), 5.0))
+    assert torch.equal(deepstack_embeddings[0][0], torch.full((1, 8), 14.0))
+    assert torch.equal(deepstack_embeddings[1][0], torch.full((1, 8), 33.0))
+
+
+def test_moss_audio_embed_input_ids_caches_packed_deepstack() -> None:
+    class _FakeLanguageModel:
+        def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+            return torch.zeros(input_ids.shape[0], 8)
+
+    model = object.__new__(MossAudioModel)
+    model.language_model = _FakeLanguageModel()
+    model.deepstack_audio_merger_list = [object(), object()]
+    model.deepstack_input_embeds = None
+
+    multimodal_embeddings = (
+        torch.cat(
+            [
+                torch.full((1, 8), 5.0),
+                torch.full((1, 8), 14.0),
+                torch.full((1, 8), 33.0),
+            ],
+            dim=-1,
+        ),
+        torch.cat(
+            [
+                torch.full((2, 8), 7.0),
+                torch.full((2, 8), 22.0),
+                torch.full((2, 8), 44.0),
+            ],
+            dim=-1,
+        ),
+    )
+    is_multimodal = torch.tensor([False, True, True, True, False])
+
+    inputs_embeds = model.embed_input_ids(
+        input_ids=torch.arange(5),
+        multimodal_embeddings=multimodal_embeddings,
+        is_multimodal=is_multimodal,
+    )
+
+    assert torch.equal(inputs_embeds[1], torch.full((8,), 5.0))
+    assert torch.equal(inputs_embeds[2], torch.full((8,), 7.0))
+    assert torch.equal(inputs_embeds[3], torch.full((8,), 7.0))
+    assert model.deepstack_input_embeds is not None
+    deepstack_tensors = model.deepstack_input_embeds.tensors
+    assert set(deepstack_tensors) == {
+        "deepstack_input_embeds_0",
+        "deepstack_input_embeds_1",
+    }
+    assert torch.equal(
+        deepstack_tensors["deepstack_input_embeds_0"][is_multimodal],
+        torch.cat([torch.full((1, 8), 14.0), torch.full((2, 8), 22.0)]),
+    )
+    assert torch.equal(
+        deepstack_tensors["deepstack_input_embeds_1"][is_multimodal],
+        torch.cat([torch.full((1, 8), 33.0), torch.full((2, 8), 44.0)]),
+    )
+    assert torch.equal(
+        deepstack_tensors["deepstack_input_embeds_0"][~is_multimodal],
+        torch.zeros(2, 8),
+    )
 
 
 def test_moss_audio_rejects_too_short_audio() -> None:

--- a/tests/models/multimodal/processing/test_moss_audio.py
+++ b/tests/models/multimodal/processing/test_moss_audio.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+
+import pytest
+import torch
+from transformers import Qwen3Config
+
+from vllm.model_executor.models.interfaces import supports_multimodal, supports_pp
+from vllm.model_executor.models.interfaces_base import is_text_generation_model
+from vllm.model_executor.models.moss_audio import (
+    DEFAULT_MAX_AUDIO_SECONDS,
+    MOSS_AUDIO_BOS_TOKEN,
+    MOSS_AUDIO_BOS_TOKEN_ID,
+    MOSS_AUDIO_EOS_TOKEN,
+    MOSS_AUDIO_EOS_TOKEN_ID,
+    MOSS_AUDIO_TOKEN,
+    MOSS_AUDIO_TOKEN_ID,
+    MossAudioConfig,
+    MossAudioEncoder,
+    MossAudioEncoderConfig,
+    MossAudioModel,
+    MossAudioMultiModalProcessor,
+    MossAudioProcessingInfo,
+    MossAudioProcessor,
+    _moss_audio_field_config,
+)
+from vllm.model_executor.models.registry import _MULTIMODAL_MODELS
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from ...registry import _MULTIMODAL_EXAMPLE_MODELS
+
+
+class _Tokenizer:
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        return [ord(char) for char in text]
+
+    def decode(self, token_ids: list[int], **kwargs: object) -> str:
+        del kwargs
+        return "".join(chr(token_id) for token_id in token_ids)
+
+    def batch_decode(
+        self, batch_token_ids: list[list[int]], **kwargs: object
+    ) -> list[str]:
+        return [self.decode(token_ids, **kwargs) for token_ids in batch_token_ids]
+
+
+class _Info:
+    def __init__(self, processor: MossAudioProcessor) -> None:
+        self.processor = processor
+
+    def get_hf_processor(self, **kwargs: object) -> MossAudioProcessor:
+        del kwargs
+        return self.processor
+
+
+class _ProcessingContext:
+    def __init__(self) -> None:
+        self.tokenizer = _Tokenizer()
+
+    def get_tokenizer(self) -> _Tokenizer:
+        return self.tokenizer
+
+
+class _OutKwargs:
+    def __init__(self, data: dict[str, torch.Tensor]) -> None:
+        self.data = data
+
+    def get_data(self) -> dict[str, torch.Tensor]:
+        return self.data
+
+
+class _ModelConfig:
+    def __init__(self) -> None:
+        self.hf_config = MossAudioConfig(language_config=Qwen3Config())
+        self.multimodal_config = None
+
+
+class _ParallelConfig:
+    def __init__(
+        self,
+        tensor_parallel_size: int = 1,
+        pipeline_parallel_size: int = 1,
+    ) -> None:
+        self.tensor_parallel_size = tensor_parallel_size
+        self.pipeline_parallel_size = pipeline_parallel_size
+
+
+class _VllmConfig:
+    def __init__(self, parallel_config: _ParallelConfig) -> None:
+        self.model_config = _ModelConfig()
+        self.quant_config = None
+        self.parallel_config = parallel_config
+
+
+def _patch_tensor_parallel_for_linear_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm.model_executor.layers.linear as linear_layers
+    import vllm.model_executor.models.moss_audio as moss_audio_module
+    import vllm.model_executor.parameter as parameter_module
+
+    monkeypatch.setattr(
+        moss_audio_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        linear_layers,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(linear_layers, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+
+
+def test_moss_audio_processor_expands_audio_placeholder() -> None:
+    processor = MossAudioProcessor(_Tokenizer())
+    prompt = (
+        f"before {MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN} after"
+    )
+    raw_mel_len = 17
+    audio = torch.zeros(160 * raw_mel_len)
+
+    processed = processor(text=prompt, audio=[audio])
+    input_ids = processed["input_ids"][0].tolist()
+    expected_audio_tokens = MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)
+
+    assert input_ids.count(MOSS_AUDIO_BOS_TOKEN_ID) == 1
+    assert input_ids.count(MOSS_AUDIO_EOS_TOKEN_ID) == 1
+    assert input_ids.count(MOSS_AUDIO_TOKEN_ID) == expected_audio_tokens
+    assert processed["audio_data"].shape == (1, 128, raw_mel_len)
+    assert processed["audio_data_seqlens"].tolist() == [raw_mel_len]
+
+
+def test_moss_audio_time_markers_are_not_embedding_targets() -> None:
+    processor = MossAudioProcessor(_Tokenizer(), enable_time_marker=True)
+    mm_processor = object.__new__(MossAudioMultiModalProcessor)
+    mm_processor.info = _Info(processor)
+
+    audio_len = 320
+    audio_token_len = MossAudioEncoder.compute_num_audio_tokens(audio_len)
+    update = mm_processor._get_prompt_updates(
+        mm_items=None,
+        hf_processor_mm_kwargs={},
+        out_mm_kwargs=_OutKwargs(
+            {"audio_data_seqlens": torch.tensor([audio_len], dtype=torch.long)}
+        ),
+    )[0].resolve(0)
+
+    full = update.content.full
+    is_embed = update.content.is_embed(None, full)
+
+    assert full[0] == MOSS_AUDIO_BOS_TOKEN_ID
+    assert full[-1] == MOSS_AUDIO_EOS_TOKEN_ID
+    assert is_embed.sum().item() == audio_token_len
+    assert len(full) > audio_token_len + 2
+
+
+def test_moss_audio_processing_info_caches_default_processor() -> None:
+    info = MossAudioProcessingInfo(_ProcessingContext())
+
+    processor = info.get_hf_processor()
+    same_processor = info.get_hf_processor()
+    explicit_default_processor = info.get_hf_processor(enable_time_marker=False)
+    time_marker_processor = info.get_hf_processor(enable_time_marker=True)
+
+    assert same_processor is processor
+    assert explicit_default_processor is processor
+    assert time_marker_processor is not processor
+    assert not processor.enable_time_marker
+    assert time_marker_processor.enable_time_marker
+
+
+def test_moss_audio_encoder_vectorized_mask_matches_token_count() -> None:
+    config = MossAudioEncoderConfig(
+        output_dim=8,
+        num_mel_bins=8,
+        n_window=4,
+        conv_chunksize=2,
+    )
+    encoder = object.__new__(MossAudioEncoder)
+    encoder.config = config
+    encoder.deepstack_encoder_layer_indexes = []
+    encoder.chunk_frames = config.n_window * 2
+    encoder.conv_chunksize = config.conv_chunksize
+
+    def _encode_chunk_batch(
+        input_features: torch.Tensor,
+        seq_lengths: torch.Tensor,
+        output_deepstack_hidden_states: bool,
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        assert not output_deepstack_hidden_states
+        downsampled_lengths = MossAudioEncoder._compute_downsampled_length(seq_lengths)
+        return (
+            input_features.new_ones(
+                input_features.shape[0],
+                int(downsampled_lengths.max().item()),
+                config.output_dim,
+            ),
+            [],
+        )
+
+    encoder._encode_chunk_batch = _encode_chunk_batch
+    feature_lens = torch.tensor([5, 13], dtype=torch.long)
+    input_features = torch.randn(2, config.num_mel_bins, 13)
+
+    hidden_states, deepstack = MossAudioEncoder.forward(
+        encoder,
+        input_features,
+        feature_lens=feature_lens,
+        output_deepstack_hidden_states=False,
+    )
+
+    expected_tokens = sum(
+        MossAudioEncoder.compute_num_audio_tokens(int(length))
+        for length in feature_lens
+    )
+    assert hidden_states.shape == (1, expected_tokens, config.output_dim)
+    assert deepstack is None
+
+
+def test_moss_audio_field_config_and_interfaces() -> None:
+    fields = _moss_audio_field_config({})
+
+    assert set(fields) == {"audio_data", "audio_data_seqlens"}
+    assert (
+        MossAudioModel.get_placeholder_str("audio", 0)
+        == f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+    )
+    assert supports_multimodal(MossAudioModel)
+    assert is_text_generation_model(MossAudioModel)
+    assert not supports_pp(MossAudioModel)
+
+
+def test_moss_audio_registry_entries() -> None:
+    assert _MULTIMODAL_MODELS["MossAudioModel"] == ("moss_audio", "MossAudioModel")
+    assert (
+        _MULTIMODAL_EXAMPLE_MODELS["MossAudioModel"].default
+        == "OpenMOSS-Team/MOSS-Audio-4B-Instruct"
+    )
+
+
+@pytest.mark.parametrize(
+    ("parallel_config", "message"),
+    [
+        (_ParallelConfig(tensor_parallel_size=2), "tensor_parallel_size=1"),
+        (_ParallelConfig(pipeline_parallel_size=2), "pipeline_parallel_size=1"),
+    ],
+)
+def test_moss_audio_rejects_unsupported_parallelism(
+    parallel_config: _ParallelConfig,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        MossAudioModel(vllm_config=_VllmConfig(parallel_config))
+
+
+def test_moss_audio_deepstack_requires_matching_audio_token_count() -> None:
+    model = object.__new__(MossAudioModel)
+    inputs_embeds = torch.zeros(4, 8)
+    is_multimodal = torch.tensor([False, True, True, False])
+
+    with pytest.raises(ValueError, match="DeepStack audio token count mismatch"):
+        model._cache_deepstack_input_embeds(
+            inputs_embeds=inputs_embeds,
+            deepstack_embeddings=((torch.ones(1, 8),),),
+            is_multimodal=is_multimodal,
+        )
+
+
+def test_moss_audio_deepstack_disabled_skips_cache() -> None:
+    class _FakeAudioEncoder:
+        dtype = torch.float32
+
+        def __init__(self) -> None:
+            self.output_deepstack_hidden_states: bool | None = None
+
+        def __call__(
+            self,
+            audio_data: torch.Tensor,
+            *,
+            feature_lens: torch.Tensor,
+            output_deepstack_hidden_states: bool,
+        ) -> tuple[torch.Tensor, None]:
+            del audio_data
+            self.output_deepstack_hidden_states = output_deepstack_hidden_states
+            audio_lengths = MossAudioEncoder._compute_downsampled_length(feature_lens)
+            total_tokens = int(audio_lengths.sum().item())
+            return torch.ones(1, total_tokens, 8), None
+
+    class _IdentityAdapter:
+        def __call__(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            return hidden_states
+
+    model = object.__new__(MossAudioModel)
+    audio_encoder = _FakeAudioEncoder()
+    model.audio_encoder = audio_encoder
+    model.audio_adapter = _IdentityAdapter()
+    model.deepstack_audio_merger_list = []
+    model.deepstack_input_embeds = None
+
+    multimodal_embeddings = model.embed_multimodal(
+        audio_data=torch.zeros(2, 128, 9),
+        audio_data_seqlens=torch.tensor([8, 9], dtype=torch.long),
+    )
+
+    assert audio_encoder.output_deepstack_hidden_states is False
+    assert len(multimodal_embeddings) == 1
+    assert [embeds.shape for embeds in multimodal_embeddings[0]] == [
+        torch.Size([1, 8]),
+        torch.Size([2, 8]),
+    ]
+    assert model.deepstack_input_embeds is None
+
+
+def test_moss_audio_rejects_too_short_audio() -> None:
+    processor = MossAudioProcessor(_Tokenizer())
+    prompt = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+
+    with pytest.raises(ValueError, match="too short"):
+        processor(text=prompt, audio=[torch.empty(0)])
+
+    model = object.__new__(MossAudioModel)
+    with pytest.raises(ValueError, match="too short"):
+        model._parse_and_validate_audio_input(
+            audio_data=torch.zeros(1, 128, 1),
+            audio_data_seqlens=torch.tensor([0], dtype=torch.long),
+        )
+
+
+def test_moss_audio_max_tokens_uses_default_30s_limit() -> None:
+    info = object.__new__(MossAudioProcessingInfo)
+
+    raw_mel_len = math.ceil((DEFAULT_MAX_AUDIO_SECONDS * 16000) / 160)
+    assert info.get_mm_max_tokens_per_item(seq_len=2048, mm_counts={"audio": 1}) == {
+        "audio": MossAudioEncoder.compute_num_audio_tokens(raw_mel_len),
+    }
+
+
+def test_moss_audio_encoder_loads_realistic_attention_weight_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.config.device import DeviceConfig
+
+    _patch_tensor_parallel_for_linear_layers(monkeypatch)
+    config = MossAudioEncoderConfig(
+        d_model=8,
+        output_dim=8,
+        num_mel_bins=8,
+        encoder_layers=1,
+        encoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        downsample_hidden_size=2,
+        deepstack_encoder_layer_indexes=[],
+    )
+    vllm_config = VllmConfig(device_config=DeviceConfig(device="cpu"))
+    with set_current_vllm_config(vllm_config):
+        encoder = MossAudioEncoder(config)
+
+    assert "load_weights" not in MossAudioEncoder.__dict__
+
+    attention = encoder.layers[0].self_attn
+    assert hasattr(attention, "q_proj")
+    assert hasattr(attention, "k_proj")
+    assert hasattr(attention, "v_proj")
+    assert hasattr(attention, "out_proj")
+    assert not hasattr(attention, "qkv")
+    assert attention.k_proj.bias is None
+
+    attn_output = attention(
+        torch.randn(1, 3, config.d_model),
+        torch.ones(1, 3, dtype=torch.bool),
+    )
+    assert attn_output.shape == (1, 3, config.d_model)
+
+    weight_names = [
+        "layers.0.self_attn.q_proj.weight",
+        "layers.0.self_attn.q_proj.bias",
+        "layers.0.self_attn.k_proj.weight",
+        "layers.0.self_attn.v_proj.weight",
+        "layers.0.self_attn.v_proj.bias",
+        "layers.0.self_attn.out_proj.weight",
+        "layers.0.self_attn.out_proj.bias",
+        "conv1.weight",
+        "conv1.bias",
+    ]
+    params = dict(encoder.named_parameters(remove_duplicate=False))
+    assert "layers.0.self_attn.k_proj.bias" not in params
+
+    expected_weights = {
+        name: torch.full_like(params[name], fill_value=float(i + 1))
+        for i, name in enumerate(weight_names)
+    }
+    loaded = AutoWeightsLoader(encoder).load_weights(expected_weights.items())
+
+    assert loaded == set(weight_names)
+    assert not any(".qkv." in name for name in loaded)
+    for name, expected_weight in expected_weights.items():
+        assert torch.equal(params[name], expected_weight)
+
+
+def test_moss_audio_weight_mapper_preserves_language_model_prefix() -> None:
+    mapped = MossAudioModel.hf_to_vllm_mapper.apply_list(
+        [
+            "language_model.layers.0.self_attn.q_proj.weight",
+            "lm_head.weight",
+            "audio_encoder.layers.0.self_attn.q_proj.weight",
+        ]
+    )
+
+    assert mapped == [
+        "language_model.model.layers.0.self_attn.q_proj.weight",
+        "language_model.lm_head.weight",
+        "audio_encoder.layers.0.self_attn.q_proj.weight",
+    ]
+
+
+def test_moss_audio_weight_mapper_matches_hf_index_names() -> None:
+    mapped = MossAudioModel.hf_to_vllm_mapper.apply_list(
+        [
+            "audio_encoder.layers.0.self_attn.q_proj.weight",
+            "audio_encoder.layers.0.self_attn.q_proj.bias",
+            "audio_encoder.layers.0.self_attn.k_proj.weight",
+            "audio_encoder.layers.0.self_attn.v_proj.weight",
+            "audio_encoder.layers.0.self_attn.v_proj.bias",
+            "audio_encoder.conv1.weight",
+            "audio_adapter.gate_proj.weight",
+            "deepstack_audio_merger_list.0.down_proj.weight",
+            "language_model.layers.0.self_attn.q_proj.weight",
+            "language_model.norm.weight",
+            "lm_head.weight",
+        ]
+    )
+
+    assert mapped == [
+        "audio_encoder.layers.0.self_attn.q_proj.weight",
+        "audio_encoder.layers.0.self_attn.q_proj.bias",
+        "audio_encoder.layers.0.self_attn.k_proj.weight",
+        "audio_encoder.layers.0.self_attn.v_proj.weight",
+        "audio_encoder.layers.0.self_attn.v_proj.bias",
+        "audio_encoder.conv1.weight",
+        "audio_adapter.gate_proj.weight",
+        "deepstack_audio_merger_list.0.down_proj.weight",
+        "language_model.model.layers.0.self_attn.q_proj.weight",
+        "language_model.model.norm.weight",
+        "language_model.lm_head.weight",
+    ]

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1030,6 +1030,10 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         tokenizer_mode="kimi_audio",
         trust_remote_code=True,
     ),
+    "MossAudioModel": _HfExamplesInfo(
+        "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
+        trust_remote_code=True,
+    ),
     "KimiK25ForConditionalGeneration": _HfExamplesInfo(
         "moonshotai/Kimi-K2.5",
         trust_remote_code=True,

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1032,6 +1032,11 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     ),
     "MossAudioModel": _HfExamplesInfo(
         "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
+        extras={
+            "4b-thinking": "OpenMOSS-Team/MOSS-Audio-4B-Thinking",
+            "8b-instruct": "OpenMOSS-Team/MOSS-Audio-8B-Instruct",
+            "8b-thinking": "OpenMOSS-Team/MOSS-Audio-8B-Thinking",
+        },
         trust_remote_code=True,
     ),
     "KimiK25ForConditionalGeneration": _HfExamplesInfo(

--- a/vllm/model_executor/models/moss_audio.py
+++ b/vllm/model_executor/models/moss_audio.py
@@ -53,7 +53,11 @@ from vllm.multimodal.processing import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import MultiModalEmbeddings, SupportsMultiModal
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+    _require_is_multimodal,
+)
 from .qwen3 import Qwen3ForCausalLM, Qwen3Model
 from .utils import (
     AutoWeightsLoader,
@@ -142,6 +146,17 @@ class MossAudioConfig(PretrainedConfig):
             kwargs.setdefault(key, getattr(self.language_config, key, None))
         kwargs.setdefault("tie_word_embeddings", False)
         super().__init__(**kwargs)
+
+        for key in (
+            "hidden_size",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "max_position_embeddings",
+            "rms_norm_eps",
+        ):
+            if hasattr(self.language_config, key):
+                setattr(self, key, getattr(self.language_config, key))
 
     def get_text_config(self, decoder: bool = False) -> Qwen3Config:
         return self.language_config
@@ -904,6 +919,27 @@ class MossAudioProcessor:
         input_ids = []
         cursor = 0
         placeholder = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+        if not audio_list:
+            while True:
+                match_idx = prompt_text.find(placeholder, cursor)
+                if match_idx < 0:
+                    break
+                prefix = prompt_text[cursor:match_idx]
+                input_ids.extend(
+                    self.tokenizer.encode(prefix, add_special_tokens=False)
+                )
+                input_ids.extend(
+                    [self.audio_start_id, self.audio_token_id, self.audio_end_id]
+                )
+                cursor = match_idx + len(placeholder)
+            suffix = prompt_text[cursor:]
+            input_ids.extend(self.tokenizer.encode(suffix, add_special_tokens=False))
+            data: dict[str, torch.Tensor] = {
+                "input_ids": torch.tensor([input_ids], dtype=torch.long),
+                "attention_mask": torch.ones((1, len(input_ids)), dtype=torch.long),
+            }
+            return BatchFeature(data=data, tensor_type=return_tensors)
+
         for item_idx, _ in enumerate(audio_list):
             match_idx = prompt_text.find(placeholder, cursor)
             if match_idx < 0:
@@ -926,7 +962,7 @@ class MossAudioProcessor:
             )
         input_ids.extend(self.tokenizer.encode(suffix, add_special_tokens=False))
 
-        data: dict[str, torch.Tensor] = {
+        data = {
             "input_ids": torch.tensor([input_ids], dtype=torch.long),
             "attention_mask": torch.ones((1, len(input_ids)), dtype=torch.long),
         }
@@ -1086,11 +1122,15 @@ class MossAudioMultiModalProcessor(BaseMultiModalProcessor[MossAudioProcessingIn
                 for length in lens
             ]
 
-        def get_replacement(item_idx: int) -> PromptUpdateDetails[list[int]]:
+        def get_replacement(
+            item_idx: int,
+            suffix_token_ids: list[int] | None = None,
+        ) -> PromptUpdateDetails[list[int]]:
             num_tokens = audio_token_lens[item_idx]
             if num_tokens == 0:
                 raise ValueError("The audio is too short to be represented.")
             audio_token_ids = processor.build_audio_placeholder_ids(num_tokens)
+            suffix_token_ids = suffix_token_ids or []
             is_embed = torch.tensor(
                 [token_id == processor.audio_token_id for token_id in audio_token_ids],
                 dtype=torch.bool,
@@ -1100,26 +1140,54 @@ class MossAudioMultiModalProcessor(BaseMultiModalProcessor[MossAudioProcessingIn
                     processor.audio_start_id,
                     *audio_token_ids,
                     processor.audio_end_id,
+                    *suffix_token_ids,
                 ],
                 is_embed=lambda _tokenizer, _seq: torch.cat(
                     [
                         torch.tensor([False]),
                         is_embed,
                         torch.tensor([False]),
+                        torch.zeros(len(suffix_token_ids), dtype=torch.bool),
                     ]
                 ),
             )
 
-        return [
-            PromptReplacement(
-                modality="audio",
-                target=[
+        placeholder = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+        prompt_update_specs = [
+            (
+                [
                     processor.audio_start_id,
                     processor.audio_token_id,
                     processor.audio_end_id,
                 ],
-                replacement=get_replacement,
+                [],
             )
+        ]
+        for suffix in ("", "\n"):
+            tokenizer_target = processor.tokenizer.encode(
+                placeholder + suffix,
+                add_special_tokens=False,
+            )
+            suffix_token_ids = processor.tokenizer.encode(
+                suffix,
+                add_special_tokens=False,
+            )
+            if any(target == tokenizer_target for target, _ in prompt_update_specs):
+                continue
+            prompt_update_specs.append((tokenizer_target, suffix_token_ids))
+
+        return [
+            PromptReplacement(
+                modality="audio",
+                target=target,
+                replacement=(
+                    lambda item_idx, suffix_token_ids=suffix_token_ids: get_replacement(
+                        item_idx,
+                        suffix_token_ids,
+                    )
+                ),
+            )
+            for target, suffix_token_ids in prompt_update_specs
         ]
 
 
@@ -1275,7 +1343,7 @@ class MossAudioModel(nn.Module, SupportsMultiModal):
         self,
         audio_data: torch.Tensor,
         audio_data_seqlens: torch.Tensor,
-    ) -> tuple[tuple[torch.Tensor, ...], ...]:
+    ) -> tuple[torch.Tensor, ...]:
         last_hidden_state, deepstack = self.audio_encoder(
             audio_data.to(self.audio_encoder.dtype),
             feature_lens=audio_data_seqlens,
@@ -1289,6 +1357,11 @@ class MossAudioModel(nn.Module, SupportsMultiModal):
 
         deepstack_embeddings: list[tuple[torch.Tensor, ...]] = []
         if deepstack is not None:
+            if len(deepstack) < len(self.deepstack_audio_merger_list):
+                raise RuntimeError(
+                    "DeepStack output count does not match configured audio "
+                    "merger count."
+                )
             for idx, hidden_states in enumerate(
                 deepstack[: len(self.deepstack_audio_merger_list)]
             ):
@@ -1297,13 +1370,65 @@ class MossAudioModel(nn.Module, SupportsMultiModal):
                     tuple(ds_embeds.squeeze(0).split(audio_lengths, dim=0))
                 )
 
-        return (main_embeddings, *deepstack_embeddings)
+        if not deepstack_embeddings:
+            return main_embeddings
+
+        return tuple(
+            torch.cat(
+                [
+                    main_embedding,
+                    *(
+                        layer_embeddings[item_idx]
+                        for layer_embeddings in deepstack_embeddings
+                    ),
+                ],
+                dim=-1,
+            )
+            for item_idx, main_embedding in enumerate(main_embeddings)
+        )
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
         audio_input = self._parse_and_validate_audio_input(**kwargs)
         if audio_input is None:
             return ()
         return self._process_audio_input(*audio_input)
+
+    def _split_multimodal_embeddings(
+        self,
+        multimodal_embeddings: MultiModalEmbeddings,
+        hidden_size: int,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[tuple[torch.Tensor, ...], ...]]:
+        if isinstance(multimodal_embeddings, torch.Tensor):
+            embeddings = tuple(multimodal_embeddings.unbind(0))
+        else:
+            embeddings = tuple(multimodal_embeddings)
+
+        if len(embeddings) == 0:
+            return (), ()
+
+        deepstack_count = len(self.deepstack_audio_merger_list)
+        if all(embedding.shape[-1] == hidden_size for embedding in embeddings):
+            return embeddings, ()
+
+        packed_hidden_size = hidden_size * (deepstack_count + 1)
+        if deepstack_count == 0 or any(
+            embedding.shape[-1] != packed_hidden_size for embedding in embeddings
+        ):
+            got = [int(embedding.shape[-1]) for embedding in embeddings]
+            raise ValueError(
+                "MOSS-Audio multimodal embedding width mismatch: expected "
+                f"{hidden_size} or {packed_hidden_size}, got {got}."
+            )
+
+        split_by_item = [
+            torch.split(embedding, hidden_size, dim=-1) for embedding in embeddings
+        ]
+        main_embeddings = tuple(parts[0] for parts in split_by_item)
+        deepstack_embeddings = tuple(
+            tuple(parts[layer_idx + 1] for parts in split_by_item)
+            for layer_idx in range(deepstack_count)
+        )
+        return main_embeddings, deepstack_embeddings
 
     def _cache_deepstack_input_embeds(
         self,
@@ -1350,14 +1475,15 @@ class MossAudioModel(nn.Module, SupportsMultiModal):
         self.deepstack_input_embeds = None
         if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
             return inputs_embeds
-        if is_multimodal is None:
-            raise ValueError("is_multimodal is required for MOSS-Audio inputs.")
+        is_multimodal = _require_is_multimodal(is_multimodal)
+        multimodal_embeddings, deepstack_embeddings = self._split_multimodal_embeddings(
+            multimodal_embeddings,
+            hidden_size=int(inputs_embeds.shape[-1]),
+        )
 
-        main_embeddings = multimodal_embeddings[0]
-        deepstack_embeddings = tuple(multimodal_embeddings[1:])
         inputs_embeds = _merge_multimodal_embeddings(
             inputs_embeds=inputs_embeds,
-            multimodal_embeddings=main_embeddings,
+            multimodal_embeddings=multimodal_embeddings,
             is_multimodal=is_multimodal,
         )
         self._cache_deepstack_input_embeds(

--- a/vllm/model_executor/models/moss_audio.py
+++ b/vllm/model_executor/models/moss_audio.py
@@ -3,6 +3,7 @@
 """Inference-only MOSS-Audio model compatible with HuggingFace weights."""
 
 import math
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -52,6 +53,7 @@ from vllm.multimodal.processing import (
     PromptUpdateDetails,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 from .interfaces import (
     MultiModalEmbeddings,
@@ -73,6 +75,87 @@ MOSS_AUDIO_TOKEN_ID = 151654
 MOSS_AUDIO_BOS_TOKEN_ID = 151669
 MOSS_AUDIO_EOS_TOKEN_ID = 151670
 DEFAULT_MAX_AUDIO_SECONDS = 30
+DEFAULT_MOSS_AUDIO_MEL_CONFIG = {
+    "mel_dim": 128,
+    "mel_sr": 16000,
+    "mel_hop_length": 160,
+    "mel_n_fft": 400,
+}
+MOSS_AUDIO_PLACEHOLDER = (
+    f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+)
+MOSS_AUDIO_SPAN_RE = re.compile(
+    f"{re.escape(MOSS_AUDIO_BOS_TOKEN)}"
+    f"(?:{re.escape(MOSS_AUDIO_TOKEN)})+"
+    f"{re.escape(MOSS_AUDIO_EOS_TOKEN)}"
+)
+MOSS_AUDIO_PROCESSOR_CONFIG_KEYS = {
+    "audio_token_id",
+    "audio_start_id",
+    "audio_end_id",
+    "enable_time_marker",
+    "mel_config",
+}
+
+
+def _normalize_moss_audio_mel_config(
+    mel_config: Mapping[str, object] | None = None,
+) -> dict[str, int]:
+    config = dict(DEFAULT_MOSS_AUDIO_MEL_CONFIG)
+    config.update(_extract_moss_audio_mel_config(mel_config))
+    return config
+
+
+def _extract_moss_audio_mel_config(
+    mel_config: Mapping[str, object] | None = None,
+) -> dict[str, int]:
+    config: dict[str, int] = {}
+    if mel_config is None:
+        return config
+
+    aliases = {
+        "mel_dim": ("mel_dim", "feature_size", "n_mels", "num_mel_bins"),
+        "mel_sr": ("mel_sr", "sampling_rate", "sample_rate"),
+        "mel_hop_length": ("mel_hop_length", "hop_length"),
+        "mel_n_fft": ("mel_n_fft", "n_fft"),
+    }
+    for target_key, source_keys in aliases.items():
+        for source_key in source_keys:
+            if source_key in mel_config:
+                config[target_key] = int(mel_config[source_key])
+                break
+
+    return config
+
+
+def _filter_moss_audio_processor_config(
+    config: Mapping[str, object] | None,
+) -> dict[str, object]:
+    if not config:
+        return {}
+
+    return {
+        key: value
+        for key, value in config.items()
+        if key in MOSS_AUDIO_PROCESSOR_CONFIG_KEYS
+    }
+
+
+def _merge_moss_audio_processor_configs(
+    *configs: Mapping[str, object] | None,
+) -> dict[str, object]:
+    merged: dict[str, object] = {}
+    merged_mel_config: dict[str, int] = {}
+    for config in configs:
+        filtered = _filter_moss_audio_processor_config(config)
+        mel_config = filtered.pop("mel_config", None)
+        merged.update(filtered)
+        if isinstance(mel_config, Mapping):
+            merged_mel_config.update(_extract_moss_audio_mel_config(mel_config))
+
+    if merged_mel_config:
+        merged["mel_config"] = merged_mel_config
+    return merged
 
 
 @dataclass
@@ -795,19 +878,23 @@ class MossAudioProcessor:
         audio_start_id: int = MOSS_AUDIO_BOS_TOKEN_ID,
         audio_end_id: int = MOSS_AUDIO_EOS_TOKEN_ID,
         enable_time_marker: bool = False,
+        mel_config: Mapping[str, object] | None = None,
     ) -> None:
         self.tokenizer = tokenizer
         self.audio_token_id = int(audio_token_id)
         self.audio_start_id = int(audio_start_id)
         self.audio_end_id = int(audio_end_id)
         self.enable_time_marker = bool(enable_time_marker)
+        self.mel_config = _normalize_moss_audio_mel_config(mel_config)
         self.feature_extractor = WhisperFeatureExtractor(
-            feature_size=128,
-            sampling_rate=16000,
-            hop_length=160,
-            n_fft=400,
+            feature_size=self.mel_config["mel_dim"],
+            sampling_rate=self.mel_config["mel_sr"],
+            hop_length=self.mel_config["mel_hop_length"],
+            n_fft=self.mel_config["mel_n_fft"],
         )
-        self.audio_tokens_per_second = 12.5
+        self.audio_tokens_per_second = self.mel_config["mel_sr"] / (
+            self.mel_config["mel_hop_length"] * 8
+        )
         self.time_marker_every_seconds = 2
         self.time_marker_every_audio_tokens = int(
             self.audio_tokens_per_second * self.time_marker_every_seconds
@@ -842,6 +929,22 @@ class MossAudioProcessor:
             wav[None, ...], device="cpu"
         )
         return torch.from_numpy(feats[0])
+
+    def _get_default_audio_prompt(self) -> str:
+        return MOSS_AUDIO_PLACEHOLDER
+
+    def _ensure_audio_placeholders(
+        self,
+        prompt_text: str,
+        num_audios: int,
+    ) -> str:
+        if num_audios == 0 or MOSS_AUDIO_SPAN_RE.search(prompt_text):
+            return prompt_text
+
+        audio_prompt = self._get_default_audio_prompt() * num_audios
+        if prompt_text:
+            return f"{audio_prompt}\n{prompt_text}"
+        return audio_prompt
 
     def _build_audio_tokens_with_time_markers(self, audio_seq_len: int) -> list[int]:
         total_duration_seconds = audio_seq_len / self.audio_tokens_per_second
@@ -908,7 +1011,10 @@ class MossAudioProcessor:
 
         if mels:
             max_length = max(raw_lengths)
-            audio_batch = torch.zeros((len(mels), 128, max_length), dtype=torch.float32)
+            audio_batch = torch.zeros(
+                (len(mels), self.mel_config["mel_dim"], max_length),
+                dtype=torch.float32,
+            )
             for index, mel in enumerate(mels):
                 audio_batch[index, :, : mel.shape[-1]] = mel
             audio_data_seqlens = torch.tensor(raw_lengths, dtype=torch.long)
@@ -916,22 +1022,19 @@ class MossAudioProcessor:
             audio_batch = None
             audio_data_seqlens = None
 
+        prompt_text = self._ensure_audio_placeholders(prompt_text, len(audio_list))
         input_ids = []
         cursor = 0
-        placeholder = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
         if not audio_list:
-            while True:
-                match_idx = prompt_text.find(placeholder, cursor)
-                if match_idx < 0:
-                    break
-                prefix = prompt_text[cursor:match_idx]
+            for match in MOSS_AUDIO_SPAN_RE.finditer(prompt_text):
+                prefix = prompt_text[cursor : match.start()]
                 input_ids.extend(
                     self.tokenizer.encode(prefix, add_special_tokens=False)
                 )
                 input_ids.extend(
                     [self.audio_start_id, self.audio_token_id, self.audio_end_id]
                 )
-                cursor = match_idx + len(placeholder)
+                cursor = match.end()
             suffix = prompt_text[cursor:]
             input_ids.extend(self.tokenizer.encode(suffix, add_special_tokens=False))
             data: dict[str, torch.Tensor] = {
@@ -940,22 +1043,23 @@ class MossAudioProcessor:
             }
             return BatchFeature(data=data, tensor_type=return_tensors)
 
+        span_iter = iter(MOSS_AUDIO_SPAN_RE.finditer(prompt_text))
         for item_idx, _ in enumerate(audio_list):
-            match_idx = prompt_text.find(placeholder, cursor)
-            if match_idx < 0:
+            match = next(span_iter, None)
+            if match is None:
                 raise ValueError(
                     "Audio placeholder count mismatch: expected one "
-                    f"{placeholder!r} span per audio item."
+                    f"{MOSS_AUDIO_PLACEHOLDER!r} span per audio item."
                 )
-            prefix = prompt_text[cursor:match_idx]
+            prefix = prompt_text[cursor : match.start()]
             input_ids.extend(self.tokenizer.encode(prefix, add_special_tokens=False))
             input_ids.append(self.audio_start_id)
             input_ids.extend(self.build_audio_placeholder_ids(token_lens[item_idx]))
             input_ids.append(self.audio_end_id)
-            cursor = match_idx + len(placeholder)
+            cursor = match.end()
 
         suffix = prompt_text[cursor:]
-        if placeholder in suffix:
+        if MOSS_AUDIO_SPAN_RE.search(suffix):
             raise ValueError(
                 "Audio placeholder count mismatch: found more placeholder spans "
                 "than audio items."
@@ -993,39 +1097,82 @@ class MossAudioProcessingInfo(BaseProcessingInfo):
             ),
         )
 
-    def get_hf_processor(self, **kwargs: object) -> MossAudioProcessor:
-        enable_time_marker = bool(kwargs.get("enable_time_marker", False))
-        processor_kwargs = {
-            key: kwargs[key]
-            for key in ("audio_token_id", "audio_start_id", "audio_end_id")
-            if key in kwargs
-        }
-        has_custom_kwargs = (
-            enable_time_marker
-            or bool(processor_kwargs)
-            or any(
-                key
-                not in {
-                    "enable_time_marker",
-                    "audio_token_id",
-                    "audio_start_id",
-                    "audio_end_id",
-                }
-                for key in kwargs
-            )
-        )
-        if not has_custom_kwargs:
-            default_processor = getattr(self, "_default_hf_processor", None)
-            if default_processor is None:
-                default_processor = MossAudioProcessor(self.get_tokenizer())
-                self._default_hf_processor = default_processor
-            return default_processor
+    def _get_processor_config_defaults(self) -> dict[str, object]:
+        cached_defaults = getattr(self, "_processor_config_defaults", None)
+        if cached_defaults is not None:
+            return cached_defaults
 
-        return MossAudioProcessor(
+        model_config = self.ctx.model_config
+        for file_name in ("processor_config.json", "preprocessor_config.json"):
+            config = get_hf_file_to_dict(
+                file_name,
+                model_config.model,
+                model_config.revision,
+            )
+            defaults = _filter_moss_audio_processor_config(config)
+            if defaults:
+                self._processor_config_defaults = defaults
+                return defaults
+
+        defaults = {}
+        self._processor_config_defaults = defaults
+        return defaults
+
+    @staticmethod
+    def _get_processor_cache_key(kwargs: Mapping[str, object]) -> tuple[object, ...]:
+        mel_config = _normalize_moss_audio_mel_config(
+            kwargs.get("mel_config") if isinstance(kwargs.get("mel_config"), Mapping)
+            else None
+        )
+        return (
+            int(kwargs.get("audio_token_id", MOSS_AUDIO_TOKEN_ID)),
+            int(kwargs.get("audio_start_id", MOSS_AUDIO_BOS_TOKEN_ID)),
+            int(kwargs.get("audio_end_id", MOSS_AUDIO_EOS_TOKEN_ID)),
+            bool(kwargs.get("enable_time_marker", False)),
+            tuple(sorted(mel_config.items())),
+        )
+
+    def get_hf_processor(self, **kwargs: object) -> MossAudioProcessor:
+        merged_kwargs = _merge_moss_audio_processor_configs(
+            self._get_processor_config_defaults(),
+            self.ctx.get_merged_mm_kwargs({}),
+            kwargs,
+        )
+        mel_config = _normalize_moss_audio_mel_config(
+            merged_kwargs.get("mel_config")
+            if isinstance(merged_kwargs.get("mel_config"), Mapping)
+            else None
+        )
+        processor_kwargs = {
+            "audio_token_id": int(
+                merged_kwargs.get("audio_token_id", MOSS_AUDIO_TOKEN_ID)
+            ),
+            "audio_start_id": int(
+                merged_kwargs.get("audio_start_id", MOSS_AUDIO_BOS_TOKEN_ID)
+            ),
+            "audio_end_id": int(
+                merged_kwargs.get("audio_end_id", MOSS_AUDIO_EOS_TOKEN_ID)
+            ),
+            "enable_time_marker": bool(merged_kwargs.get("enable_time_marker", False)),
+            "mel_config": mel_config,
+        }
+
+        cache = getattr(self, "_hf_processor_cache", None)
+        if cache is None:
+            cache = {}
+            self._hf_processor_cache = cache
+
+        cache_key = self._get_processor_cache_key(processor_kwargs)
+        processor = cache.get(cache_key)
+        if processor is not None:
+            return processor
+
+        processor = MossAudioProcessor(
             self.get_tokenizer(),
-            enable_time_marker=enable_time_marker,
             **processor_kwargs,
         )
+        cache[cache_key] = processor
+        return processor
 
     def get_feature_extractor(self, **kwargs: object) -> WhisperFeatureExtractor:
         return self.get_hf_processor(**kwargs).feature_extractor
@@ -1034,8 +1181,9 @@ class MossAudioProcessingInfo(BaseProcessingInfo):
         return {"audio": None}
 
     def get_data_parser(self) -> MultiModalDataParser:
+        processor = self.get_hf_processor()
         return MossAudioMultiModalDataParser(
-            target_sr=16000,
+            target_sr=processor.mel_config["mel_sr"],
             target_channels=1,
             expected_hidden_size=self._get_expected_hidden_size(),
         )
@@ -1047,17 +1195,18 @@ class MossAudioProcessingInfo(BaseProcessingInfo):
     ) -> Mapping[str, int] | None:
         if mm_counts.get("audio", 0) <= 0:
             return {}
-        raw_mel_len = math.ceil((16000 * DEFAULT_MAX_AUDIO_SECONDS) / 160)
+        processor = self.get_hf_processor()
+        raw_mel_len = math.ceil(
+            (processor.mel_config["mel_sr"] * DEFAULT_MAX_AUDIO_SECONDS)
+            / processor.mel_config["mel_hop_length"]
+        )
         return {"audio": MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)}
 
 
 class MossAudioDummyInputsBuilder(BaseDummyInputsBuilder[MossAudioProcessingInfo]):
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
         num_audios = mm_counts.get("audio", 0)
-        return (
-            f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
-            * num_audios
-        )
+        return MOSS_AUDIO_PLACEHOLDER * num_audios
 
     def get_dummy_mm_data(
         self,
@@ -1088,8 +1237,14 @@ class MossAudioMultiModalProcessor(BaseMultiModalProcessor[MossAudioProcessingIn
         audios = mm_data.pop("audios", [])
         if audios:
             mm_data["audio"] = audios
+        mm_kwargs = dict(mm_kwargs)
+        processor_kwargs = _filter_moss_audio_processor_config(mm_kwargs)
+        tok_kwargs = {
+            key: value for key, value in tok_kwargs.items()
+            if key not in MOSS_AUDIO_PROCESSOR_CONFIG_KEYS
+        }
         return self.info.ctx.call_hf_processor(
-            self.info.get_hf_processor(**mm_kwargs),
+            self.info.get_hf_processor(**processor_kwargs),
             dict(text=prompt, **mm_data),
             dict(**tok_kwargs),
         )
@@ -1152,7 +1307,6 @@ class MossAudioMultiModalProcessor(BaseMultiModalProcessor[MossAudioProcessingIn
                 ),
             )
 
-        placeholder = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
         prompt_update_specs = [
             (
                 [
@@ -1165,7 +1319,7 @@ class MossAudioMultiModalProcessor(BaseMultiModalProcessor[MossAudioProcessingIn
         ]
         for suffix in ("", "\n"):
             tokenizer_target = processor.tokenizer.encode(
-                placeholder + suffix,
+                MOSS_AUDIO_PLACEHOLDER + suffix,
                 add_special_tokens=False,
             )
             suffix_token_ids = processor.tokenizer.encode(
@@ -1226,7 +1380,7 @@ class MossAudioModel(nn.Module, SupportsMultiModal):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("audio"):
-            return f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+            return MOSS_AUDIO_PLACEHOLDER
         raise ValueError("Only audio modality is supported")
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
@@ -1524,5 +1678,8 @@ class MossAudioModel(nn.Module, SupportsMultiModal):
         return self.language_model.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["audio_encoder.embed_positions"],
+        )
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm/model_executor/models/moss_audio.py
+++ b/vllm/model_executor/models/moss_audio.py
@@ -1,0 +1,1402 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only MOSS-Audio model compatible with HuggingFace weights."""
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import BatchFeature, PretrainedConfig, Qwen3Config
+from transformers.models.whisper import WhisperFeatureExtractor
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.config.multimodal import BaseDummyOptions
+from vllm.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.inputs import ModalityData, MultiModalDataDict
+from vllm.model_executor.layers.activation import _ACTIVATION_REGISTRY
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (
+    AudioItem,
+    MultiModalFieldConfig,
+    MultiModalKwargsItems,
+)
+from vllm.multimodal.parse import (
+    DictEmbeddingItems,
+    ModalityDataItems,
+    MultiModalDataItems,
+    MultiModalDataParser,
+)
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    PromptReplacement,
+    PromptUpdate,
+    PromptUpdateDetails,
+)
+from vllm.sequence import IntermediateTensors
+
+from .interfaces import MultiModalEmbeddings, SupportsMultiModal
+from .qwen3 import Qwen3ForCausalLM, Qwen3Model
+from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    _merge_multimodal_embeddings,
+    maybe_prefix,
+)
+
+MOSS_AUDIO_TOKEN = "<|AUDIO|>"
+MOSS_AUDIO_BOS_TOKEN = "<|audio_bos|>"
+MOSS_AUDIO_EOS_TOKEN = "<|audio_eos|>"
+MOSS_AUDIO_TOKEN_ID = 151654
+MOSS_AUDIO_BOS_TOKEN_ID = 151669
+MOSS_AUDIO_EOS_TOKEN_ID = 151670
+DEFAULT_MAX_AUDIO_SECONDS = 30
+
+
+@dataclass
+class MossAudioEncoderConfig:
+    d_model: int = 1280
+    output_dim: int = 1280
+    num_mel_bins: int = 128
+    encoder_layers: int = 32
+    encoder_attention_heads: int = 20
+    encoder_ffn_dim: int = 5120
+    downsample_rate: int = 8
+    downsample_hidden_size: int = 480
+    encoder_attention_window_size: int = 100
+    max_source_positions: int = 1500
+    dropout: float = 0.1
+    attention_dropout: float = 0.1
+    activation_dropout: float = 0.0
+    activation_function: str = "gelu"
+    layer_norm_eps: float = 1e-5
+    _attn_implementation: str = "eager"
+    pretrained_path: str = ""
+    n_window: int = 200
+    conv_chunksize: int = 64
+    deepstack_encoder_layer_indexes: list[int] = field(
+        default_factory=lambda: [8, 16, 24]
+    )
+
+    @classmethod
+    def from_config(cls, config: object) -> "MossAudioEncoderConfig":
+        if isinstance(config, cls):
+            return config
+        if isinstance(config, Mapping):
+            values = {
+                key: value
+                for key, value in config.items()
+                if key in cls.__dataclass_fields__
+            }
+        else:
+            values = {
+                key: getattr(config, key)
+                for key in cls.__dataclass_fields__
+                if hasattr(config, key)
+            }
+        return cls(**values)
+
+
+class MossAudioConfig(PretrainedConfig):
+    model_type = "moss_audio"
+    is_composition = True
+
+    def __init__(
+        self,
+        audio_config: Mapping[str, object] | MossAudioEncoderConfig | None = None,
+        language_config: Mapping[str, object] | Qwen3Config | None = None,
+        adapter_hidden_size: int = 8192,
+        ignore_index: int = -100,
+        deepstack_num_inject_layers: int | None = None,
+        **kwargs: object,
+    ) -> None:
+        self.audio_config = MossAudioEncoderConfig.from_config(audio_config or {})
+        if isinstance(language_config, Qwen3Config):
+            self.language_config = language_config
+        else:
+            self.language_config = Qwen3Config(**(language_config or {}))
+
+        self.adapter_hidden_size = adapter_hidden_size
+        self.ignore_index = ignore_index
+        self.deepstack_num_inject_layers = deepstack_num_inject_layers
+
+        for key in ("num_hidden_layers", "eos_token_id", "bos_token_id", "vocab_size"):
+            kwargs.setdefault(key, getattr(self.language_config, key, None))
+        kwargs.setdefault("tie_word_embeddings", False)
+        super().__init__(**kwargs)
+
+    def get_text_config(self, decoder: bool = False) -> Qwen3Config:
+        return self.language_config
+
+
+class SinusoidsPositionEmbedding(nn.Module):
+    def __init__(self, num_positions: int, embedding_dim: int) -> None:
+        super().__init__()
+        del num_positions  # Kept for config compatibility.
+        max_timescale = 10000.0
+        log_timescale_increment = math.log(max_timescale) / (embedding_dim // 2 - 1)
+        inv_timescales = torch.exp(
+            -log_timescale_increment * torch.arange(embedding_dim // 2).float()
+        )
+        self.register_buffer("inv_timescales", inv_timescales, persistent=False)
+
+    def forward(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        scaled_time = (
+            torch.arange(seq_len, device=device, dtype=self.inv_timescales.dtype)[
+                :, None
+            ]
+            * self.inv_timescales[None, :]
+        )
+        return torch.cat([scaled_time.sin(), scaled_time.cos()], dim=1).unsqueeze(0)
+
+
+class MossAudioAttention(nn.Module):
+    def __init__(
+        self,
+        config: MossAudioEncoderConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.num_heads = config.encoder_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"d_model ({self.embed_dim}) must be divisible by "
+                f"encoder_attention_heads ({self.num_heads})."
+            )
+
+        tp_size = get_tensor_model_parallel_world_size()
+        if self.num_heads % tp_size != 0:
+            raise ValueError(
+                "MOSS-Audio audio encoder attention heads must be divisible by "
+                f"tensor parallel size. Got {self.num_heads=} and {tp_size=}."
+            )
+        self.num_local_heads = self.num_heads // tp_size
+        # TODO: can use QKVParallelLinear
+        self.q_proj = ColumnParallelLinear(
+            input_size=self.embed_dim,
+            output_size=self.embed_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_proj",
+        )
+        self.k_proj = ColumnParallelLinear(
+            input_size=self.embed_dim,
+            output_size=self.embed_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.k_proj",
+        )
+        self.v_proj = ColumnParallelLinear(
+            input_size=self.embed_dim,
+            output_size=self.embed_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.v_proj",
+        )
+        self.out_proj = RowParallelLinear(
+            input_size=self.embed_dim,
+            output_size=self.embed_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.out_proj",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        q, _ = self.q_proj(hidden_states)
+        k, _ = self.k_proj(hidden_states)
+        v, _ = self.v_proj(hidden_states)
+        q = q.view(batch_size, seq_len, -1, self.head_dim).transpose(1, 2)
+        k = k.view(batch_size, seq_len, -1, self.head_dim).transpose(1, 2)
+        v = v.view(batch_size, seq_len, -1, self.head_dim).transpose(1, 2)
+        attn_output = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attention_mask[:, None, None, :],
+            dropout_p=0.0,
+            scale=self.head_dim**-0.5,
+        )
+        output, _ = self.out_proj(
+            attn_output.transpose(1, 2).reshape(
+                batch_size,
+                seq_len,
+                -1,
+            )
+        )
+        return output
+
+
+class MossAudioEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: MossAudioEncoderConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.self_attn = MossAudioAttention(
+            config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+        )
+        self.self_attn_layer_norm = nn.LayerNorm(
+            config.d_model, eps=config.layer_norm_eps
+        )
+        self.activation_fn = _ACTIVATION_REGISTRY[config.activation_function]
+        self.activation_dropout = config.activation_dropout
+        self.dropout = config.dropout
+        self.fc1 = ColumnParallelLinear(
+            config.d_model,
+            config.encoder_ffn_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc1",
+        )
+        self.fc2 = RowParallelLinear(
+            config.encoder_ffn_dim,
+            config.d_model,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc2",
+        )
+        self.final_layer_norm = nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, attention_mask)
+        hidden_states = residual + F.dropout(
+            hidden_states, p=self.dropout, training=self.training
+        )
+
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states, _ = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = F.dropout(
+            hidden_states, p=self.activation_dropout, training=self.training
+        )
+        hidden_states, _ = self.fc2(hidden_states)
+        hidden_states = residual + F.dropout(
+            hidden_states, p=self.dropout, training=self.training
+        )
+        return hidden_states
+
+
+class MossAudioEncoder(nn.Module):
+    def __init__(
+        self,
+        config: MossAudioEncoderConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.gelu = nn.GELU()
+        self.conv1 = nn.Conv2d(
+            1,
+            config.downsample_hidden_size,
+            kernel_size=(3, 3),
+            stride=(2, 2),
+            padding=(1, 1),
+        )
+        self.conv2 = nn.Conv2d(
+            config.downsample_hidden_size,
+            config.downsample_hidden_size,
+            kernel_size=(3, 3),
+            stride=(2, 2),
+            padding=(1, 1),
+        )
+        self.conv3 = nn.Conv2d(
+            config.downsample_hidden_size,
+            config.downsample_hidden_size,
+            kernel_size=(3, 3),
+            stride=(2, 2),
+            padding=(1, 1),
+        )
+
+        conv_freq = self._compute_downsampled_length(
+            torch.tensor(config.num_mel_bins)
+        ).item()
+        self.stem_proj = ReplicatedLinear(
+            config.downsample_hidden_size * int(conv_freq),
+            config.d_model,
+            bias=True,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.stem_proj",
+        )
+        self.embed_positions = SinusoidsPositionEmbedding(
+            config.max_source_positions, config.d_model
+        )
+        self.layers = nn.ModuleList(
+            [
+                MossAudioEncoderLayer(
+                    config,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.layers.{layer_idx}",
+                )
+                for layer_idx in range(config.encoder_layers)
+            ]
+        )
+        self.layer_norm = nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
+        self.out_proj = ReplicatedLinear(
+            config.d_model,
+            config.output_dim,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.out_proj",
+        )
+
+        self.deepstack_encoder_layer_indexes = list(
+            config.deepstack_encoder_layer_indexes or []
+        )
+        self._deepstack_capture_map = {
+            layer_idx: capture_idx
+            for capture_idx, layer_idx in enumerate(
+                self.deepstack_encoder_layer_indexes
+            )
+        }
+        self.n_window = int(config.n_window)
+        self.chunk_frames = int(self.n_window * 2)
+        self.conv_chunksize = int(config.conv_chunksize)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.conv1.weight.dtype
+
+    @staticmethod
+    def _compute_downsampled_length(lengths: torch.Tensor) -> torch.Tensor:
+        def conv_out_len(length: torch.Tensor) -> torch.Tensor:
+            return (length - 1) // 2 + 1
+
+        return conv_out_len(conv_out_len(conv_out_len(lengths)))
+
+    @staticmethod
+    def compute_num_audio_tokens(raw_mel_len: int) -> int:
+        lengths = torch.tensor(raw_mel_len, dtype=torch.long)
+        return int(MossAudioEncoder._compute_downsampled_length(lengths).item())
+
+    def _encode_chunk_batch(
+        self,
+        input_features: torch.Tensor,
+        seq_lengths: torch.Tensor,
+        output_deepstack_hidden_states: bool = True,
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        if input_features.dim() == 2:
+            input_features = input_features.unsqueeze(0)
+
+        downsampled_lengths = self._compute_downsampled_length(seq_lengths)
+        x = input_features.unsqueeze(1)
+        x = self.gelu(self.conv1(x))
+        x = self.gelu(self.conv2(x))
+        x = self.gelu(self.conv3(x))
+        x = x.permute(0, 3, 1, 2).contiguous().flatten(2)
+        x = self.stem_proj(x)
+
+        max_len = int(downsampled_lengths.max().item())
+        if x.size(1) > max_len:
+            x = x[:, :max_len, :]
+        x = x + self.embed_positions(x.shape[1], x.device).to(x.dtype)
+
+        attention_mask = (
+            torch.arange(x.size(1), device=x.device)[None, :]
+            < downsampled_lengths[:, None]
+        )
+
+        deepstack_hidden_states: list[torch.Tensor | None] = []
+        if output_deepstack_hidden_states:
+            deepstack_hidden_states = [None] * len(self.deepstack_encoder_layer_indexes)
+        for layer_idx, layer in enumerate(self.layers):
+            x = layer(x, attention_mask)
+            if output_deepstack_hidden_states:
+                capture_idx = self._deepstack_capture_map.get(layer_idx)
+                if capture_idx is not None:
+                    deepstack_hidden_states[capture_idx] = x
+
+        x = self.layer_norm(x)
+        x = self.out_proj(x)
+
+        if not output_deepstack_hidden_states:
+            return x, []
+
+        ordered_deepstack_hidden_states = [
+            hidden_states
+            for hidden_states in deepstack_hidden_states
+            if hidden_states is not None
+        ]
+        ordered_deepstack_hidden_states = [
+            self.out_proj(hidden_states)
+            for hidden_states in ordered_deepstack_hidden_states
+        ]
+        return x, ordered_deepstack_hidden_states
+
+    def forward(
+        self,
+        input_features: torch.Tensor,
+        feature_lens: torch.Tensor | None = None,
+        output_deepstack_hidden_states: bool = True,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, ...] | None]:
+        if input_features.dim() == 3:
+            if feature_lens is None:
+                feature_lens = torch.full(
+                    (input_features.size(0),),
+                    input_features.size(-1),
+                    dtype=torch.long,
+                    device=input_features.device,
+                )
+            else:
+                feature_lens = feature_lens.to(
+                    device=input_features.device, dtype=torch.long
+                )
+            valid_chunks = [
+                input_features[i, :, : int(feature_lens[i].item())]
+                for i in range(int(input_features.shape[0]))
+            ]
+            input_features = torch.cat(valid_chunks, dim=1)
+        elif input_features.dim() != 2:
+            raise ValueError(
+                f"Expected [n_mels, T] or [B, n_mels, T], got "
+                f"{tuple(input_features.shape)}."
+            )
+
+        if feature_lens is None:
+            feature_lens = torch.tensor(
+                [int(input_features.shape[1])],
+                device=input_features.device,
+                dtype=torch.long,
+            )
+        else:
+            feature_lens = feature_lens.to(
+                device=input_features.device, dtype=torch.long
+            )
+
+        chunk_num = torch.ceil(
+            feature_lens.to(torch.float32) / self.chunk_frames
+        ).long()
+        chunk_lengths = torch.full(
+            (int(chunk_num.sum().item()),),
+            self.chunk_frames,
+            dtype=torch.long,
+            device=feature_lens.device,
+        )
+        tail_chunk_index = F.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
+        chunk_lengths[tail_chunk_index] = feature_lens % self.chunk_frames
+        chunk_lengths[chunk_lengths == 0] = self.chunk_frames
+
+        chunk_list = input_features.T.split(chunk_lengths.tolist(), dim=0)
+        padded_feature = nn.utils.rnn.pad_sequence(
+            chunk_list, batch_first=True
+        ).transpose(1, 2)
+
+        feature_lens_after_cnn = self._compute_downsampled_length(chunk_lengths)
+        t_down_max = (
+            int(feature_lens_after_cnn.max().item())
+            if feature_lens_after_cnn.numel() > 0
+            else 0
+        )
+        indices = torch.arange(t_down_max, device=padded_feature.device)
+        padded_mask_after_cnn = indices[None, :] < feature_lens_after_cnn[:, None]
+
+        num_deepstack = len(self.deepstack_encoder_layer_indexes)
+        should_output_deepstack = output_deepstack_hidden_states and num_deepstack > 0
+        padded_embeds: list[torch.Tensor] = []
+        deepstack_padded_embeds: list[list[torch.Tensor]] = [
+            [] for _ in range(num_deepstack if should_output_deepstack else 0)
+        ]
+        for feat_chunk, len_chunk in zip(
+            padded_feature.split(self.conv_chunksize, dim=0),
+            chunk_lengths.split(self.conv_chunksize, dim=0),
+        ):
+            out, deepstack_outs = self._encode_chunk_batch(
+                feat_chunk,
+                len_chunk,
+                output_deepstack_hidden_states=should_output_deepstack,
+            )
+            if out.shape[1] < t_down_max:
+                out = F.pad(out, (0, 0, 0, t_down_max - out.shape[1]))
+            padded_embeds.append(out)
+
+            if should_output_deepstack:
+                if len(deepstack_outs) != num_deepstack:
+                    raise RuntimeError(
+                        "DeepStack output count does not match configured "
+                        "layer indexes."
+                    )
+                for capture_idx, ds in enumerate(deepstack_outs):
+                    if ds.shape[1] < t_down_max:
+                        ds = F.pad(ds, (0, 0, 0, t_down_max - ds.shape[1]))
+                    deepstack_padded_embeds[capture_idx].append(ds)
+
+        if padded_embeds:
+            padded_embed = torch.cat(padded_embeds, dim=0)
+        else:
+            padded_embed = torch.empty(
+                (0, t_down_max, self.config.output_dim),
+                device=padded_feature.device,
+                dtype=padded_feature.dtype,
+            )
+
+        last_hidden_state = padded_embed[padded_mask_after_cnn].unsqueeze(0)
+
+        deepstack_states: tuple[torch.Tensor, ...] | None = None
+        if should_output_deepstack:
+            collected: list[torch.Tensor] = []
+            for chunks_list in deepstack_padded_embeds:
+                if chunks_list:
+                    ds = torch.cat(chunks_list, dim=0)
+                    collected.append(ds[padded_mask_after_cnn].unsqueeze(0))
+                else:
+                    collected.append(
+                        torch.empty(
+                            (1, 0, self.config.output_dim),
+                            device=padded_feature.device,
+                            dtype=padded_embed.dtype,
+                        )
+                    )
+            deepstack_states = tuple(collected)
+
+        return last_hidden_state, deepstack_states
+
+
+class GatedMLP(nn.Module):
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.gate_proj = ReplicatedLinear(
+            input_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.gate_proj",
+        )
+        self.up_proj = ReplicatedLinear(
+            input_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.up_proj",
+        )
+        self.down_proj = ReplicatedLinear(
+            hidden_size,
+            output_size,
+            bias=False,
+            quant_config=quant_config,
+            return_bias=False,
+            prefix=f"{prefix}.down_proj",
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "deepstack_input_embeds": 0,
+    }
+)
+class MossQwen3Model(Qwen3Model):
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        for layer_idx, layer in enumerate(
+            self.layers[self.start_layer : self.end_layer],
+            start=self.start_layer,
+        ):
+            hidden_states, residual = layer(positions, hidden_states, residual)
+            if deepstack_input_embeds is not None and layer_idx < len(
+                deepstack_input_embeds
+            ):
+                hidden_states = (
+                    hidden_states
+                    + deepstack_input_embeds[f"deepstack_input_embeds_{layer_idx}"]
+                )
+            self._maybe_add_hidden_state(
+                aux_hidden_states,
+                layer_idx - self.start_layer + 1,
+                hidden_states,
+                residual,
+            )
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+
+class MossQwen3ForCausalLM(Qwen3ForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super(Qwen3ForCausalLM, self).__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.vllm_config = vllm_config
+        self.quant_config = quant_config
+        self.model = MossQwen3Model(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            from .utils import PPMissingLayer
+
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            deepstack_input_embeds=deepstack_input_embeds,
+        )
+
+
+def _moss_audio_field_config(
+    hf_inputs: Mapping[str, torch.Tensor],
+) -> Mapping[str, MultiModalFieldConfig]:
+    return {
+        "audio_data": MultiModalFieldConfig.batched("audio"),
+        "audio_data_seqlens": MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+    }
+
+
+class MossAudioMultiModalDataParser(MultiModalDataParser):
+    def _parse_audio_data(
+        self,
+        data: dict[str, torch.Tensor] | ModalityData[AudioItem],
+    ) -> ModalityDataItems[Any, Any] | None:
+        if isinstance(data, dict):
+            return DictEmbeddingItems(
+                data,
+                modality="audio",
+                required_fields={"audio_data", "audio_data_seqlens"},
+                fields_factory=_moss_audio_field_config,
+            )
+
+        return super()._parse_audio_data(data)
+
+
+class MossAudioProcessor:
+    model_input_names = [
+        "input_ids",
+        "attention_mask",
+        "audio_data",
+        "audio_data_seqlens",
+    ]
+
+    def __init__(
+        self,
+        tokenizer: object,
+        *,
+        audio_token_id: int = MOSS_AUDIO_TOKEN_ID,
+        audio_start_id: int = MOSS_AUDIO_BOS_TOKEN_ID,
+        audio_end_id: int = MOSS_AUDIO_EOS_TOKEN_ID,
+        enable_time_marker: bool = False,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.audio_token_id = int(audio_token_id)
+        self.audio_start_id = int(audio_start_id)
+        self.audio_end_id = int(audio_end_id)
+        self.enable_time_marker = bool(enable_time_marker)
+        self.feature_extractor = WhisperFeatureExtractor(
+            feature_size=128,
+            sampling_rate=16000,
+            hop_length=160,
+            n_fft=400,
+        )
+        self.audio_tokens_per_second = 12.5
+        self.time_marker_every_seconds = 2
+        self.time_marker_every_audio_tokens = int(
+            self.audio_tokens_per_second * self.time_marker_every_seconds
+        )
+        self._digit_token_ids = {
+            "0": 15,
+            "1": 16,
+            "2": 17,
+            "3": 18,
+            "4": 19,
+            "5": 20,
+            "6": 21,
+            "7": 22,
+            "8": 23,
+            "9": 24,
+        }
+
+    @staticmethod
+    def conv3_downsample_len(raw_mel_len: int) -> int:
+        return MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)
+
+    def _extract_mel(self, audio: np.ndarray | torch.Tensor) -> torch.Tensor:
+        if isinstance(audio, torch.Tensor):
+            wav = audio.detach().to("cpu", dtype=torch.float32).numpy()
+        else:
+            wav = np.asarray(audio, dtype=np.float32)
+        if wav.size == 0:
+            raise ValueError("The audio is too short to be represented.")
+        if wav.ndim == 2:
+            wav = wav[0]
+        feats = self.feature_extractor._np_extract_fbank_features(
+            wav[None, ...], device="cpu"
+        )
+        return torch.from_numpy(feats[0])
+
+    def _build_audio_tokens_with_time_markers(self, audio_seq_len: int) -> list[int]:
+        total_duration_seconds = audio_seq_len / self.audio_tokens_per_second
+        num_full_seconds = int(total_duration_seconds)
+        token_ids: list[int] = []
+        audio_tokens_consumed = 0
+        for second in range(
+            self.time_marker_every_seconds,
+            num_full_seconds + 1,
+            self.time_marker_every_seconds,
+        ):
+            marker_pos = (
+                second // self.time_marker_every_seconds
+            ) * self.time_marker_every_audio_tokens
+            audio_segment_len = marker_pos - audio_tokens_consumed
+            if audio_segment_len > 0:
+                token_ids.extend([self.audio_token_id] * audio_segment_len)
+                audio_tokens_consumed += audio_segment_len
+            token_ids.extend(self._digit_token_ids[digit] for digit in str(second))
+
+        remaining = audio_seq_len - audio_tokens_consumed
+        if remaining > 0:
+            token_ids.extend([self.audio_token_id] * remaining)
+        return token_ids
+
+    def build_audio_placeholder_ids(self, num_audio_tokens: int) -> list[int]:
+        if self.enable_time_marker:
+            return self._build_audio_tokens_with_time_markers(num_audio_tokens)
+        return [self.audio_token_id] * num_audio_tokens
+
+    def __call__(
+        self,
+        text: str | Sequence[str] | None = None,
+        audios: Sequence[np.ndarray | torch.Tensor] | None = None,
+        audio: Sequence[np.ndarray | torch.Tensor] | None = None,
+        return_tensors: str = "pt",
+        **kwargs: object,
+    ) -> BatchFeature:
+        del kwargs
+        if isinstance(text, (list, tuple)):
+            if len(text) != 1:
+                raise ValueError(f"Expected text batch size 1, got {len(text)}")
+            prompt_text = text[0]
+        elif text is None:
+            prompt_text = ""
+        else:
+            prompt_text = text
+
+        audio_list = audios if audios is not None else audio
+        audio_list = [] if audio_list is None else list(audio_list)
+
+        mels: list[torch.Tensor] = []
+        raw_lengths: list[int] = []
+        token_lens: list[int] = []
+        for one_audio in audio_list:
+            mel = self._extract_mel(one_audio)
+            raw_len = int(mel.shape[-1])
+            num_tokens = self.conv3_downsample_len(raw_len)
+            if raw_len <= 0 or num_tokens <= 0:
+                raise ValueError("The audio is too short to be represented.")
+            mels.append(mel)
+            raw_lengths.append(raw_len)
+            token_lens.append(num_tokens)
+
+        if mels:
+            max_length = max(raw_lengths)
+            audio_batch = torch.zeros((len(mels), 128, max_length), dtype=torch.float32)
+            for index, mel in enumerate(mels):
+                audio_batch[index, :, : mel.shape[-1]] = mel
+            audio_data_seqlens = torch.tensor(raw_lengths, dtype=torch.long)
+        else:
+            audio_batch = None
+            audio_data_seqlens = None
+
+        input_ids = []
+        cursor = 0
+        placeholder = f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+        for item_idx, _ in enumerate(audio_list):
+            match_idx = prompt_text.find(placeholder, cursor)
+            if match_idx < 0:
+                raise ValueError(
+                    "Audio placeholder count mismatch: expected one "
+                    f"{placeholder!r} span per audio item."
+                )
+            prefix = prompt_text[cursor:match_idx]
+            input_ids.extend(self.tokenizer.encode(prefix, add_special_tokens=False))
+            input_ids.append(self.audio_start_id)
+            input_ids.extend(self.build_audio_placeholder_ids(token_lens[item_idx]))
+            input_ids.append(self.audio_end_id)
+            cursor = match_idx + len(placeholder)
+
+        suffix = prompt_text[cursor:]
+        if placeholder in suffix:
+            raise ValueError(
+                "Audio placeholder count mismatch: found more placeholder spans "
+                "than audio items."
+            )
+        input_ids.extend(self.tokenizer.encode(suffix, add_special_tokens=False))
+
+        data: dict[str, torch.Tensor] = {
+            "input_ids": torch.tensor([input_ids], dtype=torch.long),
+            "attention_mask": torch.ones((1, len(input_ids)), dtype=torch.long),
+        }
+        if audio_batch is not None and audio_data_seqlens is not None:
+            data["audio_data"] = audio_batch
+            data["audio_data_seqlens"] = audio_data_seqlens
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def decode(self, *args: object, **kwargs: object) -> str:
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def batch_decode(self, *args: object, **kwargs: object) -> list[str]:
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+
+class MossAudioProcessingInfo(BaseProcessingInfo):
+    def get_hf_config(self) -> MossAudioConfig:
+        config = self.ctx.get_hf_config()
+        if isinstance(config, MossAudioConfig):
+            return config
+        return MossAudioConfig(
+            audio_config=getattr(config, "audio_config", None),
+            language_config=getattr(config, "language_config", None),
+            adapter_hidden_size=getattr(config, "adapter_hidden_size", 8192),
+            ignore_index=getattr(config, "ignore_index", -100),
+            deepstack_num_inject_layers=getattr(
+                config, "deepstack_num_inject_layers", None
+            ),
+        )
+
+    def get_hf_processor(self, **kwargs: object) -> MossAudioProcessor:
+        enable_time_marker = bool(kwargs.get("enable_time_marker", False))
+        processor_kwargs = {
+            key: kwargs[key]
+            for key in ("audio_token_id", "audio_start_id", "audio_end_id")
+            if key in kwargs
+        }
+        has_custom_kwargs = (
+            enable_time_marker
+            or bool(processor_kwargs)
+            or any(
+                key
+                not in {
+                    "enable_time_marker",
+                    "audio_token_id",
+                    "audio_start_id",
+                    "audio_end_id",
+                }
+                for key in kwargs
+            )
+        )
+        if not has_custom_kwargs:
+            default_processor = getattr(self, "_default_hf_processor", None)
+            if default_processor is None:
+                default_processor = MossAudioProcessor(self.get_tokenizer())
+                self._default_hf_processor = default_processor
+            return default_processor
+
+        return MossAudioProcessor(
+            self.get_tokenizer(),
+            enable_time_marker=enable_time_marker,
+            **processor_kwargs,
+        )
+
+    def get_feature_extractor(self, **kwargs: object) -> WhisperFeatureExtractor:
+        return self.get_hf_processor(**kwargs).feature_extractor
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        return {"audio": None}
+
+    def get_data_parser(self) -> MultiModalDataParser:
+        return MossAudioMultiModalDataParser(
+            target_sr=16000,
+            target_channels=1,
+            expected_hidden_size=self._get_expected_hidden_size(),
+        )
+
+    def get_mm_max_tokens_per_item(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> Mapping[str, int] | None:
+        if mm_counts.get("audio", 0) <= 0:
+            return {}
+        raw_mel_len = math.ceil((16000 * DEFAULT_MAX_AUDIO_SECONDS) / 160)
+        return {"audio": MossAudioEncoder.compute_num_audio_tokens(raw_mel_len)}
+
+
+class MossAudioDummyInputsBuilder(BaseDummyInputsBuilder[MossAudioProcessingInfo]):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        num_audios = mm_counts.get("audio", 0)
+        return (
+            f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+            * num_audios
+        )
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions],
+    ) -> MultiModalDataDict:
+        num_audios = mm_counts.get("audio", 0)
+        audio_overrides = mm_options.get("audio")
+        return {
+            "audio": self._get_dummy_audios(
+                length=16000,
+                num_audios=num_audios,
+                overrides=audio_overrides,
+            )
+        }
+
+
+class MossAudioMultiModalProcessor(BaseMultiModalProcessor[MossAudioProcessingInfo]):
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        mm_data = dict(mm_data)
+        audios = mm_data.pop("audios", [])
+        if audios:
+            mm_data["audio"] = audios
+        return self.info.ctx.call_hf_processor(
+            self.info.get_hf_processor(**mm_kwargs),
+            dict(text=prompt, **mm_data),
+            dict(**tok_kwargs),
+        )
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        return _moss_audio_field_config(hf_inputs)
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
+        out_mm_data = out_mm_kwargs.get_data()
+        audio_data_seqlens = out_mm_data.get("audio_data_seqlens")
+        if audio_data_seqlens is None:
+            audio_token_lens: list[int] = []
+        else:
+            if isinstance(audio_data_seqlens, torch.Tensor):
+                lens = audio_data_seqlens.reshape(-1).tolist()
+            else:
+                lens = list(audio_data_seqlens)
+            audio_token_lens = [
+                MossAudioEncoder.compute_num_audio_tokens(int(length))
+                for length in lens
+            ]
+
+        def get_replacement(item_idx: int) -> PromptUpdateDetails[list[int]]:
+            num_tokens = audio_token_lens[item_idx]
+            if num_tokens == 0:
+                raise ValueError("The audio is too short to be represented.")
+            audio_token_ids = processor.build_audio_placeholder_ids(num_tokens)
+            is_embed = torch.tensor(
+                [token_id == processor.audio_token_id for token_id in audio_token_ids],
+                dtype=torch.bool,
+            )
+            return PromptUpdateDetails(
+                full=[
+                    processor.audio_start_id,
+                    *audio_token_ids,
+                    processor.audio_end_id,
+                ],
+                is_embed=lambda _tokenizer, _seq: torch.cat(
+                    [
+                        torch.tensor([False]),
+                        is_embed,
+                        torch.tensor([False]),
+                    ]
+                ),
+            )
+
+        return [
+            PromptReplacement(
+                modality="audio",
+                target=[
+                    processor.audio_start_id,
+                    processor.audio_token_id,
+                    processor.audio_end_id,
+                ],
+                replacement=get_replacement,
+            )
+        ]
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    MossAudioMultiModalProcessor,
+    info=MossAudioProcessingInfo,
+    dummy_inputs=MossAudioDummyInputsBuilder,
+)
+class MossAudioModel(nn.Module, SupportsMultiModal):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
+
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "lm_head.": "language_model.lm_head.",
+            "language_model.embed_tokens.": "language_model.model.embed_tokens.",
+            "language_model.layers.": "language_model.model.layers.",
+            "language_model.norm.": "language_model.model.norm.",
+        }
+    )
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("audio"):
+            return f"{MOSS_AUDIO_BOS_TOKEN}{MOSS_AUDIO_TOKEN}{MOSS_AUDIO_EOS_TOKEN}"
+        raise ValueError("Only audio modality is supported")
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        config = vllm_config.model_config.hf_config
+        if not isinstance(config, MossAudioConfig):
+            config = MossAudioConfig(
+                audio_config=getattr(config, "audio_config", None),
+                language_config=getattr(config, "language_config", None),
+                adapter_hidden_size=getattr(config, "adapter_hidden_size", 8192),
+                ignore_index=getattr(config, "ignore_index", -100),
+                deepstack_num_inject_layers=getattr(
+                    config, "deepstack_num_inject_layers", None
+                ),
+            )
+        self.config = config
+        self.quant_config = vllm_config.quant_config
+        self.multimodal_config = vllm_config.model_config.multimodal_config
+
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.tensor_parallel_size != 1:
+            raise ValueError(
+                "MossAudioModel currently supports only tensor_parallel_size=1; "
+                f"got {parallel_config.tensor_parallel_size}."
+            )
+        if parallel_config.pipeline_parallel_size != 1:
+            raise ValueError(
+                "MossAudioModel currently supports only pipeline_parallel_size=1; "
+                f"got {parallel_config.pipeline_parallel_size}."
+            )
+
+        audio_config = MossAudioEncoderConfig.from_config(self.config.audio_config)
+        language_config = self.config.language_config
+        self.audio_token_id = MOSS_AUDIO_TOKEN_ID
+        self.deepstack_input_embeds: IntermediateTensors | None = None
+
+        with self._mark_tower_model(vllm_config, "audio"):
+            self.audio_encoder = MossAudioEncoder(
+                audio_config,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "audio_encoder"),
+            )
+            self.audio_adapter = GatedMLP(
+                input_size=audio_config.output_dim,
+                hidden_size=self.config.adapter_hidden_size,
+                output_size=language_config.hidden_size,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "audio_adapter"),
+            )
+
+            deepstack_k = len(audio_config.deepstack_encoder_layer_indexes or [])
+            if self.config.deepstack_num_inject_layers is not None:
+                deepstack_k = min(
+                    deepstack_k,
+                    int(self.config.deepstack_num_inject_layers),
+                )
+            self.deepstack_audio_merger_list = nn.ModuleList(
+                [
+                    GatedMLP(
+                        input_size=audio_config.output_dim,
+                        hidden_size=self.config.adapter_hidden_size,
+                        output_size=language_config.hidden_size,
+                        quant_config=self.quant_config,
+                        prefix=maybe_prefix(
+                            prefix,
+                            f"deepstack_audio_merger_list.{layer_idx}",
+                        ),
+                    )
+                    for layer_idx in range(deepstack_k)
+                ]
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = MossQwen3ForCausalLM(
+                vllm_config=vllm_config.with_hf_config(
+                    language_config, architectures=["Qwen3ForCausalLM"]
+                ),
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+
+    def _parse_and_validate_audio_input(
+        self, **kwargs: object
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        audio_data = kwargs.pop("audio_data", None)
+        audio_data_seqlens = kwargs.pop("audio_data_seqlens", None)
+        if audio_data is None:
+            return None
+        if audio_data_seqlens is None:
+            raise ValueError(
+                "audio_data_seqlens is required when audio_data is provided."
+            )
+        if not isinstance(audio_data, torch.Tensor):
+            raise TypeError("audio_data must be a torch.Tensor.")
+        if not isinstance(audio_data_seqlens, torch.Tensor):
+            audio_data_seqlens = torch.tensor(audio_data_seqlens, dtype=torch.long)
+        audio_data_seqlens = audio_data_seqlens.to(dtype=torch.long).reshape(-1)
+        audio_token_lens = MossAudioEncoder._compute_downsampled_length(
+            audio_data_seqlens
+        )
+        if (
+            audio_data_seqlens.numel() == 0
+            or torch.any(audio_data_seqlens <= 0).item()
+            or torch.any(audio_token_lens <= 0).item()
+        ):
+            raise ValueError("The audio is too short to be represented.")
+        return audio_data, audio_data_seqlens
+
+    def _process_audio_input(
+        self,
+        audio_data: torch.Tensor,
+        audio_data_seqlens: torch.Tensor,
+    ) -> tuple[tuple[torch.Tensor, ...], ...]:
+        last_hidden_state, deepstack = self.audio_encoder(
+            audio_data.to(self.audio_encoder.dtype),
+            feature_lens=audio_data_seqlens,
+            output_deepstack_hidden_states=len(self.deepstack_audio_merger_list) > 0,
+        )
+        audio_embeds = self.audio_adapter(last_hidden_state)
+        audio_lengths = MossAudioEncoder._compute_downsampled_length(
+            audio_data_seqlens.to(device=audio_embeds.device, dtype=torch.long)
+        ).tolist()
+        main_embeddings = tuple(audio_embeds.squeeze(0).split(audio_lengths, dim=0))
+
+        deepstack_embeddings: list[tuple[torch.Tensor, ...]] = []
+        if deepstack is not None:
+            for idx, hidden_states in enumerate(
+                deepstack[: len(self.deepstack_audio_merger_list)]
+            ):
+                ds_embeds = self.deepstack_audio_merger_list[idx](hidden_states)
+                deepstack_embeddings.append(
+                    tuple(ds_embeds.squeeze(0).split(audio_lengths, dim=0))
+                )
+
+        return (main_embeddings, *deepstack_embeddings)
+
+    def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
+        audio_input = self._parse_and_validate_audio_input(**kwargs)
+        if audio_input is None:
+            return ()
+        return self._process_audio_input(*audio_input)
+
+    def _cache_deepstack_input_embeds(
+        self,
+        inputs_embeds: torch.Tensor,
+        deepstack_embeddings: tuple[tuple[torch.Tensor, ...], ...],
+        is_multimodal: torch.Tensor,
+    ) -> None:
+        if len(deepstack_embeddings) == 0:
+            self.deepstack_input_embeds = None
+            return
+        flat_by_layer = [
+            torch.cat(layer_embeds, dim=0).to(
+                device=inputs_embeds.device, dtype=inputs_embeds.dtype
+            )
+            for layer_embeds in deepstack_embeddings
+        ]
+        num_mm_tokens = int(is_multimodal.sum().item())
+        if any(layer.shape[0] != num_mm_tokens for layer in flat_by_layer):
+            got = [int(layer.shape[0]) for layer in flat_by_layer]
+            raise ValueError(
+                "DeepStack audio token count mismatch: "
+                f"expected {num_mm_tokens}, got {got}."
+            )
+        data = {}
+        for layer_idx, layer_embeds in enumerate(flat_by_layer):
+            scattered = inputs_embeds.new_zeros(inputs_embeds.shape)
+            scattered[is_multimodal] = layer_embeds
+            data[f"deepstack_input_embeds_{layer_idx}"] = scattered
+        self.deepstack_input_embeds = IntermediateTensors(data)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.language_model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+
+        self.deepstack_input_embeds = None
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        if is_multimodal is None:
+            raise ValueError("is_multimodal is required for MOSS-Audio inputs.")
+
+        main_embeddings = multimodal_embeddings[0]
+        deepstack_embeddings = tuple(multimodal_embeddings[1:])
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=main_embeddings,
+            is_multimodal=is_multimodal,
+        )
+        self._cache_deepstack_input_embeds(
+            inputs_embeds,
+            deepstack_embeddings,
+            is_multimodal,
+        )
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        if intermediate_tensors is not None:
+            raise ValueError(
+                "MossAudioModel does not support pipeline parallelism yet."
+            )
+
+        deepstack_input_embeds = self.deepstack_input_embeds
+        hidden_states = self.language_model(
+            input_ids,
+            positions,
+            intermediate_tensors=None,
+            inputs_embeds=inputs_embeds,
+            deepstack_input_embeds=deepstack_input_embeds,
+        )
+        self.deepstack_input_embeds = None
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        return self.language_model.compute_logits(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -454,6 +454,7 @@ _MULTIMODAL_MODELS = {
     "KimiVLForConditionalGeneration": ("kimi_vl", "KimiVLForConditionalGeneration"),
     "KimiK25ForConditionalGeneration": ("kimi_k25", "KimiK25ForConditionalGeneration"),
     "MoonshotKimiaForCausalLM": ("kimi_audio", "KimiAudioForConditionalGeneration"),
+    "MossAudioModel": ("moss_audio", "MossAudioModel"),
     "LightOnOCRForConditionalGeneration": (
         "lightonocr",
         "LightOnOCRForConditionalGeneration",

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -545,6 +545,50 @@ class Gemma4ModelArchConfigConvertor(ModelArchConfigConvertorBase):
         return max(head_dim, global_head_dim) or super().get_head_size()
 
 
+class MossAudioModelArchConfigConvertor(ModelArchConfigConvertorBase):
+    def _language_config(self) -> PretrainedConfig:
+        return self.hf_config.language_config
+
+    def get_num_hidden_layers(self) -> int:
+        return getattr(self._language_config(), "num_hidden_layers", 0)
+
+    def get_total_num_attention_heads(self) -> int:
+        return getattr(self._language_config(), "num_attention_heads", 0)
+
+    def get_vocab_size(self) -> int:
+        return getattr(self._language_config(), "vocab_size", 0)
+
+    def get_hidden_size(self) -> int:
+        return getattr(self._language_config(), "hidden_size", 0)
+
+    def get_head_size(self) -> int:
+        head_dim = getattr(self._language_config(), "head_dim", None)
+        if head_dim is not None:
+            return head_dim
+        total_num_attention_heads = self.get_total_num_attention_heads()
+        if total_num_attention_heads == 0:
+            return 0
+        return self.get_hidden_size() // total_num_attention_heads
+
+    def get_total_num_kv_heads(self) -> int:
+        return getattr(
+            self._language_config(),
+            "num_key_value_heads",
+            self.get_total_num_attention_heads(),
+        )
+
+    def derive_max_model_len_and_key(self) -> tuple[float, str | None]:
+        language_config = self._language_config()
+        max_position_embeddings = getattr(
+            language_config,
+            "max_position_embeddings",
+            None,
+        )
+        if max_position_embeddings is None:
+            return super().derive_max_model_len_and_key()
+        return max_position_embeddings, "language_config.max_position_embeddings"
+
+
 # hf_config.model_type -> convertor class
 MODEL_ARCH_CONFIG_CONVERTORS = {
     "cohere_asr": CohereAsrModelArchConfigConvertor,
@@ -566,6 +610,7 @@ MODEL_ARCH_CONFIG_CONVERTORS = {
     "mimo_v2_flash": MimoV2ModelArchConfigConvertor,
     "mimo_v2_mtp": MimoV2MTPModelArchConfigConvertor,
     "mimo_v2_omni_mtp": MimoV2MTPModelArchConfigConvertor,
+    "moss_audio": MossAudioModelArchConfigConvertor,
     "mpt": MPTModelArchConfigConvertor,
     "nemotron-nas": NemotronNasModelArchConfigConvertor,
     "pangu_ultra_moe_mtp": PanguUltraMoeMTPModelArchConfigConvertor,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Closes #43431.

Add MOSS-Audio support and OpenAI-compatible audio chat completion coverage.

Duplicate-work check: `43431 in:body` found this draft PR (#43816). `MOSS-Audio` / `OpenMOSS-Team` keyword checks only found #42009 for MOSS-VL, which is a different scope.

AI assistance was used for this PR.

## Test Plan

```bash
.venv/bin/python -m pytest tests/models/multimodal/processing/test_moss_audio.py -q

export VLLM_ASSETS_CACHE=/tmp/vllm-assets
export HF_ENDPOINT=https://hf-mirror.com
export TMPDIR=/hy-tmp/tmp
export PATH=/root/vllm/.venv/bin:$PATH
.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_moss_audio.py -v -s
```

Also manually smoke-tested four MOSS-Audio models with both `audio_url` and `input_audio`.

E2E audio input:

- Source: existing vLLM public test asset from `vllm/assets/audio.py`
- Asset: `AudioAsset("winning_call")`, resolved by vLLM from `s3://vllm-public-assets`
- File: `multimodal_asset/winning_call.ogg`
- URL: `https://vllm-public-assets.s3.us-west-2.amazonaws.com/multimodal_asset/winning_call.ogg`
- Duration: about 25.4s, sample rate 44100
- Formats tested: `audio_url` data URL and `input_audio` base64 WAV

## Test Result

- `tests/models/multimodal/processing/test_moss_audio.py`: `32 passed, 20 warnings in 82.67s`
- `tests/entrypoints/openai/chat_completion/test_moss_audio.py`: `2 passed, 16 warnings in 86.08s`
- Four-model E2E on A100 40GB passed:
  - `OpenMOSS-Team/MOSS-Audio-4B-Instruct`
  - `OpenMOSS-Team/MOSS-Audio-4B-Thinking`
  - `OpenMOSS-Team/MOSS-Audio-8B-Instruct`
  - `OpenMOSS-Team/MOSS-Audio-8B-Thinking`

All four models loaded successfully and returned non-empty assistant content for both `audio_url` and `input_audio`.

Output samples:

| Model | `audio_url` output | `input_audio` output |
|---|---|---|
| `OpenMOSS-Team/MOSS-Audio-4B-Instruct` | `The audio is a recording of a person speaking in a language that is not English. The person is speaking in a conversational tone, and the recording is of` (`finish_reason=length`) | `The audio is a recording of a person speaking in a language that is not English. The person is speaking in a conversational tone, and the recording is of` (`finish_reason=length`) |
| `OpenMOSS-Team/MOSS-Audio-4B-Thinking` | `<think>\nTo determine what is happening in the audio, I need to listen carefully to the sound clip. The audio consists of a series of short, distinct sounds` (`finish_reason=length`) | `<think>\nTo determine what is happening in the audio, I need to listen carefully to the audio clip. The audio consists of a series of beeps and clicks` (`finish_reason=length`) |
| `OpenMOSS-Team/MOSS-Audio-8B-Instruct` | `A person is speaking in a quiet indoor setting, with a brief pause in their speech.` (`finish_reason=stop`) | `A person is speaking in a quiet indoor setting, with a brief pause in their speech.` (`finish_reason=stop`) |
| `OpenMOSS-Team/MOSS-Audio-8B-Thinking` | `<think>\n**Analyzing the Audio Clip**\n\nOkay, the task is straightforward: I need to identify and describe what's happening in the provided audio clip. My` (`finish_reason=length`) | `<think>\n**Analyzing the Audio Clip**\n\nOkay, the task is straightforward: I need to identify and describe what's happening in the provided audio clip. My` (`finish_reason=length`) |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
