### PR TITLE
fix: record prefix cache stats after allocation

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1562,6 +1562,42 @@ def test_kv_connector_unable_to_allocate(use_ec_connector, ec_role):
     assert len(scheduler.waiting) == 0
 
 
+def test_prefix_cache_stats_skip_failed_allocation():
+    block_size = 4
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        block_size=block_size,
+        num_blocks=2,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=block_size * 2,
+        max_tokens=1,
+        block_size=block_size,
+    )
+    scheduler.add_request(request)
+
+    empty_hits = tuple(
+        () for _ in range(scheduler.kv_cache_manager.num_kv_cache_groups)
+    )
+    scheduler.kv_cache_manager.coordinator.find_longest_cache_hit = Mock(
+        return_value=(empty_hits, block_size)
+    )
+    scheduler.kv_cache_manager.allocate_slots = Mock(return_value=None)
+
+    output = scheduler.schedule()
+
+    assert len(output.num_scheduled_tokens) == 0
+    assert len(scheduler.running) == 0
+    assert len(scheduler.waiting) == 1
+
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert stats.requests == 0
+    assert stats.queries == 0
+    assert stats.hits == 0
+
+
 @pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.parametrize(
     "use_ec_connector, ec_role", [(False, None), (True, "ec_consumer")]

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -223,15 +223,24 @@ class KVCacheManager:
             )
         )
 
-        if self.log_stats:
-            assert self.prefix_cache_stats is not None
-            self.prefix_cache_stats.record(
-                num_tokens=request.num_tokens,
-                num_hits=num_new_computed_tokens,
-                preempted=request.num_preemptions > 0,
-            )
-
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
+
+    def record_prefix_cache_stats(
+        self, request: Request, num_new_computed_tokens: int
+    ) -> None:
+        if (
+            not self.log_stats
+            or not self.enable_caching
+            or request.skip_reading_prefix_cache
+        ):
+            return
+
+        assert self.prefix_cache_stats is not None
+        self.prefix_cache_stats.record(
+            num_tokens=request.num_tokens,
+            num_hits=num_new_computed_tokens,
+            preempted=request.num_preemptions > 0,
+        )
 
     def allocate_slots(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -591,6 +591,7 @@ class Scheduler(SchedulerInterface):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                record_local_prefix_cache_stats = False
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
@@ -598,6 +599,7 @@ class Scheduler(SchedulerInterface):
                     new_computed_blocks, num_new_local_computed_tokens = (
                         self.kv_cache_manager.get_computed_blocks(request)
                     )
+                    record_local_prefix_cache_stats = True
 
                     # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
@@ -744,6 +746,11 @@ class Scheduler(SchedulerInterface):
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
                     break
+
+                if record_local_prefix_cache_stats:
+                    self.kv_cache_manager.record_prefix_cache_stats(
+                        request, num_new_local_computed_tokens
+                    )
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that


### PR DESCRIPTION
﻿## Summary
- move local prefix-cache stat recording until after KV slot allocation succeeds
- avoid counting cache lookups for requests that stay in the waiting queue after allocation failure
- add a scheduler regression test for the failed-allocation path

Fixes #43736.

## Tests
- `python -m py_compile vllm\v1\core\kv_cache_manager.py vllm\v1\core\sched\scheduler.py tests\v1\core\test_scheduler.py`
- `python -m ruff check vllm\v1\core\kv_cache_manager.py vllm\v1\core\sched\scheduler.py tests\v1\core\test_scheduler.py`
- `git diff --check`

## To verify
- `pytest tests/v1/core/test_scheduler.py::test_prefix_cache_stats_skip_failed_allocation -q`

I could not run the targeted pytest locally on Windows because repository-level test loading imports `vllm.LLM`, which needs Linux-only/runtime dependencies in this checkout (`uvloop`, then `llguidance`). The added test is included for CI coverage.
