### PR TITLE
[Feat][rust-vllm] add rust frontend in api_server entrypoint

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -703,6 +703,22 @@ async def run_server_worker(
         sock.close()
 
 
+def run_entrypoint(args: Namespace) -> None:
+    if envs.VLLM_RUST_FRONTEND_PATH:
+        if args.api_server_count is not None and args.api_server_count > 1:
+            logger.warning(
+                "Ignoring --api-server-count=%d when using rust front-end process",
+                args.api_server_count,
+            )
+        args.api_server_count = 1
+        args.model_tag = args.model
+        from vllm.entrypoints.cli.serve import run_multi_api_server
+
+        run_multi_api_server(args)
+    else:
+        uvloop.run(run_server(args))
+
+
 if __name__ == "__main__":
     # NOTE(simon):
     # This section should be in sync with vllm/entrypoints/cli/main.py for CLI
@@ -715,4 +731,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    uvloop.run(run_server(args))
+    run_entrypoint(args)


### PR DESCRIPTION



## Purpose

The logic for enabling the Rust frontend at the `openai.api_server` entry point is currently missing; this PR adds the necessary logic to address this.

## Test Plan

```
$ VLLM_USE_RUST_FRONTEND=1 python -m vllm.entrypoints.openai.api_server --model /new-model/MiniMax-M2.7 --trust-remote-code --tensor-parallel-size 4
....... we can look this log
Launching Rust frontend: /home/jovyan/code/vllm/vllm/vllm-rs frontend --listen-fd 38 --input-address ipc:///tmp/fe65fd80-3b3c-4869-898e-c7b011ecfa54 --output-address ipc:///tmp/b3629d55-2feb-4c31-aae5-2432184a9633 --engine-count 1 --args-json {"model": "/new-model/MiniMax-M2.7", "model_tag": "/new-model/MiniMax-M2.7", "tensor_parallel_size": 4, "trust_remote_code": true}
......
[src/server/src/lib.rs:133] starting OpenAI server bind_address=0.0.0.0:8000 model=/new-model/MiniMax-M2.7
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

