### PR TITLE
Fix: XXE Vulnerability to Avoid Sensitive Local File Leakage

### DIFF
--- a/tests/tool_parsers/test_minicpm5xml_tool_parser.py
+++ b/tests/tool_parsers/test_minicpm5xml_tool_parser.py
@@ -733,3 +733,20 @@ def test_extract_tool_calls_streaming_multiple(parser: ToolParser) -> None:
         "nums": [7, 8, 9],
         "exact": False,
     }
+
+
+def test_xml_external_entity_prevention(parser: ToolParser) -> None:
+    request = make_request(make_tools_weather())
+    text = (
+        '<!DOCTYPE test [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>'
+        '<function name="get_weather">'
+        '<param name="city">&xxe;</param>'
+        '<param name="date">2024-06-27</param>'
+        '</function>\n'
+    )
+    out = parser.extract_tool_calls(text, request)
+    if out.tools_called:
+        args = json.loads(out.tool_calls[0].function.arguments)
+        # Should not resolve external entity.
+        assert args["city"] != "root:x:0:0:root:/root:/bin/bash"
+        assert args["city"] in (None, "", "&xxe;")

--- a/vllm/tool_parsers/minicpm5xml_tool_parser.py
+++ b/vllm/tool_parsers/minicpm5xml_tool_parser.py
@@ -330,9 +330,9 @@ def _parse_function_block(
     try:
         if _HAS_LXML:
             try:
-                parser = ET.XMLParser(**{"strip_cdata": False})  # type: ignore[call-arg]
+                parser = ET.XMLParser(**{"strip_cdata": False}, resolve_entities=False)  # type: ignore[call-arg]
             except TypeError:
-                parser = ET.XMLParser()
+                parser = ET.XMLParser(resolve_entities=False)
             root = ET.fromstring(block, parser=parser)
         else:
             root = ET.fromstring(block)


### PR DESCRIPTION
 
## Purpose

Trigger Scenario
  1. vLLM runs in a production environment where an older version of the  lxml  library ( < 5.0.0 ) is pre-installed.
  2. An attacker sends a chat request with a prompt injection payload.
  3. The prompt manipulates the LLM to generate a tool call XML block containing a custom  <!DOCTYPE>  declaration referencing system-pointing external  entities (e.g.  file:///etc/passwd ).

Observed Behavior
  The tool call parser minicpm5xml_tool_parser.py processes the LLM-generated XML output via  lxml.etree.XMLParser . Because  resolve_entities  is not  configured, it  defaults to  True  under older  lxml  versions. The parser loads the external system resource, reads local files or queries network endpoints, and embeds  the sensitive content into the parameters returned directly to the user in the API response.

Expected Behavior
  The parser must ignore external entities and only parse the tags and literal text nodes. It should not make any local file read operations or external network requests.

Root Cause
The  lxml.etree.XMLParser  instantiations in minicpm5xml_tool_parser.py do not configure  resolve_entities=False . Because  lxml  is not locked to version 5.0.0  or  higher in production dependency setups, the system can run under vulnerable old releases where entity resolution defaults to  True .

Fix
Explicitly configure  resolve_entities=False  for all  lxml.etree.XMLParser  initializations in minicpm5xml_tool_parser.py. Because the parser only extracts tag   names, attributes, and inner texts, it has no functional requirement to resolve XML entities. Disabling entity resolution is entirely safe and introduces  zero functional regression risk. Add security tests in test_minicpm5xml_tool_parser.py to ensure external entities are always bypassed.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

