### PR TITLE
[CI failure] Fix OLMo Hybrid RoPE config handling

### DIFF
--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -7,7 +7,11 @@ only get the `eos_token_id` from the tokenizer as defined by
 """
 
 from vllm.tokenizers import get_tokenizer
-from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.config import (
+    patch_rope_parameters,
+    try_get_generation_config,
+)
+from vllm.transformers_utils.configs.olmo_hybrid import OlmoHybridConfig
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +34,22 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+def test_olmo_hybrid_null_rope_theta_disables_rope():
+    config = OlmoHybridConfig(rope_parameters={"rope_theta": None})
+
+    assert config.rope_parameters is None
+    patch_rope_parameters(config)
+    assert config.rope_parameters is None
+
+
+def test_olmo_hybrid_rope_parameters_default_rope_type():
+    config = OlmoHybridConfig(rope_parameters={"rope_theta": 500000.0})
+
+    assert config.rope_parameters == {
+        "rope_theta": 500000.0,
+        "rope_type": "default",
+    }
+    patch_rope_parameters(config)
+    assert config.rope_parameters["rope_type"] == "default"

--- a/vllm/transformers_utils/configs/olmo_hybrid.py
+++ b/vllm/transformers_utils/configs/olmo_hybrid.py
@@ -1,8 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
+from typing import Any
 
 from transformers.configuration_utils import PretrainedConfig
+
+
+def _normalize_rope_parameters(
+    rope_parameters: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if rope_parameters is None:
+        return None
+
+    rope_parameters = dict(rope_parameters)
+    if set(rope_parameters) == {"rope_theta"} and rope_parameters["rope_theta"] is None:
+        return None
+
+    rope_parameters.setdefault("rope_type", "default")
+    return rope_parameters
 
 
 class OlmoHybridConfig(PretrainedConfig):
@@ -284,7 +298,7 @@ class OlmoHybridConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.attention_bias = attention_bias
         self.attention_dropout = attention_dropout
-        self.rope_parameters = rope_parameters
+        self.rope_parameters = _normalize_rope_parameters(rope_parameters)
 
         self.tie_word_embeddings = tie_word_embeddings
         self.pad_token_id = pad_token_id


### PR DESCRIPTION
## Purpose

Fix a failing CI job that is blocking this PR https://github.com/vllm-project/vllm/pull/43609 from merging:
https://buildkite.com/vllm/ci/builds/68454/canvas?jid=019e6a4d-57da-44a9-bbdc-fe88ecb323d6

The CI failure (`test_can_initialize_large_subset[OlmoHybridForCausalLM]`) is unrelated to the changes in this PR but occurs on the same pipeline.

## Error message

```python
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  Value error, rope_parameters should have a 'rope_type' key
```

 <img width="1589" height="566" alt="image" src="https://github.com/user-attachments/assets/56536441-14bb-45ee-b770-6bbdfc796844" />

## Root Cause

The `allenai/OlmoHybrid` HuggingFace config contains a `rope_parameters` dict that lacks the required `rope_type` key (e.g. `{"rope_theta": None}`). `OlmoHybridConfig.__init__` stored this value as-is without normalization,
so the raw dict propagated to vLLM's `ModelConfig` pydantic validator, which requires `rope_parameters` to either be `None` or contain a `rope_type` key — causing a `ValidationError` at engine initialization.


## Proposed Fix

Add `_normalize_rope_parameters()` in `OlmoHybridConfig.__init__` to sanitize `rope_parameters` at config load time before it reaches `ModelConfig` validation:

- `{"rope_theta": None}` (and only that key) → `None` (null theta signals RoPE is disabled)
- Any other non-`None` dict missing `rope_type` → inject `"rope_type": "default"`
- `None` → `None` (no-op)

This ensures `rope_parameters` always satisfies vLLM's invariant (`None` or a dict with `rope_type`) by the time `ModelConfig` is constructed.


## Test Plan

```python
python -m pytest \
  tests/models/test_initialization.py::test_can_initialize_large_subset[OlmoHybridForCausalLM] \
  -v -s
```


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

