### PR TITLE
[Bugfix][V1][Spec Decode] Don't mutate M-RoPE state from draft-path _gather_mm_embeddings (#43820)

### DIFF
--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -733,6 +733,85 @@ def test_set_inputs_first_pass_parallel_drafting():
             )
 
 
+def test_gather_mm_embeddings_for_drafter_does_not_mutate_mrope_state():
+    """
+    Issue #43820: when the spec-decode draft path calls
+    `_gather_mm_embeddings` with `shift_computed_tokens=1`, the pruning +
+    M-RoPE branch must not mutate any per-request or runner-wide M-RoPE
+    state.
+
+    `propose_draft_token_ids` captures `target_positions` as a view into
+    `self.mrope_positions.gpu` before this call. Without the `for_drafter`
+    guard, the pruning branch would:
+      - overwrite `req_state.mrope_positions`,
+      - reassign `req_state.mrope_position_delta`,
+      - run `_calc_mrope_positions` + `self.mrope_positions.copy_to_gpu`,
+    which mutates the buffer `target_positions` views and corrupts the
+    drafter's positions input.
+
+    This test calls the real method with a mock runner, asserts that none
+    of the mutation paths run, and verifies that the recompute is invoked
+    with the *shifted* `num_computed_tokens` (so the embedding window and
+    the recompute boundary agree).
+    """
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    num_computed_tokens = 10
+    shift = 1
+    num_scheduled_tokens = 4
+
+    req_state = mock.MagicMock()
+    req_state.num_computed_tokens = num_computed_tokens
+    req_state.mm_features = []  # skip inner mm-gather loop; pruning branch still runs
+    req_state.mrope_positions = torch.tensor([[0, 1, 2, 3]] * 3, dtype=torch.long)
+    req_state.mrope_position_delta = -5
+    req_state.prompt_token_ids = [1, 2, 3, 4]
+
+    initial_mrope_positions = req_state.mrope_positions.clone()
+    initial_mrope_position_delta = req_state.mrope_position_delta
+
+    runner = mock.MagicMock()
+    runner.is_multimodal_pruning_enabled = True
+    runner.uses_mrope = True
+    runner.requests = {"req_A": req_state}
+    runner.input_batch.req_ids = ["req_A"]
+
+    # Distinct values so any mutation would be detectable.
+    new_mrope_positions = torch.full((3, num_scheduled_tokens), 99, dtype=torch.long)
+    new_delta = -42
+    runner.model.recompute_mrope_positions.return_value = (
+        [],  # cleaned mm_embeds (empty since mm_features=[])
+        new_mrope_positions,
+        new_delta,
+    )
+
+    scheduler_output = mock.MagicMock()
+    scheduler_output.num_scheduled_tokens = {"req_A": num_scheduled_tokens}
+    scheduler_output.total_num_scheduled_tokens = num_scheduled_tokens
+
+    GPUModelRunner._gather_mm_embeddings(
+        runner,
+        scheduler_output,
+        shift_computed_tokens=shift,
+        for_drafter=True,
+    )
+
+    # No per-request mutation.
+    assert torch.equal(req_state.mrope_positions, initial_mrope_positions)
+    assert req_state.mrope_position_delta == initial_mrope_position_delta
+
+    # No runner-wide mutation.
+    runner._calc_mrope_positions.assert_not_called()
+    runner.mrope_positions.copy_to_gpu.assert_not_called()
+
+    # The recompute itself MUST run (it strips position channels from mm_embeds).
+    runner.model.recompute_mrope_positions.assert_called_once()
+    kwargs = runner.model.recompute_mrope_positions.call_args.kwargs
+    # And it must use the *shifted* num_computed_tokens so the embedding
+    # window and the recompute boundary line up.
+    assert kwargs["num_computed_tokens"] == num_computed_tokens + shift
+
+
 @pytest.mark.parametrize("method", ["eagle", "eagle3"])
 @pytest.mark.parametrize("attn_backend", get_attn_backend_list_based_on_platform())
 @pytest.mark.parametrize("pp_size", [1, 2])

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3072,7 +3072,14 @@ class GPUModelRunner(
         self,
         scheduler_output: "SchedulerOutput",
         shift_computed_tokens: int = 0,
+        for_drafter: bool = False,
     ) -> tuple[list[torch.Tensor], torch.Tensor]:
+        # `for_drafter=True` is set when the draft path calls this with a
+        # non-zero `shift_computed_tokens`. In that mode we must NOT mutate
+        # `req_state.mrope_positions`, `req_state.mrope_position_delta`, or
+        # the shared `self.mrope_positions` GPU buffer — `target_positions`
+        # in `propose_draft_token_ids` is a view into that buffer, and the
+        # main forward pass already wrote the authoritative values into it.
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
 
         mm_embeds = list[torch.Tensor]()
@@ -3146,17 +3153,24 @@ class GPUModelRunner(
 
             if self.is_multimodal_pruning_enabled and self.uses_mrope:
                 assert req_state.mrope_positions is not None
-                should_sync_mrope_positions = True
+                # We still need to call `recompute_mrope_positions` in the
+                # draft path because it strips position channels from
+                # `mm_embeds_req`. The returned positions/delta are discarded
+                # when `for_drafter=True`.
                 mm_embeds_req, new_mrope_positions, new_delta = (
                     self.model.recompute_mrope_positions(
                         input_ids=req_state.prompt_token_ids,
                         multimodal_embeddings=mm_embeds_req,
                         mrope_positions=req_state.mrope_positions,
-                        num_computed_tokens=req_state.num_computed_tokens,
+                        num_computed_tokens=num_computed_tokens
+                        if for_drafter
+                        else req_state.num_computed_tokens,
                     )
                 )
-                req_state.mrope_positions.copy_(new_mrope_positions)
-                req_state.mrope_position_delta = new_delta
+                if not for_drafter:
+                    should_sync_mrope_positions = True
+                    req_state.mrope_positions.copy_(new_mrope_positions)
+                    req_state.mrope_position_delta = new_delta
 
             mm_embeds.extend(mm_embeds_req)
             req_start_idx += num_scheduled_tokens
@@ -4990,9 +5004,15 @@ class GPUModelRunner(
                         target_hidden_states = hidden_states[:total_num_tokens]
 
             if self.supports_mm_inputs and self.drafter.supports_mm_inputs:
+                # `for_drafter=True` keeps this call read-only with respect to
+                # per-request and runner-wide mrope state. Without it, the
+                # pruning branch would overwrite the `self.mrope_positions`
+                # GPU buffer that `target_positions` views, corrupting the
+                # drafter's positions input. See issue #43820.
                 mm_embed_inputs = self._gather_mm_embeddings(
                     scheduler_output,
                     shift_computed_tokens=1,
+                    for_drafter=True,
                 )
             else:
                 mm_embed_inputs = None


### PR DESCRIPTION
## Summary

Fixes #43820 — speculative decoding with multimodal pruning + M-RoPE produced output that diverged from the non-speculative reference. Root cause: the draft path's `_gather_mm_embeddings(scheduler_output, shift_computed_tokens=1)` call ran the multimodal-pruning + M-RoPE mutation sequence (`req_state.mrope_positions.copy_(...)`, reassigning `req_state.mrope_position_delta`, then `_calc_mrope_positions` + `self.mrope_positions.copy_to_gpu(...)`). The last two overwrote the very GPU buffer that `target_positions` in `propose_draft_token_ids` is a view into, so by the time `drafter.propose(target_positions=...)` ran, positions for multimodal rows no longer matched the shifted embedding window the gather had just produced. The recompute also took the unshifted `req_state.num_computed_tokens`, so the embedding overlap window and the recompute boundary disagreed by one token even before the in-place mutation hit.

Fix is a `for_drafter: bool` flag on `_gather_mm_embeddings`:

- The draft path still calls `recompute_mrope_positions` (required to strip position channels from `mm_embeds_req`) but discards the returned positions / delta. `req_state.mrope_positions`, `req_state.mrope_position_delta`, and the shared `self.mrope_positions` GPU buffer are all left untouched.
- In `for_drafter=True` mode the recompute also takes the *shifted* `num_computed_tokens`, so its boundary matches the embedding window the same call just chose.
- The main forward pass (`shift_computed_tokens=0`, `for_drafter=False`) is unchanged.

## Relation to #42349

@eppaneamd's #42349 addresses a separate layer of the same MRoPE + EAGLE + multimodal-pruning interaction — decode-step position arithmetic in the proposer (`delta + context_len` written to all 3 M-RoPE dims, instead of dim-0 replication). It introduces a per-request delta buffer (`_mrope_deltas_cpu` / `_mrope_deltas_dirty`) updated by `_gather_mm_embeddings` on pruning events.

The two PRs are independent and compose cleanly. When #42349 lands, whoever rebases second should extend the `for_drafter` guard added here to also skip the two writes #42349 introduces to that buffer (one-line addition for each). I tried bundling them and it was a mess — this version ships against current main on its own.

## Why this isn't a duplicate

Per AGENTS.md duplicate-work checks:

```
gh issue view 43820 --repo vllm-project/vllm --comments  # no other PRs linked
gh pr list --repo vllm-project/vllm --state open --search "43820 in:body"  # empty
gh pr list --repo vllm-project/vllm --state open --search "mrope speculative multimodal pruning"  # only #42349, different layer
gh pr list --repo vllm-project/vllm --state open --search "shift_computed_tokens"  # empty
```

## Test plan

- [x] `pre-commit run --files vllm/v1/worker/gpu_model_runner.py tests/v1/spec_decode/test_eagle.py` — all hooks pass.
- [x] New unit test `test_gather_mm_embeddings_for_drafter_does_not_mutate_mrope_state` passes via stubbed import on macOS / CPU. (`test_eagle.py` cannot collect natively on macOS because `get_attn_backend_list_based_on_platform()` raises at module import — a pre-existing constraint that affects every test in the file. CI runs it natively.)
- [ ] End-to-end Qwen3-VL spec-decode + pruning verification (the issue's three-label harness: `no_spec_prune` vs `spec_no_prune` vs `spec_prune_current`) — requires a CUDA host with `Qwen/Qwen3-VL-4B-Instruct` + `AngelSlim/Qwen3-VL-4B-Instruct_eagle3`. Left for CI / reviewers.

## AI assistance

Claude was used to draft this change. I personally reviewed every changed line and ran the commands above.
