### PR TITLE
[KDA] Add FlashKDA prefill backend

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -713,6 +713,7 @@ class EngineArgs:
 
     fail_on_environ_validation: bool = False
     gdn_prefill_backend: Literal["flashinfer", "triton", "cutedsl"] | None = None
+    kda_prefill_backend: Literal["triton", "flashkda"] | None = None
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -1536,6 +1537,13 @@ class EngineArgs:
             default=None,
             help="Select GDN prefill backend.",
         )
+        parser.add_argument(
+            "--kda-prefill-backend",
+            dest="kda_prefill_backend",
+            choices=["triton", "flashkda"],
+            default=None,
+            help="Select KDA prefill backend.",
+        )
         return parser
 
     @classmethod
@@ -2225,6 +2233,8 @@ class EngineArgs:
 
         if self.gdn_prefill_backend is not None:
             self.additional_config["gdn_prefill_backend"] = self.gdn_prefill_backend
+        if self.kda_prefill_backend is not None:
+            self.additional_config["kda_prefill_backend"] = self.kda_prefill_backend
 
         config = VllmConfig(
             model_config=model_config,

--- a/vllm/model_executor/layers/fla/ops/kda.py
+++ b/vllm/model_executor/layers/fla/ops/kda.py
@@ -1273,12 +1273,19 @@ def chunk_kda(
     ],
     key=["H", "D"],
 )
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["g_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
 @triton.jit
 def kda_gate_fwd_kernel(
     g,
     A,
     y,
     g_bias,
+    lower_bound,
     beta: tl.constexpr,
     threshold: tl.constexpr,
     T,
@@ -1287,12 +1294,13 @@ def kda_gate_fwd_kernel(
     BT: tl.constexpr,
     BD: tl.constexpr,
     HAS_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
 ):
     i_t, i_h = tl.program_id(0), tl.program_id(1)
     n_t = i_t * BT
 
     b_a = tl.load(A + i_h).to(tl.float32)
-    b_a = -tl.exp(b_a)
+    b_a = tl.exp(b_a)
 
     stride_row = H * D
     stride_col = 1
@@ -1325,13 +1333,16 @@ def kda_gate_fwd_kernel(
         )
         b_g = b_g + b_bias[None, :]
 
-    # softplus(x, beta) = (1/beta) * log(1 + exp(beta * x))
-    # When beta * x > threshold, use linear approximation x
-    # Use threshold to switch to linear when beta*x > threshold
-    g_scaled = b_g * beta
-    use_linear = g_scaled > threshold
-    sp = tl.where(use_linear, b_g, (1.0 / beta) * log(1.0 + tl.exp(g_scaled)))
-    b_y = b_a * sp
+    if USE_LOWER_BOUND:
+        b_y = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        # softplus(x, beta) = (1/beta) * log(1 + exp(beta * x))
+        # When beta * x > threshold, use linear approximation x
+        # Use threshold to switch to linear when beta*x > threshold
+        g_scaled = b_g * beta
+        use_linear = g_scaled > threshold
+        sp = tl.where(use_linear, b_g, (1.0 / beta) * log(1.0 + tl.exp(g_scaled)))
+        b_y = -b_a * sp
 
     tl.store(y_ptr, b_y.to(y.dtype.element_ty), boundary_check=(0, 1))
 
@@ -1343,13 +1354,22 @@ def fused_kda_gate(
     g_bias: torch.Tensor | None = None,
     beta: float = 1.0,
     threshold: float = 20.0,
+    lower_bound: float | None = None,
 ) -> torch.Tensor:
     """
-    Forward pass for KDA gate:
+    Forward pass for KDA gate.
+
+    If lower_bound is present:
+        g = lower_bound * sigmoid(exp(A) * (g + g_bias))
+    else:
+        g = -exp(A) * softplus(g + g_bias, beta)
+
+    Arguments:
       input g: [..., H*D]
       param A: [H] or [1, 1, H, 1]
       beta: softplus beta parameter
       threshold: softplus threshold parameter
+      lower_bound: optional lower_bound parameter
       return  : [..., H, D]
     """
     orig_shape = g.shape[:-1]
@@ -1370,13 +1390,13 @@ def fused_kda_gate(
         A,
         y,
         g_bias,
+        lower_bound,
         beta,
         threshold,
         T,
         H,
         head_k_dim,
         BD=next_power_of_2(head_k_dim),
-        HAS_BIAS=g_bias is not None,
     )
 
     y = y.view(*orig_shape, H, head_k_dim)

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -41,7 +41,9 @@ from ..ops.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 logger = init_logger(__name__)
 
 
-def resolve_kda_prefill_backend(backend: str, head_dim: int) -> str:
+def resolve_kda_prefill_backend(
+    backend: str, head_dim: int, lower_bound: float | None
+) -> str:
     if backend == "flashkda":
         is_installed = importlib.util.find_spec("flash_kda") is not None
         capability = current_platform.get_device_capability()
@@ -50,21 +52,27 @@ def resolve_kda_prefill_backend(backend: str, head_dim: int) -> str:
         )
         is_cuda = current_platform.is_cuda()
         platform_supported = is_cuda and current_platform.has_device_capability(90)
-        head_dim_supported = head_dim == 128
 
-        if is_installed and platform_supported and head_dim_supported:
+        if (
+            is_installed
+            and platform_supported
+            and head_dim == 128
+            and lower_bound is not None
+        ):
             logger.info_once("Using FlashKDA KDA prefill backend.")
             return "flashkda"
 
         logger.warning_once(
             "KDA prefill backend 'flashkda' requires flash_kda installed, "
-            "CUDA >=SM90, and head_dim=128. Current state: "
+            "CUDA >=SM90, head_dim=128, and lower_bound set. Current state: "
             "flash_kda_installed=%s, is_cuda=%s, capability=%s, head_dim=%d. "
+            "lower_bound=%s. "
             "Falling back to Triton/FLA.",
             is_installed,
             is_cuda,
             capability_str,
             head_dim,
+            lower_bound,
         )
 
     return "triton"
@@ -122,10 +130,12 @@ class KimiKdaPrefill(CustomOp):
             if isinstance(additional_config, dict)
             else "auto"
         )
-        active_backend = resolve_kda_prefill_backend(backend, head_dim)
-        self.kda_prefill_backend = active_backend
         self.head_dim = head_dim
         self.lower_bound = lower_bound
+        active_backend = resolve_kda_prefill_backend(
+            backend, head_dim, self.lower_bound
+        )
+        self.kda_prefill_backend = active_backend
 
         if active_backend == "flashkda":
             self._forward_method = self.forward_flashkda

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -1,20 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib.util
+
 import torch
 from einops import rearrange
 from torch import nn
 
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.distributed import (
-    divide,
-)
+from vllm.distributed import divide
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
 from vllm.model_executor.model_loader.weight_utils import sharded_weight_loader
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
@@ -38,6 +39,37 @@ from ..mamba_utils import (
 from ..ops.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
 logger = init_logger(__name__)
+
+FLASHKDA_LOWER_BOUND = -5.0
+
+
+def resolve_kda_prefill_backend(backend: str, head_dim: int) -> str:
+    if backend == "flashkda":
+        is_installed = importlib.util.find_spec("flash_kda") is not None
+        capability = current_platform.get_device_capability()
+        capability_str = (
+            capability.as_version_str() if capability is not None else "unavailable"
+        )
+        is_cuda = current_platform.is_cuda()
+        platform_supported = is_cuda and current_platform.has_device_capability(90)
+        head_dim_supported = head_dim == 128
+
+        if is_installed and platform_supported and head_dim_supported:
+            logger.info_once("Using FlashKDA KDA prefill backend.")
+            return "flashkda"
+
+        logger.warning_once(
+            "KDA prefill backend 'flashkda' requires flash_kda installed, "
+            "CUDA >=SM90, and head_dim=128. Current state: "
+            "flash_kda_installed=%s, is_cuda=%s, capability=%s, head_dim=%d. "
+            "Falling back to Triton/FLA.",
+            is_installed,
+            is_cuda,
+            capability_str,
+            head_dim,
+        )
+
+    return "triton"
 
 
 def kda_attention(
@@ -225,6 +257,13 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefix=f"{prefix}.o_proj",
         )
 
+        additional_config = vllm_config.additional_config
+        assert isinstance(additional_config, dict)
+        prefill_backend = additional_config.get("kda_prefill_backend", "auto")
+        self.prefill_backend = resolve_kda_prefill_backend(
+            prefill_backend, self.head_dim
+        )
+
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -241,11 +280,15 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         k = self.k_proj(hidden_states)[0]
         v = self.v_proj(hidden_states)[0]
 
-        beta = self.b_proj(hidden_states)[0].float().sigmoid()
+        beta = self.b_proj(hidden_states)[0]
         g1 = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
-        g1 = fused_kda_gate(g1, self.A_log, self.head_dim, g_bias=self.dt_bias)
-        beta = beta.unsqueeze(0)
-        g1 = g1.unsqueeze(0)
+        if self.prefill_backend == "flashkda":
+            beta = beta.to(hidden_states.dtype).unsqueeze(0)
+            g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
+        else:
+            beta = beta.float().sigmoid().unsqueeze(0)
+            g1 = fused_kda_gate(g1, self.A_log, self.head_dim, g_bias=self.dt_bias)
+            g1 = g1.unsqueeze(0)
 
         g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
         g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
@@ -298,8 +341,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         q_proj_states = q_proj_states[:num_actual_tokens]
         k_proj_states = k_proj_states[:num_actual_tokens]
         v_proj_states = v_proj_states[:num_actual_tokens]
-        g1 = g1[:num_actual_tokens]
-        beta = beta[:num_actual_tokens]
+        g1 = g1[:, :num_actual_tokens]
+        beta = beta[:, :num_actual_tokens]
 
         (conv_state_q, conv_state_k, conv_state_v, recurrent_state) = constant_caches
         # conv_state must be (..., dim, width-1) for the conv kernels.
@@ -398,24 +441,50 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             zero_idx = non_spec_state_indices_tensor[~has_initial_state]
             recurrent_state[zero_idx] = 0
             initial_state = recurrent_state[non_spec_state_indices_tensor].contiguous()
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = chunk_kda(
-                q=q,
-                k=k,
-                v=v,
-                g=g1,
-                beta=beta,
-                initial_state=initial_state,
-                output_final_state=True,
-                use_qk_l2norm_in_kernel=True,
-                cu_seqlens=non_spec_query_start_loc,
-            )
+            if self.prefill_backend == "flashkda":
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = self._flashkda_forward(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g=g1,
+                    beta=beta,
+                    initial_state=initial_state,
+                    cu_seqlens=non_spec_query_start_loc,
+                )
+            else:
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = chunk_kda(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g=g1,
+                    beta=beta,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    use_qk_l2norm_in_kernel=True,
+                    cu_seqlens=non_spec_query_start_loc,
+                )
             # Init cache
             recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state
         else:
             assert non_spec_query_start_loc is not None
+            assert non_spec_state_indices_tensor is not None
+            cu_seqlens = non_spec_query_start_loc[
+                : attn_metadata_narrowed.num_decodes + 1
+            ]
+            if self.prefill_backend == "flashkda":
+                beta = beta.float().sigmoid()
+                g1 = fused_kda_gate(
+                    rearrange(g1, "1 n h d -> n (h d)"),
+                    self.A_log,
+                    self.head_dim,
+                    g_bias=self.dt_bias,
+                ).unsqueeze(0)
             (
                 core_attn_out_non_spec,
                 last_recurrent_state,
@@ -427,11 +496,40 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 beta=beta,
                 initial_state=recurrent_state,
                 use_qk_l2norm_in_kernel=True,
-                cu_seqlens=non_spec_query_start_loc[
-                    : attn_metadata_narrowed.num_decodes + 1
-                ],
+                cu_seqlens=cu_seqlens,
                 ssm_state_indices=non_spec_state_indices_tensor,
             )
         core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
             0, :num_actual_tokens
         ]
+
+    def _flashkda_forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        import flash_kda
+
+        final_state = torch.empty_like(initial_state)
+        out = torch.empty_like(v)
+        flash_kda.fwd(
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            g.contiguous(),
+            beta.contiguous(),
+            self.head_dim**-0.5,
+            out,
+            self.A_log.reshape(-1).contiguous(),
+            self.dt_bias.view(self.local_num_heads, self.head_dim).contiguous(),
+            FLASHKDA_LOWER_BOUND,
+            initial_state=initial_state.contiguous(),
+            final_state=final_state,
+            cu_seqlens=cu_seqlens,
+        )
+        return out, final_state

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -40,8 +40,6 @@ from ..ops.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
 logger = init_logger(__name__)
 
-FLASHKDA_LOWER_BOUND = -5.0
-
 
 def resolve_kda_prefill_backend(backend: str, head_dim: int) -> str:
     if backend == "flashkda":
@@ -115,7 +113,7 @@ direct_register_custom_op(
 
 @CustomOp.register("kimi_kda_prefill")
 class KimiKdaPrefill(CustomOp):
-    def __init__(self, head_dim: int) -> None:
+    def __init__(self, head_dim: int, lower_bound: float | None) -> None:
         super().__init__()
         vllm_config = get_current_vllm_config()
         additional_config = vllm_config.additional_config
@@ -127,6 +125,7 @@ class KimiKdaPrefill(CustomOp):
         active_backend = resolve_kda_prefill_backend(backend, head_dim)
         self.kda_prefill_backend = active_backend
         self.head_dim = head_dim
+        self.lower_bound = lower_bound
 
         if active_backend == "flashkda":
             self._forward_method = self.forward_flashkda
@@ -150,6 +149,7 @@ class KimiKdaPrefill(CustomOp):
             A_log,
             self.head_dim,
             g_bias=dt_bias,
+            lower_bound=self.lower_bound,
         ).unsqueeze(0)
         beta = beta.float().sigmoid()
         return chunk_kda(
@@ -194,7 +194,7 @@ class KimiKdaPrefill(CustomOp):
             out,
             A_log.reshape(-1),
             dt_bias.view(-1, self.head_dim),
-            FLASHKDA_LOWER_BOUND,
+            self.lower_bound,
             initial_state=initial_state,
             final_state=final_state,
             cu_seqlens=cu_seqlens,
@@ -346,7 +346,10 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefix=f"{prefix}.o_proj",
         )
 
-        self.kda_prefill = KimiKdaPrefill(head_dim=self.head_dim)
+        self.lower_bound = kda_config.get("lower_bound", None)
+        self.kda_prefill = KimiKdaPrefill(
+            head_dim=self.head_dim, lower_bound=self.lower_bound
+        )
 
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -547,6 +550,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.A_log,
                 self.head_dim,
                 g_bias=self.dt_bias,
+                lower_bound=self.lower_bound,
             ).unsqueeze(0)
             (
                 core_attn_out_non_spec,

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -180,6 +180,10 @@ class KimiKdaPrefill(CustomOp):
 
         final_state = torch.empty_like(initial_state)
         out = torch.empty_like(v)
+
+        # TODO: support int32 cu_seqlens in FlashKDA
+        if cu_seqlens is not None:
+            cu_seqlens = cu_seqlens.to(torch.int64)
         flash_kda.fwd(
             q,
             k,

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -11,7 +11,7 @@ from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import divide
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.custom_op import CustomOp, PluggableLayer
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
 from vllm.model_executor.model_loader.weight_utils import sharded_weight_loader
 from vllm.model_executor.utils import set_weight_attrs
@@ -111,6 +111,91 @@ direct_register_custom_op(
     mutates_args=["core_attn_out"],
     fake_impl=kda_attention_fake,
 )
+
+
+@CustomOp.register("kimi_kda_prefill")
+class KimiKdaPrefill(CustomOp):
+    def __init__(self, head_dim: int) -> None:
+        super().__init__()
+        vllm_config = get_current_vllm_config()
+        additional_config = vllm_config.additional_config
+        backend = (
+            additional_config.get("kda_prefill_backend", "auto")
+            if isinstance(additional_config, dict)
+            else "auto"
+        )
+        active_backend = resolve_kda_prefill_backend(backend, head_dim)
+        self.kda_prefill_backend = active_backend
+        self.head_dim = head_dim
+
+        if active_backend == "flashkda":
+            self._forward_method = self.forward_flashkda
+        else:
+            self._forward_method = self.forward_native
+
+    def forward_native(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        g = fused_kda_gate(
+            rearrange(g, "1 n h d -> n (h d)"),
+            A_log,
+            self.head_dim,
+            g_bias=dt_bias,
+        ).unsqueeze(0)
+        beta = beta.float().sigmoid()
+        return chunk_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=initial_state,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seqlens,
+        )
+
+    def forward_flashkda(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        import flash_kda
+
+        final_state = torch.empty_like(initial_state)
+        out = torch.empty_like(v)
+        flash_kda.fwd(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            self.head_dim**-0.5,
+            out,
+            A_log.reshape(-1),
+            dt_bias.view(-1, self.head_dim),
+            FLASHKDA_LOWER_BOUND,
+            initial_state=initial_state,
+            final_state=final_state,
+            cu_seqlens=cu_seqlens,
+        )
+        return out, final_state
 
 
 @PluggableLayer.register("kimi_gated_delta_net_attention")
@@ -257,12 +342,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefix=f"{prefix}.o_proj",
         )
 
-        additional_config = vllm_config.additional_config
-        assert isinstance(additional_config, dict)
-        prefill_backend = additional_config.get("kda_prefill_backend", "auto")
-        self.prefill_backend = resolve_kda_prefill_backend(
-            prefill_backend, self.head_dim
-        )
+        self.kda_prefill = KimiKdaPrefill(head_dim=self.head_dim)
 
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -280,15 +360,9 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         k = self.k_proj(hidden_states)[0]
         v = self.v_proj(hidden_states)[0]
 
-        beta = self.b_proj(hidden_states)[0]
+        beta = self.b_proj(hidden_states)[0].to(hidden_states.dtype).unsqueeze(0)
         g1 = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
-        if self.prefill_backend == "flashkda":
-            beta = beta.to(hidden_states.dtype).unsqueeze(0)
-            g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
-        else:
-            beta = beta.float().sigmoid().unsqueeze(0)
-            g1 = fused_kda_gate(g1, self.A_log, self.head_dim, g_bias=self.dt_bias)
-            g1 = g1.unsqueeze(0)
+        g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
 
         g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
         g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
@@ -441,34 +515,20 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             zero_idx = non_spec_state_indices_tensor[~has_initial_state]
             recurrent_state[zero_idx] = 0
             initial_state = recurrent_state[non_spec_state_indices_tensor].contiguous()
-            if self.prefill_backend == "flashkda":
-                (
-                    core_attn_out_non_spec,
-                    last_recurrent_state,
-                ) = self._flashkda_forward(
-                    q=q,
-                    k=k,
-                    v=v,
-                    g=g1,
-                    beta=beta,
-                    initial_state=initial_state,
-                    cu_seqlens=non_spec_query_start_loc,
-                )
-            else:
-                (
-                    core_attn_out_non_spec,
-                    last_recurrent_state,
-                ) = chunk_kda(
-                    q=q,
-                    k=k,
-                    v=v,
-                    g=g1,
-                    beta=beta,
-                    initial_state=initial_state,
-                    output_final_state=True,
-                    use_qk_l2norm_in_kernel=True,
-                    cu_seqlens=non_spec_query_start_loc,
-                )
+            (
+                core_attn_out_non_spec,
+                last_recurrent_state,
+            ) = self.kda_prefill(
+                q=q,
+                k=k,
+                v=v,
+                g=g1,
+                beta=beta,
+                initial_state=initial_state,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                cu_seqlens=non_spec_query_start_loc,
+            )
             # Init cache
             recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state
         else:
@@ -477,14 +537,13 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             cu_seqlens = non_spec_query_start_loc[
                 : attn_metadata_narrowed.num_decodes + 1
             ]
-            if self.prefill_backend == "flashkda":
-                beta = beta.float().sigmoid()
-                g1 = fused_kda_gate(
-                    rearrange(g1, "1 n h d -> n (h d)"),
-                    self.A_log,
-                    self.head_dim,
-                    g_bias=self.dt_bias,
-                ).unsqueeze(0)
+            beta = beta.float().sigmoid()
+            g1 = fused_kda_gate(
+                rearrange(g1, "1 n h d -> n (h d)"),
+                self.A_log,
+                self.head_dim,
+                g_bias=self.dt_bias,
+            ).unsqueeze(0)
             (
                 core_attn_out_non_spec,
                 last_recurrent_state,
@@ -502,34 +561,3 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
             0, :num_actual_tokens
         ]
-
-    def _flashkda_forward(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        g: torch.Tensor,
-        beta: torch.Tensor,
-        initial_state: torch.Tensor,
-        cu_seqlens: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        import flash_kda
-
-        final_state = torch.empty_like(initial_state)
-        out = torch.empty_like(v)
-        flash_kda.fwd(
-            q.contiguous(),
-            k.contiguous(),
-            v.contiguous(),
-            g.contiguous(),
-            beta.contiguous(),
-            self.head_dim**-0.5,
-            out,
-            self.A_log.reshape(-1).contiguous(),
-            self.dt_bias.view(self.local_num_heads, self.head_dim).contiguous(),
-            FLASHKDA_LOWER_BOUND,
-            initial_state=initial_state.contiguous(),
-            final_state=final_state,
-            cu_seqlens=cu_seqlens,
-        )
-        return out, final_state


### PR DESCRIPTION


## Purpose

This PR adds FlashKDA as an alternative KDA prefill backend. Unfortunately, FlashKDA uses the new gate equation which is not compatible with `moonshotai/Kimi-Linear-48B-A3B-Instruct`

Old gate equation (no `lower_bound`)

```
g = -exp(A_log) * softplus(a + dt_bias)
```

New gate equation (with `lower_bound`, currently used in FlashKDA)

```
g = lower_bound * sigmoid(exp(A_log) * (a + dt_bias))
```

I attempted to add the old gate equation in FlashKDA (https://github.com/MoonshotAI/FlashKDA/pull/7), but e2e testing with Kimi-Linear reveals that this does not work: FlashKDA materializes `exp(-g_cu)`, which will explode to inf without `lower_bound`. The current in-tree Triton/FLA kernel uses a slightly different formulation to avoid inf.

Hence, this PR acts as a proof-of-concept for FlashKDA integration, and show preliminary speedup results.

`moonshotai/Kimi-Linear-48B-A3B-Instruct` on 1xGB200. 8k-1k 256 concurrency

Backend | TPGS | TTFT | TPOT
---|---|---|---
Triton | 35776 tok/s | 6.90 s | 53.99 ms
FlashKDA | 39961 tok/s (+11.7%) | 5.75 s (-16.7%) | 48.21 ms (-10.7%)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

