### PR TITLE
fix: skip missing MultiConnector Prometheus metrics

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from prometheus_client import Counter, Gauge, Histogram
 import torch
 
 from tests.v1.kv_connector.unit.utils import create_vllm_config
@@ -20,7 +21,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     SupportsHMA,
     supports_hma,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
     MultiConnector,
     MultiKVConnectorStats,
@@ -65,6 +69,14 @@ class MockConnector(KVConnectorBase_V1):
         cls, data: dict[str, Any] | None = None
     ) -> KVConnectorStats | None:
         return MockConnectorStats(data=data) if data is not None else None
+
+    @classmethod
+    def build_prom_metrics(
+        cls, vllm_config, metric_types, labelnames, per_engine_labelvalues
+    ) -> KVConnectorPromMetrics | None:
+        return MockConnectorPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
 
     def start_load_kv(self, forward_context, **kwargs):
         pass
@@ -118,6 +130,19 @@ class MockHMAConnector(KVConnectorBase_V1, SupportsHMA):
 
     def request_finished_all_groups(self, request, block_ids):
         return (False, None)
+
+
+class MockConnectorPromMetrics(KVConnectorPromMetrics):
+    def __init__(
+        self, vllm_config, metric_types, labelnames, per_engine_labelvalues
+    ):
+        super().__init__(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
+        self.observations: list[tuple[dict[str, Any], int]] = []
+
+    def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        self.observations.append((transfer_stats_data, engine_idx))
 
 
 # Register mock connectors
@@ -807,6 +832,48 @@ class TestMultiConnectorStats:
         # One non-empty
         stats.data["NixlConnector"].data["transfer_duration"].append(1.0)
         assert not stats.is_empty()
+
+
+class TestMultiConnectorPromMetrics:
+    def test_observe_ignores_connectors_without_prom_metrics(self):
+        vllm_config = create_vllm_config()
+        vllm_config.kv_transfer_config = KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "MockConnector",
+                        "kv_role": "kv_both",
+                        "kv_connector_module_path": "tests.v1.kv_connector.unit.test_multi_connector",
+                    },
+                    {
+                        "kv_connector": "MooncakeConnector",
+                        "kv_role": "kv_both",
+                    },
+                ]
+            },
+        )
+
+        prom_metrics = MultiConnector.build_prom_metrics(
+            vllm_config,
+            metric_types={Gauge: Gauge, Counter: Counter, Histogram: Histogram},
+            labelnames=[],
+            per_engine_labelvalues={0: []},
+        )
+
+        assert prom_metrics is not None
+        prom_metrics.observe(
+            {
+                "MockConnector": {"data": {"mock_field": [1, 2, 3]}},
+                "MooncakeConnector": {"data": {"ignored_field": [4, 5, 6]}},
+            },
+            engine_idx=7,
+        )
+
+        mock_prom_metrics = prom_metrics._prom_metrics["MockConnector"]
+        assert isinstance(mock_prom_metrics, MockConnectorPromMetrics)
+        assert mock_prom_metrics.observations == [({"mock_field": [1, 2, 3]}, 7)]
 
 
 def test_multi_connector_overrides_all_base_methods():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -118,11 +118,10 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         for connector_id, stats_data in transfer_stats_data.items():
-            assert connector_id in self._prom_metrics, (
-                f"{connector_id} is not contained in the list of registered connectors "
-                f"with Prometheus metrics support: {self._prom_metrics.keys()}"
-            )
-            self._prom_metrics[connector_id].observe(stats_data["data"], engine_idx)
+            prom_metrics = self._prom_metrics.get(connector_id)
+            if prom_metrics is None:
+                continue
+            prom_metrics.observe(stats_data["data"], engine_idx)
 
 
 class MultiConnector(KVConnectorBase_V1, SupportsHMA):


### PR DESCRIPTION
Fixes #43828.

## Summary
- stop `MultiKVConnectorPromMetrics.observe()` from asserting when a child connector reports stats but does not register Prometheus metrics
- keep recording metrics for connectors that do expose Prometheus metrics
- add a regression test that mixes a metrics-capable connector with `MooncakeConnector`

## Why
`MultiConnector.build_prom_metrics()` already skips child connectors whose `build_prom_metrics()` returns `None`. The crash came later in `observe()`, which still assumed every connector in the aggregated stats payload had a registered metrics handler.

That mismatch turns mixed setups like `MultiConnector + MooncakeConnector` into a 500 even though the missing piece is only optional Prometheus reporting.

## Validation
- `python3 -m py_compile vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py tests/v1/kv_connector/unit/test_multi_connector.py`
- `pytest -q tests/v1/kv_connector/unit/test_multi_connector.py -k 'prom_metrics or TestMultiConnectorStats'` *(blocked locally: `ModuleNotFoundError: No module named 'tblib'` from `tests/conftest.py` before the target tests start)*
