### PR TITLE
fix: validate num_gpu_blocks_override is positive at config construction

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
@@ -2362,3 +2362,24 @@ def test_hma_not_disabled_when_kv_events_enabled():
     assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False, (
         "kv_events_config must not force-disable the hybrid KV cache manager."
     )
+
+
+def test_num_gpu_blocks_override_rejects_non_positive():
+    """CacheConfig must reject non-positive num_gpu_blocks_override values."""
+    from pydantic import ValidationError
+
+    # 0 should be rejected
+    with pytest.raises(ValidationError, match="greater than"):
+        CacheConfig(num_gpu_blocks_override=0)
+
+    # Negative should be rejected
+    with pytest.raises(ValidationError, match="greater than"):
+        CacheConfig(num_gpu_blocks_override=-1)
+
+    # None (no override) should be accepted
+    cfg = CacheConfig(num_gpu_blocks_override=None)
+    assert cfg.num_gpu_blocks_override is None
+
+    # Positive values should be accepted
+    cfg = CacheConfig(num_gpu_blocks_override=16)
+    assert cfg.num_gpu_blocks_override == 16

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -83,7 +83,7 @@ class CacheConfig:
     is_attention_free: bool = False
     """Whether the model is attention-free. This is primarily set in
     `ModelConfig` and that value should be manually duplicated here."""
-    num_gpu_blocks_override: int | None = None
+    num_gpu_blocks_override: int | None = Field(default=None, gt=0)
     """Number of GPU blocks to use. This overrides the profiled `num_gpu_blocks`
     if specified. Does nothing if `None`. Used for testing preemption."""
     sliding_window: int | None = None

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -154,7 +154,9 @@ class BlockPool:
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
-        assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
+        assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0, (
+            f"num_gpu_blocks must be a positive integer, got {num_gpu_blocks!r}"
+        )
         self.num_gpu_blocks = num_gpu_blocks
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size


### PR DESCRIPTION
## Summary

Reject non-positive values (0, -1, etc.) for `num_gpu_blocks_override` at `CacheConfig` construction time using pydantic's `gt=0` constraint.

This follows the same pattern established in #43794 for `block_size` and `hash_block_size`.

## Changes

1. **`vllm/config/cache.py`**: Changed `num_gpu_blocks_override: int | None = None` to `num_gpu_blocks_override: int | None = Field(default=None, gt=0)` — rejects 0 and negative values at construction with a clear pydantic `ValidationError`.

2. **`vllm/v1/core/block_pool.py`**: Added descriptive error message to the bare `assert` in `BlockPool.__init__` so that if a non-positive value somehow reaches this point, the error message includes the actual value received.

3. **`tests/v1/core/test_kv_cache_utils.py`**: Added `test_num_gpu_blocks_override_rejects_non_positive()` test verifying that 0 and -1 are rejected while `None` and positive integers are accepted.

## Why not duplicating

No existing open PRs address this specific validation gap. This is a direct follow-up to #43794 which landed the same pattern for other CacheConfig fields.

## Testing

```
pytest tests/v1/core/test_kv_cache_utils.py::test_num_gpu_blocks_override_rejects_non_positive -v
```

## AI Attribution

This PR was created with AI assistance. The human submitter has reviewed all changes.

Fixes #43842
