### PR TITLE
Fix data source selection in query_statistics.json

### DIFF
--- a/examples/observability/dashboards/grafana/query_statistics.json
+++ b/examples/observability/dashboards/grafana/query_statistics.json
@@ -686,7 +686,7 @@
   "templating": {
     "list": [
       {
-        "current": { "text": "Prometheus", "value": "4184fc20-68a7-483a-8d9b-7caa59c680dd" },
+        "current": {},
         "label": "datasource",
         "name": "DS_PROMETHEUS",
         "options": [],
@@ -702,6 +702,10 @@
         "multi": true,
         "name": "Deployment_id",
         "options": [],
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "query": {
           "qryType": 1,
           "query": "label_values(vllm:request_success_total,model_name)",


### PR DESCRIPTION


## Purpose

`query_statistics.json` has a bug where if you have multiple vllm Prometheus data sources the selection drop down doesn't work and the dashboard only shows data for the default data source.

This commit fixes this by removing the hardcoded data source in `current` and making sure we select data source based on a variable.

## Test Plan

Load original `query_statistics.json` into Grafana with two or more vllm Prometheus data sources. Note that the dashboard only shows data when the default data source is selected in the drop down.

Apply the code change by creating a new dashboard with the changes applied.

Note that the drop down now correctly selects data source and the dashboard updates.

## Test Result

The drop down now correctly selects data source and the dashboard updates.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

