### PR TITLE
[Doc] Clarify NIXL KV metrics aggregation semantics

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -136,6 +136,14 @@ python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
     - In bidirectional mode, the decoder caches KV blocks for multi-turn conversations. This TTL controls how long those blocks are held before being released. Unlike the prefiller lease, this TTL is not renewed via heartbeats.
     - Example: `--kv-transfer-config '{"kv_connector_extra_config": {"decoder_kv_blocks_ttl": 600}}'`
 
+## Metrics
+
+NIXL connector metrics are exposed via the standard `/metrics` endpoint.
+
+- See [Production Metrics](../usage/metrics.md#nixl-metrics-aggregation-semantics)
+  for details on aggregation semantics (worker-level observations, engine-level
+  aggregation, and how to query across engines).
+
 ## Bidirectional KV Transfer (Multi-turn)
 
 In standard disaggregated prefilling, KV cache flows in one direction: Prefill (P) computes the KV cache and Decode (D) reads from P. For multi-turn conversations this is wasteful — D already holds the KV cache corresponding to the generated tokens from prior turns, yet P must recompute it from scratch on every new turn. Bidirectional KV transfer lets P **pull** existing KV blocks from D via RDMA before computing only the new tokens, significantly reducing Time-To-First-Token (TTFT) for long-prefill such as **multi-turn heavy scenarios**.

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -45,6 +45,29 @@ The following metrics are exposed:
 
 --8<-- "docs/generated/metrics/nixl_connector.inc.md"
 
+### NIXL metrics aggregation semantics
+
+NIXL connector metrics are emitted from transfer events on worker processes and
+are then aggregated before they are exposed on `/metrics`.
+
+- **Aggregation scope:** For each scheduler update, worker-level NIXL transfer
+  stats are merged into a single engine-level payload.
+- **Histograms:** Every transfer observation is recorded; histogram buckets are
+  cumulative by definition in Prometheus.
+- **Counters:** Failure counters (`*_failed_*`, `*_kv_expired_reqs`) are
+  increment-only and accumulate over the process lifetime.
+- **Metric labels:** NIXL metrics are tracked per engine label set. To compute a
+  service-wide value, sum across engine label values in your PromQL query.
+- **Time window behavior:** The in-memory transfer stats buffers used for
+  periodic logging are reset after they are consumed, but Prometheus counters
+  and histograms remain cumulative across scrapes.
+
+Example PromQL (sum across all engines):
+
+```promql
+sum by (model_name) (rate(vllm:nixl_num_failed_transfers[5m]))
+```
+
 ## Model Flops Utilization (MFU) Performance Metrics
 
 These metrics are available via `--enable-mfu-metrics`:


### PR DESCRIPTION
- document NIXL KV connector metric aggregation semantics in production metrics docs
- clarify worker-to-engine aggregation behavior, cumulative counter/histogram behavior, and cross-engine query guidance
- add a metrics section in NixlConnector usage docs linking to the new aggregation semantics section
- Closes #41230
- Docs-only change.