### PR TITLE
Feature: Enable Flashinfer non-gated MoE bf16

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
@@ -11,6 +11,9 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    activation_to_flashinfer_int,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
 )
@@ -54,8 +57,8 @@ class TrtLlmBf16Experts(mk.FusedMoEExpertsMonolithic):
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
-        """BF16 kernels do not support non-gated MoE"""
-        return False
+        """BF16 kernels support non-gated MoE via RELU2_NO_MUL."""
+        return True
 
     @staticmethod
     def _supports_quant_scheme(
@@ -67,7 +70,8 @@ class TrtLlmBf16Experts(mk.FusedMoEExpertsMonolithic):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in [MoEActivation.SILU]
+        """Supports SiLU (gated) and RELU^2 (non-gated) activations."""
+        return activation in [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
 
     @staticmethod
     def _supports_routing_method(
@@ -123,6 +127,8 @@ class TrtLlmBf16Experts(mk.FusedMoEExpertsMonolithic):
     ) -> torch.Tensor:
         import flashinfer
 
+        assert activation in [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
+
         return flashinfer.fused_moe.trtllm_bf16_moe(
             routing_logits=router_logits,
             routing_bias=e_score_correction_bias,
@@ -138,4 +144,5 @@ class TrtLlmBf16Experts(mk.FusedMoEExpertsMonolithic):
             local_num_experts=self.local_num_experts,
             routed_scaling_factor=routed_scaling_factor,
             routing_method_type=self.routing_method_type,
+            activation_type=activation_to_flashinfer_int(activation),
         )

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    align_moe_weights_for_fi,
     convert_moe_weights_to_flashinfer_trtllm_block_layout,
     swap_w13_to_w31,
 )
@@ -269,11 +270,30 @@ def convert_to_unquantized_kernel_format(
             w13_weight = swap_w13_to_w31(w13_weight)
 
     elif unquantized_backend == UnquantizedMoeBackend.FLASHINFER_TRTLLM:
+        is_act_and_mul = layer.moe_config.is_act_and_mul
+        if not is_act_and_mul:
+            # Kernel requires intermediate_size_per_partition % 128 == 0 (BlockMajorK
+            # weight layout uses block_k=128). Pad along the intermediate dim when
+            # the model + TP split don't satisfy the constraint.
+            original_intermediate = w2_weight.shape[2]
+            w13_weight, w2_weight, padded_intermediate = align_moe_weights_for_fi(
+                w13_weight, w2_weight, is_act_and_mul, min_alignment=128
+            )
+            if padded_intermediate != original_intermediate:
+                layer.moe_config.intermediate_size_per_partition = padded_intermediate
+                logger.warning_once(
+                    "Non-gated MoE intermediate size %d is not a multiple of 128; "
+                    "padding up/down projection weights to %d to satisfy the "
+                    "FlashInfer TRT-LLM BF16 kernel alignment constraint.",
+                    original_intermediate,
+                    padded_intermediate,
+                )
         _cache_permute_indices: dict[torch.Size, torch.Tensor] = {}
         w13_weight, w2_weight = convert_moe_weights_to_flashinfer_trtllm_block_layout(
             _cache_permute_indices,
             w13_weight,
             w2_weight,
+            is_gated_act_gemm=is_act_and_mul,
         )
 
     return w13_weight.contiguous(), w2_weight.contiguous()

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -275,19 +275,11 @@ def convert_to_unquantized_kernel_format(
             # Kernel requires intermediate_size_per_partition % 128 == 0 (BlockMajorK
             # weight layout uses block_k=128). Pad along the intermediate dim when
             # the model + TP split don't satisfy the constraint.
-            original_intermediate = w2_weight.shape[2]
             w13_weight, w2_weight, padded_intermediate = align_moe_weights_for_fi(
                 w13_weight, w2_weight, is_act_and_mul, min_alignment=128
             )
-            if padded_intermediate != original_intermediate:
-                layer.moe_config.intermediate_size_per_partition = padded_intermediate
-                logger.warning_once(
-                    "Non-gated MoE intermediate size %d is not a multiple of 128; "
-                    "padding up/down projection weights to %d to satisfy the "
-                    "FlashInfer TRT-LLM BF16 kernel alignment constraint.",
-                    original_intermediate,
-                    padded_intermediate,
-                )
+            layer.moe_config.intermediate_size_per_partition = padded_intermediate
+
         _cache_permute_indices: dict[torch.Size, torch.Tensor] = {}
         w13_weight, w2_weight = convert_moe_weights_to_flashinfer_trtllm_block_layout(
             _cache_permute_indices,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -108,6 +108,7 @@ def convert_moe_weights_to_flashinfer_trtllm_block_layout(
     cache_permute_indices: dict[torch.Size, torch.Tensor],
     w13_weight: torch.Tensor,
     w2_weight: torch.Tensor,
+    is_gated_act_gemm: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Convert expert weights to FlashInfer's block layout.
 
@@ -166,9 +167,11 @@ def convert_moe_weights_to_flashinfer_trtllm_block_layout(
             cache_permute_indices,
             w13_expert_uint8,
             epilogue_tile_m,
+            is_gated_act_gemm=is_gated_act_gemm,
         )
-        rows = w13_expert_uint8.shape[0]
-        permute_indices = (permute_indices + rows // 2) % rows
+        if is_gated_act_gemm:
+            rows = w13_expert_uint8.shape[0]
+            permute_indices = (permute_indices + rows // 2) % rows
         _copy_permuted_expert_to_block_layout(
             w13_weights_shuffled_tensor[i],
             w13_expert_uint8,
@@ -288,12 +291,12 @@ def align_trtllm_fp4_moe_hidden_dim_for_fi(
     return padded_w13, padded_w13_scale, padded_w2, padded_w2_scale, padded_hidden_size
 
 
-def align_fp8_moe_weights_for_fi(
+def align_moe_weights_for_fi(
     w13: torch.Tensor, w2: torch.Tensor, is_act_and_mul: bool, min_alignment: int = 16
 ) -> tuple[torch.Tensor, torch.Tensor, int]:
     """Pad intermediate size so FlashInfer kernels' alignment constraints hold.
 
-    Some FlashInfer FP8 MoE kernels require the (gated) intermediate size
+    Some FlashInfer MoE kernels require the (gated) intermediate size
     used for GEMM to be divisible by a small alignment value. When this is
     not satisfied (e.g. with certain tensor-parallel sizes), we pad the
     gate/up and down projection weights along the intermediate dim.
@@ -492,7 +495,7 @@ def prepare_fp8_moe_layer_for_fi(
     # for the gate-up proj. Pad the weights to respect this.
     if not block_quant:
         min_alignment = 16 if is_gated else 128
-        w13, w2, new_intermediate = align_fp8_moe_weights_for_fi(
+        w13, w2, new_intermediate = align_moe_weights_for_fi(
             w13,
             w2,
             layer.moe_config.is_act_and_mul,


### PR DESCRIPTION
## Purpose
Add support for flashinfer non-gated MoE bf16. Note that this PR makes flashinfer-trtllm backend the new default for non-gated MoE bf16 models for sm100.

Shows perf gain of ~15% e2e for below benchmark.

## Test Result

MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
on 1 gb200 node.

```
perf cmd:
vllm bench serve --backend vllm --host 0.0.0.0 --port 8000 --model $MODEL --num-prompts 256 --trust-remote-code --ignore-eos --max-concurrency 128 --random-input-len 1000 --random-output-len 8000 --no-stream --dataset-name random --seed 42

accuracy cmd:
lm_eval   --model local-completions   --model_args base_url=http://127.0.0.1:8000/v1/completions,model=$MODEL,tokenized_requests=False,tokenizer_backend=None,num_concurrent=999,timeout=120,max_retries=5,max_length=8192   --tasks gsm8k   --num_fewshot 5   --batch_size auto --seed 42
```

flashinfer:
serve cmd:
```
vllm serve --model $MODEL --trust-remote-code --no-enable-prefix-caching
```

result:
```
============ Serving Benchmark Result ============
Successful requests:                     256
Failed requests:                         0
Maximum request concurrency:             128
Benchmark duration (s):                  168.94
Total input tokens:                      256000
Total generated tokens:                  2048000
Request throughput (req/s):              1.52
Output token throughput (tok/s):         12122.92
Peak output token throughput (tok/s):    14414.00
Peak concurrent requests:                253.00
Total token throughput (tok/s):          13638.29
---------------Time to First Token----------------
Mean TTFT (ms):                          714.38
Median TTFT (ms):                        705.93
P99 TTFT (ms):                           1225.32
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.47
Median TPOT (ms):                        10.47
P99 TPOT (ms):                           10.86
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.47
Median ITL (ms):                         10.15
P99 ITL (ms):                            13.02
==================================================
```
gsm8k:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5580|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.8408|±  |0.0101|
```

Verified for tp4 as well.

triton:
serve cmd:
```
vllm serve --model $MODEL --trust-remote-code --no-enable-prefix-caching --moe-backend triton
```

result:
```
============ Serving Benchmark Result ============
Successful requests:                     256
Failed requests:                         0
Maximum request concurrency:             128
Benchmark duration (s):                  195.63
Total input tokens:                      256000
Total generated tokens:                  2048000
Request throughput (req/s):              1.31
Output token throughput (tok/s):         10468.91
Peak output token throughput (tok/s):    12160.00
Peak concurrent requests:                194.00
Total token throughput (tok/s):          11777.52
---------------Time to First Token----------------
Mean TTFT (ms):                          2959.75
Median TTFT (ms):                        2645.33
P99 TTFT (ms):                           6450.03
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.85
Median TPOT (ms):                        11.85
P99 TPOT (ms):                           11.95
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.85
Median ITL (ms):                         11.45
P99 ITL (ms):                            13.91
==================================================
```

gsm8k:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5572|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.8469|±  |0.0099|
```