### PR TITLE
[ROCm] Fix padded MoE weight loading

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -709,6 +709,28 @@ class FusedMoE(PluggableLayer):
                     expert_data = expert_data.narrow(dim, 0, loaded_weight.shape[dim])
         return expert_data
 
+    def _moe_checkpoint_shard_stride(
+        self,
+        shard_dim: int,
+        loaded_weight: torch.Tensor,
+        shard_size: int,
+    ) -> int | None:
+        """Return the real checkpoint TP stride when the param shard is padded.
+
+        The checkpoint keeps the unpadded full expert tensor, so padded
+        ``shard_size`` cannot be used as the checkpoint indexing stride.
+        """
+        moe_cfg = self.moe_config
+        i_unpadded = getattr(moe_cfg, "intermediate_size_per_partition_unpadded", None)
+        i_padded = getattr(moe_cfg, "intermediate_size_per_partition", None)
+        if i_unpadded is None or i_padded is None or i_unpadded >= i_padded:
+            return None
+        full_ckpt = loaded_weight.shape[shard_dim]
+        if full_ckpt % self.tp_size != 0:
+            return None
+        ckpt_stride = full_ckpt // self.tp_size
+        return ckpt_stride if ckpt_stride < shard_size else None
+
     def _load_w13(
         self,
         expert_data: torch.Tensor,
@@ -727,16 +749,15 @@ class FusedMoE(PluggableLayer):
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor)
         # and we're not loading the full weight
         if not load_full and loaded_weight.ndim > 0:
-            # Handle padding: loaded_weight might be smaller than shard_size on last
-            # TP rank
-            start_offset = shard_size * tp_rank
+            ckpt_stride = self._moe_checkpoint_shard_stride(
+                shard_dim, loaded_weight, shard_size
+            )
+            stride = ckpt_stride if ckpt_stride is not None else shard_size
+            start_offset = stride * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
-                # If there is no available weight to load for this TP rank
-                # (can happen on last TP rank with padding), we can skip
-                # loading and return early
                 return
-            narrow_size = min(shard_size, available)
+            narrow_size = min(stride, available)
             loaded_weight = loaded_weight.narrow(shard_dim, start_offset, narrow_size)
         # Narrow parameter and load.
         # w1, gate_proj: Load into first logical weight of w13.
@@ -770,16 +791,15 @@ class FusedMoE(PluggableLayer):
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor)
         # and we're not loading the full weight
         if not load_full and loaded_weight.ndim > 0:
-            # Handle padding: loaded_weight might be smaller than shard_size on last
-            # TP rank
-            start_offset = shard_size * tp_rank
+            ckpt_stride = self._moe_checkpoint_shard_stride(
+                shard_dim, loaded_weight, shard_size
+            )
+            stride = ckpt_stride if ckpt_stride is not None else shard_size
+            start_offset = stride * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
-                # If there is no available weight to load for this TP rank
-                # (can happen on last TP rank with padding), we can skip
-                # loading and return early
                 return
-            narrow_size = min(shard_size, available)
+            narrow_size = min(stride, available)
             loaded_weight = loaded_weight.narrow(shard_dim, start_offset, narrow_size)
         # w2, down_proj: Load into only logical weight of w2.
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -53,6 +53,41 @@ LAYERWISE_INFO: WeakKeyDictionary[torch.nn.Module, LayerReloadingInfo] = (
 LOADING_LAYERS: WeakSet[torch.nn.Module] = WeakSet()
 
 
+def _moe_padded_shard_numel(
+    layer: torch.nn.Module,
+    param_name: str,
+    copied_numel: int,
+) -> int | None:
+    """Convert unpadded FusedMoE weight copy counts to padded param counts."""
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+    if not isinstance(layer, FusedMoE):
+        return None
+    if param_name not in ("w13_weight", "w2_weight"):
+        return None
+
+    moe_cfg = layer.moe_config
+
+    hidden_padded = moe_cfg.hidden_dim
+    i_padded = moe_cfg.intermediate_size_per_partition
+
+    hidden_unpadded = moe_cfg.hidden_dim_unpadded or hidden_padded
+    i_unpadded = moe_cfg.intermediate_size_per_partition_unpadded or i_padded
+
+    has_padding = i_unpadded < i_padded or hidden_unpadded < hidden_padded
+    if not has_padding:
+        return None
+
+    padded_shard_numel = i_padded * hidden_padded
+    unpadded_shard_numel = i_unpadded * hidden_unpadded
+    if copied_numel == 0:
+        return int(padded_shard_numel)
+    if copied_numel > unpadded_shard_numel:
+        return None
+
+    return int(copied_numel * padded_shard_numel // unpadded_shard_numel)
+
+
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
     """
     Get information related to restoring and layerwise processing. If no previous
@@ -173,7 +208,11 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
 
         # Buffer loaded weights, track loading progress
         info.loaded_weights.append((param_name, bound_args))
-        num_loaded, ret = get_numel_loaded(original_loader, bound_args)
+        counter_numel, ret = get_numel_loaded(original_loader, bound_args)
+
+        num_loaded = _moe_padded_shard_numel(layer, param_name, counter_numel)
+        if num_loaded is None:
+            num_loaded = counter_numel
         info.load_numel += num_loaded
 
         logger.debug(


### PR DESCRIPTION
## Purpose

Fix padded MoE checkpoint loading for pure tensor-parallel serving with the ROCm
AITER MXFP4 MoE backend.

For some MXFP4 MoE configurations on ROCm with the AITER MoE backend, vLLM pads the destination MoE weight shapes for backend/kernel alignment while the checkpoint tensors remain unpadded. The previous loader used the padded destination shard size as the checkpoint slicing stride. When padding is present, this can make later TP ranks read from the wrong checkpoint offsets. With TP=4 or TP=8 on `amd/Qwen3-235B-A22B-Instruct-2507-MXFP4`, the last one or more TP ranks can start at or beyond the end of the checkpoint tensor and load zero checkpoint elements for `w13` and `w2`.

This PR uses the real checkpoint TP stride when slicing loaded MoE checkpoint tensors, while preserving the padded destination parameter shape. It also adjusts layerwise reload accounting for padded MoE weights so progress reflects the padded destination size.

## Test Plan

Run the following self-contained repro script on current `main` and on this PR branch:

Validation environment:

- Platform: ROCm
- Docker image: `rocm/vllm-dev:nightly`
- Current `main` commit: `b372ad3e9`
- This PR branch commit: `fe00c4598`

The script runs with tensor parallelism (`TP=4`) and the default expert parallel setting (`EP=1`). It creates a temporary `sitecustomize.py` probe that is automatically imported when `vllm serve` starts. The probe monkey-patches `FusedMoE._load_w13` and `FusedMoE._load_w2`, records runtime MoE weight loading shapes only for weight tensors, and ignores MXFP4 scale tensors. After the server starts, it summarizes the expected checkpoint load dimension per TP rank (`checkpoint dim / TP`) and the actual checkpoint load dimension used by the current branch.

```bash
cat >/tmp/moe_padding_repro.sh <<'SH'
#!/usr/bin/env bash
set -euo pipefail

WORK_DIR=$(mktemp -d)
RECORDS="${WORK_DIR}/moe_padding_records.jsonl"
: >moe_padding_repro.log
trap 'kill "${server_pid:-}" 2>/dev/null || true' EXIT

cat >"${WORK_DIR}/sitecustomize.py" <<'PY'
import json
import os

from vllm.model_executor.layers.fused_moe.layer import FusedMoE

records_path = os.environ["MOE_PADDING_RECORDS"]
seen = set()


def record(self, name, expert_data, shard_dim, loaded_weight, tp_rank):
    if loaded_weight.ndim == 0 or (name, tp_rank) in seen:
        return

    shard = expert_data.shape[shard_dim]
    if name == "w13" and self.moe_config.is_act_and_mul:
        shard //= 2

    loaded = loaded_weight.shape[shard_dim]
    if loaded % self.tp_size != 0 or loaded * 4 <= shard:
        return

    checkpoint_stride_fn = getattr(self, "_moe_checkpoint_shard_stride", None)
    actual_stride = (
        checkpoint_stride_fn(shard_dim, loaded_weight, shard)
        if checkpoint_stride_fn is not None
        else None
    )
    actual_stride = actual_stride if actual_stride is not None else shard
    seen.add((name, tp_rank))

    row = {
        "name": name,
        "tp_rank": tp_rank,
        "padded_shard": shard,
        "checkpoint_dim": loaded,
        "expected_stride": loaded // self.tp_size,
        "actual_dim": max(0, min(actual_stride, loaded - actual_stride * tp_rank)),
    }
    with open(records_path, "a", encoding="utf-8") as f:
        f.write(json.dumps(row, sort_keys=True) + "\n")


orig_w13, orig_w2 = FusedMoE._load_w13, FusedMoE._load_w2


def load_w13(self, expert_data, shard_dim, shard_id, loaded_weight, tp_rank,
             load_full=False):
    if not load_full:
        record(self, "w13", expert_data, shard_dim, loaded_weight, tp_rank)
    return orig_w13(self, expert_data, shard_dim, shard_id, loaded_weight,
                    tp_rank, load_full)


def load_w2(self, expert_data, shard_dim, loaded_weight, tp_rank, load_full=False):
    if not load_full:
        record(self, "w2", expert_data, shard_dim, loaded_weight, tp_rank)
    return orig_w2(self, expert_data, shard_dim, loaded_weight, tp_rank, load_full)


FusedMoE._load_w13 = load_w13
FusedMoE._load_w2 = load_w2
PY

(
  PYTHONPATH="${WORK_DIR}:${PYTHONPATH:-}" \
  MOE_PADDING_RECORDS="${RECORDS}" \
  VLLM_ROCM_USE_AITER=1 \
  vllm serve amd/Qwen3-235B-A22B-Instruct-2507-MXFP4 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --enable-auto-tool-choice \
    --tool-call-parser hermes \
    --moe-backend aiter
) 2>&1 | tee moe_padding_repro.log &
server_pid=$!

while kill -0 "${server_pid}" 2>/dev/null; do
  if grep -q "Application startup complete" moe_padding_repro.log 2>/dev/null; then
    break
  fi
  sleep 2
done

if ! kill -0 "${server_pid}" 2>/dev/null; then
  wait "${server_pid}"
  exit $?
fi

python - "${RECORDS}" <<'PY'
import sys
import json

groups = {}
with open(sys.argv[1], encoding="utf-8") as f:
    for line in f:
        row = json.loads(line)
        groups.setdefault(row["name"], {})[row["tp_rank"]] = row

print("\n===== MoE padding loading summary =====", flush=True)
print("The numbers below are computed from tensor shapes observed during this run.", flush=True)
for name, per_tp in sorted(groups.items()):
    ranks = sorted(per_tp)
    first = per_tp[ranks[0]]
    expected_load = [per_tp[i]["expected_stride"] for i in ranks]
    actual_load = [per_tp[i]["actual_dim"] for i in ranks]

    print(f"\n{name}", flush=True)
    print(f"  TP num: {len(ranks)}", flush=True)
    print(f"  TP order: {ranks}", flush=True)
    print(f"  MoE sharded dim before padding: {first['checkpoint_dim']}", flush=True)
    print(f"  MoE sharded dim after padding per TP: {first['padded_shard']}", flush=True)
    print(
        "  expected checkpoint load dim by TP (checkpoint dim / TP): "
        f"{expected_load}",
        flush=True,
    )
    print(
        "  actual checkpoint load dim by TP: "
        f"{actual_load}",
        flush=True,
    )
print("\n======================================", flush=True)
print("Server is still running. Press Ctrl-C to stop it.", flush=True)
PY

wait "${server_pid}"
SH

bash /tmp/moe_padding_repro.sh
```

## Test Result

Current `main`:
`w13` and `w2` use padded shard sizes as checkpoint slicing strides, so TP rank 3 loads `0` checkpoint dimensions.

<img width="650" height="300" alt="image" src="https://github.com/user-attachments/assets/a318682e-8a75-4b89-98a5-33d7067c8fe2" />



This PR branch:
`w13` and `w2` load the expected checkpoint dimensions on all TP ranks.

<img width="650" height="300" alt="image" src="https://github.com/user-attachments/assets/9216d657-06af-4192-9822-300fba2d7a17" />

