### PR TITLE
Terminal Benchmark for Tool Calling (Qwen3)

### DIFF
--- a/run-harbor-terminal-2-bench.sh
+++ b/run-harbor-terminal-2-bench.sh
@@ -1,0 +1,8 @@
+harbor run -d "terminal-bench/terminal-bench-2" \
+  --agent-import-path terminal_agents.CmdQwenHarborAgent:CmdQwenHarborAgent \
+  -m "Qwen/Qwen3-Coder-30B-A3B-Instruct" \
+  --ak api_base=http://localhost:7557/v1 \
+  --debug
+
+# For specific task, add -i argument, e.g.,
+#     -i "terminal-bench/fix-git"

--- a/run-terminal-bench.sh
+++ b/run-terminal-bench.sh
@@ -1,0 +1,10 @@
+tb run \
+    --agent-import-path terminal_agents.CmdQwenTerminalAgent:CmdQwenTerminalAgent \
+    --model Qwen/Qwen3-4B \
+    --dataset-name terminal-bench-core \
+    --dataset-version 0.1.1 \
+    --n-concurrent 1 \
+    --log-level debug
+
+# For specific task, add --task-id argument, e.g.,
+#     --task-id hello-world

--- a/run-terminal-bench.sh
+++ b/run-terminal-bench.sh
@@ -1,6 +1,6 @@
 tb run \
     --agent-import-path terminal_agents.CmdQwenTerminalAgent:CmdQwenTerminalAgent \
-    --model Qwen/Qwen3-4B \
+    --model Qwen/Qwen3-Coder-30B-A3B-Instruct \
     --dataset-name terminal-bench-core \
     --dataset-version 0.1.1 \
     --n-concurrent 1 \

--- a/terminal_agents/CmdQwenHarborAgent.py
+++ b/terminal_agents/CmdQwenHarborAgent.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_shell_command",
+            "description": "Run one shell command in /app.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                },
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "mark_task_complete",
+            "description": "Call when the task is done.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+class CmdQwenHarborAgent(BaseAgent):
+    def __init__(
+        self,
+        logs_dir: Path,
+        model_name: str | None = None,
+        api_base: str = "http://localhost:7557/v1",
+        api_key: str = "EMPTY",
+        max_turns: int = 100,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(logs_dir=logs_dir, model_name=model_name, **kwargs)
+        self._client = AsyncOpenAI(base_url=api_base, api_key=api_key)
+        self._max_turns = max_turns
+
+    @staticmethod
+    def name() -> str:
+        return "cmd-qwen-harbor"
+
+    def version(self) -> str | None:
+        return "1.0.0"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        pass
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        messages: list[dict[str, Any]] = [{"role": "user", "content": instruction}]
+
+        for _ in range(self._max_turns):
+            resp = await self._client.chat.completions.create(
+                model=self.model_name,
+                messages=messages,
+                tools=TOOLS,
+                tool_choice="auto",
+            )
+            msg = resp.choices[0].message
+
+            if not msg.tool_calls:
+                break
+
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": msg.content or "",
+                    "tool_calls": [
+                        {
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            },
+                        }
+                        for tc in msg.tool_calls
+                    ],
+                }
+            )
+
+            for tc in msg.tool_calls:
+                args = json.loads(tc.function.arguments or "{}")
+                if tc.function.name == "run_shell_command":
+                    result = await environment.exec(args["command"], cwd="/app")
+                    out = result.stdout or result.stderr or ""
+                    if result.return_code != 0:
+                        out = f"{out}\n[exit code: {result.return_code}]".strip()
+                else:
+                    out = "ok"
+
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": out,
+                    }
+                )
+
+                if tc.function.name == "mark_task_complete":
+                    return
+
+        if resp.usage:
+            context.n_input_tokens = resp.usage.prompt_tokens
+            context.n_output_tokens = resp.usage.completion_tokens

--- a/terminal_agents/CmdQwenTerminalAgent.py
+++ b/terminal_agents/CmdQwenTerminalAgent.py
@@ -46,7 +46,7 @@ class CmdQwenTerminalAgent(BaseAgent):
 
     def __init__(
         self,
-        model_name: str = "Qwen/Qwen3-Coder-30B-A3B-Instruct,
+        model_name: str = "Qwen/Qwen3-Coder-30B-A3B-Instruct",
         api_base: str = "http://localhost:7557/v1",
         api_key: str = "EMPTY",
         max_turns: int = 20,

--- a/terminal_agents/CmdQwenTerminalAgent.py
+++ b/terminal_agents/CmdQwenTerminalAgent.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+import json
+
+from openai import OpenAI
+from terminal_bench.agents.base_agent import AgentResult, BaseAgent
+from terminal_bench.agents.failure_mode import FailureMode
+from terminal_bench.terminal.tmux_session import TmuxSession
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_shell_command",
+            "description": "Run one shell command in /app. Use for all file/shell work.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Single shell command, e.g. printf 'Hello, world!\\n' > hello.txt",
+                    },
+                    "block": {
+                        "type": "boolean",
+                        "description": "Wait for command to finish before next step",
+                        "default": True,
+                    },
+                },
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "mark_task_complete",
+            "description": "Call when tests should pass; no more commands needed.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+class CmdQwenTerminalAgent(BaseAgent):
+    @staticmethod
+    def name() -> str:
+        return "cmd-qwen-terminal-agent"
+
+    def __init__(
+        self,
+        model_name: str = "Qwen/Qwen3-4B",
+        api_base: str = "http://localhost:7557/v1",
+        api_key: str = "EMPTY",
+        max_turns: int = 20,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._client = OpenAI(base_url=api_base, api_key=api_key)
+        self._model_name = model_name
+        self._max_turns = max_turns
+    def _dispatch_tool(self, name: str, args: dict, session: TmuxSession) -> str:
+        if name == "run_shell_command":
+            cmd = args["command"]
+            session.send_keys([cmd, "Enter"], block=args.get("block", True))
+            return session.capture_pane()[-4000:]  # truncate if needed
+        if name == "mark_task_complete":
+            return "ok"
+        return f"unknown tool: {name}"
+
+    def perform_task(
+        self,
+        instruction: str,
+        session: TmuxSession,
+        logging_dir: Path | None = None,
+    ) -> AgentResult:
+        model = self._client.models.list().data[0].id
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You solve terminal tasks by calling tools. "
+                    "Work in /app. One command per run_shell_command call."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Task:\n{instruction}\n\n"
+                    f"Terminal:\n{session.capture_pane()}"
+                ),
+            },
+        ]
+        for _ in range(self._max_turns):
+            resp = self._client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=TOOLS,
+                tool_choice="auto",
+                temperature=0,
+            )
+            msg = resp.choices[0].message
+            # No tools → model answered in plain text (still a vLLM call, not tool path)
+            if not msg.tool_calls:
+                messages.append({"role": "assistant", "content": msg.content or ""})
+                break
+            # Assistant turn with tool_calls (this is what you're benchmarking)
+            messages.append({
+                "role": "assistant",
+                "content": msg.content or "",
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ],
+            })
+            done = False
+            for tc in msg.tool_calls:
+                args = json.loads(tc.function.arguments)
+                result = self._dispatch_tool(tc.function.name, args, session)
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": result,
+                })
+                if tc.function.name == "mark_task_complete":
+                    done = True
+            if done:
+                break
+        return AgentResult(failure_mode=FailureMode.NONE)

--- a/terminal_agents/CmdQwenTerminalAgent.py
+++ b/terminal_agents/CmdQwenTerminalAgent.py
@@ -46,7 +46,7 @@ class CmdQwenTerminalAgent(BaseAgent):
 
     def __init__(
         self,
-        model_name: str = "Qwen/Qwen3-4B",
+        model_name: str = "Qwen/Qwen3-Coder-30B-A3B-Instruct,
         api_base: str = "http://localhost:7557/v1",
         api_key: str = "EMPTY",
         max_turns: int = 20,


### PR DESCRIPTION
This is an experimental PR for benchmarking tool calling with Qwen3.

### How to run (2xH100 example)
Server:
```
vllm serve Qwen/Qwen3-Coder-30B-A3B-Instruct --port 7557 --enable-auto-tool-choice --tool-call-parser qwen3_coder --chat-template examples/tool_chat_template_qwen3coder.jinja -tp 2
```
Benchmark:
```
./run_terminal_bench.sh
```