### PR TITLE
[BugFix] Fix extract_hidden_states CUDA graph padding polluting KV cache

### DIFF
--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -15,6 +15,7 @@ from typing import ClassVar
 import torch
 import torch.nn as nn
 
+import vllm._custom_ops as ops
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
 from vllm.forward_context import get_forward_context
@@ -82,9 +83,32 @@ def basic_cache(
     to_cache: torch.Tensor,  # shape: [seq_len, num_heads, head_size]
     kv_cache: torch.Tensor,  # shape: [num_blocks, block_size, num_heads, head_size]
     slot_mapping: torch.Tensor,  # shape: [seq_len]
+    kv_cache_dtype: str,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
 ):
-    block_size = kv_cache.shape[1]
-    kv_cache[slot_mapping // block_size, slot_mapping % block_size] = to_cache
+    if not to_cache.is_cuda:
+        block_size = kv_cache.shape[1]
+        valid = slot_mapping >= 0
+        kv_cache[
+            slot_mapping[valid] // block_size,
+            slot_mapping[valid] % block_size,
+        ] = to_cache[valid]
+        return
+
+    # Use the existing fixed-shape cache update kernel on CUDA. It skips
+    # negative slot ids internally without materializing slot_mapping[valid],
+    # which keeps CUDA graph replay safe when padding slots change to -1.
+    ops.reshape_and_cache_flash(
+        to_cache,
+        to_cache,
+        kv_cache,
+        kv_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
 
 
 ######### CacheOnlyAttentionBackend ########
@@ -221,7 +245,14 @@ class CacheOnlyAttentionImpl(AttentionImpl):
             f"KV cache must be {self.kv_cache_torch_dtype}, got {kv_cache.dtype}"
         )
 
-        basic_cache(to_cache, kv_cache, slot_mapping)
+        basic_cache(
+            to_cache,
+            kv_cache,
+            slot_mapping,
+            self.kv_cache_dtype,
+            layer._k_scale,
+            layer._v_scale,
+        )
 
     def forward(self, *args, **kwargs):
         # Empty implementation of abstract method


### PR DESCRIPTION
## Description

Fix a bug where CUDA graph padding tokens in `extract_hidden_states` corrupt the KV cache.

### Root Cause

`basic_cache()` in `vllm/model_executor/models/extract_hidden_states.py` directly indexed into the KV cache using `slot_mapping` without handling `PADDING_SLOT_ID = -1`. In Python:

- `-1 // block_size = -1` (last block)
- `-1 % block_size = block_size - 1` (last position in block)

This caused padding tokens' hidden states to overwrite the last valid KV cache slot.

### Fix

Use the existing fixed-shape `reshape_and_cache_flash` cache update op for CUDA tensors. The underlying CUDA kernel already skips negative slot ids:

```cpp
if (slot_idx < 0) {
  return;
}
```

This avoids data-dependent boolean indexing during CUDA graph replay while matching the standard KV cache update behavior used by other attention backends.

A CPU fallback keeps the same negative-slot filtering semantics for non-CUDA tensors.

### Testing

- Reproduced the original negative-indexing corruption on an 8x H20 machine with a minimal repro script
- Verified the corrected semantics keep padding slots from updating the cache
- Ran `git diff --check HEAD~1..HEAD`

### Related Issue

Fixes #43810

---

AI assistance was used in the development of this PR.
