### PR TITLE
[ROCm][Bugfix] Fix _rocm_aiter_topk_softmax_impl crash on older aiter (5-arg vs 7-arg)

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -266,15 +266,24 @@ def _rocm_aiter_topk_softmax_impl(
 ) -> None:
     from aiter import topk_softmax
 
-    topk_softmax(
-        topk_weights,
-        topk_indices,
-        token_expert_indices,
-        gating_output,
-        renormalize,
-        num_shared_experts,
-        shared_expert_scoring_func,
-    )
+    if rocm_aiter_ops.topk_softmax_supports_fused_sigmoid():
+        topk_softmax(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            num_shared_experts,
+            shared_expert_scoring_func,
+        )
+    else:
+        topk_softmax(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+        )
 
 
 def _rocm_aiter_topk_softmax_fake(


### PR DESCRIPTION



## Purpose

On ROCm with an aiter build older than commit `02d8af55e`, any MoE model served with
`VLLM_ROCM_USE_AITER_MOE=1` crashes on the first forward pass:

```
RuntimeError: aiter::topk_softmax() expected at most 5 argument(s) but received 7 argument(s).
Declaration: aiter::topk_softmax(Tensor(a0!) topk_weights, Tensor(a1!) topk_indices,
Tensor(a2!) token_expert_indices, Tensor(a3!) gating_output, bool need_renorm) -> ()
```

This PR wires the existing version-detection helper into the one call site that was missed.

Related issue: https://github.com/vllm-project/vllm/issues/43873

## Test Plan
Coming soon.

## Test Result
Coming soon.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

