### PR TITLE
[Bugfix] Account for TP/PP sharding in KV cache memory check

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2270,6 +2270,54 @@ def test_check_enough_kv_cache_memory_respects_num_gpu_blocks_override():
         get_kv_cache_configs(vllm_config, [kv_cache_specs], [large_available_memory])
 
 
+def test_check_enough_kv_cache_memory_accounts_for_tp_pp_sharding():
+    """KV cache memory check must account for tensor/pipeline parallelism.
+
+    With TP/PP, the KV cache is distributed across multiple GPUs, so the
+    per-GPU available memory should be multiplied by the number of workers
+    sharing the KV cache (TP × PP) before comparing against the total
+    required memory. Without this, multi-GPU deployments with KV offloading
+    would fail to start even when the aggregated KV capacity is sufficient.
+
+    See: https://github.com/vllm-project/vllm/issues/43755
+    """
+    from vllm.config import ParallelConfig
+
+    # Create a config with TP=8, PP=2 (16 GPUs total)
+    model_config = ModelConfig(max_model_len=16384)
+    parallel_config = ParallelConfig(
+        tensor_parallel_size=8,
+        pipeline_parallel_size=2,
+    )
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        parallel_config=parallel_config,
+    )
+
+    # Calculate memory per block per layer
+    # block_size=16, num_kv_heads=2, head_size=64, dtype=float32 (4 bytes)
+    # KV cache: 2 (K+V) * 16 * 2 * 64 * 4 = 16384 bytes per block per layer
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+    }
+
+    # With TP=8, PP=2, we have 16 GPUs sharing the KV cache.
+    # Per-GPU available memory: 1024 blocks worth (16 MB per layer)
+    # Total available across 16 GPUs: 16384 blocks worth
+    # Required for max_model_len=16384: 1024 blocks per layer * 2 layers = 2048 blocks
+    # 2048 blocks < 16384 blocks, so this should PASS
+    per_gpu_available_memory = mem_per_block_per_layer * 1024  # 1024 blocks per GPU
+
+    # This should NOT raise because the aggregated memory across 16 GPUs
+    # (1024 * 16 = 16384 blocks) is more than enough for 2048 blocks needed.
+    # Without the TP/PP fix, this would incorrectly raise ValueError because
+    # it would compare per-GPU memory (1024 blocks) against total needed (2048 blocks).
+    get_kv_cache_configs(vllm_config, [kv_cache_specs], [per_gpu_available_memory])
+
+
 def test_unify_hybrid_kv_cache_specs():
     # 1. has_full_attention and has_sliding_window
     before_spec_1 = new_kv_cache_spec()

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -693,6 +693,7 @@ def _check_enough_kv_cache_memory(
     get_needed_memory: Callable[[], int],
     max_model_len: int,
     estimate_max_model_len: Callable[[int], int],
+    num_kv_shards: int = 1,
 ):
     if available_memory <= 0:
         raise ValueError(
@@ -705,6 +706,13 @@ def _check_enough_kv_cache_memory(
         )
 
     needed_memory = get_needed_memory()
+
+    # Account for KV cache sharding across tensor/pipeline parallel workers.
+    # With TP/PP, the KV cache is distributed across multiple GPUs, so the
+    # effective available memory per worker is multiplied by the number of
+    # workers sharing the KV cache.
+    if num_kv_shards > 1:
+        available_memory *= num_kv_shards
 
     if needed_memory > available_memory:
         estimated_max_len = estimate_max_model_len(available_memory)
@@ -811,11 +819,20 @@ def check_enough_kv_cache_memory(
 
     # No need to check for available memory if the kv_cache_spec is empty
     if kv_cache_spec:
+        # Calculate the number of KV cache shards across tensor/pipeline
+        # parallel workers. With TP/PP, the KV cache is distributed across
+        # multiple GPUs, so we need to account for this when checking if
+        # there is enough memory.
+        num_kv_shards = (
+            vllm_config.parallel_config.tensor_parallel_size
+            * vllm_config.parallel_config.pipeline_parallel_size
+        )
         _check_enough_kv_cache_memory(
             available_memory,
             lambda: max_memory_usage_bytes(vllm_config, kv_cache_spec.values()),
             vllm_config.model_config.max_model_len,
             lambda am: estimate_max_model_len(vllm_config, kv_cache_spec, am),
+            num_kv_shards=num_kv_shards,
         )
 
 
@@ -2031,6 +2048,14 @@ def get_kv_cache_configs(
             vllm_config, projected_groups_per_worker, available_memory
         )
 
+    # Calculate the number of KV cache shards across tensor/pipeline parallel
+    # workers. With TP/PP, the KV cache is distributed across multiple GPUs,
+    # so we need to account for this when checking if there is enough memory.
+    num_kv_shards = (
+        vllm_config.parallel_config.tensor_parallel_size
+        * vllm_config.parallel_config.pipeline_parallel_size
+    )
+
     # Check if the available memory is enough per worker.
     for groups, avail_mem in zip(projected_groups_per_worker, available_memory):
         if not groups:
@@ -2040,6 +2065,7 @@ def get_kv_cache_configs(
             partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
             vllm_config.model_config.max_model_len,
             partial(_estimate_max_model_len_from_groups, vllm_config, groups),
+            num_kv_shards=num_kv_shards,
         )
 
     kv_cache_configs: list[KVCacheConfig] = []


### PR DESCRIPTION
## Summary

This PR fixes a bug where `_check_enough_kv_cache_memory` was comparing per-GPU available memory against total required memory without accounting for tensor/pipeline parallelism sharding. This caused multi-GPU deployments with KV offloading to fail at startup even when the aggregated KV capacity was sufficient.

## Problem

When KV offloading is enabled (`--kv_offloading_backend native` or `lmcache`) in a multi-GPU deployment with Tensor Parallelism (TP) and/or Pipeline Parallelism (PP), the memory check incorrectly compares:
- **Available**: per-GPU KV cache memory (e.g., 15.57 GiB)
- **Required**: total KV cache for `max_model_len` across all model layers (e.g., 223.68 GiB)

This causes a spurious `ValueError` that prevents the engine from starting, even though the aggregated KV capacity across all GPUs is sufficient.

### Example
With TP=8, PP=2 on 2 nodes × 8 × H100 80GB (16 GPUs total):
- Per-GPU available: 15.57 GiB
- Total required: 223.68 GiB
- **Current behavior**: 15.57 < 223.68 → FAIL ❌
- **Expected behavior**: 15.57 × 16 = 249.12 > 223.68 → PASS ✓

## Fix

With TP/PP, the KV cache is distributed across multiple GPUs, so the effective available memory per worker should be multiplied by the number of workers sharing the KV cache (TP × PP) before comparing against the total required memory.

This fix:
1. Adds a `num_kv_shards` parameter to `_check_enough_kv_cache_memory` (default=1 for backward compatibility)
2. Multiplies `available_memory` by `num_kv_shards` before the comparison
3. Updates both callers (`check_enough_kv_cache_memory` and `get_kv_cache_configs`) to pass the correct value calculated from `tensor_parallel_size × pipeline_parallel_size`

## Testing

Added a new test `test_check_enough_kv_cache_memory_accounts_for_tp_pp_sharding` that verifies:
- With TP=8, PP=2 (16 GPUs), per-GPU memory of 1024 blocks is sufficient for a model requiring 2048 blocks total
- Without the fix, this would incorrectly raise `ValueError`

## Impact

This bug makes KV offloading **completely unusable** for any multi-GPU distributed deployment with `TP > 1` or `PP > 1` and a large `max_model_len`. Since KV offloading is specifically motivated by scenarios where GPU memory is limited relative to context length, this affects the most common real-world use cases for the feature.

Fixes: https://github.com/vllm-project/vllm/issues/43755

## Checklist

- [x] The purpose of this PR is explained in this message
- [x] The PR has a clear scope (bugfix only)
- [x] Tests have been added to verify the fix
- [x] The code follows the project's style guidelines
- [x] Commits are signed off (DCO)

---

**Note**: This PR was created with AI assistance. All code has been reviewed and tested by the human submitter.