### PR TITLE
chore: update RunAI Model Streamer to 0.16.0

### DIFF
--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -16,7 +16,7 @@ packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
-runai-model-streamer[s3,gcs,azure]==0.15.7
+runai-model-streamer[s3,gcs,azure]==0.16.0
 conch-triton-kernels==1.2.1
 timm>=1.0.17
 # amd-quark: required for Quark quantization on ROCm 

--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -56,7 +56,7 @@ grpcio-reflection==1.78.0
 arctic-inference == 0.1.1; platform_machine == "x86_64" # Required for suffix decoding test
 numba == 0.65.0 # Required for N-gram speculative decoding
 numpy
-runai-model-streamer[s3,gcs,azure]==0.15.7
+runai-model-streamer[s3,gcs,azure]==0.16.0
 fastsafetensors>=0.2.2; platform_machine == "x86_64" # 0.2.2 contains important fixes for multi-GPU mem usage
 instanttensor>=0.1.5; platform_machine == "x86_64"
 pydantic>=2.12 # 2.11 leads to error on python 3.13

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -846,13 +846,13 @@ rpds-py==0.20.1
     #   referencing
 rsa==4.9.1
     # via google-auth
-runai-model-streamer==0.15.7
+runai-model-streamer==0.16.0
     # via -r requirements/test/cuda.in
-runai-model-streamer-azure==0.15.7
+runai-model-streamer-azure==0.16.0
     # via runai-model-streamer
-runai-model-streamer-gcs==0.15.7
+runai-model-streamer-gcs==0.16.0
     # via runai-model-streamer
-runai-model-streamer-s3==0.15.7
+runai-model-streamer-s3==0.16.0
     # via runai-model-streamer
 s3transfer==0.10.3
     # via boto3

--- a/requirements/test/nightly-torch.txt
+++ b/requirements/test/nightly-torch.txt
@@ -42,7 +42,7 @@ tritonclient>=2.51.0
 
 numba == 0.65.0 # Required for N-gram speculative decoding
 numpy
-runai-model-streamer[s3,gcs,azure]==0.15.7
+runai-model-streamer[s3,gcs,azure]==0.16.0
 fastsafetensors>=0.2.2
 instanttensor>=0.1.5
 pydantic>=2.12 # 2.11 leads to error on python 3.13

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -55,7 +55,7 @@ grpcio-reflection==1.78.0
 arctic-inference==0.1.1 # Required for suffix decoding test
 numba==0.65.0 # Required for N-gram speculative decoding
 numpy
-runai-model-streamer[s3,gcs,azure]==0.15.7
+runai-model-streamer[s3,gcs,azure]==0.16.0
 fastsafetensors @ git+https://github.com/foundation-model-stack/fastsafetensors.git@0.2.2 # PyPI only ships CUDA wheels
 instanttensor>=0.1.5
 pydantic>=2.12 # 2.11 leads to error on python 3.13

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -1041,15 +1041,15 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-runai-model-streamer==0.15.7
+runai-model-streamer==0.16.0
     # via
     #   -c requirements/rocm.txt
     #   -r requirements/test/rocm.in
-runai-model-streamer-azure==0.15.7
+runai-model-streamer-azure==0.16.0
     # via runai-model-streamer
-runai-model-streamer-gcs==0.15.7
+runai-model-streamer-gcs==0.16.0
     # via runai-model-streamer
-runai-model-streamer-s3==0.15.7
+runai-model-streamer-s3==0.16.0
     # via runai-model-streamer
 s3transfer==0.16.0
     # via boto3


### PR DESCRIPTION
Update runai-model-streamer and its extras (s3, gcs, azure) from 0.15.7 to 0.16.0 across all requirement files, setup.py, Dockerfile, and docker/versions.json.




## Purpose
To pick latest changes for Azure Blob changes

## Test Plan
Tested locally

## Test Result
Changes tested with Azure blob

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

