### PR TITLE
[Bugfix][DeepSeekV4] Handle optional scale tensors for W4A16-FP8 artifacts

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -150,6 +150,12 @@ class DeepseekV4MLA(nn.Module):
 
         self.kv_norm = kv_norm
         self.wo_a = wo_a
+        # Cache wo_a quant state at init so torch.compile does not need to
+        # trace hasattr() on an attribute that may or may not exist.
+        self._wo_a_is_unquantized = (
+            not hasattr(wo_a, "weight_scale_inv")
+            and not hasattr(wo_a, "weight_scale")
+        )
 
         self._wo_a_act_quant = QuantFP8(
             static=False,
@@ -260,7 +266,10 @@ class DeepseekV4MLA(nn.Module):
         o = o_padded[:, : self.n_local_heads, :]
 
         # Keep ROCm on the BF16 reference wo_a path util kernel ready.
-        if current_platform.is_rocm():
+        # Also use the BF16 reference path when wo_a is unquantized. The
+        # rocm_inv_rope_einsum helper already handles both the quantized and
+        # BF16 wo_a cases via its own hasattr check.
+        if current_platform.is_rocm() or self._wo_a_is_unquantized:
             z = rocm_inv_rope_einsum(
                 self.rotary_emb,
                 o,
@@ -285,7 +294,15 @@ class DeepseekV4MLA(nn.Module):
         )
 
         wo_a_fp8 = self.wo_a.weight
-        wo_a_scale = self.wo_a.weight_scale_inv
+        # CompressedTensorsW8A16Fp8 BLOCK strategy renames `weight_scale` ->
+        # `weight_scale_inv` in process_weights_after_loading
+        # (compressed_tensors_w8a16_fp8.py:130). The W8A8Fp8 BLOCK strategy
+        # delegates to fp8_linear.process_weights_after_loading, which preserves
+        # whichever name was on disk (`weight_scale` or `weight_scale_inv`).
+        # Fall back so both scheme paths reach the same einsum entry point.
+        wo_a_scale = getattr(self.wo_a, "weight_scale_inv", None)
+        if wo_a_scale is None:
+            wo_a_scale = self.wo_a.weight_scale
 
         z = torch.empty(
             (num_tokens, self.n_local_groups, self.o_lora_rank),

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1117,14 +1117,23 @@ class DeepseekV4Model(nn.Module):
                     continue
                 if weight_name not in name:
                     continue
-                name = name.replace(weight_name, param_name)
+                mapped_name = name.replace(weight_name, param_name)
 
-                if is_pp_missing_parameter(name, self):
+                if is_pp_missing_parameter(mapped_name, self):
                     break
-                param = params_dict[name]
+                if mapped_name not in params_dict:
+                    if (
+                        param_name == "compressor.fused_wkv_wgate"
+                        and mapped_name.endswith(
+                            (".weight_scale", ".weight_scale_inv", ".input_scale")
+                        )
+                    ):
+                        break
+                    raise KeyError(mapped_name)
+                param = params_dict[mapped_name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
-                loaded_params.add(name)
+                loaded_params.add(mapped_name)
                 break
             else:
                 if ".experts." in name:
@@ -1175,6 +1184,12 @@ class DeepseekV4Model(nn.Module):
                 else:
                     if is_pp_missing_parameter(name, self):
                         continue
+                    if name not in params_dict:
+                        if name.endswith(
+                            (".weight_scale", ".weight_scale_inv", ".input_scale")
+                        ):
+                            continue
+                        raise KeyError(name)
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader


### PR DESCRIPTION
## Summary

This PR fixes DeepSeek-V4 weight loading and attention scale handling for W4A16-FP8 artifacts where some optional scale tensors are present in the checkpoint but not materialized as model parameters.

In particular, this fixes two failure modes observed on current `main` when loading `DeepSeek-V4-Flash-W4A16-FP8-MTP`:

```text
KeyError: layers.10.attn.mla_attn.compressor.fused_wkv_wgate.weight_scale
AttributeError: 'ColumnParallelLinear' object has no attribute 'weight_scale_inv'
```

The changes are limited to DeepSeek-V4:

- Skip optional scale tensors when the checkpoint contains them but the corresponding parameter slot is not present.
- Fall back from `weight_scale_inv` to `weight_scale` for `wo_a`.
- Use the BF16 reference path when `wo_a` is unquantized.

## Why

Some DeepSeek-V4 W4A16-FP8 artifacts may include optional scale tensors such as:

```text
.weight_scale
.weight_scale_inv
.input_scale
```

but the current model parameter dictionary does not always have a matching parameter slot for every such key. The loader currently indexes `params_dict[name]` directly and fails with `KeyError`.

Separately, the attention path assumes `wo_a.weight_scale_inv` exists. In some quantization paths, the scale is kept as `weight_scale`; in unquantized/BF16 cases, there is no scale tensor at all.

## Validation

Tested on:

```text
GPU: 2x NVIDIA H20
vLLM base: current main
Model: DeepSeek-V4-Flash-W4A16-FP8-MTP
TP: 2
max_model_len: 4096
kv_cache_dtype: fp8
safetensors_load_strategy: prefetch
```

Server command:

```bash
vllm serve "$MODEL" \
  --host 127.0.0.1 \
  --port 8000 \
  --tensor-parallel-size 2 \
  --kv-cache-dtype fp8 \
  --dtype auto \
  --gpu-memory-utilization 0.92 \
  --max-model-len 4096 \
  --max-num-seqs 4 \
  --max-num-batched-tokens 4096 \
  --safetensors-load-strategy prefetch
```

Result:

```text
- current main without this patch fails during model loading / initialization
- with this patch, the model loads successfully
- CUDA graph/profile completes
- server reaches Application startup complete
- /v1/completions returns 200 OK
```

Smoke request:

```bash
curl http://127.0.0.1:8000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "'"$MODEL"'",
    "prompt": "Hello, briefly explain what vLLM is.",
    "max_tokens": 16,
    "temperature": 0
  }'
```

Observed response:

```text
HTTP 200 OK
completion_tokens: 16
```

Also checked:

```bash
python -m py_compile \
  vllm/models/deepseek_v4/attention.py \
  vllm/models/deepseek_v4/nvidia/model.py
```
