### PR TITLE
[Bugfix][DeepSeekV4] Skip MTP quant config for BF16 draft weights

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -63,6 +63,74 @@ logger = init_logger(__name__)
 _EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.w[123]\.scale$")
 
 
+def _mtp_block_is_quantized_on_disk(vllm_config: VllmConfig) -> bool:
+    """Detect whether the MTP block weights on disk carry quantization scales.
+
+    Some DSV4 artifacts exclude the MTP block from quantization calibration and
+    ship MTP weights as BF16. Those weights do not have companion
+    ``.weight_scale`` / ``.weight_scale_inv`` / ``.weight_packed`` keys for
+    ``mtp.*`` modules.
+
+    If we apply the main model's ``quant_config`` to the MTP draft model in
+    that case, the FusedMoE inside ``mtp_block.ffn`` allocates parameter slots
+    matching the main quant scheme (``w13_weight_packed`` for NVFP4,
+    ``weight_scale_inv`` for FP8_BLOCK, etc.). The loader then iterates the
+    on-disk ``w1.weight``/``w2.weight``/``w3.weight`` keys, the expert mapping
+    rewrites the suffix to the quantized name, and ``params_dict[name]`` fails
+    with ``KeyError``. The attention forward path independently fails with
+    ``AttributeError: ColumnParallelLinear has no attribute weight_scale`` /
+    ``weight_scale_inv`` because the unquantized ``wo_a`` has no scale tensors.
+
+    Read the safetensors index for the artifact, scan for any ``mtp.*`` key
+    whose suffix indicates quantization. Returns True if found, False otherwise.
+    Returns True on any error (conservative: match current upstream behavior).
+    """
+    import json
+    from pathlib import Path
+
+    try:
+        model_path = vllm_config.speculative_config.draft_model_config.model
+        if model_path is None:
+            return True
+        # Local artifact: model.safetensors.index.json is at the root.
+        # HF-cached artifact: same layout under ~/.cache/huggingface/hub/...
+        # Both go through the same Path() handling below.
+        idx_path = Path(model_path) / "model.safetensors.index.json"
+        if not idx_path.exists():
+            return True  # No sharded index; assume single-shard quant (current behavior)
+
+        with idx_path.open() as f:
+            idx = json.load(f)
+        weight_map = idx.get("weight_map", {})
+
+        # Scan only ``mtp.*`` keys for quantization-scale suffixes. This is
+        # the minimum information needed; we don't need to read tensor headers.
+        quant_suffixes = (
+            ".weight_scale",
+            ".weight_scale_inv",
+            ".weight_packed",
+            ".weight_global_scale",
+            ".input_global_scale",
+            ".weight_zero_point",
+        )
+        for key in weight_map:
+            if not key.startswith("mtp."):
+                continue
+            if any(key.endswith(suf) for suf in quant_suffixes):
+                return True
+
+        # No MTP quant scales found: MTP weights are unquantized (BF16).
+        return False
+    except Exception as e:
+        logger.warning(
+            "Could not detect MTP block quantization state from artifact "
+            "index, defaulting to quantized (current upstream behavior). "
+            "Error: %s",
+            e,
+        )
+        return True
+
+
 class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
     def __init__(
         self,
@@ -76,7 +144,23 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         assert vllm_config.speculative_config is not None
         config = vllm_config.speculative_config.draft_model_config.hf_config
         self.config = config
-        quant_config = vllm_config.quant_config
+
+        # MTP block construction: if the artifact's MTP weights are BF16 on
+        # disk (no quantization scales for any ``mtp.*`` key), bypass the
+        # main model's quant_config for the entire MTP draft tower. See
+        # ``_mtp_block_is_quantized_on_disk`` and vLLM issue #43304 for the
+        # rationale.
+        if _mtp_block_is_quantized_on_disk(vllm_config):
+            quant_config = vllm_config.quant_config
+        else:
+            quant_config = None
+            logger.info_once(
+                "MTP block weights are BF16 on disk (no quant scales for "
+                "mtp.* keys in the safetensors index). Constructing the MTP "
+                "draft tower without quantization to match the artifact "
+                "shape. This unblocks --speculative-config method=mtp for "
+                "artifacts that exclude the MTP block from calibration."
+            )
         self.rms_norm_eps = config.rms_norm_eps
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
## Summary

This PR fixes DeepSeek-V4 MTP draft model construction for artifacts whose `mtp.*` weights are BF16 on disk.

Some DeepSeek-V4 artifacts exclude the MTP block from quantization calibration. In that case, the target model is quantized, but the MTP draft block is stored as BF16 and does not have MTP-specific quantization scale tensors in the safetensors index.

Before this change, the MTP draft tower always reused the main model's `quant_config`. That makes the draft model allocate quantized parameter slots for the MTP block, while the checkpoint provides BF16 `mtp.*` weights. The loader then fails when mapping the on-disk weights to quantized parameter names.

This PR detects whether the MTP block has quantization tensors on disk. If no `mtp.*` quantization scale / packed-weight keys are found, the draft tower is constructed without `quant_config` so that its parameter structure matches the BF16 checkpoint.

Related PR:

- #43892 fixes an earlier DeepSeek-V4 optional-scale loading issue for the same artifact. The code change in this PR is independent, but the end-to-end validation below was run together with #43892 because current `main` otherwise fails before reaching the MTP draft model path.

## Scope

This PR is limited to DeepSeek-V4 MTP draft model construction.

It does not change the target model quantization path.

It does not attempt to fix DeepGEMM `next_n=3` support. For this PR, the primary validation target is `num_speculative_tokens=1`, which maps to the existing DeepGEMM `next_n=2` path.

## Implementation

The helper `_mtp_block_is_quantized_on_disk()` reads `model.safetensors.index.json` from the draft model path and scans only `mtp.*` keys.

It returns `True` if it finds any MTP quantization-related suffix, such as:

```text
.weight_scale
.weight_scale_inv
.weight_packed
.weight_global_scale
.input_global_scale
.weight_zero_point
```

If no such key is found for `mtp.*`, the MTP block is treated as BF16 on disk and the draft tower uses:

```python
quant_config = None
```

The fallback is conservative: if the index is missing or cannot be read, the code keeps the current upstream behavior and assumes the MTP block is quantized.

## Validation

Tested on:

```text
GPU: 2x NVIDIA H20
vLLM base: current main + #43892
Model: DeepSeek-V4-Flash-W4A16-FP8-MTP
TP: 2
max_model_len: 4096
kv_cache_dtype: fp8
safetensors_load_strategy: prefetch
```

Server command:

```bash
vllm serve "$MODEL" \
  --host 127.0.0.1 \
  --port 8000 \
  --tensor-parallel-size 2 \
  --kv-cache-dtype fp8 \
  --dtype auto \
  --gpu-memory-utilization 0.92 \
  --max-model-len 4096 \
  --max-num-seqs 4 \
  --max-num-batched-tokens 4096 \
  --safetensors-load-strategy prefetch \
  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
```

Observed log:

```text
MTP block weights are BF16 on disk (no quant scales for mtp.* keys in the safetensors index).
Constructing the MTP draft tower without quantization to match the artifact shape.
MTP draft model loaded: 31 params
```

Result:

```text
- MTP draft model loads successfully
- server reaches Application startup complete
- /v1/completions returns 200 OK
- spec_decode metrics are emitted
```

Smoke request:

```bash
curl http://127.0.0.1:8000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "'"$MODEL"'",
    "prompt": "Write one short sentence about speculative decoding.",
    "max_tokens": 16,
    "temperature": 0
  }'
```

Observed response:

```text
HTTP 200 OK
completion_tokens: 16
```

Also checked:

```bash
python -m py_compile vllm/models/deepseek_v4/nvidia/mtp.py
```

## Note

I also verified `num_speculative_tokens=2` locally with a patched DeepGEMM build that supports SM90 paged MQA logits `next_n=3`, but that DeepGEMM change is separate from this vLLM-side fix. This PR only addresses the MTP draft model quantization mismatch.
