### PR TITLE
[Misc] add option to prevent private networks access for media urls

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -13,6 +13,9 @@ This page teaches you how to pass multi-modal inputs to [multi-modal models](../
 
     This restriction is especially important if you run vLLM in a containerized environment where the vLLM pods may have unrestricted access to internal networks.
 
+    A less restrictive flag is also available to limit media access to public domains only. This can be activated by setting `--forbid-media-private-networks-access`.
+    Note that when this flag is set, the HTTP redirects are automatically prevented.
+
 ## Offline Inference
 
 To input multi-modal data, follow this schema in [vllm.inputs.PromptType][]:

--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -85,6 +85,10 @@ significantly reduce the attack surface for these types of abuse.
 Also, consider setting `VLLM_MEDIA_URL_ALLOW_REDIRECTS=0` to prevent HTTP
 redirects from being followed to bypass domain restrictions.
 
+For use cases where all the public domains are allowed,
+`--forbid-media-private-networks-access` can be used to restrict domains resolution
+to public IPs.
+
 ### 5. **Restrict Media Decode Sizes:**
 
 Compressed media files can expand into gigabytes of memory during decoding. vLLM

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -196,6 +196,11 @@ pub struct EngineUnsupportedArgs {
     #[arg(long)]
     pub allowed_media_domains: Option<Unsupported>,
 
+    /// If set, only media URLs that belong to a public domain can be used for
+    /// multi-modal inputs.
+    #[arg(long)]
+    pub forbid_media_private_networks_access: Option<Unsupported>,
+
     /// The specific revision to use for the tokenizer on the Hugging Face Hub.
     /// It can be a branch name, a tag name, or a commit id. If unspecified,
     /// will use the default version.

--- a/tests/entrypoints/serve/tokenize/test_serving_tokenization.py
+++ b/tests/entrypoints/serve/tokenize/test_serving_tokenization.py
@@ -46,6 +46,7 @@ class MockModelConfig:
     diff_sampling_param: dict | None = None
     allowed_local_media_path: str = ""
     allowed_media_domains: list[str] | None = None
+    forbid_media_private_networks_access: bool = False
     encoder_config = None
     generation_config: str = "auto"
     media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)

--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -33,6 +33,15 @@ TEST_VIDEO_URLS = [
     "https://github.com/opencv/opencv/raw/refs/tags/4.12.0/samples/data/vtest.avi",
 ]
 
+TEST_VIDEO_URLS_PRIVATE_NETWORK = [
+    "http://localhost/does-not-exist.mp4",
+    "http://localhost:9000/does-not-exist.mp4",
+    "http://127.0.0.1/does-not-exist.avi",
+    "http://127.0.0.1.nip.io/does/not/exist.mp4",
+    "http://192.168.0.2/does-not-exist.avi",
+    "http://192.168.0.5:8006/does-not-exist.avi",
+]
+
 
 @pytest.fixture(scope="module")
 def url_images(local_asset_server) -> dict[str, Image.Image]:
@@ -339,6 +348,24 @@ async def test_allowed_media_domains(video_url: str, num_frames: int):
 
     with pytest.raises(ValueError):
         _, _ = await connector.fetch_video_async(disallowed_url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("private_video_url", TEST_VIDEO_URLS_PRIVATE_NETWORK)
+async def test_forbid_private_networks_access_for_media(private_video_url: str):
+    connector = MediaConnector(
+        media_io_kwargs={
+            "video": {
+                "forbid_private_networks_access": True,
+            }
+        },
+    )
+
+    with pytest.raises(ValueError):
+        _, _ = await connector.fetch_video_async(private_video_url)
+
+    with pytest.raises(ValueError):
+        _, _ = await connector.fetch_video_async(private_video_url)
 
 
 @pytest.mark.asyncio

--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -86,7 +86,9 @@ async def test_fetch_image_base64(
         allowed_media_domains=[
             "www.bogotobogo.com",
             "github.com",
-        ]
+        ],
+        # Private domain restriction should not apply to data URLs.
+        forbid_media_private_networks_access=True,
     )
     url_image = url_images[raw_image_url]
 
@@ -354,11 +356,7 @@ async def test_allowed_media_domains(video_url: str, num_frames: int):
 @pytest.mark.parametrize("private_video_url", TEST_VIDEO_URLS_PRIVATE_NETWORK)
 async def test_forbid_private_networks_access_for_media(private_video_url: str):
     connector = MediaConnector(
-        media_io_kwargs={
-            "video": {
-                "forbid_private_networks_access": True,
-            }
-        },
+        forbid_media_private_networks_access=True,
     )
 
     with pytest.raises(ValueError):

--- a/tests/renderers/test_chat_utils_prompt_embeds.py
+++ b/tests/renderers/test_chat_utils_prompt_embeds.py
@@ -97,6 +97,7 @@ def _make_mock_model_config(*, enable_prompt_embeds: bool = True) -> mock.MagicM
     mc.multimodal_config = None
     mc.allowed_local_media_path = None
     mc.allowed_media_domains = None
+    mc.forbid_media_private_networks_access = False
     # Test text-only code path in `MultiModalItemTracker.resolve_items`.
     mc.is_multimodal_model = False
     # `safe_load_prompt_embeds` pins each tensor to the model's hidden_size

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -40,6 +40,7 @@ def _model_config():
         multimodal_config=None,
         allowed_local_media_path="",
         allowed_media_domains=None,
+        forbid_media_private_networks_access=False,
         enable_prompt_embeds=False,
     )
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -168,6 +168,9 @@ class ModelConfig:
     allowed_media_domains: list[str] | None = None
     """If set, only media URLs that belong to this domain can be used for
     multi-modal inputs. """
+    forbid_media_private_networks_access: bool = False
+    """If set, only media URLs that resolve to a public domain can be used for
+    multi-modal inputs. """
     revision: str | None = None
     """The specific model version to use. It can be a branch name, a tag name,
     or a commit id. If unspecified, will use the default version."""
@@ -378,6 +381,7 @@ class ModelConfig:
             "hf_config_path",
             "allowed_local_media_path",
             "allowed_media_domains",
+            "forbid_media_private_networks_access",
             "tokenizer_revision",
             "spec_target_max_model_len",
             "enforce_eager",

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -110,7 +110,9 @@ class MultiModalConfig:
     media_io_kwargs: dict[str, dict[str, Any]] = Field(default_factory=dict)
     """Additional args passed to process media inputs, keyed by modalities.
     For example, to set num_frames for video, set
-    `--media-io-kwargs '{"video": {"num_frames": 40} }'`"""
+    `--media-io-kwargs '{"video": {"num_frames": 40} }'`
+    or to forbid private private networks access for images, set
+    `--media-io-kwargs '{"image": {"forbid_private_networks_access": true} }'`"""
     mm_processor_kwargs: dict[str, object] | None = None
     """Arguments to be forwarded to the model's processor for multi-modal data,
     e.g., image processor. Overrides for the multi-modal processor obtained

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -110,9 +110,7 @@ class MultiModalConfig:
     media_io_kwargs: dict[str, dict[str, Any]] = Field(default_factory=dict)
     """Additional args passed to process media inputs, keyed by modalities.
     For example, to set num_frames for video, set
-    `--media-io-kwargs '{"video": {"num_frames": 40} }'`
-    or to forbid private private networks access for images, set
-    `--media-io-kwargs '{"image": {"forbid_private_networks_access": true} }'`"""
+    `--media-io-kwargs '{"video": {"num_frames": 40} }'`"""
     mm_processor_kwargs: dict[str, object] | None = None
     """Arguments to be forwarded to the model's processor for multi-modal data,
     e.g., image processor. Overrides for the multi-modal processor obtained

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -729,6 +729,7 @@ class SpeculativeConfig:
                     trust_remote_code=self.target_model_config.trust_remote_code,
                     allowed_local_media_path=self.target_model_config.allowed_local_media_path,
                     allowed_media_domains=self.target_model_config.allowed_media_domains,
+                    forbid_media_private_networks_access=self.target_model_config.forbid_media_private_networks_access,
                     dtype=self.target_model_config.dtype,
                     seed=self.target_model_config.seed,
                     revision=self.revision,

--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import functools
+import ssl
 import time
 from collections.abc import Callable, Coroutine, Mapping, MutableMapping
 from pathlib import Path
@@ -10,7 +11,9 @@ from typing import Any, ParamSpec, TypeVar
 
 import aiohttp
 import requests
-from urllib3.util import parse_url
+from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
+from urllib3.util import Url, parse_url
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -197,6 +200,83 @@ def _async_retry(
     return wrapper  # type: ignore[return-value]
 
 
+class SSRFSafeClient(requests.Session):
+    """Wrapper class of the request.Session client that sends requests
+    using the pre-validated IP obtained for the original domain used in the URL.
+    This client is used when the --forbid-media-private-networks-access flag is
+    enforced to prevent TOCTOU DNS rebinding SSRF bypass.
+    """
+
+    def __init__(self, url: str, pre_validated_ip: str, *args, **kwargs):
+        self.pre_validated_ip = pre_validated_ip
+        # Extract hostname and scheme to be injected into adapter
+        self.parsed_url = parse_url(url)
+        self.scheme = self.parsed_url.scheme
+        self.original_hostname = self.parsed_url.hostname or self.parsed_url.host or ""
+
+        # Initialize requests.session
+        super().__init__(*args, **kwargs)
+
+        # Enforce original host headers on that session
+        self._update_headers()
+        # Mount original-host-aware custom adapter for that session session
+        self._setup_adapter()
+
+    # Monky-patch the client.request of the request.Session object. This ensure
+    # that all the helpers methods of the client (GET, OPTIONS, etc ...) will
+    # use the pre-validated-ip instead of the original domain.
+    def request(self, method: str, url: str, *args, **kwargs):  # type: ignore
+        # Reconstruct the url, replacing the hostname with the pre-validated IP address
+        ip_url = self._get_ip_url(self.parsed_url, self.pre_validated_ip)
+        return super().request(method, ip_url, *args, **kwargs)
+
+    def _setup_adapter(self):
+        is_ssl = self.scheme == "https"
+        adapter = SSRFSafeAdapter(self.original_hostname, is_ssl)
+        # Mount a custom adapter to the schema matching the url.
+        # For https requests, the adapter will ensure https certificate is
+        # checked against cn=original_hostname and not the ip present in url.
+        self.mount(f"{self.scheme}://", adapter)
+
+    def _update_headers(self):
+        # Send request with proper Host header (original hostname)
+        self.headers.update(
+            {
+                "Host": self.original_hostname,
+            }
+        )
+
+    @staticmethod
+    def _get_ip_url(parsed_url, ip_to_enforce):
+        return Url(
+            scheme=parsed_url.scheme,
+            auth=parsed_url.auth,
+            host=ip_to_enforce,
+            port=parsed_url.port,
+            path=parsed_url.path,
+            query=parsed_url.query,
+            fragment=parsed_url.fragment,
+        )
+
+
+class SSRFSafeAdapter(HTTPAdapter):
+    """Adapter that connects to an IP address
+    but validates TLS for the original host.
+    """
+
+    def __init__(self, original_hostname, is_ssl, *args, **kwargs):
+        self.original_hostname = original_hostname
+        self.is_ssl = is_ssl
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["server_hostname"] = self.original_hostname
+        if self.is_ssl:
+            context = ssl.create_default_context()
+            kwargs["ssl_context"] = context
+        self.poolmanager = PoolManager(*args, **kwargs)
+
+
 class HTTPConnection:
     """Helper class to send HTTP requests."""
 
@@ -213,6 +293,11 @@ class HTTPConnection:
             self._sync_client = requests.Session()
 
         return self._sync_client
+
+    def get_sync_ssrf_safe_client(
+        self, url: str, pre_validated_ip: str
+    ) -> SSRFSafeClient:
+        return SSRFSafeClient(url, pre_validated_ip)
 
     # NOTE: We intentionally use an async function even though it is not
     # required, so that the client is only accessible inside async event loop
@@ -241,10 +326,15 @@ class HTTPConnection:
         timeout: float | None = None,
         extra_headers: Mapping[str, str] | None = None,
         allow_redirects: bool = True,
+        pre_validated_ip: str | None = None,
     ):
         self._validate_http_url(url)
 
         client = self.get_sync_client()
+        if pre_validated_ip:
+            # If a pre-validated IP has been provided, we use a custom client
+            # to enforce that IP and prevent DNS rebinding
+            client = self.get_sync_ssrf_safe_client(url, pre_validated_ip)
         extra_headers = extra_headers or {}
 
         return client.get(
@@ -262,8 +352,12 @@ class HTTPConnection:
         timeout: float | None = None,
         extra_headers: Mapping[str, str] | None = None,
         allow_redirects: bool = True,
+        pre_validated_ip: str | None = None,
     ):
         self._validate_http_url(url)
+
+        # TODO: if a pre-validated IP is provided, build a custom
+        # aiohttp.TCPConnector with custom resolver that returns the pre-validated IP
 
         client = await self.get_async_client()
         extra_headers = extra_headers or {}
@@ -277,10 +371,18 @@ class HTTPConnection:
 
     @_sync_retry
     def get_bytes(
-        self, url: str, *, timeout: float | None = None, allow_redirects: bool = True
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+        allow_redirects: bool = True,
+        pre_validated_ip: str | None = None,
     ) -> bytes:
         with self.get_response(
-            url, timeout=timeout, allow_redirects=allow_redirects
+            url,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            pre_validated_ip=pre_validated_ip,
         ) as r:
             r.raise_for_status()
 
@@ -293,9 +395,13 @@ class HTTPConnection:
         *,
         timeout: float | None = None,
         allow_redirects: bool = True,
+        pre_validated_ip: str | None = None,
     ) -> bytes:
         async with await self.get_async_response(
-            url, timeout=timeout, allow_redirects=allow_redirects
+            url,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            pre_validated_ip=pre_validated_ip,
         ) as r:
             r.raise_for_status()
 

--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import functools
+import socket
 import ssl
 import time
 from collections.abc import Callable, Coroutine, Mapping, MutableMapping
@@ -11,6 +12,7 @@ from typing import Any, ParamSpec, TypeVar
 
 import aiohttp
 import requests
+from aiohttp.resolver import AsyncResolver, ResolveResult
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 from urllib3.util import Url, parse_url
@@ -28,6 +30,8 @@ _T = TypeVar("_T")
 # Attempt N uses: base_timeout * (_RETRY_BACKOFF_FACTOR ** N) for the
 # per-attempt timeout and sleeps _RETRY_BACKOFF_FACTOR ** N seconds.
 _RETRY_BACKOFF_FACTOR = 4
+
+_NUMERIC_SOCKET_FLAGS = socket.AI_NUMERICHOST | socket.AI_NUMERICSERV
 
 
 def _is_retryable(exc: Exception) -> bool:
@@ -277,6 +281,27 @@ class SSRFSafeAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(*args, **kwargs)
 
 
+class SSRFSafeAsyncResolverWrapper(AsyncResolver):
+    def __init__(self, pre_validated_ip: str, *args: Any, **kwargs: Any):
+        self.pre_validated_ip = pre_validated_ip
+
+    async def resolve(
+        self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
+    ):
+        return [
+            ResolveResult(
+                hostname=host,
+                host=self.pre_validated_ip,
+                port=port,
+                family=socket.AF_INET6
+                if ":" in self.pre_validated_ip
+                else socket.AF_INET,
+                proto=0,
+                flags=_NUMERIC_SOCKET_FLAGS,
+            )
+        ]
+
+
 class HTTPConnection:
     """Helper class to send HTTP requests."""
 
@@ -307,6 +332,13 @@ class HTTPConnection:
 
         return self._async_client
 
+    async def get_async_ssrf_safe_client(
+        self, pre_validated_ip: str
+    ) -> aiohttp.ClientSession:
+        resolver = SSRFSafeAsyncResolverWrapper(pre_validated_ip)
+        connector = aiohttp.TCPConnector(resolver=resolver)
+        return aiohttp.ClientSession(connector=connector)
+
     def _validate_http_url(self, url: str):
         parsed_url = parse_url(url)
 
@@ -333,7 +365,7 @@ class HTTPConnection:
         client = self.get_sync_client()
         if pre_validated_ip:
             # If a pre-validated IP has been provided, we use a custom client
-            # to enforce that IP and prevent DNS rebinding
+            # to enforce that IP in the request and prevent DNS rebinding.
             client = self.get_sync_ssrf_safe_client(url, pre_validated_ip)
         extra_headers = extra_headers or {}
 
@@ -356,10 +388,11 @@ class HTTPConnection:
     ):
         self._validate_http_url(url)
 
-        # TODO: if a pre-validated IP is provided, build a custom
-        # aiohttp.TCPConnector with custom resolver that returns the pre-validated IP
-
         client = await self.get_async_client()
+        if pre_validated_ip:
+            # If a pre-validated IP has been provided, we use a custom client
+            # to enforce that IP in the request and prevent DNS rebinding.
+            client = await self.get_async_ssrf_safe_client(pre_validated_ip)
         extra_headers = extra_headers or {}
 
         return client.get(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -428,6 +428,9 @@ class EngineArgs:
     trust_remote_code: bool = ModelConfig.trust_remote_code
     allowed_local_media_path: str = ModelConfig.allowed_local_media_path
     allowed_media_domains: list[str] | None = ModelConfig.allowed_media_domains
+    forbid_media_private_networks_access: bool = (
+        ModelConfig.forbid_media_private_networks_access
+    )
     download_dir: str | None = LoadConfig.download_dir
     safetensors_load_strategy: SafetensorsLoadStrategy | None = (
         LoadConfig.safetensors_load_strategy
@@ -810,6 +813,10 @@ class EngineArgs:
         )
         model_group.add_argument(
             "--allowed-media-domains", **model_kwargs["allowed_media_domains"]
+        )
+        model_group.add_argument(
+            "--forbid-media-private-networks-access",
+            **model_kwargs["forbid_media_private_networks_access"],
         )
         model_group.add_argument("--revision", **model_kwargs["revision"])
         model_group.add_argument("--code-revision", **model_kwargs["code_revision"])
@@ -1616,6 +1623,7 @@ class EngineArgs:
             trust_remote_code=self.trust_remote_code,
             allowed_local_media_path=self.allowed_local_media_path,
             allowed_media_domains=self.allowed_media_domains,
+            forbid_media_private_networks_access=self.forbid_media_private_networks_access,
             dtype=self.dtype,
             seed=self.seed,
             revision=self.revision,

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -572,6 +572,10 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
         return self._model_config.allowed_media_domains
 
     @property
+    def forbid_media_private_networks_access(self):
+        return self._model_config.forbid_media_private_networks_access
+
+    @property
     def mm_registry(self):
         return MULTIMODAL_REGISTRY
 
@@ -929,6 +933,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
             media_io_kwargs=tracker.media_io_kwargs,
             allowed_local_media_path=tracker.allowed_local_media_path,
             allowed_media_domains=tracker.allowed_media_domains,
+            forbid_media_private_networks_access=tracker.forbid_media_private_networks_access,
         )
 
         self._mm_processor_kwargs = mm_processor_kwargs
@@ -1076,6 +1081,7 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
             media_io_kwargs=tracker.media_io_kwargs,
             allowed_local_media_path=tracker.allowed_local_media_path,
             allowed_media_domains=tracker.allowed_media_domains,
+            forbid_media_private_networks_access=tracker.forbid_media_private_networks_access,
         )
         self._mm_processor_kwargs: dict[str, Any] | None = mm_processor_kwargs
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -88,6 +88,8 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             environments.
         allowed_media_domains: If set, only media URLs that belong to this
             domain can be used for multi-modal inputs.
+        forbid_media_private_networks_access: If set, only media URLs that
+            belong to a public domain can be used for multi-modal inputs.
         tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
         dtype: The data type for the model weights and activations. Currently,
@@ -185,6 +187,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         trust_remote_code: bool = False,
         allowed_local_media_path: str = "",
         allowed_media_domains: list[str] | None = None,
+        forbid_media_private_networks_access: bool = False,
         tensor_parallel_size: int = 1,
         dtype: ModelDType = "auto",
         quantization: QuantizationMethods | None = None,
@@ -312,6 +315,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             trust_remote_code=trust_remote_code,
             allowed_local_media_path=allowed_local_media_path,
             allowed_media_domains=allowed_media_domains,
+            forbid_media_private_networks_access=forbid_media_private_networks_access,
             tensor_parallel_size=tensor_parallel_size,
             dtype=dtype,
             quantization=quantization,

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -290,13 +290,21 @@ class MediaConnector:
                 f"{url_spec.hostname}"
             )
 
-    def _assert_network_is_public(self, url_spec: Url) -> None:
+    def _assert_network_is_public(self, url_spec: Url) -> str:
         hostname = url_spec.hostname
+        ipv4_addresses = []
+        ipv6_addresses = []
         try:
             results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
             for result in results:
-                _, _, _, _, sockaddr = result
+                family, _, _, _, sockaddr = result
                 address = sockaddr[0]
+
+                if family == socket.AF_INET:
+                    ipv4_addresses.append(address)
+                elif family == socket.AF_INET6:
+                    ipv6_addresses.append(address)
+
                 ip_obj = ipaddress.ip_address(address)
                 # here we rely on ip_obj.is_global as ipaddress.is_private returns False
                 # for CGNAT addresses, which are used internally by cloud providers
@@ -310,12 +318,19 @@ class MediaConnector:
         except socket.gaierror as e:
             raise ValueError(f"Unable to resolve URL domain '{hostname}': {e}") from e
 
-    def _maybe_validate_private_networks_access(self, url: str | Url) -> None:
+        # this is just a safety check to please the linter, but if we end up here we
+        # have at least an ip address in one of the ip lists.
+        pre_validated_ip = (
+            ipv4_addresses[0] if len(ipv4_addresses) > 0 else ipv6_addresses[0]
+        )
+        return str(pre_validated_ip)
+
+    def _maybe_validate_private_networks_access(self, url: str | Url) -> str | None:
         if not self.forbid_media_private_networks_access:
-            return
+            return None
         if not isinstance(url, Url):
             url = parse_url(url)
-        self._assert_network_is_public(url)
+        return self._assert_network_is_public(url)
 
     def load_from_url(
         self,
@@ -331,7 +346,7 @@ class MediaConnector:
 
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
-            self._maybe_validate_private_networks_access(url_spec)
+            pre_validated_ip = self._maybe_validate_private_networks_access(url_spec)
 
             cached = self._get_cached_bytes(url)
             if cached is not None:
@@ -344,6 +359,7 @@ class MediaConnector:
                 allow_redirects=False
                 if self.forbid_media_private_networks_access
                 else envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                pre_validated_ip=pre_validated_ip,
             )
 
             self._put_cached_bytes(url, data)
@@ -374,7 +390,7 @@ class MediaConnector:
 
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
-            self._maybe_validate_private_networks_access(url_spec)
+            pre_validated_ip = self._maybe_validate_private_networks_access(url_spec)
 
             cached = await loop.run_in_executor(
                 global_thread_pool, self._get_cached_bytes, url
@@ -392,6 +408,7 @@ class MediaConnector:
                 allow_redirects=False
                 if self.forbid_media_private_networks_access
                 else envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                pre_validated_ip=pre_validated_ip,
             )
 
             await loop.run_in_executor(

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -295,7 +295,11 @@ class MediaConnector:
                 _, _, _, _, sockaddr = result
                 address = sockaddr[0]
                 ip_obj = ipaddress.ip_address(address)
-                if ip_obj.is_private:
+                # here we rely on ip_obj.is_global as ipaddress.is_private returns False
+                # for CGNAT addresses, which are used internally by cloud providers
+                # (e.g., AWS EKS default pod CIDR). An attacker could supply a URL
+                # resolving to this range to reach internal services.
+                if not ip_obj.is_global:
                     raise ValueError(
                         f"The media URL must resolve to a public domain. "
                         f"Input media URL: {url_spec.url}"

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -348,7 +348,9 @@ class MediaConnector:
             data = connection.get_bytes(
                 url_spec.url,
                 timeout=fetch_timeout,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                allow_redirects=False
+                if forbid_private_networks_access
+                else envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
             )
 
             self._put_cached_bytes(url, data)
@@ -398,7 +400,9 @@ class MediaConnector:
             data = await connection.async_get_bytes(
                 url_spec.url,
                 timeout=fetch_timeout,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                allow_redirects=False
+                if forbid_private_networks_access
+                else envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
             )
 
             await loop.run_in_executor(

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -329,10 +329,9 @@ class MediaConnector:
 
         url_spec = parse_url(url)
 
-        self._maybe_validate_private_networks_access(url_spec)
-
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
+            self._maybe_validate_private_networks_access(url_spec)
 
             cached = self._get_cached_bytes(url)
             if cached is not None:
@@ -373,10 +372,9 @@ class MediaConnector:
 
         url_spec = parse_url(url)
 
-        self._maybe_validate_private_networks_access(url_spec)
-
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
+            self._maybe_validate_private_networks_access(url_spec)
 
             cached = await loop.run_in_executor(
                 global_thread_pool, self._get_cached_bytes, url

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -5,7 +5,9 @@ import asyncio
 import atexit
 import contextlib
 import hashlib
+import ipaddress
 import os
+import socket
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -46,6 +48,8 @@ MODALITY_IO_MAP: dict[str, type[MediaIO]] = {
     "image": ImageMediaIO,
     "video": VideoMediaIO,
 }
+
+FORBID_PRIVATE_NETWORKS_ACCESS_IO_KWARGS = "forbid_private_networks_access"
 
 
 def merge_media_io_kwargs(
@@ -283,17 +287,55 @@ class MediaConnector:
                 f"{url_spec.hostname}"
             )
 
+    def _assert_network_is_public(self, url_spec: Url) -> None:
+        hostname = url_spec.hostname
+        try:
+            results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
+            for result in results:
+                _, _, _, _, sockaddr = result
+                address = sockaddr[0]
+                ip_obj = ipaddress.ip_address(address)
+                if ip_obj.is_private:
+                    raise ValueError(
+                        f"The media URL must resolve to a public domain. "
+                        f"Input media URL: {url_spec.url}"
+                    )
+        except socket.gaierror as e:
+            raise ValueError(f"Unable to resolve URL domain '{hostname}': {e}") from e
+
+    def _maybe_validate_private_networks_access(
+        self, url: str | Url, forbid_private_networks_access: bool = False
+    ) -> None:
+        if not forbid_private_networks_access:
+            return
+        if not isinstance(url, Url):
+            url = parse_url(url)
+        self._assert_network_is_public(url)
+
+    def _get_forbid_private_networks_access_for_modality(self, modality: str):
+        return (
+            self.media_io_kwargs.get(modality, {}).get(
+                FORBID_PRIVATE_NETWORKS_ACCESS_IO_KWARGS, None
+            )
+            is not None
+        )
+
     def load_from_url(
         self,
         url: str,
         media_io: MediaIO[_M],
         *,
         fetch_timeout: int | None = None,
+        forbid_private_networks_access: bool = False,
     ) -> _M:  # type: ignore[type-var]
         if url[:5].lower() == "data:":
             return self._load_data_url(url, media_io)
 
         url_spec = parse_url(url)
+
+        self._maybe_validate_private_networks_access(
+            url_spec, forbid_private_networks_access
+        )
 
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
@@ -324,6 +366,7 @@ class MediaConnector:
         media_io: MediaIO[_M],
         *,
         fetch_timeout: int | None = None,
+        forbid_private_networks_access: bool = False,
     ) -> _M:
         loop = asyncio.get_running_loop()
 
@@ -334,6 +377,10 @@ class MediaConnector:
             return await future
 
         url_spec = parse_url(url)
+
+        self._maybe_validate_private_networks_access(
+            url_spec, forbid_private_networks_access
+        )
 
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
@@ -376,11 +423,15 @@ class MediaConnector:
         Load audio from a URL.
         """
         audio_io = AudioMediaIO(**self.media_io_kwargs.get("audio", {}))
+        forbid_private_networks_access = (
+            self._get_forbid_private_networks_access_for_modality("audio")
+        )
 
         return self.load_from_url(
             audio_url,
             audio_io,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
+            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     async def fetch_audio_async(
@@ -391,11 +442,15 @@ class MediaConnector:
         Asynchronously fetch audio from a URL.
         """
         audio_io = AudioMediaIO(**self.media_io_kwargs.get("audio", {}))
+        forbid_private_networks_access = (
+            self._get_forbid_private_networks_access_for_modality("audio")
+        )
 
         return await self.load_from_url_async(
             audio_url,
             audio_io,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
+            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     def fetch_image(
@@ -412,12 +467,16 @@ class MediaConnector:
         image_io = ImageMediaIO(
             image_mode=image_mode, **self.media_io_kwargs.get("image", {})
         )
+        forbid_private_networks_access = (
+            self._get_forbid_private_networks_access_for_modality("image")
+        )
 
         try:
             return self.load_from_url(
                 image_url,
                 image_io,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
+                forbid_private_networks_access=forbid_private_networks_access,
             )
         except UnidentifiedImageError as e:
             # convert to ValueError to be properly caught upstream
@@ -437,12 +496,16 @@ class MediaConnector:
         image_io = ImageMediaIO(
             image_mode=image_mode, **self.media_io_kwargs.get("image", {})
         )
+        forbid_private_networks_access = (
+            self._get_forbid_private_networks_access_for_modality("image")
+        )
 
         try:
             return await self.load_from_url_async(
                 image_url,
                 image_io,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
+                forbid_private_networks_access=forbid_private_networks_access,
             )
         except UnidentifiedImageError as e:
             # convert to ValueError to be properly caught upstream
@@ -467,11 +530,15 @@ class MediaConnector:
         ):
             video_io_kwargs["video_backend"] = video_backend
         video_io = VideoMediaIO(image_io, **video_io_kwargs)
+        forbid_private_networks_access = (
+            self._get_forbid_private_networks_access_for_modality("video")
+        )
 
         return self.load_from_url(
             video_url,
             video_io,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
+            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     async def fetch_video_async(
@@ -495,11 +562,15 @@ class MediaConnector:
         ):
             video_io_kwargs["video_backend"] = video_backend
         video_io = VideoMediaIO(image_io, **video_io_kwargs)
+        forbid_private_networks_access = (
+            self._get_forbid_private_networks_access_for_modality("video")
+        )
 
         return await self.load_from_url_async(
             video_url,
             video_io,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
+            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     def fetch_image_embedding(

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -49,8 +49,6 @@ MODALITY_IO_MAP: dict[str, type[MediaIO]] = {
     "video": VideoMediaIO,
 }
 
-FORBID_PRIVATE_NETWORKS_ACCESS_IO_KWARGS = "forbid_private_networks_access"
-
 
 def merge_media_io_kwargs(
     defaults: dict[str, dict[str, Any]] | None,
@@ -89,6 +87,7 @@ class MediaConnector:
         *,
         allowed_local_media_path: str = "",
         allowed_media_domains: list[str] | None = None,
+        forbid_media_private_networks_access: bool = False,
     ) -> None:
         """
         Args:
@@ -100,6 +99,9 @@ class MediaConnector:
             allowed_local_media_path: A local directory to load media files from.
             allowed_media_domains: If set, only media URLs that belong to this
                                    domain can be used for multi-modal inputs.
+            forbid_media_private_networks_access: If set, only media URLs that
+                                   belong to a public domain can be used for
+                                   multimodal inputs.
         """
         super().__init__()
 
@@ -128,6 +130,7 @@ class MediaConnector:
         if allowed_media_domains is None:
             allowed_media_domains = []
         self.allowed_media_domains = allowed_media_domains
+        self.forbid_media_private_networks_access = forbid_media_private_networks_access
 
         # Media download cache (opt-in via VLLM_MEDIA_CACHE)
         self._media_cache_dir: str | None = None
@@ -307,22 +310,12 @@ class MediaConnector:
         except socket.gaierror as e:
             raise ValueError(f"Unable to resolve URL domain '{hostname}': {e}") from e
 
-    def _maybe_validate_private_networks_access(
-        self, url: str | Url, forbid_private_networks_access: bool = False
-    ) -> None:
-        if not forbid_private_networks_access:
+    def _maybe_validate_private_networks_access(self, url: str | Url) -> None:
+        if not self.forbid_media_private_networks_access:
             return
         if not isinstance(url, Url):
             url = parse_url(url)
         self._assert_network_is_public(url)
-
-    def _get_forbid_private_networks_access_for_modality(self, modality: str):
-        return (
-            self.media_io_kwargs.get(modality, {}).get(
-                FORBID_PRIVATE_NETWORKS_ACCESS_IO_KWARGS, None
-            )
-            is not None
-        )
 
     def load_from_url(
         self,
@@ -330,16 +323,13 @@ class MediaConnector:
         media_io: MediaIO[_M],
         *,
         fetch_timeout: int | None = None,
-        forbid_private_networks_access: bool = False,
     ) -> _M:  # type: ignore[type-var]
         if url[:5].lower() == "data:":
             return self._load_data_url(url, media_io)
 
         url_spec = parse_url(url)
 
-        self._maybe_validate_private_networks_access(
-            url_spec, forbid_private_networks_access
-        )
+        self._maybe_validate_private_networks_access(url_spec)
 
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
@@ -353,7 +343,7 @@ class MediaConnector:
                 url_spec.url,
                 timeout=fetch_timeout,
                 allow_redirects=False
-                if forbid_private_networks_access
+                if self.forbid_media_private_networks_access
                 else envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
             )
 
@@ -372,7 +362,6 @@ class MediaConnector:
         media_io: MediaIO[_M],
         *,
         fetch_timeout: int | None = None,
-        forbid_private_networks_access: bool = False,
     ) -> _M:
         loop = asyncio.get_running_loop()
 
@@ -384,9 +373,7 @@ class MediaConnector:
 
         url_spec = parse_url(url)
 
-        self._maybe_validate_private_networks_access(
-            url_spec, forbid_private_networks_access
-        )
+        self._maybe_validate_private_networks_access(url_spec)
 
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
@@ -405,7 +392,7 @@ class MediaConnector:
                 url_spec.url,
                 timeout=fetch_timeout,
                 allow_redirects=False
-                if forbid_private_networks_access
+                if self.forbid_media_private_networks_access
                 else envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
             )
 
@@ -431,15 +418,11 @@ class MediaConnector:
         Load audio from a URL.
         """
         audio_io = AudioMediaIO(**self.media_io_kwargs.get("audio", {}))
-        forbid_private_networks_access = (
-            self._get_forbid_private_networks_access_for_modality("audio")
-        )
 
         return self.load_from_url(
             audio_url,
             audio_io,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
-            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     async def fetch_audio_async(
@@ -450,15 +433,11 @@ class MediaConnector:
         Asynchronously fetch audio from a URL.
         """
         audio_io = AudioMediaIO(**self.media_io_kwargs.get("audio", {}))
-        forbid_private_networks_access = (
-            self._get_forbid_private_networks_access_for_modality("audio")
-        )
 
         return await self.load_from_url_async(
             audio_url,
             audio_io,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
-            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     def fetch_image(
@@ -475,16 +454,12 @@ class MediaConnector:
         image_io = ImageMediaIO(
             image_mode=image_mode, **self.media_io_kwargs.get("image", {})
         )
-        forbid_private_networks_access = (
-            self._get_forbid_private_networks_access_for_modality("image")
-        )
 
         try:
             return self.load_from_url(
                 image_url,
                 image_io,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
-                forbid_private_networks_access=forbid_private_networks_access,
             )
         except UnidentifiedImageError as e:
             # convert to ValueError to be properly caught upstream
@@ -504,16 +479,12 @@ class MediaConnector:
         image_io = ImageMediaIO(
             image_mode=image_mode, **self.media_io_kwargs.get("image", {})
         )
-        forbid_private_networks_access = (
-            self._get_forbid_private_networks_access_for_modality("image")
-        )
 
         try:
             return await self.load_from_url_async(
                 image_url,
                 image_io,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
-                forbid_private_networks_access=forbid_private_networks_access,
             )
         except UnidentifiedImageError as e:
             # convert to ValueError to be properly caught upstream
@@ -538,15 +509,11 @@ class MediaConnector:
         ):
             video_io_kwargs["video_backend"] = video_backend
         video_io = VideoMediaIO(image_io, **video_io_kwargs)
-        forbid_private_networks_access = (
-            self._get_forbid_private_networks_access_for_modality("video")
-        )
 
         return self.load_from_url(
             video_url,
             video_io,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
-            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     async def fetch_video_async(
@@ -570,15 +537,11 @@ class MediaConnector:
         ):
             video_io_kwargs["video_backend"] = video_backend
         video_io = VideoMediaIO(image_io, **video_io_kwargs)
-        forbid_private_networks_access = (
-            self._get_forbid_private_networks_access_for_modality("video")
-        )
 
         return await self.load_from_url_async(
             video_url,
             video_io,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
-            forbid_private_networks_access=forbid_private_networks_access,
         )
 
     def fetch_image_embedding(


### PR DESCRIPTION


## Purpose

For multimodal models, users can provide media urls in their requests to be downloaded by vllm before being passed on to the models.
Those media urls can therefore be used to scan local (private) resources accessible internally by the network vllm is deployed on.

The `--allowed-media-domains` engine argument can be used to only allow urls for specific domains, however this argument cannot really be used to allow any public resources to be accessed.

This PR introduces the ability to prevent private networks access for the media inputs by declaring a new `--forbid-media-private-networks-access` engine argument.

## Test Plan

Start vllm with the `--forbid-media-private-networks-access` engine argument.

Make a request with a media url pointing to a private network:

```
{
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "image_url": {
            "url": "http://localhost:9002/some/path/image.png"
          },
          "type": "image_url"
        },
        {
          "text": "describe this picture",
          "type": "text"
        }
      ]
    }
  ],
  "model": "gemma-4-26b-a4b-it",
  "stream": false
}

```

The response should be:
```
{
  "error": {
    "message": "The media URL must resolve to a public domain. Input media URL: http://localhost:9002/some/path/image.png",
    "type": "BadRequestError",
    "param": null,
    "code": 400
  }
}
```

Note: this only concerns models for which the download of media is handled by vllm (e.g.: mistral models relying on the mistral tokenizer of `mistral_common` can bypass this mechanism as the download of the media is handled by `mistral_common`) 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

