### PR TITLE
[ROCm][DSv4] Remove device pipeline stall in sparse attention

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -996,9 +996,7 @@ def build_ragged_indices_from_dense(
     max_width = indices.shape[1] if indices.ndim == 2 else 0
     lengths = lengths.clamp(min=0, max=max_width).contiguous()
 
-    indptr = torch.zeros(
-        indices.shape[0] + 1, dtype=torch.int32, device=indices.device
-    )
+    indptr = torch.zeros(indices.shape[0] + 1, dtype=torch.int32, device=indices.device)
     torch.cumsum(lengths, dim=0, out=indptr[1:])
 
     if indices.numel() == 0:

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -996,15 +996,18 @@ def build_ragged_indices_from_dense(
     max_width = indices.shape[1] if indices.ndim == 2 else 0
     lengths = lengths.clamp(min=0, max=max_width).contiguous()
 
-    indptr = torch.empty(indices.shape[0] + 1, dtype=torch.int32, device=indices.device)
-    indptr[0] = 0
+    indptr = torch.zeros(
+        indices.shape[0] + 1, dtype=torch.int32, device=indices.device
+    )
     torch.cumsum(lengths, dim=0, out=indptr[1:])
 
     if indices.numel() == 0:
         flat = torch.empty(0, dtype=torch.int32, device=indices.device)
     else:
         flat = torch.empty(
-            int(indptr[-1].item()), dtype=torch.int32, device=indices.device
+            indices.shape[0] * max_width,
+            dtype=torch.int32,
+            device=indices.device,
         )
         if flat.numel() > 0:
             block_size = 128


### PR DESCRIPTION



## Purpose
On ROCm's DSv4 paths, there are visible GPU bubbles in each `build_ragged_indices_from_dense` invocation caused by two interacting factors:
- The host overhead of `indptr[0] = 0`
- The D2H copy of `indptr[-1].item()` needing synchronization

This PR addresses these by using a single zeros call for tensor creation, and using known parameters known at host-side for buffer creation so that subsequent kernel calls can be promptly enqueued without waiting for the host-device sync.

The enlarging of the `flat` buffer size to `tokens * max_width` is compatible with all its downstream consumers:
- `_sparse_attn_prefill_ragged_kernel` accesses indices through `indptr[i] : indptr[i+1]` and doesn't read past `indptr[-1]`.
- `_sparse_attn_decode_ragged_kernel` similar to the previous consumer, doesn't read past `indptr[-1]`.
- `_copy_ragged_to_graph_buffers` copies all items from `flat` to pre-allocated buffers. The last dimensions of the buffers are the same as the `max_entries_per_row` values passed into the `_copy_ragged_to_graph_buffers` consumer at both the SWA and c128a paths, satisfying `max_entries_per_row == max_width`.

Main
<img width="1319" height="369" alt="image" src="https://github.com/user-attachments/assets/e48bcdff-765f-4847-875a-233427b5fc21" />

PR
<img width="1213" height="315" alt="image" src="https://github.com/user-attachments/assets/1797e3c0-5d4f-4536-8c2e-4cbc24943aa1" />


## Test Plan
Benchmark and accuracy test with lm_eval

Model: `deepseek-ai/DeepSeek-V4-Pro`

Server
```
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_LINEAR=1 \
HSA_TOOLS_DISABLE_REGISTER=1 \
VLLM_DSV4_ROCM_GRAPH_SAFE=1 \
vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --host localhost \
  --port 8001 \
  --dtype auto \
  --tensor-parallel-size 8 \
  --max-num-seqs 128 \
  --distributed-executor-backend mp \
  --trust-remote-code \
  --gpu-memory-utilization 0.8 \
  --moe-backend triton_unfused \
  --tokenizer-mode deepseek_v4 \
  --reasoning-parser deepseek_v4 \
  --kv-cache-dtype fp8_e4m3 \
  --no-enable-prefix-caching \
  --compilation-config '{"mode":3,"cudagraph_mode": "FULL_AND_PIECEWISE"}'
```

Benchmark
```
vllm bench serve --port 8001 --model deepseek-ai/DeepSeek-V4-Pro --dataset-name random --random-input-len 2048 --random-output-len 1024 --max-concurrency 64 --num-prompts 320 --ignore-eos --temperature 0
```

lm_eval
```
lm_eval --model local-completions --model_args model=deepseek-ai/DeepSeek-V4-Pro,base_url=http://0.0.0.0:8001/v1/completions,tokenizer_backend=None,tokenized_requests=False,num_concurrent=128,max_retries=10,max_gen_toks=2048,timeout=60000 --batch_size auto --tasks gsm8k --num_fewshot 20
```
## Test Result

Benchmark
ISL/OSL 2K/1K, C64, 320 reqs
Metrics | Main | PR | Diff (%)
-- | -- | -- | --
Request Throughput (req/s) | 0.89 | 0.91 | +2.25%
Output Token Throughput (tok/s) | 911.40 | 936.93 | +2.80%
Total Token Throughput (tok/s) | 2734.19 | 2810.78 | +2.80%
Median TTFT (ms) | 1955.34 | 1836.67 | -6.07%
Median TPOT (ms) | 66.89 | 65.40 | -2.23%
Median ITL (ms) | 58.76 | 57.89 | -1.48%


lm_eval with gsm8k
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9507|_  |0.0060|
|     |       |strict-match    |    20|exact_match|_  |0.9515|_  |0.0059|



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

