### PR TITLE
fix: avoid ZeroDivisionError in FP8 scaled MM kernels with high TP (closes #43174)

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/pytorch.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/pytorch.py
@@ -52,6 +52,9 @@ class TorchFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         # https://github.com/vllm-project/vllm/issues/32269
         vllm_config = get_current_vllm_config().compilation_config
         pad_output = vllm_config.mode < CompilationMode.VLLM_COMPILE
+        # Guard against zero division in downstream scaling (e.g., deepgemm_post_process_fp8_weight_block)
+        if pad_output and self.weight_scale is not None and self.weight_scale.numel() == 0:
+            return None
         return 17 if pad_output else None
 
 


### PR DESCRIPTION
## What
In dual-node H20 setups with TP=16, loading FP8 models triggers a ZeroDivisionError in `deepgemm_post_process_fp8_weight_block`. The error occurs because a padding value of 17 in `get_output_padding` leads to an empty or zero-size scale tensor in certain sharding scenarios, causing division by zero.

## Fix
Added a guard in `get_output_padding` to check that the weight scale tensor is non-empty before returning the padding value. If the scale tensor is empty, we skip padding to avoid the downstream division by zero.

Closes #43174