### PR TITLE
Validate num_gpu_blocks_override in CacheConfig

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ import vllm.config.vllm as vllm_config_module
 import vllm.envs as envs
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
+    CacheConfig,
     CompilationConfig,
     KernelConfig,
     ModelConfig,
@@ -1320,6 +1321,19 @@ def test_scheduler_config_init():
     with pytest.raises(AttributeError):
         # InitVar does not become an attribute
         print(SchedulerConfig.default_factory().max_model_len)
+
+
+@pytest.mark.parametrize("num_gpu_blocks_override", [0, -1])
+def test_cache_config_num_gpu_blocks_override_must_be_positive(
+    num_gpu_blocks_override,
+):
+    with pytest.raises(ValidationError):
+        CacheConfig(num_gpu_blocks_override=num_gpu_blocks_override)
+
+
+def test_cache_config_num_gpu_blocks_override_defaults_to_none():
+    assert CacheConfig().num_gpu_blocks_override is None
+    assert CacheConfig(num_gpu_blocks_override=1).num_gpu_blocks_override == 1
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -83,7 +83,7 @@ class CacheConfig:
     is_attention_free: bool = False
     """Whether the model is attention-free. This is primarily set in
     `ModelConfig` and that value should be manually duplicated here."""
-    num_gpu_blocks_override: int | None = None
+    num_gpu_blocks_override: int | None = Field(default=None, gt=0)
     """Number of GPU blocks to use. This overrides the profiled `num_gpu_blocks`
     if specified. Does nothing if `None`. Used for testing preemption."""
     sliding_window: int | None = None


### PR DESCRIPTION
﻿Reject num_gpu_blocks_override=0 in CacheConfig. The override is only useful when it gives cache setup a positive block count, so 0 should fail at validation time.

Added a small test for zero/negative values and kept None as the default case.

Validation:
- python -m pytest --noconftest tests/test_config.py -q -k "cache_config_num_gpu_blocks_override"
- python -m ruff check vllm/config/cache.py tests/test_config.py
- python -m ruff format --check vllm/config/cache.py tests/test_config.py
- python -m py_compile vllm/config/cache.py tests/test_config.py
