### PR TITLE
feat(benchmark): support custom system prompt, request_id tracking, and length filtering controls in bench serve

### DIFF
--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -314,9 +314,10 @@ class BenchmarkDataset(ABC):
             needed = num_requests - len(requests)
             additional = []
             for i in range(needed):
+                orig_req = random.choice(requests)
                 req = replace(
-                    random.choice(requests),
-                    request_id=request_id_prefix + str(len(requests) + i),
+                    orig_req,
+                    request_id=f"{request_id_prefix}_{i}_of_{orig_req.request_id}",
                 )
                 additional.append(req)
             requests.extend(additional)
@@ -336,14 +337,26 @@ class BenchmarkDataset(ABC):
 # -----------------------------------------------------------------------------
 
 
+MAX_PROMPT_LEN = 1024
+MAX_TOTAL_LEN = 2048
+DISABLE_LEN_FILTER = False
+
+
 def is_valid_sequence(
     prompt_len: int,
     output_len: int,
     min_len: int = 4,
-    max_prompt_len: int = 1024,
-    max_total_len: int = 2048,
+    max_prompt_len: int | None = None,
+    max_total_len: int | None = None,
     skip_min_output_len_check: bool = False,
 ) -> bool:
+    global MAX_PROMPT_LEN, MAX_TOTAL_LEN, DISABLE_LEN_FILTER
+    if DISABLE_LEN_FILTER:
+        return True
+    if max_prompt_len is None:
+        max_prompt_len = MAX_PROMPT_LEN
+    if max_total_len is None:
+        max_total_len = MAX_TOTAL_LEN
     """
     Validate a sequence based on prompt and output lengths.
 
@@ -1365,6 +1378,8 @@ class ShareGPTDataset(BenchmarkDataset):
             for entry in self.data
             if "conversations" in entry and len(entry["conversations"]) >= 2
         ]
+        for idx, entry in enumerate(self.data):
+            entry["request_id"] = entry.get("request_id", str(idx))
         random.seed(self.random_seed)
         if not getattr(self, "disable_shuffle", False):
             random.shuffle(self.data)
@@ -1424,7 +1439,7 @@ class ShareGPTDataset(BenchmarkDataset):
                     expected_output_len=new_output_len,
                     lora_request=lora_request,
                     multi_modal_data=mm_content,
-                    request_id=request_id_prefix + str(ind),
+                    request_id=entry['request_id'],
                 )
             )
             ind += 1
@@ -1664,6 +1679,23 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         "--disable-shuffle",
         action="store_true",
         help="Disable shuffling of dataset samples for deterministic ordering.",
+    )
+    parser.add_argument(
+        "--max-prompt-len",
+        type=int,
+        default=1024,
+        help="Maximum prompt length allowed for sequence validation.",
+    )
+    parser.add_argument(
+        "--max-total-len",
+        type=int,
+        default=2048,
+        help="Maximum combined (prompt + output) length allowed for sequence validation.",
+    )
+    parser.add_argument(
+        "--disable-len-filter",
+        action="store_true",
+        help="Disable prompt/sequence length filtering/validation.",
     )
 
     # group for dataset specific arguments
@@ -2092,6 +2124,14 @@ def _parse_range_ratio(value: str) -> RangeRatio:
 
 
 def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
+    global DISABLE_LEN_FILTER, MAX_PROMPT_LEN, MAX_TOTAL_LEN
+    if hasattr(args, "disable_len_filter") and args.disable_len_filter:
+        DISABLE_LEN_FILTER = True
+    if hasattr(args, "max_prompt_len") and args.max_prompt_len is not None:
+        MAX_PROMPT_LEN = args.max_prompt_len
+    if hasattr(args, "max_total_len") and args.max_total_len is not None:
+        MAX_TOTAL_LEN = args.max_total_len
+
     if not hasattr(args, "request_id_prefix"):
         args.request_id_prefix = ""
 

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -83,6 +83,7 @@ class RequestFuncInput:
     # uses this list directly and skips building messages from `prompt` and
     # `multi_modal_content`.
     chat_messages: list[dict[str, Any]] | None = None
+    system_prompt: str | None = None
 
 
 @dataclass
@@ -326,18 +327,23 @@ def _get_chat_messages(
     mm_position: Literal["first", "last"] = "last",
 ) -> list[dict[str, Any]]:
     prompt = request_func_input.prompt
-    if _is_chat_messages(prompt):
-        return prompt  # type: ignore[return-value]
+    messages = []
+    if request_func_input.system_prompt:
+        messages.append({"role": "system", "content": request_func_input.system_prompt})
 
-    return [
-        {
-            "role": "user",
-            "content": _get_chat_content(
-                request_func_input,
-                mm_position=mm_position,
-            ),
-        }
-    ]
+    if _is_chat_messages(prompt):
+        messages.extend(prompt)
+    else:
+        messages.append(
+            {
+                "role": "user",
+                "content": _get_chat_content(
+                    request_func_input,
+                    mm_position=mm_position,
+                ),
+            }
+        )
+    return messages
 
 
 async def async_request_openai_chat_completions(

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -100,6 +100,7 @@ class RequestFuncOutput:
     error: str = ""
     start_time: float = 0.0
     input_audio_duration: float = 0.0  # in seconds
+    request_id: str = ""
 
 
 class RequestFunc(Protocol):
@@ -371,6 +372,7 @@ async def async_request_openai_chat_completions(
 
     output = RequestFuncOutput()
     output.prompt_len = request_func_input.prompt_len
+    output.request_id = request_func_input.request_id or ""
 
     generated_text = ""
     ttft = 0.0

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1208,6 +1208,7 @@ async def benchmark(
             "start_times": [output.start_time for output in outputs],
             "generated_texts": [output.generated_text for output in outputs],
             "errors": [output.error for output in outputs],
+            "request_ids": [output.request_id for output in outputs],
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
             "max_concurrent_requests": metrics.max_concurrent_requests,
             "rtfx": metrics.rtfx,
@@ -1221,6 +1222,7 @@ async def benchmark(
             "total_token_throughput": metrics.total_token_throughput,
             "input_lens": [output.prompt_len for output in outputs],
             "errors": [output.error for output in outputs],
+            "request_ids": [output.request_id for output in outputs],
         }
 
     if rps_change_events:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -795,6 +795,7 @@ async def benchmark(
     ready_check_timeout_sec: int = 600,
     ssl_context: ssl.SSLContext | bool | None = None,
     self_timed: bool = False,
+    system_prompt: str | None = None,
 ):
     try:
         request_func = ASYNC_REQUEST_FUNCS[endpoint_type]
@@ -1032,6 +1033,7 @@ async def benchmark(
             extra_body=per_request_extra_body,
             request_id=request_id,
             chat_messages=request.chat_messages,
+            system_prompt=system_prompt,
         )
         tasks.append(
             asyncio.create_task(
@@ -1502,6 +1504,12 @@ def add_cli_args(parser: FlexibleArgumentParser):
     # Use 127.0.0.1 here instead of localhost to force the use of ipv4
     parser.add_argument("--host", type=str, default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--system-prompt",
+        type=str,
+        default=None,
+        help="System prompt/instruction to be passed with each request.",
+    )
     parser.add_argument(
         "--endpoint",
         type=str,
@@ -2124,6 +2132,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         ready_check_timeout_sec=args.ready_check_timeout_sec,
         ssl_context=ssl_context,
         self_timed=args.self_timed,
+        system_prompt=args.system_prompt,
     )
 
     # Save config and results to json


### PR DESCRIPTION
### Summary
This PR enhances `vllm bench serve` with three key features:

1. **Custom System Prompt**: Adds `--system-prompt` to prepend system instructions to chat requests.
2. **`request_id` Tracking**: Preserves and tracks dataset-level `request_id`s throughout the benchmark, outputting them in the final results for easier downstream analysis.
3. **Length Validation Controls**: Introduces `--disable-len-filter`, `--max-prompt-len`, and `--max-total-len` to customize or completely bypass prompt length filtering.