### PR TITLE
Pad NVFP4 Marlin MoE intermediate tiles

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -323,24 +323,56 @@ def prepare_nvfp4_moe_layer_for_marlin(
 
     # WEIGHT
     # Repack weights to marlin format
+    padded_N = _round_up(N, 64)
+
+    def pad_weight_for_marlin(
+        weight: torch.Tensor,
+        size_n: int,
+        size_k: int,
+        padded_size_n: int,
+        padded_size_k: int,
+        num_shards: int,
+    ) -> torch.Tensor:
+        n_pad_per_shard = padded_size_n // num_shards - size_n // num_shards
+        k_pad_bytes = (padded_size_k - size_k) // 2
+        if n_pad_per_shard == 0 and k_pad_bytes == 0:
+            return weight
+        if num_shards == 1:
+            return torch.nn.functional.pad(weight, (0, k_pad_bytes, 0, n_pad_per_shard))
+        weight = weight.reshape(num_shards, size_n // num_shards, size_k // 2)
+        weight = torch.nn.functional.pad(
+            weight, (0, k_pad_bytes, 0, n_pad_per_shard, 0, 0)
+        )
+        return weight.reshape(padded_size_n, padded_size_k // 2)
+
     def repack_weight(weight: torch.Tensor, name: str) -> torch.Tensor:
         tensor_list = []
         num_shards = 2 if is_act_and_mul else 1
         if "w13" in name:
             size_n, size_k = N * num_shards, K
+            padded_size_n, padded_size_k = padded_N * num_shards, K
         else:
             size_n, size_k = K, N
+            padded_size_n, padded_size_k = K, padded_N
 
         assert weight.shape == (E, size_n, size_k // 2)
 
         for i in range(E):
-            qweight = weight[i].view(torch.int32).T.contiguous()
+            expert_weight = pad_weight_for_marlin(
+                weight[i],
+                size_n,
+                size_k,
+                padded_size_n,
+                padded_size_k,
+                num_shards,
+            )
+            qweight = expert_weight.view(torch.int32).T.contiguous()
 
             marlin_qweight = ops.gptq_marlin_repack(
                 b_q_weight=qweight,
                 perm=perm,
-                size_k=size_k,
-                size_n=size_n,
+                size_k=padded_size_k,
+                size_n=padded_size_n,
                 num_bits=4,
                 is_a_8bit=is_a_8bit,
             )
@@ -362,19 +394,36 @@ def prepare_nvfp4_moe_layer_for_marlin(
         num_shards = 2 if is_act_and_mul else 1
         if "w13" in name:
             size_n, size_k = N * num_shards, K
+            padded_size_n, padded_size_k = padded_N * num_shards, K
         else:
             size_n, size_k = K, N
+            padded_size_n, padded_size_k = K, padded_N
+
+        def pad_scale_for_marlin(scale: torch.Tensor) -> torch.Tensor:
+            n_pad_per_shard = padded_size_n // num_shards - size_n // num_shards
+            k_pad_groups = padded_size_k // GROUP_SIZE - size_k // GROUP_SIZE
+            if n_pad_per_shard == 0 and k_pad_groups == 0:
+                return scale
+            if num_shards == 1:
+                return torch.nn.functional.pad(
+                    scale, (0, k_pad_groups, 0, n_pad_per_shard)
+                )
+            scale = scale.reshape(num_shards, size_n // num_shards, -1)
+            scale = torch.nn.functional.pad(
+                scale, (0, k_pad_groups, 0, n_pad_per_shard, 0, 0)
+            )
+            return scale.reshape(padded_size_n, padded_size_k // GROUP_SIZE)
 
         # All experts share one global_scale, so compute the max
         # scale_factor across all experts first, then apply uniformly.
         combined_scale_factor = _nvfp4_compute_scale_factor(scales, param_dtype)
 
         for i in range(E):
-            scale = scales[i].T
+            scale = pad_scale_for_marlin(scales[i]).T
             marlin_scales = marlin_permute_scales(
                 s=scale,
-                size_k=size_k,
-                size_n=size_n,
+                size_k=padded_size_k,
+                size_n=padded_size_n,
                 group_size=GROUP_SIZE,
                 is_a_8bit=is_a_8bit,
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

  ## Purpose

  Pad NVFP4 Marlin MoE intermediate sizes so the rank-local WNA16 MoE
  repack and GEMM dimensions satisfy Marlin tile requirements.

  Without this, some TP configurations can produce rank-local intermediate
  sizes that are valid model dimensions but invalid Marlin repack/GEMM
  dimensions. The change pads the intermediate size used by the Marlin
  MoE path and keeps the padded extents consistent across weight, scale,
  and bias handling.

  ## Test Plan

  Run Nemotron 3 Super NVFP4 with tensor parallelism:

  ```bash
  vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
    --quantization modelopt \
    --tensor-parallel-size 4 \
    --trust-remote-code \
    --max-model-len 4096 \
    --max-num-batched-tokens 2560 \
    --max-num-seqs 1 \
    --gpu-memory-utilization 0.85
```

  Also exercised the same configuration through the local serve sanity
  script, which starts vllm serve and sends OpenAI-compatible chat
  completion requests.

  ## Test Result

  The TP4 NVFP4 serve sanity run completed successfully.

```
  TEST=nemo3super
  MODEL_REPO=nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
  TP=4
  QUANTIZATION=modelopt
  server ready after 245s
...
  Job Complete - Exit code: 0
```

this also requires the code from https://github.com/vllm-project/vllm/pull/43910 and https://github.com/vllm-project/vllm/pull/42610

  ———
  <details>
  <summary>Essential Elements of an Effective PR Description Checklist</summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues
    this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and
    after, or e2e results.
  - [ ] (Optional) The necessary documentation update, such as updating
    supported_models.md and examples for a new model.
  </details>