### PR TITLE
[Bugfix][SM121] Extend TrtLlmFp8ExpertsBase device gate to SM_12x (consumer Blackwell / DGX Spark)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -62,11 +62,13 @@ class TrtLlmFp8ExpertsBase:
 
     @staticmethod
     def _supports_current_device() -> bool:
-        """Supports only Blackwell-family GPUs."""
+        """Supports SM_10x (datacenter Blackwell) and SM_12x (consumer/DGX Spark)."""
         p = current_platform
         return (
             p.is_cuda()
-            and p.is_device_capability_family(100)
+            and (
+                p.is_device_capability_family(100) or p.is_device_capability_family(120)
+            )
             and has_flashinfer_trtllm_fused_moe()
         )
 


### PR DESCRIPTION
## Summary

`TrtLlmFp8ExpertsBase._supports_current_device()` gated on `is_device_capability_family(100)` (SM_10x — B100/B200 datacenter Blackwell only). This caused MXFP8 MoE to always fall back to MARLIN W8A16 on SM_120/SM_121 hardware (RTX 5000-series, DGX Spark / GB10), even though SM_12x implements the same `tcgen05.mma` MX tensor core instructions as SM_10x.

**One-line fix:** add `or is_device_capability_family(120)` to include SM_12x.

This is the vLLM-side gate. Full enablement requires FlashInfer to ship `flashinfer_trtllm_moe` compiled for SM_12x targets (tracked in #43906).

## Root cause

```python
# Before
@staticmethod
def _supports_current_device() -> bool:
    p = current_platform
    return (
        p.is_cuda()
        and p.is_device_capability_family(100)   # SM_10x only
        and has_flashinfer_trtllm_fused_moe()
    )
```

On SM_121: `is_device_capability_family(100)` → `False` → MARLIN fallback.

```python
# After
    return (
        p.is_cuda()
        and (p.is_device_capability_family(100)
             or p.is_device_capability_family(120))   # SM_10x + SM_12x
        and has_flashinfer_trtllm_fused_moe()
    )
```

## Verification on NVIDIA GB10 / DGX Spark (SM_121)

```python
>>> current_platform.get_device_capability()
DeviceCapability(major=12, minor=1)
>>> current_platform.is_device_capability_family(100)
False    # was blocking TRTLLM path
>>> current_platform.is_device_capability_family(120)
True     # now passes device gate
```

Server log before this fix:
```
INFO [mxfp8.py:88] Using 'MARLIN' MxFp8 MoE backend.
```

With this fix applied + FlashInfer compiled for SM_121, the TRTLLM path will be used and MoE layers will execute on the native Blackwell MX path rather than dequantizing to BF16.

## Related

- #43906 — bug report with full diagnosis (filed from DGX Spark hardware)
- #43507 — analogous issue for CUTLASS MoE on SM_12x (different backend, same exclusion pattern)
- #40082 — SM_121 FlashInfer + CUTLASS support for non-MoE linear layers

## Testing

Verified on NVIDIA GB10 / DGX Spark (SM_121) — the only consumer SM_121 hardware currently accessible for testing outside of NVIDIA/Google. Happy to run follow-up tests once FlashInfer ships SM_12x kernel binaries.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)