### PR TITLE
Fix Qwen3-ASR chat/render path for input_audio multimodal requests

### DIFF
--- a/tests/entrypoints/openai/test_mm_serde.py
+++ b/tests/entrypoints/openai/test_mm_serde.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Roundtrip tests for multimodal serde used by the disagg generate endpoint."""
 
+import json
+
+import pytest
 import torch
 
 from vllm.entrypoints.serve.disagg.mm_serde import (
@@ -17,8 +20,31 @@ from vllm.multimodal.inputs import (
     MultiModalFieldElem,
     MultiModalFlatField,
     MultiModalKwargsItem,
+    MultiModalKwargsItems,
     MultiModalSharedField,
 )
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_unencoded_mm_kwargs_items_are_not_json_serializable():
+    """Raw multimodal kwargs must be encoded before JSON transport (#37581)."""
+    raw = MultiModalKwargsItems(
+        {
+            "audio": [
+                MultiModalKwargsItem(
+                    {
+                        "input_audio_features": MultiModalFieldElem(
+                            data=torch.tensor([1.0]),
+                            field=MultiModalBatchedField(),
+                        ),
+                    }
+                )
+            ]
+        }
+    )
+    with pytest.raises(TypeError):
+        json.dumps({"kwargs_data": {"audio": [raw]}})
 
 
 def test_mm_kwargs_item_roundtrip():

--- a/tests/models/multimodal/generation/test_qwen3_asr.py
+++ b/tests/models/multimodal/generation/test_qwen3_asr.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.model_executor.models.qwen3_asr import Qwen3ASRForConditionalGeneration
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_post_process_output_strips_language_prefix():
+    raw = "language English<asr_text>hello world"
+    assert (
+        Qwen3ASRForConditionalGeneration.post_process_output(raw) == "hello world"
+    )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -65,6 +65,8 @@ from vllm.entrypoints.utils import get_max_tokens, should_include_usage
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
+from vllm.model_executor.model_loader import get_model_cls
+from vllm.model_executor.models.interfaces import supports_transcription
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser import ParserManager
 from vllm.parser.abstract_parser import Parser
@@ -149,6 +151,10 @@ class OpenAIServingChat(OpenAIServing):
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
+        model_cls = get_model_cls(self.model_config)
+        self._transcription_model_cls = (
+            model_cls if supports_transcription(model_cls) else None
+        )
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
         self.override_max_tokens = (
@@ -177,6 +183,12 @@ class OpenAIServingChat(OpenAIServing):
                 chat_template_kwargs=self.default_chat_template_kwargs,
             )
         )
+
+    def _post_process_chat_output_text(self, text: str) -> str:
+        """Strip ASR-specific prefixes when using chat completions on STT models."""
+        if self._transcription_model_cls is None:
+            return text
+        return self._transcription_model_cls.post_process_output(text)
 
     def _effective_chat_template_kwargs(
         self, request: ChatCompletionRequest
@@ -1113,17 +1125,18 @@ class OpenAIServingChat(OpenAIServing):
                 choices.append(choice_data)
                 continue
 
+            processed_text = self._post_process_chat_output_text(output.text)
             if reasoning_parser:
                 # If the reasoning parser is enabled,
                 # tool calls are extracted exclusively from the content.
                 reasoning, content = reasoning_parser.extract_reasoning(
-                    output.text, request=request
+                    processed_text, request=request
                 )
                 if not request.include_reasoning:
                     reasoning = None
             else:
                 reasoning = None
-                content = output.text
+                content = processed_text
 
             auto_tools_called = False
             # if auto tools are not enabled, and a named tool choice using


### PR DESCRIPTION
Fixes #37581.

- Validates hexfusion’s 0.21.0 retest: `/v1/chat/completions/render` encoding is already on `main` via `encode_mm_kwargs_item`.
- Fixes remaining #37581 symptom: `/v1/chat/completions` for transcription models now applies `post_process_output()` (same as `/v1/audio/transcriptions`).

## Test plan
- [x] CPU: `pytest tests/models/multimodal/generation/test_qwen3_asr.py tests/entrypoints/openai/test_mm_serde.py`
- [ ] GPU: maintainer/reporter to confirm Qwen3-ASR serve repro if needed