### PR TITLE
[Bugfix][MLA] Fix LSE log-base mismatch in DCP + FlashInfer MLA decode

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -179,10 +179,12 @@ steps:
   - vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
   - vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_two_sided.py
   - vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+  - vllm/v1/attention/backend.py
   - vllm/v1/attention/backends/flashinfer.py
   - vllm/v1/attention/backends/mla/cutlass_mla.py
   - vllm/v1/attention/backends/mla/flashinfer_mla.py
   - vllm/v1/attention/selector.py
+  - vllm/model_executor/layers/attention/mla_attention.py
   - vllm/platforms/cuda.py
   - tests/kernels/test_top_k_per_row.py
   commands:

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -216,7 +216,7 @@ MLA decode backends are selected using the standard
 | Backend | Dtypes | KV Dtypes | Block Sizes | Head Sizes | Sink | Non-Causal | Sparse | MM Prefix | DCP | Attention Types | Compute Cap. |
 | ------- | ------ | --------- | ----------- | ---------- | ---- | ---------- | ------ | --------- | --- | --------------- | ------------ |
 | `CUTLASS_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 128 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 10.x |
-| `FLASHINFER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 10.x |
+| `FLASHINFER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 10.x |
 | `FLASHINFER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 10.x |
 | `FLASHMLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x-10.x |
 | `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 9.x-10.x |

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,8 @@ torchaudio==2.11.0
 # These must be updated alongside torch
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.11.post2
-flashinfer-cubin==0.6.11.post2
+flashinfer-python==0.6.12rc2
+flashinfer-cubin==0.6.12rc2
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
 # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to

--- a/tests/kernels/attention/test_flashinfer_mla_decode.py
+++ b/tests/kernels/attention/test_flashinfer_mla_decode.py
@@ -117,3 +117,128 @@ def test_flashinfer_mla_decode(dtype: torch.dtype, bs: int, block_size: int):
     )
     out_ans = out_ans.squeeze(1)
     torch.testing.assert_close(out_ans, out_ref, atol=1e-2, rtol=1e-2)
+
+
+def test_flashinfer_mla_decode_dcp_combine_matches_no_dcp():
+    """Simulate DCP=N at kernel level and check it reproduces no-DCP.
+
+    Mirrors what ``MLAAttention.forward`` does in production under
+    DCP > 1:
+    - Each rank computes per-shard attention output + LSE on its slice
+      of the KV cache (via the trtllm-gen MLA decode kernel).
+    - Allgathered LSEs are passed to ``correct_attn_out`` (the inner
+      kernel of ``cp_lse_ag_out_rs``) along with ``is_lse_base_on_e``
+      sourced from the impl's ``lse_base_on_e`` ClassVar -- ``False``
+      for FlashInfer because its LSE is in log2.
+    - Each rank's reweighted output is summed for the final result.
+
+    This test simulates that DCP path on a single device (no NCCL, no
+    multi-rank spawn) by manually splitting the per-batch block table
+    across N "ranks" and stacking the per-rank LSEs before calling
+    ``correct_attn_out``. The combined output is asserted close to the
+    reference produced by a single full-KV kernel call.
+
+    If the DCP combine math regresses (broken ``IS_BASE_E`` branch,
+    wrong ``lse_base_on_e`` ClassVar, miswired call site, etc.), the
+    simulated DCP output will diverge from the reference and this test
+    fails.
+    """
+    from vllm.v1.attention.backends.mla.flashinfer_mla import FlashInferMLAImpl
+    from vllm.v1.attention.ops.common import correct_attn_out
+
+    # Anchor on the production ClassVar so the test exercises the same
+    # kernel branch MLAAttention picks at runtime.
+    is_base_e = FlashInferMLAImpl.lse_base_on_e
+
+    torch.set_default_device("cuda")
+    torch.manual_seed(7)
+
+    bs = 2
+    num_heads = 128
+    kv_lora_rank = 512
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64
+    qk_head_dim = kv_lora_rank + qk_rope_head_dim
+    block_size = 64
+    scale = (qk_nope_head_dim + qk_rope_head_dim) ** -0.5
+    dtype = torch.bfloat16
+
+    # Simulate DCP=4. seq_len must split cleanly: each rank gets
+    # pages_per_rank * block_size tokens.
+    n_ranks = 4
+    pages_per_rank = 4
+    n_pages = n_ranks * pages_per_rank  # 16
+    seq_len = n_pages * block_size  # 1024
+    seq_lens_full = torch.full((bs,), seq_len, dtype=torch.int32)
+    seq_lens_per_rank = torch.full((bs,), seq_len // n_ranks, dtype=torch.int32)
+
+    # Unique block IDs per batch, random permutation so rank-i's pages
+    # aren't trivially the first N entries of the global block table.
+    all_block_ids = torch.randperm(bs * n_pages, dtype=torch.int32)
+    block_tables_full = all_block_ids.view(bs, n_pages).contiguous()
+
+    kv_cache = torch.randn(bs * n_pages, block_size, qk_head_dim, dtype=dtype)
+    q = torch.randn(bs, num_heads, qk_head_dim, dtype=dtype)
+
+    workspace_buffer = torch.zeros(
+        FLASHINFER_WORKSPACE_BUFFER_SIZE,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+    def _decode(block_tables, seq_lens, max_seq_len):
+        out, lse = trtllm_batch_decode_with_kv_cache_mla(
+            query=q.unsqueeze(1),
+            kv_cache=kv_cache.unsqueeze(1),
+            workspace_buffer=workspace_buffer,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            bmm1_scale=scale,
+            return_lse=True,
+        )
+        # out: (bs, 1, num_heads, kv_lora_rank), lse: (bs, num_heads)
+        return out.squeeze(1), lse
+
+    # Reference: full KV, no DCP.
+    ref_out, _ = _decode(block_tables_full, seq_lens_full, seq_len)
+
+    # Per-rank: each rank sees ``pages_per_rank`` consecutive pages of
+    # the global block table (the simplest DCP layout -- interleave_size
+    # equals block_size). Same Q on every rank.
+    per_rank_outs = []
+    per_rank_lses = []
+    for rank in range(n_ranks):
+        bt_r = block_tables_full[
+            :, rank * pages_per_rank : (rank + 1) * pages_per_rank
+        ].contiguous()
+        out_r, lse_r = _decode(bt_r, seq_lens_per_rank, seq_len // n_ranks)
+        per_rank_outs.append(out_r)
+        per_rank_lses.append(lse_r)
+
+    # Stack LSEs to (N, B, H) as ``correct_attn_out`` expects.
+    all_lses = torch.stack(per_rank_lses, dim=0)
+
+    # For each rank, apply the kernel's per-rank reweighting and
+    # accumulate. Clone the per-rank output because ``correct_attn_out``
+    # writes back in-place.
+    combined = torch.zeros_like(ref_out)
+    for rank in range(n_ranks):
+        out_r = per_rank_outs[rank].clone()
+        corrected_r, _ = correct_attn_out(
+            out_r,
+            all_lses,
+            rank,
+            ctx=None,
+            is_lse_base_on_e=is_base_e,
+        )
+        combined = combined + corrected_r
+
+    # Compare combined DCP=4 output to the no-DCP reference. The
+    # tolerance is looser than test_flashinfer_mla_decode (1e-2) because
+    # the DCP path does extra arithmetic (per-rank reweight + sum) which
+    # accumulates more rounding error.
+    torch.testing.assert_close(combined, ref_out, atol=2e-2, rtol=2e-2)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -780,14 +780,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         attn_out,
                         lse,
                         get_dcp_group(),
-                        is_lse_base_on_e=True,
+                        is_lse_base_on_e=self.impl.lse_base_on_e,
                     )
                 else:
                     attn_out = cp_lse_ag_out_rs(
                         attn_out,
                         lse,
                         get_dcp_group(),
-                        is_lse_base_on_e=True,
+                        is_lse_base_on_e=self.impl.lse_base_on_e,
                     )
 
             # v_up projection

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -699,6 +699,17 @@ class AttentionImplBase(ABC, Generic[T]):
     # Some features like decode context parallelism require the softmax lse.
     can_return_lse_for_decode: bool = False
 
+    # Base of the logarithm used by this backend when returning softmax lse.
+    # True  => natural log (lse = ln(sum(exp(qk))))
+    #          -- e.g. Triton MLA, FlashAttention, FlashMLA, Cutlass MLA
+    # False => base 2      (lse = log2(sum(exp(qk))))
+    #          -- e.g. FlashInfer trtllm-gen MLA
+    # The DCP combine kernel (cp_lse_ag_out_rs / dcp_a2a_lse_reduce in
+    # vllm/v1/attention/ops/common.py) branches on this via its IS_BASE_E
+    # constexpr; getting it wrong silently corrupts the cross-shard
+    # softmax denominator.
+    lse_base_on_e: bool = True
+
     # Whether the attention impl supports Prefill Context Parallelism.
     supports_pcp: bool = False
     # Whether the attention impl(or ops) supports MTP

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -104,6 +104,8 @@ g_fi_workspace = torch.zeros(
 
 
 class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
+    can_return_lse_for_decode: bool = True
+
     def __init__(
         self,
         num_heads: int,
@@ -187,7 +189,8 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
             if is_quantized_kv_cache(self.kv_cache_dtype):
                 self.bmm2_scale *= layer._k_scale_float
 
-        o = trtllm_batch_decode_with_kv_cache_mla(
+        return_lse = self.need_to_return_lse_for_decode
+        kernel_out = trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv_c_and_k_pe_cache.unsqueeze(1),
             workspace_buffer=self._workspace_buffer,
@@ -199,11 +202,14 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
             max_seq_len=attn_metadata.max_seq_len,
             bmm1_scale=self.bmm1_scale,
             bmm2_scale=self.bmm2_scale,
+            return_lse=return_lse,
         )
+        if return_lse:
+            o, lse = kernel_out
+        else:
+            o, lse = kernel_out, None
 
         # Flatten the output for consistent shape
         o = o.view(-1, o.shape[-2], o.shape[-1])
 
-        # TODO: Return LSE pending support from Flashinfer API:
-        # https://github.com/flashinfer-ai/flashinfer/pull/1566
-        return o, None
+        return o, lse

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -105,6 +105,13 @@ g_fi_workspace = torch.zeros(
 
 class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
     can_return_lse_for_decode: bool = True
+    # trtllm-gen MLA decode emits LSE in log2 (per flashinfer's own
+    # reference at flashinfer/trace/templates/attention.py:81:
+    # `logsumexp / log(2.0)`). Override the AttentionImplBase default
+    # so MLAAttention's DCP combine branches on the correct base
+    # (IS_BASE_E=False uses tl.exp2/tl.log2 natively, avoiding an FP
+    # multiply per decode step).
+    lse_base_on_e: bool = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

FlashInfer's trtllm-gen MLA returns **log2** LSE, where as other attn kernels returns natural log. When combining DCP partial attention outputs it produces incorrect softmax denominators and corrupted attention values.

Converts the LSE from log2 to natural log.

## Quick audit on decode MLA backends

All other DCP-capable MLA backends return LSE in natural log:

| backend | LSE base | evidence |
|---|---|---|
| `triton_mla` | natural log | `e_max + tl.log(e_sum)` in `triton_decode_attention.py` |
| `flashattn_mla` | natural log | FA3 docstring: *"log of the softmax normalization factor"* |
| `flashmla` | natural log | docstring formula `exp(lse) / (exp(lse) + exp(attn_sink))` (uses `exp`, not `exp2`) |
| `cutlass_mla` | natural log | reduction kernel uses `expf(local_lse - lse_max)`; test ref uses `torch.logsumexp` |
| `flashinfer_mla` | **log2** | (fixed by this PR) |

So no other backend needs a similar fix.

## Test plan

Verified on **Kimi-K2.5-NVFP4 + FP8 KV + DCP=4 + FLASHINFER_MLA** (Blackwell GB200, on top of this PR's parent #43729 and #40609)

- token level match against **TEP4** reference.
- 5-shot GSM8K (full 1319 problems, completions API, temperature=0):

  | config | flexible-extract | strict-match |
  |---|---|---|
  | Baseline (TEP4, no DCP, FLASHINFER_MLA) | 0.9356 | 0.9363 |
  | DCP=4 + FLASHINFER_MLA (this PR) | 0.9363 | 0.9371 |
  | **Δ (DCP − baseline)** | **+0.07%** | **+0.08%** |
