### PR TITLE
[Core] Improve startup failure diagnostics for early subprocess exits

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1204,8 +1204,16 @@ def wait_for_engine_startup(
         if len(events) > 1 or events[0][0] != handshake_socket:
             # One of the local core processes exited.
             finished = proc_manager.finished_procs() if proc_manager else {}
+
+            # Sometimes a process exits before the process manager updates
+            # its finished process list, so check exit codes directly too.
+            if not finished and proc_manager is not None:
+                for proc in proc_manager.procs:
+                    if proc.exitcode is not None:
+                        finished[proc.name] = proc.exitcode
+            
             if coord_process is not None and coord_process.exitcode is not None:
-                finished[coord_process.name] = coord_process.exitcode
+                            finished[coord_process.name] = coord_process.exitcode
             raise RuntimeError(
                 "Engine core initialization failed. "
                 "See root cause above. "

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1213,7 +1213,7 @@ def wait_for_engine_startup(
                         finished[proc.name] = proc.exitcode
             
             if coord_process is not None and coord_process.exitcode is not None:
-                            finished[coord_process.name] = coord_process.exitcode
+                finished[coord_process.name] = coord_process.exitcode
             raise RuntimeError(
                 "Engine core initialization failed. "
                 "See root cause above. "


### PR DESCRIPTION
### Summary

Improve diagnostics in wait_for_engine_startup() when a core engine subprocess exits during initialization before the process manager has populated its finished process list.

In some startup failure scenarios, the startup poller detects that a subprocess has exited, but finished_procs() may still return an empty dictionary. This results in unhelpful error messages such as:

RuntimeError: Engine core initialization failed.
See root cause above. Failed core proc(s): {}

This change adds a fallback that directly inspects subprocess exit codes when the finished process list is temporarily unavailable, providing more useful failure information.

### Repro Information
Observed during
pytest tests/models/test_initialization.py
Environment
CI environment
Python 3.12
AMD ROCm CI runners (MI250 / MI355)
Failure

The startup monitor observed a subprocess exit, but:

proc_manager.finished_procs()

returned:

`{}`

resulting in incomplete diagnostics for startup failures.

### Changes

Added a fallback path in wait_for_engine_startup():

```
# Sometimes a process exits before the process manager updates
# its finished process list, so check exit codes directly too.
if not finished and proc_manager is not None:
    for proc in proc_manager.procs:
        if proc.exitcode is not None:
            finished[proc.name] = proc.exitcode
```

This preserves existing behavior while improving visibility into early subprocess failures.

### Notes

This change improves observability and debuggability only. It does not modify engine startup behavior, process lifecycle management, or failure handling logic.

### AI-assisted contribution disclosure

This PR was developed with assistance from AI tools for log analysis and debugging guidance. All code changes and reasoning were manually reviewed and validated by me before submission.