### PR TITLE
[CI] Enable prefix caching in BFCL benchmark

### DIFF
--- a/.buildkite/scripts/tool_call/run-bfcl-eval.sh
+++ b/.buildkite/scripts/tool_call/run-bfcl-eval.sh
@@ -70,7 +70,7 @@ echo "============================================"
 # ---- Install bfcl-eval if missing ----
 if ! python3 -c "import bfcl_eval" 2>/dev/null; then
     echo "Installing bfcl-eval..."
-    pip install "bfcl-eval>=2025.10.20.1,<2026"
+    uv pip install "bfcl-eval>=2025.10.20.1,<2026"
 fi
 
 # ---- Cleanup handler ----
@@ -100,7 +100,7 @@ SERVE_ARGS=(
     --tensor-parallel-size "$TP_SIZE"
     --max-model-len "$MAX_MODEL_LEN"
     --enforce-eager
-    --no-enable-prefix-caching
+    --enable-prefix-caching
 )
 
 # Append reasoning parser if specified


### PR DESCRIPTION

## Purpose

Enable prefix caching for BFCL runs. Because it's multiturn benchmark, prefix caching will greatly increase up benchmark throughput.

Also fixes BFCL install to use `uv pip` instead of `pip`.

Note that to fully staturate GPUs, `BFCL_NUM_THREAD`, which determines max number of requests in flight, may need to be increased.

## Test Plan

```
BFCL_MODEL="openai/gpt-oss-20b" \
BFCL_TOOL_CALL_PARSER=openai \
BFCL_TP_SIZE=2 \
BFCL_MAX_MODEL_LEN=16384 \
BFCL_NUM_THREADS=128 \
bash .buildkite/scripts/tool_call/run-bfcl-eval.sh
```

## Test Result

Before:
~10 min
```
🦍 Model: openai_gpt-oss-20b
🔍 Running test: multi_turn_base
✅ Test completed: multi_turn_base. 🎯 Accuracy: 41.00%
🔍 Running test: multi_turn_long_context
✅ Test completed: multi_turn_long_context. 🎯 Accuracy: 22.50%
🔍 Running test: multi_turn_miss_func
✅ Test completed: multi_turn_miss_func. 🎯 Accuracy: 31.50%
🔍 Running test: multi_turn_miss_param
✅ Test completed: multi_turn_miss_param. 🎯 Accuracy: 35.00%
```

After:
 ~5 min
```
🦍 Model: openai_gpt-oss-20b
🔍 Running test: multi_turn_base
✅ Test completed: multi_turn_base. 🎯 Accuracy: 39.00%
🔍 Running test: multi_turn_long_context
✅ Test completed: multi_turn_long_context. 🎯 Accuracy: 22.00%
🔍 Running test: multi_turn_miss_func
✅ Test completed: multi_turn_miss_func. 🎯 Accuracy: 32.00%
🔍 Running test: multi_turn_miss_param
✅ Test completed: multi_turn_miss_param. 🎯 Accuracy: 36.50%
```

Results within run to run variance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

