### PR TITLE
fix: make FusedMoE expert-map logging meta safe

### DIFF
--- a/tests/model_executor/layers/test_expert_map_manager.py
+++ b/tests/model_executor/layers/test_expert_map_manager.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
+from vllm.model_executor.layers.fused_moe.expert_map_manager import (
+    ExpertMapManager,
+)
+
+
+def make_ep_config() -> FusedMoEParallelConfig:
+    return FusedMoEParallelConfig(
+        tp_size=1,
+        tp_rank=0,
+        pcp_size=1,
+        pcp_rank=0,
+        dp_size=1,
+        dp_rank=0,
+        ep_size=2,
+        ep_rank=0,
+        sp_size=1,
+        use_ep=True,
+        all2all_backend="allgather_reducescatter",
+        enable_eplb=False,
+    )
+
+
+def test_expert_map_logging_is_meta_safe():
+    with torch.device("meta"):
+        manager = ExpertMapManager(
+            max_num_batched_tokens=16,
+            top_k=2,
+            global_num_experts=8,
+            num_redundant_experts=0,
+            num_expert_group=None,
+            moe_parallel_config=make_ep_config(),
+            placement_strategy="linear",
+            enable_eplb=False,
+        )
+
+    assert manager.expert_map is not None
+    assert manager.expert_map.is_meta
+    assert manager.get_compressed_map_string() == "<meta expert_map shape=(8,)>"

--- a/vllm/model_executor/layers/fused_moe/expert_map_manager.py
+++ b/vllm/model_executor/layers/fused_moe/expert_map_manager.py
@@ -405,6 +405,9 @@ class ExpertMapManager:
         if self._expert_map is None:
             return f"[0..{self.global_num_experts - 1}]"
 
+        if self._expert_map.is_meta:
+            return f"<meta expert_map shape={tuple(self._expert_map.shape)}>"
+
         global_indices = torch.where(self._expert_map != -1)[0]
         local_indices = self._expert_map[global_indices]
         return ", ".join(


### PR DESCRIPTION
#### Summary

`ExpertMapManager` logs a compressed expert-map string during EP initialization. The stringification path calls `.item()` on entries from `_expert_map`.

When a model is constructed on the `meta` device, `_expert_map` is also a meta tensor, and the log-only `.item()` path can fail during construction even though the runtime expert map would be materialized later.

This PR makes `get_compressed_map_string()` return a descriptive placeholder for meta expert maps instead of reading tensor values.

#### Why

The compressed map is only used for logging. Avoiding `.item()` on meta keeps meta-device model construction safe without changing real tensor behavior.

#### Tests

- `python3 -m py_compile vllm/model_executor/layers/fused_moe/expert_map_manager.py tests/model_executor/layers/test_expert_map_manager.py`
- Added `test_expert_map_logging_is_meta_safe`.

I could not run pytest locally in this checkout because local test dependencies (`torch`, `pytest`) are not installed; CI should exercise the new test.
