### PR TITLE
b12x nvfp4 w4a16 use a16 fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -757,7 +757,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.11.post2
+ARG FLASHINFER_VERSION=0.6.11.post3
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.11.post2"
+      "default": "0.6.11.post3"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,8 @@ torchaudio==2.11.0
 # These must be updated alongside torch
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.11.post2
-flashinfer-cubin==0.6.11.post2
+flashinfer-python==0.6.11.post3
+flashinfer-cubin==0.6.11.post3
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
 # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to

--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -90,6 +90,7 @@ def _process_b12x_weights(
 @pytest.mark.parametrize("e", [8, 16])
 @pytest.mark.parametrize("topk", [1, 2, 4])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("activation_precision", ["fp4", "bf16"])
 @torch.inference_mode()
 def test_flashinfer_b12x_moe(
     m: int,
@@ -98,6 +99,7 @@ def test_flashinfer_b12x_moe(
     e: int,
     topk: int,
     dtype: torch.dtype,
+    activation_precision: str,
     workspace_init,
 ):
     """Test FlashInferB12xExperts against a BF16 torch reference.
@@ -106,6 +108,14 @@ def test_flashinfer_b12x_moe(
     dispatch, W1 GEMM, SwiGLU, and W2 GEMM into one call.  We verify
     correctness against ``torch_moe`` using generous tolerances to account
     for the internal FP4 quantization of activations and weights.
+
+    Two activation precisions are exercised:
+      * ``fp4`` (W4A4, modelopt path): activations re-quantized to FP4
+        before each GEMM. Set ``a1_gscale`` / ``a2_gscale`` on the quant
+        config (any non-None tensor enables this branch).
+      * ``bf16`` (W4A16, compressed-tensors `nvfp4-pack-quantized` path):
+        activations kept in BF16; the kernel dequantizes weights instead.
+        ``a1_gscale`` / ``a2_gscale`` are left as ``None``.
 
     Scale convention
     ----------------
@@ -169,13 +179,26 @@ def test_flashinfer_b12x_moe(
         # All per-expert alphas are 1.0 (global_scale = 1.0, no compensation).
         ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
 
+        # W4A4: pass identity activation global scales; B12x re-quantizes
+        # activations to FP4.  W4A16: leave them as None; activations stay
+        # in BF16 and the kernel dequantizes weights instead.
+        if activation_precision == "fp4":
+            a1_gscale = ones_e
+            a2_gscale = ones_e
+            source_format = "modelopt"
+        else:
+            a1_gscale = None
+            a2_gscale = None
+            source_format = "compressed_tensors"
+
         quant_config = nvfp4_moe_quant_config(
             g1_alphas=ones_e,
             g2_alphas=ones_e,
-            a1_gscale=ones_e,
-            a2_gscale=ones_e,
+            a1_gscale=a1_gscale,
+            a2_gscale=a2_gscale,
             w1_scale=w1_blockscale,
             w2_scale=w2_blockscale,
+            source_format=source_format,
         )
 
         moe_config = make_dummy_moe_config(
@@ -190,6 +213,9 @@ def test_flashinfer_b12x_moe(
             moe_config=moe_config,
             quant_config=quant_config,
         )
+        # Cross-check the precision/source-format auto-detection.
+        assert experts.activation_precision == activation_precision
+        assert experts.source_format == source_format
         _process_b12x_weights(
             experts,
             w1_blockscale,
@@ -234,6 +260,7 @@ def test_flashinfer_b12x_moe(
 @pytest.mark.parametrize("e", [8, 16])
 @pytest.mark.parametrize("topk", [1, 2, 4])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("activation_precision", ["fp4", "bf16"])
 @torch.inference_mode()
 def test_flashinfer_b12x_moe_relu2(
     m: int,
@@ -242,6 +269,7 @@ def test_flashinfer_b12x_moe_relu2(
     e: int,
     topk: int,
     dtype: torch.dtype,
+    activation_precision: str,
     workspace_init,
 ):
     """Test FlashInferB12xExperts with ReLU2 (non-gated) activation.
@@ -249,6 +277,10 @@ def test_flashinfer_b12x_moe_relu2(
     ReLU2 is used by Nemotron-H style models.  Unlike the gated SiLU
     path, w1 has shape [E, N, K] (not [E, 2N, K]) and the activation
     is relu(x)^2 without a gate/up split.
+
+    Parametrized over ``activation_precision`` (``"fp4"`` for W4A4 /
+    modelopt and ``"bf16"`` for W4A16 / compressed-tensors); Nemotron-H 3.5
+    is the production user of the ReLU2 + W4A16 combination.
     """
     set_random_seed(7)
     with set_current_vllm_config(
@@ -286,13 +318,23 @@ def test_flashinfer_b12x_moe_relu2(
 
         ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
 
+        if activation_precision == "fp4":
+            a1_gscale = ones_e
+            a2_gscale = ones_e
+            source_format = "modelopt"
+        else:
+            a1_gscale = None
+            a2_gscale = None
+            source_format = "compressed_tensors"
+
         quant_config = nvfp4_moe_quant_config(
             g1_alphas=ones_e,
             g2_alphas=ones_e,
-            a1_gscale=ones_e,
-            a2_gscale=ones_e,
+            a1_gscale=a1_gscale,
+            a2_gscale=a2_gscale,
             w1_scale=w1_blockscale,
             w2_scale=w2_blockscale,
+            source_format=source_format,
         )
 
         moe_config = make_dummy_moe_config(
@@ -309,6 +351,8 @@ def test_flashinfer_b12x_moe_relu2(
             moe_config=moe_config,
             quant_config=quant_config,
         )
+        assert experts.activation_precision == activation_precision
+        assert experts.source_format == source_format
         _process_b12x_weights(
             experts,
             w1_blockscale,
@@ -361,4 +405,5 @@ def test_flashinfer_b12x_moe_relu2(
 
 
 if __name__ == "__main__":
-    test_flashinfer_b12x_moe(16, 128, 256, 8, 2, torch.bfloat16)
+    test_flashinfer_b12x_moe(16, 128, 256, 8, 2, torch.bfloat16, "fp4")
+    test_flashinfer_b12x_moe(16, 128, 256, 8, 2, torch.bfloat16, "bf16")

--- a/tests/kernels/moe/test_flashinfer_b12x_moe.py
+++ b/tests/kernels/moe/test_flashinfer_b12x_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -8,8 +10,7 @@ from vllm.platforms import current_platform
 
 if not current_platform.is_device_capability_family(120):
     pytest.skip(
-        reason="FlashInfer CuteDSL SM12x MoE requires SM120 "
-        "(RTX Pro 6000 / DGX Spark).",
+        reason="FlashInfer B12x MoE requires SM120 (RTX Pro 6000 / DGX Spark).",
         allow_module_level=True,
     )
 
@@ -18,8 +19,8 @@ from vllm.utils.flashinfer import has_flashinfer_b12x_moe
 if not has_flashinfer_b12x_moe():
     pytest.skip(
         reason=(
-            "FlashInfer cute_dsl_fused_moe_nvfp4 / convert_sf_to_mma_layout "
-            "not available in installed FlashInfer (needs PRs #3051 and #3066)."
+            "FlashInfer B12xMoEWrapper not available in installed "
+            "FlashInfer (needs PR #3080)."
         ),
         allow_module_level=True,
     )
@@ -40,7 +41,6 @@ from vllm.model_executor.layers.fused_moe.config import nvfp4_moe_quant_config
 from vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe import (
     FlashInferB12xExperts,
 )
-from vllm.utils.flashinfer import flashinfer_convert_sf_to_mma_layout
 from vllm.utils.torch_utils import set_random_seed
 
 # Dimensions chosen to satisfy FP4 alignment requirements (k multiple of 256,
@@ -59,15 +59,31 @@ def _reorder_gate_up_to_up_gate(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Swap gate and up-projection halves along dim=1 to [up, gate] order.
 
-    The SM12x kernel expects weights in [up (w3), gate (w1)] order while the
+    The B12x kernel expects weights in [up (w3), gate (w1)] order while the
     BF16 reference uses [gate (w1), up (w3)].  This replicates the reordering
-    done at model-load time by ``prepare_nvfp4_moe_layer_for_fi_or_cutlass``.
+    done at model-load time by the FP4 layer-prep helper.
     """
     n = w.shape[1] // 2
     return (
         torch.cat([w[:, n:, :], w[:, :n, :]], dim=1),
         torch.cat([w_s[:, n:, :], w_s[:, :n, :]], dim=1),
     )
+
+
+def _process_b12x_weights(
+    experts: FlashInferB12xExperts,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    w1_scale_2: torch.Tensor,
+    w2_scale_2: torch.Tensor,
+) -> None:
+    layer = SimpleNamespace(
+        w13_weight_scale=w1_scale,
+        w13_weight_scale_2=w1_scale_2,
+        w2_weight_scale=w2_scale,
+        w2_weight_scale_2=w2_scale_2,
+    )
+    experts.process_weights_after_loading(layer)
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
@@ -174,22 +190,12 @@ def test_flashinfer_b12x_moe(
             moe_config=moe_config,
             quant_config=quant_config,
         )
-        # In production, process_weights_after_loading computes these after
-        # normalizing block scales. In the test the scales are already in final
-        # form (global_scale=1.0), so we compute the MMA layouts directly.
-        num_experts_w1, m1, k1_sf = w1_blockscale.shape
-        experts.w1_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            w1_blockscale.reshape(num_experts_w1 * m1, k1_sf),
-            m=m1,
-            k=k1_sf * 16,
-            num_groups=num_experts_w1,
-        )
-        num_experts_w2, m2, k2_sf = w2_blockscale.shape
-        experts.w2_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            w2_blockscale.reshape(num_experts_w2 * m2, k2_sf),
-            m=m2,
-            k=k2_sf * 16,
-            num_groups=num_experts_w2,
+        _process_b12x_weights(
+            experts,
+            w1_blockscale,
+            w2_blockscale,
+            ones_e,
+            ones_e,
         )
 
         kernel = mk.FusedMoEKernel(
@@ -222,6 +228,136 @@ def test_flashinfer_b12x_moe(
         torch_output = torch_moe(a, w1_bf16, w2_bf16, score, topk)
 
         torch.testing.assert_close(sm12x_output, torch_output, atol=2e-1, rtol=2e-1)
+
+
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
+@pytest.mark.parametrize("e", [8, 16])
+@pytest.mark.parametrize("topk", [1, 2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.inference_mode()
+def test_flashinfer_b12x_moe_relu2(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    dtype: torch.dtype,
+    workspace_init,
+):
+    """Test FlashInferB12xExperts with ReLU2 (non-gated) activation.
+
+    ReLU2 is used by Nemotron-H style models.  Unlike the gated SiLU
+    path, w1 has shape [E, N, K] (not [E, 2N, K]) and the activation
+    is relu(x)^2 without a gate/up split.
+    """
+    set_random_seed(7)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+
+        # Non-gated: w1 shape is (e, n, k), not (e, 2n, k).
+        w1_bf16 = torch.randn((e, n, k), device="cuda", dtype=dtype) / 15
+        w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 15
+
+        gs = torch.ones(1, device="cuda", dtype=torch.float32)
+        sf_vec_size = 16
+
+        # W1: no gate/up reordering for non-gated.
+        w1_flat = w1_bf16.reshape(e * n, k)
+        w1_q_flat, w1_sf_flat = fp4_quantize(
+            w1_flat,
+            global_scale=gs,
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w1_q = w1_q_flat.view(e, n, k // 2)
+        w1_blockscale = w1_sf_flat.view(e, n, w1_sf_flat.shape[1])
+
+        w2_flat = w2_bf16.reshape(e * k, n)
+        w2_q_flat, w2_sf_flat = fp4_quantize(
+            w2_flat,
+            global_scale=gs,
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w2_q = w2_q_flat.view(e, k, n // 2)
+        w2_blockscale = w2_sf_flat.view(e, k, w2_sf_flat.shape[1])
+
+        ones_e = torch.ones(e, device="cuda", dtype=torch.float32)
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=ones_e,
+            g2_alphas=ones_e,
+            a1_gscale=ones_e,
+            a2_gscale=ones_e,
+            w1_scale=w1_blockscale,
+            w2_scale=w2_blockscale,
+        )
+
+        moe_config = make_dummy_moe_config(
+            num_experts=e,
+            experts_per_token=topk,
+            hidden_dim=k,
+            intermediate_size_per_partition=n,
+            in_dtype=dtype,
+            activation=MoEActivation.RELU2_NO_MUL,
+            is_act_and_mul=False,
+        )
+
+        experts = FlashInferB12xExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        )
+        _process_b12x_weights(
+            experts,
+            w1_blockscale,
+            w2_blockscale,
+            ones_e,
+            ones_e,
+        )
+
+        kernel = mk.FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
+            experts,
+            inplace=False,
+        )
+
+        score = torch.randn((m, e), device="cuda", dtype=dtype)
+        topk_weights, topk_ids, _ = fused_topk(a, score, topk, renormalize=False)
+
+        b12x_output = kernel.apply(
+            hidden_states=a,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=e,
+            activation=MoEActivation.RELU2_NO_MUL,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+        )
+
+        torch_output = torch_moe(
+            a,
+            w1_bf16,
+            w2_bf16,
+            score,
+            topk,
+            activation=MoEActivation.RELU2_NO_MUL,
+        )
+
+        torch.testing.assert_close(
+            b12x_output,
+            torch_output,
+            atol=2e-1,
+            rtol=2e-1,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/kernels/moe/test_w4a16_propagation.py
+++ b/tests/kernels/moe/test_w4a16_propagation.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for use_a16 propagation in NVFP4 MoE quant configs.
+
+Regression test for the gap where ``use_a16`` in
+``ModelOptNvFp4FusedMoE`` / ``CompressedTensorsW4A4Nvfp4MoEMethod``
+only gated backend selection but left activation global scales flowing
+through to the kernel via ``a1_gscale``.  After the fix, a missing /
+``None`` activation scale must produce a quant config with
+``a1_gscale=None``, which signals ``activation_precision="bf16"`` in
+``FlashInferB12xExperts``.  No SM12x hardware required — this exercises
+the config builder, not the kernel.
+"""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    make_nvfp4_moe_quant_config,
+)
+
+
+def _dummy_weight_scales(e: int, n: int, k: int):
+    w13_scale = torch.zeros((e, 2 * n, k // 16), dtype=torch.uint8)
+    w2_scale = torch.zeros((e, k, n // 16), dtype=torch.uint8)
+    w13_scale_2 = torch.ones(e, dtype=torch.float32)
+    w2_scale_2 = torch.ones(e, dtype=torch.float32)
+    return w13_scale, w2_scale, w13_scale_2, w2_scale_2
+
+
+def test_w4a16_b12x_yields_none_a_gscale():
+    """W4A16 (a13_scale=None) on the B12x backend yields a1_gscale=None.
+
+    Pre-fix behavior: ``make_nvfp4_moe_quant_config`` only routed MARLIN
+    through the W4A16 builder; B12x with ``a13_scale=None`` would have
+    crashed on ``1.0 / None`` in the W4A4 branch.  Post-fix: any backend
+    with ``a13_scale=None`` routes to ``nvfp4_w4a16_moe_quant_config``.
+    """
+    w13_scale, w2_scale, w13_scale_2, w2_scale_2 = _dummy_weight_scales(8, 64, 128)
+    config = make_nvfp4_moe_quant_config(
+        backend=NvFp4MoeBackend.FLASHINFER_B12X,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        w13_scale_2=w13_scale_2,
+        w2_scale_2=w2_scale_2,
+        a13_scale=None,
+        a2_scale=None,
+    )
+    assert config.a1_gscale is None
+    assert config.a2_gscale is None
+
+
+def test_w4a4_b12x_populates_a_gscale():
+    """W4A4 (a13_scale not None) on B12x should still populate a1_gscale.
+
+    Regression guard: the W4A16 routing must be triggered only by
+    ``a13_scale is None`` — not by backend choice — so the W4A4 path
+    remains intact.
+    """
+    w13_scale, w2_scale, w13_scale_2, w2_scale_2 = _dummy_weight_scales(8, 64, 128)
+    a13_scale = torch.full((8,), 0.5, dtype=torch.float32)
+    a2_scale = torch.full((8,), 0.5, dtype=torch.float32)
+    config = make_nvfp4_moe_quant_config(
+        backend=NvFp4MoeBackend.FLASHINFER_B12X,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        w13_scale_2=w13_scale_2,
+        w2_scale_2=w2_scale_2,
+        a13_scale=a13_scale,
+        a2_scale=a2_scale,
+    )
+    assert config.a1_gscale is not None
+    assert config.a2_gscale is not None
+
+
+def test_w4a16_marlin_yields_none_a_gscale():
+    """MARLIN W4A16 (already correct pre-fix) — keeps working post-fix."""
+    w13_scale, w2_scale, w13_scale_2, w2_scale_2 = _dummy_weight_scales(8, 64, 128)
+    config = make_nvfp4_moe_quant_config(
+        backend=NvFp4MoeBackend.MARLIN,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        w13_scale_2=w13_scale_2,
+        w2_scale_2=w2_scale_2,
+        a13_scale=None,
+        a2_scale=None,
+    )
+    assert config.a1_gscale is None
+    assert config.a2_gscale is None

--- a/tests/kernels/moe/utils.py
+++ b/tests/kernels/moe/utils.py
@@ -53,6 +53,8 @@ def make_dummy_moe_config(
     hidden_dim: int = 1,
     intermediate_size_per_partition: int = 1,
     in_dtype: torch.dtype = torch.bfloat16,
+    activation: MoEActivation = MoEActivation.SILU,
+    is_act_and_mul: bool = True,
 ) -> FusedMoEConfig:
     """
     This is a dummy config for the mk constructor interface
@@ -69,7 +71,8 @@ def make_dummy_moe_config(
         num_local_experts=num_experts,
         num_logical_experts=num_experts,
         moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
-        activation=MoEActivation.SILU,
+        activation=activation,
+        is_act_and_mul=is_act_and_mul,
         in_dtype=in_dtype,
         device="cuda",
         routing_method=RoutingMethodType.TopK,

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -256,6 +256,12 @@ class FusedMoEQuantConfig:
 
     mx_alignment: int = 0
 
+    # Identifies the upstream quantization format the weights were exported
+    # from (e.g. "modelopt", "compressed_tensors"). Backends that need to
+    # interpret a shared weight payload differently per source (FlashInfer
+    # B12x NVFP4) read this; most MoE methods can ignore it.
+    source_format: str | None = None
+
     def __post_init__(self):
         assert not self.per_act_token_quant or self.block_shape is None, (
             "illegal quantization"
@@ -506,6 +512,7 @@ class FusedMoEQuantConfig:
         gemm1_alpha: float | None = None,
         gemm1_beta: float | None = None,
         gemm1_clamp_limit: float | None = None,
+        source_format: str | None = None,
     ) -> "FusedMoEQuantConfig":
         """
         General builder function for a FusedMoEQuantConfig.
@@ -577,6 +584,7 @@ class FusedMoEQuantConfig:
             gemm1_alpha=gemm1_alpha,
             gemm1_beta=gemm1_beta,
             gemm1_clamp_limit=gemm1_clamp_limit,
+            source_format=source_format,
         )
         assert quant_config.per_act_token_quant == per_act_token_quant
         assert quant_config.per_out_ch_quant == per_out_ch_quant
@@ -806,6 +814,7 @@ def nvfp4_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
     is_scale_swizzled: bool = True,
     gemm1_clamp_limit: float | None = None,
+    source_format: str | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for mxfp4 activations and nvp4 weights.
@@ -825,6 +834,7 @@ def nvfp4_moe_quant_config(
         block_shape=None,
         is_scale_swizzled=is_scale_swizzled,
         gemm1_clamp_limit=gemm1_clamp_limit,
+        source_format=source_format,
     )
 
 
@@ -852,6 +862,7 @@ def nvfp4_w4a16_moe_quant_config(
     g2_alphas: torch.Tensor,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
+    source_format: str | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for 16-but activations and nvp4 weights.
@@ -863,6 +874,7 @@ def nvfp4_w4a16_moe_quant_config(
         g1_alphas=g1_alphas,
         g2_alphas=g2_alphas,
         weight_dtype="nvfp4",
+        source_format=source_format,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -131,7 +131,13 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,
     ) -> bool:
-        return (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic)
+        # b12x performs in-kernel BF16->FP4 activation quant, so W4A16
+        # NVFP4 checkpoints (activation_key=None, e.g. mixed-precision
+        # compressed-tensors layouts) are runtime-compatible.
+        return (weight_key, activation_key) in (
+            (kNvfp4Static, kNvfp4Dynamic),
+            (kNvfp4Static, None),
+        )
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -204,9 +204,17 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         assert self.g1_alphas is not None and self.g2_alphas is not None, (
             "g1_alphas and g2_alphas must not be None for FlashInferB12xExperts"
         )
-        assert self.a2_gscale is not None, (
-            "a2_gscale must not be None for FlashInferB12xExperts"
-        )
+        # W4A16 NVFP4 checkpoints may have a2_gscale=None; b12x quantizes FC2
+        # input dynamically, so a uniform 1.0 scale per expert is equivalent
+        # to the bake-in done in process_weights_after_loading for static-
+        # quant checkpoints.
+        fc2_input_scale = self.a2_gscale
+        if fc2_input_scale is None:
+            fc2_input_scale = torch.ones(
+                self.num_local_experts,
+                device=hidden_states.device,
+                dtype=torch.float32,
+            )
 
         top_k = topk_ids.shape[1]
 
@@ -217,7 +225,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,
             w1_alpha=self.g1_alphas,
-            fc2_input_scale=self.a2_gscale,
+            fc2_input_scale=fc2_input_scale,
             w2_weight=w2,
             w2_weight_sf=self.w2_sf_mma,
             w2_alpha=self.g2_alphas,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import TYPE_CHECKING
+
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -17,13 +19,17 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kNvfp4Dynamic,
     kNvfp4Static,
+    kNvfp4StaticGroupScale,
+    kStaticTensorScale,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
-    flashinfer_b12x_fused_moe,
     flashinfer_convert_sf_to_mma_layout,
     has_flashinfer_b12x_moe,
 )
+
+if TYPE_CHECKING:
+    from flashinfer.fused_moe import B12xMoEWrapper
 
 
 class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
@@ -42,6 +48,11 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
     Only NVFP4 (kNvfp4Static/kNvfp4Dynamic) quantization is supported.
     """
 
+    _ACTIVATION_MAP: dict[MoEActivation, str] = {
+        MoEActivation.SILU: "silu",
+        MoEActivation.RELU2_NO_MUL: "relu2",
+    }
+
     def __init__(
         self,
         moe_config: FusedMoEConfig,
@@ -54,6 +65,41 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.out_dtype = moe_config.in_dtype
         self.num_local_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
+
+        # Shape params for B12xMoEWrapper construction.
+        self.global_num_experts = moe_config.num_experts
+        self.topk = moe_config.experts_per_token
+        self.hidden_dim = moe_config.hidden_dim
+        self.intermediate_size_per_partition = (
+            moe_config.intermediate_size_per_partition
+        )
+        self.max_num_tokens = moe_config.max_num_tokens
+        self.local_expert_offset = self.ep_rank * self.num_local_experts
+
+        activation = moe_config.activation
+        if activation not in self._ACTIVATION_MAP:
+            raise ValueError(
+                f"FlashInferB12xExperts does not support "
+                f"activation {activation!r}. "
+                f"Supported: {list(self._ACTIVATION_MAP.keys())}"
+            )
+        self._activation_str = self._ACTIVATION_MAP[activation]
+
+        self.activation_precision = (
+            "fp4" if quant_config.a1_gscale is not None else "bf16"
+        )
+
+        # source_format selects how the FlashInfer kernel interprets the
+        # FP4 byte payload. Set by the parent quant method on
+        # FusedMoEQuantConfig; fall back to "modelopt" if upstream hasn't
+        # been wired through yet.
+        self.source_format = quant_config.source_format or "modelopt"
+
+        # Lazily created on first apply() call.
+        self._wrapper: B12xMoEWrapper | None = None
+        # Populated in process_weights_after_loading.
+        self.w1_sf_mma: torch.Tensor | None = None
+        self.w2_sf_mma: torch.Tensor | None = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Normalise block scales to absorb the per-expert weight global scale
@@ -87,26 +133,27 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         if self.a2_gscale is not None:
             self.a2_gscale.fill_(1.0)
 
-        # Precompute MMA-layout views of the weight scale factors once here
-        # rather than recomputing on every forward pass.
-        assert self.w1_scale is not None
-        num_experts_w1, m1, k1_sf = self.w1_scale.shape
-        k1 = k1_sf * 16
+        # Precompute MMA-layout views of the (now-rewritten) weight scale
+        # factors once here rather than recomputing on every forward pass.
+        # Converts swizzled 3D scale factors [E, M, K_sf] to the 6D MMA
+        # layout expected by the SM12x kernel's _get_weight_views().
+        assert self.w1_scale is not None and self.w2_scale is not None
+        sf_vec_size = 16
+        E_w1, M_w1, K_sf_w1 = self.w1_scale.shape
         self.w1_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            self.w1_scale.reshape(num_experts_w1 * m1, k1_sf),
-            m=m1,
-            k=k1,
-            num_groups=num_experts_w1,
+            self.w1_scale.reshape(E_w1 * M_w1, K_sf_w1),
+            m=M_w1,
+            k=K_sf_w1 * sf_vec_size,
+            num_groups=E_w1,
+            sf_vec_size=sf_vec_size,
         )
-
-        assert self.w2_scale is not None
-        num_experts_w2, m2, k2_sf = self.w2_scale.shape
-        k2 = k2_sf * 16
+        E_w2, M_w2, K_sf_w2 = self.w2_scale.shape
         self.w2_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            self.w2_scale.reshape(num_experts_w2 * m2, k2_sf),
-            m=m2,
-            k=k2,
-            num_groups=num_experts_w2,
+            self.w2_scale.reshape(E_w2 * M_w2, K_sf_w2),
+            m=M_w2,
+            k=K_sf_w2 * sf_vec_size,
+            num_groups=E_w2,
+            sf_vec_size=sf_vec_size,
         )
 
     @staticmethod
@@ -124,24 +171,31 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
-        return False
+        return True
 
     @staticmethod
     def _supports_quant_scheme(
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,
     ) -> bool:
-        # b12x performs in-kernel BF16->FP4 activation quant, so W4A16
-        # NVFP4 checkpoints (activation_key=None, e.g. mixed-precision
-        # compressed-tensors layouts) are runtime-compatible.
-        return (weight_key, activation_key) in (
-            (kNvfp4Static, kNvfp4Dynamic),
-            (kNvfp4Static, None),
+        # Original W4A4 NVFP4 (modelopt format). For modelopt W4A16, the
+        # key shape is the same; use_a16 on the quant method disambiguates.
+        if (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic):
+            return True
+
+        # W4A16 NVFP4 compressed-tensors `nvfp4-pack-quantized`.
+        return (
+            weight_key is not None
+            and weight_key.dtype == torch.uint8
+            and weight_key.scale == kNvfp4StaticGroupScale
+            and weight_key.scale2 == kStaticTensorScale
+            and weight_key.symmetric
+            and activation_key is None
         )
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation == MoEActivation.SILU
+        return activation in (MoEActivation.SILU, MoEActivation.RELU2_NO_MUL)
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
@@ -173,12 +227,30 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @property
     def expects_unquantized_inputs(self) -> bool:
-        # b12x_fused_moe expects BF16 hidden states and performs its own FP4
+        # B12xMoEWrapper expects BF16 hidden states and performs its own FP4
         # quantization internally.  Returning True prevents the modular kernel
-        # from pre-quantizing activations, which would produce an FP4-packed
-        # tensor with size(-1)=k//2 and break the scale-factor conversion that
-        # expects size(-1)=k.
+        # from pre-quantizing activations.
         return True
+
+    def _ensure_wrapper(self) -> None:
+        """Lazily create B12xMoEWrapper on first use."""
+        if self._wrapper is not None:
+            return
+
+        from flashinfer.fused_moe import B12xMoEWrapper
+
+        self._wrapper = B12xMoEWrapper(
+            num_experts=self.global_num_experts,
+            top_k=self.topk,
+            hidden_size=self.hidden_dim,
+            intermediate_size=self.intermediate_size_per_partition,
+            use_cuda_graph=True,
+            max_num_tokens=self.max_num_tokens,
+            num_local_experts=self.num_local_experts,
+            activation=self._activation_str,
+            activation_precision=self.activation_precision,
+            source_format=self.source_format,
+        )
 
     def apply(
         self,
@@ -215,13 +287,15 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
                 device=hidden_states.device,
                 dtype=torch.float32,
             )
+        assert self.w1_sf_mma is not None and self.w2_sf_mma is not None, (
+            "process_weights_after_loading must run before FlashInferB12xExperts.apply"
+        )
 
-        top_k = topk_ids.shape[1]
+        self._ensure_wrapper()
+        assert self._wrapper is not None
 
-        flashinfer_b12x_fused_moe(
+        result = self._wrapper.run(
             x=hidden_states,
-            token_selected_experts=topk_ids.to(torch.int32),
-            token_final_scales=topk_weights,
             w1_weight=w1,
             w1_weight_sf=self.w1_sf_mma,
             w1_alpha=self.g1_alphas,
@@ -229,9 +303,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             w2_weight=w2,
             w2_weight_sf=self.w2_sf_mma,
             w2_alpha=self.g2_alphas,
-            num_experts=global_num_experts,
-            top_k=top_k,
-            num_local_experts=self.num_local_experts,
-            output_dtype=self.out_dtype,
-            output=output,
+            token_selected_experts=topk_ids.to(torch.int32),
+            token_final_scales=topk_weights,
         )
+        output.copy_(result)

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -59,8 +59,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         quant_config: FusedMoEQuantConfig,
     ):
         super().__init__(moe_config=moe_config, quant_config=quant_config)
-        assert quant_config.quant_dtype == "nvfp4", (
-            "FlashInferB12xExperts only supports nvfp4 quantization."
+        # W4A4 sets quant_dtype="nvfp4"; W4A16 sets quant_dtype=None.
+        # Either way, weights must be nvfp4 for this kernel.
+        assert quant_config.weight_quant_dtype == "nvfp4", (
+            "FlashInferB12xExperts only supports nvfp4 weight quantization."
         )
         self.out_dtype = moe_config.in_dtype
         self.num_local_experts = moe_config.num_local_experts

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -349,11 +349,11 @@ def convert_to_nvfp4_moe_kernel_format(
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
+    torch.Tensor | None,
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
+    torch.Tensor | None,
 ]:
     if nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
         (
@@ -471,12 +471,12 @@ def make_nvfp4_moe_quant_config(
     w2_scale: torch.Tensor,
     w13_scale_2: torch.Tensor,
     w2_scale_2: torch.Tensor,
-    a13_scale: torch.Tensor,
-    a2_scale: torch.Tensor,
+    a13_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
     swiglu_limit: float | None = None,
     source_format: str | None = None,
 ) -> FusedMoEQuantConfig:
-    if backend == NvFp4MoeBackend.MARLIN:
+    if backend == NvFp4MoeBackend.MARLIN or a13_scale is None:
         return nvfp4_w4a16_moe_quant_config(
             g1_alphas=w13_scale_2,
             g2_alphas=w2_scale_2,
@@ -500,6 +500,9 @@ def make_nvfp4_moe_quant_config(
     # The expert's process_weights_after_loading will fuse activation
     # scales in-place. Since the quant config references the same tensor
     # as the registered parameter, EPLB rearrangement stays in sync.
+    # a13_scale / a2_scale are guaranteed non-None here: the W4A16
+    # (a13_scale is None) branch returned above.
+    assert a13_scale is not None and a2_scale is not None
     return nvfp4_moe_quant_config(
         g1_alphas=w13_scale_2,
         g2_alphas=w2_scale_2,

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -474,6 +474,7 @@ def make_nvfp4_moe_quant_config(
     a13_scale: torch.Tensor,
     a2_scale: torch.Tensor,
     swiglu_limit: float | None = None,
+    source_format: str | None = None,
 ) -> FusedMoEQuantConfig:
     if backend == NvFp4MoeBackend.MARLIN:
         return nvfp4_w4a16_moe_quant_config(
@@ -481,6 +482,7 @@ def make_nvfp4_moe_quant_config(
             g2_alphas=w2_scale_2,
             w1_scale=w13_scale,
             w2_scale=w2_scale,
+            source_format=source_format,
         )
     elif backend == NvFp4MoeBackend.EMULATION:
         return nvfp4_moe_quant_config(
@@ -491,6 +493,7 @@ def make_nvfp4_moe_quant_config(
             w1_scale=w13_scale,
             w2_scale=w2_scale,
             gemm1_clamp_limit=swiglu_limit,
+            source_format=source_format,
         )
 
     # Pass w13_scale_2 / w2_scale_2 directly as g1/g2_alphas.
@@ -515,6 +518,7 @@ def make_nvfp4_moe_quant_config(
             )
         ),
         gemm1_clamp_limit=swiglu_limit,
+        source_format=source_format,
     )
 
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -259,6 +259,7 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
+            source_format="compressed_tensors",
         )
 
     def apply_monolithic(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -43,6 +43,7 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
     ):
         super().__init__(moe)
         self.group_size = 16
+        self.use_a16 = use_a16
 
         # Select experts implementation.
         self.nvfp4_backend, self.experts_cls = select_nvfp4_moe_backend(
@@ -212,11 +213,11 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             w13=layer.w13_weight,
             w13_scale=layer.w13_weight_scale,
             w13_scale_2=(1.0 / w13_weight_global_scale),
-            a13_scale=(1.0 / layer.w13_input_global_scale),
+            a13_scale=(None if self.use_a16 else (1.0 / layer.w13_input_global_scale)),
             w2=layer.w2_weight,
             w2_scale=layer.w2_weight_scale,
             w2_scale_2=(1.0 / layer.w2_weight_global_scale),
-            a2_scale=(1.0 / layer.w2_input_global_scale),
+            a2_scale=(None if self.use_a16 else (1.0 / layer.w2_input_global_scale)),
             is_act_and_mul=self.moe.is_act_and_mul,
         )
 
@@ -256,8 +257,8 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             w2_scale=layer.w2_weight_scale,
             w13_scale_2=layer.w13_weight_scale_2,
             w2_scale_2=layer.w2_weight_scale_2,
-            a13_scale=layer.w13_input_scale,
-            a2_scale=layer.w2_input_scale,
+            a13_scale=None if self.use_a16 else layer.w13_input_scale,
+            a2_scale=None if self.use_a16 else layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
             source_format="compressed_tensors",
         )

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1388,12 +1388,11 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
     ) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
-        # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. With
-        # activation_key=None every W4A4 backend's _supports_quant_scheme
-        # rejects itself (they all require (kNvfp4Static, kNvfp4Dynamic)
-        # exactly); only Marlin survives. Marlin's MoE path drops
-        # activation scales in convert_to_nvfp4_moe_kernel_format, so no
-        # other change is needed.
+        # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. Backends that
+        # accept activation_key=None (Marlin, FlashInferB12xExperts) run in
+        # bf16-activation mode; the activation scales loaded from the
+        # checkpoint must be suppressed in process_weights_after_loading and
+        # get_fused_moe_quant_config so a13_scale/a2_scale propagate as None.
         self.use_a16 = quant_config.quant_method == "W4A16_NVFP4"
         self.nvfp4_backend, self.experts_cls = select_nvfp4_moe_backend(
             config=self.moe,
@@ -1566,11 +1565,11 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             w13=layer.w13_weight,
             w13_scale=layer.w13_weight_scale,
             w13_scale_2=w13_weight_scale_2,
-            a13_scale=layer.w13_input_scale,
+            a13_scale=None if self.use_a16 else layer.w13_input_scale,
             w2=layer.w2_weight,
             w2_scale=layer.w2_weight_scale,
             w2_scale_2=layer.w2_weight_scale_2,
-            a2_scale=layer.w2_input_scale,
+            a2_scale=None if self.use_a16 else layer.w2_input_scale,
             is_act_and_mul=self.moe.is_act_and_mul,
         )
 
@@ -1601,8 +1600,8 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             w2_scale=layer.w2_weight_scale,
             w13_scale_2=layer.w13_weight_scale_2,
             w2_scale_2=layer.w2_weight_scale_2,
-            a13_scale=layer.w13_input_scale,
-            a2_scale=layer.w2_input_scale,
+            a13_scale=None if self.use_a16 else layer.w13_input_scale,
+            a2_scale=None if self.use_a16 else layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
             source_format="modelopt",
         )

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1604,6 +1604,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
+            source_format="modelopt",
         )
 
     @property
@@ -2386,6 +2387,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
             if quant_algo == "W4A16_NVFP4":
                 return ModelOptNvFp4W4A16LinearMethod(self.w4a16_nvfp4_config)
             # Layer not in quantized_layers — leave unquantized
+            return UnquantizedLinearMethod()
+
+        if isinstance(layer, ParallelLMHead):
+            if quant_algo == "FP8":
+                return ModelOptFp8LinearMethod(self.fp8_config)
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4LinearMethod(self.nvfp4_config)
             return UnquantizedLinearMethod()
 
         if isinstance(layer, RoutedExperts):

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -388,5 +388,8 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
             w2_scale = torch.nn.functional.pad(w2_scale, (0, pad_size // 16))
 
         w2_scale = swizzle_blockscale(w2_scale)
+        layer.moe_config.intermediate_size_per_partition = (
+            layer.moe_config.intermediate_size_per_partition + pad_size
+        )
 
     return w13, w13_scale, w13_scale_2, a13_scale, w2, w2_scale, w2_scale_2, a2_scale

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -290,21 +290,21 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     w13: torch.Tensor,
     w13_scale: torch.Tensor,
     w13_scale_2: torch.Tensor,
-    a13_scale: torch.Tensor,
+    a13_scale: torch.Tensor | None,
     w2: torch.Tensor,
     w2_scale: torch.Tensor,
     w2_scale_2: torch.Tensor,
-    a2_scale: torch.Tensor,
+    a2_scale: torch.Tensor | None,
     is_act_and_mul: bool,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
+    torch.Tensor | None,
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
+    torch.Tensor | None,
 ]:
     # Delayed import for circular dependency avoidance.
     from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
@@ -334,13 +334,17 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     ):
         w13, w13_scale = reorder_w1w3_to_w3w1(w13, w13_scale)
 
-    # For some FI kernels, the input scales are shared by all experts.
-    if is_global_sf_supported_for_nvfp4_backend(backend):
-        num_experts = w13.shape[0]
-        a13_scale = a13_scale.max().to(torch.float32).expand(num_experts)
-        a2_scale = a2_scale.max().to(torch.float32).expand(num_experts)
-    else:
-        a13_scale = a13_scale.max(dim=1).values.to(torch.float32)
+    # W4A16: activations stay in BF16 inside the kernel, no scale needed.
+    # When a13_scale is provided, a2_scale is provided too (W4A4 path).
+    if a13_scale is not None:
+        assert a2_scale is not None
+        # For some FI kernels, the input scales are shared by all experts.
+        if is_global_sf_supported_for_nvfp4_backend(backend):
+            num_experts = w13.shape[0]
+            a13_scale = a13_scale.max().to(torch.float32).expand(num_experts)
+            a2_scale = a2_scale.max().to(torch.float32).expand(num_experts)
+        else:
+            a13_scale = a13_scale.max(dim=1).values.to(torch.float32)
 
     # Shuffle weights and scales for FI TRTLLM NVFP4 MoE kernels.
     if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -216,7 +216,11 @@ def prepare_fp4_layer_for_marlin(
 
     part_size_n = layer.output_size_per_partition
     part_size_k = layer.input_size_per_partition
-    param_dtype = layer.params_dtype
+    # VocabParallelEmbedding / ParallelLMHead does not store params_dtype as an
+    # attribute
+    param_dtype = getattr(layer, "params_dtype", None)
+    if param_dtype is None:
+        param_dtype = torch.get_default_dtype()
 
     assert layer.weight.shape == (part_size_n, part_size_k // 2)
 

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -439,12 +439,17 @@ class VocabParallelEmbedding(PluggableLayer):
         # If parameter does not have output dim, then it should
         # be copied onto all gpus (e.g. g_idx for act_order gptq).
         if output_dim is None:
+            # AutoQuantize-quantized lm_head emits FP4 scalar scales
+            # (input_scale, weight_scale_2). Their on-disk shape is () while
+            # PerTensorScaleParameter materializes them as (1,) -- same numel,
+            # different rank. Reshape rather than asserting. The broader
+            # numel-match check subsumes the earlier ndim==0-only handling.
             if (
-                loaded_weight.ndim == 0
-                and param.data.ndim == 1
-                and param.data.numel() == 1
+                param.data.shape != loaded_weight.shape
+                and param.data.numel() == loaded_weight.numel()
             ):
-                loaded_weight = loaded_weight.reshape(1)
+                param.data.copy_(loaded_weight.reshape(param.data.shape))
+                return
             assert param.data.shape == loaded_weight.shape
             param.data.copy_(loaded_weight)
             return


### PR DESCRIPTION
## Summary

`make_nvfp4_moe_quant_config` only routes W4A16 to `nvfp4_w4a16_moe_quant_config` when `backend == NvFp4MoeBackend.MARLIN`. With FlashInferB12xExperts now accepting `(kNvfp4Static, None)` (per #43332 / #43341), W4A16 checkpoints reach `make_nvfp4_moe_quant_config` with the activation scales still loaded — real calibrated values (for modelopt) or uninitialized `torch.empty()` (for compressed-tensors). The function then either:

- **modelopt:** silently dispatches the W4A4 branch with calibrated activation scales — running W4A4 inference on a W4A16-labeled checkpoint (silent correctness bug; no crash);
- **compressed-tensors:** computes `1.0 / uninitialized_tensor`, then fails FlashInfer's kernel-side `source_format='compressed_tensors' requires quant_mode='w4a16'` check.

## Changes

- `make_nvfp4_moe_quant_config`: route to `nvfp4_w4a16_moe_quant_config` when `a13_scale is None`, regardless of backend (previously MARLIN-only). Type hints on `a13_scale` / `a2_scale` widened to `Tensor | None`.
- `ModelOptNvFp4FusedMoE` and `CompressedTensorsW4A4Nvfp4MoEMethod`: when `self.use_a16`, pass `a13_scale=None` / `a2_scale=None` at both call sites (`process_weights_after_loading` + `get_fused_moe_quant_config`). CT MoE also stores `use_a16` on `self` (the constructor argument was previously unstored).
- `prepare_nvfp4_moe_layer_for_fi_or_cutlass`: skip `.max()` reductions on `None` activation scales.
- `FlashInferB12xExperts.__init__`: assert on `weight_quant_dtype == "nvfp4"` instead of `quant_dtype` (which is `None` for W4A16).
- New no-GPU regression test: `tests/kernels/moe/test_w4a16_propagation.py`.

## Dependencies

This PR is stacked on **#43332** (B12x `_supports_quant_scheme` accepts W4A16 + `apply()` `fc2_input_scale` fallback) and **#43341** (`activation_precision` + `source_format` plumbing). Both deps are currently included in this branch as commits 1–4; the actual fix is the final commit. Once **#43332** and **#43341** merge, this PR rebases to a clean diff against main.

> Marked Draft until those dependencies land.

## Duplicate-work check

No open PR addresses the `make_nvfp4_moe_quant_config` routing or the modelopt / CT `use_a16` propagation. The neighboring PRs (#43332, #43341, #43333) extend B12x's *acceptance* of W4A16 but leave the routing-and-propagation gap unresolved — without this PR, even with those merged, modelopt W4A16 silently runs W4A4 and compressed-tensors W4A16 crashes.

## Test plan

**Unit (no GPU):**

```
pytest tests/kernels/moe/test_w4a16_propagation.py -v
```

3 tests covering W4A16 B12x / W4A4 B12x / W4A16 MARLIN routing — all pass.

**E2E on SM121 (B12x) with #43332+#43341 applied:**

Verified end-to-end on representative W4A16 NVFP4 MoE checkpoints — both modelopt (`quant_algo=W4A16_NVFP4`) and compressed-tensors (`nvfp4-pack-quantized`). Each loads, compiles, captures CUDA graphs, and generates sensible output on B12x. With `FLASHINFER_LOGLEVEL=3`, every `B12xMoEWrapper.__init__` call per run reports `activation_precision='bf16'` and the expected `source_format` for the checkpoint origin (`'modelopt'` vs `'compressed_tensors'`).

## AI assistance disclosure

AI assistance was used for commit-message drafting and resolving conflicts when rebasing onto #43332 / #43341. Every changed line was reviewed locally by the submitter, and the unit + E2E tests were run end-to-end before opening this PR.
