### PR TITLE
[Bugfix] V1: clear stale allowed_token_ids mask in InputBatch.condense

### DIFF
--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -378,6 +378,62 @@ def test_swap_states_in_input_batch(device: str, batch_size: int, swap_list: lis
     _compare_objs(input_batch, ref_input_batch)
 
 
+@pytest.mark.parametrize("device", DEVICES)
+def test_condense_clears_stale_allowed_token_ids_mask(device: str):
+    """condense() must clear the mask row a constrained request is moved out
+    of. Otherwise a later request that reuses that row without
+    allowed_token_ids inherits the stale whitelist.
+    See https://github.com/vllm-project/vllm/issues/43894.
+    """
+    batch_size = 4
+    allowed_token_id = 13
+    input_batch = InputBatch(
+        max_num_reqs=batch_size,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        device=torch.device(device),
+        pin_memory=is_pin_memory_available(),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[1],
+        kernel_block_sizes=[1],
+    )
+
+    def _make_req(suffix: int, allowed_token_ids=None) -> CachedRequestState:
+        return CachedRequestState(
+            req_id=f"req_id_{suffix}",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(allowed_token_ids=allowed_token_ids),
+            pooling_params=None,
+            mm_features=[],
+            block_ids=([],),
+            generator=None,
+            num_computed_tokens=0,
+            output_token_ids=[],
+        )
+
+    # Only req_id_2 is constrained, and it lands on the highest row.
+    assert input_batch.add_request(_make_req(0)) == 0
+    assert input_batch.add_request(_make_req(1)) == 1
+    assert input_batch.add_request(_make_req(2, [allowed_token_id])) == 2
+
+    mask = input_batch.allowed_token_ids_mask_cpu_tensor
+    assert mask is not None
+    # The constrained row masks every token except the single allowed id.
+    assert not mask[2][allowed_token_id].item()
+    assert int(mask[2].sum().item()) == VOCAB_SIZE - 1
+
+    # Free row 0, then condense: req_id_2 slides from row 2 down into row 0.
+    input_batch.remove_request("req_id_0")
+    input_batch.condense()
+    assert input_batch.req_id_to_index["req_id_2"] == 0
+    assert int(mask[2].sum().item()) == 0
+
+    # A new unrestricted request reuses row 2 and must stay unconstrained.
+    assert input_batch.add_request(_make_req(3)) == 2
+    assert "req_id_3" not in input_batch.has_allowed_token_ids
+    assert int(mask[2].sum().item()) == 0
+
+
 def _construct_pooling_request(req_id_suffix: int, pooling_params=None):
     from vllm.pooling_params import PoolingParams
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -795,6 +795,10 @@ class InputBatch:
                 self.allowed_token_ids_mask_cpu_tensor[empty_index] = (
                     self.allowed_token_ids_mask_cpu_tensor[last_req_index]
                 )
+                # Clear the vacated source row so a later request that reuses
+                # this index without allowed_token_ids does not inherit the
+                # stale mask. False means we don't fill with -inf.
+                self.allowed_token_ids_mask_cpu_tensor[last_req_index].fill_(False)
 
             bad_words_token_ids = self.bad_words_token_ids.pop(last_req_index, None)
             if bad_words_token_ids is not None:


### PR DESCRIPTION

## Purpose
Fixes #43894.

`InputBatch.condense()` copies `allowed_token_ids_mask_cpu_tensor` from a moved request's row into the freed index but never clears the source row. `add_request` only writes that row when the new request sets `allowed_token_ids`, so unrestricted request that later reuses the index keeps the previous request's whitelist and is sampled against a stale mask. This clears the vacated row with `fill_(False)`, the same way `remove_request` does.

## Test Plan
`pytest tests/v1/worker/test_gpu_input_batch.py -v -k condense_clears_stale`

## Test Result
```
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/logyx/vllm-fork/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/logyx/vllm-fork
configfile: pyproject.toml
plugins: asyncio-1.4.0, shard-0.1.2, cov-7.1.0, schemathesis-4.20.2, anyio-4.13.0, typeguard-4.5.2, buildkite-test-collector-0.1.9, timeout-2.4.0, mock-3.15.1, forked-1.6.0, hypothesis-6.153.6, rerunfailures-16.3
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9 items / 8 deselected / 1 selected
Running 1 items in this shard: tests/v1/worker/test_gpu_input_batch.py::test_condense_clears_stale_allowed_token_ids_mask[cuda:0]

tests/v1/worker/test_gpu_input_batch.py::test_condense_clears_stale_allowed_token_ids_mask[cuda:0] PASSED
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

AI assistance: Claude was used to navigate codebase, locate fix, and draft PR. All code and tests were manually verified/run.

