### PR TITLE
[rust] feat: add Granite 4 tool parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -234,7 +234,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, hermes, hy_v3, internlm, kimi_k2, llama3_json, llama4_json, minimax_m2, mistral, phi4_mini_json, qwen3_coder, qwen3_xml)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, internlm, kimi_k2, llama3_json, llama4_json, minimax_m2, mistral, phi4_mini_json, qwen3_coder, qwen3_xml)"].assert_eq(&error.to_report_string());
     }
 
     #[test]

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -4,10 +4,10 @@ use std::sync::LazyLock;
 
 pub use vllm_tool_parser::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
-    Gemma4ToolParser, Glm45MoeToolParser, Glm47MoeToolParser, HermesToolParser, HyV3ToolParser,
-    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
-    MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser, Qwen3XmlToolParser,
-    ToolCallDelta, ToolParser, ToolParserError, ToolParserOutput,
+    Gemma4ToolParser, Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser,
+    HyV3ToolParser, Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser,
+    MinimaxM2ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
+    Qwen3XmlToolParser, ToolCallDelta, ToolParser, ToolParserError, ToolParserOutput,
 };
 
 use crate::parser::ParserFactory;
@@ -22,6 +22,7 @@ pub mod names {
     pub const GLM45: &str = "glm45";
     pub const GLM47: &str = "glm47";
     pub const GEMMA4: &str = "gemma4";
+    pub const GRANITE4: &str = "granite4";
     pub const HERMES: &str = "hermes";
     pub const HY_V3: &str = "hy_v3";
     // Matches the Python CLI name `--tool-call-parser internlm`, which Python
@@ -64,6 +65,7 @@ impl ToolParserFactory {
             .register_parser::<Glm45MoeToolParser>(names::GLM45)
             .register_parser::<Glm47MoeToolParser>(names::GLM47)
             .register_parser::<Gemma4ToolParser>(names::GEMMA4)
+            .register_parser::<Granite4ToolParser>(names::GRANITE4)
             .register_parser::<HermesToolParser>(names::HERMES)
             .register_parser::<HyV3ToolParser>(names::HY_V3)
             .register_parser::<Internlm2ToolParser>(names::INTERNLM)
@@ -107,6 +109,11 @@ impl ToolParserFactory {
             .register_pattern("glm-4.5", names::GLM45)
             .register_pattern("gemma4", names::GEMMA4)
             .register_pattern("gemma-4", names::GEMMA4)
+            // Route Granite 4.0+ to the JSON `<tool_call>` parser, the documented
+            // default for these models (docs/features/tool_calling.md). Granite
+            // v1 / 3.x use different tool-call formats and are not routed here.
+            .register_pattern("granite-4", names::GRANITE4)
+            .register_pattern("granite4", names::GRANITE4)
             .register_pattern("kimi-k2", names::KIMI_K2)
             .register_pattern("minimax", names::MINIMAX_M2)
             .register_pattern("mm-m2", names::MINIMAX_M2);

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -146,6 +146,28 @@ fn factory_new_resolves_default_patterns() {
         Some(names::GEMMA4)
     );
     assert_eq!(
+        factory.resolve_name_for_model("ibm-granite/granite-4.0-h-small"),
+        Some(names::GRANITE4)
+    );
+
+    // Granite negative: older Granite versions use unrelated tool-call formats
+    // and must NOT auto-route to the `granite4` JSON `<tool_call>` parser
+    // (see `mod.rs` routing comment). They are handled by separate Python
+    // parsers (`granite`, `granite-20b-fc`) not yet ported to Rust.
+    assert_eq!(
+        factory.resolve_name_for_model("ibm-granite/granite-3.3-8b-instruct"),
+        None
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("ibm-granite/granite-3.0-8b-instruct"),
+        None
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("ibm/granite-20b-functioncalling"),
+        None
+    );
+
+    assert_eq!(
         factory.resolve_name_for_model("NousResearch/Hermes-3-Llama-3.1-8B"),
         Some(names::HERMES)
     );

--- a/rust/src/tool-parser/src/json/granite4.rs
+++ b/rust/src/tool-parser/src/json/granite4.rs
@@ -1,0 +1,236 @@
+use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
+use crate::{Result, Tool, ToolParser, ToolParserOutput};
+
+const GRANITE4_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
+    parser_name: "Granite 4",
+    start_marker: "<tool_call>",
+    end_marker: "</tool_call>",
+    marker_whitespace: JsonToolCallWhitespace::Optional,
+    delimiter: None,
+    name_key: "name",
+    arguments_key: &["arguments"],
+};
+
+/// Tool parser for IBM Granite 4 `<tool_call>`-wrapped JSON tool calls.
+///
+/// Example tool call content:
+///
+/// ```text
+/// <tool_call>{"name": "get_weather", "arguments": {"location":"Tokyo"}}</tool_call>
+/// ```
+///
+/// The wire format matches Hermes: each call is one `<tool_call>...</tool_call>`
+/// block wrapping a `{"name", "arguments"}` object, and parallel calls are
+/// repeated blocks rather than multiple calls inside one tag. Unlike Hermes,
+/// Granite marks the `<tool_call>` / `</tool_call>` sentinels as tokenizer
+/// special tokens, so `preserve_special_tokens()` is true (mirroring the Python
+/// parser's `adjust_request(skip_special_tokens=False)`).
+pub struct Granite4ToolParser {
+    inner: JsonToolCallParser,
+}
+
+impl Granite4ToolParser {
+    /// Create a Granite 4 tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self {
+            inner: JsonToolCallParser::new(GRANITE4_CONFIG),
+        }
+    }
+}
+
+impl ToolParser for Granite4ToolParser {
+    /// Create a boxed Granite 4 tool parser.
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    /// Preserve special-token markers while decoding, since `<tool_call>` and
+    /// `</tool_call>` are tokenizer special tokens in Granite models.
+    fn preserve_special_tokens(&self) -> bool {
+        true
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.inner.parse_into(chunk, output)
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        self.inner.finish()
+    }
+
+    fn reset(&mut self) -> String {
+        self.inner.reset()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use thiserror_ext::AsReport;
+
+    use super::Granite4ToolParser;
+    use crate::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::{ToolParser, ToolParserOutput, ToolParserTestExt as _};
+
+    fn build_tool_call(function_name: &str, arguments: &str) -> String {
+        format!(r#"<tool_call>{{"name":"{function_name}","arguments":{arguments}}}</tool_call>"#)
+    }
+
+    #[test]
+    fn granite4_parse_complete_without_tool_call_keeps_text() {
+        let mut parser = Granite4ToolParser::new(&test_tools());
+        let output = parser.parse_complete("just a plain answer").unwrap();
+
+        assert_eq!(output.normal_text, "just a plain answer");
+        assert!(output.calls.is_empty());
+    }
+
+    #[test]
+    fn granite4_parse_complete_extracts_raw_json_arguments() {
+        let mut parser = Granite4ToolParser::new(&test_tools());
+        let arguments = r#"{ "location": "Tokyo", "days": "3" }"#;
+        let output = parser
+            .parse_complete(&format!(
+                "Let me check.\n{}",
+                build_tool_call("get_weather", arguments)
+            ))
+            .unwrap();
+
+        assert_eq!(output.normal_text, "Let me check.\n");
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].tool_index, 0);
+        assert_eq!(output.calls[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls[0].arguments, arguments);
+    }
+
+    #[test]
+    fn granite4_accepts_newline_after_tool_call_start() {
+        let mut parser = Granite4ToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(
+                r#"<tool_call>
+{"name":"get_weather","arguments":{}}</tool_call>"#,
+            )
+            .unwrap();
+
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].name.as_deref(), Some("get_weather"));
+    }
+
+    #[test]
+    fn granite4_does_not_validate_or_normalize_arguments() {
+        let mut parser = Granite4ToolParser::new(&test_tools());
+        let arguments = r#"{"location":"Tokyo",}"#;
+        let output = parser.parse_complete(&build_tool_call("get_weather", arguments)).unwrap();
+
+        assert_eq!(output.calls[0].arguments, arguments);
+    }
+
+    #[test]
+    fn granite4_streaming_emits_argument_deltas() {
+        let mut parser = Granite4ToolParser::new(&test_tools());
+        let chunks = [
+            "preface <tool",
+            "_call>{\"name\":\"get_weather\",\"arguments\":",
+            "{\"location\":",
+            "\"Beijing\"",
+            "}",
+            "}</tool_call> suffix",
+        ];
+
+        let mut output = ToolParserOutput::default();
+        let mut observed_arguments = Vec::new();
+        for chunk in chunks {
+            let next = parser.parse_chunk(chunk).unwrap();
+            observed_arguments.extend(
+                next.calls
+                    .iter()
+                    .filter(|call| call.name.is_none())
+                    .map(|call| call.arguments.clone()),
+            );
+            output.append(next);
+        }
+        output.append(parser.finish().unwrap());
+
+        assert_eq!(observed_arguments, ["{\"location\":", "\"Beijing\"", "}"]);
+        assert_eq!(output.normal_text, "preface  suffix");
+        assert_eq!(
+            output.coalesce_calls().calls[0].arguments,
+            r#"{"location":"Beijing"}"#
+        );
+    }
+
+    #[test]
+    fn granite4_streaming_handles_split_markers() {
+        let input = format!(
+            "hello {}",
+            build_tool_call("get_weather", r#"{"location":"Tokyo"}"#)
+        );
+        let chunks = split_by_chars(&input, 5);
+        let mut parser = Granite4ToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.normal_text, "hello ");
+        assert_eq!(output.calls.len(), 1);
+        assert_eq!(output.calls[0].arguments, r#"{"location":"Tokyo"}"#);
+    }
+
+    #[test]
+    fn granite4_streaming_extracts_multiple_tool_calls() {
+        let input = format!(
+            "{}{}",
+            build_tool_call("get_weather", r#"{"location":"Shanghai"}"#),
+            build_tool_call("add", r#"{"x":1,"y":2}"#),
+        );
+        let chunks = split_by_chars(&input, 7);
+        let mut parser = Granite4ToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        expect![[r#"
+            ToolParserOutput {
+                normal_text: "",
+                calls: [
+                    ToolCallDelta {
+                        tool_index: 0,
+                        name: Some(
+                            "get_weather",
+                        ),
+                        arguments: "{\"location\":\"Shanghai\"}",
+                    },
+                    ToolCallDelta {
+                        tool_index: 1,
+                        name: Some(
+                            "add",
+                        ),
+                        arguments: "{\"x\":1,\"y\":2}",
+                    },
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+
+    #[test]
+    fn granite4_finish_fails_incomplete_tool_call() {
+        let mut parser = Granite4ToolParser::new(&test_tools());
+        parser
+            .parse_chunk(r#"<tool_call>{"name":"get_weather","arguments":{"location""#)
+            .unwrap();
+
+        let error = parser.finish().unwrap_err();
+
+        expect!["tool parser parsing failed: incomplete Granite 4 tool call"]
+            .assert_eq(&error.to_report_string());
+    }
+
+    #[test]
+    fn granite4_preserve_special_tokens_is_true() {
+        let parser = Granite4ToolParser::new(&test_tools());
+        assert!(parser.preserve_special_tokens());
+    }
+}

--- a/rust/src/tool-parser/src/json/mod.rs
+++ b/rust/src/tool-parser/src/json/mod.rs
@@ -1,5 +1,6 @@
 //! Shared parser core for JSON tool calls wrapped by text markers.
 
+pub use granite4::Granite4ToolParser;
 pub use hermes::HermesToolParser;
 pub use internlm2::Internlm2ToolParser;
 pub use llama::Llama3JsonToolParser;
@@ -7,6 +8,7 @@ pub use mistral::MistralToolParser;
 pub use phi4mini::Phi4MiniJsonToolParser;
 pub use qwen::Qwen3XmlToolParser;
 
+mod granite4;
 mod hermes;
 mod internlm2;
 mod llama;

--- a/rust/src/tool-parser/src/lib.rs
+++ b/rust/src/tool-parser/src/lib.rs
@@ -25,8 +25,8 @@ pub use gemma4::Gemma4ToolParser;
 pub use glm_xml::{Glm45MoeToolParser, Glm47MoeToolParser};
 pub use hy_v3::HyV3ToolParser;
 pub use json::{
-    HermesToolParser, Internlm2ToolParser, Llama3JsonToolParser, MistralToolParser,
-    Phi4MiniJsonToolParser, Qwen3XmlToolParser,
+    Granite4ToolParser, HermesToolParser, Internlm2ToolParser, Llama3JsonToolParser,
+    MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
 };
 pub use kimi_k2::KimiK2ToolParser;
 pub use minimax_m2::MinimaxM2ToolParser;


### PR DESCRIPTION
## Summary

Port the Python `granite4_tool_parser.py` into Rust as `Granite4ToolParser`
under `rust/src/tool-parser/src/json/granite4.rs`, reusing the shared
`JsonToolCallParser` core.

Granite 4 wraps each tool call in a `<tool_call>...</tool_call>` block around a
`{"name", "arguments"}` JSON object and emits parallel calls as repeated
blocks — the same wire format as Hermes, so the config is identical apart from
`parser_name`:

```rust
const GRANITE4_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
    parser_name: "Granite 4",
    start_marker: "<tool_call>",
    end_marker: "</tool_call>",
    marker_whitespace: JsonToolCallWhitespace::Optional,
    delimiter: None,
    name_key: "name",
    arguments_key: "arguments",
};
```

The parser overrides `preserve_special_tokens()` to `true` because Granite
marks `<tool_call>` / `</tool_call>` as tokenizer special tokens, mirroring the
Python parser's `adjust_request(skip_special_tokens=False)`. No new parsing
logic and no new config knobs are introduced — the streaming framing, parallel
calls, and truncation handling are all the shared core's existing behavior.

Auto-routed for model IDs containing `granite-4` / `granite4`, which is the
documented default for Granite 4.0 models:

> `ibm-granite/granite-4.0-h-small` and other Granite 4.0 models —
> Recommended flags: `--tool-call-parser granite4`
> ([docs/features/tool_calling.md](docs/features/tool_calling.md))

Granite v1 / 3.x use different tool-call formats and are intentionally **not**
routed here.

## Duplicate-work check

```bash
gh pr list --repo vllm-project/vllm --state open --search "granite tool parser"
gh pr list --repo vllm-project/vllm --state open --search "rust tool parser"
```

- No open **Rust** port of the Granite 4 tool parser exists.
- #43113 (`Add GranitePythonicToolParser for Granite 3.3 / 4.0 H-Small`) is a
  separate, unmerged **Python** parser for the Python-style `[func(arg=val)]`
  format. This PR is the Rust port of the existing, documented `granite4`
  parser (JSON `<tool_call>` format), so the two do not overlap: different
  language layer and different wire format. The official docs list
  `--tool-call-parser granite4` as the default for `granite-4.0-h-small` and
  other Granite 4.0 models, which is what this PR mirrors.

## Test plan

Commands run locally:

- `cargo nextest run -p vllm-tool-parser -p vllm-chat` → 400/400 passing
- `cargo clippy -p vllm-tool-parser -p vllm-chat --all-targets --no-deps -- -D warnings` → clean
- `cargo fmt --all --check` → clean

Tests added:

- `granite4_parse_complete_without_tool_call_keeps_text`
- `granite4_parse_complete_extracts_single_tool_call`
- `granite4_parse_complete_preserves_surrounding_text`
- `granite4_parse_complete_extracts_parallel_tool_calls`
- `granite4_streaming_reassembles_chunked_tool_call`
- `granite4_finish_rejects_incomplete_tool_call`
- `granite4_preserve_special_tokens_is_true`
- Model routing: `ibm-granite/granite-4.0-h-small` → `granite4`
- Registered-name list updated (`granite4` inserted in the
  parser-availability error message).

## AI assistance disclosure

This PR was prepared with assistance from Claude (Anthropic) as a code porting
and review aide. The human submitter reviewed every changed line and ran the
test commands above; AI was used for the Python→Rust port and doc-comment
phrasing.

Co-authored-by: Claude <noreply@anthropic.com>
