### PR TITLE
[Bugfix][DeepSeek-V4] Append generation prompt when last message is system

### DIFF
--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -96,6 +96,36 @@ def test_deepseek_v4_enables_thinking_with_compatible_kwargs(kwargs):
     assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>Hello<｜Assistant｜><think>")
 
 
+def test_deepseek_v4_appends_generation_prompt_for_trailing_system():
+    # Agent frameworks commonly append a context-only system message
+    # (environment details, locale, date, etc.) as the final message before
+    # asking the model to respond. The generation prompt must still be
+    # emitted; otherwise the model sees no <｜Assistant｜> turn and returns
+    # empty content.
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Environment: production"},
+        ],
+        tokenize=False,
+    )
+
+    assert prompt.endswith("<｜Assistant｜></think>")
+
+
+def test_deepseek_v4_appends_thinking_generation_prompt_for_trailing_system():
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Environment: production"},
+        ],
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
 def test_deepseek_v4_uses_v4_tool_prompt_from_request_tools():
     tools = [
         {

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -387,7 +387,7 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
             prompt += thinking_end_token if thinking_mode != "thinking" else thinking_start_token
             prompt += task_sp_token
 
-    elif messages[index].get("role") in ["user", "developer"]:
+    elif messages[index].get("role") in ["user", "developer", "system"]:
         # Normal generation: append Assistant + thinking token
         prompt += ASSISTANT_SP_TOKEN
         if not drop_thinking and thinking_mode == "thinking":


### PR DESCRIPTION
## Purpose

The DeepSeek-V4 chat encoder (`vllm/tokenizers/deepseek_v4_encoding.py`) only
appends the `<｜Assistant｜>` generation prompt when the **final** message role
is `user` or `developer`. When the final message is a `system` message, no
assistant prompt is appended, so the model sees no assistant turn and emits
EOS immediately — the request returns HTTP 200 with `finish_reason="stop"`,
`completion_tokens=1`, and **empty `content`**.

A trailing `system` message is a common pattern: agent frameworks frequently
inject an environment/context system message (timestamp, locale, working
directory, reminders, etc.) as the last message right before asking the model
to respond, to keep the leading system prompt prefix-cache friendly.

This is a regression relative to DeepSeek-V3.2, whose Jinja chat template
handles this case via its `ns.is_only_sys` fallback. The DeepSeek official API,
as well as several hosted providers, also handle a trailing `system` message
correctly; only self-hosted vLLM/SGLang (which use this encoder) reproduce the
empty output.

### Fix

Add `system` to the generation-prompt role allow-list:

```python
elif messages[index].get("role") in ["user", "developer", "system"]:
    # Normal generation: append Assistant + thinking token
    prompt += ASSISTANT_SP_TOKEN
```

`latest_reminder` is intentionally **not** added: it has special handling in
the early-return logic at the top of `render_message` (it is treated like
`assistant` in the "what may follow" check), so adding it would emit a
duplicate assistant prompt for `[user, latest_reminder]` sequences. Limiting
the change to `system` precisely matches the V3.2 `ns.is_only_sys` behavior.

## Test Plan

Added two unit tests to `tests/tokenizers_/test_deepseek_v4.py` covering a
trailing `system` message in both chat and thinking modes:

```bash
pytest tests/tokenizers_/test_deepseek_v4.py -k trailing_system
```

## Test Result

Before the fix, a trailing `system` message produces a prompt with no
`<｜Assistant｜>` token at all:

```
encode_messages([{"role":"user","content":"Hello"},
                 {"role":"system","content":"Env: prod"}], thinking_mode="chat")
# before: '<｜begin▁of▁sentence｜><｜User｜>HelloEnv: prod'           <- no assistant prompt
# after (chat):     '...<｜User｜>HelloEnv: prod<｜Assistant｜></think>'
# after (thinking): '...<｜User｜>HelloEnv: prod<｜Assistant｜><think>'
```

Regression checks (rendered prompt is byte-for-byte identical before/after, and
the assistant prompt is never duplicated):

| Case | assistant prompt count (after) | changed vs before |
|---|:---:|:---:|
| trailing system | 1 | fixed (was 0) |
| leading system + user | 1 | unchanged |
| user only | 1 | unchanged |
| multi-turn | 2 | unchanged |

`ruff check` and `ruff format --check` pass on the changed files.
