### PR TITLE
[Bugfix] Split mixed reasoning/content streaming deltas

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -29,6 +29,7 @@ from vllm.entrypoints.openai.chat_completion.serving import (
     _make_prompt_tokens_details,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
     ErrorResponse,
     RequestResponseMetadata,
 )
@@ -2126,3 +2127,102 @@ async def test_streaming_n_gt1_independent_tool_parsers():
             f"Choice {choice_idx}: expected finish_reason='tool_calls', "
             f"got '{reasons[0]}'"
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_streaming_splits_reasoning_and_content_boundary_delta():
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    class MixedReasoningContentParser:
+        tool_parser = None
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._stream_state = MagicMock()
+
+        def parse_delta(self, *args: Any, **kwargs: Any) -> DeltaMessage:
+            delta_text = kwargs["delta_text"]
+            if not delta_text:
+                return DeltaMessage()
+            return DeltaMessage(reasoning="final thought.", content="Answer starts.")
+
+    serving_chat.parser_cls = MixedReasoningContentParser
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        stream=True,
+    )
+    tokenizer = MagicMock()
+
+    async def result_generator():
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="final thought.</think>Answer starts.",
+                    token_ids=[101, 2, 102],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                )
+            ],
+            finished=False,
+        )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="",
+                    token_ids=[],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                )
+            ],
+            finished=True,
+        )
+
+    reasoning_chunks: list[str] = []
+    content_chunks: list[str] = []
+    async for chunk_str in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        if not chunk_str.strip() or "data: [DONE]" in chunk_str:
+            continue
+        data = json.loads(chunk_str[6:].strip())
+        for choice in data.get("choices", []):
+            delta = choice.get("delta", {})
+            assert not (
+                delta.get("reasoning")
+                and (delta.get("content") is not None or delta.get("tool_calls"))
+            )
+            if delta.get("reasoning"):
+                reasoning_chunks.append(delta["reasoning"])
+            if delta.get("content"):
+                content_chunks.append(delta["content"])
+
+    assert reasoning_chunks == ["final thought."]
+    assert content_chunks == ["Answer starts."]

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -720,36 +720,46 @@ class OpenAIServingChat(OpenAIServing):
 
                         finish_reason_sent[i] = True
 
-                    choice_data = maybe_filter_parallel_tool_calls(choice_data, request)
-                    chunk = ChatCompletionStreamResponse(
-                        id=request_id,
-                        object=chunk_object_type,
-                        created=created_time,
-                        choices=[choice_data],
-                        model=model_name,
+                    split_choice_data = self._split_reasoning_boundary_delta(
+                        choice_data
                     )
-                    # Stamp the fingerprint on terminal chunks only (those with
-                    # finish_reason set). When ``include_usage`` is on, the
-                    # trailing usage chunk below overrides this as the true
-                    # final message.
-                    if (
-                        not include_usage
-                        and self.system_fingerprint is not None
-                        and choice_data.finish_reason is not None
-                    ):
-                        chunk.system_fingerprint = self.system_fingerprint
-
-                    # handle usage stats if requested & if continuous
-                    if include_continuous_usage:
-                        completion_tokens = previous_num_tokens[i]
-                        chunk.usage = UsageInfo(
-                            prompt_tokens=num_prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            total_tokens=num_prompt_tokens + completion_tokens,
+                    for choice_index, split_choice in enumerate(split_choice_data):
+                        split_choice = maybe_filter_parallel_tool_calls(
+                            split_choice, request
+                        )
+                        chunk = ChatCompletionStreamResponse(
+                            id=request_id,
+                            object=chunk_object_type,
+                            created=created_time,
+                            choices=[split_choice],
+                            model=model_name,
                         )
 
-                    data = chunk.model_dump_json(exclude_unset=True)
-                    yield f"data: {data}\n\n"
+                        # Stamp the fingerprint on terminal chunks only (those with
+                        # finish_reason set). When ``include_usage`` is on, the
+                        # trailing usage chunk below overrides this as the true
+                        # final message.
+                        if (
+                            not include_usage
+                            and self.system_fingerprint is not None
+                            and split_choice.finish_reason is not None
+                        ):
+                            chunk.system_fingerprint = self.system_fingerprint
+
+                        # handle usage stats if requested & if continuous
+                        if (
+                            include_continuous_usage
+                            and choice_index == len(split_choice_data) - 1
+                        ):
+                            completion_tokens = previous_num_tokens[i]
+                            chunk.usage = UsageInfo(
+                                prompt_tokens=num_prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                total_tokens=num_prompt_tokens + completion_tokens,
+                            )
+
+                        data = chunk.model_dump_json(exclude_unset=True)
+                        yield f"data: {data}\n\n"
 
             # once the final token is handled, if stream_options.include_usage
             # is sent, send the usage
@@ -1195,3 +1205,36 @@ class OpenAIServingChat(OpenAIServing):
                 )
 
         return ChatCompletionLogProbs(content=logprobs_content)
+
+    @staticmethod
+    def _split_reasoning_boundary_delta(
+        choice_data: ChatCompletionResponseStreamChoice,
+    ) -> list[ChatCompletionResponseStreamChoice]:
+        delta = choice_data.delta
+        if not delta.reasoning or not (delta.content is not None or delta.tool_calls):
+            return [choice_data]
+
+        reasoning_choice = choice_data.model_copy(
+            update={
+                "delta": DeltaMessage(reasoning=delta.reasoning),
+                "logprobs": None,
+                "finish_reason": None,
+                "stop_reason": None,
+                "token_ids": None,
+            },
+            deep=True,
+        )
+
+        remaining_delta_kwargs: dict[str, Any] = {}
+        if delta.content is not None:
+            remaining_delta_kwargs["content"] = delta.content
+        if delta.tool_calls:
+            remaining_delta_kwargs["tool_calls"] = [
+                tc.model_copy(deep=True) for tc in delta.tool_calls
+            ]
+        remaining_delta = DeltaMessage(**remaining_delta_kwargs)
+        remaining_choice = choice_data.model_copy(
+            update={"delta": remaining_delta},
+            deep=True,
+        )
+        return [reasoning_choice, remaining_choice]


### PR DESCRIPTION
Fixes #43933.

## Summary
- split Chat Completions streaming deltas when a parser returns both `reasoning` and follow-up `content`/`tool_calls` in the same `DeltaMessage`
- keep finish metadata, token ids, logprobs, and continuous usage on the final split chunk only
- add a raw SSE regression test that asserts no streamed delta contains non-empty reasoning together with content/tool calls

## Rationale
DeepSeek-compatible clients may follow DeepSeek's documented `if reasoning_content ... else content` streaming pattern. If vLLM emits reasoning and content in the same delta, those clients can drop the content part. This keeps internal parser behavior unchanged and only splits the Chat Completions stream sent to clients.

## Test Plan
Rebased onto `main` at `cd10ed6f9f` (2026-09-15).

- `pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_splits_reasoning_and_content_boundary_delta -q` → 1 passed
- same test with the `serving.py` change reverted (`git checkout main -- vllm/entrypoints/openai/chat_completion/serving.py`) → 1 failed with `AssertionError: assert not ('final thought.' and ('Answer starts.' is not None))`, i.e. the mixed `reasoning` + `content` delta is exactly what current `main` emits
- full file run on both trees (`HF_HUB_OFFLINE=1 pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -q`): `main` → 17 failed / 22 passed / 10 errors; with this change → 16 failed / 23 passed / 10 errors. The only difference is the new regression test (fails on `main`, passes here); the remaining failures and errors are offline tokenizer downloads, identical on both trees.
- `pre-commit run --files vllm/entrypoints/openai/chat_completion/serving.py tests/entrypoints/openai/chat_completion/test_serving_chat.py` → all hooks pass

Note: the local `pre-commit` git hook in this container points at a python without the `pre_commit` module, so the commit was created with `--no-verify` after the hooks above were run directly.

AI assistance was used to rebase this branch and re-run the checks on latest `main`; the change and its tests are understood and reviewed by the submitter.
