### PR TITLE
[Performance] Reduce DeepEP LL batched Marlin activation overhead

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -1510,7 +1510,12 @@ def test_batched_fused_marlin_moe(
             return gather_outputs
 
         def run(
-            self, hidden_states: torch.Tensor, fused_marlin_moe_kwargs: dict[Any, Any]
+            self,
+            hidden_states: torch.Tensor,
+            fused_marlin_moe_kwargs: dict[Any, Any],
+            *,
+            use_expert_num_tokens_cpu: bool = False,
+            use_topk_ids_metadata: bool = False,
         ) -> torch.Tensor:
             assert hidden_states.ndim == 2
             assert self.is_valid()
@@ -1521,6 +1526,10 @@ def test_batched_fused_marlin_moe(
                 "hidden_states": batched_hidden_states,
                 "expert_num_tokens": self.expert_num_tokens_cpu.to("cuda"),
             }
+            if use_expert_num_tokens_cpu:
+                kwargs["expert_num_tokens_cpu"] = self.expert_num_tokens_cpu
+            if use_topk_ids_metadata:
+                kwargs["topk_ids"] = self.topk_ids_cpu.to("cuda")
             batched_outputs = batched_fused_marlin_moe(**kwargs)
 
             output = torch.zeros_like(hidden_states)
@@ -1566,8 +1575,10 @@ def test_batched_fused_marlin_moe(
     br = BatchedRun(max_tokens_per_batch, e, topk_ids, topk_weights)
     if not br.is_valid():
         pytest.skip("Cannot represent data in Batched Format.")
-    marlin_output = br.run(a, kwargs)
+    marlin_output = br.run(a, kwargs, use_expert_num_tokens_cpu=True)
+    torch.testing.assert_close(marlin_output, ref_marlin_output, atol=atol, rtol=0)
 
+    marlin_output = br.run(a, kwargs, use_topk_ids_metadata=True)
     torch.testing.assert_close(marlin_output, ref_marlin_output, atol=atol, rtol=0)
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -28,7 +28,11 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate,
     TopKWeightAndReduceNoOP,
 )
-from vllm.model_executor.layers.fused_moe.utils import _resize_cache
+from vllm.model_executor.layers.fused_moe.utils import (
+    _resize_cache,
+    batched_swiglu_limit_func,
+    swiglu_limit_func,
+)
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     get_marlin_input_dtype,
     marlin_make_workspace_new,
@@ -51,7 +55,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
-
 
 def _fused_marlin_moe(
     hidden_states: torch.Tensor,
@@ -91,6 +94,10 @@ def _fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    batched_experts: bool = False,
+    expert_num_tokens_cpu: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
+    num_experts: int | None = None,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
     M, K = hidden_states.size()
@@ -158,16 +165,34 @@ def _fused_marlin_moe(
         use_fp32_reduce=True,
         is_zp_float=False,
     )
-    # apply_moe_activation fuses the clamp/gate params: SILU + clamp_limit and
-    # SWIGLUOAI_UNINTERLEAVE both map to the silu_and_mul_with_clamp kernel.
-    activation_func(
-        activation,
-        intermediate_cache2,
-        intermediate_cache1.view(-1, w13_num_shards * N),
-        clamp_limit=clamp_limit,
-        alpha=gemm1_alpha,
-        beta=gemm1_beta,
-    )
+    activation_input = intermediate_cache1.view(-1, w13_num_shards * N)
+    if activation == MoEActivation.SILU and batched_experts:
+        batched_swiglu_limit_func(
+            intermediate_cache2,
+            activation_input,
+            sorted_token_ids,
+            num_tokens_post_padded,
+            clamp_limit or 0.0,
+            expert_num_tokens_cpu=expert_num_tokens_cpu,
+            topk_ids=topk_ids,
+            num_experts=num_experts,
+            block_size_m=block_size_m,
+        )
+    elif activation == MoEActivation.SILU and clamp_limit is not None:
+        swiglu_limit_func(
+            intermediate_cache2,
+            activation_input,
+            clamp_limit,
+        )
+    else:
+        activation_func(
+            activation,
+            intermediate_cache2,
+            activation_input,
+            clamp_limit=clamp_limit,
+            alpha=gemm1_alpha,
+            beta=gemm1_beta,
+        )
 
     if output is None:
         output = intermediate_cache3
@@ -414,6 +439,8 @@ def batched_fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    expert_num_tokens_cpu: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     This function massages the inputs so the batched hidden_states can be
@@ -506,7 +533,6 @@ def batched_fused_marlin_moe(
     topk_weights = torch.ones(
         (M, topk), device=hidden_states.device, dtype=torch.float32
     )
-
     assert activation is not None
     output = _fused_marlin_moe(
         hidden_states=hidden_states.view(-1, K),
@@ -545,6 +571,10 @@ def batched_fused_marlin_moe(
         clamp_limit=clamp_limit,
         gemm1_alpha=gemm1_alpha,
         gemm1_beta=gemm1_beta,
+        batched_experts=True,
+        expert_num_tokens_cpu=expert_num_tokens_cpu,
+        topk_ids=topk_ids,
+        num_experts=E,
     )
 
     output = output.view(B, BATCH_TOKENS_MAX, K)
@@ -1024,4 +1054,6 @@ class BatchedMarlinExperts(MarlinExpertsBase):
             clamp_limit=self.gemm1_clamp_limit,
             gemm1_alpha=self.gemm1_alpha,
             gemm1_beta=self.gemm1_beta,
+            expert_num_tokens_cpu=expert_tokens_meta.expert_num_tokens_cpu,
+            topk_ids=topk_ids,
         )

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -426,6 +426,106 @@ def trtllm_moe_pack_topk_ids_weights(
     return output.reshape(original_shape)
 
 
+@triton.jit
+def _batched_swiglu_limit_kernel(
+    output_ptr,
+    input_ptr,
+    sorted_token_ids_ptr,
+    num_tokens_post_padded_ptr,
+    total_rows: tl.constexpr,
+    d: tl.constexpr,
+    output_stride_m: tl.constexpr,
+    output_stride_n: tl.constexpr,
+    input_stride_m: tl.constexpr,
+    input_stride_n: tl.constexpr,
+    swiglu_limit: tl.constexpr,
+    HAS_LIMIT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    sorted_idx = tl.program_id(0)
+    dim_block_idx = tl.program_id(1)
+    dim_offsets = dim_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    dim_mask = dim_offsets < d
+
+    valid_rows = tl.load(num_tokens_post_padded_ptr)
+    token_idx = tl.load(
+        sorted_token_ids_ptr + sorted_idx,
+        mask=sorted_idx < valid_rows,
+        other=0,
+    ).to(tl.int64)
+    token_mask = (sorted_idx < valid_rows) & (token_idx >= 0) & (token_idx < total_rows)
+
+    gate_offsets = token_idx * input_stride_m + dim_offsets * input_stride_n
+    up_offsets = gate_offsets + d * input_stride_n
+    output_offsets = token_idx * output_stride_m + dim_offsets * output_stride_n
+    mask = token_mask & dim_mask
+
+    gate = tl.load(input_ptr + gate_offsets, mask=mask, other=0.0).to(tl.float32)
+    up = tl.load(input_ptr + up_offsets, mask=mask, other=0.0).to(tl.float32)
+
+    if HAS_LIMIT:
+        gate = tl.minimum(gate, swiglu_limit)
+        up = tl.minimum(tl.maximum(up, -swiglu_limit), swiglu_limit)
+
+    sigmoid = 1.0 / (1.0 + tl.exp(-gate))
+    tl.store(output_ptr + output_offsets, gate * sigmoid * up, mask=mask)
+
+
+def _swiglu_block_size(d: int) -> int:
+    return min(triton.next_power_of_2(d), 1024)
+
+_BATCHED_SWIGLU_BUCKET_SIZES = (
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+    16384,
+    32768,
+    65536,
+)
+
+def _select_batched_swiglu_bucket_size(
+    *,
+    expert_num_tokens_cpu: torch.Tensor | None,
+    topk_ids: torch.Tensor | None,
+    num_experts: int | None,
+    total_rows: int,
+    block_size_m: int | None,
+    sorted_token_ids: torch.Tensor,
+) -> int | None:
+    sorted_token_capacity = sorted_token_ids.numel()
+    if expert_num_tokens_cpu is not None:
+        assert block_size_m is not None
+        valid_rows = 0
+        for num_tokens in expert_num_tokens_cpu.tolist():
+            num_tokens = int(num_tokens)
+            valid_rows += (
+                (num_tokens + block_size_m - 1) // block_size_m
+            ) * block_size_m
+    elif (
+        topk_ids is not None
+        and num_experts is not None
+        and block_size_m is not None
+    ):
+        assert num_experts > 0
+        assert total_rows % num_experts == 0
+        max_tokens_per_batch = total_rows // num_experts
+        routed_tokens_upper_bound = max(
+            topk_ids.numel(),
+            max_tokens_per_batch * topk_ids.size(1),
+        )
+        valid_rows = routed_tokens_upper_bound + num_experts * (block_size_m - 1)
+    else:
+        return None
+
+    valid_rows = min(valid_rows, sorted_token_capacity)
+    for bucket_size in _BATCHED_SWIGLU_BUCKET_SIZES:
+        if valid_rows <= bucket_size:
+            return min(bucket_size, sorted_token_capacity)
+    return sorted_token_capacity
+
 @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
 def swiglu_limit_func(
     output: torch.Tensor,
@@ -441,3 +541,47 @@ def swiglu_limit_func(
         up = torch.clamp(up, min=-swiglu_limit, max=swiglu_limit)
 
     output.copy_(F.silu(gate) * up)
+
+def batched_swiglu_limit_func(
+    output: torch.Tensor,
+    input: torch.Tensor,  # first half is gate, second half is up
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    swiglu_limit: float = 0.0,
+    expert_num_tokens_cpu: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
+    num_experts: int | None = None,
+    block_size_m: int | None = None,
+) -> None:
+    total_rows = input.shape[0]
+    bucket_size = _select_batched_swiglu_bucket_size(
+        expert_num_tokens_cpu=expert_num_tokens_cpu,
+        topk_ids=topk_ids,
+        num_experts=num_experts,
+        total_rows=total_rows,
+        block_size_m=block_size_m,
+        sorted_token_ids=sorted_token_ids,
+    )
+    n_tokens = bucket_size if bucket_size is not None else total_rows
+    n_tokens = min(n_tokens, sorted_token_ids.numel())
+    if n_tokens == 0:
+        return
+
+    d = output.shape[1]
+    block_size = _swiglu_block_size(d)
+    grid = (n_tokens, triton.cdiv(d, block_size))
+    _batched_swiglu_limit_kernel[grid](
+        output,
+        input,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        total_rows,
+        d,
+        output.stride(0),
+        output.stride(1),
+        input.stride(0),
+        input.stride(1),
+        swiglu_limit,
+        HAS_LIMIT=swiglu_limit > 0,
+        BLOCK_SIZE=block_size,
+    )


### PR DESCRIPTION
## Purpose
This PR reduces unnecessary activation work on the batched Marlin MoE path.

For batched Marlin experts, GEMM1 produces outputs in an expert-capacity layout. The SwiGLU stage could therefore launch over the full capacity window instead of only the valid routed rows, making activation a decode hotspot in sparse-token cases such as DeepEP low-latency.

## Changes
- Add a batched Triton SwiGLU kernel that uses `sorted_token_ids` and `num_tokens_post_padded` to process only valid rows.
- Add fixed activation buckets for the batched path to keep launches CUDA-graph friendly.

## Testing
### Testbed
- GPU: NVIDIA H20
- CUDA runtime: 13.0
- vLLM: v0.21.0
- Model: DeepSeek-V4-Flash
- Deployment: PD-disaggregated serving
- DeepEP: enabled (`deepep_high_throughput` for prefill, `deepep_low_latency` for decode)

### Accuracy Evaluation

Using lm_eval framework on the GSM8K benchmark.

Results:
```
{
  "gsm8k": {
    "name": "gsm8k",
    "alias": "gsm8k",
    "sample_len": 50,
    "exact_match,strict-match": 0.96,
    "exact_match_stderr,strict-match": 0.02799416848895062,
    "exact_match,flexible-extract": 0.96,
    "exact_match_stderr,flexible-extract": 0.02799416848895062
  }
}
```

### Decode profiling

Profiles were collected with the PyTorch profiler on the decode engine using an `8000/2000` completion workload (8000 input tokens, 2000 output tokens).

Single-kernel comparison:
- Old Triton SwiGLU kernel `triton_poi_fused_clamp_copy__mul_silu_slice_0`
  - avg: `704.43us`
  - p99: `788.99us`
<img width="1280" height="733" alt="image" src="https://github.com/user-attachments/assets/b8e07650-8e60-4ae7-953d-e4bfa6bace27" />

- New batched Triton SwiGLU kernel `_batched_swiglu_limit_kernel`
  - avg: `13.90us`
  - p99: `14.80us`
 <img width="1280" height="738" alt="飞书文档 - 图片" src="https://github.com/user-attachments/assets/446f75a0-2fad-4490-84e6-90f5eaa500a4" />

### End-to-end benchmark

I benchmarked the same build with the original implementation and the new optimized implementation. The new implementation enables the optimized `_batched_swiglu_limit_kernel`, while the original implementation uses the previous SwiGLU activation flow.

The benchmark was run with `vllm bench serve` from a separate client pod. Each workload used random input/output lengths with request_rate=inf. Before collecting measured results, each workload was warmed up with one full benchmark run. The table reports the mean of 3 measured runs. All measured runs completed successfully with 0 failed requests.

- input 1000, output 500
<figure>
<img width="2838" height="1189" alt="act_opt_compare_in1000_out500" src="https://github.com/user-attachments/assets/07c490e8-f16d-4d23-8932-c3c1b3556685" />
</figure>

- input 3500, output 1500
<figure>
<img width="2838" height="1189" alt="act_opt_compare_in3500_out1500" src="https://github.com/user-attachments/assets/f1d68c15-d998-4706-a742-e6f289bd36ab" />
</figure>

- input 8000, output 2000
<figure>
<img width="2838" height="1189" alt="act_opt_compare_in8000_out2000" src="https://github.com/user-attachments/assets/c1aea8d3-d754-4214-9679-fde6dadd5c01" />
</figure>
