### PR TITLE
[ROCm][CI] Fix AITER unified attention for encoder-decoder cross-attention

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -134,6 +134,30 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         self.unified_attention = unified_attention
         self.supports_quant_query_input = True
 
+    def _split_kv_cache(
+        self, kv_cache: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.attn_type != AttentionType.ENCODER_DECODER:
+            return kv_cache.unbind(1)
+
+        # NOTE: Encoder-decoder layers can share the same raw KV allocation with
+        # ROCM_ATTN decoder layers, whose physical layout is K/V first. Keep
+        # this cross-attention path on that physical layout so block IDs do not
+        # alias different bytes across the shared allocation.
+        num_blocks, _, block_size, num_kv_heads, head_size = kv_cache.shape
+        block_stride = block_size * num_kv_heads * head_size
+        kv_cache = kv_cache.as_strided(
+            (2, num_blocks, block_size, num_kv_heads, head_size),
+            (
+                num_blocks * block_stride,
+                block_stride,
+                num_kv_heads * head_size,
+                head_size,
+                1,
+            ),
+        )
+        return kv_cache.unbind(0)
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -194,7 +218,7 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
                 layer,
             )
 
-        key_cache, value_cache = kv_cache.unbind(1)
+        key_cache, value_cache = self._split_kv_cache(kv_cache)
 
         softmax_scale = self.scale
         if is_quantized_kv_cache(self.kv_cache_dtype):
@@ -243,7 +267,7 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             # For encoder attention,
             # we use direct Q, K, V tensors without caching
             return
-        key_cache, value_cache = kv_cache.unbind(1)
+        key_cache, value_cache = self._split_kv_cache(kv_cache)
 
         # Reshape the input keys and values and store them in the cache.
         ops.reshape_and_cache_flash(
@@ -276,7 +300,7 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             # For encoder attention,
             # we use direct Q, K, V tensors without caching
             return
-        key_cache, value_cache = kv_cache.unbind(1)
+        key_cache, value_cache = self._split_kv_cache(kv_cache)
         flash_layout = True
 
         is_fp8_kv_cache = is_quantized_kv_cache(self.kv_cache_dtype)


### PR DESCRIPTION
Fixes ROCm AITER unified attention for encoder-decoder cross-attention when it shares KV cache storage with ROCM_ATTN decoder self-attention. It addresses the regression was introduced by [vllm-project/vllm#43660](https://github.com/vllm-project/vllm/pull/43660). That PR changed `RocmAiterUnifiedAttentionBackend.get_kv_cache_shape` from K/V-first:

```python
(2, num_blocks, block_size, num_kv_heads, head_size)
```

to blocks-first:

```python
(num_blocks, 2, block_size, num_kv_heads, head_size)
```

That is correct for the standalone AITER unified layout, but Nemotron Parse on ROCm selects a mixed backend setup:
- decoder self-attention: `ROCM_ATTN`
- encoder-decoder cross-attention: `ROCM_AITER_UNIFIED_ATTN`

`ROCM_ATTN` still uses K/V-first KV cache storage. For encoder-decoder models, those attention groups can share the same raw KV allocation, so viewing the same storage with different physical block dimensions makes identical block IDs address different byte ranges.

Auto git bisect:
- Known good commit tested: `e1814f822d51225e0c6240386d65b2182758c2a4`
- Parent tested good: `53a20886752bdf8f26c4c5121458c514096da107`
- Culprit commit: `5b115bb8a33d72820075450ecefcd292607bfe57`
- Culprit PR: [vllm-project/vllm#43660](https://github.com/vllm-project/vllm/pull/43660)

Repro (https://buildkite.com/vllm/ci/builds/68772/list?sid=019e7064-4e20-4a46-ae08-e6d8692426ab&tab=output):

```bash
pytest -s -v models/multimodal/generation/test_nemotron_parse.py::test_models[5-bfloat16-nvidia/NVIDIA-Nemotron-Parse-v1.2]
```


cc @kenroche 