### PR TITLE
kv_offload: eviction-triggered store for OffloadingConnector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
@@ -10,6 +10,9 @@ from vllm.v1.kv_offload.worker.worker import TransferSpec
 
 ReqId = str
 
+# Prefix for synthetic request-ids used by eviction-triggered store batches.
+LAZY_STORE_PREFIX = "__lazy_store__"
+
 
 @dataclass
 class TransferJob:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from itertools import islice
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from vllm.distributed.kv_events import BlockRemoved, BlockStored, KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    LAZY_STORE_PREFIX,
     OffloadingConnectorMetadata,
     OffloadingWorkerMetadata,
     ReqId,
@@ -17,6 +19,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -37,6 +40,9 @@ from vllm.v1.kv_offload.base import (
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
+
+if TYPE_CHECKING:
+    from vllm.v1.core.block_pool import BlockPool
 
 logger = init_logger(__name__)
 
@@ -304,6 +310,21 @@ class OffloadingConnectorScheduler:
         # be freed before a request finishes).
         self._block_id_to_pending_jobs: dict[int, set[int]] = {}
 
+        # Eviction-triggered store mode (opt-in via KV_OFFLOAD_LAZY_STORE=1).
+        # Instead of offloading every newly-computed full block, the GPU
+        # block pool notifies us at HBM eviction time and we schedule a
+        # D->H copy of the just-evicted block on the next scheduler step.
+        # Single-group only; multi-group support requires the listener to
+        # carry the kv_group index.
+        self._gpu_block_pool: BlockPool | None = None
+        self._lazy_store = (
+            os.environ.get("KV_OFFLOAD_LAZY_STORE", "0") == "1"
+            and self.config.block_size_factor == 1
+            and len(self.config.kv_group_configs) == 1
+        )
+        self._lazy_counter = 0
+        self._pending_evictions: list[tuple[int, BlockHash]] = []
+
     def _generate_job_id(self) -> int:
         job_id = self._job_counter
         self._job_counter += 1
@@ -334,6 +355,20 @@ class OffloadingConnectorScheduler:
                 break
             hit_count += 1
         return hit_count if not defer_lookup else None
+
+    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+        """Bind the GPU block pool. In lazy-store mode, register an eviction
+        listener so we can schedule a D->H copy per HBM eviction."""
+        self._gpu_block_pool = gpu_block_pool
+        if self._lazy_store and hasattr(
+            gpu_block_pool, "register_eviction_listener"
+        ):
+            gpu_block_pool.register_eviction_listener(self._on_eviction)
+        elif self._lazy_store:
+            self._lazy_store = False
+
+    def _on_eviction(self, block_id: int, block_hash: BlockHash) -> None:
+        self._pending_evictions.append((block_id, block_hash))
 
     def _sliding_window_lookup(
         self,
@@ -861,6 +896,65 @@ class OffloadingConnectorScheduler:
 
         return store_jobs
 
+    def _build_eviction_store_jobs(
+        self, store_jobs: dict[int, TransferJob]
+    ) -> None:
+        """Schedule a D->H copy for every block the GPU prefix cache just
+        evicted (collected by `_on_eviction`). Single kv-group only.
+
+        Pallas gather is dispatched on the same compute stream as the
+        upcoming `model.forward()`, so stream serialization ensures the
+        gather reads the about-to-be-overwritten block before the new
+        owner writes to it; no GPU-block pinning required.
+        """
+        if not self._pending_evictions:
+            return
+        evictions = self._pending_evictions
+        self._pending_evictions = []
+
+        synthetic_req_id = f"{LAZY_STORE_PREFIX}{self._lazy_counter}"
+        req_context = ReqContext(req_id=synthetic_req_id)
+
+        seen: set[BlockHash] = set()
+        block_ids: list[int] = []
+        offload_keys: list[OffloadKey] = []
+        for bid, bh in evictions:
+            if bh in seen:
+                continue
+            seen.add(bh)
+            key = make_offload_key(bh, 0)
+            if self.manager.lookup(key, req_context):
+                continue
+            block_ids.append(bid)
+            offload_keys.append(key)
+        if not offload_keys:
+            return
+
+        store_output = self.manager.prepare_store(offload_keys, req_context)
+        if store_output is None or not store_output.keys_to_store:
+            return
+
+        key_to_bid = dict(zip(offload_keys, block_ids))
+        src_block_ids = [key_to_bid[k] for k in store_output.keys_to_store]
+        src_spec = GPULoadStoreSpec(
+            src_block_ids,
+            group_sizes=(len(src_block_ids),),
+            block_indices=(0,),
+        )
+
+        job_id = self._generate_job_id()
+        self._jobs[job_id] = TransferJobStatus(
+            req_id=synthetic_req_id,
+            pending_count=self.config.num_workers,
+            keys=set(store_output.keys_to_store),
+            is_store=True,
+        )
+        store_jobs[job_id] = TransferJob(
+            req_id=synthetic_req_id,
+            transfer_spec=(src_spec, store_output.store_spec),
+        )
+        self._lazy_counter += 1
+
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
@@ -880,9 +974,12 @@ class OffloadingConnectorScheduler:
         ):
             self._current_batch_jobs_to_flush.update(self._jobs.keys())
 
+        store_jobs = self._build_store_jobs(scheduler_output)
+        if self._lazy_store:
+            self._build_eviction_store_jobs(store_jobs)
         meta = OffloadingConnectorMetadata(
             load_jobs=self._current_batch_load_jobs,
-            store_jobs=self._build_store_jobs(scheduler_output),
+            store_jobs=store_jobs,
             jobs_to_flush=self._current_batch_jobs_to_flush,
         )
         self._current_batch_load_jobs = {}
@@ -915,6 +1012,17 @@ class OffloadingConnectorScheduler:
             if job_status.pending_count > 0:
                 continue
             assert job_status.pending_count == 0
+
+            # Eviction-triggered stores have a synthetic req_id and no
+            # _req_status entry; complete them with a stub ReqContext and
+            # skip the per-request bookkeeping.
+            if job_status.req_id.startswith(LAZY_STORE_PREFIX):
+                assert job_status.is_store
+                self.manager.complete_store(
+                    job_status.keys, ReqContext(req_id=job_status.req_id)
+                )
+                del self._jobs[job_id]
+                continue
 
             req_status = self._req_status[job_status.req_id]
             if job_status.is_store:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -71,6 +71,10 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
         if self.connector_scheduler is not None:
             self.connector_scheduler.shutdown()
 
+    def bind_gpu_block_pool(self, gpu_block_pool) -> None:
+        if self.connector_scheduler is not None:
+            self.connector_scheduler.bind_gpu_block_pool(gpu_block_pool)
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -181,6 +181,17 @@ class BlockPool:
 
         self.metrics_collector = metrics_collector
 
+        # Listeners invoked inside _maybe_evict_cached_block, just before
+        # block.reset_hash(), with (block_id, BlockHash). Allows callers
+        # (e.g. an offloading connector) to capture the hash and schedule
+        # work against the still-intact KV data.
+        self._eviction_listeners: list = []
+
+    def register_eviction_listener(self, fn) -> None:
+        """Register fn(block_id: int, block_hash: BlockHash) to be called
+        on every prefix-cache eviction."""
+        self._eviction_listeners.append(fn)
+
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
     ) -> list[KVCacheBlock] | None:
@@ -386,6 +397,11 @@ class BlockPool:
             # block not found in cached_block_hash_to_block,
             # eviction is not needed
             return False
+
+        if self._eviction_listeners:
+            bh = get_block_hash(block_hash)
+            for fn in self._eviction_listeners:
+                fn(block.block_id, bh)
 
         block.reset_hash()
 


### PR DESCRIPTION
## Purpose

The current `OffloadingConnector` offloads every newly-computed full KV block to host as it's produced. With prefix caching, this means host always holds a **superset** of HBM — when the HBM prefix-cache lookup runs (before the external lookup), it serves any hot block first, so the host pool ends up exercised only for blocks already evicted from HBM. On large-model + small-HBM deployments (e.g. 480B MoE on a single 8-chip TPU host), the host pool effectively gets ~zero hits and just absorbs D→H write churn.

This PR adds an opt-in **eviction-triggered** ("lazy") store mode:

- `BlockPool` gains a `register_eviction_listener(fn)` API; listeners are called from inside `_maybe_evict_cached_block` (just before `block.reset_hash()`) with `(block_id, BlockHash)`.
- `OffloadingConnectorScheduler` registers a listener and collects evictions into `_pending_evictions`.
- Each `build_connector_meta`, `_build_eviction_store_jobs` drains the list and emits one `TransferJob` per batch (synthetic `req_id` prefixed with `LAZY_STORE_PREFIX`).
- `update_connector_output` recognises synthetic ids and calls `manager.complete_store` with a stub `ReqContext`, bypassing per-request bookkeeping.

The transfer's gather is dispatched on the same compute stream as the upcoming `model.forward()`, so stream serialisation guarantees the gather reads the about-to-be-overwritten block **before** forward writes to it — no GPU-block pinning required.

Opt in via `KV_OFFLOAD_LAZY_STORE=1`. Single kv-group only (`block_size_factor == 1`, `len(kv_group_configs) == 1`); fall-back is unchanged eager behaviour. Default behaviour is unchanged.

## Test Plan

### Unit tests (regression)
```
pytest -v \
  tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py \
  tests/v1/kv_connector/unit/test_offloading_connector.py \
  tests/v1/kv_offload/cpu/test_manager.py
```

### End-to-end (Qwen3-Coder-480B-A35B-Instruct-FP8, 8-chip TPU host, FP8 weights)

Same workload, only `KV_OFFLOAD_LAZY_STORE` differs:
```
vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
  --tensor-parallel-size=8 --enable-expert-parallel --quantization fp8 \
  --gpu-memory-utilization=0.85 --async-scheduling \
  --kv-offloading-size 400 \
  --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both", \
    "kv_connector_extra_config":{"spec_name":"...","spec_module_path":"..."}}'

# bench
vllm bench serve --dataset-name prefix_repetition \
  --prefix-repetition-num-prefixes 96 \
  --prefix-repetition-prefix-len 16384 \
  --prefix-repetition-output-len 256 \
  --num-prompts 1024 --max-concurrency 64 \
  --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
```
Working set: 96 × 16384 = 1.57M tokens — **overflows** HBM cache at GPU=0.85 (~780K tokens) by ~2×, fits in the 400 GiB host pool (~1.9M tokens). 10.7× per-prefix reuse.

## Test Result

| Metric | `KV_OFFLOAD_LAZY_STORE=0` (eager) | `KV_OFFLOAD_LAZY_STORE=1` (eviction-triggered) |
|---|---|---|
| Output throughput | 270 tok/s | **421 tok/s (+56%)** |
| External cache hit rate | 0% (HBM-only) ¹ | **85.7%** |
| HBM cache hit rate | 17.1% | 2.4% |
| Total cache hit rate | 17.1% | **88.1%** |
| D2H volume | 0 GB ¹ | 402 GB |
| H2D volume | 0 GB ¹ | 2.83 TB |
| Successful / total requests | 960 / 960 | 960 / 960 |
| Benchmark duration | 910 s | 584 s |

¹ The "eager" column was run with `OFFLOAD_MODE=off` (no offloading at all) since at this workload eager-offload is strictly worse than no-offload (working set overflows HBM; host pool fills with redundant copies and provides ~0 hits). The eviction-triggered column is offload-on.

On a smaller workload that fits in HBM (30B MoE / Qwen3-Coder-30B-A3B-Instruct-FP8, 192p × 384, GPU=0.40), eviction-triggered still wins apples-to-apples vs eager-offload: external hit 7.8% → 25.3%, throughput 705 → 730 tok/s (+3.5%), D2H churn 970 GB → 686 GB (−29%). The benefit scales with how badly the working set overflows HBM and how expensive recompute is.

Only tested on TPU where D2H leverage a staging buffer. Additional work may be needed on GPU to avoid race condition between D2H and H2D.