### PR TITLE
[ROCm][Perf] Enable AR+RMS fusion for GemmaRMSNorm models 

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1456,6 +1456,51 @@ class AiterAllreduceFusedAddRMSNormGroupQuantWithIndexerPattern(
         return _replacement
 
 
+class AiterAllreduceFusedAddRMSNormWithCopyPattern(BasePattern, VllmPatternReplacement):
+    """Non-quant AR+RMS fusion for all_reduce with 2 users (copy_).
+
+    In GemmaRMSNorm models, the post-attention all_reduce has a copy_
+    node for cross-chunk residual state, giving it 2 users and preventing
+    the standard pattern from matching. This pattern returns ar_out as
+    an explicit output so the pattern matcher rewires external users
+    (the copy_) to the fused kernel's residual output.
+    """
+
+    def __init__(self, epsilon, dtype, device):
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.FUSED_OP = rocm_aiter_ops.get_fused_allreduce_rmsnorm_op()
+
+    def get_inputs(self):
+        return [self.empty(5, 16), self.empty(5, 16), self.empty(16)]
+
+    @property
+    def pattern(self):
+        eps = self.epsilon
+
+        def _pattern(residual, input_, weight):
+            ar_out = tensor_model_parallel_all_reduce(input_)
+            rms, res_out = vllm.ir.ops.fused_add_rms_norm(ar_out, residual, weight, eps)
+            return rms, res_out, ar_out
+
+        return _pattern
+
+    @property
+    def replacement(self):
+        eps = self.epsilon
+
+        def _replacement(residual, input_, weight):
+            fused = self.FUSED_OP(
+                input_=input_,
+                residual=residual,
+                weight=weight.to(input_.dtype),
+                epsilon=eps,
+            )
+            return fused[0], fused[1], fused[1]
+
+        return _replacement
+
+
 class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
     def __init__(self, config: VllmConfig) -> None:
         super().__init__(config, "rocm_aiter_allreduce_fusion_pass")
@@ -1520,9 +1565,13 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
             return
 
         max_token_num = max_size // (hidden_dim * element_size)
+        # Cap at max_cudagraph_capture_size so fusion only fires
+        # for decode. Prefill uses quickreduce + triton rmsnorm.
+        max_cg = config.compilation_config.max_cudagraph_capture_size or 512
         self.max_token_num = min(
             max_token_num,
             config.scheduler_config.max_num_batched_tokens,
+            max_cg,
         )
 
         # Only register the AR+RMS+per-group-FP8-quant patterns when the
@@ -1540,6 +1589,15 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
                 "aiter past PR #2823 to enable the trailing per-group "
                 "FP8 quant fusion."
             )
+
+        # Non-quant copy-aware pattern for post-attention allreduce
+        for epsilon in [1e-5, 1e-6]:
+            self.register(
+                AiterAllreduceFusedAddRMSNormWithCopyPattern(
+                    epsilon, self.model_dtype, self.device
+                )
+            )
+            torch._inductor.pattern_matcher._seen_patterns.clear()
 
         for epsilon in [1e-5, 1e-6]:
             # Quant-fused variants must register first so the pattern matcher

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -151,7 +151,7 @@ class GemmaRMSNorm(CustomOp):
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """PyTorch-native implementation equivalent to forward()."""
-        weight = self.weight.float() + 1.0
+        weight = self.weight.data.to(x.dtype) + 1.0
         if residual is None:
             return ir.ops.rms_norm(x, weight, self.variance_epsilon)
         return ir.ops.fused_add_rms_norm(x, residual, weight, self.variance_epsilon)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1002,9 +1002,13 @@ class RocmPlatform(Platform):
         using_inductor = cc.backend == "inductor" and cc.mode != CompilationMode.NONE
         default = ["native"] if using_inductor else ["vllm_c", "native"]
 
-        #  Aiter rms norm perform best when CUDA Graph capture is enabled.
-        # TODO(luka/TJ) remove env vars completely
-        if (
+        #  When allreduce+rmsnorm fusion is enabled (default on ROCm TP>1),
+        # use native priority so triton can fuse rmsnorm with adjacent ops.
+        # The aiter CK rmsnorm is opaque to triton and blocks fusion.
+        fuse_ar_rms = cc.pass_config.fuse_allreduce_rms
+        if using_inductor and fuse_ar_rms is not False:
+            rms_norm = default  # ["native"]
+        elif (
             cc.cudagraph_mode != CUDAGraphMode.NONE
             and envs.VLLM_ROCM_USE_AITER
             and envs.VLLM_ROCM_USE_AITER_RMSNORM


### PR DESCRIPTION
Enable the `fuse_allreduce_rms` compilation pass for models using `GemmaRMSNorm` (Qwen3-Next, Gemma) at TP>1. Fuses `allreduce + residual_add + rmsnorm [+ FP8 quant]` into a single AITER kernel during decode, with quickreduce fallback for prefill via compile range split.

Builds on top of #42864. Based on the weight dtype fix by @tpopp 

## Purpose

`GemmaRMSNorm.forward_native` bypasses the IR ops that the AR+RMS fusion pattern matcher needs, preventing any allreduce+rmsnorm fusion at TP>1. This PR fixes that by emitting `ir.ops.fused_add_rms_norm` in `GemmaRMSNorm`, adding a copy-aware pattern for the post-attention allreduce, auto-setting native IR priority, and guarding the fusion to decode-only compile ranges.

4 changes across 3 files:
- `vllm/model_executor/layers/layernorm.py`: Emit `ir.ops.rms_norm` / `ir.ops.fused_add_rms_norm` in `GemmaRMSNorm.forward_native` (non-inplace to avoid `copy_` from functionalization)
- `vllm/compilation/passes/fusion/allreduce_rms_fusion.py`: New `AiterAllreduceFusedAddRMSNormWithCopyPattern` for `all_reduce` nodes with 2 users; cap `max_token_num` at `max_cudagraph_capture_size` for decode-only fusion
- `vllm/platforms/rocm.py`: Auto-set `ir_op_priority` to `["native"]` for rmsnorm ops when `fuse_allreduce_rms` is enabled

## Test Plan

**Model:** Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
**Hardware:** MI355X, ROCm 7.2
**Image:** `vllm/vllm-openai-rocm:nightly-626fa9bba5663a5cf6a870debf031ee344ddb822` (vLLM 0.21.1rc1) + this PR + #42864

```bash
# Fusion ON (this PR)
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
  --tensor-parallel-size 2 \
  --attention-backend ROCM_AITER_UNIFIED_ATTN \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","compile_ranges_endpoints":[512],"custom_ops":["-rms_norm","-silu_and_mul","-quant_fp8"],"pass_config":{"fuse_norm_quant":true}}'

# Fusion OFF (baseline)
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
  --tensor-parallel-size 2 \
  --attention-backend ROCM_AITER_UNIFIED_ATTN \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["-rms_norm","-silu_and_mul","-quant_fp8"],"pass_config":{"fuse_norm_quant":true,"fuse_allreduce_rms":false}}'
```

Env vars (both configs):
```
VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1
VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
VLLM_ROCM_USE_AITER_MHA=0
VLLM_ROCM_AITER_MOE_DISPATCH_POLICY=2
```

- Accuracy: `lm_eval --tasks gsm8k` (5-shot, full 1319 samples)
- Throughput: `vllm bench serve --dataset-name random`, 1k/1k and 8k/1k at c=4,8,16,32

## Test Result

### Accuracy (GSM8K 5-shot, full 1319 samples)

| Config | Flexible | Strict |
|--------|--------:|-------:|
| TP2 Off | 86.1% | 81.5% |
| TP2 On | 86.1% | 82.0% |
| TP4 Off | 85.6% | 81.4% |
| TP4 On | 85.8% | 81.9% |

No accuracy regression. All pass thresholds (flex >= 85%, strict >= 80%).

### Throughput — TP2 (tok/s)

| Conc | 1k/1k Off | 1k/1k On | Δ | 8k/1k Off | 8k/1k On | Δ |
|------|----------:|---------:|---:|----------:|---------:|---:|
| 4 | 706 | 799 | +13.2% | 701 | 746 | +6.4% |
| 8 | 1413 | 1514 | +7.2% | 1220 | 1278 | +4.8% |
| 16 | 2353 | 2430 | +3.3% | 1827 | 1893 | +3.6% |
| 32 | 4158 | 4279 | +2.9% | 2779 | 2842 | +2.3% |

### Throughput — TP4 (tok/s)

| Conc | 1k/1k Off | 1k/1k On | Δ | 8k/1k Off | 8k/1k On | Δ |
|------|----------:|---------:|---:|----------:|---------:|---:|
| 4 | 817 | 815 | -0.2% | 762 | 772 | +1.3% |
| 8 | 1562 | 1586 | +1.6% | 1383 | 1399 | +1.2% |
| 16 | 2866 | 2886 | +0.7% | 2297 | 2330 | +1.4% |
| 32 | 5192 | 5306 | +2.2% | 3526 | 3586 | +1.7% |

No regressions at any concurrency or workload.

