### PR TITLE
[Bugfix] Corrupted MLA + linear attention

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -237,7 +237,11 @@ class SingleTypeKVCacheManager(ABC):
                 cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
             )
             req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+            if type(self.kv_cache_spec) in (
+                FullAttentionSpec,
+                TQFullAttentionSpec,
+                MLAAttentionSpec,
+            ):
                 self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
@@ -265,7 +269,11 @@ class SingleTypeKVCacheManager(ABC):
         else:
             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
             req_blocks.extend(new_blocks)
-            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+            if type(self.kv_cache_spec) in (
+                FullAttentionSpec,
+                TQFullAttentionSpec,
+                MLAAttentionSpec,
+            ):
                 self.new_block_ids.extend(b.block_id for b in new_blocks)
             return new_blocks
 


### PR DESCRIPTION
## Problem

I noticed that for Kimi Linear, once the KV cache is filled up, the model starts outputting garbage. After a lot of debugging with Codex, we found out that it's related to #35219, which fixed the problem for Qwen. Kimi Linear uses MLA, which is somehow not covered by that PR. I'm not too familiar with KV cache management code, but the fix in this PR (done by Codex) seems to fix the issue.

This problem was not surfaced before probably because Kimi Linear is the only MLA + Linear attention model.

Note: this problem only affects FlashMLA and FlashInfer MLA backends, which does not mask out tail KV cache page (relies on `* 0` to get zeros, which is only true for non-nan and non-inf inputs). Triton MLA masks the inputs, hence it's not affected.

cc @ZJY0516 

## Validation

The easiest way to observe the original problem is to run gsm8k for multiple epochs to fill up the KV cache. Once the KV cache is full, the model starts outputting garbage, and the eval scores dropped.

Epoch | Main | This PR
---|---|---
Epoch 0 | 0.9075 | 0.8946
Epoch 1 | 0.7096 | 0.8931
Epoch 2 | 0.0136 | 0.8886
Epoch 3 | 0.0061 | 0.8961
Epoch 4 | 0.0144 | 0.8969

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

