### PR TITLE
[Bugfix]: preserve DeepSeek V4 ubatch metadata for DBO prefills

### DIFF
--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -131,6 +131,21 @@ def test_make_metadata_with_slice_mixed_batch(mixed_small_metadata):
     assert torch.equal(result.seq_lens, torch.tensor([40, 48]))
 
 
+def test_make_metadata_with_slice_preserves_dbo_metadata(mixed_small_metadata):
+    mixed_small_metadata.positions = torch.arange(
+        mixed_small_metadata.num_actual_tokens
+    )
+    mixed_small_metadata.is_prefilling = torch.tensor(
+        [False, True, True], dtype=torch.bool
+    )
+    ubatch_slice = UBatchSlice(slice(1, 3), slice(1, 7))
+
+    result = _make_metadata_with_slice(ubatch_slice, mixed_small_metadata)
+
+    assert torch.equal(result.positions, torch.arange(1, 7))
+    assert torch.equal(result.is_prefilling, torch.tensor([True, True]))
+
+
 def test_split_attn_metadata_decode_batch(large_decode_metadata):
     """Test splitting decode batch into two equal parts"""
     num_tokens = large_decode_metadata.num_reqs

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -794,6 +794,15 @@ def test_split_indexer_prefill_chunks_single_request_overflow():
     assert out == expected
 
 
+def test_split_indexer_prefill_chunks_skips_zero_query_noop_chunk():
+    seq_lens = torch.tensor([0, 100])
+    query_lens = torch.tensor([0, 5])
+
+    out = split_indexer_prefill_chunks(seq_lens, query_lens, 50, 10000)
+
+    assert out == [(slice(1, 2), slice(0, 5))]
+
+
 def test_triton_convert_returns_valid_counts():
     """Test that return_valid_counts correctly counts non-negative indices."""
     device = torch.device(DEVICE_TYPE)

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -107,6 +107,10 @@ def split_indexer_prefill_chunks(
             end += 1
 
         req_slice = slice(start + request_offset, end + request_offset)
+        # Zero-query rows can appear from padded requests in full-CG/ubatch metadata.
+        # They produce no logits/indexer work, so skip the no-op chunk.
+        if chunk_m == 0:
+            continue
         max_q = max(1, max_logits_elems // chunk_n) if chunk_n > 0 else chunk_m
         for q_off in range(0, chunk_m, max_q):
             sub_m = min(max_q, chunk_m - q_off)

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -477,12 +477,14 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         seq_lens = common_attn_metadata.seq_lens
         slot_mapping = common_attn_metadata.slot_mapping
         block_table = common_attn_metadata.block_table_tensor
+        use_is_prefilling = common_attn_metadata.is_prefilling is not None
 
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
                 common_attn_metadata,
                 decode_threshold=self.reorder_batch_threshold,
                 require_uniform=not self.use_flattening,
+                treat_short_extends_as_decodes=not use_is_prefilling,
             )
         )
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -837,13 +837,14 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         seq_lens = common_attn_metadata.seq_lens
         slot_mapping = common_attn_metadata.slot_mapping
         block_table = common_attn_metadata.block_table_tensor
+        use_is_prefilling = common_attn_metadata.is_prefilling is not None
         dcp_local_seq_lens = common_attn_metadata.dcp_local_seq_lens
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
                 common_attn_metadata,
                 decode_threshold=self.decode_threshold,
                 require_uniform=not (self.use_flattening or self.supports_varlen),
-                treat_short_extends_as_decodes=not self.use_pcp,
+                treat_short_extends_as_decodes=not (self.use_pcp or use_is_prefilling),
             )
         )
 

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -236,6 +236,11 @@ def _make_metadata_with_slice(
         if attn_metadata.positions is not None
         else None
     )
+    is_prefilling = (
+        attn_metadata.is_prefilling[request_slice]
+        if attn_metadata.is_prefilling is not None
+        else None
+    )
 
     return CommonAttentionMetadata(
         query_start_loc=query_start_loc,
@@ -248,6 +253,7 @@ def _make_metadata_with_slice(
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
         positions=positions,
+        is_prefilling=is_prefilling,
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -231,6 +231,11 @@ def _make_metadata_with_slice(
 
     block_table_tensor = attn_metadata.block_table_tensor[request_slice]
     slot_mapping = attn_metadata.slot_mapping[token_slice]
+    positions = (
+        attn_metadata.positions[token_slice]
+        if attn_metadata.positions is not None
+        else None
+    )
 
     return CommonAttentionMetadata(
         query_start_loc=query_start_loc,
@@ -242,6 +247,7 @@ def _make_metadata_with_slice(
         max_seq_len=max_seq_len,
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
+        positions=positions,
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,


### PR DESCRIPTION
## Purpose

Fix a crash on the DeepSeek V4 Flash MLA sparse DBO prefill path.

When long-prefill requests trigger DBO ubatching, `split_attn_metadata()` rebuilds `CommonAttentionMetadata` for each ubatch. That rebuild dropped fields needed by the downstream sparse attention paths.

This change:
- preserves `positions` with `attn_metadata.positions[token_slice]`
- preserves `is_prefilling` with `attn_metadata.is_prefilling[request_slice]`
- makes the DeepSeek sparse indexer use `is_prefilling` when available, so prefill continuations are not misclassified after ubatch splitting
- adds a regression test to verify that DBO ubatch metadata slicing preserves token-aligned `positions` and request-aligned `is_prefilling`.

Issue #43964 is one example of this issue.

## Duplicate-work check

Current `main` at `92bdee05cb4ea5e94c4cce3eb0544f51d6eece8d` still drops `positions` and `is_prefilling` in `_make_metadata_with_slice()`. PR #49542 was opened after this PR and overlaps only with the `positions` fix; it does not preserve `is_prefilling` or protect the short-prefill classification. Merged PR #51538 changes other DeepSeek V4 sparse-MLA paths but does not fix ubatch metadata slicing.

## Test Plan

### Testbed

- vLLM image: `vllm/vllm-openai:v0.27.1`
- Hardware: single node, `8 x NVIDIA H20`
- Model: `DeepSeek-V4-Flash-0731`
- Runtime: DP8 + EP + DBO

### vLLM Start Command

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
VLLM_USE_DEEP_GEMM=1 \
vllm serve "$MODEL" \
  --served-model-name dsv4 \
  --trust-remote-code \
  --tokenizer-mode deepseek_v4 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --enable-dbo \
  --dbo-prefill-token-threshold 256 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --attention-backend FLASHMLA_SPARSE \
  --attention_config.indexer_kv_dtype=mxfp4 \
  --max-model-len 8192 \
  --max-num-batched-tokens 512 \
  --max-num-seqs 128 \
  --enforce-eager \
  --port 8000
```

### Benchmark

```bash
vllm bench serve \
  --backend vllm \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --model "$MODEL" \
  --served-model-name dsv4 \
  --dataset-name random \
  --random-input-len 1024 \
  --random-output-len 8 \
  --random-range-ratio '{"input":0.2,"output":0.0}' \
  --num-prompts 64 \
  --request-rate inf \
  --max-concurrency 64 \
  --ignore-eos
```

## Test Result

### Baseline

Original `v0.27.1` fails during DBO/C128A metadata construction:

```text
AssertionError: positions is required for C128A metadata build
RuntimeError: Worker failed with error 'positions is required for C128A metadata build'
```

Relevant stack:

```text
vllm/v1/worker/gpu_model_runner.py", line 2603, in _build_attention_metadata
  _build_attn_group_metadata(kv_cache_gid, attn_gid, _cm, ubid)
vllm/models/deepseek_v4/sparse_mla.py", line 220, in build
  c128a_fields = self._build_c128a_metadata(cm, req_id_per_token)
vllm/models/deepseek_v4/sparse_mla.py", line 261, in _build_c128a_metadata
  assert cm.positions is not None, (
```

### With This PR

Service starts successfully:

```text
Application startup complete.
```

Benchmark result:

```text
Successful requests:                     64
Failed requests:                         0
Total input tokens:                      65790
Total generated tokens:                  512
Request throughput (req/s):              1.05
Output token throughput (tok/s):         8.36
```

No occurrences of:

```text
positions is required
attention.hpp:346
EngineDeadError
```