### PR TITLE
[CI] Make Model Executor test hangs fail fast with a traceback

### DIFF
--- a/.buildkite/test_areas/model_executor.yaml
+++ b/.buildkite/test_areas/model_executor.yaml
@@ -14,5 +14,12 @@ steps:
   commands:
     - apt-get update && apt-get install -y curl libsodium23
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-    - pytest -v -s model_executor -m '(not slow_test)'
-    - pytest -v -s entrypoints/openai/completion/test_tensorizer_entrypoint.py
+    # Dump tracebacks of all threads if a test hangs, so a wedged GPU/CUDA
+    # init surfaces a stack instead of silently stalling.
+    - export PYTHONFAULTHANDLER=1
+    # Per-test watchdog: a single hung test (e.g. stuck during engine/CUDA
+    # init) fails fast with a traceback instead of running until the global
+    # build timeout. The `thread` method also handles hangs inside C/CUDA
+    # calls that the signal method cannot interrupt.
+    - pytest -v -s model_executor -m '(not slow_test)' --timeout=900 --timeout-method=thread
+    - pytest -v -s entrypoints/openai/completion/test_tensorizer_entrypoint.py --timeout=900 --timeout-method=thread


### PR DESCRIPTION
## Summary

In build [68772](https://buildkite.com/vllm/ci/builds/68772) (scheduled *Full CI run - daily*), the **Model Executor** step hung for **~10 hours** before being cancelled, blocking the nightly.

Root cause (from the logs): a single test —
`tests/model_executor/model_loader/fastsafetensors_loader/test_fastsafetensors_loader.py::test_model_loader_download_files` —
wedged during engine/CUDA init inside the EngineCore subprocess. The last line ever emitted was the sampler init:

```
(EngineCore pid=506) ... topk_topp_sampler.py:45] Using FlashInfer for top-p & top-k sampling.
```

…logged from `GPUModelRunner.__init__` (sampler construction). The next expected line, `load_model()`'s `"Starting to load model ..."`, **never appeared** — so it froze in the tail of `GPUModelRunner.__init__` (GPU persistent-buffer / pinned-memory allocation), *before* weight loading. Then ~9h55m of total silence until the global build cancellation. The step's existing `timeout_in_minutes: 35` did **not** reap the job, consistent with a hang in an uninterruptible CUDA path.

## Change

Defense-in-depth so a hung test fails fast **with a stack trace** instead of stalling the whole nightly:

- `export PYTHONFAULTHANDLER=1` — lets faulthandler dump all-thread tracebacks.
- `pytest --timeout=900 --timeout-method=thread` per-test watchdog. The `thread` method fires even for hangs inside C/CUDA calls that the signal method can't interrupt, and dumps tracebacks before terminating — turning a 10h silent stall into a fast, diagnosable failure.

`pytest-timeout==2.3.1` is already pinned in `requirements/test/cuda.txt`, so **no new dependency** is introduced.

> Note: this is the safety-net layer. The underlying intermittent GPU/CUDA wedge during model-runner init is tracked separately; this PR ensures it can no longer cost 10h of CI and that the next occurrence produces an actionable traceback.

## Not a duplicate

Searched open PRs for `model_executor` + `timeout`, `pytest-timeout`, and "Model Executor hang" — no existing PR adds a per-test timeout / faulthandler to this CI step.

## Testing

This is a CI-config-only change (`.buildkite/test_areas/model_executor.yaml`). Validated that:
- `pytest-timeout==2.3.1` is present in the CUDA test image (`requirements/test/cuda.txt`).
- The `--timeout`/`--timeout-method` flags and `PYTHONFAULTHANDLER` are no-ops on the happy path and only engage when a test exceeds 900s.

CI on this PR exercises the modified Model Executor step end-to-end.

## AI assistance

AI assistance (Claude) was used to investigate the build logs and author this change. The change has been reviewed line-by-line before submission.