### PR TITLE
[CI] Fix smoke test step key to bypass block gate

### DIFF
--- a/.buildkite/image_build/image_build.yaml
+++ b/.buildkite/image_build/image_build.yaml
@@ -14,7 +14,7 @@ steps:
           limit: 2
 
   - label: ":docker: :smoking: Non-root smoke tests"
-    key: image-smoke-test
+    key: image-build-smoke-test
     depends_on:
       - image-build
     commands:


### PR DESCRIPTION
## Summary

- Renames the non-root smoke test step key from `image-smoke-test` to `image-build-smoke-test`
- The pipeline-generator's `_step_should_run()` auto-runs steps whose key starts with `"image-build"` — the previous key didn't match, causing a manual block step to be inserted

Follow-up fix for #43712.

## Test plan
- [ ] Verify the smoke test step runs automatically without a manual block gate in Buildkite

🤖 Generated with [Claude Code](https://claude.com/claude-code)