### PR TITLE
[BugFix] [GDN] Read linear_key_head_dim from hf_text_config for multimodal models

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -177,7 +177,7 @@ def _resolve_gdn_prefill_backend(
         return backend, "triton"
 
     head_k_dim = getattr(
-        vllm_config.model_config.hf_config, "linear_key_head_dim", None
+        vllm_config.model_config.hf_text_config, "linear_key_head_dim", None
     )
 
     supports_flashinfer = False
@@ -218,7 +218,7 @@ def _log_gdn_backend_decision(
 ) -> None:
     """Log the GDN prefill backend choice in the attention-selector style."""
     head_k_dim = getattr(
-        vllm_config.model_config.hf_config, "linear_key_head_dim", None
+        vllm_config.model_config.hf_text_config, "linear_key_head_dim", None
     )
     chosen = {
         "flashinfer": "FlashInfer",


### PR DESCRIPTION
## Summary

For multimodal Qwen3.5 models (e.g. [Qwen3.5-397B-A17B](https://huggingface.co/Qwen/Qwen3.5-397B-A17B/blob/main/config.json)), `linear_key_head_dim` (128) lives on `hf_text_config`, not `hf_config`. GDN prefill backend selection only read `hf_config`, so `head_k_dim` was `None` and CuteDSL/FlashInfer on Blackwell (SM100) was never enabled:

`INFO 05-29 16:47:49 [qwen_gdn_linear_attn.py:228] Using Triton/FLA GDN prefill kernel (requested=auto, head_k_dim=None).`

This mirrors the pattern used elsewhere in vLLM for multimodal configs (e.g. MLA backends reading from `hf_text_config`).

Related: #43273 — CuteDSL GDN prefill on SM100 gates on `head_k_dim == 128`; without this fix, multimodal Qwen3.5 models never satisfy that check.

## Changes

- Fall back to `vllm_config.model_config.hf_text_config` when resolving `linear_key_head_dim` in `_resolve_gdn_prefill_backend` and `_log_gdn_backend_decision`.

