### PR TITLE
[AMD][Bugfix][Quantization] Honor fused-name match in is_layer_skipped

### DIFF
--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -25,6 +25,9 @@ from vllm.model_executor.layers.quantization.quark.quark import (  # noqa: E501
 from vllm.model_executor.layers.quantization.quark.quark_moe import (  # noqa: E501
     QuarkW8A8Int8MoEMethod,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
 from vllm.platforms import current_platform
 
 from .reference_mxfp4 import dq_mxfp4_torch, qdq_mxfp4_torch
@@ -437,3 +440,88 @@ def test_mxfp4_dequant_kernel_match_quark(
     out_torch = dq_mxfp4_torch(w_mxfp4, scale, float_dtype)
 
     assert torch.equal(out_hip, out_torch)
+
+
+# Unit tests for ``is_layer_skipped`` fused-name handling.
+
+FUSED_MAPPING = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+}
+
+
+def test_fused_name_listed_directly_is_skipped():
+    # Regression for Step-3.5-Flash-FP8: the checkpoint lists the fused
+    # name (``qkv_proj``) directly in ``modules_to_not_convert``. When a
+    # ``packed_modules_mapping`` is registered on the model, the fused
+    # match must still win over per-shard expansion.
+    ignored = ["model.layers.0.self_attn.qkv_proj"]
+    assert is_layer_skipped(
+        prefix="model.layers.0.self_attn.qkv_proj",
+        ignored_layers=ignored,
+        fused_mapping=FUSED_MAPPING,
+    )
+    assert is_layer_skipped(
+        prefix="model.layers.0.mlp.gate_up_proj",
+        ignored_layers=["model.layers.0.mlp.gate_up_proj"],
+        fused_mapping=FUSED_MAPPING,
+    )
+
+
+def test_unfused_shards_listed_is_skipped():
+    # Quark INT8 style: per-shard names listed; all shards present means
+    # the fused layer is skipped via expansion.
+    ignored = [
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.0.self_attn.k_proj",
+        "model.layers.0.self_attn.v_proj",
+    ]
+    assert is_layer_skipped(
+        prefix="model.layers.0.self_attn.qkv_proj",
+        ignored_layers=ignored,
+        fused_mapping=FUSED_MAPPING,
+    )
+
+
+def test_partial_shards_raises():
+    # Only some shards listed -> ambiguous, must raise. Fused name is
+    # not in ignored_layers, so we fall through to per-shard expansion.
+    ignored = ["model.layers.0.self_attn.q_proj"]
+    with pytest.raises(ValueError):
+        is_layer_skipped(
+            prefix="model.layers.0.self_attn.qkv_proj",
+            ignored_layers=ignored,
+            fused_mapping=FUSED_MAPPING,
+        )
+
+
+def test_not_skipped_when_nothing_listed():
+    assert not is_layer_skipped(
+        prefix="model.layers.0.self_attn.qkv_proj",
+        ignored_layers=["model.layers.0.mlp.gate_up_proj"],
+        fused_mapping=FUSED_MAPPING,
+    )
+
+
+def test_non_fused_layer_unaffected():
+    assert is_layer_skipped(
+        prefix="model.layers.0.self_attn.o_proj",
+        ignored_layers=["model.layers.0.self_attn.o_proj"],
+        fused_mapping=FUSED_MAPPING,
+    )
+    assert not is_layer_skipped(
+        prefix="model.layers.0.self_attn.o_proj",
+        ignored_layers=["model.layers.1.self_attn.o_proj"],
+        fused_mapping=FUSED_MAPPING,
+    )
+
+
+def test_substr_match_on_fused_name():
+    # skip_with_substr=True path: fused-name substring match should also
+    # short-circuit before shard expansion.
+    assert is_layer_skipped(
+        prefix="model.layers.0.self_attn.qkv_proj",
+        ignored_layers=["self_attn.qkv_proj"],
+        fused_mapping=FUSED_MAPPING,
+        skip_with_substr=True,
+    )

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -520,7 +520,15 @@ def is_layer_skipped(
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that
     # each shard of the fused layer has the same scheme.
-    if proj_name in fused_mapping:
+    #
+    # Some checkpoints (e.g. block-FP8 Step-3.5-Flash) already list the
+    # fused name (e.g. ``self_attn.qkv_proj``) directly in
+    # ``modules_to_not_convert``. Honor that fused-name match first so
+    # those layers are still correctly skipped even when a
+    # ``packed_modules_mapping`` is registered on the model.
+    if proj_name in fused_mapping and match_func(prefix, ignored_layers):
+        is_skipped = True
+    elif proj_name in fused_mapping:
         shard_prefixes = [
             prefix.replace(proj_name, shard_proj_name)
             for shard_proj_name in fused_mapping[proj_name]


### PR DESCRIPTION


## Purpose

PR #41892 (https://github.com/vllm-project/vllm/pull/41892) introduced a bug that breaks Step-3.5-Flash-FP8 on vLLM v0.22.0+: every prompt degenerates to a stream of `<｜begin▁of▁sentence｜>` tokens regardless of input. Reproduced on ROCm vLLM 0.22.0+rocm722, TP=4, MI308X with the official `stepfun-ai/Step-3.5-Flash-FP8` checkpoint.

```
[DEGENERATED] finish=length
  prompt    : 'The capital of France is'
  completion: '<｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜>'

[DEGENERATED] finish=length
  prompt    : '1 + 1 ='
  completion: '<｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜>'

[DEGENERATED] finish=length
  prompt    : 'Hello, my name is'
  completion: '<｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜>'

[DEGENERATED] finish=length
  prompt    : 'Once upon a time,'
  completion: '<｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜begin▁of▁sentence｜>'

```

Root cause: #41892 registered a `packed_modules_mapping = {qkv_proj: [q_proj,k_proj,v_proj], gate_up_proj: [gate_proj,up_proj]}` on `Step3p5ForCausalLM` so that Quark INT8 exports (whose `modules_to_not_convert` lists unfused per-shard names) are handled correctly，https://huggingface.co/nameistoken/Step-3.5-Flash-Quark-W8A8-INT8/blob/main/config.json.
 However, the block-FP8 Step-3.5-Flash-FP8 checkpoint lists **fused** names directly in `modules_to_not_convert` (e.g. `model.layers.0.self_attn.qkv_proj`, `model.layers.0.mlp.gate_up_proj`). With the new mapping in place, `is_layer_skipped` unconditionally expands `qkv_proj` to its unfused shards and looks those up in `ignored_layers`. The unfused names are not present, so attention/MLP layers that should stay in BF16 are routed through `Fp8LinearMethod` and produce corrupted logits.
https://huggingface.co/stepfun-ai/Step-3.5-Flash-FP8/blob/main/config.json

Fix: in `is_layer_skipped`, when the projection name is in `fused_mapping` AND the fused prefix itself already matches an entry in `ignored_layers`, return skipped directly. Only fall back to the per-shard expansion when the fused name does not match. This keeps the Quark INT8 behavior from #41892 intact while restoring correct behavior for FP8/other exports that list fused names. One file changed, +9/-1.

## Test Plan

Verification on ROCm MI308X (TP=4) with Step-3.5-Flash-FP8:
  * Without this commit: `test_raw_completion.py` produces wrong output -- every prompt degenerates to repeated `<｜begin▁of▁sentence｜>` tokens.
  * With this commit: `test_raw_completion.py` output is normal (coherent completions on 4/4 sanity prompts), and gsm8k eval also runs normally.

## Test Result

```
[OK] finish=length
  prompt    : 'The capital of France is'
  completion: ' Paris. The capital of Germany is Berlin. The capital of Italy is Rome. The capital of Spain'

[OK] finish=length
  prompt    : '1 + 1 ='
  completion: ' 3: The Myth of the Two-Party System\n\nby\n\nMichael J. Malbin\n\n'

[OK] finish=length
  prompt    : 'Hello, my name is'
  completion: ' Dr. David F. Dinges. I am a Professor in the Department of Psychiatry at the University'

[OK] finish=length
  prompt    : 'Once upon a time,'
  completion: ' in a small village nestled in the heart of a dense forest, there lived a young girl named Lily'
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

