### PR TITLE
[Frontend] Warn when VLLM_PLUGINS names a plugin we never discovered

### DIFF
--- a/tests/plugins_tests/test_load_plugins_warning.py
+++ b/tests/plugins_tests/test_load_plugins_warning.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the warning surfaced when a name in ``VLLM_PLUGINS`` does
+not match any entry-point discovered for the requested group.
+
+The motivating scenario is a developer doing ``pip install -e .`` whose
+package ships an entry-point under ``vllm.general_plugins`` but who
+also has a stale ``.egg-info`` from a previous ``python setup.py
+develop`` shadowing the new ``.dist-info``. Discovery returns the
+stale dist (without the entry-point), the plugin is silently skipped,
+and the user sees the downstream "Model architectures are not
+supported" error with no breadcrumb.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import vllm.plugins as plugins_mod
+
+
+class _FakeEntryPoint:
+    """Minimal duck-typed stand-in for ``importlib.metadata.EntryPoint``."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.value = f"fake_module:{name}"
+
+    def load(self):
+        return lambda: None
+
+
+def _patched_entry_points(names):
+    """Return a callable mimicking ``importlib.metadata.entry_points``."""
+
+    def _ep(group: str):
+        del group  # the fake doesn't care
+        return [_FakeEntryPoint(n) for n in names]
+
+    return _ep
+
+
+class _RecordingHandler(logging.Handler):
+    """Handler that captures every record seen, independent of pytest's
+    `caplog` (vLLM disables logger propagation, which bypasses caplog)."""
+
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def _capture_records():
+    """Attach a recording handler to the vllm.plugins logger."""
+    handler = _RecordingHandler()
+    plugins_mod.logger.addHandler(handler)
+    return handler
+
+
+def _detach(handler):
+    plugins_mod.logger.removeHandler(handler)
+
+
+def test_warning_emitted_for_missing_plugin():
+    handler = _capture_records()
+    try:
+        with (
+            patch(
+                "vllm.plugins.envs.VLLM_PLUGINS",
+                ["does_not_exist", "lora_filesystem_resolver"],
+            ),
+            patch(
+                "importlib.metadata.entry_points",
+                _patched_entry_points(["lora_filesystem_resolver"]),
+            ),
+        ):
+            plugins_mod.load_plugins_by_group(plugins_mod.DEFAULT_PLUGINS_GROUP)
+    finally:
+        _detach(handler)
+
+    matches = [
+        r
+        for r in handler.records
+        if "does_not_exist" in r.getMessage() and r.levelno >= logging.WARNING
+    ]
+    assert matches, (
+        "expected a WARNING mentioning the missing plugin name, "
+        f"got records: {[r.getMessage() for r in handler.records]}"
+    )
+
+
+def test_no_warning_when_all_allowed_plugins_resolve():
+    handler = _capture_records()
+    try:
+        with (
+            patch("vllm.plugins.envs.VLLM_PLUGINS", ["lora_filesystem_resolver"]),
+            patch(
+                "importlib.metadata.entry_points",
+                _patched_entry_points(["lora_filesystem_resolver"]),
+            ),
+        ):
+            plugins_mod.load_plugins_by_group(plugins_mod.DEFAULT_PLUGINS_GROUP)
+    finally:
+        _detach(handler)
+
+    bad = [r for r in handler.records if "VLLM_PLUGINS requested" in r.getMessage()]
+    assert not bad, (
+        "no warning expected when every allowed plugin resolves, "
+        f"got: {[r.getMessage() for r in bad]}"
+    )
+
+
+def test_no_warning_when_vllm_plugins_unset():
+    handler = _capture_records()
+    try:
+        with (
+            patch("vllm.plugins.envs.VLLM_PLUGINS", None),
+            patch(
+                "importlib.metadata.entry_points",
+                _patched_entry_points(["lora_filesystem_resolver"]),
+            ),
+        ):
+            plugins_mod.load_plugins_by_group(plugins_mod.DEFAULT_PLUGINS_GROUP)
+    finally:
+        _detach(handler)
+
+    bad = [r for r in handler.records if "VLLM_PLUGINS requested" in r.getMessage()]
+    assert not bad, (
+        "no warning expected when VLLM_PLUGINS is unset, "
+        f"got: {[r.getMessage() for r in bad]}"
+    )

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -63,6 +63,27 @@ def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
             except Exception:
                 logger.exception("Failed to load plugin %s", plugin.name)
 
+    # If VLLM_PLUGINS named entries that we never discovered, surface a
+    # warning so the user can debug their install rather than silently
+    # falling through to "plugin not loaded". Common causes: package not
+    # `pip install`-ed in the current interpreter; a stale `.egg-info`
+    # shadowing the new `.dist-info`; the entry-point missing from
+    # `pyproject.toml` for the requested group.
+    if allowed_plugins is not None:
+        discovered_names = {p.name for p in discovered_plugins}
+        missing = [name for name in allowed_plugins if name not in discovered_names]
+        if missing:
+            logger.warning(
+                "VLLM_PLUGINS requested %s but entry-point group %r "
+                "only discovered %s. Common causes: package not "
+                "installed in this interpreter; a stale `.egg-info` "
+                "shadowing the new `.dist-info`; the entry-point "
+                "missing from `pyproject.toml`.",
+                missing,
+                group,
+                sorted(discovered_names),
+            )
+
     return plugins
 
 


### PR DESCRIPTION
## What

This adds a single `logger.warning(...)` in `vllm/plugins/__init__.py:load_plugins_by_group`. The warning fires when a name listed in `VLLM_PLUGINS` does not match any entry-point discovered for the requested group.

## Why this matters

Right now this failure mode is completely silent. The discovery loop iterates over `discovered_plugins`, the requested name simply does not match anything, the loop ends, and whatever subsystem expected that plugin breaks downstream. The most common downstream symptom is `ValueError: Model architectures ['...'] are not supported` from `ModelRegistry`, which gives the user zero hint that the actual problem was on the plugin discovery side.

I ran into this on a real deployment and it cost me several hours to track down. The setup was a normal looking editable install workflow:

1. We did `pip install -e .` on a project that declares an entry-point under `[project.entry-points."vllm.general_plugins"]` in `pyproject.toml`.
2. We had `PYTHONPATH=src:.` set so the source tree was importable from the test harness.
3. A stale `src/<pkg>.egg-info/` from an old `python setup.py develop` was still on disk.
4. `importlib.metadata.distributions()` found two distributions with the same name. The stale `.egg-info` (which did not contain the entry-point) won the lookup, and the new `.dist-info` (which did contain it) was hidden.
5. `entry_points(group="vllm.general_plugins")` silently returned the version without our plugin.
6. The subprocess `EngineCore` then failed with `Model architectures not supported`, with no log line at all linking the failure back to plugin discovery.

We only found the root cause by manually instrumenting `vllm.plugins.__init__.py` with print statements in the installed venv. That is not a debugging experience anyone should have to repeat. The plugin author has no way to tell from the user-facing error that they should look at `entry_points()` at all.

Other variants of the same class of bug that this warning would catch immediately:

* Wheel installed in one virtualenv, but vLLM is being invoked from a different interpreter that does not see that wheel.
* Typo in the plugin name in `VLLM_PLUGINS` (`"my_plugin"` vs `"my-plugin"`).
* Entry-point registered under the wrong group (`vllm.platform_plugins` instead of `vllm.general_plugins`, or vice versa).
* User shipped a wheel that forgot to declare the entry-point in `pyproject.toml` at all.

In all of these cases, the only signal the user gets today is a misleading downstream error. A warning at the discovery layer turns hours of debugging into seconds.

## What the change does

The added code runs at the end of `load_plugins_by_group`, after discovery and after the regular load loop has had a chance to load anything it could. It compares the requested set of plugins against the names that were actually discovered, and if any are missing it logs a single WARNING. The message names the missing plugins, the group that was scanned, the entries that were discovered, and a short list of the three most common root causes so the user has a useful starting point.

```python
if allowed_plugins is not None:
    discovered_names = {p.name for p in discovered_plugins}
    missing = [name for name in allowed_plugins
               if name not in discovered_names]
    if missing:
        logger.warning(
            "VLLM_PLUGINS requested %s but entry-point group %r "
            "only discovered %s. Common causes: package not "
            "installed in this interpreter; a stale `.egg-info` "
            "shadowing the new `.dist-info`; the entry-point "
            "missing from `pyproject.toml`.",
            missing, group, sorted(discovered_names),
        )
```

## What the change does not do

* It does not raise. The legacy behavior of silently skipping the missing plugin is preserved, so this is fully backwards compatible.
* It does not touch the `VLLM_PLUGINS=None` "load everything" path. Users who do not opt into the filter see no new output.
* It does not change any public API or any exported symbol.
* It does not affect performance. The added work is a single set difference per call to `load_plugins_by_group`, which already runs at most a handful of times per process during startup.

## Test plan

`tests/plugins_tests/test_load_plugins_warning.py` adds three regression tests:

1. `test_warning_emitted_for_missing_plugin`. Patches `entry_points()` to return only `lora_filesystem_resolver`, sets `VLLM_PLUGINS=["does_not_exist", "lora_filesystem_resolver"]`, and asserts that at least one record at WARNING level mentions `"does_not_exist"`.
2. `test_no_warning_when_all_allowed_plugins_resolve`. Sets `VLLM_PLUGINS=["lora_filesystem_resolver"]`, asserts no `"VLLM_PLUGINS requested"` warning is emitted.
3. `test_no_warning_when_vllm_plugins_unset`. Sets `VLLM_PLUGINS=None`, asserts no `"VLLM_PLUGINS requested"` warning is emitted. This guards the legacy behavior.

The tests attach a small recording `logging.Handler` directly to `vllm.plugins.logger` rather than relying on pytest's `caplog`. We do that because vLLM disables logger propagation in its standard setup, which makes `caplog` miss records from named loggers.

Local results:

```
$ pytest tests/plugins_tests/test_load_plugins_warning.py -v
3 passed in 3.10s

$ ruff check vllm/plugins/__init__.py tests/plugins_tests/test_load_plugins_warning.py
All checks passed!

$ ruff format --check vllm/plugins/__init__.py tests/plugins_tests/test_load_plugins_warning.py
2 files already formatted
```

## Scope

* Two files touched, one source and one test.
* About 155 lines added in total, most of which is the test file.
* No new runtime dependencies.
* No new build steps.
* No doc changes needed. The warning itself is the doc.

I am happy to iterate on the wording of the warning, the root cause list, or the placement of the check if reviewers prefer a different shape.
