### PR TITLE
[Frontend] Add OpenAIBaseModel.get_extra_fields() public accessor

### DIFF
--- a/tests/entrypoints/openai/test_get_extra_fields.py
+++ b/tests/entrypoints/openai/test_get_extra_fields.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for OpenAIBaseModel.get_extra_fields().
+
+The OpenAI API accepts arbitrary extra fields by spec. vLLM preserves them
+via Pydantic's ``extra="allow"`` configuration on
+:class:`OpenAIBaseModel`, but until now downstream consumers had to read
+them from ``model.__pydantic_extra__`` which is a private Pydantic API
+that has changed shape between Pydantic releases.
+
+``get_extra_fields()`` exposes that information as a public, documented
+:class:`dict` so middleware, external safety classifiers, audit pipelines
+and similar consumers can read it without dipping into Pydantic
+internals.
+"""
+
+from __future__ import annotations
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
+
+
+def _minimal_chat_body(**extras):
+    body = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    body.update(extras)
+    return body
+
+
+def test_get_extra_fields_returns_unknown_fields_for_chat():
+    req = ChatCompletionRequest.model_validate(
+        _minimal_chat_body(
+            audit_session_id="abc-123",
+            experimental_safety=True,
+            custom_meta={"tenant": "geodesia"},
+        )
+    )
+    extras = req.get_extra_fields()
+    assert extras == {
+        "audit_session_id": "abc-123",
+        "experimental_safety": True,
+        "custom_meta": {"tenant": "geodesia"},
+    }
+
+
+def test_get_extra_fields_empty_when_only_known_fields():
+    req = ChatCompletionRequest.model_validate(_minimal_chat_body())
+    assert req.get_extra_fields() == {}
+
+
+def test_get_extra_fields_returns_copy_not_alias():
+    """Mutating the returned dict must not change the model state.
+
+    Consumers can therefore safely mutate the returned dict in place
+    (for example to redact sensitive values before logging) without
+    accidentally corrupting the original request.
+    """
+    req = ChatCompletionRequest.model_validate(
+        _minimal_chat_body(audit_session_id="abc-123")
+    )
+    extras = req.get_extra_fields()
+    extras["audit_session_id"] = "REDACTED"
+    assert req.get_extra_fields() == {"audit_session_id": "abc-123"}
+
+
+def test_get_extra_fields_works_on_completion_request():
+    req = CompletionRequest.model_validate(
+        {
+            "model": "test-model",
+            "prompt": "Hello",
+            "audit_session_id": "xyz",
+        }
+    )
+    assert req.get_extra_fields() == {"audit_session_id": "xyz"}
+
+
+def test_get_extra_fields_on_arbitrary_openaibasemodel_subclass():
+    """The method is defined on ``OpenAIBaseModel`` so it works on
+    every subclass, not just request models."""
+
+    class DummyModel(OpenAIBaseModel):
+        known: int = 0
+
+    obj = DummyModel.model_validate({"known": 1, "unknown_a": "alpha", "unknown_b": 2})
+    assert obj.get_extra_fields() == {"unknown_a": "alpha", "unknown_b": 2}
+
+
+def test_get_extra_fields_returns_dict_type():
+    req = ChatCompletionRequest.model_validate(_minimal_chat_body(custom="x"))
+    extras = req.get_extra_fields()
+    assert isinstance(extras, dict)

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -55,6 +55,38 @@ class OpenAIBaseModel(BaseModel):
             )
         return result
 
+    def get_extra_fields(self) -> dict[str, Any]:
+        """Return any unknown fields received in the request.
+
+        OpenAI-compatible servers accept extra fields by spec, and vLLM
+        preserves them via Pydantic's ``extra="allow"`` configuration on
+        :class:`OpenAIBaseModel`. This method exposes those fields as a
+        public, documented :class:`dict` so downstream consumers (custom
+        middleware, external safety classifiers, audit pipelines, A/B
+        routing layers, etc.) can read them without relying on Pydantic's
+        private ``__pydantic_extra__`` attribute, which is not part of
+        Pydantic's stable public API.
+
+        Returns:
+            A copy of the dict mapping each unknown field name to its
+            received value. Empty dict if the request only contained
+            known fields.
+
+        Example::
+
+            req = ChatCompletionRequest.model_validate(
+                {
+                    "model": "my-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "audit_session_id": "abc-123",
+                    "experimental_safety": True,
+                }
+            )
+            req.get_extra_fields()
+            # {'audit_session_id': 'abc-123', 'experimental_safety': True}
+        """
+        return dict(self.model_extra or {})
+
 
 class ErrorInfo(OpenAIBaseModel):
     message: str


### PR DESCRIPTION
## What

This adds a small public method `get_extra_fields()` on `OpenAIBaseModel` that returns any unknown fields the client passed in the request, as a plain `dict[str, Any]`.

## Why this matters

`OpenAIBaseModel` already accepts arbitrary extra fields, by spec, via `model_config = ConfigDict(extra="allow")`. That part is great.

The gap is on the reading side. Today, if you write a custom middleware, an external safety classifier, an audit pipeline, an A/B routing layer, or anything else that needs to look at request fields beyond the OpenAI surface, you have two choices, both bad:

1. Reach into Pydantic's `__pydantic_extra__` attribute. That attribute is not part of Pydantic's stable public API, and its shape has actually shifted between Pydantic minor releases. If we recommend that in vLLM docs we are signing up for breakage when Pydantic 3 lands.
2. Re-serialize the model and diff against the known field set yourself. Possible, but every downstream consumer ends up writing the same nine-line helper, and they each get the corner cases slightly wrong (alias handling, nested models, etc).

The fix is small. We already have everything we need, we just need to expose it under a name that is part of vLLM's public API contract.

```python
def get_extra_fields(self) -> dict[str, Any]:
    return dict(self.model_extra or {})
```

That is the whole behavioral change. Two more lines for the type signature, the rest of the diff is the docstring with an example and the tests.

## What this change does not do

* It does not change any existing behavior. Requests that worked yesterday still work.
* It does not mutate the model. `get_extra_fields()` returns a copy.
* It does not strip or redact anything. Consumers see exactly what the client sent. If they want to redact, they mutate the returned dict, which does not affect the request.
* It does not add a new dependency, a new config flag, a new env var, or any new public class.
* It does not touch any of the request validators, including the existing `__log_extra_fields__` wrap validator. The DEBUG log line that already records extras stays exactly as it was.

## Example downstream usage

```python
from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest

@app.middleware("http")
async def audit_middleware(request, call_next):
    body = await request.json()
    req = ChatCompletionRequest.model_validate(body)
    extras = req.get_extra_fields()
    if audit_id := extras.get("audit_session_id"):
        record_audit(audit_id, req.model)
    return await call_next(request)
```

Without this PR, the middleware author has to write:

```python
extras = req.__pydantic_extra__ or {}  # private, may break in Pydantic 3
```

or worse:

```python
known = set(ChatCompletionRequest.model_fields)
extras = {k: v for k, v in body.items() if k not in known}
# missed: aliases, nested defaults that look like extras after model_dump, etc.
```

Both of those bugs have shown up in real downstream code. A documented one-liner on the base class removes the temptation.

## Test plan

`tests/entrypoints/openai/test_get_extra_fields.py` adds six regression tests:

1. `test_get_extra_fields_returns_unknown_fields_for_chat`. Posts a chat request with three different extras (string, bool, nested dict) and asserts they all come back.
2. `test_get_extra_fields_empty_when_only_known_fields`. Asserts that a request with only standard fields returns `{}`.
3. `test_get_extra_fields_returns_copy_not_alias`. Mutates the returned dict and asserts the original request is unchanged. This is load-bearing because real middleware tends to redact secrets in place before logging.
4. `test_get_extra_fields_works_on_completion_request`. Smoke test against `CompletionRequest` to confirm the method is reachable from every subclass, not just `ChatCompletionRequest`.
5. `test_get_extra_fields_on_arbitrary_openaibasemodel_subclass`. Same again but on an inline subclass, to make the contract explicit: it's defined on the base.
6. `test_get_extra_fields_returns_dict_type`. Type guard.

Local run:

```
$ python validate_extra_fields.py   # standalone runner against the installed wheel
PASS  test_get_extra_fields_returns_unknown_fields_for_chat
PASS  test_get_extra_fields_empty_when_only_known_fields
PASS  test_get_extra_fields_returns_copy_not_alias
PASS  test_get_extra_fields_works_on_completion_request
PASS  test_get_extra_fields_on_arbitrary_openaibasemodel_subclass
PASS  test_get_extra_fields_returns_dict_type
6/6 passed

$ ruff check vllm/entrypoints/openai/engine/protocol.py tests/entrypoints/openai/test_get_extra_fields.py
All checks passed!

$ ruff format --check vllm/entrypoints/openai/engine/protocol.py tests/entrypoints/openai/test_get_extra_fields.py
2 files already formatted
```

End-to-end check: I also ran a real vLLM 0.21 server with this patch applied, sent a chat completion request with two unknown fields, and verified both the response stayed correct AND the downstream middleware could read the extras through `get_extra_fields()`. No regressions in any of the existing scoring paths.

## Scope

* Files touched: 2 (one source, one test).
* Lines added: 126 (most is the test file plus the docstring).
* No new dependencies.
* No new build steps.
* No doc changes required because the docstring is the doc.

Happy to iterate on the method name (`get_extras`, `extra_fields_dict`, `unknown_fields`, etc), the placement (on `OpenAIBaseModel` vs on each request class), or to move the method onto a separate accessor class if reviewers prefer.
