### PR TITLE
[Bugfix] Fix Ray placement group allocation with grouped nodes

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -575,7 +575,9 @@ class CoreEngineActorManager:
             node_ip_keys = [
                 key
                 for key in node_resources
-                if key != "node:__internal_head__" and key.startswith("node:")
+                if key != "node:__internal_head__"
+                and key.startswith("node:")
+                and "_group_" not in key
             ]
             assert len(node_ip_keys) == 1, (
                 f"Zero or multiple node IP keys found in node resources: {node_ip_keys}"
@@ -653,6 +655,9 @@ class CoreEngineActorManager:
                 local_dp_ranks.append(i)
                 if len(placement_groups) == dp_size:
                     break
+
+            if len(placement_groups) == dp_size:
+                break
 
         if len(placement_groups) < dp_size:
             raise ValueError(


### PR DESCRIPTION
## Purpose
Two fixes for placement group allocation in CoreEngineActorManager:

1. Filter out Ray's internal `_group_` node resource keys when determining node IPs. These synthetic keys can cause the single-IP assertion to fail on multi-node clusters. Without it we may see like
```
AssertionError: Zero or multiple node IP keys found in node resources: ['node:10.0.138.58_group_0_469ed99b5126bd68fd21abc8f7e203000000', 'node:10.0.138.58_group_4f8edb24c07c41c234365d36314403000000', 'node:10.0.138.58_group_0_b60c56b43ce628a657b16a1e0da903000000', 'node:10.0.138.58_group_0_4f8edb24c07c41c234365d36314403000000', 'node:10.0.138.58_group_e47ac2817baf73cfdccd164f862d03000000', 'node:10.0.138.58_group_469ed99b5126bd68fd21abc8f7e203000000', 'node:10.0.138.58', 'node:10.0.138.58_group_b60c56b43ce628a657b16a1e0da903000000', 'node:10.0.138.58_group_0_e47ac2817baf73cfdccd164f862d03000000']
```
and we only need the `node:<ip>` entry.

3. Add missing outer loop break when enough placement groups have been allocated, preventing unnecessary iteration + extra allocations over remaining bundles. Without it we were seeing
```
assert len(placement_groups) == dp_size, (
(VLLMWorkerActor pid=373, ip=10.152.62.214) (APIServer pid=437)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VLLMWorkerActor pid=373, ip=10.152.62.214) (APIServer pid=437) AssertionError: Created 40 DP placement groups, expected 32
```


Co-authored-by: Claude

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

