### PR TITLE
Revert "[ROCm][Perf] Support N=5 in wvSplitK skinny GEMM kernels for speculative decoding"

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1277,12 +1277,6 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
         else
           WVSPLIT_TILE_CFG(64, 16, sYT, 4)
         break;
-      case 5:
-        if (use_wave32)
-          WVSPLIT_TILE_CFG(32, 16, sYT, 5)
-        else
-          WVSPLIT_TILE_CFG(64, 16, sYT, 5)
-        break;
       default:
         throw std::runtime_error(
             "Unsupported N value: " + std::to_string(M_in) + "," +

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -178,7 +178,7 @@ def rocm_unquantized_gemm_impl(
 
     if use_skinny:
         x_view = x.reshape(-1, x.size(-1))
-        if m > 8 and 0 < n <= 5:
+        if m > 8 and 0 < n <= 4:
             cu_count = num_compute_units()
             out = ops.wvSplitK(weight, x_view, cu_count, bias)
             return out.reshape(*x.shape[:-1], weight.shape[0])


### PR DESCRIPTION
Reverts vllm-project/vllm#40687

```
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^               
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]   File "/app/dsv4tilelang/rocm-dsv4-csa-multistream/vllm/_custom_ops.
py", line 2264, in wvSplitK                                                                                                                   
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]     return torch.ops._rocm_C.wvSplitK(a, b, bias, cu_count)          
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 
1209, in __call__                                                                                                                             
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]     return self._op(*args, **kwargs)                                 
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^                                 
(Worker_TP7 pid=254984) ERROR 05-29 15:53:44 [multiproc_executor.py:966] RuntimeError: Unsupported N value: 16160,7168,5  
```

server command on mi355

```
#!/bin/bash

rm -rf /root/.cache/vllm

VLLM_ROCM_USE_AITER=1 \
vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --host localhost \
  --port 8001 \
  --dtype auto \
  --tensor-parallel-size 8 \
  --max-num-seqs 256 \
  --distributed-executor-backend mp \
  --trust-remote-code \
  --gpu-memory-utilization 0.6 \
  --moe-backend aiter \
  --tokenizer-mode deepseek_v4 \
  --reasoning-parser deepseek_v4 \
  --kv-cache-dtype fp8_e4m3 \
  --compilation-config '{"mode":3,"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
| tee dsv4graph-multistream.log
```

lmeval

```
#!/bin/bash
MODEL=deepseek-ai/DeepSeek-V4-Pro
lm_eval --model local-completions --model_args model=$MODEL,base_url=http://0.0.0.0:8001/v1/completions,num_concurrent=256,max_retries=10,max_gen_toks=2048,max_length=1048576,timeout=60000,trust_remote_code=True --batch_size auto --tasks gsm8k --num_fewshot 20 \
  --output_path ./results_deepseekv4multistream_numshot20 \
  --log_samples \
| tee lmeval_deepseekv4multistream_numshot20.log
```

We should look more into the kernel's dispatching logic before re-enablement. 