### PR TITLE
[Bug] Fix torch device issue for MOE permute

### DIFF
--- a/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
+++ b/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
@@ -74,6 +74,9 @@ class MoEPermuteScratch:
         self.sort_workspace = torch.empty(
             sorter_size, dtype=torch.int8, device=self.device
         )
+        # torch.device("cuda") in config, after initialized,
+        # will be changed to cuda:{index}, so we need to refresh here.
+        self.device = self.token_expert_indices.device
 
     def validate(self, hidden_states: torch.Tensor, topk_ids: torch.Tensor) -> None:
         n_token, n_hidden = hidden_states.shape


### PR DESCRIPTION
## Purpose

Fix torch device issue for MOE permute

`vllm serve nm-testing/fp8_dynamic_moe-e2e`

Originally

```bash
(EngineCore pid=796067)   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/experts/fallback.py", line 164, in apply
(EngineCore pid=796067)     experts.apply(
(EngineCore pid=796067)   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py", line 373, in apply
(EngineCore pid=796067)     run_cutlass_moe_fp8(
(EngineCore pid=796067)   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py", line 196, in run_cutlass_moe_fp8
(EngineCore pid=796067)     a1q, a1q_scale, expert_first_token_offset, inv_perm, _ = moe_permute(
(EngineCore pid=796067)                                                              ^^^^^^^^^^^^
(EngineCore pid=796067)   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py", line 195, in moe_permute
(EngineCore pid=796067)     scratch.validate(hidden_states, topk_ids)
(EngineCore pid=796067)   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py", line 80, in validate
(EngineCore pid=796067)     assert hidden_states.device == self.device
(EngineCore pid=796067)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=796067) AssertionError
```

Now

```bash
(APIServer pid=788168) INFO:     Started server process [788168]
(APIServer pid=788168) INFO:     Waiting for application startup.
(APIServer pid=788168) INFO:     Application startup complete.
```
