### PR TITLE
[Frontend] Clean up stop_token_ids override for Harmony

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -57,7 +57,6 @@ from vllm.entrypoints.openai.engine.serving import (
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
-    get_stop_tokens_for_assistant_actions,
     get_streamable_parser_for_assistant,
     parse_chat_output,
 )
@@ -158,13 +157,6 @@ class OpenAIServingChat(OpenAIServing):
             else getattr(mc, "override_generation_config", {}).get("max_new_tokens")
         )
         self.use_harmony = self.model_config.hf_config.model_type == "gpt_oss"
-        if self.use_harmony:
-            if "stop_token_ids" not in self.default_sampling_params:
-                self.default_sampling_params["stop_token_ids"] = []
-            self.default_sampling_params["stop_token_ids"].extend(
-                get_stop_tokens_for_assistant_actions()
-            )
-
         self.tool_call_id_type = get_tool_call_id_type(self.model_config)
 
         # NOTE(woosuk): While OpenAI's chat completion API supports browsing

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -365,10 +365,6 @@ def render_for_completion(messages: list[Message]) -> list[int]:
     return token_ids
 
 
-def get_stop_tokens_for_assistant_actions() -> list[int]:
-    return get_encoding().stop_tokens_for_assistant_actions()
-
-
 def get_streamable_parser_for_assistant() -> StreamableParser:
     return StreamableParser(get_encoding(), role=Role.ASSISTANT)
 

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -372,8 +372,6 @@ class ResponsesRequest(OpenAIBaseModel):
         if (frequency_penalty := self.frequency_penalty) is None:
             frequency_penalty = default_sampling_params.get("frequency_penalty", 0.0)
 
-        stop_token_ids = default_sampling_params.get("stop_token_ids")
-
         # Structured output
         structured_outputs = self.structured_outputs
 
@@ -409,7 +407,6 @@ class ResponsesRequest(OpenAIBaseModel):
             top_k=top_k,
             max_tokens=max_tokens,
             logprobs=self.top_logprobs if self.is_include_output_logprobs() else None,
-            stop_token_ids=stop_token_ids,
             stop=stop,
             frequency_penalty=frequency_penalty,
             presence_penalty=presence_penalty,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -46,7 +46,6 @@ from vllm.entrypoints.openai.engine.serving import (
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_developer_message,
-    get_stop_tokens_for_assistant_actions,
     get_system_message,
     get_user_message,
     has_custom_tools,
@@ -221,13 +220,6 @@ class OpenAIServingResponses(OpenAIServing):
             logger.warning(
                 "For gpt-oss, we ignore --enable-auto-tool-choice "
                 "and always enable tool use."
-            )
-            # OpenAI models have two EOS-like tokens: <|return|> and <|call|>.
-            # We need to add them to the stop token ids.
-            if "stop_token_ids" not in self.default_sampling_params:
-                self.default_sampling_params["stop_token_ids"] = []
-            self.default_sampling_params["stop_token_ids"].extend(
-                get_stop_tokens_for_assistant_actions()
             )
 
         self.tool_call_id_type = get_tool_call_id_type(self.model_config)


### PR DESCRIPTION


## Purpose

Cleanup after #22519, which should now be resolved. GPT-OSS models now ship the Harmony `<|return|>` and `<|call|>` stop tokens in `generation_config.json`, so the original issue (root caused at [comment](https://github.com/vllm-project/vllm/issues/22519#issuecomment-3942551416)) is already fixed without extra OpenAI-layer plumbing.

This PR removes the dead `default_sampling_params["stop_token_ids"]` write from the Chat Completions serving path, where that value is never read, and removes the redundant Harmony-specific `stop_token_ids` injection/read path from the Responses API so it relies on the same `generation_config.json`-driven EOS handling as the rest of serving.

Behavioral change worth noting: in the Responses API, Harmony previously still terminated on `<|return|>` and `<|call|>` even with `ignore_eos=True` because those tokens were injected as explicit `stop_token_ids`. Non-Harmony models did not do this and followed `generation_config.json`-driven behavior, so after this cleanup Harmony matches the non-Harmony path: `ignore_eos=True` ignores those model-defined `<|return|>` and `<|call|>` tokens as well.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_sampling_params.py \
  tests/entrypoints/openai/chat_completion/test_chat.py \
  tests/entrypoints/openai/parser/test_harmony_utils.py \
  -v
```

BFCL sanity check.

## Test Result

All tests pass (122 unit tests + 36 integration tests that require GPU).

```
# Chat Completions API
🦍 Model: openai_gpt-oss-20b
🔍 Running test: multi_turn_base
✅ Test completed: multi_turn_base. 🎯 Accuracy: 38.50%
🔍 Running test: multi_turn_long_context
✅ Test completed: multi_turn_long_context. 🎯 Accuracy: 22.50%
🔍 Running test: multi_turn_miss_func
✅ Test completed: multi_turn_miss_func. 🎯 Accuracy: 36.50%
🔍 Running test: multi_turn_miss_param
✅ Test completed: multi_turn_miss_param. 🎯 Accuracy: 35.50%

# Responses APi
🦍 Model: openai_gpt-oss-20b
🔍 Running test: multi_turn_base
✅ Test completed: multi_turn_base. 🎯 Accuracy: 37.00%
🔍 Running test: multi_turn_long_context
✅ Test completed: multi_turn_long_context. 🎯 Accuracy: 20.50%
🔍 Running test: multi_turn_miss_func
✅ Test completed: multi_turn_miss_func. 🎯 Accuracy: 24.50%
🔍 Running test: multi_turn_miss_param
✅ Test completed: multi_turn_miss_param. 🎯 Accuracy: 30.50%
```
Inline with perf on main.

cc @sfeng33 @bbrowning 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

