### PR TITLE
[Feature] Add tanh softcapping support to FlexAttention backend

### DIFF
--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -77,6 +77,31 @@ def pad_to_multiple(x: torch.Tensor, multiple: int, dim: int):
     return F.pad(x, pad_list, mode="constant", value=0)
 
 
+def create_tanh_softcap_score_mod(
+    soft_cap: float,
+) -> _score_mod_signature:
+    """Creates a score_mod function that applies tanh softcapping.
+
+    Args:
+        soft_cap: The softcapping value. Attention scores will be transformed
+            as: soft_cap * tanh(score / soft_cap)
+
+    Returns:
+        A score_mod function compatible with FlexAttention.
+    """
+    def tanh_softcap(
+        score: torch.Tensor,
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        return soft_cap * torch.tanh(score / soft_cap)
+
+    return tanh_softcap
+
+
 class FlexAttentionBackend(AttentionBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [
         torch.float16,
@@ -1020,10 +1045,6 @@ class FlexAttentionImpl(AttentionImpl):
 
         self.kv_cache_dtype = kv_cache_dtype
         self.logits_soft_cap = logits_soft_cap
-        if self.logits_soft_cap is not None:
-            raise NotImplementedError(
-                "FlexAttention does not support logits soft cap yet."
-            )
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
@@ -1135,6 +1156,17 @@ class FlexAttentionImpl(AttentionImpl):
             attn_metadata.logical_mask_mod = layer_mask_mod
             attn_metadata.mask_mod = attn_metadata.get_mask_mod()
             needs_rebuild_block_mask = True
+
+        # Handle logits soft capping via score_mod
+        if self.logits_soft_cap is not None:
+            if attn_metadata.score_mod is None:
+                attn_metadata.score_mod = create_tanh_softcap_score_mod(
+                    self.logits_soft_cap
+                )
+                # Transform the score_mod to handle physical-to-logical conversion
+                attn_metadata.transformed_score_mod = (
+                    attn_metadata.get_transformed_score_mod()
+                )
 
         layer_hint = getattr(layer, "block_sparsity_hint", None)
         if (

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -89,6 +89,7 @@ def create_tanh_softcap_score_mod(
     Returns:
         A score_mod function compatible with FlexAttention.
     """
+
     def tanh_softcap(
         score: torch.Tensor,
         b: torch.Tensor,
@@ -1158,15 +1159,14 @@ class FlexAttentionImpl(AttentionImpl):
             needs_rebuild_block_mask = True
 
         # Handle logits soft capping via score_mod
-        if self.logits_soft_cap is not None:
-            if attn_metadata.score_mod is None:
-                attn_metadata.score_mod = create_tanh_softcap_score_mod(
-                    self.logits_soft_cap
-                )
-                # Transform the score_mod to handle physical-to-logical conversion
-                attn_metadata.transformed_score_mod = (
-                    attn_metadata.get_transformed_score_mod()
-                )
+        if self.logits_soft_cap is not None and attn_metadata.score_mod is None:
+            attn_metadata.score_mod = create_tanh_softcap_score_mod(
+                self.logits_soft_cap
+            )
+            # Transform the score_mod to handle physical-to-logical conversion
+            attn_metadata.transformed_score_mod = (
+                attn_metadata.get_transformed_score_mod()
+            )
 
         layer_hint = getattr(layer, "block_sparsity_hint", None)
         if (


### PR DESCRIPTION
## Summary

This PR adds tanh softcapping support to the FlexAttention backend, resolving the gap mentioned in #16078.

## Motivation

Models like Gemma-2 that use logits soft capping currently fail with FlexAttention backend:
```
NotImplementedError: FlexAttention does not support logits soft cap yet.
```

This prevents these models from using FLEX_ATTENTION for batch invariance testing and production use.

## Implementation

Implements the tanh softcapping formula: `soft_cap * tanh(score / soft_cap)` using FlexAttention's score_mod mechanism, following the same approach as other attention backends (FlashAttention, Triton).

**Changes:**
1. Added `create_tanh_softcap_score_mod()` function to generate the score_mod
2. Removed `NotImplementedError` for `logits_soft_cap` in FlexAttentionImpl.__init__()
3. Updated `forward()` method to apply softcapping via score_mod when configured

The implementation follows the exact pattern suggested by @yewentao256 in #16078, using the score_mod infrastructure that was already built into FlexAttention.

## Testing

**Local testing:** Implemented and validated code structure against vLLM patterns. Full GPU testing deferred to CI due to infrastructure constraints (OpenShift security policies prevented local GPU testing).

**Expected results with this change:**
- **FLASH_ATTN:** 5/5 tests PASSED ✓ (already passing)
- **TRITON_ATTN:** 4/4 tests PASSED ✓ (already passing)  
- **FLEX_ATTENTION:** Should now PASS ✓ (currently fails without this fix)

For google/gemma-2-2b-it batch invariance validation. See related PR #43656.

## References

- Requested by @yewentao256 in https://github.com/vllm-project/vllm/pull/16078#issuecomment-2645789562
- Related documentation PR: #43656
- Implementation location suggested: https://github.com/drisspg/vllm/blob/891345dd545ad86ca57163f34d4ea7696610dea3/vllm/v1/attention/backends/flex_attention.py#L433

## Checklist

- [x] Implementation follows established vLLM patterns
- [x] Tanh softcapping formula matches other backends
- [x] Code is ready for CI testing
- [x] DCO sign-off included in commit