### PR TITLE
[Bugfix] Fall back to buffered I/O if O_DIRECT fails in secondary tier fs

### DIFF
--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import errno
 import logging
 import os
 import random
@@ -49,27 +50,36 @@ def store_block(
     # Write block atomically. Cast to a flat byte view so the slice uses byte
     # indices; the raw memoryview may be multi-dimensional with itemsize > 1.
     view_slice = buffer.cast("B")[offset : offset + block_size]
-    try:
-        fd = os.open(
-            tmp_path,
-            os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC | O_DIRECT,
-            0o644,
-        )
+
+    use_direct = bool(O_DIRECT)
+    while True:
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC
+        if use_direct:
+            flags |= O_DIRECT
         try:
-            written = os.write(fd, view_slice)
-            if written < len(view_slice):
-                raise OSError(
-                    f"Short write: expected {len(view_slice)} bytes, wrote {written}"
+            fd = os.open(tmp_path, flags, 0o644)
+            try:
+                written = os.write(fd, view_slice)
+                if written < len(view_slice):
+                    raise OSError(
+                        f"Short write: expected {len(view_slice)} bytes,"
+                        f" wrote {written}"
+                    )
+            finally:
+                os.close(fd)
+            os.replace(tmp_path, dest_path)
+            return
+        except OSError as exc:
+            try:
+                os.remove(tmp_path)
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Failed to remove temp file %s: %s", tmp_path, cleanup_exc
                 )
-        finally:
-            os.close(fd)
-        os.replace(tmp_path, dest_path)
-    except Exception:
-        try:
-            os.remove(tmp_path)
-        except OSError as cleanup_exc:
-            logger.warning("Failed to remove temp file %s: %s", tmp_path, cleanup_exc)
-        raise
+            if use_direct and exc.errno == errno.EINVAL:
+                use_direct = False
+                continue
+            raise
 
 
 def load_block(
@@ -81,21 +91,33 @@ def load_block(
     """
     Load callback: read one KV block from disk. Remove the file on failure.
     """
-    fd: int | None = None
     view_slice = view.cast("B")[offset : offset + block_size]
-    try:
-        fd = os.open(source_path, os.O_RDONLY | O_DIRECT)
-        bytes_read = os.readv(fd, [view_slice])
-        if bytes_read < block_size:
-            raise OSError(f"Short read: expected {block_size} bytes, read {bytes_read}")
-    except Exception:
+
+    use_direct = bool(O_DIRECT)
+    while True:
+        flags = os.O_RDONLY | (O_DIRECT if use_direct else 0)
+        fd: int | None = None
         try:
-            os.remove(source_path)
-        except OSError as cleanup_exc:
-            logger.warning(
-                "Failed to remove unreadable file %s: %s", source_path, cleanup_exc
-            )
-        raise
-    finally:
-        if fd is not None:
-            os.close(fd)
+            fd = os.open(source_path, flags)
+            bytes_read = os.readv(fd, [view_slice])
+            if bytes_read < block_size:
+                raise OSError(
+                    f"Short read: expected {block_size} bytes, read {bytes_read}"
+                )
+            return
+        except OSError as exc:
+            if use_direct and exc.errno == errno.EINVAL:
+                use_direct = False
+                continue
+            try:
+                os.remove(source_path)
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Failed to remove unreadable file %s: %s",
+                    source_path,
+                    cleanup_exc,
+                )
+            raise
+        finally:
+            if fd is not None:
+                os.close(fd)

--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -51,11 +51,8 @@ def store_block(
     # indices; the raw memoryview may be multi-dimensional with itemsize > 1.
     view_slice = buffer.cast("B")[offset : offset + block_size]
 
-    use_direct = bool(O_DIRECT)
-    while True:
-        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC
-        if use_direct:
-            flags |= O_DIRECT
+    base = os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC
+    for flags in [base | O_DIRECT, base] if O_DIRECT else [base]:
         try:
             fd = os.open(tmp_path, flags, 0o644)
             try:
@@ -76,9 +73,8 @@ def store_block(
                 logger.warning(
                     "Failed to remove temp file %s: %s", tmp_path, cleanup_exc
                 )
-            if use_direct and exc.errno == errno.EINVAL:
-                use_direct = False
-                continue
+            if exc.errno == errno.EINVAL and (flags & O_DIRECT):
+                continue  # retry without O_DIRECT
             raise
 
 
@@ -93,9 +89,7 @@ def load_block(
     """
     view_slice = view.cast("B")[offset : offset + block_size]
 
-    use_direct = bool(O_DIRECT)
-    while True:
-        flags = os.O_RDONLY | (O_DIRECT if use_direct else 0)
+    for flags in [os.O_RDONLY | O_DIRECT, os.O_RDONLY] if O_DIRECT else [os.O_RDONLY]:
         fd: int | None = None
         try:
             fd = os.open(source_path, flags)
@@ -106,17 +100,17 @@ def load_block(
                 )
             return
         except OSError as exc:
-            if use_direct and exc.errno == errno.EINVAL:
-                use_direct = False
-                continue
-            try:
-                os.remove(source_path)
-            except OSError as cleanup_exc:
-                logger.warning(
-                    "Failed to remove unreadable file %s: %s",
-                    source_path,
-                    cleanup_exc,
-                )
+            if exc.errno == errno.EINVAL and (flags & O_DIRECT):
+                continue  # retry without O_DIRECT
+            if exc.errno != errno.ENOENT:
+                try:
+                    os.remove(source_path)
+                except OSError as cleanup_exc:
+                    logger.warning(
+                        "Failed to remove unreadable file %s: %s",
+                        source_path,
+                        cleanup_exc,
+                    )
             raise
         finally:
             if fd is not None:


### PR DESCRIPTION
This issue exposed in the `V1 Core + KV + Metrics` test group in AMD CI:
```
pytest -v -s tests/v1/kv_offload/test_fs_tier.py
============================================================= short test summary info ==============================================================
FAILED tests/v1/kv_offload/test_fs_tier.py::test_store_creates_file_and_lookup_succeeds - assert False
FAILED tests/v1/kv_offload/test_fs_tier.py::test_multiple_jobs_tracked_independently - AssertionError: assert False is True
FAILED tests/v1/kv_offload/test_fs_tier.py::test_multi_block_job_partial_failure - assert False
FAILED tests/v1/kv_offload/test_fs_tier.py::test_store_load_data_integrity - assert False
===================================================== 4 failed, 5 passed, 17 warnings in 2.93s =====================================================
```
(e.g. [build 8978](https://buildkite.com/vllm/amd-ci/builds/8978/list?sid=019e72f6-7110-4ea5-9ad6-1532df189b12&tab=output))

The `test_fs_tier.py` test was added recently in https://github.com/vllm-project/vllm/pull/41735, which implements file system secondary tier for multi-tier offload. The implementation relies on `O_DIRECT` in the store and load methods, but doesn't allow for any sort of fallback if it fails. This PR implements a fallback because `O_DIRECT` access fails in AMD CI. The `os.open` and `os.write` calls return `EINVAL` with `O_DIRECT` enabled. This isn't inherently a ROCm specific issue, but it is sensitive to things like linux kernel version https://stackoverflow.com/questions/41257656/what-does-o-direct-really-mean. 

With the fallback in place, I am seeing the following when running the test:
```
========================================================== 9 passed, 17 warnings in 3.22s ==========================================================
```