### PR TITLE
[Kernel][Helion][1/N] Add Helion kernel for silu_and_mul_dynamic_per_token_quant

### DIFF
--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -713,6 +713,7 @@ class TestHelionKernelWrapper:
 
         new_op = Mock()
         registered_ops: dict[str, Mock] = {}
+        mutates_args = ["y"]
 
         class MockNamespace:
             def __getattr__(self, name):
@@ -748,6 +749,7 @@ class TestHelionKernelWrapper:
                 raw_kernel_func=sample_kernel,
                 op_name="test_kernel",
                 fake_impl=fake_impl,
+                mutates_args=mutates_args,
                 config_picker=default_picker,
             )
             result = wrapper._get_or_register_custom_op()
@@ -755,6 +757,7 @@ class TestHelionKernelWrapper:
             mock_register.assert_called_once()
             assert result is new_op
             assert mock_register.call_args[1]["op_func"] is mock_decorated
+            assert mock_register.call_args[1]["mutates_args"] is mutates_args
 
 
 class TestKernelRegistry:

--- a/tests/kernels/helion/test_silu_and_mul_dynamic_per_token_quant.py
+++ b/tests/kernels/helion/test_silu_and_mul_dynamic_per_token_quant.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the rms_norm helion kernel
+Run `pytest tests/kernels/helion/test_silu_and_mul_dynamic_per_token_quant.py`.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from tests.kernels.helion.utils import skip_if_platform_unsupported
+from tests.kernels.quant_utils import FP8_DTYPE
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.silu_and_mul_dynamic_per_token_quant import (
+    _pick_cache,
+    baseline,
+    pick_config,
+    silu_and_mul_dynamic_per_token_quant,
+)
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+from vllm.utils.torch_utils import set_random_seed
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+
+def _generate_fake_input(num_tokens: int, intermediate_size: int) -> tuple[Any, ...]:
+    with FakeTensorMode():
+        in_dtype: torch.dtype = torch.bfloat16
+        out_dtype: torch.dtype = current_platform.fp8_dtype()
+        scale_dtype: torch.dtype = torch.float32
+        input = torch.randn(
+            num_tokens, 2 * intermediate_size, device="cuda", dtype=in_dtype
+        )
+        result = torch.empty(
+            num_tokens, intermediate_size, device=input.device, dtype=out_dtype
+        )
+        scale = torch.empty((num_tokens, 1), device=input.device, dtype=scale_dtype)
+        scale_ub = torch.mean(input).to(scale_dtype)
+        args = (result, input, scale, scale_ub)
+        return args
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+class TestSiluAndMulDynamicPerTokenQuantConfigPicker:
+    def setup_method(self):
+        _pick_cache.clear()
+
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            CaseKey({"intermediate_size": 2048, "num_tokens": 16}),
+            CaseKey({"intermediate_size": 4096, "num_tokens": 16}),
+        ]
+
+        args = _generate_fake_input(16, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey({"intermediate_size": 4096, "num_tokens": 16})
+
+    def test_config_picker_closest_match(self):
+        config_keys = [
+            CaseKey({"intermediate_size": 2048, "num_tokens": 16}),
+            CaseKey({"intermediate_size": 2048, "num_tokens": 32}),
+            CaseKey({"intermediate_size": 4096, "num_tokens": 16}),
+            CaseKey({"intermediate_size": 4096, "num_tokens": 32}),
+        ]
+
+        args = _generate_fake_input(20, 3000)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey({"intermediate_size": 2048, "num_tokens": 32})
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[dict] = []
+
+        args = _generate_fake_input(16, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
+    def test_config_picker_fallback_to_largest(self):
+        config_keys = [
+            CaseKey({"intermediate_size": 2048, "num_tokens": 16}),
+            CaseKey({"intermediate_size": 4096, "num_tokens": 16}),
+        ]
+
+        args = _generate_fake_input(32, 8192)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey({"intermediate_size": 4096, "num_tokens": 16})
+
+
+class TestSiluAndMulDynamicPerTokenQuantCorrectness:
+    @pytest.mark.parametrize("num_tokens", [1, 7, 4096])
+    @pytest.mark.parametrize("intermediate_size", [17, 1024, 1025, 1026, 5137, 8193])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float])
+    @pytest.mark.parametrize("has_scale_ub", [True, False])
+    @pytest.mark.parametrize("seed", [0])
+    def test_silu_and_mul_dynamic_per_token_quant(
+        self,
+        num_tokens: int,
+        intermediate_size: int,
+        dtype: torch.dtype,
+        has_scale_ub: bool,
+        seed: int,
+    ) -> None:
+        skip_if_platform_unsupported("silu_and_mul_dynamic_per_token_quant")
+        set_random_seed(seed)
+
+        ref_x = (
+            torch.rand(num_tokens, 2 * intermediate_size, dtype=dtype, device="cuda")
+            + 1e-6
+        )
+        ops_x = ref_x.clone()
+
+        scale_ub = (
+            torch.mean(SiluAndMul.forward_native(ref_x)).to(
+                dtype=torch.float32, device="cuda"
+            )
+            if has_scale_ub
+            else None
+        )
+
+        ref_out = torch.empty(
+            num_tokens, intermediate_size, device="cuda", dtype=FP8_DTYPE
+        )
+        ref_scales = torch.empty(
+            (ref_x.shape[0], 1), device="cuda", dtype=torch.float32
+        )
+        baseline(ref_out, ref_x, ref_scales, scale_ub)
+
+        ops_out = torch.empty(
+            num_tokens, intermediate_size, device="cuda", dtype=FP8_DTYPE
+        )
+        ops_scales = torch.empty(
+            (ref_x.shape[0], 1), device="cuda", dtype=torch.float32
+        )
+        silu_and_mul_dynamic_per_token_quant(ops_out, ops_x, ops_scales, scale_ub)
+
+        torch.testing.assert_close(ref_scales, ops_scales)
+        # allow 1 ULP difference
+        assert (
+            ref_out.view(torch.uint8).to(torch.int16)
+            - ops_out.view(torch.uint8).to(torch.int16)
+        ).abs().max() <= 1
+
+
+class TestSiluAndMulDynamicPerTokenQuantIntegration:
+    def test_kernel_registration_integration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        assert "silu_and_mul_dynamic_per_token_quant" in registered_kernels
+
+        kernel_wrapper = registered_kernels["silu_and_mul_dynamic_per_token_quant"]
+        assert kernel_wrapper.op_name == "silu_and_mul_dynamic_per_token_quant"
+        assert kernel_wrapper._config_picker is not None
+        assert kernel_wrapper._mutates_args == ["result", "input", "scale"]
+
+    def test_fake_impl_functionality(self):
+        skip_if_platform_unsupported("silu_and_mul_dynamic_per_token_quant")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["silu_and_mul_dynamic_per_token_quant"]
+        fake_impl = kernel_wrapper._fake_impl
+
+        args = _generate_fake_input(16, 4096)
+        assert fake_impl(*args) is None

--- a/tests/kernels/helion/utils.py
+++ b/tests/kernels/helion/utils.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helion Kernel test utils"""
+
+import pytest
+import torch
+
+from vllm.kernels.helion.config_manager import ConfigManager
+
+
+def skip_if_platform_unsupported(op_name: str):
+    try:
+        from vllm.kernels.helion.utils import get_canonical_gpu_name
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        platform = get_canonical_gpu_name()
+
+        try:
+            config_manager = ConfigManager.get_instance()
+        except RuntimeError:
+            config_manager = ConfigManager()
+
+        configs = config_manager.get_platform_configs(op_name, platform)
+        if len(configs) == 0:
+            pytest.skip(f"Current GPU platform not supported for {op_name} kernel")
+
+    except (ImportError, RuntimeError, KeyError):
+        pytest.skip(f"Error detecting platform support for {op_name} kernel")

--- a/vllm/kernels/helion/configs/silu_and_mul_dynamic_per_token_quant/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/silu_and_mul_dynamic_per_token_quant/nvidia_b200.json
@@ -1,0 +1,2140 @@
+[
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        4
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        4,
+        3
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        4
+      ],
+      "range_warp_specializes": [
+        true,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        true,
+        true,
+        false
+      ],
+      "range_flattens": [
+        false,
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 64,
+      "atomic_indexing": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        4
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        4
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        1,
+        4
+      ],
+      "range_warp_specializes": [
+        false,
+        true,
+        null
+      ],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        true,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 8,
+      "maxnreg": 128,
+      "atomic_indexing": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        4
+      ],
+      "range_warp_specializes": [
+        true,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        false,
+        null,
+        null
+      ],
+      "range_flattens": [
+        false,
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 4,
+      "maxnreg": 128,
+      "atomic_indexing": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        4
+      ],
+      "range_warp_specializes": [
+        true,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        false,
+        null,
+        null
+      ],
+      "range_flattens": [
+        false,
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 4,
+      "maxnreg": 128,
+      "atomic_indexing": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        true
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        4
+      ],
+      "range_warp_specializes": [
+        true,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        false,
+        null,
+        null
+      ],
+      "range_flattens": [
+        false,
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 4,
+      "maxnreg": 128,
+      "atomic_indexing": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        4,
+        3
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        true
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        4
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        4
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        32768
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 1024
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        32768
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 1024
+    },
+    "config": {
+      "block_sizes": [
+        2048,
+        16384
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        true
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 1024
+    },
+    "config": {
+      "block_sizes": [
+        2048,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 2048
+    },
+    "config": {
+      "block_sizes": [
+        1024,
+        8192
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        1
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        false,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 2048
+    },
+    "config": {
+      "block_sizes": [
+        1024,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 2048
+    },
+    "config": {
+      "block_sizes": [
+        1024,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 4096
+    },
+    "config": {
+      "block_sizes": [
+        1024,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 4096
+    },
+    "config": {
+      "block_sizes": [
+        2048,
+        16384
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        true
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 4096
+    },
+    "config": {
+      "block_sizes": [
+        512,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        null
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 8192
+    },
+    "config": {
+      "block_sizes": [
+        1024,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 8192
+    },
+    "config": {
+      "block_sizes": [
+        2048,
+        16384
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        null,
+        true
+      ],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 8192
+    },
+    "config": {
+      "block_sizes": [
+        1024,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        1,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false,
+        false
+      ],
+      "range_multi_buffers": [
+        null,
+        true,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "atomic_indexing": [],
+      "range_num_stages": []
+    }
+  }
+]

--- a/vllm/kernels/helion/configs/silu_and_mul_dynamic_per_token_quant/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/silu_and_mul_dynamic_per_token_quant/nvidia_h100.json
@@ -1,0 +1,2177 @@
+[
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        4096
+      ],
+      "range_unroll_factors": [
+        2,
+        0,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 8,
+      "maxnreg": 64
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        1024
+      ],
+      "range_unroll_factors": [
+        4,
+        1,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 4,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        1024
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        false,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 8,
+      "maxnreg": 64
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        8192
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        8192
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        true,
+        null,
+        false
+      ],
+      "range_flattens": [
+        false,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 1,
+      "maxnreg": 128
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        3,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        4,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        32768,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        1,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        32768
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 1024
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 1024
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        32768
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 1024
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        16384
+      ],
+      "range_unroll_factors": [
+        0,
+        4,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 2048
+    },
+    "config": {
+      "block_sizes": [
+        4096,
+        32768
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        1
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        true,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 2048
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 2048
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 4096
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        1,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 4096
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        0,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 4096
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 8192
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        1,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 8192
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        4096
+      ],
+      "range_unroll_factors": [
+        0,
+        4,
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 8192
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 6144,
+      "num_tokens": 16384
+    },
+    "config": {
+      "block_sizes": [
+        8192,
+        1024
+      ],
+      "range_unroll_factors": [
+        0,
+        4,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 12288,
+      "num_tokens": 16384
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        4096
+      ],
+      "range_unroll_factors": [
+        1,
+        2,
+        4
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null,
+        null,
+        true
+      ],
+      "range_flattens": [
+        false,
+        true,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 128,
+      "maxnreg": 64
+    }
+  },
+  {
+    "key": {
+      "intermediate_size": 25600,
+      "num_tokens": 16384
+    },
+    "config": {
+      "block_sizes": [
+        16384,
+        2048
+      ],
+      "range_unroll_factors": [
+        0,
+        2,
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null,
+        false,
+        false
+      ],
+      "range_flattens": [
+        null,
+        false,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  }
+]

--- a/vllm/kernels/helion/ops/silu_and_mul_dynamic_per_token_quant.py
+++ b/vllm/kernels/helion/ops/silu_and_mul_dynamic_per_token_quant.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from itertools import product
+from typing import Any
+
+import torch
+
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_fp8_min_max,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+import helion
+import helion.language as hl
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+def _get_fp8_dtype() -> torch.dtype:
+    return current_platform.fp8_dtype()
+
+
+def _get_int8_min_max() -> tuple[int, int]:
+    qtype_traits = torch.iinfo(torch.int8)
+    return qtype_traits.min, qtype_traits.max
+
+
+def _get_int8_min_scaling_factor() -> float:
+    return torch.finfo(torch.float32).eps
+
+
+def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
+    # TODO(xiaohongchen1991): it is difficult for kernel author to cover all input
+    # property combination. Currently, dtypes are fixed. We need optimization to
+    # bucket/skip some combinations
+    num_tokens_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
+    intermediate_size_list = [6144, 12288, 25600]
+    in_dtype: torch.dtype = torch.bfloat16
+    out_dtype: torch.dtype = current_platform.fp8_dtype()
+    scale_dtype: torch.dtype = torch.float32
+    inputs = {}
+    for num_tokens, intermediate_size in product(
+        num_tokens_list, intermediate_size_list
+    ):
+        input = torch.randn(
+            num_tokens, 2 * intermediate_size, device="cuda", dtype=in_dtype
+        )
+        result = torch.empty(
+            num_tokens, intermediate_size, device=input.device, dtype=out_dtype
+        )
+        scale = torch.empty((num_tokens, 1), device=input.device, dtype=scale_dtype)
+        scale_ub = torch.mean(input).to(scale_dtype)
+
+        config_key = CaseKey(
+            {"intermediate_size": intermediate_size, "num_tokens": num_tokens}
+        )
+        inputs[config_key] = (result, input, scale, scale_ub)
+
+    return inputs
+
+
+_pick_cache: dict[tuple[int, int], CaseKey | None] = {}
+
+
+def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
+    """Pick the best pre-tuned config for the given input shape.
+
+    Selection strategy:
+      1. Find the closest intermediate_size among available configs
+         (exact match preferred).
+      2. Among the num_tokens values tuned for that intermediate_size, pick
+         the smallest num_tokens >= the input's num_tokens. If the input is
+         larger than all available num_tokens, fall back to the largest.
+    """
+
+    if not config_keys:
+        return None
+
+    result, *_ = args
+    num_tokens, intermediate_size = result.shape
+
+    cache_key = (num_tokens, intermediate_size)
+    cached = _pick_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    configs: dict[int, list[int]] = {}
+    for key in config_keys:
+        if key.is_default():
+            continue
+        configs.setdefault(key["intermediate_size"], []).append(key["num_tokens"])
+
+    if not configs:
+        return None
+
+    best_intermediate_size = min(configs, key=lambda s: abs(s - intermediate_size))
+    available_num_tokens = sorted(configs[best_intermediate_size])
+    best_num_tokens = next(
+        (n for n in available_num_tokens if n >= num_tokens), available_num_tokens[-1]
+    )
+
+    result = CaseKey(
+        {"intermediate_size": best_intermediate_size, "num_tokens": best_num_tokens}
+    )
+    _pick_cache[cache_key] = result
+    return result
+
+
+def fake_impl(
+    result: torch.Tensor,  # [num_tokens, intermediate_size]
+    input: torch.Tensor,  # [num_tokens, 2 * intermediate_size]
+    scale: torch.Tensor,  # [num_tokens, 1]
+    scale_ub: torch.Tensor | None = None,  # scalar tensor
+) -> None:
+    return
+
+
+def baseline(
+    result: torch.Tensor,  # [num_tokens, intermediate_size]
+    input: torch.Tensor,  # [num_tokens, 2 * intermediate_size]
+    scale: torch.Tensor,  # [num_tokens, 1]
+    scale_ub: torch.Tensor | None = None,  # scalar tensor
+):
+    import vllm._custom_ops as ops
+    from vllm.model_executor.layers.activation import SiluAndMul
+
+    silu_and_mul_out = SiluAndMul.forward_native(input)
+
+    intermediate_size = silu_and_mul_out.shape[1]
+    # Overwrite first half of input in-place to match Helion kernel impl.
+    # This is needed to pass Helion autotuning baseline check.
+    input[:, :intermediate_size].copy_(silu_and_mul_out.to(input.dtype))
+
+    out, scale_out = ops.scaled_fp8_quant(
+        silu_and_mul_out, scale=None, scale_ub=scale_ub, use_per_token_if_dynamic=True
+    )
+    result.copy_(out)
+    scale.copy_(scale_out)
+
+
+@register_kernel(
+    mutates_args=["result", "input", "scale"],
+    config_picker=pick_config,
+    input_generator=generate_inputs,
+    fake_impl=fake_impl,
+    helion_settings=helion.Settings(
+        autotune_baseline_fn=baseline,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    ),
+)  # type: ignore[misc]
+def silu_and_mul_dynamic_per_token_quant(
+    result: torch.Tensor,  # [num_tokens, intermediate_size]
+    input: torch.Tensor,  # [num_tokens, 2 * intermediate_size]
+    scale: torch.Tensor,  # [num_tokens, 1]
+    scale_ub: torch.Tensor | None = None,  # scalar tensor
+) -> None:
+    # This code assumes batch_dim and num_tokens are flattened
+    assert input.ndim == 2
+    num_tokens, two_intermediate_size = input.shape
+    hl.specialize(two_intermediate_size)
+
+    assert two_intermediate_size % 2 == 0
+    intermediate_size = two_intermediate_size // 2
+
+    assert result.shape[0] == num_tokens
+    assert result.shape[1] == intermediate_size
+
+    assert scale.shape[0] == num_tokens
+    assert scale.dtype == torch.float32
+    assert input.stride()[-1] == 1
+    assert result.stride()[-1] == 1
+
+    fp8_min, fp8_max = get_fp8_min_max()
+    inv_fp8_max = 1.0 / fp8_max
+    min_scaling_factor = inv_fp8_max / 512.0
+
+    for tile_m in hl.tile(num_tokens, block_size=1):
+        s_blk = hl.zeros([tile_m], dtype=torch.float32)
+
+        for tile_n in hl.tile(intermediate_size):
+            x_a_blk = input[tile_m, tile_n].to(torch.float32)
+            x_b_blk = hl.load(
+                input,
+                [tile_m, tile_n.index + intermediate_size],
+                extra_mask=((tile_n.index + intermediate_size) < two_intermediate_size)[
+                    None, :
+                ],
+            ).to(torch.float32)
+            x_blk = x_a_blk * torch.sigmoid(x_a_blk) * x_b_blk
+            input[tile_m, tile_n] = x_blk.to(input.dtype)
+            tmp_blk = torch.amax(torch.abs(x_blk), dim=-1)
+            s_blk = torch.maximum(s_blk, tmp_blk)
+
+        if scale_ub is not None:
+            scale_ub_s = hl.load(scale_ub, [])
+            s_blk = s_blk.clamp(max=scale_ub_s)
+        s_blk = s_blk * inv_fp8_max
+        s_blk = s_blk.clamp(min=min_scaling_factor)
+        scale[tile_m, 0] = s_blk
+
+        for tile_n in hl.tile(intermediate_size):
+            x_blk = input[tile_m, tile_n].to(torch.float32)
+            y_blk = x_blk / s_blk[:, None]
+
+            result[tile_m, tile_n] = y_blk.clamp(fp8_min, fp8_max).to(result.dtype)

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -260,6 +260,7 @@ class HelionKernelWrapper:
         op_name: str,
         fake_impl: Callable,
         config_picker: ConfigPicker,
+        mutates_args: list[str] | None = None,
         helion_settings: helion.Settings | None = None,
         input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
     ):
@@ -272,6 +273,7 @@ class HelionKernelWrapper:
         self.helion_settings = helion_settings
         self._config_picker = config_picker
         self._input_generator = input_generator
+        self._mutates_args = mutates_args
         self._configured_kernel: ConfiguredHelionKernel | None = None
         # TODO(@gmagogsfm): Remove this disable flag once integrated with vLLM IR,
         # which handles op enablement/disablement.
@@ -357,7 +359,7 @@ class HelionKernelWrapper:
         direct_register_custom_op(
             op_name=self.op_name,
             op_func=configured_kernel._decorated_kernel,
-            mutates_args=None,
+            mutates_args=self._mutates_args,
             fake_impl=self._fake_impl,
             target_lib=vllm_helion_lib,
         )
@@ -402,6 +404,7 @@ def register_kernel(
     *,
     config_picker: ConfigPicker,
     fake_impl: Callable | None = None,
+    mutates_args: list[str] | None = None,
     helion_settings: helion.Settings | None = None,
     input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
 ) -> Callable[[Callable], HelionKernelWrapper]:
@@ -455,6 +458,7 @@ def register_kernel(
             op_name=final_op_name,
             fake_impl=final_fake_impl,
             config_picker=config_picker,
+            mutates_args=mutates_args,
             helion_settings=helion_settings,
             input_generator=input_generator,
         )


### PR DESCRIPTION
## Purpose
vLLM does not yet support a fusion pass that combines silu_and_mul with dynamic_per_token_quant. As a result, enabling the Helion FP8 quantization custom op can lead to end-to-end performance regressions, even when the standalone Helion fp8_quant kernel outperforms the default implementation.

The primary reason is that the kernel-level performance gain is offset by the additional kernel launch overhead. Without the custom op, torch.compile is able to fuse silu_and_mul and dynamic_per_token_quant into a single kernel. However, when the Helion custom op is used, this fusion opportunity is lost.

This PR is to introduce Helion kernel for ```silu_and_mul_dynamic_per_token_quant``` operation to solve the above issue. This is a subtask for https://github.com/vllm-project/vllm/issues/32962.

### Kernel level benchmark
**Environment**
Python: 3.12.12
Pytorch: 2.11.0
Cuda: 13.0
Helion: 1.0.0

**Benchmark Setup**
Latency measure: ```triton.testing.do_bench_cudagraph(rep=1000)```
Baseline: ```torch.compile``` 

**Autotuning Setup**
Default "full" autotuning effort. i.e. LFBOTreeSearch with initial_population=FROM_RANDOM, copies=5, max_generations=20, similarity_penalty=1.0.

**Results**
| Kernel | Speedup against torch.compile (H100) | Speedup against torch.compile (B200) | 
|---|---:|---:|
| silu_and_mul_dynamic_per_token_quant | 1.256x | 1.420x | 

* H100: https://gist.github.com/xiaohongchen1991/64e36e674ed22b732d31fbd99981a26e
* B200: https://gist.github.com/xiaohongchen1991/fa3dbd76f3a44898a6c177817f5155d8

### End-to-end benchmark
Results provided in https://github.com/vllm-project/vllm/issues/32962

## Test Plan

- [x] Test correctness
  - Added unit test to cover its correctness
- [x] Benchmark kernel performance 

## Test Result
### Unit test to cover correctness 
All unit test cases to cover its correctness passed. 
```
pytest tests/kernels/helion/test_silu_and_mul_dynamic_per_token_quant.py
```

### Kernel benchmarking
See the results above.