### PR TITLE
[ROCm] Fused single-launch per-tensor-dynamic FP8 quant (gfx950)

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -808,6 +808,18 @@ def _rocm_aiter_per_tensor_quant_impl(
     quant_dtype: torch.dtype,
     scale: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # Fused single-launch kernel for dynamic FP8-e4m3 (gfx950); else aiter.
+    if (
+        envs.VLLM_ROCM_USE_AITER_FUSED_PER_TENSOR_QUANT
+        and scale is None
+        and quant_dtype == torch.float8_e4m3fn
+    ):
+        from vllm.model_executor.layers.quantization.utils.fused_pertensor_fp8_quant import (  # noqa: E501
+            fused_per_tensor_dynamic_fp8_quant,
+        )
+
+        return fused_per_tensor_dynamic_fp8_quant(x)
+
     from aiter.ops.quant import per_tensor_quant_hip
 
     return per_tensor_quant_hip(x, scale, quant_dtype)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -127,6 +127,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
+    VLLM_ROCM_USE_AITER_FUSED_PER_TENSOR_QUANT: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -1166,6 +1167,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
+    ),
+    # Fused single-launch per-tensor-dynamic FP8 quant (gfx950); byte-exact, opt-in.
+    "VLLM_ROCM_USE_AITER_FUSED_PER_TENSOR_QUANT": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_FUSED_PER_TENSOR_QUANT", "False").lower()
+        in ("true", "1")
     ),
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM": lambda: (

--- a/vllm/model_executor/layers/quantization/utils/fused_pertensor_fp8_quant.py
+++ b/vllm/model_executor/layers/quantization/utils/fused_pertensor_fp8_quant.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused single-launch per-tensor-dynamic FP8-e4m3 quant for ROCm/gfx950.
+
+Replaces aiter's 3-kernel triplet with a single Triton launch in the decode
+regime. Output is byte-identical to the aiter triplet (accuracy-neutral).
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+FP8_MAX = 448.0  # OCP E4M3 max on gfx950 (not FNUZ)
+_FP8_MAX = tl.constexpr(448.0)
+# recip-mul (not divide) reproduces aiter's folded scale bit-for-bit
+_INV_FP8_MAX = tl.constexpr(1.0 / 448.0)
+
+SINGLE_BLOCK_CAP = 40960  # single-block 1-launch cap
+MULTIBLOCK_CAP = 8_388_608  # 2-launch cap; above this -> aiter fallback (prefill)
+
+_SB_BLOCK = 16384  # single-block grid-stride chunk
+_NPART = 256  # amax-partial count == grid width (MI355X has 256 CUs)
+_MB_BLOCK = 4096  # multi-block grid-stride chunk
+
+
+@triton.jit
+def _fused_pt_quant_singleblock(
+    x_ptr,  # *bf16 [N] (flattened)
+    out_ptr,  # *fp8e4m3 [N]
+    scale_ptr,  # *f32 [1]
+    N,
+    BLOCK: tl.constexpr,
+):
+    # pass 1: global amax
+    amax = tl.zeros([BLOCK], dtype=tl.float32)
+    off = tl.arange(0, BLOCK)
+    i = 0
+    while i < N:
+        idx = i + off
+        mask = idx < N
+        v = tl.load(x_ptr + idx, mask=mask, other=0.0).to(tl.float32)
+        amax = tl.maximum(amax, tl.abs(v))
+        i += BLOCK
+    scale = tl.max(amax, axis=0) * _INV_FP8_MAX
+    tl.store(scale_ptr, scale)
+    inv_scale = 1.0 / scale
+
+    # pass 2: quantize
+    i = 0
+    while i < N:
+        idx = i + off
+        mask = idx < N
+        v = tl.load(x_ptr + idx, mask=mask, other=0.0).to(tl.float32)
+        q = v * inv_scale
+        q = tl.minimum(tl.maximum(q, -_FP8_MAX), _FP8_MAX)
+        tl.store(out_ptr + idx, q.to(tl.float8e4nv), mask=mask)
+        i += BLOCK
+
+
+@triton.jit
+def _amax_partial(x_ptr, partial_ptr, N, BLOCK: tl.constexpr):
+    # each block writes its own partial slot; max is order-independent -> byte-exact
+    pid = tl.program_id(0)
+    nprog = tl.num_programs(0)
+    off = tl.arange(0, BLOCK)
+    amax = tl.zeros([BLOCK], dtype=tl.float32)
+    i = pid * BLOCK
+    stride = nprog * BLOCK
+    while i < N:
+        idx = i + off
+        mask = idx < N
+        v = tl.load(x_ptr + idx, mask=mask, other=0.0).to(tl.float32)
+        amax = tl.maximum(amax, tl.abs(v))
+        i += stride
+    tl.store(partial_ptr + pid, tl.max(amax, axis=0))
+
+
+@triton.jit
+def _quant_from_partials(
+    x_ptr,
+    out_ptr,
+    scale_ptr,
+    partial_ptr,
+    N,
+    NPART: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    nprog = tl.num_programs(0)
+    # global amax from partials (order-independent max -> byte-exact)
+    poff = tl.arange(0, NPART)
+    amax = tl.max(tl.load(partial_ptr + poff), axis=0)
+    scale = amax * _INV_FP8_MAX
+    if pid == 0:
+        tl.store(scale_ptr, scale)
+    inv_scale = 1.0 / scale
+    off = tl.arange(0, BLOCK)
+    i = pid * BLOCK
+    stride = nprog * BLOCK
+    while i < N:
+        idx = i + off
+        mask = idx < N
+        v = tl.load(x_ptr + idx, mask=mask, other=0.0).to(tl.float32)
+        q = v * inv_scale
+        q = tl.minimum(tl.maximum(q, -_FP8_MAX), _FP8_MAX)
+        tl.store(out_ptr + idx, q.to(tl.float8e4nv), mask=mask)
+        i += stride
+
+
+def fused_per_tensor_dynamic_fp8_quant(
+    x: torch.Tensor,
+    out: torch.Tensor | None = None,
+    scale: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-tensor dynamic FP8-e4m3 quant; returns ``(x_fp8, scale[1])``.
+
+    Byte-identical to ``aiter.dynamic_per_tensor_quant`` for every dispatch path.
+    """
+    x = x.contiguous()
+    N = x.numel()
+    if out is None:
+        out = torch.empty(x.shape, dtype=torch.float8_e4m3fn, device=x.device)
+    if scale is None:
+        scale = torch.empty(1, dtype=torch.float32, device=x.device)
+
+    if N <= SINGLE_BLOCK_CAP:
+        _fused_pt_quant_singleblock[(1,)](x, out, scale, N, BLOCK=_SB_BLOCK)
+        return out, scale
+
+    if N <= MULTIBLOCK_CAP:
+        partials = torch.empty(_NPART, dtype=torch.float32, device=x.device)
+        _amax_partial[(_NPART,)](x, partials, N, BLOCK=_MB_BLOCK)
+        _quant_from_partials[(_NPART,)](
+            x, out, scale, partials, N, NPART=_NPART, BLOCK=_MB_BLOCK
+        )
+        return out, scale
+
+    # prefill: aiter fallback
+    import aiter
+
+    aiter.dynamic_per_tensor_quant(out, x, scale)
+    return out, scale


### PR DESCRIPTION
## Summary

vLLM's per-tensor **dynamic** FP8 activation quant on the ROCm aiter path
(`_rocm_aiter_per_tensor_quant_impl` → `aiter.dynamic_per_tensor_quant`) issues a
**3-kernel triplet** per quantized linear input: `initializeScale` →
`data_to_scale_kernel` → `scaled_quant_kernel`. At decode batch sizes this is
**launch / CUDA-graph-node bound**, not bandwidth bound (≈160 such ops per decode
step for a 40-layer model × 4 GEMM inputs).

This PR adds a Triton kernel that fuses the triplet into a **single launch** and
routes to it for the dynamic FP8-e4m3 case, behind an opt-in env var.

- `N ≤ 40960` → 1 launch (single-block grid-stride amax+quantize) — decode conc ≤ 8 hot path
- `N ≤ 8M` → 2 launches (multi-CU partial-amax → quantize) — decode conc ≥ 16
- otherwise (prefill) → aiter triplet (quant is negligible there)

**Byte-identical** to the aiter triplet (the scale is computed as
`amax * (1/448)` reciprocal-multiply to match aiter's compiler-folded constant
bit-for-bit; `max` reduction is order-independent so the 2-launch path is exact
too). Gated strictly on `torch.float8_e4m3fn`, so MI300 (e4m3**fnuz**) falls
through unchanged.

## Gating

New opt-in env var **`VLLM_ROCM_USE_AITER_FUSED_PER_TENSOR_QUANT`** (default
`False`). Inert unless set → zero behavior change for existing deployments.

## Results

Mistral-Small-3.1-24B FP8, MI355X (gfx950), TP=1, CUDA-graph decode,
ISL=2000/OSL=500:

- **~8% geomean interactivity uplift across concurrency 1–128**; per-conc
  inter-token-latency **−11% @conc1 → −3% @conc128**.
- **GSM8K 0.895 (unchanged)** vs the aiter triplet — accuracy-neutral.
- Byte-exactness verified across the decode shapes (M ∈ {1,8,16,64,128},
  K ∈ {5120,4096,32768}): 0 byte mismatches vs `aiter.dynamic_per_tensor_quant`.

## Not a duplicate

The related open ROCm quant PRs fuse quant **into another op** — #42864
(AR+RMSNorm+per-group quant), #42832 (RoPE+static-Q quant), #32419
(RMSNorm+per_tensor quant). This PR instead optimizes the **standalone
per-tensor-dynamic quant** that fires for *all four* decode GEMM inputs
(including the silu/non-RMSNorm-fed ones the fusion PRs don't cover), and is
complementary to them.

## Testing

- [x] Byte-exactness + microbench vs `aiter.dynamic_per_tensor_quant` (standalone, gfx950)
- [x] E2E perf + GSM8K on Mistral-Small-24B (numbers above) — captured on the
      validated downstream image (vLLM v0.20.2); kernel logic in this PR is identical
- [ ] **TODO (submitter):** rebuild + re-validate E2E/GSM8K on *this* branch
- [ ] **TODO (submitter):** `pre-commit run --all-files`
- [ ] **TODO (submitter):** relevant unit tests

## Note

AI assistance (Claude) was used to author this change; the human submitter is
reviewing every line and will complete the validation checklist above before
marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
