### PR TITLE
[Bugfix] Fix integer overflow in libtorch_stable/activation_kernels.cu pointer arithmetic

### DIFF
--- a/csrc/libtorch_stable/activation_kernels.cu
+++ b/csrc/libtorch_stable/activation_kernels.cu
@@ -79,9 +79,11 @@ __global__ void act_and_mul_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., 2, d]
     const int d, const float limit) {
-  const scalar_t* x_ptr = input + blockIdx.x * 2 * d;
+  // Promote blockIdx.x to int64_t before multiplying by 2 * d (#42860).
+  const int64_t token_idx = blockIdx.x;
+  const scalar_t* x_ptr = input + token_idx * 2 * d;
   const scalar_t* y_ptr = x_ptr + d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  scalar_t* out_ptr = out + token_idx * d;
 
   if constexpr (use_vec) {
     using cuda_t = typename CUDATypeConverter<scalar_t>::Type;
@@ -317,9 +319,10 @@ template <typename scalar_t, typename packed_t,
 __global__ void act_and_mul_kernel_with_param(
     scalar_t* __restrict__ out, const scalar_t* __restrict__ input, const int d,
     const float param) {
-  const scalar_t* x_ptr = input + blockIdx.x * 2 * d;
+  const int64_t token_idx = blockIdx.x;
+  const scalar_t* x_ptr = input + token_idx * 2 * d;
   const scalar_t* y_ptr = x_ptr + d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  scalar_t* out_ptr = out + token_idx * d;
 
   if constexpr (use_vec) {
     using cuda_t = typename CUDATypeConverter<scalar_t>::Type;
@@ -526,8 +529,9 @@ __global__ void activation_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., d]
     const int d) {
-  const scalar_t* in_ptr = input + blockIdx.x * d;
-  scalar_t* out_ptr = out + blockIdx.x * d;
+  const int64_t token_idx = blockIdx.x;
+  const scalar_t* in_ptr = input + token_idx * d;
+  scalar_t* out_ptr = out + token_idx * d;
 
   if constexpr (use_vec) {
     // Fast path: 128-bit/256-bit vectorized loop


### PR DESCRIPTION
# What does this PR do?

`act_and_mul_kernel`, `act_and_mul_kernel_with_param`, and `activation_kernel` in `csrc/libtorch_stable/activation_kernels.cu` compute pointer offsets via `blockIdx.x * d` (or `* 2 * d`) where `blockIdx.x` is `unsigned int` and `d` is `int`, so the product is evaluated in 32-bit and overflows once it exceeds INT_MAX. For large hidden sizes this corrupts the pointer arithmetic and reads/writes the wrong memory.

Lift `const int64_t token_idx = blockIdx.x;` near the top of each affected kernel and substitute into the buggy multiplications. Matches the existing `swigluoai_and_mul_kernel` pattern in the same file. One-line comment at the first site; subsequent sites use the same pattern without restating.

Replaces #42861 (against the pre-migration `csrc/activation_kernels.cu`) which was opened before #42663 moved the kernels into `csrc/libtorch_stable/`. Substantive fix is unchanged. Diff lands at the new path with @mgoin's "one line at most" comment-trim ask pre-applied.

Closes #42860

## Test Plan

- [ ] Build + activation tests via CI.

## Duplicate-work check

`gh pr list --repo vllm-project/vllm --state open --search "libtorch_stable activation_kernels"` returns nothing else for #42860. Pre-migration sibling #42861 is being closed in favor of this PR.

## AI Assistance Disclosure

Drafted with Claude assistance. I am the human contributor accountable for this PR; I read every changed line and verified the int64_t promotion matches the existing `swigluoai_and_mul_kernel` precedent in the same file.
