### PR TITLE
[Bugfix] Fix integer overflow in libtorch_stable/layernorm_kernels.cu pointer arithmetic

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -67,7 +67,9 @@ __global__ void rms_norm_kernel(
   }
   __syncthreads();
 
-  scalar_t* out_row = out + blockIdx.x * hidden_size;
+  // Promote blockIdx.x to int64_t before multiplying by hidden_size (#42862).
+  const int64_t token_idx = blockIdx.x;
+  scalar_t* out_row = out + token_idx * hidden_size;
   auto* v_in = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(input_row);
   auto* v_w = reinterpret_cast<const vec_n_t<scalar_t, VEC_SIZE>*>(weight);
   auto* v_out = reinterpret_cast<vec_n_t<scalar_t, VEC_SIZE>*>(out_row);
@@ -115,9 +117,10 @@ fused_add_rms_norm_kernel(
   auto* __restrict__ weight_v =
       reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
+  const int64_t token_idx = blockIdx.x;
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    int64_t id = token_idx * vec_hidden_size + idx;
+    int64_t strided_id = token_idx * vec_input_stride + idx;
     _f16Vec<scalar_t, width> temp = input_v[strided_id];
     temp += residual_v[id];
     variance += temp.sum_squares();
@@ -134,8 +137,8 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    int64_t id = token_idx * vec_hidden_size + idx;
+    int64_t strided_id = token_idx * vec_input_stride + idx;
     _f16Vec<scalar_t, width> res = residual_v[id];
     _f16Vec<scalar_t, width> w = weight_v[idx];
     _f16Vec<scalar_t, width> out;
@@ -164,12 +167,13 @@ fused_add_rms_norm_kernel(
   __shared__ float s_variance;
   float variance = 0.0f;
 
+  const int64_t token_idx = blockIdx.x;
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * hidden_size + idx];
+    scalar_t z = input[token_idx * input_stride + idx];
+    z += residual[token_idx * hidden_size + idx];
     float x = (float)z;
     variance += x * x;
-    residual[blockIdx.x * hidden_size + idx] = z;
+    residual[token_idx * hidden_size + idx] = z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -182,9 +186,9 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * hidden_size + idx];
+    float x = (float)residual[token_idx * hidden_size + idx];
     float w = (float)weight[idx];
-    input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
+    input[token_idx * input_stride + idx] = (scalar_t)(x * s_variance * w);
   }
 }
 


### PR DESCRIPTION
# What does this PR do?

`rms_norm_kernel` and both `fused_add_rms_norm_kernel` specializations in `csrc/libtorch_stable/layernorm_kernels.cu` compute pointer offsets via `blockIdx.x * hidden_size` (or `vec_hidden_size` / `input_stride`) where `blockIdx.x` is `unsigned int` and `hidden_size` is `int`, so the product is evaluated in 32-bit and overflows once it exceeds INT_MAX.

Reporter's failing case in #42862: model `royokong/e5-v`, `hidden_size=4096`, `seq_len=8129`, `batch_size=129`. Flat token dimension is `1048641`, and `blockIdx.x * hidden_size = 1048641 * 4096 = 4.29 billion`, crossing the 32-bit boundary at row ~524288.

Lift `const int64_t token_idx = blockIdx.x;` near the top of each affected kernel and substitute into the buggy multiplications. The `int id` local in the vec specialization is also widened to `int64_t` so it can index the same large flat arrays without truncation. Matches the sibling fix in #44026 and the existing `swigluoai_and_mul_kernel` pattern.

Sites left unchanged because `input_stride_d2` / `vec_input_stride` / `input_stride` are already `int64_t`, which promotes the multiply: `rms_norm_kernel` line 30, vec lines 120/138, generic line 167/186. The blockIdx.x division/modulo at lines 33-40 has no multiply, no overflow concern.

Replaces #42863 (against the pre-migration `csrc/layernorm_kernels.cu`) which was opened before #43209 moved the kernels into `csrc/libtorch_stable/`. Substantive fix is unchanged. Diff lands at the new path with @mgoin's "one line at most" comment-trim ask pre-applied.

Reported by @molly-ting.

Closes #42862

## Test Plan

- [ ] Build + relevant layernorm tests via CI.

## Duplicate-work check

`gh pr list --repo vllm-project/vllm --state open --search "libtorch_stable layernorm_kernels"` returns nothing else for #42862. Pre-migration sibling #42863 is being closed in favor of this PR.

## AI Assistance Disclosure

Drafted with Claude assistance. I am the human contributor accountable for this PR; I read every changed line, traced which `blockIdx.x * <stride>` sites were already int64_t-safe (and so left unchanged), and verified the int64_t promotion matches the existing `swigluoai_and_mul_kernel` precedent.
