### PR TITLE
[Bugfix] DeepSeek V4: skip expert tensor when no mapping succeeds (AMD + NVIDIA)

### DIFF
--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -822,6 +822,7 @@ class DeepseekV4Model(nn.Module):
                         and loaded_weight.dtype == torch.float8_e8m0fnu
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
+                    success = False
                     for mapping in expert_mapping:
                         param_name, weight_name, expert_id, expert_shard_id = mapping
                         if weight_name not in name:
@@ -847,6 +848,9 @@ class DeepseekV4Model(nn.Module):
                         if success:
                             name = name_mapped
                             break
+                    if not success:
+                        # Skip when no mapping bound name_mapped (#42769).
+                        continue
                     loaded_params.add(name_mapped)
                     continue
                 elif "attn_sink" in name:

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1154,6 +1154,7 @@ class DeepseekV4Model(nn.Module):
                         and loaded_weight.dtype == torch.float8_e8m0fnu
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
+                    success = False
                     for mapping in expert_mapping:
                         param_name, weight_name, expert_id, expert_shard_id = mapping
                         if weight_name not in name:
@@ -1179,6 +1180,9 @@ class DeepseekV4Model(nn.Module):
                         if success:
                             name = name_mapped
                             break
+                    if not success:
+                        # Skip when no mapping bound name_mapped (#42769).
+                        continue
                     loaded_params.add(name_mapped)
                     continue
                 elif "attn_sink" in name:


### PR DESCRIPTION
# What does this PR do?

`DeepseekV4Model.load_weights` in both `vllm/models/deepseek_v4/nvidia/model.py` and `vllm/models/deepseek_v4/amd/model.py` walks `expert_mapping` and assigns `name_mapped` inside the loop. When no entry matches (e.g. a quantization-specific layout like `.tq_packed` outside the standard gate_proj / up_proj / down_proj set), the loop falls through without binding `name_mapped`, and `loaded_params.add(name_mapped)` raises `UnboundLocalError`.

Track a `success = False` flag initialized before the loop and skip the add when no mapping succeeded. This also covers the silent-failure paths where a mapping does match but `is_pp_missing_parameter` or `weight_loader` returns False; those were previously appending a stale `name_mapped` from a different iteration. Shape matches the sibling `deepseek_v4_mtp.py` expert-loading path, which adds to `loaded_params` only inside the `if success:` branch.

After #43004 ([Model Refactoring] Migrate DeepSeek V4 to `vllm/models/` [1/N]) the single `vllm/model_executor/models/deepseek_v4.py` file split into per-backend forks under `vllm/models/deepseek_v4/{amd,nvidia}/model.py`, and both forks carry the same buggy expert-loading block. The same fix is applied to both.

Replaces #42804 (against the pre-migration `vllm/model_executor/models/deepseek_v4.py`).

Closes #42769

## Test Plan

- [ ] Existing DeepSeek V4 load_weights coverage via CI.

## Duplicate-work check

`gh pr list --repo vllm-project/vllm --state open --search "deepseek_v4 expert mapping name_mapped"` returns nothing else for #42769. Pre-migration sibling #42804 is being closed in favor of this PR.

## AI Assistance Disclosure

Drafted with Claude assistance. I am the human contributor accountable for this PR; I read every changed line, confirmed the AMD and NVIDIA forks carry byte-identical buggy blocks in the relevant region, and verified the `if success:` pattern matches the precedent in `deepseek_v4_mtp.py`.
