### PR TITLE
[Bugfix] DeepSeek V4: support transformers >= 4.57 normalized compress_ratios (AMD + NVIDIA)

### DIFF
--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -258,7 +258,19 @@ class DeepseekV4Attention(nn.Module):
         # we do this for because MTP layer is not included
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
-            self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            if hasattr(config, "compress_ratios"):
+                raw = config.compress_ratios[layer_id]
+            else:
+                # transformers >= 4.57 normalizes compress_ratios into
+                # layer_types + compress_rates (#42741).
+                rates = getattr(config, "compress_rates", None) or {}
+                layer_types = getattr(config, "layer_types", None) or []
+                raw = (
+                    rates.get(layer_types[layer_id], 0)
+                    if layer_id < len(layer_types)
+                    else 0
+                )
+            self.compress_ratio = max(1, raw)
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -641,7 +641,19 @@ class DeepseekV4Attention(nn.Module):
         # we do this for because MTP layer is not included
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
-            self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            if hasattr(config, "compress_ratios"):
+                raw = config.compress_ratios[layer_id]
+            else:
+                # transformers >= 4.57 normalizes compress_ratios into
+                # layer_types + compress_rates (#42741).
+                rates = getattr(config, "compress_rates", None) or {}
+                layer_types = getattr(config, "layer_types", None) or []
+                raw = (
+                    rates.get(layer_types[layer_id], 0)
+                    if layer_id < len(layer_types)
+                    else 0
+                )
+            self.compress_ratio = max(1, raw)
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps


### PR DESCRIPTION
# What does this PR do?

`DeepseekV4Attention.__init__` in both `vllm/models/deepseek_v4/nvidia/model.py` and `vllm/models/deepseek_v4/amd/model.py` reads `config.compress_ratios[layer_id]` directly. transformers >= 4.57 normalizes the same JSON field on `DeepseekV4Config.__init__` into `layer_types` (list[str]) + `compress_rates` (dict[str, int]) and stops exposing `compress_ratios`, so every DSV4 model fails to load with:

```
AttributeError: 'DeepseekV4Config' object has no attribute 'compress_ratios'. Did you mean: 'compress_rates'?
```

Read from the normalized fields when `compress_ratios` is absent. The per-layer ratio is reconstructed via the documented 1-to-1 mapping `compress_ratios[i] == compress_rates.get(layer_types[i], 0)`, and the existing `max(1, ...)` clamp keeps the downstream invariant (compress ratio is never 0) intact. Legacy configs with `compress_ratios` keep the original code path, so anyone pinning a pre-4.57 transformers stack sees no behavior change.

After #43004 ([Model Refactoring] Migrate DeepSeek V4 to `vllm/models/`) the single `vllm/model_executor/models/deepseek_v4.py` file split into per-backend forks under `vllm/models/deepseek_v4/{amd,nvidia}/model.py`, and both forks carry the same buggy direct attribute access. The same fix is applied to both.

Replaces #42806 (against the pre-migration `vllm/model_executor/models/deepseek_v4.py`).

Closes #42741

## Test Plan

- [ ] DeepSeek V4 model load with transformers >= 4.57 (where `compress_ratios` is absent) via CI.
- [ ] DeepSeek V4 model load with transformers < 4.57 (legacy `compress_ratios` path) via CI.

## Duplicate-work check

`gh pr list --repo vllm-project/vllm --state open --search "deepseek_v4 compress_ratios transformers"` returns nothing else for #42741. Pre-migration sibling #42806 is being closed in favor of this PR.

## AI Assistance Disclosure

Drafted with Claude assistance. I am the human contributor accountable for this PR; I read every changed line, confirmed the AMD and NVIDIA forks carry byte-identical direct `config.compress_ratios[layer_id]` accesses in `DeepseekV4Attention.__init__`, and verified the normalized-field reconstruction against the documented 1-to-1 mapping.
