### PR TITLE
[Bugfix] Fix merge error from #42647

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -94,7 +94,6 @@ def _get_priority_backends(
         WNA16MoEBackend.MARLIN,
         WNA16MoEBackend.BATCHED_MARLIN,
     ]
-    return _AVAILABLE_BACKENDS
 
     if not may_have_bias:
         _AVAILABLE_BACKENDS.append(WNA16MoEBackend.TRITON)
@@ -921,17 +920,6 @@ def convert_to_wna16_moe_kernel_format(
             w2_qzeros,
             None,
             None,
-            w13_bias,
-            w2_bias,
-        )
-    elif backend == WNA16MoEBackend.FLASHINFER_TRTLLM:
-        return _process_weights_flashinfer(
-            w13,
-            w2,
-            w13_scale,
-            w2_scale,
-            w13_g_idx,
-            w2_g_idx,
             w13_bias,
             w2_bias,
         )


### PR DESCRIPTION

## Purpose

Some of the code in `int_wna16.py` got merged incorrectly in #42647 leading to an early exit from backend selection and a redundant if statement in weight conversion.  The early exit in backend selection could potentially cause previously running models to fail due to the other backends not being supported.

Also fixes broken `quantization` import when `humming` module is not installed. This was broken prior to #42647 

## Test Plan

tests/compile/h100/test_startup.py::test_model_startup[kimi_k2.5]
tests/evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[Qwen1.5-MoE-W4A16-CT] --config-list-file=configs/models-small.txt

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

