### PR TITLE
[Model][DSV4] Add MixtureOfExperts protocol support for EPLB

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -8,13 +8,14 @@ import regex as re
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.logger import init_logger
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
     mhc_fused_post_pre_tilelang,
@@ -41,7 +42,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.interfaces import MixtureOfExperts, SupportsPP
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -59,6 +60,8 @@ from vllm.models.deepseek_v4.attention import (
 )
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
 from vllm.sequence import IntermediateTensors
+
+logger = init_logger(__name__)
 
 
 class DeepseekV4MLP(nn.Module):
@@ -480,6 +483,15 @@ class DeepseekV4MoE(nn.Module):
                 prefix=f"{prefix}.shared_experts",
             )
 
+        # EPLB metadata.
+        self.n_shared_experts = config.n_shared_experts or 0
+        vllm_cfg = get_current_vllm_config()
+        eplb_config = vllm_cfg.parallel_config.eplb_config
+        self.enable_eplb = vllm_cfg.parallel_config.enable_eplb
+        self.n_redundant_experts = eplb_config.num_redundant_experts
+        self.n_logical_experts = self.n_routed_experts
+        self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
+
         if self.use_mega_moe:
             self._init_mega_moe_experts(vllm_config, config, prefix)
         else:
@@ -523,6 +535,11 @@ class DeepseekV4MoE(nn.Module):
         self.n_local_experts = config.n_routed_experts // self.tp_size
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
+        self.n_local_physical_experts = self.n_physical_experts // self.tp_size
+        self.physical_expert_start = self.tp_rank * self.n_local_physical_experts
+        self.physical_expert_end = (
+            self.physical_expert_start + self.n_local_physical_experts
+        )
 
         self.experts = FusedMoE(
             shared_experts=self.shared_experts,
@@ -540,6 +557,8 @@ class DeepseekV4MoE(nn.Module):
             hash_indices_table=self.gate.tid2eid,
             swiglu_limit=self.swiglu_limit,
             router_logits_dtype=torch.float32,
+            enable_eplb=self.enable_eplb,
+            num_redundant_experts=self.n_redundant_experts,
         )
 
     def forward(
@@ -1259,7 +1278,46 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
     )
 
 
-class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
+class DeepseekV4MixtureOfExperts(MixtureOfExperts):
+    moe_mlp_layers: list[DeepseekV4MoE]
+
+    def extract_moe_parameters(self, example_moe: DeepseekV4MoE | None):
+        if example_moe is None:
+            self.num_moe_layers = 0
+            self.num_expert_groups = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_shared_experts = 0
+            self.num_redundant_experts = 0
+            logger.warning("DeepSeekV4: No DeepseekV4MoE layer found in model.layers.")
+        else:
+            self.num_logical_experts = example_moe.n_logical_experts
+            self.num_physical_experts = example_moe.n_physical_experts
+            self.num_local_physical_experts = example_moe.n_local_physical_experts
+            self.num_routed_experts = example_moe.n_routed_experts
+            self.num_shared_experts = example_moe.n_shared_experts
+            self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_physical_experts = num_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            if hasattr(moe, "experts") and hasattr(moe.experts, "update_expert_map"):
+                moe.experts.update_expert_map()
+
+
+class DeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV4MixtureOfExperts):
     model_cls = DeepseekV4Model
 
     # Default mapper assumes the original FP4-expert checkpoint layout.
@@ -1290,6 +1348,27 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
         self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.model.make_empty_intermediate_tensors
         )
+        self.num_moe_layers = config.num_hidden_layers
+        self.set_moe_parameters()
+
+    def set_moe_parameters(self):
+        self.expert_weights = []
+        self.num_expert_groups = 1
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            assert isinstance(layer, DeepseekV4DecoderLayer)
+            if isinstance(layer.ffn, DeepseekV4MoE):
+                example_moe = layer.ffn
+                self.moe_mlp_layers.append(layer.ffn)
+                # Only FusedMoE-backed layers support EPLB;
+                # MegaMoE manages expert parallelism separately.
+                if isinstance(layer.ffn.experts, FusedMoE):
+                    self.moe_layers.append(layer.ffn.experts)
+        self.extract_moe_parameters(example_moe)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)


### PR DESCRIPTION
## Summary

Implement the `MixtureOfExperts` protocol for `DeepseekV4ForCausalLM` to enable Expert-Parallel Load Balancing (EPLB) support.

## Changes

1. **EPLB metadata fields in `DeepseekV4MoE.__init__`**: Added `n_shared_experts`, `enable_eplb`, `n_redundant_experts`, `n_logical_experts`, `n_physical_experts`, `n_local_physical_experts`, `physical_expert_start/end` — consistent with the pattern used in DeepseekV2, Glm4MoE, and Ernie4.5.

2. **FusedMoE constructor**: Pass `enable_eplb` and `num_redundant_experts` to the `FusedMoE` constructor in the non-MegaMoE path.

3. **`DeepseekV4MixtureOfExperts` mixin class**: New class inheriting from `MixtureOfExperts` protocol, implementing:
   - `extract_moe_parameters()` — extracts MoE metadata from an example layer
   - `update_physical_experts_metadata()` — updates expert counts and propagates to all MoE layers

4. **`DeepseekV4ForCausalLM`**: Now inherits from `DeepseekV4MixtureOfExperts` and calls `set_moe_parameters()` in `__init__` to populate `moe_layers`, `moe_mlp_layers`, and MoE metadata.

## Design Decisions

- Only `FusedMoE`-backed layers are added to `moe_layers` (the list consumed by the EPLB controller). `DeepseekV4MegaMoEExperts` layers are excluded because MegaMoE manages expert parallelism through its own mechanism and does not expose the `get_expert_weights()`/`set_eplb_state()` interface.
- All MoE layers (both FusedMoE and MegaMoE) are tracked in `moe_mlp_layers` for `update_physical_experts_metadata()`.

## Testing

- Verified Python syntax validity
- Verified ruff lint and format checks pass
