### PR TITLE
[Bugfix] Fix benchmark_moe.py after inplace mechanism removal

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -271,7 +271,6 @@ def benchmark_config(
                     moe_config=moe_config,
                     quant_config=quant_config,
                 ),
-                inplace=not disable_inplace(),
             )
 
         with override_config(config):
@@ -279,7 +278,6 @@ def benchmark_config(
                 x, input_gating, topk, renormalize=not use_deep_gemm
             )
 
-            inplace = not disable_inplace()
             if use_deep_gemm:
                 return deep_gemm_experts.apply(
                     x,
@@ -298,7 +296,6 @@ def benchmark_config(
                 w2,
                 topk_weights,
                 topk_ids,
-                inplace=inplace,
                 quant_config=quant_config,
             )
 


### PR DESCRIPTION
## Purpose

PR #43727 ([MoE] Remove inplace fused experts mechanism) removed
`disable_inplace()` from `vllm/model_executor/layers/fused_moe/utils.py`
and dropped the `inplace` parameter from both `fused_experts()` and
`FusedMoEKernel.__init__()`. However, `benchmarks/kernels/benchmark_moe.py`
was not updated, so running the benchmark on current `main` crashes with:

```
NameError: name 'disable_inplace' is not defined
  File "benchmarks/kernels/benchmark_moe.py", line 282, in run
    inplace = not disable_inplace()
                  ^^^^^^^^^^^^^^^
```

This PR removes the three stale references:
- Line 274: `inplace=not disable_inplace(),` in `FusedMoEKernel(...)` constructor
- Line 282: the local `inplace = not disable_inplace()` assignment
- Line 301: `inplace=inplace,` in the `fused_experts(...)` call

After the fix, `benchmark_moe.py` runs both with and without `--tune`.

## Test Plan

Tested on a single NVIDIA H100 80GB HBM3, vLLM main at commit
7b98f498c (precompiled cu128 + torch 2.11.0+cu128, triton 3.6.0)

```bash
.venv/bin/python benchmarks/kernels/benchmark_moe.py \
    --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
    -tp 4 --dtype fp8_w8a8 \
    --batch-size 1 4 16 64 256 1024
```

## Test Result

Before this PR: crashes immediately with `NameError`.

After this PR: completes successfully, producing per-batch-size kernel times,
e.g.:
```
Batch size: 1,   Kernel time: 29.26 us
Batch size: 4,   Kernel time: 36.38 us
Batch size: 16,  Kernel time: 78.58 us
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
