### PR TITLE
Revert "[Bugfix][CPU] Remove invalid extra deps" (#43977)

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -165,23 +165,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/vllm-workspace/.deps,sharing=locked \
     VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
 
-######################### TRITON-CPU BUILD IMAGE #########################
-FROM base AS vllm-triton-cpu-build
-
-WORKDIR /vllm-workspace
-
-RUN mkdir dist
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cache/ccache \
-    --mount=type=cache,target=/vllm-workspace/.deps,sharing=locked \
-    if [ "$TARGETARCH" = "amd64" ] || [ "$VLLM_CPU_X86" != "0" ]; then \
-        git clone --recurse-submodules "https://github.com/triton-lang/triton-cpu.git"; \
-        cd triton-cpu; \
-        git checkout "270e696d"; \
-        uv build --wheel --out-dir=../dist; \
-    fi
-
 ######################### TEST DEPS #########################
 FROM base AS vllm-test-deps
 
@@ -274,14 +257,7 @@ WORKDIR /vllm-workspace
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=bind,from=vllm-build,src=/vllm-workspace/dist,target=dist \
-    uv pip install "$(realpath dist/*.whl)[audio]"
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cache/ccache \
-    --mount=type=bind,from=vllm-triton-cpu-build,src=/vllm-workspace/dist,target=dist \
-    if [ "$TARGETARCH" = "amd64" ] || [ "$VLLM_CPU_X86" != "0" ]; then \
-        uv pip install "$(realpath dist/*.whl)"; \
-    fi
+    uv pip install "$(realpath dist/*.whl)[audio,triton-cpu]"
 
 # Add labels to document build configuration
 LABEL org.opencontainers.image.title="vLLM CPU"

--- a/setup.py
+++ b/setup.py
@@ -1195,6 +1195,11 @@ setup(
             "opentelemetry-exporter-otlp>=1.26.0",
             "opentelemetry-semantic-conventions-ai>=0.4.1",
         ],
+        "triton-cpu": [
+            "triton @ "
+            "git+https://github.com/triton-lang/triton-cpu.git@270e696d ; "
+            "platform_machine == 'x86_64'",
+        ],  # Remove after stable release
     },
     cmdclass=cmdclass,
     package_data=package_data,


### PR DESCRIPTION
## Revert of #43977

This reverts commit 3f6f508e14b7c5325b74cf1ab541c9330611b9a2.

**Reason:** This PR changed `docker/Dockerfile.cpu` and `setup.py`, which triggered a full Rust rebuild during CPU Docker image creation. The rebuild exposed a pre-existing compilation error: `no method named vllm_version found for reference &vllm_engine_core_client::EngineCoreClient` in `rust/src/server/src/routes/version.rs` (introduced by PR #43854).

**Impact:** 2 CPU test suites failed in nightly build #68973:
- CPU-Multi-Modal Model Tests 3
- CPU-Quantization Model Tests

**Note:** The root cause is a missing `vllm_version()` method on `EngineCoreClient` (from PR #43854), but reverting this PR restores the cached Docker layer that avoids the Rust rebuild. A proper fix should add the missing method to the Rust client before re-landing this change.

---
*Auto-generated by CI failure analyzer*