### PR TITLE
[Frontend] Hoist role="system" messages into top-level system for Anthropic /v1/messages

### DIFF
--- a/tests/entrypoints/anthropic/test_system_hoist.py
+++ b/tests/entrypoints/anthropic/test_system_hoist.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for hoisting ``role="system"`` messages into ``system``.
+
+Anthropic's spec keeps the system prompt in the top-level ``system`` field and
+only allows ``user``/``assistant`` roles inside ``messages[]``. Some clients
+(notably Claude Code) instead emit the system prompt as a ``role="system"``
+entry inside ``messages[]``. ``AnthropicMessagesRequest.hoist_system_messages``
+is a lenient-compat ``model_validator(mode="before")`` that pulls such entries
+out into the top-level ``system`` field before per-message validation runs.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
+
+_convert = AnthropicServingMessages._convert_anthropic_to_openai_request
+
+
+def _make_request(messages: list[dict], **kwargs) -> AnthropicMessagesRequest:
+    return AnthropicMessagesRequest(
+        model="test-model",
+        max_tokens=128,
+        messages=messages,
+        **kwargs,
+    )
+
+
+def _system_texts(request: AnthropicMessagesRequest) -> list[tuple[str, str]]:
+    """Flatten the (parsed) ``system`` field to ``(type, text)`` pairs."""
+    assert not isinstance(request.system, str)
+    return [(block.type, block.text) for block in request.system]
+
+
+class TestHoistSystemMessages:
+    def test_string_system_message_is_hoisted(self):
+        """A role="system" entry with string content moves to ``system``."""
+        request = _make_request(
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+        assert _system_texts(request) == [("text", "You are helpful.")]
+        assert [m.role for m in request.messages] == ["user"]
+
+    def test_block_list_system_message_is_hoisted(self):
+        """A role="system" entry with content blocks is preserved as blocks."""
+        request = _make_request(
+            [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Be terse."}],
+                },
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+        assert _system_texts(request) == [("text", "Be terse.")]
+        assert len(request.messages) == 1
+
+    def test_existing_top_level_system_is_kept_first(self):
+        """Pre-existing top-level system stays ahead of hoisted entries."""
+        request = _make_request(
+            [
+                {"role": "system", "content": "From messages."},
+                {"role": "user", "content": "Hi"},
+            ],
+            system="From top level.",
+        )
+        assert _system_texts(request) == [
+            ("text", "From top level."),
+            ("text", "From messages."),
+        ]
+
+    def test_multiple_system_messages_preserve_order(self):
+        request = _make_request(
+            [
+                {"role": "system", "content": "First."},
+                {"role": "user", "content": "Hi"},
+                {"role": "system", "content": "Second."},
+                {"role": "assistant", "content": "Hello"},
+            ]
+        )
+        assert _system_texts(request) == [
+            ("text", "First."),
+            ("text", "Second."),
+        ]
+        assert [m.role for m in request.messages] == ["user", "assistant"]
+
+    def test_no_system_message_leaves_request_unchanged(self):
+        request = _make_request(
+            [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Hello"},
+            ]
+        )
+        assert request.system is None
+        assert [m.role for m in request.messages] == ["user", "assistant"]
+
+    def test_spec_compliant_top_level_system_untouched(self):
+        """Requests that already follow the spec are not modified."""
+        request = _make_request(
+            [{"role": "user", "content": "Hi"}],
+            system="You are helpful.",
+        )
+        assert request.system == "You are helpful."
+        assert len(request.messages) == 1
+
+    def test_invalid_role_still_rejected(self):
+        """Non-system invalid roles must still fail validation."""
+        with pytest.raises(ValidationError):
+            _make_request([{"role": "tool", "content": "x"}])
+
+    def test_hoisted_system_flows_through_conversion(self):
+        """End-to-end: a hoisted system message becomes an OpenAI system msg."""
+        request = _make_request(
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+        result = _convert(request)
+        assert result.messages[0] == {
+            "role": "system",
+            "content": "You are helpful.",
+        }
+        assert result.messages[1]["role"] == "user"

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -114,6 +114,37 @@ class AnthropicOutputConfig(BaseModel):
     format: AnthropicJsonOutputFormat | None = None
 
 
+def _normalize_system_blocks(content: Any) -> list[dict[str, Any]]:
+    """Normalize Anthropic system content to a list of text content blocks.
+
+    Accepts the shapes a system prompt may take — ``None``, a plain string, a
+    list of content blocks (dicts or already-parsed objects), or a stray
+    object — and returns a list of ``{"type": "text", "text": ...}`` blocks.
+    Non-text blocks are passed through unchanged so downstream consumers can
+    still inspect them. Used by ``AnthropicMessagesRequest.hoist_system_messages``
+    to merge hoisted ``role="system"`` entries with any existing top-level
+    ``system`` field.
+    """
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if isinstance(content, list):
+        blocks: list[dict[str, Any]] = []
+        for block in content:
+            if isinstance(block, str):
+                if block:
+                    blocks.append({"type": "text", "text": block})
+            elif isinstance(block, dict):
+                blocks.append(block)
+            else:
+                # Already-parsed block model (e.g. AnthropicContentBlock).
+                dump = getattr(block, "model_dump", None)
+                blocks.append(dump(exclude_none=True) if dump else block)
+        return blocks
+    return [{"type": "text", "text": str(content)}]
+
+
 class AnthropicMessagesRequest(BaseModel):
     """Anthropic Messages API request"""
 
@@ -143,6 +174,50 @@ class AnthropicMessagesRequest(BaseModel):
             "Will be accessible by the template."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def hoist_system_messages(cls, data: Any) -> Any:
+        """Hoist ``role="system"`` entries from ``messages[]`` into ``system``.
+
+        Anthropic's spec only allows ``user``/``assistant`` roles inside
+        ``messages[]`` and carries the system prompt in the top-level ``system``
+        field. However, Claude Code (and some other clients) emit the system
+        prompt as a ``role="system"`` entry *inside* ``messages[]``, which the
+        strict per-message ``Literal["user", "assistant"]`` validator rejects
+        with HTTP 400. Be lenient: pull any such entries out and prepend them to
+        the top-level ``system`` field before per-message validation runs.
+
+        Order is preserved and any pre-existing top-level ``system`` content is
+        kept ahead of the hoisted entries. Content is normalized to a list of
+        content blocks so downstream handling (e.g. billing-header stripping in
+        the serving layer) still applies. Returns ``data`` unchanged when there
+        is nothing to hoist or the shape is unexpected, so it is safe to run
+        unconditionally.
+        """
+        if not isinstance(data, dict):
+            return data
+        messages = data.get("messages")
+        if not isinstance(messages, list):
+            return data
+
+        hoisted: list[dict[str, Any]] = []
+        kept: list[Any] = []
+        for message in messages:
+            if isinstance(message, dict) and message.get("role") == "system":
+                hoisted.extend(_normalize_system_blocks(message.get("content")))
+            else:
+                kept.append(message)
+
+        if not hoisted:
+            return data
+
+        blocks = _normalize_system_blocks(data.get("system")) + hoisted
+
+        patched = dict(data)
+        patched["messages"] = kept
+        patched["system"] = blocks
+        return patched
 
     @field_validator("model")
     @classmethod


### PR DESCRIPTION
## Purpose

The Anthropic Messages spec keeps the system prompt in the top-level `system`
field and only allows `user`/`assistant` roles inside `messages[]`. However,
**Claude Code** (and some other Anthropic-compatible clients) emit the system
prompt as a `role="system"` entry *inside* `messages[]`. vLLM's native
`/v1/messages` endpoint validates each message against
`Literal["user", "assistant"]`, so these requests are rejected with HTTP 400:

```
{'type': 'literal_error', 'loc': ('body', 'messages', N, 'role'),
 'msg': "Input should be 'user' or 'assistant'", 'input': 'system'}
```

This is a small lenient-compat enhancement (relates to #21313, "Support
Anthropic `/v1/messages`"). It adds a `@model_validator(mode="before")` on
`AnthropicMessagesRequest` that hoists any `role="system"` entries out of
`messages[]` into the top-level `system` field before per-message validation
runs, so strict clients keep working unchanged while lenient clients like
Claude Code are accepted.

Behavior:

- Order is preserved; any pre-existing top-level `system` content is kept ahead
  of the hoisted entries.
- Hoisted content is normalized to text content blocks, so the serving layer's
  existing `_convert_system_message` handling (including the Claude Code
  billing-header stripping) still applies.
- Requests that already follow the spec (no `system` role in `messages[]`) are
  returned untouched.
- Invalid non-system roles are still rejected as before.

Anthropic's real API does not accept `system` inside `messages[]`; this is
intentionally a lenient superset for client compatibility, not a spec change.

## Test Plan

New unit tests in `tests/entrypoints/anthropic/test_system_hoist.py` covering:
string system messages, content-block system messages, merging with an existing
top-level `system`, multiple system messages preserving order, spec-compliant
requests left untouched, invalid roles still rejected, and an end-to-end check
that a hoisted system message becomes an OpenAI `system` message through
`_convert_anthropic_to_openai_request`.

```
pytest tests/entrypoints/anthropic/test_system_hoist.py
```

## Test Result

The hoist/validator logic was verified against pydantic 2.13 (loading
`protocol.py` in isolation): all assertions pass — system entries are hoisted in
order, existing top-level `system` is preserved first, spec-compliant requests
are untouched, and invalid roles still raise `ValidationError`. `ruff check` and
`ruff format --check` (v0.14.0, matching `.pre-commit-config.yaml`) both pass on
the changed files.
