### PR TITLE
[Bugfix][Anthropic] Normalize Claude Code system messages

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -9,7 +9,11 @@ Also covers extended-thinking edge cases such as ``redacted_thinking``
 blocks echoed back by Anthropic clients.
 """
 
+import pytest
+from pydantic import ValidationError
+
 from vllm.entrypoints.anthropic.protocol import (
+    AnthropicCountTokensRequest,
     AnthropicMessagesRequest,
 )
 from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
@@ -28,6 +32,86 @@ def _make_request(
         messages=messages,
         **kwargs,
     )
+
+
+# ======================================================================
+# Claude Code role normalization
+# ======================================================================
+
+
+class TestClaudeCodeRoleNormalization:
+    def test_system_role_message_moves_to_system_prompt(self):
+        request = _make_request(
+            [
+                {"role": "system", "content": "You are terse."},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+
+        result = _convert(request)
+
+        assert result.messages[0] == {
+            "role": "system",
+            "content": "You are terse.",
+        }
+        assert result.messages[1] == {"role": "user", "content": "Hello"}
+
+    def test_system_role_message_merges_after_existing_system(self):
+        request = _make_request(
+            [
+                {"role": "system", "content": "Add this too."},
+                {"role": "user", "content": "Hello"},
+            ],
+            system="Keep this. ",
+        )
+
+        result = _convert(request)
+
+        assert result.messages[0] == {
+            "role": "system",
+            "content": "Keep this. Add this too.",
+        }
+
+    def test_system_role_message_preserves_content_blocks(self):
+        request = _make_request(
+            [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Block system."}],
+                },
+                {"role": "user", "content": "Hello"},
+            ],
+            system=[{"type": "text", "text": "Existing system. "}],
+        )
+
+        result = _convert(request)
+
+        assert result.messages[0] == {
+            "role": "system",
+            "content": "Existing system. Block system.",
+        }
+
+    def test_count_tokens_request_normalizes_claude_code_system_role(self):
+        request = AnthropicCountTokensRequest(
+            model="test-model",
+            system="Keep this. ",
+            messages=[
+                {"role": "system", "content": "Add this too."},
+                {"role": "user", "content": "User request"},
+            ],
+        )
+
+        result = _convert(request)
+
+        assert [message.role for message in request.messages] == ["user"]
+        assert result.messages == [
+            {"role": "system", "content": "Keep this. Add this too."},
+            {"role": "user", "content": "User request"},
+        ]
+
+    def test_unknown_role_still_fails_validation(self):
+        with pytest.raises(ValidationError):
+            _make_request([{"role": "tool", "content": "not accepted"}])
 
 
 # ======================================================================

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -8,6 +8,75 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
+def _content_to_system_blocks(content: Any) -> list[Any]:
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        return content
+    return [{"type": "text", "text": str(content)}]
+
+
+def _merge_system_content(
+    existing_system: Any, system_message_content: list[Any]
+) -> str | list[Any] | None:
+    if not system_message_content:
+        return existing_system
+
+    if existing_system is None and len(system_message_content) == 1:
+        content = system_message_content[0]
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return content
+
+    system_blocks: list[Any] = []
+    if existing_system is not None:
+        system_blocks.extend(_content_to_system_blocks(existing_system))
+    for content in system_message_content:
+        system_blocks.extend(_content_to_system_blocks(content))
+    return system_blocks
+
+
+def _normalize_claude_code_message_roles(data: Any) -> Any:
+    """Move Claude Code system messages into the Anthropic system field."""
+    if not isinstance(data, dict):
+        return data
+
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return data
+
+    normalized_messages: list[Any] = []
+    system_message_content: list[Any] = []
+    changed = False
+
+    for message in messages:
+        if not isinstance(message, dict):
+            normalized_messages.append(message)
+            continue
+
+        role = message.get("role")
+        if role == "system":
+            system_message_content.append(message.get("content", ""))
+            changed = True
+            continue
+
+        normalized_messages.append(message)
+
+    if not changed:
+        return data
+
+    normalized_data = dict(data)
+    normalized_data["messages"] = normalized_messages
+    if system_message_content:
+        normalized_data["system"] = _merge_system_content(
+            data.get("system"), system_message_content
+        )
+    return normalized_data
+
+
 class AnthropicError(BaseModel):
     """Error structure for Anthropic API"""
 
@@ -144,6 +213,11 @@ class AnthropicMessagesRequest(BaseModel):
         ),
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_claude_code_message_roles(cls, data: Any) -> Any:
+        return _normalize_claude_code_message_roles(data)
+
     @field_validator("model")
     @classmethod
     def validate_model(cls, v):
@@ -246,6 +320,11 @@ class AnthropicCountTokensRequest(BaseModel):
             "Will be accessible by the template."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_claude_code_message_roles(cls, data: Any) -> Any:
+        return _normalize_claude_code_message_roles(data)
 
     @field_validator("model")
     @classmethod


### PR DESCRIPTION
## Purpose

Fixes #44000.

Fix Claude Code compatibility after newer Claude Code builds started sending a
`system` role inside the Anthropic `messages` array.

The failure shows up before request conversion, during Pydantic validation:

```text
API Error: 400 1 validation error:
{'type': 'literal_error', 'loc': ('body', 'messages', 1, 'role'), 'msg': "Input should be 'user' or 'assistant'", 'input': 'system', 'ctx': {'expected': "'user' or 'assistant'"}}
```
(Pasted the full error here for SEO)

I looked through the installed Claude Code bundles I have locally, including
`2.1.157`, to check the reported `ctx` / `msg` roles before deciding what to
normalize. I did not find any `ctx` or `msg` message roles in the bundle. The
only hits were unrelated internal strings, such as validation context variables
(`ctx`) and generic JS/MIME strings (`msg`). Because of that, this PR
intentionally does not expand the role enum to include `ctx` or `msg`.

The fix keeps `AnthropicMessage.role` strict as `user | assistant`, and
normalizes only the confirmed non-standard input shape before Pydantic validates
`messages`:

- remove `messages[*].role == "system"` entries from `messages`
- merge their content into the top-level Anthropic `system` field
- preserve existing top-level `system` content first
- keep unknown roles rejected by the existing strict validation

I chose to merge into top-level `system` because that matches the Anthropic
Messages API convention: conversational turns live in `messages`, while system
prompt content belongs in `system`. It also keeps the non-standard input shape
contained at the Anthropic protocol boundary, instead of allowing it to pass
deeper into request conversion.

A future flag could support preserving/injecting system messages at their
original position for users who explicitly want that behavior, but I left that
out here to keep this PR narrowly scoped. For the compatibility issue,
normalizing into the standard Anthropic `system` field seems like the least
surprising behavior.

This overlaps with #43959, but the main differences in this version are:

- applies the normalization to both `AnthropicMessagesRequest` and
  `AnthropicCountTokensRequest`
- keeps the message role enum strict instead of accepting non-standard roles
  downstream
- includes tests for preserving/merging system content and keeping unrelated
  roles rejected

(AI assistance was used while preparing this patch; I reviewed the changed code
and tests rigorously.)

## Test Plan

```bash
python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
python -m compileall vllm/entrypoints/anthropic tests/entrypoints/anthropic
git diff --check
```

I also built and ran this branch locally against my own Claude Code / agentic
workloads for an end-to-end compatibility check, using Claude Code `2.1.157`
through both the VS Code extension and the CLI.

## Test Result

```text
tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
31 passed

compileall passed
git diff --check passed
```

The local end-to-end agentic workload also completed successfully with this
normalization in place against Claude Code `2.1.157` through both the VS Code
extension and the CLI.
