### PR TITLE
[Feature] [EPD] [EC Connector] Add ECSharedMemoryConnector for disagg…

### DIFF
--- a/tests/v1/core/test_ec_connector_cache_manager.py
+++ b/tests/v1/core/test_ec_connector_cache_manager.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.ec_connector_cache_manager import ECConnectorCacheManager
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.request import Request
+
+_init = False
+
+
+def _vllm_config() -> VllmConfig:
+    config = Mock(spec=VllmConfig)
+    config.model_config = Mock()
+    config.model_config.get_hidden_size = Mock(return_value=768)
+    config.model_config.dtype = torch.float16
+    config.kv_transfer_config = None
+    return config
+
+
+def _request(req_id: str, mm_id: str, num_embeds: int = 4) -> Request:
+    global _init
+    if not _init:
+        init_none_hash(sha256)
+        _init = True
+    block_hasher = get_request_block_hasher(16, sha256)
+    mm_feature = MultiModalFeatureSpec(
+        data=None,
+        mm_position=PlaceholderRange(offset=0, length=num_embeds),
+        identifier=mm_id,
+        modality="image",
+    )
+    return Request(
+        request_id=req_id,
+        prompt_token_ids=[0] * 8,
+        sampling_params=SamplingParams(max_tokens=16),
+        pooling_params=None,
+        mm_features=[mm_feature],
+        block_hasher=block_hasher,
+    )
+
+
+def test_allocate_and_mark_consumer_received():
+    cfg = _vllm_config()
+    m = ECConnectorCacheManager(cache_size=100, vllm_config=cfg)
+    req = _request("r1", "h1", num_embeds=10)
+    assert m.can_allocate(req, 0, encoder_compute_budget=100, num_embeds_to_schedule=0)
+    m.allocate(req, 0)
+    assert m.num_free_slots == 90
+    m.mark_consumer_received("h1")
+    assert "h1" in m.freeable
+    assert m.num_freeable_slots == 100
+
+
+def test_can_allocate_evicts_freeable():
+    cfg = _vllm_config()
+    m = ECConnectorCacheManager(cache_size=20, vllm_config=cfg)
+    r1 = _request("a", "x", num_embeds=10)
+    assert m.can_allocate(r1, 0, 100, 0)
+    m.allocate(r1, 0)
+    m.mark_consumer_received("x")
+    r2 = _request("b", "y", num_embeds=15)
+    assert m.can_allocate(r2, 0, 100, 0)
+    freed = m.get_freed_mm_hashes()
+    assert "x" in freed
+
+
+def test_free_encoder_input():
+    cfg = _vllm_config()
+    m = ECConnectorCacheManager(cache_size=50, vllm_config=cfg)
+    req = _request("r", "z", num_embeds=5)
+    m.can_allocate(req, 0, 100, 0)
+    m.allocate(req, 0)
+    m.free_encoder_input(req, 0)
+    assert "z" in m.freeable
+
+
+def test_ec_connector_capacity_embeds_default():
+    from vllm.config import ECTransferConfig
+    from vllm.config.ec_transfer import (
+        DEFAULT_EC_CONNECTOR_CAPACITY_EMBEDS,
+        EC_CONNECTOR_CAPACITY_EMBEDS_KEY,
+    )
+
+    cfg = ECTransferConfig(
+        ec_connector="ECSharedMemoryConnector", ec_role="ec_producer"
+    )
+    assert (
+        cfg.get_ec_connector_capacity_embeds() == DEFAULT_EC_CONNECTOR_CAPACITY_EMBEDS
+    )
+
+    custom = ECTransferConfig(
+        ec_connector="ECSharedMemoryConnector",
+        ec_role="ec_producer",
+        ec_connector_extra_config={EC_CONNECTOR_CAPACITY_EMBEDS_KEY: 4096},
+    )
+    assert custom.get_ec_connector_capacity_embeds() == 4096
+
+
+def test_cache_manager_enabled_by_connector_class():
+    from vllm.config import ECTransferConfig
+    from vllm.distributed.ec_transfer.ec_connector.example_connector import (
+        ECExampleConnector,
+    )
+    from vllm.distributed.ec_transfer.ec_connector.factory import ECConnectorFactory
+    from vllm.distributed.ec_transfer.ec_connector.shared_memory_connector import (
+        ECSharedMemoryConnector,
+    )
+
+    assert ECExampleConnector.supports_ec_connector_cache_manager is False
+    assert ECSharedMemoryConnector.supports_ec_connector_cache_manager is True
+
+    example_cls = ECConnectorFactory.get_connector_class(
+        ECTransferConfig(ec_connector="ECExampleConnector", ec_role="ec_producer")
+    )
+    shm_cls = ECConnectorFactory.get_connector_class(
+        ECTransferConfig(ec_connector="ECSharedMemoryConnector", ec_role="ec_producer")
+    )
+    assert example_cls.supports_ec_connector_cache_manager is False
+    assert shm_cls.supports_ec_connector_cache_manager is True

--- a/tests/v1/ec_connector/unit/test_shared_memory_connector.py
+++ b/tests/v1/ec_connector/unit/test_shared_memory_connector.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for ECSharedMemoryConnector."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig
+from vllm.config.ec_transfer import DEFAULT_EC_CONNECTOR_CAPACITY_EMBEDS
+from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorRole
+from vllm.distributed.ec_transfer.ec_connector.shared_memory_connector import (
+    _HEADER_PREFIX_BYTES,
+    _MAGIC,
+    ECSharedMemoryConnector,
+    ECSharedMemoryConnectorMetadata,
+    _shm_name,
+    _total_shm_size,
+)
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm.v1.core.sched.output import SchedulerOutput
+
+pytestmark = pytest.mark.cpu_test
+
+_SHM_MODULE = "vllm.distributed.ec_transfer.ec_connector.shared_memory_connector"
+
+
+class MockRequest:
+    def __init__(self, request_id: str, mm_hashes: list[str]):
+        self.request_id = request_id
+        self.mm_features = []
+        for mm_hash in mm_hashes:
+            feature = MultiModalFeatureSpec(
+                data=None,
+                modality="image",
+                identifier=mm_hash,
+                mm_position=PlaceholderRange(offset=0, length=100),
+            )
+            self.mm_features.append(feature)
+
+
+def _make_config(*, is_producer: bool, is_consumer: bool) -> Mock:
+    config = Mock(spec=VllmConfig)
+    config.ec_transfer_config = Mock()
+    config.ec_transfer_config.get_ec_connector_capacity_embeds = Mock(
+        return_value=DEFAULT_EC_CONNECTOR_CAPACITY_EMBEDS
+    )
+    config.ec_transfer_config.is_ec_producer = is_producer
+    config.ec_transfer_config.is_ec_consumer = is_consumer
+    config.model_config = Mock()
+    config.model_config.get_hidden_size = Mock(return_value=768)
+    config.model_config.dtype = torch.float16
+    config.kv_transfer_config = None
+    return config
+
+
+@pytest.fixture
+def mock_vllm_config():
+    return _make_config(is_producer=True, is_consumer=False)
+
+
+@pytest.fixture
+def mock_vllm_config_consumer():
+    return _make_config(is_producer=False, is_consumer=True)
+
+
+@pytest.fixture
+def mock_request_with_3_mm():
+    return MockRequest("test_req_123", ["hash1", "hash2", "hash3"])
+
+
+class TestShmName:
+    def test_shm_name_normalizes_slash_identifier(self):
+        name = _shm_name("my/lora:abc123")
+        assert len(name) == 64
+        assert "/" not in name
+
+    def test_shm_name_deterministic(self):
+        assert _shm_name("hash1") == _shm_name("hash1")
+        assert _shm_name("hash1") != _shm_name("hash2")
+
+
+class TestECSharedMemoryConnectorMetadata:
+    def test_init(self):
+        metadata = ECSharedMemoryConnectorMetadata()
+        assert metadata.mm_hashes == []
+
+    def test_add_mm_hash(self):
+        metadata = ECSharedMemoryConnectorMetadata()
+        metadata.add_mm_hash("hash1")
+        metadata.add_mm_hash("hash2")
+        assert metadata.mm_hashes == ["hash1", "hash2"]
+
+
+class TestECSharedMemoryConnectorInit:
+    def test_init_with_ec_transfer_config(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        assert connector.role == ECConnectorRole.WORKER
+        assert len(connector._mm_hashes_need_loads) == 0
+
+    def test_init_without_ec_transfer_config(self):
+        config = Mock(spec=VllmConfig)
+        config.ec_transfer_config = None
+        with pytest.raises(ValueError, match="ec_transfer_config must be set"):
+            ECSharedMemoryConnector(vllm_config=config, role=ECConnectorRole.WORKER)
+
+
+class TestECSharedMemoryConnectorSerializeDeserialize:
+    def test_serialize_deserialize_real(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        original = torch.randn(10, 768)
+        serialized = connector._serialize_cache(original)
+        with patch("vllm.platforms.current_platform") as mock_platform:
+            mock_platform.device_type = "cpu"
+            restored = connector._deserialize_cache(serialized)
+        assert torch.equal(original.cpu(), restored.cpu())
+
+    def test_flat_format_roundtrip_large(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        original = torch.randn(16384, 2048, dtype=torch.bfloat16)
+        serialized = connector._serialize_cache(original)
+        with patch("vllm.platforms.current_platform") as mock_platform:
+            mock_platform.device_type = "cpu"
+            restored = connector._deserialize_cache(memoryview(serialized))
+        assert restored.shape == original.shape
+        assert restored.dtype == original.dtype
+        assert torch.equal(original, restored)
+
+
+class TestECSharedMemoryConnectorSaveCaches:
+    @patch(f"{_SHM_MODULE}.get_tensor_model_parallel_rank", return_value=0)
+    def test_save_caches_saves_to_shared_memory(self, mock_tp_rank, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        mm_hash = "test_hash"
+        encoder_cache = {mm_hash: torch.randn(10, 768)}
+        payload = connector._serialize_cache(encoder_cache[mm_hash])
+        total = _total_shm_size(len(payload))
+
+        with patch("multiprocessing.shared_memory.SharedMemory") as mock_shm:
+            mock_shm_instance = MagicMock()
+            mock_shm_instance.size = total
+            mock_shm_instance.buf = bytearray(total)
+            mock_shm.return_value = mock_shm_instance
+
+            connector.save_caches(encoder_cache, mm_hash)
+
+            mock_shm.assert_called()
+            assert mm_hash in connector._pending_sends
+
+    def test_save_caches_consumer_skips(self, mock_vllm_config_consumer):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config_consumer, role=ECConnectorRole.WORKER
+        )
+        with patch("multiprocessing.shared_memory.SharedMemory") as mock_shm:
+            connector.save_caches({"test_hash": torch.randn(10, 768)}, "test_hash")
+            mock_shm.assert_not_called()
+
+
+class TestECSharedMemoryConnectorLoadCaches:
+    def test_start_load_caches_loads_from_shared_memory(
+        self, mock_vllm_config_consumer
+    ):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config_consumer, role=ECConnectorRole.WORKER
+        )
+        mm_hash = "test_hash"
+        tensor = torch.randn(10, 768)
+        metadata = ECSharedMemoryConnectorMetadata()
+        metadata.add_mm_hash(mm_hash)
+        connector.bind_connector_metadata(metadata)
+
+        serialized = connector._serialize_cache(tensor)
+        size_bytes = len(serialized)
+        total_size = _total_shm_size(size_bytes)
+        mock_buf = bytearray(total_size)
+        mock_buf[0:4] = _MAGIC
+        mock_buf[4:_HEADER_PREFIX_BYTES] = size_bytes.to_bytes(8, "little")
+        mock_buf[_HEADER_PREFIX_BYTES : _HEADER_PREFIX_BYTES + size_bytes] = serialized
+        mock_buf[_HEADER_PREFIX_BYTES + size_bytes] = 0
+
+        with patch("multiprocessing.shared_memory.SharedMemory") as mock_shm_class:
+            mock_shm = MagicMock()
+            mock_shm.size = total_size
+            mock_shm.buf = mock_buf
+            mock_shm_class.return_value = mock_shm
+            with patch("vllm.platforms.current_platform") as mock_platform:
+                mock_platform.device_type = "cpu"
+                encoder_cache: dict[str, torch.Tensor] = {}
+                connector.start_load_caches(encoder_cache)
+                assert mm_hash in encoder_cache
+
+
+class TestECSharedMemoryConnectorHasCacheItem:
+    def test_has_cache_item_exists(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.SCHEDULER
+        )
+        with (
+            patch(f"{_SHM_MODULE}.os.path.exists", return_value=True),
+            patch(f"{_SHM_MODULE}._is_readable_shm_file", return_value=True),
+        ):
+            assert connector.has_cache_item("hash1") is True
+
+    def test_has_cache_item_missing(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.SCHEDULER
+        )
+        with patch(f"{_SHM_MODULE}.os.path.exists", return_value=False):
+            assert connector.has_cache_item("hash1") is False
+
+    def test_has_cache_item_rejects_invalid_magic(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.SCHEDULER
+        )
+        with (
+            patch(f"{_SHM_MODULE}.os.path.exists", return_value=True),
+            patch(f"{_SHM_MODULE}._is_readable_shm_file", return_value=False),
+        ):
+            assert connector.has_cache_item("hash1") is False
+
+    def test_start_load_caches_skips_invalid_magic(self, mock_vllm_config_consumer):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config_consumer, role=ECConnectorRole.WORKER
+        )
+        mm_hash = "bad_hash"
+        metadata = ECSharedMemoryConnectorMetadata()
+        metadata.add_mm_hash(mm_hash)
+        connector.bind_connector_metadata(metadata)
+
+        mock_buf = bytearray(64)
+        mock_buf[:8] = b"pickle!!"
+
+        with patch("multiprocessing.shared_memory.SharedMemory") as mock_shm_class:
+            mock_shm = MagicMock()
+            mock_shm.size = len(mock_buf)
+            mock_shm.buf = mock_buf
+            mock_shm_class.return_value = mock_shm
+            encoder_cache: dict[str, torch.Tensor] = {}
+            connector.start_load_caches(encoder_cache)
+            assert mm_hash not in encoder_cache
+            mock_shm.close.assert_called_once()
+
+
+class TestECSharedMemoryConnectorStateManagement:
+    def test_update_state_after_alloc_consumer(self, mock_vllm_config_consumer):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config_consumer, role=ECConnectorRole.SCHEDULER
+        )
+        request = MockRequest("req", ["hash1"])
+        with patch.object(connector, "has_cache_item", return_value=True):
+            connector.update_state_after_alloc(request, index=0)
+        assert "hash1" in connector._mm_hashes_need_loads
+
+    def test_update_state_after_alloc_producer_skips(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.SCHEDULER
+        )
+        request = MockRequest("req", ["hash1"])
+        connector.update_state_after_alloc(request, index=0)
+        assert "hash1" not in connector._mm_hashes_need_loads
+
+    def test_build_connector_meta(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.SCHEDULER
+        )
+        connector._mm_hashes_need_loads.update({"hash1", "hash2"})
+        metadata = connector.build_connector_meta(Mock(spec=SchedulerOutput))
+        assert isinstance(metadata, ECSharedMemoryConnectorMetadata)
+        assert set(metadata.mm_hashes) == {"hash1", "hash2"}
+        assert len(connector._mm_hashes_need_loads) == 0
+
+
+class TestECSharedMemoryConnectorLifecycle:
+    def test_get_finished_producer_ack(self, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        mm_hash = "h1"
+        connector._pending_sends.add(mm_hash)
+        ser = connector._serialize_cache(torch.randn(2, 3))
+        sz = len(ser)
+        buf = bytearray(8 + sz + 1)
+        buf[:8] = sz.to_bytes(8, "little")
+        buf[8 : 8 + sz] = ser
+        buf[8 + sz] = 1
+        with (
+            patch(f"{_SHM_MODULE}.os.path.exists", return_value=True),
+            patch(f"{_SHM_MODULE}.os.open", return_value=5),
+            patch(f"{_SHM_MODULE}.os.pread") as mock_pread,
+            patch(f"{_SHM_MODULE}.os.close"),
+            patch(f"{_SHM_MODULE}.os.fstat") as mock_fstat,
+        ):
+            mock_fstat.return_value.st_size = _HEADER_PREFIX_BYTES + sz + 1
+            mock_pread.side_effect = [_MAGIC, sz.to_bytes(8, "little"), bytes([1])]
+            sending, recving = connector.get_finished(set())
+        assert sending is not None and mm_hash in sending
+        assert recving is None
+
+    def test_get_finished_consumer_pending_recvs(self, mock_vllm_config_consumer):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config_consumer, role=ECConnectorRole.WORKER
+        )
+        connector._pending_recvs.update({"a", "b"})
+        sending, recving = connector.get_finished(set())
+        assert sending is None
+        assert recving == {"a", "b"}
+
+    @patch(f"{_SHM_MODULE}.get_tensor_model_parallel_rank", return_value=0)
+    def test_free_physical_cache_unlinks(self, mock_tp_rank, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        connector._pending_sends.add("x")
+        with patch.object(connector, "_unlink_shm") as mock_unlink:
+            connector.free_physical_cache("x")
+            mock_unlink.assert_called_once_with("x")
+        assert "x" not in connector._pending_sends
+
+    @patch(f"{_SHM_MODULE}.get_tensor_model_parallel_rank", return_value=1)
+    def test_free_physical_cache_skips_non_tp0(self, mock_tp_rank, mock_vllm_config):
+        connector = ECSharedMemoryConnector(
+            vllm_config=mock_vllm_config, role=ECConnectorRole.WORKER
+        )
+        with patch.object(connector, "_unlink_shm") as mock_unlink:
+            connector.free_physical_cache("x")
+            mock_unlink.assert_not_called()
+
+
+class TestECSharedMemoryConnectorIntegration:
+    @patch(f"{_SHM_MODULE}.get_tensor_model_parallel_rank", return_value=0)
+    def test_save_and_load_roundtrip_real_shm(self, mock_tp_rank):
+        from multiprocessing import shared_memory
+
+        producer_cfg = _make_config(is_producer=True, is_consumer=False)
+        consumer_cfg = _make_config(is_producer=False, is_consumer=True)
+        producer = ECSharedMemoryConnector(
+            vllm_config=producer_cfg, role=ECConnectorRole.WORKER
+        )
+        consumer = ECSharedMemoryConnector(
+            vllm_config=consumer_cfg, role=ECConnectorRole.WORKER
+        )
+
+        mm_hash = "integration_hash"
+        shm_name = _shm_name(mm_hash)
+        tensor = torch.randn(128, 768, dtype=torch.float16)
+        encoder_cache = {mm_hash: tensor}
+
+        try:
+            producer.save_caches(encoder_cache, mm_hash)
+
+            metadata = ECSharedMemoryConnectorMetadata()
+            metadata.add_mm_hash(mm_hash)
+            consumer.bind_connector_metadata(metadata)
+
+            loaded: dict[str, torch.Tensor] = {}
+            with patch("vllm.platforms.current_platform") as mock_platform:
+                mock_platform.device_type = "cpu"
+                consumer.start_load_caches(loaded)
+
+            assert mm_hash in loaded
+            assert torch.equal(tensor.cpu(), loaded[mm_hash].cpu())
+        finally:
+            try:
+                shm = shared_memory.SharedMemory(name=shm_name)
+                shm.close()
+                shm.unlink()
+            except FileNotFoundError:
+                pass

--- a/vllm/config/ec_transfer.py
+++ b/vllm/config/ec_transfer.py
@@ -11,6 +11,9 @@ ECProducer = Literal["ec_producer", "ec_both"]
 ECConsumer = Literal["ec_consumer", "ec_both"]
 ECRole = Literal[ECProducer, ECConsumer]
 
+EC_CONNECTOR_CAPACITY_EMBEDS_KEY = "ec_connector_capacity_embeds"
+DEFAULT_EC_CONNECTOR_CAPACITY_EMBEDS = 11468800
+
 
 @config
 class ECTransferConfig:
@@ -105,3 +108,9 @@ class ECTransferConfig:
 
     def get_from_extra_config(self, key, default) -> Any:
         return self.ec_connector_extra_config.get(key, default)
+
+    def get_ec_connector_capacity_embeds(self) -> int:
+        return self.get_from_extra_config(
+            EC_CONNECTOR_CAPACITY_EMBEDS_KEY,
+            DEFAULT_EC_CONNECTOR_CAPACITY_EMBEDS,
+        )

--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -24,7 +24,7 @@ The class provides the following primitives:
 
 import enum
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
 
@@ -57,6 +57,9 @@ class ECConnectorMetadata(ABC):  # noqa: B024
 
 
 class ECConnectorBase(ABC):
+    supports_ec_connector_cache_manager: ClassVar[bool] = False
+    """Whether scheduler-side :class:`ECConnectorCacheManager` is required."""
+
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole):
         self._connector_metadata: ECConnectorMetadata | None = None
         self._vllm_config = vllm_config
@@ -189,6 +192,13 @@ class ECConnectorBase(ABC):
             call to this method (this call or a prior one).
         """
         return None, None
+
+    def free_physical_cache(self, mm_hash: str) -> None:
+        """Drop connector backing storage for ``mm_hash`` on this worker.
+
+        Default is a no-op; connectors that own out-of-band storage override.
+        """
+        return
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/ec_transfer/ec_connector/factory.py
+++ b/vllm/distributed/ec_transfer/ec_connector/factory.py
@@ -83,3 +83,8 @@ ECConnectorFactory.register_connector(
     "vllm.distributed.ec_transfer.ec_connector.example_connector",
     "ECExampleConnector",
 )
+ECConnectorFactory.register_connector(
+    "ECSharedMemoryConnector",
+    "vllm.distributed.ec_transfer.ec_connector.shared_memory_connector",
+    "ECSharedMemoryConnector",
+)

--- a/vllm/distributed/ec_transfer/ec_connector/shared_memory_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/shared_memory_connector.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import hashlib
+import os
+import struct
+from dataclasses import dataclass, field
+from multiprocessing import shared_memory
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed import get_tensor_model_parallel_rank
+from vllm.distributed.ec_transfer.ec_connector.base import (
+    ECConnectorBase,
+    ECConnectorMetadata,
+    ECConnectorRole,
+)
+from vllm.logger import init_logger
+from vllm.utils.mem_constants import MiB_bytes
+from vllm.v1.core.sched.output import SchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+# Shared-memory wire format (little-endian):
+#
+#   [0:4)       magic "ECv1"
+#   [4:12)      payload_size (8 bytes, little-endian)
+#   [12:48)     tensor header (ndim, dtype_code, shape[8])
+#   [48:...)     raw tensor bytes (flattened uint8 view)
+#   [last byte] ACK (0=pending, 1=done)
+#
+# payload_size covers the tensor header plus raw bytes (excludes magic, size
+# field, and ACK). tensor_header = ndim (i32) + dtype_code (i32) + shape[8]
+# (8 x i32).
+_MAGIC = b"ECv1"
+_MAGIC_BYTES = len(_MAGIC)
+SIZE_FIELD_BYTES = 8
+_HEADER_PREFIX_BYTES = _MAGIC_BYTES + SIZE_FIELD_BYTES
+_NDIM_SHAPE_SLOTS = 8
+_HEADER_SIZE = 4 + 4 + 4 * _NDIM_SHAPE_SLOTS
+ACK_DONE = 1
+ACK_PENDING = 0
+
+# EC cache tensors follow model_config.dtype (fp16/bf16/fp32 in practice).
+# float64 is included for completeness; quantized/int dtypes are not supported.
+_DTYPE_TO_CODE: dict[torch.dtype, int] = {
+    torch.float16: 0,
+    torch.bfloat16: 1,
+    torch.float32: 2,
+    torch.float64: 3,
+}
+_CODE_TO_DTYPE: dict[int, torch.dtype] = {v: k for k, v in _DTYPE_TO_CODE.items()}
+
+
+def _shm_name(identifier: str) -> str:
+    """Map mm identifier to a POSIX-safe shared memory name."""
+    return hashlib.sha256(identifier.encode()).hexdigest()
+
+
+def _payload_size(num_bytes: int) -> int:
+    return _HEADER_SIZE + num_bytes
+
+
+def _total_shm_size(payload_size: int) -> int:
+    return _HEADER_PREFIX_BYTES + payload_size + 1
+
+
+def _ack_index(payload_size: int) -> int:
+    return _HEADER_PREFIX_BYTES + payload_size
+
+
+def _validate_payload_size(payload_size: int, shm_size: int) -> bool:
+    if payload_size < _HEADER_SIZE:
+        return False
+    return payload_size <= shm_size - _HEADER_PREFIX_BYTES - 1
+
+
+def _try_unpack_header(header: bytes) -> tuple[torch.dtype, tuple[int, ...]] | None:
+    try:
+        return _unpack_header(header)
+    except ValueError:
+        return None
+
+
+def _is_readable_shm_file(path: str) -> bool:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        if os.pread(fd, _MAGIC_BYTES, 0) != _MAGIC:
+            return False
+        size_buf = os.pread(fd, SIZE_FIELD_BYTES, _MAGIC_BYTES)
+        if len(size_buf) < SIZE_FIELD_BYTES:
+            return False
+        payload_size = int.from_bytes(size_buf, "little")
+        if not _validate_payload_size(payload_size, os.fstat(fd).st_size):
+            return False
+        header = os.pread(fd, _HEADER_SIZE, _HEADER_PREFIX_BYTES)
+        if len(header) < _HEADER_SIZE:
+            return False
+        return _try_unpack_header(header) is not None
+    finally:
+        os.close(fd)
+
+
+def _pack_header(tensor: torch.Tensor) -> bytes:
+    ndim = tensor.dim()
+    if ndim > _NDIM_SHAPE_SLOTS:
+        raise ValueError(f"EC cache tensor ndim={ndim} exceeds max {_NDIM_SHAPE_SLOTS}")
+    dtype_code = _DTYPE_TO_CODE.get(tensor.dtype)
+    if dtype_code is None:
+        raise ValueError(f"Unsupported EC cache dtype: {tensor.dtype}")
+    shape = list(tensor.shape) + [0] * (_NDIM_SHAPE_SLOTS - ndim)
+    return struct.pack("<ii8i", ndim, dtype_code, *shape)
+
+
+def _unpack_header(header: bytes | memoryview) -> tuple[torch.dtype, tuple[int, ...]]:
+    ndim, dtype_code, *shape_slots = struct.unpack("<ii8i", header[:_HEADER_SIZE])
+    dtype = _CODE_TO_DTYPE.get(dtype_code)
+    if dtype is None:
+        raise ValueError(f"Unsupported EC cache dtype code: {dtype_code}")
+    return dtype, tuple(shape_slots[:ndim])
+
+
+def _shm_path(name: str) -> str:
+    return f"/dev/shm/{name}"
+
+
+def _write_shm_segment(buf: memoryview | bytearray, cpu_tensor: torch.Tensor) -> int:
+    """Write magic + flat EC cache payload into ``buf``. Returns payload size."""
+    buf[0:_MAGIC_BYTES] = _MAGIC
+    if not cpu_tensor.is_contiguous():
+        cpu_tensor = cpu_tensor.contiguous()
+    header = _pack_header(cpu_tensor)
+    raw = cpu_tensor.view(torch.uint8).numpy()
+    payload_size = _payload_size(raw.nbytes)
+    buf[_MAGIC_BYTES:_HEADER_PREFIX_BYTES] = payload_size.to_bytes(
+        SIZE_FIELD_BYTES, "little"
+    )
+    payload_offset = _HEADER_PREFIX_BYTES
+    buf[payload_offset : payload_offset + _HEADER_SIZE] = header
+    data_offset = payload_offset + _HEADER_SIZE
+    data_end = data_offset + raw.nbytes
+    buf[data_offset:data_end] = memoryview(raw).cast("B")
+    buf[_ack_index(payload_size)] = ACK_PENDING
+    return payload_size
+
+
+def _read_tensor_from_payload(
+    buf: memoryview | bytearray,
+    payload_offset: int,
+    payload_size: int,
+    *,
+    sync_device: bool = True,
+) -> torch.Tensor:
+    from vllm.platforms import current_platform
+
+    header_end = payload_offset + _HEADER_SIZE
+    dtype, shape = _unpack_header(buf[payload_offset:header_end])
+    data_offset = header_end
+    num_bytes = payload_size - _HEADER_SIZE
+    # Clone immediately so the returned tensor does not pin the SHM mapping.
+    cpu_tensor = (
+        torch.frombuffer(buf[data_offset : data_offset + num_bytes], dtype=dtype)
+        .reshape(shape)
+        .clone()
+    )
+    device_type = current_platform.device_type
+    if device_type == "cpu":
+        return cpu_tensor
+    device_tensor = cpu_tensor.to(device_type, non_blocking=True)
+    if sync_device and device_type == "cuda" and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    return device_tensor
+
+
+@dataclass
+class ECSharedMemoryConnectorMetadata(ECConnectorMetadata):
+    mm_hashes: list[str] = field(default_factory=list)
+
+    def add_mm_hash(self, mm_hash: str) -> None:
+        self.mm_hashes.append(mm_hash)
+
+
+class ECSharedMemoryConnector(ECConnectorBase):
+    """EC connector backed by POSIX shared memory segments."""
+
+    supports_ec_connector_cache_manager = True
+
+    def __init__(self, vllm_config: VllmConfig, role: ECConnectorRole):
+        super().__init__(vllm_config=vllm_config, role=role)
+        transfer_config = vllm_config.ec_transfer_config
+        if transfer_config is None:
+            raise ValueError("ec_transfer_config must be set for ECConnectorBase")
+        self._mm_hashes_need_loads: set[str] = set()
+        self._pending_sends: set[str] = set()
+        self._pending_recvs: set[str] = set()
+        mc = vllm_config.model_config
+        encoder_slot_bytes = mc.get_hidden_size() * mc.dtype.itemsize
+        ec_capacity_embeds = transfer_config.get_ec_connector_capacity_embeds()
+        scheduler_slot_budget_bytes = encoder_slot_bytes * ec_capacity_embeds
+        logger.info(
+            "ECSharedMemoryConnector init: scheduler_slot_budget=%.3f MiB "
+            "(ec_connector_capacity_embeds=%d, encoder_slot_bytes=%d)",
+            scheduler_slot_budget_bytes / MiB_bytes,
+            ec_capacity_embeds,
+            encoder_slot_bytes,
+        )
+
+    @staticmethod
+    def _serialize_cache(tensor: torch.Tensor) -> bytes:
+        cpu_tensor = tensor.detach().contiguous().cpu()
+        header = _pack_header(cpu_tensor)
+        raw = cpu_tensor.view(torch.uint8).numpy().tobytes()
+        return header + raw
+
+    @staticmethod
+    def _deserialize_cache(payload: bytes | memoryview) -> torch.Tensor:
+        if not isinstance(payload, bytes):
+            payload = bytes(payload)
+        return _read_tensor_from_payload(payload, 0, len(payload))
+
+    @staticmethod
+    def _unlink_shm(mm_hash: str) -> None:
+        try:
+            shm = shared_memory.SharedMemory(name=_shm_name(mm_hash))
+        except OSError:
+            return
+        try:
+            shm.unlink()
+        finally:
+            shm.close()
+
+    def start_load_caches(self, encoder_cache, **kwargs) -> None:
+        metadata: ECConnectorMetadata = self._get_connector_metadata()
+        assert isinstance(metadata, ECSharedMemoryConnectorMetadata)
+        for mm_hash in metadata.mm_hashes:
+            if mm_hash in encoder_cache:
+                continue
+            try:
+                shm = shared_memory.SharedMemory(name=_shm_name(mm_hash))
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+            try:
+                if bytes(shm.buf[:_MAGIC_BYTES]) != _MAGIC:
+                    continue
+                payload_size = int.from_bytes(
+                    shm.buf[_MAGIC_BYTES:_HEADER_PREFIX_BYTES], "little"
+                )
+                if not _validate_payload_size(payload_size, shm.size):
+                    continue
+                payload_offset = _HEADER_PREFIX_BYTES
+                tensor = _read_tensor_from_payload(
+                    shm.buf, payload_offset, payload_size
+                )
+                encoder_cache[mm_hash] = tensor
+                payload_end = _ack_index(payload_size)
+                if shm.size > payload_end:
+                    shm.buf[payload_end] = ACK_DONE
+                self._pending_recvs.add(mm_hash)
+            finally:
+                shm.close()
+
+    def save_caches(self, encoder_cache, mm_hash, **kwargs) -> None:
+        if not self.is_producer or self.role != ECConnectorRole.WORKER:
+            return
+        if get_tensor_model_parallel_rank() != 0:
+            return
+        tensor = encoder_cache[mm_hash]
+        cpu_tensor = tensor.detach().contiguous().cpu()
+        payload_size = _payload_size(cpu_tensor.view(torch.uint8).numel())
+        total_size = _total_shm_size(payload_size)
+        shm_name = _shm_name(mm_hash)
+        shm = None
+        try:
+            try:
+                shm = shared_memory.SharedMemory(
+                    name=shm_name, create=True, size=total_size
+                )
+            except FileExistsError:
+                shm = shared_memory.SharedMemory(name=shm_name)
+                if shm.size < total_size:
+                    shm.close()
+                    shm = None
+                    self._unordered_resize_shm(mm_hash, total_size)
+                    shm = shared_memory.SharedMemory(name=shm_name)
+            _write_shm_segment(shm.buf, cpu_tensor)
+            self._pending_sends.add(mm_hash)
+        finally:
+            if shm is not None:
+                shm.close()
+
+    def _unordered_resize_shm(self, mm_hash: str, new_size: int) -> None:
+        self._unlink_shm(mm_hash)
+        shared_memory.SharedMemory(
+            name=_shm_name(mm_hash), create=True, size=new_size
+        ).close()
+
+    @staticmethod
+    def _is_send_acknowledged(mm_hash: str) -> bool | None:
+        path = _shm_path(_shm_name(mm_hash))
+        if not os.path.exists(path):
+            return None
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            if os.pread(fd, _MAGIC_BYTES, 0) != _MAGIC:
+                return False
+            size_buf = os.pread(fd, SIZE_FIELD_BYTES, _MAGIC_BYTES)
+            if len(size_buf) < SIZE_FIELD_BYTES:
+                return False
+            payload_size = int.from_bytes(size_buf, "little")
+            if not _validate_payload_size(payload_size, os.fstat(fd).st_size):
+                return False
+            ack_buf = os.pread(fd, 1, _ack_index(payload_size))
+            return len(ack_buf) == 1 and ack_buf[0] == ACK_DONE
+        finally:
+            os.close(fd)
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        if self.role != ECConnectorRole.WORKER:
+            return None, None
+        if not self.is_producer:
+            recving, self._pending_recvs = self._pending_recvs, set()
+            return None, recving or None
+
+        finished: set[str] = set()
+        for mm_hash in list(self._pending_sends):
+            ack = self._is_send_acknowledged(mm_hash)
+            if ack is None:
+                self._pending_sends.discard(mm_hash)
+            elif ack:
+                finished.add(mm_hash)
+                self._pending_sends.discard(mm_hash)
+        return finished or None, None
+
+    def free_physical_cache(self, mm_hash: str) -> None:
+        self._pending_sends.discard(mm_hash)
+        self._pending_recvs.discard(mm_hash)
+        if get_tensor_model_parallel_rank() != 0:
+            return
+        self._unlink_shm(mm_hash)
+
+    def has_cache_item(self, identifier: str) -> bool:
+        path = _shm_path(_shm_name(identifier))
+        if not os.path.exists(path):
+            return False
+        return _is_readable_shm_file(path)
+
+    def update_state_after_alloc(self, request: "Request", index: int) -> None:
+        mm_hash = request.mm_features[index].identifier
+        if not self.is_consumer:
+            return
+        if not self.has_cache_item(mm_hash):
+            return
+        self._mm_hashes_need_loads.add(mm_hash)
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> ECConnectorMetadata:
+        meta = ECSharedMemoryConnectorMetadata()
+        for mm_hash in self._mm_hashes_need_loads:
+            meta.add_mm_hash(mm_hash)
+        self._mm_hashes_need_loads.clear()
+        return meta

--- a/vllm/v1/core/ec_connector_cache_manager.py
+++ b/vllm/v1/core/ec_connector_cache_manager.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import OrderedDict
+from typing import TYPE_CHECKING
+
+from vllm.logger import init_logger
+from vllm.utils.mem_constants import GiB_bytes, MiB_bytes
+from vllm.v1.request import Request
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+
+class ECConnectorCacheManager:
+    """Bookkeeping for EC connector embedding slots (scheduler-side).
+
+    Mirrors :class:`EncoderCacheManager` state shape so the scheduler can
+    apply the same ``can_allocate`` / ``allocate`` / ``free_encoder_input``
+    patterns. Producer paths release connector capacity when the consumer
+    acknowledges transfer via ``mark_consumer_received``.
+
+    Eviction from ``freeable`` is **lazy**: on each ``can_allocate``, entries are
+    popped only until ``num_free_slots`` is large enough for **this** request's
+    ``num_embeds``. Many 0-ref rows may remain in ``freeable`` until later
+    allocations force more evictions; there is no "flush all on new request."
+    """
+
+    def __init__(self, cache_size: int, vllm_config: "VllmConfig"):
+        self.cache_size = cache_size
+        self.num_free_slots = cache_size
+        self.num_freeable_slots = cache_size
+        self.cached: dict[str, set[str]] = {}
+        self.freeable: OrderedDict[str, int] = OrderedDict()
+        self.freed: list[str] = []
+        self._mm_hash_num_embeds: dict[str, int] = {}
+
+        hidden_size = vllm_config.model_config.get_hidden_size()
+        dtype_bytes = vllm_config.model_config.dtype.itemsize
+        self._slot_bytes = hidden_size * dtype_bytes
+        total_bytes = self._slot_bytes * cache_size
+        logger.info(
+            "ECConnectorCacheManager init: ec_connector_capacity_embeds=%d slots, "
+            "per-slot=%d B (%.3f MB), total=%.2f MB (%.3f GB), "
+            "free_slots=%d freeable_slots=%d",
+            cache_size,
+            self._slot_bytes,
+            self._slot_bytes / MiB_bytes,
+            total_bytes / MiB_bytes,
+            total_bytes / GiB_bytes,
+            self.num_free_slots,
+            self.num_freeable_slots,
+        )
+
+    def check_and_update_cache(self, request: Request, input_id: int) -> bool:
+        mm_hash = request.mm_features[input_id].identifier
+        if mm_hash not in self.cached:
+            return False
+        if not self.cached[mm_hash]:
+            num_encoder_embeds = self.freeable.pop(mm_hash)
+            self.num_freeable_slots -= num_encoder_embeds
+        self.cached[mm_hash].add(request.request_id)
+        return True
+
+    def can_allocate(
+        self,
+        request: Request,
+        input_id: int,
+        encoder_compute_budget: int,
+        num_embeds_to_schedule: int,
+    ) -> bool:
+        num_embeds = request.get_num_encoder_embeds(input_id)
+        if num_embeds > encoder_compute_budget:
+            return False
+        num_embeds += num_embeds_to_schedule
+        if num_embeds <= self.num_free_slots:
+            return True
+        if num_embeds > self.num_freeable_slots:
+            return False
+        while num_embeds > self.num_free_slots:
+            mm_hash, num_free_embeds = self.freeable.popitem(last=False)
+            self.cached.pop(mm_hash, None)
+            self.freed.append(mm_hash)
+            self._mm_hash_num_embeds.pop(mm_hash, None)
+            self.num_free_slots += num_free_embeds
+        return True
+
+    def allocate(self, request: Request, input_id: int) -> None:
+        mm_hash = request.mm_features[input_id].identifier
+        request_id = request.request_id
+        if mm_hash not in self.cached:
+            self.cached[mm_hash] = set()
+        num_encoder_embeds = request.get_num_encoder_embeds(input_id)
+        assert self.num_free_slots >= num_encoder_embeds
+        assert self.num_freeable_slots >= num_encoder_embeds
+        self.cached[mm_hash].add(request_id)
+        self._mm_hash_num_embeds[mm_hash] = num_encoder_embeds
+        self.num_free_slots -= num_encoder_embeds
+        self.num_freeable_slots -= num_encoder_embeds
+
+    def get_cached_input_ids(self, request: Request) -> set[int]:
+        return {
+            input_id
+            for input_id in range(len(request.mm_features))
+            if request.mm_features[input_id].identifier in self.cached
+        }
+
+    def free_encoder_input(self, request: Request, input_id: int) -> None:
+        req_id = request.request_id
+        mm_hash = request.mm_features[input_id].identifier
+        if not self.cached.get(mm_hash, None):
+            return
+        self.cached[mm_hash].discard(req_id)
+        if not self.cached[mm_hash]:
+            num_encoder_embeds = request.get_num_encoder_embeds(input_id)
+            self.freeable[mm_hash] = num_encoder_embeds
+            self.num_freeable_slots += num_encoder_embeds
+
+    def free(self, request: Request) -> None:
+        input_ids = self.get_cached_input_ids(request).copy()
+        for input_id in input_ids:
+            self.free_encoder_input(request, input_id)
+
+    def mark_consumer_received(self, mm_hash: str) -> None:
+        """Producer: consumer ACKed the transfer. Consumer: load finished.
+
+        Moves connector bookkeeping for ``mm_hash`` to ``freeable`` when refs
+        were held in ``cached``.
+        """
+        if mm_hash not in self.cached:
+            return
+        self.cached.pop(mm_hash)
+        num_encoder_embeds = self._mm_hash_num_embeds.pop(mm_hash, None)
+        if num_encoder_embeds is None:
+            return
+        self.freeable[mm_hash] = num_encoder_embeds
+        self.num_freeable_slots += num_encoder_embeds
+
+    def get_freed_mm_hashes(self) -> list[str]:
+        freed = self.freed
+        self.freed = []
+        return freed

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -213,6 +213,9 @@ class SchedulerOutput:
     # list of mm_hash strings associated with the encoder outputs to be
     # freed from the encoder cache.
     free_encoder_mm_hashes: list[str]
+    # mm_hash strings whose EC connector physical storage should be dropped
+    # on workers (shm unlink, network cache entry, etc.).
+    free_ec_connector_mm_hashes: list[str] = field(default_factory=list)
 
     # Request IDs that are preempted in this step.
     # Only used for v2 model runner.
@@ -252,6 +255,7 @@ class SchedulerOutput:
             num_common_prefix_blocks=[],
             finished_req_ids=set(),
             free_encoder_mm_hashes=[],
+            free_ec_connector_mm_hashes=[],
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.v1.core.ec_connector_cache_manager import ECConnectorCacheManager
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
@@ -139,10 +140,24 @@ class Scheduler(SchedulerInterface):
             self.parallel_config.data_parallel_index,
         )
         self.ec_connector = None
+        self.ec_connector_cache_manager: ECConnectorCacheManager | None = None
         if self.vllm_config.ec_transfer_config is not None:
             self.ec_connector = ECConnectorFactory.create_connector(
                 config=self.vllm_config, role=ECConnectorRole.SCHEDULER
             )
+            if type(self.ec_connector).supports_ec_connector_cache_manager:
+                ec_transfer_config = self.vllm_config.ec_transfer_config
+                assert ec_transfer_config is not None
+                capacity = ec_transfer_config.get_ec_connector_capacity_embeds()
+                self.ec_connector_cache_manager = ECConnectorCacheManager(
+                    cache_size=capacity, vllm_config=self.vllm_config
+                )
+                logger.info(
+                    "Scheduler enabled ECConnectorCacheManager "
+                    "ec_connector=%s ec_connector_capacity_embeds=%d",
+                    type(self.ec_connector).__name__,
+                    capacity,
+                )
 
         num_gpu_blocks = self.cache_config.num_gpu_blocks
         assert num_gpu_blocks is not None and num_gpu_blocks > 0
@@ -527,12 +542,16 @@ class Scheduler(SchedulerInterface):
                 # Allocate the encoder cache.
                 for i in encoder_inputs_to_schedule:
                     self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector_cache_manager is not None:
+                        self.ec_connector_cache_manager.allocate(request, i)
                     if self.ec_connector is not None:
                         self.ec_connector.update_state_after_alloc(request, i)
                 encoder_compute_budget = new_encoder_compute_budget
             if external_load_encoder_input:
                 for i in external_load_encoder_input:
                     self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector_cache_manager is not None:
+                        self.ec_connector_cache_manager.allocate(request, i)
                     if self.ec_connector is not None:
                         self.ec_connector.update_state_after_alloc(request, i)
 
@@ -743,6 +762,8 @@ class Scheduler(SchedulerInterface):
                     # manager
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
+                        if self.ec_connector_cache_manager is not None:
+                            self.ec_connector_cache_manager.free(request)
                     break
 
                 # KVTransfer: the connector uses this info to determine
@@ -814,6 +835,8 @@ class Scheduler(SchedulerInterface):
                     # Allocate the encoder cache.
                     for i in encoder_inputs_to_schedule:
                         self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector_cache_manager is not None:
+                            self.ec_connector_cache_manager.allocate(request, i)
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
                     encoder_compute_budget = new_encoder_compute_budget
@@ -821,6 +844,8 @@ class Scheduler(SchedulerInterface):
                 if external_load_encoder_input:
                     for i in external_load_encoder_input:
                         self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector_cache_manager is not None:
+                            self.ec_connector_cache_manager.allocate(request, i)
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
 
@@ -905,6 +930,11 @@ class Scheduler(SchedulerInterface):
             # the previous and the current steps.
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
+            free_ec_connector_mm_hashes=(
+                self.ec_connector_cache_manager.get_freed_mm_hashes()
+                if self.ec_connector_cache_manager is not None
+                else []
+            ),
             new_block_ids_to_zero=new_block_ids_to_zero,
         )
 
@@ -943,6 +973,8 @@ class Scheduler(SchedulerInterface):
         )
         self.kv_cache_manager.free(request)
         self.encoder_cache_manager.free(request)
+        if self.ec_connector_cache_manager is not None:
+            self.ec_connector_cache_manager.free(request)
         request.status = RequestStatus.PREEMPTED
         request.num_computed_tokens = 0
         if request.spec_token_ids:
@@ -1225,6 +1257,19 @@ class Scheduler(SchedulerInterface):
                     # the request in this step.
                     num_new_tokens = 0
                 break
+            if (
+                self.ec_connector_cache_manager is not None
+                and not self.ec_connector_cache_manager.can_allocate(
+                    request, i, encoder_compute_budget, num_embeds_to_schedule
+                )
+            ):
+                if num_computed_tokens + shift_computed_tokens < start_pos:
+                    num_new_tokens = start_pos - (
+                        num_computed_tokens + shift_computed_tokens
+                    )
+                else:
+                    num_new_tokens = 0
+                break
 
             # Calculate the number of embeddings to schedule in the current range
             # of scheduled encoder placeholder tokens.
@@ -1323,6 +1368,16 @@ class Scheduler(SchedulerInterface):
                 kv_connector_output.invalid_block_ids,
                 num_scheduled_tokens,
             )
+
+        ec_connector_output = model_runner_output.ec_connector_output
+        if (
+            ec_connector_output is not None
+            and self.ec_connector_cache_manager is not None
+        ):
+            for mm_hash in ec_connector_output.finished_sending or ():
+                self.ec_connector_cache_manager.mark_consumer_received(mm_hash)
+            for mm_hash in ec_connector_output.finished_recving or ():
+                self.ec_connector_cache_manager.mark_consumer_received(mm_hash)
 
         # Persist per-step routed experts into the scheduler-side slot
         # buffer (CPU->CPU fancy-index assign; ~few MB per step).
@@ -1689,10 +1744,18 @@ class Scheduler(SchedulerInterface):
                 # we know we're done with the encoder input. Cross Attention
                 # KVs have been calculated and cached already.
                 self.encoder_cache_manager.free_encoder_input(request, input_id)
+                if self.ec_connector_cache_manager is not None:
+                    self.ec_connector_cache_manager.free_encoder_input(
+                        request, input_id
+                    )
             elif start_pos + num_tokens <= request.num_computed_tokens:
                 # The encoder output is already processed and stored
                 # in the decoder's KV cache.
                 self.encoder_cache_manager.free_encoder_input(request, input_id)
+                if self.ec_connector_cache_manager is not None:
+                    self.ec_connector_cache_manager.free_encoder_input(
+                        request, input_id
+                    )
 
     def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
         for req_id, spec_token_ids in zip(
@@ -1852,6 +1915,8 @@ class Scheduler(SchedulerInterface):
 
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
         self.encoder_cache_manager.free(request)
+        if self.ec_connector_cache_manager is not None:
+            self.ec_connector_cache_manager.free(request)
         request_id = request.request_id
         self.finished_req_ids.add(request_id)
         if self.finished_req_ids_dict is not None:

--- a/vllm/v1/worker/ec_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/ec_connector_model_runner_mixin.py
@@ -35,6 +35,17 @@ class ECConnectorModelRunnerMixin:
         connector.save_caches(encoder_cache=encoder_cache, mm_hash=mm_hash)
 
     @staticmethod
+    def maybe_free_ec_connector_physical(scheduler_output: "SchedulerOutput") -> None:
+        if not has_ec_transfer():
+            return
+        hashes = scheduler_output.free_ec_connector_mm_hashes
+        if not hashes:
+            return
+        connector = get_ec_transfer()
+        for mm_hash in hashes:
+            connector.free_physical_cache(mm_hash)
+
+    @staticmethod
     def maybe_get_ec_connector_output(
         scheduler_output: "SchedulerOutput",
         encoder_cache: dict[str, torch.Tensor],

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1152,6 +1152,8 @@ class GPUModelRunner(
         for mm_hash in scheduler_output.free_encoder_mm_hashes:
             self.encoder_cache.pop(mm_hash, None)
 
+        self.maybe_free_ec_connector_physical(scheduler_output)
+
         # Remove the unscheduled requests from the persistent batch.
         # NOTE(woosuk): The unscheduled requests are either preempted requests
         # or running requests that are not scheduled in this step. We remove


### PR DESCRIPTION
## 1 Purpose

### Before This PR (baseline after #25233 merge)

The disaggregated Encoder framework already provides an EC connector abstraction, but the connector side has **no independent capacity management or physical resource reclamation**:

| Dimension | Capability before PR | Limitation |
|-----------|------------------------|------------|
| **EC transport backend** | `ECExampleConnector` / `ECSharedStorageConnector`: encoder output written to **disk** (safetensors); PD loads on demand | High disk I/O latency; TTFT noticeably affected under high concurrency |
| **Scheduler-side EC management** | Only `EncoderCacheManager`: manages **in-process** GPU encoder cache slots on PD workers | Manages PD-local cache only; **does not track connector external storage usage** |
| **Connector capacity limit** | No `ec_connector_capacity_embeds`; producer can write unboundedly to SHM/disk | In SHM scenarios `/dev/shm` may be exhausted; no backpressure |
| **Physical resource reclamation** | `ECConnectorBase` has no `free_physical_cache()`; evict only clears PD-local `encoder_cache` | Producer-side SHM segments / disk files **are not automatically deleted on scheduler evict** |
| **Transfer lifecycle** | Example connector has no ACK; `get_finished()` is essentially empty | Producer does not know when consumer finishes reading; cannot precisely release connector slots |
| **Connector selection** | Factory registers only Example / SharedStorage connectors | Co-located E/P/D on the same host cannot use a zero-copy SHM path |

**Typical data flow before this PR (disk connector example):**

```text
Encoder (producer)                PD (consumer)
     │                                  │
     ├─ save_caches → write safetensors │
     │                                  ├─ has_cache_item → check file exists
     │                                  ├─ start_load_caches → read disk → GPU
     │                                  └─ encoder_cache discarded after use (local)
     │
     └─ disk files linger; no scheduler-side capacity control
```

### New capabilities after this PR

| Dimension | Added after PR | Value |
|-----------|----------------|-------|
| **`ECSharedMemoryConnector`** | Producer writes `/dev/shm`; consumer reads SHM + writes ACK byte | Low-latency transfer for co-located EPD; avoids disk I/O |
| **`ECConnectorCacheManager`** | Independent scheduler-side bookkeeping; limits connector usage by **embed slot count** | Backpressure on connector under high concurrency; prevents unbounded SHM growth |
| **`ec_connector_capacity_embeds`** | Configurable total connector capacity (default 11,468,800 embeds) | Convert to byte budget via model hidden_size × dtype for ops tuning |
| **Lazy eviction + physical release** | `can_allocate` evict → `free_ec_connector_mm_hashes` → worker `free_physical_cache()` → SHM `unlink` | Scheduler evict aligned with physical SHM segment lifecycle |
| **ACK-driven slot reclamation** | Consumer ACK → `get_finished(finished_recving)` → `mark_consumer_received()` | Producer-side slots become `freeable` only after transfer completes; avoids premature/late release |
| **Opt-in mechanism** | Manager enabled only when `supports_ec_connector_cache_manager = True` | Disk connectors unchanged; backward compatible |

**Typical data flow after this PR (SHM + cache manager):**

```text
Encoder Scheduler                         PD Scheduler
     │                                        │
     ├─ ECConnectorCacheManager               ├─ ECConnectorCacheManager (optional on consumer)
     ├─ can_allocate → schedule only if capacity OK
     ├─ allocate → occupy connector slot      ├─ allocate
     │                                        │
Encoder Worker                            PD Worker
     ├─ save_caches → write /dev/shm             ├─ start_load_caches → read SHM → clone to GPU
     ├─ get_finished → wait for ACK              ├─ write ACK_DONE
     │                                        │
Encoder Scheduler                         PD Scheduler
     ├─ mark_consumer_received → slot→freeable │
     ├─ can_allocate evict → freed[]           │
     │                                        │
Encoder Worker                            PD Worker
     └─ free_physical_cache → shm.unlink       └─ (local encoder_cache pop)
```

- **Before PR**: EC connector only "transfers data"; scheduler does not track how much external resource the connector uses, and there is no SHM backend.
- **After PR**: EC connector provides a complete loop of **SHM transfer + scheduler-side capacity ledger + ACK synchronization + physical SHM reclamation**, making high-concurrency EPD scenarios more controllable and faster.

### ECConnectorCacheManager logic

`ECConnectorCacheManager` is a **scheduler-process** connector resource ledger that **coexists in parallel** with `EncoderCacheManager` (which manages PD worker GPU encoder cache), with **separate responsibilities**.

#### Why is it needed?

| Manager | Manages | Process |
|---------|---------|---------|
| `EncoderCacheManager` | Encoder embedding cache in PD worker **GPU memory** | Scheduler bookkeeping; worker holds tensors |
| `ECConnectorCacheManager` | Embed slots occupied by **connector external storage** (SHM segments, etc.) | Scheduler bookkeeping; worker executes unlink |

SHM connector segments live under `/dev/shm` and are not in the PD `encoder_cache` dict. Without an independent manager, the scheduler cannot know how much SHM the producer has written or when to evict/unlink.

#### Core data structures

```text
cache_size              # total capacity (embed slot count, from ec_connector_capacity_embeds)
num_free_slots          # slots immediately available for allocation
num_freeable_slots      # slots reclaimable via eviction (0-ref in cached + pending delete in freeable)

cached:   mm_hash → set[request_id]     # referenced (in-flight transfer or PD still using)
freeable: mm_hash → num_embeds (FIFO)   # logically deletable; evicted on can_allocate
freed:    list[mm_hash]                 # hashes evicted this step; passed to worker for physical delete
_mm_hash_num_embeds                     # mm_hash → embed count; used by mark_consumer_received
```

#### Lifecycle (chronological)

##### 1. Initialization (scheduler startup)

- Condition: `ec_connector.supports_ec_connector_cache_manager == True` (only `ECSharedMemoryConnector`)
- Read `ec_transfer_config.get_ec_connector_capacity_embeds()` as `cache_size`
- Log total byte budget (`hidden_size × dtype × cache_size`)

##### 2. Before schedule: `can_allocate(request, input_id, ...)`

In `_try_schedule_encoder_inputs`, checked **in parallel with** `EncoderCacheManager.can_allocate`:

- If `num_embeds > num_free_slots`, **FIFO lazy evict** from `freeable` (`popitem(last=False)`)
- Evicted `mm_hash` entries go to `freed[]`; next step notifies worker via `free_physical_cache()`
- If still insufficient after evict → **pause scheduling that request** (backpressure)

> Lazy eviction: does not clear all of `freeable` at once; evicts only until the current request's required slots are satisfied.

##### 3. On successful schedule: `allocate(request, input_id)`

- Called **in sync with** `encoder_cache_manager.allocate`
- Add `request_id` to `cached[mm_hash]`; decrement `num_free_slots` and `num_freeable_slots`

##### 4. Transfer complete: `mark_consumer_received(mm_hash)`

In `update_from_output`, based on worker-reported `ec_connector_output`:

- Producer: `mm_hash` in `finished_sending` (consumer has ACK'd)
- Consumer: `mm_hash` in `finished_recving` (load complete)

Move from `cached` to `freeable`; **return `num_freeable_slots`** (slot is logically reclaimable; SHM file remains until evict triggers unlink).

##### 5. Request end: `free` / `free_encoder_input`

- Same pattern as `EncoderCacheManager`: when request completes or an mm input is no longer needed, decrement ref count
- Ref count reaches zero → enter `freeable`

##### 6. Physical delete: `get_freed_mm_hashes()` → `free_ec_connector_mm_hashes`

- When building `SchedulerOutput` each step, pass `freed[]` to worker
- Worker calls `connector.free_physical_cache(mm_hash)` → SHM `unlink`

##### 7. Comparison with EncoderCacheManager

| Operation | EncoderCacheManager | ECConnectorCacheManager |
|-----------|---------------------|-------------------------|
| Capacity unit | PD encoder embed slots | Connector embed slots |
| Enable condition | Multimodal encoder present | connector `supports_ec_connector_cache_manager=True` |
| Evict consequence | PD worker pops `encoder_cache` | Producer worker SHM unlink |
| Transfer ACK | None | `mark_consumer_received` depends on ACK |

### Configuration

```json
{
  "ec_connector_extra_config": {
    "ec_connector_capacity_embeds": 11468800
  }
}
```

- Key: `ec_connector_capacity_embeds`
- Default: `11_468_800` embeds
- Producer scheduler **must** care; consumer-side manager is mainly for symmetric bookkeeping

---

## 2 Sequence Diagram

On top of EPD participants, **EncConn** / **PDConn** are `ECSharedMemoryConnector` instances in each process (scheduler and worker each hold one; shown merged in the diagram).

```mermaid
sequenceDiagram
    autonumber
    participant Client
    participant Proxy as EPD Proxy
    participant EncAPI as Encoder API
    participant EncSch as Encoder Scheduler
    participant EncMgr as ECConnectorCacheManager<br/>(Encoder)
    participant EncW as Encoder Worker
    participant EncConn as ECSharedMemoryConnector<br/>(Encoder)
    participant SHM as /dev/shm
    participant PDAPI as PD API
    participant PDSch as PD Scheduler
    participant PDMgr as ECConnectorCacheManager<br/>(PD)
    participant PDW as PD Worker
    participant PDConn as ECSharedMemoryConnector<br/>(PD)

    Client->>Proxy: chat/completions (4K image)
    Proxy->>EncAPI: POST encode primer
    EncAPI->>EncSch: schedule encoder input

    EncSch->>EncMgr: can_allocate(mm_hash)
    alt insufficient slots
        EncMgr->>EncMgr: lazy evict → freed[]
        EncSch->>EncW: free_ec_connector_mm_hashes
        EncW->>EncConn: free_physical_cache
        EncConn->>SHM: unlink segment
    end
    EncSch->>EncMgr: allocate(mm_hash)

    EncSch->>EncW: SchedulerOutput (encode step)
    EncW->>EncW: embed_multimodal (ViT encode)
    EncW->>EncConn: save_caches (sync)
    EncConn->>SHM: write EC segment (ACK=pending)

    Proxy->>PDAPI: POST decode
    PDAPI->>PDSch: schedule request

    PDSch->>PDConn: has_cache_item(mm_hash)
    PDConn->>SHM: probe segment
    PDConn-->>PDSch: hit
    PDSch->>PDMgr: can_allocate + allocate
    PDSch->>PDConn: build_connector_meta
    PDSch->>PDW: SchedulerOutput + ec_connector_metadata

    PDW->>PDConn: start_load_caches (sync)
    PDConn->>SHM: read EC → GPU encoder_cache
    PDConn->>SHM: ACK=done
    PDW->>PDW: gather_mm_embeddings + prefill

    PDW->>PDConn: get_finished
    PDConn-->>PDSch: finished_recving
    PDSch->>PDMgr: mark_consumer_received
    EncW->>EncConn: get_finished
    EncConn-->>EncSch: finished_sending (ACK seen)
    EncSch->>EncMgr: mark_consumer_received

    PDW-->>Client: first token (TTFT)
    Note over Client,PDW: subsequent decode steps do not load EC
```

### ECSharedMemoryConnector methods vs EPD stages

| Stage | Role | Method | Internal state / side effects |
|-------|------|--------|-------------------------------|
| Before PD schedule | Consumer Scheduler | `has_cache_item(mm_hash)` | `os.path.exists` + pread validate ECv1/header |
| After PD allocate | Consumer Scheduler | `update_state_after_alloc` | `_mm_hashes_need_loads += mm_hash` |
| Each scheduler step | Consumer Scheduler | `build_connector_meta` | Output `mm_hashes[]`; clear need_loads |
| Encode complete | Producer Worker | `save_caches` | create/resize SHM; `_pending_sends += mm_hash` |
| Prefill first step | Consumer Worker | `start_load_caches` | clone→GPU; write ACK; `_pending_recvs += mm_hash` |
| Step end | Worker | `get_finished` | Producer: poll ACK→`finished_sending`; Consumer: `finished_recving` |
| Evict | Producer Worker | `free_physical_cache` | `_unlink_shm`; clear pending sets |
| Full pipeline | Scheduler | `ECConnectorCacheManager` | `can_allocate`/`allocate`/`mark_consumer_received`/evict→`freed[]` |

### Key synchronization points (current implementation)

| Step | ECSharedMemoryConnector behavior | Log keywords |
|------|----------------------------------|--------------|
| **save_caches** | GPU tensor → CPU contiguous → write full SHM segment; ACK=PENDING; **sync blocking** encode step | `ec_connector save_caches ... ms=` |
| **has_cache_item** | Scheduler-side pread probe; does not mmap full payload | `scheduler ec_has_cache_item ... hit=` |
| **start_load_caches** | SHM mmap → validate → clone → H2D; write ACK=DONE; **sync blocking** prefill first step | `ec_connector start_load_caches ... ms=` |
| **get_finished (producer)** | `_is_send_acknowledged` pread last byte | `finished_sending` |
| **get_finished (consumer)** | Return `_pending_recvs` | `finished_recving` |
| **free_physical_cache** | TP0 `_unlink_shm`; clear `_pending_sends` / `_pending_recvs` | `free_ec_connector_mm_hashes` |

---

## 3 Test Plan & Test Results

**Environment**

| Item | Value |
|------|-------|
| Model | Qwen3-VL-2B-Thinking |
| Image size | 4K |
| Topology | Disaggregated E + PD (proxy) |
| EC connectors under test | `ECSharedMemoryConnector` vs `ECExampleConnector` |

### 3.1 Usage Example

1 Encoder + 1 PD:
`examples/online_serving/disaggregated_encoder/shared_storage_connector/disagg_1e1pd_example.sh`

Encoder (producer):

```bash
vllm serve <model> \
  --max-num-seqs 16 \
  --ec-transfer-config '{
    "ec_connector": "ECSharedMemoryConnector",
    "ec_role": "ec_producer",
    "ec_connector_extra_config": {
      "ec_connector_capacity_embeds": 11468800
    }
  }'
```

PD / Decode (consumer):

```bash
vllm serve <model> \
  --max-num-seqs 16 \
  --ec-transfer-config '{
    "ec_connector": "ECSharedMemoryConnector",
    "ec_role": "ec_consumer"
  }'
```

### 3.2 Benchmark

```bash
vllm bench serve \
  --backend             openai-chat \
  --tokenizer /data/models/Qwen3-VL-2B-Thinking/ \
  --endpoint            /v1/chat/completions \
  --model               "qwen" \
  --dataset-name        random-mm \
  --num-prompts         16 \
  --seed $(date +%s) \
  --port                8001 \
  --random-input-len    300 \
  --random-output-len   2 \
  --max-concurrency 1 \
  --random-mm-base-items-per-request 1 \
  --random-mm-limit-mm-per-prompt '{"image": 1, "video": 0}' \
  --random-mm-bucket-config '{(4096, 4096, 1): 1.0}' \
  --save-result \
  --result-dir bench_results \
  --metadata "max_concurrency=1" \
  --metadata "num_prompts=16"
```

```bash
vllm bench serve \
  --backend             openai-chat \
  --tokenizer /data/l30039280/models/Qwen3-VL-2B-Thinking/ \
  --endpoint            /v1/chat/completions \
  --model               "qwen" \
  --dataset-name        random-mm \
  --num-prompts         32 \
  --seed $(date +%s) \
  --port                8001 \
  --random-input-len    300 \
  --random-output-len   2 \
  --max-concurrency 16 \
  --random-mm-base-items-per-request 1 \
  --random-mm-limit-mm-per-prompt '{"image": 1, "video": 0}' \
  --random-mm-bucket-config '{(4096, 4096, 1): 1.0}' \
  --save-result \
  --result-dir bench_results \
  --metadata "max_concurrency=16" \
  --metadata "num_prompts=32"
```

### 3.3 High concurrency (`max_concurrency=16`, 32 completed requests per run)

| Connector | Run | mean_ttft_ms | median_ttft_ms |
|-----------|-----|--------------|----------------|
| **shm** | 1 | 61397.81 | 61605.30 |
| **shm** | 2 | 60294.15 | 62032.19 |
| **example** | 1 | 62967.42 | 63942.68 |
| **example** | 2 | 61940.85 | 63473.33 |

- SHM vs example (avg of 2 runs): **~2.6% lower mean TTFT**, **~2.9% lower median TTFT**
- Both runs: 32/32 completed, 0 failed

### 3.4 Low concurrency (`max_concurrency=1`, 16 completed requests per run)

| Connector | Run | mean_ttft_ms | median_ttft_ms |
|-----------|-----|--------------|----------------|
| **shm** | 1 | 7041.30 | 7001.01 |
| **shm** | 2 | 7025.37 | 6955.21 |
| **shm** | 3 | 7036.69 | 6984.38 |
| **example** | 1 | 7158.31 | 7136.87 |
| **example** | 2 | 7134.99 | 7133.49 |
| **example** | 3 | 7186.27 | 7158.89 |

- SHM vs example (avg of 3 runs): **~1.8% lower mean TTFT** (~7034 ms vs ~7160 ms)
- All runs: 16/16 completed, 0 failed

**Takeaway**: SHM connector shows consistent TTFT improvement over the disk-based example connector at both concurrency levels, with larger relative gain under high concurrency where disk I/O and connector capacity pressure are more visible.

---

## 4 Encode / EC Optimization Share of End-to-End TTFT

### 4.1 Connector-layer latency (save + load, per-image mean)

Parsed from logs: `ec_connector save_caches` / `start_load_caches` (112 single-image load samples each):

| Stage | SHM (ms) | Example/disk (ms) | Δ (example − shm) |
|-------|----------|-------------------|-------------------|
| **save_caches** (Encoder) | 311.4 | 446.9 | **+135.5 ms** |
| **start_load_caches** (PD) | 72.4 | 41.9 | −30.5 ms |
| **EC transfer total** | **383.8** | **488.8** | **+105.0 ms** |

> SHM mainly benefits the **save side** (no safetensors disk write); load is slightly slower due to SHM→GPU clone vs local file read, but save savings dominate; total still ~105 ms/image better.

### 4.2 Share of TTFT (two concurrency scenarios)

| Scenario | mean TTFT (shm) | mean TTFT (example) | TTFT Δ | EC Δ as % of TTFT Δ | EC as % of absolute TTFT |
|----------|-----------------|---------------------|--------|---------------------|--------------------------|
| **concurrency=1** | ~7034 ms | ~7160 ms | **126 ms** | **~83%** | ~5.5% (488/7160) |
| **concurrency=16** | ~60846 ms | ~62454 ms | **1608 ms** | **~6–10%*** | **<1%** (488/62454) |

\* Under high concurrency, TTFT Δ is not only from EC save/load but also encoder queue amplification from disk I/O contention; encoder batch `embed_multimodal num_items=6` can reach **40–47 s** in logs, while EC save ~300 ms/image is negligible.

### 4.3 End-to-end path breakdown (concurrency=1, illustrative)

Using example connector logs (single-image cold path):

```text
TTFT (~7160 ms) approximate breakdown:
├── Proxy → Encoder queue + ViT encode (embed_multimodal)     ~3450 ms   (~48%)
├── EC save (disk safetensors)                              ~447 ms    (~6%)
├── EC load (PD start_load_caches)                          ~42 ms     (~0.6%)
├── PD prefill first step (preprocess + forward 8192 tokens) ~1400 ms   (~20%)
└── Scheduling queue / network / first decode token, etc.    ~2300 ms   (~32%)
```

SHM optimization directly replaces **EC save/load total ~105 ms**; at concurrency=1 it accounts for **~83%** of TTFT improvement and **~1.5%** of absolute TTFT.

### 4.4 Scenarios with maximum EPD benefit

| Scenario | Why benefit is large | Expected effect |
|----------|----------------------|-----------------|
| **Co-located E+P+D** | POSIX SHM zero network hop; target scenario for this PR | ~30% faster on save side (311 vs 447 ms) |
| **High concurrency + multi-image writes** | Disk connector: 16-way concurrent safetensors writes, severe I/O contention | ~2.6% TTFT improvement; mainly I/O pressure relief + cache manager backpressure |
| **High resolution / large EC tensor** | EC payload ∝ embed slots; disk read/write grows linearly | SHM advantage scales with tensor size (~16688 embeds for current 4K single image) |
| **Repeated mm_hash (cache hit)** | Skip encode; only load + prefill remain | EC load share rises; SHM vs disk gap more sensitive |
| **Independent encoder scaling** | E and PD resources decoupled; encoder no longer PD bottleneck | EPD architecture value; connector optimization reduces EC transfer drag on PD TTFT |

**Benchmark bottleneck note**: At 4K + concurrency=16, TTFT ~60 s; **encoder compute/queueing is the main cause** (`embed_multimodal` batch dominates), not EC connector. SHM's value: with encoder already disaggregated, downgrade EC transfer from "disk I/O bottleneck" to "memory bandwidth operation", and lay groundwork for async / multi-node.

---

## 5 Future Outlook

### 5.1 Current limitations

| Limitation | Current state |
|------------|---------------|
| Deployment topology | **Single-host** `/dev/shm`; Encoder / PD must be on same host |
| save_caches | **Synchronous**: blocks inside `encode_only_step`, GPU→CPU→SHM |
| start_load_caches | **Synchronous**: blocks on prefill first step, SHM→CPU clone→GPU |
| ACK | Producer **polls** ACK byte via `get_finished` |
| Multi-node | Not supported; SHM cannot cross nodes |

### 5.2 Planned optimization directions

```text
Phase 1 (this PR)          Phase 2                 Phase 3
─────────────────────────────────────────────────────────────
Single-host SHM sync       →  Async save/load        →  Multi-node EC transfer
save/load                  →  Pipeline overlap       →  NIXL / RDMA /
ECConnectorCacheManager    →  encode with transfer   →  Mooncake / Redis
capacity + evict + ACK     →  parallel               →
```

**Phase 2 — Async save/load**

- Producer: submit `save_caches` to background thread / CUDA stream; encode step non-blocking; `wait_for_save()` syncs when scheduler needs ACK
- Consumer: prefetch `start_load_caches` (trigger after proxy completes encode); embedding ready at prefill time
- Goal: overlap EC transfer with encoder next batch / PD scheduling; further compress ~400 ms EC segment in TTFT

**Phase 3 — Multi-node support**

- Abstract transport layer on `ECConnectorBase`: SHM (local) vs NIXL/RDMA (remote; see #26009)
- `ECConnectorCacheManager` continues scheduler-side slot ledger; physical backend pluggable
- Cross-node EC payload still far smaller than KV cache; suitable for dedicated low-latency connector
