### PR TITLE
fix(ngram): sync ngram_gpu acceptance rate to match CPU

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -117,8 +117,12 @@ class CpuGpuBuffer:
         pin_memory: bool,
         with_numpy: bool = True,
     ) -> None:
-        self.cpu = torch.zeros(*size, dtype=dtype, device="cpu", pin_memory=pin_memory)
-        self.gpu = torch.zeros_like(self.cpu, device=device)
+        # these buffers are mutable runtime state, so allocate them as normal
+        with torch.inference_mode(False):
+            self.cpu = torch.zeros(
+                *size, dtype=dtype, device="cpu", pin_memory=pin_memory
+            )
+            self.gpu = torch.zeros_like(self.cpu, device=device)
         self.np: np.ndarray
         # To keep type hints simple (avoiding generics and subclasses), we
         # only conditionally create the numpy array attribute. This can cause

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4682,7 +4682,17 @@ class GPUModelRunner(
         assert self.draft_token_ids_event is not None
         assert self.draft_token_ids_cpu is not None
         self.draft_token_ids_event.synchronize()
-        return self.draft_token_ids_cpu[: len(req_ids)].tolist(), req_ids
+        num_reqs = len(req_ids)
+        draft_token_ids = self.draft_token_ids_cpu[:num_reqs].tolist()
+        if self._num_valid_draft_tokens_cpu is not None:
+            assert self._num_valid_draft_tokens_event is not None
+            self._num_valid_draft_tokens_event.synchronize()
+            valid_counts = self._num_valid_draft_tokens_cpu[:num_reqs].tolist()
+            draft_token_ids = [
+                list(row[: max(0, min(int(v), len(row)))])
+                for row, v in zip(draft_token_ids, valid_counts)
+            ]
+        return draft_token_ids, req_ids
 
     def _copy_valid_sampled_token_count(
         self, next_token_ids: torch.Tensor, valid_sampled_tokens_count: torch.Tensor


### PR DESCRIPTION
When ngram_gpu produces per-request valid draft token counts, use them to
truncate the draft token IDs before returning, avoiding invalid tokens being
passed to downstream consumers.

## Purpose

Fix speculative decoding acceptance rate undercounting in **sync scheduling**
mode with ngram_gpu. When the ngram proposer fails to match, draft token IDs
contain invalid entries (filled with `-1`). These invalid tokens were returned
as-is by `_get_draft_token_ids_cpu()`, inflating the draft-token denominator
in `make_spec_decoding_stats()` and making the reported acceptance rate appear
lower than it actually is.

**Before:** `_get_draft_token_ids_cpu()` returned all draft tokens including
invalid `-1` placeholders.

**After:** It now reads `_num_valid_draft_tokens_cpu` (already populated during
`execute_model()`) and truncates each request's draft token list to the valid
count, so only legitimately drafted tokens reach the scheduler stats.

## Test Plan

Run any model with ngram_gpu speculative decoding in **sync** scheduling mode
and observe the acceptance rate metric.

```bash
python -m vllm.entrypoints.openai.api_server \
    --model <model_path> \
    --speculative-config '{"method":"ngram_gpu","num_speculative_tokens":5,"prompt_lookup_max":5,"prompt_lookup_min":1}' \
    --disable-async-scheduling