### PR TITLE
fix(ngram): match async ngram_gpu acceptance rate to CPU

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1395,6 +1395,7 @@ class Scheduler(SchedulerInterface):
                     num_accepted_tokens=num_accepted,
                     num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
                     request_id=req_id,
+                    ngram_invalid_spec_tokens=model_runner_output.ngram_invalid_spec_tokens,
                 )
 
             # Free encoder inputs only after the step has actually executed.
@@ -2024,13 +2025,20 @@ class Scheduler(SchedulerInterface):
         num_accepted_tokens: int,
         num_invalid_spec_tokens: dict[str, int] | None,
         request_id: str,
+        ngram_invalid_spec_tokens: dict[str, int] | None = None,
     ) -> SpecDecodingStats | None:
-        if not self.log_stats or not num_draft_tokens:
+        if not self.log_stats:
             return None
-        if spec_decoding_stats is None:
-            spec_decoding_stats = SpecDecodingStats.new(self.num_spec_tokens)
+        if not num_draft_tokens:
+            return spec_decoding_stats
         if num_invalid_spec_tokens:
             num_draft_tokens -= num_invalid_spec_tokens.get(request_id, 0)
+        if ngram_invalid_spec_tokens:
+            num_draft_tokens -= ngram_invalid_spec_tokens.get(request_id, 0)
+        if num_draft_tokens <= 0:
+            return spec_decoding_stats
+        if spec_decoding_stats is None:
+            spec_decoding_stats = SpecDecodingStats.new(self.num_spec_tokens)
         spec_decoding_stats.observe_draft(
             num_draft_tokens=num_draft_tokens, num_accepted_tokens=num_accepted_tokens
         )

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -280,6 +280,8 @@ class ModelRunnerOutput:
     # ``None`` when ``enable_return_routed_experts`` is off.
     routed_experts: RoutedExpertsLists | None = None
 
+    ngram_invalid_spec_tokens: dict[str, int] | None = None
+
     @staticmethod
     def with_kv_conn_output_only(
         kv_connector_output: KVConnectorOutput | None,

--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -469,7 +469,7 @@ def update_scheduler_for_invalid_drafts(
     num_valid_draft_tokens_cpu: torch.Tensor,
     scheduler_output: "SchedulerOutput",
     req_id_to_index: dict[str, int],
-) -> None:
+) -> dict[str, int]:
     """Trim invalid speculative slots using per-request valid draft counts.
 
     Args:
@@ -477,9 +477,13 @@ def update_scheduler_for_invalid_drafts(
         num_valid_draft_tokens_cpu: CPU buffer of valid draft counts.
         scheduler_output: Scheduler metadata to update in-place.
         req_id_to_index: Request-id to batch-index mapping.
+
+    Returns:
+        Mapping from request id to the number of invalid draft tokens trimmed.
     """
     req_data = scheduler_output.scheduled_cached_reqs
     num_valid_draft_tokens_event.synchronize()
+    invalid_counts: dict[str, int] = {}
 
     for req_id in req_data.req_ids:
         req_index = req_id_to_index.get(req_id)
@@ -496,6 +500,8 @@ def update_scheduler_for_invalid_drafts(
         valid_k = max(0, min(valid_k, scheduled_k))
 
         tokens_to_trim = scheduled_k - valid_k
+        if tokens_to_trim > 0:
+            invalid_counts[req_id] = tokens_to_trim
         scheduler_output.total_num_scheduled_tokens -= tokens_to_trim
         scheduler_output.num_scheduled_tokens[req_id] -= tokens_to_trim
 
@@ -505,6 +511,8 @@ def update_scheduler_for_invalid_drafts(
             scheduler_output.scheduled_spec_decode_tokens[req_id] = spec_token_ids[
                 :valid_k
             ]
+
+    return invalid_counts
 
 
 def update_ngram_gpu_tensors_incremental(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -833,6 +833,7 @@ class GPUModelRunner(
         self._num_valid_draft_tokens_cpu: torch.Tensor | None = None
         self._num_valid_draft_tokens_event: torch.cuda.Event | None = None
         self._num_valid_draft_tokens_copy_stream: torch.cuda.Stream | None = None
+        self._ngram_invalid_spec_tokens: dict[str, int] | None = None
         if (
             self.speculative_config is not None
             and self.speculative_config.use_ngram_gpu()
@@ -1178,6 +1179,7 @@ class GPUModelRunner(
             self.speculative_config is not None
             and self.speculative_config.use_ngram_gpu()
         )
+        self._ngram_invalid_spec_tokens = None
         if is_ngram_gpu:
             ngram_gpu_new_reqs: list[CachedRequestState] = []
 
@@ -1265,11 +1267,16 @@ class GPUModelRunner(
         ):
             for req_id, toks in scheduled_spec_tokens.items():
                 original_num_spec_per_req[req_id] = len(toks)
-            update_scheduler_for_invalid_drafts(
-                self._num_valid_draft_tokens_event,
-                self._num_valid_draft_tokens_cpu,
-                scheduler_output,
-                self.input_batch.req_id_to_index,
+            assert self._num_valid_draft_tokens_event is not None
+            assert self._num_valid_draft_tokens_cpu is not None
+            self._ngram_invalid_spec_tokens = (
+                update_scheduler_for_invalid_drafts(
+                    self._num_valid_draft_tokens_event,
+                    self._num_valid_draft_tokens_cpu,
+                    scheduler_output,
+                    self.input_batch.req_id_to_index,
+                )
+                or None
             )
         if self.use_async_spec_decode:
             self.prev_num_draft_tokens.np.fill(0)
@@ -4525,6 +4532,11 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts=None,
+                ngram_invalid_spec_tokens=(
+                    self._ngram_invalid_spec_tokens.copy()
+                    if self._ngram_invalid_spec_tokens
+                    else None
+                ),
             )
 
         if not self.use_async_scheduling:


### PR DESCRIPTION
[ngram][async] Fix ngram_gpu acceptance rate to match CPU ngram

In async scheduling, ngram_gpu's reported acceptance rate was lower than CPU
ngram because update_scheduler_for_invalid_drafts() trimmed invalid drafts on
the worker side but never communicated the trimmed count back to the scheduler,
inflating the draft-token denominator in SpecDecodingStats.

Problem:
When using ngram GPU speculative decoding, update_scheduler_for_invalid_drafts() trims invalid draft tokens on the GPU side, but the trimmed count was not accounted for in the scheduler's SpecDecodingStats. This caused num_draft_tokens to be inflated, leading to inaccurate acceptance rate reporting.

Solution:
- Make update_scheduler_for_invalid_drafts() return a dict mapping request id to the number of trimmed invalid tokens.
- Pass this count through ModelRunnerOutput.ngram_invalid_spec_tokens to the scheduler, where make_spec_decoding_stats() subtracts it from num_draft_tokens before computing stats.




## Purpose

Fix speculative decoding acceptance rate undercounting in **async scheduling**
mode with ngram_gpu. The reported acceptance rate was lower than CPU ngram
because `update_scheduler_for_invalid_drafts()` trimmed invalid drafts on the
worker side but never reported the trimmed count back to the scheduler,
inflating the `num_draft_tokens` denominator in `make_spec_decoding_stats()`.

After this fix, ngram_gpu's acceptance rate in async mode aligns with CPU
ngram's.

Files changed:

- **`vllm/v1/spec_decode/ngram_proposer_gpu.py`** — `update_scheduler_for_invalid_drafts()`:
  - Return type changed from `-> None` to `-> dict[str, int]`.
  - Collects `tokens_to_trim` per request into `invalid_counts` dict and returns it.

- **`vllm/v1/worker/gpu_model_runner.py`** — 3 changes:
  - `__init__()`: Add `self._ngram_invalid_spec_tokens: dict[str, int] | None = None` instance variable.
  - `_update_states()`: Capture return value from `update_scheduler_for_invalid_drafts()` into `self._ngram_invalid_spec_tokens` (with `or None` to convert empty dict).
  - `sample_tokens()`: Pass `self._ngram_invalid_spec_tokens.copy()` into `ModelRunnerOutput` constructor.

- **`vllm/v1/outputs.py`** — `ModelRunnerOutput`:
  - Add field `ngram_invalid_spec_tokens: dict[str, int] | None = None`.

- **`vllm/v1/core/sched/scheduler.py`** — 2 changes:
  - `update_from_output()`: Pass `model_runner_output.ngram_invalid_spec_tokens` to `make_spec_decoding_stats()`.
  - `make_spec_decoding_stats()`: New parameter `ngram_invalid_spec_tokens`. Subtract from `num_draft_tokens`. Add guard against `num_draft_tokens <= 0` after subtractions. Preserve existing `spec_decoding_stats` on early return instead of dropping it.

## Test Plan

Run any model with ngram_gpu speculative decoding in **async** scheduling mode
(default) and compare acceptance rate with CPU ngram baseline.

```bash
# ngram_gpu (async, default)
python -m vllm.entrypoints.openai.api_server \
    --model <model_path> \
    --speculative-config '{"method":"ngram_gpu","num_speculative_tokens":5,"prompt_lookup_max":5,"prompt_lookup_min":1}'

# CPU ngram (baseline)
python -m vllm.entrypoints.openai.api_server \
    --model <model_path> \
    --speculative-config '{"method":"ngram","num_speculative_tokens":5,"prompt_lookup_max":5,"prompt_lookup_min":1}'
