### PR TITLE
fix: skip stale LRU cache order entries

### DIFF
--- a/tests/utils_/test_cache.py
+++ b/tests/utils_/test_cache.py
@@ -123,3 +123,28 @@ def test_lru_cache():
     assert 2 in cache
     assert 4 in cache
     assert 6 in cache
+
+
+def test_lru_cache_popitem_skips_stale_order_entry():
+    cache = TestLRUCache(2)
+    cache.touch("stale")
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    assert list(cache.order) == ["stale", "a", "b"]
+
+    assert cache.popitem() == ("a", 1)
+    assert list(cache.order) == ["b"]
+    assert set(cache.cache) == {"b"}
+    assert "stale" not in cache.pinned_items
+
+
+def test_lru_cache_put_cleans_stale_order_entry_before_eviction():
+    cache = TestLRUCache(1)
+    cache.touch("stale")
+    cache.put("a", 1)
+
+    cache.put("b", 2)
+
+    assert list(cache.order) == ["b"]
+    assert set(cache.cache) == {"b"}

--- a/vllm/utils/cache.py
+++ b/vllm/utils/cache.py
@@ -190,18 +190,18 @@ class LRUCache(cachetools.LRUCache[_K, _V]):
 
     def popitem(self, remove_pinned: bool = False):
         """Remove and return the `(key, value)` pair least recently used."""
-        if not remove_pinned:
-            # pop the oldest item in the cache that is not pinned
-            lru_key = next(
-                (key for key in self.order if key not in self.pinned_items),
-                ALL_PINNED_SENTINEL,
-            )
-            if lru_key is ALL_PINNED_SENTINEL:
-                raise RuntimeError(
-                    "All items are pinned, cannot remove oldest from the cache."
-                )
+        for lru_key in list(self.order):
+            if lru_key not in self:
+                del self._LRUCache__order[lru_key]  # type: ignore
+                self.pinned_items.discard(lru_key)
+                continue
+            if remove_pinned or lru_key not in self.pinned_items:
+                break
         else:
-            lru_key = next(iter(self.order))
+            raise RuntimeError(
+                "All items are pinned, cannot remove oldest from the cache."
+            )
+
         value = self.pop(cast(_K, lru_key))
         return (lru_key, value)
 


### PR DESCRIPTION
﻿Fixes #43941.

## Summary
- make `LRUCache.popitem()` discard stale order entries that no longer have backing cache data
- keep pinned-entry behavior unchanged for real cache items
- add regressions for direct `popitem()` eviction and `put()` eviction after a stale `touch()` entry

## To verify
- `python -m pytest tests/utils_/test_cache.py -q --confcutdir=tests/utils_`
- `python -m ruff check vllm/utils/cache.py tests/utils_/test_cache.py`
- `python -m ruff format --check vllm/utils/cache.py tests/utils_/test_cache.py`
- `python -m py_compile vllm/utils/cache.py tests/utils_/test_cache.py`
- `git diff --check`
