### PR TITLE
[MRV2][DSV4] Reset FlashMLA tile metadata in prefill capture

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
@@ -61,6 +61,24 @@ class PrefillEagleCudaGraphManager(EagleCudaGraphManagerBase):
             )
             attn_state = full_cg_attn_states[desc]
             attn_metadata, slot_mappings = attn_state
+
+            # NOTE: Band-aid fix for Deepseek V4 FlashMLA tile scheduler planner.
+            # Draft prefill reuses the target's captured metadata, so its
+            # FlashMLA tile schedulers are already planned. Reset them so the
+            # planner re-runs inside the draft's own FULL graph on capture.
+            if isinstance(attn_metadata, dict):
+                for md in attn_metadata.values():
+                    for name in (
+                        "tile_sched_swaonly",
+                        "tile_sched_c4a",
+                        "tile_sched_c128a",
+                    ):
+                        sched = getattr(md, name, None)
+                        if sched is not None:
+                            sched.have_initialized = False
+                            sched.tile_scheduler_metadata = None
+                            sched.num_splits = None
+
             fwd = lambda cg_mode: forward_fn(
                 num_reqs,
                 num_tokens,

--- a/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
@@ -66,7 +66,7 @@ class PrefillEagleCudaGraphManager(EagleCudaGraphManagerBase):
             # Draft prefill reuses the target's captured metadata, so its
             # FlashMLA tile schedulers are already planned. Reset them so the
             # planner re-runs inside the draft's own FULL graph on capture.
-            if isinstance(attn_metadata, dict):
+            if desc.cg_mode == CUDAGraphMode.FULL and isinstance(attn_metadata, dict):
                 for md in attn_metadata.values():
                     for name in (
                         "tile_sched_swaonly",


### PR DESCRIPTION
Currently, MRV2 raises an error when using DSv4 with MTP. This PR fixes the bug by resetting FlashMLA tile schedule and ensuring it's re-built inside the captured `forward`.