### PR TITLE
Enable FlashInfer autotune cache by default

### DIFF
--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -325,7 +325,8 @@ Most cache paths default to subdirectories under a single root. Changing `VLLM_C
 | --- | --- | --- |
 | `VLLM_CACHE_ROOT` | `~/.cache/vllm` | Base cache directory. Respects `XDG_CACHE_HOME` if set. All paths below inherit from this unless explicitly overridden. |
 | *(torch.compile)* | `$VLLM_CACHE_ROOT/torch_compile_cache/` | Compilation cache for AOT-compiled models, Inductor graphs, and Triton kernels. Controlled by `VLLM_DISABLE_COMPILE_CACHE` (set to `1` to disable). |
-| `VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR` | `$VLLM_CACHE_ROOT/flashinfer_autotune_cache/<flashinfer-version>/<arch>/<cache-hash>/` | FlashInfer autotune config cache. |
+| `VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE` | `0` | Disables the persistent FlashInfer autotune config cache when set to `1`. |
+| `VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR` | `$VLLM_CACHE_ROOT/flashinfer_autotune_cache/<flashinfer-version>/<arch>/<cache-hash>/` | FlashInfer autotune config cache location. |
 | `VLLM_ASSETS_CACHE` | `$VLLM_CACHE_ROOT/assets/` | Downloaded assets (e.g., tokenizer files). |
 | `VLLM_XLA_CACHE_PATH` | `$VLLM_CACHE_ROOT/xla_cache/` | XLA/TPU compilation cache. |
 | `VLLM_MEDIA_CACHE` | *(disabled)* | Optional cache for downloaded media (images, video, audio). Not enabled unless explicitly set. |

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -187,6 +187,7 @@ if TYPE_CHECKING:
     VLLM_USE_FUSED_MOE_GROUPED_TOPK: bool = True
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
+    VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
@@ -1535,6 +1536,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "MOONCAKE_REQUESTER_LOCAL_HOSTNAME": lambda: os.getenv(
         "MOONCAKE_REQUESTER_LOCAL_HOSTNAME"
     ),
+    # Disable the persistent file cache for FlashInfer autotune results.
+    "VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE", "0"))
+    ),
     # Override the directory for the FlashInfer autotune config cache.
     "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR": lambda: os.getenv(
         "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR", None
@@ -2043,6 +2048,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOG_STATS_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
         "VLLM_TUNED_CONFIG_FOLDER",
+        "VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE",
         "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR",
         "VLLM_ENGINE_ITERATION_TIMEOUT_S",
         "VLLM_HTTP_TIMEOUT_KEEP_ALIVE",

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -112,12 +112,6 @@ def kernel_warmup(worker: "Worker"):
         )
 
 
-# TODO: remove once FlashInfer upstream fixes the persistent file cache
-# to resolve collisions like `use_8x4_sf_layout=True/False`, which causes
-# invalid tactics to be chosen
-_FLASHINFER_USE_PERSISTENT_CACHE = False
-
-
 def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     """
     Autotune FlashInfer operations.
@@ -134,7 +128,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     import vllm.utils.flashinfer as fi_utils
     from vllm.distributed.parallel_state import get_world_group
 
-    if not _FLASHINFER_USE_PERSISTENT_CACHE:
+    if envs.VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE:
         with torch.inference_mode(), fi_utils.autotune():
             runner._dummy_run(
                 num_tokens=runner.scheduler_config.max_num_batched_tokens,


### PR DESCRIPTION
## Summary

PR #43119 temporarily disabled the persistent FI autotune file cache unconditionally because FI did not distinguish runner-specific kernel parameters like `use_8x4_sf_layout`, which could select invalid cached tactics.

FI has already fixed the cache-key collision upstream in https://github.com/flashinfer-ai/flashinfer/pull/3367, and the fix is expected in the upcoming stable FI v0.6.13 release. Since this PR was opened, the expected default has changed: this now enables the persistent FI autotune file cache by default while adding `VLLM_DISABLE_FLASHINFER_AUTOTUNE_CACHE=1` for users who want to opt out.

Even after the fix is available in stable FI releases, this env var is still useful as an explicit control for persistent autotune cache usage, separate from the in-memory autotune path.

cc @mgoin