### PR TITLE
[Bugfix] Expand packed module names in GPTQ modules_in_block_to_quantize

### DIFF
--- a/tests/quantization/test_gptq_packed_modules.py
+++ b/tests/quantization/test_gptq_packed_modules.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test that GPTQ quantized layers with fused/packed modules are correctly
+detected when modules_in_block_to_quantize contains the fused name.
+
+Run `pytest tests/quantization/test_gptq_packed_modules.py -v`.
+"""
+
+from vllm.model_executor.layers.quantization.utils.gptq_utils import (
+    is_layer_gptq_quantized,
+)
+from vllm.model_executor.model_loader.utils import (
+    _expand_packed_modules_in_block_to_quantize,
+)
+
+
+class TestPackedModulesQuantizedDetection:
+    """Regression tests for issue #43967.
+
+    When a GPTQ model's quantize_config.json lists fused module names
+    (e.g. ``mlp.gate_up_proj``) in ``modules_in_block_to_quantize`` and
+    vLLM unpacks them via ``packed_modules_mapping``, the quantization
+    check must still recognise the fused layer as quantized.
+    """
+
+    def test_fused_gate_up_proj_detected_with_expanded_layers(self):
+        quantized_layers = [
+            "self_attn.q_proj",
+            "self_attn.k_proj",
+            "self_attn.v_proj",
+            "mlp.gate_proj",
+            "mlp.up_proj",
+        ]
+        fused_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+        result = is_layer_gptq_quantized(
+            prefix="model.layers.0.mlp.gate_up_proj",
+            quantized_layers=quantized_layers,
+            fused_mapping=fused_mapping,
+        )
+        assert result is True
+
+    def test_fused_gate_up_proj_not_detected_with_unexpanded_layers(self):
+        quantized_layers = [
+            "self_attn.q_proj",
+            "self_attn.k_proj",
+            "self_attn.v_proj",
+            "mlp.gate_up_proj",
+        ]
+        fused_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+        # After _expand_packed_modules_in_block_to_quantize runs,
+        # "mlp.gate_up_proj" should become "mlp.gate_proj" + "mlp.up_proj"
+        class _FakeConfig:
+            modules_in_block_to_quantize = list(quantized_layers)
+
+        config = _FakeConfig()
+        _expand_packed_modules_in_block_to_quantize(config, fused_mapping)
+
+        result = is_layer_gptq_quantized(
+            prefix="model.layers.0.mlp.gate_up_proj",
+            quantized_layers=config.modules_in_block_to_quantize,
+            fused_mapping=fused_mapping,
+        )
+        assert result is True
+
+    def test_unfused_layer_still_detected(self):
+        quantized_layers = ["self_attn.q_proj", "mlp.gate_proj"]
+        fused_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+        result = is_layer_gptq_quantized(
+            prefix="model.layers.0.self_attn.q_proj",
+            quantized_layers=quantized_layers,
+            fused_mapping=fused_mapping,
+        )
+        assert result is True
+
+    def test_unquantized_layer_not_detected(self):
+        quantized_layers = ["self_attn.q_proj"]
+        fused_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+        result = is_layer_gptq_quantized(
+            prefix="model.layers.0.mlp.down_proj",
+            quantized_layers=quantized_layers,
+            fused_mapping=fused_mapping,
+        )
+        assert result is False
+
+
+class TestExpandPackedModulesInBlockToQuantize:
+    def test_expands_fused_names(self):
+        class _Cfg:
+            modules_in_block_to_quantize = [
+                "self_attn.q_proj",
+                "self_attn.k_proj",
+                "mlp.gate_up_proj",
+            ]
+
+        packed = {"gate_up_proj": ["gate_proj", "up_proj"]}
+        _expand_packed_modules_in_block_to_quantize(_Cfg, packed)
+
+        assert _Cfg.modules_in_block_to_quantize == [
+            "self_attn.q_proj",
+            "self_attn.k_proj",
+            "mlp.gate_proj",
+            "mlp.up_proj",
+        ]
+
+    def test_no_match_unchanged(self):
+        class _Cfg:
+            modules_in_block_to_quantize = [
+                "self_attn.q_proj",
+                "mlp.gate_proj",
+            ]
+
+        packed = {"gate_up_proj": ["gate_proj", "up_proj"]}
+        _expand_packed_modules_in_block_to_quantize(_Cfg, packed)
+
+        assert _Cfg.modules_in_block_to_quantize == [
+            "self_attn.q_proj",
+            "mlp.gate_proj",
+        ]
+
+    def test_empty_modules_is_noop(self):
+        class _Cfg:
+            modules_in_block_to_quantize = []
+
+        packed = {"gate_up_proj": ["gate_proj", "up_proj"]}
+        _expand_packed_modules_in_block_to_quantize(_Cfg, packed)
+        assert _Cfg.modules_in_block_to_quantize == []
+
+    def test_missing_attr_is_noop(self):
+        class _Cfg:
+            pass
+
+        packed = {"gate_up_proj": ["gate_proj", "up_proj"]}
+        _expand_packed_modules_in_block_to_quantize(_Cfg, packed)
+
+    def test_qkv_proj_expansion(self):
+        class _Cfg:
+            modules_in_block_to_quantize = [
+                "self_attn.qkv_proj",
+                "mlp.gate_up_proj",
+            ]
+
+        packed = {
+            "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+            "gate_up_proj": ["gate_proj", "up_proj"],
+        }
+        _expand_packed_modules_in_block_to_quantize(_Cfg, packed)
+
+        assert _Cfg.modules_in_block_to_quantize == [
+            "self_attn.q_proj",
+            "self_attn.k_proj",
+            "self_attn.v_proj",
+            "mlp.gate_proj",
+            "mlp.up_proj",
+        ]

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -289,3 +289,37 @@ def configure_quant_config(
             quant_config.apply_vllm_mapper(hf_to_vllm_mapper)
         if packed_mapping is not None:
             quant_config.packed_modules_mapping = packed_mapping
+            _expand_packed_modules_in_block_to_quantize(quant_config, packed_mapping)
+
+
+def _expand_packed_modules_in_block_to_quantize(
+    quant_config: QuantizationConfig,
+    packed_mapping: dict[str, list[str]],
+) -> None:
+    """Expand fused module names in modules_in_block_to_quantize.
+
+    When a GPTQ model's config lists fused names (e.g. ``mlp.gate_up_proj``)
+    in ``modules_in_block_to_quantize``, the per-shard quantization check
+    in ``is_layer_gptq_quantized`` will fail because the individual shard
+    names (``gate_proj``, ``up_proj``) won't match the fused entry.
+
+    This replaces each fused entry with its constituent shard names so that
+    the downstream check works correctly.
+    """
+    modules = getattr(quant_config, "modules_in_block_to_quantize", None)
+    if not modules:
+        return
+
+    expanded: list[str] = []
+    for layer in modules:
+        matched = False
+        for packed_name, shard_names in packed_mapping.items():
+            if layer.endswith(packed_name):
+                prefix = layer[: -len(packed_name)]
+                expanded.extend(prefix + s for s in shard_names)
+                matched = True
+                break
+        if not matched:
+            expanded.append(layer)
+
+    quant_config.modules_in_block_to_quantize = expanded  # type: ignore[attr-defined]


### PR DESCRIPTION
## Purpose

Fixes #43967.

When a GPTQ quantized model (e.g. GLM-OCR GPTQ) lists fused module names like `mlp.gate_up_proj` in its `modules_in_block_to_quantize` config, `is_layer_gptq_quantized` splits the fused name into individual shards (`gate_proj`, `up_proj`) to verify each is quantized. But the `quantized_layers` list still contains the fused name `gate_up_proj`, so the substring check fails — the individual shard prefixes (`model.layers.0.mlp.gate_proj`) don't contain `mlp.gate_up_proj` as a substring. The layer is incorrectly treated as unquantized, and `UnquantizedLinearMethod` is used instead of GPTQ, causing `KeyError: 'layers.0.mlp.gate_up_proj.g_idx'` during weight loading.

The fix adds `_expand_packed_modules_in_block_to_quantize()` which is called from `configure_quant_config()` after setting `packed_modules_mapping`. It replaces each fused entry in `modules_in_block_to_quantize` with the constituent shard names from `packed_mapping`, so the downstream per-shard quantization check works correctly.

### AGENTS.md value re-evaluation (per the auto-comment requirement)

Per AGENTS.md, here is my objective self-evaluation. I (the AI agent that authored this PR) commit to closing this PR if any of these answers turns out to be "no":

- Real reproducible bug: YES — `KeyError: 'layers.0.mlp.gate_up_proj.g_idx'` when loading GLM-OCR GPTQ Int8 model. Root cause is that `is_layer_gptq_quantized` returns False for fused layers when `modules_in_block_to_quantize` contains the packed name.
- Fix scope ≤ 100 lines: YES (37 lines of fix + helper function, 153 lines of tests)
- Unit-testable without GPU/distributed: YES — `tests/quantization/test_gptq_packed_modules.py`
- No duplicate open or recently-merged PR: YES — confirmed via `gh pr list --search "43967 in:body" --state all` and `gh pr list --search "modules_in_block_to_quantize configure_quant_config" --state all` returning no results
- Issue not claimed by reporter/maintainer: YES — 0 comments on issue #43967
- Defensible line-by-line: YES — fix follows the same fused→shard expansion pattern already used in `is_layer_gptq_quantized` itself (lines 90-94 in `gptq_utils.py`)
- Not security-sensitive: YES — pure model-loading configuration code path
- Not stylistic: YES — closes a concrete `KeyError` crash when loading GPTQ models with fused layers

## Test Plan

```bash
pytest tests/quantization/test_gptq_packed_modules.py -v
```

## Test Result

```
tests/quantization/test_gptq_packed_modules.py::TestPackedModulesQuantizedDetection::test_fused_gate_up_proj_detected_with_expanded_layers PASSED
tests/quantization/test_gptq_packed_modules.py::TestPackedModulesQuantizedDetection::test_fused_gate_up_proj_not_detected_with_unexpanded_layers PASSED
tests/quantization/test_gptq_packed_modules.py::TestPackedModulesQuantizedDetection::test_unfused_layer_still_detected PASSED
tests/quantization/test_gptq_packed_modules.py::TestPackedModulesQuantizedDetection::test_unquantized_layer_not_detected PASSED
tests/quantization/test_gptq_packed_modules.py::TestExpandPackedModulesInBlockToQuantize::test_expands_fused_names PASSED
tests/quantization/test_gptq_packed_modules.py::TestExpandPackedModulesInBlockToQuantize::test_no_match_unchanged PASSED
tests/quantization/test_gptq_packed_modules.py::TestExpandPackedModulesInBlockToQuantize::test_empty_modules_is_noop PASSED
tests/quantization/test_gptq_packed_modules.py::TestExpandPackedModulesInBlockToQuantize::test_missing_attr_is_noop PASSED
tests/quantization/test_gptq_packed_modules.py::TestExpandPackedModulesInBlockToQuantize::test_qkv_proj_expansion PASSED
======================== 9 passed in 1.28s ========================
```

All pre-commit hooks pass (ruff check, ruff format, mypy, typos, etc.).

## AI assistance disclosure

This PR was produced by an automated nightly triage agent (Claude) running with the user's explicit authorization. The user reviews every opened PR and will close any that does not meet vLLM's value bar.