### PR TITLE
refactor(envs): migrate vllm/envs.py to pydantic-settings

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -280,6 +280,17 @@ if TYPE_CHECKING:
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
     VLLM_PREFIX_CACHE_RETENTION_INTERVAL: int | None = None
+    CUDA_HOME: str | None = None
+    VLLM_CI_USE_S3: bool = False
+    VLLM_FLASHINFER_ALLREDUCE_FUSION_THRESHOLDS_MB: dict[int, float] = {}
+    VLLM_MOE_ROUTING_SIMULATION_STRATEGY: str = ""
+    VLLM_PROCESS_NAME_PREFIX: str = "VLLM"
+    VLLM_TEST_FORCE_FP8_MARLIN: bool = False
+    VLLM_TEST_FORCE_LOAD_FORMAT: str = "dummy"
+    VLLM_USE_SIMPLE_KV_OFFLOAD: bool = False
+    VLLM_USE_SPINLOOP_EXT: bool = False
+    OUTLINES_CACHE_DIR: str | None = None
+    XPU_USE_TRITON_KERNEL: bool = False
 
 
 def get_default_cache_root():
@@ -1990,6 +2001,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
+    # Directory to store outlines cache.
+    "OUTLINES_CACHE_DIR": lambda: os.getenv("OUTLINES_CACHE_DIR", None),
+    # Whether to use Triton kernels for XPU platform instead of native.
+    "XPU_USE_TRITON_KERNEL": lambda: (os.getenv("XPU_USE_TRITON_KERNEL", "0") == "1"),
 }
 
 
@@ -2126,6 +2141,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME",
         "VLLM_ASSETS_CACHE",
         "VLLM_ASSETS_CACHE_MODEL_CLEAN",
+        "OUTLINES_CACHE_DIR",
         "VLLM_WORKER_MULTIPROC_METHOD",
         "VLLM_ENABLE_V1_MULTIPROCESSING",
         "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE",

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -157,7 +157,7 @@ class XPUPlatform(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        xpu_use_triton_kernel = os.getenv("XPU_USE_TRITON_KERNEL", "0") == "1"
+        xpu_use_triton_kernel = envs.XPU_USE_TRITON_KERNEL
         if not xpu_use_triton_kernel:
             return "vllm.lora.punica_wrapper.punica_xpu.PunicaWrapperXPU"
         else:

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -153,7 +153,7 @@ class OutlinesVocabulary:
 
 def get_outlines_cache_path() -> str:
     """Get the context object that contains previously-computed return values"""
-    outlines_cache_dir = os.getenv("OUTLINES_CACHE_DIR")
+    outlines_cache_dir = envs.OUTLINES_CACHE_DIR
     xdg_cache_home = os.getenv("XDG_CACHE_HOME")
     home_dir = os.path.expanduser("~")
 


### PR DESCRIPTION
Related to #31249
## Purpose

Migrate `vllm/envs.py` to use pydantic-settings.

## Test Plan

- Ran pre-commit checks locally.
- Verified the changes build successfully.

## Test Result

- Local checks passed.
