### PR TITLE
[MRV2] Remove Eagle's dedicated CUDA graph pool

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 import torch
 
-from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -19,27 +18,7 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 
-class EagleCudaGraphManagerBase(CudaGraphManager):
-    """Base CudaGraphManager for Eagle with a dedicated graph pool."""
-
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        device: torch.device,
-        cudagraph_mode: CUDAGraphMode,
-        decode_query_len: int,
-    ):
-        super().__init__(vllm_config, device, cudagraph_mode, decode_query_len)
-
-        # Use a dedicated pool for Eagle to avoid memory overlap with the main
-        # model's cudagraph. The base class uses a shared global pool, but Eagle's
-        # internal allocations (e.g., gumbel_sample temporaries) can conflict with
-        # the main model's allocations when sharing the same pool.
-        if cudagraph_mode:
-            self.pool = torch.cuda.graph_pool_handle()
-
-
-class PrefillEagleCudaGraphManager(EagleCudaGraphManagerBase):
+class PrefillEagleCudaGraphManager(CudaGraphManager):
     """Eagle CudaGraphManager for prefill, using pre-built attention states
     from the target model's capture."""
 
@@ -74,7 +53,7 @@ class PrefillEagleCudaGraphManager(EagleCudaGraphManagerBase):
         super().capture(create_forward_fn, progress_bar_desc)
 
 
-class DecodeEagleCudaGraphManager(EagleCudaGraphManagerBase):
+class DecodeEagleCudaGraphManager(CudaGraphManager):
     """Eagle CudaGraphManager for decode draft generation, building its own
     attention metadata from scratch."""
 

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -145,9 +145,6 @@ class EagleSpeculator:
             cudagraph_mode,
             decode_query_len=1,
         )
-        # Share a single pool between prefill and decode since they never
-        # execute concurrently.
-        self.decode_cudagraph_manager.pool = self.prefill_cudagraph_manager.pool
 
     def load_model(self, target_model: nn.Module) -> None:
         target_attn_layer_names = get_layers_from_vllm_config(


### PR DESCRIPTION
The initial MRV2 eagle support (https://github.com/vllm-project/vllm/pull/29559) used a separate graph pool for eagle from the main model.

https://github.com/vllm-project/vllm/pull/35959 carried that behavior forward (with a somewhat misleading comment)

This doesnt actually appear to be required; we can save memory by making the main model and eagle share a graph memory pool

### Test plan

Setup: meta-llama/Llama-3.1-8B-Instruct + yuhuili/EAGLE-LLaMA3.1-Instruct-8B (5 spec tokens), H200, VLLM_USE_V2_MODEL_RUNNER=1

Graph pool memory: 1.39 GiB (main, 2 pools) → 1.12 GiB (branch), 0.27 GiB saved

GSM8K accuracy (200q, 5-shot, temp=0): 75.5% (main) vs 76.5% (branch) — no regression

Acceptance rates: identical — pos0: 62.0% vs 61.9%, overall: 18.4% vs 18.3%

#### Serve:
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --spec-model yuhuili/EAGLE-LLaMA3.1-Instruct-8B \
  --spec-tokens 5 --max-model-len 4096 --gpu-memory-utilization 0.9 --port 8192
```

#### Eval:
```
python tests/evals/gsm8k/gsm8k_eval.py --num-questions 200 --port 8192
```

#### Acceptance rates:
```
curl -s localhost:8192/metrics | grep spec_decode_num | grep -v created
```


### AI-assisted contribution disclosure

This PR was developed with assistance from AI tools for coding and running evals. All code changes and reasoning were manually reviewed and validated by me before submission.