### PR TITLE
[Perf] Gate AR+RMSNorm fusion cap on the active fast all-reduce threshold

### DIFF
--- a/tests/compile/passes/distributed/test_fi_fusion_cap_helper.py
+++ b/tests/compile/passes/distributed/test_fi_fusion_cap_helper.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the FlashInfer AR+RMSNorm fusion byte-cap clamp helper.
+
+These tests are pure (no GPU required) — they exercise the table-driven
+``effective_fi_allreduce_fusion_max_bytes`` against the (capability,
+world_size) cells from ``CUSTOM_ALL_REDUCE_MAX_SIZES`` and
+``NCCL_SYMM_MEM_ALL_REDUCE_CONFIG``.
+"""
+
+import pytest
+
+from vllm.distributed.device_communicators.all_reduce_utils import (
+    CUSTOM_ALL_REDUCE_MAX_SIZES,
+    NCCL_SYMM_MEM_ALL_REDUCE_CONFIG,
+    effective_fi_allreduce_fusion_max_bytes,
+)
+
+KiB = 1024
+MiB = 1024 * 1024
+
+
+def test_sm90_ws8_multimem_clamps_to_256kb():
+    # FI cap for sm90 ws8 is 0.5MB; multimem takes over at
+    # CUSTOM_ALL_REDUCE_MAX_SIZES["9.0"][8] = 256KB. Helper must clamp.
+    base = MiB // 2  # 0.5 MB
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="9.0",
+        world_size=8,
+        base_cap_bytes=base,
+        multimem_active=True,
+        nccl_symm_active=False,
+    )
+    assert out == CUSTOM_ALL_REDUCE_MAX_SIZES["9.0"][8] == MiB // 4
+
+
+def test_sm90_ws8_no_fast_path_returns_base():
+    # symm-mem off, NCCL-symm-mem off: no fast path active -> no clamp.
+    base = MiB // 2
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="9.0",
+        world_size=8,
+        base_cap_bytes=base,
+        multimem_active=False,
+        nccl_symm_active=False,
+    )
+    assert out == base
+
+
+def test_sm90_ws8_nccl_symm_clamps_to_128kib():
+    # NCCL_SYMM_MEM_ALL_REDUCE_CONFIG: ws8 custom_AR range is (16K, 128K)
+    # i.e. NCCL symm-mem takes over above 128K.
+    base = MiB // 2
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="9.0",
+        world_size=8,
+        base_cap_bytes=base,
+        multimem_active=False,
+        nccl_symm_active=True,
+    )
+    expected = NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["custom_ar_preferred_ranges"][8][1]
+    assert out == expected == 128 * KiB
+
+
+def test_sm90_ws8_both_active_takes_lower_threshold():
+    # multimem -> 256KB, NCCL symm-mem -> 128KiB. min wins -> 128 KiB.
+    base = MiB // 2
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="9.0",
+        world_size=8,
+        base_cap_bytes=base,
+        multimem_active=True,
+        nccl_symm_active=True,
+    )
+    assert out == 128 * KiB
+
+
+def test_sm90_ws2_not_in_multimem_list_no_clamp():
+    # sm90 ws2 is not in _WORLD_SIZES_MULTIMEM; caller passes
+    # multimem_active=False. Result unchanged.
+    base = 64 * MiB  # FI cap for sm90 ws2
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="9.0",
+        world_size=2,
+        base_cap_bytes=base,
+        multimem_active=False,
+        nccl_symm_active=False,
+    )
+    assert out == base
+
+
+def test_sm103_ws8_custom_ge_fi_cap_is_noop():
+    # sm10.3 ws8: CUSTOM_ALL_REDUCE_MAX_SIZES["10.3"][8] = 4 MB which is >=
+    # the FI cap (2 MB). min(2MB, 4MB) = 2MB -> no-op.
+    fi_cap_bytes = 2 * MiB
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="10.3",
+        world_size=8,
+        base_cap_bytes=fi_cap_bytes,
+        multimem_active=True,
+        nccl_symm_active=False,
+    )
+    assert out == fi_cap_bytes
+
+
+def test_unknown_capability_returns_base():
+    # Capability not in the constants table -> no clamp.
+    base = MiB // 2
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="7.5",
+        world_size=8,
+        base_cap_bytes=base,
+        multimem_active=True,
+        nccl_symm_active=False,
+    )
+    assert out == base
+
+
+def test_nccl_symm_above_always_use_world_size_clamps_to_zero():
+    # ws > always_use_above_world_size (default 8): NCCL symm-mem wins for
+    # all sizes -> fusion never wins -> cap = 0.
+    base = MiB
+    always_above = NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["always_use_above_world_size"]
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str="9.0",
+        world_size=always_above + 1,
+        base_cap_bytes=base,
+        multimem_active=False,
+        nccl_symm_active=True,
+    )
+    assert out == 0
+
+
+@pytest.mark.parametrize(
+    ("capability_str", "world_size", "base_bytes", "expected"),
+    [
+        ("9.0", 8, MiB // 2, MiB // 4),  # 256 KB
+        ("9.0", 4, 2 * MiB, 32 * MiB),  # CUSTOM 32MB > FI 2MB -> no-op (2MB)
+        ("10.0", 8, MiB, MiB),  # CUSTOM 1MB == FI 1MB -> 1MB
+    ],
+)
+def test_multimem_only_table(capability_str, world_size, base_bytes, expected):
+    out = effective_fi_allreduce_fusion_max_bytes(
+        capability_str=capability_str,
+        world_size=world_size,
+        base_cap_bytes=base_bytes,
+        multimem_active=True,
+        nccl_symm_active=False,
+    )
+    assert out == min(base_bytes, expected)

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -11,6 +11,7 @@ import torch.fx as fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
 from torch._inductor.pattern_matcher import PatternMatcherPass
 
+import vllm.envs as envs
 import vllm.ir.ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.passes.fusion.rms_quant_fusion import (
@@ -19,7 +20,11 @@ from vllm.compilation.passes.fusion.rms_quant_fusion import (
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
 from vllm.distributed import get_tp_group, tensor_model_parallel_all_reduce
+from vllm.distributed.device_communicators.all_reduce_utils import (
+    effective_fi_allreduce_fusion_max_bytes,
+)
 from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+from vllm.distributed.device_communicators.symm_mem import SymmMemCommunicator
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -794,6 +799,32 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                 self.tp_size,
             )
             return
+        # Clamp the fusion byte cap by the active fast unfused-AR threshold:
+        # on multimem-capable hardware ``multimem_all_reduce`` takes over
+        # above ``CUSTOM_ALL_REDUCE_MAX_SIZES[cap][ws]`` and is faster than
+        # flashinfer's one-shot AR, so keeping the fusion eligible above that
+        # point trades a fast unfused AR for a slower fused one. No-op on
+        # configurations without a multimem / NCCL-symm-mem fast path.
+        capability = current_platform.get_device_capability()
+        if capability is not None:
+            capability_str = capability.as_version_str()
+            multimem_active = (
+                envs.VLLM_ALLREDUCE_USE_SYMM_MEM
+                and capability_str in SymmMemCommunicator._WORLD_SIZES_MULTIMEM
+                and self.tp_size
+                in SymmMemCommunicator._WORLD_SIZES_MULTIMEM[capability_str]
+            )
+            # NCCL symm-mem gating is implemented + unit-tested in the helper
+            # but left disabled here pending hardware validation: the
+            # 256KB-512KB regression was only measured for the multimem path.
+            # Enabling the nccl_symm_active path is a follow-up.
+            max_size = effective_fi_allreduce_fusion_max_bytes(
+                capability_str=capability_str,
+                world_size=self.tp_size,
+                base_cap_bytes=max_size,
+                multimem_active=multimem_active,
+                nccl_symm_active=False,
+            )
         element_size = torch.tensor([], dtype=self.model_dtype).element_size()
         self.max_token_num = max_size // (self.hidden_dim * element_size)
         # take the min to save workspace size and we'll never use more

--- a/vllm/distributed/device_communicators/all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/all_reduce_utils.py
@@ -97,6 +97,58 @@ NCCL_SYMM_MEM_ALL_REDUCE_CONFIG: dict[str, Any] = {
 }
 
 
+def effective_fi_allreduce_fusion_max_bytes(
+    *,
+    capability_str: str,
+    world_size: int,
+    base_cap_bytes: int,
+    multimem_active: bool,
+    nccl_symm_active: bool,
+) -> int:
+    """Clamp the FlashInfer AR+RMSNorm fusion byte cap by the active fast
+    unfused-AR threshold.
+
+    On multimem-capable NVLink Hopper/Blackwell (e.g. sm90, TP>=4), the
+    flashinfer one-shot AR+RMSNorm fusion is slower than the unfused
+    ``multimem_all_reduce`` above ``CUSTOM_ALL_REDUCE_MAX_SIZES[cap][ws]``.
+    If NCCL symm-mem is enabled, it takes over above the upper bound of
+    ``NCCL_SYMM_MEM_ALL_REDUCE_CONFIG['custom_ar_preferred_ranges'][ws]``.
+    This returns the minimum of ``base_cap_bytes`` and whichever fast-AR
+    threshold is active, so the fusion stops firing in the band where the
+    unfused path wins. Returns ``base_cap_bytes`` unchanged when no
+    multimem/NCCL-symm-mem path is active for this ``(capability, world_size)``.
+    """
+    threshold: int | None = None
+    if (
+        multimem_active
+        and capability_str in CUSTOM_ALL_REDUCE_MAX_SIZES
+        and world_size in CUSTOM_ALL_REDUCE_MAX_SIZES[capability_str]
+    ):
+        threshold = CUSTOM_ALL_REDUCE_MAX_SIZES[capability_str][world_size]
+
+    if nccl_symm_active:
+        ranges = NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["custom_ar_preferred_ranges"]
+        always_above = NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["always_use_above_world_size"]
+        nccl_threshold: int | None = None
+        if world_size in ranges:
+            # NCCL symm-mem takes over above the upper bound of the
+            # custom-AR-preferred range.
+            nccl_threshold = ranges[world_size][1]
+        elif world_size > always_above:
+            # NCCL symm-mem is preferred for all sizes above this world size.
+            nccl_threshold = 0
+        if nccl_threshold is not None:
+            threshold = (
+                min(threshold, nccl_threshold)
+                if threshold is not None
+                else nccl_threshold
+            )
+
+    if threshold is None:
+        return base_cap_bytes
+    return min(base_cap_bytes, threshold)
+
+
 def should_nccl_symm_mem_allreduce(world_size: int, input_tensor: torch.Tensor) -> bool:
     """
     Determine if NCCL symmetric memory allreduce should be used.


### PR DESCRIPTION
Part of #44079

## Purpose
On multimem-capable NVLink Hopper (sm90, TP>=4) the flashinfer AR+RMSNorm fusion fires up to 0.5MB, displacing the faster `multimem_all_reduce` in the 256KB-512KB band. This caps the fusion at the size where the faster unfused AR takes over, derived from the same constants the communicator uses (`CUSTOM_ALL_REDUCE_MAX_SIZES`, `NCCL_SYMM_MEM_ALL_REDUCE_CONFIG`), gated on symm-mem/multimem availability. No change on non-multimem nodes.

See #44079 for full analysis. Net regression in 256KB-512KB: -1.9..-4.3us/op; -3.4%/-7.4% decode tok/s at B=96/128 (Qwen3-30B-A3B TP8). Disabling symm-mem flips the band back to a win => the regression is multimem-specific.

## Change
Pure helper `effective_fi_allreduce_fusion_max_bytes(...)` (unit-tested, GPU-free) next to the dispatch constants in `all_reduce_utils.py`. Called from `AllReduceFusionPass.__init__` right after `flashinfer_max_size(tp_size)`. Defaults unchanged; the clamp only bites where `CUSTOM_ALL_REDUCE_MAX_SIZES[cap][ws] < FI cap` (sm90 ws8).

Scope: only the multimem path is enabled here (the 256KB-512KB regression was measured for multimem). The helper also implements + unit-tests an NCCL-symm-mem threshold, but it is gated off at the call site pending hardware validation — a follow-up.

## Test Plan
- Unit (`tests/compile/passes/distributed/test_fi_fusion_cap_helper.py`, GPU-free): helper clamp matrix — sm90 ws8 multimem-on -> 256KB; off -> 0.5MB; nccl-symm -> 128KiB; both -> 128KiB; ws2 not in multimem list -> unchanged; unknown capability -> unchanged; sm103 ws8 CUSTOM>=FI -> no-op. 11 passed.
- Multi-GPU regression: `tests/compile/passes/distributed/test_fusion_all_reduce.py` (`@multi_gpu_test(num_gpus=2)`, TP=2) -> 16 passed on 2xH200 — confirms no breakage. Note the clamp is inert at TP=2 (ws=2 is not in the multimem world-size set), so this validates "no regression," not the clamp's active path. The clamp is **perf-only** (it lowers `max_token_num`): shapes <= the cap fuse exactly as before; shapes > the cap fall back to the existing, tested unfused `all_reduce + fused_add_rms_norm` path — no kernel change, so TP>=4 numerical correctness is unaffected. The clamp's active cap value at TP8 is confirmed by the introspection below and the end-to-end result.
- End-to-end (8xH200 TP8, Qwen3-30B-A3B decode, median of 6): cap 0.5 vs 0.25 -> +3.4%/+7.4% tok/s at B=96/128, ~0 at B<=64 (band-localized, outside ~0.2-0.3% per-batch noise) — confirms the regression is real in serving and that lowering the cap recovers it.
- Pass introspection (8xH200, sm90), post-fix: cap 0.5MB -> 256KiB under default (symm_mem ON); 0.5MB unchanged under symm_mem OFF; `VLLM_USE_NCCL_SYMM_MEM` has no effect (gated off). Helper unit tests separately cover the nccl-symm thresholds.
- Pre-commit clean (ruff/yapf/mypy/SPDX/typos/`torch.cuda` gate).

DCO signed off. AI assistance was used during implementation; the submitter read every changed line and is responsible for defending the design under maintainer review.