### PR TITLE
[Core] Avoid scheduler `RoutedExpertsManager` import unless needed

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -24,9 +24,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
-    RoutedExpertsManager,
-)
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
 from vllm.v1.core.encoder_cache_manager import (
@@ -268,6 +265,10 @@ class Scheduler(SchedulerInterface):
             assert self.dcp_world_size == 1 and self.pcp_world_size == 1, (
                 "enable_return_routed_experts does not support context parallelism "
                 "(dcp_world_size > 1 or pcp_world_size > 1)"
+            )
+
+            from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+                RoutedExpertsManager,
             )
 
             self.routed_experts_mgr = RoutedExpertsManager(


### PR DESCRIPTION
This pulls in various other imports/overhead that's typically not needed, like `nixl_ep` (and can fail, see for example https://buildkite.com/vllm/ci/builds/69051/list?jid=019e7af7-d9d3-47c2-9ab0-7fc3ca69a267&tab=output).