### PR TITLE
fix: bind structured-output grammar on Responses API when reasoning parser is active

### DIFF
--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -310,9 +310,22 @@ class ResponsesRequest(OpenAIBaseModel):
         # chat templates require explicit opt-in (e.g., Gemma4 defaults
         # enable_thinking to false). For templates that don't declare the
         # variable, resolve_chat_template_kwargs filters it out harmlessly.
+        #
+        # When structured output (text.format.json_schema) is requested
+        # and reasoning is NOT configured, disable thinking so the
+        # structured output lands in the grammar-constrained content
+        # channel (issue #44012).
         user_kwargs = self.chat_template_kwargs or {}
         if reasoning_effort is not None and "enable_thinking" not in user_kwargs:
             extra_kwargs["enable_thinking"] = reasoning_effort != "none"
+        elif reasoning_effort is None and "enable_thinking" not in user_kwargs:
+            has_structured = (
+                self.text is not None
+                and self.text.format is not None
+                and self.text.format.type == "json_schema"
+            )
+            if has_structured:
+                extra_kwargs["enable_thinking"] = False
 
         return ChatParams(
             chat_template=default_template,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -496,6 +496,11 @@ class OpenAIServingResponses(OpenAIServing):
                             struct_out.structural_tag, self.tool_server
                         ),
                     )
+            reasoning_ended: bool | None = None
+            if self.parser and self.parser.reasoning_parser_cls is not None:
+                reasoning_ended = reasoning_parser.is_reasoning_end(
+                    engine_input.get("prompt_token_ids") or []
+                )
             generator = self._generate_with_builtin_tools(
                 request_id=request.request_id,
                 engine_input=engine_input,
@@ -504,6 +509,7 @@ class OpenAIServingResponses(OpenAIServing):
                 lora_request=lora_request,
                 priority=request.priority,
                 trace_headers=trace_headers,
+                reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs
                 if self.parser and self.parser.reasoning_parser_cls is not None
                 else None,
@@ -653,6 +659,7 @@ class OpenAIServingResponses(OpenAIServing):
         lora_request: LoRARequest | None = None,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
+        reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ):
         max_model_len = self.model_config.max_model_len
@@ -677,6 +684,7 @@ class OpenAIServingResponses(OpenAIServing):
                 lora_request=lora_request,
                 trace_headers=trace_headers,
                 priority=priority,
+                reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
 


### PR DESCRIPTION
## Description

Fixes #44012

When a reasoning parser is configured (e.g. `--reasoning-parser qwen3`), the Responses API (`/v1/responses`) path failed to pass the `reasoning_ended` signal to the engine. This caused two problems:

1. **Grammar never bound**: The structured-output grammar (`text.format.json_schema`) was never applied to the generation, so the model could produce invalid JSON (bracket-spam like `}]}]}`).
2. **Output in wrong channel**: The output was classified as unconstrained reasoning content instead of a grammar-constrained message, making `output_text` null.

## Root cause

In the Chat Completions API (`/v1/chat/completions`), `reasoning_ended` is computed from the prompt token IDs and passed to `engine_client.generate()`. This tells the engine's `StructuredOutputManager.should_fill_bitmask()` that reasoning has ended, so the grammar bitmask is applied.

The Responses API path omitted `reasoning_ended` entirely, so the engine never learned that reasoning had ended, skipped the grammar bitmask, and the output was generated without constraints.

## Changes

### `vllm/entrypoints/openai/responses/serving.py`

- Compute `reasoning_ended` from the prompt token IDs before calling `_generate_with_builtin_tools`, matching the Chat API pattern.
- Add `reasoning_ended` parameter to `_generate_with_builtin_tools` and forward it to `engine_client.generate()`.

### `vllm/entrypoints/openai/responses/protocol.py`

- When structured output (`text.format.json_schema`) is requested **and** reasoning effort is not explicitly set, default `enable_thinking` to `False` so the reasoning parser treats output as content.

## Testing

- ✅ Existing `test_structured_output` and `test_structured_output_with_parse` continue to pass (they don't use `--reasoning-parser`).
- ✅ The fix matches the Chat Completions API pattern, minimizing behavioral differences between the two APIs.
- ✅ No new imports or dependencies.

## Checklist

- [x] Code changes
- [x] No new imports required