### PR TITLE
[Bugfix] Quark: set moe_quant_config in QuarkW8A8Int8MoEMethod

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -762,6 +762,8 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
                 max_w13_scales, requires_grad=False
             )
 
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:


### PR DESCRIPTION
# [Bugfix] Quark: set `moe_quant_config` in `QuarkW8A8Int8MoEMethod.process_weights_after_loading`

## Summary

`QuarkW8A8Int8MoEMethod.process_weights_after_loading` is missing the assignment
`self.moe_quant_config = self.get_fused_moe_quant_config(layer)` that every other
MoE quant method performs.

## Effect

`apply()` passes `quant_config=self.moe_quant_config` to `fused_experts(...)`, but
`self.moe_quant_config` stays at its initial value of `None` (set in
`FusedMoEMethodBase.__init__`). `fused_experts` then falls back to
`FUSED_MOE_UNQUANTIZED_CONFIG` (in which `use_int8_w8a8 = False`), and the Triton
`fused_moe_kernel` silently runs the BF16 path even though:

- The model's INT8 weights are correctly loaded
- The activation quantization (`_per_token_quant_int8` / `dynamic_scaled_int8_quant`)
  correctly fires upstream

Net result: any Quark W8A8 INT8 quantized MoE model has its MoE expert GEMMs
silently dispatched to the unquantized BF16 path. Outputs are still coherent
(weights get implicitly cast inside the kernel), but the INT8 tensor-core
compute path is never used.

## How other backends handle this (where I cross-referenced)

These all explicitly assign `self.moe_quant_config = self.get_fused_moe_quant_config(layer)`
inside their `process_weights_after_loading`:

- `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_int8.py:145`
- `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py:332`
- `vllm/model_executor/layers/quantization/awq_marlin.py:695`
- `vllm/model_executor/layers/quantization/auto_gptq.py:729`
- `vllm/model_executor/layers/quantization/modelopt.py:894,1591`
- `vllm/model_executor/layers/quantization/mxfp4.py:362,696`
- `vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py:193`

`QuarkW8A8Int8MoEMethod` (and likely `QuarkW8A8Fp8MoEMethod` / `QuarkW4A8Fp8MoEMethod`
too — see "Follow-ups" below) is the one that was missing it.

## Repro

Model: any Quark W8A8 INT8 MoE model. I used:
[`nameistoken/Qwen3.6-35B-A3B-Quark-W8A8-INT8`](https://huggingface.co/nameistoken/Qwen3.6-35B-A3B-Quark-W8A8-INT8)

Environment: vLLM 0.22.0, torch 2.11.0, A100 80GB.

Trace of `fused_moe_kernel` before fix: BF16 compute path
(`accumulator += tl.dot(a, b)` in the `else` branch at fused_moe.py:512).

Trace after fix: INT8 compute path
(`use_int8_w8a8=True`, INT8 operands → INT8 tensor cores).

## Measured impact (A100 80GB, single-stream prefill TTFT)

| L | Before fix | After fix | Δ |
|---|---|---|---|
| 1 | 12.3 ms | 11.6 ms | -6% |
| 500 | 65.7 ms | 60.6 ms | -8% |
| **1000** | **174.3 ms** | **150.6 ms** | **-14%** |
| 2000 | 166.0 ms | 164.6 ms | -1% |
| 4000 | 206.3 ms | 203.8 ms | -1% |
| 8000 | 379.8 ms | 377.1 ms | -1% |

Modest wins at L≥2K because the MoE Triton kernel is already memory/launch-bound
on A100 for this model's shapes (E=256, N=512, hidden=2048), not compute-bound.
A separate `benchmark_moe.py` autotune for these shapes would be the next lever.

Quality unchanged on a small smoke test (identical outputs for 4 prompts).

## Follow-ups (not in this PR)

- `QuarkW8A8Fp8MoEMethod` and `QuarkW4A8Fp8MoEMethod` show the same pattern
  in their `process_weights_after_loading` and likely need the same line.
  Not tested in this PR — flagging for a follow-up.

## Test plan

- Built locally, verified `quark_moe.py` parses, the assignment runs (added a
  one-shot `print` and removed it before this commit).
- Ran a 4-prompt quality check against the model above — outputs identical
  to the pre-fix version.
- Ran a full TTFT timing sweep across L=1..8000 (numbers above).
- Existing vLLM tests untouched.