### PR TITLE
Reject negative config values for logprobs and prefill threshold

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1322,6 +1322,40 @@ def test_scheduler_config_init():
         print(SchedulerConfig.default_factory().max_model_len)
 
 
+@pytest.mark.parametrize("max_logprobs", [-1, 0, 20])
+def test_model_config_accepts_valid_max_logprobs(max_logprobs):
+    config = ModelConfig(max_logprobs=max_logprobs)
+
+    assert config.max_logprobs == max_logprobs
+
+
+def test_model_config_rejects_negative_max_logprobs():
+    with pytest.raises(ValidationError, match="max_logprobs"):
+        ModelConfig(max_logprobs=-2)
+
+
+@pytest.mark.parametrize("long_prefill_token_threshold", [0, 1])
+def test_scheduler_config_accepts_valid_long_prefill_token_threshold(
+    long_prefill_token_threshold,
+):
+    config = SchedulerConfig(
+        long_prefill_token_threshold=long_prefill_token_threshold,
+        max_model_len=128,
+        is_encoder_decoder=False,
+    )
+
+    assert config.long_prefill_token_threshold == long_prefill_token_threshold
+
+
+def test_scheduler_config_rejects_negative_long_prefill_token_threshold():
+    with pytest.raises(ValidationError, match="long_prefill_token_threshold"):
+        SchedulerConfig(
+            long_prefill_token_threshold=-1,
+            max_model_len=128,
+            is_encoder_decoder=False,
+        )
+
+
 @pytest.mark.parametrize(
     (
         "model_id",

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -775,6 +775,16 @@ class ModelConfig:
     def _lowercase_tokenizer_mode(cls, tokenizer_mode: str) -> str:
         return tokenizer_mode.lower()
 
+    @field_validator("max_logprobs", mode="after")
+    @classmethod
+    def validate_max_logprobs(cls, max_logprobs: int) -> int:
+        if max_logprobs == -1 or max_logprobs >= 0:
+            return max_logprobs
+        raise ValueError(
+            "max_logprobs must be a non-negative integer or -1 "
+            f"(no cap), got {max_logprobs}."
+        )
+
     @field_validator("quantization", mode="before")
     @classmethod
     def validate_quantization_before(cls, value: Any) -> Any:

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -221,6 +221,18 @@ class SchedulerConfig:
         """Skip validation if the value is `None` when initialisation is delayed."""
         return None if value is None else handler(value)
 
+    @field_validator("long_prefill_token_threshold", mode="after")
+    @classmethod
+    def validate_long_prefill_token_threshold(
+        cls, long_prefill_token_threshold: int
+    ) -> int:
+        if long_prefill_token_threshold < 0:
+            raise ValueError(
+                "long_prefill_token_threshold must be >= 0 "
+                f"(0 = off, > 0 = clamp), got {long_prefill_token_threshold}."
+            )
+        return long_prefill_token_threshold
+
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.


### PR DESCRIPTION
## Problem

Fixes #43985.

Two CLI-configurable integer fields accepted negative values that are not meaningful downstream:

- `max_logprobs < -1` survives config validation, then either becomes a confusing cap like `max allowed: -5` or a silent no-op when logprobs are not requested.
- `long_prefill_token_threshold < 0` is stored as-is, but the scheduler clamp only runs for positive thresholds, so the user-provided value is silently ineffective.

## Fix

- Add a `ModelConfig.max_logprobs` validator that accepts `-1` and non-negative values, and rejects all other negatives.
- Add a `SchedulerConfig.long_prefill_token_threshold` validator that rejects negative values.
- Add config tests for accepted boundary values and rejected negatives.

## Test

- `uvx ruff check vllm/config/model.py vllm/config/scheduler.py tests/test_config.py`
- `python3` AST parse for the three changed files
- `git diff --check`

I also attempted the targeted pytest command:

```bash
uv run pytest tests/test_config.py::test_model_config_accepts_valid_max_logprobs tests/test_config.py::test_model_config_rejects_negative_max_logprobs tests/test_config.py::test_scheduler_config_accepts_valid_long_prefill_token_threshold tests/test_config.py::test_scheduler_config_rejects_negative_long_prefill_token_threshold -q
```

but dependency resolution failed locally on macOS because the project currently resolves a `torch==2.11.0+cpu` split that is unavailable for the supported macOS markers. I kept the tests narrow so CI can exercise them in the repo's expected environment.

## Risk

Low. This only rejects invalid negative config values. Existing defaults, non-negative values, and `max_logprobs=-1` keep their current behavior.
