### PR TITLE
[Bugfix][P2P Nccl] Use kv_rank as port_offset to avoid ZMQ port conflict

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -92,12 +92,19 @@ class P2pNcclConnector(KVConnectorBase_V1):
             get_world_group().local_rank if role == KVConnectorRole.WORKER else 0
         )
 
+        # In manual multi-process deployments (e.g. disaggregated_prefill.py),
+        # each process has its own world group where rank=0.
+        # Use the explicitly-configured kv_rank as port_offset so prefill and
+        # decode instances bind different ZMQ ports.
+        kv_rank = self._kv_transfer_config.kv_rank
+        port_offset = kv_rank if kv_rank is not None else self._rank
+
         self.p2p_nccl_engine = (
             P2pNcclEngine(
                 local_rank=self._local_rank,
                 config=self._kv_transfer_config,
                 hostname="",
-                port_offset=self._rank,
+                port_offset=port_offset,
             )
             if role == KVConnectorRole.WORKER
             else None


### PR DESCRIPTION
## Purpose

  When P2pNcclConnector is used in manual multi-process deployments
  (e.g. `examples/offline_inference/disaggregated_prefill.py`), each
  process has its own world group where `get_world_group().rank` returns
  0 for both prefill and decode instances. Both bind the same ZMQ port
  and crash with `Address already in use`.

  This fix uses the explicitly-configured `kv_rank` (already set to 0/1
  in the example) as `port_offset` when available, keeping `self._rank`
  unchanged for correct NCCL rank semantics.

  Fixes #44061

  ## Test Plan

  ```bash
  pytest tests/v1/kv_connector/unit/test_p2p_nccl_port_offset.py -v
  pytest tests/v1/kv_connector/unit/test_config.py -v
  pre-commit run ruff-check --files
  vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py

  Test Result

  - New unit tests: 9/9 passed
  - Existing config tests: no regression (11/13 passed, 2 pre-existing failures on
  single-GPU machine)
  - Lint: ruff-check passed
  - Integration: requires 2 GPUs — blocked on single-GPU machine

  Notes

  - AI assistance was used (Claude); every line reviewed by the submitter
