### PR TITLE
[LMCache] fix missing cache_salt in free_lookup_locks call

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -869,6 +869,7 @@ class LMCacheMPConnectorUpstream(KVConnectorBase_V1):
                         start=0,
                         end=free_end,
                         request_id=request.request_id,
+                        cache_salt=tracker.cache_salt,
                     )
                     logger.debug(
                         "Free locks of tokens %d-%d since it is cached by vLLM.",


### PR DESCRIPTION

## Purpose

Fix #44096 . `update_state_after_alloc` calls `free_lookup_locks` without `cache_salt`, which defaults to `""`. Since the preceding `maybe_submit_lookup_request` was called with `tracker.cache_salt`, the server builds a different `ObjectKey` on the free path and cannot find the lock to release. Matched KV chunks stay read-locked until TTL expiry and cannot be evicted.

Affects multi-tenant deployments where `cache_salt` is set per request.


One line: pass `cache_salt=tracker.cache_salt` to `free_lookup_locks` in `update_state_after_alloc`, matching what `maybe_submit_lookup_request` used.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

