### PR TITLE
[Bugfix] Split terminal tool-call finish chunks

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2126,3 +2126,39 @@ async def test_streaming_n_gt1_independent_tool_parsers():
             f"Choice {choice_idx}: expected finish_reason='tool_calls', "
             f"got '{reasons[0]}'"
         )
+
+
+@pytest.mark.skip_global_cleanup
+class TestTerminalToolCallFinishSplit:
+    def test_terminal_argument_chunk_requires_finish_split(self):
+        """A final argument fragment should be sent before the finish chunk."""
+        from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaMessage,
+            DeltaToolCall,
+        )
+
+        delta_message = DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    function=DeltaFunctionCall(arguments='"}'),
+                )
+            ]
+        )
+
+        assert OpenAIServingChat._should_split_terminal_tool_call_chunk(
+            delta_message, "tool_calls"
+        )
+        assert not OpenAIServingChat._should_split_terminal_tool_call_chunk(
+            delta_message, None
+        )
+
+    def test_empty_finish_chunk_does_not_require_split(self):
+        from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+        from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+
+        assert not OpenAIServingChat._should_split_terminal_tool_call_chunk(
+            DeltaMessage(), "tool_calls"
+        )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -717,6 +717,48 @@ class OpenAIServingChat(OpenAIServing):
                                 else None
                             ),
                         )
+                        if self._should_split_terminal_tool_call_chunk(
+                            delta_message, finish_reason_
+                        ):
+                            arg_choice_data = ChatCompletionResponseStreamChoice(
+                                index=i,
+                                delta=delta_message,
+                                logprobs=logprobs,
+                                finish_reason=None,
+                                token_ids=(
+                                    as_list(output.token_ids)
+                                    if request.return_token_ids
+                                    else None
+                                ),
+                            )
+                            arg_choice_data = maybe_filter_parallel_tool_calls(
+                                arg_choice_data, request
+                            )
+                            arg_chunk = ChatCompletionStreamResponse(
+                                id=request_id,
+                                object=chunk_object_type,
+                                created=created_time,
+                                choices=[arg_choice_data],
+                                model=model_name,
+                            )
+                            if include_continuous_usage:
+                                completion_tokens = previous_num_tokens[i]
+                                arg_chunk.usage = UsageInfo(
+                                    prompt_tokens=num_prompt_tokens,
+                                    completion_tokens=completion_tokens,
+                                    total_tokens=(
+                                        num_prompt_tokens + completion_tokens
+                                    ),
+                                )
+                            arg_data = arg_chunk.model_dump_json(exclude_unset=True)
+                            yield f"data: {arg_data}\n\n"
+
+                            choice_data = ChatCompletionResponseStreamChoice(
+                                index=i,
+                                delta=DeltaMessage(),
+                                finish_reason=finish_reason_,
+                                stop_reason=output.stop_reason,
+                            )
 
                         finish_reason_sent[i] = True
 
@@ -1195,3 +1237,28 @@ class OpenAIServingChat(OpenAIServing):
                 )
 
         return ChatCompletionLogProbs(content=logprobs_content)
+
+    @staticmethod
+    def _get_delta_function_arguments(
+        function: Any | None,
+    ) -> str | None:
+        if isinstance(function, dict):
+            arguments = function.get("arguments")
+            return arguments if isinstance(arguments, str) else None
+        arguments = getattr(function, "arguments", None)
+        return arguments if isinstance(arguments, str) else None
+
+    @staticmethod
+    def _should_split_terminal_tool_call_chunk(
+        delta_message: DeltaMessage,
+        finish_reason: str | None,
+    ) -> bool:
+        if finish_reason != "tool_calls":
+            return False
+        for tool_call in delta_message.tool_calls:
+            arguments = OpenAIServingChat._get_delta_function_arguments(
+                tool_call.function
+            )
+            if arguments:
+                return True
+        return False


### PR DESCRIPTION
## Summary

Fixes #44098.

Latest main includes #45915, which rewrote the GLM parser path and supersedes the previous duplicate metadata / remaining-args part of this PR. This PR is now narrowed to the remaining serving-layer stream shape:

- if the terminal tool-call delta still contains non-empty `function.arguments`, emit that argument delta with `finish_reason=null`
- then emit a separate empty finish chunk with `finish_reason="tool_calls"`

## Duplicate-work check

- Checked latest main with #45915 merged. The parser rewrite covers the metadata re-emission case.
- I did not find an existing open PR covering the remaining generic finish-chunk split in `chat_completion_stream_generator`.

## Testing

```bash
ruff check vllm/entrypoints/openai/chat_completion/serving.py tests/entrypoints/openai/chat_completion/test_serving_chat.py
.venv/bin/python -m py_compile vllm/entrypoints/openai/chat_completion/serving.py tests/entrypoints/openai/chat_completion/test_serving_chat.py
.venv/bin/python -m pytest -q tests/entrypoints/openai/chat_completion/test_serving_chat.py::TestTerminalToolCallFinishSplit
```

Results:

- `ruff check`: passed
- `py_compile`: passed
- targeted pytest: `2 passed`

## AI assistance

AI assistance was used to narrow this PR after retesting latest main. The human submitter should review every changed line and the CI result.
