### PR TITLE
[LMCache] fix lookup lock leak when request is aborted before alloc

### DIFF
--- a/tests/v1/kv_connector/unit/test_lmcache_mp_connector.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_mp_connector.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import (
+    LMCacheMPConnectorUpstream,
+    LMCacheMPRequestState,
+    LMCacheMPRequestTracker,
+)
+
+
+def test_prefetch_locks_released_on_abort():
+    req = MagicMock()
+    req.request_id = "test-request-1"
+    req.all_token_ids = list(range(32))
+    req.block_hashes = []
+    req.cache_salt = ""
+    tracker = LMCacheMPRequestTracker(req)
+    tracker.num_lmcache_hit_blocks = 2
+    assert tracker.state == LMCacheMPRequestState.PREFETCHING
+
+    connector = object.__new__(LMCacheMPConnectorUpstream)
+    connector.vllm_block_size = 16
+    connector.scheduler_adapter = MagicMock()
+    connector.request_trackers = {"test-request-1": tracker}
+
+    connector._cleanup_request_tracker("test-request-1")
+
+    connector.scheduler_adapter.cleanup_lookup_result.assert_called_once_with(
+        "test-request-1"
+    )
+    connector.scheduler_adapter.free_lookup_locks.assert_called_once_with(
+        token_ids=list(range(32)), start=0, end=32, request_id="test-request-1"
+    )
+
+
+def test_no_double_release_after_alloc():
+    req = MagicMock()
+    req.request_id = "test-request-1"
+    req.all_token_ids = list(range(32))
+    req.block_hashes = []
+    req.cache_salt = ""
+    tracker = LMCacheMPRequestTracker(req)
+    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
+    tracker.num_lmcache_hit_blocks = 2
+
+    connector = object.__new__(LMCacheMPConnectorUpstream)
+    connector.vllm_block_size = 16
+    connector.scheduler_adapter = MagicMock()
+    connector.request_trackers = {"test-request-1": tracker}
+
+    connector._cleanup_request_tracker("test-request-1")
+
+    connector.scheduler_adapter.cleanup_lookup_result.assert_not_called()
+    connector.scheduler_adapter.free_lookup_locks.assert_not_called()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -1183,12 +1183,26 @@ class LMCacheMPConnectorUpstream(KVConnectorBase_V1):
         Clean up request tracker and associated lookup future for a request.
         This should be called when a request is finished to prevent memory leak.
         """
-        # Clean up request tracker
-        if self.request_trackers.pop(request_id, None):
-            logger.debug(
-                "[KVConnector] Cleaned up request_tracker for request %s",
-                request_id,
-            )
+        tracker = self.request_trackers.pop(request_id, None)
+        if tracker is None:
+            return
+
+        # update_state_after_alloc was never called (aborted in PREFETCHING):
+        # clean up lookup state that it would normally handle.
+        if tracker.state == LMCacheMPRequestState.PREFETCHING:
+            self.scheduler_adapter.cleanup_lookup_result(request_id)
+            if tracker.num_lmcache_hit_blocks > 0:
+                self.scheduler_adapter.free_lookup_locks(
+                    token_ids=list(tracker.all_token_ids),
+                    start=0,
+                    end=tracker.num_lmcache_hit_blocks * self.vllm_block_size,
+                    request_id=request_id,
+                )
+
+        logger.debug(
+            "[KVConnector] Cleaned up request_tracker for request %s",
+            request_id,
+        )
 
 
 # At module load time, prefer the external LMCacheMPConnector shipped with the


### PR DESCRIPTION
## Purpose
Fix #44100

When a request is aborted after `get_num_new_matched_tokens` submits a lookup but before `update_state_after_alloc` is called, `_cleanup_request_tracker` is the only cleanup path. It only pops the tracker — it never calls `cleanup_lookup_result` or `free_lookup_locks`. `_pending_lookups` retains the request_id and read locks on matched KV chunks are never released until TTL expiry, blocking eviction.

`update_state_after_alloc` correctly handles both on the normal path; this fix mirrors that behaviour in the abort path.

Trigger conditions: client disconnect, request timeout.


## Fix

In `_cleanup_request_tracker`, when the tracker is still in `PREFETCHING` state, call `cleanup_lookup_result` and `free_lookup_locks` — mirroring what `update_state_after_alloc` does on the normal path. The `PREFETCHING` guard is necessary: `update_state_after_alloc` already handles cleanup for `WAITING_FOR_LOAD` and `READY` states; calling `free_lookup_locks` again there would release locks on chunks still being retrieved.


## Test

Ran `tests/v1/kv_connector/unit/test_lmcache_integration.py` — 8 passed in 5.44s.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

