### PR TITLE
[Bugfix] Honor tool_choice=None / "none" in Chat Completions streaming

### DIFF
--- a/tests/entrypoints/openai/test_tool_choice_content_none.py
+++ b/tests/entrypoints/openai/test_tool_choice_content_none.py
@@ -92,3 +92,169 @@ def test_responses_parser_allows_named_tool_choice_with_none_content():
 
     assert content is None
     assert tool_calls == []
+
+
+class _StubParser(DelegatingParser):
+    """DelegatingParser stub that records whether the tool parser ran.
+
+    Skips the real reasoning / tool parsers so ``parse_delta`` jumps directly
+    into the tool-call phase on the first delta. ``_extract_tool_calls_streaming``
+    flips ``tool_parser_called`` to ``True`` and emits a synthetic tool call,
+    so a passing test (``tool_parser_called is False``) proves the new
+    ``tool_choice=None``/``"none"`` guard short-circuited before the parser.
+    """
+
+    def __init__(self):
+        super().__init__(tokenizer=None)
+        # Start past the reasoning phase so parse_delta enters the tool-call
+        # block on the very first delta.
+        self._stream_state.reasoning_ended = True
+        self.tool_parser_called = False
+
+    def _in_tool_call_phase(self, state) -> bool:  # type: ignore[override]
+        # Decouple from self._tool_parser (which is None on the stub).
+        return state.reasoning_ended
+
+    def is_reasoning_end(self, input_ids):
+        return False
+
+    def extract_content_ids(self, input_ids):
+        return input_ids
+
+    def extract_reasoning(self, model_output, request):
+        return None, model_output
+
+    def extract_reasoning_streaming(self, **kwargs):
+        return None
+
+    def extract_tool_calls(self, model_output, request):
+        return None
+
+    def _extract_tool_calls_streaming(
+        self,
+        previous_text,
+        current_text,
+        delta_text,
+        previous_token_ids,
+        current_token_ids,
+        delta_token_ids,
+        request,
+        tool_call_idx,
+        tool_call_id_type,
+        function_name_returned,
+    ):
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaToolCall,
+        )
+
+        self.tool_parser_called = True
+        delta_message = DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call_test",
+                    type="function",
+                    function=DeltaFunctionCall(name="t", arguments=""),
+                )
+            ]
+        )
+        return delta_message, True
+
+
+def _make_streaming_request(tool_choice):
+    payload = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "test"}],
+        "stream": True,
+    }
+    if tool_choice is not None:
+        payload["tool_choice"] = tool_choice
+        payload["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+    return ChatCompletionRequest.model_validate(payload)
+
+
+def test_parse_delta_with_tool_choice_none_skips_tool_parser():
+    """Explicit ``tool_choice="none"`` must not invoke the streaming tool parser
+    and must surface the raw delta text as ``DeltaMessage.content``."""
+    parser = _StubParser()
+    request = _make_streaming_request(tool_choice="none")
+
+    delta = parser.parse_delta(
+        delta_text="<tool_call>{}</tool_call>",
+        delta_token_ids=[1, 2, 3],
+        request=request,
+    )
+
+    assert parser.tool_parser_called is False
+    assert delta is not None
+    assert delta.content == "<tool_call>{}</tool_call>"
+    assert delta.tool_calls == []
+
+
+def test_parse_delta_with_omitted_tool_choice_skips_tool_parser():
+    """No-tools request with omitted ``tool_choice`` (``request.tool_choice
+    is None``) must not invoke the streaming tool parser either, mirroring the
+    non-streaming guard ``not request.tool_choice or request.tool_choice ==
+    "none"`` in chat_completion/serving.py."""
+    parser = _StubParser()
+    request = _make_streaming_request(tool_choice=None)
+    assert request.tool_choice in (None, "none")
+
+    delta = parser.parse_delta(
+        delta_text="<tool_call>{}</tool_call>",
+        delta_token_ids=[1, 2, 3],
+        request=request,
+    )
+
+    assert parser.tool_parser_called is False
+    assert delta is not None
+    assert delta.content == "<tool_call>{}</tool_call>"
+    assert delta.tool_calls == []
+
+
+def test_parse_delta_without_tool_choice_none_still_runs_tool_parser():
+    """Sanity: the bypass is gated on ``tool_choice in (None, "none")``;
+    other values (e.g. ``"auto"``) must still hit the tool parser."""
+    parser = _StubParser()
+    request = _make_streaming_request(tool_choice="auto")
+
+    delta = parser.parse_delta(
+        delta_text="<tool_call>{}</tool_call>",
+        delta_token_ids=[1, 2, 3],
+        request=request,
+    )
+
+    assert parser.tool_parser_called is True
+    assert delta is not None
+    assert delta.tool_calls
+    assert delta.tool_calls[0].id == "call_test"
+
+
+def test_parse_delta_tool_choice_none_multiple_chunks_remain_content():
+    """Multiple deltas under ``tool_choice="none"`` must all stay in content."""
+    parser = _StubParser()
+    request = _make_streaming_request(tool_choice="none")
+
+    chunks = ["<tool_", "call>{", "}</tool_", "call>"]
+    contents: list[str | None] = []
+    for i, chunk in enumerate(chunks):
+        delta = parser.parse_delta(
+            delta_text=chunk,
+            delta_token_ids=[i],
+            request=request,
+        )
+        assert delta is not None
+        contents.append(delta.content)
+
+    assert parser.tool_parser_called is False
+    assert contents[0] == "<tool_"
+    assert "".join(c or "" for c in contents) == "".join(chunks)

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -709,31 +709,49 @@ class DelegatingParser(Parser):
             # A boundary delta may carry both reasoning and tool call,
             # save it before the tool parser overwrites delta_message.
             reasoning = delta_message.reasoning if delta_message else None
-            delta_message, state.function_name_returned = (
-                self._extract_tool_calls_streaming(
-                    previous_text=state.previous_text,
-                    current_text=current_text,
-                    delta_text=delta_text,
-                    previous_token_ids=state.previous_token_ids,
-                    current_token_ids=current_token_ids,
-                    delta_token_ids=delta_token_ids,
-                    request=request,  # type: ignore[arg-type]
-                    tool_call_idx=state.history_tool_call_cnt,
-                    tool_call_id_type=state.tool_call_id_type,
-                    function_name_returned=state.function_name_returned,
+
+            if not request.tool_choice or request.tool_choice == "none":
+                # tool_choice="none" or omitted: skip the tool parser and
+                # surface any remaining model output as plain content, matching
+                # the non-streaming Chat Completions branch in
+                # entrypoints/openai/chat_completion/serving.py:
+                #   elif not request.tool_choice or request.tool_choice == "none":
+                #       message = ChatMessage(role=..., content=content)
+                # Because the tool parser is never invoked,
+                # state.function_name_returned stays untouched and the
+                # downstream `tools_streamed[i]` flag stays False, so the
+                # finish_reason naturally falls back to "stop".
+                if delta_text:
+                    if delta_message is None:
+                        delta_message = DeltaMessage(content=delta_text)
+                    else:
+                        delta_message.content = delta_text
+            else:
+                delta_message, state.function_name_returned = (
+                    self._extract_tool_calls_streaming(
+                        previous_text=state.previous_text,
+                        current_text=current_text,
+                        delta_text=delta_text,
+                        previous_token_ids=state.previous_token_ids,
+                        current_token_ids=current_token_ids,
+                        delta_token_ids=delta_token_ids,
+                        request=request,  # type: ignore[arg-type]
+                        tool_call_idx=state.history_tool_call_cnt,
+                        tool_call_id_type=state.tool_call_id_type,
+                        function_name_returned=state.function_name_returned,
+                    )
                 )
-            )
+                if (
+                    delta_message
+                    and delta_message.tool_calls
+                    and delta_message.tool_calls[0].id is not None
+                ):
+                    state.history_tool_call_cnt += 1
+
             if reasoning:
                 if not delta_message:
                     delta_message = DeltaMessage()
                 delta_message.reasoning = reasoning
-
-            if (
-                delta_message
-                and delta_message.tool_calls
-                and delta_message.tool_calls[0].id is not None
-            ):
-                state.history_tool_call_cnt += 1
 
         # No phase active: pass through as content
         if (


### PR DESCRIPTION
## Summary

Fixes #42747.

Streaming Chat Completions with `tool_choice="none"` — or omitted on a no-tools request, where `request.tool_choice` ends up as `None` — could still produce `delta.tool_calls` and finish with `finish_reason="tool_calls"` whenever the server was launched with a `--tool-call-parser` and the model output happened to match that parser's tool-call format. Non-streaming Chat Completions already handles both cases correctly.

### Root cause

`DelegatingParser.parse_delta` in `vllm/parser/abstract_parser.py` invokes `_extract_tool_calls_streaming` unconditionally once the stream enters the tool-call phase, without inspecting `request.tool_choice`. The non-streaming path at `vllm/entrypoints/openai/chat_completion/serving.py` already short-circuits both cases:

```python
elif not request.tool_choice or request.tool_choice == "none":
    message = ChatMessage(role=role, reasoning=reasoning, content=content)
```

The streaming path was missing the equivalent guard.

### Fix

In `DelegatingParser.parse_delta`, when `not request.tool_choice or request.tool_choice == "none"`, skip `_extract_tool_calls_streaming` and surface any remaining (post-reasoning) text as plain `content`. Because the tool parser is never invoked, `state.function_name_returned` stays untouched and the downstream `tools_streamed[i]` flag stays `False`, so `finish_reason` naturally falls back to `"stop"`. Reasoning extraction is untouched.

## Difference from #42752

#42752 was the original attempt at this fix and at the time this PR was opened was OPEN, `CONFLICTING` with main, last updated 2026-05-23, and **only guarded on `request.tool_choice == "none"`**. The review feedback on that PR (gemini-code-assist, 2026-05-15) explicitly asked to **broaden the check to also cover `request.tool_choice is None`** — the no-tools request case raised by @QwertyJack in the comment thread under #42747.

This PR implements that broader guard so streaming matches the non-streaming `not request.tool_choice or request.tool_choice == "none"` semantics exactly. Acknowledging @hoobnn for the original direction; happy to close this if #42752 is updated with the same broader guard.

This logic has been independently validated downstream in [vllm-project/vllm-ascend#9776](https://github.com/vllm-project/vllm-ascend/pull/9776) against vLLM v0.20.2.

## Duplicate-PR check (per AGENTS.md)

```
gh issue view 42747 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "42747 in:body"
```

- #42752 (@hoobnn, OPEN, stale 2 weeks at PR-open time, CONFLICTING, pre-commit FAILURE): same approach, narrower guard, awaiting author response to broaden.
- #42868 (OPEN): unrelated approach — patches `chat_completion/serving.py`, not `abstract_parser.py`; touches a different surface area.

This PR is materially different from #42752 in the guard scope.

## Test plan

Added in `tests/entrypoints/openai/test_tool_choice_content_none.py`:

- [x] `test_parse_delta_with_tool_choice_none_skips_tool_parser` — explicit `tool_choice="none"`: parser is not invoked, raw delta text surfaces as `DeltaMessage.content`.
- [x] `test_parse_delta_with_omitted_tool_choice_skips_tool_parser` — omitted `tool_choice` on a no-tools request (`request.tool_choice is None`): parser is not invoked, raw delta text surfaces as content. **This is the additional case beyond #42752.**
- [x] `test_parse_delta_without_tool_choice_none_still_runs_tool_parser` — sanity: `tool_choice="auto"` still hits the tool parser (no regression).
- [x] `test_parse_delta_tool_choice_none_multiple_chunks_remain_content` — multi-chunk streaming stays in content mode across deltas.

A local `pytest` run was not possible in the contributing environment (macOS aarch64, no `torch` available). The new tests rely only on `vllm.entrypoints.openai.chat_completion.protocol`, `vllm.parser.abstract_parser` and a stub parser; they will run on CI on this PR.

AI assistance was used (Claude) to draft the patch and the test stub, mirroring the already-reviewed approach in #42752.

---

**Closing note (2026-05-31)**: @hoobnn has folded the broader guard into #42752 and rebased it onto current `main` with the same `request.tool_choice is None` regression coverage. Closing this PR as duplicate of #42752 per its now-equivalent scope. Thanks @hoobnn for picking it up.
