### PR TITLE
[BugFix] Omit empty tool_calls from OpenAI chat responses

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_completion_with_function_calling.py
+++ b/tests/entrypoints/openai/chat_completion/test_completion_with_function_calling.py
@@ -540,8 +540,8 @@ async def test_max_tokens_with_tool_choice_required(
         tool_choice=tool_choice,
     )
     # When `tool_choice="required"` and the tokens of `tools` exceed `max_tokens`,
-    # both `tool_calls` and `content` should be empty.
+    # `tool_calls` should be absent and `content` should be empty.
     # This behavior should be consistent with OpenAI.
     choice = chat_completion.choices[0]
     assert choice.finish_reason == "length"
-    assert len(choice.message.tool_calls) == 0
+    assert choice.message.tool_calls is None

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -465,7 +465,7 @@ class TestGPTOSSChat:
         )
 
         msg = tool_choice_none.choices[0].message
-        assert len(msg.tool_calls) == 0
+        assert msg.tool_calls is None
 
 
 class TestGPTOSSSpeculativeChat:

--- a/tests/entrypoints/openai/test_tool_choice_content_none.py
+++ b/tests/entrypoints/openai/test_tool_choice_content_none.py
@@ -2,8 +2,25 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    FunctionCall,
+    ToolCall,
+    UsageInfo,
+)
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.abstract_parser import DelegatingParser
 
@@ -86,3 +103,99 @@ def test_responses_parser_allows_named_tool_choice_with_none_content():
 
     assert content is None
     assert tool_calls == []
+
+
+def _chat_response(message: ChatMessage) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="test-model",
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=message,
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def test_chat_completion_response_omits_empty_tool_calls_payload():
+    response = _chat_response(ChatMessage(role="assistant", content="done"))
+
+    payload = response.model_dump()
+
+    assert "tool_calls" not in payload["choices"][0]["message"]
+    parsed = OpenAIChatCompletion.model_validate(payload)
+    assert parsed.choices[0].message.tool_calls is None
+
+
+def test_chat_completion_response_keeps_non_empty_tool_calls_payload():
+    response = _chat_response(
+        ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_weather",
+                        arguments='{"city": "Beijing"}',
+                    )
+                )
+            ],
+        )
+    )
+
+    message = response.model_dump()["choices"][0]["message"]
+
+    assert len(message["tool_calls"]) == 1
+    assert message["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def _stream_response(delta: DeltaMessage) -> ChatCompletionStreamResponse:
+    return ChatCompletionStreamResponse(
+        id="chatcmpl-test",
+        object="chat.completion.chunk",
+        created=1,
+        model="test-model",
+        choices=[
+            ChatCompletionResponseStreamChoice(
+                index=0,
+                delta=delta,
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def test_chat_completion_stream_response_omits_empty_tool_calls_payload():
+    response = _stream_response(DeltaMessage(content="done", tool_calls=[]))
+
+    payload = response.model_dump(exclude_unset=True)
+    payload_json = response.model_dump_json(exclude_unset=True)
+
+    assert "tool_calls" not in payload["choices"][0]["delta"]
+    parsed = ChatCompletionChunk.model_validate_json(payload_json)
+    assert parsed.choices[0].delta.tool_calls is None
+
+
+def test_chat_completion_stream_response_keeps_non_empty_tool_calls_payload():
+    response = _stream_response(
+        DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call-test",
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name="get_weather",
+                        arguments='{"city": "Beijing"}',
+                    ),
+                )
+            ]
+        )
+    )
+
+    delta = response.model_dump(exclude_unset=True)["choices"][0]["delta"]
+
+    assert len(delta["tool_calls"]) == 1
+    assert delta["tool_calls"][0]["function"]["name"] == "get_weather"

--- a/tests/entrypoints/openai/test_tool_choice_content_none.py
+++ b/tests/entrypoints/openai/test_tool_choice_content_none.py
@@ -123,8 +123,10 @@ def test_chat_completion_response_omits_empty_tool_calls_payload():
     response = _chat_response(ChatMessage(role="assistant", content="done"))
 
     payload = response.model_dump()
+    payload_exclude_unset = response.model_dump(exclude_unset=True)
 
     assert "tool_calls" not in payload["choices"][0]["message"]
+    assert "tool_calls" not in payload_exclude_unset["choices"][0]["message"]
     parsed = OpenAIChatCompletion.model_validate(payload)
     assert parsed.choices[0].message.tool_calls is None
 
@@ -168,7 +170,7 @@ def _stream_response(delta: DeltaMessage) -> ChatCompletionStreamResponse:
 
 
 def test_chat_completion_stream_response_omits_empty_tool_calls_payload():
-    response = _stream_response(DeltaMessage(content="done", tool_calls=[]))
+    response = _stream_response(DeltaMessage(content="done"))
 
     payload = response.model_dump(exclude_unset=True)
     payload_json = response.model_dump_json(exclude_unset=True)

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -66,6 +66,13 @@ class ChatMessage(OpenAIBaseModel):
     # vLLM-specific fields that are not in OpenAI spec
     reasoning: str | None = None
 
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if data.get("tool_calls") == []:
+            data.pop("tool_calls")
+        return data
+
 
 class ChatCompletionLogProb(OpenAIBaseModel):
     token: str

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -69,7 +69,7 @@ class ChatMessage(OpenAIBaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
-        if data.get("tool_calls") == []:
+        if len(data.get("tool_calls", [])) == 0:
             data.pop("tool_calls")
         return data
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -70,7 +70,7 @@ class ChatMessage(OpenAIBaseModel):
     def _serialize(self, handler):
         data = handler(self)
         if len(data.get("tool_calls", [])) == 0:
-            data.pop("tool_calls")
+            data.pop("tool_calls", None)
         return data
 
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -356,7 +356,7 @@ class DeltaMessage(OpenAIBaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
-        if data.get("tool_calls") == []:
+        if len(data.get("tool_calls", [])) == 0:
             data.pop("tool_calls")
         return data
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -357,7 +357,7 @@ class DeltaMessage(OpenAIBaseModel):
     def _serialize(self, handler):
         data = handler(self)
         if len(data.get("tool_calls", [])) == 0:
-            data.pop("tool_calls")
+            data.pop("tool_calls", None)
         return data
 
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -353,6 +353,13 @@ class DeltaMessage(OpenAIBaseModel):
     reasoning: str | None = None
     tool_calls: list[DeltaToolCall] = Field(default_factory=list)
 
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if data.get("tool_calls") == []:
+            data.pop("tool_calls")
+        return data
+
 
 class GenerationError(Exception):
     """raised when finish_reason indicates internal server error (500)"""


### PR DESCRIPTION
Fixes #44104.

### What this PR does / why we need it

This PR omits empty `tool_calls` arrays from serialized OpenAI chat completion responses:

- non-stream `message.tool_calls == []`
- stream `delta.tool_calls == []`

Non-empty tool calls are preserved unchanged.

This fixes an OpenAI API compatibility issue where final assistant responses after a tool result can contain normal text with `finish_reason="stop"`, but still serialize `tool_calls: []`. OpenAI SDK clients then see `message.tool_calls is not None`, enter the tool-call path, and fail when indexing the empty list.

### Does this PR introduce any user-facing change?

Yes. OpenAI-compatible chat completion responses no longer include empty `tool_calls` arrays. This aligns the response shape with the absence of tool calls while preserving non-empty tool-call payloads.

### Duplicate-work check

- `gh issue view 44104 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "44104 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "empty tool_calls OpenAI chat responses"`

Result: #44105 is the only open PR directly addressing #44104 / empty `tool_calls` response serialization. Broader keyword hits are unrelated parser/model changes.

### How was this patch tested?

- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/entrypoints/openai/test_tool_choice_content_none.py`
- `uv run --with ruff --no-project ruff check vllm/entrypoints/openai/chat_completion/protocol.py vllm/entrypoints/openai/engine/protocol.py tests/entrypoints/openai/test_tool_choice_content_none.py tests/entrypoints/openai/chat_completion/test_completion_with_function_calling.py tests/entrypoints/openai/chat_completion/test_serving_chat.py`

Results:

- pytest: `6 passed`
- ruff: passed

### AI assistance

AI assistance was used to investigate the CI failure, add the serializer guard for unset default `tool_calls`, and align affected OpenAI SDK integration test expectations with omitted empty `tool_calls`. The human submitter should review every changed line and the final CI result.
