### PR TITLE
[Frontend][ToolParser] emit tool name blocks in advance in MinimaxM2

### DIFF
--- a/tests/tool_parsers/test_minimax_m2_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m2_tool_parser.py
@@ -310,7 +310,11 @@ class TestDeltaMessageFormat:
     """Verify the shape of emitted DeltaMessage / DeltaToolCall."""
 
     def test_tool_call_fields(self, parser):
-        """Each emitted tool call has id, name, arguments, type, index."""
+        """Each emitted tool call has id, name, arguments, type, index.
+
+        With early name emission the complete invoke produces two
+        DeltaToolCall entries: a name-only opening chunk followed by
+        an arguments-only content chunk."""
         results = _feed(
             parser,
             [
@@ -320,16 +324,30 @@ class TestDeltaMessageFormat:
             ],
         )
         tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
-        assert len(tc_deltas) == 1
-        tc = tc_deltas[0]
-        assert tc.index == 0
-        assert tc.type == "function"
-        assert tc.id is not None and tc.id.startswith("call_")
-        assert tc.function.name == "fn"
-        assert json.loads(tc.function.arguments) == {"k": "v"}
+        assert len(tc_deltas) == 2
+
+        # First: name-only opening chunk
+        name_tc = tc_deltas[0]
+        assert name_tc.index == 0
+        assert name_tc.type == "function"
+        assert name_tc.id is not None and name_tc.id.startswith("call_")
+        assert name_tc.function.name == "fn"
+        assert name_tc.function.arguments is None
+
+        # Second: arguments-only content chunk
+        args_tc = tc_deltas[1]
+        assert args_tc.index == 0
+        assert args_tc.id is None
+        assert args_tc.type is None
+        assert args_tc.function.name is None
+        assert json.loads(args_tc.function.arguments) == {"k": "v"}
 
     def test_multi_invoke_indices(self, parser):
-        """Multiple invokes get sequential indices."""
+        """Multiple invokes get sequential indices.
+
+        With early name emission each invoke produces two
+        DeltaToolCalls (name + args), so indices appear as
+        [0, 0, 1, 1]."""
         results = _feed(
             parser,
             [
@@ -341,7 +359,7 @@ class TestDeltaMessageFormat:
         )
         tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
         indices = [tc.index for tc in tc_deltas]
-        assert indices == [0, 1]
+        assert indices == [0, 0, 1, 1]
 
 
 # ---------------------------------------------------------------------------
@@ -678,3 +696,109 @@ class TestNoneStringPreservation:
         assert len(tc) == 1
         parsed = json.loads(tc[0]["arguments"])
         assert parsed["value"] == "nil"
+
+
+# ---------------------------------------------------------------------------
+# Name / parameter separation (name-first streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestSeparateNameParam:
+    def test_both_tools_in_one_chunk(self, parser):
+        """Both tools' full content arrives in one chunk."""
+        results = _feed(
+            parser,
+            [
+                "<minimax:tool_call>"
+                '<invoke name="tool1"><parameter name="x">1</parameter></invoke>'
+                '<invoke name="tool2"><parameter name="y">2</parameter></invoke>'
+                "</minimax:tool_call>",
+            ],
+        )
+        tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
+        assert len(tc_deltas) == 4
+
+        self._assert_name_chunk(tc_deltas[0], 0, "tool1")
+        self._assert_args_chunk(tc_deltas[1], 0, {"x": "1"})
+        self._assert_name_chunk(tc_deltas[2], 1, "tool2")
+        self._assert_args_chunk(tc_deltas[3], 1, {"y": "2"})
+
+        tc = _collect_tool_calls(results)
+        assert tc[0]["name"] == "tool1"
+        assert tc[1]["name"] == "tool2"
+        assert json.loads(tc[0]["arguments"]) == {"x": "1"}
+        assert json.loads(tc[1]["arguments"]) == {"y": "2"}
+
+    def test_two_invokes_in_two_batches(self, parser):
+        """First invoke complete, then second invoke complete."""
+        results = _feed(
+            parser,
+            [
+                "<minimax:tool_call>"
+                '<invoke name="tool1"><parameter name="x">1</parameter></invoke>',
+                '<invoke name="tool2"><parameter name="y">2</parameter></invoke>'
+                "</minimax:tool_call>",
+            ],
+        )
+        tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
+        assert len(tc_deltas) == 4
+
+        self._assert_name_chunk(tc_deltas[0], 0, "tool1")
+        self._assert_args_chunk(tc_deltas[1], 0, {"x": "1"})
+        self._assert_name_chunk(tc_deltas[2], 1, "tool2")
+        self._assert_args_chunk(tc_deltas[3], 1, {"y": "2"})
+
+    def test_step_by_step(self, parser):
+        """name_tool1, args_tool1, name_tool2, args_tool2 arrive one by one."""
+        results = _feed(
+            parser,
+            [
+                '<minimax:tool_call><invoke name="tool1">',
+                '<parameter name="x">1</parameter></invoke>',
+                '<invoke name="tool2">',
+                '<parameter name="y">2</parameter></invoke>',
+                "</minimax:tool_call>",
+            ],
+        )
+        tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
+        assert len(tc_deltas) == 4
+
+        self._assert_name_chunk(tc_deltas[0], 0, "tool1")
+        self._assert_args_chunk(tc_deltas[1], 0, {"x": "1"})
+        self._assert_name_chunk(tc_deltas[2], 1, "tool2")
+        self._assert_args_chunk(tc_deltas[3], 1, {"y": "2"})
+
+    def test_overlap(self, parser):
+        """name_tool1, then args_tool1+name_tool2 together, then args_tool2."""
+        results = _feed(
+            parser,
+            [
+                '<minimax:tool_call><invoke name="tool1">',
+                '<parameter name="x">1</parameter></invoke><invoke name="tool2">',
+                '<parameter name="y">2</parameter></invoke>',
+                "</minimax:tool_call>",
+            ],
+        )
+        tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
+        assert len(tc_deltas) == 4
+
+        self._assert_name_chunk(tc_deltas[0], 0, "tool1")
+        self._assert_args_chunk(tc_deltas[1], 0, {"x": "1"})
+        self._assert_name_chunk(tc_deltas[2], 1, "tool2")
+        self._assert_args_chunk(tc_deltas[3], 1, {"y": "2"})
+
+    @staticmethod
+    def _assert_name_chunk(tc, expected_index, expected_name):
+        assert tc.index == expected_index
+        assert tc.type == "function"
+        assert tc.id is not None and tc.id.startswith("call_")
+        assert tc.function.name == expected_name
+        assert tc.function.arguments is None
+
+    @staticmethod
+    def _assert_args_chunk(tc, expected_index, expected_args):
+        assert tc.index == expected_index
+        assert tc.id is None
+        assert tc.type is None
+        assert tc.function.name is None
+        assert json.loads(tc.function.arguments) == expected_args

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -53,6 +53,10 @@ class MinimaxM2ToolParser(ToolParser):
         self.parameter_complete_regex = re.compile(
             r"<parameter name=(.*?)</parameter>", re.DOTALL
         )
+        self.invoke_name_regex = re.compile(r"<invoke name=([^>]+)>", re.DOTALL)
+
+        # Early name emission tracking
+        self.current_tool_name_index: int = 0
 
         if not self.model_tokenizer:
             raise ValueError(
@@ -302,41 +306,63 @@ class MinimaxM2ToolParser(ToolParser):
         Tracks progress via ``current_tool_index`` so each block is
         extracted exactly once across successive streaming calls.
         """
+        # Early name emission: scan for invoke openings that may not yet
+        # be complete, and expose them as name-only DeltaToolCalls.
+        # Completed invokes are always processed before new name-only
+        # invokes so that the stream order is never inverted.
         complete_invokes = self.invoke_complete_regex.findall(current_text)
+        name_invokes = self.invoke_name_regex.findall(current_text)
         delta_tool_calls: list[DeltaToolCall] = []
 
-        while len(complete_invokes) > self.current_tool_index:
-            invoke_str = complete_invokes[self.current_tool_index]
-            tool_call = self._parse_single_invoke(
-                invoke_str,
-                self.tools,
-            )
-            if not tool_call:
+        while (
+            len(complete_invokes) > self.current_tool_index
+            or len(name_invokes) > self.current_tool_name_index
+        ):
+            # Phase 1: catch up current_tool_index to
+            # current_tool_name_index — emit args-only for invokes whose
+            # name was already sent.
+            if self.current_tool_index < min(
+                len(complete_invokes), self.current_tool_name_index
+            ):
+                invoke_str = complete_invokes[self.current_tool_index]
+                tool_call = self._parse_single_invoke(invoke_str, self.tools)
                 self.current_tool_index += 1
+                if tool_call:
+                    args_json = tool_call.function.arguments
+                    self.prev_tool_call_arr.append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(args_json),
+                        }
+                    )
+                    self.streamed_args_for_tool.append(args_json)
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=self.current_tool_index - 1,
+                            function=DeltaFunctionCall(arguments=args_json),
+                        )
+                    )
                 continue
 
-            args_json = tool_call.function.arguments
-            idx = self.current_tool_index
-            self.current_tool_index += 1
-
-            self.prev_tool_call_arr.append(
-                {
-                    "name": tool_call.function.name,
-                    "arguments": json.loads(args_json),
-                }
-            )
-            self.streamed_args_for_tool.append(args_json)
-            delta_tool_calls.append(
-                DeltaToolCall(
-                    index=idx,
-                    id=self._generate_tool_call_id(),
-                    function=DeltaFunctionCall(
-                        name=tool_call.function.name,
-                        arguments=args_json,
-                    ),
-                    type="function",
+            # Phase 2: advance current_tool_name_index — emit a name-only
+            # chunk for the next invoke whose opening we can see.
+            if self.current_tool_name_index < len(name_invokes):
+                name_str = name_invokes[self.current_tool_name_index]
+                function_name = self._extract_name(name_str)
+                call_id = self._generate_tool_call_id()
+                idx = self.current_tool_name_index
+                self.current_tool_name_index += 1
+                delta_tool_calls.append(
+                    DeltaToolCall(
+                        index=idx,
+                        id=call_id,
+                        type="function",
+                        function=DeltaFunctionCall(name=function_name),
+                    )
                 )
-            )
+                continue
+            # will not happen
+            break
 
         return delta_tool_calls
 
@@ -418,6 +444,7 @@ class MinimaxM2ToolParser(ToolParser):
             self.prev_tool_call_arr.clear()
             self.streamed_args_for_tool.clear()
             self.is_tool_call_started = tool_call_starting
+            self.current_tool_name_index = 0
 
         # Pass through content before any tool call.
         if not self.is_tool_call_started:


### PR DESCRIPTION
## Purpose

This PR emit tool name blocks in advance for the MiniMax-M2 streaming tool call parser. Currently, when the model generates a tool call such as:

```
<invoke name="update_page"><parameter name="html_content" string="false"><!DOCTYPE html>...</parameter></invoke>
```

The parser must wait for the entire `<invoke>...</invoke>` block to close before emitting any `DeltaToolCall` to the client. However, for tools like file updates or HTML page generation, the arguments can be extremely large, a single HTML page may require 15K tokens, which at 400 tokens/s takes nearly 40 seconds to generate. During this time, the client receives no tool call feedback at all.

By emitting the function name early, the client can immediately perceive that the LLM is generating tool call arguments, resulting in a significantly better user experience for LLM applications. This is especially impactful for tools involving large argument payloads such as file updates, code generation, or document creation.

## Test Plan

Run the MiniMax-M2 tool parser unit tests:

```bash
pytest tests/tool_parsers/test_minimax_m2_tool_parser.py -v
```

The new test class `TestSeparateNameParam` covers four streaming scenarios:

| Test | Scenario |
|------|----------|
| `test_both_tools_in_one_chunk` | Two complete invokes arrive in a single delta chunk |
| `test_two_invokes_in_two_batches` | First invoke completes, then second invoke arrives |
| `test_step_by_step` | Sequential: name1 → args1 → name2 → args2 |
| `test_overlap` | Interleaved: name1 → args1+name2 (same batch) → args2 |

Existing tests (`TestNonStreamingToolCall`, `TestStreamingToolCall`) have been updated to expect the new two-chunk output format.
