### PR TITLE
[Kernel] Add optional TileLang backend for bf16 activation-and-mul ops

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -106,6 +106,7 @@ if TYPE_CHECKING:
     VLLM_FORCE_AOT_LOAD: bool = False
     VLLM_USE_MEGA_AOT_ARTIFACT: bool = False
     VLLM_USE_TRITON_AWQ: bool = False
+    VLLM_USE_TILELANG_ACTIVATION_OPS: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
@@ -1051,6 +1052,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will use Triton implementations of AWQ.
     "VLLM_USE_TRITON_AWQ": lambda: bool(int(os.getenv("VLLM_USE_TRITON_AWQ", "0"))),
+    # If set, activation ops may use optional TileLang implementations.
+    # Individual ops still validate platform, dtype, layout, and shape.
+    "VLLM_USE_TILELANG_ACTIVATION_OPS": lambda: bool(
+        int(os.getenv("VLLM_USE_TILELANG_ACTIVATION_OPS", "0"))
+    ),
     # If set, allow loading or unloading lora adapters in runtime,
     "VLLM_ALLOW_RUNTIME_LORA_UPDATING": lambda: (
         os.environ.get("VLLM_ALLOW_RUNTIME_LORA_UPDATING", "0").strip().lower()

--- a/vllm/model_executor/kernels/activation/__init__.py
+++ b/vllm/model_executor/kernels/activation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/model_executor/kernels/activation/tilelang.py
+++ b/vllm/model_executor/kernels/activation/tilelang.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TileLang activation op wrappers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import cache
+from typing import Any
+
+import torch
+
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@cache
+def _get_tilelang_activation_kernel(
+    kernel_name: str,
+    block_size: int = 1024,
+    threads: int = 128,
+):
+    from vllm.model_executor.kernels.activation import tilelang_kernels
+
+    return getattr(tilelang_kernels, kernel_name)(
+        BLOCK_SIZE=block_size,
+        threads=threads,
+    )
+
+
+def _validate_act_and_mul_tilelang_args(
+    out: torch.Tensor,
+    x: torch.Tensor,
+) -> int:
+    assert x.dtype == torch.bfloat16
+    assert out.dtype == torch.bfloat16
+    assert x.ndim > 0
+    assert x.shape[-1] % 2 == 0
+
+    hidden = x.shape[-1] // 2
+    assert out.shape == x.shape[:-1] + (hidden,)
+    assert x.is_contiguous()
+    assert out.is_contiguous()
+    return hidden
+
+
+def _run_act_and_mul_tilelang(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    kernel_name: str,
+    *args: float,
+) -> None:
+    hidden = _validate_act_and_mul_tilelang_args(out, x)
+    if x.numel() == 0:
+        return
+
+    x_2d = x.view(-1, x.shape[-1])
+    out_2d = out.view(-1, hidden)
+    kernel = _get_tilelang_activation_kernel(kernel_name)
+    kernel(x_2d, out_2d, *args)
+
+
+def silu_and_mul_tilelang(out: torch.Tensor, x: torch.Tensor) -> None:
+    """Compute bf16 SiLU-and-mul into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(out, x, "silu_and_mul_tilelang_kernel")
+
+
+def mul_and_silu_tilelang(out: torch.Tensor, x: torch.Tensor) -> None:
+    """Compute bf16 mul-and-SiLU into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(out, x, "mul_and_silu_tilelang_kernel")
+
+
+def fatrelu_and_mul_tilelang(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    threshold: float,
+) -> None:
+    """Compute bf16 FATReLU-and-mul into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(out, x, "fatrelu_and_mul_tilelang_kernel", threshold)
+
+
+def silu_and_mul_with_clamp_tilelang(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    swiglu_limit: float,
+) -> None:
+    """Compute bf16 clamped SiLU-and-mul into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(
+        out,
+        x,
+        "silu_and_mul_with_clamp_tilelang_kernel",
+        swiglu_limit,
+    )
+
+
+def gelu_and_mul_tilelang(out: torch.Tensor, x: torch.Tensor) -> None:
+    """Compute bf16 GELU-and-mul into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(out, x, "gelu_and_mul_tilelang_kernel")
+
+
+def gelu_tanh_and_mul_tilelang(out: torch.Tensor, x: torch.Tensor) -> None:
+    """Compute bf16 tanh-approx GELU-and-mul into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(out, x, "gelu_tanh_and_mul_tilelang_kernel")
+
+
+def swigluoai_and_mul_tilelang(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    alpha: float,
+    limit: float,
+) -> None:
+    """Compute bf16 GPT-OSS SwiGLU OAI into a pre-allocated tensor."""
+    _run_act_and_mul_tilelang(
+        out,
+        x,
+        "swigluoai_and_mul_tilelang_kernel",
+        alpha,
+        limit,
+    )
+
+
+def swiglustep_and_mul_tilelang(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    limit: float,
+) -> None:
+    """Compute bf16 SwiGLU-step-and-mul into a pre-allocated output tensor."""
+    _run_act_and_mul_tilelang(out, x, "swiglustep_and_mul_tilelang_kernel", limit)
+
+
+def _activation_tilelang_fake(*args: object, **kwargs: object) -> None:
+    return None
+
+
+_TILELANG_ACTIVATION_OPS: tuple[tuple[str, Callable[..., Any]], ...] = (
+    ("silu_and_mul_tilelang", silu_and_mul_tilelang),
+    ("mul_and_silu_tilelang", mul_and_silu_tilelang),
+    ("fatrelu_and_mul_tilelang", fatrelu_and_mul_tilelang),
+    ("silu_and_mul_with_clamp_tilelang", silu_and_mul_with_clamp_tilelang),
+    ("gelu_and_mul_tilelang", gelu_and_mul_tilelang),
+    ("gelu_tanh_and_mul_tilelang", gelu_tanh_and_mul_tilelang),
+    ("swigluoai_and_mul_tilelang", swigluoai_and_mul_tilelang),
+    ("swiglustep_and_mul_tilelang", swiglustep_and_mul_tilelang),
+)
+
+for _op_name, _op_func in _TILELANG_ACTIVATION_OPS:
+    direct_register_custom_op(
+        op_name=_op_name,
+        op_func=_op_func,
+        mutates_args=["out"],
+        fake_impl=_activation_tilelang_fake,
+    )

--- a/vllm/model_executor/kernels/activation/tilelang_kernels.py
+++ b/vllm/model_executor/kernels/activation/tilelang_kernels.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TileLang activation kernels."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_tilelang
+
+if TYPE_CHECKING or current_platform.is_cuda_alike():
+    if not has_tilelang():
+        raise ImportError(
+            "tilelang is required for TileLang activation kernels but is not "
+            "installed. "
+        )
+    import tilelang
+    import tilelang.language as T
+else:
+    tilelang = None  # type: ignore[assignment]
+    T = None  # type: ignore[assignment]
+
+
+if tilelang is not None:
+
+    @tilelang.jit
+    def silu_and_mul_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 SiLU-and-mul."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col].astype(T.float32)
+                        silu = (T.sigmoid(gate) * gate).astype(T.bfloat16)
+                        y[by, col] = silu * x[by, col + HIDDEN]
+
+        return kernel
+
+    @tilelang.jit
+    def mul_and_silu_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 mul-and-SiLU."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col + HIDDEN].astype(T.float32)
+                        silu = (T.sigmoid(gate) * gate).astype(T.bfloat16)
+                        y[by, col] = x[by, col] * silu
+
+        return kernel
+
+    @tilelang.jit
+    def fatrelu_and_mul_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 FATReLU-and-mul."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+            threshold: T.float32,
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col]
+                        if gate > threshold:
+                            y[by, col] = gate * x[by, col + HIDDEN]
+                        else:
+                            y[by, col] = T.bfloat16(0.0)
+
+        return kernel
+
+    @tilelang.jit
+    def silu_and_mul_with_clamp_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 clamped SiLU-and-mul."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+            limit: T.float32,
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col].astype(T.float32)
+                        up = x[by, col + HIDDEN].astype(T.float32)
+                        gate_clamped = T.min(gate, limit)
+                        up_clamped = T.min(T.max(up, -limit), limit)
+                        silu = (T.sigmoid(gate_clamped) * gate_clamped).astype(
+                            T.bfloat16
+                        )
+                        y[by, col] = silu * up_clamped.astype(T.bfloat16)
+
+        return kernel
+
+    @tilelang.jit
+    def gelu_and_mul_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 GELU-and-mul."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col].astype(T.float32)
+                        gelu = (
+                            0.5 * gate * (1.0 + T.erf(gate * 0.7071067811865476))
+                        ).astype(T.bfloat16)
+                        y[by, col] = gelu * x[by, col + HIDDEN]
+
+        return kernel
+
+    @tilelang.jit
+    def gelu_tanh_and_mul_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 tanh-approx GELU-and-mul."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col].astype(T.float32)
+                        inner = gate + 0.044715 * gate * gate * gate
+                        gelu = (
+                            0.5 * gate * (1.0 + T.tanh(0.7978845608028654 * inner))
+                        ).astype(T.bfloat16)
+                        y[by, col] = gelu * x[by, col + HIDDEN]
+
+        return kernel
+
+    @tilelang.jit
+    def swigluoai_and_mul_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 GPT-OSS SwiGLU OAI."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+            alpha: T.float32,
+            limit: T.float32,
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col * 2].astype(T.float32)
+                        up = x[by, col * 2 + 1].astype(T.float32)
+                        gate_clamped = T.min(gate, limit)
+                        up_clamped = T.min(T.max(up, -limit), limit)
+                        glu = gate_clamped * T.sigmoid(gate_clamped * alpha)
+                        y[by, col] = ((up_clamped + 1.0) * glu).astype(T.bfloat16)
+
+        return kernel
+
+    @tilelang.jit
+    def swiglustep_and_mul_tilelang_kernel(
+        BLOCK_SIZE: int = 1024,
+        threads: int = 128,
+    ):
+        """Build a TileLang kernel for bf16 SwiGLU-step-and-mul."""
+        NUM_TOKENS = T.dynamic("NUM_TOKENS")
+        HIDDEN = T.dynamic("HIDDEN")
+
+        @T.prim_func
+        def kernel(
+            x: T.Tensor[[NUM_TOKENS, HIDDEN * 2], T.bfloat16],
+            y: T.Tensor[[NUM_TOKENS, HIDDEN], T.bfloat16],
+            limit: T.float32,
+        ):
+            with T.Kernel(
+                T.ceildiv(HIDDEN, BLOCK_SIZE), NUM_TOKENS, threads=threads
+            ) as (bx, by):
+                col_start = bx * BLOCK_SIZE
+
+                for i in T.Parallel(BLOCK_SIZE):
+                    col = col_start + i
+                    if col < HIDDEN:
+                        gate = x[by, col].astype(T.float32)
+                        up = x[by, col + HIDDEN].astype(T.float32)
+                        gate_silu = T.sigmoid(gate) * gate
+                        gate_clamped = T.min(gate_silu, limit)
+                        up_clamped = T.min(T.max(up, -limit), limit)
+                        y[by, col] = (gate_clamped * up_clamped).astype(T.bfloat16)
+
+        return kernel
+
+else:
+
+    def _unavailable_tilelang_kernel(*args: object, **kwargs: object):
+        raise RuntimeError(
+            "TileLang activation kernels are only available on CUDA-like "
+            "platforms with tilelang installed."
+        )
+
+    silu_and_mul_tilelang_kernel = _unavailable_tilelang_kernel
+    mul_and_silu_tilelang_kernel = _unavailable_tilelang_kernel
+    fatrelu_and_mul_tilelang_kernel = _unavailable_tilelang_kernel
+    silu_and_mul_with_clamp_tilelang_kernel = _unavailable_tilelang_kernel
+    gelu_and_mul_tilelang_kernel = _unavailable_tilelang_kernel
+    gelu_tanh_and_mul_tilelang_kernel = _unavailable_tilelang_kernel
+    swigluoai_and_mul_tilelang_kernel = _unavailable_tilelang_kernel
+    swiglustep_and_mul_tilelang_kernel = _unavailable_tilelang_kernel

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+import vllm.envs as envs
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -74,6 +75,52 @@ def swiglustep_and_mul_triton(
     )
 
 
+def _should_use_tilelang_activation(x: torch.Tensor) -> bool:
+    return (
+        envs.VLLM_USE_TILELANG_ACTIVATION_OPS
+        and current_platform.is_cuda_alike()
+        and x.dtype == torch.bfloat16
+        and x.ndim > 0
+        and x.shape[-1] % 2 == 0
+        and x.is_contiguous()
+    )
+
+
+def _try_run_tilelang_activation_op(
+    op_name: str,
+    out: torch.Tensor,
+    x: torch.Tensor,
+    *args: float,
+) -> bool:
+    if not _should_use_tilelang_activation(x):
+        return False
+
+    try:
+        import vllm.model_executor.kernels.activation.tilelang  # noqa: F401
+
+        op = getattr(torch.ops.vllm, op_name)
+    except (AttributeError, ImportError) as err:
+        logger.warning_once(
+            "TileLang %s is unavailable; falling back to the default "
+            "implementation. Error: %s",
+            op_name,
+            err,
+        )
+        return False
+
+    try:
+        op(out, x, *args)
+    except ImportError as err:
+        logger.warning_once(
+            "TileLang %s is unavailable; falling back to the default "
+            "implementation. Error: %s",
+            op_name,
+            err,
+        )
+        return False
+    return True
+
+
 # --8<-- [start:fatrelu_and_mul]
 @CustomOp.register("fatrelu_and_mul")
 class FatreluAndMul(CustomOp):
@@ -109,6 +156,15 @@ class FatreluAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        if _try_run_tilelang_activation_op(
+            "fatrelu_and_mul_tilelang",
+            out,
+            x,
+            self.threshold,
+        ):
+            return out
+
         self.op(out, x, self.threshold)
         return out
 
@@ -144,6 +200,10 @@ class SiluAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        if _try_run_tilelang_activation_op("silu_and_mul_tilelang", out, x):
+            return out
+
         self.op(out, x)
         return out
 
@@ -186,6 +246,15 @@ class SiluAndMulWithClamp(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        if _try_run_tilelang_activation_op(
+            "silu_and_mul_with_clamp_tilelang",
+            out,
+            x,
+            self.swiglu_limit,
+        ):
+            return out
+
         self.op(out, x, self.swiglu_limit)
         return out
 
@@ -223,6 +292,10 @@ class MulAndSilu(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        if _try_run_tilelang_activation_op("mul_and_silu_tilelang", out, x):
+            return out
+
         self.op(out, x)
         return out
 
@@ -365,6 +438,15 @@ class GeluAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        op_name = (
+            "gelu_tanh_and_mul_tilelang"
+            if self.approximate == "tanh"
+            else "gelu_and_mul_tilelang"
+        )
+        if _try_run_tilelang_activation_op(op_name, out, x):
+            return out
+
         self.op(out, x)
         return out
 
@@ -400,6 +482,16 @@ class SwigluOAIAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        if _try_run_tilelang_activation_op(
+            "swigluoai_and_mul_tilelang",
+            out,
+            x,
+            self.alpha,
+            self.limit,
+        ):
+            return out
+
         torch.ops._C.swigluoai_and_mul(out, x, self.alpha, self.limit)
         return out
 
@@ -438,6 +530,15 @@ class SwigluStepAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+
+        if _try_run_tilelang_activation_op(
+            "swiglustep_and_mul_tilelang",
+            out,
+            x,
+            self.limit,
+        ):
+            return out
+
         swiglustep_and_mul_triton(out, x, self.limit)
         return out
 


### PR DESCRIPTION
## Summary

Hi, this is my first PR to vLLM. This PR adds optional TileLang implementations for bf16 activation-and-mul ops. The new path is disabled by default and can be enabled with `VLLM_USE_TILELANG_ACTIVATION_OPS=1`.

Since I'm a first-time contributor, CI is blocked by the pre-run-check. Could a maintainer please add the ready label so CI can run? Happy to address any feedback. Thanks!

Covered ops:
- silu_and_mul
- mul_and_silu
- fatrelu_and_mul
- silu_and_mul_with_clamp
- gelu_and_mul
- gelu_tanh_and_mul
- swigluoai_and_mul
- swiglustep_and_mul

The dispatch is intentionally placed inside the existing CUDA activation path because TileLang is an alternative CUDA-like implementation. Each route checks platform, dtype, contiguity, and shape before dispatching; otherwise it falls back to the existing implementation.

## Motivation

Local benchmarks showed shape-dependent performance. TileLang wins for some shapes and loses for others, so this PR keeps the existing implementations as the default and exposes TileLang as an opt-in path for experimentation and future tuning.

The value of this PR is to introduce a low-intrusion TileLang activation-kernel path in vLLM:
- no default behavior change,
- a shared activation-level env flag instead of per-op flags,
- strict dtype/layout/platform checks,
- fallback to the existing implementation when unsupported,
- correctness and op registration tests,
- a reusable structure for future TileLang activation kernels and tuning.

## Benchmark

Environment:
- GPU: GeForce RTX 4080 SUPER
- dtype: bf16
- Compared against existing `_C.silu_and_mul`
- Correctness: max_abs=0, max_rel=0 for all listed shapes

Representative results:

tokens | hidden | tilelang ms | _C ms | _C/TL | TL GB/s | _C GB/s
-- | -- | -- | -- | -- | -- | --
1 | 1024 | 0.0078 | 0.0101 | 1.288 | 0.8 | 0.6
1 | 1536 | 0.0071 | 0.0099 | 1.393 | 1.3 | 0.9
1 | 4096 | 0.0071 | 0.0098 | 1.383 | 3.5 | 2.5
16 | 1024 | 0.0094 | 0.0098 | 1.040 | 10.4 | 10.0
16 | 1536 | 0.0071 | 0.0098 | 1.379 | 20.7 | 15.1
16 | 4096 | 0.0100 | 0.0101 | 1.008 | 39.4 | 39.1
128 | 1024 | 0.0075 | 0.0100 | 1.327 | 104.8 | 79.0
128 | 1536 | 0.0070 | 0.0103 | 1.487 | 169.7 | 114.1
128 | 4096 | 0.0072 | 0.0103 | 1.424 | 436.4 | 306.4
1024 | 1024 | 0.0083 | 0.0105 | 1.263 | 755.3 | 597.9
1024 | 1536 | 0.0087 | 0.0108 | 1.233 | 1080.2 | 876.4
1024 | 4096 | 0.0149 | 0.0117 | 0.789 | 1694.5 | 2147.1
4096 | 1024 | 0.0139 | 0.0115 | 0.826 | 1811.1 | 2192.7
4096 | 1536 | 0.0194 | 0.0129 | 0.664 | 1942.2 | 2922.9
4096 | 4096 | 0.1576 | 0.1608 | 1.020 | 638.7 | 625.9
8192 | 1024 | 0.0240 | 0.0149 | 0.621 | 2093.0 | 3371.2
8192 | 1536 | 0.1193 | 0.1196 | 1.003 | 633.1 | 631.3
8192 | 4096 | 0.3120 | 0.3259 | 1.045 | 645.2 | 617.7
16384 | 1024 | 0.1579 | 0.1608 | 1.018 | 637.6 | 626.2
16384 | 1536 | 0.2355 | 0.2460 | 1.045 | 641.2 | 613.8
16384 | 4096 | 0.6241 | 0.6596 | 1.057 | 645.2 | 610.5
32768 | 1024 | 0.3145 | 0.3251 | 1.034 | 640.2 | 619.3
32768 | 1536 | 0.4695 | 0.4871 | 1.037 | 643.2 | 619.9
32768 | 4096 | 1.2439 | 1.3301 | 1.069 | 647.4 | 605.4

There is an example shows the performance when `tokens = 32768`.

<img width="1661" height="766" alt="image" src="https://github.com/user-attachments/assets/41f6d323-a574-4c6e-ad97-30afcff1d81f" />

Conclusion: performance is shape-dependent; therefore the feature is opt-in.

## Tests

- `.venv/bin/python -m pytest tests/kernels/core/test_activation.py -q`
  - `254 passed`
- `git diff --check`
  - passed

The tests cover:
- all TileLang activation wrappers for bf16 correctness,
- representative `opcheck()` coverage for no-scalar, one-scalar, and two-scalar custom-op signatures,
- env-var opt-in routing,
- fp16/fp32 fallback.

## Duplicate-work check

I have checked all gh prs, no duplicate work found.

## AI assistance

AI assistance (gpt-5.5) was used to help draft and iterate on the implementation and tests. I reviewed the generated changes and validated them with the commands above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

