### PR TITLE
fix(scheduler): reject non-positive max_num_scheduled_tokens at construction time

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1301,6 +1301,20 @@ def test_scheduler_config_init():
         # InitVar does not become an attribute
         print(SchedulerConfig.default_factory().max_model_len)
 
+    # Regression: max_num_scheduled_tokens must reject non-positive values at
+    # construction time (matches behavior of sibling max_num_batched_tokens
+    # and the existing <= 0 check on the speculative-decoding path; see #44123).
+    sched_kwargs = dict(max_model_len=2048, is_encoder_decoder=False)
+    # None is the sentinel meaning "default to max_num_batched_tokens".
+    SchedulerConfig(max_num_scheduled_tokens=None, **sched_kwargs)
+    # Positive integers are accepted.
+    SchedulerConfig(max_num_scheduled_tokens=4096, **sched_kwargs)
+    # Zero and negative integers are rejected by the field constraint.
+    with pytest.raises(ValidationError):
+        SchedulerConfig(max_num_scheduled_tokens=0, **sched_kwargs)
+    with pytest.raises(ValidationError):
+        SchedulerConfig(max_num_scheduled_tokens=-1, **sched_kwargs)
+
 
 @pytest.mark.parametrize(
     (

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -53,7 +53,7 @@ class SchedulerConfig:
     In real usage, this should be set in `EngineArgs.create_engine_config`.
     """
 
-    max_num_scheduled_tokens: int | None = None
+    max_num_scheduled_tokens: int | None = Field(default=None, ge=1)
     """Maximum number of tokens that the scheduler may issue in a single iteration.
     
     This is usually equal to max_num_batched_tokens, but can be smaller in cases


### PR DESCRIPTION
Fixes #44123

The `<= 0` guard on `SchedulerConfig.max_num_scheduled_tokens` exists in `VllmConfig._set_max_num_scheduled_tokens` but is gated behind `speculative_config is not None`. Without speculative decoding a negative value survives construction, propagates through `Scheduler.__init__` (truthiness fallback at `scheduler.py:104` treats negatives as truthy), and trips a bare `assert token_budget >= 0` inside `schedule()`.

This matches the sibling `max_num_batched_tokens` field by adding `Field(default=None, ge=1)` — non-positive values rejected at field validation regardless of speculative-decoding mode. The post_init `<= 0` guard stays for the derived-value path (`max_num_batched_tokens - scheduled_token_delta` computed inside the method).

## Before
```
[1] SchedulerConfig(max_num_scheduled_tokens=-1) -> -1 (no validation)
[2] VllmConfig built; speculative_config is None: True ; field == -1 (guard skipped)
[3] scheduler.py:104 fallback -> effective = -1 (propagates)
[4] token_budget = -1 -> assert token_budget >= 0 FAILS (bare AssertionError)
```

## After
```
1. None
2. 4096
3. 0 rejected: ge=1 constraint
4. -1 rejected: ge=1 constraint
```

(Repro from the verbatim test in #44123; standalone pydantic verification above.)

## Test
Adds 4 assertions to `test_scheduler_config_init` in `tests/test_config.py` covering None / positive / 0 / negative.