### PR TITLE
[KV Offload] Async CPU memory pinning for SimpleCPUOffloadConnector

### DIFF
--- a/docs/features/cpu_kv_offload.md
+++ b/docs/features/cpu_kv_offload.md
@@ -1,0 +1,79 @@
+# CPU KV Cache Offloading
+
+vLLM can offload KV cache blocks that don't fit in GPU memory to CPU RAM and reload them when needed.
+This is handled by the `SimpleCPUOffloadConnector` using the CUDA DMA engine, bridging between GPU VRAM and regular
+CPU RAM.
+
+The `SimpleCPUOffloadConnector` builds on [prefix caching](automatic_prefix_caching.md) instead of throwing away evicted
+blocks. These blocks are copied to a pinned buffer of CPU memory.
+Transfers run on low-priority CUDA streams and don't interfere with the forward pass.
+
+**Good for**: long or repeated contexts (shared system prompts, documents) and models under GPU memory pressure.  
+**Not for**: cross-node KV cache transfer. This connector offloads to local CPU RAM only. If you need to ship KV cache
+between a dedicated prefill node and a decode node over the network, see [Disaggregated Prefilling](disagg_prefill.md).
+
+## Enabling it
+
+```bash
+# Recommended: via environment variable
+VLLM_USE_SIMPLE_KV_OFFLOAD=1 vllm serve <model> --kv-cache-offload-gb 64
+
+# Or directly via --kv-transfer-config
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "SimpleCPUOffloadConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {"cpu_bytes_to_use": 68719476736}
+  }'
+```
+
+Requires prefix caching (on by default in V1).
+
+## Configuration options
+
+All options go inside `kv_connector_extra_config`:
+
+| Key                         | Type | Default | Description                                                                                       |
+|-----------------------------|------|---------|---------------------------------------------------------------------------------------------------|
+| `cpu_bytes_to_use`          | int  | 8 GB    | Total CPU buffer size in bytes, split evenly across TP ranks.                                     |
+| `cpu_bytes_to_use_per_rank` | int  | —       | Per-rank override. Takes precedence over `cpu_bytes_to_use`.                                      |
+| `lazy_offload`              | bool | `false` | `true`: offload blocks just before GPU eviction. `false`: offload as soon as KV data is computed. |
+| `async_register_cache`      | bool | `false` | See below.                                                                                        |
+
+## Async startup pinning
+
+Before the GPU can use regular system RAM, every page in the buffer must be pinned. The OS needs to lock each page at
+a fixed physical address so the GPU's DMA engine always knows where to write.
+
+Two operations are needed before the GPU can use regular system RAM:
+
+1. **Zero-fill** — `torch.zeros` allocates the buffer and writes zeros to every page, forcing the OS to back each
+   page with physical RAM. At 50 GB/s memory bandwidth, 1 TB takes roughly 20 seconds.
+2. **Pinning** — `cudaHostRegister` walks every page again and locks it at a fixed physical address so the GPU's DMA
+   engine can reach it directly. For 1 TB that's 256 million pages and can take several minutes.
+
+By default, both steps happen synchronously on startup, blocking the HTTP server until they finish.
+
+Set `async_register_cache: true` to move **both** steps to a background thread. The engine starts immediately and
+serves requests using GPU-only caching. CPU offloading activates automatically once all workers finish — no restart
+needed.
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "SimpleCPUOffloadConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "cpu_bytes_to_use": 1099511627776,
+      "async_register_cache": true
+    }
+  }'
+```
+
+Use this whenever the CPU buffer is large (tens of GB+) and fast startup matters, e.g. autoscaling.
+
+### What happens during the pin window
+
+While pinning is in progress, the scheduler gate is closed and only GPU VRAM is used.
+In the unlikely event that the GPU VRAM is full before the pinning is done, the engine falls back to recomputing the
+prefix as a cache miss.

--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -43,6 +43,8 @@ Now supports 9 types of connectors:
 
   For multi-tier offloading (e.g., CPU + filesystem tier) and the full configuration reference, see the [KV Offloading Usage Guide](kv_offloading_usage.md).
 
+- **SimpleCPUOffloadConnector**: lightweight alternative to `OffloadingConnector`. Offloads KV blocks to local CPU RAM on the same machine. Does not transfer KV cache across nodes. For cross-node prefill/decode setups use one of the network-capable connectors above. See [CPU KV Cache Offloading](cpu_kv_offload.md) for more.
+
 - **FlexKVConnectorV1**: refer to [examples/disaggregated/flexkv_connector/prefix_caching_flexkv.py](../../examples/disaggregated/flexkv_connector/prefix_caching_flexkv.py) for the example usage of FlexKVConnectorV1. FlexKV is a distributed KV Store and multi-level cache management system for ultra-large-scale LLM inference.
 
   ```bash

--- a/tests/v1/simple_kv_offload/test_async_register.py
+++ b/tests/v1/simple_kv_offload/test_async_register.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for async cudaHostRegister gate in SimpleCPUOffloadConnector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import torch
+
+from tests.v1.simple_kv_offload.test_scheduler import (
+    _make_kv_cache_config,
+    _make_vllm_config,
+    make_scheduler,
+)
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.simple_kv_offload.manager import SimpleCPUOffloadScheduler
+from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadWorkerMetadata
+from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+
+BLOCK_SIZE = 16
+HEAD_SIZE = 16
+NUM_KV_HEADS = 1
+DTYPE = torch.float16
+_BYTES_PER_BLOCK = BLOCK_SIZE * NUM_KV_HEADS * HEAD_SIZE * 2 * DTYPE.itemsize
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_async_scheduler(
+    num_cpu_blocks: int = 8,
+    num_gpu_blocks: int = 16,
+    world_size: int = 1,
+) -> SimpleCPUOffloadScheduler:
+    kv_cache_config = _make_kv_cache_config(num_gpu_blocks)
+    vllm_config = _make_vllm_config()
+    vllm_config.parallel_config.world_size = world_size
+    return SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=_BYTES_PER_BLOCK * num_cpu_blocks,
+        scheduler_block_size=BLOCK_SIZE,
+        hash_block_size=BLOCK_SIZE,
+        async_register_cache=True,
+    )
+
+
+class _FakeWorker(SimpleCPUOffloadWorker):
+    """Worker with all CUDA calls replaced by no-ops for unit testing."""
+
+    def _setup_device(self) -> None:
+        pass
+
+    def _create_streams_and_backend(self) -> None:
+        pass
+
+
+def _make_worker(
+    async_register: bool = False,
+    worker_rank: int = 0,
+) -> _FakeWorker:
+    return _FakeWorker(
+        vllm_config=_make_vllm_config(),
+        kv_cache_config=_make_kv_cache_config(num_blocks=4),
+        cpu_capacity_bytes=_BYTES_PER_BLOCK * 4,
+        worker_rank=worker_rank,
+        async_register_cache=async_register,
+    )
+
+
+def _signal_ready(sched: SimpleCPUOffloadScheduler, rank: int) -> None:
+    meta = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={},
+        ready_worker_ids=frozenset({rank}),
+    )
+    sched.update_connector_output(
+        KVConnectorOutput(
+            finished_recving=None,
+            finished_sending=None,
+            kv_connector_worker_meta=meta,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# SimpleCPUOffloadWorkerMetadata aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_unions_ready_ids_and_sums_store_events():
+    # Given
+    m0 = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={1: 1},
+        ready_worker_ids=frozenset({0}),
+    )
+    m1 = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={1: 1, 2: 1},
+        ready_worker_ids=frozenset({1}),
+    )
+
+    # When
+    merged = m0.aggregate(m1)
+
+    # Then
+    assert isinstance(merged, SimpleCPUOffloadWorkerMetadata)
+    assert merged.ready_worker_ids == frozenset({0, 1})
+    assert merged.completed_store_events == {1: 2, 2: 1}
+
+
+def test_aggregate_deduplicates_same_rank():
+    # Given
+    m0 = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={},
+        ready_worker_ids=frozenset({3}),
+    )
+    m1 = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={},
+        ready_worker_ids=frozenset({3}),
+    )
+
+    # When
+    merged = m0.aggregate(m1)
+
+    # Then
+    assert merged.ready_worker_ids == frozenset({3})
+
+
+# ---------------------------------------------------------------------------
+# SimpleCPUOffloadScheduler gate behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_gate_open_by_default_in_sync_mode():
+    # Given
+    fix = make_scheduler()
+
+    # Then
+    assert fix.scheduler._gate_open is True
+
+
+def test_gate_closed_on_construction_in_async_mode():
+    # Given
+    sched = _make_async_scheduler()
+
+    # Then
+    assert sched._gate_open is False
+
+
+def test_gate_blocks_get_num_new_matched_tokens():
+    # Given
+    sched = _make_async_scheduler()
+
+    # When
+    result = sched.get_num_new_matched_tokens(MagicMock(), num_computed_tokens=0)
+
+    # Then
+    assert result == (0, False)
+
+
+def test_gate_blocks_build_connector_meta():
+    # Given
+    from vllm.v1.simple_kv_offload.metadata import (
+        INVALID_JOB_ID,
+        SimpleCPUOffloadMetadata,
+    )
+
+    sched = _make_async_scheduler()
+
+    # When
+    meta = sched.build_connector_meta(MagicMock())
+
+    # Then
+    assert isinstance(meta, SimpleCPUOffloadMetadata)
+    assert meta.load_event == INVALID_JOB_ID
+    assert meta.store_event == INVALID_JOB_ID
+    assert not meta.load_gpu_blocks
+    assert not meta.store_gpu_blocks
+
+
+def test_gate_opens_when_single_rank_signals_ready():
+    # Given
+    sched = _make_async_scheduler(world_size=1)
+    assert not sched._gate_open
+
+    # When
+    _signal_ready(sched, rank=0)
+
+    # Then
+    assert sched._gate_open
+
+
+def test_gate_stays_closed_until_all_ranks_signal():
+    # Given
+    sched = _make_async_scheduler(world_size=2)
+
+    # When
+    _signal_ready(sched, rank=0)
+
+    # Then
+    assert not sched._gate_open
+
+    # When
+    _signal_ready(sched, rank=1)
+
+    # Then
+    assert sched._gate_open
+
+
+def test_gate_ignores_repeated_signals_from_same_rank():
+    # Given
+    sched = _make_async_scheduler(world_size=2)
+    for _ in range(3):
+        _signal_ready(sched, rank=0)
+
+    # When
+    _signal_ready(sched, rank=1)
+
+    # Then
+    assert sched._gate_open
+
+
+# ---------------------------------------------------------------------------
+# SimpleCPUOffloadWorker readiness signal
+# ---------------------------------------------------------------------------
+
+
+def test_worker_pin_done_set_after_sync_init():
+    # Given
+    w = _make_worker(async_register=False)
+    w.gpu_kv_caches = {}
+
+    # When
+    w._do_alloc_pin_init(pin_memory=False)
+
+    # Then
+    assert w._pin_done.is_set()
+
+
+def test_worker_pin_done_unset_before_async_init():
+    # Given
+    w = _make_worker(async_register=True)
+
+    # Then
+    assert not w._pin_done.is_set()
+
+
+def test_worker_silent_before_pin_done():
+    # Given
+    w = _make_worker(async_register=True)
+    assert not w._pin_done.is_set()
+
+    # When
+    result = w.build_connector_worker_meta()
+
+    # Then
+    assert result is None
+
+
+def test_worker_emits_ready_ids_exactly_once():
+    # Given
+    w = _make_worker(async_register=True, worker_rank=7)
+    w._pin_done.set()
+
+    # When
+    meta = w.build_connector_worker_meta()
+
+    # Then
+    assert meta is not None
+    assert meta.ready_worker_ids == frozenset({7})
+
+    # When
+    meta2 = w.build_connector_worker_meta()
+
+    # Then
+    assert meta2 is None
+
+
+def test_worker_emits_stores_and_readiness_together():
+    # Given
+    w = _make_worker(async_register=True, worker_rank=2)
+    w._pin_done.set()
+    w._completed_store_events = {42: 1}
+
+    # When
+    meta = w.build_connector_worker_meta()
+
+    # Then
+    assert meta is not None
+    assert meta.ready_worker_ids == frozenset({2})
+    assert meta.completed_store_events == {42: 1}
+    assert w._completed_store_events == {}
+
+
+def test_async_pin_sets_accelerator_device_before_pinning():
+    # Given
+    class _RecordingWorker(_FakeWorker):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.device_calls: list = []
+
+        def _setup_device(self) -> None:
+            self.device_calls.append(self.device)
+
+    w = _RecordingWorker(
+        vllm_config=_make_vllm_config(),
+        kv_cache_config=_make_kv_cache_config(num_blocks=4),
+        cpu_capacity_bytes=_BYTES_PER_BLOCK * 4,
+        async_register_cache=True,
+    )
+    w.device = torch.device("cpu")
+    w.gpu_kv_caches = {}
+
+    # When
+    w._start_async_pin(pin_memory=False)
+    w._pin_done.wait(timeout=5.0)
+
+    # Then
+    assert w.device_calls == [torch.device("cpu")]
+    assert w._pin_done.is_set()
+
+
+def test_async_pin_failure_leaves_pin_done_unset():
+    # Given
+    class _FailingWorker(_FakeWorker):
+        def _setup_device(self) -> None:
+            raise RuntimeError("accelerator boom")
+
+    w = _FailingWorker(
+        vllm_config=_make_vllm_config(),
+        kv_cache_config=_make_kv_cache_config(num_blocks=4),
+        cpu_capacity_bytes=_BYTES_PER_BLOCK * 4,
+        async_register_cache=True,
+    )
+    w.device = torch.device("cpu")
+    w.gpu_kv_caches = {}
+
+    # When
+    w._start_async_pin(pin_memory=False)
+    # Give the thread a moment to raise and be caught.
+
+    # Then
+    assert not w._pin_done.is_set()
+
+
+def test_async_thread_sets_pin_done_on_completion():
+    # Given
+    w = _make_worker(async_register=True)
+    gpu_tensor = torch.zeros(4, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE, 2, dtype=DTYPE)
+
+    # When
+    w.register_kv_caches({"layer_0": gpu_tensor})
+    completed = w._pin_done.wait(timeout=5.0)
+
+    # Then
+    assert completed, "Background thread did not set _pin_done within timeout"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import torch
+from pydantic import BaseModel, ConfigDict
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
@@ -38,8 +39,14 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-# Default CPU capacity: 8 GB
-DEFAULT_CPU_CAPACITY_BYTES = 8 * (1024**3)
+
+class _ExtraConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    cpu_bytes_to_use: int = 8 * (1024**3)  # 8 GB
+    cpu_bytes_to_use_per_rank: int | None = None
+    lazy_offload: bool = False
+    async_register_cache: bool = False
 
 
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
@@ -54,27 +61,24 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         super().__init__(vllm_config, role, kv_cache_config)
 
         enable_prefix_caching = vllm_config.cache_config.enable_prefix_caching
-        extra_config = self._kv_transfer_config.kv_connector_extra_config or {}
+        cfg = _ExtraConfig(**(self._kv_transfer_config.kv_connector_extra_config or {}))
 
-        cpu_capacity_bytes = int(
-            extra_config.get("cpu_bytes_to_use", DEFAULT_CPU_CAPACITY_BYTES)
-        )
         # cpu_bytes_to_use is server-wide for compatibility;
         # cpu_bytes_to_use_per_rank overrides for per-rank capacity.
         world_size = vllm_config.parallel_config.world_size
-        cpu_capacity_per_rank = cpu_capacity_bytes // world_size
-        if "cpu_bytes_to_use_per_rank" in extra_config:
-            explicit = int(extra_config["cpu_bytes_to_use_per_rank"])
-            if explicit != cpu_capacity_per_rank:
-                logger.warning(
-                    "cpu_bytes_to_use_per_rank (%.2f GB) != "
-                    "cpu_bytes_to_use/world_size (%.2f GB). Using per-rank value.",
-                    explicit / (1024**3),
-                    cpu_capacity_per_rank / (1024**3),
-                )
-            cpu_capacity_per_rank = explicit
-
-        lazy_offload = bool(extra_config.get("lazy_offload", False))
+        cpu_capacity_per_rank = cfg.cpu_bytes_to_use // world_size
+        if (
+            cfg.cpu_bytes_to_use_per_rank is not None
+            and cfg.cpu_bytes_to_use_per_rank != cpu_capacity_per_rank
+        ):
+            logger.warning(
+                "cpu_bytes_to_use_per_rank (%.2f GB) != "
+                "cpu_bytes_to_use/world_size (%.2f GB). Using per-rank value.",
+                cfg.cpu_bytes_to_use_per_rank / (1024**3),
+                cpu_capacity_per_rank / (1024**3),
+            )
+        if cfg.cpu_bytes_to_use_per_rank is not None:
+            cpu_capacity_per_rank = cfg.cpu_bytes_to_use_per_rank
 
         self.scheduler_manager: SimpleCPUOffloadScheduler | None = None
         self.worker_handler: SimpleCPUOffloadWorker | None = None
@@ -87,12 +91,13 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
             return
 
         logger.info(
-            "SimpleCPUOffloadConnector: role=%s, "
-            "per_rank=%.2f GB, world_size=%d, mode=%s",
+            "SimpleCPUOffloadConnector: role=%s, %.2f GB/rank,"
+            " world_size=%d, mode=%s%s",
             role.name,
             cpu_capacity_per_rank / (1024**3),
             world_size,
-            "lazy" if lazy_offload else "eager",
+            "lazy" if cfg.lazy_offload else "eager",
+            ", async_register_cache=True" if cfg.async_register_cache else "",
         )
 
         if role == KVConnectorRole.SCHEDULER:
@@ -108,11 +113,16 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 cpu_capacity_per_rank,
                 scheduler_block_size=scheduler_block_size,
                 hash_block_size=hash_block_size,
-                lazy_offload=lazy_offload,
+                lazy_offload=cfg.lazy_offload,
+                async_register_cache=cfg.async_register_cache,
             )
         elif role == KVConnectorRole.WORKER:
             self.worker_handler = SimpleCPUOffloadWorker(
-                vllm_config, kv_cache_config, cpu_capacity_per_rank
+                vllm_config,
+                kv_cache_config,
+                cpu_capacity_per_rank,
+                worker_rank=vllm_config.parallel_config.rank,
+                async_register_cache=cfg.async_register_cache,
             )
 
     # --- Worker-side methods ---

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -75,6 +75,7 @@ class SimpleCPUOffloadScheduler:
         scheduler_block_size: int,
         hash_block_size: int,
         lazy_offload: bool = False,
+        async_register_cache: bool = False,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -176,6 +177,12 @@ class SimpleCPUOffloadScheduler:
         self._expected_worker_count = vllm_config.parallel_config.world_size
         self._store_event_pending_counts: dict[int, int] = {}
 
+        # Async-register gate: CPU offload is blocked until all workers have
+        # completed their cudaHostRegister background thread.
+        # In sync mode (default) the gate is open from the start.
+        self._gate_open: bool = not async_register_cache
+        self._ready_worker_ids: set[int] = set()
+
     @staticmethod
     def _derive_cpu_config(
         gpu_config: "KVCacheConfig", cpu_capacity_bytes: int
@@ -244,6 +251,9 @@ class SimpleCPUOffloadScheduler:
     ) -> tuple[int | None, bool]:
         """Return (num_new_tokens, is_async) from consecutive CPU cache hits."""
 
+        if not self._gate_open:
+            return 0, False
+
         # Pins found CPU blocks so they survive LRU eviction until
         # update_state_after_alloc() consumes them. Any pin from an earlier
         # call on the same request (e.g. retry after a failed allocate_slots)
@@ -302,7 +312,8 @@ class SimpleCPUOffloadScheduler:
         # Pop the CPU hit cached by get_num_new_matched_tokens(). The
         # found blocks were pinned there to survive LRU eviction in the window
         # between get_num_new_matched_tokens() and this matching call.
-        pending = self._pending_cpu_hits.pop(req_id, None)
+        # Gate closed = CPU memory not yet pinned, don't load from it.
+        pending = self._pending_cpu_hits.pop(req_id, None) if self._gate_open else None
 
         if num_external_tokens == 0:
             if pending is not None:
@@ -406,6 +417,9 @@ class SimpleCPUOffloadScheduler:
         self,
         scheduler_output: SchedulerOutput,
     ) -> SimpleCPUOffloadMetadata:
+        if not self._gate_open:
+            return SimpleCPUOffloadMetadata()
+
         # --- Stores ---
         store_event = -1
         store_gpu, store_cpu, store_req_ids = self.prepare_store_specs(scheduler_output)
@@ -687,6 +701,18 @@ class SimpleCPUOffloadScheduler:
                 self._process_store_event(event_idx)
             else:
                 self._store_event_pending_counts[event_idx] = total
+
+        # --- Readiness gate ---
+        was_closed = not self._gate_open
+        if was_closed and meta.ready_worker_ids:
+            self._ready_worker_ids.update(meta.ready_worker_ids)
+            self._gate_open = len(self._ready_worker_ids) >= self._expected_worker_count
+        if was_closed and self._gate_open:
+            logger.info(
+                "SimpleCPUOffloadScheduler: all %d workers ready, "
+                "CPU offload gate open.",
+                self._expected_worker_count,
+            )
 
     def _process_store_event(self, event_idx: int) -> None:
         """Process a fully-completed store event."""

--- a/vllm/v1/simple_kv_offload/metadata.py
+++ b/vllm/v1/simple_kv_offload/metadata.py
@@ -40,15 +40,21 @@ class SimpleCPUOffloadMetadata(KVConnectorMetadata):
 
 @dataclass
 class SimpleCPUOffloadWorkerMetadata(KVConnectorWorkerMetadata):
-    """Worker -> Scheduler metadata for completed store events.
+    """Worker -> Scheduler metadata for completed store events and readiness.
 
     Each worker reports {event_idx: 1} for newly completed stores.
     ``aggregate()`` sums counts across workers within a step.
     The scheduler-side manager accumulates across steps and processes
     a store completion only when count reaches ``world_size``.
+
+    ``ready_worker_ids`` carries the global rank of a worker whose async
+    cudaHostRegister background thread has completed.  The scheduler
+    accumulates these across steps (the set naturally deduplicates repeated
+    signals) and opens the CPU-offload gate once all expected workers report.
     """
 
     completed_store_events: dict[int, int]
+    ready_worker_ids: frozenset[int] = field(default_factory=frozenset)
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
@@ -57,4 +63,7 @@ class SimpleCPUOffloadWorkerMetadata(KVConnectorWorkerMetadata):
         merged = dict(self.completed_store_events)
         for k, v in other.completed_store_events.items():
             merged[k] = merged.get(k, 0) + v
-        return SimpleCPUOffloadWorkerMetadata(completed_store_events=merged)
+        return SimpleCPUOffloadWorkerMetadata(
+            completed_store_events=merged,
+            ready_worker_ids=self.ready_worker_ids | other.ready_worker_ids,
+        )

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -2,12 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Worker-side handler for SimpleCPUOffloadConnector."""
 
+import threading
 from typing import TYPE_CHECKING
 
 import torch
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
@@ -30,6 +32,8 @@ class SimpleCPUOffloadWorker:
         vllm_config: VllmConfig,
         kv_cache_config: "KVCacheConfig | None",
         cpu_capacity_bytes: int,
+        worker_rank: int = 0,
+        async_register_cache: bool = False,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -67,6 +71,17 @@ class SimpleCPUOffloadWorker:
         # Completed store events to report via build_connector_worker_meta
         self._completed_store_events: dict[int, int] = {}
 
+        # Async pin state
+        self._worker_rank = worker_rank
+        self._async_register = async_register_cache
+        # _pin_done: set when memory allocation + cudaHostRegister complete.
+        # Never cleared; readable from any thread after set.
+        self._pin_done = threading.Event()
+        # _readiness_emitted: ensures we signal the scheduler exactly once.
+        # Separate from _pin_done (which is never cleared) so that we don't
+        # re-emit the same signal on every subsequent scheduler step.
+        self._readiness_emitted = False
+
     def register_kv_caches(
         self,
         kv_caches: dict[str, torch.Tensor],
@@ -82,6 +97,8 @@ class SimpleCPUOffloadWorker:
         """
         if not kv_caches:
             logger.warning("No KV caches to offload.")
+            # Nothing to pin; mark as ready so the async gate still opens.
+            self._pin_done.set()
             return
 
         # Resolve each entry to a representative tensor for storage
@@ -158,25 +175,72 @@ class SimpleCPUOffloadWorker:
             logger.warning(
                 "Pinned memory not available. CPU offload performance may be degraded."
             )
-
         self.gpu_kv_caches = unique_gpu_caches
-        self.cpu_kv_caches = {}
-        for name, gpu_tensor in unique_gpu_caches.items():
-            cpu_shape = (self.num_cpu_blocks,) + gpu_tensor.shape[1:]
-            # Allocate non-pinned first, then pin via cudaHostRegister to
-            # bypass PyTorch's CUDACachingHostAllocator which rounds up to
-            # the next power of 2 (e.g. 100 GB -> 128 GB).
-            tensor = torch.zeros(cpu_shape, dtype=gpu_tensor.dtype, device="cpu")
-            if pin_memory:
-                pin_tensor(tensor)
-            self.cpu_kv_caches[name] = tensor
 
-        # Use lowest priority so KV cache I/O yields to compute streams.
+        if self._async_register:
+            self._start_async_pin(pin_memory)
+        else:
+            self._do_alloc_pin_init(pin_memory)
+
+    def _do_alloc_pin_init(self, pin_memory: bool) -> None:
+        # Allocate non-pinned first, then pin via cudaHostRegister to
+        # bypass PyTorch's CUDACachingHostAllocator which rounds up to
+        # the next power of 2 (e.g. 100 GB -> 128 GB).
+        assert self.gpu_kv_caches is not None
+        self.cpu_kv_caches = {}
+        for name, gpu_tensor in self.gpu_kv_caches.items():
+            cpu_shape = (self.num_cpu_blocks,) + gpu_tensor.shape[1:]
+            tensor = torch.zeros(cpu_shape, dtype=gpu_tensor.dtype, device="cpu")
+            self.cpu_kv_caches[name] = tensor
+        if pin_memory:
+            for tensor in self.cpu_kv_caches.values():
+                pin_tensor(tensor)
+        self._create_streams_and_backend()
+        self._pin_done.set()
+
+    def _start_async_pin(self, pin_memory: bool) -> None:
+        """Background thread does the init. Main thread returns now so the
+        engine can finish initialisation and start serving requests."""
+
+        def _pin_task() -> None:
+            try:
+                self._setup_device()
+                self._do_alloc_pin_init(pin_memory)
+                logger.info(
+                    "SimpleCPUOffloadWorker rank=%d: async pin complete",
+                    self._worker_rank,
+                )
+            except Exception:
+                # Leave _pin_done unset so the scheduler gate never opens.
+                # The engine continues serving GPU-only instead of crashing.
+                logger.exception(
+                    "SimpleCPUOffloadWorker rank=%d: async pin failed; "
+                    "CPU offload permanently disabled for this worker.",
+                    self._worker_rank,
+                )
+
+        threading.Thread(
+            target=_pin_task,
+            daemon=True,
+            name=f"vllm-kv-pin-{self._worker_rank}",
+        ).start()
+
+    def _setup_device(self) -> None:
+        # New threads start without a CUDA context. Re-establish the device
+        # context so subsequent CUDA calls target the correct GPU.
+        # current_platform.set_device also forces eager context initialisation
+        # via a zero-tensor allocation, working around pytorch/pytorch#155668.
+        assert self.device is not None
+        current_platform.set_device(self.device)
+
+    def _create_streams_and_backend(self) -> None:
+        # Use the lowest priority so KV cache I/O yields to compute streams.
         low_pri, _ = torch.cuda.Stream.priority_range()
         self.load_stream = torch.cuda.Stream(priority=low_pri)
         self.store_stream = torch.cuda.Stream(priority=low_pri)
-
         # Initialize copy backend with caches and streams.
+        assert self.gpu_kv_caches is not None
+        assert self.cpu_kv_caches is not None
         self._backend.init(
             self.gpu_kv_caches,
             self.cpu_kv_caches,
@@ -267,11 +331,22 @@ class SimpleCPUOffloadWorker:
         return None, finished_recving or None
 
     def build_connector_worker_meta(self) -> SimpleCPUOffloadWorkerMetadata | None:
-        """Return completed store events since the last call."""
-        if not self._completed_store_events:
+        """Return completed store events and readiness signal since the last call.
+
+        Emits ready_worker_ids exactly once, guarded by _readiness_emitted.
+        _pin_done is never cleared; the flag prevents re-emitting on every
+        subsequent step after the gate has already opened.
+        """
+        has_stores = bool(self._completed_store_events)
+        ready_ids: frozenset[int] = frozenset()
+        if self._pin_done.is_set() and not self._readiness_emitted:
+            ready_ids = frozenset({self._worker_rank})
+            self._readiness_emitted = True
+        if not has_stores and not ready_ids:
             return None
         meta = SimpleCPUOffloadWorkerMetadata(
             completed_store_events=self._completed_store_events,
+            ready_worker_ids=ready_ids,
         )
         self._completed_store_events = {}
         return meta


### PR DESCRIPTION
## Purpose

Implements request form issue #42632

`SimpleCPUOffloadConnector` pins its CPU buffer via cudaHostRegister on startup. 
This was done synchronously and blocked the HTTP server. So the engine couldn't serve any requests until pinning finishes.

This PR offloads the init to a background thread when the flag `async_register_cache: true` is set.

The engine starts immediately and uses GPU-only caching while pinning runs. After pinning a gate is set so that CPU offloading kicks in.

Seems like its aligning with the KV cache ofloading roadmap #39749

## Test Plan

```
python -m pytest tests/v1/simple_kv_offload
```

## Test Result

```bash
 32 passed, 1 skipped, 16 warnings in 22.13s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>