### PR TITLE
fix: release LMCache lookup locks on abort

### DIFF
--- a/tests/v1/kv_connector/unit/test_lmcache_mp_connector.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_mp_connector.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import enum
+import logging
+import sys
+import types
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+_STUBBED_MODULES: list[str] = []
+
+
+def _set_stub(name: str, module: types.ModuleType) -> None:
+    if name not in sys.modules:
+        sys.modules[name] = module
+        _STUBBED_MODULES.append(name)
+
+
+def _install_optional_dependency_stubs() -> None:
+    modules = {
+        "lmcache": types.ModuleType("lmcache"),
+        "lmcache.integration": types.ModuleType("lmcache.integration"),
+        "lmcache.integration.vllm": types.ModuleType("lmcache.integration.vllm"),
+        "lmcache.v1": types.ModuleType("lmcache.v1"),
+        "lmcache.v1.multiprocess": types.ModuleType("lmcache.v1.multiprocess"),
+    }
+    for name, module in modules.items():
+        _set_stub(name, module)
+
+    vllm_utils = cast(Any, types.ModuleType("lmcache.integration.vllm.utils"))
+    vllm_utils.mla_enabled = lambda _model_config: False
+    _set_stub("lmcache.integration.vllm.utils", vllm_utils)
+
+    lmcache_utils = cast(Any, types.ModuleType("lmcache.utils"))
+    lmcache_utils.init_logger = logging.getLogger
+    lmcache_utils._lmcache_nvtx_annotate = lambda func: func
+    _set_stub("lmcache.utils", lmcache_utils)
+
+    custom_types = cast(Any, types.ModuleType("lmcache.v1.multiprocess.custom_types"))
+
+    class BlockAllocationRecord:
+        pass
+
+    custom_types.BlockAllocationRecord = BlockAllocationRecord
+    _set_stub("lmcache.v1.multiprocess.custom_types", custom_types)
+
+    _set_stub("uvloop", types.ModuleType("uvloop"))
+    request_module = cast(Any, types.ModuleType("vllm.v1.request"))
+
+    class RequestStatus(enum.Enum):
+        PREEMPTED = enum.auto()
+
+    request_module.RequestStatus = RequestStatus
+    _set_stub("vllm.v1.request", request_module)
+
+    lmcache_integration = cast(
+        Any,
+        types.ModuleType(
+            "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration"
+        ),
+    )
+
+    class LoadStoreOp:
+        def __init__(self, token_ids, block_ids, start, end, **kwargs):
+            self.token_ids = token_ids
+            self.block_ids = block_ids
+            self.start = start
+            self.end = end
+
+        def __len__(self):
+            return len(self.block_ids)
+
+    class ParallelStrategy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    lmcache_integration.LMCacheMPSchedulerAdapter = object
+    lmcache_integration.LMCacheMPWorkerAdapter = object
+    lmcache_integration.LoadStoreOp = LoadStoreOp
+    lmcache_integration.ParallelStrategy = ParallelStrategy
+    _set_stub(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration",
+        lmcache_integration,
+    )
+
+
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import (
+        LMCacheMPConnectorUpstream,
+        LMCacheMPRequestState,
+        LMCacheMPRequestTracker,
+    )
+except ImportError:
+    sys.modules.pop(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector",
+        None,
+    )
+    _install_optional_dependency_stubs()
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import (
+        LMCacheMPConnectorUpstream,
+        LMCacheMPRequestState,
+        LMCacheMPRequestTracker,
+    )
+
+    for module_name in reversed(_STUBBED_MODULES):
+        sys.modules.pop(module_name, None)
+
+
+def _make_tracker(state: LMCacheMPRequestState) -> LMCacheMPRequestTracker:
+    request = MagicMock()
+    request.request_id = "req-1"
+    request.cache_salt = ""
+    request.all_token_ids = list(range(64))
+    request.block_hashes = []
+
+    tracker = LMCacheMPRequestTracker(request)
+    tracker.state = state
+    tracker.num_lmcache_hit_blocks = 3
+    tracker.num_vllm_hit_blocks = 1
+    return tracker
+
+
+def _make_connector(tracker: LMCacheMPRequestTracker) -> LMCacheMPConnectorUpstream:
+    connector = object.__new__(LMCacheMPConnectorUpstream)
+    connector.vllm_block_size = 16
+    connector.scheduler_adapter = MagicMock()
+    connector.request_trackers = {tracker.request_id: tracker}
+    return connector
+
+
+def test_cleanup_prefetching_tracker_releases_lookup_locks():
+    tracker = _make_tracker(LMCacheMPRequestState.PREFETCHING)
+    connector = _make_connector(tracker)
+
+    connector._cleanup_request_tracker("req-1")
+
+    connector.scheduler_adapter.cleanup_lookup_result.assert_called_once_with("req-1")
+    connector.scheduler_adapter.free_lookup_locks.assert_called_once_with(
+        token_ids=list(range(64)),
+        start=0,
+        end=48,
+        request_id="req-1",
+    )
+    assert "req-1" not in connector.request_trackers
+
+
+def test_cleanup_non_prefetching_tracker_does_not_release_lookup_locks_again():
+    tracker = _make_tracker(LMCacheMPRequestState.WAITING_FOR_LOAD)
+    connector = _make_connector(tracker)
+
+    connector._cleanup_request_tracker("req-1")
+
+    connector.scheduler_adapter.cleanup_lookup_result.assert_not_called()
+    connector.scheduler_adapter.free_lookup_locks.assert_not_called()
+    assert "req-1" not in connector.request_trackers

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -1183,8 +1183,17 @@ class LMCacheMPConnectorUpstream(KVConnectorBase_V1):
         Clean up request tracker and associated lookup future for a request.
         This should be called when a request is finished to prevent memory leak.
         """
-        # Clean up request tracker
-        if self.request_trackers.pop(request_id, None):
+        tracker = self.request_trackers.pop(request_id, None)
+        if tracker is not None:
+            if tracker.state == LMCacheMPRequestState.PREFETCHING:
+                self.scheduler_adapter.cleanup_lookup_result(request_id)
+                if tracker.num_lmcache_hit_blocks > 0:
+                    self.scheduler_adapter.free_lookup_locks(
+                        token_ids=list(tracker.all_token_ids),
+                        start=0,
+                        end=tracker.num_lmcache_hit_blocks * self.vllm_block_size,
+                        request_id=request_id,
+                    )
             logger.debug(
                 "[KVConnector] Cleaned up request_tracker for request %s",
                 request_id,


### PR DESCRIPTION
﻿### What this PR does

Fixes the abort cleanup path for LMCache MP lookups.

If a request finishes while its tracker is still in `PREFETCHING`, the connector has not gone through `update_state_after_alloc()`. That normal path is what currently removes the lookup result and releases LMCache read locks. On an abort before allocation, `_cleanup_request_tracker()` only removed the tracker and then `end_session()` ran, leaving lookup state and read locks behind.

This PR makes the request-finished cleanup path release the lookup resources for that pre-allocation state:

- remove the scheduler-side lookup future/result
- release all LMCache-hit lookup locks for the request
- keep the existing behavior for `WAITING_FOR_LOAD` / `READY`, where the normal allocation path has already done the lookup cleanup and releasing again would be wrong

Fixes #44100

### How this was tested

- `python -m pytest --confcutdir=tests\v1\kv_connector\unit tests\v1\kv_connector\unit\test_lmcache_mp_connector.py -q`
- `python -m ruff check vllm\distributed\kv_transfer\kv_connector\v1\lmcache_mp_connector.py tests\v1\kv_connector\unit\test_lmcache_mp_connector.py`
- `python -m ruff format --check vllm\distributed\kv_transfer\kv_connector\v1\lmcache_mp_connector.py tests\v1\kv_connector\unit\test_lmcache_mp_connector.py`
- `git diff --check -- vllm\distributed\kv_transfer\kv_connector\v1\lmcache_mp_connector.py tests\v1\kv_connector\unit\test_lmcache_mp_connector.py`

Note: this Windows test environment cannot install `lmcache` from `requirements/kv_connectors.txt` because its wheel build tries to compile CUDA extensions and requires `CUDA_HOME`. The new unit test stubs only the optional import surface needed to exercise this scheduler cleanup method.
