### PR TITLE
[Bugfix] Default rope_type to "default" when rope_parameters lacks it

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -431,8 +431,11 @@ def patch_legacy_rope_type(rope_parameters: dict[str, Any] | None) -> None:
         if "rope_type" not in rope_parameters and "type" in rope_parameters:
             rope_parameters["rope_type"] = rope_parameters["type"]
             logger.info("Replacing legacy 'type' key with 'rope_type'")
-        # Case 3: No rope_type field present - nothing to patch
+        # Case 3: No rope_type field present - default to standard RoPE.
+        # Models that set rope_parameters without rope_type (e.g. only
+        # rope_theta) should behave identically to rope_type="default".
         if "rope_type" not in rope_parameters:
+            rope_parameters["rope_type"] = "default"
             return
         # Patch legacy rope_type values with warning
         if rope_parameters["rope_type"] == "su":


### PR DESCRIPTION
## Lineage

- #43846 — changed `patch_legacy_rope_type` to `return` (instead of `raise ValueError`) when `rope_parameters` has no `rope_type` key (merged May 28)
- PR #43625 CI ran after #43846 merged and still failed with `OlmoHybridForCausalLM` init — silently returning left the dict malformed for downstream callers

This PR completes the fix: inject `rope_type: "default"` instead of returning silently.

## Problem

`patch_legacy_rope_type` handles the case where `rope_parameters` is set but has no `rope_type` key by returning without setting anything. This leaves the dict in a state that can still fail downstream validation (e.g. `validate_rope()` in transformers v5).

Note: `rotary_embedding/__init__.py` already does `rope_parameters.get("rope_type", "default")`, so the kernel handles a missing `rope_type` fine. This change makes the normalization layer consistent with that.

## Fix

One line: when `rope_parameters` is present but missing `rope_type`, inject `"default"` before returning.

## Tests

```
pre-commit run --files vllm/transformers_utils/config.py  # all passed
```

AI assistance used: Claude Code (Anthropic) assisted with root cause analysis and this fix.