### PR TITLE
[Bugfix][Kimi] Preserve dotted tool names and strip streamed argument whitespace

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -580,3 +580,74 @@ class TestStreamingIntervals:
         assert len(rec.tool_calls) == 1
         assert rec.tool_calls[0].function.name == "get_weather"
         assert json.loads(rec.tool_calls[0].function.arguments) == {"city": "Beijing"}
+
+
+class TestToolNameAndArgumentFidelity:
+    """Tool names containing dots must be preserved (not truncated to the last
+    dotted segment), and streamed argument fragments must concatenate to exactly
+    the non-streaming arguments (no leading/trailing whitespace drift)."""
+
+    @pytest.mark.parametrize(
+        "wire_id, expected_name",
+        [
+            ("functions.get_weather:0", "get_weather"),
+            ("get_weather:0", "get_weather"),  # no functions. prefix
+            ("functions.my.namespace.do_thing:0", "my.namespace.do_thing"),
+            ("functions.functions:0", "functions"),  # tool literally named functions
+        ],
+    )
+    def test_dotted_tool_name_nonstreaming(self, parser, wire_id, expected_name):
+        _, tool_calls = run_tool_extraction(
+            parser, _wrap(_tool(wire_id, '{"x": 1}')), streaming=False
+        )
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == expected_name
+
+    @pytest.mark.parametrize(
+        "wire_id, expected_name",
+        [
+            ("functions.get_weather:0", "get_weather"),
+            ("functions.my.namespace.do_thing:0", "my.namespace.do_thing"),
+        ],
+    )
+    def test_dotted_tool_name_streaming(
+        self, kimi_k2_tokenizer, wire_id, expected_name
+    ):
+        deltas = _chunk_tokenized_deltas(
+            kimi_k2_tokenizer, _wrap(_tool(wire_id, '{"x": 1}')), stream_interval=1
+        )
+        parser = KimiK2ToolParser(kimi_k2_tokenizer)
+        rec = run_tool_extraction_streaming(
+            parser, deltas, assert_one_tool_per_delta=False
+        )
+        assert len(rec.tool_calls) == 1
+        assert rec.tool_calls[0].function.name == expected_name
+
+    @pytest.mark.parametrize("stream_interval", [1, 2, 3, 5, 8])
+    def test_streaming_arguments_match_nonstreaming_with_whitespace(
+        self, kimi_k2_tokenizer, stream_interval
+    ):
+        # Kimi emits whitespace around the JSON under the whitespace-tolerant
+        # grammar; streamed fragments must concatenate to exactly the
+        # non-streaming arguments.
+        output = (
+            SECTION_BEGIN
+            + TOOL_BEGIN
+            + "functions.get_weather:0 "
+            + ARG_BEGIN
+            + ' {"city": "SF"} '
+            + TOOL_END
+            + SECTION_END
+        )
+        ns_parser = KimiK2ToolParser(kimi_k2_tokenizer)
+        _, nonstream = run_tool_extraction(ns_parser, output, streaming=False)
+
+        deltas = _chunk_tokenized_deltas(kimi_k2_tokenizer, output, stream_interval)
+        st_parser = KimiK2ToolParser(kimi_k2_tokenizer)
+        rec = run_tool_extraction_streaming(
+            st_parser, deltas, assert_one_tool_per_delta=False
+        )
+
+        assert len(rec.tool_calls) == 1
+        assert nonstream[0].function.arguments == rec.tool_calls[0].function.arguments
+        assert json.loads(rec.tool_calls[0].function.arguments) == {"city": "SF"}

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -95,7 +95,7 @@ class KimiK2ToolParser(ToolParser):
                 for match in function_call_tuples:
                     function_id, function_args = match
                     # function_id: functions.get_weather:0 or get_weather:0
-                    function_name = function_id.split(":")[0].split(".")[-1]
+                    function_name = function_id.split(":")[0].removeprefix("functions.")
                     tool_calls.append(
                         ToolCall(
                             id=function_id,
@@ -179,7 +179,7 @@ class KimiK2ToolParser(ToolParser):
             return None, None
 
         tool_id = match.group(1).strip()
-        tool_name = tool_id.split(":")[0].split(".")[-1]
+        tool_name = tool_id.split(":")[0].removeprefix("functions.")
         return tool_id, tool_name
 
     def _split_tool_call(self, tool_call: str) -> tuple[str | None, str | None]:
@@ -193,7 +193,7 @@ class KimiK2ToolParser(ToolParser):
         if arg_pos == -1:
             return None, None
         header = tool_call[:arg_pos].strip()
-        tool_args = tool_call[arg_pos + len(self.tool_call_arg_token) :]
+        tool_args = tool_call[arg_pos + len(self.tool_call_arg_token) :].strip()
         return header, tool_args
 
     def _compute_args_diff(self, index: int, tool_args: str | None) -> str | None:


### PR DESCRIPTION
## Purpose

Fix two Kimi K2 parser fidelity issues.

First, dotted tool names were truncated because the parser split the emitted id on `.` and kept only the last segment. The parser now removes only the `functions.` prefix, preserving names such as `my.namespace.do_thing`.

Second, streamed argument deltas kept surrounding whitespace while non-streaming parsing trimmed it. The streamed path now strips the argument slice so concatenated streaming arguments match the non-streaming final arguments.

Duplicate-work check: open PR searches for `Kimi dotted tool names`, `Kimi stream arguments whitespace`, `KimiK2ToolParser removeprefix functions`, `Kimi _split_tool_call strip arguments`, and `streaming arguments match nonstreaming Kimi` found no duplicate. #38443 is a different Kimi streaming regex fix for a newline before the tool id.

No docs update is needed. AI assistance was used; I reviewed the changed code and test results.

## Test Plan

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -q
pre-commit run --files \
  tests/tool_parsers/test_kimi_k2_tool_parser.py \
  vllm/tool_parsers/kimi_k2_tool_parser.py
```

## Test Result

Local validation after rebasing on `origin/main`:

```bash
# pytest assertions passed with torch.accelerator.empty_cache disabled locally
# to avoid a macOS MPS teardown bug unrelated to these tests.
61 passed
```

```bash
pre-commit run --files \
  tests/tool_parsers/test_kimi_k2_tool_parser.py \
  vllm/tool_parsers/kimi_k2_tool_parser.py
# Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable.
</details>
