### PR TITLE
[Bugfix][Kimi] Surface raw output when a tool-call section parses no calls

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -9,6 +9,7 @@ import pytest
 
 from tests.tool_parsers.utils import (
     run_tool_extraction,
+    run_tool_extraction_nonstreaming,
     run_tool_extraction_streaming,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -174,6 +175,37 @@ class TestExtractToolCalls:
         content, tool_calls = run_tool_extraction(parser, model_output, streaming=False)
         assert len(tool_calls) == 1
         assert tool_calls[0].function.name == "valid"
+
+    def test_tool_call_token_in_arg_value_surfaces_raw_output(self, parser):
+        """Regression: a section that parses no calls surfaces raw output.
+
+        The non-streaming regex bounds an argument value with a tempered
+        lookahead ``(?!<|tool_call_begin|>)``. If the argument *value* contains
+        the literal ``<|tool_call_begin|>`` text, the lookahead trips and
+        ``findall`` returns zero matches even though the section marker is
+        present. The section starts at index 0, so the sliced content is empty.
+        The parser must return ``tools_called=False`` with the raw output as
+        content rather than an empty assistant message (tools_called=True with
+        no calls and content=None).
+        """
+        model_output = _wrap(
+            _tool("functions.run_code:0", '{"code": "print(\'<|tool_call_begin|>\')"}')
+        )
+        extracted = run_tool_extraction_nonstreaming(parser, model_output)
+        assert extracted.tools_called is False
+        assert extracted.tool_calls == []
+        assert extracted.content == model_output
+
+    def test_well_formed_call_still_parses(self, parser):
+        """Guard: the raw-output fallback must not over-fire on valid calls."""
+        model_output = "Sure. " + _wrap(
+            _tool("functions.get_weather:0", '{"city": "Beijing"}')
+        )
+        extracted = run_tool_extraction_nonstreaming(parser, model_output)
+        assert extracted.tools_called is True
+        assert len(extracted.tool_calls) == 1
+        assert extracted.tool_calls[0].function.name == "get_weather"
+        assert extracted.content == "Sure. "
 
     def test_native_id_extracted(self, parser):
         """Regression: parser extracts native ID onto ToolCall (PR #32768)."""

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -107,6 +107,14 @@ class KimiK2ToolParser(ToolParser):
                     )
 
                 content = model_output[: model_output.find(self.tool_calls_start_token)]
+                if not tool_calls:
+                    # Section marker present but nothing parsed (e.g. a special
+                    # token literal inside an argument value broke the call
+                    # boundary). Surface the raw output as content instead of an
+                    # empty message with tools_called=True and no calls.
+                    return ExtractedToolCallInformation(
+                        tools_called=False, tool_calls=[], content=model_output
+                    )
                 return ExtractedToolCallInformation(
                     tools_called=True,
                     tool_calls=tool_calls,


### PR DESCRIPTION
## Purpose

Preserve Kimi K2 raw output when the non-streaming parser sees a tool-call section marker but parses zero tool calls.

A literal `<|tool_call_begin|>` inside an argument value can break the current regex match. Before this change, the parser returned `tools_called=True`, `tool_calls=[]`, and `content=None`, producing an empty assistant turn. This change treats that case as non-tool text and returns the original model output as content.

Duplicate-work check: open PR searches for `Kimi tool_calls_section_begin no calls content none`, `Kimi extract_tool_calls empty tool_calls content`, `tool_call_begin argument value Kimi parser`, `kimi_k2 findall zero tool calls`, and `tool section parses no calls` found no duplicate. #44058 is related but only fixes the `tools_called` boolean; it does not restore dropped content.

No docs update is needed. AI assistance was used; I reviewed the changed code and test results.

## Test Plan

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -q
pre-commit run --files \
  tests/tool_parsers/test_kimi_k2_tool_parser.py \
  vllm/tool_parsers/kimi_k2_tool_parser.py
```

## Test Result

Local validation after rebasing on `origin/main`:

```bash
# pytest assertions passed with torch.accelerator.empty_cache disabled locally
# to avoid a macOS MPS teardown bug unrelated to these tests.
52 passed
```

```bash
pre-commit run --files \
  tests/tool_parsers/test_kimi_k2_tool_parser.py \
  vllm/tool_parsers/kimi_k2_tool_parser.py
# Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable.
</details>
