### PR TITLE
[Bugfix][Frontend] Avoid KeyError in tool_choice validation for tools missing a function key

### DIFF
--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -3,7 +3,10 @@
 
 import pytest
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionRequest,
+)
 
 
 def test_chat_completion_request_with_no_tools():
@@ -61,6 +64,63 @@ def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
                 "tools": None,
             }
         )
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        # MCP-style flat tool with no top-level "function" key.
+        {"type": "mcp", "name": "get_weather"},
+        # Empty tool object.
+        {},
+        # "function" present but not a dict.
+        {"type": "function", "function": None},
+    ],
+)
+def test_named_tool_choice_with_tool_missing_function_raises_clean_error(tool):
+    # A named tool_choice combined with a tool entry that lacks the expected
+    # ``{"function": {"name": ...}}`` structure must surface as a clean
+    # validation error (400-class), not a ``KeyError`` (which would become a
+    # 500). The invalid tool simply fails to match the requested name.
+    with pytest.raises(ValueError, match="does not match any of the specified `tools`"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [tool],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            }
+        )
+
+
+def test_named_tool_choice_with_matching_valid_tool_validates():
+    # Regression guard: a valid tool plus a matching named tool_choice must
+    # still validate successfully (the defensive lookup must not change
+    # behavior for well-formed tools).
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        }
+    )
+    assert isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
+    assert request.tool_choice.function.name == "get_weather"
 
 
 def test_reasoning_content_normalized_to_reasoning():

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -3,7 +3,10 @@
 
 import pytest
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionRequest,
+)
 from vllm.exceptions import VLLMValidationError
 
 
@@ -62,6 +65,65 @@ def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
                 "tools": None,
             }
         )
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        # MCP-style flat tool with no top-level "function" key.
+        {"type": "mcp", "name": "get_weather"},
+        # Empty tool object.
+        {},
+        # "function" present but not a dict.
+        {"type": "function", "function": None},
+    ],
+)
+def test_named_tool_choice_with_tool_missing_function_raises_clean_error(tool):
+    # A named tool_choice combined with a tool entry that lacks the expected
+    # ``{"function": {"name": ...}}`` structure must surface as a clean
+    # validation error (400-class), not a ``KeyError`` (which would become a
+    # 500). The invalid tool simply fails to match the requested name.
+    with pytest.raises(
+        VLLMValidationError, match="does not match any of the specified `tools`"
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [tool],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            }
+        )
+
+
+def test_named_tool_choice_with_matching_valid_tool_validates():
+    # Regression guard: a valid tool plus a matching named tool_choice must
+    # still validate successfully (the defensive lookup must not change
+    # behavior for well-formed tools).
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        }
+    )
+    assert isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
+    assert request.tool_choice.function.name == "get_weather"
 
 
 def test_reasoning_content_normalized_to_reasoning():

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -836,7 +836,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         parameter="tool_choice.function.name",
                     )
                 for tool in data["tools"]:
-                    if tool["function"]["name"] == function_name:
+                    # Defensive: not every tool entry carries a top-level
+                    # ``function`` key (e.g. MCP-style ``{"type": "mcp",
+                    # "name": ...}``, OpenAI Responses-API flat shapes, or an
+                    # empty ``{}``). Skip any entry that doesn't match the
+                    # expected ``{"function": {"name": ...}}`` structure rather
+                    # than indexing blindly, which would raise ``KeyError`` and
+                    # surface as an HTTP 500 instead of a 400.
+                    fn = tool.get("function") if isinstance(tool, dict) else None
+                    if isinstance(fn, dict) and fn.get("name") == function_name:
                         valid_tool = True
                         break
                 if not valid_tool:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -971,7 +971,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         parameter="tool_choice.function.name",
                     )
                 for tool in data["tools"]:
-                    if tool["function"]["name"] == function_name:
+                    # Defensive: not every tool entry carries a top-level
+                    # ``function`` key (e.g. MCP-style ``{"type": "mcp",
+                    # "name": ...}``, OpenAI Responses-API flat shapes, or an
+                    # empty ``{}``). Skip any entry that doesn't match the
+                    # expected ``{"function": {"name": ...}}`` structure rather
+                    # than indexing blindly, which would raise ``KeyError`` and
+                    # surface as an HTTP 500 instead of a 400.
+                    fn = tool.get("function") if isinstance(tool, dict) else None
+                    if isinstance(fn, dict) and fn.get("name") == function_name:
                         valid_tool = True
                         break
                 if not valid_tool:


### PR DESCRIPTION
## Purpose

Fix named Chat Completions `tool_choice` validation when `tools` contains an entry without a usable `function` object.

`ChatCompletionRequest.check_tool_usage` runs on the raw request dict. It previously indexed `tool["function"]["name"]`, so MCP-style tools, empty objects, or `function=None` could raise `KeyError` and surface as HTTP 500. This change only matches dict-shaped function entries and lets malformed entries fall through to the existing validation error path (HTTP 400). Valid matching tools are unchanged.

Duplicate-work check: open PR searches for `check_tool_usage tool_choice function KeyError`, `named tool_choice tools function name`, `tool_choice function name missing function`, `MCP tools tool_choice function key`, and `protocol.py tool_choice function name` found no duplicate fix. Related Kimi/parser PRs do not modify this validator.

No docs update is needed. AI assistance was used; I reviewed the changed code and test results.

## Test Plan

```bash
.venv/bin/python -m pytest tests/tool_use/test_chat_completion_request_validations.py -q
pre-commit run --files \
  tests/tool_use/test_chat_completion_request_validations.py \
  vllm/entrypoints/openai/chat_completion/protocol.py
```

## Test Result

Local validation after rebasing on `origin/main`:

```bash
# pytest assertions passed with torch.accelerator.empty_cache disabled locally
# to avoid a macOS MPS teardown bug unrelated to these tests.
13 passed
```

```bash
pre-commit run --files \
  tests/tool_use/test_chat_completion_request_validations.py \
  vllm/entrypoints/openai/chat_completion/protocol.py
# Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not applicable.
</details>
