### PR TITLE
fix(internlm2_tool_parser): prevent ValueError when output has multiple tool-call markers

### DIFF
--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -9,6 +9,8 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction_nonstreaming
+from vllm.tool_parsers import ToolParserManager
 from vllm.tokenizers import TokenizerLike
 
 
@@ -120,3 +122,19 @@ class TestInternLM2ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    def test_multiple_action_start_markers_no_valueerror(self, tokenizer):
+        """Regression: output with two <|action_start|><|plugin|> markers must not
+        raise ValueError (too many values to unpack) — fixed by split(..., 1)."""
+        model_output = (
+            "Some text"
+            "<|action_start|><|plugin|>"
+            '{"name": "get_weather", "parameters": {"city": "Tokyo"}}'
+            "<|action_end|>"
+            "<|action_start|><|plugin|>"
+            '{"name": "get_time", "parameters": {}}'
+            "<|action_end|>"
+        )
+        parser = ToolParserManager.get_tool_parser("internlm")(tokenizer)
+        result = run_tool_extraction_nonstreaming(parser, model_output)
+        assert result.tools_called is True

--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -9,7 +9,10 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
-from tests.tool_parsers.utils import run_tool_extraction_nonstreaming
+from tests.tool_parsers.utils import (
+    run_tool_extraction_nonstreaming,
+    run_tool_extraction_streaming,
+)
 from vllm.tool_parsers import ToolParserManager
 from vllm.tokenizers import TokenizerLike
 
@@ -123,18 +126,55 @@ class TestInternLM2ToolParser(ToolParserTests):
             },
         )
 
-    def test_multiple_action_start_markers_no_valueerror(self, tokenizer):
-        """Regression: output with two <|action_start|><|plugin|> markers must not
-        raise ValueError (too many values to unpack) — fixed by split(..., 1)."""
+    def test_multiple_action_start_markers_extracts_all(self, tokenizer):
+        """Regression for #44139.
+
+        Output with two <|action_start|><|plugin|> blocks must not raise
+        ValueError (too many values to unpack), and — unlike a bare
+        split(..., 1) guard — must extract *both* tool calls instead of
+        silently dropping the second one.
+        """
         model_output = (
-            "Some text"
+            "Let me check both for you. "
             "<|action_start|><|plugin|>"
             '{"name": "get_weather", "parameters": {"city": "Tokyo"}}'
             "<|action_end|>"
             "<|action_start|><|plugin|>"
-            '{"name": "get_time", "parameters": {}}'
+            '{"name": "get_time", "parameters": {"tz": "Asia/Tokyo"}}'
             "<|action_end|>"
         )
         parser = ToolParserManager.get_tool_parser("internlm")(tokenizer)
         result = run_tool_extraction_nonstreaming(parser, model_output)
+
         assert result.tools_called is True
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert result.tool_calls[0].function.arguments == '{"city": "Tokyo"}'
+        assert result.tool_calls[1].function.name == "get_time"
+        assert result.tool_calls[1].function.arguments == '{"tz": "Asia/Tokyo"}'
+        # Leading natural-language text is preserved as content.
+        assert result.content == "Let me check both for you. "
+
+    def test_multiple_action_start_markers_streaming_no_valueerror(self, tokenizer):
+        """Regression for #44139 (streaming path).
+
+        The second <|action_start|><|plugin|> marker arrives in a later chunk,
+        so this exercises the streaming split that originally raised
+        ValueError. Streaming consumption must complete without crashing and
+        surface the first tool call (the streaming path is single-tool by
+        design — see the xfail markers in test_config).
+        """
+        model_output = (
+            "<|action_start|><|plugin|>"
+            '{"name": "get_weather", "parameters": {"city": "Tokyo"}}'
+            "<|action_end|>"
+            "<|action_start|><|plugin|>"
+            '{"name": "get_time", "parameters": {"tz": "Asia/Tokyo"}}'
+            "<|action_end|>"
+        )
+        parser = ToolParserManager.get_tool_parser("internlm")(tokenizer)
+        # Must not raise ValueError as the second marker streams in.
+        reconstructor = run_tool_extraction_streaming(
+            parser, model_output, assert_one_tool_per_delta=False
+        )
+        assert reconstructor.tool_calls[0].function.name == "get_weather"

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -77,7 +77,7 @@ class Internlm2ToolParser(ToolParser):
             return None
 
         new_delta = current_text[last_pos:]
-        text, action = new_delta.split("<|action_start|><|plugin|>")
+        text, action = new_delta.split("<|action_start|><|plugin|>", 1)
 
         if len(text) > 0:
             self.position = self.position + len(text)
@@ -202,7 +202,7 @@ class Internlm2ToolParser(ToolParser):
         text = model_output
         tools = self.tools
         if "<|action_start|><|plugin|>" in text:
-            text, action = text.split("<|action_start|><|plugin|>")
+            text, action = text.split("<|action_start|><|plugin|>", 1)
             action = action.split("<|action_end|>".strip())[0]
             action = action[action.find("{") :]
             action_dict = json.loads(action)

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -200,33 +200,43 @@ class Internlm2ToolParser(ToolParser):
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
         text = model_output
-        tools = self.tools
         if "<|action_start|><|plugin|>" in text:
-            text, action = text.split("<|action_start|><|plugin|>", 1)
-            action = action.split("<|action_end|>".strip())[0]
-            action = action[action.find("{") :]
-            action_dict = json.loads(action)
-            name, parameters = (
-                action_dict["name"],
-                json.dumps(
-                    action_dict.get("parameters", action_dict.get("arguments", {})),
-                    ensure_ascii=False,
-                ),
-            )
+            # The model may emit more than one
+            # `<|action_start|><|plugin|>...<|action_end|>` block in a single
+            # output. Splitting on the first marker only and unpacking into two
+            # variables raised `ValueError: too many values to unpack` and, once
+            # guarded with `maxsplit=1`, silently dropped every call after the
+            # first. Iterate over all markers so each tool call is extracted.
+            segments = text.split("<|action_start|><|plugin|>")
+            # Text before the first marker is the assistant's natural-language
+            # content; everything after a marker is a tool-call block.
+            content = segments[0]
 
-            if not tools or name not in [t.function.name for t in tools]:
-                ExtractedToolCallInformation(
-                    tools_called=False, tool_calls=[], content=text
+            tool_calls: list[ToolCall] = []
+            for action in segments[1:]:
+                action = action.split("<|action_end|>".strip())[0]
+                action = action[action.find("{") :]
+                action_dict = json.loads(action)
+                name, parameters = (
+                    action_dict["name"],
+                    json.dumps(
+                        action_dict.get(
+                            "parameters", action_dict.get("arguments", {})
+                        ),
+                        ensure_ascii=False,
+                    ),
                 )
 
-            tool_calls = [
-                ToolCall(function=FunctionCall(name=name, arguments=parameters))
-            ]
-            return ExtractedToolCallInformation(
-                tools_called=True,
-                tool_calls=tool_calls,
-                content=text if len(text) > 0 else None,
-            )
+                tool_calls.append(
+                    ToolCall(function=FunctionCall(name=name, arguments=parameters))
+                )
+
+            if tool_calls:
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=content if len(content) > 0 else None,
+                )
 
         return ExtractedToolCallInformation(
             tools_called=False, tool_calls=[], content=text


### PR DESCRIPTION
## What's broken

When an InternLM2 model produces output with more than one `<|action_start|><|plugin|>` marker, both `extract_tool_calls` and `extract_tool_calls_streaming` crash:

```
ValueError: too many values to unpack (expected 2)
```

The crash happens at the lines `text, action = text.split("< |action_start|><|plugin|>")` in each method. If the delimiter appears more than once, `split()` returns 3+ items and the 2-variable unpack fails.

## Why it happens

Both lines call `str.split(delimiter)` without a `maxsplit` argument. The code assumes the delimiter appears exactly once, but that assumption breaks as soon as the model emits a second tool-call block or repeats the marker.

## Fix

Changed both calls to `split("<|action_start|><|plugin|>", 1)`. This splits only on the first occurrence, keeping the behavior correct for single-marker output while no longer crashing on multi-marker output.

## Test

Added `test_multiple_action_start_markers_no_valueerror` to `tests/tool_parsers/test_internlm2_tool_parser.py`. It passes a model output string containing two `<|action_start|><|plugin|>` markers to `extract_tool_calls` and asserts `tools_called is True` — confirming the parser returns a result instead of raising `ValueError`.

Fixes #44139