### PR TITLE
[CI][NIXL] Pin nixl < 1.2.0 pending validation

### DIFF
--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -2,5 +2,5 @@ lmcache >= 0.3.9
 # CuPy 14.1.0 imports pytest from cupy.testing._random. Use <14.1.0
 # until a fixed newer release is verified for runtime images.
 cupy-cuda13x < 14.1.0
-nixl >= 1.1.0 # Required for disaggregated prefill
+nixl >= 1.1.0, < 1.2.0 # Required for disaggregated prefill; 1.2.0 not yet validated
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
## What

One-line upper bound in `requirements/kv_connectors.txt`:

```diff
-nixl >= 1.1.0 # Required for disaggregated prefill
+nixl >= 1.1.0, < 1.2.0 # Required for disaggregated prefill; 1.2.0 not yet validated
```

## Why

nixl 1.2.0 (released May 30) broke all 8 `nixlconnector-pd-*` CI jobs. Root cause: both `nixl-cu12` and `nixl-cu13` write `nixl_ep_cpp.so` to the same unnamespaced `site-packages/nixl_ep/` location. When the meta-package upgrades, cu12 lands last and clobbers the cu13 binary, causing:

```
ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
```

When `nixl >= 1.1.0` resolves to 1.1.0 (already in the Docker image), the test-time install is a no-op and the Dockerfile's `force-reinstall` of `nixl-cu13` stays in place. Once 1.2.0 appeared the install upgraded, triggered the collision, and killed every nixl job simultaneously.

Upstream packaging issue filed: https://github.com/ai-dynamo/nixl/issues/1705

Follows the same pattern as #39851. Timeline evidence: PR #43977 (merged May 29) passed all 8 nixl tests; PR #43881 (merged May 30) failed all 8 — only change between them was nixl 1.2.0 publishing to PyPI.

## Test plan

- [ ] `nixlconnector-pd-*` CI jobs pass
- [ ] `v1-core-plus-kv-plus-metrics` passes

## AI assistance disclosure

Investigation and implementation were AI-assisted (Claude Sonnet 4.6). Root cause confirmed via binary inspection of both wheels (`readelf -d nixl_ep_cpp.so`), timeline analysis, and matching against the actual error log. All changes reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)