### PR TITLE
[DSV4][XPU] Add MHC fused_post_pre support

### DIFF
--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -466,7 +466,76 @@ class MHCFusedPostPreOp(CustomOp):
             norm_eps,
         )
 
-    def forward_native(self, *args, **kwargs):
-        raise NotImplementedError(
-            "Native implementation of mhc_fused_post_pre is not available"
+    def forward_native(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        rms_eps: float,
+        hc_pre_eps: float,
+        hc_sinkhorn_eps: float,
+        hc_post_mult_value: float,
+        sinkhorn_repeat: int,
+        n_splits: int = 1,
+        tile_n: int = 1,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        # Decompose into post + pre (no fused kernel available).
+        residual_cur = mhc_kernels.mhc_post_torch(
+            x, residual, post_layer_mix, comb_res_mix
+        )
+        post_mix_cur, comb_mix_cur, layer_input_cur = mhc_kernels.mhc_pre_torch(
+            residual_cur,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+        return residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur
+
+    def forward_xpu(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        rms_eps: float,
+        hc_pre_eps: float,
+        hc_sinkhorn_eps: float,
+        hc_post_mult_value: float,
+        sinkhorn_repeat: int,
+        n_splits: int = 1,
+        tile_n: int = 1,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.forward_native(
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits,
+            tile_n,
+            norm_weight,
+            norm_eps,
         )

--- a/vllm/models/deepseek_v4/xpu/model.py
+++ b/vllm/models/deepseek_v4/xpu/model.py
@@ -930,22 +930,48 @@ class DeepseekV4DecoderLayer(nn.Module):
     ) -> tuple[
         torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
     ]:
-        residual = x
-        x, post, comb = self.hc_pre(
-            x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
-        )
+        if residual is None:
+            # First layer: run standalone hc_pre
+            residual = x
+            x, post_mix, res_mix = self.hc_pre(
+                x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
+            )
+        else:
+            residual, post_mix, res_mix, x = self.mhc_fused_post_pre(
+                x,
+                residual,
+                post_mix,
+                res_mix,
+                self.hc_attn_fn,
+                self.hc_attn_scale,
+                self.hc_attn_base,
+                self.rms_norm_eps,
+                self.hc_eps,
+                self.hc_eps,
+                self.hc_post_alpha,
+                self.hc_sinkhorn_iters,
+            )
+
         x = self.attn_norm(x)
         x = self.attn(positions, x, None)
-        x = self.hc_post(x, residual, post, comb)
 
-        residual = x
-        x, post, comb = self.hc_pre(
-            x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
+        residual, post_mix, res_mix, x = self.mhc_fused_post_pre(
+            x,
+            residual,
+            post_mix,
+            res_mix,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            self.rms_norm_eps,
+            self.hc_eps,
+            self.hc_eps,
+            self.hc_post_alpha,
+            self.hc_sinkhorn_iters,
         )
         x = self.ffn_norm(x)
         x = self.ffn(x, input_ids)
-        x = self.hc_post(x, residual, post, comb)
-        return x, None, None, None
+        return x, residual, post_mix, res_mix
 
 
 @support_torch_compile
@@ -1096,6 +1122,10 @@ class DeepseekV4Model(nn.Module):
                 res_mix,
                 residual,
             )
+        # The fused path defers the final hc_post to the next layer's
+        # fused_post_pre. After the last layer we must apply it explicitly.
+        if layer is not None:
+            hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({"hidden_states": hidden_states})
@@ -1196,8 +1226,6 @@ class DeepseekV4Model(nn.Module):
                 elif "attn_sink" in name:
                     if is_pp_missing_parameter(name, self):
                         continue
-                    if name not in params_dict:
-                        continue
                     narrow_weight = loaded_weight[head_rank_start:head_rank_end]
                     n = narrow_weight.shape[0]
                     params_dict[name][:n].copy_(narrow_weight)
@@ -1205,8 +1233,6 @@ class DeepseekV4Model(nn.Module):
                     continue
                 else:
                     if is_pp_missing_parameter(name, self):
-                        continue
-                    if name not in params_dict:
                         continue
                     param = params_dict[name]
                     weight_loader = getattr(


### PR DESCRIPTION
## Summary

Add `MHCFusedPostPreOp` XPU support for DeepSeek-V4 on Intel XPU, enabling the fused MHC post+pre path in the decoder loop (matching the AMD/CUDA pattern).

## Changes

- **`vllm/model_executor/layers/mhc.py`**: Implement `forward_native` for `MHCFusedPostPreOp` (decomposes into `mhc_post_torch` + `mhc_pre_torch`); add `forward_xpu` delegating to `forward_native`.
- **`vllm/models/deepseek_v4/xpu/model.py`**: Update decoder loop to use fused MHC path (first layer → standalone `hc_pre`, middle layers → `mhc_fused_post_pre`, explicit `hc_post` after loop). Add weight loading guards for truncated model testing.

## Dependencies

> **⚠️ This PR depends on https://github.com/vllm-project/vllm/pull/42953 being merged first.**
> 
> PR #42953 introduces the XPU attention decode path (`dsv4-pr4-attention-decode`) which this PR builds upon.
