### PR TITLE
fix(internlm2_tool_parser): avoid ValueError on repeated action markers

### DIFF
--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -10,6 +10,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTests,
 )
 from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.internlm2_tool_parser import Internlm2ToolParser
 
 
 class TestInternLM2ToolParser(ToolParserTests):
@@ -120,3 +121,42 @@ class TestInternLM2ToolParser(ToolParserTests):
                 ),
             },
         )
+
+
+def test_extract_tool_calls_multiple_action_start_markers(default_tokenizer):
+    parser = Internlm2ToolParser(default_tokenizer)
+    request = MagicMock()
+
+    model_output = (
+        "prefix text "
+        '<|action_start|><|plugin|>{"name":"tool1","parameters":{"x":1}}<|action_end|>'
+        '<|action_start|><|plugin|>{"name":"tool2","parameters":{"x":2}}<|action_end|>'
+    )
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    assert result.content == "prefix text "
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "tool1"
+
+
+def test_extract_tool_calls_streaming_multiple_action_start_markers(default_tokenizer):
+    parser = Internlm2ToolParser(default_tokenizer)
+    request = MagicMock()
+
+    current_text = (
+        "prefix text "
+        '<|action_start|><|plugin|>{"name":"tool1","parameters":{"x":1}}<|action_end|>'
+        '<|action_start|><|plugin|>{"name":"tool2","parameters":{"x":2}}<|action_end|>'
+    )
+    delta = parser.extract_tool_calls_streaming(
+        previous_text="",
+        current_text=current_text,
+        delta_text=current_text,
+        previous_token_ids=[],
+        current_token_ids=[],
+        delta_token_ids=[],
+        request=request,
+    )
+
+    assert delta is not None

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -77,7 +77,7 @@ class Internlm2ToolParser(ToolParser):
             return None
 
         new_delta = current_text[last_pos:]
-        text, action = new_delta.split("<|action_start|><|plugin|>")
+        text, action = new_delta.split("<|action_start|><|plugin|>", 1)
 
         if len(text) > 0:
             self.position = self.position + len(text)
@@ -202,7 +202,7 @@ class Internlm2ToolParser(ToolParser):
         text = model_output
         tools = self.tools
         if "<|action_start|><|plugin|>" in text:
-            text, action = text.split("<|action_start|><|plugin|>")
+            text, action = text.split("<|action_start|><|plugin|>", 1)
             action = action.split("<|action_end|>".strip())[0]
             action = action[action.find("{") :]
             action_dict = json.loads(action)


### PR DESCRIPTION
## Summary
- use `split(..., 1)` in both InternLM2 parsing paths so repeated `<|action_start|><|plugin|>` markers do not raise unpacking errors
- add regression tests for non-streaming and streaming extraction with repeated markers

## Validation
- `pytest -q tests/tool_parsers/test_internlm2_tool_parser.py -k multiple_action_start_markers` *(fails locally because `tblib` is not installed in this environment)*

Fixes #44139
