### PR TITLE
fix(logits_processor): raise user-friendly ValueError when FQCN lacks ':' separator

### DIFF
--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -24,6 +24,7 @@ from vllm.v1.sample.logits_processor import (
     STR_SPEC_DEC_REJECTS_LOGITSPROCS,
     LogitsProcessor,
 )
+from vllm.v1.sample.logits_processor import _load_logitsprocs_by_fqcns
 
 # Create a mixture of requests which do and don't utilize the dummy logitproc
 sampling_params_list = [
@@ -286,3 +287,9 @@ def test_rejects_custom_logitsprocs(
         # Require that loading a model alongside the logitproc raises
         # the appropriate exception.
         LLM(**llm_kwargs)
+
+
+def test_load_logitsprocs_by_fqcns_missing_colon():
+    """FQCN string without ':' should raise a user-friendly ValueError."""
+    with pytest.raises(ValueError, match="missing the required ':' separator"):
+        _load_logitsprocs_by_fqcns(["mymodule.MyCustomLogitsProcessor"])

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -125,7 +125,13 @@ def _load_logitsprocs_by_fqcns(
             continue
 
         logger.debug("- Loading logits processor %s", logitproc)
-        module_path, qualname = logitproc.split(":")
+        if ":" not in logitproc:
+            raise ValueError(
+                f"Logits processor FQCN {logitproc!r} is missing the required "
+                "':' separator. Expected format: '<module>:<type>', "
+                "e.g. 'mymodule.submodule:MyLogitsProcessor'."
+            )
+        module_path, qualname = logitproc.split(":", maxsplit=1)
 
         try:
             # Load module


### PR DESCRIPTION
## What's broken

When a user passes a logits processor FQCN string without the required colon separator — e.g. `"mymodule.MyCustomLogitsProcessor"` instead of `"mymodule:MyCustomLogitsProcessor"` — `_load_logitsprocs_by_fqcns` in `vllm/v1/sample/logits_processor/__init__.py` crashes with Python's opaque `ValueError: not enough values to unpack (expected 2, got 1)` rather than telling the user what they got wrong.

## Why it happens

Line 128 performs `module_path, qualname = logitproc.split(":")` with no prior check that the string actually contains a colon. The function's docstring documents the `<module>:<type>` syntax requirement but provides no validation before the unpack.

## Fix

Added a guard clause before the split that checks for the presence of `:` and raises a clear `ValueError` naming the offending string and the expected format. Changed `split(":")` to `split(":", maxsplit=1)` so a colon inside the class name (unusual but valid in some Python contexts) does not silently truncate the qualname.

## Test

Added `test_load_logitsprocs_by_fqcns_missing_colon` in `tests/v1/logits_processors/test_custom_offline.py`. It calls `_load_logitsprocs_by_fqcns` with a colon-free FQCN and asserts the resulting `ValueError` message contains `"missing the required ':' separator"`.

Fixes #44154