### PR TITLE
fix(__init__): validate colon separator in logits processor FQCN strings

### DIFF
--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -1228,3 +1228,13 @@ def test_thinking_budget_invalid_budget_rejected(invalid_budget):
 
     with pytest.raises(VLLMValidationError, match="thinking_token_budget"):
         SamplingParams(thinking_token_budget=invalid_budget)
+
+
+@pytest.mark.parametrize("bad_fqcn", [
+    "mypackage.mymodule.MyLogitsProcessor",  # missing colon
+    "my:package:MyClass",                    # two colons
+])
+def test_load_logitsprocs_by_fqcns_invalid_format_raises(bad_fqcn):
+    from vllm.v1.sample.logits_processor import _load_logitsprocs_by_fqcns
+    with pytest.raises(ValueError, match="<module>:<qualname>"):
+        _load_logitsprocs_by_fqcns([bad_fqcn])

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -125,7 +125,13 @@ def _load_logitsprocs_by_fqcns(
             continue
 
         logger.debug("- Loading logits processor %s", logitproc)
-        module_path, qualname = logitproc.split(":")
+        parts = logitproc.split(":")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Logits processor FQCN must be in the format "
+                f"'<module>:<qualname>', got: {logitproc!r}"
+            )
+        module_path, qualname = parts
 
         try:
             # Load module


### PR DESCRIPTION
## What's broken

When a user passes a logits processor as a plain dotted path string (e.g. `"mypackage.mymodule.MyLogitsProcessor"`) instead of the required `"<module>:<qualname>"` format, `_load_logitsprocs_by_fqcns()` crashes engine initialization with `ValueError: not enough values to unpack (expected 2, got 1)`. The same crash occurs with two colons. Neither case gives the user any hint about the expected format.

## Why it happens

Line 128 unpacks `logitproc.split(":")` directly into `(module_path, qualname)` with no guard on the number of parts.

## Fix

Split into `parts` first, check `len(parts) != 2`, and raise a descriptive `ValueError` that names the required `'<module>:<qualname>'` format before unpacking.

## Test

Added `test_load_logitsprocs_by_fqcns_invalid_format_raises` in `tests/v1/logits_processors/test_correctness.py` covering both the no-colon and two-colon edge cases.

Fixes #44156