### PR TITLE
Fix(rope): preserve rope_theta in rope_parameters when loading transformers v5 checkpoints with transformers v4

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -482,12 +482,18 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
                 or ompe is not None
             ) and not getattr(config, "rope_parameters", None):
                 config.rope_parameters = {"rope_type": "default"}
-            # Patch legacy fields into rope_parameters
-            if rope_theta is not None:
+            # Patch legacy fields into rope_parameters if not already present
+            if (rope_theta is not None
+                    and "rope_theta" not in config.rope_parameters):
                 config.rope_parameters["rope_theta"] = rope_theta
-            if partial_rotary_factor is not None:
-                config.rope_parameters["partial_rotary_factor"] = partial_rotary_factor
-            if ompe is not None:
+            if (partial_rotary_factor is not None
+                    and "partial_rotary_factor" not in
+                    config.rope_parameters):
+                config.rope_parameters["partial_rotary_factor"] = (
+                    partial_rotary_factor)
+            if (ompe is not None
+                    and "original_max_position_embeddings" not in
+                    config.rope_parameters):
                 config.rope_parameters["original_max_position_embeddings"] = ompe
             patch_legacy_rope_type(getattr(config, "rope_parameters", None))
     elif rope_theta is not None or getattr(config, "rope_parameters", None):


### PR DESCRIPTION
Problem
When a model is trained and saved with transformers v5, rope_theta is stored inside rope_parameters:

`{"rope_parameters": {"rope_type": "default", "rope_theta": 500000.0}}
`
However, when loading this checkpoint with transformers v4 installed (which vLLM currently bundles), the transformers v4 config constructor sets config.rope_theta = 10000.0 (the default value) because it does not recognize the rope_parameters field.

In patch_rope_parameters(), the following code then unconditionally overwrites the correct value already present in rope_parameters:

```
# Patch legacy fields into rope_parameters
if rope_theta is not None:
    config.rope_parameters["rope_theta"] = rope_theta  # ← blindly overwrites 500000.0 with 10000.0
```
This causes the model to silently use the wrong RoPE base frequency (10000.0 instead of the intended 500000.0), leading to degraded or incorrect inference results — with no warning or error.

Root Cause
getattr_iter(config, ["rope_theta", ...]) returns config.rope_theta = 10000.0 (the transformers v4 default), and the patch block does not check whether rope_parameters already has rope_theta set from the JSON config.

Fix
Add existence guards so that legacy fields are only patched into rope_parameters when they are not already present:

```
# Patch legacy fields into rope_parameters if not already present
if (rope_theta is not None
        and "rope_theta" not in config.rope_parameters):
    config.rope_parameters["rope_theta"] = rope_theta
if (partial_rotary_factor is not None
        and "partial_rotary_factor" not in
        config.rope_parameters):
    config.rope_parameters["partial_rotary_factor"] = (
        partial_rotary_factor)
if (ompe is not None
        and "original_max_position_embeddings" not in
        config.rope_parameters):
    config.rope_parameters["original_max_position_embeddings"] = ompe
```

Impact
Any model checkpoint saved with transformers v5 that has a non-default rope_theta (e.g. Qwen2.5-7B: 1000000, LLaMA-3: 500000) will silently use rope_theta=10000 when served with a vLLM build using transformers v4, resulting in incorrect positional encodings.