### PR TITLE
[Bugfix] Limit split to first marker in internlm2 tool parser

### DIFF
--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -77,7 +77,7 @@ class Internlm2ToolParser(ToolParser):
             return None
 
         new_delta = current_text[last_pos:]
-        text, action = new_delta.split("<|action_start|><|plugin|>")
+        text, action = new_delta.split("<|action_start|><|plugin|>", 1)
 
         if len(text) > 0:
             self.position = self.position + len(text)
@@ -202,7 +202,7 @@ class Internlm2ToolParser(ToolParser):
         text = model_output
         tools = self.tools
         if "<|action_start|><|plugin|>" in text:
-            text, action = text.split("<|action_start|><|plugin|>")
+            text, action = text.split("<|action_start|><|plugin|>", 1)
             action = action.split("<|action_end|>".strip())[0]
             action = action[action.find("{") :]
             action_dict = json.loads(action)


### PR DESCRIPTION
## Bug

`Internlm2ToolParser.extract_tool_calls` and `extract_tool_calls_streaming` split the model output on the `<|action_start|><|plugin|>` marker and unpack the result into exactly two variables:

```python
text, action = text.split("<|action_start|><|plugin|>")
```

When the output contains more than one such marker — e.g. a model that repeats the tool-call header or attempts parallel tool calls — `str.split()` returns 3+ parts and the unpacking raises:

```
ValueError: too many values to unpack (expected 2)
```

## Root cause

Both call sites (`extract_tool_calls_streaming`, line 80, and `extract_tool_calls`, line 205) call `str.split(delimiter)` with no `maxsplit`, so any input with two or more markers breaks the two-target unpack.

## Fix

Pass `maxsplit=1` at both sites so only the first marker is used as the split point. The parser already keeps just the first tool call (`action` is immediately truncated at the first `<|action_end|>`, and the code notes InternLM2 "is not support parallel tool calls"), so this is behavior-preserving for the normal single-call case and simply stops crashing when extra markers are present.

Fixes #44139.
