### PR TITLE
[SpecDecode] Warn when speculative decoding acceptance rate is very low

### DIFF
--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -115,6 +115,15 @@ class SpecDecodingLogging:
             rates_str,
             draft_acceptance_rate,
         )
+
+        if draft_acceptance_rate < 15.0:
+            logger.warning(
+                "Very low speculative decoding acceptance rate (%.1f%%). "
+                "Consider reducing num_speculative_tokens or using a "
+                "different draft model/method.",
+                draft_acceptance_rate,
+            )
+
         self.reset()
 
 


### PR DESCRIPTION



## Purpose
When speculative decoding has very low acceptance rate (<15%),users currently get no signal — the metrics are logged at info level but are easy to miss. Add a `logger.warning()` so users know their spec decode configuration is underperforming.
## Test Plan
None — logging-only change with no logic or behavioral impact.
## Test Result
N/A — verified correctness by code review.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

