### PR TITLE
[Kernel] Fuse align and sort for small-batch many-expert routing

### DIFF
--- a/benchmarks/kernels/benchmark_moe_align_block_size.py
+++ b/benchmarks/kernels/benchmark_moe_align_block_size.py
@@ -34,7 +34,7 @@ configs = list(
 small_batch_many_expert_configs = (
     list(itertools.product([1, 16, 64, 128], [256], [8], [16, 64]))
     + list(itertools.product([1, 16, 64, 128], [384], [8], [16, 64]))
-    + list(itertools.product([1, 16, 64, 128], [512], [10], [16, 64]))
+    + list(itertools.product([1, 16, 64, 96], [512], [10], [16, 64]))
 )
 
 

--- a/benchmarks/kernels/benchmark_moe_align_block_size.py
+++ b/benchmarks/kernels/benchmark_moe_align_block_size.py
@@ -30,6 +30,12 @@ configs = list(
     itertools.product(num_tokens_range, num_experts_range, topk_range, ep_size_range)
 )
 
+# Decode-like many-expert shapes. Includes M=129 as a fallback boundary for
+# E=256, topk=8 because the fast path is guarded by numel <= 1024.
+small_batch_many_expert_configs = list(
+    itertools.product([1, 16, 64, 128, 129], [256], [8], [16, 64])
+)
+
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
@@ -68,8 +74,41 @@ def benchmark(num_tokens, num_experts, topk, ep_size, provider):
     return 1000 * ms, 1000 * max_ms, 1000 * min_ms
 
 
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_tokens", "num_experts", "topk", "block_size"],
+        x_vals=small_batch_many_expert_configs,
+        line_arg="provider",
+        line_vals=["vllm"],
+        line_names=["vLLM"],
+        plot_name="moe-align-block-size-small-batch-many-expert",
+        args={},
+    )
+)
+def benchmark_small_batch_many_expert(
+    num_tokens, num_experts, topk, block_size, provider
+):
+    set_random_seed(0)
+    topk_ids = get_topk_ids(num_tokens, num_experts, topk)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "vllm":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: moe_align_block_size(topk_ids, block_size, num_experts),
+            quantiles=quantiles,
+        )
+
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--small-batch-many-expert",
+        action="store_true",
+        help="Benchmark decode-like many-expert shapes.",
+    )
     parser.add_argument(
         "--num_experts",
         type=int,
@@ -85,4 +124,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    benchmark.run(print_data=True, show_plots=True)
+    if args.small_batch_many_expert:
+        benchmark_small_batch_many_expert.run(print_data=True, show_plots=True)
+    else:
+        benchmark.run(print_data=True, show_plots=True)

--- a/benchmarks/kernels/benchmark_moe_align_block_size.py
+++ b/benchmarks/kernels/benchmark_moe_align_block_size.py
@@ -30,10 +30,11 @@ configs = list(
     itertools.product(num_tokens_range, num_experts_range, topk_range, ep_size_range)
 )
 
-# Decode-like many-expert shapes. Includes M=129 as a fallback boundary for
-# E=256, topk=8 because the fast path is guarded by numel <= 1024.
-small_batch_many_expert_configs = list(
-    itertools.product([1, 16, 64, 128, 129], [256], [8], [16, 64])
+# Decode-like many-expert shapes from real MoE models
+small_batch_many_expert_configs = (
+    list(itertools.product([1, 16, 64, 128], [256], [8], [16, 64]))
+    + list(itertools.product([1, 16, 64, 128], [384], [8], [16, 64]))
+    + list(itertools.product([1, 16, 64, 96], [512], [10], [16, 64]))
 )
 
 

--- a/benchmarks/kernels/benchmark_moe_align_block_size.py
+++ b/benchmarks/kernels/benchmark_moe_align_block_size.py
@@ -34,7 +34,7 @@ configs = list(
 small_batch_many_expert_configs = (
     list(itertools.product([1, 16, 64, 128], [256], [8], [16, 64]))
     + list(itertools.product([1, 16, 64, 128], [384], [8], [16, 64]))
-    + list(itertools.product([1, 16, 64, 96], [512], [10], [16, 64]))
+    + list(itertools.product([1, 16, 64, 128], [512], [10], [16, 64]))
 )
 
 

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -346,7 +346,7 @@ __global__ void count_and_sort_expert_tokens_kernel(
       max_num_tokens_padded, nullptr, 0, topk_num, has_expert_map);
 }
 
-template <typename scalar_t>
+template <typename scalar_t, int32_t NUM_THREADS>
 __global__ void moe_align_small_batch_many_expert_kernel(
     const scalar_t* __restrict__ topk_ids,
     int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
@@ -357,22 +357,26 @@ __global__ void moe_align_small_batch_many_expert_kernel(
   int32_t* expert_counts = shared_mem;
   int32_t* cumsum = expert_counts + num_experts;
   int32_t* write_offsets = cumsum + num_experts + 1;
+  // SMEM copy of expert_id per token so scatter avoids re-reading topk_ids.
+  int32_t* staging_expert = write_offsets + num_experts;
 
-  const size_t tid = threadIdx.x;
+  const int32_t tid = threadIdx.x;
 
-  for (int32_t expert_id = threadIdx.x; expert_id < num_experts;
-       expert_id += blockDim.x) {
+  // Phase 1: init
+  for (int32_t expert_id = tid; expert_id < num_experts;
+       expert_id += NUM_THREADS) {
     expert_counts[expert_id] = 0;
   }
-
-  for (size_t i = tid; i < max_num_tokens_padded; i += blockDim.x) {
-    sorted_token_ids[i] = numel;
+  for (size_t i = tid; i < max_num_tokens_padded; i += NUM_THREADS) {
+    sorted_token_ids[i] = static_cast<int32_t>(numel);
   }
 
   __syncthreads();
 
-  for (size_t i = tid; i < numel; i += blockDim.x) {
+  // Phase 2: count + stage expert_id to SMEM
+  for (size_t i = tid; i < numel; i += NUM_THREADS) {
     int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
+    staging_expert[i] = expert_id;
     if (expert_id >= 0 && expert_id < num_experts) {
       atomicAdd(&expert_counts[expert_id], 1);
     }
@@ -380,11 +384,12 @@ __global__ void moe_align_small_batch_many_expert_kernel(
 
   __syncthreads();
 
-  using BlockScan = cub::BlockScan<int32_t, 1024>;
+  // Phase 3: BlockScan prefix sum
+  using BlockScan = cub::BlockScan<int32_t, NUM_THREADS>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
   int32_t padded_expert_count = 0;
-  int32_t expert_id = threadIdx.x;
+  int32_t expert_id = tid;
   if (expert_id < num_experts) {
     padded_expert_count =
         CEILDIV(expert_counts[expert_id], block_size) * block_size;
@@ -398,31 +403,31 @@ __global__ void moe_align_small_batch_many_expert_kernel(
     write_offsets[expert_id] = cumsum_val;
   }
   if (expert_id == num_experts) {
-    cumsum[expert_id] = cumsum_val;
+    cumsum[num_experts] = cumsum_val;
     total_tokens_post_pad[0] = cumsum_val;
   }
 
   __syncthreads();
 
-  if (threadIdx.x < num_experts) {
-    for (int32_t i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1];
-         i += block_size) {
-      expert_ids[i / block_size] = threadIdx.x;
+  // Phase 4: fill expert_ids, -1 tail, and scatter
+  if (tid < num_experts) {
+    for (int32_t i = cumsum[tid]; i < cumsum[tid + 1]; i += block_size) {
+      expert_ids[i / block_size] = tid;
     }
   }
 
-  const size_t fill_start_idx = cumsum[num_experts] / block_size + threadIdx.x;
-  for (size_t i = fill_start_idx; i < max_num_m_blocks; i += blockDim.x) {
+  const int32_t num_tokens_post_pad_val = cumsum[num_experts];
+  const size_t fill_start_idx = num_tokens_post_pad_val / block_size + tid;
+  for (size_t i = fill_start_idx; i < max_num_m_blocks; i += NUM_THREADS) {
     expert_ids[i] = -1;
   }
 
-  __syncthreads();
-
-  for (size_t i = tid; i < numel; i += blockDim.x) {
-    int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
+  // Scatter: read expert_id from SMEM, token index = loop i.
+  for (size_t i = tid; i < numel; i += NUM_THREADS) {
+    int32_t expert_id = staging_expert[i];
     if (expert_id >= 0 && expert_id < num_experts) {
       int32_t rank_post_pad = atomicAdd(&write_offsets[expert_id], 1);
-      sorted_token_ids[rank_post_pad] = i;
+      sorted_token_ids[rank_post_pad] = static_cast<int32_t>(i);
     }
   }
 }
@@ -613,18 +618,44 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
             (topk_ids.numel() < 1024) && (num_experts <= 64);
 
         if (small_batch_many_expert_mode) {
-          constexpr int32_t threads = 1024;
           const int32_t shared_mem_size =
-              (3 * num_experts + 1) * sizeof(int32_t);
-          auto small_batch_many_expert_kernel =
-              vllm::moe::moe_align_small_batch_many_expert_kernel<scalar_t>;
-          small_batch_many_expert_kernel<<<1, threads, shared_mem_size,
-                                           stream>>>(
-              topk_ids.data_ptr<scalar_t>(),
-              sorted_token_ids.data_ptr<int32_t>(),
-              experts_ids.data_ptr<int32_t>(),
-              num_tokens_post_pad.data_ptr<int32_t>(), num_experts, block_size,
-              topk_ids.numel(), sorted_token_ids.size(0), experts_ids.size(0));
+              (3 * num_experts + 1 +
+               static_cast<int32_t>(topk_ids.numel())) *
+              sizeof(int32_t);
+          if (num_experts <= 128) {
+            auto kernel =
+                vllm::moe::moe_align_small_batch_many_expert_kernel<scalar_t,
+                                                                    256>;
+            kernel<<<1, 256, shared_mem_size, stream>>>(
+                topk_ids.data_ptr<scalar_t>(),
+                sorted_token_ids.data_ptr<int32_t>(),
+                experts_ids.data_ptr<int32_t>(),
+                num_tokens_post_pad.data_ptr<int32_t>(), num_experts,
+                block_size, topk_ids.numel(), sorted_token_ids.size(0),
+                experts_ids.size(0));
+          } else if (num_experts <= 384) {
+            auto kernel =
+                vllm::moe::moe_align_small_batch_many_expert_kernel<scalar_t,
+                                                                    512>;
+            kernel<<<1, 512, shared_mem_size, stream>>>(
+                topk_ids.data_ptr<scalar_t>(),
+                sorted_token_ids.data_ptr<int32_t>(),
+                experts_ids.data_ptr<int32_t>(),
+                num_tokens_post_pad.data_ptr<int32_t>(), num_experts,
+                block_size, topk_ids.numel(), sorted_token_ids.size(0),
+                experts_ids.size(0));
+          } else {
+            auto kernel =
+                vllm::moe::moe_align_small_batch_many_expert_kernel<scalar_t,
+                                                                    1024>;
+            kernel<<<1, 1024, shared_mem_size, stream>>>(
+                topk_ids.data_ptr<scalar_t>(),
+                sorted_token_ids.data_ptr<int32_t>(),
+                experts_ids.data_ptr<int32_t>(),
+                num_tokens_post_pad.data_ptr<int32_t>(), num_experts,
+                block_size, topk_ids.numel(), sorted_token_ids.size(0),
+                experts_ids.size(0));
+          }
         } else if (small_batch_expert_mode) {
           const int32_t threads = max((int32_t)num_experts, WARP_SIZE);
           const int32_t shared_mem_size =

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -346,6 +346,87 @@ __global__ void count_and_sort_expert_tokens_kernel(
       max_num_tokens_padded, nullptr, 0, topk_num, has_expert_map);
 }
 
+template <typename scalar_t>
+__global__ void moe_align_small_batch_many_expert_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad, int32_t num_experts,
+    int32_t block_size, size_t numel, int32_t max_num_tokens_padded,
+    int32_t max_num_m_blocks) {
+  extern __shared__ int32_t shared_mem[];
+  int32_t* expert_counts = shared_mem;
+  int32_t* cumsum = expert_counts + num_experts;
+  int32_t* write_offsets = cumsum + num_experts + 1;
+
+  const size_t tid = threadIdx.x;
+
+  for (int32_t expert_id = threadIdx.x; expert_id < num_experts;
+       expert_id += blockDim.x) {
+    expert_counts[expert_id] = 0;
+  }
+
+  for (size_t i = tid; i < max_num_tokens_padded; i += blockDim.x) {
+    sorted_token_ids[i] = numel;
+  }
+
+  __syncthreads();
+
+  for (size_t i = tid; i < numel; i += blockDim.x) {
+    int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
+    if (expert_id >= 0 && expert_id < num_experts) {
+      atomicAdd(&expert_counts[expert_id], 1);
+    }
+  }
+
+  __syncthreads();
+
+  using BlockScan = cub::BlockScan<int32_t, 1024>;
+  __shared__ typename BlockScan::TempStorage temp_storage;
+
+  int32_t padded_expert_count = 0;
+  int32_t expert_id = threadIdx.x;
+  if (expert_id < num_experts) {
+    padded_expert_count =
+        CEILDIV(expert_counts[expert_id], block_size) * block_size;
+  }
+
+  int32_t cumsum_val;
+  BlockScan(temp_storage).ExclusiveSum(padded_expert_count, cumsum_val);
+
+  if (expert_id < num_experts) {
+    cumsum[expert_id] = cumsum_val;
+    write_offsets[expert_id] = cumsum_val;
+  }
+  if (expert_id == num_experts) {
+    cumsum[expert_id] = cumsum_val;
+    total_tokens_post_pad[0] = cumsum_val;
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < num_experts) {
+    for (int32_t i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1];
+         i += block_size) {
+      expert_ids[i / block_size] = threadIdx.x;
+    }
+  }
+
+  const size_t fill_start_idx = cumsum[num_experts] / block_size + threadIdx.x;
+  for (size_t i = fill_start_idx; i < max_num_m_blocks; i += blockDim.x) {
+    expert_ids[i] = -1;
+  }
+
+  __syncthreads();
+
+  for (size_t i = tid; i < numel; i += blockDim.x) {
+    int32_t expert_id = static_cast<int32_t>(topk_ids[i]);
+    if (expert_id >= 0 && expert_id < num_experts) {
+      int32_t rank_post_pad = atomicAdd(&write_offsets[expert_id], 1);
+      sorted_token_ids[rank_post_pad] = i;
+    }
+  }
+}
+
 template <typename scalar_t, int TOPK>
 __global__ void moe_sum_kernel(
     scalar_t* __restrict__ out,          // [..., d]
@@ -521,10 +602,30 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
   VLLM_DISPATCH_INTEGRAL_AND_UNSIGNED_TYPES(
       topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
         // calc needed amount of shared mem for `cumsum` tensors
+        // The existing small_batch_expert_mode keeps per-thread per-expert
+        // counters in shared memory, which scales poorly for many experts.
+        // Use a compact shared histogram for small-batch many-expert decode
+        // shapes instead. Small expert counts keep using the existing path.
+        bool small_batch_many_expert_mode =
+            !has_expert_map && topk_ids.dim() == 2 && num_experts > 64 &&
+            topk_ids.numel() <= 1024;
         bool small_batch_expert_mode =
             (topk_ids.numel() < 1024) && (num_experts <= 64);
 
-        if (small_batch_expert_mode) {
+        if (small_batch_many_expert_mode) {
+          constexpr int32_t threads = 1024;
+          const int32_t shared_mem_size =
+              (3 * num_experts + 1) * sizeof(int32_t);
+          auto small_batch_many_expert_kernel =
+              vllm::moe::moe_align_small_batch_many_expert_kernel<scalar_t>;
+          small_batch_many_expert_kernel<<<1, threads, shared_mem_size,
+                                           stream>>>(
+              topk_ids.data_ptr<scalar_t>(),
+              sorted_token_ids.data_ptr<int32_t>(),
+              experts_ids.data_ptr<int32_t>(),
+              num_tokens_post_pad.data_ptr<int32_t>(), num_experts, block_size,
+              topk_ids.numel(), sorted_token_ids.size(0), experts_ids.size(0));
+        } else if (small_batch_expert_mode) {
           const int32_t threads = max((int32_t)num_experts, WARP_SIZE);
           const int32_t shared_mem_size =
               ((threads + 1) * num_experts + (num_experts + 1)) *

--- a/tests/kernels/moe/test_moe_align_block_size.py
+++ b/tests/kernels/moe/test_moe_align_block_size.py
@@ -242,6 +242,58 @@ def test_moe_align_block_size(
     ).all(), "expert_ids should contain valid expert indices"
 
 
+@pytest.mark.parametrize(
+    ("m", "topk", "num_experts"),
+    [
+        (1, 1, 96),
+        (16, 2, 160),
+        (64, 8, 256),
+        (128, 8, 256),
+        (64, 16, 512),
+        (129, 8, 256),
+    ],
+)
+@pytest.mark.parametrize("block_size", [16, 32, 64])
+@pytest.mark.parametrize("pad_sorted_ids", [False, True])
+def test_moe_align_block_size_small_batch_many_expert(
+    m: int,
+    topk: int,
+    num_experts: int,
+    block_size: int,
+    pad_sorted_ids: bool,
+):
+    """Test the many-expert small-batch fast-path plus fallback boundary."""
+    topk_ids = torch.empty((m, topk), device="cuda", dtype=torch.int32)
+    for i in range(m):
+        topk_ids[i] = torch.randperm(num_experts, device="cuda")[:topk]
+
+    actual_sorted_ids, actual_expert_ids, actual_num_tokens = moe_align_block_size(
+        topk_ids=topk_ids,
+        block_size=block_size,
+        num_experts=num_experts,
+        pad_sorted_ids=pad_sorted_ids,
+    )
+    golden_sorted_ids, golden_expert_ids, golden_num_tokens = (
+        torch_moe_align_block_size(
+            topk_ids=topk_ids,
+            block_size=block_size,
+            num_experts=num_experts,
+            pad_sorted_ids=pad_sorted_ids,
+        )
+    )
+
+    torch.testing.assert_close(actual_num_tokens, golden_num_tokens, atol=0, rtol=0)
+    torch.testing.assert_close(actual_expert_ids, golden_expert_ids, atol=0, rtol=0)
+    _verify_expert_level_sorting(
+        actual_sorted_ids,
+        golden_sorted_ids,
+        actual_expert_ids,
+        block_size,
+        actual_num_tokens.item(),
+        m * topk,
+    )
+
+
 @pytest.mark.parametrize("m", [16, 32, 2048])
 @pytest.mark.parametrize("topk", [2, 4])
 @pytest.mark.parametrize("num_experts", [8, 64])


### PR DESCRIPTION
## Purpose

This PR adds a CUDA fast path for `moe_align_block_size` when routing small batches across many experts.

The existing generic path launches two kernels:

- `moe_align_block_size_kernel`
- `count_and_sort_expert_tokens_kernel`

For decode-like many-expert shapes, the work is small enough to fit in one CTA.

This does not simply widen the existing `moe_align_block_size_small_batch_expert_kernel` from #19572. That kernel uses per-thread per-expert counters, so at `num_experts=256` it needs about 264 KB dynamic shared memory and fails to launch on H800.

## Test Plan

#### Correctness

```bash
CUDA_VISIBLE_DEVICES=0 pytest -q \
  tests/kernels/moe/test_moe_align_block_size.py::test_moe_align_block_size_small_batch_many_expert

CUDA_VISIBLE_DEVICES=0 pytest -q \
  tests/kernels/moe/test_moe.py -k moe_align_block_size_opcheck
```

#### Microbench

```bash
CUDA_VISIBLE_DEVICES=0 python3 benchmarks/kernels/benchmark_moe_align_block_size.py \
  --small-batch-many-expert
```

#### Serve (4*H800)

```bash
VLLM_USE_DEEP_GEMM_E8M0=0 vllm serve MiniMaxAI/MiniMax-M2.7 \
  -tp 4 \
  --tool-call-parser minimax_m2 \
  --reasoning-parser minimax_m2 \
  --enable-auto-tool-choice \
  --trust-remote-code \
  --no-enable-prefix-caching
```
```bash
vllm bench serve \
--backend openai-chat \
--model MiniMaxAI/MiniMax-M2.7 \
--endpoint /v1/chat/completions \
--host 127.0.0.1 \
--port 8000 \
--dataset-name random \
--num-prompts 1024 \
--random-input-len 8192 \
--random-output-len 1024 \
--random-range-ratio 0.0 \
--num-warmups 16 \
--request-rate inf \
--max-concurrency 16 \
--save-result
```
```
python3 tests/evals/gsm8k/gsm8k_eval.py 
```



## Test Result


| M | E | topk | block | main | branch | speedup |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 256 | 8 | 16 | 9.22us | 6.24us | **1.48x** |
| 1 | 256 | 8 | 64 | 9.38us | 6.11us | **1.53x** |
| 16 | 256 | 8 | 16 | 9.57us | 6.43us | **1.49x** |
| 16 | 256 | 8 | 64 | 9.54us | 6.66us | **1.43x** |
| 64 | 256 | 8 | 16 | 9.73us | 6.66us | **1.46x** |
| 64 | 256 | 8 | 64 | 9.76us | 7.68us | **1.27x** |
| 128 | 256 | 8 | 16 | 9.95us | 7.62us | **1.31x** |
| 128 | 256 | 8 | 64 | 9.89us | 8.64us | **1.14x** |
| 1 | 384 | 8 | 16 | 9.28us | 6.14us | **1.51x** |
| 1 | 384 | 8 | 64 | 9.38us | 6.27us | **1.49x** |
| 16 | 384 | 8 | 16 | 9.76us | 6.62us | **1.47x** |
| 16 | 384 | 8 | 64 | 9.66us | 6.82us | **1.42x** |
| 64 | 384 | 8 | 16 | 9.89us | 7.10us | **1.39x** |
| 64 | 384 | 8 | 64 | 9.86us | 8.13us | **1.21x** |
| 128 | 384 | 8 | 16 | 9.76us | 7.78us | **1.26x** |
| 128 | 384 | 8 | 64 | 9.79us | 8.99us | **1.09x** |
| 1 | 512 | 10 | 16 | 9.47us | 6.66us | **1.42x** |
| 1 | 512 | 10 | 64 | 9.41us | 6.53us | **1.44x** |
| 16 | 512 | 10 | 16 | 9.66us | 6.82us | **1.42x** |
| 16 | 512 | 10 | 64 | 9.57us | 7.23us | **1.32x** |
| 64 | 512 | 10 | 16 | 10.02us | 7.74us | **1.29x** |
| 64 | 512 | 10 | 64 | 10.05us | 9.18us | **1.09x** |
| 96 | 512 | 10 | 16 | 9.92us | 7.90us | **1.26x** |
| 96 | 512 | 10 | 64 | 9.86us | 9.38us | **1.05x** |

bs=16 ISL8k OSL 1k (main 8b8546da1) 5us ->  (PR fbecc1741) 2.6us -> (PR 48cff7740) 2.3us
[dp0_pp0_tp0_dcp0_ep0_rank0.1780295027612105177.pt.trace.json.gz](https://github.com/user-attachments/files/28455987/dp0_pp0_tp0_dcp0_ep0_rank0.1780295027612105177.pt.trace.json.gz)

<img width="1231" height="488" alt="image" src="https://github.com/user-attachments/assets/e2e1e128-07d9-47de-9e3d-53185d30113d" />

[dp0_pp0_tp0_dcp0_ep0_rank0.1780294200259094010.pt.trace.json.gz](https://github.com/user-attachments/files/28455992/dp0_pp0_tp0_dcp0_ep0_rank0.1780294200259094010.pt.trace.json.gz)

<img width="1579" height="520" alt="image" src="https://github.com/user-attachments/assets/7ff1fd4b-749f-4763-b6a3-41d4aa240c94" />

<img width="1273" height="365" alt="image" src="https://github.com/user-attachments/assets/63aa02bc-100b-4792-a02c-fa0dbd72fe5a" />

main 8b8546da1
```
============ Serving Benchmark Result ============
Successful requests:                     1024      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  1146.81   
Total input tokens:                      8427520   
Total generated tokens:                  1048576   
Request throughput (req/s):              0.89      
Output token throughput (tok/s):         914.34    
Peak output token throughput (tok/s):    1120.00   
Peak concurrent requests:                28.00     
Total token throughput (tok/s):          8262.98   
---------------Time to First Token----------------
Mean TTFT (ms):                          1562.49   
Median TTFT (ms):                        1688.63   
P99 TTFT (ms):                           2405.77   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.99     
Median TPOT (ms):                        15.93     
P99 TPOT (ms):                           17.44     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.22     
Median ITL (ms):                         14.88     
P99 ITL (ms):                            237.56    
==================================================
```

PR 48cff7740
```
============ Serving Benchmark Result ============
Successful requests:                     1024      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  1139.57   
Total input tokens:                      8427520   
Total generated tokens:                  1048576   
Request throughput (req/s):              0.90      
Output token throughput (tok/s):         920.15    
Peak output token throughput (tok/s):    1136.00   
Peak concurrent requests:                26.00     
Total token throughput (tok/s):          8315.51   
---------------Time to First Token----------------
Mean TTFT (ms):                          1576.22   
Median TTFT (ms):                        1703.38   
P99 TTFT (ms):                           2176.11   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.86     
Median TPOT (ms):                        15.79     
P99 TPOT (ms):                           17.28     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.97     
Median ITL (ms):                         14.73     
P99 ITL (ms):                            237.35    
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

