### PR TITLE
[Model] Add HyperCLOVAX-SEED-Think-14B reasoning and tool parsers

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -22,6 +22,7 @@ vLLM currently supports the following reasoning models:
 | [GLM-4.5 series](https://huggingface.co/collections/zai-org/glm-45-687c621d34bda8c9e4bf503b) | `glm45` | `json`, `regex` | ✅ |
 | [Holo2 series](https://huggingface.co/collections/Hcompany/holo2) | `holo2` | `json`, `regex` | ✅ |
 | [Hunyuan A13B series](https://huggingface.co/collections/tencent/hunyuan-a13b-685ec38e5b46321e3ea7c4be) | `hunyuan_a13b` | `json`, `regex` | ✅ |
+| [HyperCLOVAX-SEED-Think-14B](https://huggingface.co/naver-hyperclovax/HyperCLOVAX-SEED-Think-14B) | `hyperclovax_seed_think_14b` | `json`, `regex` | ✅ |
 | [IBM Granite 3.2 language models](https://huggingface.co/collections/ibm-granite/granite-32-language-models-67b3bc8c13508f6d064cff9a) | `granite` | ❌ | ❌ |
 | [MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) | `minimax_m2_append_think` | `json`, `regex` | ✅ |
 | [Qwen3 series](https://huggingface.co/collections/Qwen/qwen3-67dd247413f0e2e4f653967f) | `qwen3` | `json`, `regex` | ✅ |

--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -475,6 +475,16 @@ Supported models:
 
 Flags: `--tool-call-parser apertus`
 
+### HyperCLOVAX-SEED-Think-14B Models (`hyperclovax_seed_think_14b`)
+
+Supported models:
+
+* `naver-hyperclovax/HyperCLOVAX-SEED-Think-14B`
+
+This model emits tool calls as a JSON array following a `<|im_start|>assistant -> tool/function_call` delimiter, and wraps reasoning in `/think` blocks. Use it together with the matching reasoning parser so the reasoning/tool boundary is detected correctly (which also lets the structured-output grammar engage for `tool_choice="required"`).
+
+Flags: `--tool-call-parser hyperclovax_seed_think_14b --reasoning-parser hyperclovax_seed_think_14b --chat-template examples/tool_chat_template_hyperclovax_seed_think_14b.jinja`
+
 ### Models with Pythonic Tool Calls (`pythonic`)
 
 A growing number of models output a python list to represent tool calls instead of using JSON. This has the advantage of inherently supporting parallel tool calls and removing ambiguity around the JSON schema required for tool calls. The `pythonic` tool parser can support such models.

--- a/examples/tool_chat_template_hyperclovax_seed_think_14b.jinja
+++ b/examples/tool_chat_template_hyperclovax_seed_think_14b.jinja
@@ -1,0 +1,100 @@
+{% if tools is not defined or tools is none %}
+    {{- '<|im_start|>tool_list\n<|im_end|>\n' }}
+{%- else %}
+    {{- '<|im_start|>tool_list\n[' }}
+    {%- for tool in tools %}
+        {{- '{"name": "' }}
+        {{- tool.function.name }}
+        {{- '", ' }}
+        {{- '"description": "' }}
+        {{- tool.function.description }}
+        {{- '"' }}
+        {%- if tool.function.parameters is defined %}
+            {{- ', "parameters": ' }}
+            {{- tool.function.parameters | tojson }}
+        {%- endif %}
+        {{- '}' }}
+        {%- if not loop.last %}
+            {{- ', ' }}
+        {%- endif %}
+    {%- endfor %}
+{{- ']<|im_end|>\n' }}
+{%- endif %}
+
+{%- set ns = namespace(is_searching=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.is_searching and (message.role == 'user' or message.role == 'tool') %}
+        {%- set ns.last_query_index = index %}
+        {%- set ns.is_searching = false %}
+    {%- endif %}
+{%- endfor %}
+
+{%- for message in messages %}
+    {%- if loop.index0 == 0 and message.role != 'system' %}
+        {{- '<|im_start|>system\n<|im_end|>\n' }}
+    {%- endif %}
+
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+
+    {%- set reasoning_content = '' %}
+    {%- if message.reasoning_content is defined and message.reasoning_content is not none %}
+        {%- set reasoning_content = message.reasoning_content %}    
+    {%- endif %}
+    {%- if message.role == "assistant" %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if reasoning_content %}
+                {{- '<|im_start|>assistant/think\n' + reasoning_content.strip('\n') + '<|im_end|>\n' }}
+            {%- endif %}
+        {%- endif %}
+
+        {%- if content %}
+            {{- '<|im_start|>assistant\n' + content.strip('\n') + '<|im_end|>' }}
+            {%- if message.tool_calls %}
+                {{- '\n' }}
+            {%- else %}
+                {{- '<|endofturn|>\n' }}
+            {%- endif %}
+        {%- endif %}
+
+        {%- if message.tool_calls %}
+            {{- '<|im_start|>assistant -> tool/function_call\n[' }}
+            {%- for tool_call in message.tool_calls %}
+                {%- if not loop.first %}
+                    {{- ', ' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}' }}
+                {%- endfor %}
+            {{- ']<|im_end|><|stop|>\n' }}
+
+        {%- endif %}
+    {%- elif message.role == "tool" %}
+        {{- '<|im_start|>tool/function_call\n' + content + '<|im_end|>\n' }}
+    {%- else %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {%- if force_reasoning is defined and force_reasoning is true %}
+        {{- '<|im_start|>assistant/think\n' }}
+    {%- elif skip_reasoning is defined and skip_reasoning is true %}
+        {{- '<|im_start|>assistant\n' }}
+    {%- else %}
+        {{- '<|im_start|>assistant' }}
+    {%- endif %}
+{%- endif %}

--- a/tests/reasoning/test_hyperclovax_seed_think_14b_reasoning_parser.py
+++ b/tests/reasoning/test_hyperclovax_seed_think_14b_reasoning_parser.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the HyperCLOVAX-SEED-Think-14B reasoning parser.
+
+These tests use a mock tokenizer so they do not require the model weights.
+They cover the force_reasoning x skip_reasoning matrix (the chat_template_kwargs
+axes the parser must disambiguate), the reasoning->content boundary split, the
+reasoning-end boundary detection used by the structured-output
+(``tool_choice="required"``) path, and the streaming variants.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.reasoning import ReasoningParserManager
+from vllm.reasoning.hyperclovax_seed_think_14b_reasoning_parser import (
+    HyperCLOVAXSeedThink14BReasoningParser,
+)
+
+PARSER_NAME = "hyperclovax_seed_think_14b"
+THINK_START = "/think\n"
+ASSISTANT = "<|im_end|>\n<|im_start|>assistant"
+ROLE = " -> tool/function_call\n"
+
+
+@pytest.fixture
+def tokenizer():
+    tok = MagicMock()
+    tok.get_vocab.return_value = {}
+    # Deterministic, dependency-free encoding: one fake id per character.
+    tok.encode.side_effect = lambda text, add_special_tokens=False: (
+        [ord(ch) % 1000 for ch in text] or [0]
+    )
+    tok.tokenize.return_value = []
+    return tok
+
+
+def make_request(tool_choice=None, tools=None, **chat_template_kwargs):
+    request = MagicMock()
+    request.chat_template_kwargs = dict(chat_template_kwargs)
+    request.tool_choice = tool_choice
+    request.tools = tools
+    return request
+
+
+def build_parser(tokenizer, **chat_template_kwargs):
+    return HyperCLOVAXSeedThink14BReasoningParser(
+        tokenizer, chat_template_kwargs=chat_template_kwargs
+    )
+
+
+def _ctk(force, skip):
+    ctk = {}
+    if force is not None:
+        ctk["force_reasoning"] = force
+    if skip is not None:
+        ctk["skip_reasoning"] = skip
+    return ctk
+
+
+# The 9 (force_reasoning, skip_reasoning) combinations the 54-case matrix
+# exercises. With no boundary in the output, the mode is decided purely by the
+# flags: force_reasoning wins -> reasoning; skip_reasoning -> content;
+# otherwise (default/auto) -> content.
+_TRISTATE = [False, True, None]
+NO_BOUNDARY_CASES = []
+for _force in _TRISTATE:
+    for _skip in _TRISTATE:
+        if _force is True:
+            NO_BOUNDARY_CASES.append((_force, _skip, "thinking", "thinking", None))
+        elif _skip is True:
+            NO_BOUNDARY_CASES.append((_force, _skip, "\nanswer", None, "answer"))
+        else:
+            NO_BOUNDARY_CASES.append((_force, _skip, "answer", None, "answer"))
+
+
+class TestRegistration:
+    def test_lazy_registered(self, tokenizer):
+        cls = ReasoningParserManager.get_reasoning_parser(PARSER_NAME)
+        assert cls is HyperCLOVAXSeedThink14BReasoningParser
+        assert isinstance(cls(tokenizer), HyperCLOVAXSeedThink14BReasoningParser)
+
+
+class TestExtractReasoningMatrix:
+    @pytest.mark.parametrize("force,skip,raw,exp_r,exp_c", NO_BOUNDARY_CASES)
+    def test_no_boundary_force_skip_matrix(
+        self, tokenizer, force, skip, raw, exp_r, exp_c
+    ):
+        ctk = _ctk(force, skip)
+        parser = build_parser(tokenizer, **ctk)
+        tool_choice = "auto" if (force is not True and skip is not True) else None
+        reasoning, content = parser.extract_reasoning(
+            raw, make_request(tool_choice=tool_choice, **ctk)
+        )
+        assert reasoning == exp_r
+        assert content == exp_c
+
+    @pytest.mark.parametrize(
+        "raw,exp_r,exp_c",
+        [
+            ("reason" + ASSISTANT + "\nanswer", "reason", "answer"),
+            (THINK_START + "thinking" + ASSISTANT + "\nanswer", "thinking", "answer"),
+        ],
+    )
+    def test_boundary_splits_reasoning_and_content(self, tokenizer, raw, exp_r, exp_c):
+        parser = build_parser(tokenizer)
+        reasoning, content = parser.extract_reasoning(raw, make_request())
+        assert reasoning == exp_r
+        assert content == exp_c
+
+    def test_required_tool_call_strips_header_and_normalizes(self, tokenizer):
+        parser = build_parser(tokenizer, force_reasoning=True)
+        payload = '[{"name": "get_weather", "arguments": {"city": "Seoul"}}]'
+        out = "reason" + ASSISTANT + ROLE + payload + "<|im_end|>"
+        reasoning, content = parser.extract_reasoning(
+            out,
+            make_request(
+                tool_choice="required", tools=[{"x": 1}], force_reasoning=True
+            ),
+        )
+        assert reasoning == "reason"
+        assert content is not None
+        # The " -> tool/function_call" header and end token are stripped, and
+        # "arguments" is normalized to "parameters" for the bare JSON array.
+        assert content.startswith("[{")
+        assert '"parameters"' in content
+        assert "<|im_end|>" not in content
+        assert ROLE not in content
+
+
+def _stream_extract(parser, raw):
+    """Drive the streaming API one character per delta and rebuild the split."""
+    previous = ""
+    reasoning = ""
+    content = ""
+    for i in range(1, len(raw) + 1):
+        msg = parser.extract_reasoning_streaming(
+            previous, raw[:i], raw[i - 1], [], [], []
+        )
+        if msg is not None:
+            if getattr(msg, "reasoning", None):
+                reasoning += msg.reasoning
+            if msg.content:
+                content += msg.content
+        previous = raw[:i]
+    return reasoning or None, content or None
+
+
+class TestExtractReasoningStreaming:
+    def test_force_reasoning_streaming_splits_at_boundary(self, tokenizer):
+        parser = build_parser(tokenizer, force_reasoning=True)
+        reasoning, content = _stream_extract(parser, "reason" + ASSISTANT + "\nanswer")
+        assert reasoning == "reason"
+        assert content is not None and content.strip() == "answer"
+
+    def test_skip_reasoning_streaming_is_content(self, tokenizer):
+        parser = build_parser(tokenizer, skip_reasoning=True)
+        reasoning, content = _stream_extract(parser, "answer")
+        assert reasoning is None
+        assert content is not None and content.strip() == "answer"
+
+
+class TestIsReasoningEnd:
+    def test_bare_assistant_boundary_is_end(self, tokenizer):
+        parser = build_parser(tokenizer, force_reasoning=True)
+        # The bare "<|im_end|>\n<|im_start|>assistant" token sequence is the
+        # decisive boundary that lets the grammar engage at the right token.
+        bare_boundary_ids = parser.think_end_tokens[-1]
+        assert parser.is_reasoning_end(list(bare_boundary_ids))
+
+    def test_unrelated_ids_are_not_end(self, tokenizer):
+        parser = build_parser(tokenizer, force_reasoning=True)
+        assert not parser.is_reasoning_end([1, 2, 3])

--- a/tests/reasoning/test_hyperclovax_seed_think_14b_reasoning_parser.py
+++ b/tests/reasoning/test_hyperclovax_seed_think_14b_reasoning_parser.py
@@ -128,6 +128,20 @@ class TestExtractReasoningMatrix:
         assert "<|im_end|>" not in content
         assert ROLE not in content
 
+    def test_literal_im_end_in_argument_not_truncated(self, tokenizer):
+        # A literal <|im_end|> inside a string argument must not be taken as the
+        # tool-call boundary; the reasoner hands the full array downstream and
+        # only the trailing terminator is stripped.
+        parser = build_parser(tokenizer, force_reasoning=True)
+        payload = '[{"name": "get_weather", "arguments": {"city": "a <|im_end|> b"}}]'
+        out = "reason" + ASSISTANT + ROLE + payload + "<|im_end|>"
+        reasoning, content = parser.extract_reasoning(
+            out,
+            make_request(tool_choice="auto", tools=[{"x": 1}], force_reasoning=True),
+        )
+        assert reasoning == "reason"
+        assert content == payload
+
 
 def _stream_extract(parser, raw):
     """Drive the streaming API one character per delta and rebuild the split."""

--- a/tests/tool_parsers/test_hyperclovax_seed_think_14b_tool_parser.py
+++ b/tests/tool_parsers/test_hyperclovax_seed_think_14b_tool_parser.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the HyperCLOVAX-SEED-Think-14B tool parser.
+
+A mock tokenizer is used so the tests do not require the model weights.
+Covers the templated header form, the bare-array hand-off (after the reasoning
+parser strips the header), arguments/parameters aliasing, multiple calls, and
+the abbreviated non-template form the model sometimes emits in
+tool_choice="auto" - in both the non-streaming and streaming code paths.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.tool_parsers.abstract_tool_parser import ToolParserManager
+from vllm.tool_parsers.hyperclovax_seed_think_14b_tool_parser import (
+    HyperCLOVAXSeedThink14BToolParser,
+)
+
+PARSER_NAME = "hyperclovax_seed_think_14b"
+HEADER = " -> tool/function_call\n"
+END = "<|im_end|>"
+
+
+@pytest.fixture
+def tokenizer():
+    tok = MagicMock()
+    tok.get_vocab.return_value = {}
+    return tok
+
+
+@pytest.fixture
+def tool_parser(tokenizer):
+    return HyperCLOVAXSeedThink14BToolParser(tokenizer)
+
+
+def make_request(tools=None, tool_choice="auto"):
+    request = MagicMock()
+    request.tools = tools
+    request.tool_choice = tool_choice
+    request.chat_template_kwargs = {}
+    return request
+
+
+_TOOLS = [{"type": "function", "function": {"name": "get_weather"}}]
+
+# (label, output, needs_tools, expected_names, expected_args0)
+EXTRACT_TOOL_CASES = [
+    (
+        "header_array_arguments",
+        HEADER + '[{"name": "get_weather", "arguments": {"city": "Seoul"}}]' + END,
+        False,
+        ["get_weather"],
+        {"city": "Seoul"},
+    ),
+    (
+        "header_array_parameters_alias",
+        HEADER + '[{"name": "get_weather", "parameters": {"a": 1}}]' + END,
+        False,
+        ["get_weather"],
+        {"a": 1},
+    ),
+    (
+        "bare_array_handoff",
+        '[{"name": "get_weather", "parameters": {"city": "Busan"}}]',
+        True,
+        ["get_weather"],
+        {"city": "Busan"},
+    ),
+    (
+        "multiple_tool_calls",
+        HEADER + '[{"name": "a", "arguments": {"x": 1}}, '
+        '{"name": "b", "arguments": {"y": 2}}]' + END,
+        False,
+        ["a", "b"],
+        {"x": 1},
+    ),
+]
+
+# Outputs that must NOT be parsed as tool calls.
+NON_TOOL_CASES = [
+    # Abbreviated, non-template form sometimes emitted in tool_choice="auto":
+    # "-> tool/<func>\n{...}" - a bare object with the real function name in
+    # place of "function_call". The guarantee path is required + grammar.
+    ("abbreviated_bare_object", '-> tool/get_current_weather\n{"city": "Seoul"}'),
+    ("plain_text", "I cannot find the weather right now."),
+]
+
+
+class TestRegistration:
+    def test_lazy_registered(self, tokenizer):
+        cls = ToolParserManager.get_tool_parser(PARSER_NAME)
+        assert cls is HyperCLOVAXSeedThink14BToolParser
+        assert isinstance(cls(tokenizer), HyperCLOVAXSeedThink14BToolParser)
+
+
+class TestExtractToolCalls:
+    @pytest.mark.parametrize(
+        "label,output,needs_tools,names,args0",
+        EXTRACT_TOOL_CASES,
+        ids=[c[0] for c in EXTRACT_TOOL_CASES],
+    )
+    def test_tool_call_forms(
+        self, tool_parser, label, output, needs_tools, names, args0
+    ):
+        request = make_request(tools=_TOOLS if needs_tools else None)
+        result = tool_parser.extract_tool_calls(output, request)
+        assert result.tools_called
+        assert [tc.function.name for tc in result.tool_calls] == names
+        assert json.loads(result.tool_calls[0].function.arguments) == args0
+
+    @pytest.mark.parametrize(
+        "label,output", NON_TOOL_CASES, ids=[c[0] for c in NON_TOOL_CASES]
+    )
+    def test_non_tool_outputs_are_content(self, tool_parser, label, output):
+        result = tool_parser.extract_tool_calls(output, make_request())
+        assert not result.tools_called
+        assert result.content == output
+
+
+class TestStreaming:
+    def _collect_tool_calls(self, parser, request, full_text):
+        # Drive the streaming API one character per delta and collect deltas.
+        previous_text = ""
+        collected = []
+        for i in range(1, len(full_text) + 1):
+            msg = parser.extract_tool_calls_streaming(
+                previous_text, full_text[:i], full_text[i - 1], [], [], [], request
+            )
+            if msg is not None and msg.tool_calls:
+                collected.extend(msg.tool_calls)
+            previous_text = full_text[:i]
+        return [
+            tc.function.name for tc in collected if tc.function and tc.function.name
+        ]
+
+    @pytest.mark.parametrize(
+        "label,output,needs_tools",
+        [
+            (
+                "header_array",
+                HEADER + '[{"name": "get_weather", "arguments": {"city": "Seoul"}}]',
+                False,
+            ),
+            (
+                "bare_array",
+                '[{"name": "get_weather", "parameters": {"city": "Busan"}}]',
+                True,
+            ),
+        ],
+        ids=["header_array", "bare_array"],
+    )
+    def test_streaming_tool_call_forms(self, tool_parser, label, output, needs_tools):
+        request = make_request(tools=_TOOLS if needs_tools else None)
+        names = self._collect_tool_calls(tool_parser, request, output)
+        assert "get_weather" in names

--- a/tests/tool_parsers/test_hyperclovax_seed_think_14b_tool_parser.py
+++ b/tests/tool_parsers/test_hyperclovax_seed_think_14b_tool_parser.py
@@ -77,6 +77,24 @@ EXTRACT_TOOL_CASES = [
         ["a", "b"],
         {"x": 1},
     ),
+    # Regression: a literal <|im_end|> inside a string argument must not be
+    # treated as the tool-call boundary (parsed by JSON structure, not text cut).
+    (
+        "header_literal_im_end_in_argument",
+        HEADER
+        + '[{"name": "get_weather", "arguments": {"city": "a <|im_end|> b"}}]'
+        + END,
+        False,
+        ["get_weather"],
+        {"city": "a <|im_end|> b"},
+    ),
+    (
+        "bare_literal_im_end_in_argument",
+        '[{"name": "get_weather", "arguments": {"city": "a <|im_end|> b"}}]' + END,
+        True,
+        ["get_weather"],
+        {"city": "a <|im_end|> b"},
+    ),
 ]
 
 # Outputs that must NOT be parsed as tool calls.

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -76,6 +76,10 @@ _REASONING_PARSERS_TO_REGISTER = {
         "hy_v3_reasoning_parser",
         "HYV3ReasoningParser",
     ),
+    "hyperclovax_seed_think_14b": (
+        "hyperclovax_seed_think_14b_reasoning_parser",
+        "HyperCLOVAXSeedThink14BReasoningParser",
+    ),
     "kimi_k2": (
         "kimi_k2_reasoning_parser",
         "KimiK2ReasoningParser",

--- a/vllm/reasoning/hyperclovax_seed_think_14b_reasoning_parser.py
+++ b/vllm/reasoning/hyperclovax_seed_think_14b_reasoning_parser.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from the HyperCLOVA X vLLM plugin (NAVER Cloud, Apache-2.0).
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+)
+from vllm.logger import init_logger
+from vllm.reasoning import ReasoningParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+    from vllm.tokenizers import TokenizerLike
+
+logger = init_logger(__name__)
+
+
+class HyperCLOVAXSeedThink14BReasoningParser(ReasoningParser):
+    """Reasoning parser for ``HyperCLOVAX-SEED-Think-14B``.
+
+    The 14B model wraps reasoning after a ``/think`` prompt and switches to the
+    assistant content/tool channel at the ``<|im_end|>\\n<|im_start|>assistant``
+    delimiter. Correctly locating that boundary lets vLLM's structured-output
+    grammar engage at the right token for ``tool_choice="required"``.
+    """
+
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(tokenizer, *args, **kwargs)
+        self.chat_template_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
+
+        self.think_start_token = "/think\n"
+        self.think_end_string_base = "<|im_end|>\n<|im_start|>assistant"
+        self.non_reasoning_prompt_end_string = "<|im_start|>assistant\n"
+
+        # for streaming
+        self.non_reasoning_mode_start_token = tokenizer.encode("\n")[0]
+        self.function_call_role = " -> tool/function_call\n"
+        self.no_reasoning_content = False
+
+        # Do not treat bare <|im_end|> as reasoning end. The content turn starts
+        # only after the full assistant delimiter has been generated.
+        self.exact_think_end_strings = [
+            self.think_end_string_base + "\n",
+            self.think_end_string_base + self.function_call_role + "[{",
+            self.think_end_string_base + self.function_call_role,
+            self.think_end_string_base,
+        ]
+        self.think_end_tokens = [
+            tokenizer.encode(think_end_string)
+            for think_end_string in self.exact_think_end_strings
+        ]
+        self._think_end_specs = list(
+            zip(self.exact_think_end_strings, self.think_end_tokens, strict=False)
+        )
+        self.non_reasoning_prompt_end_tokens = tokenizer.encode(
+            self.non_reasoning_prompt_end_string
+        )
+
+        # attributes for streaming parser mixin
+        self.buffer_string = ""
+        self.special_strings = [
+            self.think_start_token,
+            self.think_end_string_base,
+            self.function_call_role,
+        ]
+        self.escaped_special_strings = [re.escape(ss) for ss in self.special_strings]
+
+        # Set to True when the tool-call role is complete after reasoning ends.
+        # Causes the reasoning parser to yield None so the downstream tool
+        # parser/required structured-output path handles subsequent JSON tokens.
+        self.is_tool_call_mode = False
+        self.is_delaying_assistant_handoff = False
+        self.is_reasoning_ended = False
+        self.has_emitted_reasoning_text = False
+
+        # Rolling token history for is_reasoning_end() in streaming paths where
+        # input_ids may be a delta (1 token) rather than the full cumulative sequence.
+        self._max_think_end_len = max(
+            (len(t) for t in self.think_end_tokens), default=0
+        )
+        self._token_history: list[int] = []
+
+    def _delta(
+        self,
+        *,
+        reasoning: str | None = None,
+        content: str | None = None,
+    ) -> DeltaMessage:
+        kwargs = {}
+        if reasoning is not None:
+            kwargs["reasoning"] = reasoning
+        if content is not None:
+            kwargs["content"] = content
+        return DeltaMessage(**kwargs)
+
+    def _is_skip_reasoning(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> bool:
+        chat_template_kwargs = request.chat_template_kwargs or {}
+        return bool(chat_template_kwargs.get("skip_reasoning", False)) and not bool(
+            chat_template_kwargs.get("force_reasoning", False)
+        )
+
+    def _is_streaming_skip_reasoning(self) -> bool:
+        return bool(
+            self.chat_template_kwargs.get("skip_reasoning", False)
+        ) and not bool(self.chat_template_kwargs.get("force_reasoning", False))
+
+    def _strip_think_start(self, model_output: str) -> tuple[bool, str]:
+        if model_output.startswith(self.think_start_token):
+            return True, model_output.partition(self.think_start_token)[2]
+        return False, model_output
+
+    def _split_first_special(self) -> tuple[str, str, str] | None:
+        matches = []
+        for special_string in self.special_strings:
+            index = self.buffer_string.find(special_string)
+            if index >= 0:
+                matches.append((index, special_string))
+        if not matches:
+            return None
+
+        index, special_string = min(matches, key=lambda item: item[0])
+        before = self.buffer_string[:index]
+        after = self.buffer_string[index + len(special_string) :]
+        return before, special_string, after
+
+    def _has_partial_think_end_suffix(self) -> bool:
+        if not self.buffer_string:
+            return False
+        if self.think_end_string_base in self.buffer_string:
+            return False
+
+        max_len = min(len(self.buffer_string), len(self.think_end_string_base) - 1)
+        for ln in range(max_len, 0, -1):
+            if self.buffer_string[-ln:] == self.think_end_string_base[:ln]:
+                return True
+        return False
+
+    def check_is_part_of_special_string(self) -> bool:
+        for special_string in self.special_strings:
+            min_len = min(len(self.buffer_string), len(special_string))
+            for length in range(min_len, 0, -1):
+                if self.buffer_string[-length:] == special_string[:length]:
+                    return True
+        return False
+
+    def _update_token_history(self, delta_token_ids: Sequence[int]) -> None:
+        if not self._max_think_end_len or not delta_token_ids:
+            return
+
+        self._token_history.extend(delta_token_ids)
+        if len(self._token_history) > self._max_think_end_len:
+            self._token_history = self._token_history[-self._max_think_end_len :]
+
+    def _normalize_tool_content(self, tool_content: str) -> str:
+        stripped = tool_content.lstrip()
+        if stripped.startswith("-"):
+            after_dash = stripped[1:].lstrip()
+            if after_dash.startswith("["):
+                tool_content = after_dash
+        return re.sub(
+            r'"arguments"(?=\s*:)',
+            '"parameters"',
+            tool_content,
+            count=1,
+        )
+
+    def _strip_tool_end_tokens(self, tool_content: str) -> str:
+        for end_token in ("<|im_end|>", "<|stop|>", "<|endofturn|>"):
+            idx = tool_content.find(end_token)
+            if idx >= 0:
+                return tool_content[:idx]
+        return tool_content
+
+    def _normalize_required_tool_content(
+        self,
+        content: str | None,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> str | None:
+        if not content or request.tool_choice != "required":
+            return content
+        return self._normalize_tool_content(content)
+
+    def _is_partial_tool_role_fragment(self, text: str) -> bool:
+        normalized = text.lstrip()
+        target = self.function_call_role.lstrip()
+        return (
+            bool(normalized) and normalized != target and target.startswith(normalized)
+        )
+
+    def _decode_token_ids(self, token_ids: Sequence[int]) -> str:
+        if not token_ids:
+            return ""
+        return self.model_tokenizer.decode(list(token_ids), skip_special_tokens=False)
+
+    def _clean_buffered_reasoning_text(self) -> str | None:
+        cleaned_reasoning = self.buffer_string
+        for special_string in self.special_strings:
+            cleaned_reasoning = cleaned_reasoning.replace(special_string, "")
+        cleaned_reasoning = self._strip_tool_end_tokens(cleaned_reasoning)
+        return cleaned_reasoning or None
+
+    def _build_tool_delta_from_text(
+        self,
+        tool_text: str,
+        reasoning: str | None = None,
+    ) -> DeltaMessage | None:
+        stripped = tool_text.lstrip("\n")
+        if not stripped.startswith(self.function_call_role):
+            return None
+
+        tool_content = self._strip_tool_end_tokens(
+            stripped[len(self.function_call_role) :]
+        )
+        tool_content = self._normalize_tool_content(tool_content.strip())
+
+        try:
+            raw_tool_calls = json.loads(tool_content)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(raw_tool_calls, list) or not raw_tool_calls:
+            return None
+
+        tool_calls = []
+        for index, raw_tool_call in enumerate(raw_tool_calls):
+            if not isinstance(raw_tool_call, dict):
+                return None
+            name = raw_tool_call.get("name")
+            arguments = raw_tool_call.get(
+                "parameters", raw_tool_call.get("arguments", {})
+            )
+            if not isinstance(name, str) or not name:
+                return None
+            if isinstance(arguments, str):
+                arguments_json = arguments
+            else:
+                arguments_json = json.dumps(arguments, ensure_ascii=False)
+            tool_calls.append(
+                DeltaToolCall(
+                    index=index,
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name=name,
+                        arguments=arguments_json,
+                    ).model_dump(exclude_none=True),
+                )
+            )
+
+        payload = {"tool_calls": tool_calls}
+        if reasoning:
+            payload["reasoning"] = reasoning
+        return DeltaMessage(**payload)
+
+    def _extract_token_based_transition(
+        self,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        decoded_current = self._decode_token_ids(current_token_ids)
+        decoded_previous = self._decode_token_ids(previous_token_ids)
+
+        if (
+            self.think_end_string_base not in decoded_current
+            or self.think_end_string_base in decoded_previous
+        ):
+            return None
+
+        _, _, tool_or_content = decoded_current.partition(self.think_end_string_base)
+        tool_delta = self._build_tool_delta_from_text(
+            tool_or_content,
+            reasoning=self._clean_buffered_reasoning_text(),
+        )
+        if tool_delta is None:
+            return None
+
+        self.buffer_string = ""
+        self.is_delaying_assistant_handoff = False
+        self.is_tool_call_mode = True
+        self.is_reasoning_ended = True
+        return tool_delta
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> tuple[str | None, str | None]:
+        chat_template_kwargs = request.chat_template_kwargs or {}
+
+        if self._is_skip_reasoning(request):
+            return None, model_output.lstrip("\n") or None
+
+        is_reasoning = bool(chat_template_kwargs.get("force_reasoning", False))
+
+        has_think_start, model_output = self._strip_think_start(model_output)
+        if has_think_start:
+            is_reasoning = True
+
+        if self.think_end_string_base not in model_output:
+            if is_reasoning:
+                # Special tokens (<|im_end|>, <|im_start|>) may be stripped from
+                # output.text. Attempt to detect a trailing JSON tool-call array.
+                last_bracket = model_output.rfind("[{")
+                if last_bracket >= 0 and getattr(request, "tools", None):
+                    candidate = model_output[last_bracket:]
+                    try:
+                        json.loads(candidate)
+                        reasoning_part = model_output[:last_bracket].strip("\n")
+                        return reasoning_part or None, candidate
+                    except json.JSONDecodeError:
+                        pass
+                return model_output.strip("\n") or None, None
+            if request.tool_choice == "auto" or request.tool_choice is None:
+                return None, model_output.lstrip("\n") or None
+
+            content = (
+                model_output.replace(self.function_call_role, "").lstrip("\n") or None
+            )
+            normalized = self._normalize_required_tool_content(content, request)
+            return None, normalized
+
+        reasoning_content, _, content = model_output.partition(
+            self.think_end_string_base
+        )
+        content = content.lstrip("\n")
+        # Strip " -> tool/function_call\n" prefix and end tokens so that
+        # downstream parsers (TypeAdapter for tool_choice="required", or our
+        # extract_tool_calls for tool_choice="auto") receive bare JSON.
+        if content.startswith(self.function_call_role):
+            content = content[len(self.function_call_role) :]
+            content = self._strip_tool_end_tokens(content)
+            content = content.strip()
+        content = self._normalize_required_tool_content(content or None, request)
+        return reasoning_content.strip("\n") or None, content
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        if self._is_streaming_skip_reasoning():
+            self.no_reasoning_content = True
+
+        force_reasoning = bool(self.chat_template_kwargs.get("force_reasoning", False))
+        if (
+            not force_reasoning
+            and current_token_ids
+            and current_token_ids[0] == self.non_reasoning_mode_start_token
+        ):
+            self.no_reasoning_content = True
+
+        if len(current_text) == 0:
+            return None
+
+        self._update_token_history(delta_token_ids)
+
+        if self.is_tool_call_mode:
+            return None
+
+        if self.no_reasoning_content:
+            return self._delta(content=delta_text)
+
+        self.buffer_string += delta_text
+
+        split_special = self._split_first_special()
+        if split_special:
+            before, special_string, after = split_special
+            self.buffer_string = ""
+
+            if special_string == self.think_start_token:
+                if after.strip():
+                    self.has_emitted_reasoning_text = True
+                return self._delta(reasoning=after)
+
+            if special_string == self.think_end_string_base:
+                is_partial_tool_role = (
+                    bool(after)
+                    and self.function_call_role.startswith(after)
+                    and after != self.function_call_role
+                )
+                if after == "" or is_partial_tool_role:
+                    self.is_delaying_assistant_handoff = True
+                    self.buffer_string = self.think_end_string_base + after
+                    cleaned_before = before if before and before.strip() else None
+                    if cleaned_before:
+                        self.has_emitted_reasoning_text = True
+                    return (
+                        self._delta(reasoning=cleaned_before)
+                        if cleaned_before
+                        else None
+                    )
+
+                self.is_delaying_assistant_handoff = False
+                if after.startswith(self.function_call_role):
+                    tool_content = after[len(self.function_call_role) :]
+                    self.is_tool_call_mode = True
+                    self.is_reasoning_ended = True
+                    return self._delta(
+                        content=self._normalize_tool_content(tool_content),
+                    )
+                self.is_reasoning_ended = True
+                return self._delta(reasoning=before, content=after)
+
+            if special_string == self.function_call_role:
+                self.is_tool_call_mode = True
+                self.is_reasoning_ended = True
+                return self._delta(
+                    content=self._normalize_tool_content(after),
+                )
+
+        if self._is_partial_tool_role_fragment(self.buffer_string):
+            return None
+
+        if self.check_is_part_of_special_string():
+            token_based_transition = self._extract_token_based_transition(
+                previous_token_ids,
+                current_token_ids,
+            )
+            if token_based_transition is not None:
+                return token_based_transition
+            return None
+
+        delta_text = self.buffer_string
+        self.buffer_string = ""
+
+        if self.is_tool_call_mode:
+            return None
+        if self.think_end_string_base in current_text:
+            self.is_delaying_assistant_handoff = False
+            self.is_reasoning_ended = True
+            return self._delta(content=delta_text)
+        if not self.has_emitted_reasoning_text and delta_text.strip() == "":
+            self.buffer_string = delta_text
+            return None
+        if delta_text.strip():
+            self.has_emitted_reasoning_text = True
+        return self._delta(reasoning=delta_text)
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        if self.is_delaying_assistant_handoff:
+            return False
+
+        if self._has_partial_think_end_suffix():
+            return False
+
+        if (
+            self.no_reasoning_content
+            or self.is_tool_call_mode
+            or self.is_reasoning_ended
+        ):
+            return True
+
+        # With skip_reasoning=True the generation prompt already ends at the
+        # assistant content channel. Tell vLLM's streaming/structured-output
+        # path that tool parsing may start from the first generated token.
+        prompt_end_len = len(self.non_reasoning_prompt_end_tokens)
+        if (
+            self._is_streaming_skip_reasoning()
+            and prompt_end_len > 0
+            and len(input_ids) >= prompt_end_len
+            and input_ids[-prompt_end_len:] == self.non_reasoning_prompt_end_tokens
+        ):
+            return True
+
+        # Check using the passed input_ids (cumulative path used by the engine).
+        for think_end_string, think_end_tokens in self._think_end_specs:
+            think_end_len = len(think_end_tokens)
+            if (
+                think_end_len > 0
+                and len(input_ids) >= think_end_len
+                and input_ids[-think_end_len:] == think_end_tokens
+            ):
+                return True
+
+        for think_end_string, think_end_tokens in self._think_end_specs:
+            think_end_len = len(think_end_tokens)
+            if (
+                think_end_len > 0
+                and len(self._token_history) >= think_end_len
+                and self._token_history[-think_end_len:] == think_end_tokens
+            ):
+                return True
+
+        return False
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        prompt_end_len = len(self.non_reasoning_prompt_end_tokens)
+        if (
+            self._is_streaming_skip_reasoning()
+            and prompt_end_len > 0
+            and len(input_ids) >= prompt_end_len
+        ):
+            for index in range(len(input_ids) - prompt_end_len, -1, -1):
+                if (
+                    input_ids[index : index + prompt_end_len]
+                    == self.non_reasoning_prompt_end_tokens
+                ):
+                    return input_ids[index + prompt_end_len :]
+
+        for think_end_tokens in self.think_end_tokens:
+            think_end_len = len(think_end_tokens)
+            if think_end_len == 0 or len(input_ids) < think_end_len:
+                continue
+
+            for index in range(len(input_ids) - think_end_len, -1, -1):
+                if input_ids[index : index + think_end_len] == think_end_tokens:
+                    return input_ids[index + think_end_len :]
+
+        return []

--- a/vllm/reasoning/hyperclovax_seed_think_14b_reasoning_parser.py
+++ b/vllm/reasoning/hyperclovax_seed_think_14b_reasoning_parser.py
@@ -182,6 +182,17 @@ class HyperCLOVAXSeedThink14BReasoningParser(ReasoningParser):
         )
 
     def _strip_tool_end_tokens(self, tool_content: str) -> str:
+        # If the content is a JSON array (the tool-call payload), find its end by
+        # JSON structure (raw_decode respects string escaping) so a literal
+        # <|im_end|> inside a string argument is not mistaken for the terminator.
+        # Fall back to literal search for non-JSON content (e.g. reasoning text).
+        stripped = tool_content.lstrip()
+        if stripped.startswith("["):
+            try:
+                _, end = json.JSONDecoder().raw_decode(stripped)
+                return stripped[:end]
+            except json.JSONDecodeError:
+                pass
         for end_token in ("<|im_end|>", "<|stop|>", "<|endofturn|>"):
             idx = tool_content.find(end_token)
             if idx >= 0:
@@ -320,9 +331,12 @@ class HyperCLOVAXSeedThink14BReasoningParser(ReasoningParser):
                 if last_bracket >= 0 and getattr(request, "tools", None):
                     candidate = model_output[last_bracket:]
                     try:
-                        json.loads(candidate)
+                        # Find the array end by JSON structure so a literal
+                        # <|im_end|> inside a string argument (or a trailing
+                        # terminator) does not break parsing.
+                        _, end = json.JSONDecoder().raw_decode(candidate)
                         reasoning_part = model_output[:last_bracket].strip("\n")
-                        return reasoning_part or None, candidate
+                        return reasoning_part or None, candidate[:end]
                     except json.JSONDecodeError:
                         pass
                 return model_output.strip("\n") or None, None

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -86,6 +86,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "hy_v3_tool_parser",
         "HYV3ToolParser",
     ),
+    "hyperclovax_seed_think_14b": (
+        "hyperclovax_seed_think_14b_tool_parser",
+        "HyperCLOVAXSeedThink14BToolParser",
+    ),
     "internlm": (
         "internlm2_tool_parser",
         "Internlm2ToolParser",

--- a/vllm/tool_parsers/hyperclovax_seed_think_14b_tool_parser.py
+++ b/vllm/tool_parsers/hyperclovax_seed_think_14b_tool_parser.py
@@ -1,0 +1,511 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from the HyperCLOVA X vLLM plugin (NAVER Cloud, Apache-2.0).
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.tokenizers import TokenizerLike
+    from vllm.tool_parsers.utils import Tool
+
+logger = init_logger(__name__)
+
+
+class HyperCLOVAXSeedThink14BToolParser(ToolParser):
+    """Tool-call parser for ``HyperCLOVAX-SEED-Think-14B``.
+
+    The 14B model emits tool calls as a JSON array following the
+    ``<|im_start|>assistant -> tool/function_call`` delimiter. This parser
+    handles that header form, the bare-array hand-off used after the reasoning
+    parser strips the header, and ``arguments``/``parameters`` aliasing.
+    """
+
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+        super().__init__(tokenizer, tools)
+
+        self.tool_call_start_token: str = " -> tool/function_call\n"
+        self.tool_call_end_token: str = "<|im_end|>"
+        # Non-greedy ``.*?`` with an explicit end-of-string anchor avoids
+        # matching a ``]`` that appears inside a string value in arguments.
+        self.tool_call_regex = re.compile(
+            r"-> tool/function_call\n(.*?)<\|im_end\|>"
+            r"|-> tool/function_call\n(.*?)\](\s*)$",
+            re.DOTALL,
+        )
+
+        # for streaming
+        self.tool_call_offset = 0
+        self.current_tool_id = -1
+        # vLLM serving references these incremental snapshots while building
+        # streamed tool-call chunks, so keep them in sync even if this parser
+        # does not read them directly.
+        self.prev_tool_call_arr = []
+        self.streamed_args_for_tool: list[str] = []
+        self.is_reasoning_ended = False
+        self.is_bare_tool_call_mode = False
+        self.pending_bare_tool_call_prefix = ""
+        self.bare_tool_call_was_reasoning_ended = False
+        self.has_emitted_reasoning_text = False
+
+        self.buffer_string = ""
+        self.special_strings = [
+            "<|im_end|>\n",
+            "<|im_end|>",
+            "<|im_start|>assistant/think\n",
+            "<|im_start|>assistant\n",
+            "-> tool/function_call\n",
+            "<|stop|>",
+            "<|endofturn|>",
+        ]
+        self.escaped_special_strings = [re.escape(ss) for ss in self.special_strings]
+
+    def _delta(
+        self, *, reasoning: str | None = None, content: str | None = None
+    ) -> DeltaMessage:
+        # Use ``is not None`` so empty strings are not silently discarded.
+        kwargs = {}
+        if reasoning is not None:
+            kwargs["reasoning"] = reasoning
+        if content is not None:
+            kwargs["content"] = content
+        return DeltaMessage(**kwargs)
+
+    # depth + string-aware JSON object boundary scanner
+    # replaces the naive brace-position scanning approach
+    def _find_json_object_end(self, text: str, start: int) -> int | None:
+        """Returns the index of the closing } that ends the JSON object
+        starting at text[start]. Returns None if the object is incomplete."""
+        depth = 0
+        in_string = False
+        escape = False
+        for i in range(start, len(text)):
+            c = text[i]
+            if escape:
+                escape = False
+                continue
+            if c == "\\" and in_string:
+                escape = True
+                continue
+            if c == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    return i
+        return None
+
+    def _normalize_function_call(self, function_call: dict) -> dict:
+        return {
+            "name": function_call.get("name", ""),
+            "arguments": function_call.get(
+                "arguments", function_call.get("parameters", {})
+            ),
+        }
+
+    def _arguments_json(self, function_call: dict) -> str:
+        return json.dumps(function_call.get("arguments", {}), ensure_ascii=False)
+
+    def _tool_names(self, request: ChatCompletionRequest) -> set[str]:
+        tool_names: set[str] = set()
+        for tool in getattr(request, "tools", None) or []:
+            if isinstance(tool, dict):
+                function = tool.get("function") or {}
+                name = function.get("name") if isinstance(function, dict) else None
+            else:
+                function = getattr(tool, "function", None)
+                name = getattr(function, "name", None)
+            if name:
+                tool_names.add(name)
+        return tool_names
+
+    def _request_skips_reasoning(self, request: ChatCompletionRequest) -> bool:
+        chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
+        return bool(chat_template_kwargs.get("skip_reasoning", False)) and not bool(
+            chat_template_kwargs.get("force_reasoning", False)
+        )
+
+    def _request_forces_reasoning(self, request: ChatCompletionRequest) -> bool:
+        chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
+        return bool(chat_template_kwargs.get("force_reasoning", False))
+
+    def _is_function_call_like(
+        self,
+        function_call: object,
+        request: ChatCompletionRequest,
+    ) -> bool:
+        if not isinstance(function_call, dict):
+            return False
+
+        name = function_call.get("name")
+        if not isinstance(name, str) or not name:
+            return False
+
+        if "arguments" not in function_call and "parameters" not in function_call:
+            return False
+
+        tool_names = self._tool_names(request)
+        return not tool_names or name in tool_names
+
+    def _is_partial_tool_role_fragment(self, text: str) -> bool:
+        normalized = text.lstrip()
+        target = self.tool_call_start_token.lstrip()
+        return (
+            bool(normalized) and normalized != target and target.startswith(normalized)
+        )
+
+    def _is_tool_role_prefix_or_fragment(self, text: str) -> bool:
+        normalized = text.lstrip()
+        target = self.tool_call_start_token.lstrip()
+        return bool(normalized) and target.startswith(normalized)
+
+    def _emit_text_delta(self, text: str | None) -> DeltaMessage | None:
+        if not text:
+            return None
+        if self.is_reasoning_ended:
+            return DeltaMessage(content=text)
+        return self._delta(reasoning=text)
+
+    def _flush_buffered_delta(self) -> DeltaMessage | None:
+        if not self.buffer_string:
+            return None
+
+        flush_text = self.buffer_string
+        self.buffer_string = ""
+        for special_string in self.special_strings:
+            flush_text = flush_text.replace(special_string, "")
+        if not flush_text or self._is_tool_role_prefix_or_fragment(flush_text):
+            return None
+        if not self.is_reasoning_ended and flush_text.strip():
+            self.has_emitted_reasoning_text = True
+        return self._emit_text_delta(flush_text)
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        if self.tool_call_start_token not in model_output:
+            # Bare array mode: reasoning parser stripped the header before handoff
+            stripped = model_output.lstrip("\n")
+            if stripped.startswith("[") and getattr(request, "tools", None):
+                try:
+                    bare_json = stripped
+                    end_idx = bare_json.find(self.tool_call_end_token)
+                    if end_idx >= 0:
+                        bare_json = bare_json[:end_idx]
+                    bare_json = bare_json.rstrip()
+                    raw_function_calls = json.loads(bare_json)
+                    if not all(
+                        self._is_function_call_like(fc, request)
+                        for fc in raw_function_calls
+                    ):
+                        raise ValueError("Bare array is not a tool-call array.")
+                    tool_calls = [
+                        ToolCall(
+                            type="function",
+                            function=FunctionCall(
+                                name=fc["name"],
+                                arguments=self._arguments_json(
+                                    self._normalize_function_call(fc)
+                                ),
+                            ),
+                        )
+                        for fc in raw_function_calls
+                    ]
+                    return ExtractedToolCallInformation(
+                        tools_called=True, tool_calls=tool_calls, content=None
+                    )
+                except Exception:
+                    logger.debug(
+                        "Bare array tool call parsing failed. raw=%s",
+                        model_output[:200],
+                    )
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        # guard against no regex match before using raw_function_calls
+        tool_call_match = self.tool_call_regex.search(model_output)
+        if not tool_call_match:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        try:
+            if tool_call_match.group(1) is not None:
+                raw_function_calls = json.loads(tool_call_match.group(1))
+            else:
+                raw_function_calls = json.loads(tool_call_match.group(2) + "]")
+
+            tool_calls = [
+                ToolCall(
+                    type="function",
+                    function=FunctionCall(
+                        name=function_call["name"],
+                        arguments=self._arguments_json(
+                            self._normalize_function_call(function_call)
+                        ),
+                    ),
+                )
+                for function_call in raw_function_calls
+            ]
+
+            # check if there is other content before tool calls
+            if (
+                "<|im_end|>\n<|im_start|>assistant -> tool/function_call\n"
+                in model_output
+            ):
+                content = model_output.split(
+                    "<|im_end|>\n<|im_start|>assistant -> tool/function_call\n"
+                )[0]
+
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=content if content else None,
+                )
+            else:
+                return ExtractedToolCallInformation(
+                    tools_called=True, tool_calls=tool_calls, content=None
+                )
+
+        # split exception handling for better diagnostics
+        except json.JSONDecodeError:
+            logger.exception(
+                "Failed to decode tool call JSON. raw=%s", model_output[:300]
+            )
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+        except KeyError as e:
+            logger.exception(
+                "Missing required field in tool call: %s. raw=%s", e, model_output[:300]
+            )
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+        except Exception:
+            logger.exception(
+                "Unexpected error extracting tool call. raw=%s", model_output[:300]
+            )
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        if self._request_skips_reasoning(request):
+            self.is_reasoning_ended = True
+        elif self._request_forces_reasoning(request) and previous_text == "":
+            # In vLLM's auto-tool + reasoning streaming path this parser is
+            # called only after the reasoning parser has found the assistant
+            # delimiter. The delimiter has already been stripped from
+            # current_text, so carry that handoff state explicitly.
+            self.is_reasoning_ended = True
+
+        # Detect bare array mode: the reasoning parser strips the
+        # " -> tool/function_call\n" header before handing off, so current_text
+        # begins with "[{" directly. Latch the flag on first detection.
+        stripped_text = current_text.lstrip("\n")
+        if (
+            not self.is_bare_tool_call_mode
+            and self.tool_call_start_token not in current_text
+            and bool(request.tools)
+        ):
+            if stripped_text == "[":
+                self.pending_bare_tool_call_prefix = stripped_text
+                return None
+            if stripped_text.startswith("[{"):
+                self.bare_tool_call_was_reasoning_ended = self.is_reasoning_ended
+                self.is_bare_tool_call_mode = True
+                self.is_reasoning_ended = True
+                self.pending_bare_tool_call_prefix = ""
+            elif self.pending_bare_tool_call_prefix:
+                delta_text = self.pending_bare_tool_call_prefix + delta_text
+                self.pending_bare_tool_call_prefix = ""
+
+        if self.tool_call_start_token in current_text or self.is_bare_tool_call_mode:
+            # flush any buffered reasoning text before switching
+            # to tool call parsing, so content accumulated in buffer_string is
+            # not silently lost on branch transition
+            pending = self._flush_buffered_delta()
+
+            if self.tool_call_start_token in current_text:
+                function_call_text = current_text.split(self.tool_call_start_token)[-1]
+            else:
+                # bare array mode: reasoning parser already stripped the header
+                function_call_text = stripped_text
+            function_call_text = function_call_text[self.tool_call_offset :]
+
+            # find first { outside strings
+            opening_brace_index = None
+            for idx, c in enumerate(function_call_text):
+                if c == "{":
+                    opening_brace_index = idx
+                    break
+
+            if opening_brace_index is None:
+                return pending
+
+            # use depth+string-aware scanner instead of naive brace search
+            closing_brace_index = self._find_json_object_end(
+                function_call_text, opening_brace_index
+            )
+
+            if closing_brace_index is None:
+                return pending
+
+            try:
+                raw_function_call = json.loads(
+                    function_call_text[opening_brace_index : closing_brace_index + 1]
+                )
+                if not self._is_function_call_like(raw_function_call, request):
+                    if self.is_bare_tool_call_mode:
+                        self.is_bare_tool_call_mode = False
+                        self.is_reasoning_ended = (
+                            self.bare_tool_call_was_reasoning_ended
+                        )
+                        self.tool_call_offset = 0
+                        return (
+                            DeltaMessage(content=stripped_text)
+                            if self.is_reasoning_ended
+                            else self._delta(reasoning=stripped_text)
+                        )
+                    return pending
+
+                _function_call = self._normalize_function_call(raw_function_call)
+                self.current_tool_id += 1
+                # accumulate absolute offset, not relative closing index
+                self.tool_call_offset = self.tool_call_offset + closing_brace_index + 1
+                self.prev_tool_call_arr.append(_function_call)
+                arguments = self._arguments_json(_function_call)
+                self.streamed_args_for_tool.append(arguments)
+
+                return DeltaMessage(
+                    tool_calls=[
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            type="function",
+                            id=f"hcx_tool_call_{self.current_tool_id}",
+                            function=DeltaFunctionCall(
+                                name=_function_call.get("name", ""), arguments=arguments
+                            ).model_dump(exclude_none=True),
+                        )
+                    ]
+                )
+
+            except json.JSONDecodeError:
+                logger.debug(
+                    "Decode error: %s",
+                    function_call_text[opening_brace_index : closing_brace_index + 1],
+                )
+                return pending
+
+        else:
+            # removed `len(current_token_ids) == 2` heuristic
+            # reasoning termination based on explicit template markers
+            if "<|im_end|>\n<|im_start|>assistant" in current_text:
+                self.is_reasoning_ended = True
+
+            # set up buffer for special string processing
+            self.buffer_string += delta_text
+            buffered_content = ""
+
+            if not self.is_reasoning_ended and (
+                self._is_partial_tool_role_fragment(current_text)
+                or self._is_tool_role_prefix_or_fragment(self.buffer_string)
+            ):
+                return None
+
+            if (
+                not self.is_reasoning_ended
+                and not self.has_emitted_reasoning_text
+                and self.buffer_string.strip() == ""
+            ):
+                return None
+
+            if self.check_is_special_string():
+                buffered_content, delta_text = self.remove_special_string()
+                self.buffer_string = delta_text
+
+                if self.is_reasoning_ended:
+                    return self._emit_text_delta(buffered_content)
+                else:
+                    if self._is_tool_role_prefix_or_fragment(buffered_content):
+                        return None
+                    if buffered_content and buffered_content.strip():
+                        self.has_emitted_reasoning_text = True
+                    return self._emit_text_delta(buffered_content)
+
+            if self.check_is_part_of_special_string():
+                return None
+            else:
+                delta_text = self.buffer_string
+                self.buffer_string = ""
+
+            if self.is_reasoning_ended:
+                return self._emit_text_delta(delta_text)
+            if self._is_tool_role_prefix_or_fragment(delta_text):
+                return None
+            if delta_text and delta_text.strip():
+                self.has_emitted_reasoning_text = True
+            return self._emit_text_delta(delta_text)
+
+    def _find_first_special_string(self) -> tuple[int, str] | None:
+        first_match = None
+        for special_string in self.special_strings:
+            index = self.buffer_string.find(special_string)
+            if index < 0:
+                continue
+            if first_match is None or index < first_match[0]:
+                first_match = (index, special_string)
+        return first_match
+
+    def remove_special_string(self) -> tuple[str, str]:
+        first_match = self._find_first_special_string()
+        if first_match is None:
+            return self.buffer_string, ""
+        start, special_string = first_match
+        end = start + len(special_string)
+        return self.buffer_string[:start], self.buffer_string[end:]
+
+    def check_is_special_string(self) -> bool:
+        return self._find_first_special_string() is not None
+
+    def check_is_part_of_special_string(self) -> bool:
+        for special_string in self.special_strings:
+            min_len = min(len(self.buffer_string), len(special_string))
+            for length in range(min_len, 0, -1):
+                if self.buffer_string[-length:] == special_string[:length]:
+                    return True
+        return False

--- a/vllm/tool_parsers/hyperclovax_seed_think_14b_tool_parser.py
+++ b/vllm/tool_parsers/hyperclovax_seed_think_14b_tool_parser.py
@@ -127,6 +127,15 @@ class HyperCLOVAXSeedThink14BToolParser(ToolParser):
     def _arguments_json(self, function_call: dict) -> str:
         return json.dumps(function_call.get("arguments", {}), ensure_ascii=False)
 
+    def _decode_tool_call_array(self, text: str) -> list[dict]:
+        # Parse the tool-call array by JSON structure (raw_decode respects JSON
+        # string escaping) instead of cutting at a literal <|im_end|>, which can
+        # legitimately appear inside a JSON string argument.
+        raw_function_calls, _ = json.JSONDecoder().raw_decode(text.lstrip())
+        if not isinstance(raw_function_calls, list):
+            raise ValueError("Tool-call payload must be a JSON array.")
+        return raw_function_calls
+
     def _tool_names(self, request: ChatCompletionRequest) -> set[str]:
         tool_names: set[str] = set()
         for tool in getattr(request, "tools", None) or []:
@@ -211,12 +220,7 @@ class HyperCLOVAXSeedThink14BToolParser(ToolParser):
             stripped = model_output.lstrip("\n")
             if stripped.startswith("[") and getattr(request, "tools", None):
                 try:
-                    bare_json = stripped
-                    end_idx = bare_json.find(self.tool_call_end_token)
-                    if end_idx >= 0:
-                        bare_json = bare_json[:end_idx]
-                    bare_json = bare_json.rstrip()
-                    raw_function_calls = json.loads(bare_json)
+                    raw_function_calls = self._decode_tool_call_array(stripped)
                     if not all(
                         self._is_function_call_like(fc, request)
                         for fc in raw_function_calls
@@ -246,18 +250,13 @@ class HyperCLOVAXSeedThink14BToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
-        # guard against no regex match before using raw_function_calls
-        tool_call_match = self.tool_call_regex.search(model_output)
-        if not tool_call_match:
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=model_output
-            )
-
         try:
-            if tool_call_match.group(1) is not None:
-                raw_function_calls = json.loads(tool_call_match.group(1))
-            else:
-                raw_function_calls = json.loads(tool_call_match.group(2) + "]")
+            # Locate the array by JSON structure, not by cutting at the literal
+            # <|im_end|> token (which can appear inside a string argument).
+            _, _, function_call_text = model_output.partition(
+                self.tool_call_start_token
+            )
+            raw_function_calls = self._decode_tool_call_array(function_call_text)
 
             tool_calls = [
                 ToolCall(


### PR DESCRIPTION
## Summary
Adds built-in reasoning and tool parsers for `naver-hyperclovax/HyperCLOVAX-SEED-Think-14B`,
registered as `hyperclovax_seed_think_14b` for both `--reasoning-parser` and
`--tool-call-parser`:

```bash
vllm serve naver-hyperclovax/HyperCLOVAX-SEED-Think-14B \
  --reasoning-parser hyperclovax_seed_think_14b \
  --tool-call-parser hyperclovax_seed_think_14b \
  --enable-auto-tool-choice
```

The model emits tool calls as `<|im_start|>assistant -> tool/function_call\n[{...}]` and
reasoning after a `/think` prompt; this parser turns that into structured `reasoning_content`
and `tool_calls`. (It is a separate parser from the 32B variant, whose chat template and
tool-call format differ.)

## Attribution & test versions
The parser logic is adapted from the official HyperCLOVA X vLLM plugin
(https://github.com/NAVER-Cloud-HyperCLOVA-X/hcx-vllm-plugin) — the plugin linked from the
HuggingFace model card — and ported to vLLM's built-in conventions (single self-contained
module, lazy registration, modernized imports).

The reference plugin's last tool-parser commit is ~10 months old, so to preserve its import
compatibility it is tested on **`vllm/vllm-openai:v0.9.2`**, while this PR (modernized imports)
is tested on **`v0.21.0`**.

## The problem and the fix (`tool_choice="required"`)
The reference plugin's reasoning-end boundary detection (`is_reasoning_end` /
`extract_content_ids`) is not tuned for the structured-output path, so vLLM's grammar engages
at the wrong token for `tool_choice="required"`. This PR tightens that boundary so the grammar
applies from the correct token.

**Test matrix — 54 cases** (each axis varied independently):

| group | axes | count |
|--|--|--|
| tool | `tool_choice` {auto, required} × `stream` {true, false} × `force_reasoning` {none, true, false} × `skip_reasoning` {none, true, false} | 2×2×3×3 = **36** |
| reasoner | `force_reasoning` {none, true, false} × `skip_reasoning` {none, true, false} × `stream` {true, false} | 3×3×2 = **18** |
| **total** | | **54** |

Each matrix was run **with and without** the model card's recommended tool-use system prompt:

| parser (vLLM version) × system prompt | required (ok/18) | auto tool_calls (/18) | reasoner (/18) | errors |
|--|--|--|--|--|
| reference (v0.9.2) + official prompt | **0/18** | 18/18 | 18/18 | 3× HTTP 400 |
| **this PR** (v0.21.0) + official prompt | **18/18** | 18/18 | 18/18 | 0 |
| **this PR** (v0.21.0) + no prompt | **18/18** | 0/18 | 18/18 | 0 |
| reference (v0.9.2) + no prompt | **0/18** | 0/18 | 18/18 | 4× HTTP 400 |

Two independent axes:
- **`required` is decided by the parser (system-prompt-independent).** The reference plugin
  fails 18/18 regardless of prompt — `finish_reason=stop` instead of `tool_calls`, HTTP 400
  with `force_reasoning`, or no tool call when streaming. This PR passes **18/18 regardless**.
- **`auto` is decided by the system prompt (parser-independent).** With the recommended
  tool-use prompt both reach 18/18; without it both reach 0/18 (see model-format limitation
  below).
- **`reasoner` is correct in all four conditions.**

## Model-format limitation under `auto` (not a parser bug)
Without the model card's recommended tool-use system prompt, the model follows the prompt
format it was trained on less reliably, and `tool_choice="auto"` produces two off-spec cases.
Ideal output (per the chat template):

```text
<|im_start|>assistant -> tool/function_call
[{"name": "get_current_weather", "arguments": {"location": "Seoul", "unit": "celsius"}}]<|im_end|>
```

Observed off-spec cases (`auto`, empty system prompt, input `"서울 날씨 알려줘."` + a
`get_current_weather` tool; `temperature=0, seed=42`):

```text
# Case 1 — real function name instead of "function_call", bare object instead of array.
#          (The tool intent is present, just off-format.)
-> tool/get_current_weather
{"location": "Seoul", "unit": "celsius"}

# Case 2 — plain text, no tool call at all. (The model chose not to call a tool.)
현재 서울의 날씨 정보를 가져올 수 없습니다. 하지만, 아래 링크를 통해 ...
```

- Under **`tool_choice="required"`** the boundary fix lets vLLM's grammar force the canonical
  `[{...}]` form, so **both cases come out as valid tool calls** (the 18/18 above).
- Under **`auto`** there is no grammar, so neither is recovered: Case 1 is off-format and
  Case 2 has no tool intent to recover from. The parser returns the text as `content` rather
  than fabricating a call.

This is a **model-format limitation** (the model adheres to a specific system-prompt format),
not a parser defect: supplying the recommended tool-use system prompt makes `auto` produce
valid calls too (18/18 in the matrix). What the parser *does* add on top of the required-path
fix is robust handling of canonical-format variants (bare-array hand-off, `arguments`↔
`parameters`, dash-prefixed arrays, multiple calls).

## Update — non-streaming `<|im_end|>` boundary fix (review feedback)

Addressing @Incheonkirin's review
(https://github.com/vllm-project/vllm/pull/44171#issuecomment-4672111272): in the
non-streaming path a literal `<|im_end|>` inside a JSON **string argument** was taken as
the tool-call boundary (text search via `find("<|im_end|>")` / the regex), truncating the
JSON so `json.loads` failed and the call was silently dropped (`tools_called=False`).

- The tool-call array is now located by JSON structure with `json.JSONDecoder().raw_decode`
  (respects JSON string escaping) instead of cutting at the literal token.
- Applied to **both** the tool parser (`extract_tool_calls`) and the reasoning parser
  (`_strip_tool_end_tokens` / `extract_reasoning`): in the non-streaming auto+reasoning path
  the reasoning parser strips the boundary before the tool parser receives the payload, so
  both need the structure-aware approach.
- `raw_decode` accepts trailing data after `]` (the terminator token) where the previous
  slicing rejected it; kept as-is since the trailing content is harmless here.

This is the originating PR for these parsers; the change above addresses review feedback on
this same PR (not a separate/duplicate change).

## Tests run
**Unit (mock tokenizer, no GPU) — 29/29 passed** (26 existing + 3 new regression cases for a literal `<|im_end|>` inside an argument)
```bash
python -m pytest tests/reasoning/test_hyperclovax_seed_think_14b_reasoning_parser.py \
                 tests/tool_parsers/test_hyperclovax_seed_think_14b_tool_parser.py -v
```
Covers the 9-combination `force_reasoning × skip_reasoning` matrix, reasoning↔content boundary
split, streaming, `is_reasoning_end` boundary detection, and the tool-call forms above, in both
non-streaming and streaming paths.

**End-to-end:** the 54-case matrix above (14B served with the built-in parser).
**Lint:** `ruff check` and `ruff format --check` pass.

## AI assistance
This PR was prepared with AI assistance (Claude Code). The human submitter reviewed every
changed line and ran the tests above.

## Naming note
Uses the `_14b` suffix to distinguish it from the 32B variant, whose chat template and
tool-call format differ. Happy to rename per maintainer preference.

