### PR TITLE
[Frontend] Make tokenizer batch wait timeout configurable

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -232,6 +232,14 @@ def test_hf_token_cli_arg(cli_args, expected):
     assert args.hf_token == expected
 
 
+def test_tokenizer_batch_wait_timeout_cli_arg():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    args = parser.parse_args(["--tokenizer-batch-wait-timeout-s", "0"])
+
+    assert args.tokenizer_batch_wait_timeout_s == 0
+
+
 @pytest.mark.parametrize(
     ("arg", "expected"),
     [

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -538,6 +538,7 @@ class MockModelConfig:
     is_encoder_decoder: bool = False
     is_multimodal_model: bool = False
     renderer_num_workers: int = 1
+    tokenizer_batch_wait_timeout_s: float = 0.002
     enable_prompt_embeds: bool = False
 
     def get_diff_sampling_param(self):

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -55,6 +55,7 @@ class MockModelConfig:
     is_encoder_decoder: bool = False
     is_multimodal_model: bool = False
     renderer_num_workers: int = 1
+    tokenizer_batch_wait_timeout_s: float = 0.002
 
     def get_diff_sampling_param(self):
         return self.diff_sampling_param or {}

--- a/tests/entrypoints/openai/completion/test_lora_resolvers.py
+++ b/tests/entrypoints/openai/completion/test_lora_resolvers.py
@@ -55,6 +55,7 @@ class MockModelConfig:
     is_encoder_decoder: bool = False
     is_multimodal_model: bool = False
     renderer_num_workers: int = 1
+    tokenizer_batch_wait_timeout_s: float = 0.002
 
     def get_diff_sampling_param(self):
         return self.diff_sampling_param or {}

--- a/tests/renderers/test_completions.py
+++ b/tests/renderers/test_completions.py
@@ -39,6 +39,7 @@ class MockModelConfig:
     is_encoder_decoder: bool = False
     is_multimodal_model: bool = False
     renderer_num_workers: int = 1
+    tokenizer_batch_wait_timeout_s: float = 0.002
     hidden_size: int = 768
     dtype: torch.dtype = torch.float32
 
@@ -132,6 +133,12 @@ class TestValidatePrompt:
 
 
 class TestRenderPrompt:
+    @pytest.mark.asyncio
+    async def test_async_tokenizer_uses_configured_batch_wait_timeout(self):
+        renderer = _build_renderer(MockModelConfig(tokenizer_batch_wait_timeout_s=0))
+
+        assert renderer.get_async_tokenizer().batch_wait_timeout_s == 0
+
     def test_tokens_input(self):
         renderer = _build_renderer(MockModelConfig())
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -339,6 +339,11 @@ class ModelConfig:
     The offline `LLM` entrypoint uses the synchronous renderer path and
     processes prompts (including multimodal preprocessing) serially, so
     this setting has no effect there."""
+    tokenizer_batch_wait_timeout_s: float = Field(default=0.002, ge=0)
+    """Maximum time in seconds for the async renderer tokenizer to wait for
+    additional encode/decode requests before running a micro-batch. Set to 0
+    to disable the waiting delay for latency-sensitive, low-concurrency
+    serving."""
 
     # Pooler config
     pooler_config: PoolerConfig | None = None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -574,6 +574,7 @@ class EngineArgs:
     )
     io_processor_plugin: str | None = None
     renderer_num_workers: int = 1
+    tokenizer_batch_wait_timeout_s: float = ModelConfig.tokenizer_batch_wait_timeout_s
     skip_mm_profiling: bool = MultiModalConfig.skip_mm_profiling
     video_pruning_rate: float | None = MultiModalConfig.video_pruning_rate
     mm_tensor_ipc: MMTensorIPC = MultiModalConfig.mm_tensor_ipc
@@ -865,6 +866,10 @@ class EngineArgs:
         model_group.add_argument(
             "--renderer-num-workers",
             **model_kwargs["renderer_num_workers"],
+        )
+        model_group.add_argument(
+            "--tokenizer-batch-wait-timeout-s",
+            **model_kwargs["tokenizer_batch_wait_timeout_s"],
         )
 
         # Model loading arguments
@@ -1624,6 +1629,7 @@ class EngineArgs:
             mm_tensor_ipc=self.mm_tensor_ipc,
             io_processor_plugin=self.io_processor_plugin,
             renderer_num_workers=self.renderer_num_workers,
+            tokenizer_batch_wait_timeout_s=self.tokenizer_batch_wait_timeout_s,
         )
 
     def validate_tensorizer_args(self):

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -149,7 +149,9 @@ class BaseRenderer(ABC, Generic[_T]):
     def get_async_tokenizer(self) -> AsyncMicrobatchTokenizer:
         if self._async_tokenizer is None:
             self._async_tokenizer = AsyncMicrobatchTokenizer(
-                self.get_tokenizer(), executor=self._executor
+                self.get_tokenizer(),
+                batch_wait_timeout_s=self.model_config.tokenizer_batch_wait_timeout_s,
+                executor=self._executor,
             )
 
         return self._async_tokenizer


### PR DESCRIPTION
## Purpose

`AsyncMicrobatchTokenizer` currently uses a fixed `batch_wait_timeout_s=0.002`.
This is useful for microbatching, but it also adds about 2ms of frontend latency
for low-concurrency, small-model, single-token-output workloads.

This PR makes the tokenizer batch wait timeout configurable through
`--tokenizer-batch-wait-timeout-s`, while preserving the existing default value
of `0.002`.

Users who prioritize low latency over tokenizer microbatching can now set:

```bash
--tokenizer-batch-wait-timeout-s 0
```

Related frontend/tokenization context:
- #19334 introduced async tokenizer microbatching.
- #39763 discussed frontend preprocessing overhead and the tokenizer wait impact.
- #27407 is related frontend latency investigation context.

Duplicate check:
- Searched open PRs for `batch_wait_timeout_s`.
- Searched open PRs for `AsyncMicrobatchTokenizer`.
- Searched open PRs for `tokenizer batch wait timeout`.
- Found no open PR that adds the same configurable tokenizer batch wait timeout.

AI assistance was used to help inspect the code path, implement the change, and
prepare test/benchmark commands. I reviewed the changed lines and validated the
behavior.

## Test Plan

Unit tests:

```bash
.venv/bin/python -m pytest \
  tests/engine/test_arg_utils.py::test_tokenizer_batch_wait_timeout_cli_arg \
  tests/renderers/test_completions.py::TestRenderPrompt::test_async_tokenizer_uses_configured_batch_wait_timeout \
  -v
```

OpenAI endpoint regression tests:

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/completion/test_completion_error.py \
  tests/entrypoints/openai/chat_completion/test_chat_error.py \
  tests/entrypoints/serve/tokenize/test_serving_tokenization.py \
  -v
```

Lint:

```bash
.venv/bin/pre-commit run ruff-check --files \
  vllm/config/model.py \
  vllm/engine/arg_utils.py \
  vllm/renderers/base.py \
  tests/engine/test_arg_utils.py \
  tests/renderers/test_completions.py \
  tests/entrypoints/openai/completion/test_completion_error.py \
  tests/entrypoints/openai/completion/test_lora_resolvers.py \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py
```

Online smoke test:

```bash
CUDA_VISIBLE_DEVICES=1 .venv/bin/python -m vllm.entrypoints.cli.main serve \
  Qwen/Qwen3-0.6B \
  --served-model-name test-model \
  --max-model-len 1024 \
  --host 127.0.0.1 \
  --port 43395 \
  --tokenizer-batch-wait-timeout-s 0 \
  --gpu-memory-utilization 0.80
```

Then verified both endpoints:
- `/v1/completions`
- `/v1/chat/completions`

## Test Result

Unit tests:

```text
2 passed
```

OpenAI endpoint regression tests:

```text
23 passed
```

Lint:

```text
ruff-check: Passed
```

Online smoke test:

```text
Server started successfully with tokenizer_batch_wait_timeout_s: 0.0
/v1/completions returned HTTP 200
/v1/chat/completions returned HTTP 200
```

Benchmark setup:
- Model: `Qwen/Qwen3-0.6B`
- Input length: 16 tokens
- Output length: 1 token
- Requests: 200
- Warmups: 20
- Request rate: `inf`
- Compared default `0.002s` vs configured `0s`

E2E TTFT results:

| Endpoint | Max concurrency | 0.002s mean TTFT | 0s mean TTFT | Delta |
|---|---:|---:|---:|---:|
| `/v1/completions` | 1 | 8.66 ms | 6.45 ms | -2.20 ms |
| `/v1/chat/completions` | 1 | 8.84 ms | 6.51 ms | -2.33 ms |
| `/v1/completions` | 2 | 11.87 ms | 10.13 ms | -1.73 ms |
| `/v1/chat/completions` | 2 | 13.18 ms | 11.29 ms | -1.88 ms |
| `/v1/completions` | 4 | 14.03 ms | 10.45 ms | -3.58 ms |
| `/v1/chat/completions` | 4 | 15.73 ms | 11.37 ms | -4.36 ms |

Render-only latency results:

| Endpoint | Concurrency | 0.002s mean | 0s mean | Delta |
|---|---:|---:|---:|---:|
| `/v1/completions/render` | 1 | 3.01 ms | 0.90 ms | -2.12 ms |
| `/v1/chat/completions/render` | 1 | 3.25 ms | 1.00 ms | -2.25 ms |
| `/v1/completions/render` | 2 | 3.50 ms | 1.35 ms | -2.16 ms |
| `/v1/chat/completions/render` | 2 | 4.06 ms | 1.66 ms | -2.40 ms |
| `/v1/completions/render` | 4 | 4.20 ms | 2.58 ms | -1.63 ms |
| `/v1/chat/completions/render` | 4 | 5.31 ms | 3.62 ms | -1.70 ms |