### PR TITLE
fix offline disaggregated prefill request ids for P2P NCCL

### DIFF
--- a/examples/disaggregated/disaggregated_prefill.py
+++ b/examples/disaggregated/disaggregated_prefill.py
@@ -9,14 +9,75 @@ and then transfer the KV cache between them.
 import os
 import time
 from multiprocessing import Event, Process
+from uuid import uuid4
 
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
+from vllm.sampling_params import RequestOutputKind
+from vllm.utils.network_utils import get_ip
+
+MODEL = os.environ.get(
+    "VLLM_DISAGG_PREFILL_MODEL", "meta-llama/Meta-Llama-3.1-8B-Instruct"
+)
+PREFILL_KV_PORT = 14579
+DECODE_KV_PORT = 14580
 
 
-def run_prefill(prefill_done):
+def _build_request_ids(num_requests: int, host: str) -> list[str]:
+    prefill_addr = f"{host}:{PREFILL_KV_PORT}"
+    decode_addr = f"{host}:{DECODE_KV_PORT}"
+    return [
+        (
+            f"___prefill_addr_{prefill_addr}"
+            f"___decode_addr_{decode_addr}_{uuid4().hex}"
+        )
+        for _ in range(num_requests)
+    ]
+
+
+def _generate_with_request_ids(
+    llm: LLM,
+    prompts: list[str],
+    sampling_params: SamplingParams,
+    request_ids: list[str],
+):
+    if len(prompts) != len(request_ids):
+        raise ValueError("prompts and request_ids must have the same length")
+
+    params = sampling_params.clone()
+    params.output_kind = RequestOutputKind.FINAL_ONLY
+
+    request_order = {
+        request_id: index for index, request_id in enumerate(request_ids)
+    }
+    internal_request_ids: list[str] = []
+
+    try:
+        for request_id, prompt in zip(request_ids, prompts):
+            prompt_input = llm._preprocess_cmpl_one(prompt)
+            internal_request_ids.append(
+                llm.llm_engine.add_request(request_id, prompt_input, params)
+            )
+
+        outputs = []
+        while llm.llm_engine.has_unfinished_requests():
+            outputs.extend(
+                output
+                for output in llm.llm_engine.step()
+                if output.finished
+            )
+
+        return sorted(outputs, key=lambda output: request_order[output.request_id])
+    except Exception:
+        if internal_request_ids:
+            llm.llm_engine.abort_request(internal_request_ids, internal=True)
+        raise
+
+
+def run_prefill(prefill_done, request_ids):
     # We use GPU 0 for prefill node.
     os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+    os.environ["VLLM_DISABLE_REQUEST_ID_RANDOMIZATION"] = "1"
 
     # The prefill node receives two requests, while the decode node receives
     # three requests. So the decode node will only receive the KV Cache for
@@ -39,18 +100,19 @@ def run_prefill(prefill_done):
         kv_role="kv_producer",
         kv_rank=0,
         kv_parallel_size=2,
+        kv_port=PREFILL_KV_PORT,
     )
 
     # Set GPU memory utilization to 0.8 for an A6000 GPU with 40GB
     # memory. You may need to adjust the value to fit your GPU.
     llm = LLM(
-        model="meta-llama/Meta-Llama-3.1-8B-Instruct",
+        model=MODEL,
         kv_transfer_config=ktc,
         max_model_len=2000,
         gpu_memory_utilization=0.8,
     )
 
-    llm.generate(prompts, sampling_params)
+    _generate_with_request_ids(llm, prompts, sampling_params, request_ids)
     print("Prefill node is finished.")
     prefill_done.set()
 
@@ -63,9 +125,10 @@ def run_prefill(prefill_done):
         print("Script stopped by user.")
 
 
-def run_decode(prefill_done):
+def run_decode(prefill_done, request_ids):
     # We use GPU 1 for decode node.
     os.environ["CUDA_VISIBLE_DEVICES"] = "1"
+    os.environ["VLLM_DISABLE_REQUEST_ID_RANDOMIZATION"] = "1"
 
     prompts = [
         "Hello, my name is",
@@ -83,12 +146,13 @@ def run_decode(prefill_done):
         kv_role="kv_consumer",
         kv_rank=1,
         kv_parallel_size=2,
+        kv_port=DECODE_KV_PORT,
     )
 
     # Set GPU memory utilization to 0.8 for an A6000 GPU with 40GB
     # memory. You may need to adjust the value to fit your GPU.
     llm = LLM(
-        model="meta-llama/Meta-Llama-3.1-8B-Instruct",
+        model=MODEL,
         kv_transfer_config=ktc,
         max_model_len=2000,
         gpu_memory_utilization=0.8,
@@ -100,7 +164,7 @@ def run_decode(prefill_done):
 
     # At this point when the prefill_done is set, the kv-cache should have been
     # transferred to this decode node, so we can start decoding.
-    outputs = llm.generate(prompts, sampling_params)
+    outputs = _generate_with_request_ids(llm, prompts, sampling_params, request_ids)
     for output in outputs:
         prompt = output.prompt
         generated_text = output.outputs[0].text
@@ -108,9 +172,10 @@ def run_decode(prefill_done):
 
 
 def main():
+    request_ids = _build_request_ids(num_requests=3, host=get_ip())
     prefill_done = Event()
-    prefill_process = Process(target=run_prefill, args=(prefill_done,))
-    decode_process = Process(target=run_decode, args=(prefill_done,))
+    prefill_process = Process(target=run_prefill, args=(prefill_done, request_ids))
+    decode_process = Process(target=run_decode, args=(prefill_done, request_ids))
 
     # Start prefill node
     prefill_process.start()

--- a/tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
+++ b/tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import unittest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector import (
+    P2pNcclConnector,
+)
+
+
+class TestP2pNcclConnectorRequestIdParsing(unittest.TestCase):
+    def test_extracts_prefill_and_decode_addresses(self):
+        request_id = (
+            "___prefill_addr_10.0.0.1:14579"
+            "___decode_addr_10.0.0.2:14580_deadbeefdeadbeefdeadbeefdeadbeef"
+        )
+
+        self.assertEqual(
+            P2pNcclConnector.parse_request_id(request_id, True),
+            ("10.0.0.2", 14580),
+        )
+        self.assertEqual(
+            P2pNcclConnector.parse_request_id(request_id, False),
+            ("10.0.0.1", 14579),
+        )
+
+    def test_rejects_plain_offline_request_id(self):
+        with self.assertRaisesRegex(ValueError, "does not contain hostname and port"):
+            P2pNcclConnector.parse_request_id("0-9000a856", True)


### PR DESCRIPTION
## Summary
Fixes #44062.

- split the prefill and decode KV ports in `examples/disaggregated/disaggregated_prefill.py`
- generate endpoint-encoded request IDs for the offline example so it matches the current `P2pNcclConnector` contract
- add a focused unit test for `P2pNcclConnector.parse_request_id`

## Why this is not duplicating existing work
- I checked issue #44062 comments and searched related PRs/issues around `44062`, `disaggregated_prefill`, and `P2pNcclConnector`.
- This PR overlaps with prior discussion around request ID handling in `P2pNcclConnector`, including work referenced in #33947, #42931, #42839, and possibly #34277, but it does not try to generalize that broader effort.
- Instead, it keeps the scope narrow by fixing the offline `disaggregated_prefill.py` example path in #44062 so the example follows the current `P2pNcclConnector` contract.

## Reproduction
Before this change, running the offline example could fail due to:
- same-run KV port collision
- `ValueError: Request id ... does not contain hostname and port`

After this change, the example no longer fails at those original points and progresses to NCCL communicator setup.

## Tests run
```bash
python -m unittest \
  tests/v1/kv_connector/unit/test_p2p_nccl_connector.py
```

I also reran the offline example locally with:

```bash
VLLM_DISAGG_PREFILL_MODEL=model/Qwen3-8B \
python \
  examples/disaggregated/disaggregated_prefill.py
```

## Local environment limitation
On my local 4x RTX 4090 machine, no GPU pair supports CUDA peer access
(`torch.cuda.can_device_access_peer(i, j) == False` for all pairs), so the
example now fails later during NCCL send/recv instead of at the original
request-id parsing site. This appears to be a separate hardware/runtime
limitation rather than the original bug in #44062.

## Out of scope
- no broader `P2pNcclConnector` protocol redesign
- no migration to `kv_transfer_params`
- no general refactor of disaggregated serving flows

## AI assistance
This PR was prepared with AI assistance. I manually reviewed the final diff and ran the commands listed above.