### PR TITLE
[Bugfix][Benchmark] Fix dataset stats plot filename

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -253,7 +253,7 @@ vllm serve Qwen/Qwen2-VL-7B-Instruct
 
 ```bash
 # run benchmarking script
-vllm bench serve--save-result --save-detailed \
+vllm bench serve --save-result --save-detailed \
   --backend openai-chat \
   --model Qwen/Qwen2-VL-7B-Instruct \
   --endpoint /v1/chat/completions \

--- a/tests/benchmarks/test_serve_result_filename.py
+++ b/tests/benchmarks/test_serve_result_filename.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from argparse import Namespace
+
+
+def test_compute_result_filename_for_dataset_stats_plot(tmp_path):
+    from vllm.benchmarks.serve import compute_result_filename
+
+    args = Namespace(
+        append_result=False,
+        backend="openai",
+        max_concurrency=None,
+        plot_dataset_stats=True,
+        plot_timeline=False,
+        ramp_up_strategy=None,
+        request_rate=float("inf"),
+        result_dir=str(tmp_path),
+        result_filename=None,
+        save_result=False,
+    )
+
+    file_name = compute_result_filename(
+        args=args,
+        model_id="meta-llama/Llama-3.2-1B-Instruct",
+        label=None,
+        current_dt="20260101-010203",
+    )
+
+    assert file_name == str(
+        tmp_path / "openai-infqps-Llama-3.2-1B-Instruct-20260101-010203.json"
+    )

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1232,7 +1232,12 @@ def compute_result_filename(
     Returns:
         The computed filename path or None if no result saving is requested
     """
-    if not (args.plot_timeline or args.save_result or args.append_result):
+    if not (
+        args.plot_timeline
+        or getattr(args, "plot_dataset_stats", False)
+        or args.save_result
+        or args.append_result
+    ):
         return None
 
     base_model_id = model_id.split("/")[-1]


### PR DESCRIPTION
Fix `--plot-dataset-stats` in `vllm bench serve` when it is used without
`--save-result`, `--append-result`, or `--plot-timeline`.

`compute_result_filename()` did not include `plot_dataset_stats`, so this path
could not derive an output filename for the generated plot.

This PR adds that missing condition, adds a regression test, and fixes a nearby
benchmark docs command typo.

I did not find an open PR for this specific filename path.

Tested with:
- `python -m pytest tests/benchmarks/test_serve_result_filename.py::test_compute_result_filename_for_dataset_stats_plot -q --noconftest`
- `python -m ruff check vllm/benchmarks/serve.py tests/benchmarks/test_serve_result_filename.py`
- `python -m ruff format --check vllm/benchmarks/serve.py tests/benchmarks/test_serve_result_filename.py`
- `python -m py_compile vllm/benchmarks/serve.py tests/benchmarks/test_serve_result_filename.py`
- `git diff --check`

AI assistance was used only for follow-up validation after the changes were made. I manually reviewed all changes and take full responsibility for this PR.