### PR TITLE
[codex] Unit test SageMaker LoRA load not found

### DIFF
--- a/tests/entrypoints/sagemaker/test_sagemaker_lora_adapters.py
+++ b/tests/entrypoints/sagemaker/test_sagemaker_lora_adapters.py
@@ -1,11 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from http import HTTPStatus
+
 import openai  # use the official async_client for correctness check
 import pytest
 import requests
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from ...utils import RemoteOpenAIServer
 from .conftest import MODEL_NAME_SMOLLM
+
+
+class _FakeLoRAModelHandler:
+    def __init__(self):
+        self.load_requests = []
+
+    async def load_lora_adapter(self, request):
+        from vllm.entrypoints.utils import create_error_response
+
+        self.load_requests.append(request)
+        return create_error_response(
+            "LoRA adapter nonexistent-adapter does not exist",
+            "NotFoundError",
+            HTTPStatus.NOT_FOUND,
+        )
+
+    async def unload_lora_adapter(self, request):
+        raise AssertionError("unexpected unload request")
+
+
+def _build_sagemaker_lora_test_client(
+    monkeypatch, model_handler: _FakeLoRAModelHandler
+) -> TestClient:
+    from model_hosting_container_standards.common.handler import handler_registry
+    from model_hosting_container_standards.sagemaker.sagemaker_loader import (
+        SageMakerFunctionLoader,
+    )
+
+    from vllm.entrypoints.sagemaker.api_router import sagemaker_standards_bootstrap
+    from vllm.entrypoints.serve.lora.api_router import attach_router
+
+    handler_registry.clear()
+    SageMakerFunctionLoader._default_function_loader = None
+    monkeypatch.setenv("VLLM_ALLOW_RUNTIME_LORA_UPDATING", "True")
+
+    app = FastAPI()
+    app.state.openai_serving_models = model_handler
+    attach_router(app)
+    return TestClient(sagemaker_standards_bootstrap(app))
 
 
 @pytest.mark.asyncio
@@ -64,15 +107,23 @@ async def test_sagemaker_unload_adapter_happy_path(
     assert adapter_name not in adapter_ids
 
 
-@pytest.mark.asyncio
-async def test_sagemaker_load_adapter_not_found(
-    basic_server_with_lora: RemoteOpenAIServer,
-):
-    load_response = requests.post(
-        basic_server_with_lora.url_for("adapters"),
-        json={"name": "nonexistent-adapter", "src": "/path/does/not/exist"},
-    )
+@pytest.mark.skip_global_cleanup
+def test_sagemaker_load_adapter_not_found(monkeypatch):
+    model_handler = _FakeLoRAModelHandler()
+
+    with _build_sagemaker_lora_test_client(monkeypatch, model_handler) as client:
+        load_response = client.post(
+            "/adapters",
+            json={"name": "nonexistent-adapter", "src": "/path/does/not/exist"},
+        )
+
     assert load_response.status_code == 404
+    assert len(model_handler.load_requests) == 1
+    load_request = model_handler.load_requests[0]
+    assert load_request.lora_name == "nonexistent-adapter"
+    assert load_request.lora_path == "/path/does/not/exist"
+    assert load_request.load_inplace is False
+    assert load_request.is_3d_lora_weight is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Replace the SageMaker load-adapter not-found e2e server test with an in-process FastAPI TestClient test.
- Use the real vLLM LoRA router and SageMaker bootstrap with a fake `OpenAIServingModels` handler.
- Assert /adapters maps body.name/body.src to the expected load request fields and preserves the 404 response.

## Validation
- `/Users/khluu/vllm/.venv/bin/python -m pytest tests/entrypoints/sagemaker/test_sagemaker_lora_adapters.py::test_sagemaker_load_adapter_not_found -q`
- `/Users/khluu/vllm/.venv/bin/python -m ruff check tests/entrypoints/sagemaker/test_sagemaker_lora_adapters.py`