### PR TITLE
[codex] Unit test chat logit bias validation

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py
@@ -1,78 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import openai
 import pytest
-import pytest_asyncio
 
-from tests.utils import RemoteOpenAIServer
-from vllm.config import ModelConfig
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams
 
-MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+pytestmark = pytest.mark.skip_global_cleanup
 
 
-def get_vocab_size(model_name):
-    config = ModelConfig(
-        model=model_name,
-        seed=0,
-        dtype="bfloat16",
+class _FakeModelConfig:
+    max_logprobs = 5
+    logits_processors = None
+
+    def __init__(self, vocab_size: int):
+        self._vocab_size = vocab_size
+
+    def get_vocab_size(self) -> int:
+        return self._vocab_size
+
+
+def _verify_logit_bias(logit_bias: dict[str, float], vocab_size: int) -> None:
+    params = SamplingParams.from_optional(max_tokens=5, logit_bias=logit_bias)
+    params.verify(
+        model_config=_FakeModelConfig(vocab_size),
+        speculative_config=None,
+        structured_outputs_config=None,
+        tokenizer=None,
     )
-    return config.get_vocab_size()
 
 
-@pytest.fixture(scope="module")
-def server():
-    args = [
-        "--dtype",
-        "bfloat16",
-        "--max-model-len",
-        "1024",
-        "--enforce-eager",
-    ]
-
-    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
-        yield remote_server
-
-
-@pytest_asyncio.fixture
-async def client(server):
-    async with server.get_async_client() as async_client:
-        yield async_client
-
-
-@pytest.mark.asyncio
-async def test_chat_logit_bias_valid(client):
-    """Test that valid logit_bias values are accepted in chat completions."""
-    vocab_size = get_vocab_size(MODEL_NAME)
+def test_chat_logit_bias_valid():
+    """Test that valid logit_bias token IDs are accepted."""
+    vocab_size = 10
     valid_token_id = vocab_size - 1
 
-    completion = await client.chat.completions.create(
-        model=MODEL_NAME,
-        messages=[{"role": "user", "content": "Testing valid logit bias"}],
-        max_tokens=5,
-        logit_bias={str(valid_token_id): 1.0},
-    )
-
-    assert completion.choices[0].message.content is not None
+    _verify_logit_bias({str(valid_token_id): 1.0}, vocab_size)
 
 
-@pytest.mark.asyncio
-async def test_chat_logit_bias_invalid(client):
-    """Test that invalid logit_bias values are rejected in chat completions."""
-    vocab_size = get_vocab_size(MODEL_NAME)
+def test_chat_logit_bias_invalid():
+    """Test that invalid logit_bias token IDs are rejected."""
+    vocab_size = 10
     invalid_token_id = vocab_size + 1
 
-    with pytest.raises(openai.BadRequestError) as excinfo:
-        await client.chat.completions.create(
-            model=MODEL_NAME,
-            messages=[{"role": "user", "content": "Testing invalid logit bias"}],
-            max_tokens=5,
-            logit_bias={str(invalid_token_id): 1.0},
-        )
+    with pytest.raises(VLLMValidationError) as excinfo:
+        _verify_logit_bias({str(invalid_token_id): 1.0}, vocab_size)
 
     error = excinfo.value
-    error_message = str(error)
-
-    assert error.status_code == 400
-    assert str(invalid_token_id) in error_message
-    assert str(vocab_size) in error_message
+    assert error.parameter == "logit_bias"
+    assert error.value == [invalid_token_id]
+    assert str(invalid_token_id) in str(error)
+    assert str(vocab_size) in str(error)


### PR DESCRIPTION
## Summary
- Replace the chat logit-bias server test with a direct unit test of `SamplingParams` validation.
- Avoid downloading model config and starting a vLLM OpenAI server for the valid/invalid token-id cases.
- Keep coverage for OpenAI-style string token IDs by constructing params through `SamplingParams.from_optional`.

## Validation
- `/Users/khluu/vllm/.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -q`
- `/Users/khluu/vllm/.venv/bin/python -m ruff check tests/entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py`