### PR TITLE
[Bugfix][GGUF] Accept file-type-only quant types (IQ2_M, IQ3_XS, ...) in remote GGUF model IDs

### DIFF
--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -81,6 +81,23 @@ class TestIsRemoteGGUF:
         assert not is_remote_gguf("repo/model:INVALID_M")
         assert not is_remote_gguf("repo/model:Q9_K_M")
 
+    def test_is_remote_gguf_file_type_only_quants(self):
+        """Test is_remote_gguf with file-type-only quant types.
+
+        Regression test for #42734.
+        """
+        # IQ2_M/IQ3_M/IQ3_XS/MXFP4_MOE are valid LlamaFileType file types
+        # with no GGMLQuantizationType member (and no valid base after
+        # suffix stripping, e.g. IQ2_M -> IQ2 which does not exist)
+        assert is_remote_gguf("unsloth/Qwen3.6-35B-A3B-GGUF:IQ2_M")
+        assert is_remote_gguf("repo/model:IQ3_M")
+        assert is_remote_gguf("repo/model:IQ3_XS")
+        assert is_remote_gguf("repo/model:MXFP4_MOE")
+
+        # Genuinely unknown types are still rejected
+        assert not is_remote_gguf("repo/model:IQ9_M")
+        assert not is_remote_gguf("repo/model:NOTATYPE")
+
     def test_is_remote_gguf_nonstandard_quant_type(self):
         """Test is_remote_gguf with non-standard quant types containing
         a known GGML type."""
@@ -99,6 +116,12 @@ class TestIsRemoteGGUF:
 
         # No dash separator → not recognized as prefixed
         assert not is_remote_gguf("repo/model:UDIQ4NL")
+
+        # Vendor-prefixed file-type-only quants (#42734): the trailing
+        # token (IQ2_M/IQ3_M/IQ3_XS) is a LlamaFileType file type
+        assert is_remote_gguf("unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ2_M")
+        assert is_remote_gguf("user/Model-GGUF:UD-IQ3_M")
+        assert is_remote_gguf("user/Model-GGUF:UD-IQ3_XS")
 
     def test_is_remote_gguf_without_colon(self):
         """Test is_remote_gguf without colon."""

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import gguf
 import regex as re
-from gguf.constants import Keys, VisionProjectorType
+from gguf.constants import Keys, LlamaFileType, VisionProjectorType
 from gguf.quants import GGMLQuantizationType
 from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 
@@ -90,10 +90,17 @@ _GGUF_QUANT_SUFFIXES = ("_M", "_S", "_L", "_XL", "_XS", "_XXS")
 def is_valid_gguf_quant_type(gguf_quant_type: str) -> bool:
     """Check if the quant type is a valid GGUF quant type.
 
-    Supports both exact GGML quant types (e.g., Q4_K, IQ1_S) and
-    extended naming conventions (e.g., Q4_K_M, Q3_K_S, Q5_K_L).
+    The ``quant_type`` in a ``repo_id:quant_type`` reference selects a
+    ``.gguf`` *file*, so it is a ``LlamaFileType`` (file type), not a
+    ``GGMLQuantizationType`` (tensor type). Some file types (e.g.
+    ``IQ2_M``, ``IQ3_XS``, ``MXFP4_MOE``) have no tensor-type member, so
+    both enums are accepted. Extended size suffixes are also supported
+    (e.g. ``Q4_K_M`` -> ``Q4_K``).
     """
-    # Check for exact match first
+    # Accept either a GGUF file type (LlamaFileType, prefixed with
+    # "MOSTLY_") or a tensor quantization type (GGMLQuantizationType).
+    if getattr(LlamaFileType, f"MOSTLY_{gguf_quant_type}", None) is not None:
+        return True
     if getattr(GGMLQuantizationType, gguf_quant_type, None) is not None:
         return True
 


### PR DESCRIPTION
## Purpose

Fixes #42734.

`vllm serve <repo>:UD-IQ2_M` (and any `repo_id:quant_type` reference whose quant is `IQ2_M`, `IQ3_M`, `IQ3_XS`, or `MXFP4_MOE`) fails with `Repo id must use alphanumeric chars...`: the whole string is treated as a plain repo id instead of a remote GGUF reference.

**Root cause.** `is_valid_gguf_quant_type()` only checks `GGMLQuantizationType` (the *tensor* quantization enum), but the `quant_type` in a `repo_id:quant_type` reference is a GGUF *file* type (`LlamaFileType`) used to select the `.gguf` file. These are two distinct gguf enums, and `IQ2_M`/`IQ3_M`/`IQ3_XS`/`MXFP4_MOE` exist only in `LlamaFileType` — they have no `GGMLQuantizationType` member, and no valid base after suffix stripping (`IQ2_M` → `IQ2`, which doesn't exist). So `is_remote_gguf()` returns `False` and the reference is rejected. `UD-IQ1_S`/`UD-IQ1_M` work only because `IQ1_S`/`IQ1_M` happen to exist in *both* enums, which is why the check added in #39471 didn't surface this.

This matches the upstream conclusion in ggml-org/llama.cpp#23085: the gguf maintainer confirms this is a downstream (vLLM) issue and that `general.file_type` must be parsed with `LlamaFileType`. It also cannot be addressed by adding `IQ2_M` to `GGMLQuantizationType` upstream, because `GGMLQuantizationType.IQ1_M` and `LlamaFileType.MOSTLY_IQ2_M` both equal `29` in the shared int space.

**Fix.** Accept either enum in `is_valid_gguf_quant_type()`: a `LlamaFileType` file type (members are prefixed `MOSTLY_`) or a `GGMLQuantizationType` tensor type. The existing suffix handling for extended names (e.g. `Q4_K_M` → `Q4_K`) is preserved. Minimal change, no special-case table, so newly added file types are picked up automatically.

This is orthogonal to #41488 (remote GGUF loading under ModelScope), which handles config/download/MoE-arch for already-recognized quants and does not touch the validation gate; the two are complementary.

## Test Plan

- Unit: extend `tests/transformers_utils/test_utils.py::TestIsRemoteGGUF` to cover file-type-only quants (`IQ2_M`/`IQ3_M`/`IQ3_XS`/`MXFP4_MOE`), with and without a vendor prefix (`UD-`), plus negative cases (`IQ9_M`, `NOTATYPE`). Each new assertion was confirmed to fail on the unpatched code and pass after the fix.
- E2E: serve a real model through a file-type-only quant reference and generate, confirming the reference now flows past parsing into a working load and generation.

## Test Result

Unit tests:

```
$ pytest tests/transformers_utils/test_utils.py -q
23 passed
```

E2E — real generation through the remote-ref path this PR unblocks:

```
model = "bartowski/Qwen2.5-0.5B-Instruct-GGUF:IQ2_M"   # file-type-only quant

INFO ... Resolved architecture: Qwen2ForCausalLM
INFO ... Model loading took 0.31 GiB memory ... load_format=gguf

PROMPT='The capital of France is'  GEN=' Paris. It is the oldest capital city in the world, ...'
PROMPT='Q: 2+2=? A:'               GEN=' 4 B: 5 C: 6 D: 7 ...'
```

Before this PR, the same reference is rejected at startup with `Repo id must use alphanumeric chars...`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
