### PR TITLE
[Examples] Refactor Qwen3.6 MTP EP load-balance experiment

### DIFF
--- a/examples/features/speculative_decoding/mtp_ep_experiment_analysis.py
+++ b/examples/features/speculative_decoding/mtp_ep_experiment_analysis.py
@@ -1,0 +1,654 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from mtp_ep_load_balance_utils import (
+    SCHEMA_VERSION,
+    build_condition_metrics,
+    build_speedup_rows,
+    normalize_time_components,
+    reorder_histograms_by_expert_order,
+    sort_experts_desc,
+    summarize_step_time_components,
+)
+
+PLOT_MODULE = None
+
+
+@dataclass
+class LoadedConditionData:
+    batch_size: int
+    draft_length: int
+    selected_dataset_indices: np.ndarray
+    prompt_lengths: np.ndarray
+    condition_latency_ms: float
+    step_histograms: np.ndarray
+    step_total_tokens: np.ndarray
+    step_total_ms: np.ndarray
+    step_attention_ms: np.ndarray
+    step_routing_ms: np.ndarray
+    step_prepare_ms: np.ndarray
+    step_finalize_ms: np.ndarray
+    step_ffn_ms: np.ndarray
+    captured_step_kinds: np.ndarray
+    layers: np.ndarray
+    avg_histograms: np.ndarray
+    num_forward_steps_total: int
+    num_captured_steps: int
+    num_dropped_steps: int
+
+
+def import_plot_module():
+    global PLOT_MODULE
+    if PLOT_MODULE is None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        from matplotlib import pyplot as plt
+
+        PLOT_MODULE = plt
+    return PLOT_MODULE
+
+
+def ensure_analysis_dirs(output_dir: Path) -> dict[str, Path]:
+    tables_dir = output_dir / "tables"
+    plots_dir = output_dir / "plots"
+    speedup_dir = plots_dir / "speedup"
+    time_dir = plots_dir / "step_time_breakdown"
+    load_grids_dir = plots_dir / "expert_load" / "grids"
+    load_overlays_dir = plots_dir / "expert_load" / "overlays"
+    for path in (
+        tables_dir,
+        speedup_dir,
+        time_dir,
+        load_grids_dir,
+        load_overlays_dir,
+    ):
+        path.mkdir(parents=True, exist_ok=True)
+    return {
+        "tables": tables_dir,
+        "speedup": speedup_dir,
+        "time": time_dir,
+        "load_grids": load_grids_dir,
+        "load_overlays": load_overlays_dir,
+    }
+
+
+def save_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError(f"Cannot write empty CSV: {path}")
+    with path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _scalar(npz: Any, key: str, cast: type) -> Any:
+    value = npz[key]
+    return cast(value.reshape(-1)[0])
+
+
+def load_condition_data(path: Path) -> LoadedConditionData:
+    with np.load(path, allow_pickle=False) as npz:
+        schema_version = _scalar(npz, "schema_version", int)
+        if schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported schema_version={schema_version} for {path}."
+            )
+        return LoadedConditionData(
+            batch_size=_scalar(npz, "batch_size", int),
+            draft_length=_scalar(npz, "draft_length", int),
+            selected_dataset_indices=np.asarray(npz["selected_dataset_indices"]),
+            prompt_lengths=np.asarray(npz["prompt_lengths"]),
+            condition_latency_ms=_scalar(npz, "condition_latency_ms", float),
+            step_histograms=np.asarray(npz["step_histograms"]),
+            step_total_tokens=np.asarray(npz["step_total_tokens"]),
+            step_total_ms=np.asarray(npz["step_total_ms"]),
+            step_attention_ms=np.asarray(npz["step_attention_ms"]),
+            step_routing_ms=np.asarray(npz["step_routing_ms"]),
+            step_prepare_ms=np.asarray(npz["step_prepare_ms"]),
+            step_finalize_ms=np.asarray(npz["step_finalize_ms"]),
+            step_ffn_ms=np.asarray(npz["step_ffn_ms"]),
+            captured_step_kinds=np.asarray(npz["captured_step_kinds"]),
+            layers=np.asarray(npz["layers"]),
+            avg_histograms=np.asarray(npz["avg_histograms"]),
+            num_forward_steps_total=_scalar(npz, "num_forward_steps_total", int),
+            num_captured_steps=_scalar(npz, "num_captured_steps", int),
+            num_dropped_steps=_scalar(npz, "num_dropped_steps", int),
+        )
+
+
+def load_manifest(output_dir: Path) -> dict[str, Any]:
+    manifest_path = output_dir / "collect_manifest.json"
+    with manifest_path.open("r", encoding="utf-8") as fp:
+        manifest = json.load(fp)
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported schema_version={manifest['schema_version']} in manifest."
+        )
+    return manifest
+
+
+def load_all_conditions(output_dir: Path) -> tuple[dict[str, Any], dict[tuple[int, int], LoadedConditionData]]:
+    manifest = load_manifest(output_dir)
+    results: dict[tuple[int, int], LoadedConditionData] = {}
+    for condition in manifest["conditions"]:
+        path = output_dir / condition["raw_path"]
+        data = load_condition_data(path)
+        results[(data.batch_size, data.draft_length)] = data
+    return manifest, results
+
+
+def build_step_time_rows(
+    manifest: dict[str, Any],
+    results: dict[tuple[int, int], LoadedConditionData],
+) -> list[dict[str, float | int]]:
+    batch_sizes = tuple(manifest["batch_sizes"])
+    draft_lengths = tuple(manifest["draft_lengths"])
+    rows: list[dict[str, float | int]] = []
+    baseline_totals: dict[int, float] = {}
+    partial_rows: dict[tuple[int, int], dict[str, float | int]] = {}
+
+    for batch_size in batch_sizes:
+        for draft_length in draft_lengths:
+            data = results[(batch_size, draft_length)]
+            summary = summarize_step_time_components(
+                data.step_total_ms,
+                data.step_attention_ms,
+                data.step_routing_ms,
+                data.step_prepare_ms,
+                data.step_finalize_ms,
+                data.step_ffn_ms,
+            )
+            row: dict[str, float | int] = {
+                "batch_size": batch_size,
+                "draft_length": draft_length,
+                "num_steps": int(data.step_histograms.shape[0]),
+                **summary,
+            }
+            partial_rows[(batch_size, draft_length)] = row
+            if draft_length == 0:
+                baseline_totals[batch_size] = float(summary["avg_step_total_ms"])
+
+    for batch_size in batch_sizes:
+        baseline_total = baseline_totals[batch_size]
+        for draft_length in draft_lengths:
+            row = dict(partial_rows[(batch_size, draft_length)])
+            row.update(normalize_time_components(row, baseline_total))
+            rows.append(row)
+    return rows
+
+
+def build_load_distribution_rows(
+    manifest: dict[str, Any],
+    results: dict[tuple[int, int], LoadedConditionData],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    batch_sizes = tuple(manifest["batch_sizes"])
+    draft_lengths = tuple(manifest["draft_lengths"])
+    layers = tuple(results[(batch_sizes[0], draft_lengths[0])].layers.tolist())
+
+    load_metric_rows: list[dict[str, Any]] = []
+    condition_sorted_rows: list[dict[str, Any]] = []
+    baseline_sorted_rows: list[dict[str, Any]] = []
+
+    for batch_size in batch_sizes:
+        baseline_data = results[(batch_size, 0)]
+        baseline_avg = baseline_data.avg_histograms
+        _, baseline_order = sort_experts_desc(baseline_avg)
+        for draft_length in draft_lengths:
+            data = results[(batch_size, draft_length)]
+            metrics_rows = build_condition_metrics(
+                batch_size=batch_size,
+                draft_length=draft_length,
+                num_steps=data.num_captured_steps,
+                layers=layers,
+                avg_histograms=data.avg_histograms,
+                baseline_histograms=baseline_avg,
+            )
+            load_metric_rows.extend(metrics_rows)
+
+            condition_sorted_counts, condition_order = sort_experts_desc(
+                data.avg_histograms
+            )
+            baseline_sorted_counts = reorder_histograms_by_expert_order(
+                data.avg_histograms,
+                baseline_order,
+            )
+
+            for layer_row, layer_idx in enumerate(layers):
+                for expert_rank, expert_id in enumerate(condition_order[layer_row]):
+                    condition_sorted_rows.append(
+                        {
+                            "batch_size": batch_size,
+                            "draft_length": draft_length,
+                            "layer": layer_idx,
+                            "expert_rank": expert_rank,
+                            "expert_id": int(expert_id),
+                            "avg_routed_assignments_per_step": float(
+                                condition_sorted_counts[layer_row, expert_rank]
+                            ),
+                        }
+                    )
+                for expert_rank, expert_id in enumerate(baseline_order[layer_row]):
+                    baseline_sorted_rows.append(
+                        {
+                            "batch_size": batch_size,
+                            "draft_length": draft_length,
+                            "layer": layer_idx,
+                            "expert_rank": expert_rank,
+                            "expert_id": int(expert_id),
+                            "avg_routed_assignments_per_step": float(
+                                baseline_sorted_counts[layer_row, expert_rank]
+                            ),
+                        }
+                    )
+    return load_metric_rows, condition_sorted_rows, baseline_sorted_rows
+
+
+def plot_speedup_vs_draft_length(
+    plot_dir: Path,
+    speedup_rows: list[dict[str, float | int]],
+    batch_sizes: tuple[int, ...],
+    draft_lengths: tuple[int, ...],
+) -> Path:
+    plt = import_plot_module()
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for batch_size in batch_sizes:
+        y = [
+            next(
+                row["speedup"]
+                for row in speedup_rows
+                if row["batch_size"] == batch_size
+                and row["draft_length"] == draft_length
+            )
+            for draft_length in draft_lengths
+        ]
+        ax.plot(draft_lengths, y, marker="o", linewidth=2, label=f"bs={batch_size}")
+    ax.axhline(1.0, color="#666666", linewidth=1, linestyle="--")
+    ax.set_xlabel("draft_length")
+    ax.set_ylabel("speedup vs draft_length=0")
+    ax.set_title("Speedup vs Draft Length")
+    ax.legend()
+    ax.grid(alpha=0.25)
+    path = plot_dir / "speedup_vs_draft_length.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_speedup_vs_batch_size(
+    plot_dir: Path,
+    speedup_rows: list[dict[str, float | int]],
+    batch_sizes: tuple[int, ...],
+    draft_lengths: tuple[int, ...],
+) -> Path:
+    plt = import_plot_module()
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for draft_length in draft_lengths:
+        y = [
+            next(
+                row["speedup"]
+                for row in speedup_rows
+                if row["batch_size"] == batch_size
+                and row["draft_length"] == draft_length
+            )
+            for batch_size in batch_sizes
+        ]
+        ax.plot(batch_sizes, y, marker="o", linewidth=2, label=f"d={draft_length}")
+    ax.axhline(1.0, color="#666666", linewidth=1, linestyle="--")
+    ax.set_xlabel("batch_size")
+    ax.set_ylabel("speedup vs draft_length=0")
+    ax.set_title("Speedup vs Batch Size")
+    ax.legend()
+    ax.grid(alpha=0.25)
+    path = plot_dir / "speedup_vs_batch_size.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_step_time_breakdown(
+    plot_dir: Path,
+    batch_size: int,
+    draft_lengths: tuple[int, ...],
+    step_rows: list[dict[str, float | int]],
+) -> Path:
+    plt = import_plot_module()
+    rows = [
+        next(
+            row
+            for row in step_rows
+            if row["batch_size"] == batch_size and row["draft_length"] == draft_length
+        )
+        for draft_length in draft_lengths
+    ]
+    x = np.arange(len(draft_lengths))
+    attention = np.asarray(
+        [row["normalized_attention_ms"] for row in rows], dtype=np.float64
+    )
+    routing = np.asarray(
+        [row["normalized_routing_ms"] for row in rows], dtype=np.float64
+    )
+    all2all = np.asarray(
+        [row["normalized_all2all_ms"] for row in rows], dtype=np.float64
+    )
+    ffn = np.asarray(
+        [row["normalized_ffn_ms"] for row in rows], dtype=np.float64
+    )
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.bar(x, attention, label="Attention", color="#4e79a7")
+    ax.bar(x, routing, bottom=attention, label="Routing", color="#f28e2b")
+    ax.bar(
+        x,
+        all2all,
+        bottom=attention + routing,
+        label="ALL2ALL",
+        color="#59a14f",
+    )
+    ax.bar(
+        x,
+        ffn,
+        bottom=attention + routing + all2all,
+        label="FFN",
+        color="#e15759",
+    )
+    for idx, row in enumerate(rows):
+        total_height = attention[idx] + routing[idx] + all2all[idx] + ffn[idx]
+        ax.text(
+            idx,
+            total_height + 0.02,
+            f"{float(row['ffn_share']) * 100:.1f}%",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(d) for d in draft_lengths])
+    ax.set_xlabel("draft_length")
+    ax.set_ylabel("normalized avg step time")
+    ax.set_title(f"Step Time Breakdown (batch_size={batch_size})")
+    ax.legend()
+    ax.grid(axis="y", alpha=0.25)
+    path = plot_dir / f"batch_size_{batch_size:03d}.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_condition_grid(
+    plot_dir: Path,
+    batch_size: int,
+    draft_lengths: tuple[int, ...],
+    load_metric_rows: list[dict[str, Any]],
+    results: dict[tuple[int, int], LoadedConditionData],
+) -> Path:
+    plt = import_plot_module()
+    sample = results[(batch_size, draft_lengths[0])]
+    layers = tuple(sample.layers.tolist())
+    fig, axes = plt.subplots(
+        len(layers),
+        len(draft_lengths),
+        figsize=(4.2 * len(draft_lengths), 2.8 * len(layers)),
+        squeeze=False,
+        constrained_layout=True,
+    )
+    for row_idx, layer_idx in enumerate(layers):
+        for col_idx, draft_length in enumerate(draft_lengths):
+            ax = axes[row_idx][col_idx]
+            data = results[(batch_size, draft_length)]
+            sorted_counts, sorted_ids = sort_experts_desc(data.avg_histograms)
+            counts = sorted_counts[row_idx]
+            expert_ids = sorted_ids[row_idx]
+            metrics_row = next(
+                row
+                for row in load_metric_rows
+                if row["batch_size"] == batch_size
+                and row["draft_length"] == draft_length
+                and row["layer"] == layer_idx
+            )
+            tick_positions = np.linspace(
+                0,
+                counts.size - 1,
+                num=min(8, counts.size),
+                dtype=int,
+            )
+            ax.bar(np.arange(counts.size), counts, color="#1f77b4", width=1.0)
+            ax.set_xticks(tick_positions)
+            ax.set_xticklabels([str(expert_ids[pos]) for pos in tick_positions])
+            ax.set_title(
+                f"layer={layer_idx}, draft={draft_length}\n"
+                f"bal={metrics_row['balancedness']:.4f}, "
+                f"gini={metrics_row['gini']:.4f}",
+                fontsize=10,
+            )
+            if col_idx == 0:
+                ax.set_ylabel("avg routed count")
+            if row_idx == len(layers) - 1:
+                ax.set_xlabel("expert id (condition-sorted)")
+    path = plot_dir / f"batch_size_{batch_size:03d}_grid.png"
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_overlay(
+    plot_dir: Path,
+    batch_size: int,
+    draft_lengths: tuple[int, ...],
+    results: dict[tuple[int, int], LoadedConditionData],
+) -> Path:
+    plt = import_plot_module()
+    baseline = results[(batch_size, 0)]
+    layers = tuple(baseline.layers.tolist())
+    _, baseline_order = sort_experts_desc(baseline.avg_histograms)
+    colors = ["#4e79a7", "#f28e2b", "#59a14f", "#e15759"]
+    fig, axes = plt.subplots(len(layers), 1, figsize=(10, 3.0 * len(layers)))
+    if len(layers) == 1:
+        axes = [axes]
+    for row_idx, layer_idx in enumerate(layers):
+        ax = axes[row_idx]
+        tick_positions = np.linspace(
+            0,
+            baseline_order.shape[1] - 1,
+            num=min(8, baseline_order.shape[1]),
+            dtype=int,
+        )
+        tick_labels = [str(baseline_order[row_idx, pos]) for pos in tick_positions]
+        for color, draft_length in zip(colors[: len(draft_lengths)], draft_lengths):
+            data = results[(batch_size, draft_length)]
+            counts = reorder_histograms_by_expert_order(
+                data.avg_histograms,
+                baseline_order,
+            )[row_idx]
+            ax.plot(
+                np.arange(counts.size),
+                counts,
+                linewidth=1.8,
+                color=color,
+                label=f"d={draft_length}",
+            )
+        ax.set_title(f"layer={layer_idx}")
+        ax.set_xticks(tick_positions)
+        ax.set_xticklabels(tick_labels)
+        ax.set_ylabel("avg routed count")
+        ax.grid(alpha=0.25)
+    axes[-1].set_xlabel("expert id (baseline-sorted)")
+    axes[0].legend(ncol=len(draft_lengths), loc="upper right")
+    path = plot_dir / f"batch_size_{batch_size:03d}_overlay.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def build_report(
+    output_dir: Path,
+    manifest: dict[str, Any],
+    speedup_rows: list[dict[str, float | int]],
+    step_rows: list[dict[str, float | int]],
+    load_metric_rows: list[dict[str, Any]],
+) -> str:
+    batch_sizes = tuple(manifest["batch_sizes"])
+    draft_lengths = tuple(manifest["draft_lengths"])
+    lines = [
+        "# Qwen3.6 MTP-EP 三子实验报告",
+        "",
+        "## 实验设置",
+        "",
+        f"- 模型：`{manifest['model']}`",
+        (
+            f"- 数据集：`{manifest['dataset']}` / "
+            f"`{manifest['dataset_config']}` / `{manifest['dataset_split']}`"
+        ),
+        f"- batch_size：`{', '.join(map(str, batch_sizes))}`",
+        f"- draft_length：`{', '.join(map(str, draft_lengths))}`",
+        f"- max_tokens：`{manifest['max_tokens']}`",
+        f"- warmup_rounds：`{manifest.get('warmup_rounds', 0)}`",
+        "",
+        "## Speedup",
+        "",
+    ]
+
+    for batch_size in batch_sizes:
+        candidates = [
+            row
+            for row in speedup_rows
+            if row["batch_size"] == batch_size and row["draft_length"] != 0
+        ]
+        best = max(candidates, key=lambda row: float(row["speedup"]))
+        speedup_summaries = ", ".join(
+            f"d={row['draft_length']}:{float(row['speedup']):.3f}x"
+            for row in candidates
+        )
+        lines.append(
+            f"- batch_size={batch_size}: {speedup_summaries}; "
+            f"best=d={best['draft_length']} ({float(best['speedup']):.3f}x)"
+        )
+
+    lines.extend(["", "## 每次验证时间开销分解", ""])
+    for batch_size in batch_sizes:
+        rows = [
+            row for row in step_rows if row["batch_size"] == batch_size
+        ]
+        lines.append(f"### batch_size={batch_size}")
+        for row in rows:
+            lines.append(
+                f"- draft_length={row['draft_length']}: "
+                f"avg_step={float(row['avg_step_total_ms']):.2f} ms, "
+                f"attention={float(row['avg_attention_ms']):.2f} ms, "
+                f"routing={float(row['avg_routing_ms']):.2f} ms, "
+                f"all2all={float(row['avg_all2all_ms']):.2f} ms, "
+                f"ffn={float(row['avg_ffn_ms']):.2f} ms "
+                f"({float(row['ffn_share']) * 100:.1f}%)"
+            )
+
+    lines.extend(["", "## Expert Load 分布", ""])
+    for batch_size in batch_sizes:
+        lines.append(f"### batch_size={batch_size}")
+        batch_rows = [row for row in load_metric_rows if row["batch_size"] == batch_size]
+        layers = sorted({int(row["layer"]) for row in batch_rows})
+        for layer in layers:
+            candidates = [
+                row
+                for row in batch_rows
+                if row["layer"] == layer and row["draft_length"] != 0
+            ]
+            worst = min(candidates, key=lambda row: float(row["balancedness_delta"]))
+            lines.append(
+                f"- layer {layer}: worst balancedness delta at "
+                f"d={worst['draft_length']} "
+                f"(Δbal={float(worst['balancedness_delta']):+.4f}, "
+                f"Δg={float(worst['gini_delta']):+.4f})"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def analyze_experiment(
+    input_dir: Path,
+    *,
+    skip_plots: bool = False,
+    skip_report: bool = False,
+) -> None:
+    manifest, results = load_all_conditions(input_dir)
+    batch_sizes = tuple(manifest["batch_sizes"])
+    draft_lengths = tuple(manifest["draft_lengths"])
+    dirs = ensure_analysis_dirs(input_dir)
+
+    latency_by_condition = {
+        condition: data.condition_latency_ms for condition, data in results.items()
+    }
+    speedup_rows = build_speedup_rows(
+        latency_by_condition,
+        batch_sizes,
+        draft_lengths,
+    )
+    step_rows = build_step_time_rows(manifest, results)
+    (
+        load_metric_rows,
+        condition_sorted_rows,
+        baseline_sorted_rows,
+    ) = build_load_distribution_rows(manifest, results)
+
+    save_csv(dirs["tables"] / "speedup_metrics.csv", speedup_rows)
+    save_csv(dirs["tables"] / "step_time_breakdown.csv", step_rows)
+    save_csv(dirs["tables"] / "load_balance_metrics.csv", load_metric_rows)
+    save_csv(
+        dirs["tables"] / "averaged_distributions_condition_sorted.csv",
+        condition_sorted_rows,
+    )
+    save_csv(
+        dirs["tables"] / "averaged_distributions_baseline_sorted.csv",
+        baseline_sorted_rows,
+    )
+
+    if not skip_plots:
+        plot_speedup_vs_draft_length(
+            dirs["speedup"], speedup_rows, batch_sizes, draft_lengths
+        )
+        plot_speedup_vs_batch_size(
+            dirs["speedup"], speedup_rows, batch_sizes, draft_lengths
+        )
+        for batch_size in batch_sizes:
+            plot_step_time_breakdown(
+                dirs["time"],
+                batch_size,
+                draft_lengths,
+                step_rows,
+            )
+            plot_condition_grid(
+                dirs["load_grids"],
+                batch_size,
+                draft_lengths,
+                load_metric_rows,
+                results,
+            )
+            plot_overlay(
+                dirs["load_overlays"],
+                batch_size,
+                draft_lengths,
+                results,
+            )
+
+    if not skip_report:
+        report = build_report(
+            input_dir,
+            manifest,
+            speedup_rows,
+            step_rows,
+            load_metric_rows,
+        )
+        with (input_dir / "实验报告.md").open("w", encoding="utf-8") as fp:
+            fp.write(report)

--- a/examples/features/speculative_decoding/mtp_ep_experiment_analysis.py
+++ b/examples/features/speculative_decoding/mtp_ep_experiment_analysis.py
@@ -13,12 +13,14 @@ import numpy as np
 
 from mtp_ep_load_balance_utils import (
     SCHEMA_VERSION,
+    TPOT_DEFINITION,
+    build_rank_load_from_histograms,
     build_condition_metrics,
     build_speedup_rows,
-    normalize_time_components,
+    normalize_global_time_components,
     reorder_histograms_by_expert_order,
     sort_experts_desc,
-    summarize_step_time_components,
+    summarize_global_step_time_components,
 )
 
 PLOT_MODULE = None
@@ -28,9 +30,21 @@ PLOT_MODULE = None
 class LoadedConditionData:
     batch_size: int
     draft_length: int
+    data_parallel_size: int
+    num_samples: int
+    batch_size_scope: str
+    mixed_step_policy: str
+    tpot_definition: str
     selected_dataset_indices: np.ndarray
     prompt_lengths: np.ndarray
+    output_lengths: np.ndarray
     condition_latency_ms: float
+    decode_time_total_ms: float
+    num_output_tokens_total: int
+    num_generation_tokens_total: int
+    num_output_tokens_excl_first_total: int
+    tpot_ms: float
+    decode_throughput_tok_s: float
     step_histograms: np.ndarray
     step_total_tokens: np.ndarray
     step_total_ms: np.ndarray
@@ -40,11 +54,24 @@ class LoadedConditionData:
     step_finalize_ms: np.ndarray
     step_ffn_ms: np.ndarray
     captured_step_kinds: np.ndarray
+    global_step_indices: np.ndarray
+    global_step_total_ms: np.ndarray
+    global_step_ffn_ms: np.ndarray
+    global_step_other_ms: np.ndarray
+    global_step_kinds: np.ndarray
+    expert_to_ep_rank: np.ndarray
     layers: np.ndarray
     avg_histograms: np.ndarray
     num_forward_steps_total: int
     num_captured_steps: int
+    num_global_candidate_steps: int
+    num_global_captured_steps: int
     num_dropped_steps: int
+    num_prefill_dropped_steps: int
+    num_mixed_dropped_steps: int
+    num_global_prefill_dropped_steps: int
+    num_global_mixed_dropped_steps: int
+    num_global_non_target_dropped_steps: int
 
 
 def import_plot_module():
@@ -64,22 +91,25 @@ def ensure_analysis_dirs(output_dir: Path) -> dict[str, Path]:
     plots_dir = output_dir / "plots"
     speedup_dir = plots_dir / "speedup"
     time_dir = plots_dir / "step_time_breakdown"
-    load_grids_dir = plots_dir / "expert_load" / "grids"
-    load_overlays_dir = plots_dir / "expert_load" / "overlays"
+    expert_load_dir = plots_dir / "expert_load"
+    rank_load_dir = plots_dir / "rank_load"
+    rank_traces_dir = plots_dir / "rank_traces"
     for path in (
         tables_dir,
         speedup_dir,
         time_dir,
-        load_grids_dir,
-        load_overlays_dir,
+        expert_load_dir,
+        rank_load_dir,
+        rank_traces_dir,
     ):
         path.mkdir(parents=True, exist_ok=True)
     return {
         "tables": tables_dir,
         "speedup": speedup_dir,
         "time": time_dir,
-        "load_grids": load_grids_dir,
-        "load_overlays": load_overlays_dir,
+        "expert_load": expert_load_dir,
+        "rank_load": rank_load_dir,
+        "rank_traces": rank_traces_dir,
     }
 
 
@@ -92,6 +122,153 @@ def save_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
+def load_rank_trace_payload(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def build_rank_trace_rows(
+    condition_name: str,
+    trace_payloads: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not trace_payloads:
+        return rows
+    if not any(payload.get("trace_samples") for payload in trace_payloads):
+        return rows
+
+    origin_ms = min(
+        sample["step_start_time_ms"]
+        for payload in trace_payloads
+        for sample in payload.get("trace_samples", [])
+    )
+    for payload in trace_payloads:
+        dp_rank = int(payload["dp_rank"])
+        for order_idx, sample in enumerate(payload.get("trace_samples", [])):
+            phase_totals = sample["phase_totals_ms"]
+            rows.append(
+                {
+                    "condition": condition_name,
+                    "batch_size": int(payload["batch_size"]),
+                    "draft_length": int(payload["draft_length"]),
+                    "dp_rank": dp_rank,
+                    "trace_order": order_idx,
+                    "step_index": int(sample["step_index"]),
+                    "step_kind": sample["step_kind"],
+                    "total_scheduled_tokens": int(sample["total_scheduled_tokens"]),
+                    "step_start_offset_ms": (
+                        float(sample["step_start_time_ms"]) - origin_ms
+                    ),
+                    "step_end_offset_ms": (
+                        float(sample["step_end_time_ms"]) - origin_ms
+                    ),
+                    "step_total_ms": float(sample["step_total_ms"]),
+                    "attention_ms": float(phase_totals["attention"]),
+                    "routing_ms": float(phase_totals["routing"]),
+                    "prepare_ms": float(phase_totals["prepare"]),
+                    "finalize_ms": float(phase_totals["finalize"]),
+                    "ffn_ms": float(phase_totals["ffn"]),
+                }
+            )
+    return rows
+
+
+def plot_rank_trace_timeline(
+    plot_dir: Path,
+    condition_name: str,
+    trace_payloads: list[dict[str, Any]],
+) -> Path | None:
+    samples_exist = any(payload.get("trace_samples") for payload in trace_payloads)
+    if not samples_exist:
+        return None
+
+    plt = import_plot_module()
+    label_colors = {
+        "attention": "#4E79A7",
+        "routing": "#F28E2B",
+        "prepare": "#E15759",
+        "ffn": "#59A14F",
+        "finalize": "#76B7B2",
+    }
+    origin_ms = min(
+        sample["step_start_time_ms"]
+        for payload in trace_payloads
+        for sample in payload.get("trace_samples", [])
+    )
+    max_end_ms = max(
+        sample["step_end_time_ms"]
+        for payload in trace_payloads
+        for sample in payload.get("trace_samples", [])
+    )
+
+    fig, axes = plt.subplots(
+        len(trace_payloads),
+        1,
+        figsize=(12, 2.8 * len(trace_payloads)),
+        sharex=True,
+    )
+    if len(trace_payloads) == 1:
+        axes = [axes]
+
+    for ax, payload in zip(axes, trace_payloads):
+        dp_rank = int(payload["dp_rank"])
+        samples = sorted(
+            payload.get("trace_samples", []),
+            key=lambda item: float(item["step_start_time_ms"]),
+        )
+        for sample_idx, sample in enumerate(samples):
+            y = len(samples) - sample_idx - 1
+            start_ms = float(sample["step_start_time_ms"]) - origin_ms
+            total_ms = float(sample["step_total_ms"])
+            ax.broken_barh(
+                [(start_ms, total_ms)],
+                (y - 0.35, 0.7),
+                facecolors="none",
+                edgecolors="#444444",
+                linewidth=0.8,
+            )
+            for event in sample["events"]:
+                label = str(event["label"])
+                event_start = start_ms + float(event["start_ms"])
+                duration = float(event["duration_ms"])
+                ax.broken_barh(
+                    [(event_start, duration)],
+                    (y - 0.35, 0.7),
+                    facecolors=label_colors.get(label, "#999999"),
+                    edgecolors="none",
+                )
+            ax.text(
+                start_ms - 1.0,
+                y,
+                f"step={int(sample['step_index'])}",
+                ha="right",
+                va="center",
+                fontsize=8,
+            )
+        ax.set_title(f"dp_rank={dp_rank}")
+        ax.set_yticks([])
+        ax.grid(axis="x", alpha=0.25)
+
+    handles = [
+        plt.Rectangle((0, 0), 1, 1, color=color)
+        for color in label_colors.values()
+    ]
+    fig.legend(
+        handles,
+        list(label_colors.keys()),
+        ncol=len(label_colors),
+        loc="upper center",
+    )
+    axes[-1].set_xlabel("wall-clock offset within traced samples (ms)")
+    axes[-1].set_xlim(0.0, max_end_ms - origin_ms)
+    fig.suptitle(f"{condition_name} DP rank event timeline", y=0.98)
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    path = plot_dir / f"{condition_name}_timeline.png"
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
 def _scalar(npz: Any, key: str, cast: type) -> Any:
     value = npz[key]
     return cast(value.reshape(-1)[0])
@@ -102,14 +279,34 @@ def load_condition_data(path: Path) -> LoadedConditionData:
         schema_version = _scalar(npz, "schema_version", int)
         if schema_version != SCHEMA_VERSION:
             raise ValueError(
-                f"Unsupported schema_version={schema_version} for {path}."
+                "Unsupported raw schema_version="
+                f"{schema_version} for {path}. Re-run `collect` with the current "
+                "runtime before `analyze`."
             )
         return LoadedConditionData(
             batch_size=_scalar(npz, "batch_size", int),
             draft_length=_scalar(npz, "draft_length", int),
+            data_parallel_size=_scalar(npz, "data_parallel_size", int),
+            num_samples=_scalar(npz, "num_samples", int),
+            batch_size_scope=_scalar(npz, "batch_size_scope", str),
+            mixed_step_policy=_scalar(npz, "mixed_step_policy", str),
+            tpot_definition=_scalar(npz, "tpot_definition", str),
             selected_dataset_indices=np.asarray(npz["selected_dataset_indices"]),
             prompt_lengths=np.asarray(npz["prompt_lengths"]),
+            output_lengths=np.asarray(npz["output_lengths"]),
             condition_latency_ms=_scalar(npz, "condition_latency_ms", float),
+            decode_time_total_ms=_scalar(npz, "decode_time_total_ms", float),
+            num_output_tokens_total=_scalar(npz, "num_output_tokens_total", int),
+            num_generation_tokens_total=_scalar(
+                npz, "num_generation_tokens_total", int
+            ),
+            num_output_tokens_excl_first_total=_scalar(
+                npz, "num_output_tokens_excl_first_total", int
+            ),
+            tpot_ms=_scalar(npz, "tpot_ms", float),
+            decode_throughput_tok_s=_scalar(
+                npz, "decode_throughput_tok_s", float
+            ),
             step_histograms=np.asarray(npz["step_histograms"]),
             step_total_tokens=np.asarray(npz["step_total_tokens"]),
             step_total_ms=np.asarray(npz["step_total_ms"]),
@@ -119,26 +316,141 @@ def load_condition_data(path: Path) -> LoadedConditionData:
             step_finalize_ms=np.asarray(npz["step_finalize_ms"]),
             step_ffn_ms=np.asarray(npz["step_ffn_ms"]),
             captured_step_kinds=np.asarray(npz["captured_step_kinds"]),
+            global_step_indices=np.asarray(npz["global_step_indices"]),
+            global_step_total_ms=np.asarray(npz["global_step_total_ms"]),
+            global_step_ffn_ms=np.asarray(npz["global_step_ffn_ms"]),
+            global_step_other_ms=np.asarray(npz["global_step_other_ms"]),
+            global_step_kinds=np.asarray(npz["global_step_kinds"]),
+            expert_to_ep_rank=np.asarray(npz["expert_to_ep_rank"]),
             layers=np.asarray(npz["layers"]),
             avg_histograms=np.asarray(npz["avg_histograms"]),
             num_forward_steps_total=_scalar(npz, "num_forward_steps_total", int),
             num_captured_steps=_scalar(npz, "num_captured_steps", int),
+            num_global_candidate_steps=_scalar(
+                npz, "num_global_candidate_steps", int
+            ),
+            num_global_captured_steps=_scalar(
+                npz, "num_global_captured_steps", int
+            ),
             num_dropped_steps=_scalar(npz, "num_dropped_steps", int),
+            num_prefill_dropped_steps=_scalar(npz, "num_prefill_dropped_steps", int),
+            num_mixed_dropped_steps=_scalar(npz, "num_mixed_dropped_steps", int),
+            num_global_prefill_dropped_steps=_scalar(
+                npz, "num_global_prefill_dropped_steps", int
+            ),
+            num_global_mixed_dropped_steps=_scalar(
+                npz, "num_global_mixed_dropped_steps", int
+            ),
+            num_global_non_target_dropped_steps=_scalar(
+                npz, "num_global_non_target_dropped_steps", int
+            ),
         )
 
 
 def load_manifest(output_dir: Path) -> dict[str, Any]:
     manifest_path = output_dir / "collect_manifest.json"
+    if not manifest_path.exists():
+        return synthesize_manifest(output_dir)
     with manifest_path.open("r", encoding="utf-8") as fp:
         manifest = json.load(fp)
     if manifest["schema_version"] != SCHEMA_VERSION:
         raise ValueError(
-            f"Unsupported schema_version={manifest['schema_version']} in manifest."
+            "Unsupported manifest schema_version="
+            f"{manifest['schema_version']}. Re-run `collect` with the current "
+            "runtime before `analyze`."
         )
     return manifest
 
 
-def load_all_conditions(output_dir: Path) -> tuple[dict[str, Any], dict[tuple[int, int], LoadedConditionData]]:
+def synthesize_manifest(output_dir: Path) -> dict[str, Any]:
+    run_metadata_path = output_dir / "run_metadata.json"
+    run_metadata: dict[str, Any] = {}
+    if run_metadata_path.exists():
+        with run_metadata_path.open("r", encoding="utf-8") as fp:
+            run_metadata = json.load(fp)
+
+    raw_paths = sorted((output_dir / "raw").glob("*.npz"))
+    if not raw_paths:
+        raise FileNotFoundError(
+            f"No collect_manifest.json or raw/*.npz found under {output_dir}."
+        )
+
+    conditions: list[dict[str, Any]] = []
+    batch_sizes: set[int] = set()
+    draft_lengths: set[int] = set()
+    first_data: LoadedConditionData | None = None
+    for raw_path in raw_paths:
+        data = load_condition_data(raw_path)
+        if first_data is None:
+            first_data = data
+        batch_sizes.add(data.batch_size)
+        draft_lengths.add(data.draft_length)
+        conditions.append(
+            {
+                "batch_size": data.batch_size,
+                "draft_length": data.draft_length,
+                "raw_path": str(Path("raw") / raw_path.name),
+                "condition_latency_ms": data.condition_latency_ms,
+                "decode_time_total_ms": data.decode_time_total_ms,
+                "num_output_tokens_total": data.num_output_tokens_total,
+                "num_generation_tokens_total": data.num_generation_tokens_total,
+                "num_output_tokens_excl_first_total": (
+                    data.num_output_tokens_excl_first_total
+                ),
+                "tpot_ms": data.tpot_ms,
+                "decode_throughput_tok_s": data.decode_throughput_tok_s,
+                "num_forward_steps_total": data.num_forward_steps_total,
+                "num_captured_steps": data.num_captured_steps,
+                "num_global_candidate_steps": data.num_global_candidate_steps,
+                "num_global_captured_steps": data.num_global_captured_steps,
+                "num_dropped_steps": data.num_dropped_steps,
+                "num_prefill_dropped_steps": data.num_prefill_dropped_steps,
+                "num_mixed_dropped_steps": data.num_mixed_dropped_steps,
+                "num_global_prefill_dropped_steps": (
+                    data.num_global_prefill_dropped_steps
+                ),
+                "num_global_mixed_dropped_steps": (
+                    data.num_global_mixed_dropped_steps
+                ),
+                "num_global_non_target_dropped_steps": (
+                    data.num_global_non_target_dropped_steps
+                ),
+            }
+        )
+
+    assert first_data is not None
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "model": run_metadata.get("model", "unknown"),
+        "dataset": run_metadata.get("dataset", "unknown"),
+        "dataset_config": run_metadata.get("dataset_config"),
+        "dataset_split": run_metadata.get("dataset_split", "unknown"),
+        "batch_sizes": sorted(batch_sizes),
+        "draft_lengths": sorted(draft_lengths),
+        "data_parallel_size": int(
+            run_metadata.get("data_parallel_size", first_data.data_parallel_size)
+        ),
+        "batch_size_scope": run_metadata.get(
+            "batch_size_scope", first_data.batch_size_scope
+        ),
+        "num_samples": int(run_metadata.get("num_samples", first_data.num_samples)),
+        "max_tokens": int(run_metadata.get("max_tokens", 0)),
+        "layers": run_metadata.get("layers", first_data.layers.tolist()),
+        "warmup_rounds": int(run_metadata.get("warmup_rounds", 0)),
+        "trace_steps_per_rank": int(run_metadata.get("trace_steps_per_rank", 0)),
+        "mixed_step_policy": run_metadata.get(
+            "mixed_step_policy", first_data.mixed_step_policy
+        ),
+        "tpot_definition": run_metadata.get(
+            "tpot_definition", first_data.tpot_definition
+        ),
+        "conditions": conditions,
+    }
+
+
+def load_all_conditions(
+    output_dir: Path,
+) -> tuple[dict[str, Any], dict[tuple[int, int], LoadedConditionData]]:
     manifest = load_manifest(output_dir)
     results: dict[tuple[int, int], LoadedConditionData] = {}
     for condition in manifest["conditions"]:
@@ -161,18 +473,39 @@ def build_step_time_rows(
     for batch_size in batch_sizes:
         for draft_length in draft_lengths:
             data = results[(batch_size, draft_length)]
-            summary = summarize_step_time_components(
-                data.step_total_ms,
-                data.step_attention_ms,
-                data.step_routing_ms,
-                data.step_prepare_ms,
-                data.step_finalize_ms,
-                data.step_ffn_ms,
+            summary = summarize_global_step_time_components(
+                data.global_step_total_ms,
+                data.global_step_ffn_ms,
+                data.global_step_other_ms,
             )
             row: dict[str, float | int] = {
                 "batch_size": batch_size,
                 "draft_length": draft_length,
-                "num_steps": int(data.step_histograms.shape[0]),
+                "decode_step_scope": (
+                    "verification_only" if draft_length > 0 else "decode_only"
+                ),
+                "num_steps": int(data.global_step_indices.shape[0]),
+                "num_forward_steps_total": data.num_forward_steps_total,
+                "num_captured_steps": data.num_captured_steps,
+                "num_global_candidate_steps": data.num_global_candidate_steps,
+                "num_global_captured_steps": data.num_global_captured_steps,
+                "num_dropped_steps": data.num_dropped_steps,
+                "num_prefill_dropped_steps": data.num_prefill_dropped_steps,
+                "num_mixed_dropped_steps": data.num_mixed_dropped_steps,
+                "num_global_prefill_dropped_steps": (
+                    data.num_global_prefill_dropped_steps
+                ),
+                "num_global_mixed_dropped_steps": (
+                    data.num_global_mixed_dropped_steps
+                ),
+                "num_global_non_target_dropped_steps": (
+                    data.num_global_non_target_dropped_steps
+                ),
+                "global_captured_step_ratio": (
+                    data.num_global_captured_steps / data.num_global_candidate_steps
+                    if data.num_global_candidate_steps > 0
+                    else 0.0
+                ),
                 **summary,
             }
             partial_rows[(batch_size, draft_length)] = row
@@ -183,7 +516,7 @@ def build_step_time_rows(
         baseline_total = baseline_totals[batch_size]
         for draft_length in draft_lengths:
             row = dict(partial_rows[(batch_size, draft_length)])
-            row.update(normalize_time_components(row, baseline_total))
+            row.update(normalize_global_time_components(row, baseline_total))
             rows.append(row)
     return rows
 
@@ -191,7 +524,12 @@ def build_step_time_rows(
 def build_load_distribution_rows(
     manifest: dict[str, Any],
     results: dict[tuple[int, int], LoadedConditionData],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]:
     batch_sizes = tuple(manifest["batch_sizes"])
     draft_lengths = tuple(manifest["draft_lengths"])
     layers = tuple(results[(batch_sizes[0], draft_lengths[0])].layers.tolist())
@@ -199,6 +537,7 @@ def build_load_distribution_rows(
     load_metric_rows: list[dict[str, Any]] = []
     condition_sorted_rows: list[dict[str, Any]] = []
     baseline_sorted_rows: list[dict[str, Any]] = []
+    rank_load_rows: list[dict[str, Any]] = []
 
     for batch_size in batch_sizes:
         baseline_data = results[(batch_size, 0)]
@@ -209,12 +548,17 @@ def build_load_distribution_rows(
             metrics_rows = build_condition_metrics(
                 batch_size=batch_size,
                 draft_length=draft_length,
-                num_steps=data.num_captured_steps,
+                num_steps=data.num_global_captured_steps,
                 layers=layers,
                 avg_histograms=data.avg_histograms,
                 baseline_histograms=baseline_avg,
             )
             load_metric_rows.extend(metrics_rows)
+            rank_load = build_rank_load_from_histograms(
+                data.avg_histograms,
+                data.expert_to_ep_rank,
+                data.data_parallel_size,
+            )
 
             condition_sorted_counts, condition_order = sort_experts_desc(
                 data.avg_histograms
@@ -251,7 +595,24 @@ def build_load_distribution_rows(
                             ),
                         }
                     )
-    return load_metric_rows, condition_sorted_rows, baseline_sorted_rows
+                for ep_rank in range(data.data_parallel_size):
+                    rank_load_rows.append(
+                        {
+                            "batch_size": batch_size,
+                            "draft_length": draft_length,
+                            "layer": layer_idx,
+                            "ep_rank": ep_rank,
+                            "avg_routed_assignments_per_step": float(
+                                rank_load[layer_row, ep_rank]
+                            ),
+                        }
+                    )
+    return (
+        load_metric_rows,
+        condition_sorted_rows,
+        baseline_sorted_rows,
+        rank_load_rows,
+    )
 
 
 def plot_speedup_vs_draft_length(
@@ -265,7 +626,7 @@ def plot_speedup_vs_draft_length(
     for batch_size in batch_sizes:
         y = [
             next(
-                row["speedup"]
+                row["tpot_speedup"]
                 for row in speedup_rows
                 if row["batch_size"] == batch_size
                 and row["draft_length"] == draft_length
@@ -275,8 +636,8 @@ def plot_speedup_vs_draft_length(
         ax.plot(draft_lengths, y, marker="o", linewidth=2, label=f"bs={batch_size}")
     ax.axhline(1.0, color="#666666", linewidth=1, linestyle="--")
     ax.set_xlabel("draft_length")
-    ax.set_ylabel("speedup vs draft_length=0")
-    ax.set_title("Speedup vs Draft Length")
+    ax.set_ylabel("TPOT speedup vs draft_length=0")
+    ax.set_title("TPOT Speedup vs Draft Length")
     ax.legend()
     ax.grid(alpha=0.25)
     path = plot_dir / "speedup_vs_draft_length.png"
@@ -297,7 +658,7 @@ def plot_speedup_vs_batch_size(
     for draft_length in draft_lengths:
         y = [
             next(
-                row["speedup"]
+                row["tpot_speedup"]
                 for row in speedup_rows
                 if row["batch_size"] == batch_size
                 and row["draft_length"] == draft_length
@@ -307,11 +668,43 @@ def plot_speedup_vs_batch_size(
         ax.plot(batch_sizes, y, marker="o", linewidth=2, label=f"d={draft_length}")
     ax.axhline(1.0, color="#666666", linewidth=1, linestyle="--")
     ax.set_xlabel("batch_size")
-    ax.set_ylabel("speedup vs draft_length=0")
-    ax.set_title("Speedup vs Batch Size")
+    ax.set_ylabel("TPOT speedup vs draft_length=0")
+    ax.set_title("TPOT Speedup vs Global Batch Size")
     ax.legend()
     ax.grid(alpha=0.25)
-    path = plot_dir / "speedup_vs_batch_size.png"
+    path = plot_dir / "tpot_speedup_vs_batch_size.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_decode_throughput_speedup_vs_batch_size(
+    plot_dir: Path,
+    speedup_rows: list[dict[str, float | int]],
+    batch_sizes: tuple[int, ...],
+    draft_lengths: tuple[int, ...],
+) -> Path:
+    plt = import_plot_module()
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for draft_length in draft_lengths:
+        y = [
+            next(
+                row["decode_throughput_speedup"]
+                for row in speedup_rows
+                if row["batch_size"] == batch_size
+                and row["draft_length"] == draft_length
+            )
+            for batch_size in batch_sizes
+        ]
+        ax.plot(batch_sizes, y, marker="o", linewidth=2, label=f"d={draft_length}")
+    ax.axhline(1.0, color="#666666", linewidth=1, linestyle="--")
+    ax.set_xlabel("batch_size")
+    ax.set_ylabel("decode throughput speedup vs draft_length=0")
+    ax.set_title("Decode Throughput Speedup vs Global Batch Size")
+    ax.legend()
+    ax.grid(alpha=0.25)
+    path = plot_dir / "decode_throughput_speedup_vs_batch_size.png"
     fig.tight_layout()
     fig.savefig(path, dpi=200)
     plt.close(fig)
@@ -334,38 +727,24 @@ def plot_step_time_breakdown(
         for draft_length in draft_lengths
     ]
     x = np.arange(len(draft_lengths))
-    attention = np.asarray(
-        [row["normalized_attention_ms"] for row in rows], dtype=np.float64
-    )
-    routing = np.asarray(
-        [row["normalized_routing_ms"] for row in rows], dtype=np.float64
-    )
-    all2all = np.asarray(
-        [row["normalized_all2all_ms"] for row in rows], dtype=np.float64
+    other = np.asarray(
+        [row["normalized_other_ms"] for row in rows], dtype=np.float64
     )
     ffn = np.asarray(
         [row["normalized_ffn_ms"] for row in rows], dtype=np.float64
     )
 
     fig, ax = plt.subplots(figsize=(8, 5))
-    ax.bar(x, attention, label="Attention", color="#4e79a7")
-    ax.bar(x, routing, bottom=attention, label="Routing", color="#f28e2b")
-    ax.bar(
-        x,
-        all2all,
-        bottom=attention + routing,
-        label="ALL2ALL",
-        color="#59a14f",
-    )
+    ax.bar(x, other, label="Other", color="#4e79a7")
     ax.bar(
         x,
         ffn,
-        bottom=attention + routing + all2all,
+        bottom=other,
         label="FFN",
         color="#e15759",
     )
     for idx, row in enumerate(rows):
-        total_height = attention[idx] + routing[idx] + all2all[idx] + ffn[idx]
+        total_height = other[idx] + ffn[idx]
         ax.text(
             idx,
             total_height + 0.02,
@@ -377,11 +756,53 @@ def plot_step_time_breakdown(
     ax.set_xticks(x)
     ax.set_xticklabels([str(d) for d in draft_lengths])
     ax.set_xlabel("draft_length")
-    ax.set_ylabel("normalized avg step time")
-    ax.set_title(f"Step Time Breakdown (batch_size={batch_size})")
+    ax.set_ylabel("normalized avg decode/verification-only step time")
+    ax.set_title(f"FFN/Other Step Time Breakdown (batch_size={batch_size})")
     ax.legend()
     ax.grid(axis="y", alpha=0.25)
     path = plot_dir / f"batch_size_{batch_size:03d}.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_ffn_vs_draft_length(
+    plot_dir: Path,
+    batch_sizes: tuple[int, ...],
+    draft_lengths: tuple[int, ...],
+    step_rows: list[dict[str, float | int]],
+) -> Path:
+    plt = import_plot_module()
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for batch_size in batch_sizes:
+        baseline_ffn_ms = float(
+            next(
+                row["avg_ffn_ms"]
+                for row in step_rows
+                if row["batch_size"] == batch_size and row["draft_length"] == 0
+            )
+        )
+        y = [
+            float(
+                next(
+                    row["avg_ffn_ms"]
+                    for row in step_rows
+                    if row["batch_size"] == batch_size
+                    and row["draft_length"] == draft_length
+                )
+            )
+            / baseline_ffn_ms
+            for draft_length in draft_lengths
+        ]
+        ax.plot(draft_lengths, y, marker="o", linewidth=2, label=f"bs={batch_size}")
+    ax.axhline(1.0, color="#666666", linewidth=1, linestyle="--")
+    ax.set_xlabel("draft_length")
+    ax.set_ylabel("avg_ffn_ms / avg_ffn_ms(d=0)")
+    ax.set_title("FFN vs Draft Length")
+    ax.legend()
+    ax.grid(alpha=0.25)
+    path = plot_dir / "ffn_vs_draft_length.png"
     fig.tight_layout()
     fig.savefig(path, dpi=200)
     plt.close(fig)
@@ -444,7 +865,7 @@ def plot_condition_grid(
     return path
 
 
-def plot_overlay(
+def plot_expert_load(
     plot_dir: Path,
     batch_size: int,
     draft_lengths: tuple[int, ...],
@@ -483,11 +904,74 @@ def plot_overlay(
         ax.set_title(f"layer={layer_idx}")
         ax.set_xticks(tick_positions)
         ax.set_xticklabels(tick_labels)
-        ax.set_ylabel("avg routed count")
+        ax.set_ylabel("avg routed assignments per global step")
         ax.grid(alpha=0.25)
     axes[-1].set_xlabel("expert id (baseline-sorted)")
     axes[0].legend(ncol=len(draft_lengths), loc="upper right")
-    path = plot_dir / f"batch_size_{batch_size:03d}_overlay.png"
+    path = plot_dir / f"batch_size_{batch_size:03d}_expert_load.png"
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+    return path
+
+
+def plot_rank_load(
+    plot_dir: Path,
+    batch_size: int,
+    draft_lengths: tuple[int, ...],
+    rank_load_rows: list[dict[str, Any]],
+) -> Path:
+    plt = import_plot_module()
+    layers = sorted(
+        {
+            int(row["layer"])
+            for row in rank_load_rows
+            if row["batch_size"] == batch_size
+        }
+    )
+    ep_ranks = sorted(
+        {
+            int(row["ep_rank"])
+            for row in rank_load_rows
+            if row["batch_size"] == batch_size
+        }
+    )
+    colors = ["#4e79a7", "#f28e2b", "#59a14f", "#e15759"]
+    fig, axes = plt.subplots(len(layers), 1, figsize=(9, 3.0 * len(layers)))
+    if len(layers) == 1:
+        axes = [axes]
+    x = np.arange(len(ep_ranks))
+    for row_idx, layer_idx in enumerate(layers):
+        ax = axes[row_idx]
+        width = 0.8 / max(len(draft_lengths), 1)
+        for draft_idx, draft_length in enumerate(draft_lengths):
+            values = [
+                next(
+                    float(row["avg_routed_assignments_per_step"])
+                    for row in rank_load_rows
+                    if row["batch_size"] == batch_size
+                    and row["draft_length"] == draft_length
+                    and row["layer"] == layer_idx
+                    and row["ep_rank"] == ep_rank
+                )
+                for ep_rank in ep_ranks
+            ]
+            offset = (draft_idx - (len(draft_lengths) - 1) / 2.0) * width
+            ax.bar(
+                x + offset,
+                values,
+                width=width,
+                color=colors[draft_idx % len(colors)],
+                label=f"d={draft_length}",
+            )
+        ax.set_title(f"layer={layer_idx}")
+        ax.set_xticks(x)
+        ax.set_xticklabels([str(rank) for rank in ep_ranks])
+        ax.set_ylabel("avg routed assignments per global step")
+        ax.grid(axis="y", alpha=0.25)
+    axes[-1].set_xlabel("EP rank")
+    axes[0].legend(ncol=len(draft_lengths), loc="upper right")
+    path = plot_dir / f"batch_size_{batch_size:03d}_rank_load.png"
     fig.tight_layout()
     fig.savefig(path, dpi=200)
     plt.close(fig)
@@ -504,7 +988,7 @@ def build_report(
     batch_sizes = tuple(manifest["batch_sizes"])
     draft_lengths = tuple(manifest["draft_lengths"])
     lines = [
-        "# Qwen3.6 MTP-EP 三子实验报告",
+        "# Qwen3.6 MTP DP+EP 三子实验报告",
         "",
         "## 实验设置",
         "",
@@ -513,12 +997,17 @@ def build_report(
             f"- 数据集：`{manifest['dataset']}` / "
             f"`{manifest['dataset_config']}` / `{manifest['dataset_split']}`"
         ),
-        f"- batch_size：`{', '.join(map(str, batch_sizes))}`",
+        f"- global batch_size：`{', '.join(map(str, batch_sizes))}`",
         f"- draft_length：`{', '.join(map(str, draft_lengths))}`",
+        f"- data_parallel_size：`{manifest['data_parallel_size']}`",
+        f"- num_samples：`{manifest['num_samples']}`",
+        f"- batch_size_scope：`{manifest['batch_size_scope']}`",
+        f"- mixed_step_policy：`{manifest['mixed_step_policy']}`",
+        f"- TPOT 定义：`{manifest.get('tpot_definition', TPOT_DEFINITION)}`",
         f"- max_tokens：`{manifest['max_tokens']}`",
         f"- warmup_rounds：`{manifest.get('warmup_rounds', 0)}`",
         "",
-        "## Speedup",
+        "## TPOT Speedup",
         "",
     ]
 
@@ -528,17 +1017,17 @@ def build_report(
             for row in speedup_rows
             if row["batch_size"] == batch_size and row["draft_length"] != 0
         ]
-        best = max(candidates, key=lambda row: float(row["speedup"]))
+        best = max(candidates, key=lambda row: float(row["tpot_speedup"]))
         speedup_summaries = ", ".join(
-            f"d={row['draft_length']}:{float(row['speedup']):.3f}x"
+            f"d={row['draft_length']}:{float(row['tpot_speedup']):.3f}x"
             for row in candidates
         )
         lines.append(
             f"- batch_size={batch_size}: {speedup_summaries}; "
-            f"best=d={best['draft_length']} ({float(best['speedup']):.3f}x)"
+            f"best=d={best['draft_length']} ({float(best['tpot_speedup']):.3f}x)"
         )
 
-    lines.extend(["", "## 每次验证时间开销分解", ""])
+    lines.extend(["", "## Decode/Verification-only 时间开销分解", ""])
     for batch_size in batch_sizes:
         rows = [
             row for row in step_rows if row["batch_size"] == batch_size
@@ -548,17 +1037,21 @@ def build_report(
             lines.append(
                 f"- draft_length={row['draft_length']}: "
                 f"avg_step={float(row['avg_step_total_ms']):.2f} ms, "
-                f"attention={float(row['avg_attention_ms']):.2f} ms, "
-                f"routing={float(row['avg_routing_ms']):.2f} ms, "
-                f"all2all={float(row['avg_all2all_ms']):.2f} ms, "
-                f"ffn={float(row['avg_ffn_ms']):.2f} ms "
-                f"({float(row['ffn_share']) * 100:.1f}%)"
+                f"ffn={float(row['avg_ffn_ms']):.2f} ms, "
+                f"other={float(row['avg_other_ms']):.2f} ms, "
+                f"({float(row['ffn_share']) * 100:.1f}%), "
+                f"global_captured={int(row['num_global_captured_steps'])}, "
+                f"global_candidates={int(row['num_global_candidate_steps'])}, "
+                f"prefill_drop={int(row['num_global_prefill_dropped_steps'])}, "
+                f"mixed_drop={int(row['num_global_mixed_dropped_steps'])}"
             )
 
-    lines.extend(["", "## Expert Load 分布", ""])
+    lines.extend(["", "## Decode/Verification-only Expert Load 分布", ""])
     for batch_size in batch_sizes:
         lines.append(f"### batch_size={batch_size}")
-        batch_rows = [row for row in load_metric_rows if row["batch_size"] == batch_size]
+        batch_rows = [
+            row for row in load_metric_rows if row["batch_size"] == batch_size
+        ]
         layers = sorted({int(row["layer"]) for row in batch_rows})
         for layer in layers:
             candidates = [
@@ -587,11 +1080,21 @@ def analyze_experiment(
     draft_lengths = tuple(manifest["draft_lengths"])
     dirs = ensure_analysis_dirs(input_dir)
 
-    latency_by_condition = {
-        condition: data.condition_latency_ms for condition, data in results.items()
+    decode_time_ms_by_condition = {
+        condition: data.decode_time_total_ms for condition, data in results.items()
+    }
+    generation_tokens_by_condition = {
+        condition: data.num_generation_tokens_total
+        for condition, data in results.items()
+    }
+    output_tokens_excl_first_by_condition = {
+        condition: data.num_output_tokens_excl_first_total
+        for condition, data in results.items()
     }
     speedup_rows = build_speedup_rows(
-        latency_by_condition,
+        decode_time_ms_by_condition,
+        generation_tokens_by_condition,
+        output_tokens_excl_first_by_condition,
         batch_sizes,
         draft_lengths,
     )
@@ -600,6 +1103,7 @@ def analyze_experiment(
         load_metric_rows,
         condition_sorted_rows,
         baseline_sorted_rows,
+        rank_load_rows,
     ) = build_load_distribution_rows(manifest, results)
 
     save_csv(dirs["tables"] / "speedup_metrics.csv", speedup_rows)
@@ -613,13 +1117,39 @@ def analyze_experiment(
         dirs["tables"] / "averaged_distributions_baseline_sorted.csv",
         baseline_sorted_rows,
     )
+    save_csv(dirs["tables"] / "rank_load_metrics.csv", rank_load_rows)
+
+    rank_trace_rows: list[dict[str, Any]] = []
+    for condition in manifest["conditions"]:
+        condition_name = Path(condition["raw_path"]).stem
+        partial_dir = input_dir / "_dp_partials" / condition_name
+        trace_paths = sorted(partial_dir.glob("rank_*.trace.json"))
+        if not trace_paths:
+            continue
+        trace_payloads = [load_rank_trace_payload(path) for path in trace_paths]
+        rank_trace_rows.extend(build_rank_trace_rows(condition_name, trace_payloads))
+        if not skip_plots:
+            plot_rank_trace_timeline(
+                dirs["rank_traces"],
+                condition_name,
+                trace_payloads,
+            )
+
+    if rank_trace_rows:
+        save_csv(dirs["tables"] / "rank_trace_summary.csv", rank_trace_rows)
 
     if not skip_plots:
-        plot_speedup_vs_draft_length(
-            dirs["speedup"], speedup_rows, batch_sizes, draft_lengths
-        )
         plot_speedup_vs_batch_size(
             dirs["speedup"], speedup_rows, batch_sizes, draft_lengths
+        )
+        plot_decode_throughput_speedup_vs_batch_size(
+            dirs["speedup"], speedup_rows, batch_sizes, draft_lengths
+        )
+        plot_ffn_vs_draft_length(
+            dirs["time"],
+            batch_sizes,
+            draft_lengths,
+            step_rows,
         )
         for batch_size in batch_sizes:
             plot_step_time_breakdown(
@@ -628,18 +1158,17 @@ def analyze_experiment(
                 draft_lengths,
                 step_rows,
             )
-            plot_condition_grid(
-                dirs["load_grids"],
+            plot_expert_load(
+                dirs["expert_load"],
                 batch_size,
                 draft_lengths,
-                load_metric_rows,
                 results,
             )
-            plot_overlay(
-                dirs["load_overlays"],
+            plot_rank_load(
+                dirs["rank_load"],
                 batch_size,
                 draft_lengths,
-                results,
+                rank_load_rows,
             )
 
     if not skip_report:

--- a/examples/features/speculative_decoding/mtp_ep_experiment_runtime.py
+++ b/examples/features/speculative_decoding/mtp_ep_experiment_runtime.py
@@ -23,26 +23,92 @@ from mtp_ep_load_balance_utils import (
     DEFAULT_DATASET,
     DEFAULT_DATASET_CONFIG,
     DEFAULT_DATASET_SPLIT,
+    FinishedRequestStatTotals,
     SCHEMA_VERSION,
     StepTiming,
+    aggregate_global_step_time_components,
     aggregate_worker_step_timings,
     average_step_histograms,
+    classify_step_capture,
+    compute_num_output_tokens_excluding_first,
+    compute_decode_throughput_tok_s,
+    compute_tpot_ms_from_finished_stats,
     count_layer_expert_histograms,
+    merge_expert_to_ep_rank_maps,
+    num_condition_rounds,
+    shard_global_batch_indices,
     select_dataset_indices,
-    select_step_routing_data,
+    TPOT_DEFINITION,
 )
+from vllm.utils.network_utils import get_open_port
+from vllm.v1.metrics.loggers import StatLoggerBase
 
 if TYPE_CHECKING:
     from argparse import Namespace
+
+
+class FinishedRequestStatsLogger(StatLoggerBase):
+    def __init__(self, vllm_config: Any, engine_index: int = 0) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.decode_time_total_ms = 0.0
+        self.num_generation_tokens_total = 0
+        self.num_output_tokens_excl_first_total = 0
+
+    def record(
+        self,
+        scheduler_stats: Any | None,
+        iteration_stats: Any | None,
+        mm_cache_stats: Any | None = None,
+        engine_idx: int = 0,
+    ) -> None:
+        if iteration_stats is None:
+            return
+        for finished_req in iteration_stats.finished_requests:
+            num_generation_tokens = int(finished_req.num_generation_tokens)
+            self.decode_time_total_ms += float(finished_req.decode_time) * 1000.0
+            self.num_generation_tokens_total += num_generation_tokens
+            self.num_output_tokens_excl_first_total += max(
+                num_generation_tokens - 1,
+                0,
+            )
+
+    def log_engine_initialized(self) -> None:
+        return
+
+    def snapshot(self) -> FinishedRequestStatTotals:
+        return FinishedRequestStatTotals(
+            decode_time_total_ms=self.decode_time_total_ms,
+            num_generation_tokens_total=self.num_generation_tokens_total,
+            num_output_tokens_excl_first_total=(
+                self.num_output_tokens_excl_first_total
+            ),
+        )
+
+
+_FINISHED_REQUEST_STATS_LOGGER_ATTR = "_mtp_ep_finished_request_stats_logger"
 
 
 @dataclass
 class ConditionRawData:
     batch_size: int
     draft_length: int
+    data_parallel_size: int
+    num_samples: int
+    batch_size_scope: str
+    mixed_step_policy: str
+    tpot_definition: str
     selected_dataset_indices: np.ndarray
     prompt_lengths: np.ndarray
+    output_lengths: np.ndarray
     condition_latency_ms: float
+    decode_time_total_ms: float
+    num_output_tokens_total: int
+    num_generation_tokens_total: int
+    num_output_tokens_excl_first_total: int
+    tpot_ms: float
+    decode_throughput_tok_s: float
     step_histograms: np.ndarray
     step_total_tokens: np.ndarray
     step_total_ms: np.ndarray
@@ -52,11 +118,24 @@ class ConditionRawData:
     step_finalize_ms: np.ndarray
     step_ffn_ms: np.ndarray
     captured_step_kinds: np.ndarray
+    global_step_indices: np.ndarray
+    global_step_total_ms: np.ndarray
+    global_step_ffn_ms: np.ndarray
+    global_step_other_ms: np.ndarray
+    global_step_kinds: np.ndarray
+    expert_to_ep_rank: np.ndarray
     layers: np.ndarray
     avg_histograms: np.ndarray
     num_forward_steps_total: int
     num_captured_steps: int
+    num_global_candidate_steps: int
+    num_global_captured_steps: int
     num_dropped_steps: int
+    num_prefill_dropped_steps: int
+    num_mixed_dropped_steps: int
+    num_global_prefill_dropped_steps: int
+    num_global_mixed_dropped_steps: int
+    num_global_non_target_dropped_steps: int
 
     def to_npz_payload(self) -> dict[str, np.ndarray]:
         step_all2all_ms = self.step_prepare_ms + self.step_finalize_ms
@@ -64,10 +143,38 @@ class ConditionRawData:
             "schema_version": np.asarray([SCHEMA_VERSION], dtype=np.int64),
             "batch_size": np.asarray([self.batch_size], dtype=np.int64),
             "draft_length": np.asarray([self.draft_length], dtype=np.int64),
+            "data_parallel_size": np.asarray([self.data_parallel_size], dtype=np.int64),
+            "num_samples": np.asarray([self.num_samples], dtype=np.int64),
+            "batch_size_scope": np.asarray([self.batch_size_scope]),
+            "mixed_step_policy": np.asarray([self.mixed_step_policy]),
+            "tpot_definition": np.asarray([self.tpot_definition]),
             "selected_dataset_indices": self.selected_dataset_indices,
             "prompt_lengths": self.prompt_lengths,
+            "output_lengths": self.output_lengths,
             "condition_latency_ms": np.asarray(
                 [self.condition_latency_ms], dtype=np.float64
+            ),
+            "decode_time_total_ms": np.asarray(
+                [self.decode_time_total_ms], dtype=np.float64
+            ),
+            "decode_only_total_ms": np.asarray(
+                [self.decode_time_total_ms], dtype=np.float64
+            ),
+            "num_output_tokens_total": np.asarray(
+                [self.num_output_tokens_total], dtype=np.int64
+            ),
+            "num_generation_tokens_total": np.asarray(
+                [self.num_generation_tokens_total], dtype=np.int64
+            ),
+            "num_output_tokens_excl_first_total": np.asarray(
+                [self.num_output_tokens_excl_first_total], dtype=np.int64
+            ),
+            "num_output_tokens_excl_first": np.asarray(
+                [self.num_output_tokens_excl_first_total], dtype=np.int64
+            ),
+            "tpot_ms": np.asarray([self.tpot_ms], dtype=np.float64),
+            "decode_throughput_tok_s": np.asarray(
+                [self.decode_throughput_tok_s], dtype=np.float64
             ),
             "step_histograms": self.step_histograms,
             "step_total_tokens": self.step_total_tokens,
@@ -79,6 +186,13 @@ class ConditionRawData:
             "step_all2all_ms": step_all2all_ms,
             "step_ffn_ms": self.step_ffn_ms,
             "captured_step_kinds": self.captured_step_kinds,
+            "global_step_indices": self.global_step_indices,
+            "global_step_total_ms": self.global_step_total_ms,
+            "global_step_ffn_ms": self.global_step_ffn_ms,
+            "global_step_ffn_phase_ms": self.global_step_ffn_ms,
+            "global_step_other_ms": self.global_step_other_ms,
+            "global_step_kinds": self.global_step_kinds,
+            "expert_to_ep_rank": self.expert_to_ep_rank,
             "layers": self.layers,
             "avg_histograms": self.avg_histograms,
             "num_forward_steps_total": np.asarray(
@@ -87,8 +201,29 @@ class ConditionRawData:
             "num_captured_steps": np.asarray(
                 [self.num_captured_steps], dtype=np.int64
             ),
+            "num_global_candidate_steps": np.asarray(
+                [self.num_global_candidate_steps], dtype=np.int64
+            ),
+            "num_global_captured_steps": np.asarray(
+                [self.num_global_captured_steps], dtype=np.int64
+            ),
             "num_dropped_steps": np.asarray(
                 [self.num_dropped_steps], dtype=np.int64
+            ),
+            "num_prefill_dropped_steps": np.asarray(
+                [self.num_prefill_dropped_steps], dtype=np.int64
+            ),
+            "num_mixed_dropped_steps": np.asarray(
+                [self.num_mixed_dropped_steps], dtype=np.int64
+            ),
+            "num_global_prefill_dropped_steps": np.asarray(
+                [self.num_global_prefill_dropped_steps], dtype=np.int64
+            ),
+            "num_global_mixed_dropped_steps": np.asarray(
+                [self.num_global_mixed_dropped_steps], dtype=np.int64
+            ),
+            "num_global_non_target_dropped_steps": np.asarray(
+                [self.num_global_non_target_dropped_steps], dtype=np.int64
             ),
         }
 
@@ -99,27 +234,142 @@ class CollectedConditionSummary:
     draft_length: int
     raw_path: str
     condition_latency_ms: float
+    decode_time_total_ms: float
+    num_output_tokens_total: int
+    num_generation_tokens_total: int
+    num_output_tokens_excl_first_total: int
+    tpot_ms: float
+    decode_throughput_tok_s: float
+    num_forward_steps_total: int
+    num_captured_steps: int
+    num_global_candidate_steps: int
+    num_global_captured_steps: int
+    num_dropped_steps: int
+    num_prefill_dropped_steps: int
+    num_mixed_dropped_steps: int
+    num_global_prefill_dropped_steps: int
+    num_global_mixed_dropped_steps: int
+    num_global_non_target_dropped_steps: int
+
+
+@dataclass
+class RankConditionData:
+    selected_dataset_indices: np.ndarray
+    prompt_lengths: np.ndarray
+    output_lengths: np.ndarray
+    step_histograms: np.ndarray
+    step_total_tokens: np.ndarray
+    step_total_ms: np.ndarray
+    step_attention_ms: np.ndarray
+    step_routing_ms: np.ndarray
+    step_prepare_ms: np.ndarray
+    step_finalize_ms: np.ndarray
+    step_ffn_ms: np.ndarray
+    captured_step_kinds: np.ndarray
+    captured_step_indices: np.ndarray
+    captured_step_start_time_ms: np.ndarray
+    captured_step_end_time_ms: np.ndarray
+    captured_prepare_start_time_ms: np.ndarray
+    captured_finalize_end_time_ms: np.ndarray
+    candidate_first_ep_collective_seq_ids: np.ndarray
+    candidate_step_kinds: np.ndarray
+    candidate_drop_reasons: np.ndarray
+    candidate_step_total_tokens: np.ndarray
+    candidate_step_total_ms: np.ndarray
+    candidate_step_ffn_ms: np.ndarray
+    candidate_step_histograms: np.ndarray
+    expert_to_ep_rank: np.ndarray
+    condition_latency_ms: float
+    decode_time_total_ms: float
+    num_generation_tokens_total: int
+    num_output_tokens_excl_first_total: int
     num_forward_steps_total: int
     num_captured_steps: int
     num_dropped_steps: int
+    num_prefill_dropped_steps: int
+    num_mixed_dropped_steps: int
+    trace_samples: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_npz_payload(self) -> dict[str, np.ndarray]:
+        return {
+            "selected_dataset_indices": self.selected_dataset_indices,
+            "prompt_lengths": self.prompt_lengths,
+            "output_lengths": self.output_lengths,
+            "step_histograms": self.step_histograms,
+            "step_total_tokens": self.step_total_tokens,
+            "step_total_ms": self.step_total_ms,
+            "step_attention_ms": self.step_attention_ms,
+            "step_routing_ms": self.step_routing_ms,
+            "step_prepare_ms": self.step_prepare_ms,
+            "step_finalize_ms": self.step_finalize_ms,
+            "step_ffn_ms": self.step_ffn_ms,
+            "captured_step_kinds": self.captured_step_kinds,
+            "captured_step_indices": self.captured_step_indices,
+            "captured_step_start_time_ms": self.captured_step_start_time_ms,
+            "captured_step_end_time_ms": self.captured_step_end_time_ms,
+            "captured_prepare_start_time_ms": self.captured_prepare_start_time_ms,
+            "captured_finalize_end_time_ms": self.captured_finalize_end_time_ms,
+            "candidate_first_ep_collective_seq_ids": (
+                self.candidate_first_ep_collective_seq_ids
+            ),
+            "candidate_step_kinds": self.candidate_step_kinds,
+            "candidate_drop_reasons": self.candidate_drop_reasons,
+            "candidate_step_total_tokens": self.candidate_step_total_tokens,
+            "candidate_step_total_ms": self.candidate_step_total_ms,
+            "candidate_step_ffn_ms": self.candidate_step_ffn_ms,
+            "candidate_step_histograms": self.candidate_step_histograms,
+            "expert_to_ep_rank": self.expert_to_ep_rank,
+            "condition_latency_ms": np.asarray(
+                [self.condition_latency_ms], dtype=np.float64
+            ),
+            "decode_time_total_ms": np.asarray(
+                [self.decode_time_total_ms], dtype=np.float64
+            ),
+            "num_generation_tokens_total": np.asarray(
+                [self.num_generation_tokens_total], dtype=np.int64
+            ),
+            "num_output_tokens_excl_first_total": np.asarray(
+                [self.num_output_tokens_excl_first_total], dtype=np.int64
+            ),
+            "num_forward_steps_total": np.asarray(
+                [self.num_forward_steps_total], dtype=np.int64
+            ),
+            "num_captured_steps": np.asarray(
+                [self.num_captured_steps], dtype=np.int64
+            ),
+            "num_dropped_steps": np.asarray(
+                [self.num_dropped_steps], dtype=np.int64
+            ),
+            "num_prefill_dropped_steps": np.asarray(
+                [self.num_prefill_dropped_steps], dtype=np.int64
+            ),
+            "num_mixed_dropped_steps": np.asarray(
+                [self.num_mixed_dropped_steps], dtype=np.int64
+            ),
+        }
 
 
 @dataclass
 class StepAccumulator:
+    step_start_time_ms: float = 0.0
+    first_ep_collective_seq_id: int | None = None
     attention_ms: float = 0.0
     routing_ms: float = 0.0
     prepare_ms: float = 0.0
     finalize_ms: float = 0.0
     ffn_ms: float = 0.0
+    events: list[dict[str, float | str]] = field(default_factory=list)
 
 
 @dataclass
 class WorkerInstrumentationState:
     enabled: bool = False
-    pending_step_timings: deque[dict[str, float]] = field(default_factory=deque)
+    pending_step_records: deque[dict[str, Any]] = field(default_factory=deque)
     current_step: StepAccumulator | None = None
     enter_step_logs: int = 0
     queued_step_logs: int = 0
+    next_step_index: int = 0
+    next_ep_collective_seq_id: int = 0
 
 
 _WORKER_STATE = WorkerInstrumentationState()
@@ -141,7 +391,7 @@ def condition_name(batch_size: int, draft_length: int) -> str:
 
 def default_output_dir() -> Path:
     timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
-    return Path("results") / f"qwen3_6_mtp_ep_{timestamp}"
+    return Path("results") / f"qwen3_6_mtp_dp_ep_{timestamp}"
 
 
 def ensure_collect_dirs(output_dir: Path) -> dict[str, Path]:
@@ -165,6 +415,9 @@ def save_run_metadata(output_dir: Path, args: Any) -> None:
         "dataset_split": args.dataset_split,
         "batch_sizes": list(args.batch_sizes),
         "draft_lengths": list(args.draft_lengths),
+        "data_parallel_size": args.data_parallel_size,
+        "batch_size_scope": "global",
+        "num_samples": args.num_samples,
         "max_tokens": args.max_tokens,
         "max_model_len": args.max_model_len,
         "tensor_parallel_size": args.tensor_parallel_size,
@@ -173,6 +426,9 @@ def save_run_metadata(output_dir: Path, args: Any) -> None:
         "num_experts": args.num_experts,
         "enforce_eager": args.enforce_eager,
         "warmup_rounds": args.warmup_rounds,
+        "trace_steps_per_rank": args.trace_steps_per_rank,
+        "mixed_step_policy": "drop_step",
+        "tpot_definition": TPOT_DEFINITION,
         "vllm_enable_v1_multiprocessing": os.environ.get(
             "VLLM_ENABLE_V1_MULTIPROCESSING"
         ),
@@ -195,18 +451,47 @@ def save_collect_manifest(
         "dataset_split": args.dataset_split,
         "batch_sizes": list(args.batch_sizes),
         "draft_lengths": list(args.draft_lengths),
+        "data_parallel_size": args.data_parallel_size,
+        "batch_size_scope": "global",
+        "num_samples": args.num_samples,
         "max_tokens": args.max_tokens,
         "layers": list(args.layers),
         "warmup_rounds": args.warmup_rounds,
+        "trace_steps_per_rank": args.trace_steps_per_rank,
+        "mixed_step_policy": "drop_step",
+        "tpot_definition": TPOT_DEFINITION,
         "conditions": [
             {
                 "batch_size": summary.batch_size,
                 "draft_length": summary.draft_length,
                 "raw_path": summary.raw_path,
                 "condition_latency_ms": summary.condition_latency_ms,
+                "decode_time_total_ms": summary.decode_time_total_ms,
+                "num_output_tokens_total": summary.num_output_tokens_total,
+                "num_generation_tokens_total": (
+                    summary.num_generation_tokens_total
+                ),
+                "num_output_tokens_excl_first_total": (
+                    summary.num_output_tokens_excl_first_total
+                ),
+                "tpot_ms": summary.tpot_ms,
+                "decode_throughput_tok_s": summary.decode_throughput_tok_s,
                 "num_forward_steps_total": summary.num_forward_steps_total,
                 "num_captured_steps": summary.num_captured_steps,
+                "num_global_candidate_steps": summary.num_global_candidate_steps,
+                "num_global_captured_steps": summary.num_global_captured_steps,
                 "num_dropped_steps": summary.num_dropped_steps,
+                "num_prefill_dropped_steps": summary.num_prefill_dropped_steps,
+                "num_mixed_dropped_steps": summary.num_mixed_dropped_steps,
+                "num_global_prefill_dropped_steps": (
+                    summary.num_global_prefill_dropped_steps
+                ),
+                "num_global_mixed_dropped_steps": (
+                    summary.num_global_mixed_dropped_steps
+                ),
+                "num_global_non_target_dropped_steps": (
+                    summary.num_global_non_target_dropped_steps
+                ),
             }
             for summary in condition_summaries
         ],
@@ -220,17 +505,51 @@ def load_condition_summary(raw_path: Path) -> CollectedConditionSummary:
         batch_size = int(data["batch_size"][0])
         draft_length = int(data["draft_length"][0])
         condition_latency_ms = float(data["condition_latency_ms"][0])
+        decode_time_total_ms = float(data["decode_time_total_ms"][0])
+        num_output_tokens_total = int(data["num_output_tokens_total"][0])
+        num_generation_tokens_total = int(data["num_generation_tokens_total"][0])
+        num_output_tokens_excl_first_total = int(
+            data["num_output_tokens_excl_first_total"][0]
+        )
+        tpot_ms = float(data["tpot_ms"][0])
+        decode_throughput_tok_s = float(data["decode_throughput_tok_s"][0])
         num_forward_steps_total = int(data["num_forward_steps_total"][0])
         num_captured_steps = int(data["num_captured_steps"][0])
+        num_global_candidate_steps = int(data["num_global_candidate_steps"][0])
+        num_global_captured_steps = int(data["num_global_captured_steps"][0])
         num_dropped_steps = int(data["num_dropped_steps"][0])
+        num_prefill_dropped_steps = int(data["num_prefill_dropped_steps"][0])
+        num_mixed_dropped_steps = int(data["num_mixed_dropped_steps"][0])
+        num_global_prefill_dropped_steps = int(
+            data["num_global_prefill_dropped_steps"][0]
+        )
+        num_global_mixed_dropped_steps = int(
+            data["num_global_mixed_dropped_steps"][0]
+        )
+        num_global_non_target_dropped_steps = int(
+            data["num_global_non_target_dropped_steps"][0]
+        )
     return CollectedConditionSummary(
         batch_size=batch_size,
         draft_length=draft_length,
         raw_path=str(raw_path.relative_to(raw_path.parent.parent)),
         condition_latency_ms=condition_latency_ms,
+        decode_time_total_ms=decode_time_total_ms,
+        num_output_tokens_total=num_output_tokens_total,
+        num_generation_tokens_total=num_generation_tokens_total,
+        num_output_tokens_excl_first_total=num_output_tokens_excl_first_total,
+        tpot_ms=tpot_ms,
+        decode_throughput_tok_s=decode_throughput_tok_s,
         num_forward_steps_total=num_forward_steps_total,
         num_captured_steps=num_captured_steps,
+        num_global_candidate_steps=num_global_candidate_steps,
+        num_global_captured_steps=num_global_captured_steps,
         num_dropped_steps=num_dropped_steps,
+        num_prefill_dropped_steps=num_prefill_dropped_steps,
+        num_mixed_dropped_steps=num_mixed_dropped_steps,
+        num_global_prefill_dropped_steps=num_global_prefill_dropped_steps,
+        num_global_mixed_dropped_steps=num_global_mixed_dropped_steps,
+        num_global_non_target_dropped_steps=num_global_non_target_dropped_steps,
     )
 
 
@@ -251,14 +570,15 @@ def load_prompt_items(args: Namespace) -> list[dict[str, list[int]]]:
         args.dataset_config,
         split=args.dataset_split,
     )
-    if hasattr(args, "batch_sizes"):
-        max_samples = max(args.batch_sizes)
-    else:
-        max_samples = args.batch_size
+    selected_indices = select_dataset_indices(args.num_samples, len(dataset))
     prompt_items: list[dict[str, list[int]]] = []
-    for item in dataset.select(range(min(max_samples, len(dataset)))):
+    for item in dataset.select(selected_indices.tolist()):
+        message = item["instruction"].strip()
+        input_code = item["input"].strip()
+        if input_code:
+            message = f"{message}\n\nInput Code:\n{input_code}"
         token_ids = tokenizer.apply_chat_template(
-            [{"role": "user", "content": item["question"]}],
+            [{"role": "user", "content": message}],
             add_generation_prompt=True,
             enable_thinking=False,
             return_dict=True,
@@ -296,6 +616,15 @@ def prepare_prompt_cache(args: Namespace, output_dir: Path) -> Path:
     return cache_path
 
 
+def validate_parallel_config(args: Namespace) -> None:
+    if args.tensor_parallel_size != 1:
+        raise ValueError(
+            "This experiment only supports DP+EP with tensor_parallel_size=1."
+        )
+    if args.data_parallel_size < 1:
+        raise ValueError("data_parallel_size must be >= 1.")
+
+
 def create_llm(args: Namespace, batch_size: int, draft_length: int):
     from vllm import LLM
 
@@ -307,7 +636,7 @@ def create_llm(args: Namespace, batch_size: int, draft_length: int):
             "max_model_len": args.max_model_len,
         }
 
-    return LLM(
+    llm = LLM(
         model=args.model,
         trust_remote_code=True,
         tensor_parallel_size=args.tensor_parallel_size,
@@ -320,7 +649,19 @@ def create_llm(args: Namespace, batch_size: int, draft_length: int):
         gpu_memory_utilization=args.gpu_memory_utilization,
         speculative_config=speculative_config,
         enforce_eager=args.enforce_eager,
+        disable_log_stats=False,
     )
+    logger = FinishedRequestStatsLogger(llm.llm_engine.vllm_config)
+    llm.llm_engine.logger_manager.stat_loggers.append(logger)
+    setattr(llm, _FINISHED_REQUEST_STATS_LOGGER_ATTR, logger)
+    return llm
+
+
+def get_finished_request_stats_logger(llm: Any) -> FinishedRequestStatsLogger:
+    logger = getattr(llm, _FINISHED_REQUEST_STATS_LOGGER_ATTR, None)
+    if logger is None:
+        raise RuntimeError("Finished-request stats logger was not attached to LLM.")
+    return logger
 
 
 def get_inproc_handles(llm: Any) -> tuple[Any, Any]:
@@ -347,11 +688,30 @@ def _measure_worker_section(label: str, fn: Callable, *args: Any, **kwargs: Any)
     if not _WORKER_STATE.enabled or current_step is None:
         return fn(*args, **kwargs)
 
+    ep_collective_seq_id = None
+    if label in ("prepare", "finalize"):
+        ep_collective_seq_id = _WORKER_STATE.next_ep_collective_seq_id
+        _WORKER_STATE.next_ep_collective_seq_id += 1
+        if current_step.first_ep_collective_seq_id is None:
+            current_step.first_ep_collective_seq_id = ep_collective_seq_id
+
     _synchronize_device()
     start = time.perf_counter()
     result = fn(*args, **kwargs)
     _synchronize_device()
-    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    end = time.perf_counter()
+    elapsed_ms = (end - start) * 1000.0
+    start_ms = start * 1000.0 - current_step.step_start_time_ms
+    end_ms = end * 1000.0 - current_step.step_start_time_ms
+    current_step.events.append(
+        {
+            "label": label,
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "duration_ms": elapsed_ms,
+            "ep_collective_seq_id": ep_collective_seq_id,
+        }
+    )
     if label == "prepare":
         current_step.prepare_ms += elapsed_ms
     elif label == "finalize":
@@ -365,6 +725,45 @@ def _measure_worker_section(label: str, fn: Callable, *args: Any, **kwargs: Any)
     else:
         raise ValueError(f"Unknown measured label: {label}")
     return result
+
+
+def _extract_input_batch_metadata(input_batch: Any) -> dict[str, Any]:
+    req_ids = list(getattr(input_batch, "req_ids", ()))
+    if hasattr(input_batch, "is_prefilling_np"):
+        has_prefill = bool(np.any(input_batch.is_prefilling_np))
+    elif hasattr(input_batch, "num_computed_tokens_cpu") and hasattr(
+        input_batch, "num_prompt_tokens"
+    ):
+        num_reqs = int(getattr(input_batch, "num_reqs", len(req_ids)))
+        has_prefill = bool(
+            np.any(
+                input_batch.num_computed_tokens_cpu[:num_reqs]
+                < input_batch.num_prompt_tokens[:num_reqs]
+            )
+        )
+    else:
+        has_prefill = False
+    return {
+        "req_ids": req_ids,
+        "has_prefill": has_prefill,
+    }
+
+
+def _extract_worker_step_metadata(worker: Any) -> dict[str, Any]:
+    model_runner = getattr(worker, "model_runner", None)
+    execute_model_state = getattr(model_runner, "execute_model_state", None)
+    input_batch = getattr(execute_model_state, "input_batch", None)
+    if input_batch is not None:
+        return _extract_input_batch_metadata(input_batch)
+
+    input_batch = getattr(model_runner, "input_batch", None)
+    if input_batch is not None:
+        return _extract_input_batch_metadata(input_batch)
+
+    return {
+        "req_ids": [],
+        "has_prefill": False,
+    }
 
 
 def _install_worker_hooks() -> None:
@@ -381,8 +780,6 @@ def _install_worker_hooks() -> None:
 
     if _ORIGINAL_WORKER_EXECUTE_MODEL is not None:
         return
-
-    from types import NoneType
 
     from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
     from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
@@ -423,24 +820,43 @@ def _install_worker_hooks() -> None:
             )
             _WORKER_STATE.enter_step_logs += 1
 
-        _WORKER_STATE.current_step = StepAccumulator()
+        step_index = _WORKER_STATE.next_step_index
         _synchronize_device()
         start = time.perf_counter()
+        _WORKER_STATE.current_step = StepAccumulator(
+            step_start_time_ms=start * 1000.0
+        )
         try:
             output = _ORIGINAL_WORKER_EXECUTE_MODEL(self, scheduler_output)
             _synchronize_device()
-            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            end = time.perf_counter()
+            elapsed_ms = (end - start) * 1000.0
             assert _WORKER_STATE.current_step is not None
-            _WORKER_STATE.pending_step_timings.append(
+            _WORKER_STATE.pending_step_records.append(
                 {
-                    "total_ms": elapsed_ms,
-                    "attention_ms": _WORKER_STATE.current_step.attention_ms,
-                    "routing_ms": _WORKER_STATE.current_step.routing_ms,
-                    "prepare_ms": _WORKER_STATE.current_step.prepare_ms,
-                    "finalize_ms": _WORKER_STATE.current_step.finalize_ms,
-                    "ffn_ms": _WORKER_STATE.current_step.ffn_ms,
+                    "timing": {
+                        "total_ms": elapsed_ms,
+                        "attention_ms": _WORKER_STATE.current_step.attention_ms,
+                        "routing_ms": _WORKER_STATE.current_step.routing_ms,
+                        "prepare_ms": _WORKER_STATE.current_step.prepare_ms,
+                        "finalize_ms": _WORKER_STATE.current_step.finalize_ms,
+                        "ffn_ms": _WORKER_STATE.current_step.ffn_ms,
+                    },
+                    "metadata": _extract_worker_step_metadata(self),
+                    "trace": {
+                        "step_index": step_index,
+                        "first_ep_collective_seq_id": (
+                            _WORKER_STATE.current_step.first_ep_collective_seq_id
+                        ),
+                        "step_start_time_ms": (
+                            _WORKER_STATE.current_step.step_start_time_ms
+                        ),
+                        "step_end_time_ms": end * 1000.0,
+                        "events": list(_WORKER_STATE.current_step.events),
+                    },
                 }
             )
+            _WORKER_STATE.next_step_index += 1
             if _WORKER_STATE.queued_step_logs < 3:
                 print(
                     "[worker_timing] queued "
@@ -607,16 +1023,18 @@ def _install_worker_hooks() -> None:
 def install_experiment_hooks_worker(worker: Any) -> bool:
     _install_worker_hooks()
     _WORKER_STATE.enabled = False
-    _WORKER_STATE.pending_step_timings.clear()
+    _WORKER_STATE.pending_step_records.clear()
     _WORKER_STATE.current_step = None
     _WORKER_STATE.enter_step_logs = 0
     _WORKER_STATE.queued_step_logs = 0
+    _WORKER_STATE.next_step_index = 0
+    _WORKER_STATE.next_ep_collective_seq_id = 0
     return True
 
 
 def start_condition_collection_worker(worker: Any) -> bool:
     _WORKER_STATE.enabled = True
-    _WORKER_STATE.pending_step_timings.clear()
+    _WORKER_STATE.pending_step_records.clear()
     _WORKER_STATE.current_step = None
     _WORKER_STATE.enter_step_logs = 0
     _WORKER_STATE.queued_step_logs = 0
@@ -625,8 +1043,8 @@ def start_condition_collection_worker(worker: Any) -> bool:
 
 def stop_condition_collection_worker(worker: Any) -> dict[str, int]:
     _WORKER_STATE.enabled = False
-    pending = len(_WORKER_STATE.pending_step_timings)
-    _WORKER_STATE.pending_step_timings.clear()
+    pending = len(_WORKER_STATE.pending_step_records)
+    _WORKER_STATE.pending_step_records.clear()
     _WORKER_STATE.current_step = None
     return {"pending_timings": pending}
 
@@ -635,15 +1053,58 @@ def pop_step_timing_worker(
     worker: Any,
     timeout_s: float = 5.0,
     poll_s: float = 0.01,
-) -> dict[str, float] | None:
+) -> dict[str, Any] | None:
     deadline = time.perf_counter() + timeout_s
     while time.perf_counter() < deadline:
-        if _WORKER_STATE.pending_step_timings:
-            return _WORKER_STATE.pending_step_timings.popleft()
+        if _WORKER_STATE.pending_step_records:
+            return _WORKER_STATE.pending_step_records.popleft()
         time.sleep(poll_s)
-    if _WORKER_STATE.pending_step_timings:
-        return _WORKER_STATE.pending_step_timings.popleft()
+    if _WORKER_STATE.pending_step_records:
+        return _WORKER_STATE.pending_step_records.popleft()
     return None
+
+
+def collect_expert_to_ep_rank_worker(worker: Any) -> np.ndarray:
+    model_runner = getattr(worker, "model_runner", None)
+    model = getattr(model_runner, "model", None)
+    if model is None:
+        return np.empty((0,), dtype=np.int64)
+
+    for module in model.modules():
+        expert_map = getattr(module, "_expert_map", None)
+        if expert_map is None:
+            expert_map_manager = getattr(module, "expert_map_manager", None)
+            expert_map = getattr(expert_map_manager, "expert_map", None)
+        global_num_experts = getattr(module, "global_num_experts", None)
+        ep_rank = getattr(module, "ep_rank", None)
+        if expert_map is None or global_num_experts is None or ep_rank is None:
+            continue
+        expert_map_cpu = expert_map.detach().cpu().numpy()
+        result = np.full((int(global_num_experts),), -1, dtype=np.int64)
+        result[np.asarray(expert_map_cpu[: int(global_num_experts)]) >= 0] = int(
+            ep_rank
+        )
+        return result
+    return np.empty((0,), dtype=np.int64)
+
+
+def _extract_step_phase_boundaries(
+    worker_trace: dict[str, Any],
+) -> tuple[float, float]:
+    step_start_time_ms = float(worker_trace["step_start_time_ms"])
+    prepare_events = [
+        step_start_time_ms + float(event["start_ms"])
+        for event in worker_trace["events"]
+        if str(event["label"]) == "prepare"
+    ]
+    finalize_events = [
+        step_start_time_ms + float(event["end_ms"])
+        for event in worker_trace["events"]
+        if str(event["label"]) == "finalize"
+    ]
+    if not prepare_events or not finalize_events:
+        return float("nan"), float("nan")
+    return min(prepare_events), max(finalize_events)
 
 
 def _close_ffn_component(step_timing: StepTiming, tol_ms: float = 1e-3) -> float:
@@ -670,6 +1131,7 @@ class SchedulerStepRecorder:
         use_spec_decode: bool,
         layers: tuple[int, ...],
         num_experts: int,
+        trace_steps_limit: int = 0,
     ) -> None:
         self.scheduler = scheduler
         self.model_executor = model_executor
@@ -686,9 +1148,25 @@ class SchedulerStepRecorder:
         self.step_finalize_ms: list[float] = []
         self.step_ffn_ms: list[float] = []
         self.step_kinds: list[str] = []
+        self.step_indices: list[int] = []
+        self.step_start_time_ms: list[float] = []
+        self.step_end_time_ms: list[float] = []
+        self.prepare_start_time_ms: list[float] = []
+        self.finalize_end_time_ms: list[float] = []
+        self.candidate_first_ep_collective_seq_ids: list[int] = []
+        self.candidate_step_kinds: list[str] = []
+        self.candidate_drop_reasons: list[str] = []
+        self.candidate_step_total_tokens: list[int] = []
+        self.candidate_step_total_ms: list[float] = []
+        self.candidate_step_ffn_ms: list[float] = []
+        self.candidate_step_histograms: list[np.ndarray] = []
         self.num_forward_steps_total = 0
         self.num_dropped_steps = 0
+        self.num_prefill_dropped_steps = 0
+        self.num_mixed_dropped_steps = 0
         self.debug_update_logs = 0
+        self.trace_steps_limit = trace_steps_limit
+        self.trace_samples: list[dict[str, Any]] = []
 
     def __enter__(self) -> "SchedulerStepRecorder":
         self._original_update = self.scheduler.update_from_output
@@ -705,43 +1183,156 @@ class SchedulerStepRecorder:
                     f"num_forward_steps_total={self.num_forward_steps_total}",
                     flush=True,
                 )
-            worker_timings = self.model_executor.collective_rpc(
+            worker_records = self.model_executor.collective_rpc(
                 pop_step_timing_worker,
                 timeout=30,
             )
-            step_timing = aggregate_worker_step_timings(worker_timings)
+            step_timing = aggregate_worker_step_timings(
+                [
+                    None if record is None else record["timing"]
+                    for record in worker_records
+                ]
+            )
+            worker_metadata = next(
+                (
+                    record["metadata"]
+                    for record in worker_records
+                    if record is not None and record.get("metadata")
+                ),
+                None,
+            )
+            worker_trace = next(
+                (
+                    record["trace"]
+                    for record in worker_records
+                    if record is not None and record.get("trace") is not None
+                ),
+                None,
+            )
             self.num_forward_steps_total += 1
 
-            captured_step = select_step_routing_data(
+            capture_decision = classify_step_capture(
                 scheduler_output,
                 model_runner_output,
+                worker_step_metadata=worker_metadata,
                 use_spec_decode=self.use_spec_decode,
             )
+            captured_step = capture_decision.captured_step
+            ffn_ms = _close_ffn_component(step_timing)
+            first_ep_collective_seq_id = -1
+            if worker_trace is not None:
+                raw_ep_seq = worker_trace.get("first_ep_collective_seq_id")
+                first_ep_collective_seq_id = (
+                    -1 if raw_ep_seq is None else int(raw_ep_seq)
+                )
+            candidate_histogram = np.zeros(
+                (len(self.layers), self.num_experts), dtype=np.int64
+            )
+            candidate_total_tokens = 0
+            if captured_step is not None:
+                candidate_histogram = count_layer_expert_histograms(
+                    captured_step.routing_data,
+                    layers=self.layers,
+                    num_experts=self.num_experts,
+                )
+                candidate_total_tokens = captured_step.total_scheduled_tokens
+
+            self.candidate_first_ep_collective_seq_ids.append(
+                first_ep_collective_seq_id
+            )
+            self.candidate_step_kinds.append(capture_decision.local_step_kind)
+            self.candidate_drop_reasons.append(capture_decision.drop_reason or "")
+            self.candidate_step_total_tokens.append(candidate_total_tokens)
+            self.candidate_step_total_ms.append(step_timing.total_ms)
+            self.candidate_step_ffn_ms.append(ffn_ms)
+            self.candidate_step_histograms.append(candidate_histogram)
+
             if captured_step is None:
                 self.num_dropped_steps += 1
+                if capture_decision.drop_reason == "prefill":
+                    self.num_prefill_dropped_steps += 1
+                elif capture_decision.drop_reason == "mixed":
+                    self.num_mixed_dropped_steps += 1
             else:
-                self.step_histograms.append(
-                    count_layer_expert_histograms(
-                        captured_step.routing_data,
-                        layers=self.layers,
-                        num_experts=self.num_experts,
-                    )
-                )
+                self.step_histograms.append(candidate_histogram)
                 self.step_total_tokens.append(captured_step.total_scheduled_tokens)
                 self.step_total_ms.append(step_timing.total_ms)
                 self.step_attention_ms.append(step_timing.attention_ms)
                 self.step_routing_ms.append(step_timing.routing_ms)
                 self.step_prepare_ms.append(step_timing.prepare_ms)
                 self.step_finalize_ms.append(step_timing.finalize_ms)
-                self.step_ffn_ms.append(_close_ffn_component(step_timing))
+                self.step_ffn_ms.append(ffn_ms)
                 self.step_kinds.append(captured_step.step_kind)
+                if worker_trace is None:
+                    prepare_start_ms = float("nan")
+                    finalize_end_ms = float("nan")
+                    step_index = -1
+                    step_start_time_ms = float("nan")
+                    step_end_time_ms = float("nan")
+                    trace_events = []
+                else:
+                    prepare_start_ms, finalize_end_ms = _extract_step_phase_boundaries(
+                        worker_trace
+                    )
+                    step_index = int(worker_trace["step_index"])
+                    step_start_time_ms = float(worker_trace["step_start_time_ms"])
+                    step_end_time_ms = float(worker_trace["step_end_time_ms"])
+                    trace_events = list(worker_trace["events"])
+                self.step_indices.append(first_ep_collective_seq_id)
+                self.step_start_time_ms.append(step_start_time_ms)
+                self.step_end_time_ms.append(step_end_time_ms)
+                self.prepare_start_time_ms.append(prepare_start_ms)
+                self.finalize_end_time_ms.append(finalize_end_ms)
+                if (
+                    self.trace_steps_limit > 0
+                    and len(self.trace_samples) < self.trace_steps_limit
+                ):
+                    self.trace_samples.append(
+                        {
+                            "step_index": step_index,
+                            "first_ep_collective_seq_id": (
+                                first_ep_collective_seq_id
+                            ),
+                            "step_start_time_ms": step_start_time_ms,
+                            "step_end_time_ms": step_end_time_ms,
+                            "step_total_ms": float(step_timing.total_ms),
+                            "step_kind": captured_step.step_kind,
+                            "total_scheduled_tokens": int(
+                                captured_step.total_scheduled_tokens
+                            ),
+                            "request_ids": list(captured_step.request_ids),
+                            "events": [
+                                {
+                                    "label": str(event["label"]),
+                                    "start_ms": float(event["start_ms"]),
+                                    "end_ms": float(event["end_ms"]),
+                                    "duration_ms": float(event["duration_ms"]),
+                                    "ep_collective_seq_id": (
+                                        None
+                                        if event.get("ep_collective_seq_id") is None
+                                        else int(event["ep_collective_seq_id"])
+                                    ),
+                                }
+                                for event in trace_events
+                            ],
+                            "phase_totals_ms": {
+                                "attention": float(step_timing.attention_ms),
+                                "routing": float(step_timing.routing_ms),
+                                "prepare": float(step_timing.prepare_ms),
+                                "finalize": float(step_timing.finalize_ms),
+                                "ffn": float(ffn_ms),
+                            },
+                        }
+                    )
 
             if self.debug_update_logs < 5:
                 print(
                     "[recorder] update end "
                     f"use_spec_decode={self.use_spec_decode} "
                     f"captured={captured_step is not None} "
-                    f"step_kind={captured_step.step_kind if captured_step else 'none'} "
+                    f"drop_reason={capture_decision.drop_reason or 'none'} "
+                    f"step_kind={capture_decision.local_step_kind} "
+                    f"ep_seq={first_ep_collective_seq_id} "
                     f"total_ms={step_timing.total_ms:.3f}",
                     flush=True,
                 )
@@ -757,213 +1348,774 @@ class SchedulerStepRecorder:
             self.scheduler.update_from_output = self._original_update
 
 
-def collect_condition(
-    args: Namespace,
-    prompt_items: list[dict[str, list[int]]],
-    raw_dir: Path,
+def _append_optional_arg(command: list[str], flag: str, value: Any) -> None:
+    if value is None:
+        return
+    command.extend([flag, str(value)])
+
+
+def _empty_step_histograms(args: Namespace) -> np.ndarray:
+    return np.empty((0, len(args.layers), args.num_experts), dtype=np.int64)
+
+
+def _empty_str_array() -> np.ndarray:
+    return np.asarray([], dtype=np.str_)
+
+
+def _empty_int_array() -> np.ndarray:
+    return np.asarray([], dtype=np.int64)
+
+
+def _empty_float_array() -> np.ndarray:
+    return np.asarray([], dtype=np.float64)
+
+
+def _empty_candidate_histograms(args: Namespace) -> np.ndarray:
+    return np.empty((0, len(args.layers), args.num_experts), dtype=np.int64)
+
+
+def _check_pending_timings(
+    pending_counts: list[dict[str, int]],
     *,
     batch_size: int,
     draft_length: int,
-) -> CollectedConditionSummary:
-    from vllm import SamplingParams
-
-    print(
-        f"[collect] start batch_size={batch_size} draft_length={draft_length}",
-        flush=True,
-    )
-    llm = create_llm(args, batch_size, draft_length)
-    print(
-        f"[collect] llm created batch_size={batch_size} draft_length={draft_length}",
-        flush=True,
-    )
-    scheduler, model_executor = get_inproc_handles(llm)
-    print(
-        f"[collect] inproc handles ready batch_size={batch_size} "
-        f"draft_length={draft_length} model_executor={type(model_executor).__name__}",
-        flush=True,
-    )
-    print(
-        f"[collect] install hooks begin batch_size={batch_size} "
-        f"draft_length={draft_length}",
-        flush=True,
-    )
-    model_executor.collective_rpc(install_experiment_hooks_worker, timeout=30)
-    print(
-        f"[collect] install hooks end batch_size={batch_size} "
-        f"draft_length={draft_length}",
-        flush=True,
-    )
-    sampling_params = SamplingParams(
-        temperature=0.0,
-        max_tokens=args.max_tokens,
-        ignore_eos=True,
-    )
-    use_spec_decode = draft_length > 0
-    selected_indices = select_dataset_indices(batch_size, len(prompt_items))
-    prompt_batch = [prompt_items[idx] for idx in selected_indices]
-    prompt_lengths = np.asarray(
-        [len(item["prompt_token_ids"]) for item in prompt_batch],
-        dtype=np.int64,
-    )
-    if args.warmup_rounds > 0:
-        print(
-            f"[collect] warmup begin batch_size={batch_size} "
-            f"draft_length={draft_length} rounds={args.warmup_rounds}",
-            flush=True,
+    round_idx: int,
+) -> None:
+    pending_values = [item["pending_timings"] for item in pending_counts]
+    if not any(pending_values):
+        return
+    if len(set(pending_values)) != 1:
+        raise RuntimeError(
+            "Worker timing queues ended with inconsistent leftover counts: "
+            f"{pending_counts}"
         )
-        for warmup_idx in range(args.warmup_rounds):
-            llm.generate(prompt_batch, sampling_params=sampling_params, use_tqdm=False)
-            print(
-                f"[collect] warmup done batch_size={batch_size} "
-                f"draft_length={draft_length} round={warmup_idx + 1}",
-                flush=True,
-            )
     print(
-        f"[collect] start collection begin batch_size={batch_size} "
-        f"draft_length={draft_length}",
-        flush=True,
-    )
-    model_executor.collective_rpc(start_condition_collection_worker, timeout=30)
-    print(
-        f"[collect] start collection end batch_size={batch_size} "
-        f"draft_length={draft_length}",
+        "[collect-rank] warning leftover worker timings were discarded "
+        f"batch_size={batch_size} draft_length={draft_length} "
+        f"round={round_idx} pending_per_worker={pending_values[0]}",
         flush=True,
     )
 
+
+def _run_recorded_round(
+    llm: Any,
+    scheduler: Any,
+    model_executor: Any,
+    sampling_params: Any,
+    prompt_batch: list[dict[str, list[int]]],
+    *,
+    batch_size: int,
+    draft_length: int,
+    round_idx: int,
+    use_spec_decode: bool,
+    layers: tuple[int, ...],
+    num_experts: int,
+    trace_steps_limit: int,
+) -> tuple[Any, SchedulerStepRecorder, float]:
+    model_executor.collective_rpc(start_condition_collection_worker, timeout=30)
     try:
         with SchedulerStepRecorder(
             scheduler,
             model_executor,
             use_spec_decode=use_spec_decode,
-            layers=tuple(args.layers),
-            num_experts=args.num_experts,
+            layers=layers,
+            num_experts=num_experts,
+            trace_steps_limit=trace_steps_limit,
         ) as recorder:
-            print(
-                f"[collect] generate begin batch_size={batch_size} "
-                f"draft_length={draft_length}",
-                flush=True,
+            start = time.perf_counter()
+            outputs = llm.generate(
+                prompt_batch,
+                sampling_params=sampling_params,
+                use_tqdm=False,
+            )
+            round_latency_ms = (time.perf_counter() - start) * 1000.0
+    finally:
+        pending_counts = model_executor.collective_rpc(stop_condition_collection_worker)
+        _check_pending_timings(
+            pending_counts,
+            batch_size=batch_size,
+            draft_length=draft_length,
+            round_idx=round_idx,
+        )
+    return outputs, recorder, round_latency_ms
+
+
+def _local_prompt_batch(
+    prompt_items: list[dict[str, list[int]]],
+    indices: np.ndarray,
+) -> list[dict[str, list[int]]]:
+    return [prompt_items[int(idx)] for idx in indices.tolist()]
+
+
+def collect_condition_for_rank(args: Namespace) -> RankConditionData:
+    from vllm import SamplingParams
+
+    validate_parallel_config(args)
+    prompt_items = load_prompt_items(args)
+    if not prompt_items:
+        raise RuntimeError("Prompt cache is empty.")
+
+    dp_rank = args.dp_rank
+    print(
+        f"[collect-rank] start dp_rank={dp_rank} batch_size={args.batch_size} "
+        f"draft_length={args.draft_length}",
+        flush=True,
+    )
+
+    os.environ["VLLM_DP_RANK"] = str(args.dp_rank)
+    os.environ["VLLM_DP_RANK_LOCAL"] = str(args.dp_local_rank)
+    os.environ["VLLM_DP_SIZE"] = str(args.data_parallel_size)
+    os.environ["VLLM_DP_MASTER_IP"] = args.dp_master_ip
+    os.environ["VLLM_DP_MASTER_PORT"] = str(args.dp_master_port)
+
+    llm = create_llm(args, args.batch_size, args.draft_length)
+    scheduler, model_executor = get_inproc_handles(llm)
+    model_executor.collective_rpc(install_experiment_hooks_worker, timeout=30)
+
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=args.max_tokens,
+        ignore_eos=True,
+    )
+    use_spec_decode = args.draft_length > 0
+    total_rounds = num_condition_rounds(args.num_samples, args.batch_size)
+
+    warmup_indices = next(
+        (
+            shard_global_batch_indices(
+                num_samples=args.num_samples,
+                global_batch_size=args.batch_size,
+                round_idx=round_idx,
+                dp_size=args.data_parallel_size,
+                dp_rank=dp_rank,
+            )
+            for round_idx in range(total_rounds)
+            if len(
+                shard_global_batch_indices(
+                    num_samples=args.num_samples,
+                    global_batch_size=args.batch_size,
+                    round_idx=round_idx,
+                    dp_size=args.data_parallel_size,
+                    dp_rank=dp_rank,
+                )
+            )
+            > 0
+        ),
+        np.empty((0,), dtype=np.int64),
+    )
+    warmup_batch = (
+        _local_prompt_batch(prompt_items, warmup_indices)
+        if len(warmup_indices) > 0
+        else [prompt_items[0]]
+    )
+
+    if args.warmup_rounds > 0:
+        for _ in range(args.warmup_rounds):
+            llm.generate(warmup_batch, sampling_params=sampling_params, use_tqdm=False)
+    finished_stats_logger = get_finished_request_stats_logger(llm)
+    finished_stats_logger.reset()
+    rank_expert_maps = model_executor.collective_rpc(
+        collect_expert_to_ep_rank_worker,
+        timeout=30,
+    )
+    valid_rank_maps = [
+        np.asarray(rank_map, dtype=np.int64)
+        for rank_map in rank_expert_maps
+        if np.asarray(rank_map).shape == (args.num_experts,)
+    ]
+    expert_to_ep_rank = merge_expert_to_ep_rank_maps(
+        valid_rank_maps,
+        num_experts=args.num_experts,
+        ep_size=args.data_parallel_size,
+    )
+
+    selected_indices_parts: list[np.ndarray] = []
+    prompt_lengths_parts: list[np.ndarray] = []
+    output_lengths_parts: list[np.ndarray] = []
+    step_histograms_parts: list[np.ndarray] = []
+    step_total_tokens_parts: list[np.ndarray] = []
+    step_total_ms_parts: list[np.ndarray] = []
+    step_attention_ms_parts: list[np.ndarray] = []
+    step_routing_ms_parts: list[np.ndarray] = []
+    step_prepare_ms_parts: list[np.ndarray] = []
+    step_finalize_ms_parts: list[np.ndarray] = []
+    step_ffn_ms_parts: list[np.ndarray] = []
+    step_kinds_parts: list[np.ndarray] = []
+    step_indices_parts: list[np.ndarray] = []
+    step_start_time_ms_parts: list[np.ndarray] = []
+    step_end_time_ms_parts: list[np.ndarray] = []
+    prepare_start_time_ms_parts: list[np.ndarray] = []
+    finalize_end_time_ms_parts: list[np.ndarray] = []
+    candidate_first_ep_collective_seq_id_parts: list[np.ndarray] = []
+    candidate_step_kind_parts: list[np.ndarray] = []
+    candidate_drop_reason_parts: list[np.ndarray] = []
+    candidate_step_total_tokens_parts: list[np.ndarray] = []
+    candidate_step_total_ms_parts: list[np.ndarray] = []
+    candidate_step_ffn_ms_parts: list[np.ndarray] = []
+    candidate_step_histogram_parts: list[np.ndarray] = []
+    trace_samples: list[dict[str, Any]] = []
+    condition_latency_ms = 0.0
+    num_forward_steps_total = 0
+    num_captured_steps = 0
+    num_dropped_steps = 0
+    num_prefill_dropped_steps = 0
+    num_mixed_dropped_steps = 0
+    finished_stats = FinishedRequestStatTotals(0.0, 0, 0)
+
+    try:
+        for round_idx in range(total_rounds):
+            local_indices = shard_global_batch_indices(
+                num_samples=args.num_samples,
+                global_batch_size=args.batch_size,
+                round_idx=round_idx,
+                dp_size=args.data_parallel_size,
+                dp_rank=dp_rank,
+            )
+            capture_round = len(local_indices) > 0
+            prompt_batch = (
+                _local_prompt_batch(prompt_items, local_indices)
+                if capture_round
+                else [prompt_items[0]]
             )
             start = time.perf_counter()
-            llm.generate(prompt_batch, sampling_params=sampling_params, use_tqdm=False)
-            condition_latency_ms = (time.perf_counter() - start) * 1000.0
-            print(
-                f"[collect] generate end batch_size={batch_size} "
-                f"draft_length={draft_length}",
-                flush=True,
-            )
-
-        pending_counts = model_executor.collective_rpc(stop_condition_collection_worker)
-        pending_values = [item["pending_timings"] for item in pending_counts]
-        if any(pending_values):
-            if len(set(pending_values)) != 1:
-                raise RuntimeError(
-                    "Worker timing queues ended with inconsistent leftover counts: "
-                    f"{pending_counts}"
+            if capture_round:
+                outputs, recorder, _ = _run_recorded_round(
+                    llm,
+                    scheduler,
+                    model_executor,
+                    sampling_params,
+                    prompt_batch,
+                    batch_size=args.batch_size,
+                    draft_length=args.draft_length,
+                    round_idx=round_idx,
+                    use_spec_decode=use_spec_decode,
+                    layers=tuple(args.layers),
+                    num_experts=args.num_experts,
+                    trace_steps_limit=args.trace_steps_per_rank,
                 )
-            print(
-                "[collect] warning leftover worker timings were discarded "
-                f"batch_size={batch_size} draft_length={draft_length} "
-                f"pending_per_worker={pending_values[0]}",
-                flush=True,
-            )
+            else:
+                outputs = llm.generate(
+                    prompt_batch,
+                    sampling_params=sampling_params,
+                    use_tqdm=False,
+                )
+                recorder = None
+            condition_latency_ms += (time.perf_counter() - start) * 1000.0
 
-        if not recorder.step_histograms:
-            raise RuntimeError(
-                "No routed-expert steps were captured for "
-                f"batch_size={batch_size}, draft_length={draft_length}."
-            )
+            if not capture_round:
+                continue
+            if recorder is None:
+                raise AssertionError("Recorder must exist for captured rounds.")
 
-        step_histograms = np.stack(recorder.step_histograms, axis=0)
-        step_total_tokens = np.asarray(recorder.step_total_tokens, dtype=np.int64)
-        step_total_ms = np.asarray(recorder.step_total_ms, dtype=np.float64)
-        step_attention_ms = np.asarray(recorder.step_attention_ms, dtype=np.float64)
-        step_routing_ms = np.asarray(recorder.step_routing_ms, dtype=np.float64)
-        step_prepare_ms = np.asarray(recorder.step_prepare_ms, dtype=np.float64)
-        step_finalize_ms = np.asarray(recorder.step_finalize_ms, dtype=np.float64)
-        step_ffn_ms = np.asarray(recorder.step_ffn_ms, dtype=np.float64)
-        avg_histograms = average_step_histograms(step_histograms)
-        raw_data = ConditionRawData(
-            batch_size=batch_size,
-            draft_length=draft_length,
-            selected_dataset_indices=selected_indices,
-            prompt_lengths=prompt_lengths,
-            condition_latency_ms=condition_latency_ms,
-            step_histograms=step_histograms,
-            step_total_tokens=step_total_tokens,
-            step_total_ms=step_total_ms,
-            step_attention_ms=step_attention_ms,
-            step_routing_ms=step_routing_ms,
-            step_prepare_ms=step_prepare_ms,
-            step_finalize_ms=step_finalize_ms,
-            step_ffn_ms=step_ffn_ms,
-            captured_step_kinds=np.asarray(recorder.step_kinds),
-            layers=np.asarray(args.layers, dtype=np.int64),
-            avg_histograms=avg_histograms,
-            num_forward_steps_total=recorder.num_forward_steps_total,
-            num_captured_steps=len(recorder.step_histograms),
-            num_dropped_steps=recorder.num_dropped_steps,
-        )
-        raw_path = raw_dir / f"{condition_name(batch_size, draft_length)}.npz"
-        raw_path.parent.mkdir(parents=True, exist_ok=True)
-        np.savez_compressed(raw_path, **raw_data.to_npz_payload())
-        print(
-            "[collect] finished "
-            f"batch_size={batch_size} draft_length={draft_length} "
-            f"captured_steps={len(recorder.step_histograms)} "
-            f"latency_ms={condition_latency_ms:.3f}",
-            flush=True,
-        )
-        return CollectedConditionSummary(
-            batch_size=batch_size,
-            draft_length=draft_length,
-            raw_path=str(raw_path.relative_to(raw_dir.parent)),
-            condition_latency_ms=condition_latency_ms,
-            num_forward_steps_total=recorder.num_forward_steps_total,
-            num_captured_steps=len(recorder.step_histograms),
-            num_dropped_steps=recorder.num_dropped_steps,
-        )
+            selected_indices_parts.append(local_indices.astype(np.int64, copy=False))
+            prompt_lengths_parts.append(
+                np.asarray(
+                    [len(item["prompt_token_ids"]) for item in prompt_batch],
+                    dtype=np.int64,
+                )
+            )
+            output_lengths_parts.append(
+                np.asarray(
+                    [len(output.outputs[0].token_ids) for output in outputs],
+                    dtype=np.int64,
+                )
+            )
+            candidate_first_ep_collective_seq_id_parts.append(
+                np.asarray(
+                    recorder.candidate_first_ep_collective_seq_ids,
+                    dtype=np.int64,
+                )
+            )
+            candidate_step_kind_parts.append(
+                np.asarray(recorder.candidate_step_kinds, dtype=np.str_)
+            )
+            candidate_drop_reason_parts.append(
+                np.asarray(recorder.candidate_drop_reasons, dtype=np.str_)
+            )
+            candidate_step_total_tokens_parts.append(
+                np.asarray(recorder.candidate_step_total_tokens, dtype=np.int64)
+            )
+            candidate_step_total_ms_parts.append(
+                np.asarray(recorder.candidate_step_total_ms, dtype=np.float64)
+            )
+            candidate_step_ffn_ms_parts.append(
+                np.asarray(recorder.candidate_step_ffn_ms, dtype=np.float64)
+            )
+            if recorder.candidate_step_histograms:
+                candidate_step_histogram_parts.append(
+                    np.stack(recorder.candidate_step_histograms, axis=0).astype(
+                        np.int64
+                    )
+                )
+            if recorder.step_histograms:
+                step_histograms_parts.append(
+                    np.stack(recorder.step_histograms, axis=0).astype(np.int64)
+                )
+                step_total_tokens_parts.append(
+                    np.asarray(recorder.step_total_tokens, dtype=np.int64)
+                )
+                step_total_ms_parts.append(
+                    np.asarray(recorder.step_total_ms, dtype=np.float64)
+                )
+                step_attention_ms_parts.append(
+                    np.asarray(recorder.step_attention_ms, dtype=np.float64)
+                )
+                step_routing_ms_parts.append(
+                    np.asarray(recorder.step_routing_ms, dtype=np.float64)
+                )
+                step_prepare_ms_parts.append(
+                    np.asarray(recorder.step_prepare_ms, dtype=np.float64)
+                )
+                step_finalize_ms_parts.append(
+                    np.asarray(recorder.step_finalize_ms, dtype=np.float64)
+                )
+                step_ffn_ms_parts.append(
+                    np.asarray(recorder.step_ffn_ms, dtype=np.float64)
+                )
+                step_kinds_parts.append(np.asarray(recorder.step_kinds, dtype=np.str_))
+                step_indices_parts.append(
+                    np.asarray(recorder.step_indices, dtype=np.int64)
+                )
+                step_start_time_ms_parts.append(
+                    np.asarray(recorder.step_start_time_ms, dtype=np.float64)
+                )
+                step_end_time_ms_parts.append(
+                    np.asarray(recorder.step_end_time_ms, dtype=np.float64)
+                )
+                prepare_start_time_ms_parts.append(
+                    np.asarray(recorder.prepare_start_time_ms, dtype=np.float64)
+                )
+                finalize_end_time_ms_parts.append(
+                    np.asarray(recorder.finalize_end_time_ms, dtype=np.float64)
+                )
+
+            num_forward_steps_total += recorder.num_forward_steps_total
+            num_captured_steps += len(recorder.step_histograms)
+            num_dropped_steps += recorder.num_dropped_steps
+            num_prefill_dropped_steps += recorder.num_prefill_dropped_steps
+            num_mixed_dropped_steps += recorder.num_mixed_dropped_steps
+            if args.trace_steps_per_rank > 0 and recorder.trace_samples:
+                remaining = args.trace_steps_per_rank - len(trace_samples)
+                if remaining > 0:
+                    trace_samples.extend(recorder.trace_samples[:remaining])
     finally:
-        print(
-            f"[collect] teardown begin batch_size={batch_size} "
-            f"draft_length={draft_length}",
-            flush=True,
-        )
+        finished_stats = finished_stats_logger.snapshot()
         try:
             llm.llm_engine.engine_core.shutdown()
-            print(
-                f"[collect] shutdown done batch_size={batch_size} "
-                f"draft_length={draft_length}",
-                flush=True,
-            )
         except Exception:
-            print(
-                f"[collect] shutdown failed batch_size={batch_size} "
-                f"draft_length={draft_length}",
-                flush=True,
-            )
+            pass
         del llm
-        print(
-            f"[collect] llm deleted batch_size={batch_size} "
-            f"draft_length={draft_length}",
-            flush=True,
+
+    candidate_first_ep_collective_seq_ids = (
+        np.concatenate(candidate_first_ep_collective_seq_id_parts, axis=0)
+        if candidate_first_ep_collective_seq_id_parts
+        else _empty_int_array()
+    )
+    candidate_step_kinds = (
+        np.concatenate(candidate_step_kind_parts, axis=0)
+        if candidate_step_kind_parts
+        else _empty_str_array()
+    )
+    candidate_drop_reasons = (
+        np.concatenate(candidate_drop_reason_parts, axis=0)
+        if candidate_drop_reason_parts
+        else _empty_str_array()
+    )
+    candidate_step_total_tokens = (
+        np.concatenate(candidate_step_total_tokens_parts, axis=0)
+        if candidate_step_total_tokens_parts
+        else _empty_int_array()
+    )
+    candidate_step_total_ms = (
+        np.concatenate(candidate_step_total_ms_parts, axis=0)
+        if candidate_step_total_ms_parts
+        else _empty_float_array()
+    )
+    candidate_step_ffn_ms = (
+        np.concatenate(candidate_step_ffn_ms_parts, axis=0)
+        if candidate_step_ffn_ms_parts
+        else _empty_float_array()
+    )
+    candidate_step_histograms = (
+        np.concatenate(candidate_step_histogram_parts, axis=0)
+        if candidate_step_histogram_parts
+        else _empty_candidate_histograms(args)
+    )
+
+    if not step_histograms_parts:
+        return RankConditionData(
+            selected_dataset_indices=np.concatenate(selected_indices_parts, axis=0)
+            if selected_indices_parts
+            else np.empty((0,), dtype=np.int64),
+            prompt_lengths=np.concatenate(prompt_lengths_parts, axis=0)
+            if prompt_lengths_parts
+            else np.empty((0,), dtype=np.int64),
+            output_lengths=np.concatenate(output_lengths_parts, axis=0)
+            if output_lengths_parts
+            else np.empty((0,), dtype=np.int64),
+            step_histograms=_empty_step_histograms(args),
+            step_total_tokens=np.empty((0,), dtype=np.int64),
+            step_total_ms=np.empty((0,), dtype=np.float64),
+            step_attention_ms=np.empty((0,), dtype=np.float64),
+            step_routing_ms=np.empty((0,), dtype=np.float64),
+            step_prepare_ms=np.empty((0,), dtype=np.float64),
+            step_finalize_ms=np.empty((0,), dtype=np.float64),
+            step_ffn_ms=np.empty((0,), dtype=np.float64),
+            captured_step_kinds=_empty_str_array(),
+            captured_step_indices=_empty_int_array(),
+            captured_step_start_time_ms=_empty_float_array(),
+            captured_step_end_time_ms=_empty_float_array(),
+            captured_prepare_start_time_ms=_empty_float_array(),
+            captured_finalize_end_time_ms=_empty_float_array(),
+            candidate_first_ep_collective_seq_ids=(
+                candidate_first_ep_collective_seq_ids
+            ),
+            candidate_step_kinds=candidate_step_kinds,
+            candidate_drop_reasons=candidate_drop_reasons,
+            candidate_step_total_tokens=candidate_step_total_tokens,
+            candidate_step_total_ms=candidate_step_total_ms,
+            candidate_step_ffn_ms=candidate_step_ffn_ms,
+            candidate_step_histograms=candidate_step_histograms,
+            expert_to_ep_rank=expert_to_ep_rank,
+            condition_latency_ms=condition_latency_ms,
+            decode_time_total_ms=finished_stats.decode_time_total_ms,
+            num_generation_tokens_total=(
+                finished_stats.num_generation_tokens_total
+            ),
+            num_output_tokens_excl_first_total=(
+                finished_stats.num_output_tokens_excl_first_total
+            ),
+            num_forward_steps_total=num_forward_steps_total,
+            num_captured_steps=num_captured_steps,
+            num_dropped_steps=num_dropped_steps,
+            num_prefill_dropped_steps=num_prefill_dropped_steps,
+            num_mixed_dropped_steps=num_mixed_dropped_steps,
+            trace_samples=trace_samples,
         )
-        print(
-            f"[collect] teardown done batch_size={batch_size} "
-            f"draft_length={draft_length}",
-            flush=True,
+
+    return RankConditionData(
+        selected_dataset_indices=np.concatenate(selected_indices_parts, axis=0),
+        prompt_lengths=np.concatenate(prompt_lengths_parts, axis=0),
+        output_lengths=np.concatenate(output_lengths_parts, axis=0),
+        step_histograms=np.concatenate(step_histograms_parts, axis=0),
+        step_total_tokens=np.concatenate(step_total_tokens_parts, axis=0),
+        step_total_ms=np.concatenate(step_total_ms_parts, axis=0),
+        step_attention_ms=np.concatenate(step_attention_ms_parts, axis=0),
+        step_routing_ms=np.concatenate(step_routing_ms_parts, axis=0),
+        step_prepare_ms=np.concatenate(step_prepare_ms_parts, axis=0),
+        step_finalize_ms=np.concatenate(step_finalize_ms_parts, axis=0),
+        step_ffn_ms=np.concatenate(step_ffn_ms_parts, axis=0),
+        captured_step_kinds=np.concatenate(step_kinds_parts, axis=0),
+        captured_step_indices=np.concatenate(step_indices_parts, axis=0),
+        captured_step_start_time_ms=np.concatenate(step_start_time_ms_parts, axis=0),
+        captured_step_end_time_ms=np.concatenate(step_end_time_ms_parts, axis=0),
+        captured_prepare_start_time_ms=np.concatenate(
+            prepare_start_time_ms_parts, axis=0
+        ),
+        captured_finalize_end_time_ms=np.concatenate(
+            finalize_end_time_ms_parts, axis=0
+        ),
+        candidate_first_ep_collective_seq_ids=candidate_first_ep_collective_seq_ids,
+        candidate_step_kinds=candidate_step_kinds,
+        candidate_drop_reasons=candidate_drop_reasons,
+        candidate_step_total_tokens=candidate_step_total_tokens,
+        candidate_step_total_ms=candidate_step_total_ms,
+        candidate_step_ffn_ms=candidate_step_ffn_ms,
+        candidate_step_histograms=candidate_step_histograms,
+        expert_to_ep_rank=expert_to_ep_rank,
+        condition_latency_ms=condition_latency_ms,
+        decode_time_total_ms=finished_stats.decode_time_total_ms,
+        num_generation_tokens_total=finished_stats.num_generation_tokens_total,
+        num_output_tokens_excl_first_total=(
+            finished_stats.num_output_tokens_excl_first_total
+        ),
+        num_forward_steps_total=num_forward_steps_total,
+        num_captured_steps=num_captured_steps,
+        num_dropped_steps=num_dropped_steps,
+        num_prefill_dropped_steps=num_prefill_dropped_steps,
+        num_mixed_dropped_steps=num_mixed_dropped_steps,
+        trace_samples=trace_samples,
+    )
+
+
+def save_rank_condition_data(path: Path, data: RankConditionData) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(path, **data.to_npz_payload())
+
+
+def rank_trace_path(rank_output_path: Path) -> Path:
+    return rank_output_path.with_suffix(".trace.json")
+
+
+def save_rank_trace_samples(path: Path, args: Any, data: RankConditionData) -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "batch_size": args.batch_size,
+        "draft_length": args.draft_length,
+        "data_parallel_size": args.data_parallel_size,
+        "dp_rank": args.dp_rank,
+        "trace_steps_per_rank": args.trace_steps_per_rank,
+        "trace_samples": data.trace_samples,
+    }
+    with path.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+
+def load_rank_condition_data(path: Path) -> RankConditionData:
+    with np.load(path, allow_pickle=False) as data:
+        return RankConditionData(
+            selected_dataset_indices=np.asarray(data["selected_dataset_indices"]),
+            prompt_lengths=np.asarray(data["prompt_lengths"]),
+            output_lengths=np.asarray(data["output_lengths"]),
+            step_histograms=np.asarray(data["step_histograms"]),
+            step_total_tokens=np.asarray(data["step_total_tokens"]),
+            step_total_ms=np.asarray(data["step_total_ms"]),
+            step_attention_ms=np.asarray(data["step_attention_ms"]),
+            step_routing_ms=np.asarray(data["step_routing_ms"]),
+            step_prepare_ms=np.asarray(data["step_prepare_ms"]),
+            step_finalize_ms=np.asarray(data["step_finalize_ms"]),
+            step_ffn_ms=np.asarray(data["step_ffn_ms"]),
+            captured_step_kinds=np.asarray(data["captured_step_kinds"]),
+            captured_step_indices=np.asarray(data["captured_step_indices"]),
+            captured_step_start_time_ms=np.asarray(
+                data["captured_step_start_time_ms"]
+            ),
+            captured_step_end_time_ms=np.asarray(data["captured_step_end_time_ms"]),
+            captured_prepare_start_time_ms=np.asarray(
+                data["captured_prepare_start_time_ms"]
+            ),
+            captured_finalize_end_time_ms=np.asarray(
+                data["captured_finalize_end_time_ms"]
+            ),
+            candidate_first_ep_collective_seq_ids=np.asarray(
+                data["candidate_first_ep_collective_seq_ids"]
+            ),
+            candidate_step_kinds=np.asarray(data["candidate_step_kinds"]),
+            candidate_drop_reasons=np.asarray(data["candidate_drop_reasons"]),
+            candidate_step_total_tokens=np.asarray(
+                data["candidate_step_total_tokens"]
+            ),
+            candidate_step_total_ms=np.asarray(data["candidate_step_total_ms"]),
+            candidate_step_ffn_ms=np.asarray(data["candidate_step_ffn_ms"]),
+            candidate_step_histograms=np.asarray(data["candidate_step_histograms"]),
+            expert_to_ep_rank=np.asarray(data["expert_to_ep_rank"]),
+            condition_latency_ms=float(data["condition_latency_ms"][0]),
+            decode_time_total_ms=float(data["decode_time_total_ms"][0]),
+            num_generation_tokens_total=int(data["num_generation_tokens_total"][0]),
+            num_output_tokens_excl_first_total=int(
+                data["num_output_tokens_excl_first_total"][0]
+            ),
+            num_forward_steps_total=int(data["num_forward_steps_total"][0]),
+            num_captured_steps=int(data["num_captured_steps"][0]),
+            num_dropped_steps=int(data["num_dropped_steps"][0]),
+            num_prefill_dropped_steps=int(data["num_prefill_dropped_steps"][0]),
+            num_mixed_dropped_steps=int(data["num_mixed_dropped_steps"][0]),
+            trace_samples=[],
         )
 
 
-def collect_one_condition(args: Namespace, output_dir: Path) -> CollectedConditionSummary:
-    dirs = ensure_collect_dirs(output_dir)
-    prompt_items = load_prompt_items(args)
-    return collect_condition(
-        args,
-        prompt_items,
-        dirs["raw"],
+def collect_one_rank(args: Namespace) -> None:
+    data = collect_condition_for_rank(args)
+    save_rank_condition_data(args.rank_output_path, data)
+    if args.trace_steps_per_rank > 0 and data.trace_samples:
+        save_rank_trace_samples(rank_trace_path(args.rank_output_path), args, data)
+
+
+def _aggregate_rank_condition_data(
+    args: Namespace,
+    partials: list[RankConditionData],
+    *,
+    condition_latency_ms: float,
+) -> ConditionRawData:
+    selected_indices = np.concatenate(
+        [partial.selected_dataset_indices for partial in partials],
+        axis=0,
+    )
+    expected_indices = select_dataset_indices(args.num_samples, args.num_samples)
+    if selected_indices.shape != expected_indices.shape or not np.array_equal(
+        np.sort(selected_indices, kind="stable"),
+        expected_indices,
+    ):
+        raise RuntimeError("DP shard aggregation dropped or duplicated dataset items.")
+
+    order = np.argsort(selected_indices, kind="stable")
+    selected_indices = selected_indices[order]
+    prompt_lengths = np.concatenate(
+        [partial.prompt_lengths for partial in partials], axis=0
+    )[order]
+    output_lengths = np.concatenate(
+        [partial.output_lengths for partial in partials], axis=0
+    )[order]
+
+    expert_to_ep_rank = merge_expert_to_ep_rank_maps(
+        [partial.expert_to_ep_rank for partial in partials],
+        num_experts=args.num_experts,
+        ep_size=args.data_parallel_size,
+    )
+    expected_step_kind = "verification_only" if args.draft_length > 0 else "decode_only"
+    global_steps = aggregate_global_step_time_components(
+        [
+            {
+                "candidate_first_ep_collective_seq_ids": (
+                    partial.candidate_first_ep_collective_seq_ids
+                ),
+                "candidate_step_kinds": partial.candidate_step_kinds,
+                "candidate_step_total_ms": partial.candidate_step_total_ms,
+                "candidate_step_ffn_ms": partial.candidate_step_ffn_ms,
+                "candidate_step_total_tokens": partial.candidate_step_total_tokens,
+                "candidate_step_histograms": partial.candidate_step_histograms,
+            }
+            for partial in partials
+        ],
+        data_parallel_size=args.data_parallel_size,
+        expected_step_kind=expected_step_kind,
+        layers=tuple(args.layers),
+        num_experts=args.num_experts,
+    )
+    if global_steps.global_step_indices.size == 0:
+        raise RuntimeError(
+            "No globally aligned captured steps survived strict DP intersection for "
+            f"batch_size={args.batch_size}, draft_length={args.draft_length}. "
+            "Re-run collect and inspect per-rank capture coverage."
+        )
+
+    decode_time_total_ms = sum(partial.decode_time_total_ms for partial in partials)
+    num_output_tokens_total = int(output_lengths.sum())
+    num_generation_tokens_total = sum(
+        partial.num_generation_tokens_total for partial in partials
+    )
+    num_output_tokens_excl_first_total = sum(
+        partial.num_output_tokens_excl_first_total for partial in partials
+    )
+    if num_output_tokens_excl_first_total == 0:
+        num_output_tokens_excl_first_total = compute_num_output_tokens_excluding_first(
+            output_lengths
+        )
+    tpot_ms = compute_tpot_ms_from_finished_stats(
+        decode_time_total_ms,
+        num_output_tokens_excl_first_total,
+    )
+    decode_throughput_tok_s = compute_decode_throughput_tok_s(
+        num_generation_tokens_total,
+        decode_time_total_ms,
+    )
+
+    return ConditionRawData(
         batch_size=args.batch_size,
         draft_length=args.draft_length,
+        data_parallel_size=args.data_parallel_size,
+        num_samples=args.num_samples,
+        batch_size_scope="global",
+        mixed_step_policy="drop_step",
+        tpot_definition=TPOT_DEFINITION,
+        selected_dataset_indices=selected_indices,
+        prompt_lengths=prompt_lengths,
+        output_lengths=output_lengths,
+        condition_latency_ms=condition_latency_ms,
+        decode_time_total_ms=decode_time_total_ms,
+        num_output_tokens_total=num_output_tokens_total,
+        num_generation_tokens_total=num_generation_tokens_total,
+        num_output_tokens_excl_first_total=num_output_tokens_excl_first_total,
+        tpot_ms=tpot_ms,
+        decode_throughput_tok_s=decode_throughput_tok_s,
+        step_histograms=global_steps.global_step_histograms,
+        step_total_tokens=global_steps.global_step_total_tokens,
+        step_total_ms=global_steps.global_step_total_ms,
+        step_attention_ms=np.empty((0,), dtype=np.float64),
+        step_routing_ms=np.empty((0,), dtype=np.float64),
+        step_prepare_ms=np.empty((0,), dtype=np.float64),
+        step_finalize_ms=np.empty((0,), dtype=np.float64),
+        step_ffn_ms=global_steps.global_step_ffn_ms,
+        captured_step_kinds=global_steps.global_step_kinds,
+        global_step_indices=global_steps.global_step_indices,
+        global_step_total_ms=global_steps.global_step_total_ms,
+        global_step_ffn_ms=global_steps.global_step_ffn_ms,
+        global_step_other_ms=global_steps.global_step_other_ms,
+        global_step_kinds=global_steps.global_step_kinds,
+        expert_to_ep_rank=expert_to_ep_rank,
+        layers=np.asarray(args.layers, dtype=np.int64),
+        avg_histograms=average_step_histograms(global_steps.global_step_histograms),
+        num_forward_steps_total=sum(
+            partial.num_forward_steps_total for partial in partials
+        ),
+        num_captured_steps=sum(partial.num_captured_steps for partial in partials),
+        num_global_candidate_steps=global_steps.num_global_candidate_steps,
+        num_global_captured_steps=global_steps.num_global_captured_steps,
+        num_dropped_steps=sum(partial.num_dropped_steps for partial in partials),
+        num_prefill_dropped_steps=sum(
+            partial.num_prefill_dropped_steps for partial in partials
+        ),
+        num_mixed_dropped_steps=sum(
+            partial.num_mixed_dropped_steps for partial in partials
+        ),
+        num_global_prefill_dropped_steps=(
+            global_steps.num_global_prefill_dropped_steps
+        ),
+        num_global_mixed_dropped_steps=global_steps.num_global_mixed_dropped_steps,
+        num_global_non_target_dropped_steps=(
+            global_steps.num_global_non_target_dropped_steps
+        ),
     )
+
+
+def collect_one_condition(
+    args: Namespace,
+    output_dir: Path,
+) -> CollectedConditionSummary:
+    validate_parallel_config(args)
+    dirs = ensure_collect_dirs(output_dir)
+    if getattr(args, "prompt_cache_path", None) is None:
+        args.prompt_cache_path = prepare_prompt_cache(args, dirs["root"])
+    partial_dir = dirs["root"] / "_dp_partials" / condition_name(
+        args.batch_size, args.draft_length
+    )
+    partial_dir.mkdir(parents=True, exist_ok=True)
+    dp_master_ip = "127.0.0.1"
+    dp_master_port = get_open_port()
+
+    processes: list[subprocess.Popen[str]] = []
+    partial_paths: list[Path] = []
+    cwd = Path(__file__).resolve().parent.parent.parent.parent
+    start = time.perf_counter()
+    for dp_rank in range(args.data_parallel_size):
+        partial_path = partial_dir / f"rank_{dp_rank:02d}.npz"
+        partial_paths.append(partial_path)
+        command = _build_collect_one_rank_command(
+            args,
+            output_dir,
+            Path(__file__).resolve().parent
+            / "qwen3_6_mtp_ep_load_balance_experiment.py",
+            dp_rank=dp_rank,
+            dp_local_rank=dp_rank,
+            dp_master_ip=dp_master_ip,
+            dp_master_port=dp_master_port,
+            rank_output_path=partial_path,
+        )
+        processes.append(
+            subprocess.Popen(
+                command,
+                cwd=cwd,
+                env=os.environ.copy(),
+                text=True,
+            )
+        )
+    exit_code = 0
+    for proc in processes:
+        proc.wait()
+        if proc.returncode:
+            exit_code = proc.returncode
+    if exit_code:
+        raise subprocess.CalledProcessError(exit_code, "collect-one-rank")
+
+    partials = [load_rank_condition_data(path) for path in partial_paths]
+    raw_data = _aggregate_rank_condition_data(
+        args,
+        partials,
+        condition_latency_ms=(time.perf_counter() - start) * 1000.0,
+    )
+    raw_path = dirs["raw"] / f"{condition_name(args.batch_size, args.draft_length)}.npz"
+    np.savez_compressed(raw_path, **raw_data.to_npz_payload())
+    return load_condition_summary(raw_path)
 
 
 def _build_collect_one_command(
@@ -983,14 +2135,16 @@ def _build_collect_one_command(
         args.model,
         "--dataset",
         args.dataset,
-        "--dataset-config",
-        args.dataset_config,
         "--dataset-split",
         args.dataset_split,
         "--batch-size",
         str(batch_size),
         "--draft-length",
         str(draft_length),
+        "--num-samples",
+        str(args.num_samples),
+        "--data-parallel-size",
+        str(args.data_parallel_size),
         "--max-tokens",
         str(args.max_tokens),
         "--max-model-len",
@@ -1007,16 +2161,54 @@ def _build_collect_one_command(
         str(prompt_cache),
         "--warmup-rounds",
         str(args.warmup_rounds),
+        "--trace-steps-per-rank",
+        str(getattr(args, "trace_steps_per_rank", 0)),
     ]
+    _append_optional_arg(command, "--dataset-config", args.dataset_config)
     command.extend(["--layers", *(str(layer) for layer in args.layers)])
-    if args.enforce_eager:
-        command.append("--enforce-eager")
-    else:
-        command.append("--no-enforce-eager")
+    command.append("--enforce-eager" if args.enforce_eager else "--no-enforce-eager")
+    return command
+
+
+def _build_collect_one_rank_command(
+    args: Namespace,
+    output_dir: Path,
+    entrypoint: Path,
+    *,
+    dp_rank: int,
+    dp_local_rank: int,
+    dp_master_ip: str,
+    dp_master_port: int,
+    rank_output_path: Path,
+) -> list[str]:
+    command = _build_collect_one_command(
+        args,
+        output_dir,
+        entrypoint,
+        batch_size=args.batch_size,
+        draft_length=args.draft_length,
+        prompt_cache=Path(args.prompt_cache_path),
+    )
+    command[2] = "collect-one-rank"
+    command.extend(
+        [
+            "--dp-rank",
+            str(dp_rank),
+            "--dp-local-rank",
+            str(dp_local_rank),
+            "--dp-master-ip",
+            dp_master_ip,
+            "--dp-master-port",
+            str(dp_master_port),
+            "--rank-output-path",
+            str(rank_output_path),
+        ]
+    )
     return command
 
 
 def collect_experiment(args: Namespace, output_dir: Path, entrypoint: Path) -> None:
+    validate_parallel_config(args)
     dirs = ensure_collect_dirs(output_dir)
     save_run_metadata(dirs["root"], args)
     prompts_cache = prepare_prompt_cache(args, dirs["root"])
@@ -1025,7 +2217,7 @@ def collect_experiment(args: Namespace, output_dir: Path, entrypoint: Path) -> N
         for draft_length in args.draft_lengths:
             print(
                 f"[collect-parent] launching batch_size={batch_size} "
-                f"draft_length={draft_length}",
+                f"draft_length={draft_length} dp={args.data_parallel_size}",
                 flush=True,
             )
             command = _build_collect_one_command(

--- a/examples/features/speculative_decoding/mtp_ep_experiment_runtime.py
+++ b/examples/features/speculative_decoding/mtp_ep_experiment_runtime.py
@@ -1,0 +1,1049 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MethodType
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+from mtp_ep_load_balance_utils import (
+    DEFAULT_DATASET,
+    DEFAULT_DATASET_CONFIG,
+    DEFAULT_DATASET_SPLIT,
+    SCHEMA_VERSION,
+    StepTiming,
+    aggregate_worker_step_timings,
+    average_step_histograms,
+    count_layer_expert_histograms,
+    select_dataset_indices,
+    select_step_routing_data,
+)
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+
+@dataclass
+class ConditionRawData:
+    batch_size: int
+    draft_length: int
+    selected_dataset_indices: np.ndarray
+    prompt_lengths: np.ndarray
+    condition_latency_ms: float
+    step_histograms: np.ndarray
+    step_total_tokens: np.ndarray
+    step_total_ms: np.ndarray
+    step_attention_ms: np.ndarray
+    step_routing_ms: np.ndarray
+    step_prepare_ms: np.ndarray
+    step_finalize_ms: np.ndarray
+    step_ffn_ms: np.ndarray
+    captured_step_kinds: np.ndarray
+    layers: np.ndarray
+    avg_histograms: np.ndarray
+    num_forward_steps_total: int
+    num_captured_steps: int
+    num_dropped_steps: int
+
+    def to_npz_payload(self) -> dict[str, np.ndarray]:
+        step_all2all_ms = self.step_prepare_ms + self.step_finalize_ms
+        return {
+            "schema_version": np.asarray([SCHEMA_VERSION], dtype=np.int64),
+            "batch_size": np.asarray([self.batch_size], dtype=np.int64),
+            "draft_length": np.asarray([self.draft_length], dtype=np.int64),
+            "selected_dataset_indices": self.selected_dataset_indices,
+            "prompt_lengths": self.prompt_lengths,
+            "condition_latency_ms": np.asarray(
+                [self.condition_latency_ms], dtype=np.float64
+            ),
+            "step_histograms": self.step_histograms,
+            "step_total_tokens": self.step_total_tokens,
+            "step_total_ms": self.step_total_ms,
+            "step_attention_ms": self.step_attention_ms,
+            "step_routing_ms": self.step_routing_ms,
+            "step_prepare_ms": self.step_prepare_ms,
+            "step_finalize_ms": self.step_finalize_ms,
+            "step_all2all_ms": step_all2all_ms,
+            "step_ffn_ms": self.step_ffn_ms,
+            "captured_step_kinds": self.captured_step_kinds,
+            "layers": self.layers,
+            "avg_histograms": self.avg_histograms,
+            "num_forward_steps_total": np.asarray(
+                [self.num_forward_steps_total], dtype=np.int64
+            ),
+            "num_captured_steps": np.asarray(
+                [self.num_captured_steps], dtype=np.int64
+            ),
+            "num_dropped_steps": np.asarray(
+                [self.num_dropped_steps], dtype=np.int64
+            ),
+        }
+
+
+@dataclass
+class CollectedConditionSummary:
+    batch_size: int
+    draft_length: int
+    raw_path: str
+    condition_latency_ms: float
+    num_forward_steps_total: int
+    num_captured_steps: int
+    num_dropped_steps: int
+
+
+@dataclass
+class StepAccumulator:
+    attention_ms: float = 0.0
+    routing_ms: float = 0.0
+    prepare_ms: float = 0.0
+    finalize_ms: float = 0.0
+    ffn_ms: float = 0.0
+
+
+@dataclass
+class WorkerInstrumentationState:
+    enabled: bool = False
+    pending_step_timings: deque[dict[str, float]] = field(default_factory=deque)
+    current_step: StepAccumulator | None = None
+    enter_step_logs: int = 0
+    queued_step_logs: int = 0
+
+
+_WORKER_STATE = WorkerInstrumentationState()
+_ORIGINAL_WORKER_EXECUTE_MODEL = None
+_ORIGINAL_ROUTER_SELECT_EXPERTS = None
+_ORIGINAL_QWEN2_MLP_FORWARD = None
+_ORIGINAL_QWEN3_MLP_FORWARD = None
+_ORIGINAL_QWEN3_NEXT_ATTN_FORWARD = None
+_ORIGINAL_QWEN_GDN_FORWARD = None
+_ORIGINAL_MODULAR_PREPARE = None
+_ORIGINAL_MODULAR_FUSED_EXPERTS = None
+_ORIGINAL_MODULAR_FINALIZE = None
+_ORIGINAL_MONOLITHIC_APPLY = None
+
+
+def condition_name(batch_size: int, draft_length: int) -> str:
+    return f"batch_{batch_size:03d}_draft_{draft_length:02d}"
+
+
+def default_output_dir() -> Path:
+    timestamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+    return Path("results") / f"qwen3_6_mtp_ep_{timestamp}"
+
+
+def ensure_collect_dirs(output_dir: Path) -> dict[str, Path]:
+    raw_dir = output_dir / "raw"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    return {"root": output_dir, "raw": raw_dir}
+
+
+def prompt_cache_path(output_dir: Path) -> Path:
+    return output_dir / "prompt_cache.json"
+
+
+def save_run_metadata(output_dir: Path, args: Any) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "model": args.model,
+        "dataset": args.dataset,
+        "dataset_config": args.dataset_config,
+        "dataset_split": args.dataset_split,
+        "batch_sizes": list(args.batch_sizes),
+        "draft_lengths": list(args.draft_lengths),
+        "max_tokens": args.max_tokens,
+        "max_model_len": args.max_model_len,
+        "tensor_parallel_size": args.tensor_parallel_size,
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "layers": list(args.layers),
+        "num_experts": args.num_experts,
+        "enforce_eager": args.enforce_eager,
+        "warmup_rounds": args.warmup_rounds,
+        "vllm_enable_v1_multiprocessing": os.environ.get(
+            "VLLM_ENABLE_V1_MULTIPROCESSING"
+        ),
+    }
+    with (output_dir / "run_metadata.json").open("w", encoding="utf-8") as fp:
+        json.dump(metadata, fp, ensure_ascii=False, indent=2)
+
+
+def save_collect_manifest(
+    output_dir: Path,
+    args: Any,
+    condition_summaries: list[CollectedConditionSummary],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "model": args.model,
+        "dataset": args.dataset,
+        "dataset_config": args.dataset_config,
+        "dataset_split": args.dataset_split,
+        "batch_sizes": list(args.batch_sizes),
+        "draft_lengths": list(args.draft_lengths),
+        "max_tokens": args.max_tokens,
+        "layers": list(args.layers),
+        "warmup_rounds": args.warmup_rounds,
+        "conditions": [
+            {
+                "batch_size": summary.batch_size,
+                "draft_length": summary.draft_length,
+                "raw_path": summary.raw_path,
+                "condition_latency_ms": summary.condition_latency_ms,
+                "num_forward_steps_total": summary.num_forward_steps_total,
+                "num_captured_steps": summary.num_captured_steps,
+                "num_dropped_steps": summary.num_dropped_steps,
+            }
+            for summary in condition_summaries
+        ],
+    }
+    with (output_dir / "collect_manifest.json").open("w", encoding="utf-8") as fp:
+        json.dump(manifest, fp, ensure_ascii=False, indent=2)
+
+
+def load_condition_summary(raw_path: Path) -> CollectedConditionSummary:
+    with np.load(raw_path, allow_pickle=False) as data:
+        batch_size = int(data["batch_size"][0])
+        draft_length = int(data["draft_length"][0])
+        condition_latency_ms = float(data["condition_latency_ms"][0])
+        num_forward_steps_total = int(data["num_forward_steps_total"][0])
+        num_captured_steps = int(data["num_captured_steps"][0])
+        num_dropped_steps = int(data["num_dropped_steps"][0])
+    return CollectedConditionSummary(
+        batch_size=batch_size,
+        draft_length=draft_length,
+        raw_path=str(raw_path.relative_to(raw_path.parent.parent)),
+        condition_latency_ms=condition_latency_ms,
+        num_forward_steps_total=num_forward_steps_total,
+        num_captured_steps=num_captured_steps,
+        num_dropped_steps=num_dropped_steps,
+    )
+
+
+def load_prompt_items(args: Namespace) -> list[dict[str, list[int]]]:
+    cache_path = getattr(args, "prompt_cache_path", None)
+    if cache_path is not None:
+        return load_prompt_items_from_cache(Path(cache_path))
+
+    from datasets import load_dataset
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model,
+        trust_remote_code=True,
+    )
+    dataset = load_dataset(
+        args.dataset,
+        args.dataset_config,
+        split=args.dataset_split,
+    )
+    if hasattr(args, "batch_sizes"):
+        max_samples = max(args.batch_sizes)
+    else:
+        max_samples = args.batch_size
+    prompt_items: list[dict[str, list[int]]] = []
+    for item in dataset.select(range(min(max_samples, len(dataset)))):
+        token_ids = tokenizer.apply_chat_template(
+            [{"role": "user", "content": item["question"]}],
+            add_generation_prompt=True,
+            enable_thinking=False,
+            return_dict=True,
+        ).input_ids
+        prompt_items.append({"prompt_token_ids": token_ids})
+    return prompt_items
+
+
+def save_prompt_items_cache(
+    prompt_items: list[dict[str, list[int]]],
+    cache_path: Path,
+) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "prompt_token_ids": [item["prompt_token_ids"] for item in prompt_items],
+    }
+    with cache_path.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp)
+
+
+def load_prompt_items_from_cache(cache_path: Path) -> list[dict[str, list[int]]]:
+    with cache_path.open("r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+    prompt_token_ids = payload["prompt_token_ids"]
+    return [{"prompt_token_ids": list(token_ids)} for token_ids in prompt_token_ids]
+
+
+def prepare_prompt_cache(args: Namespace, output_dir: Path) -> Path:
+    cache_path = prompt_cache_path(output_dir)
+    if cache_path.exists():
+        return cache_path
+    prompt_items = load_prompt_items(args)
+    save_prompt_items_cache(prompt_items, cache_path)
+    return cache_path
+
+
+def create_llm(args: Namespace, batch_size: int, draft_length: int):
+    from vllm import LLM
+
+    speculative_config = None
+    if draft_length > 0:
+        speculative_config = {
+            "method": "mtp",
+            "num_speculative_tokens": draft_length,
+            "max_model_len": args.max_model_len,
+        }
+
+    return LLM(
+        model=args.model,
+        trust_remote_code=True,
+        tensor_parallel_size=args.tensor_parallel_size,
+        async_scheduling=False,
+        enable_expert_parallel=True,
+        enable_return_routed_experts=True,
+        enable_eplb=False,
+        max_model_len=args.max_model_len,
+        max_num_seqs=batch_size,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        speculative_config=speculative_config,
+        enforce_eager=args.enforce_eager,
+    )
+
+
+def get_inproc_handles(llm: Any) -> tuple[Any, Any]:
+    engine_core_client = llm.llm_engine.engine_core
+    if not hasattr(engine_core_client, "engine_core"):
+        raise RuntimeError(
+            "This experiment requires in-proc V1 execution. "
+            "Set VLLM_ENABLE_V1_MULTIPROCESSING=0 before running."
+        )
+    engine_core = engine_core_client.engine_core
+    return engine_core.scheduler, engine_core.model_executor
+
+
+def _synchronize_device() -> None:
+    from vllm.platforms import current_platform
+
+    synchronize = current_platform.synchronize
+    if synchronize is not None:
+        synchronize()
+
+
+def _measure_worker_section(label: str, fn: Callable, *args: Any, **kwargs: Any):
+    current_step = _WORKER_STATE.current_step
+    if not _WORKER_STATE.enabled or current_step is None:
+        return fn(*args, **kwargs)
+
+    _synchronize_device()
+    start = time.perf_counter()
+    result = fn(*args, **kwargs)
+    _synchronize_device()
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    if label == "prepare":
+        current_step.prepare_ms += elapsed_ms
+    elif label == "finalize":
+        current_step.finalize_ms += elapsed_ms
+    elif label == "attention":
+        current_step.attention_ms += elapsed_ms
+    elif label == "routing":
+        current_step.routing_ms += elapsed_ms
+    elif label == "ffn":
+        current_step.ffn_ms += elapsed_ms
+    else:
+        raise ValueError(f"Unknown measured label: {label}")
+    return result
+
+
+def _install_worker_hooks() -> None:
+    global _ORIGINAL_WORKER_EXECUTE_MODEL
+    global _ORIGINAL_ROUTER_SELECT_EXPERTS
+    global _ORIGINAL_QWEN2_MLP_FORWARD
+    global _ORIGINAL_QWEN3_MLP_FORWARD
+    global _ORIGINAL_QWEN3_NEXT_ATTN_FORWARD
+    global _ORIGINAL_QWEN_GDN_FORWARD
+    global _ORIGINAL_MODULAR_PREPARE
+    global _ORIGINAL_MODULAR_FUSED_EXPERTS
+    global _ORIGINAL_MODULAR_FINALIZE
+    global _ORIGINAL_MONOLITHIC_APPLY
+
+    if _ORIGINAL_WORKER_EXECUTE_MODEL is not None:
+        return
+
+    from types import NoneType
+
+    from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+        QwenGatedDeltaNetAttention,
+    )
+    from vllm.model_executor.layers.fused_moe.modular_kernel import (
+        FusedMoEKernelModularImpl,
+        FusedMoEKernelMonolithicImpl,
+    )
+    from vllm.model_executor.models.qwen2_moe import Qwen2MoeMLP
+    from vllm.model_executor.models.qwen3_moe import Qwen3MoeMLP
+    from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+    from vllm.v1.worker.gpu_worker import Worker
+
+    _ORIGINAL_WORKER_EXECUTE_MODEL = Worker.execute_model
+    _ORIGINAL_ROUTER_SELECT_EXPERTS = BaseRouter.select_experts
+    _ORIGINAL_QWEN2_MLP_FORWARD = Qwen2MoeMLP.forward
+    _ORIGINAL_QWEN3_MLP_FORWARD = Qwen3MoeMLP.forward
+    _ORIGINAL_QWEN3_NEXT_ATTN_FORWARD = Qwen3NextAttention.forward
+    _ORIGINAL_QWEN_GDN_FORWARD = QwenGatedDeltaNetAttention.forward
+    _ORIGINAL_MODULAR_PREPARE = FusedMoEKernelModularImpl._prepare
+    _ORIGINAL_MODULAR_FUSED_EXPERTS = FusedMoEKernelModularImpl._fused_experts
+    _ORIGINAL_MODULAR_FINALIZE = FusedMoEKernelModularImpl._finalize
+    _ORIGINAL_MONOLITHIC_APPLY = FusedMoEKernelMonolithicImpl.apply
+
+    def patched_worker_execute_model(self, scheduler_output):
+        if (
+            not _WORKER_STATE.enabled
+            or scheduler_output.total_num_scheduled_tokens <= 0
+        ):
+            return _ORIGINAL_WORKER_EXECUTE_MODEL(self, scheduler_output)
+
+        if _WORKER_STATE.enter_step_logs < 3:
+            print(
+                "[worker_timing] execute begin "
+                f"scheduled_tokens={scheduler_output.total_num_scheduled_tokens}",
+                flush=True,
+            )
+            _WORKER_STATE.enter_step_logs += 1
+
+        _WORKER_STATE.current_step = StepAccumulator()
+        _synchronize_device()
+        start = time.perf_counter()
+        try:
+            output = _ORIGINAL_WORKER_EXECUTE_MODEL(self, scheduler_output)
+            _synchronize_device()
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            assert _WORKER_STATE.current_step is not None
+            _WORKER_STATE.pending_step_timings.append(
+                {
+                    "total_ms": elapsed_ms,
+                    "attention_ms": _WORKER_STATE.current_step.attention_ms,
+                    "routing_ms": _WORKER_STATE.current_step.routing_ms,
+                    "prepare_ms": _WORKER_STATE.current_step.prepare_ms,
+                    "finalize_ms": _WORKER_STATE.current_step.finalize_ms,
+                    "ffn_ms": _WORKER_STATE.current_step.ffn_ms,
+                }
+            )
+            if _WORKER_STATE.queued_step_logs < 3:
+                print(
+                    "[worker_timing] queued "
+                    f"total_ms={elapsed_ms:.3f} "
+                    f"attention_ms={_WORKER_STATE.current_step.attention_ms:.3f} "
+                    f"routing_ms={_WORKER_STATE.current_step.routing_ms:.3f} "
+                    f"prepare_ms={_WORKER_STATE.current_step.prepare_ms:.3f} "
+                    f"finalize_ms={_WORKER_STATE.current_step.finalize_ms:.3f} "
+                    f"ffn_ms={_WORKER_STATE.current_step.ffn_ms:.3f}",
+                    flush=True,
+                )
+                _WORKER_STATE.queued_step_logs += 1
+            return output
+        finally:
+            _WORKER_STATE.current_step = None
+
+    def patched_router_select_experts(self, *args, **kwargs):
+        return _measure_worker_section(
+            "routing",
+            _ORIGINAL_ROUTER_SELECT_EXPERTS,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_qwen2_mlp_forward(self, *args, **kwargs):
+        return _measure_worker_section(
+            "ffn",
+            _ORIGINAL_QWEN2_MLP_FORWARD,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_qwen3_mlp_forward(self, *args, **kwargs):
+        return _measure_worker_section(
+            "ffn",
+            _ORIGINAL_QWEN3_MLP_FORWARD,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_qwen3_next_attention_forward(self, *args, **kwargs):
+        return _measure_worker_section(
+            "attention",
+            _ORIGINAL_QWEN3_NEXT_ATTN_FORWARD,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_qwen_gdn_forward(self, *args, **kwargs):
+        return _measure_worker_section(
+            "attention",
+            _ORIGINAL_QWEN_GDN_FORWARD,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_modular_prepare(self, *args, **kwargs):
+        return _measure_worker_section(
+            "prepare",
+            _ORIGINAL_MODULAR_PREPARE,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_modular_fused_experts(self, *args, **kwargs):
+        return _measure_worker_section(
+            "ffn",
+            _ORIGINAL_MODULAR_FUSED_EXPERTS,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_modular_finalize(self, *args, **kwargs):
+        return _measure_worker_section(
+            "finalize",
+            _ORIGINAL_MODULAR_FINALIZE,
+            self,
+            *args,
+            **kwargs,
+        )
+
+    def patched_monolithic_apply(
+        self,
+        hidden_states,
+        w1,
+        w2,
+        router_logits,
+        activation,
+        global_num_experts,
+        expert_map,
+        apply_router_weight_on_input,
+        num_expert_group=None,
+        e_score_correction_bias=None,
+        routed_scaling_factor=None,
+        topk_group=None,
+    ):
+        if not _WORKER_STATE.enabled or _WORKER_STATE.current_step is None:
+            return _ORIGINAL_MONOLITHIC_APPLY(
+                self,
+                hidden_states,
+                w1,
+                w2,
+                router_logits,
+                activation,
+                global_num_experts,
+                expert_map,
+                apply_router_weight_on_input,
+                num_expert_group=num_expert_group,
+                e_score_correction_bias=e_score_correction_bias,
+                routed_scaling_factor=routed_scaling_factor,
+                topk_group=topk_group,
+            )
+
+        a1q, a1q_scale, router_logits = _measure_worker_section(
+            "prepare",
+            self.prepare_finalize.prepare,
+            hidden_states,
+            router_logits=router_logits,
+            quant_config=self.fused_experts.quant_config,
+            defer_input_quant=self.fused_experts.expects_unquantized_inputs,
+        )
+        fused_out = _measure_worker_section(
+            "ffn",
+            self.fused_experts.apply,
+            hidden_states=a1q,
+            w1=w1,
+            w2=w2,
+            router_logits=router_logits,
+            activation=activation,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            a1q_scale=a1q_scale,
+            num_expert_group=num_expert_group,
+            e_score_correction_bias=e_score_correction_bias,
+            routed_scaling_factor=routed_scaling_factor,
+            topk_group=topk_group,
+        )
+        return _measure_worker_section(
+            "finalize",
+            self.prepare_finalize.finalize,
+            fused_out,
+        )
+
+    Worker.execute_model = patched_worker_execute_model
+    BaseRouter.select_experts = patched_router_select_experts
+    Qwen2MoeMLP.forward = patched_qwen2_mlp_forward
+    Qwen3MoeMLP.forward = patched_qwen3_mlp_forward
+    Qwen3NextAttention.forward = patched_qwen3_next_attention_forward
+    QwenGatedDeltaNetAttention.forward = patched_qwen_gdn_forward
+    FusedMoEKernelModularImpl._prepare = patched_modular_prepare
+    FusedMoEKernelModularImpl._fused_experts = patched_modular_fused_experts
+    FusedMoEKernelModularImpl._finalize = patched_modular_finalize
+    FusedMoEKernelMonolithicImpl.apply = patched_monolithic_apply
+
+
+def install_experiment_hooks_worker(worker: Any) -> bool:
+    _install_worker_hooks()
+    _WORKER_STATE.enabled = False
+    _WORKER_STATE.pending_step_timings.clear()
+    _WORKER_STATE.current_step = None
+    _WORKER_STATE.enter_step_logs = 0
+    _WORKER_STATE.queued_step_logs = 0
+    return True
+
+
+def start_condition_collection_worker(worker: Any) -> bool:
+    _WORKER_STATE.enabled = True
+    _WORKER_STATE.pending_step_timings.clear()
+    _WORKER_STATE.current_step = None
+    _WORKER_STATE.enter_step_logs = 0
+    _WORKER_STATE.queued_step_logs = 0
+    return True
+
+
+def stop_condition_collection_worker(worker: Any) -> dict[str, int]:
+    _WORKER_STATE.enabled = False
+    pending = len(_WORKER_STATE.pending_step_timings)
+    _WORKER_STATE.pending_step_timings.clear()
+    _WORKER_STATE.current_step = None
+    return {"pending_timings": pending}
+
+
+def pop_step_timing_worker(
+    worker: Any,
+    timeout_s: float = 5.0,
+    poll_s: float = 0.01,
+) -> dict[str, float] | None:
+    deadline = time.perf_counter() + timeout_s
+    while time.perf_counter() < deadline:
+        if _WORKER_STATE.pending_step_timings:
+            return _WORKER_STATE.pending_step_timings.popleft()
+        time.sleep(poll_s)
+    if _WORKER_STATE.pending_step_timings:
+        return _WORKER_STATE.pending_step_timings.popleft()
+    return None
+
+
+def _close_ffn_component(step_timing: StepTiming, tol_ms: float = 1e-3) -> float:
+    unattributed_ms = step_timing.unattributed_ms
+    if unattributed_ms < -tol_ms:
+        raise RuntimeError(
+            "Step timing components exceeded total step time: "
+            f"total_ms={step_timing.total_ms:.6f}, "
+            f"attention_ms={step_timing.attention_ms:.6f}, "
+            f"routing_ms={step_timing.routing_ms:.6f}, "
+            f"all2all_ms={step_timing.all2all_ms:.6f}, "
+            f"ffn_ms={step_timing.ffn_ms:.6f}, "
+            f"unattributed_ms={unattributed_ms:.6f}"
+        )
+    return step_timing.ffn_ms + max(unattributed_ms, 0.0)
+
+
+class SchedulerStepRecorder:
+    def __init__(
+        self,
+        scheduler: Any,
+        model_executor: Any,
+        *,
+        use_spec_decode: bool,
+        layers: tuple[int, ...],
+        num_experts: int,
+    ) -> None:
+        self.scheduler = scheduler
+        self.model_executor = model_executor
+        self.use_spec_decode = use_spec_decode
+        self.layers = layers
+        self.num_experts = num_experts
+        self._original_update = None
+        self.step_histograms: list[np.ndarray] = []
+        self.step_total_tokens: list[int] = []
+        self.step_total_ms: list[float] = []
+        self.step_attention_ms: list[float] = []
+        self.step_routing_ms: list[float] = []
+        self.step_prepare_ms: list[float] = []
+        self.step_finalize_ms: list[float] = []
+        self.step_ffn_ms: list[float] = []
+        self.step_kinds: list[str] = []
+        self.num_forward_steps_total = 0
+        self.num_dropped_steps = 0
+        self.debug_update_logs = 0
+
+    def __enter__(self) -> "SchedulerStepRecorder":
+        self._original_update = self.scheduler.update_from_output
+
+        def wrapped_update(
+            scheduler_self: Any,
+            scheduler_output: Any,
+            model_runner_output: Any,
+        ) -> Any:
+            if self.debug_update_logs < 5:
+                print(
+                    "[recorder] update begin "
+                    f"use_spec_decode={self.use_spec_decode} "
+                    f"num_forward_steps_total={self.num_forward_steps_total}",
+                    flush=True,
+                )
+            worker_timings = self.model_executor.collective_rpc(
+                pop_step_timing_worker,
+                timeout=30,
+            )
+            step_timing = aggregate_worker_step_timings(worker_timings)
+            self.num_forward_steps_total += 1
+
+            captured_step = select_step_routing_data(
+                scheduler_output,
+                model_runner_output,
+                use_spec_decode=self.use_spec_decode,
+            )
+            if captured_step is None:
+                self.num_dropped_steps += 1
+            else:
+                self.step_histograms.append(
+                    count_layer_expert_histograms(
+                        captured_step.routing_data,
+                        layers=self.layers,
+                        num_experts=self.num_experts,
+                    )
+                )
+                self.step_total_tokens.append(captured_step.total_scheduled_tokens)
+                self.step_total_ms.append(step_timing.total_ms)
+                self.step_attention_ms.append(step_timing.attention_ms)
+                self.step_routing_ms.append(step_timing.routing_ms)
+                self.step_prepare_ms.append(step_timing.prepare_ms)
+                self.step_finalize_ms.append(step_timing.finalize_ms)
+                self.step_ffn_ms.append(_close_ffn_component(step_timing))
+                self.step_kinds.append(captured_step.step_kind)
+
+            if self.debug_update_logs < 5:
+                print(
+                    "[recorder] update end "
+                    f"use_spec_decode={self.use_spec_decode} "
+                    f"captured={captured_step is not None} "
+                    f"step_kind={captured_step.step_kind if captured_step else 'none'} "
+                    f"total_ms={step_timing.total_ms:.3f}",
+                    flush=True,
+                )
+                self.debug_update_logs += 1
+
+            return self._original_update(scheduler_output, model_runner_output)
+
+        self.scheduler.update_from_output = MethodType(wrapped_update, self.scheduler)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._original_update is not None:
+            self.scheduler.update_from_output = self._original_update
+
+
+def collect_condition(
+    args: Namespace,
+    prompt_items: list[dict[str, list[int]]],
+    raw_dir: Path,
+    *,
+    batch_size: int,
+    draft_length: int,
+) -> CollectedConditionSummary:
+    from vllm import SamplingParams
+
+    print(
+        f"[collect] start batch_size={batch_size} draft_length={draft_length}",
+        flush=True,
+    )
+    llm = create_llm(args, batch_size, draft_length)
+    print(
+        f"[collect] llm created batch_size={batch_size} draft_length={draft_length}",
+        flush=True,
+    )
+    scheduler, model_executor = get_inproc_handles(llm)
+    print(
+        f"[collect] inproc handles ready batch_size={batch_size} "
+        f"draft_length={draft_length} model_executor={type(model_executor).__name__}",
+        flush=True,
+    )
+    print(
+        f"[collect] install hooks begin batch_size={batch_size} "
+        f"draft_length={draft_length}",
+        flush=True,
+    )
+    model_executor.collective_rpc(install_experiment_hooks_worker, timeout=30)
+    print(
+        f"[collect] install hooks end batch_size={batch_size} "
+        f"draft_length={draft_length}",
+        flush=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=args.max_tokens,
+        ignore_eos=True,
+    )
+    use_spec_decode = draft_length > 0
+    selected_indices = select_dataset_indices(batch_size, len(prompt_items))
+    prompt_batch = [prompt_items[idx] for idx in selected_indices]
+    prompt_lengths = np.asarray(
+        [len(item["prompt_token_ids"]) for item in prompt_batch],
+        dtype=np.int64,
+    )
+    if args.warmup_rounds > 0:
+        print(
+            f"[collect] warmup begin batch_size={batch_size} "
+            f"draft_length={draft_length} rounds={args.warmup_rounds}",
+            flush=True,
+        )
+        for warmup_idx in range(args.warmup_rounds):
+            llm.generate(prompt_batch, sampling_params=sampling_params, use_tqdm=False)
+            print(
+                f"[collect] warmup done batch_size={batch_size} "
+                f"draft_length={draft_length} round={warmup_idx + 1}",
+                flush=True,
+            )
+    print(
+        f"[collect] start collection begin batch_size={batch_size} "
+        f"draft_length={draft_length}",
+        flush=True,
+    )
+    model_executor.collective_rpc(start_condition_collection_worker, timeout=30)
+    print(
+        f"[collect] start collection end batch_size={batch_size} "
+        f"draft_length={draft_length}",
+        flush=True,
+    )
+
+    try:
+        with SchedulerStepRecorder(
+            scheduler,
+            model_executor,
+            use_spec_decode=use_spec_decode,
+            layers=tuple(args.layers),
+            num_experts=args.num_experts,
+        ) as recorder:
+            print(
+                f"[collect] generate begin batch_size={batch_size} "
+                f"draft_length={draft_length}",
+                flush=True,
+            )
+            start = time.perf_counter()
+            llm.generate(prompt_batch, sampling_params=sampling_params, use_tqdm=False)
+            condition_latency_ms = (time.perf_counter() - start) * 1000.0
+            print(
+                f"[collect] generate end batch_size={batch_size} "
+                f"draft_length={draft_length}",
+                flush=True,
+            )
+
+        pending_counts = model_executor.collective_rpc(stop_condition_collection_worker)
+        pending_values = [item["pending_timings"] for item in pending_counts]
+        if any(pending_values):
+            if len(set(pending_values)) != 1:
+                raise RuntimeError(
+                    "Worker timing queues ended with inconsistent leftover counts: "
+                    f"{pending_counts}"
+                )
+            print(
+                "[collect] warning leftover worker timings were discarded "
+                f"batch_size={batch_size} draft_length={draft_length} "
+                f"pending_per_worker={pending_values[0]}",
+                flush=True,
+            )
+
+        if not recorder.step_histograms:
+            raise RuntimeError(
+                "No routed-expert steps were captured for "
+                f"batch_size={batch_size}, draft_length={draft_length}."
+            )
+
+        step_histograms = np.stack(recorder.step_histograms, axis=0)
+        step_total_tokens = np.asarray(recorder.step_total_tokens, dtype=np.int64)
+        step_total_ms = np.asarray(recorder.step_total_ms, dtype=np.float64)
+        step_attention_ms = np.asarray(recorder.step_attention_ms, dtype=np.float64)
+        step_routing_ms = np.asarray(recorder.step_routing_ms, dtype=np.float64)
+        step_prepare_ms = np.asarray(recorder.step_prepare_ms, dtype=np.float64)
+        step_finalize_ms = np.asarray(recorder.step_finalize_ms, dtype=np.float64)
+        step_ffn_ms = np.asarray(recorder.step_ffn_ms, dtype=np.float64)
+        avg_histograms = average_step_histograms(step_histograms)
+        raw_data = ConditionRawData(
+            batch_size=batch_size,
+            draft_length=draft_length,
+            selected_dataset_indices=selected_indices,
+            prompt_lengths=prompt_lengths,
+            condition_latency_ms=condition_latency_ms,
+            step_histograms=step_histograms,
+            step_total_tokens=step_total_tokens,
+            step_total_ms=step_total_ms,
+            step_attention_ms=step_attention_ms,
+            step_routing_ms=step_routing_ms,
+            step_prepare_ms=step_prepare_ms,
+            step_finalize_ms=step_finalize_ms,
+            step_ffn_ms=step_ffn_ms,
+            captured_step_kinds=np.asarray(recorder.step_kinds),
+            layers=np.asarray(args.layers, dtype=np.int64),
+            avg_histograms=avg_histograms,
+            num_forward_steps_total=recorder.num_forward_steps_total,
+            num_captured_steps=len(recorder.step_histograms),
+            num_dropped_steps=recorder.num_dropped_steps,
+        )
+        raw_path = raw_dir / f"{condition_name(batch_size, draft_length)}.npz"
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(raw_path, **raw_data.to_npz_payload())
+        print(
+            "[collect] finished "
+            f"batch_size={batch_size} draft_length={draft_length} "
+            f"captured_steps={len(recorder.step_histograms)} "
+            f"latency_ms={condition_latency_ms:.3f}",
+            flush=True,
+        )
+        return CollectedConditionSummary(
+            batch_size=batch_size,
+            draft_length=draft_length,
+            raw_path=str(raw_path.relative_to(raw_dir.parent)),
+            condition_latency_ms=condition_latency_ms,
+            num_forward_steps_total=recorder.num_forward_steps_total,
+            num_captured_steps=len(recorder.step_histograms),
+            num_dropped_steps=recorder.num_dropped_steps,
+        )
+    finally:
+        print(
+            f"[collect] teardown begin batch_size={batch_size} "
+            f"draft_length={draft_length}",
+            flush=True,
+        )
+        try:
+            llm.llm_engine.engine_core.shutdown()
+            print(
+                f"[collect] shutdown done batch_size={batch_size} "
+                f"draft_length={draft_length}",
+                flush=True,
+            )
+        except Exception:
+            print(
+                f"[collect] shutdown failed batch_size={batch_size} "
+                f"draft_length={draft_length}",
+                flush=True,
+            )
+        del llm
+        print(
+            f"[collect] llm deleted batch_size={batch_size} "
+            f"draft_length={draft_length}",
+            flush=True,
+        )
+        print(
+            f"[collect] teardown done batch_size={batch_size} "
+            f"draft_length={draft_length}",
+            flush=True,
+        )
+
+
+def collect_one_condition(args: Namespace, output_dir: Path) -> CollectedConditionSummary:
+    dirs = ensure_collect_dirs(output_dir)
+    prompt_items = load_prompt_items(args)
+    return collect_condition(
+        args,
+        prompt_items,
+        dirs["raw"],
+        batch_size=args.batch_size,
+        draft_length=args.draft_length,
+    )
+
+
+def _build_collect_one_command(
+    args: Namespace,
+    output_dir: Path,
+    entrypoint: Path,
+    *,
+    batch_size: int,
+    draft_length: int,
+    prompt_cache: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(entrypoint),
+        "collect-one",
+        "--model",
+        args.model,
+        "--dataset",
+        args.dataset,
+        "--dataset-config",
+        args.dataset_config,
+        "--dataset-split",
+        args.dataset_split,
+        "--batch-size",
+        str(batch_size),
+        "--draft-length",
+        str(draft_length),
+        "--max-tokens",
+        str(args.max_tokens),
+        "--max-model-len",
+        str(args.max_model_len),
+        "--tensor-parallel-size",
+        str(args.tensor_parallel_size),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--num-experts",
+        str(args.num_experts),
+        "--output-dir",
+        str(output_dir),
+        "--prompt-cache-path",
+        str(prompt_cache),
+        "--warmup-rounds",
+        str(args.warmup_rounds),
+    ]
+    command.extend(["--layers", *(str(layer) for layer in args.layers)])
+    if args.enforce_eager:
+        command.append("--enforce-eager")
+    else:
+        command.append("--no-enforce-eager")
+    return command
+
+
+def collect_experiment(args: Namespace, output_dir: Path, entrypoint: Path) -> None:
+    dirs = ensure_collect_dirs(output_dir)
+    save_run_metadata(dirs["root"], args)
+    prompts_cache = prepare_prompt_cache(args, dirs["root"])
+    condition_summaries: list[CollectedConditionSummary] = []
+    for batch_size in args.batch_sizes:
+        for draft_length in args.draft_lengths:
+            print(
+                f"[collect-parent] launching batch_size={batch_size} "
+                f"draft_length={draft_length}",
+                flush=True,
+            )
+            command = _build_collect_one_command(
+                args,
+                dirs["root"],
+                entrypoint,
+                batch_size=batch_size,
+                draft_length=draft_length,
+                prompt_cache=prompts_cache,
+            )
+            subprocess.run(
+                command,
+                check=True,
+                cwd=entrypoint.parent.parent.parent.parent,
+                env=os.environ.copy(),
+            )
+            raw_path = dirs["raw"] / f"{condition_name(batch_size, draft_length)}.npz"
+            summary = load_condition_summary(raw_path)
+            condition_summaries.append(summary)
+
+    save_collect_manifest(dirs["root"], args, condition_summaries)

--- a/examples/features/speculative_decoding/mtp_ep_load_balance_utils.py
+++ b/examples/features/speculative_decoding/mtp_ep_load_balance_utils.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+SCHEMA_VERSION = 2
+
+DEFAULT_MODEL = "Qwen/Qwen3.6-35B-A3B"
+DEFAULT_DATASET = "openai/gsm8k"
+DEFAULT_DATASET_CONFIG = "main"
+DEFAULT_DATASET_SPLIT = "test"
+DEFAULT_BATCH_SIZES = (32, 64, 128, 256, 512, 1024)
+DEFAULT_DRAFT_LENGTHS = (0, 2, 4, 6)
+DEFAULT_LAYERS = (0, 9, 19, 29, 39)
+DEFAULT_NUM_EXPERTS = 256
+DEFAULT_MAX_TOKENS = 128
+DEFAULT_MAX_MODEL_LEN = 4096
+
+
+@dataclass(frozen=True)
+class CapturedStep:
+    step_kind: str
+    routing_data: np.ndarray
+    total_scheduled_tokens: int
+    request_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StepTiming:
+    total_ms: float
+    attention_ms: float
+    routing_ms: float
+    prepare_ms: float
+    finalize_ms: float
+    ffn_ms: float
+
+    @property
+    def all2all_ms(self) -> float:
+        return self.prepare_ms + self.finalize_ms
+
+    @property
+    def prepare_finalize_ms(self) -> float:
+        return self.all2all_ms
+
+    @property
+    def unattributed_ms(self) -> float:
+        return (
+            self.total_ms
+            - self.attention_ms
+            - self.routing_ms
+            - self.all2all_ms
+            - self.ffn_ms
+        )
+
+
+def should_capture_baseline_decode_step(scheduler_output: Any) -> bool:
+    num_scheduled_tokens = getattr(scheduler_output, "num_scheduled_tokens", {})
+    scheduled_spec_tokens = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        {},
+    )
+    return (
+        bool(num_scheduled_tokens)
+        and not scheduled_spec_tokens
+        and all(num_tokens == 1 for num_tokens in num_scheduled_tokens.values())
+    )
+
+
+def should_capture_mtp_verification_step(scheduler_output: Any) -> bool:
+    scheduled_spec_tokens = getattr(
+        scheduler_output,
+        "scheduled_spec_decode_tokens",
+        {},
+    )
+    return bool(scheduled_spec_tokens)
+
+
+def _request_offsets(
+    req_ids: list[str],
+    num_scheduled_tokens: dict[str, int],
+) -> dict[str, int]:
+    offsets: dict[str, int] = {}
+    offset = 0
+    for req_id in req_ids:
+        if req_id not in num_scheduled_tokens:
+            continue
+        offsets[req_id] = offset
+        offset += num_scheduled_tokens[req_id]
+    return offsets
+
+
+def select_step_routing_data(
+    scheduler_output: Any,
+    model_runner_output: Any,
+    use_spec_decode: bool,
+) -> CapturedStep | None:
+    routed_experts = getattr(model_runner_output, "routed_experts", None)
+    if routed_experts is None:
+        return None
+
+    routing_data = np.asarray(routed_experts.routing_data)
+    req_ids = list(getattr(model_runner_output, "req_ids", []))
+    num_scheduled_tokens = dict(getattr(scheduler_output, "num_scheduled_tokens", {}))
+    expected_rows = sum(num_scheduled_tokens.get(req_id, 0) for req_id in req_ids)
+    if routing_data.shape[0] != expected_rows:
+        raise ValueError(
+            "routing_data rows do not match the scheduled token layout: "
+            f"{routing_data.shape[0]} vs {expected_rows}."
+        )
+
+    if use_spec_decode:
+        if not should_capture_mtp_verification_step(scheduler_output):
+            return None
+        offsets = _request_offsets(req_ids, num_scheduled_tokens)
+        selected_req_ids = tuple(
+            req_id
+            for req_id in req_ids
+            if req_id in scheduler_output.scheduled_spec_decode_tokens
+        )
+        if not selected_req_ids:
+            return None
+
+        selected_segments = []
+        total_scheduled_tokens = 0
+        for req_id in selected_req_ids:
+            segment_offset = offsets[req_id]
+            segment_len = num_scheduled_tokens[req_id]
+            selected_segments.append(
+                routing_data[segment_offset : segment_offset + segment_len]
+            )
+            total_scheduled_tokens += segment_len
+
+        return CapturedStep(
+            step_kind="mtp_verification",
+            routing_data=np.concatenate(selected_segments, axis=0),
+            total_scheduled_tokens=total_scheduled_tokens,
+            request_ids=selected_req_ids,
+        )
+
+    if not should_capture_baseline_decode_step(scheduler_output):
+        return None
+
+    return CapturedStep(
+        step_kind="baseline_decode",
+        routing_data=routing_data,
+        total_scheduled_tokens=routing_data.shape[0],
+        request_ids=tuple(req_ids),
+    )
+
+
+def count_layer_expert_histograms(
+    routing_data: np.ndarray,
+    layers: tuple[int, ...] = DEFAULT_LAYERS,
+    num_experts: int = DEFAULT_NUM_EXPERTS,
+) -> np.ndarray:
+    if routing_data.ndim != 3:
+        raise ValueError(
+            "routing_data must be a rank-3 array shaped as "
+            "(num_tokens, num_layers, topk)."
+        )
+
+    histograms = np.zeros((len(layers), num_experts), dtype=np.int64)
+    for row_idx, layer_idx in enumerate(layers):
+        layer_assignments = routing_data[:, layer_idx, :].reshape(-1)
+        histograms[row_idx] = np.bincount(
+            layer_assignments,
+            minlength=num_experts,
+        )[:num_experts]
+    return histograms
+
+
+def average_step_histograms(step_histograms: np.ndarray) -> np.ndarray:
+    if step_histograms.size == 0:
+        raise ValueError("step_histograms must contain at least one captured step.")
+    return step_histograms.mean(axis=0)
+
+
+def sort_experts_desc(avg_histograms: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    sorted_expert_ids = np.argsort(-avg_histograms, axis=1, kind="stable")
+    sorted_histograms = np.take_along_axis(
+        avg_histograms,
+        sorted_expert_ids,
+        axis=1,
+    )
+    return sorted_histograms, sorted_expert_ids
+
+
+def reorder_histograms_by_expert_order(
+    avg_histograms: np.ndarray,
+    expert_order: np.ndarray,
+) -> np.ndarray:
+    return np.take_along_axis(avg_histograms, expert_order, axis=1)
+
+
+def aggregate_worker_step_timings(
+    worker_timings: list[dict[str, float] | None],
+) -> StepTiming:
+    valid_timings = [timing for timing in worker_timings if timing is not None]
+    if not valid_timings:
+        raise ValueError("Expected at least one worker timing bundle.")
+    return StepTiming(
+        total_ms=max(timing["total_ms"] for timing in valid_timings),
+        attention_ms=max(timing["attention_ms"] for timing in valid_timings),
+        routing_ms=max(timing["routing_ms"] for timing in valid_timings),
+        prepare_ms=max(timing["prepare_ms"] for timing in valid_timings),
+        finalize_ms=max(timing["finalize_ms"] for timing in valid_timings),
+        ffn_ms=max(timing["ffn_ms"] for timing in valid_timings),
+    )
+
+
+def compute_balancedness(counts: np.ndarray) -> float:
+    counts = np.asarray(counts, dtype=np.float64)
+    max_count = counts.max(initial=0.0)
+    if max_count <= 0:
+        return 1.0
+    return float(counts.mean() / max_count)
+
+
+def compute_gini(counts: np.ndarray) -> float:
+    counts = np.sort(np.asarray(counts, dtype=np.float64))
+    total = counts.sum()
+    if total <= 0:
+        return 0.0
+
+    n = counts.size
+    index = np.arange(1, n + 1, dtype=np.float64)
+    numerator = np.sum((2 * index - n - 1) * counts)
+    return float(numerator / (n * total))
+
+
+def classify_imbalance_change(
+    balancedness_delta: float,
+    gini_delta: float,
+    tol: float = 1e-12,
+) -> str:
+    if abs(balancedness_delta) <= tol and abs(gini_delta) <= tol:
+        return "unchanged"
+    if balancedness_delta < -tol and gini_delta >= -tol:
+        return "worsened"
+    if balancedness_delta > tol and gini_delta <= tol:
+        return "improved"
+    return "mixed"
+
+
+def build_condition_metrics(
+    *,
+    batch_size: int,
+    draft_length: int,
+    num_steps: int,
+    layers: tuple[int, ...],
+    avg_histograms: np.ndarray,
+    baseline_histograms: np.ndarray,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for layer_row, layer_idx in enumerate(layers):
+        avg_counts = avg_histograms[layer_row]
+        baseline_counts = baseline_histograms[layer_row]
+
+        avg_total = float(avg_counts.sum())
+        baseline_total = float(baseline_counts.sum())
+        balancedness = compute_balancedness(avg_counts)
+        baseline_balancedness = compute_balancedness(baseline_counts)
+        gini = compute_gini(avg_counts)
+        baseline_gini = compute_gini(baseline_counts)
+
+        rows.append(
+            {
+                "batch_size": batch_size,
+                "draft_length": draft_length,
+                "layer": layer_idx,
+                "num_steps": num_steps,
+                "avg_total_routed_assignments_per_step": avg_total,
+                "baseline_avg_total_routed_assignments_per_step": baseline_total,
+                "avg_total_routed_assignments_delta": avg_total - baseline_total,
+                "balancedness": balancedness,
+                "baseline_balancedness": baseline_balancedness,
+                "balancedness_delta": balancedness - baseline_balancedness,
+                "balancedness_relative_change": (
+                    balancedness / baseline_balancedness - 1.0
+                    if baseline_balancedness > 0
+                    else 0.0
+                ),
+                "gini": gini,
+                "baseline_gini": baseline_gini,
+                "gini_delta": gini - baseline_gini,
+                "imbalance_change": classify_imbalance_change(
+                    balancedness - baseline_balancedness,
+                    gini - baseline_gini,
+                ),
+            }
+        )
+    return rows
+
+
+def select_dataset_indices(batch_size: int, available_items: int) -> np.ndarray:
+    if batch_size > available_items:
+        raise ValueError(
+            f"Requested batch_size={batch_size}, but only {available_items} "
+            "dataset items are available."
+        )
+    return np.arange(batch_size, dtype=np.int64)
+
+
+def build_speedup_rows(
+    latency_by_condition: dict[tuple[int, int], float],
+    batch_sizes: tuple[int, ...],
+    draft_lengths: tuple[int, ...],
+) -> list[dict[str, float | int]]:
+    rows: list[dict[str, float | int]] = []
+    for batch_size in batch_sizes:
+        baseline_latency = latency_by_condition[(batch_size, 0)]
+        for draft_length in draft_lengths:
+            latency_ms = latency_by_condition[(batch_size, draft_length)]
+            rows.append(
+                {
+                    "batch_size": batch_size,
+                    "draft_length": draft_length,
+                    "condition_latency_ms": latency_ms,
+                    "baseline_latency_ms": baseline_latency,
+                    "speedup": (
+                        baseline_latency / latency_ms if latency_ms > 0 else 0.0
+                    ),
+                }
+            )
+    return rows
+
+
+def summarize_step_time_components(
+    step_total_ms: np.ndarray,
+    step_attention_ms: np.ndarray,
+    step_routing_ms: np.ndarray,
+    step_prepare_ms: np.ndarray,
+    step_finalize_ms: np.ndarray,
+    step_ffn_ms: np.ndarray,
+) -> dict[str, float]:
+    avg_total_ms = float(np.mean(step_total_ms))
+    avg_attention_ms = float(np.mean(step_attention_ms))
+    avg_routing_ms = float(np.mean(step_routing_ms))
+    avg_prepare_ms = float(np.mean(step_prepare_ms))
+    avg_finalize_ms = float(np.mean(step_finalize_ms))
+    avg_all2all_ms = avg_prepare_ms + avg_finalize_ms
+    avg_ffn_ms = float(np.mean(step_ffn_ms))
+    return {
+        "avg_step_total_ms": avg_total_ms,
+        "avg_attention_ms": avg_attention_ms,
+        "avg_routing_ms": avg_routing_ms,
+        "avg_prepare_ms": avg_prepare_ms,
+        "avg_finalize_ms": avg_finalize_ms,
+        "avg_all2all_ms": avg_all2all_ms,
+        "avg_ffn_ms": avg_ffn_ms,
+    }
+
+
+def normalize_time_components(
+    summary_row: dict[str, float | int],
+    baseline_total_ms: float,
+) -> dict[str, float]:
+    if baseline_total_ms <= 0:
+        raise ValueError("baseline_total_ms must be positive.")
+    return {
+        "normalized_attention_ms": (
+            float(summary_row["avg_attention_ms"]) / baseline_total_ms
+        ),
+        "normalized_routing_ms": (
+            float(summary_row["avg_routing_ms"]) / baseline_total_ms
+        ),
+        "normalized_all2all_ms": (
+            float(summary_row["avg_all2all_ms"]) / baseline_total_ms
+        ),
+        "normalized_ffn_ms": (
+            float(summary_row["avg_ffn_ms"]) / baseline_total_ms
+        ),
+        "ffn_share": (
+            float(summary_row["avg_ffn_ms"])
+            / float(summary_row["avg_step_total_ms"])
+            if float(summary_row["avg_step_total_ms"]) > 0
+            else 0.0
+        ),
+    }

--- a/examples/features/speculative_decoding/mtp_ep_load_balance_utils.py
+++ b/examples/features/speculative_decoding/mtp_ep_load_balance_utils.py
@@ -3,23 +3,29 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 5
 
 DEFAULT_MODEL = "Qwen/Qwen3.6-35B-A3B"
-DEFAULT_DATASET = "openai/gsm8k"
-DEFAULT_DATASET_CONFIG = "main"
-DEFAULT_DATASET_SPLIT = "test"
-DEFAULT_BATCH_SIZES = (32, 64, 128, 256, 512, 1024)
+DEFAULT_DATASET = "likaixin/InstructCoder"
+DEFAULT_DATASET_CONFIG = None
+DEFAULT_DATASET_SPLIT = "train"
+DEFAULT_BATCH_SIZES = (32, 64, 128, 256, 512)
 DEFAULT_DRAFT_LENGTHS = (0, 2, 4, 6)
 DEFAULT_LAYERS = (0, 9, 19, 29, 39)
 DEFAULT_NUM_EXPERTS = 256
 DEFAULT_MAX_TOKENS = 128
 DEFAULT_MAX_MODEL_LEN = 4096
+DEFAULT_NUM_SAMPLES = 512
+TPOT_DEFINITION = (
+    "tpot_ms = built_in_decode_time_total_ms / "
+    "sum(max(num_generation_tokens - 1, 0))"
+)
 
 
 @dataclass(frozen=True)
@@ -28,6 +34,13 @@ class CapturedStep:
     routing_data: np.ndarray
     total_scheduled_tokens: int
     request_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StepCaptureDecision:
+    captured_step: CapturedStep | None
+    local_step_kind: str
+    drop_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -58,6 +71,122 @@ class StepTiming:
         )
 
 
+@dataclass(frozen=True)
+class GlobalStepTimingAggregation:
+    global_step_indices: np.ndarray
+    global_step_total_ms: np.ndarray
+    global_step_ffn_ms: np.ndarray
+    global_step_other_ms: np.ndarray
+    global_step_kinds: np.ndarray
+    global_step_histograms: np.ndarray
+    global_step_total_tokens: np.ndarray
+    num_global_candidate_steps: int
+    num_global_captured_steps: int
+    num_global_prefill_dropped_steps: int
+    num_global_mixed_dropped_steps: int
+    num_global_non_target_dropped_steps: int
+
+
+@dataclass(frozen=True)
+class FinishedRequestStatTotals:
+    decode_time_total_ms: float
+    num_generation_tokens_total: int
+    num_output_tokens_excl_first_total: int
+
+
+def classify_step_capture(
+    scheduler_output: Any,
+    model_runner_output: Any,
+    worker_step_metadata: dict[str, Any] | None,
+    use_spec_decode: bool,
+) -> StepCaptureDecision:
+    routed_experts = getattr(model_runner_output, "routed_experts", None)
+    if routed_experts is None:
+        return StepCaptureDecision(
+            captured_step=None,
+            local_step_kind="missing_routing",
+            drop_reason="missing_routing",
+        )
+
+    routing_data = np.asarray(routed_experts.routing_data)
+    req_ids = tuple(getattr(model_runner_output, "req_ids", ()))
+    num_scheduled_tokens = dict(getattr(scheduler_output, "num_scheduled_tokens", {}))
+    expected_rows = sum(num_scheduled_tokens.get(req_id, 0) for req_id in req_ids)
+    if routing_data.shape[0] != expected_rows:
+        raise ValueError(
+            "routing_data rows do not match the scheduled token layout: "
+            f"{routing_data.shape[0]} vs {expected_rows}."
+        )
+
+    scheduled_spec_tokens = dict(
+        getattr(scheduler_output, "scheduled_spec_decode_tokens", {})
+    )
+    metadata_req_ids = req_ids
+    has_prefill = False
+    if worker_step_metadata is not None:
+        metadata_req_ids = tuple(worker_step_metadata.get("req_ids", ()))
+        if metadata_req_ids and metadata_req_ids != req_ids:
+            raise ValueError(
+                "worker step metadata req_ids do not match model runner output: "
+                f"{metadata_req_ids} vs {req_ids}."
+            )
+        has_prefill = bool(worker_step_metadata.get("has_prefill", False))
+
+    if has_prefill:
+        return StepCaptureDecision(
+            captured_step=None,
+            local_step_kind="prefill",
+            drop_reason="prefill",
+        )
+
+    if use_spec_decode:
+        if not scheduled_spec_tokens:
+            return StepCaptureDecision(
+                captured_step=None,
+                local_step_kind="non_target",
+                drop_reason="non_target",
+            )
+        if set(req_ids) != set(scheduled_spec_tokens):
+            return StepCaptureDecision(
+                captured_step=None,
+                local_step_kind="mixed",
+                drop_reason="mixed",
+            )
+        return StepCaptureDecision(
+            captured_step=CapturedStep(
+                step_kind="verification_only",
+                routing_data=routing_data,
+                total_scheduled_tokens=expected_rows,
+                request_ids=req_ids,
+            ),
+            local_step_kind="verification_only",
+        )
+
+    if scheduled_spec_tokens:
+        return StepCaptureDecision(
+            captured_step=None,
+            local_step_kind="mixed",
+            drop_reason="mixed",
+        )
+    if not num_scheduled_tokens or not all(
+        num_tokens == 1 for num_tokens in num_scheduled_tokens.values()
+    ):
+        return StepCaptureDecision(
+            captured_step=None,
+            local_step_kind="non_target",
+            drop_reason="non_target",
+        )
+    return StepCaptureDecision(
+        captured_step=CapturedStep(
+            step_kind="decode_only",
+            routing_data=routing_data,
+            total_scheduled_tokens=routing_data.shape[0],
+            request_ids=req_ids,
+        ),
+        local_step_kind="decode_only",
+    )
+
+
 def should_capture_baseline_decode_step(scheduler_output: Any) -> bool:
     num_scheduled_tokens = getattr(scheduler_output, "num_scheduled_tokens", {})
     scheduled_spec_tokens = getattr(
@@ -81,77 +210,17 @@ def should_capture_mtp_verification_step(scheduler_output: Any) -> bool:
     return bool(scheduled_spec_tokens)
 
 
-def _request_offsets(
-    req_ids: list[str],
-    num_scheduled_tokens: dict[str, int],
-) -> dict[str, int]:
-    offsets: dict[str, int] = {}
-    offset = 0
-    for req_id in req_ids:
-        if req_id not in num_scheduled_tokens:
-            continue
-        offsets[req_id] = offset
-        offset += num_scheduled_tokens[req_id]
-    return offsets
-
-
 def select_step_routing_data(
     scheduler_output: Any,
     model_runner_output: Any,
     use_spec_decode: bool,
 ) -> CapturedStep | None:
-    routed_experts = getattr(model_runner_output, "routed_experts", None)
-    if routed_experts is None:
-        return None
-
-    routing_data = np.asarray(routed_experts.routing_data)
-    req_ids = list(getattr(model_runner_output, "req_ids", []))
-    num_scheduled_tokens = dict(getattr(scheduler_output, "num_scheduled_tokens", {}))
-    expected_rows = sum(num_scheduled_tokens.get(req_id, 0) for req_id in req_ids)
-    if routing_data.shape[0] != expected_rows:
-        raise ValueError(
-            "routing_data rows do not match the scheduled token layout: "
-            f"{routing_data.shape[0]} vs {expected_rows}."
-        )
-
-    if use_spec_decode:
-        if not should_capture_mtp_verification_step(scheduler_output):
-            return None
-        offsets = _request_offsets(req_ids, num_scheduled_tokens)
-        selected_req_ids = tuple(
-            req_id
-            for req_id in req_ids
-            if req_id in scheduler_output.scheduled_spec_decode_tokens
-        )
-        if not selected_req_ids:
-            return None
-
-        selected_segments = []
-        total_scheduled_tokens = 0
-        for req_id in selected_req_ids:
-            segment_offset = offsets[req_id]
-            segment_len = num_scheduled_tokens[req_id]
-            selected_segments.append(
-                routing_data[segment_offset : segment_offset + segment_len]
-            )
-            total_scheduled_tokens += segment_len
-
-        return CapturedStep(
-            step_kind="mtp_verification",
-            routing_data=np.concatenate(selected_segments, axis=0),
-            total_scheduled_tokens=total_scheduled_tokens,
-            request_ids=selected_req_ids,
-        )
-
-    if not should_capture_baseline_decode_step(scheduler_output):
-        return None
-
-    return CapturedStep(
-        step_kind="baseline_decode",
-        routing_data=routing_data,
-        total_scheduled_tokens=routing_data.shape[0],
-        request_ids=tuple(req_ids),
-    )
+    return classify_step_capture(
+        scheduler_output,
+        model_runner_output,
+        worker_step_metadata=None,
+        use_spec_decode=use_spec_decode,
+    ).captured_step
 
 
 def count_layer_expert_histograms(
@@ -301,80 +370,282 @@ def build_condition_metrics(
 def select_dataset_indices(batch_size: int, available_items: int) -> np.ndarray:
     if batch_size > available_items:
         raise ValueError(
-            f"Requested batch_size={batch_size}, but only {available_items} "
+            f"Requested num_samples={batch_size}, but only {available_items} "
             "dataset items are available."
         )
     return np.arange(batch_size, dtype=np.int64)
 
 
+def num_condition_rounds(num_samples: int, global_batch_size: int) -> int:
+    if global_batch_size <= 0:
+        raise ValueError("global_batch_size must be positive.")
+    return math.ceil(num_samples / global_batch_size)
+
+
+def shard_global_batch_indices(
+    *,
+    num_samples: int,
+    global_batch_size: int,
+    round_idx: int,
+    dp_size: int,
+    dp_rank: int,
+) -> np.ndarray:
+    if dp_size <= 0:
+        raise ValueError("dp_size must be positive.")
+    if not 0 <= dp_rank < dp_size:
+        raise ValueError(f"dp_rank={dp_rank} must be in [0, {dp_size}).")
+    start = round_idx * global_batch_size
+    stop = min(start + global_batch_size, num_samples)
+    if start >= stop:
+        return np.empty((0,), dtype=np.int64)
+    round_indices = np.arange(start, stop, dtype=np.int64)
+    floor = len(round_indices) // dp_size
+    remainder = len(round_indices) % dp_size
+    local_start = dp_rank * floor + min(dp_rank, remainder)
+    local_len = floor + (1 if dp_rank < remainder else 0)
+    return round_indices[local_start : local_start + local_len]
+
+
 def build_speedup_rows(
-    latency_by_condition: dict[tuple[int, int], float],
+    decode_time_ms_by_condition: dict[tuple[int, int], float],
+    generation_tokens_by_condition: dict[tuple[int, int], int],
+    output_tokens_excl_first_by_condition: dict[tuple[int, int], int],
     batch_sizes: tuple[int, ...],
     draft_lengths: tuple[int, ...],
 ) -> list[dict[str, float | int]]:
     rows: list[dict[str, float | int]] = []
     for batch_size in batch_sizes:
-        baseline_latency = latency_by_condition[(batch_size, 0)]
+        baseline_decode_time_ms = decode_time_ms_by_condition[(batch_size, 0)]
+        baseline_generation_tokens = generation_tokens_by_condition[(batch_size, 0)]
+        baseline_output_tokens_excl_first = output_tokens_excl_first_by_condition[
+            (batch_size, 0)
+        ]
+        baseline_tpot = compute_tpot_ms_from_finished_stats(
+            baseline_decode_time_ms,
+            baseline_output_tokens_excl_first,
+        )
+        baseline_decode_throughput = compute_decode_throughput_tok_s(
+            baseline_generation_tokens,
+            baseline_decode_time_ms,
+        )
         for draft_length in draft_lengths:
-            latency_ms = latency_by_condition[(batch_size, draft_length)]
+            decode_time_total_ms = decode_time_ms_by_condition[
+                (batch_size, draft_length)
+            ]
+            num_generation_tokens_total = generation_tokens_by_condition[
+                (batch_size, draft_length)
+            ]
+            num_output_tokens_excl_first_total = (
+                output_tokens_excl_first_by_condition[(batch_size, draft_length)]
+            )
+            tpot_ms = compute_tpot_ms_from_finished_stats(
+                decode_time_total_ms,
+                num_output_tokens_excl_first_total,
+            )
+            decode_throughput = compute_decode_throughput_tok_s(
+                num_generation_tokens_total,
+                decode_time_total_ms,
+            )
             rows.append(
                 {
                     "batch_size": batch_size,
                     "draft_length": draft_length,
-                    "condition_latency_ms": latency_ms,
-                    "baseline_latency_ms": baseline_latency,
-                    "speedup": (
-                        baseline_latency / latency_ms if latency_ms > 0 else 0.0
+                    "decode_time_total_ms": decode_time_total_ms,
+                    "num_generation_tokens_total": num_generation_tokens_total,
+                    "num_output_tokens_excl_first_total": (
+                        num_output_tokens_excl_first_total
+                    ),
+                    "tpot_ms": tpot_ms,
+                    "baseline_tpot_ms": baseline_tpot,
+                    "tpot_speedup": (
+                        baseline_tpot / tpot_ms if tpot_ms > 0 else 0.0
+                    ),
+                    "decode_throughput_tok_s": decode_throughput,
+                    "baseline_decode_throughput_tok_s": baseline_decode_throughput,
+                    "decode_throughput_speedup": (
+                        decode_throughput / baseline_decode_throughput
+                        if baseline_decode_throughput > 0
+                        else 0.0
                     ),
                 }
             )
     return rows
 
 
-def summarize_step_time_components(
+def aggregate_global_step_time_components(
+    rank_step_data: list[dict[str, np.ndarray]],
+    *,
+    data_parallel_size: int,
+    expected_step_kind: str,
+    layers: tuple[int, ...],
+    num_experts: int,
+    tol_ms: float = 1e-3,
+) -> GlobalStepTimingAggregation:
+    if data_parallel_size <= 0:
+        raise ValueError("data_parallel_size must be positive.")
+    if len(rank_step_data) != data_parallel_size:
+        raise ValueError(
+            "rank_step_data length must match data_parallel_size: "
+            f"{len(rank_step_data)} vs {data_parallel_size}."
+        )
+
+    per_step_records: dict[int, list[dict[str, Any]]] = {}
+    for rank_idx, rank_data in enumerate(rank_step_data):
+        step_indices = np.asarray(
+            rank_data["candidate_first_ep_collective_seq_ids"], dtype=np.int64
+        )
+        step_kinds = np.asarray(rank_data["candidate_step_kinds"], dtype=np.str_)
+        step_total_ms = np.asarray(
+            rank_data["candidate_step_total_ms"], dtype=np.float64
+        )
+        step_ffn_ms = np.asarray(rank_data["candidate_step_ffn_ms"], dtype=np.float64)
+        step_total_tokens = np.asarray(
+            rank_data["candidate_step_total_tokens"], dtype=np.int64
+        )
+        step_histograms = np.asarray(rank_data["candidate_step_histograms"])
+        size = step_indices.shape[0]
+        for array_name, array in (
+            ("candidate_step_kinds", step_kinds),
+            ("candidate_step_total_ms", step_total_ms),
+            ("candidate_step_ffn_ms", step_ffn_ms),
+            ("candidate_step_total_tokens", step_total_tokens),
+        ):
+            if array.shape[0] != size:
+                raise ValueError(
+                    f"Rank {rank_idx} {array_name} has inconsistent length: "
+                    f"{array.shape[0]} vs {size}."
+                )
+        if step_histograms.shape != (size, len(layers), num_experts):
+            raise ValueError(
+                f"Rank {rank_idx} candidate_step_histograms has shape "
+                f"{step_histograms.shape}; expected "
+                f"{(size, len(layers), num_experts)}."
+            )
+
+        seen_step_indices: set[int] = set()
+        for idx in range(size):
+            step_index = int(step_indices[idx])
+            if step_index < 0:
+                continue
+            if step_index in seen_step_indices:
+                raise ValueError(
+                    f"Rank {rank_idx} produced duplicate first_ep_collective_seq_id="
+                    f"{step_index}."
+                )
+            seen_step_indices.add(step_index)
+
+            record = {
+                "rank_idx": rank_idx,
+                "step_kind": str(step_kinds[idx]),
+                "step_total_ms": float(step_total_ms[idx]),
+                "step_ffn_ms": float(step_ffn_ms[idx]),
+                "step_total_tokens": int(step_total_tokens[idx]),
+                "step_histograms": step_histograms[idx],
+            }
+            per_step_records.setdefault(step_index, []).append(record)
+
+    global_step_indices: list[int] = []
+    global_step_total_ms: list[float] = []
+    global_step_ffn_ms: list[float] = []
+    global_step_other_ms: list[float] = []
+    global_step_kinds: list[str] = []
+    global_step_histograms: list[np.ndarray] = []
+    global_step_total_tokens: list[int] = []
+    num_global_prefill_dropped_steps = 0
+    num_global_mixed_dropped_steps = 0
+    num_global_non_target_dropped_steps = 0
+
+    for step_index in sorted(per_step_records):
+        records = per_step_records[step_index]
+        if len(records) != data_parallel_size:
+            num_global_non_target_dropped_steps += 1
+            continue
+
+        step_kinds = {str(record["step_kind"]) for record in records}
+        if "prefill" in step_kinds:
+            num_global_prefill_dropped_steps += 1
+            continue
+        if "mixed" in step_kinds:
+            num_global_mixed_dropped_steps += 1
+            continue
+        if step_kinds != {expected_step_kind}:
+            num_global_non_target_dropped_steps += 1
+            continue
+
+        total_ms = max(float(record["step_total_ms"]) for record in records)
+        ffn_ms = max(float(record["step_ffn_ms"]) for record in records)
+        other_ms = total_ms - ffn_ms
+        if ffn_ms < 0:
+            raise ValueError(
+                f"Captured first_ep_collective_seq_id={step_index} produced "
+                f"negative FFN time: {ffn_ms:.6f} ms."
+            )
+        if other_ms < -tol_ms:
+            raise ValueError(
+                "Captured first_ep_collective_seq_id="
+                f"{step_index} produced negative Other time: {other_ms:.6f} ms."
+            )
+
+        global_step_indices.append(step_index)
+        global_step_total_ms.append(total_ms)
+        global_step_ffn_ms.append(ffn_ms)
+        global_step_other_ms.append(other_ms)
+        global_step_kinds.append(expected_step_kind)
+        global_step_histograms.append(
+            np.sum([record["step_histograms"] for record in records], axis=0)
+        )
+        global_step_total_tokens.append(
+            sum(int(record["step_total_tokens"]) for record in records)
+        )
+
+    if global_step_histograms:
+        histogram_array = np.stack(global_step_histograms, axis=0).astype(np.int64)
+    else:
+        histogram_array = np.empty((0, len(layers), num_experts), dtype=np.int64)
+
+    return GlobalStepTimingAggregation(
+        global_step_indices=np.asarray(global_step_indices, dtype=np.int64),
+        global_step_total_ms=np.asarray(global_step_total_ms, dtype=np.float64),
+        global_step_ffn_ms=np.asarray(global_step_ffn_ms, dtype=np.float64),
+        global_step_other_ms=np.asarray(global_step_other_ms, dtype=np.float64),
+        global_step_kinds=np.asarray(global_step_kinds, dtype=np.str_),
+        global_step_histograms=histogram_array,
+        global_step_total_tokens=np.asarray(global_step_total_tokens, dtype=np.int64),
+        num_global_candidate_steps=len(per_step_records),
+        num_global_captured_steps=len(global_step_indices),
+        num_global_prefill_dropped_steps=num_global_prefill_dropped_steps,
+        num_global_mixed_dropped_steps=num_global_mixed_dropped_steps,
+        num_global_non_target_dropped_steps=num_global_non_target_dropped_steps,
+    )
+
+
+def summarize_global_step_time_components(
     step_total_ms: np.ndarray,
-    step_attention_ms: np.ndarray,
-    step_routing_ms: np.ndarray,
-    step_prepare_ms: np.ndarray,
-    step_finalize_ms: np.ndarray,
     step_ffn_ms: np.ndarray,
+    step_other_ms: np.ndarray,
 ) -> dict[str, float]:
     avg_total_ms = float(np.mean(step_total_ms))
-    avg_attention_ms = float(np.mean(step_attention_ms))
-    avg_routing_ms = float(np.mean(step_routing_ms))
-    avg_prepare_ms = float(np.mean(step_prepare_ms))
-    avg_finalize_ms = float(np.mean(step_finalize_ms))
-    avg_all2all_ms = avg_prepare_ms + avg_finalize_ms
     avg_ffn_ms = float(np.mean(step_ffn_ms))
+    avg_other_ms = float(np.mean(step_other_ms))
     return {
         "avg_step_total_ms": avg_total_ms,
-        "avg_attention_ms": avg_attention_ms,
-        "avg_routing_ms": avg_routing_ms,
-        "avg_prepare_ms": avg_prepare_ms,
-        "avg_finalize_ms": avg_finalize_ms,
-        "avg_all2all_ms": avg_all2all_ms,
         "avg_ffn_ms": avg_ffn_ms,
+        "avg_other_ms": avg_other_ms,
     }
 
 
-def normalize_time_components(
+def normalize_global_time_components(
     summary_row: dict[str, float | int],
     baseline_total_ms: float,
 ) -> dict[str, float]:
     if baseline_total_ms <= 0:
         raise ValueError("baseline_total_ms must be positive.")
     return {
-        "normalized_attention_ms": (
-            float(summary_row["avg_attention_ms"]) / baseline_total_ms
-        ),
-        "normalized_routing_ms": (
-            float(summary_row["avg_routing_ms"]) / baseline_total_ms
-        ),
-        "normalized_all2all_ms": (
-            float(summary_row["avg_all2all_ms"]) / baseline_total_ms
-        ),
         "normalized_ffn_ms": (
             float(summary_row["avg_ffn_ms"]) / baseline_total_ms
+        ),
+        "normalized_other_ms": (
+            float(summary_row["avg_other_ms"]) / baseline_total_ms
         ),
         "ffn_share": (
             float(summary_row["avg_ffn_ms"])
@@ -382,4 +653,129 @@ def normalize_time_components(
             if float(summary_row["avg_step_total_ms"]) > 0
             else 0.0
         ),
+        "other_share": (
+            float(summary_row["avg_other_ms"])
+            / float(summary_row["avg_step_total_ms"])
+            if float(summary_row["avg_step_total_ms"]) > 0
+            else 0.0
+        ),
     }
+
+
+def compute_num_output_tokens_excluding_first(
+    output_lengths: np.ndarray,
+) -> int:
+    output_lengths = np.asarray(output_lengths, dtype=np.int64)
+    return int(np.maximum(output_lengths - 1, 0).sum())
+
+
+def compute_tpot_ms(
+    decode_only_total_ms: float,
+    output_lengths: np.ndarray,
+) -> float:
+    num_output_tokens_excl_first = compute_num_output_tokens_excluding_first(
+        output_lengths
+    )
+    if num_output_tokens_excl_first <= 0:
+        return 0.0
+    return decode_only_total_ms / num_output_tokens_excl_first
+
+
+def compute_tpot_ms_from_finished_stats(
+    decode_time_total_ms: float,
+    num_output_tokens_excl_first_total: int,
+) -> float:
+    if num_output_tokens_excl_first_total <= 0:
+        return 0.0
+    return decode_time_total_ms / num_output_tokens_excl_first_total
+
+
+def compute_decode_throughput_tok_s(
+    num_generation_tokens_total: int,
+    decode_time_total_ms: float,
+) -> float:
+    if decode_time_total_ms <= 0:
+        return 0.0
+    return num_generation_tokens_total / (decode_time_total_ms / 1000.0)
+
+
+def build_expert_to_ep_rank(
+    *,
+    num_experts: int,
+    ep_size: int,
+    placement_strategy: str = "linear",
+) -> np.ndarray:
+    if ep_size <= 0:
+        raise ValueError("ep_size must be positive.")
+    if num_experts <= 0:
+        raise ValueError("num_experts must be positive.")
+    expert_to_rank = np.full((num_experts,), -1, dtype=np.int64)
+    if placement_strategy == "linear":
+        base = num_experts // ep_size
+        remainder = num_experts % ep_size
+        for ep_rank in range(ep_size):
+            local_count = base + (1 if ep_rank < remainder else 0)
+            start = ep_rank * base + min(ep_rank, remainder)
+            expert_to_rank[start : start + local_count] = ep_rank
+    elif placement_strategy == "round_robin":
+        for expert_id in range(num_experts):
+            expert_to_rank[expert_id] = expert_id % ep_size
+    else:
+        raise ValueError(f"Unsupported expert placement strategy: {placement_strategy}")
+    if np.any(expert_to_rank < 0):
+        raise ValueError("Expert to EP rank mapping is incomplete.")
+    return expert_to_rank
+
+
+def merge_expert_to_ep_rank_maps(
+    rank_maps: list[np.ndarray],
+    *,
+    num_experts: int,
+    ep_size: int,
+) -> np.ndarray:
+    if not rank_maps:
+        return build_expert_to_ep_rank(num_experts=num_experts, ep_size=ep_size)
+    merged = np.full((num_experts,), -1, dtype=np.int64)
+    for rank_map in rank_maps:
+        rank_map = np.asarray(rank_map, dtype=np.int64)
+        if rank_map.shape != (num_experts,):
+            raise ValueError(
+                f"expert_to_ep_rank map has shape {rank_map.shape}; "
+                f"expected {(num_experts,)}."
+            )
+        owned = rank_map >= 0
+        conflicts = owned & (merged >= 0) & (merged != rank_map)
+        if np.any(conflicts):
+            conflict_ids = np.flatnonzero(conflicts)[:8].tolist()
+            raise ValueError(
+                "Conflicting expert to EP rank ownership for experts "
+                f"{conflict_ids}."
+            )
+        merged[owned] = rank_map[owned]
+    if np.any(merged < 0):
+        fallback = build_expert_to_ep_rank(num_experts=num_experts, ep_size=ep_size)
+        merged[merged < 0] = fallback[merged < 0]
+    return merged
+
+
+def build_rank_load_from_histograms(
+    avg_histograms: np.ndarray,
+    expert_to_ep_rank: np.ndarray,
+    ep_size: int,
+) -> np.ndarray:
+    avg_histograms = np.asarray(avg_histograms, dtype=np.float64)
+    expert_to_ep_rank = np.asarray(expert_to_ep_rank, dtype=np.int64)
+    if avg_histograms.ndim != 2:
+        raise ValueError("avg_histograms must be shaped as (layers, experts).")
+    if expert_to_ep_rank.shape != (avg_histograms.shape[1],):
+        raise ValueError(
+            "expert_to_ep_rank length must match avg_histograms expert dimension."
+        )
+    rank_load = np.zeros((avg_histograms.shape[0], ep_size), dtype=np.float64)
+    for expert_id, ep_rank in enumerate(expert_to_ep_rank):
+        if not 0 <= int(ep_rank) < ep_size:
+            raise ValueError(
+                f"expert_id={expert_id} has invalid ep_rank={int(ep_rank)}."
+            )
+        rank_load[:, int(ep_rank)] += avg_histograms[:, expert_id]
+    return rank_load

--- a/examples/features/speculative_decoding/qwen3_6_mtp_ep_load_balance_experiment.py
+++ b/examples/features/speculative_decoding/qwen3_6_mtp_ep_load_balance_experiment.py
@@ -22,6 +22,7 @@ from mtp_ep_load_balance_utils import (
     DEFAULT_MAX_MODEL_LEN,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
+    DEFAULT_NUM_SAMPLES,
     DEFAULT_NUM_EXPERTS,
 )
 
@@ -31,6 +32,7 @@ def add_common_runtime_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--dataset", default=DEFAULT_DATASET)
     parser.add_argument("--dataset-config", default=DEFAULT_DATASET_CONFIG)
     parser.add_argument("--dataset-split", default=DEFAULT_DATASET_SPLIT)
+    parser.add_argument("--num-samples", type=int, default=DEFAULT_NUM_SAMPLES)
     parser.add_argument(
         "--batch-sizes",
         nargs="+",
@@ -45,7 +47,8 @@ def add_common_runtime_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
     parser.add_argument("--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN)
-    parser.add_argument("--tensor-parallel-size", type=int, default=2)
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--data-parallel-size", type=int, default=2)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
     parser.add_argument(
         "--layers",
@@ -58,15 +61,18 @@ def add_common_runtime_args(parser: argparse.ArgumentParser) -> None:
         "--output-dir",
         type=Path,
         default=None,
-        help="Runtime output directory. Defaults to results/qwen3_6_mtp_ep_<UTC timestamp>.",
+        help=(
+            "Runtime output directory. Defaults to "
+            "results/qwen3_6_mtp_dp_ep_<UTC timestamp>."
+        ),
     )
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Collect and analyze the Qwen3.6 MTP-EP speedup, step-time, and "
-            "expert-load experiment."
+            "Collect and analyze the Qwen3.6 MTP DP+EP TPOT, decode-only "
+            "step-time, and expert-load experiment."
         )
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -80,13 +86,22 @@ def parse_args() -> argparse.Namespace:
         "--enforce-eager",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Force eager mode during collection to avoid compile/cudagraph cold start effects.",
+        help=(
+            "Force eager mode during collection to avoid compile/cudagraph "
+            "cold start effects."
+        ),
     )
     collect_parser.add_argument(
         "--warmup-rounds",
         type=int,
         default=1,
         help="Number of unmeasured warmup generate rounds per condition.",
+    )
+    collect_parser.add_argument(
+        "--trace-steps-per-rank",
+        type=int,
+        default=0,
+        help="Record the first N captured step event traces per DP rank.",
     )
     collect_one_parser = subparsers.add_parser(
         "collect-one",
@@ -99,12 +114,16 @@ def parse_args() -> argparse.Namespace:
     collect_one_parser.add_argument("--batch-size", type=int, required=True)
     collect_one_parser.add_argument("--draft-length", type=int, required=True)
     collect_one_parser.add_argument(
+        "--num-samples", type=int, default=DEFAULT_NUM_SAMPLES
+    )
+    collect_one_parser.add_argument(
         "--max-tokens", type=int, default=DEFAULT_MAX_TOKENS
     )
     collect_one_parser.add_argument(
         "--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN
     )
-    collect_one_parser.add_argument("--tensor-parallel-size", type=int, default=2)
+    collect_one_parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    collect_one_parser.add_argument("--data-parallel-size", type=int, default=2)
     collect_one_parser.add_argument(
         "--gpu-memory-utilization", type=float, default=0.85
     )
@@ -137,6 +156,74 @@ def parse_args() -> argparse.Namespace:
         action=argparse.BooleanOptionalAction,
         default=True,
     )
+    collect_one_parser.add_argument(
+        "--trace-steps-per-rank",
+        type=int,
+        default=0,
+    )
+    collect_one_rank_parser = subparsers.add_parser(
+        "collect-one-rank",
+        help=argparse.SUPPRESS,
+    )
+    collect_one_rank_parser.add_argument("--model", default=DEFAULT_MODEL)
+    collect_one_rank_parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    collect_one_rank_parser.add_argument(
+        "--dataset-config", default=DEFAULT_DATASET_CONFIG
+    )
+    collect_one_rank_parser.add_argument(
+        "--dataset-split", default=DEFAULT_DATASET_SPLIT
+    )
+    collect_one_rank_parser.add_argument("--batch-size", type=int, required=True)
+    collect_one_rank_parser.add_argument("--draft-length", type=int, required=True)
+    collect_one_rank_parser.add_argument(
+        "--num-samples", type=int, default=DEFAULT_NUM_SAMPLES
+    )
+    collect_one_rank_parser.add_argument(
+        "--max-tokens", type=int, default=DEFAULT_MAX_TOKENS
+    )
+    collect_one_rank_parser.add_argument(
+        "--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN
+    )
+    collect_one_rank_parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    collect_one_rank_parser.add_argument("--data-parallel-size", type=int, default=2)
+    collect_one_rank_parser.add_argument(
+        "--gpu-memory-utilization", type=float, default=0.85
+    )
+    collect_one_rank_parser.add_argument(
+        "--layers",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_LAYERS),
+    )
+    collect_one_rank_parser.add_argument(
+        "--num-experts", type=int, default=DEFAULT_NUM_EXPERTS
+    )
+    collect_one_rank_parser.add_argument("--output-dir", type=Path, required=True)
+    collect_one_rank_parser.add_argument(
+        "--prompt-cache-path",
+        type=Path,
+        default=None,
+    )
+    collect_one_rank_parser.add_argument("--warmup-rounds", type=int, default=1)
+    collect_one_rank_parser.add_argument(
+        "--enforce-eager",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    collect_one_rank_parser.add_argument(
+        "--trace-steps-per-rank",
+        type=int,
+        default=0,
+    )
+    collect_one_rank_parser.add_argument("--dp-rank", type=int, required=True)
+    collect_one_rank_parser.add_argument("--dp-local-rank", type=int, required=True)
+    collect_one_rank_parser.add_argument("--dp-master-ip", required=True)
+    collect_one_rank_parser.add_argument("--dp-master-port", type=int, required=True)
+    collect_one_rank_parser.add_argument(
+        "--rank-output-path",
+        type=Path,
+        required=True,
+    )
 
     analyze_parser = subparsers.add_parser(
         "analyze",
@@ -146,7 +233,10 @@ def parse_args() -> argparse.Namespace:
         "--input-dir",
         type=Path,
         required=True,
-        help="Experiment root directory containing collect_manifest.json and raw/*.npz.",
+        help=(
+            "Experiment root directory containing collect_manifest.json and "
+            "raw/*.npz."
+        ),
     )
     analyze_parser.add_argument(
         "--skip-plots",
@@ -176,6 +266,13 @@ def main() -> None:
     if args.command == "collect-one":
         args.layers = tuple(args.layers)
         collect_one_condition(args, args.output_dir)
+        return
+
+    if args.command == "collect-one-rank":
+        args.layers = tuple(args.layers)
+        from mtp_ep_experiment_runtime import collect_one_rank
+
+        collect_one_rank(args)
         return
 
     analyze_experiment(

--- a/examples/features/speculative_decoding/qwen3_6_mtp_ep_load_balance_experiment.py
+++ b/examples/features/speculative_decoding/qwen3_6_mtp_ep_load_balance_experiment.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from mtp_ep_experiment_analysis import analyze_experiment
+from mtp_ep_experiment_runtime import (
+    collect_experiment,
+    collect_one_condition,
+    default_output_dir,
+)
+from mtp_ep_load_balance_utils import (
+    DEFAULT_BATCH_SIZES,
+    DEFAULT_DATASET,
+    DEFAULT_DATASET_CONFIG,
+    DEFAULT_DATASET_SPLIT,
+    DEFAULT_DRAFT_LENGTHS,
+    DEFAULT_LAYERS,
+    DEFAULT_MAX_MODEL_LEN,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL,
+    DEFAULT_NUM_EXPERTS,
+)
+
+
+def add_common_runtime_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--dataset-config", default=DEFAULT_DATASET_CONFIG)
+    parser.add_argument("--dataset-split", default=DEFAULT_DATASET_SPLIT)
+    parser.add_argument(
+        "--batch-sizes",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_BATCH_SIZES),
+    )
+    parser.add_argument(
+        "--draft-lengths",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_DRAFT_LENGTHS),
+    )
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    parser.add_argument("--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN)
+    parser.add_argument("--tensor-parallel-size", type=int, default=2)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    parser.add_argument(
+        "--layers",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_LAYERS),
+    )
+    parser.add_argument("--num-experts", type=int, default=DEFAULT_NUM_EXPERTS)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Runtime output directory. Defaults to results/qwen3_6_mtp_ep_<UTC timestamp>.",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Collect and analyze the Qwen3.6 MTP-EP speedup, step-time, and "
+            "expert-load experiment."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect_parser = subparsers.add_parser(
+        "collect",
+        help="Run all experiment conditions once and save raw data.",
+    )
+    add_common_runtime_args(collect_parser)
+    collect_parser.add_argument(
+        "--enforce-eager",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Force eager mode during collection to avoid compile/cudagraph cold start effects.",
+    )
+    collect_parser.add_argument(
+        "--warmup-rounds",
+        type=int,
+        default=1,
+        help="Number of unmeasured warmup generate rounds per condition.",
+    )
+    collect_one_parser = subparsers.add_parser(
+        "collect-one",
+        help=argparse.SUPPRESS,
+    )
+    collect_one_parser.add_argument("--model", default=DEFAULT_MODEL)
+    collect_one_parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    collect_one_parser.add_argument("--dataset-config", default=DEFAULT_DATASET_CONFIG)
+    collect_one_parser.add_argument("--dataset-split", default=DEFAULT_DATASET_SPLIT)
+    collect_one_parser.add_argument("--batch-size", type=int, required=True)
+    collect_one_parser.add_argument("--draft-length", type=int, required=True)
+    collect_one_parser.add_argument(
+        "--max-tokens", type=int, default=DEFAULT_MAX_TOKENS
+    )
+    collect_one_parser.add_argument(
+        "--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN
+    )
+    collect_one_parser.add_argument("--tensor-parallel-size", type=int, default=2)
+    collect_one_parser.add_argument(
+        "--gpu-memory-utilization", type=float, default=0.85
+    )
+    collect_one_parser.add_argument(
+        "--layers",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_LAYERS),
+    )
+    collect_one_parser.add_argument(
+        "--num-experts", type=int, default=DEFAULT_NUM_EXPERTS
+    )
+    collect_one_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+    )
+    collect_one_parser.add_argument(
+        "--prompt-cache-path",
+        type=Path,
+        default=None,
+    )
+    collect_one_parser.add_argument(
+        "--warmup-rounds",
+        type=int,
+        default=1,
+    )
+    collect_one_parser.add_argument(
+        "--enforce-eager",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+
+    analyze_parser = subparsers.add_parser(
+        "analyze",
+        help="Generate CSV tables, plots, and 实验报告.md from raw data.",
+    )
+    analyze_parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Experiment root directory containing collect_manifest.json and raw/*.npz.",
+    )
+    analyze_parser.add_argument(
+        "--skip-plots",
+        action="store_true",
+        help="Skip plot generation.",
+    )
+    analyze_parser.add_argument(
+        "--skip-report",
+        action="store_true",
+        help="Skip 实验报告.md generation.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "collect":
+        args.batch_sizes = tuple(args.batch_sizes)
+        args.draft_lengths = tuple(args.draft_lengths)
+        args.layers = tuple(args.layers)
+        if 0 not in args.draft_lengths:
+            raise ValueError("draft_length=0 must be present as the baseline.")
+        output_dir = args.output_dir or default_output_dir()
+        collect_experiment(args, output_dir, Path(__file__).resolve())
+        return
+
+    if args.command == "collect-one":
+        args.layers = tuple(args.layers)
+        collect_one_condition(args, args.output_dir)
+        return
+
+    analyze_experiment(
+        args.input_dir,
+        skip_plots=args.skip_plots,
+        skip_report=args.skip_report,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/examples/test_qwen3_6_mtp_ep_load_balance.py
+++ b/tests/examples/test_qwen3_6_mtp_ep_load_balance.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+
+def _load_module(module_name: str, file_name: str):
+    module_dir = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "features"
+        / "speculative_decoding"
+    )
+    if str(module_dir) not in sys.path:
+        sys.path.insert(0, str(module_dir))
+    module_path = module_dir / file_name
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+helper = _load_module(
+    "mtp_ep_load_balance_utils",
+    "mtp_ep_load_balance_utils.py",
+)
+runtime = _load_module(
+    "mtp_ep_experiment_runtime",
+    "mtp_ep_experiment_runtime.py",
+)
+
+
+def _scheduler_output(num_scheduled_tokens, scheduled_spec_decode_tokens):
+    return SimpleNamespace(
+        num_scheduled_tokens=num_scheduled_tokens,
+        scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+    )
+
+
+def _model_runner_output(req_ids, routing_data):
+    return SimpleNamespace(
+        req_ids=req_ids,
+        routed_experts=SimpleNamespace(routing_data=routing_data),
+    )
+
+
+def test_step_selection_skips_baseline_prefill_and_keeps_decode_step():
+    prefill_output = _scheduler_output({"0": 4, "1": 5}, {})
+    decode_output = _scheduler_output({"0": 1, "1": 1}, {})
+    prefill_routing_data = np.zeros((9, 40, 2), dtype=np.int64)
+    prefill_model_output = _model_runner_output(["0", "1"], prefill_routing_data)
+    decode_routing_data = np.zeros((2, 40, 2), dtype=np.int64)
+    decode_model_output = _model_runner_output(["0", "1"], decode_routing_data)
+
+    assert not helper.should_capture_baseline_decode_step(prefill_output)
+    assert helper.select_step_routing_data(
+        prefill_output,
+        prefill_model_output,
+        use_spec_decode=False,
+    ) is None
+
+    captured = helper.select_step_routing_data(
+        decode_output,
+        decode_model_output,
+        use_spec_decode=False,
+    )
+    assert captured is not None
+    assert captured.step_kind == "baseline_decode"
+    assert captured.total_scheduled_tokens == 2
+    np.testing.assert_array_equal(captured.routing_data, decode_routing_data)
+
+
+def test_step_selection_only_keeps_mtp_verification_steps():
+    no_spec_routing_data = np.arange(2 * 40 * 2, dtype=np.int64).reshape(2, 40, 2)
+    no_spec_model_output = _model_runner_output(
+        ["req_b", "req_a"],
+        no_spec_routing_data,
+    )
+
+    no_spec_output = _scheduler_output({"req_b": 1, "req_a": 1}, {})
+    assert not helper.should_capture_mtp_verification_step(no_spec_output)
+    assert helper.select_step_routing_data(
+        no_spec_output,
+        no_spec_model_output,
+        use_spec_decode=True,
+    ) is None
+
+    routing_data = np.arange(5 * 40 * 2, dtype=np.int64).reshape(5, 40, 2)
+    model_output = _model_runner_output(["req_b", "req_a"], routing_data)
+    mtp_output = _scheduler_output(
+        {"req_b": 2, "req_a": 3},
+        {"req_a": [7, 8], "req_b": [9]},
+    )
+    captured = helper.select_step_routing_data(
+        mtp_output,
+        model_output,
+        use_spec_decode=True,
+    )
+    assert captured is not None
+    assert captured.step_kind == "mtp_verification"
+    assert captured.request_ids == ("req_b", "req_a")
+    assert captured.total_scheduled_tokens == 5
+    np.testing.assert_array_equal(captured.routing_data, routing_data)
+
+
+def test_counting_and_descending_reorder_are_correct():
+    routing_data = np.zeros((2, 40, 2), dtype=np.int64)
+
+    routing_data[0, 0, :] = [5, 1]
+    routing_data[1, 0, :] = [5, 2]
+    routing_data[0, 9, :] = [7, 7]
+    routing_data[1, 9, :] = [3, 7]
+
+    histograms = helper.count_layer_expert_histograms(
+        routing_data,
+        layers=(0, 9),
+        num_experts=8,
+    )
+
+    expected_layer0 = np.array([0, 1, 1, 0, 0, 2, 0, 0])
+    expected_layer9 = np.array([0, 0, 0, 1, 0, 0, 0, 3])
+    np.testing.assert_array_equal(histograms[0], expected_layer0)
+    np.testing.assert_array_equal(histograms[1], expected_layer9)
+
+    sorted_counts, sorted_ids = helper.sort_experts_desc(histograms.astype(np.float64))
+    np.testing.assert_array_equal(sorted_counts[0, :3], np.array([2.0, 1.0, 1.0]))
+    np.testing.assert_array_equal(sorted_ids[0, :3], np.array([5, 1, 2]))
+    np.testing.assert_array_equal(sorted_counts[1, :2], np.array([3.0, 1.0]))
+    np.testing.assert_array_equal(sorted_ids[1, :2], np.array([7, 3]))
+
+
+def test_metric_logic_matches_balancedness_gini_and_relative_change():
+    avg_histograms = np.array([[10.0, 3.0, 2.0, 1.0]])
+    baseline_histograms = np.array([[4.0, 4.0, 4.0, 4.0]])
+
+    rows = helper.build_condition_metrics(
+        batch_size=32,
+        draft_length=2,
+        num_steps=5,
+        layers=(0,),
+        avg_histograms=avg_histograms,
+        baseline_histograms=baseline_histograms,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["batch_size"] == 32
+    assert row["draft_length"] == 2
+    assert row["num_steps"] == 5
+    assert row["avg_total_routed_assignments_per_step"] == 16.0
+    assert row["balancedness"] == 0.4
+    assert row["baseline_balancedness"] == 1.0
+    assert row["balancedness_delta"] == -0.6
+    assert row["balancedness_relative_change"] == -0.6
+    assert row["gini"] > row["baseline_gini"]
+    assert row["imbalance_change"] == "worsened"
+
+
+def test_aggregate_worker_step_timings_uses_max_per_component():
+    timing = helper.aggregate_worker_step_timings(
+        [
+            {
+                "total_ms": 10.0,
+                "attention_ms": 1.5,
+                "routing_ms": 0.5,
+                "prepare_ms": 2.0,
+                "finalize_ms": 1.5,
+                "ffn_ms": 4.0,
+            },
+            {
+                "total_ms": 11.0,
+                "attention_ms": 1.0,
+                "routing_ms": 0.75,
+                "prepare_ms": 1.0,
+                "finalize_ms": 2.5,
+                "ffn_ms": 3.0,
+            },
+        ]
+    )
+    assert timing.total_ms == 11.0
+    assert timing.attention_ms == 1.5
+    assert timing.routing_ms == 0.75
+    assert timing.prepare_ms == 2.0
+    assert timing.finalize_ms == 2.5
+    assert timing.ffn_ms == 4.0
+    assert timing.all2all_ms == 4.5
+    assert timing.unattributed_ms == 0.25
+
+
+def test_step_time_summary_and_normalization_are_correct():
+    summary = helper.summarize_step_time_components(
+        step_total_ms=np.array([10.0, 14.0]),
+        step_attention_ms=np.array([1.0, 2.0]),
+        step_routing_ms=np.array([0.5, 1.5]),
+        step_prepare_ms=np.array([2.0, 4.0]),
+        step_finalize_ms=np.array([1.0, 3.0]),
+        step_ffn_ms=np.array([5.5, 3.5]),
+    )
+    assert summary["avg_step_total_ms"] == 12.0
+    assert summary["avg_attention_ms"] == 1.5
+    assert summary["avg_routing_ms"] == 1.0
+    assert summary["avg_prepare_ms"] == 3.0
+    assert summary["avg_finalize_ms"] == 2.0
+    assert summary["avg_all2all_ms"] == 5.0
+    assert summary["avg_ffn_ms"] == 4.5
+
+    normalized = helper.normalize_time_components(summary, baseline_total_ms=8.0)
+    assert normalized["normalized_attention_ms"] == 0.1875
+    assert normalized["normalized_routing_ms"] == 0.125
+    assert normalized["normalized_all2all_ms"] == 0.625
+    assert normalized["normalized_ffn_ms"] == 0.5625
+    assert normalized["ffn_share"] == 0.375
+
+
+def test_close_ffn_component_folds_small_residual_into_ffn():
+    closed = runtime._close_ffn_component(
+        helper.StepTiming(
+            total_ms=10.0,
+            attention_ms=2.0,
+            routing_ms=1.0,
+            prepare_ms=1.0,
+            finalize_ms=1.0,
+            ffn_ms=4.0,
+        )
+    )
+    assert closed == 5.0
+
+
+def test_speedup_and_dataset_slicing_helpers_are_correct():
+    rows = helper.build_speedup_rows(
+        {
+            (32, 0): 20.0,
+            (32, 2): 10.0,
+            (32, 4): 8.0,
+            (64, 0): 30.0,
+            (64, 2): 15.0,
+            (64, 4): 12.0,
+        },
+        batch_sizes=(32, 64),
+        draft_lengths=(0, 2, 4),
+    )
+    assert next(
+        row["speedup"]
+        for row in rows
+        if row["batch_size"] == 32 and row["draft_length"] == 2
+    ) == 2.0
+    np.testing.assert_array_equal(
+        helper.select_dataset_indices(4, 8),
+        np.array([0, 1, 2, 3]),
+    )
+
+
+def test_prompt_cache_roundtrip(tmp_path):
+    prompt_items = [
+        {"prompt_token_ids": [1, 2, 3]},
+        {"prompt_token_ids": [4, 5]},
+    ]
+    cache_path = tmp_path / "prompt_cache.json"
+    runtime.save_prompt_items_cache(prompt_items, cache_path)
+
+    args = SimpleNamespace(prompt_cache_path=cache_path, batch_size=2)
+    loaded = runtime.load_prompt_items(args)
+    assert loaded == prompt_items
+
+
+def test_stop_condition_collection_worker_clears_pending_timings():
+    runtime._WORKER_STATE.pending_step_timings.clear()
+    runtime._WORKER_STATE.pending_step_timings.append({"total_ms": 1.0})
+    runtime._WORKER_STATE.pending_step_timings.append({"total_ms": 2.0})
+    runtime._WORKER_STATE.enabled = True
+
+    result = runtime.stop_condition_collection_worker(None)
+
+    assert result == {"pending_timings": 2}
+    assert runtime._WORKER_STATE.enabled is False
+    assert len(runtime._WORKER_STATE.pending_step_timings) == 0
+
+
+def test_collect_one_command_includes_prompt_cache_and_warmup(tmp_path):
+    args = SimpleNamespace(
+        model="m",
+        dataset="d",
+        dataset_config="cfg",
+        dataset_split="split",
+        max_tokens=128,
+        max_model_len=4096,
+        tensor_parallel_size=2,
+        gpu_memory_utilization=0.85,
+        num_experts=256,
+        layers=(0, 9),
+        enforce_eager=True,
+        warmup_rounds=1,
+    )
+    command = runtime._build_collect_one_command(
+        args,
+        tmp_path / "out",
+        tmp_path / "entry.py",
+        batch_size=32,
+        draft_length=4,
+        prompt_cache=tmp_path / "prompt_cache.json",
+    )
+    assert "--prompt-cache-path" in command
+    assert str(tmp_path / "prompt_cache.json") in command
+    assert "--warmup-rounds" in command
+    assert command[command.index("--warmup-rounds") + 1] == "1"
+
+
+def test_baseline_order_reordering_is_stable():
+    avg_histograms = np.array(
+        [
+            [4.0, 2.0, 1.0, 0.0],
+            [1.0, 3.0, 0.0, 2.0],
+        ]
+    )
+    _, baseline_order = helper.sort_experts_desc(avg_histograms)
+    target_histograms = np.array(
+        [
+            [10.0, 20.0, 30.0, 40.0],
+            [7.0, 5.0, 1.0, 9.0],
+        ]
+    )
+    reordered = helper.reorder_histograms_by_expert_order(
+        target_histograms,
+        baseline_order,
+    )
+    np.testing.assert_array_equal(reordered[0], np.array([10.0, 20.0, 30.0, 40.0]))
+    np.testing.assert_array_equal(reordered[1], np.array([5.0, 9.0, 7.0, 1.0]))

--- a/tests/examples/test_qwen3_6_mtp_ep_load_balance.py
+++ b/tests/examples/test_qwen3_6_mtp_ep_load_balance.py
@@ -67,14 +67,24 @@ def test_step_selection_skips_baseline_prefill_and_keeps_decode_step():
         prefill_model_output,
         use_spec_decode=False,
     ) is None
-
-    captured = helper.select_step_routing_data(
-        decode_output,
-        decode_model_output,
+    prefill_decision = helper.classify_step_capture(
+        prefill_output,
+        prefill_model_output,
+        worker_step_metadata={"req_ids": ["0", "1"], "has_prefill": True},
         use_spec_decode=False,
     )
+    assert prefill_decision.captured_step is None
+    assert prefill_decision.drop_reason == "prefill"
+
+    decision = helper.classify_step_capture(
+        decode_output,
+        decode_model_output,
+        worker_step_metadata={"req_ids": ["0", "1"], "has_prefill": False},
+        use_spec_decode=False,
+    )
+    captured = decision.captured_step
     assert captured is not None
-    assert captured.step_kind == "baseline_decode"
+    assert captured.step_kind == "decode_only"
     assert captured.total_scheduled_tokens == 2
     np.testing.assert_array_equal(captured.routing_data, decode_routing_data)
 
@@ -100,16 +110,35 @@ def test_step_selection_only_keeps_mtp_verification_steps():
         {"req_b": 2, "req_a": 3},
         {"req_a": [7, 8], "req_b": [9]},
     )
-    captured = helper.select_step_routing_data(
+    decision = helper.classify_step_capture(
         mtp_output,
         model_output,
+        worker_step_metadata={
+            "req_ids": ["req_b", "req_a"],
+            "has_prefill": False,
+        },
         use_spec_decode=True,
     )
+    captured = decision.captured_step
     assert captured is not None
-    assert captured.step_kind == "mtp_verification"
+    assert captured.step_kind == "verification_only"
     assert captured.request_ids == ("req_b", "req_a")
     assert captured.total_scheduled_tokens == 5
     np.testing.assert_array_equal(captured.routing_data, routing_data)
+
+
+def test_mixed_mtp_step_is_dropped_without_request_reslicing():
+    routing_data = np.arange(3 * 40 * 2, dtype=np.int64).reshape(3, 40, 2)
+    model_output = _model_runner_output(["req_a", "req_b"], routing_data)
+    mtp_output = _scheduler_output({"req_a": 2, "req_b": 1}, {"req_a": [7]})
+    decision = helper.classify_step_capture(
+        mtp_output,
+        model_output,
+        worker_step_metadata={"req_ids": ["req_a", "req_b"], "has_prefill": False},
+        use_spec_decode=True,
+    )
+    assert decision.captured_step is None
+    assert decision.drop_reason == "mixed"
 
 
 def test_counting_and_descending_reorder_are_correct():
@@ -196,29 +225,140 @@ def test_aggregate_worker_step_timings_uses_max_per_component():
     assert timing.unattributed_ms == 0.25
 
 
-def test_step_time_summary_and_normalization_are_correct():
-    summary = helper.summarize_step_time_components(
+def _rank_candidate_data(seq_ids, kinds, total_ms, ffn_ms, hist_values=None):
+    size = len(seq_ids)
+    histograms = np.zeros((size, 1, 4), dtype=np.int64)
+    if hist_values is not None:
+        histograms[:, 0, :] = np.asarray(hist_values, dtype=np.int64)
+    return {
+        "candidate_first_ep_collective_seq_ids": np.asarray(seq_ids, dtype=np.int64),
+        "candidate_step_kinds": np.asarray(kinds, dtype=np.str_),
+        "candidate_step_total_ms": np.asarray(total_ms, dtype=np.float64),
+        "candidate_step_ffn_ms": np.asarray(ffn_ms, dtype=np.float64),
+        "candidate_step_total_tokens": np.full((size,), 2, dtype=np.int64),
+        "candidate_step_histograms": histograms,
+    }
+
+
+def test_global_step_time_aggregation_keeps_strict_ep_seq_intersection():
+    result = helper.aggregate_global_step_time_components(
+        [
+            _rank_candidate_data(
+                [7],
+                ["verification_only"],
+                [10.0],
+                [4.0],
+                [[1, 2, 0, 0]],
+            ),
+            _rank_candidate_data(
+                [7],
+                ["verification_only"],
+                [11.0],
+                [5.0],
+                [[0, 1, 3, 0]],
+            ),
+        ],
+        data_parallel_size=2,
+        expected_step_kind="verification_only",
+        layers=(0,),
+        num_experts=4,
+    )
+    np.testing.assert_array_equal(result.global_step_indices, np.array([7]))
+    np.testing.assert_array_equal(
+        result.global_step_kinds,
+        np.array(["verification_only"]),
+    )
+    np.testing.assert_allclose(result.global_step_total_ms, np.array([11.0]))
+    np.testing.assert_allclose(result.global_step_ffn_ms, np.array([5.0]))
+    np.testing.assert_allclose(result.global_step_other_ms, np.array([6.0]))
+    np.testing.assert_array_equal(
+        result.global_step_histograms[0, 0],
+        np.array([1, 3, 3, 0]),
+    )
+    assert result.num_global_candidate_steps == 1
+    assert result.num_global_captured_steps == 1
+
+
+def test_global_step_time_aggregation_drops_prefill_global_step():
+    result = helper.aggregate_global_step_time_components(
+        [
+            _rank_candidate_data([7], ["decode_only"], [10.0], [4.0]),
+            _rank_candidate_data([7], ["prefill"], [11.0], [5.0]),
+        ],
+        data_parallel_size=2,
+        expected_step_kind="decode_only",
+        layers=(0,),
+        num_experts=4,
+    )
+    assert result.global_step_indices.size == 0
+    assert result.num_global_prefill_dropped_steps == 1
+
+
+def test_global_step_time_aggregation_drops_mixed_global_step():
+    result = helper.aggregate_global_step_time_components(
+        [
+            _rank_candidate_data([7], ["verification_only"], [10.0], [4.0]),
+            _rank_candidate_data([7], ["mixed"], [11.0], [5.0]),
+        ],
+        data_parallel_size=2,
+        expected_step_kind="verification_only",
+        layers=(0,),
+        num_experts=4,
+    )
+    assert result.global_step_indices.size == 0
+    assert result.num_global_mixed_dropped_steps == 1
+
+
+def test_global_step_time_aggregation_drops_missing_join_key():
+    result = helper.aggregate_global_step_time_components(
+        [
+            _rank_candidate_data([7], ["decode_only"], [10.0], [4.0]),
+            _rank_candidate_data([-1], ["decode_only"], [11.0], [5.0]),
+        ],
+        data_parallel_size=2,
+        expected_step_kind="decode_only",
+        layers=(0,),
+        num_experts=4,
+    )
+    assert result.global_step_indices.size == 0
+    assert result.num_global_non_target_dropped_steps == 1
+
+
+def test_global_step_time_aggregation_rejects_negative_other_time():
+    try:
+        helper.aggregate_global_step_time_components(
+            [
+                _rank_candidate_data([7], ["decode_only"], [5.0], [6.0]),
+                _rank_candidate_data([7], ["decode_only"], [4.0], [3.0]),
+            ],
+            data_parallel_size=2,
+            expected_step_kind="decode_only",
+            layers=(0,),
+            num_experts=4,
+        )
+    except ValueError as exc:
+        assert "negative Other time" in str(exc)
+    else:
+        raise AssertionError("Expected negative Other time to fail.")
+
+
+def test_global_step_time_summary_and_normalization_are_correct():
+    summary = helper.summarize_global_step_time_components(
         step_total_ms=np.array([10.0, 14.0]),
-        step_attention_ms=np.array([1.0, 2.0]),
-        step_routing_ms=np.array([0.5, 1.5]),
-        step_prepare_ms=np.array([2.0, 4.0]),
-        step_finalize_ms=np.array([1.0, 3.0]),
-        step_ffn_ms=np.array([5.5, 3.5]),
+        step_ffn_ms=np.array([4.0, 6.0]),
+        step_other_ms=np.array([6.0, 8.0]),
     )
     assert summary["avg_step_total_ms"] == 12.0
-    assert summary["avg_attention_ms"] == 1.5
-    assert summary["avg_routing_ms"] == 1.0
-    assert summary["avg_prepare_ms"] == 3.0
-    assert summary["avg_finalize_ms"] == 2.0
-    assert summary["avg_all2all_ms"] == 5.0
-    assert summary["avg_ffn_ms"] == 4.5
+    assert summary["avg_ffn_ms"] == 5.0
+    assert summary["avg_other_ms"] == 7.0
 
-    normalized = helper.normalize_time_components(summary, baseline_total_ms=8.0)
-    assert normalized["normalized_attention_ms"] == 0.1875
-    assert normalized["normalized_routing_ms"] == 0.125
-    assert normalized["normalized_all2all_ms"] == 0.625
-    assert normalized["normalized_ffn_ms"] == 0.5625
-    assert normalized["ffn_share"] == 0.375
+    normalized = helper.normalize_global_time_components(
+        summary, baseline_total_ms=8.0
+    )
+    assert normalized["normalized_ffn_ms"] == 0.625
+    assert normalized["normalized_other_ms"] == 0.875
+    assert normalized["ffn_share"] == 5.0 / 12.0
+    assert normalized["other_share"] == 7.0 / 12.0
 
 
 def test_close_ffn_component_folds_small_residual_into_ffn():
@@ -245,14 +385,40 @@ def test_speedup_and_dataset_slicing_helpers_are_correct():
             (64, 2): 15.0,
             (64, 4): 12.0,
         },
+        {
+            (32, 0): 2000.0,
+            (32, 2): 1000.0,
+            (32, 4): 800.0,
+            (64, 0): 3000.0,
+            (64, 2): 1500.0,
+            (64, 4): 1200.0,
+        },
+        {
+            (32, 0): 100,
+            (32, 2): 100,
+            (32, 4): 100,
+            (64, 0): 150,
+            (64, 2): 150,
+            (64, 4): 150,
+        },
         batch_sizes=(32, 64),
         draft_lengths=(0, 2, 4),
     )
     assert next(
-        row["speedup"]
+        row["tpot_speedup"]
         for row in rows
         if row["batch_size"] == 32 and row["draft_length"] == 2
     ) == 2.0
+    assert next(
+        row["tpot_speedup"]
+        for row in rows
+        if row["batch_size"] == 32 and row["draft_length"] == 0
+    ) == 1.0
+    assert next(
+        row["decode_throughput_speedup"]
+        for row in rows
+        if row["batch_size"] == 32 and row["draft_length"] == 0
+    ) == 1.0
     np.testing.assert_array_equal(
         helper.select_dataset_indices(4, 8),
         np.array([0, 1, 2, 3]),
@@ -273,16 +439,16 @@ def test_prompt_cache_roundtrip(tmp_path):
 
 
 def test_stop_condition_collection_worker_clears_pending_timings():
-    runtime._WORKER_STATE.pending_step_timings.clear()
-    runtime._WORKER_STATE.pending_step_timings.append({"total_ms": 1.0})
-    runtime._WORKER_STATE.pending_step_timings.append({"total_ms": 2.0})
+    runtime._WORKER_STATE.pending_step_records.clear()
+    runtime._WORKER_STATE.pending_step_records.append({"timing": {"total_ms": 1.0}})
+    runtime._WORKER_STATE.pending_step_records.append({"timing": {"total_ms": 2.0}})
     runtime._WORKER_STATE.enabled = True
 
     result = runtime.stop_condition_collection_worker(None)
 
     assert result == {"pending_timings": 2}
     assert runtime._WORKER_STATE.enabled is False
-    assert len(runtime._WORKER_STATE.pending_step_timings) == 0
+    assert len(runtime._WORKER_STATE.pending_step_records) == 0
 
 
 def test_collect_one_command_includes_prompt_cache_and_warmup(tmp_path):
@@ -291,9 +457,11 @@ def test_collect_one_command_includes_prompt_cache_and_warmup(tmp_path):
         dataset="d",
         dataset_config="cfg",
         dataset_split="split",
+        num_samples=1024,
+        data_parallel_size=4,
         max_tokens=128,
         max_model_len=4096,
-        tensor_parallel_size=2,
+        tensor_parallel_size=1,
         gpu_memory_utilization=0.85,
         num_experts=256,
         layers=(0, 9),
@@ -312,6 +480,74 @@ def test_collect_one_command_includes_prompt_cache_and_warmup(tmp_path):
     assert str(tmp_path / "prompt_cache.json") in command
     assert "--warmup-rounds" in command
     assert command[command.index("--warmup-rounds") + 1] == "1"
+    assert command[command.index("--data-parallel-size") + 1] == "4"
+    assert command[command.index("--num-samples") + 1] == "1024"
+
+
+def test_dp_sharding_covers_all_samples_without_overlap():
+    shards = [
+        helper.shard_global_batch_indices(
+            num_samples=10,
+            global_batch_size=4,
+            round_idx=round_idx,
+            dp_size=3,
+            dp_rank=dp_rank,
+        )
+        for round_idx in range(helper.num_condition_rounds(10, 4))
+        for dp_rank in range(3)
+    ]
+    flat = np.concatenate(shards, axis=0)
+    np.testing.assert_array_equal(np.sort(flat), np.arange(10))
+
+
+def test_tpot_formula_matches_decode_only_definition():
+    output_lengths = np.array([5, 1, 3], dtype=np.int64)
+    assert helper.compute_num_output_tokens_excluding_first(output_lengths) == 6
+    assert helper.compute_tpot_ms(30.0, output_lengths) == 5.0
+    assert helper.compute_tpot_ms_from_finished_stats(30.0, 6) == 5.0
+    assert helper.compute_decode_throughput_tok_s(12, 300.0) == 40.0
+
+
+def test_expert_to_ep_rank_mapping_and_rank_load_are_correct():
+    expert_to_ep_rank = helper.build_expert_to_ep_rank(
+        num_experts=5,
+        ep_size=2,
+    )
+    np.testing.assert_array_equal(expert_to_ep_rank, np.array([0, 0, 0, 1, 1]))
+    avg_histograms = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]])
+    rank_load = helper.build_rank_load_from_histograms(
+        avg_histograms,
+        expert_to_ep_rank,
+        ep_size=2,
+    )
+    np.testing.assert_allclose(rank_load, np.array([[6.0, 9.0]]))
+
+
+def test_validate_parallel_config_requires_tp1():
+    args = SimpleNamespace(tensor_parallel_size=2, data_parallel_size=1)
+    try:
+        runtime.validate_parallel_config(args)
+    except ValueError as exc:
+        assert "tensor_parallel_size=1" in str(exc)
+    else:
+        raise AssertionError("Expected tensor_parallel_size validation to fail.")
+
+
+def test_extract_worker_step_metadata_supports_legacy_gpu_model_runner():
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            input_batch=SimpleNamespace(
+                req_ids=["req0", "req1"],
+                num_reqs=2,
+                num_computed_tokens_cpu=np.array([0, 8], dtype=np.int32),
+                num_prompt_tokens=np.array([16, 8], dtype=np.int32),
+            ),
+            execute_model_state=None,
+        )
+    )
+    metadata = runtime._extract_worker_step_metadata(worker)
+    assert metadata["req_ids"] == ["req0", "req1"]
+    assert metadata["has_prefill"] is True
 
 
 def test_baseline_order_reordering_is_stable():


### PR DESCRIPTION
## Summary

Refactor the Qwen3.6 MTP EP load-balance experiment for the motivation analysis pass:

- update the default experiment matrix to Qwen/Qwen3.6-35B-A3B, InstructCoder train, 512 samples, DP=2/TP=1/EP, batch sizes 32..512, draft lengths 0/2/4/6, layers 0/9/19/29/39, and max_tokens=128
- bump the raw schema to v5 so stale raw data is rejected and recollection is required
- align worker steps globally by first_ep_collective_seq_id instead of rank-local step_index
- require strict all-rank pure decode_only or verification_only steps before including a global step
- compute condition-level TPOT and decode-throughput speedups from built-in finished-request stats
- regenerate the main analysis around speedup curves, global FFN/Other breakdowns, ExpertLoad, and RankLoad

## Duplicate-work check

No issue number is associated with this local experiment refactor. The local environment does not have `gh` installed, so I could not run the exact `gh pr list` commands from AGENTS.md. I used the GitHub connector to search open PRs in `vllm-project/vllm` with these queries instead:

- `Qwen3.6 MTP EP load balance motivation experiment`: no open PRs found
- `speculative decoding MTP expert load`: returned adjacent DeepSeek/JoyAI/RIY/tool-parser/SM12x PRs, not this experiment refactor
- `qwen mtp load balance`: returned an EPLB padding PR, not this experiment refactor

## Tests

```bash
.venv/bin/python -m pytest tests/examples/test_qwen3_6_mtp_ep_load_balance.py -q
```

Result: `23 passed, 28 warnings in 4.25s`.

```bash
.venv/bin/python -m py_compile \
  examples/features/speculative_decoding/mtp_ep_load_balance_utils.py \
  examples/features/speculative_decoding/mtp_ep_experiment_runtime.py \
  examples/features/speculative_decoding/mtp_ep_experiment_analysis.py \
  examples/features/speculative_decoding/qwen3_6_mtp_ep_load_balance_experiment.py \
  tests/examples/test_qwen3_6_mtp_ep_load_balance.py
```

Result: passed.

```bash
.venv/bin/python examples/features/speculative_decoding/qwen3_6_mtp_ep_load_balance_experiment.py analyze \
  --input-dir /tmp/qwen3_6_mtp_ep_analyze_smoke
```

Result: passed on a synthetic schema-v5 analyze smoke and generated the expected speedup, step-time, ExpertLoad, and RankLoad tables/plots.

Not run:

- `ruff check`: `.venv/bin/python: No module named ruff`
- real Qwen3.6 35B `collect` smoke: not run because it launches the GPU/model experiment and is materially heavier than the local unit/analyze validation

## AI assistance disclosure

AI assistance was used to implement and validate this change. The human submitter should review every changed line and decide whether to run the real GPU collect smoke before marking this PR ready for review.