### PR TITLE
fix: skip streaming tool parsing for tool_choice none

### DIFF
--- a/tests/entrypoints/openai/test_tool_choice_content_none.py
+++ b/tests/entrypoints/openai/test_tool_choice_content_none.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Sequence
+
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.abstract_parser import DelegatingParser
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -34,6 +37,20 @@ class _DummyDelegatingParser(DelegatingParser):
 
     def extract_tool_calls(self, model_output: str, request):
         return None
+
+
+class _ExplodingToolParser(ToolParser):
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ):
+        raise AssertionError("tool parser should not be called")
 
 
 def test_parse_tool_calls_from_content_allows_named_tool_choice_with_none_content():
@@ -92,3 +109,30 @@ def test_responses_parser_allows_named_tool_choice_with_none_content():
 
     assert content is None
     assert tool_calls == []
+
+
+def test_streaming_tool_choice_none_skips_tool_parser():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": "none",
+        }
+    )
+    parser = _DummyDelegatingParser(tokenizer=None)
+    parser.tool_parser = _ExplodingToolParser(tokenizer=None)
+
+    delta = parser.parse_delta("plain text", [1], request, prompt_token_ids=[1])
+
+    assert delta is not None
+    assert delta.content == "plain text"
+    assert delta.tool_calls is None

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -651,8 +651,14 @@ class DelegatingParser(Parser):
             return False
         return not state.reasoning_ended
 
-    def _in_tool_call_phase(self, state: StreamState) -> bool:
+    def _in_tool_call_phase(
+        self,
+        state: StreamState,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> bool:
         if self._tool_parser is None:
+            return False
+        if isinstance(request, ChatCompletionRequest) and request.tool_choice == "none":
             return False
         return state.reasoning_ended
 
@@ -698,7 +704,7 @@ class DelegatingParser(Parser):
                 delta_token_ids = current_token_ids
 
         # Tool call extraction
-        if self._in_tool_call_phase(state):
+        if self._in_tool_call_phase(state, request):
             if not state.tool_call_text_started:
                 state.tool_call_text_started = True
                 state.previous_text = ""
@@ -739,7 +745,7 @@ class DelegatingParser(Parser):
         if (
             delta_message is None
             and not self._in_reasoning_phase(state)
-            and not self._in_tool_call_phase(state)
+            and not self._in_tool_call_phase(state, request)
         ):
             delta_message = DeltaMessage(content=delta_text)
 


### PR DESCRIPTION
Fixes #42747.

### Summary
- include the request in the streaming tool-call phase gate
- bypass streaming tool parsing when a Chat Completions request sets `tool_choice="none"`
- add a regression test that fails if the tool parser is invoked

### Tests
- Not run locally; patch created through the GitHub API.