### PR TITLE
[Bugfix] Reject non-positive num_gpu_blocks_override in CacheConfig

### DIFF
--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.config.cache import CacheConfig
+
+
+def test_num_gpu_blocks_override_none_is_default():
+    assert CacheConfig().num_gpu_blocks_override is None
+    assert CacheConfig(num_gpu_blocks_override=None).num_gpu_blocks_override is None
+
+
+def test_num_gpu_blocks_override_positive_is_accepted():
+    assert CacheConfig(num_gpu_blocks_override=16).num_gpu_blocks_override == 16
+
+
+@pytest.mark.parametrize("bad", [0, -1, -16])
+def test_num_gpu_blocks_override_non_positive_raises(bad):
+    # Regression test for https://github.com/vllm-project/vllm/issues/43842:
+    # a non-positive override previously reached BlockPool.__init__ and tripped
+    # a bare assertion; it must now be rejected at config construction time.
+    with pytest.raises(ValidationError):
+        CacheConfig(num_gpu_blocks_override=bad)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -83,7 +83,7 @@ class CacheConfig:
     is_attention_free: bool = False
     """Whether the model is attention-free. This is primarily set in
     `ModelConfig` and that value should be manually duplicated here."""
-    num_gpu_blocks_override: int | None = None
+    num_gpu_blocks_override: int | None = Field(default=None, gt=0)
     """Number of GPU blocks to use. This overrides the profiled `num_gpu_blocks`
     if specified. Does nothing if `None`. Used for testing preemption."""
     sliding_window: int | None = None


### PR DESCRIPTION
## Purpose

Fixes #43842.

\`--num-gpu-blocks-override 0\` (and any negative integer) currently passes argparse and \`CacheConfig\` without validation. The override later replaces a positive profiled \`num_blocks\`, and \`BlockPool.__init__\` (\`vllm/v1/core/block_pool.py:157\`) trips a bare \`assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0\` — operators get an unattributed \`AssertionError\` instead of a useful diagnostic at config construction time.

This PR mirrors the field-level \`Field(default=None, gt=0)\` shape that #43794 just landed for the sibling fields \`block_size\` and \`hash_block_size\` in the same dataclass. A non-positive override now raises a pydantic \`ValidationError\` naming the offending field and value at config-construction time:

\`\`\`
ValidationError: 1 validation error for CacheConfig
num_gpu_blocks_override
  Input should be greater than 0 [type=greater_than, input_value=0, ...]
\`\`\`

### Duplicate-work check

Per \`AGENTS.md\`:

\`\`\`
gh issue view 43842 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search \"43842 in:body\"
gh pr list --repo vllm-project/vllm --state open --search \"num_gpu_blocks_override\"
gh pr list --repo vllm-project/vllm --state open --search \"num-gpu-blocks-override validation\"
\`\`\`

No other open or closed PR targets \`num_gpu_blocks_override\`. #43794 (the recent merged sibling cluster) explicitly only covered \`block_size\` / \`hash_block_size\` / \`max_model_len\`.

## Test Plan

New \`tests/config/test_cache_config.py\` adds three focused tests:

- \`test_num_gpu_blocks_override_none_is_default\` — sanity (default behavior unchanged)
- \`test_num_gpu_blocks_override_positive_is_accepted\` — sanity (positive value works)
- \`test_num_gpu_blocks_override_non_positive_raises\` (parametrized over 0, -1, -16) — the new validation

Commands run locally:

\`\`\`bash
pre-commit run --files vllm/config/cache.py tests/config/test_cache_config.py
\`\`\`

Pydantic semantics confirmed in isolation (\`Field(gt=0)\` with default \`None\` admits \`None\` and positive integers, rejects 0 and negatives with \`ValidationError\` — which subclasses \`ValueError\` in pydantic-core).

## Test Result

\`\`\`
ruff check..........................................................................................Passed
ruff format.........................................................................................Passed
typos...............................................................................................Passed
Run mypy locally for lowest supported Python version................................................Passed
Check SPDX headers..................................................................................Passed
Check root lazy imports.............................................................................Passed
Validate configuration has default values and that each field has a docstring.......................Passed
... (all applicable hooks passed; no failures)
\`\`\`

Behavioural check against the issue reproducer:

| Input | Before | After |
|---|---|---|
| \`CacheConfig(num_gpu_blocks_override=0)\` | Silently accepted; bare \`AssertionError\` in \`BlockPool.__init__\` later | \`ValidationError: ... Input should be greater than 0\` at config construction |
| \`CacheConfig(num_gpu_blocks_override=-1)\` | Same as above | Same as above |
| \`CacheConfig(num_gpu_blocks_override=16)\` | Accepted | Accepted (no change) |
| \`CacheConfig(num_gpu_blocks_override=None)\` | Accepted (no override) | Accepted (no override; unchanged) |

Diff:

\`\`\`diff
@@ -83,7 +83,7 @@ class CacheConfig:
     is_attention_free: bool = False
-    num_gpu_blocks_override: int | None = None
+    num_gpu_blocks_override: int | None = Field(default=None, gt=0)
\`\`\`

---

## AI assistance disclosure

This change was AI-assisted (Claude). I (the submitter) reviewed every line, ran pre-commit, and stand behind the change end-to-end.