### PR TITLE
[Test][BugFix] Fix double-BOS in PD+specdec acceptance test

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py
+++ b/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py
@@ -158,6 +158,10 @@ def test_spec_decode_acceptance_length():
             max_tokens=DEFAULT_OUTPUT_LEN,
             temperature=0.0,
             top_p=1.0,
+            # Prompts are already chat-templated (contain BOS); avoid the
+            # completions API prepending a second BOS, which would lower
+            # acceptance ~5% vs the add_special_tokens=False standalone baselines.
+            extra_body={"add_special_tokens": False},
         )
         if i < 3:
             text = resp.choices[0].text.strip()[:100]


### PR DESCRIPTION
Baseline acceptance was measured using correct llama system prompt, but the test uses raw prompt with /completions API which results in an extra prepended BOS token. This in turn causes lower acceptance rates than it should.

The test was still passing in most cases because the lower acceptance rate was just within the 5% threshold.

I discovered this while investigating MRV2 test failures.