### PR TITLE
Bugfix: Accept file-type-only quant types (IQ2_M, IQ3_XS, MXFP4_MOE) in remote GGUF model IDs

### DIFF
--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -100,6 +100,33 @@ class TestIsRemoteGGUF:
         # No dash separator → not recognized as prefixed
         assert not is_remote_gguf("repo/model:UDIQ4NL")
 
+    def test_is_remote_gguf_file_type_only_quants(self):
+        """Test is_remote_gguf with file-type-only quant types.
+
+        Some quant types (``IQ2_M``, ``IQ3_M``, ``IQ3_XS``, ``MXFP4_MOE``)
+        exist only as GGUF file types (``LlamaFileType``) and have no
+        corresponding member in ``GGMLQuantizationType``.  They must be
+        accepted when used as the ``quant_type`` in a ``repo_id:quant_type``
+        reference.
+        """
+        # File-type-only quants (standalone)
+        assert is_remote_gguf("bartowski/Qwen2.5-0.5B-Instruct-GGUF:IQ2_M")
+        assert is_remote_gguf("bartowski/Qwen2.5-0.5B-Instruct-GGUF:IQ3_M")
+        assert is_remote_gguf("bartowski/Qwen2.5-0.5B-Instruct-GGUF:IQ3_XS")
+        assert is_remote_gguf(
+            "bartowski/Qwen2.5-0.5B-Instruct-GGUF:MXFP4_MOE")
+
+        # File-type-only quants with non-standard vendor prefix
+        assert is_remote_gguf("user/Model:UD-IQ2_M")
+        assert is_remote_gguf("user/Model:UD-IQ3_M")
+        assert is_remote_gguf("user/Model:UD-IQ3_XS")
+        assert is_remote_gguf("user/Model:UD-MXFP4_MOE")
+
+        # Non-existent types in the same family must still be rejected
+        assert not is_remote_gguf("repo/model:IQ9_M")
+        assert not is_remote_gguf("repo/model:IQ9_XS")
+        assert not is_remote_gguf("repo/model:MXFP5_MOE")
+
     def test_is_remote_gguf_without_colon(self):
         """Test is_remote_gguf without colon."""
         assert not is_remote_gguf("repo/model")

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import gguf
 import regex as re
-from gguf.constants import Keys, VisionProjectorType
+from gguf.constants import Keys, LlamaFileType, VisionProjectorType
 from gguf.quants import GGMLQuantizationType
 from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 
@@ -90,11 +90,23 @@ _GGUF_QUANT_SUFFIXES = ("_M", "_S", "_L", "_XL", "_XS", "_XXS")
 def is_valid_gguf_quant_type(gguf_quant_type: str) -> bool:
     """Check if the quant type is a valid GGUF quant type.
 
-    Supports both exact GGML quant types (e.g., Q4_K, IQ1_S) and
-    extended naming conventions (e.g., Q4_K_M, Q3_K_S, Q5_K_L).
+    Accepts both GGML tensor quantization types (e.g. ``Q4_K``, ``IQ1_S``)
+    and GGUF file types (e.g. ``IQ2_M``, ``IQ3_XS``, ``MXFP4_MOE``).
+
+    Extended naming conventions such as ``Q4_K_M`` are supported by suffix
+    stripping (``Q4_K_M`` -> ``Q4_K``).
+
+    File-type-only quants (members of ``LlamaFileType`` but not of
+    ``GGMLQuantizationType``) are recognised by prepending ``MOSTLY_``,
+    which matches the ``LlamaFileType`` member naming convention.
     """
-    # Check for exact match first
+    # Check for exact match in GGMLQuantizationType (tensor types)
     if getattr(GGMLQuantizationType, gguf_quant_type, None) is not None:
+        return True
+
+    # Check for exact match in LlamaFileType (file-type-only quants)
+    # LlamaFileType members are named MOSTLY_<QUANT> (e.g. MOSTLY_IQ2_M).
+    if getattr(LlamaFileType, f"MOSTLY_{gguf_quant_type}", None) is not None:
         return True
 
     # Check for extended naming conventions (e.g., Q4_K_M -> Q4_K)


### PR DESCRIPTION
Fixes #44218.

`is_valid_gguf_quant_type()` only checks `GGMLQuantizationType` (the tensor quantization enum), but the `quant_type` in a `repo_id:quant_type` reference is a GGUF *file* type (`LlamaFileType`). `IQ2_M`, `IQ3_M`, `IQ3_XS`, and `MXFP4_MOE` exist only in `LlamaFileType` — they have no `GGMLQuantizationType` member, and no valid base after suffix stripping (`IQ2_M` → `IQ2`, which does not exist). So `is_remote_gguf()` returns `False` and the reference is rejected with "Repo id must use alphanumeric chars...".

## Fix
Accept either enum in `is_valid_gguf_quant_type()`: a `LlamaFileType` file type (members are prefixed `MOSTLY_`) or a `GGMLQuantizationType` tensor type. The existing suffix handling for extended names (e.g. `Q4_K_M` → `Q4_K`) is preserved. No special-case table needed, so newly added file types are picked up automatically.

## Test Plan
- Extended `tests/transformers_utils/test_utils.py::TestIsRemoteGGUF` with a new test method covering file-type-only quants (`IQ2_M`, `IQ3_M`, `IQ3_XS`, `MXFP4_MOE`), with and without a vendor prefix (`UD-`), plus negative cases (`IQ9_M`, `IQ9_XS`, `MXFP5_MOE`).
- All 23 existing test assertions continue to pass.