### PR TITLE
[Bugfix] Reject non-positive num_gpu_blocks_override in CacheConfig

### DIFF
--- a/tests/config/test_cache_config.py
+++ b/tests/config/test_cache_config.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.config.cache import CacheConfig
+
+
+def test_num_gpu_blocks_override_none_is_default() -> None:
+    """Verify that None (the default) is accepted and leaves the field as None."""
+    cfg = CacheConfig()
+    assert cfg.num_gpu_blocks_override is None
+
+
+@pytest.mark.parametrize("value", [1, 16, 1024])
+def test_num_gpu_blocks_override_positive_is_accepted(value: int) -> None:
+    """Verify that positive integers are accepted."""
+    cfg = CacheConfig(num_gpu_blocks_override=value)
+    assert cfg.num_gpu_blocks_override == value
+
+
+@pytest.mark.parametrize("value", [0, -1, -16])
+def test_num_gpu_blocks_override_non_positive_raises(value: int) -> None:
+    """Verify that 0 and negative integers raise ValidationError."""
+    with pytest.raises(ValidationError, match="Input should be greater than 0"):
+        CacheConfig(num_gpu_blocks_override=value)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -83,7 +83,7 @@ class CacheConfig:
     is_attention_free: bool = False
     """Whether the model is attention-free. This is primarily set in
     `ModelConfig` and that value should be manually duplicated here."""
-    num_gpu_blocks_override: int | None = None
+    num_gpu_blocks_override: int | None = Field(default=None, gt=0)
     """Number of GPU blocks to use. This overrides the profiled `num_gpu_blocks`
     if specified. Does nothing if `None`. Used for testing preemption."""
     sliding_window: int | None = None


### PR DESCRIPTION
## Purpose

Fixes #43842.

`--num-gpu-blocks-override 0` (and any negative integer) currently passes argparse and `CacheConfig` without validation. The override later replaces a positive profiled `num_blocks`, and `BlockPool.__init__` (`vllm/v1/core/block_pool.py:157`) trips a bare `assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0` — operators get an unattributed `AssertionError` instead of a useful diagnostic at config construction time.

This PR mirrors the field-level `Field(default=None, gt=0)` shape that #43794 just landed for the sibling fields `block_size` and `hash_block_size` in the same dataclass. A non-positive override now raises a pydantic `ValidationError` naming the offending field and value at config-construction time.

### Changes

- **vllm/config/cache.py**: Changed `num_gpu_blocks_override: int | None = None` to `num_gpu_blocks_override: int | None = Field(default=None, gt=0)`
- **tests/config/test_cache_config.py**: New test file with three tests
  - `test_num_gpu_blocks_override_none_is_default` — default behavior unchanged
  - `test_num_gpu_blocks_override_positive_is_accepted` — positive values work
  - `test_num_gpu_blocks_override_non_positive_raises` (parametrized over 0, -1, -16) — new validation

### Test Result

| Input | Before | After |
|---|---|---|
| `CacheConfig(num_gpu_blocks_override=0)` | Silently accepted; bare `AssertionError` in `BlockPool.__init__` later | `ValidationError: ... Input should be greater than 0` at config construction |
| `CacheConfig(num_gpu_blocks_override=-1)` | Same as above | Same as above |
| `CacheConfig(num_gpu_blocks_override=16)` | Accepted | Accepted (no change) |
| `CacheConfig(num_gpu_blocks_override=None)` | Accepted (no override) | Accepted (no override; unchanged) |

## AI assistance disclosure

This change was AI-assisted (Claude). I (the submitter) reviewed every line and stand behind the change end-to-end.