### PR TITLE
[Benchmark] Enable reasoning-model (thinking) benchmarking via `--chat-template-kwargs` for client-rendered datasets

### DIFF
--- a/tests/benchmarks/test_custom_dataset_chat_template_kwargs.py
+++ b/tests/benchmarks/test_custom_dataset_chat_template_kwargs.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm.benchmarks.datasets import get_samples
+
+
+class _RecordingTokenizer:
+    """Minimal tokenizer stub that records the kwargs forwarded to
+    apply_chat_template, so we can assert chat_template_kwargs propagation
+    without loading a real model/template."""
+
+    def __init__(self) -> None:
+        self.captured_kwargs: dict | None = None
+        self.chat_template = "dummy-template"
+
+    def apply_chat_template(
+        self,
+        conversation,
+        add_generation_prompt: bool = True,
+        tokenize: bool = False,
+        **kwargs,
+    ) -> str:
+        self.captured_kwargs = kwargs
+        return conversation[0]["content"]
+
+    def __call__(self, text: str):
+        return argparse.Namespace(input_ids=list(range(len(text.split()))))
+
+
+def _args(dataset_path: str, chat_template_kwargs) -> argparse.Namespace:
+    return argparse.Namespace(
+        dataset_name="custom",
+        dataset_path=dataset_path,
+        disable_shuffle=True,
+        num_prompts=1,
+        custom_output_len=32,
+        skip_chat_template=False,
+        chat_template_kwargs=chat_template_kwargs,
+        no_oversample=False,
+        seed=0,
+        request_id_prefix="",
+    )
+
+
+def _write_one(path: Path) -> None:
+    path.write_text(json.dumps({"prompt": "hello world"}) + "\n")
+
+
+@pytest.mark.benchmark
+def test_chat_template_kwargs_forwarded(tmp_path: Path) -> None:
+    """--chat-template-kwargs must reach the client-side apply_chat_template."""
+    jsonl = tmp_path / "data.jsonl"
+    _write_one(jsonl)
+
+    tok = _RecordingTokenizer()
+    get_samples(_args(str(jsonl), {"thinking": True}), tok)
+
+    assert tok.captured_kwargs == {"thinking": True}
+
+
+@pytest.mark.benchmark
+def test_chat_template_kwargs_default_is_noop(tmp_path: Path) -> None:
+    """When not provided, no extra kwargs are passed (existing behavior)."""
+    jsonl = tmp_path / "data.jsonl"
+    _write_one(jsonl)
+
+    tok = _RecordingTokenizer()
+    get_samples(_args(str(jsonl), None), tok)
+
+    assert tok.captured_kwargs == {}

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -2055,6 +2055,7 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             tokenizer=tokenizer,
             output_len=args.custom_output_len,
             skip_chat_template=args.skip_chat_template,
+            chat_template_kwargs=getattr(args, "chat_template_kwargs", None),
             request_id_prefix=args.request_id_prefix,
             no_oversample=args.no_oversample,
         )
@@ -2381,6 +2382,7 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
                 num_requests=args.num_prompts,
                 tokenizer=tokenizer,
                 output_len=args.speed_bench_output_len,
+                chat_template_kwargs=getattr(args, "chat_template_kwargs", None),
                 enable_multimodal_chat=args.enable_multimodal_chat,
                 request_id_prefix=args.request_id_prefix,
                 no_oversample=args.no_oversample,
@@ -2468,6 +2470,7 @@ class CustomDataset(BenchmarkDataset):
         output_len: int | None = None,
         enable_multimodal_chat: bool = False,
         skip_chat_template: bool = False,
+        chat_template_kwargs: dict | None = None,
         **kwargs,
     ) -> list[SampleRequest]:
         # load all data if needed
@@ -2515,6 +2518,7 @@ class CustomDataset(BenchmarkDataset):
                         [{"role": "user", "content": prompt}],
                         add_generation_prompt=True,
                         tokenize=False,
+                        **(chat_template_kwargs or {}),
                     )
 
                 prompt_len = len(tokenizer(prompt).input_ids)

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1610,6 +1610,15 @@ def add_cli_args(parser: argparse.ArgumentParser):
     )
 
     parser.add_argument(
+        "--chat-template-kwargs",
+        type=json.loads,
+        default=None,
+        help="A JSON string of kwargs forwarded to the tokenizer's "
+        "apply_chat_template when a dataset renders prompts client-side "
+        "(e.g. custom / speed_bench). "
+        "Example: '{\"thinking\": true}' to enable reasoning models.",
+    )
+    parser.add_argument(
         "--extra-body",
         help="A JSON string representing extra body parameters to include "
         "in each request."


### PR DESCRIPTION
## Purpose

The `custom` and `speed_bench` datasets render prompts **client-side** via `tokenizer.apply_chat_template()` and, by default, post the already-rendered text to the `/v1/completions` endpoint. Because that `apply_chat_template()` call received no `chat_template_kwargs`, there was **no way to benchmark reasoning models in their reasoning ("thinking") mode** on these datasets:

- `--extra-body` only attaches fields to the request body sent to the server. The `/v1/completions` endpoint receives an already-rendered prompt string and does not apply a chat template, so a `chat_template_kwargs` field in the body never participates in rendering.
- `--default-chat-template-kwargs` only applies when the **server** renders the chat template (i.e. `/v1/chat/completions`), so it never fires on the client-pre-rendered `/v1/completions` path.

As a result, prompts were always built in non-thinking mode, so acceptance-length measurements did not reflect real reasoning workloads. This is particularly relevant for speculative-decoding (MTP) acceptance-length measurement on reasoning models, where the thinking template materially changes the output distribution.

## Changes

- Add a `--chat-template-kwargs` CLI option (JSON) to `vllm bench serve` in `vllm/benchmarks/serve.py`.
- Forward it through `get_samples` into `CustomDataset.sample()`'s `apply_chat_template()` call for both the `custom` and `speed_bench` dispatches, mirroring the existing `--skip-chat-template` plumbing.
- Add a unit test verifying the kwargs reach `apply_chat_template`, and that the default (omitted) behavior is unchanged.

## Usage

```bash
vllm bench serve \
    --dataset-name speed_bench \
    ... \
    --chat-template-kwargs '{"thinking": true}'
```

## Test

```bash
pytest tests/benchmarks/test_custom_dataset_chat_template_kwargs.py
```

Validated with DeepSeek-V4-Pro on SPEED-Bench:

- **Tokenizer level:** with `{"thinking": true}` the rendered prompt ends with an open `<think>` marker; with `{"thinking": false}` it ends with an empty closed `</think>` block (confirmed directly against the DeepSeek-V4-Pro tokenizer).
- **End-to-end (SPEED-Bench coding):** running with `--chat-template-kwargs '{"thinking": true}'`, ~75/80 generations emitted a closing `</think>` tag, confirming reasoning was active during generation; the measured acceptance length at MTP1 was ~1.80.
