### PR TITLE
[BugFix][CI] Fix added `_has_module` tests

### DIFF
--- a/tests/utils_/test_import_utils.py
+++ b/tests/utils_/test_import_utils.py
@@ -83,42 +83,6 @@ class TestHasModule:
         ):
             assert _has_module("fake_native_ext") is False
 
-    def test_returns_false_on_os_error_during_import(self):
-        """Some shared-library failures surface as ``OSError``."""
-        fake_spec = MagicMock()
-
-        with (
-            patch(
-                "vllm.utils.import_utils.importlib.util.find_spec",
-                return_value=fake_spec,
-            ),
-            patch(
-                "vllm.utils.import_utils.importlib.import_module",
-                side_effect=OSError("cannot load library"),
-            ),
-        ):
-            assert _has_module("fake_native_ext_os") is False
-
-    def test_returns_false_on_unexpected_error_during_import(self):
-        """A broken extension may raise a non-import error (e.g. ``RuntimeError``).
-
-        Such modules are not usable, so ``_has_module`` should still return
-        ``False`` rather than letting the exception propagate.
-        """
-        fake_spec = MagicMock()
-
-        with (
-            patch(
-                "vllm.utils.import_utils.importlib.util.find_spec",
-                return_value=fake_spec,
-            ),
-            patch(
-                "vllm.utils.import_utils.importlib.import_module",
-                side_effect=RuntimeError("CUDA driver version is insufficient"),
-            ),
-        ):
-            assert _has_module("fake_broken_ext") is False
-
     def test_returns_false_when_find_spec_raises(self):
         """``find_spec`` itself can raise for dotted names whose parent package
         fails to import. This should be treated as the module being unavailable.


### PR DESCRIPTION
We merged https://github.com/vllm-project/vllm/pull/44035 quickly to help with CI stability, but it introduced some new test failures due to the tests not being updated in conjunction with the post-review caught-exception narrowing change.