### PR TITLE
[Bugfix] Detect driver-level CUDA init before fork

### DIFF
--- a/tests/cuda/scripts/check_cuda_driver_init_forces_spawn.py
+++ b/tests/cuda/scripts/check_cuda_driver_init_forces_spawn.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Check that driver-level CUDA init is detected before fork."""
+
+import ctypes
+import os
+
+import torch
+
+os.environ.pop("VLLM_WORKER_MULTIPROC_METHOD", None)
+
+from vllm.utils.platform_utils import cuda_is_initialized  # noqa: E402
+
+assert not torch.cuda.is_initialized(), "CUDA initialized before driver probe"
+assert not cuda_is_initialized(), "driver probe should not initialize CUDA"
+assert not torch.cuda.is_initialized(), "driver probe initialized PyTorch CUDA"
+
+libcuda = ctypes.CDLL("libcuda.so.1")
+libcuda.cuInit.argtypes = [ctypes.c_uint]
+libcuda.cuInit.restype = ctypes.c_int
+assert libcuda.cuInit(0) == 0, "cuInit failed"
+
+assert not torch.cuda.is_initialized(), "cuInit initialized PyTorch CUDA"
+assert cuda_is_initialized(), "driver-level CUDA init was not detected"
+
+from vllm.utils.system_utils import _maybe_force_spawn  # noqa: E402
+
+_maybe_force_spawn()
+assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+print("OK")

--- a/tests/cuda/test_platform_no_cuda_init.py
+++ b/tests/cuda/test_platform_no_cuda_init.py
@@ -44,5 +44,12 @@ def test_device_count_respects_env_after_platform_import():
         )
 
 
+def test_driver_level_cuda_init_forces_spawn():
+    """Test that cuInit without PyTorch CUDA init still forces spawn."""
+    result = run_script("check_cuda_driver_init_forces_spawn.py")
+    if result.returncode != 0:
+        pytest.fail(f"Driver-level CUDA init was not detected:\n{result.stderr}")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ctypes
 import multiprocessing
 from collections.abc import Sequence
 from concurrent.futures.process import ProcessPoolExecutor
@@ -9,12 +10,42 @@ from typing import Any
 
 import torch
 
+# CUDA Driver API CUresult value for CUDA_ERROR_NOT_INITIALIZED.
+CUDA_ERROR_NOT_INITIALIZED = 3
+
+
+@cache
+def _load_cuda_driver() -> Any | None:
+    """Load libcuda and declare the driver probe signature."""
+    try:
+        libcuda = ctypes.CDLL("libcuda.so.1")
+    except OSError:
+        return None
+
+    libcuda.cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    libcuda.cuDeviceGetCount.restype = ctypes.c_int
+    return libcuda
+
+
+def _cuda_driver_is_initialized() -> bool:
+    """Check if the CUDA Driver API has already been initialized."""
+    libcuda = _load_cuda_driver()
+    if libcuda is None:
+        return False
+
+    device_count = ctypes.c_int()
+    result = libcuda.cuDeviceGetCount(ctypes.byref(device_count))
+    # cuDeviceGetCount returns CUDA_ERROR_NOT_INITIALIZED before cuInit()
+    # without initializing the driver. Any other return means the driver
+    # state is initialized or ambiguous, so avoid forking after it.
+    return result != CUDA_ERROR_NOT_INITIALIZED
+
 
 def cuda_is_initialized() -> bool:
-    """Check if CUDA is initialized."""
+    """Check if CUDA is initialized at the runtime or driver level."""
     if not torch.cuda._is_compiled():
         return False
-    return torch.cuda.is_initialized()
+    return torch.cuda.is_initialized() or _cuda_driver_is_initialized()
 
 
 def xpu_is_initialized() -> bool:
@@ -27,8 +58,7 @@ def xpu_is_initialized() -> bool:
 def cuda_get_device_properties(
     device, names: Sequence[str], init_cuda=False
 ) -> tuple[Any, ...]:
-    """Get specified CUDA device property values without initializing CUDA in
-    the current process."""
+    """Get CUDA device properties without initializing CUDA when possible."""
     if init_cuda or cuda_is_initialized():
         props = torch.cuda.get_device_properties(device)
         return tuple(getattr(props, name) for name in names)


### PR DESCRIPTION
Fixes #32611

## Purpose

`_maybe_force_spawn()` currently decides whether to avoid `fork` from `torch.cuda.is_initialized()`. That misses a real case from #32611: a parent process can initialize the CUDA Driver API through a non-PyTorch import path while PyTorch still reports CUDA as uninitialized. vLLM then forks EngineCore workers, and the child can fail during CUDA initialization.

This PR extends `cuda_is_initialized()` with a CUDA Driver API probe. `cuDeviceGetCount()` returns `CUDA_ERROR_NOT_INITIALIZED` before `cuInit()`; any other result means the driver is already initialized or ambiguous, so vLLM forces `spawn`.

This keeps the decision at the worker start-method boundary instead of special-casing FlashAttention/Cutlass imports. The relevant invariant is the inherited driver state before `fork`, not which package initialized it.

References:

- PyTorch poison-fork guidance: https://docs.pytorch.org/docs/2.9/notes/multiprocessing.html#poison-fork-in-multiprocessing
- CUDA Driver API initialization behavior: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__INITIALIZE.html

### Not a duplicate

Checked #32611 discussion, timeline cross-references, and nearby PRs. #42874 handles stale primary contexts inherited after `set_device`; #34818 and #33550/#26037 are adjacent CUDA-init/platform-help-path work. None of them makes `_maybe_force_spawn()` detect driver-only initialization before forking.

## Test Plan

- Add a CUDA regression test that calls `cuInit(0)` without initializing PyTorch CUDA, then verifies `cuda_is_initialized()` detects the driver state and `_maybe_force_spawn()` selects `spawn`.
- Re-run existing platform utility tests and changed-file lint/type checks.
- Reproduce the reporter model path with `tencent/HunyuanOCR`.

## Test Result

Base: `origin/main = 035733515` (`[Kernel][DSv4] Optimize sparse FP8 compressor kernels (#44161)`)

GPU used for CUDA/E2E validation: NVIDIA RTX PRO 6000.

Real-model repro: `tencent/HunyuanOCR` at revision `f6af82ee007fe6091b29fb3bb287b491ead41c82`.

- Old clean repro env (`vllm==0.14.0`, `flash_attn==2.8.3+cu12torch2.9cxx11abiTRUE`, `torch==2.9.1+cu128`, `transformers==4.57.6`, `nvidia-cutlass-dsl==4.5.2`): clean HunyuanOCR `LLM(...)` follows `vllm_flash_attn.flash_attn_interface -> flash_attn.cute.interface -> cutlass`; the parent CUDA driver becomes initialized while `torch.cuda.is_initialized()` remains `False`; the forked worker fails with `RuntimeError: CUDA driver initialization failed, you might not have a CUDA gpu.`
- Same env controls: explicit `VLLM_WORKER_MULTIPROC_METHOD=spawn` completes a real OCR image E2E run; monkeypatching the old env's `cuda_is_initialized()` to this PR's driver-level detection also forces `spawn` and completes the same OCR image E2E run.
- Current main: clean HunyuanOCR no longer self-pollutes the CUDA driver in this environment, but forcing parent-side `cutlass` pollution still reproduces the fork failure. With this patch, the same polluted HunyuanOCR text and OCR-image E2E runs force `spawn` and complete.

Regression/lint status: CUDA platform regression tests passed (`3 passed`), CPU platform utility tests passed (`2 passed`), and changed-file ruff/format/mypy/typos/SPDX/import/CUDA-call/diff checks passed.

Full `pre-commit run --files ...` did not complete because `actionlint` could not download Go dependencies from `proxy.golang.org`; the changed-file Python hooks and equivalent scoped checks above passed.

<details>
<summary>Commands run</summary>

- `PYTHONPATH=$PWD CUDA_VISIBLE_DEVICES=0 python -m pytest tests/cuda/test_platform_no_cuda_init.py -q --tb=short` -> `3 passed`
- `PYTHONPATH=$PWD CUDA_VISIBLE_DEVICES= python -m pytest tests/utils_/test_system_utils.py -q --tb=short` -> `2 passed`
- `ruff check vllm/utils/platform_utils.py tests/cuda/test_platform_no_cuda_init.py tests/cuda/scripts/check_cuda_driver_init_forces_spawn.py` -> passed
- `ruff format --check vllm/utils/platform_utils.py tests/cuda/test_platform_no_cuda_init.py tests/cuda/scripts/check_cuda_driver_init_forces_spawn.py` -> passed
- `python -m mypy vllm/utils/platform_utils.py --follow-imports=skip` -> passed
- `pre-commit run ruff-check --files ...`, `ruff-format`, `typos`, and `mypy-local` -> passed
- Direct scoped checks for SPDX headers, lazy imports, forbidden imports, torch CUDA calls, boolean context managers, filenames, and `git diff --check` -> passed

</details>

<details>
<summary>Driver probe and HunyuanOCR E2E reproduction scripts</summary>

Driver-only CUDA initialization probe:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export CUDA_VISIBLE_DEVICES=0

cat >/tmp/check_cuda_driver_init_forces_spawn.py <<'PY'
#!/usr/bin/env python3
import ctypes
import os

import torch

os.environ.pop("VLLM_WORKER_MULTIPROC_METHOD", None)

from vllm.utils.platform_utils import cuda_is_initialized

assert not torch.cuda.is_initialized(), "CUDA initialized before driver probe"
assert not cuda_is_initialized(), "driver probe should not initialize CUDA"
assert not torch.cuda.is_initialized(), "driver probe initialized PyTorch CUDA"

libcuda = ctypes.CDLL("libcuda.so.1")
libcuda.cuInit.argtypes = [ctypes.c_uint]
libcuda.cuInit.restype = ctypes.c_int
assert libcuda.cuInit(0) == 0, "cuInit failed"

assert not torch.cuda.is_initialized(), "cuInit initialized PyTorch CUDA"
assert cuda_is_initialized(), "driver-level CUDA init was not detected"

from vllm.utils.system_utils import _maybe_force_spawn

_maybe_force_spawn()
assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"

print("OK")
PY

python /tmp/check_cuda_driver_init_forces_spawn.py
```

HunyuanOCR E2E script:

```bash
cat >/tmp/hunyuanocr_32611_e2e.py <<'PY'
import ctypes
import os
import sys


def driver_state():
    libcuda = ctypes.CDLL("libcuda.so.1")
    libcuda.cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
    libcuda.cuDeviceGetCount.restype = ctypes.c_int
    n = ctypes.c_int(-1)
    return libcuda.cuDeviceGetCount(ctypes.byref(n)), n.value


print("DRIVER_START", driver_state(), flush=True)

if os.environ.get("POLLUTE_CUTLASS") == "1":
    import cutlass  # noqa: F401

    print("DRIVER_AFTER_CUTLASS", driver_state(), flush=True)

from vllm import LLM, SamplingParams

MODEL = os.environ.get("HUNYUAN_MODEL", "tencent/HunyuanOCR")
MODE = sys.argv[1] if len(sys.argv) > 1 else "text"

kwargs = dict(
    model=MODEL,
    max_model_len=8192,
    gpu_memory_utilization=0.2,
    trust_remote_code=True,
    limit_mm_per_prompt={"image": 1},
)
llm = LLM(**kwargs)
print("LLM_CREATED mp=", os.environ.get("VLLM_WORKER_MULTIPROC_METHOD"), flush=True)

sp = SamplingParams(max_tokens=16, temperature=0.0)

if MODE == "text":
    out = llm.generate(["Read the text in the image if one is provided."], sp, use_tqdm=False)
    print("TEXT_E2E_OK", [o.outputs[0].text for o in out], flush=True)
else:
    from PIL import Image, ImageDraw

    path = "/tmp/hunyuanocr_32611_test.png"
    image = Image.new("RGB", (640, 200), "white")
    draw = ImageDraw.Draw(image)
    draw.text((32, 72), "HunyuanOCR E2E\nIssue 32611 CUDA fork test", fill="black")
    image.save(path)

    prompt = "<｜hy_begin▁of▁sentence｜>{placeholder}提取图中的文字。<｜hy_User｜>"
    request = {
        "prompt": prompt,
        "multi_modal_data": {"image": Image.open(path)},
    }
    out = llm.generate([request], sp, use_tqdm=False)
    print("IMAGE_E2E_OK", repr(out[0].outputs[0].text), flush=True)
PY
```

Commands:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export CUDA_VISIBLE_DEVICES=0
export VLLM_USE_FLASHINFER_SAMPLER=0
export HUNYUAN_MODEL="${HUNYUAN_MODEL:-tencent/HunyuanOCR}"

# Needed for the forced parent-side pollution repro if this environment
# does not already provide `import cutlass`.
python - <<'PY'
try:
    import cutlass  # noqa: F401
except ModuleNotFoundError:
    raise SystemExit("install nvidia-cutlass-dsl first, e.g. python -m pip install nvidia-cutlass-dsl==4.5.2")
PY

# current main polluted baseline
POLLUTE_CUTLASS=1 python /tmp/hunyuanocr_32611_e2e.py text

# this PR
POLLUTE_CUTLASS=1 python /tmp/hunyuanocr_32611_e2e.py text
POLLUTE_CUTLASS=1 python /tmp/hunyuanocr_32611_e2e.py image
```

Observed output:

```text
# current main with parent-side cutlass import
DRIVER_AFTER_CUTLASS (0, 1)
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
RuntimeError: Engine core initialization failed.

# this PR, same polluted parent process
DRIVER_AFTER_CUTLASS (0, 1)
Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn' ... Reasons: CUDA is initialized
LLM_CREATED mp= spawn
TEXT_E2E_OK [' in $ $ $']

# this PR, same polluted parent process, OCR image
LLM_CREATED mp= spawn
IMAGE_E2E_OK 'HunyuanOCR E2E\nIssue 32611 CUDA fork test'
```

Old-environment clean control: in an isolated `vllm==0.14.0`, `flash_attn==2.8.3+cu12torch2.9cxx11abiTRUE`, `torch==2.9.1+cu128`, `transformers==4.57.6`, `nvidia-cutlass-dsl==4.5.2` environment, the same HunyuanOCR script without manual `POLLUTE_CUTLASS=1` follows the `vllm_flash_attn.flash_attn_interface -> flash_attn.cute.interface -> cutlass` import chain, leaves `torch.cuda.is_initialized() == False`, and fails the forked worker. Explicit `VLLM_WORKER_MULTIPROC_METHOD=spawn` and the driver-level probe both complete the same OCR image E2E.

</details>

AI assistance was used to prepare this PR.
