### PR TITLE
[Bugfix][CI] Avoid CUDA init during tests.utils import

### DIFF
--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -1,3 +1,4 @@
+# We assume uv pip install -r requirements/kv_connectors.txt is run in the image-build step.
 group: Disaggregated
 depends_on: 
   - image-build
@@ -11,7 +12,6 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 - label: Distributed FlashInfer NixlConnector PD accuracy (4 GPUs)
   key: distributed-flashinfer-nixlconnector-pd-accuracy-4-gpus
@@ -22,7 +22,6 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - FLASHINFER=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: DP EP Distributed NixlConnector PD accuracy tests (4 GPUs)
@@ -34,7 +33,6 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - DP_EP=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs)
@@ -46,7 +44,6 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - CROSS_LAYERS_BLOCKS=True bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: Hybrid SSM NixlConnector PD accuracy tests (4 GPUs)
@@ -58,7 +55,6 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - HYBRID_SSM=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs)
@@ -73,7 +69,6 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - bash v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
 
 - label: NixlConnector PD + Spec Decode acceptance (2 GPUs)
@@ -87,7 +82,6 @@ steps:
     - vllm/v1/worker/kv_connector_model_runner_mixin.py
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - bash v1/kv_connector/nixl_integration/config_sweep_spec_decode_test.sh
 
 - label: MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs)
@@ -102,5 +96,4 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - bash v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -978,8 +978,10 @@ RUN --mount=type=cache,target=/opt/uv/cache \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \
         ); \
-        # Force-reinstall the matching CUDA wheel so the correct nixl_ep_cpp.so is installed.
-        uv pip install --system --force-reinstall --no-deps nixl-cu${CUDA_MAJOR}; \
+        # Remove all nixl-cu* variants then install only the one matching this
+        # image's CUDA (nixl>=1.1.0 installs both)
+        uv pip uninstall --system nixl-cu12 nixl-cu13 2>/dev/null || true; \
+        uv pip install --system --no-deps nixl-cu${CUDA_MAJOR}; \
     fi
 
 # Optional override: install mooncake-transfer-engine from a URL instead of the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -936,6 +936,31 @@ COPY vllm/v1 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/vllm/v1
 # will not be imported by other tests
 RUN mkdir src
 RUN mv vllm src/vllm
+
+# install kv_connectors if requested (same logic as vllm-openai-base)
+ARG INSTALL_KV_CONNECTORS=false
+ARG CUDA_VERSION
+ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
+ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
+RUN --mount=type=cache,target=/opt/uv/cache \
+    --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
+    CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
+    CUDA_HOME=/usr/local/cuda; \
+    BUILD_PKGS="libcusparse-dev-${CUDA_VERSION_DASH} \
+                libcublas-dev-${CUDA_VERSION_DASH} \
+                libcusolver-dev-${CUDA_VERSION_DASH}"; \
+    if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
+        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
+            apt-get update -y && \
+            apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
+            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
+            apt-get purge -y ${BUILD_PKGS} && \
+            rm -rf /var/lib/apt/lists/* \
+        ); \
+        uv pip uninstall --system nixl-cu12 nixl-cu13 2>/dev/null || true; \
+        uv pip install --system --no-deps nixl-cu${CUDA_MAJOR}; \
+    fi
 #################### TEST IMAGE ####################
 
 #################### OPENAI API SERVER ####################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -947,6 +947,10 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system -e tests/vllm_test_utils
 
+# Prevent early CUDA initialization when CUDA-dependent packages (cupy, nixl)
+# are installed — tests that fork subprocesses would otherwise fail.
+ENV CUDA_MODULE_LOADING=LAZY
+
 # enable fast downloads from hf (for testing)
 ENV HF_XET_HIGH_PERFORMANCE 1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -887,6 +887,31 @@ RUN apt-get update -y \
 # We can specify the standard or nightly build of PyTorch
 ARG PYTORCH_NIGHTLY
 
+# install kv_connectors if requested (same logic as vllm-openai-base)
+ARG INSTALL_KV_CONNECTORS=false
+ARG CUDA_VERSION
+ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
+ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
+RUN --mount=type=cache,target=/opt/uv/cache \
+    --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
+    CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
+    CUDA_HOME=/usr/local/cuda; \
+    BUILD_PKGS="libcusparse-dev-${CUDA_VERSION_DASH} \
+                libcublas-dev-${CUDA_VERSION_DASH} \
+                libcusolver-dev-${CUDA_VERSION_DASH}"; \
+    if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
+        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
+            apt-get update -y && \
+            apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
+            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
+            apt-get purge -y ${BUILD_PKGS} && \
+            rm -rf /var/lib/apt/lists/* \
+        ); \
+        uv pip uninstall --system nixl-cu12 nixl-cu13 2>/dev/null || true; \
+        uv pip install --system --no-deps nixl-cu${CUDA_MAJOR}; \
+    fi
+    
 # Install development dependencies (for testing)
 COPY requirements/lint.txt requirements/lint.txt
 COPY requirements/test/cuda.in requirements/test/cuda.in
@@ -937,30 +962,6 @@ COPY vllm/v1 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/vllm/v1
 RUN mkdir src
 RUN mv vllm src/vllm
 
-# install kv_connectors if requested (same logic as vllm-openai-base)
-ARG INSTALL_KV_CONNECTORS=false
-ARG CUDA_VERSION
-ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
-ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
-RUN --mount=type=cache,target=/opt/uv/cache \
-    --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \
-    CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
-    CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
-    CUDA_HOME=/usr/local/cuda; \
-    BUILD_PKGS="libcusparse-dev-${CUDA_VERSION_DASH} \
-                libcublas-dev-${CUDA_VERSION_DASH} \
-                libcusolver-dev-${CUDA_VERSION_DASH}"; \
-    if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
-            apt-get update -y && \
-            apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
-            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
-            apt-get purge -y ${BUILD_PKGS} && \
-            rm -rf /var/lib/apt/lists/* \
-        ); \
-        uv pip uninstall --system nixl-cu12 nixl-cu13 2>/dev/null || true; \
-        uv pip install --system --no-deps nixl-cu${CUDA_MAJOR}; \
-    fi
 #################### TEST IMAGE ####################
 
 #################### OPENAI API SERVER ####################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -947,10 +947,6 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system -e tests/vllm_test_utils
 
-# Prevent early CUDA initialization when CUDA-dependent packages (cupy, nixl)
-# are installed — tests that fork subprocesses would otherwise fail.
-ENV CUDA_MODULE_LOADING=LAZY
-
 # enable fast downloads from hf (for testing)
 ENV HF_XET_HIGH_PERFORMANCE 1
 

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -95,7 +95,10 @@ target "test" {
   inherits = ["_common", "_labels"]
   target   = "test"
   tags     = ["vllm:test"]
-  output   = ["type=docker"]
+  args = {
+    INSTALL_KV_CONNECTORS = "true"
+  }
+  output = ["type=docker"]
 }
 
 target "openai" {
@@ -114,6 +117,7 @@ target "test-ubuntu2404" {
   args = {
     UBUNTU_VERSION          = "24.04"
     GDRCOPY_OS_VERSION      = "Ubuntu24_04"
+    INSTALL_KV_CONNECTORS   = "true"
   }
   output = ["type=docker"]
 }

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -59,13 +59,14 @@ target "_common" {
   dockerfile = "docker/Dockerfile"
   context    = "."
   args = {
-    max_jobs             = MAX_JOBS
-    nvcc_threads         = NVCC_THREADS
-    torch_cuda_arch_list = TORCH_CUDA_ARCH_LIST
-    VLLM_BUILD_COMMIT    = VLLM_BUILD_COMMIT != "unknown" ? VLLM_BUILD_COMMIT : (COMMIT != "" ? COMMIT : "unknown")
-    VLLM_BUILD_PIPELINE  = VLLM_BUILD_PIPELINE
-    VLLM_BUILD_URL       = VLLM_BUILD_URL
-    VLLM_IMAGE_TAG       = VLLM_IMAGE_TAG
+    max_jobs              = MAX_JOBS
+    nvcc_threads          = NVCC_THREADS
+    torch_cuda_arch_list  = TORCH_CUDA_ARCH_LIST
+    INSTALL_KV_CONNECTORS = "true"
+    VLLM_BUILD_COMMIT     = VLLM_BUILD_COMMIT != "unknown" ? VLLM_BUILD_COMMIT : (COMMIT != "" ? COMMIT : "unknown")
+    VLLM_BUILD_PIPELINE   = VLLM_BUILD_PIPELINE
+    VLLM_BUILD_URL        = VLLM_BUILD_URL
+    VLLM_IMAGE_TAG        = VLLM_IMAGE_TAG
   }
 }
 
@@ -95,10 +96,7 @@ target "test" {
   inherits = ["_common", "_labels"]
   target   = "test"
   tags     = ["vllm:test"]
-  args = {
-    INSTALL_KV_CONNECTORS = "true"
-  }
-  output = ["type=docker"]
+  output   = ["type=docker"]
 }
 
 target "openai" {
@@ -117,7 +115,6 @@ target "test-ubuntu2404" {
   args = {
     UBUNTU_VERSION          = "24.04"
     GDRCOPY_OS_VERSION      = "Ubuntu24_04"
-    INSTALL_KV_CONNECTORS   = "true"
   }
   output = ["type=docker"]
 }

--- a/tests/cuda/scripts/check_test_utils_no_cuda_init.py
+++ b/tests/cuda/scripts/check_test_utils_no_cuda_init.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Check that importing shared test utils does not initialize CUDA."""
+
+import sys
+from pathlib import Path
+
+import torch  # noqa: E402
+
+assert not torch.cuda.is_initialized(), "CUDA initialized before import"
+
+
+def find_repo_root() -> Path:
+    for path in Path(__file__).resolve().parents:
+        if (path / "pyproject.toml").is_file() and (
+            path / "tests" / "utils.py"
+        ).is_file():
+            return path
+    raise RuntimeError("Could not locate vLLM repository root")
+
+
+# Buildkite runs CUDA tests from /vllm-workspace/tests, so the repository root
+# is not guaranteed to be importable when this script runs as a subprocess.
+sys.path.insert(0, str(find_repo_root()))
+
+from tests.utils import create_new_process_for_each_test  # noqa: E402, F401
+
+assert not torch.cuda.is_initialized(), "CUDA was initialized during tests.utils import"
+print("OK")

--- a/tests/cuda/test_platform_no_cuda_init.py
+++ b/tests/cuda/test_platform_no_cuda_init.py
@@ -35,6 +35,13 @@ def test_platform_import_does_not_init_cuda():
         pytest.fail(f"Platform import initialized CUDA:\n{result.stderr}")
 
 
+def test_tests_utils_import_does_not_init_cuda():
+    """Test that importing tests.utils does not initialize CUDA before fork."""
+    result = run_script("check_test_utils_no_cuda_init.py")
+    if result.returncode != 0:
+        pytest.fail(f"tests.utils import initialized CUDA:\n{result.stderr}")
+
+
 def test_device_count_respects_env_after_platform_import():
     """Test that device_count respects CUDA_VISIBLE_DEVICES after import."""
     result = run_script("check_device_count_respects_env.py")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,7 @@ from collections.abc import Callable, Iterable, Sequence
 from contextlib import ExitStack, contextmanager
 from multiprocessing import Process, get_context
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from unittest.mock import patch
 
 import anthropic
@@ -47,14 +47,9 @@ from vllm.distributed import (
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.cli.serve import ServeSubcommand
 from vllm.logger import init_logger
-from vllm.model_executor.kernels.linear import (
-    _KernelT,
-    init_fp8_linear_kernel,
-)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
 )
-from vllm.model_executor.model_loader import get_model_loader
 from vllm.platforms import current_platform
 from vllm.tokenizers import get_tokenizer
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -65,6 +60,9 @@ from vllm.utils.torch_utils import (
 )
 
 logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.kernels.linear import _KernelT
 
 FP8_DTYPE = current_platform.fp8_dtype()
 
@@ -198,6 +196,10 @@ class RemoteVLLMServer:
             engine_args = AsyncEngineArgs.from_cli_args(args)
             model_config = engine_args.create_model_config()
             load_config = engine_args.create_load_config()
+
+            # Keep model-loader imports lazy: tests.utils is imported during
+            # pytest collection before some CUDA tests fork child processes.
+            from vllm.model_executor.model_loader import get_model_loader
 
             model_loader = get_model_loader(load_config)
             model_loader.download_model(model_config)
@@ -2094,7 +2096,7 @@ class TestFP8Layer(torch.nn.Module):
         out_dtype: torch.dtype | None = None,
         transpose_weights: bool = False,
         device: torch.device | None = None,
-        force_kernel: type[_KernelT] | None = None,
+        force_kernel: type["_KernelT"] | None = None,
     ):
         super().__init__()
         act_scale_desc = activation_quant_key.scale
@@ -2131,6 +2133,10 @@ class TestFP8Layer(torch.nn.Module):
             self.input_scale_ub = None
 
         out_dtype = torch.get_default_dtype() if out_dtype is None else out_dtype
+
+        # Keep FP8 kernel imports lazy so importing tests.utils does not
+        # initialize CUDA before helpers fork child processes.
+        from vllm.model_executor.kernels.linear import init_fp8_linear_kernel
 
         self.kernel = init_fp8_linear_kernel(
             activation_quant_key=activation_quant_key,


### PR DESCRIPTION
## Summary

Fixes a CUDA-before-fork failure exposed by the PR #44192 CI image changes.

`tests.utils` is imported during pytest collection by tests that only need helpers such as `create_new_process_for_each_test`. It had a top-level import of `vllm.model_executor.kernels.linear` for the `TestFP8Layer` helper. In an image where NIXL EP and FlashInfer comm are installed, that import can initialize CUDA in the parent pytest process. Forked CUDA tests then fail with:

```text
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```

This keeps those CUDA-touching imports lazy at their actual use sites and adds a canary to assert that importing `tests.utils` does not initialize CUDA. It also removes the `CUDA_MODULE_LOADING=LAZY` test-image workaround added in #44192: that environment variable does not stop this failure because the import path explicitly calls `torch.cuda.get_device_capability()`, which initializes PyTorch CUDA anyway.

## Why This Surfaced Now

Short version: this is not because the logits processor test depends on NIXL. It surfaced because #44192 made the generic CI test image more release-like by installing KV connector dependencies into it.

Before #44192, the generic test image used by unrelated tests did not install `requirements/kv_connectors.txt`, so `nixl_ep` was not available there. That meant `has_nixl_ep()` returned false and the NIXL EP fused-MoE import branch was skipped during pytest collection. After #44192 set `INSTALL_KV_CONNECTORS=true` for the shared test image, `nixl_ep` became available to every test area using that image, including unrelated logits processor tests.

So NIXL did not necessarily newly start shipping `nixl_ep`; for example, the upstream release image `vllm/vllm-openai:v0.22.0-ubuntu2404` already has `nixl`, `nixl-cu12`, `nixl-cu13`, and `nixl_ep`. The change is that unrelated CI tests started running in an image with those connector packages installed.

The exact import chain I observed is:

```text
tests.utils
  -> vllm.model_executor.kernels.linear
  -> vllm.model_executor.kernels.linear.mixed_precision.marlin
  -> vllm.model_executor.layers.quantization.utils.marlin_utils
  -> vllm.model_executor.layers.fused_moe
  -> vllm.model_executor.layers.fused_moe.all2all_utils
  -> .prepare_finalize.nixl_ep          # only when has_nixl_ep() is true
  -> vllm.distributed.device_communicators.all2all
  -> has_flashinfer_nvlink_two_sided()
  -> has_flashinfer_comm()
  -> importlib.util.find_spec("flashinfer.comm")
  -> imports parent flashinfer package
  -> flashinfer.jit.env.CompilationContext()
  -> torch.cuda.get_device_capability()
  -> torch.cuda._lazy_init()
```

That explains why this was not hit by unrelated tests before: the top-level import in `tests.utils` was already too broad, but the CUDA-initializing branch depended on optional connector packages that were not previously installed in the shared CI test image.

There were already CI steps that manually installed connector dependencies, but those were the disaggregated test steps themselves. They ran commands like `uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt` and then launched the NIXL integration scripts. Those scripts start `vllm serve` processes and run the NIXL accuracy tests; they do not import `tests.utils.create_new_process_for_each_test` during collection and then fork CUDA work from that same parent pytest process. Because Buildkite steps run in separate job containers, those manual installs also did not leak into unrelated logits processor test jobs.

I reproduced the same underlying behavior in the upstream release image `vllm/vllm-openai:v0.22.0-ubuntu2404`:

```text
dist vllm: 0.22.0
dist nixl: 1.1.0
dist nixl-cu12: 1.1.0
dist nixl-cu13: 1.1.0
dist cupy-cuda13x: 14.0.1
dist flashinfer-python: 0.6.11.post2
before import False
from vllm.model_executor.kernels.linear import _KernelT, init_fp8_linear_kernel
# stack reaches flashinfer/compilation_context.py: torch.cuda.get_device_capability()
after import True
```

Control in that same release image, simulating the old generic test image by forcing `has_nixl_ep()` false:

```text
before import False
pretend nixl_ep is absent
after import False
```

## Validation

Validated against CI image:

```text
public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:e442c13f36f707e8de75043506713b454448ba75
```

Commands run with the local checkout mounted over `/vllm-workspace`:

```bash
python3 /vllm-workspace/tests/cuda/scripts/check_test_utils_no_cuda_init.py
python3 -m pytest -q -s tests/cuda/test_platform_no_cuda_init.py
python3 -m pytest -vv -s 'v1/logits_processors/test_correctness.py::test_logitsprocs[logitsprocs_under_test0-50-cuda:0]'
python3 -m pytest -q -s --tb=short v1/logits_processors/test_correctness.py
python3 -m pytest -s -x v1/kv_connector/nixl_integration/test_nixl_imports.py
```

Focused checks also re-run with `CUDA_MODULE_LOADING` unset. The CUDA no-init file was also run from `/vllm-workspace/tests` with `PYTHONPATH` unset to match Buildkite's test cwd:

```bash
unset CUDA_MODULE_LOADING
python3 /vllm-workspace/tests/cuda/scripts/check_test_utils_no_cuda_init.py
python3 -m pytest -q -s tests/cuda/test_platform_no_cuda_init.py
python3 -m pytest -vv -s 'v1/logits_processors/test_correctness.py::test_logitsprocs[logitsprocs_under_test0-50-cuda:0]'
```

Results:

```text
check_test_utils_no_cuda_init.py: OK
tests/cuda/test_platform_no_cuda_init.py: 3 passed
reported logits processor node: 1 passed
v1/logits_processors/test_correctness.py: 28 passed
NIXL import canary: 1 passed
check_test_utils_no_cuda_init.py with CUDA_MODULE_LOADING unset: OK
tests/cuda/test_platform_no_cuda_init.py with CUDA_MODULE_LOADING unset: 3 passed
reported logits processor node with CUDA_MODULE_LOADING unset: 1 passed
```

NIXL image sanity:

```text
torch.version.cuda: 13.0
nixl: 1.2.0
nixl-cu12: not installed
nixl-cu13: 1.2.0
nixl_ep_cpp links to libcudart.so.13
```

## Notes

This is not duplicating an existing PR that I found for this specific `tests.utils` import-time CUDA initialization. AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.
