### PR TITLE
[Bugfix] Skip MiniMax RMSNorm Lamport workspace when custom all-reduce is disabled

### DIFF
--- a/tests/kernels/core/test_minimax_reduce_rms.py
+++ b/tests/kernels/core/test_minimax_reduce_rms.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for MiniMax QK RMS-norm: NCCL reference vs Lamport fused kernel."""
 
+import sys
+from types import ModuleType, SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
@@ -14,6 +17,122 @@ from vllm.model_executor.layers.minimax_rms_norm import MiniMaxText01RMSNormTP
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_open_port
 from vllm.utils.torch_utils import set_random_seed
+
+_LAMPORT_WORKSPACE_MODULE = (
+    "vllm.model_executor.layers.minimax_rms_norm.lamport_workspace"
+)
+
+
+def _patch_lamport_workspace(monkeypatch, get_allreduce_workspace):
+    module = ModuleType(_LAMPORT_WORKSPACE_MODULE)
+    module.get_allreduce_workspace = get_allreduce_workspace
+    monkeypatch.setitem(sys.modules, _LAMPORT_WORKSPACE_MODULE, module)
+
+
+def _build_minimax_norm(norm_cls):
+    from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+
+    vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
+    with set_current_vllm_config(vllm_config):
+        return norm_cls(8)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_minimax_rmsnorm_skips_workspace_when_custom_allreduce_disabled(
+    monkeypatch,
+):
+    from vllm.distributed import parallel_state
+    from vllm.model_executor.layers.minimax_rms_norm import rms_norm_tp
+
+    monkeypatch.setattr(rms_norm_tp, "_MINIMAX_FUSED_AR_RMS_QK", object())
+    monkeypatch.setattr(rms_norm_tp, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(rms_norm_tp, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parallel_state, "_ENABLE_CUSTOM_ALL_REDUCE", False)
+
+    def fail_workspace(*args, **kwargs):
+        pytest.fail("MiniMax workspace should honor disable_custom_all_reduce")
+
+    _patch_lamport_workspace(monkeypatch, fail_workspace)
+
+    norm = _build_minimax_norm(rms_norm_tp.MiniMaxText01RMSNormTP)
+
+    assert norm.workspace is None
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_minimax_rmsnorm_skips_disabled_custom_allreduce_communicator(
+    monkeypatch,
+):
+    from vllm.distributed import parallel_state
+    from vllm.model_executor.layers.minimax_rms_norm import rms_norm_tp
+
+    tp_group = SimpleNamespace(
+        cpu_group=object(),
+        device_communicator=SimpleNamespace(
+            use_custom_allreduce=True,
+            ca_comm=SimpleNamespace(disabled=True),
+        ),
+    )
+
+    monkeypatch.setattr(rms_norm_tp, "_MINIMAX_FUSED_AR_RMS_QK", object())
+    monkeypatch.setattr(rms_norm_tp, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(rms_norm_tp, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(rms_norm_tp, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "_ENABLE_CUSTOM_ALL_REDUCE", True)
+
+    def fail_workspace(*args, **kwargs):
+        pytest.fail("MiniMax workspace should follow disabled CA communicator")
+
+    _patch_lamport_workspace(monkeypatch, fail_workspace)
+
+    norm = _build_minimax_norm(rms_norm_tp.MiniMaxText01RMSNormTP)
+
+    assert norm.workspace is None
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_minimax_rmsnorm_uses_workspace_when_custom_allreduce_available(
+    monkeypatch,
+):
+    from vllm.distributed import parallel_state
+    from vllm.model_executor.layers.minimax_rms_norm import rms_norm_tp
+
+    workspace = torch.empty(0)
+    calls = []
+    tp_group = SimpleNamespace(
+        cpu_group=object(),
+        device_communicator=SimpleNamespace(
+            use_custom_allreduce=True,
+            ca_comm=SimpleNamespace(disabled=False),
+        ),
+    )
+
+    monkeypatch.setattr(rms_norm_tp, "_MINIMAX_FUSED_AR_RMS_QK", object())
+    monkeypatch.setattr(rms_norm_tp, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(rms_norm_tp, "get_tensor_model_parallel_rank", lambda: 1)
+    monkeypatch.setattr(rms_norm_tp, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "_ENABLE_CUSTOM_ALL_REDUCE", True)
+
+    def fake_workspace(**kwargs):
+        calls.append(kwargs)
+        return workspace
+
+    _patch_lamport_workspace(monkeypatch, fake_workspace)
+
+    norm = _build_minimax_norm(rms_norm_tp.MiniMaxText01RMSNormTP)
+
+    assert norm.workspace is workspace
+    assert calls == [
+        {
+            "rank": 1,
+            "world_size": 2,
+            "max_tokens": 2048,
+            "process_group": tp_group.cpu_group,
+        }
+    ]
 
 
 @ensure_current_vllm_config()

--- a/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
@@ -111,6 +111,23 @@ direct_register_custom_op(
 )
 
 
+def _should_use_minimax_fused_allreduce() -> bool:
+    from vllm.distributed.parallel_state import _ENABLE_CUSTOM_ALL_REDUCE
+
+    if not _ENABLE_CUSTOM_ALL_REDUCE:
+        return False
+
+    device_communicator = getattr(get_tp_group(), "device_communicator", None)
+    if device_communicator is None:
+        return True
+
+    if not getattr(device_communicator, "use_custom_allreduce", False):
+        return False
+
+    ca_comm = getattr(device_communicator, "ca_comm", None)
+    return ca_comm is not None and not getattr(ca_comm, "disabled", True)
+
+
 @CustomOp.register("minimax_text01_rmsnorm_tp")
 class MiniMaxText01RMSNormTP(CustomOp):
     def __init__(
@@ -138,7 +155,11 @@ class MiniMaxText01RMSNormTP(CustomOp):
         self.variance_epsilon = eps
 
         self.workspace = None
-        if _MINIMAX_FUSED_AR_RMS_QK is not None and self.tp_world > 1:
+        if (
+            _MINIMAX_FUSED_AR_RMS_QK is not None
+            and self.tp_world > 1
+            and _should_use_minimax_fused_allreduce()
+        ):
             from .lamport_workspace import (
                 get_allreduce_workspace,
             )


### PR DESCRIPTION
﻿## Summary

Fixes #44003.

MiniMax RMSNorm's Lamport fused all-reduce path currently creates a CUDA IPC workspace whenever the fused op exists and TP world size is greater than 1. That bypasses the global custom all-reduce disable path and the TP communicator's existing P2P/topology checks, so PCIe-only or P2P-limited systems can still fail during model load with `cudaErrorPeerAccessUnsupported`.

This change gates the Lamport workspace behind the same custom all-reduce availability signal:
- skip it when `--disable-custom-all-reduce` is set
- skip it when the TP device communicator did not enable custom all-reduce or its custom all-reduce communicator is disabled
- keep using it when custom all-reduce is available

When skipped, the existing tensor-parallel all-reduce fallback remains in use.

## Duplicate Check

Not a duplicate. Before opening this PR I checked:
- `gh issue view 44003 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "44003 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "MiniMax cudaErrorPeerAccessUnsupported LamportWorkspace"`
- `gh pr list --repo vllm-project/vllm --state open --search "minimax_rms_norm peer access unsupported"`

All PR searches returned no open matching PRs at the time this draft was opened.

## Tests

Current local validation:
- `wsl.exe -d Ubuntu-24.04 --cd /mnt/c/Users/34310/projects/vllm -- /home/jiayi/projects/vllm/.venv/bin/python -m pytest tests/kernels/core/test_minimax_reduce_rms.py -q`
  - Result: `3 passed, 18 skipped`
- `C:\Users\34310\.local\bin\uv.exe tool run ruff check vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py tests/kernels/core/test_minimax_reduce_rms.py`
  - Result: passed
- `C:\Users\34310\.local\bin\uv.exe tool run ruff format --check vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py tests/kernels/core/test_minimax_reduce_rms.py`
  - Result: passed
- `git diff --check`
  - Result: passed

Pending before marking ready for review:
- Add/adjust GPU-oriented validation or mock coverage for the topology path.
- Run a TP=4 `--disable-custom-all-reduce` MiniMax load check on A800 hardware.

## AI Assistance

AI assistance was used to investigate the issue, implement the patch, and draft the tests. This is opened as a draft while human review and GPU validation are completed.
