### PR TITLE
[Bugfix][Model] Qwen3-Omni: move cu_seqlens to GPU before VIT attention

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -991,6 +991,9 @@ class Qwen3Omni_VisionTransformer(nn.Module):
             )
             cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
 
+        # Move cu_seqlens to GPU; grid_thw may be on CPU during profile_run
+        # and FA3 vit attention requires cu_seqlens on CUDA.
+        cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
         hidden_states = hidden_states.unsqueeze(1)
         rotary_pos_emb_cos = rotary_pos_emb_cos.to(hidden_states.device)
         rotary_pos_emb_sin = rotary_pos_emb_sin.to(hidden_states.device)


### PR DESCRIPTION


## Purpose

Fixes #44180.

During `profile_run` the multimodal `grid_thw` arrives on CPU, so the `cu_seqlens` tensor built from it inherits the CPU device. Passing this CPU tensor into the FA3 vit attention path raises `RuntimeError: cu_seqlens_q must be on CUDA` and crashes engine init when loading `Qwen/Qwen3-Omni-30B-A3B-Thinking` (and the Instruct variant).

Move `cu_seqlens` to `self.device` after construction so the FA3 wrapper receives a CUDA tensor regardless of where `grid_thw` lives. The sibling `qwen3_vl` model already routes `cu_seqlens` through `MMEncoderAttention.maybe_recompute_cu_seqlens(..., device=self.device)` for the same reason; this PR mirrors that guarantee minimally for `qwen3_omni_moe_thinker`.

**Why this is not a duplicate:** `gh pr list --repo vllm-project/vllm --state open --search "qwen3_omni"` returns 0 open PRs.

## Test Plan

Reproduce and verify on a single H100 80 GB (CUDA 13, driver 580.105.08), matching the reporter's environment.

```bash
uv venv --python 3.12 && source .venv/bin/activate
uv pip install vllm==0.22.0 hf_transfer
export HF_HUB_ENABLE_HF_TRANSFER=1
hf download Qwen/Qwen3-Omni-30B-A3B-Thinking
```

Repro script (matches the failing config in #44180):

```python
from vllm import LLM
llm = LLM(
    model="Qwen/Qwen3-Omni-30B-A3B-Thinking",
    trust_remote_code=True,
    max_model_len=4096,
    gpu_memory_utilization=0.9,
    enforce_eager=True,
    limit_mm_per_prompt={"image": 1, "video": 1, "audio": 1},
)
print("LOAD_OK")
```

Lint:

```bash
ruff check vllm/model_executor/models/qwen3_omni_moe_thinker.py
ruff format --check vllm/model_executor/models/qwen3_omni_moe_thinker.py
```

## Test Result

**Before patch (crashes during profile_run):**

```
File ".../vllm/model_executor/models/qwen3_omni_moe_thinker.py", line 671, in forward
    x = x + self.attn(...
File ".../vllm/v1/attention/ops/vit_attn_wrappers.py", line 51, in flash_attn_maxseqlen_wrapper
    output = flash_attn_varlen_func(...
File ".../vllm/vllm_flash_attn/flash_attn_interface.py", line 328, in flash_attn_varlen_func
    out, softmax_lse, _, _ = torch.ops._vllm_fa3_C.fwd(...
RuntimeError: cu_seqlens_q must be on CUDA
RuntimeError: Engine core initialization failed.
```

**After patch:**

```
INFO 06-02 00:02:29 [gpu_worker.py:466] Available KV cache memory: 9.41 GiB
INFO 06-02 00:02:29 [kv_cache_utils.py:1733] GPU KV cache size: 102,784 tokens
INFO 06-02 00:02:37 [core.py:309] init engine (profile, create kv cache, warmup model) took 873.27 s
LOAD_OK
```

End-to-end image VIT inference (224×224 solid-red PIL image, "Color shown? One word."):

```
OUT: <think>
Got it, the user is asking for the color shown in the image, and it's a single word. The image is a solid red color, ...
```

Lint: `All checks passed!` and `1 file already formatted`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

