### PR TITLE
[Bugfix][CI] Normalize NIXL connector CUDA wheel installs

### DIFF
--- a/.buildkite/scripts/install-kv-connectors.sh
+++ b/.buildkite/scripts/install-kv-connectors.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+set -euo pipefail
+
+REQUIREMENTS_FILE="${KV_CONNECTORS_REQUIREMENTS:-/vllm-workspace/requirements/kv_connectors.txt}"
+
+uv pip install --system -r "${REQUIREMENTS_FILE}"
+
+NIXL_METADATA=$(python3 - <<'PY'
+import importlib.metadata as metadata
+
+import torch
+
+cuda_version = torch.version.cuda
+if cuda_version is None:
+    raise SystemExit("torch.version.cuda is not set")
+
+print(cuda_version.split(".", 1)[0], metadata.version("nixl"))
+PY
+)
+read -r CUDA_MAJOR NIXL_VERSION <<<"${NIXL_METADATA}"
+
+# nixl>=1.1.0 can install multiple CUDA wheel variants. Keep only the variant
+# matching this CI image so nixl_ep_cpp links against the available libcudart.
+uv pip uninstall --system nixl-cu12 nixl-cu13 2>/dev/null || true
+uv pip install --system --no-deps "nixl-cu${CUDA_MAJOR}==${NIXL_VERSION}"
+
+python3 - <<'PY'
+import importlib.metadata as metadata
+
+for package_name in ("nixl", "nixl-cu12", "nixl-cu13"):
+    try:
+        version = metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        version = "not installed"
+    print(f"{package_name}: {version}")
+PY

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -11,7 +11,7 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 - label: Distributed FlashInfer NixlConnector PD accuracy (4 GPUs)
   key: distributed-flashinfer-nixlconnector-pd-accuracy-4-gpus
@@ -22,7 +22,7 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - FLASHINFER=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: DP EP Distributed NixlConnector PD accuracy tests (4 GPUs)
@@ -34,7 +34,7 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - DP_EP=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: CrossLayer KV layout Distributed NixlConnector PD accuracy tests (4 GPUs)
@@ -46,7 +46,7 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - CROSS_LAYERS_BLOCKS=True bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: Hybrid SSM NixlConnector PD accuracy tests (4 GPUs)
@@ -58,7 +58,7 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - HYBRID_SSM=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: MultiConnector (Nixl+Offloading) PD accuracy (2 GPUs)
@@ -73,7 +73,7 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_multi_connector_accuracy_test.sh
 
 - label: NixlConnector PD + Spec Decode acceptance (2 GPUs)
@@ -87,7 +87,7 @@ steps:
     - vllm/v1/worker/kv_connector_model_runner_mixin.py
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/config_sweep_spec_decode_test.sh
 
 - label: MultiConnector (Nixl+Offloading) PD edge cases (2 GPUs)
@@ -102,5 +102,5 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/offloading/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_multi_connector_edge_case_test.sh

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -86,7 +86,7 @@ steps:
     - tests/v1/metrics
     - tests/entrypoints/openai/correctness/test_lmeval.py
   commands:
-    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     # split the test to avoid interference
     - pytest -v -s -m 'not cpu_test' v1/core


### PR DESCRIPTION
## Summary

Fixes the NIXL connector CI install path without installing connector dependencies into the shared generic test image.

The original failure from the #44083 thread happened after a job-local connector install in Buildkite. The raw command:

```bash
uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
```

resolved and installed both CUDA variants:

```text
nixl==1.2.0
nixl-cu12==1.2.0
nixl-cu13==1.2.0
```

In a CUDA 13 image, importing `nixl_ep` could then pick up the CUDA 12 extension and fail with:

```text
ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
```

This PR replaces the existing connector install commands with a small helper that installs `requirements/kv_connectors.txt`, detects the image CUDA major and installed `nixl` version, removes all `nixl-cu*` variants, and reinstalls only the matching CUDA wheel pinned to the same NIXL version, e.g. `nixl-cu13==1.2.0`.

## Scope

This intentionally keeps connector dependencies scoped to the jobs that already installed them manually:

- `.buildkite/test_areas/disaggregated.yaml`
- `V1 Core + KV + Metrics` in `.buildkite/test_areas/misc.yaml`

This is different from #44192: it does not add KV connector dependencies to the shared CI test image. That keeps unrelated jobs from seeing optional connector packages they did not previously have.

Open PR search found #44192 as the overlapping broad-image approach; this PR is the narrower job-local alternative.

## Validation

Ran pre-commit on the changed files:

```bash
pre-commit run --files \
  .buildkite/scripts/install-kv-connectors.sh \
  .buildkite/test_areas/disaggregated.yaml \
  .buildkite/test_areas/misc.yaml
```

Result:

```text
Passed
```

Validated helper behavior in the CUDA 13 CI image:

```text
public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:e442c13f36f707e8de75043506713b454448ba75
```

Result summary:

```text
torch.version.cuda: 13.0
nixl: 1.2.0
nixl-cu12: not installed
nixl-cu13: 1.2.0
nixl_ep_cpp links to libcudart.so.13
```

Ran the original #44083-style test command after the helper normalized the NIXL wheels:

```bash
KV_CONNECTORS_REQUIREMENTS=/vllm-workspace/requirements/kv_connectors.txt \
  bash /tmp/install-kv-connectors.sh
export VLLM_WORKER_MULTIPROC_METHOD=spawn
pytest -v -s -m "not cpu_test" v1/core
```

Result:

```text
21 passed, 282 deselected, 22 warnings in 149.46s (0:02:29)
```

This is the same real `v1/core` command shape that previously failed during collection with `ImportError: libcudart.so.12` after the connector install.

Note: the CI image still emits the existing duplicate CuPy warning (`cupy-cuda12x`, `cupy-cuda13x`) after connector installation. This PR leaves that as a separate follow-up unless it remains an active connector-job failure after the NIXL wheel fix.

## Notes

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.
