### PR TITLE
[Model] Initialize GDN dt_bias and A_log params as float32

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/olmo_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/olmo_gdn_linear_attn.py
@@ -134,11 +134,12 @@ class OlmoHybridGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
 
         self.dt_bias = nn.Parameter(
-            torch.ones(self.num_v_heads // self.tp_size),
+            torch.ones(self.num_v_heads // self.tp_size, dtype=torch.float32),
         )
         self.A_log = nn.Parameter(
             torch.empty(
                 divide(self.num_v_heads, self.tp_size),
+                dtype=torch.float32,
             )
         )
 

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -514,7 +514,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(
-            torch.ones(self.num_v_heads // self.tp_size),
+            torch.ones(self.num_v_heads // self.tp_size, dtype=torch.float32),
         )
         self.A_log = nn.Parameter(
             torch.empty(


### PR DESCRIPTION
  The gdn_gating computation (-exp(A_log) * softplus(a + dt_bias)) is always                                                                          
  performed in float32 internally across all backends (Triton/CUDA/ROCm/NPU)                                                                          
  due to numerical stability requirements for exp() and softplus().  Make the                                                                         
  default tensor dtypes consistent with the actual compute precision by adding                                                                        
  dtype=torch.float32 to:                                                                                                                             
                                                                                                                                                      
  - QwenGatedDeltaNetAttention.dt_bias (A_log already had it)                                                                                         
  - OlmoHybridGatedDeltaNetAttention.dt_bias and A_log (both were missing)                                                                            
                                                                                                                                                      
  Kimi already had dtype=torch.float32 on dt_bias.                                                                                                    
                                                                                                                                                      
  ## Purpose                                                                                                                                          
                                                                  
  Within the same `__init__`, `A_log` was initialized as float32 (due to exp()                                                                        
  sensitivity) but `dt_bias` was left without an explicit dtype, making it
  follow `torch.get_default_dtype()` at model load time. Since both parameters                                                                        
  are consumed by the same float32 compute path across all backends, their                                                                            
  initialization should be consistent.                                                                                                                
                                                                                                                                                      
  ## Test Plan                                                                                                                                        
                                                                                                                                                      
  Existing GDN model tests cover the affected code paths:                                                                                             
   
  - Qwen3 models (e.g. Qwen3.5-4B) exercise `QwenGatedDeltaNetAttention`                                                                              
  - OlmoHybrid models exercise `OlmoHybridGatedDeltaNetAttention` 
                                                                                                                                                      
  Run: `pytest tests/models/test_models.py -k "qwen3 or olmo_hybrid" --forked`                                                                        
                                                                                                                                                      
  ## Test Result                                                                                                                                      
                                                                  
  No behavioral change — the computation was already performed in float32 in                                                                          
  all kernel implementations. This only eliminates a redundant runtime cast
  and makes the parameter dtype consistent with the actual compute precision.  