### PR TITLE
[MRV2] Use `BufferFactory` for variable `max_concurrency`

### DIFF
--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -6,7 +6,7 @@ import torch
 
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory, StagedWriteTensor
 
 
 class BlockTables:
@@ -16,8 +16,8 @@ class BlockTables:
         max_num_reqs: int,
         max_num_batched_tokens: int,
         max_num_blocks_per_group: list[int],
-        device: torch.device,
         kernel_block_sizes: list[int],
+        buffer_factory: BufferFactory,
         cp_size: int = 1,
         cp_rank: int = 0,
         cp_interleave: int = 1,
@@ -26,7 +26,7 @@ class BlockTables:
         self.kernel_block_sizes = kernel_block_sizes
         self.max_num_reqs = max_num_reqs
         self.max_num_batched_tokens = max_num_batched_tokens
-        self.device = device
+        self.device = buffer_factory.device
 
         self.cp_size = cp_size
         self.cp_rank = cp_rank
@@ -43,12 +43,12 @@ class BlockTables:
         self.block_tables: list[StagedWriteTensor] = []
         for i in range(self.num_kv_cache_groups):
             max_num_blocks = max_num_blocks_per_group[i] * self.blocks_per_kv_block[i]
-            block_table = StagedWriteTensor(
-                (self.max_num_reqs, max_num_blocks), dtype=torch.int32, device=device
+            block_table = buffer_factory.staged_write_tensor(
+                (self.max_num_reqs, max_num_blocks), torch.int32
             )
             self.block_tables.append(block_table)
 
-        self.num_blocks = UvaBackedTensor(
+        self.num_blocks = buffer_factory.uva_backed_tensor(
             (self.num_kv_cache_groups, self.max_num_reqs),
             dtype=torch.int32,
         )

--- a/vllm/v1/worker/gpu/buffer_utils.py
+++ b/vllm/v1/worker/gpu/buffer_utils.py
@@ -190,6 +190,33 @@ class StagedWriteTensor:
         self._staged_write_cu_lens.clear()
 
 
+class BufferFactory:
+    """Creates UVA-backed buffer types with a shared device and max_concurrency."""
+
+    def __init__(self, device: torch.device, max_concurrency: int = 2):
+        self.device = device
+        self.max_concurrency = max_concurrency
+
+    def uva_backed_tensor(
+        self, size: int | Sequence[int], dtype: torch.dtype
+    ) -> UvaBackedTensor:
+        return UvaBackedTensor(size, dtype, max_concurrency=self.max_concurrency)
+
+    def staged_write_tensor(
+        self,
+        size: int | Sequence[int],
+        dtype: torch.dtype,
+        uva_instead_of_gpu: bool = False,
+    ) -> StagedWriteTensor:
+        return StagedWriteTensor(
+            size,
+            dtype,
+            device=self.device,
+            max_concurrency=self.max_concurrency,
+            uva_instead_of_gpu=uva_instead_of_gpu,
+        )
+
+
 @triton.jit
 def _apply_write_kernel(
     output_ptr,

--- a/vllm/v1/worker/gpu/mm/rope.py
+++ b/vllm/v1/worker/gpu/mm/rope.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from vllm.config import ModelConfig
 from vllm.model_executor.models.interfaces import SupportsMRoPE, SupportsXDRoPE
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 
 
 class RopeState:
@@ -35,29 +35,30 @@ class RopeState:
         max_num_reqs: int,
         max_num_tokens: int,
         max_model_len: int,
-        device: torch.device,
+        buffer_factory: BufferFactory,
     ):
         self.num_dims = num_dims
         self.has_delta = has_delta
         self.max_num_reqs = max_num_reqs
         self.max_num_tokens = max_num_tokens
         self.max_model_len = max_model_len
-        self.device = device
+        self.device = buffer_factory.device
 
         # NOTE(woosuk): This tensor can be extremely large (e.g., several GBs)
         # wasting a lot of CPU memory.
-        self.prefill_positions = StagedWriteTensor(
+        self.prefill_positions = buffer_factory.staged_write_tensor(
             (max_num_reqs * num_dims, max_model_len),
-            dtype=torch.int32,
-            device=device,
+            torch.int32,
             uva_instead_of_gpu=True,
         )
         self.positions = torch.zeros(
-            (num_dims, max_num_tokens + 1), dtype=torch.int64, device=device
+            (num_dims, max_num_tokens + 1), dtype=torch.int64, device=self.device
         )
 
         # Delta is non-zero for M-RoPE, always 0 for XD-RoPE.
-        self.prefill_delta = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
+        self.prefill_delta = buffer_factory.uva_backed_tensor(
+            max_num_reqs, dtype=torch.int32
+        )
 
     def init_prefill_positions(
         self,
@@ -120,7 +121,7 @@ def get_rope_state(
     max_num_reqs: int,
     max_num_tokens: int,
     max_model_len: int,
-    device: torch.device,
+    buffer_factory: BufferFactory,
 ) -> RopeState | None:
     """Create a RopeState if the model uses multi-dimensional RoPE."""
     if model_config.uses_mrope:
@@ -131,7 +132,7 @@ def get_rope_state(
             max_num_reqs=max_num_reqs,
             max_num_tokens=max_num_tokens,
             max_model_len=max_model_len,
-            device=device,
+            buffer_factory=buffer_factory,
         )
     if model_config.uses_xdrope_dim > 0:
         assert isinstance(model, SupportsXDRoPE)
@@ -141,7 +142,7 @@ def get_rope_state(
             max_num_reqs=max_num_reqs,
             max_num_tokens=max_num_tokens,
             max_model_len=max_model_len,
-            device=device,
+            buffer_factory=buffer_factory,
         )
     return None
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -60,7 +60,7 @@ from vllm.v1.worker.gpu.attn_utils import (
     init_kv_cache,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory, async_copy_to_gpu
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
@@ -156,6 +156,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.dcp_rank = get_dcp_group().rank_in_group if self.use_dcp else 0
         self.cp_interleave = self.parallel_config.cp_kv_cache_interleave_size
 
+        # Buffer parallelism.
+        max_concurrency = self.parallel_config.pipeline_parallel_size + 1
+        self.buffer_factory = BufferFactory(self.device, max_concurrency)
+
         # Multimodal
         self.mm_registry = MULTIMODAL_REGISTRY
         self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
@@ -196,7 +200,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_batched_tokens=self.max_num_tokens,
             num_speculative_steps=self.num_speculative_steps,
             vocab_size=self.vocab_size,
-            device=self.device,
+            buffer_factory=self.buffer_factory,
         )
         self.input_buffers = InputBuffers(
             max_num_reqs=self.max_num_reqs,
@@ -215,7 +219,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.sampler = Sampler(
                 max_num_reqs=self.max_num_reqs,
                 vocab_size=self.vocab_size,
-                device=self.device,
                 req_states=self.req_states,
                 logprobs_mode=self.model_config.logprobs_mode,
                 num_speculative_tokens=self.num_speculative_steps + 1,
@@ -305,7 +308,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Initialize the components that require the model.
         self.model_state = init_model_state(
-            self.vllm_config, self.model, self.encoder_cache, self.device
+            self.vllm_config, self.model, self.encoder_cache, self.buffer_factory
         )
         if self.is_pooling_model and self.is_last_pp_rank:
             self.pooling_runner = PoolingRunner(self.model)
@@ -401,11 +404,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_reqs=self.max_num_reqs,
             max_num_batched_tokens=self.max_num_tokens,
             max_num_blocks_per_group=max_num_blocks_per_group,
-            device=self.device,
             kernel_block_sizes=kernel_block_sizes,
             cp_size=self.dcp_size,
             cp_rank=self.dcp_rank,
             cp_interleave=self.cp_interleave,
+            buffer_factory=self.buffer_factory,
         )
         initialize_mamba_ssu_backend(
             self.vllm_config.mamba_config, self.kv_cache_config

--- a/vllm/v1/worker/gpu/model_states/__init__.py
+++ b/vllm/v1/worker/gpu/model_states/__init__.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 
 
@@ -11,18 +11,19 @@ def init_model_state(
     vllm_config: VllmConfig,
     model: nn.Module,
     encoder_cache: EncoderCache | None,
-    device: torch.device,
+    buffer_factory: BufferFactory,
 ):
+    model_state_args = (vllm_config, model, encoder_cache, buffer_factory)
     if "WhisperForConditionalGeneration" in vllm_config.model_config.architectures:
         from vllm.v1.worker.gpu.model_states.whisper import WhisperModelState
 
-        return WhisperModelState(vllm_config, model, encoder_cache, device)
+        return WhisperModelState(*model_state_args)
 
     if vllm_config.model_config.is_hybrid:
         from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
-        return MambaHybridModelState(vllm_config, model, encoder_cache, device)
+        return MambaHybridModelState(*model_state_args)
 
     from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 
-    return DefaultModelState(vllm_config, model, encoder_cache, device)
+    return DefaultModelState(*model_state_args)

--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -11,6 +11,7 @@ from vllm.tasks import GenerationTask
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
@@ -26,13 +27,13 @@ class DefaultModelState(ModelState):
         vllm_config: VllmConfig,
         model: nn.Module,
         encoder_cache: EncoderCache | None,
-        device: torch.device,
+        buffer_factory: BufferFactory,
     ):
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
         self.scheduler_config = vllm_config.scheduler_config
         self.model = model
-        self.device = device
+        self.device = buffer_factory.device
 
         self.supports_mm_inputs = encoder_cache is not None
         self.max_model_len = self.model_config.max_model_len
@@ -59,7 +60,7 @@ class DefaultModelState(ModelState):
             max_num_reqs=self.max_num_reqs,
             max_num_tokens=self.max_num_tokens,
             max_model_len=self.max_model_len,
-            device=self.device,
+            buffer_factory=buffer_factory,
         )
 
     def get_supported_generation_tasks(self) -> tuple[GenerationTask, ...]:

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -11,6 +11,7 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.tasks import GenerationTask
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.states import RequestState
@@ -42,7 +43,7 @@ class ModelState(ABC):
         vllm_config: VllmConfig,
         model: nn.Module,
         encoder_cache: EncoderCache | None,
-        device: torch.device,
+        buffer_factory: BufferFactory,
     ) -> None:
         raise NotImplementedError
 

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -13,6 +13,7 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
@@ -61,9 +62,9 @@ class MambaHybridModelState(DefaultModelState):
         vllm_config: VllmConfig,
         model: nn.Module,
         encoder_cache: EncoderCache | None,
-        device: torch.device,
+        buffer_factory: BufferFactory,
     ) -> None:
-        super().__init__(vllm_config, model, encoder_cache, device)
+        super().__init__(vllm_config, model, encoder_cache, buffer_factory)
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )

--- a/vllm/v1/worker/gpu/model_states/whisper.py
+++ b/vllm/v1/worker/gpu/model_states/whisper.py
@@ -11,6 +11,7 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
@@ -47,7 +48,7 @@ class WhisperModelState(ModelState):
         vllm_config: VllmConfig,
         model: nn.Module,
         encoder_cache: EncoderCache | None,
-        device: torch.device,
+        buffer_factory: BufferFactory,
     ) -> None:
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -56,7 +57,7 @@ class WhisperModelState(ModelState):
         self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
         self.max_model_len = self.model_config.max_model_len
-        self.device = device
+        self.device = buffer_factory.device
 
         assert encoder_cache is not None
         self.encoder_cache = encoder_cache

--- a/vllm/v1/worker/gpu/sample/bad_words.py
+++ b/vllm/v1/worker/gpu/sample/bad_words.py
@@ -5,7 +5,6 @@ import torch
 
 from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
 from vllm.v1.worker.gpu.states import RequestState
 
 MAX_BAD_WORDS_TOTAL_TOKENS = 1024  # Max total tokens for all bad words per request
@@ -18,20 +17,20 @@ class BadWordsState:
         self.max_num_reqs = req_states.max_num_reqs
         self.device = req_states.device
 
+        buffer_factory = req_states.buffer_factory
+
         # flattened bad word tokens: [max_num_reqs, MAX_BAD_WORDS_TOTAL_TOKENS]
-        self.bad_word_token_ids = StagedWriteTensor(
-            (self.max_num_reqs, MAX_BAD_WORDS_TOTAL_TOKENS),
-            dtype=torch.int32,
-            device=self.device,
+        self.bad_word_token_ids = buffer_factory.staged_write_tensor(
+            (self.max_num_reqs, MAX_BAD_WORDS_TOTAL_TOKENS), torch.int32
         )
         # cumulative offsets of bad words: [max_num_reqs, MAX_NUM_BAD_WORDS + 1]
-        self.bad_word_offsets = StagedWriteTensor(
-            (self.max_num_reqs, MAX_NUM_BAD_WORDS + 1),
-            dtype=torch.int32,
-            device=self.device,
+        self.bad_word_offsets = buffer_factory.staged_write_tensor(
+            (self.max_num_reqs, MAX_NUM_BAD_WORDS + 1), torch.int32
         )
         # number of bad words per request
-        self.num_bad_words = UvaBackedTensor(self.max_num_reqs, dtype=torch.int32)
+        self.num_bad_words = buffer_factory.uva_backed_tensor(
+            self.max_num_reqs, dtype=torch.int32
+        )
 
     def add_request(self, req_idx: int, sampling_params: SamplingParams) -> None:
         bad_words_token_ids = sampling_params.bad_words_token_ids

--- a/vllm/v1/worker/gpu/sample/logit_bias.py
+++ b/vllm/v1/worker/gpu/sample/logit_bias.py
@@ -5,7 +5,7 @@ import torch
 
 from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 
 MAX_NUM_ALLOWED_TOKEN_IDS = 1024
 MAX_NUM_LOGIT_BIAS_TOKENS = 1024
@@ -13,37 +13,35 @@ MAX_NUM_STOP_TOKEN_IDS = 128
 
 
 class LogitBiasState:
-    def __init__(self, max_num_reqs: int, device: torch.device):
+    def __init__(self, max_num_reqs: int, buffer_factory: BufferFactory):
         self.max_num_reqs = max_num_reqs
 
         # Allowed token IDs.
-        self.num_allowed_token_ids = UvaBackedTensor(
+        self.num_allowed_token_ids = buffer_factory.uva_backed_tensor(
             self.max_num_reqs, dtype=torch.int32
         )
-        self.allowed_token_ids = StagedWriteTensor(
-            (self.max_num_reqs, MAX_NUM_ALLOWED_TOKEN_IDS),
-            dtype=torch.int32,
-            device=device,
+        self.allowed_token_ids = buffer_factory.staged_write_tensor(
+            (self.max_num_reqs, MAX_NUM_ALLOWED_TOKEN_IDS), torch.int32
         )
         # Logit bias.
-        self.num_logit_bias = UvaBackedTensor(self.max_num_reqs, dtype=torch.int32)
-        self.logit_bias_token_ids = StagedWriteTensor(
-            (self.max_num_reqs, MAX_NUM_LOGIT_BIAS_TOKENS),
-            dtype=torch.int32,
-            device=device,
+        self.num_logit_bias = buffer_factory.uva_backed_tensor(
+            self.max_num_reqs, dtype=torch.int32
         )
-        self.logit_bias = StagedWriteTensor(
-            (self.max_num_reqs, MAX_NUM_LOGIT_BIAS_TOKENS),
-            dtype=torch.float32,
-            device=device,
+        self.logit_bias_token_ids = buffer_factory.staged_write_tensor(
+            (self.max_num_reqs, MAX_NUM_LOGIT_BIAS_TOKENS), torch.int32
+        )
+        self.logit_bias = buffer_factory.staged_write_tensor(
+            (self.max_num_reqs, MAX_NUM_LOGIT_BIAS_TOKENS), torch.float32
         )
         # Min tokens.
-        self.min_lens = UvaBackedTensor(self.max_num_reqs, dtype=torch.int32)
-        self.num_stop_token_ids = UvaBackedTensor(self.max_num_reqs, dtype=torch.int32)
-        self.stop_token_ids = StagedWriteTensor(
-            (self.max_num_reqs, MAX_NUM_STOP_TOKEN_IDS),
-            dtype=torch.int32,
-            device=device,
+        self.min_lens = buffer_factory.uva_backed_tensor(
+            self.max_num_reqs, dtype=torch.int32
+        )
+        self.num_stop_token_ids = buffer_factory.uva_backed_tensor(
+            self.max_num_reqs, dtype=torch.int32
+        )
+        self.stop_token_ids = buffer_factory.staged_write_tensor(
+            (self.max_num_reqs, MAX_NUM_STOP_TOKEN_IDS), torch.int32
         )
 
         # Using any of the above.

--- a/vllm/v1/worker/gpu/sample/logprob.py
+++ b/vllm/v1/worker/gpu/sample/logprob.py
@@ -7,7 +7,7 @@ import torch
 from vllm.sampling_params import MAX_LOGPROB_TOKEN_IDS, SamplingParams
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 
 
 @triton.jit
@@ -222,13 +222,13 @@ class LogprobTokenIdsState:
     See `SamplingParams.logprob_token_ids`.
     """
 
-    def __init__(self, max_num_reqs: int, device: torch.device):
+    def __init__(self, max_num_reqs: int, buffer_factory: BufferFactory):
         self.max_num_reqs = max_num_reqs
-        self.num_token_ids = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
-        self.token_ids = StagedWriteTensor(
-            (max_num_reqs, MAX_LOGPROB_TOKEN_IDS),
-            dtype=torch.int32,
-            device=device,
+        self.num_token_ids = buffer_factory.uva_backed_tensor(
+            max_num_reqs, dtype=torch.int32
+        )
+        self.token_ids = buffer_factory.staged_write_tensor(
+            (max_num_reqs, MAX_LOGPROB_TOKEN_IDS), torch.int32
         )
 
     def add_request(self, req_idx: int, sampling_params: SamplingParams) -> None:

--- a/vllm/v1/worker/gpu/sample/penalties.py
+++ b/vllm/v1/worker/gpu/sample/penalties.py
@@ -7,7 +7,6 @@ from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import async_tensor_h2d
-from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor
 from vllm.v1.worker.gpu.states import RequestState
 
 
@@ -19,9 +18,10 @@ class PenaltiesState:
         self.vocab_size = req_states.vocab_size
         self.device = req_states.device
 
-        self.repetition_penalty = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
-        self.frequency_penalty = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
-        self.presence_penalty = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
+        uva_tensor = req_states.buffer_factory.uva_backed_tensor
+        self.repetition_penalty = uva_tensor(max_num_reqs, dtype=torch.float32)
+        self.frequency_penalty = uva_tensor(max_num_reqs, dtype=torch.float32)
+        self.presence_penalty = uva_tensor(max_num_reqs, dtype=torch.float32)
         self.use_penalty = np.zeros(max_num_reqs, dtype=bool)
 
         # Initialize repetition penalty manually because 0 is an invalid value for it.

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -27,7 +27,6 @@ class Sampler:
         self,
         max_num_reqs: int,
         vocab_size: int,
-        device: torch.device,
         req_states: RequestState,
         logprobs_mode: LogprobsMode = "raw_logprobs",
         num_speculative_tokens: int = 1,
@@ -39,11 +38,14 @@ class Sampler:
         self.compute_nans = envs.VLLM_COMPUTE_NANS_IN_LOGITS  # False by default.
         self.use_fp64_gumbel = use_fp64_gumbel
 
-        self.sampling_states = SamplingStates(max_num_reqs, vocab_size)
+        buffer_factory = req_states.buffer_factory
+        self.sampling_states = SamplingStates(max_num_reqs, vocab_size, buffer_factory)
         self.penalties_state = PenaltiesState(req_states)
-        self.logit_bias_state = LogitBiasState(max_num_reqs, device)
+        self.logit_bias_state = LogitBiasState(max_num_reqs, buffer_factory)
         self.bad_words_state = BadWordsState(req_states)
-        self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
+        self.logprob_token_ids_state = LogprobTokenIdsState(
+            max_num_reqs, buffer_factory
+        )
         self.num_speculative_tokens = num_speculative_tokens
 
     def add_request(

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -5,7 +5,7 @@ import torch
 
 from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
-from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 from vllm.v1.worker.gpu.sample.gumbel import apply_temperature
 from vllm.v1.worker.gpu.sample.min_p import apply_min_p
 
@@ -15,15 +15,18 @@ _NP_INT64_MAX = np.iinfo(np.int64).max
 
 
 class SamplingStates:
-    def __init__(self, max_num_reqs: int, vocab_size: int):
+    def __init__(
+        self, max_num_reqs: int, vocab_size: int, buffer_factory: BufferFactory
+    ):
         self.max_num_reqs = max_num_reqs
         self.vocab_size = vocab_size
 
-        self.temperature = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
-        self.top_k = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
-        self.top_p = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
-        self.min_p = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
-        self.seeds = UvaBackedTensor(max_num_reqs, dtype=torch.int64)
+        uva_tensor = buffer_factory.uva_backed_tensor
+        self.temperature = uva_tensor(max_num_reqs, dtype=torch.float32)
+        self.top_k = uva_tensor(max_num_reqs, dtype=torch.int32)
+        self.top_p = uva_tensor(max_num_reqs, dtype=torch.float32)
+        self.min_p = uva_tensor(max_num_reqs, dtype=torch.float32)
+        self.seeds = uva_tensor(max_num_reqs, dtype=torch.int64)
 
         # Initialize top_k and top_p manually because 0 is an invalid value for them.
         self.top_k.np.fill(self.vocab_size)

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -3,7 +3,7 @@
 import numpy as np
 import torch
 
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import BufferFactory
 
 
 class RequestState:
@@ -14,14 +14,17 @@ class RequestState:
         max_num_batched_tokens: int,
         num_speculative_steps: int,
         vocab_size: int,
-        device: torch.device,
+        buffer_factory: BufferFactory,
     ):
         self.max_num_reqs = max_num_reqs
         self.max_model_len = max_model_len
         self.max_num_batched_tokens = max_num_batched_tokens
         self.num_speculative_steps = num_speculative_steps
         self.vocab_size = vocab_size
-        self.device = device
+        self.device = buffer_factory.device
+
+        # For creating persistent UVA buffers.
+        self.buffer_factory = buffer_factory
 
         self.req_id_to_index: dict[str, int] = {}
         self.index_to_req_id: dict[int, str] = {}
@@ -30,10 +33,9 @@ class RequestState:
         # NOTE(woosuk): This tensor can be extremely large (e.g., several GBs)
         # depending on the configured max_num_reqs and max_model_len.
         # To save GPU memory, we use UVA instead of GPU for this tensor.
-        self.all_token_ids = StagedWriteTensor(
+        self.all_token_ids = buffer_factory.staged_write_tensor(
             (self.max_num_reqs, self.max_model_len),
-            dtype=torch.int32,
-            device=device,
+            torch.int32,
             uva_instead_of_gpu=True,
         )
         # NOTE(woosuk): Distinguish clearly between prompt_len and prefill_len:
@@ -45,24 +47,28 @@ class RequestState:
         # preemption, prefill_len may be greater. Differentiating between these values
         # is crucial, as certain features such as prompt logprobs or frequency penalties
         # must treat prompt and output tokens separately.
-        self.prompt_len = UvaBackedTensor(self.max_num_reqs, dtype=torch.int32)
-        self.prefill_len = UvaBackedTensor(self.max_num_reqs, dtype=torch.int32)
+        self.prompt_len = buffer_factory.uva_backed_tensor(
+            self.max_num_reqs, dtype=torch.int32
+        )
+        self.prefill_len = buffer_factory.uva_backed_tensor(
+            self.max_num_reqs, dtype=torch.int32
+        )
         # total_len = prompt_len + output_len. It grows as the request progresses.
-        self.total_len = StagedWriteTensor(
-            self.max_num_reqs, dtype=torch.int32, device=device
+        self.total_len = buffer_factory.staged_write_tensor(
+            self.max_num_reqs, torch.int32
         )
 
         # Number of computed tokens.
         self.num_computed_prefill_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
-        self.num_computed_tokens = StagedWriteTensor(
-            self.max_num_reqs, dtype=torch.int32, device=device
+        self.num_computed_tokens = buffer_factory.staged_write_tensor(
+            self.max_num_reqs, torch.int32
         )
         # Optimistic CPU mirror of num_computed_tokens (upper bound on GPU value).
         self.num_computed_tokens_np = np.zeros(self.max_num_reqs, dtype=np.int32)
 
         # Last sampled tokens.
         self.last_sampled_tokens = torch.zeros(
-            self.max_num_reqs, 1, dtype=torch.int64, device=device
+            self.max_num_reqs, 1, dtype=torch.int64, device=self.device
         )
 
         # Draft tokens.
@@ -70,11 +76,11 @@ class RequestState:
             self.max_num_reqs,
             self.num_speculative_steps,
             dtype=torch.int64,
-            device=device,
+            device=self.device,
         )
 
         self.next_prefill_tokens = torch.zeros(
-            self.max_num_reqs, dtype=torch.int32, device=device
+            self.max_num_reqs, dtype=torch.int32, device=self.device
         )
 
     @property


### PR DESCRIPTION
Needed for PP

@WoosukKwon the changes across the files actually don't turn out to be too bad. We could alternatively use a global variable which is a bit nasty but would be virtually no code change.

Or we could look into removing the circular buffers altogether and allocating cpu tensors each time.

WDYT?