### PR TITLE
[Bugfix] Fail fast or extend RoPE cache when VLLM_ALLOW_LONG_MAX_MODEL_LEN exceeds model positions

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,8 @@ from vllm.config import (
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
+from vllm.config.model import _get_and_verify_max_len
+from vllm.config.model_arch import ModelArchitectureConfig
 from vllm.config.utils import get_field
 from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
@@ -638,6 +640,151 @@ def test_get_and_verify_max_len(
     else:
         actual_max_len = model_config.get_and_verify_max_len(max_model_len)
         assert actual_max_len == expected_max_len
+
+
+def _make_model_arch_config(
+    derived_max_model_len: int,
+    max_len_key: str = "max_position_embeddings",
+    architectures: list[str] | None = None,
+    model_type: str = "llama",
+) -> ModelArchitectureConfig:
+    return ModelArchitectureConfig(
+        architectures=architectures or ["LlamaForCausalLM"],
+        model_type=model_type,
+        text_model_type=None,
+        hidden_size=1,
+        total_num_hidden_layers=1,
+        total_num_attention_heads=1,
+        head_size=1,
+        vocab_size=1,
+        total_num_kv_heads=1,
+        num_experts=0,
+        quantization_config=None,
+        is_deepseek_mla=False,
+        is_mm_prefix_lm=False,
+        derived_max_model_len_and_key=(float(derived_max_model_len), max_len_key),
+    )
+
+
+def test_allow_long_max_model_len_extends_rope_config(monkeypatch):
+    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+    hf_config = SimpleNamespace(
+        model_type="llama",
+        max_position_embeddings=16,
+        rope_parameters={"rope_type": "default"},
+    )
+
+    actual_max_len = _get_and_verify_max_len(
+        hf_config=hf_config,
+        model_arch_config=_make_model_arch_config(16),
+        tokenizer_config=None,
+        max_model_len=32,
+        disable_sliding_window=False,
+        sliding_window=None,
+    )
+
+    assert actual_max_len == 32
+    assert hf_config.max_position_embeddings == 32
+
+
+def test_allow_long_max_model_len_extends_rotary_dim_config(monkeypatch):
+    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+    hf_config = SimpleNamespace(
+        model_type="gptj",
+        max_position_embeddings=16,
+        rotary_dim=8,
+    )
+
+    actual_max_len = _get_and_verify_max_len(
+        hf_config=hf_config,
+        model_arch_config=_make_model_arch_config(
+            16,
+            architectures=["GPTJForCausalLM"],
+            model_type="gptj",
+        ),
+        tokenizer_config=None,
+        max_model_len=32,
+        disable_sliding_window=False,
+        sliding_window=None,
+    )
+
+    assert actual_max_len == 32
+    assert hf_config.max_position_embeddings == 32
+
+
+def test_allow_long_max_model_len_rejects_absolute_positions(monkeypatch):
+    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+    hf_config = SimpleNamespace(
+        model_type="bert",
+        max_position_embeddings=16,
+        position_embedding_type="absolute",
+    )
+
+    with pytest.raises(ValueError, match="absolute position embeddings"):
+        _get_and_verify_max_len(
+            hf_config=hf_config,
+            model_arch_config=_make_model_arch_config(16),
+            tokenizer_config=None,
+            max_model_len=32,
+            disable_sliding_window=False,
+            sliding_window=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architectures"),
+    [
+        ("custom", ["CustomForCausalLM"]),
+        ("gpt2", ["GPT2LMHeadModel"]),
+        ("gpt_bigcode", ["GPTBigCodeForCausalLM"]),
+        ("opt", ["OPTForCausalLM"]),
+    ],
+)
+def test_allow_long_max_model_len_rejects_non_rope_configs(
+    monkeypatch,
+    model_type,
+    architectures,
+):
+    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+    hf_config = SimpleNamespace(
+        model_type=model_type,
+        max_position_embeddings=16,
+    )
+
+    with pytest.raises(ValueError, match="unscaled RoPE"):
+        _get_and_verify_max_len(
+            hf_config=hf_config,
+            model_arch_config=_make_model_arch_config(
+                16,
+                architectures=architectures,
+                model_type=model_type,
+            ),
+            tokenizer_config=None,
+            max_model_len=32,
+            disable_sliding_window=False,
+            sliding_window=None,
+        )
+
+
+def test_allow_long_max_model_len_rejects_scaled_rope_config(monkeypatch):
+    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
+    hf_config = SimpleNamespace(
+        model_type="llama",
+        max_position_embeddings=16,
+        rope_parameters={"rope_type": "dynamic", "factor": 2.0},
+    )
+
+    with pytest.raises(ValueError, match="unscaled RoPE"):
+        _get_and_verify_max_len(
+            hf_config=hf_config,
+            model_arch_config=_make_model_arch_config(16),
+            tokenizer_config=None,
+            max_model_len=64,
+            disable_sliding_window=False,
+            sliding_window=None,
+        )
+
+    assert hf_config.max_position_embeddings == 16
 
 
 class MockConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -642,15 +642,10 @@ def test_get_and_verify_max_len(
         assert actual_max_len == expected_max_len
 
 
-def _make_model_arch_config(
-    derived_max_model_len: int,
-    max_len_key: str = "max_position_embeddings",
-    architectures: list[str] | None = None,
-    model_type: str = "llama",
-) -> ModelArchitectureConfig:
+def _make_model_arch_config(derived_max_model_len: int) -> ModelArchitectureConfig:
     return ModelArchitectureConfig(
-        architectures=architectures or ["LlamaForCausalLM"],
-        model_type=model_type,
+        architectures=["LlamaForCausalLM"],
+        model_type="llama",
         text_model_type=None,
         hidden_size=1,
         total_num_hidden_layers=1,
@@ -662,129 +657,56 @@ def _make_model_arch_config(
         quantization_config=None,
         is_deepseek_mla=False,
         is_mm_prefix_lm=False,
-        derived_max_model_len_and_key=(float(derived_max_model_len), max_len_key),
-    )
-
-
-def test_allow_long_max_model_len_extends_rope_config(monkeypatch):
-    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
-    hf_config = SimpleNamespace(
-        model_type="llama",
-        max_position_embeddings=16,
-        rope_parameters={"rope_type": "default"},
-    )
-
-    actual_max_len = _get_and_verify_max_len(
-        hf_config=hf_config,
-        model_arch_config=_make_model_arch_config(16),
-        tokenizer_config=None,
-        max_model_len=32,
-        disable_sliding_window=False,
-        sliding_window=None,
-    )
-
-    assert actual_max_len == 32
-    assert hf_config.max_position_embeddings == 32
-
-
-def test_allow_long_max_model_len_extends_rotary_dim_config(monkeypatch):
-    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
-    hf_config = SimpleNamespace(
-        model_type="gptj",
-        max_position_embeddings=16,
-        rotary_dim=8,
-    )
-
-    actual_max_len = _get_and_verify_max_len(
-        hf_config=hf_config,
-        model_arch_config=_make_model_arch_config(
-            16,
-            architectures=["GPTJForCausalLM"],
-            model_type="gptj",
+        derived_max_model_len_and_key=(
+            float(derived_max_model_len),
+            "max_position_embeddings",
         ),
-        tokenizer_config=None,
-        max_model_len=32,
-        disable_sliding_window=False,
-        sliding_window=None,
     )
-
-    assert actual_max_len == 32
-    assert hf_config.max_position_embeddings == 32
-
-
-def test_allow_long_max_model_len_rejects_absolute_positions(monkeypatch):
-    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
-    hf_config = SimpleNamespace(
-        model_type="bert",
-        max_position_embeddings=16,
-        position_embedding_type="absolute",
-    )
-
-    with pytest.raises(ValueError, match="absolute position embeddings"):
-        _get_and_verify_max_len(
-            hf_config=hf_config,
-            model_arch_config=_make_model_arch_config(16),
-            tokenizer_config=None,
-            max_model_len=32,
-            disable_sliding_window=False,
-            sliding_window=None,
-        )
 
 
 @pytest.mark.parametrize(
-    ("model_type", "architectures"),
+    ("hf_config_kwargs", "max_model_len", "error_match"),
     [
-        ("custom", ["CustomForCausalLM"]),
-        ("gpt2", ["GPT2LMHeadModel"]),
-        ("gpt_bigcode", ["GPTBigCodeForCausalLM"]),
-        ("opt", ["OPTForCausalLM"]),
+        # Unscaled RoPE (plain and partial rotary): size the cache to max_model_len.
+        ({"rope_parameters": {"rope_type": "default"}}, 32, None),
+        ({"rotary_dim": 8}, 32, None),
+        # Learned absolute position table cannot be grown by an env var.
+        ({"position_embedding_type": "absolute"}, 32, "absolute position embeddings"),
+        # Scaled RoPE and non-RoPE: refuse instead of silently faulting.
+        (
+            {"rope_parameters": {"rope_type": "dynamic", "factor": 2.0}},
+            64,
+            "unscaled RoPE",
+        ),
+        ({}, 32, "unscaled RoPE"),
     ],
 )
-def test_allow_long_max_model_len_rejects_non_rope_configs(
-    monkeypatch,
-    model_type,
-    architectures,
+def test_allow_long_max_model_len_classification(
+    monkeypatch, hf_config_kwargs, max_model_len, error_match
 ):
     monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
     hf_config = SimpleNamespace(
-        model_type=model_type,
-        max_position_embeddings=16,
+        model_type="llama", max_position_embeddings=16, **hf_config_kwargs
     )
 
-    with pytest.raises(ValueError, match="unscaled RoPE"):
-        _get_and_verify_max_len(
-            hf_config=hf_config,
-            model_arch_config=_make_model_arch_config(
-                16,
-                architectures=architectures,
-                model_type=model_type,
-            ),
-            tokenizer_config=None,
-            max_model_len=32,
-            disable_sliding_window=False,
-            sliding_window=None,
-        )
-
-
-def test_allow_long_max_model_len_rejects_scaled_rope_config(monkeypatch):
-    monkeypatch.setenv("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
-    hf_config = SimpleNamespace(
-        model_type="llama",
-        max_position_embeddings=16,
-        rope_parameters={"rope_type": "dynamic", "factor": 2.0},
-    )
-
-    with pytest.raises(ValueError, match="unscaled RoPE"):
-        _get_and_verify_max_len(
+    def run():
+        return _get_and_verify_max_len(
             hf_config=hf_config,
             model_arch_config=_make_model_arch_config(16),
             tokenizer_config=None,
-            max_model_len=64,
+            max_model_len=max_model_len,
             disable_sliding_window=False,
             sliding_window=None,
         )
 
-    assert hf_config.max_position_embeddings == 16
+    if error_match is None:
+        assert run() == max_model_len
+        assert hf_config.max_position_embeddings == max_model_len
+    else:
+        with pytest.raises(ValueError, match=error_match):
+            run()
+        # A rejected config is left untouched.
+        assert hf_config.max_position_embeddings == 16
 
 
 class MockConfig:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2115,6 +2115,85 @@ def _get_head_dtype(
         raise ValueError(f"Unknown dtype: {head_dtype}")
 
 
+_LONG_MAX_MODEL_LEN_DEFAULT_ROPE_ATTRS = (
+    "rope_theta",
+    "rotary_emb_base",
+    "rotary_dim",
+    "rotary_pct",
+    "rotary_emb_fraction",
+    "partial_rotary_factor",
+)
+
+
+def _uses_unscaled_rope_position_embeddings(
+    hf_config: PretrainedConfig, rope_parameters: dict[str, dict[str, Any]] | None
+) -> bool:
+    position_embedding_type = getattr(hf_config, "position_embedding_type", None)
+    if position_embedding_type in ("rope", "rotary"):
+        return _is_unscaled_rope_parameters(hf_config, rope_parameters)
+
+    if getattr(hf_config, "rotary", True) is False:
+        return False
+
+    if rope_parameters is not None:
+        return _is_unscaled_rope_parameters(hf_config, rope_parameters)
+
+    if getattr(hf_config, "rope_scaling", None) is not None:
+        return False
+
+    return any(
+        getattr(hf_config, attr, None) is not None
+        for attr in _LONG_MAX_MODEL_LEN_DEFAULT_ROPE_ATTRS
+    )
+
+
+def _is_unscaled_rope_parameters(
+    hf_config: PretrainedConfig,
+    rope_parameters: dict[str, dict[str, Any]] | None,
+) -> bool:
+    if rope_parameters is None:
+        return getattr(hf_config, "rope_scaling", None) is None
+
+    complex_rope_keys = (
+        "factor",
+        "mrope_section",
+        "original_max_position_embeddings",
+        "use_fope",
+    )
+    for rp in rope_parameters.values():
+        if rp.get("rope_type") != "default":
+            return False
+        if any(key in rp for key in complex_rope_keys):
+            return False
+    return True
+
+
+def _maybe_update_config_for_long_max_model_len(
+    hf_config: PretrainedConfig,
+    max_model_len: int,
+    rope_parameters: dict[str, dict[str, Any]] | None,
+) -> None:
+    if getattr(hf_config, "position_embedding_type", None) == "absolute":
+        raise ValueError(
+            "VLLM_ALLOW_LONG_MAX_MODEL_LEN cannot extend models with learned "
+            "absolute position embeddings. Use a model/config with a larger "
+            "trained context length or configure an explicit long-context "
+            "method instead."
+        )
+
+    if not _uses_unscaled_rope_position_embeddings(hf_config, rope_parameters):
+        raise ValueError(
+            "VLLM_ALLOW_LONG_MAX_MODEL_LEN can only extend unscaled RoPE "
+            "models. Use a model/config with a larger context length, or "
+            "configure an explicit long-context method such as RoPE scaling "
+            "or hf_overrides."
+        )
+
+    max_position_embeddings = getattr(hf_config, "max_position_embeddings", None)
+    if max_position_embeddings is None or max_position_embeddings < max_model_len:
+        hf_config.max_position_embeddings = max_model_len
+
+
 def _get_and_verify_max_len(
     hf_config: PretrainedConfig,
     model_arch_config: ModelArchitectureConfig,
@@ -2246,6 +2325,11 @@ def _get_and_verify_max_len(
                 "error."
             )
             if envs.VLLM_ALLOW_LONG_MAX_MODEL_LEN:
+                _maybe_update_config_for_long_max_model_len(
+                    hf_config,
+                    max_model_len,
+                    rope_parameters,
+                )
                 logger.warning_once("%s %s", msg, warning)
             else:
                 raise ValueError(


### PR DESCRIPTION

## Purpose

Fixes #17924.

When `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` is set, vLLM lets the user pick a `--max-model-len` larger than the length derived from the model config, but it only skips the config-time `ValueError` — `ModelConfig.max_model_len` grows while the model's position handling is still built from the original HF config. The V1 scheduler, KV cache and prompt validation then admit longer sequences than the model's position tables can index, so a long prompt/decode can index past the rotary cache and trigger a CUDA device-side assert (illegal memory access) on the torch.compile path; the original issue also reported garbage output when running eagerly.

This is the behavior the maintainer flagged on #20904: even with this env set, an illegal memory access should not happen. #20904 only updated the warning/error text; it did not change runtime behavior.

The fix routes the env-override branch through a single helper that classifies the model's position embedding:

- Learned absolute position embeddings (`position_embedding_type == "absolute"`): raise a clear `ValueError`. The learned position table cannot be extended by an env var, so starting such a run is guaranteed to fault or produce out-of-range reads.
- Unscaled RoPE (plain rotary, `rope_type == "default"`, no scaling): extend `hf_config.max_position_embeddings` up to the requested `max_model_len` so the rotary cache is sized for the positions the scheduler will actually produce. The existing extreme-caution warning still fires; correctness beyond the trained context remains the user's responsibility.
- Anything else — scaled RoPE (YaRN/dynamic/longrope/mRoPE), or a config we cannot positively classify as unscaled RoPE: raise a clear `ValueError` instead of silently proceeding, pointing the user to RoPE scaling / `hf_overrides` / a model with a larger trained context.

Default behavior (`VLLM_ALLOW_LONG_MAX_MODEL_LEN` unset) is unchanged: the original `ValueError` is still raised.

### Behavior change to note for reviewers

Previously this env var was permissive — it warned and proceeded for every model. It now hard-fails at startup for learned-absolute and scaled-RoPE models (and for configs not positively identified as unscaled RoPE) rather than letting them reach an illegal memory access or possibly produce invalid output. This is a deliberate tightening of the escape hatch's contract; the only path that still proceeds is the one where vLLM can keep its internal length invariants self-consistent (unscaled RoPE, by sizing the cache).

### Not a duplicate

- #20904 (merged) only changed the warning/error wording; no runtime fix.
- #17747 / #17777 / #17937 are Mistral `params.json` vs HF `config.json` length-derivation specifics, not the general env-override mismatch.
- #18755 / #31662 are Nomic/`nomic_bert`-specific max-length paths, not general generation.
- #37443 makes the speculative draft inherit the target's `hf_overrides`; it does not touch the target-model position-table mismatch that crashes here even without speculative decoding.

## Test Plan

1. E2E reproduction on current `main`: load a Llama-architecture model whose config has a small `max_position_embeddings`, set `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`, request a `max_model_len` larger than `max_position_embeddings`, and generate from a prompt longer than `max_position_embeddings` on the V1 torch.compile path. Expect the device-side assert.
2. Same reproduction after the fix: expect the run to complete (the rotary cache is sized to `max_model_len`).
3. Unit tests in `tests/test_config.py` covering the new classification: unscaled RoPE extends, partial-rotary (`rotary_dim`) extends, learned absolute rejects, scaled RoPE rejects (and leaves the config untouched), and an unclassifiable config rejects.

Repro used (minimal, deterministic — a randomly-initialized Llama config with `max_position_embeddings=16`):

```bash
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_USE_FLASHINFER_SAMPLER=0 python - <<'PY'
from vllm import LLM, SamplingParams, TokensPrompt
model = "<llama-arch model with max_position_embeddings=16>"
llm = LLM(model=model, max_model_len=32, max_num_seqs=1, gpu_memory_utilization=0.05)
mc = llm.llm_engine.model_config
print("CONFIG", mc.max_model_len, mc.hf_config.max_position_embeddings)
out = llm.generate([TokensPrompt(prompt_token_ids=[3] * 20)],
                   SamplingParams(max_tokens=1, temperature=0.0, ignore_eos=True))
print("OK", repr(out[0].outputs[0].text))
PY
```

Unit tests:

```bash
pytest tests/test_config.py::test_allow_long_max_model_len_extends_rope_config \
  tests/test_config.py::test_allow_long_max_model_len_extends_rotary_dim_config \
  tests/test_config.py::test_allow_long_max_model_len_rejects_absolute_positions \
  tests/test_config.py::test_allow_long_max_model_len_rejects_non_rope_configs \
  tests/test_config.py::test_allow_long_max_model_len_rejects_scaled_rope_config \
  tests/test_config.py::test_get_and_verify_max_len
pytest tests/test_config.py -q --tb=short
```

## Test Result

Environment: NVIDIA RTX PRO 6000 (Blackwell, SM 12.0), CUDA 13.0, PyTorch 2.11.0+cu130, Python 3.12.13, vLLM at upstream/main `023808c23`.

E2E, current `main` (before fix):

```
CONFIG 32 16
... Assertion `index out of bounds: 0 <= ... < 16` failed.
torch.AcceleratorError: CUDA error: device-side assert triggered
```

E2E, with fix (same model, same 20-token prompt, same V1 compile path):

```
CONFIG 32 32
OK ' tok57'
```

This is the same reproduction used for the before/after check: current `main` fails with `CONFIG 32 16`, and this branch completes with `CONFIG 32 32`.

Unit tests:

```
selected config tests ... 13 passed, 18 warnings
tests/test_config.py ... 151 passed, 18 warnings
```

Lint/checks: `ruff check`, `ruff format --check`, `typos`, and `git diff --check` pass on the changed files. A full `pre-commit run --files ...` was attempted but did not complete because the remote environment timed out while installing the `actionlint` Go dependency.

