### PR TITLE
[KV Offloading] Enable HMA models for Tiering Offloading

### DIFF
--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -110,7 +110,6 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             self._scheduler_mmap = scheduler_mmap
 
             # Create primary tier (CPU-based)
-            assert len(self.gpu_block_size) == 1
             primary_tier = CPUPrimaryTierOffloadingManager(
                 num_blocks=self.num_blocks,
                 cache_policy=self.eviction_policy,  # type: ignore[arg-type]


### PR DESCRIPTION
## Purpose
 On `main` running models with multiple KV cache groups, with Tiered Offloading  is gated by an assert. This PR removes that assert so we can make Tiering offloading more widely available.
 
 I observe some model failures, see `Failure` section but they dont seem to be related HMA but rather due to some incorrect interaction between the tiers. 

## Test Plan

vllm serve: 
```
    vllm serve "${model}"
    --tensor-parallel-size 2
    --max-model-len "${MAX_MODEL_LEN}"
    --kv-cache-metrics
    --kv-transfer-config "{
      \"kv_connector\":\"OffloadingConnector\",
      \"kv_role\":\"kv_both\",
      \"kv_connector_extra_config\":{
        \"spec_name\":\"TieringOffloadingSpec\",
        \"cpu_bytes_to_use\":\"5368709120\", # 5GB
        \"eviction_policy\":\"lru\",
        \"secondary_tiers\":[
          {
            \"type\": \"fs_python\",
            \"root_dir\": \"${TMP_DIR}\",
          }
        ]
      }
    }"
    --port "${VLLM_PORT}" --no-disable-hybrid-kv-cache-manager --enable-prefix-caching
```

lm_eval command: 
```
 lm_eval  --model local-completions \
      --model_args "model=${model},base_url=http://127.0.0.1:${VLLM_PORT}/v1/completions,tokenized_requests=False,num_concurrent=1000,trust_remote_code=True" \
      --tasks gsm8k  \
      --gen_kwargs temperature=0.0
```
- Launch server once
- Run lm-eval 3 times - the first lm-eval seeds the FS

I was careful to fail gpu prefix-caching by making https://github.com/vllm-project/vllm/blob/1edfd09ffd1ff3c15cea35d50441b2b9d78629f1/vllm/v1/core/kv_cache_manager.py#L211 fail unconditionally

Tested the following models with FS offloader, 
- nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8  
- openai/gpt-oss-120b  
- deepseek-ai/DeepSeek-V4-Flash    
- Qwen/Qwen3.6-35B-A3B 
- google/gemma-4-31B

## Test Result
gsm8k strict match
- nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8  -   0.9280   
- openai/gpt-oss-120b    - 0.2828 
- deepseek-ai/DeepSeek-V4-Flash  - 0.9568   

These numbers match runs made without any kv connector (normal TP=2)

## Failures:
Qwen/Qwen3.6-35B-A3B and google/gemma-4-31B fail used with FS offloading.
Qwen/Qwen3.6-35B-A3B triggers assert - https://github.com/vllm-project/vllm/blob/1edfd09ffd1ff3c15cea35d50441b2b9d78629f1/vllm/v1/core/sched/scheduler.py#L291
google/gemma-4-31B  is stuck in an infinite loop trying to store blocks.

These models pass without the FS offloader (i.e. with just the primary offloader in the Tiering offloader), suggesting that the issue is probably in the interaction between the tiers. 
