### PR TITLE
[Bugfix][OffloadingConnector] avoid request convoy when concurrent requests share blocks being loaded

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -293,6 +293,12 @@ class OffloadingConnectorScheduler:
         self._blocks_being_loaded: set[OffloadKey] | None = (
             set() if spec.vllm_config.cache_config.enable_prefix_caching else None
         )
+        # True if any request in the previous scheduling step needed blocks
+        # loaded from CPU (num_external_tokens > 0). Used to gate the
+        # _blocks_being_loaded delay: when the GPU is not under pressure,
+        # blocks found in the CPU cache are already live in GPU and delaying
+        # requests causes an unnecessary convoy without any benefit.
+        self._gpu_kv_cache_under_pressure: bool = False
 
         # Job ID counter shared by loads and stores.
         self._job_counter: int = 0
@@ -505,20 +511,32 @@ class OffloadingConnectorScheduler:
                 if sliding_window_size_in_blocks is not None:
                     offload_keys = offload_keys[-sliding_window_size_in_blocks:]
                 if any(key in self._blocks_being_loaded for key in offload_keys):
-                    # The hit blocks are already being loaded by another
-                    # request. Rather than delaying this request (which
-                    # serialises all concurrent requests sharing the same
-                    # prefix through a single load job — a request convoy),
-                    # skip the CPU hit for this turn and let the request
-                    # re-prefill. The in-flight load will warm the GPU cache
-                    # for subsequent requests without blocking this one.
-                    # See: https://github.com/vllm-project/vllm/issues/44294
-                    logger.debug(
-                        "Skipping CPU hit for request %s — blocks already"
-                        " loading; proceeding to avoid request convoy",
-                        req_status.req.request_id,
-                    )
-                    return 0
+                    if self._gpu_kv_cache_under_pressure:
+                        # GPU is under pressure: blocks genuinely need to be
+                        # loaded from CPU and the in-flight load is useful.
+                        # Delay this request so it benefits from the load that
+                        # is already in progress rather than re-prefilling.
+                        # See: https://github.com/vllm-project/vllm/issues/44294
+                        logger.debug(
+                            "Delaying request %s — blocks loading and GPU"
+                            " under pressure; will retry next step",
+                            req_status.req.request_id,
+                        )
+                        return None
+                    else:
+                        # GPU is not under pressure: the hit blocks are still
+                        # live in the GPU KV cache so no load is needed.
+                        # Delaying would create a needless request convoy.
+                        # Skip the CPU hit and let the request proceed;
+                        # the in-flight load will warm the CPU cache for
+                        # future eviction scenarios.
+                        # See: https://github.com/vllm-project/vllm/issues/44294
+                        logger.debug(
+                            "Skipping CPU hit for request %s — blocks loading"
+                            " but GPU not under pressure; avoiding convoy",
+                            req_status.req.request_id,
+                        )
+                        return 0
 
         logger.debug(
             "Request %s hit %s offloaded tokens after %s GPU hit tokens",
@@ -582,6 +600,8 @@ class OffloadingConnectorScheduler:
     ):
         if num_external_tokens == 0:
             return
+        # GPU KV cache had to evict blocks for this request — record pressure.
+        self._gpu_kv_cache_under_pressure = True
 
         req_status = self._req_status[request.request_id]
 
@@ -903,6 +923,9 @@ class OffloadingConnectorScheduler:
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
+        # Reset the GPU pressure flag for the next step. It will be set True
+        # again by update_state_after_alloc if any request needs CPU blocks.
+        self._gpu_kv_cache_under_pressure = False
         self._update_req_states(scheduler_output)
 
         # Flush jobs for preempted requests.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -505,13 +505,20 @@ class OffloadingConnectorScheduler:
                 if sliding_window_size_in_blocks is not None:
                     offload_keys = offload_keys[-sliding_window_size_in_blocks:]
                 if any(key in self._blocks_being_loaded for key in offload_keys):
-                    # hit blocks are being loaded, delay request
+                    # The hit blocks are already being loaded by another
+                    # request. Rather than delaying this request (which
+                    # serialises all concurrent requests sharing the same
+                    # prefix through a single load job — a request convoy),
+                    # skip the CPU hit for this turn and let the request
+                    # re-prefill. The in-flight load will warm the GPU cache
+                    # for subsequent requests without blocking this one.
+                    # See: https://github.com/vllm-project/vllm/issues/44294
                     logger.debug(
-                        "Delaying request %s since some of its"
-                        " blocks are already being loaded",
+                        "Skipping CPU hit for request %s — blocks already"
+                        " loading; proceeding to avoid request convoy",
                         req_status.req.request_id,
                     )
-                    return None
+                    return 0
 
         logger.debug(
             "Request %s hit %s offloaded tokens after %s GPU hit tokens",


### PR DESCRIPTION
Fixes #44294.

## Problem

When concurrent requests share prefix blocks being loaded from CPU offload
storage, `OffloadingConnector` delays **all** of them (`return None`) until the
first load completes. With a shared 10,000-token prefix and 50 concurrent
requests this serialises every request behind a single load job — a request
convoy — causing **12× TTFT inflation** and **34% throughput loss** vs
vLLM 0.17.1 on Qwen3-8B.

The convoy occurs because `_blocks_being_loaded` was introduced in PR #29087
to prevent duplicate CPU→GPU loads, but uses `return None` (delay the whole
request) rather than just suppressing the duplicate job.

## Root cause analysis

The convoy is only harmful when the GPU is **not** under KV cache pressure. In
that case the hit blocks are still live in GPU; the delay serves no purpose
because `update_state_after_alloc` will return immediately (`num_external_tokens
== 0`) and no load will be issued regardless.

When the GPU **is** under pressure (blocks evicted, `num_external_tokens > 0`),
the in-flight load is genuine and the delay allows the requesting request to
benefit from work already in progress — this is correct behaviour.

## Fix

Add a per-step boolean `_gpu_kv_cache_under_pressure`, reset in
`build_connector_meta` and set True in `update_state_after_alloc` whenever any
request has `num_external_tokens > 0`. The convoy guard in
`get_num_new_matched_tokens` uses this flag:

- **GPU under pressure** → `return None` (delay, correct — load is needed)
- **GPU not under pressure** → `return 0` (skip CPU hit, avoid convoy)

## Benchmark results (2× NVIDIA L40S, Qwen3-8B, 10K-token shared prefix)

| Concurrency | GPU state | Unpatched | Convoy-only fix | **This fix** |
|:-----------:|-----------|:---------:|:---------------:|:------------:|
| 1 | no overflow | −3.8% | −3.7% | −3.9% |
| 20 | 2× overflow | −20.5% | −38.0% (worse!) | **−32.0%** |
| 50 | 5× overflow | −40.7% | −33.8% | **−32.4%** |

The convoy-only fix (`return 0` unconditionally) hurt at 2× overflow because it
removed a natural throttle, letting all 20 requests re-prefill simultaneously.
The context-aware fix avoids this regression while still improving high-overflow
throughput.