### PR TITLE
[Bugfix] Fix speculative decoding for short_conv (LFM2) models

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -192,9 +192,14 @@ class MambaStateShapeCalculator:
         tp_world_size: int,
         intermediate_size: int,
         conv_kernel: int,
+        num_spec: int = 0,
     ) -> tuple[tuple[int, int]]:
         conv_dim = divide(intermediate_size, tp_world_size)
-        conv_state_shape = cls._orient_conv_shape(conv_dim, conv_kernel - 1)
+        # Speculative decode needs a wider conv state so the spec-aware
+        # causal_conv1d_update sliding window has room to roll back rejected
+        # tokens (kernel uses state_len = width-1 + (seqlen-1)). Mirror
+        # mamba2_state_shape, which adds num_spec for the same reason.
+        conv_state_shape = cls._orient_conv_shape(conv_dim, conv_kernel - 1 + num_spec)
         return (conv_state_shape,)
 
     @classmethod

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -75,7 +75,11 @@ class ShortConv(MambaBase, CustomOp):
             prefix=f"{prefix}.out_proj",
         )
 
-        compilation_config = get_current_vllm_config().compilation_config
+        vllm_config = get_current_vllm_config()
+        # Capture here (config context is set during model build); get_state_shape
+        # runs later outside that context. Widens conv state for spec-decode rollback.
+        self.num_spec = vllm_config.num_speculative_tokens
+        compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
@@ -129,6 +133,11 @@ class ShortConv(MambaBase, CustomOp):
             state_indices_tensor_d = attn_metadata.state_indices_tensor_d
             has_initial_states_p = attn_metadata.has_initial_states_p
             query_start_loc_p = attn_metadata.query_start_loc_p
+            # Speculative-decode metadata (verify step has >1 query token per
+            # decode request). Provided by BaseMambaAttentionMetadata; None /
+            # trivial when spec decoding is off. Mirrors mamba_mixer2.
+            num_accepted_tokens = attn_metadata.num_accepted_tokens
+            query_start_loc_d = attn_metadata.query_start_loc_d
 
         BCx, _ = self.in_proj(hidden_states)
 
@@ -191,14 +200,32 @@ class ShortConv(MambaBase, CustomOp):
 
         if has_decode:
             Bx_d = (B_d * x_d).contiguous()
-            Bx = causal_conv1d_update(
-                Bx_d,
-                conv_state,
-                conv_weights,
-                self.conv.bias,
-                activation=None,
-                conv_state_indices=state_indices_tensor_d,
-            )
+            if num_accepted_tokens is not None:
+                # Speculative decode: the verify step feeds >1 query token per
+                # decode request, so use the spec-aware conv update path
+                # (mirrors mamba_mixer2). state_indices_tensor_d is
+                # (num_decodes, 1 + num_spec_tokens) here.
+                Bx = causal_conv1d_update(
+                    Bx_d,
+                    conv_state,
+                    conv_weights,
+                    self.conv.bias,
+                    activation=None,
+                    conv_state_indices=state_indices_tensor_d,
+                    num_accepted_tokens=num_accepted_tokens,
+                    query_start_loc=query_start_loc_d,
+                    max_query_len=state_indices_tensor_d.size(-1),
+                )
+            else:
+                # Non-spec decode (1 token/request): unchanged original path.
+                Bx = causal_conv1d_update(
+                    Bx_d,
+                    conv_state,
+                    conv_weights,
+                    self.conv.bias,
+                    activation=None,
+                    conv_state_indices=state_indices_tensor_d,
+                )
             y = C_d * Bx
             conv_output_list.insert(0, y)
 
@@ -217,10 +244,13 @@ class ShortConv(MambaBase, CustomOp):
         )
 
     def get_state_shape(self) -> tuple[tuple[int, ...]]:
+        # num_spec widens the conv state for speculative-decode rollback
+        # (see short_conv_state_shape / mamba2 parity). Captured in __init__.
         return MambaStateShapeCalculator.short_conv_state_shape(
             tp_world_size=get_tensor_model_parallel_world_size(),
             intermediate_size=self.conv_dim,
             conv_kernel=self.L_cache,
+            num_spec=self.num_spec,
         )
 
     @property

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -131,6 +131,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
+from vllm.v1.attention.backends.short_conv_attn import ShortConvAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     create_fast_prefill_custom_backend,
@@ -2351,7 +2352,12 @@ class GPUModelRunner(
 
             extra_attn_metadata_args = {}
             if use_spec_decode and isinstance(
-                builder, (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder)
+                builder,
+                (
+                    Mamba2AttentionMetadataBuilder,
+                    GDNAttentionMetadataBuilder,
+                    ShortConvAttentionMetadataBuilder,
+                ),
             ):
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(


### PR DESCRIPTION
## Summary
Speculative decoding (ngram, EAGLE / EAGLE-3, any draft method) on models that use the `short_conv` layer (LiquidAI **LFM2** / **LFM2.5**) silently produces wrong output whenever a speculative token is **rejected**. Greedy spec decode must be lossless (a draft token is accepted iff it equals the target's argmax; the bonus is the target's argmax), but on `short_conv` targets the output diverges from the no-spec baseline at the **first rejected token** — so it is only correct when every draft token happens to be accepted (e.g. a degenerate repetition prompt). `mamba2` (Mamba2 / Nemotron-H / GDN) already handles this; `short_conv` was simply never wired into the same spec-decode path.

## Root cause
`short_conv`'s reject-path conv-state rollback never runs, for two reasons:

1. **The conv-state cache is too small.** `causal_conv1d_update` needs `state_len = conv_kernel-1 + num_spec` for the spec sliding window to roll the conv state back to the last-accepted token. `MambaStateShapeCalculator.short_conv_state_shape` sizes it `conv_kernel-1` (no `num_spec`), while `mamba2_state_shape` correctly adds `num_spec`.
2. **`num_accepted_tokens` never reaches `short_conv`.** `gpu_model_runner` injects `num_accepted_tokens` into the attention-metadata builder only for `Mamba2AttentionMetadataBuilder` / `GDNAttentionMetadataBuilder`. `ShortConvAttentionMetadataBuilder` subclasses `BaseMambaAttentionMetadataBuilder` directly, so it receives `num_accepted_tokens=None` and `ShortConv.forward_cuda` takes the non-spec `causal_conv1d_update` path — the kernel's `IS_SPEC_DECODING` rollback never executes.

## Fix (mirrors `mamba2`; no effect when not speculating, `num_spec=0`)
- `short_conv_state_shape(..., num_spec: int = 0)`: `conv_kernel-1` → `conv_kernel-1 + num_spec`.
- `ShortConv`: capture `self.num_spec` in `__init__`, pass it from `get_state_shape`, and use the spec-aware `causal_conv1d_update` in `forward_cuda` when `num_accepted_tokens is not None`.
- `gpu_model_runner`: add `ShortConvAttentionMetadataBuilder` to the `isinstance` gate that fills `num_accepted_tokens` (the inner `Mamba2`-only guard for `prev_last_scheduled_idx` is unchanged; `short_conv` stays in `mamba_cache_mode='none'`).

## Why this is not duplicating an existing PR
Searched open PRs for `short_conv` / `lfm2` speculative decoding: no open PR addresses this. The nearest matches are different scope — #35059 (CPU support for Mamba ShortConv / GEMM dispatch) and #33937 (mamba cache-mode null-block padding); neither wires `short_conv` into the spec-decode `num_accepted_tokens` path or widens its conv state for the spec window.

## Test commands and results
ngram spec decode (no draft model needed) on a small dense LFM2 model that uses `short_conv`, greedy, **fp32**, asserting spec output == no-spec baseline on a normal prompt. Validated on `LiquidAI/LFM2-350M`:

```python
@pytest.mark.parametrize("k", [1, 2])
def test_short_conv_ngram_spec_lossless(k):
    prompt = "Write a short story about a robot who learns to paint landscapes."
    sp = SamplingParams(temperature=0.0, max_tokens=96, ignore_eos=True)
    common = dict(model="LiquidAI/LFM2-350M", dtype="float32",
                  enforce_eager=True, max_model_len=4096, max_num_seqs=1)
    base = LLM(**common)
    base_ids = base.generate([prompt], sp)[0].outputs[0].token_ids
    del base
    spec = LLM(**common, speculative_config={
        "method": "ngram", "num_speculative_tokens": k,
        "prompt_lookup_max": 3, "prompt_lookup_min": 1})
    spec_ids = spec.generate([prompt], sp)[0].outputs[0].token_ids
    assert list(spec_ids) == list(base_ids)
```

**Result:** before this PR the spec output diverges from the no-spec baseline at the first rejected token; after this PR it matches **exactly — 96/96 for both k=1 and k=2**. (In low precision like fp8/NVFP4 the spec output tracks the baseline for dozens of tokens then may differ at a near-tie because the verify-forward processes `1+k` tokens/step vs the baseline's 1 — a generic low-precision spec-decode effect — but it is exact in fp32, confirming the rollback is correct.)

## AI assistance disclosure
This is an **AI-assisted** contribution (Claude). The change was AI-root-caused against the codebase and validated with the test above. It is a minimal, focused fix (3 files, +52/-11) that mirrors the existing `mamba2` spec-decode wiring rather than introducing new mechanisms. The submitter maintains the LFM2.5 NVFP4 quantization + speculative-decode work that this correctness bug blocks and is reviewing the change end-to-end. The commit carries a `Co-authored-by: Claude` trailer and a DCO sign-off.

## Note
Enabling EAGLE-3 for the MoE `lfm2_moe` arch additionally needs `SupportsEagle3` / `EagleModelMixin` on `Lfm2MoeForCausalLM` (templated from `nemotron_h.py`); planned as a follow-up. The three files here are the general `short_conv` spec-decode correctness fix and stand alone (testable with ngram, no draft model).
