### PR TITLE
[Bugfix] Pass EplbCommunicator to rearrange_expert_weights_inplace in test

### DIFF
--- a/tests/distributed/test_eplb_fused_moe_layer.py
+++ b/tests/distributed/test_eplb_fused_moe_layer.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed.eplb.eplb_communicator import create_eplb_communicator
 from vllm.distributed.eplb.rebalance_execute import rearrange_expert_weights_inplace
 from vllm.distributed.parallel_state import (
     ensure_model_parallel_initialized,
@@ -203,6 +204,16 @@ def _test_eplb_fml(env, world_size: int, test_config: TestConfig):
         ]
         rank_expert_weights = [fml.get_expert_weights() for fml in fml_layers]
 
+        # Build the EPLB communicator. The expert weights live on CUDA, so
+        # `create_eplb_communicator` will route through the device process
+        # group (NCCL) regardless of the `ep_group` we pass below for
+        # rank/size queries and the optional profile-buffer reservation.
+        communicator = create_eplb_communicator(
+            group_coordinator=get_tp_group(),
+            backend=None,
+            expert_weights=rank_expert_weights[0],
+        )
+
         indices = torch.zeros(
             test_config.num_layers, test_config.num_experts, dtype=torch.long
         )
@@ -218,6 +229,7 @@ def _test_eplb_fml(env, world_size: int, test_config: TestConfig):
             shuffled_indices,
             rank_expert_weights,
             ep_group,
+            communicator,
             is_profile=False,
         )
 


### PR DESCRIPTION
## Purpose

`tests/distributed/test_eplb_fused_moe_layer.py` is broken on `main`. It still calls `rearrange_expert_weights_inplace` with the old 5-argument signature:

```python
rearrange_expert_weights_inplace(
    indices,
    shuffled_indices,
    rank_expert_weights,
    ep_group,
    is_profile=False,          # <- treated as positional `communicator`
)
```

But `rearrange_expert_weights_inplace` (in `vllm/distributed/eplb/rebalance_execute.py`) now requires a `communicator: EplbCommunicator` positional argument right after `ep_group`. As a result, every rank crashes with:

```
TypeError: rearrange_expert_weights_inplace() missing 1 required positional argument: 'communicator'
```

The error is hidden by `_distributed_worker_wrapper` in `tests/distributed/eplb_utils.py` (it re-raises but the stderr from the spawned process never reaches the pytest output), so the visible failure is just `assert p.exitcode == 0` in `distributed_run`. Both parametrizations fail:

```
FAILED tests/distributed/test_eplb_fused_moe_layer.py::test_eplb_fml[True-256-256-16-4-2]
FAILED tests/distributed/test_eplb_fused_moe_layer.py::test_eplb_fml[False-256-256-16-4-2]
```

The production caller (`vllm/distributed/eplb/eplb_state.py`) and the sibling test `tests/distributed/test_eplb_execute.py` were both migrated to the new API; this test was missed.

## Fix

Build an `EplbCommunicator` via `create_eplb_communicator(...)` (matching the pattern used in `eplb_state.py` and `test_eplb_execute.py`) and pass it through. Backend is left at `None` so the default `torch_nccl` backend is used; the factory automatically routes through the device process group because expert weights live on CUDA.

## Test Plan

```bash
cd vllm/tests
pytest -v -s distributed/test_eplb_fused_moe_layer.py
```

Requires 2 GPUs.

## Test Result

Before:

```
FAILED distributed/test_eplb_fused_moe_layer.py::test_eplb_fml[True-256-256-16-4-2]
FAILED distributed/test_eplb_fused_moe_layer.py::test_eplb_fml[False-256-256-16-4-2]
======================= 2 failed, 19 warnings in 26.96s ========================
```

After:

```
distributed/test_eplb_fused_moe_layer.py::test_eplb_fml[True-256-256-16-4-2] PASSED
distributed/test_eplb_fused_moe_layer.py::test_eplb_fml[False-256-256-16-4-2] PASSED
======================= 2 passed, 19 warnings in 30.80s ========================
```

Logs confirm the communicator is constructed correctly:

```
INFO ... [eplb_communicator.py:72] Initialized EPLB communicator: TorchDistNcclEplbCommunicator.
```
