### PR TITLE
[ROCm] Fix AITER RMSNormQuantFusion for Kimi-Linear

### DIFF
--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -570,8 +570,13 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
         )
         gated_norm_shapes: set[tuple[int, int]] = set()
         for layer in gdn_layers.values():
+            num_v_heads = getattr(layer, "num_v_heads", None) or getattr(layer, "num_heads", None)
+            head_v_dim = getattr(layer, "head_v_dim", None) or getattr(layer, "head_dim", None)
+
+            assert num_v_heads is not None and head_v_dim is not None
+
             gated_norm_shapes.add(
-                (layer.num_v_heads // layer.tp_size, layer.head_v_dim)
+                (num_v_heads // layer.tp_size, head_v_dim)
             )
 
         # Make sure fused add patterns are before simple rms norm,

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -570,14 +570,16 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
         )
         gated_norm_shapes: set[tuple[int, int]] = set()
         for layer in gdn_layers.values():
-            num_v_heads = getattr(layer, "num_v_heads", None) or getattr(layer, "num_heads", None)
-            head_v_dim = getattr(layer, "head_v_dim", None) or getattr(layer, "head_dim", None)
+            num_v_heads = getattr(layer, "num_v_heads", None) or getattr(
+                layer, "num_heads", None
+            )
+            head_v_dim = getattr(layer, "head_v_dim", None) or getattr(
+                layer, "head_dim", None
+            )
 
             assert num_v_heads is not None and head_v_dim is not None
 
-            gated_norm_shapes.add(
-                (num_v_heads // layer.tp_size, head_v_dim)
-            )
+            gated_norm_shapes.add((num_v_heads // layer.tp_size, head_v_dim))
 
         # Make sure fused add patterns are before simple rms norm,
         # as the latter is a subset of the former in torch ops.


### PR DESCRIPTION


## Purpose
Launching vLLM with Kimi-Linear models (`moonshotai/Kimi-Linear-48B-A3B-Base`) and enabled AITER support crashes with `'KimiGatedDeltaNetAttention' object has no attribute 'num_v_heads'` in `rocm_aiter_fusion.py`.

Apparently, we have to use `num_heads` instead for `KimiGatedDeltaNetAttention`.

## Test Plan
Run `moonshotai/Kimi-Linear-48B-A3B-Base` with vLLM and enabled AITER, perform basic inference testing.

## Test Result
Model loads fine, basic check of inference result looks good

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

