### PR TITLE
Adding support for zentorch-gdn

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
@@ -371,19 +371,21 @@ def cpu_gdn_attention_core_zen(
         g = g.unsqueeze(0)
         beta = beta.unsqueeze(0)
 
-        # Rebase chunk_indices / chunk_offsets onto the prefill-only slice;
-        # vLLM computes them against the full non-spec batch.
-        if num_decodes > 0:
-            prefill_chunk_offsets = (
-                attn_metadata_i.chunk_offsets[num_decodes:] - num_decodes
-            )
-            prefill_chunk_indices = attn_metadata_i.chunk_indices[
-                num_decodes:
-            ].clone()
-            prefill_chunk_indices[:, 0] -= num_decodes
-        else:
-            prefill_chunk_indices = attn_metadata_i.chunk_indices
-            prefill_chunk_offsets = attn_metadata_i.chunk_offsets
+        # Recompute the FLA chunk metadata from the prefill-only cu_seqlens
+        # (prefill_query_start_loc) using the same helpers vLLM uses. The
+        # attn_metadata chunk_indices/chunk_offsets are ALREADY rebased to the
+        # prefill-only slice by GDNAttentionMetadataBuilder.build(), so peeling
+        # them again by num_decodes double-applies and produces a size mismatch
+        # (chunk_offsets.size(0) == cu_seqlens.size(0) - 1), which trips the
+        # ZENTORCH_CHECK at ChunkGatedDeltaRuleFwd.cpp:373. Building them here
+        # is self-consistent with the cu_seqlens passed to the kernel.
+        from vllm.model_executor.layers.fla.ops.index import (
+            prepare_chunk_indices,
+            prepare_chunk_offsets,
+        )
+
+        prefill_chunk_indices = prepare_chunk_indices(prefill_query_start_loc, 64)
+        prefill_chunk_offsets = prepare_chunk_offsets(prefill_query_start_loc, 64)
 
         initial_state = ssm_state[prefill_state_indices].contiguous()
         initial_state[~prefill_has_initial_state, ...] = 0

--- a/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
@@ -75,16 +75,6 @@ def cpu_gdn_attention_core(
             layer,
         )
 
-    if torch.cpu._is_amx_tile_supported():
-        return cpu_gdn_attention_core_amx(
-            mixed_qkv,
-            b,
-            a,
-            core_attn_out,
-            attn_metadata_i,
-            layer,
-        )
-
     state_indices_tensor = attn_metadata_i.non_spec_state_indices_tensor
     query_start_loc = attn_metadata_i.non_spec_query_start_loc
     assert state_indices_tensor is not None

--- a/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py
@@ -7,6 +7,7 @@ import torch
 
 import vllm._custom_ops as ops
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.kernels.linear.zentorch_utils import has_zentorch_op
 from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
 from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
     causal_conv1d_torch,
@@ -51,6 +52,38 @@ def cpu_gdn_attention_core(
         and attn_metadata_i.num_accepted_tokens is None
     ), "speculative decode not supported in CPU GDN attention."
     assert mixed_qkv.dtype == torch.bfloat16, "CPU GDN attention requires BF16."
+
+    # AMD Zen fast path takes priority over AMX/torch when zentorch is present.
+    # The op list is the set of zentorch C++ GDN core-attention kernels this
+    # path calls; the gated RMSNorm intentionally stays on the native
+    # RMSNormGated path, so gdn_rms_norm_gated is deliberately not required here.
+    if has_zentorch_op(
+        [
+            "gdn_causal_conv1d_update",
+            "gdn_fused_recurrent_gated_delta_rule_packed_decode",
+            "gdn_causal_conv1d_fn",
+            "gdn_fused_post_conv_prep",
+            "gdn_chunk_gated_delta_rule_fwd",
+        ]
+    ):
+        return cpu_gdn_attention_core_zen(
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            attn_metadata_i,
+            layer,
+        )
+
+    if torch.cpu._is_amx_tile_supported():
+        return cpu_gdn_attention_core_amx(
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            attn_metadata_i,
+            layer,
+        )
 
     state_indices_tensor = attn_metadata_i.non_spec_state_indices_tensor
     query_start_loc = attn_metadata_i.non_spec_query_start_loc
@@ -216,6 +249,172 @@ def cpu_gdn_attention_core_fake(
 ) -> None:
     """Fake implementation for torch.compile."""
     return
+
+
+def cpu_gdn_attention_core_zen(
+    mixed_qkv: torch.Tensor,
+    b: torch.Tensor,
+    a: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    attn_metadata_i: GDNAttentionMetadata,
+    layer: torch.nn.Module,
+):
+    """AMD Zen GDN core attention backed by zentorch C++ ops.
+
+    Selected by :func:`cpu_gdn_attention_core` ahead of the AMX/torch paths
+    when running on a Zen CPU with the ``zentorch`` GDN ops registered. The
+    enclosing custom op (``cpu_gdn_attention_core``) is already opaque to
+    torch.compile, so the leaf ops here need no extra inductor fallback. Only
+    the core attention is offloaded to zentorch; the gated RMSNorm in the
+    output projection stays on the native ``RMSNormGated`` path.
+    """
+    state_indices_tensor = attn_metadata_i.non_spec_state_indices_tensor
+    query_start_loc = attn_metadata_i.non_spec_query_start_loc
+    assert state_indices_tensor is not None
+    assert query_start_loc is not None
+
+    # conv_state must be (..., dim, width-1) for the conv kernels.
+    # DS layout stores it that way directly; SD layout needs a transpose.
+    layer_kv_cache = layer.kv_cache
+    conv_state = (
+        layer_kv_cache[0]
+        if is_conv_state_dim_first()
+        else layer_kv_cache[0].transpose(-1, -2)
+    )
+    ssm_state = layer_kv_cache[1]
+
+    num_decodes = attn_metadata_i.num_decodes
+    num_decode_tokens = attn_metadata_i.num_decode_tokens
+    num_prefills = attn_metadata_i.num_prefills
+    num_prefill_tokens = attn_metadata_i.num_prefill_tokens
+
+    conv_weights = layer.conv1d.weight.view(
+        layer.conv1d.weight.size(0), layer.conv1d.weight.size(2)
+    )
+    activation_str = layer.activation if layer.activation is not None else ""
+
+    if num_decodes > 0:
+        decode_mixed_qkv = mixed_qkv[:num_decode_tokens]
+        decode_b = b[:num_decode_tokens]
+        decode_a = a[:num_decode_tokens]
+        decode_state_indices = state_indices_tensor[:num_decodes]
+
+        decode_mixed_qkv = torch.ops.zentorch.gdn_causal_conv1d_update(
+            decode_mixed_qkv,
+            conv_state,
+            conv_weights,
+            layer.conv1d.bias,
+            activation_str,
+            decode_state_indices,
+            0,  # null_block_id: CPU has no paged/block KV cache
+            -1,  # pad_slot_id: CPU has no padded cache slots
+        )
+
+        out_buf = core_attn_out[:num_decode_tokens].unsqueeze(1)
+        torch.ops.zentorch.gdn_fused_recurrent_gated_delta_rule_packed_decode(
+            decode_mixed_qkv,
+            decode_a,
+            decode_b,
+            layer.A_log,
+            layer.dt_bias,
+            layer.head_k_dim**-0.5,
+            ssm_state,
+            out_buf,
+            decode_state_indices,
+            True,
+        )
+
+    if num_prefills > 0:
+        has_initial_state = attn_metadata_i.has_initial_state
+        assert has_initial_state is not None
+
+        prefill_token_start = num_decode_tokens
+        prefill_token_end = prefill_token_start + num_prefill_tokens
+        prefill_mixed_qkv = mixed_qkv[prefill_token_start:prefill_token_end]
+        prefill_b = b[prefill_token_start:prefill_token_end]
+        prefill_a = a[prefill_token_start:prefill_token_end]
+        prefill_state_indices = state_indices_tensor[
+            num_decodes : num_decodes + num_prefills
+        ]
+        prefill_query_start_loc = (
+            query_start_loc[num_decodes : num_decodes + num_prefills + 1]
+            - num_decode_tokens
+        )
+        prefill_has_initial_state = has_initial_state[
+            num_decodes : num_decodes + num_prefills
+        ]
+
+        prefill_mixed_qkv_T = prefill_mixed_qkv.transpose(0, 1)
+        prefill_mixed_qkv = torch.ops.zentorch.gdn_causal_conv1d_fn(
+            prefill_mixed_qkv_T,
+            conv_weights,
+            layer.conv1d.bias,
+            conv_state,
+            prefill_query_start_loc,
+            prefill_state_indices,
+            prefill_has_initial_state,
+            activation_str,
+            -1,  # pad_slot_id: CPU has no padded cache slots
+        ).transpose(0, 1)
+
+        (
+            query,
+            key,
+            value,
+            g,
+            beta,
+        ) = torch.ops.zentorch.gdn_fused_post_conv_prep(
+            prefill_mixed_qkv,
+            prefill_a,
+            prefill_b,
+            layer.A_log,
+            layer.dt_bias,
+            layer.num_k_heads // layer.tp_size,
+            layer.head_k_dim,
+            layer.head_v_dim,
+            True,
+            False,
+        )
+        query = query.unsqueeze(0)
+        key = key.unsqueeze(0)
+        value = value.unsqueeze(0)
+        g = g.unsqueeze(0)
+        beta = beta.unsqueeze(0)
+
+        # Rebase chunk_indices / chunk_offsets onto the prefill-only slice;
+        # vLLM computes them against the full non-spec batch.
+        if num_decodes > 0:
+            prefill_chunk_offsets = (
+                attn_metadata_i.chunk_offsets[num_decodes:] - num_decodes
+            )
+            prefill_chunk_indices = attn_metadata_i.chunk_indices[
+                num_decodes:
+            ].clone()
+            prefill_chunk_indices[:, 0] -= num_decodes
+        else:
+            prefill_chunk_indices = attn_metadata_i.chunk_indices
+            prefill_chunk_offsets = attn_metadata_i.chunk_offsets
+
+        initial_state = ssm_state[prefill_state_indices].contiguous()
+        initial_state[~prefill_has_initial_state, ...] = 0
+        o, last_recurrent_state = torch.ops.zentorch.gdn_chunk_gated_delta_rule_fwd(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            float(layer.head_k_dim**-0.5),
+            initial_state,
+            True,
+            64,  # chunk size expected by zentorch's gdn_chunk_gated_delta_rule_fwd
+            prefill_query_start_loc,
+            prefill_chunk_indices,
+            prefill_chunk_offsets,
+        )
+        o = o.to(query.dtype)
+
+        ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
+        core_attn_out[prefill_token_start:prefill_token_end] = o.squeeze(0)
 
 
 def register_cpu_gdn_attention_ops() -> None:


### PR DESCRIPTION


## Purpose

Add an in-tree CPU GatedDeltaNet (GDN) fast path for AMD Zen CPUs, backed by the
`zentorch` core-attention kernels.

Previously the zentorch GDN acceleration was applied out-of-tree by monkey-patching
`GatedDeltaNetAttention.forward_cpu`. This PR moves the dispatch in-tree so vLLM owns
the routing and the only cross-package dependency is the stable
`torch.ops.zentorch.gdn_*` op surface.

Changes:

- `vllm/model_executor/layers/mamba/ops/cpu/gdn_attention.py`:
  - Add `cpu_gdn_attention_core_zen(...)`, which offloads the GDN decode/prefill core
  attention (causal conv1d + recurrent/chunked gated-delta-rule) to the
  `torch.ops.zentorch.gdn_*` kernels.
  - In `cpu_gdn_attention_core`, dispatch to the zen path ahead of the AMX/torch paths
  when `has_zentorch_op([...])` is satisfied (i.e. running on a Zen CPU with the
  zentorch GDN ops registered). When the ops are not available, the existing
  AMX/torch reference paths are used unchanged.

Notes:

- The enclosing `cpu_gdn_attention_core` is already a registered custom op (opaque to
`torch.compile`), so the zen leaf ops require no additional inductor fallback.
- The dispatch is gated on op presence (not just platform), so a zentorch build
without the GDN ops gracefully falls back to the AMX/torch path instead of failing.

## Test Plan

Accuracy (gsm8k, Qwen3.5-9B):

```
lm_eval --model vllm --model_args pretrained=Qwen/Qwen3.5-9B,dtype=bfloat16,max_model_len=4096,language_model_only=True,block_size=16,enable_thinking=False --tasks gsm8k --batch_size auto --trust_remote_code --num_fewshot 5 --gen_kwargs "max_gen_toks=2048" --apply_chat_template --log_samples --output_path
```

Performance (throughput + profile, Qwen3.5-4B):

```
vllm bench throughput --model Qwen/Qwen3.5-4B --tensor-parallel-size 1 --language-model-only --dtype bfloat16 --max-model-len 2048 --max-num-seqs 32 --num-prompts 16 --random-input-len 128 --random-output-len 128 --profile --profiler-config '{"profiler":"torch","torch_profiler_dir":"./outputs","torch_profiler_with_stack":false,"torch_profiler_use_gzip":true}'
```

## Test Result

*TBD*

---

Essential Elements of an Effective PR Description Checklist

- The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- The test plan, such as providing test command.
- The test results, such as pasting the results comparison before and after, or e2e results
- (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

**BEFORE SUBMITTING, PLEASE READ [https://docs.vllm.ai/en/latest/contributing*](https://docs.vllm.ai/en/latest/contributing)* (anything written below this line will be removed by GitHub Actions)