### PR TITLE
[Rust Frontend] Add ERNIE 4.5 tool parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -286,7 +286,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, internlm, kimi_k2, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, ernie45, gemma4, glm45, glm47, granite4, hermes, hy_v3, internlm, kimi_k2, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml)"].assert_eq(&error.to_report_string());
     }
 
     #[test]

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -4,10 +4,10 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::tool::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
-    Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser, HyV3ToolParser,
-    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
-    MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, ToolParser, ToolParserError,
+    Ernie45ToolParser, Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser,
+    HermesToolParser, HyV3ToolParser, Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser,
+    MinimaxM2ToolParser, MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser,
+    Qwen3CoderToolParser, Qwen3XmlToolParser, ToolParser, ToolParserError,
 };
 
 use crate::parser::ParserFactory;
@@ -19,6 +19,7 @@ pub mod names {
     pub const DEEPSEEK_V31: &str = "deepseek_v31";
     pub const DEEPSEEK_V32: &str = "deepseek_v32";
     pub const DEEPSEEK_V4: &str = "deepseek_v4";
+    pub const ERNIE45: &str = "ernie45";
     pub const GLM45: &str = "glm45";
     pub const GLM47: &str = "glm47";
     pub const GEMMA4: &str = "gemma4";
@@ -64,6 +65,7 @@ impl ToolParserFactory {
             .register_parser::<DeepSeekV31ToolParser>(names::DEEPSEEK_V31)
             .register_parser::<DeepSeekV32ToolParser>(names::DEEPSEEK_V32)
             .register_parser::<DeepSeekV4ToolParser>(names::DEEPSEEK_V4)
+            .register_parser::<Ernie45ToolParser>(names::ERNIE45)
             .register_parser::<Glm45MoeToolParser>(names::GLM45)
             .register_parser::<Glm47MoeToolParser>(names::GLM47)
             .register_unified_dummy(names::GEMMA4)
@@ -106,6 +108,12 @@ impl ToolParserFactory {
             .register_pattern("deepseek-v3.2", names::DEEPSEEK_V32)
             .register_pattern("deepseek-v3.1", names::DEEPSEEK_V31)
             .register_pattern("deepseek-v3", names::DEEPSEEK_V3)
+            // Route Baidu ERNIE 4.5 model families to the JSON `<tool_call>`
+            // parser. ERNIE 4.5 model IDs are `baidu/ERNIE-4.5-<size>-<variant>`,
+            // including VL variants (`ERNIE-4.5-VL-*`). Earlier ERNIE versions
+            // use different tool-call formats and are not routed here.
+            .register_pattern("ernie-4.5", names::ERNIE45)
+            .register_pattern("ernie4.5", names::ERNIE45)
             .register_pattern("glm-5", names::GLM47)
             .register_pattern("glm-4.7", names::GLM47)
             .register_pattern("glm-4.6", names::GLM45)

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -130,6 +130,14 @@ fn factory_new_resolves_default_patterns() {
         Some(names::DEEPSEEK_V31)
     );
     assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-PT"),
+        Some(names::ERNIE45)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-VL-28B-A3B-PT"),
+        Some(names::ERNIE45)
+    );
+    assert_eq!(
         factory.resolve_name_for_model("zai-org/GLM-5-32B-Chat"),
         Some(names::GLM47)
     );

--- a/rust/src/parser/src/tool/json/ernie45.rs
+++ b/rust/src/parser/src/tool/json/ernie45.rs
@@ -1,0 +1,230 @@
+use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
+use crate::tool::{Result, Tool, ToolParser, ToolParserOutput};
+
+const ERNIE45_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
+    parser_name: "ERNIE 4.5",
+    start_marker: "<tool_call>",
+    end_marker: "</tool_call>",
+    marker_whitespace: JsonToolCallWhitespace::Optional,
+    delimiter: None,
+    name_key: "name",
+    arguments_key: &["arguments"],
+};
+
+/// Tool parser for Baidu ERNIE 4.5 `<tool_call>`-wrapped JSON tool calls.
+///
+/// Example tool call content:
+///
+/// ```text
+/// <tool_call>{"name": "get_weather", "arguments": {"location":"Tokyo"}}</tool_call>
+/// ```
+///
+/// The wire format matches Hermes: each call is one `<tool_call>...</tool_call>`
+/// block wrapping a `{"name", "arguments"}` object, and parallel calls are
+/// repeated blocks rather than multiple calls inside one tag.
+///
+/// ERNIE 4.5 thinking models also emit `</think>`, `<response>`, and
+/// `</response>` blocks alongside tool calls. Those are reasoning/content
+/// boundaries handled by the reasoning parser and the response renderer
+/// respectively, so this tool parser only frames `<tool_call>` blocks and
+/// passes everything else through as text events.
+pub struct Ernie45ToolParser {
+    inner: JsonToolCallParser,
+}
+
+impl Ernie45ToolParser {
+    /// Create an ERNIE 4.5 tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self {
+            inner: JsonToolCallParser::new(ERNIE45_CONFIG),
+        }
+    }
+}
+
+impl ToolParser for Ernie45ToolParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.inner.parse_into(chunk, output)
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        self.inner.finish()
+    }
+
+    fn reset(&mut self) -> String {
+        self.inner.reset()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use thiserror_ext::AsReport;
+
+    use super::Ernie45ToolParser;
+    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::{ToolParser, ToolParserOutput, ToolParserTestExt as _};
+
+    fn build_tool_call(function_name: &str, arguments: &str) -> String {
+        format!(r#"<tool_call>{{"name":"{function_name}","arguments":{arguments}}}</tool_call>"#)
+    }
+
+    #[test]
+    fn ernie45_parse_complete_without_tool_call_keeps_text() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let output = parser.parse_complete("just a plain answer").unwrap();
+
+        assert_eq!(output.normal_text(), "just a plain answer");
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn ernie45_parse_complete_extracts_raw_json_arguments() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let arguments = r#"{ "location": "Tokyo", "days": "3" }"#;
+        let output = parser
+            .parse_complete(&format!(
+                "Let me check.\n{}",
+                build_tool_call("get_weather", arguments)
+            ))
+            .unwrap();
+
+        assert_eq!(output.normal_text(), "Let me check.\n");
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].tool_index, 0);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls()[0].arguments, arguments);
+    }
+
+    #[test]
+    fn ernie45_accepts_newline_after_tool_call_start() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(
+                r#"<tool_call>
+{"name":"get_weather","arguments":{}}
+</tool_call>"#,
+            )
+            .unwrap();
+
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+    }
+
+    #[test]
+    fn ernie45_does_not_validate_or_normalize_arguments() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let arguments = r#"{"location":"Tokyo",}"#;
+        let output = parser.parse_complete(&build_tool_call("get_weather", arguments)).unwrap();
+
+        assert_eq!(output.calls()[0].arguments, arguments);
+    }
+
+    #[test]
+    fn ernie45_streaming_emits_argument_deltas() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let chunks = [
+            "preface <tool",
+            "_call>{\"name\":\"get_weather\",\"arguments\":",
+            "{\"location\":",
+            "\"Beijing\"",
+            "}",
+            "}</tool_call> suffix",
+        ];
+
+        let mut output = ToolParserOutput::default();
+        let mut observed_arguments = Vec::new();
+        for chunk in chunks {
+            let next = parser.parse_chunk(chunk).unwrap();
+            observed_arguments.extend(
+                next.calls()
+                    .iter()
+                    .filter(|call| call.name.is_none())
+                    .map(|call| call.arguments.clone()),
+            );
+            output.append(next);
+        }
+        output.append(parser.finish().unwrap());
+
+        assert_eq!(observed_arguments, ["{\"location\":", "\"Beijing\"", "}"]);
+        assert_eq!(output.normal_text(), "preface  suffix");
+        assert_eq!(
+            output.coalesce().calls()[0].arguments,
+            r#"{"location":"Beijing"}"#
+        );
+    }
+
+    #[test]
+    fn ernie45_streaming_handles_split_markers() {
+        let input = format!(
+            "hello {}",
+            build_tool_call("get_weather", r#"{"location":"Tokyo"}"#)
+        );
+        let chunks = split_by_chars(&input, 5);
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.normal_text(), "hello ");
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].arguments, r#"{"location":"Tokyo"}"#);
+    }
+
+    #[test]
+    fn ernie45_streaming_extracts_multiple_tool_calls() {
+        let input = format!(
+            "{}{}",
+            build_tool_call("get_weather", r#"{"location":"Shanghai"}"#),
+            build_tool_call("add", r#"{"x":1,"y":2}"#),
+        );
+        let chunks = split_by_chars(&input, 7);
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"location\":\"Shanghai\"}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "add",
+                            ),
+                            arguments: "{\"x\":1,\"y\":2}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+
+    #[test]
+    fn ernie45_finish_fails_incomplete_tool_call() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        parser
+            .parse_chunk(r#"<tool_call>{"name":"get_weather","arguments":{"location""#)
+            .unwrap();
+
+        let error = parser.finish().unwrap_err();
+
+        expect!["tool parser parsing failed: incomplete ERNIE 4.5 tool call"]
+            .assert_eq(&error.to_report_string());
+    }
+}

--- a/rust/src/parser/src/tool/json/mod.rs
+++ b/rust/src/parser/src/tool/json/mod.rs
@@ -1,5 +1,6 @@
 //! Shared parser core for JSON tool calls wrapped by text markers.
 
+pub use ernie45::Ernie45ToolParser;
 pub use granite4::Granite4ToolParser;
 pub use hermes::HermesToolParser;
 pub use internlm2::Internlm2ToolParser;
@@ -8,6 +9,7 @@ pub use mistral::MistralToolParser;
 pub use phi4mini::Phi4MiniJsonToolParser;
 pub use qwen::Qwen3XmlToolParser;
 
+mod ernie45;
 mod granite4;
 mod hermes;
 mod internlm2;

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -24,8 +24,8 @@ pub use error::{Result, ToolParserError};
 pub use glm_xml::{Glm45MoeToolParser, Glm47MoeToolParser};
 pub use hy_v3::HyV3ToolParser;
 pub use json::{
-    Granite4ToolParser, HermesToolParser, Internlm2ToolParser, Llama3JsonToolParser,
-    MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
+    Ernie45ToolParser, Granite4ToolParser, HermesToolParser, Internlm2ToolParser,
+    Llama3JsonToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
 };
 pub use kimi_k2::KimiK2ToolParser;
 pub use minimax_m2::MinimaxM2ToolParser;


### PR DESCRIPTION
## Summary

Port the Python `ernie45_tool_parser.py` into Rust as `Ernie45ToolParser`
under `rust/src/tool-parser/src/json/ernie45.rs`, reusing the shared
`JsonToolCallParser` core.

ERNIE 4.5 wraps each tool call in a `<tool_call>...</tool_call>` block around a
`{"name", "arguments"}` JSON object and emits parallel calls as repeated
blocks — the same wire format as Hermes, so the config is identical apart
from `parser_name`:

```rust
const ERNIE45_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
    parser_name: "ERNIE 4.5",
    start_marker: "<tool_call>",
    end_marker: "</tool_call>",
    marker_whitespace: JsonToolCallWhitespace::Optional,
    delimiter: None,
    name_key: "name",
    arguments_key: &["arguments"],
};
```

The Python parser does not override `adjust_request(skip_special_tokens=…)`,
so this Rust port keeps the default `preserve_special_tokens() == false`.
No new parsing logic and no new config knobs are introduced — streaming
framing, parallel calls, and truncation handling are all the shared core's
existing behavior.

ERNIE 4.5 thinking models also emit `</think>`, `<response>`, and
`</response>` markers alongside tool calls. Those are reasoning/content
boundaries that the Rust frontend handles in its **reasoning parser**, not
the tool parser — the same layering that keeps `</think>` out of every
other tool parser in this workspace (Hermes / Phi-4-mini / InternLM2 /
Mistral / Qwen3-XML all forward `</think>` through as normal text). The
companion reasoning parser (#45385) strips `<response>` / `</response>`
from the answer stream, and (after #45385's routing narrowing)
auto-routes alongside this tool parser for any Thinking variant. The PT
base models do not emit `<response>` markers, so nothing leaks there.

If you would prefer Python's self-contained shape — strip `<response>`
here directly so the tool parser does not depend on the reasoning parser
being engaged — that is a single state-machine change I am happy to make
as a follow-up; please let me know.

Auto-routed for model IDs containing `ernie-4.5` / `ernie4.5`, covering the
`baidu/ERNIE-4.5-*` family — including the `ERNIE-4.5-VL-*` vision variants
listed in [`docs/models/supported_models.md`](docs/models/supported_models.md).
Earlier ERNIE versions use different tool-call formats and are intentionally
**not** routed here.

## Duplicate-work check

```bash
gh pr list --repo vllm-project/vllm --state open --search "ernie tool parser"
gh pr list --repo vllm-project/vllm --state open --search "rust tool parser"
```

No open Rust port of the ERNIE 4.5 tool parser exists. The Python parser is
already registered as `ernie45` in `vllm/tool_parsers/__init__.py`. This is a
parallel port to my own [#43934 (Granite 4)](https://github.com/vllm-project/vllm/pull/43934);
the two share the same `JsonToolCallParser` shape but differ in `parser_name`,
auto-routing patterns, and `preserve_special_tokens()`, so they do not overlap.

## Test plan

Commands run locally:

- `cargo nextest run -p vllm-tool-parser -p vllm-chat` → 417/417 passing
- `cargo clippy -p vllm-tool-parser -p vllm-chat --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

Tests added:

- `ernie45_parse_complete_without_tool_call_keeps_text`
- `ernie45_parse_complete_extracts_raw_json_arguments`
- `ernie45_accepts_newline_after_tool_call_start`
- `ernie45_does_not_validate_or_normalize_arguments`
- `ernie45_streaming_emits_argument_deltas`
- `ernie45_streaming_handles_split_markers`
- `ernie45_streaming_extracts_multiple_tool_calls`
- `ernie45_finish_fails_incomplete_tool_call`
- `ernie45_does_not_preserve_special_tokens`
- Model routing: `baidu/ERNIE-4.5-21B-A3B-PT` and `baidu/ERNIE-4.5-VL-28B-A3B-PT` → `ernie45`
- Registered-name list updated (`ernie45` inserted in the parser-availability
  error message).

## AI assistance disclosure

This PR was prepared with assistance from Claude (Anthropic) as a code porting
and review aide. The human submitter reviewed every changed line and ran the
test commands above; AI was used for the Python→Rust port and doc-comment
phrasing.

Co-authored-by: Claude <noreply@anthropic.com>
