### PR TITLE
[CI] Skip test_online_audio_in_video_multi_videos on XPU

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -83,5 +83,6 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'pip install av &&
         cd tests &&
-        pytest -v -s entrypoints/openai/chat_completion/test_audio_in_video.py &&
+        pytest -v -s entrypoints/openai/chat_completion/test_audio_in_video.py
+        -k "not test_online_audio_in_video_multi_videos" &&
         pytest -v -s benchmarks/test_serve_cli.py'


### PR DESCRIPTION

## Purpose
The multi-video test sends two base64-encoded videos and runs multi-turn inference, which exceeds available memory on Intel XPU (Battlemage B70) causing the test to error out after ~712s.

The single-video and interleaved tests continue to run and pass. Skip only the multi-video variant via -k filter.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

