### PR TITLE
[Spec Decode] Fix Eagle3 Qwen3 architecture resolution for speculators checkpoints

### DIFF
--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -36,7 +36,13 @@ def update_eagle3(config_dict: dict, pre_trained_config: dict) -> None:
         "norm_before_residual", True
     )
     pre_trained_config["norm_before_fc"] = config_dict.get("norm_before_fc", False)
-    pre_trained_config["architectures"] = ["Eagle3LlamaForCausalLM"]
+    eagle3_arch_map = {
+        "qwen3": "Eagle3Qwen3ForCausalLM",
+    }
+    model_type = pre_trained_config.get("model_type", "llama")
+    pre_trained_config["architectures"] = [
+        eagle3_arch_map.get(model_type, "Eagle3LlamaForCausalLM")
+    ]
     if config_dict.get("eagle_aux_hidden_state_layer_ids"):
         pre_trained_config["eagle_aux_hidden_state_layer_ids"] = config_dict[
             "eagle_aux_hidden_state_layer_ids"


### PR DESCRIPTION
## Summary
- The speculators config loader in `update_eagle3()` hardcoded `Eagle3LlamaForCausalLM` as the architecture for **all** Eagle3 models, ignoring `transformer_layer_config.model_type`
- This caused Qwen3-based Eagle3 drafters (trained with `--draft-arch qwen3` in [speculators](https://github.com/vllm-project/speculators)) to load with the wrong model class, failing with `KeyError: 'layers.0.self_attn.k_norm.weight'` since the Llama variant doesn't have `q_norm`/`k_norm` attention norms
- Fix: resolve the architecture from `model_type`, mapping `qwen3` → `Eagle3Qwen3ForCausalLM` (from #43132) and defaulting to `Eagle3LlamaForCausalLM` for backward compatibility

Depends on #43132 for the `Eagle3Qwen3ForCausalLM` model class and registry entry.

## Test plan
- [x] Trained Eagle3 drafters with both `--draft-arch llama` and `--draft-arch qwen3` on Qwen/Qwen3-8B using speculators
- [x] Verified llama-arch checkpoints load and run correctly (unchanged behavior)
- [x] Verified qwen3-arch checkpoints now load correctly with this fix (previously crashed with KeyError)
- [x] Confirmed acceptance rate metrics are produced for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)