### PR TITLE
[ROCm] Fix get_device_name crash with TheRock/MagicMock amdsmi stub

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -663,13 +663,27 @@ class RocmPlatform(Platform):
     @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_name(cls, device_id: int = 0) -> str:
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = amdsmi_get_processor_handles()[physical_device_id]
-        asic_info = amdsmi_get_gpu_asic_info(handle)
-        asic_info_device_id: str = asic_info["device_id"]
-        if asic_info_device_id in _ROCM_DEVICE_ID_NAME_MAP:
-            return _ROCM_DEVICE_ID_NAME_MAP[asic_info_device_id]
-        return asic_info["market_name"]
+        try:
+            physical_device_id = cls.device_id_to_physical_device_id(
+                device_id)
+            handle = amdsmi_get_processor_handles()[physical_device_id]
+            asic_info = amdsmi_get_gpu_asic_info(handle)
+            asic_info_device_id = asic_info["device_id"]
+            # TheRock builds stub amdsmi with MagicMock, which returns
+            # mock objects instead of strings. Detect and fall back.
+            if not isinstance(asic_info_device_id, str):
+                raise TypeError("amdsmi returned mock object")
+            if asic_info_device_id in _ROCM_DEVICE_ID_NAME_MAP:
+                return _ROCM_DEVICE_ID_NAME_MAP[asic_info_device_id]
+            market_name = asic_info["market_name"]
+            if not isinstance(market_name, str):
+                raise TypeError("amdsmi returned mock object")
+            return market_name
+        except Exception:
+            # Fallback: use torch.cuda which always works
+            name = torch.cuda.get_device_name(device_id)
+            logger.info("Using torch.cuda device name: %s", name)
+            return name
 
     @classmethod
     @with_amdsmi_context


### PR DESCRIPTION
## Summary

TheRock-based Docker builds stub `amdsmi` with `unittest.mock.MagicMock`. When `get_device_name()` calls `amdsmi_get_gpu_asic_info()`, it gets MagicMock objects instead of strings for `device_id` and `market_name`. These mock objects pass the `in` membership test against the device ID map (`MagicMock.__eq__` returns a truthy MagicMock), causing downstream code to receive mock objects where it expects device name strings.

This breaks:
- MoE config file resolution (filename includes device_name)
- Any code path that uses the device name as a string

### Fix

Add `isinstance(str)` checks on amdsmi return values and fall back to `torch.cuda.get_device_name()` when they fail. The torch.cuda path always returns a real string regardless of amdsmi availability.

### Not a duplicate

- PR #40963 addresses APU VRAM reporting (different problem in the same file)
- This fix addresses the MagicMock stub behavior specific to TheRock builds, which #40963 does not cover

## Test plan

- [x] Validated on Strix Halo APU (gfx1151) with TheRock vLLM Docker image (v0.22.0)
- [x] Confirmed `torch.cuda.get_device_name()` returns correct "Radeon 8060S Graphics" when amdsmi is mocked
- [x] MoE config file resolution works correctly after fix (previously got MagicMock in filename)
- [x] Production-validated at ~38 tok/s serving Qwen3.6-35B-A3B-GPTQ-Int4

**AI assistance was used** (Claude) for debugging and patch development. All changes validated by human on physical hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)