### PR TITLE
[MRV2] Remove assignment of graph_pool in cudagraph_utils

### DIFF
--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -299,7 +299,6 @@ class CudaGraphManager:
             self.breakable_cg_runner = BreakableCUDAGraphWrapper(
                 model, self.vllm_config
             )
-            self.breakable_cg_runner.graph_pool = self.pool
 
     def run_pw_graph(self, model: nn.Module, model_inputs: dict[str, Any]) -> Any:
         if not self.use_breakable_cg:


### PR DESCRIPTION
The line is redundant since both use `current_platform.get_global_graph_pool()`. Followup from #44078