### PR TITLE
[Quant] Support compressed-tensors WNA8O8Int linears and WNInt embeddings

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -38,7 +38,7 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
-compressed-tensors == 0.15.0.1 # required for compressed-tensors
+compressed-tensors == 0.17.0 # required for compressed-tensors
 depyf==0.20.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -28,4 +28,4 @@ quack-kernels>=0.3.3
 tokenspeed-mla==0.1.2
 
 # Humming kernels for quantization gemm
-humming-kernels[cu13]==0.1.2
+humming-kernels[cu13]==0.1.4

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -143,7 +143,7 @@ colorful==0.5.8
     # via ray
 colorlog==6.10.1
     # via optuna
-compressed-tensors==0.15.0.1
+compressed-tensors==0.17.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/tests/kernels/quantization/test_quantized_embedding.py
+++ b/tests/kernels/quantization/test_quantized_embedding.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the Triton dequant-gather kernel used by
+``CompressedTensorsEmbeddingWNA16Int`` (quantized embedding lookup)."""
+
+import pytest
+import torch
+from compressed_tensors.compressors.pack_quantized.helpers import unpack_from_int32
+
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_embedding import (  # noqa: E501
+    _dequant_gather_triton,
+)
+from vllm.platforms import current_platform
+
+
+def _dequant_gather_torch(
+    ids: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    hidden: int,
+    num_bits: int,
+) -> torch.Tensor:
+    """Reference: gather packed rows by id, unpack int32-packed INT, dequant."""
+    n = ids.shape[0]
+    int8 = unpack_from_int32(weight_packed[ids], num_bits, torch.Size([n, hidden]))
+    scale_rows = weight_scale[ids]
+    w = int8.to(scale_rows.dtype)
+    if scale_rows.shape[1] == 1:
+        return w * scale_rows
+    ng = scale_rows.shape[1]
+    return (w.view(n, ng, hidden // ng) * scale_rows.unsqueeze(-1)).view(n, hidden)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton dequant kernel requires CUDA"
+)
+@pytest.mark.parametrize("num_bits", [2, 4, 8])
+@pytest.mark.parametrize("group_size", [0, 256])  # 0 -> channel
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("num_ids", [1, 17, 4096])
+def test_dequant_gather(num_bits, group_size, dtype, num_ids):
+    torch.manual_seed(0)
+    device = "cuda"
+    vocab, hidden = 1000, 2048
+    pack_factor = 32 // num_bits
+
+    # Random full-range int32 packed weights (covers the sign bit -> exercises the
+    # arithmetic-shift + mask unpack path).
+    weight_packed = torch.randint(
+        -(2**31),
+        2**31,
+        (vocab, hidden // pack_factor),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    num_groups = 1 if group_size == 0 else hidden // group_size
+    weight_scale = torch.rand(vocab, num_groups, dtype=dtype, device=device) + 0.01
+
+    ids = torch.randint(0, vocab, (num_ids,), dtype=torch.long, device=device)
+
+    out = _dequant_gather_triton(ids, weight_packed, weight_scale, hidden, num_bits)
+    ref = _dequant_gather_torch(ids, weight_packed, weight_scale, hidden, num_bits)
+
+    assert out.shape == (num_ids, hidden)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out, ref)

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -45,6 +45,9 @@ from vllm.model_executor.kernels.linear.mixed_precision.dynamic_4bit import (
 from vllm.model_executor.kernels.linear.mixed_precision.exllama import (
     ExllamaLinearKernel,
 )
+from vllm.model_executor.kernels.linear.mixed_precision.humming import (
+    HummingLinearKernel,
+)
 from vllm.model_executor.kernels.linear.mixed_precision.machete import (
     MacheteLinearKernel,
 )
@@ -345,6 +348,7 @@ _POSSIBLE_KERNELS: dict[PlatformEnum, list[type[MPLinearKernel]]] = {
         MacheteLinearKernel,
         AllSparkLinearKernel,
         MarlinLinearKernel,
+        HummingLinearKernel,
         ConchLinearKernel,
         ExllamaLinearKernel,
         TritonW4A16LinearKernel,

--- a/vllm/model_executor/kernels/linear/mixed_precision/humming.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/humming.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Humming GEMM as a mixed-precision linear kernel.
+
+Consumes the canonical MPLinear weight layout (``weight_packed`` int32 +
+``weight_scale``) and runs a weight-only GEMM. Serves bit widths / shapes the
+packed Marlin and Machete kernels cannot (2-bit, non-64-aligned).
+"""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import _has_module
+
+from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
+
+
+class HummingLinearKernel(MPLinearKernel):
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 75
+
+    @classmethod
+    def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
+        if not current_platform.is_cuda():
+            return False, "Humming is only supported on CUDA"
+        if not _has_module("humming"):
+            return False, "Humming is not installed"
+        if c.has_g_idx:
+            return False, "Humming does not support act-order (g_idx)"
+        if c.zero_points:
+            return False, "Humming linear kernel only supports symmetric weights"
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from vllm.model_executor.layers.quantization.utils.humming_utils import (
+            convert_linear_layer_to_humming_standard,
+            prepare_humming_layer,
+        )
+
+        name_map = {"weight": self.w_q_name, "weight_scale": self.w_s_name}
+        # vLLM uses group_size == -1 for channelwise; humming expects 0.
+        group_size = self.config.group_size
+        quant_config = {
+            "quant_method": "humming",
+            "dtype": "int" + str(self.config.weight_type.size_bits),
+            "group_size": 0 if group_size == -1 else group_size,
+        }
+
+        convert_linear_layer_to_humming_standard(layer=layer, name_map=name_map)
+        prepare_humming_layer(layer, quant_config)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        from humming.layer import HummingMethod
+
+        flatten_inputs = x.view(-1, x.size(-1))
+        output = HummingMethod.forward_layer(
+            layer=layer,
+            inputs=flatten_inputs,
+            compute_config=layer.compute_config,
+        )
+        return output.view(*x.shape[:-1], output.size(-1))

--- a/vllm/model_executor/kernels/linear/mixed_precision/humming.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/humming.py
@@ -1,11 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Humming GEMM as a mixed-precision linear kernel.
-
-Consumes the canonical MPLinear weight layout (``weight_packed`` int32 +
-``weight_scale``) and runs a weight-only GEMM. Serves bit widths / shapes the
-packed Marlin and Machete kernels cannot (2-bit, non-64-aligned).
-"""
+"""Humming GEMM as a mixed-precision WNA16Int linear kernel."""
 
 import torch
 
@@ -39,7 +34,6 @@ class HummingLinearKernel(MPLinearKernel):
         )
 
         name_map = {"weight": self.w_q_name, "weight_scale": self.w_s_name}
-        # vLLM uses group_size == -1 for channelwise; humming expects 0.
         group_size = self.config.group_size
         quant_config = {
             "quant_method": "humming",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -30,6 +30,9 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_embedding import (  # noqa: E501
+    CompressedTensorsEmbeddingWNA16Int,
+)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
     CompressedTensorsMoEMethod,
 )
@@ -45,6 +48,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsW8A8Int8,
     CompressedTensorsW8A8Mxfp8,
     CompressedTensorsW8A16Fp8,
+    CompressedTensorsWNA8O8Int,
     CompressedTensorsWNA16,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.transform.linear import (  # noqa: E501
@@ -57,7 +61,10 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
     should_ignore_layer,
 )
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
-from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
 from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
@@ -177,6 +184,14 @@ class CompressedTensorsConfig(QuantizationConfig):
             if quant_scheme is not None:
                 layer.scheme = quant_scheme
                 return CompressedTensorsLinearMethod(self)
+
+        # ParallelLMHead subclasses VocabParallelEmbedding but is handled above as
+        # a linear; only true embedding lookups land here.
+        if isinstance(layer, VocabParallelEmbedding):
+            scheme_dict = self.get_scheme_dict(layer, layer_name=prefix)
+            if scheme_dict and scheme_dict.get("weights") is not None:
+                return CompressedTensorsEmbeddingWNA16Int(scheme_dict["weights"])
+            return None
 
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
@@ -325,6 +340,15 @@ class CompressedTensorsConfig(QuantizationConfig):
                                 quant_config.get("input_activations")
                             )
                         )
+
+                # Static output-activation quant is applied as a float fake-quant
+                # on the layer output; capture it when present.
+                target_scheme_map[target]["output_activations"] = None
+                output_activations = quant_config.get("output_activations")
+                if output_activations:
+                    target_scheme_map[target]["output_activations"] = (
+                        QuantizationArgs.model_validate(output_activations)
+                    )
         return target_scheme_map
 
     @classmethod
@@ -609,6 +633,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         self,
         weight_quant: QuantizationArgs,
         input_quant: QuantizationArgs,
+        output_quant: QuantizationArgs | None = None,
         format: str | None = None,
         layer_name: str | None = None,
     ) -> "CompressedTensorsScheme":
@@ -632,6 +657,41 @@ class CompressedTensorsConfig(QuantizationConfig):
                 symmetric=weight_quant.symmetric,
                 group_size=weight_quant.group_size,
                 actorder=weight_quant.actorder,
+            )
+
+        # Weight N-bit INT (pack-quantized for sub-byte, int-quantized for 8-bit)
+        # with static INT8 output (and input) activation quant, applied as a float
+        # fake-quant around a weight-only matmul (not a real int8 GEMM). Selected
+        # when an output-activation scale is present, or for sub-4-bit weights that
+        # marlin-backed WNA16 cannot handle. Must come before the WNA16 check;
+        # standard 4/8-bit weight-only (no output-activation scale) still falls
+        # through to WNA16.
+        if (
+            format
+            in (
+                CompressionFormat.pack_quantized.value,
+                CompressionFormat.int_quantized.value,
+            )
+            and weight_quant.type == QuantizationType.INT
+            and not weight_quant.dynamic
+            and weight_quant.strategy
+            in (
+                QuantizationStrategy.CHANNEL.value,
+                QuantizationStrategy.GROUP.value,
+            )
+            and (
+                output_quant is not None
+                or weight_quant.num_bits not in WNA16_SUPPORTED_BITS
+            )
+        ):
+            return CompressedTensorsWNA8O8Int(
+                num_bits=weight_quant.num_bits,
+                strategy=weight_quant.strategy,
+                group_size=weight_quant.group_size,
+                has_input_act=input_quant is not None,
+                has_output_act=output_quant is not None,
+                layer_name=layer_name,
+                quant_format=format,
             )
 
         if (
@@ -729,10 +789,12 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         weight_quant = None
         input_quant = None
+        output_quant = None
         format = None
         if scheme_dict:
             weight_quant = scheme_dict.get("weights")
             input_quant = scheme_dict.get("input_activations")
+            output_quant = scheme_dict.get("output_activations")
             format = scheme_dict.get("format")
 
         if weight_quant is None:
@@ -744,6 +806,7 @@ class CompressedTensorsConfig(QuantizationConfig):
             scheme = self._get_scheme_from_parts(  # type: ignore
                 weight_quant=weight_quant,
                 input_quant=input_quant,
+                output_quant=output_quant,
                 format=format,
                 layer_name=layer_name,
             )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -675,7 +675,13 @@ class CompressedTensorsConfig(QuantizationConfig):
             and output_quant.num_bits == 8
             and not output_quant.dynamic
         )
-        needs_wNa8o8 = is_intN_weight and is_static_int8_in and is_static_int8_out
+        # Static int8-activation layers, plus sub-byte weight-only layers (e.g.
+        # 2-bit lm_head) that marlin-backed WNA16 cannot serve. Standard 4/8-bit
+        # weight-only (no activations) falls through to WNA16.
+        is_subbyte_weight_only = weight_quant.num_bits not in WNA16_SUPPORTED_BITS
+        needs_wNa8o8 = is_intN_weight and (
+            (is_static_int8_in and is_static_int8_out) or is_subbyte_weight_only
+        )
         return needs_wNa8o8
 
     def _get_scheme_from_parts(
@@ -793,7 +799,10 @@ class CompressedTensorsConfig(QuantizationConfig):
                     input_symmetric=input_quant.symmetric,
                 )
 
-        raise NotImplementedError("No compressed-tensors compatible scheme was found.")
+        raise NotImplementedError(
+            f"No compressed-tensors compatible scheme was found for {layer_name=}, "
+            f"{weight_quant=}, {input_quant=}, {output_quant=}, {format=}"
+        )
 
     def get_scheme(
         self, layer: torch.nn.Module, layer_name: str | None = None

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -189,9 +189,19 @@ class CompressedTensorsConfig(QuantizationConfig):
         # a linear; only true embedding lookups land here.
         if isinstance(layer, VocabParallelEmbedding):
             scheme_dict = self.get_scheme_dict(layer, layer_name=prefix)
-            if scheme_dict and scheme_dict.get("weights") is not None:
-                return CompressedTensorsEmbeddingWNA16Int(scheme_dict["weights"])
-            return None
+            weight_quant = scheme_dict.get("weights") if scheme_dict else None
+            if weight_quant is None:
+                return None  # unquantized embedding
+            if not (
+                isinstance(weight_quant, QuantizationArgs)
+                and self._is_wNa16_group_channel(weight_quant, None)
+                and weight_quant.type == QuantizationType.INT
+            ):
+                raise ValueError(
+                    "compressed-tensors embeddings only support weight-only INT "
+                    f"group/channel (WNA16) quantization, got: {weight_quant}"
+                )
+            return CompressedTensorsEmbeddingWNA16Int(weight_quant)
 
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
@@ -629,6 +639,45 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         return is_channel_group and input_quant_none and is_static
 
+    @staticmethod
+    def _is_wNa8o8_int(
+        weight_quant: QuantizationArgs,
+        input_quant: QuantizationArgs | None,
+        output_quant: QuantizationArgs | None,
+        format: str | None,
+    ) -> bool:
+        """Weight N-bit INT (pack-quantized for sub-byte, int-quantized for 8-bit)
+        with static per-tensor INT8 input/output activation quant, applied as a float
+        fake-quant around a weight-only matmul."""
+        is_int_pack_format = format in (
+            CompressionFormat.pack_quantized.value,
+            CompressionFormat.int_quantized.value,
+        )
+        is_channel_group = weight_quant.strategy in (
+            QuantizationStrategy.CHANNEL.value,
+            QuantizationStrategy.GROUP.value,
+        )
+        is_static_int = (
+            weight_quant.type == QuantizationType.INT and not weight_quant.dynamic
+        )
+        is_intN_weight = is_static_int and is_channel_group and is_int_pack_format
+        is_static_int8_in = (
+            input_quant is not None
+            and input_quant.type == QuantizationType.INT
+            and input_quant.strategy == QuantizationStrategy.TENSOR.value
+            and input_quant.num_bits == 8
+            and not input_quant.dynamic
+        )
+        is_static_int8_out = (
+            output_quant is not None
+            and output_quant.type == QuantizationType.INT
+            and output_quant.strategy == QuantizationStrategy.TENSOR.value
+            and output_quant.num_bits == 8
+            and not output_quant.dynamic
+        )
+        needs_wNa8o8 = is_intN_weight and is_static_int8_in and is_static_int8_out
+        return needs_wNa8o8
+
     def _get_scheme_from_parts(
         self,
         weight_quant: QuantizationArgs,
@@ -659,31 +708,9 @@ class CompressedTensorsConfig(QuantizationConfig):
                 actorder=weight_quant.actorder,
             )
 
-        # Weight N-bit INT (pack-quantized for sub-byte, int-quantized for 8-bit)
-        # with static INT8 output (and input) activation quant, applied as a float
-        # fake-quant around a weight-only matmul (not a real int8 GEMM). Selected
-        # when an output-activation scale is present, or for sub-4-bit weights that
-        # marlin-backed WNA16 cannot handle. Must come before the WNA16 check;
-        # standard 4/8-bit weight-only (no output-activation scale) still falls
-        # through to WNA16.
-        if (
-            format
-            in (
-                CompressionFormat.pack_quantized.value,
-                CompressionFormat.int_quantized.value,
-            )
-            and weight_quant.type == QuantizationType.INT
-            and not weight_quant.dynamic
-            and weight_quant.strategy
-            in (
-                QuantizationStrategy.CHANNEL.value,
-                QuantizationStrategy.GROUP.value,
-            )
-            and (
-                output_quant is not None
-                or weight_quant.num_bits not in WNA16_SUPPORTED_BITS
-            )
-        ):
+        # Must come before the WNA16 check; standard 4/8-bit weight-only (no
+        # output-activation scale) still falls through to WNA16.
+        if self._is_wNa8o8_int(weight_quant, input_quant, output_quant, format):
             return CompressedTensorsWNA8O8Int(
                 num_bits=weight_quant.num_bits,
                 strategy=weight_quant.strategy,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_embedding.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_embedding.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Quantized embedding method for compressed-tensors.
+
+Adds dequant-on-lookup support for a pack-quantized ``VocabParallelEmbedding``
+(2-8 bit INT, channel- or group-quantized). Only the gathered token rows are
+unpacked and dequantized, so the packed weight is never densified.
+"""
+
+import torch
+from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.parameter import (
+    BasevLLMParameter,
+    ChannelQuantScaleParameter,
+    GroupQuantScaleParameter,
+    PackedvLLMParameter,
+)
+from vllm.triton_utils import tl, triton
+
+__all__ = ["CompressedTensorsEmbeddingWNA16Int"]
+
+
+@triton.jit
+def _dequant_gather_kernel(
+    ids_ptr,
+    packed_ptr,
+    scale_ptr,
+    out_ptr,
+    hidden,
+    packed_cols,
+    num_groups,
+    NUM_BITS: tl.constexpr,
+    PACK_FACTOR: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Gather embedding rows by token id, unpack int32-packed INT weights, and
+    dequantize to ``out`` dtype in one pass (no int8 intermediate)."""
+    row = tl.program_id(0)
+    col = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    col_mask = col < hidden
+    tid = tl.load(ids_ptr + row).to(tl.int64)
+
+    packed_idx = col // PACK_FACTOR
+    shift = (col % PACK_FACTOR) * NUM_BITS
+    packed = tl.load(
+        packed_ptr + tid * packed_cols + packed_idx, mask=col_mask, other=0
+    )
+    q = ((packed >> shift) & ((1 << NUM_BITS) - 1)) - (1 << (NUM_BITS - 1))
+
+    if GROUP_SIZE == 0:  # channel: one scale per row
+        scale = tl.load(scale_ptr + tid)
+    else:  # group: one scale per (row, group)
+        grp = col // GROUP_SIZE
+        scale = tl.load(scale_ptr + tid * num_groups + grp, mask=col_mask, other=0.0)
+
+    out = q.to(tl.float32) * scale.to(tl.float32)
+    tl.store(
+        out_ptr + row * hidden + col, out.to(out_ptr.dtype.element_ty), mask=col_mask
+    )
+
+
+def _dequant_gather_triton(
+    ids: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    hidden: int,
+    num_bits: int,
+) -> torch.Tensor:
+    n = ids.numel()
+    out = torch.empty(n, hidden, dtype=weight_scale.dtype, device=weight_packed.device)
+    num_groups = weight_scale.shape[1]
+    group_size = 0 if num_groups == 1 else hidden // num_groups
+    block = min(triton.next_power_of_2(hidden), 1024)
+    grid = (n, triton.cdiv(hidden, block))
+    _dequant_gather_kernel[grid](
+        ids,
+        weight_packed,
+        weight_scale,
+        out,
+        hidden,
+        weight_packed.shape[1],
+        num_groups,
+        NUM_BITS=num_bits,
+        PACK_FACTOR=32 // num_bits,
+        GROUP_SIZE=group_size,
+        BLOCK=block,
+    )
+    return out
+
+
+class CompressedTensorsEmbeddingWNA16Int(QuantizeMethodBase):
+    def __init__(self, weight_quant: QuantizationArgs):
+        self.num_bits = weight_quant.num_bits
+        self.pack_factor = 32 // self.num_bits
+        self.strategy = weight_quant.strategy
+        self.group_size = weight_quant.group_size
+        self.is_group = (
+            self.strategy == QuantizationStrategy.GROUP.value
+            and self.group_size is not None
+        )
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        weight_loader = extra_weight_attrs["weight_loader"]
+        # Embedding weight is [num_embeddings(vocab), embedding_dim(hidden)];
+        # vocab is the output (partitioned) dim, hidden is the input dim.
+        vocab_pp = sum(output_partition_sizes)
+        hidden = input_size_per_partition
+        layer.hidden_size = hidden
+
+        weight_packed = PackedvLLMParameter(
+            input_dim=1,
+            output_dim=0,
+            packed_dim=1,
+            packed_factor=self.pack_factor,
+            weight_loader=weight_loader,
+            data=torch.empty(vocab_pp, hidden // self.pack_factor, dtype=torch.int32),
+        )
+
+        if self.is_group:
+            assert hidden % self.group_size == 0
+            weight_scale = GroupQuantScaleParameter(
+                output_dim=0,
+                input_dim=1,
+                weight_loader=weight_loader,
+                data=torch.empty(
+                    vocab_pp, hidden // self.group_size, dtype=params_dtype
+                ),
+            )
+        else:
+            weight_scale = ChannelQuantScaleParameter(
+                output_dim=0,
+                weight_loader=weight_loader,
+                data=torch.empty(vocab_pp, 1, dtype=params_dtype),
+            )
+
+        weight_shape = BasevLLMParameter(
+            data=torch.empty(2, dtype=torch.int64), weight_loader=weight_loader
+        )
+
+        layer.register_parameter("weight_packed", weight_packed)
+        layer.register_parameter("weight_scale", weight_scale)
+        layer.register_parameter("weight_shape", weight_shape)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        pass
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        ids = input_.reshape(-1).contiguous()
+        hidden = layer.hidden_size
+        deq = _dequant_gather_triton(
+            ids, layer.weight_packed, layer.weight_scale, hidden, self.num_bits
+        )
+        return deq.reshape(*input_.shape, hidden)
+
+    def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
+        raise NotImplementedError(
+            "CompressedTensorsEmbeddingWNA16Int supports embedding lookup only"
+        )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -11,11 +11,13 @@ from .compressed_tensors_w8a8_fp8 import CompressedTensorsW8A8Fp8
 from .compressed_tensors_w8a8_int8 import CompressedTensorsW8A8Int8
 from .compressed_tensors_w8a8_mxfp8 import CompressedTensorsW8A8Mxfp8
 from .compressed_tensors_w8a16_fp8 import CompressedTensorsW8A16Fp8
+from .compressed_tensors_wNa8o8 import CompressedTensorsWNA8O8Int
 from .compressed_tensors_wNa16 import WNA16_SUPPORTED_BITS, CompressedTensorsWNA16
 
 __all__ = [
     "CompressedTensorsScheme",
     "CompressedTensorsWNA16",
+    "CompressedTensorsWNA8O8Int",
     "CompressedTensorsW8A16Fp8",
     "CompressedTensorsW8A8Int8",
     "CompressedTensorsW8A8Fp8",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
@@ -2,35 +2,29 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Weight N-bit INT scheme with static INT8 input/output activation quant.
 
-Handles pack-quantized INT weight checkpoints that carry static per-tensor INT8
-``input_activations`` and/or ``output_activations``. An output-activation scale is
-the distinguishing signal: it means the activation quantization is reproduced as a
-float fake-quant on the layer input and output, around a weight-only matmul, rather
-than a fused int8 GEMM.
+Handles compressed-tensors INT weight checkpoints (pack-quantized int32 for
+sub-byte weights, int-quantized plain int8 for 8-bit) that carry static per-tensor
+INT8 ``input_activations`` and/or ``output_activations``. The activation quant is
+reproduced as a float fake-quant on the layer input and output, around a
+weight-only matmul, rather than a fused int8 GEMM.
 
-The scheme owns the shared weight parameters and the activation fake-quant; the
-weight matmul is delegated to a backend, chosen in this order: humming (CUDA, any
-bit width), the MP linear kernels (marlin etc.; 4/8-bit only), then a torch dequant
-reference.
+The weight matmul is delegated to a mixed-precision linear kernel chosen by
+``choose_mp_linear_kernel`` (humming for 2-bit and non-64-aligned shapes, marlin /
+machete for 64-aligned 4/8-bit). The scheme normalizes both checkpoint formats to
+the canonical packed layout the kernels expect before dispatching.
 """
 
-from abc import ABC, abstractmethod
 from collections.abc import Callable
 
 import torch
-import torch.nn.functional as F
-from compressed_tensors.compressors.pack_quantized.helpers import unpack_from_int32
+from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
 
-from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     MPLinearLayerConfig,
     choose_mp_linear_kernel,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
-)
-from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa: E501
-    WNA16_SUPPORTED_TYPES_MAP,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_repeat_scales_on_all_ranks,
@@ -42,194 +36,26 @@ from vllm.model_executor.parameter import (
     ModelWeightParameter,
     PackedvLLMParameter,
 )
-from vllm.platforms import current_platform
-from vllm.utils.import_utils import _has_module
-
-logger = init_logger(__name__)
+from vllm.scalar_type import scalar_types
 
 __all__ = ["CompressedTensorsWNA8O8Int", "fake_quant_static_int8"]
 
+WNA8O8_SUPPORTED_TYPES_MAP = {
+    2: scalar_types.uint2b2,
+    4: scalar_types.uint4b8,
+    8: scalar_types.uint8b128,
+}
+
 
 def fake_quant_static_int8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    """Static per-tensor symmetric INT8 quantize-dequantize, in x's dtype."""
+    """Static per-tensor symmetric INT8 quantize-dequantize, in x's dtype.
+
+    Kept as plain aten ops so it fuses into the surrounding compiled kernels; an
+    isolated ``@torch.compile`` region would block that fusion.
+    """
     scale = scale.to(x.dtype)
     q = torch.clamp(torch.round(x / scale), -128.0, 127.0)
     return q * scale
-
-
-class _WeightBackend(ABC):
-    """Owns the weight transform and matmul for a pack-quantized INT weight.
-
-    The shared ``weight_packed`` / ``weight_scale`` / ``weight_shape`` parameters
-    are registered by the scheme before ``maybe_create`` is called.
-    """
-
-    @classmethod
-    @abstractmethod
-    def maybe_create(cls, layer: torch.nn.Module, cfg: "_WeightConfig"):
-        """Return a backend instance if it can serve ``cfg``, else ``None``."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None: ...
-
-    @abstractmethod
-    def apply(
-        self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None
-    ) -> torch.Tensor: ...
-
-
-class _WeightConfig:
-    """Layer dimensions and quant params needed to build a weight backend."""
-
-    def __init__(self, scheme: "CompressedTensorsWNA8O8Int", **dims):
-        self.num_bits = scheme.num_bits
-        self.strategy = scheme.strategy
-        self.group_size = scheme.group_size  # -1 for channel
-        self.quant_format = scheme.quant_format
-        self.is_int_quantized = scheme.is_int_quantized
-        self.input_size = dims["input_size"]
-        self.output_size = dims["output_size"]
-        self.output_partition_sizes = dims["output_partition_sizes"]
-        self.input_size_per_partition = dims["input_size_per_partition"]
-        self.output_size_per_partition = sum(self.output_partition_sizes)
-        self.params_dtype = dims["params_dtype"]
-
-
-class _HummingBackend(_WeightBackend):
-    """humming GEMM; reads the compressed-tensors pack-quantized format natively."""
-
-    def __init__(self, method):
-        self._method = method
-
-    @classmethod
-    def maybe_create(cls, layer, cfg):
-        if not (current_platform.is_cuda() and _has_module("humming")):
-            return None
-
-        from humming.schema.compressed_tensors import CompressedTensorsWeightSchema
-
-        from vllm.model_executor.layers.quantization.humming import (
-            HummingLayerQuantizationConfig,
-            HummingLinearMethod,
-        )
-
-        schema = CompressedTensorsWeightSchema(
-            format=cfg.quant_format,
-            type="int",
-            num_bits=cfg.num_bits,
-            strategy=cfg.strategy,
-            symmetric=True,
-            group_size=None if cfg.group_size == -1 else cfg.group_size,
-        )
-        # TODO(mgoin): wire an int8 input_schema here (gated on input-activation
-        # presence) to run the GEMM with int8 activations, once its performance is
-        # validated. Today the input quant stays a fake-quant and weight-only GEMM.
-        method = HummingLinearMethod(
-            HummingLayerQuantizationConfig(weight_schema=schema)
-        )
-
-        # State HummingLinearMethod.process_weights_after_loading reads.
-        layer.register_buffer("locks", torch.zeros(1024, dtype=torch.int32))
-        layer.is_fallback = False
-        layer.param_dtype = cfg.params_dtype
-        layer.output_partition_sizes = cfg.output_partition_sizes
-        layer.output_partition_sizes_sum = cfg.output_size_per_partition
-        layer.has_bias = False
-        return cls(method)
-
-    def process_weights_after_loading(self, layer):
-        self._method.process_weights_after_loading(layer)
-
-    def apply(self, layer, x, bias):
-        return self._method.apply(layer, x, bias)
-
-
-class _MarlinBackend(_WeightBackend):
-    """MP linear kernels (marlin, machete, ...). Supports 4/8-bit only."""
-
-    def __init__(self, kernel):
-        self._kernel = kernel
-
-    @classmethod
-    def maybe_create(cls, layer, cfg):
-        # MP kernels consume the int32-packed layout only.
-        if cfg.is_int_quantized:
-            return None
-        quant_type = WNA16_SUPPORTED_TYPES_MAP.get(cfg.num_bits)
-        if quant_type is None:
-            return None
-
-        mp_config = MPLinearLayerConfig(
-            full_weight_shape=(cfg.input_size, cfg.output_size),
-            partition_weight_shape=(
-                cfg.input_size_per_partition,
-                cfg.output_size_per_partition,
-            ),
-            weight_type=quant_type,
-            act_type=cfg.params_dtype,  # activation quant applied externally
-            group_size=cfg.group_size,
-            zero_points=False,
-            has_g_idx=False,
-        )
-        try:
-            kernel_cls = choose_mp_linear_kernel(mp_config)
-        except ValueError:
-            return None
-        kernel = kernel_cls(
-            mp_config,
-            w_q_param_name="weight_packed",
-            w_s_param_name="weight_scale",
-            w_zp_param_name="weight_zero_point",
-            w_gidx_param_name="weight_g_idx",
-        )
-        return cls(kernel)
-
-    def process_weights_after_loading(self, layer):
-        self._kernel.process_weights_after_loading(layer)
-
-    def apply(self, layer, x, bias):
-        return self._kernel.apply_weights(layer, x, bias)
-
-
-class _TorchBackend(_WeightBackend):
-    """Reference path: get int8 weights and dequantize in float."""
-
-    def __init__(self, num_bits: int, is_int_quantized: bool):
-        self.num_bits = num_bits
-        self.is_int_quantized = is_int_quantized
-
-    @classmethod
-    def maybe_create(cls, layer, cfg):
-        return cls(cfg.num_bits, cfg.is_int_quantized)
-
-    def process_weights_after_loading(self, layer):
-        if self.is_int_quantized:
-            layer.weight_unpacked = layer.weight  # already int8
-            return
-        shape = torch.Size(
-            [layer.output_size_per_partition, layer.input_size_per_partition]
-        )
-        int8 = unpack_from_int32(layer.weight_packed.data, self.num_bits, shape)
-        layer.weight_unpacked = torch.nn.Parameter(
-            int8.contiguous(), requires_grad=False
-        )
-        del layer.weight_packed
-
-    def apply(self, layer, x, bias):
-        w = layer.weight_unpacked.to(x.dtype)
-        scale = layer.weight_scale.to(x.dtype)
-        if scale.shape[1] != 1:  # group: broadcast each group over the input dim
-            out_f, in_f = w.shape
-            ng = scale.shape[1]
-            w = (w.view(out_f, ng, in_f // ng) * scale.unsqueeze(-1)).view(out_f, in_f)
-        else:
-            w = w * scale
-        return F.linear(x, w, bias)
-
-
-# Tried in priority order; the first that can serve the layer wins.
-_BACKENDS = (_HummingBackend, _MarlinBackend, _TorchBackend)
 
 
 class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
@@ -253,6 +79,12 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         # "pack-quantized" (sub-byte, int32-packed) or "int-quantized" (8-bit int8).
         self.quant_format = quant_format
         self.is_int_quantized = quant_format == "int-quantized"
+        if num_bits not in WNA8O8_SUPPORTED_TYPES_MAP:
+            raise ValueError(
+                f"Unsupported num_bits = {num_bits} for WNA8O8Int; "
+                f"supported = {sorted(WNA8O8_SUPPORTED_TYPES_MAP)}"
+            )
+        self.quant_type = WNA8O8_SUPPORTED_TYPES_MAP[num_bits]
         self._input_scale: torch.Tensor | None = None
         self._output_scale: torch.Tensor | None = None
 
@@ -271,33 +103,44 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         weight_loader: Callable,
         **kwargs,
     ):
+        output_size_per_partition = sum(output_partition_sizes)
         layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = sum(output_partition_sizes)
+        layer.output_size_per_partition = output_size_per_partition
+        # Set for kernels' weight prep; also covers ParallelLMHead, which does
+        # not set these in __init__.
+        layer.output_partition_sizes = output_partition_sizes
+        layer.params_dtype = params_dtype
+        if not hasattr(layer, "has_bias"):
+            layer.has_bias = False
+
+        mp_config = MPLinearLayerConfig(
+            full_weight_shape=(input_size, output_size),
+            partition_weight_shape=(
+                input_size_per_partition,
+                output_size_per_partition,
+            ),
+            weight_type=self.quant_type,
+            act_type=params_dtype,  # activation quant applied externally (SRQ)
+            group_size=self.group_size,
+            zero_points=False,
+            has_g_idx=False,
+        )
+        self.kernel = choose_mp_linear_kernel(mp_config)(
+            mp_config,
+            w_q_param_name="weight_packed",
+            w_s_param_name="weight_scale",
+        )
+
         self._register_weight(
             layer, input_size, input_size_per_partition, params_dtype, weight_loader
         )
-
-        cfg = _WeightConfig(
-            self,
-            input_size=input_size,
-            output_size=output_size,
-            output_partition_sizes=output_partition_sizes,
-            input_size_per_partition=input_size_per_partition,
-            params_dtype=params_dtype,
-        )
-        for backend_cls in _BACKENDS:
-            backend = backend_cls.maybe_create(layer, cfg)
-            if backend is not None:
-                break
-        assert backend is not None, f"No backend found for {layer=} {cfg=}"
-        self.backend: _WeightBackend = backend
 
     def _register_weight(
         self, layer, input_size, input_size_per_partition, params_dtype, weight_loader
     ):
         out = layer.output_size_per_partition
         if self.is_int_quantized:
-            # 8-bit int weight stored directly as int8 (no packing, no shape).
+            # Plain int8 weight; packed to the canonical int32 layout after load.
             layer.register_parameter(
                 "weight",
                 ModelWeightParameter(
@@ -323,6 +166,12 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                     ),
                 ),
             )
+            layer.register_parameter(
+                "weight_shape",
+                BasevLLMParameter(
+                    data=torch.empty(2, dtype=torch.int64), weight_loader=weight_loader
+                ),
+            )
 
         # Scale: per-output-channel, or per group along the input dim under TP.
         group_size = self.group_size if self.group_size != -1 else input_size
@@ -341,13 +190,6 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                 data=scale_data, output_dim=0, weight_loader=weight_loader
             )
         layer.register_parameter("weight_scale", weight_scale)
-        if not self.is_int_quantized:
-            layer.register_parameter(
-                "weight_shape",
-                BasevLLMParameter(
-                    data=torch.empty(2, dtype=torch.int64), weight_loader=weight_loader
-                ),
-            )
 
         for name, present in (
             ("input_scale", self.has_input_act),
@@ -364,12 +206,46 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Lift the static activation scales off the layer (applied externally) so
-        # the backend only sees weight tensors. Drop uncalibrated (zero) scales.
+        # the kernel only sees weight tensors. Drop uncalibrated (zero) scales.
         self._input_scale = self._take_act_scale(layer, "input_scale")
         self._output_scale = self._take_act_scale(layer, "output_scale")
         self.has_input_act = self._input_scale is not None
         self.has_output_act = self._output_scale is not None
-        self.backend.process_weights_after_loading(layer)
+
+        if self.is_int_quantized:
+            self._pack_int_quantized_weight(layer)
+
+        self.kernel.process_weights_after_loading(layer)
+
+    def _pack_int_quantized_weight(self, layer: torch.nn.Module) -> None:
+        """Normalize an int-quantized (plain int8) weight to the canonical
+        ``weight_packed`` int32 + ``weight_shape`` layout the MP kernels expect."""
+        weight = layer.weight
+        out_features, in_features = weight.shape
+        packed = pack_to_int32(weight.data.contiguous(), self.num_bits)
+        delattr(layer, "weight")
+
+        def _noop_loader(*_, **__):
+            return None
+
+        layer.register_parameter(
+            "weight_packed",
+            PackedvLLMParameter(
+                data=packed.contiguous(),
+                input_dim=1,
+                output_dim=0,
+                packed_dim=1,
+                packed_factor=self.pack_factor,
+                weight_loader=_noop_loader,
+            ),
+        )
+        layer.register_parameter(
+            "weight_shape",
+            BasevLLMParameter(
+                data=torch.tensor([out_features, in_features], dtype=torch.int64),
+                weight_loader=_noop_loader,
+            ),
+        )
 
     @staticmethod
     def _take_act_scale(layer, name: str) -> torch.Tensor | None:
@@ -385,7 +261,7 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
     ) -> torch.Tensor:
         if self.has_input_act:
             x = fake_quant_static_int8(x, self._input_scale)
-        out = self.backend.apply(layer, x, bias)
+        out = self.kernel.apply_weights(layer, x, bias)
         if self.has_output_act:
             out = fake_quant_static_int8(out, self._output_scale)
         return out

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Weight N-bit INT scheme with static INT8 input/output activation quant.
+
+Handles pack-quantized INT weight checkpoints that carry static per-tensor INT8
+``input_activations`` and/or ``output_activations``. An output-activation scale is
+the distinguishing signal: it means the activation quantization is reproduced as a
+float fake-quant on the layer input and output, around a weight-only matmul, rather
+than a fused int8 GEMM.
+
+The scheme owns the shared weight parameters and the activation fake-quant; the
+weight matmul is delegated to a backend, chosen in this order: humming (CUDA, any
+bit width), the MP linear kernels (marlin etc.; 4/8-bit only), then a torch dequant
+reference.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as F
+from compressed_tensors.compressors.pack_quantized.helpers import unpack_from_int32
+
+from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear import (
+    MPLinearLayerConfig,
+    choose_mp_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsScheme,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa: E501
+    WNA16_SUPPORTED_TYPES_MAP,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    marlin_repeat_scales_on_all_ranks,
+)
+from vllm.model_executor.parameter import (
+    BasevLLMParameter,
+    ChannelQuantScaleParameter,
+    GroupQuantScaleParameter,
+    ModelWeightParameter,
+    PackedvLLMParameter,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import _has_module
+
+logger = init_logger(__name__)
+
+__all__ = ["CompressedTensorsWNA8O8Int", "fake_quant_static_int8"]
+
+
+def fake_quant_static_int8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Static per-tensor symmetric INT8 quantize-dequantize, in x's dtype."""
+    scale = scale.to(x.dtype)
+    q = torch.clamp(torch.round(x / scale), -128.0, 127.0)
+    return q * scale
+
+
+class _WeightBackend(ABC):
+    """Owns the weight transform and matmul for a pack-quantized INT weight.
+
+    The shared ``weight_packed`` / ``weight_scale`` / ``weight_shape`` parameters
+    are registered by the scheme before ``maybe_create`` is called.
+    """
+
+    @classmethod
+    @abstractmethod
+    def maybe_create(cls, layer: torch.nn.Module, cfg: "_WeightConfig"):
+        """Return a backend instance if it can serve ``cfg``, else ``None``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None: ...
+
+    @abstractmethod
+    def apply(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None
+    ) -> torch.Tensor: ...
+
+
+class _WeightConfig:
+    """Layer dimensions and quant params needed to build a weight backend."""
+
+    def __init__(self, scheme: "CompressedTensorsWNA8O8Int", **dims):
+        self.num_bits = scheme.num_bits
+        self.strategy = scheme.strategy
+        self.group_size = scheme.group_size  # -1 for channel
+        self.quant_format = scheme.quant_format
+        self.is_int_quantized = scheme.is_int_quantized
+        self.input_size = dims["input_size"]
+        self.output_size = dims["output_size"]
+        self.output_partition_sizes = dims["output_partition_sizes"]
+        self.input_size_per_partition = dims["input_size_per_partition"]
+        self.output_size_per_partition = sum(self.output_partition_sizes)
+        self.params_dtype = dims["params_dtype"]
+
+
+class _HummingBackend(_WeightBackend):
+    """humming GEMM; reads the compressed-tensors pack-quantized format natively."""
+
+    def __init__(self, method):
+        self._method = method
+
+    @classmethod
+    def maybe_create(cls, layer, cfg):
+        if not (current_platform.is_cuda() and _has_module("humming")):
+            return None
+
+        from humming.schema.compressed_tensors import CompressedTensorsWeightSchema
+
+        from vllm.model_executor.layers.quantization.humming import (
+            HummingLayerQuantizationConfig,
+            HummingLinearMethod,
+        )
+
+        schema = CompressedTensorsWeightSchema(
+            format=cfg.quant_format,
+            type="int",
+            num_bits=cfg.num_bits,
+            strategy=cfg.strategy,
+            symmetric=True,
+            group_size=None if cfg.group_size == -1 else cfg.group_size,
+        )
+        # TODO(mgoin): wire an int8 input_schema here (gated on input-activation
+        # presence) to run the GEMM with int8 activations, once its performance is
+        # validated. Today the input quant stays a fake-quant and weight-only GEMM.
+        method = HummingLinearMethod(
+            HummingLayerQuantizationConfig(weight_schema=schema)
+        )
+
+        # State HummingLinearMethod.process_weights_after_loading reads.
+        layer.register_buffer("locks", torch.zeros(1024, dtype=torch.int32))
+        layer.is_fallback = False
+        layer.param_dtype = cfg.params_dtype
+        layer.output_partition_sizes = cfg.output_partition_sizes
+        layer.output_partition_sizes_sum = cfg.output_size_per_partition
+        layer.has_bias = False
+        return cls(method)
+
+    def process_weights_after_loading(self, layer):
+        self._method.process_weights_after_loading(layer)
+
+    def apply(self, layer, x, bias):
+        return self._method.apply(layer, x, bias)
+
+
+class _MarlinBackend(_WeightBackend):
+    """MP linear kernels (marlin, machete, ...). Supports 4/8-bit only."""
+
+    def __init__(self, kernel):
+        self._kernel = kernel
+
+    @classmethod
+    def maybe_create(cls, layer, cfg):
+        # MP kernels consume the int32-packed layout only.
+        if cfg.is_int_quantized:
+            return None
+        quant_type = WNA16_SUPPORTED_TYPES_MAP.get(cfg.num_bits)
+        if quant_type is None:
+            return None
+
+        mp_config = MPLinearLayerConfig(
+            full_weight_shape=(cfg.input_size, cfg.output_size),
+            partition_weight_shape=(
+                cfg.input_size_per_partition,
+                cfg.output_size_per_partition,
+            ),
+            weight_type=quant_type,
+            act_type=cfg.params_dtype,  # activation quant applied externally
+            group_size=cfg.group_size,
+            zero_points=False,
+            has_g_idx=False,
+        )
+        try:
+            kernel_cls = choose_mp_linear_kernel(mp_config)
+        except ValueError:
+            return None
+        kernel = kernel_cls(
+            mp_config,
+            w_q_param_name="weight_packed",
+            w_s_param_name="weight_scale",
+            w_zp_param_name="weight_zero_point",
+            w_gidx_param_name="weight_g_idx",
+        )
+        return cls(kernel)
+
+    def process_weights_after_loading(self, layer):
+        self._kernel.process_weights_after_loading(layer)
+
+    def apply(self, layer, x, bias):
+        return self._kernel.apply_weights(layer, x, bias)
+
+
+class _TorchBackend(_WeightBackend):
+    """Reference path: get int8 weights and dequantize in float."""
+
+    def __init__(self, num_bits: int, is_int_quantized: bool):
+        self.num_bits = num_bits
+        self.is_int_quantized = is_int_quantized
+
+    @classmethod
+    def maybe_create(cls, layer, cfg):
+        return cls(cfg.num_bits, cfg.is_int_quantized)
+
+    def process_weights_after_loading(self, layer):
+        if self.is_int_quantized:
+            layer.weight_unpacked = layer.weight  # already int8
+            return
+        shape = torch.Size(
+            [layer.output_size_per_partition, layer.input_size_per_partition]
+        )
+        int8 = unpack_from_int32(layer.weight_packed.data, self.num_bits, shape)
+        layer.weight_unpacked = torch.nn.Parameter(
+            int8.contiguous(), requires_grad=False
+        )
+        del layer.weight_packed
+
+    def apply(self, layer, x, bias):
+        w = layer.weight_unpacked.to(x.dtype)
+        scale = layer.weight_scale.to(x.dtype)
+        if scale.shape[1] != 1:  # group: broadcast each group over the input dim
+            out_f, in_f = w.shape
+            ng = scale.shape[1]
+            w = (w.view(out_f, ng, in_f // ng) * scale.unsqueeze(-1)).view(out_f, in_f)
+        else:
+            w = w * scale
+        return F.linear(x, w, bias)
+
+
+# Tried in priority order; the first that can serve the layer wins.
+_BACKENDS = (_HummingBackend, _MarlinBackend, _TorchBackend)
+
+
+class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
+    def __init__(
+        self,
+        num_bits: int,
+        strategy: str,
+        group_size: int | None = None,
+        has_input_act: bool = False,
+        has_output_act: bool = False,
+        layer_name: str | None = None,
+        quant_format: str = "pack-quantized",
+    ):
+        self.num_bits = num_bits
+        self.pack_factor = 32 // num_bits
+        self.strategy = strategy
+        self.group_size = -1 if group_size is None else group_size
+        self.has_input_act = has_input_act
+        self.has_output_act = has_output_act
+        self.layer_name = layer_name
+        # "pack-quantized" (sub-byte, int32-packed) or "int-quantized" (8-bit int8).
+        self.quant_format = quant_format
+        self.is_int_quantized = quant_format == "int-quantized"
+        self._input_scale: torch.Tensor | None = None
+        self._output_scale: torch.Tensor | None = None
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_size: int,
+        input_size: int,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs,
+    ):
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = sum(output_partition_sizes)
+        self._register_weight(
+            layer, input_size, input_size_per_partition, params_dtype, weight_loader
+        )
+
+        cfg = _WeightConfig(
+            self,
+            input_size=input_size,
+            output_size=output_size,
+            output_partition_sizes=output_partition_sizes,
+            input_size_per_partition=input_size_per_partition,
+            params_dtype=params_dtype,
+        )
+        for backend_cls in _BACKENDS:
+            backend = backend_cls.maybe_create(layer, cfg)
+            if backend is not None:
+                break
+        assert backend is not None, f"No backend found for {layer=} {cfg=}"
+        self.backend: _WeightBackend = backend
+
+    def _register_weight(
+        self, layer, input_size, input_size_per_partition, params_dtype, weight_loader
+    ):
+        out = layer.output_size_per_partition
+        if self.is_int_quantized:
+            # 8-bit int weight stored directly as int8 (no packing, no shape).
+            layer.register_parameter(
+                "weight",
+                ModelWeightParameter(
+                    data=torch.empty(out, input_size_per_partition, dtype=torch.int8),
+                    input_dim=1,
+                    output_dim=0,
+                    weight_loader=weight_loader,
+                ),
+            )
+        else:
+            layer.register_parameter(
+                "weight_packed",
+                PackedvLLMParameter(
+                    input_dim=1,
+                    output_dim=0,
+                    packed_dim=1,
+                    packed_factor=self.pack_factor,
+                    weight_loader=weight_loader,
+                    data=torch.empty(
+                        out,
+                        input_size_per_partition // self.pack_factor,
+                        dtype=torch.int32,
+                    ),
+                ),
+            )
+
+        # Scale: per-output-channel, or per group along the input dim under TP.
+        group_size = self.group_size if self.group_size != -1 else input_size
+        partitioned = not marlin_repeat_scales_on_all_ranks(
+            False, self.group_size, input_size != input_size_per_partition
+        )
+        scales = (input_size_per_partition if partitioned else input_size) // group_size
+        scale_data = torch.empty(out, scales, dtype=params_dtype)
+        if partitioned:
+            assert input_size_per_partition % group_size == 0
+            weight_scale = GroupQuantScaleParameter(
+                data=scale_data, output_dim=0, input_dim=1, weight_loader=weight_loader
+            )
+        else:
+            weight_scale = ChannelQuantScaleParameter(
+                data=scale_data, output_dim=0, weight_loader=weight_loader
+            )
+        layer.register_parameter("weight_scale", weight_scale)
+        if not self.is_int_quantized:
+            layer.register_parameter(
+                "weight_shape",
+                BasevLLMParameter(
+                    data=torch.empty(2, dtype=torch.int64), weight_loader=weight_loader
+                ),
+            )
+
+        for name, present in (
+            ("input_scale", self.has_input_act),
+            ("output_scale", self.has_output_act),
+        ):
+            if present:
+                layer.register_parameter(
+                    name,
+                    BasevLLMParameter(
+                        data=torch.empty(1, dtype=torch.float32),
+                        weight_loader=weight_loader,
+                    ),
+                )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Lift the static activation scales off the layer (applied externally) so
+        # the backend only sees weight tensors. Drop uncalibrated (zero) scales.
+        self._input_scale = self._take_act_scale(layer, "input_scale")
+        self._output_scale = self._take_act_scale(layer, "output_scale")
+        self.has_input_act = self._input_scale is not None
+        self.has_output_act = self._output_scale is not None
+        self.backend.process_weights_after_loading(layer)
+
+    @staticmethod
+    def _take_act_scale(layer, name: str) -> torch.Tensor | None:
+        param = getattr(layer, name, None)
+        if param is None:
+            return None
+        scale = param.data.clone()
+        delattr(layer, name)
+        return None if float(scale.reshape(-1)[0]) == 0.0 else scale
+
+    def apply_weights(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None
+    ) -> torch.Tensor:
+        if self.has_input_act:
+            x = fake_quant_static_int8(x, self._input_scale)
+        out = self.backend.apply(layer, x, bias)
+        if self.has_output_act:
+            out = fake_quant_static_int8(out, self._output_scale)
+        return out

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
@@ -2,16 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Weight N-bit INT scheme with static INT8 input/output activation quant.
 
-Handles compressed-tensors INT weight checkpoints (pack-quantized int32 for
-sub-byte weights, int-quantized plain int8 for 8-bit) that carry static per-tensor
+Handles compressed-tensors INT weight checkpoints that carry static per-tensor
 INT8 ``input_activations`` and/or ``output_activations``. The activation quant is
 reproduced as a float fake-quant on the layer input and output, around a
 weight-only matmul, rather than a fused int8 GEMM.
-
-The weight matmul is delegated to a mixed-precision linear kernel chosen by
-``choose_mp_linear_kernel`` (humming for 2-bit and non-64-aligned shapes, marlin /
-machete for 64-aligned 4/8-bit). The scheme normalizes both checkpoint formats to
-the canonical packed layout the kernels expect before dispatching.
 """
 
 from collections.abc import Callable
@@ -48,11 +42,7 @@ WNA8O8_SUPPORTED_TYPES_MAP = {
 
 
 def fake_quant_static_int8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    """Static per-tensor symmetric INT8 quantize-dequantize, in x's dtype.
-
-    Kept as plain aten ops so it fuses into the surrounding compiled kernels; an
-    isolated ``@torch.compile`` region would block that fusion.
-    """
+    """Static per-tensor symmetric INT8 quantize-dequantize, in x's dtype."""
     scale = scale.to(x.dtype)
     q = torch.clamp(torch.round(x / scale), -128.0, 127.0)
     return q * scale

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from typing import Any
 
 import regex as re
@@ -42,6 +43,42 @@ def humming_is_layer_skipped(config: dict[str, Any], prefix: str):
     return False
 
 
+def convert_linear_layer_to_humming_standard(
+    layer: LinearBase, name_map: dict[str, str]
+):
+    """Rename/reshape a linear layer's quantized params (the canonical MPLinear
+    layout: ``weight_packed`` int32 + ``weight_scale``) into the parameter names
+    and layout humming's weight schema expects (``weight`` / ``weight_scale``)."""
+    for name, checkpoint_name in name_map.items():
+        tensor = getattr(layer, checkpoint_name)
+        delattr(layer, checkpoint_name)
+
+        if name == "weight":
+            input_dim = getattr(tensor, "input_dim", 1)
+            output_dim = getattr(tensor, "output_dim", 0)
+
+            if input_dim == 0 and output_dim == 1:
+                tensor = tensor.transpose(1, 0).contiguous()
+            else:
+                assert output_dim == 0 and input_dim == 1
+
+            tensor = tensor.view(tensor.size(0), -1).view(torch.int32)
+        elif name in ["weight_scale", "zero_point"]:
+            if getattr(tensor, "output_dim", 0) == 1:
+                tensor = tensor.transpose(0, 1).contiguous()
+            if tensor.ndim == 1:
+                tensor = tensor.unsqueeze(1)
+
+            tensor = tensor.view(torch.int32) if name == "zero_point" else tensor
+
+        if isinstance(tensor, torch.nn.Parameter):
+            param = tensor
+        else:
+            param = torch.nn.Parameter(tensor, requires_grad=False)
+
+        setattr(layer, name, param)
+
+
 def prepare_humming_layer(layer: LinearBase, quant_config: dict):
     weight_schema = BaseWeightSchema.from_config(quant_config)
     input_schema = HummingInputSchema()
@@ -51,7 +88,7 @@ def prepare_humming_layer(layer: LinearBase, quant_config: dict):
 
     # Step 1: convert weight to humming standard format
     weight_schema, tensors = weight_schema.convert_humming(
-        tensors=layer.named_parameters(),
+        tensors=dict(layer.named_parameters()),
         shape_n_stacks=shape_n_stacks,
         shape_k_stacks=shape_k_stacks,
         param_dtype=layer.params_dtype,
@@ -63,23 +100,37 @@ def prepare_humming_layer(layer: LinearBase, quant_config: dict):
         delattr(layer, name)
 
     for name, tensor in tensors.items():
+        if isinstance(tensor, torch.nn.Parameter):
+            tensor = tensor.data
         param = torch.nn.Parameter(tensor, requires_grad=False)
         setattr(layer, name, param)
 
     # Step 2: transform weight (humming standard format) for forwarding
     HummingMethod.prepare_layer_meta(
         layer=layer,
-        shape_n=layer.output_partition_sizes_sum,
+        shape_n=sum(layer.output_partition_sizes),
         shape_k=layer.input_size_per_partition,
         weight_schema=weight_schema,
         input_schema=input_schema,
         pad_n_to_multiple=256,
         pad_k_to_multiple=128,
         has_bias=layer.has_bias,
-        torch_dtype=layer.param_dtype,
+        torch_dtype=layer.params_dtype,
     )
 
     HummingMethod.transform_humming_layer(layer)
+    if not hasattr(layer, "locks"):
+        device = layer.weight.device
+        locks = torch.zeros(1024, dtype=torch.int32, device=device)
+        layer.register_buffer("locks", locks)
+
+    compute_config = {
+        "use_batch_invariant": envs.VLLM_BATCH_INVARIANT,
+        "use_f16_accum": envs.VLLM_HUMMING_USE_F16_ACCUM,
+        "gemm_type": "dense",
+    }
+
+    layer.compute_config = json.dumps(compute_config)
 
 
 def prepare_humming_moe_layer(layer: RoutedExperts, quant_config: dict):

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -83,7 +83,12 @@ def prepare_humming_layer(layer: LinearBase, quant_config: dict):
     weight_schema = BaseWeightSchema.from_config(quant_config)
     input_schema = HummingInputSchema()
 
-    shape_k_stacks = [layer.input_size_per_partition]
+    # ReplicatedLinear has no TP partitioning and so does not set
+    # input_size_per_partition; for it that is just input_size.
+    input_size_per_partition = getattr(
+        layer, "input_size_per_partition", layer.input_size
+    )
+    shape_k_stacks = [input_size_per_partition]
     shape_n_stacks = layer.output_partition_sizes
 
     # Step 1: convert weight to humming standard format
@@ -109,7 +114,7 @@ def prepare_humming_layer(layer: LinearBase, quant_config: dict):
     HummingMethod.prepare_layer_meta(
         layer=layer,
         shape_n=sum(layer.output_partition_sizes),
-        shape_k=layer.input_size_per_partition,
+        shape_k=input_size_per_partition,
         weight_schema=weight_schema,
         input_schema=input_schema,
         pad_n_to_multiple=256,

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1052,12 +1052,14 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         # Embedding scale = sqrt(hidden_size), cast to model dtype to avoid
-        # mixed-precision drift from bf16 * fp32 across deep stacks.
+        # mixed-precision drift from bf16 * fp32 across deep stacks. Read the
+        # dtype from the config rather than embed_tokens.weight, which does not
+        # exist when the embedding is quantized.
         self.register_buffer(
             "normalizer",
             torch.tensor(
                 config.hidden_size**0.5,
-                dtype=self.embed_tokens.weight.dtype,
+                dtype=vllm_config.model_config.dtype,
             ),
             persistent=False,
         )
@@ -1111,7 +1113,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             )
             self.hidden_states = torch.zeros(
                 (max_num_tokens, config.hidden_size),
-                dtype=self.embed_tokens.weight.dtype,
+                dtype=vllm_config.model_config.dtype,
                 device=device,
             )
             if (
@@ -1124,7 +1126,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                         config.num_hidden_layers,
                         self.hidden_size_per_layer_input,
                     ),
-                    dtype=self.embed_tokens.weight.dtype,
+                    dtype=vllm_config.model_config.dtype,
                     device=device,
                 )
             else:

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1052,9 +1052,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         # Embedding scale = sqrt(hidden_size), cast to model dtype to avoid
-        # mixed-precision drift from bf16 * fp32 across deep stacks. Read the
-        # dtype from the config rather than embed_tokens.weight, which does not
-        # exist when the embedding is quantized.
+        # mixed-precision drift from bf16 * fp32 across deep stacks.
         self.register_buffer(
             "normalizer",
             torch.tensor(

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1011,6 +1011,7 @@ class Gemma4ForConditionalGeneration(
         self.config = config
         self.quant_config = quant_config
         self.multimodal_config = multimodal_config
+        self.model_dtype = vllm_config.model_config.dtype
 
         # Only quantize towers when the quant method supports their
         # dimensions.  BNB/torchao handle arbitrary sizes; other methods
@@ -1247,7 +1248,6 @@ class Gemma4ForConditionalGeneration(
         vt = self.vision_tower
         vision_cfg = self.config.vision_config
         pooling_k2 = vision_cfg.pooling_kernel_size**2
-        target_dtype = self.language_model.model.embed_tokens.weight.dtype
 
         # Concurrent requests with different image resolutions may
         # arrive as a list of per-image tensors, while same-resolution
@@ -1292,7 +1292,7 @@ class Gemma4ForConditionalGeneration(
                     pv_tensor,
                     pp_tensor,
                     pad_tensor,
-                ).to(target_dtype)
+                ).to(self.model_dtype)
                 encoder_outputs = vt.encoder(
                     inputs_embeds=inputs_embeds,
                     attention_mask=~pad_tensor,
@@ -1329,12 +1329,8 @@ class Gemma4ForConditionalGeneration(
             all_valid_states[orig_idx] = valid_states
             valid_lens[orig_idx] = valid_states.shape[0]
 
-        # Use embed_tokens dtype as compute dtype; embedding_projection.weight
-        # may be uint8 under BnB 4-bit, which would corrupt the cast.
-        target_dtype = self.language_model.model.embed_tokens.weight.dtype
-
         # Project all images in a single batched call.
-        flat_valid_states = torch.cat(all_valid_states, dim=0).to(target_dtype)
+        flat_valid_states = torch.cat(all_valid_states, dim=0).to(self.model_dtype)
         flat_proj_embs = self.embed_vision(
             inputs_embeds=flat_valid_states.unsqueeze(0)
         ).squeeze(0)
@@ -1374,7 +1370,6 @@ class Gemma4ForConditionalGeneration(
         vt = self.vision_tower
         vision_cfg = self.config.vision_config
         pooling_k2 = vision_cfg.pooling_kernel_size**2
-        target_dtype = self.language_model.model.embed_tokens.weight.dtype
 
         if isinstance(frame_counts, torch.Tensor):
             fc_list = frame_counts.tolist()
@@ -1406,7 +1401,7 @@ class Gemma4ForConditionalGeneration(
                 pv_chunk,
                 pp_chunk,
                 pad_chunk,
-            ).to(target_dtype)
+            ).to(self.model_dtype)
             encoder_outputs = vt.encoder(
                 inputs_embeds=inputs_embeds,
                 attention_mask=~pad_chunk,
@@ -1441,7 +1436,9 @@ class Gemma4ForConditionalGeneration(
             frame_valid_lens.append(valid_states.shape[0])
 
         # Project all frames in a single batched call.
-        flat_valid_states = torch.cat(all_frame_valid_states, dim=0).to(target_dtype)
+        flat_valid_states = torch.cat(all_frame_valid_states, dim=0).to(
+            self.model_dtype
+        )
         flat_proj_embs = self.embed_vision(
             inputs_embeds=flat_valid_states.unsqueeze(0)
         ).squeeze(0)

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1014,13 +1014,19 @@ class Gemma4ForConditionalGeneration(
         self.model_dtype = vllm_config.model_config.dtype
 
         # Only quantize towers when the quant method supports their
-        # dimensions.  BNB/torchao handle arbitrary sizes; other methods
-        # (Marlin, FP8, …) require dimensions divisible by 64, which
-        # the vision tower (intermediate_size=4304) does not satisfy.
+        # dimensions.  BNB/torchao/compressed-tensors resolve quantization
+        # per-layer and handle arbitrary sizes; other methods (Marlin, FP8, …)
+        # require dimensions divisible by 64, which the vision tower
+        # (intermediate_size=4304) does not satisfy.
         if quant_config and quant_config.get_name() in [
             "bitsandbytes",
             "torchao",
+            "compressed-tensors",
         ]:
+            # compressed-tensors falls back to an unquantized linear for tower
+            # layers that match no scheme (e.g. the dequantized audio
+            # ffw_layer_1 / linear_start / post), and its WNA8O8Int humming/torch
+            # path handles the non-64-aligned tower dimensions.
             tower_quant = quant_config
         else:
             vision_cfg = config.vision_config

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1014,19 +1014,15 @@ class Gemma4ForConditionalGeneration(
         self.model_dtype = vllm_config.model_config.dtype
 
         # Only quantize towers when the quant method supports their
-        # dimensions.  BNB/torchao/compressed-tensors resolve quantization
-        # per-layer and handle arbitrary sizes; other methods (Marlin, FP8, …)
-        # require dimensions divisible by 64, which the vision tower
-        # (intermediate_size=4304) does not satisfy.
+        # dimensions.  BNB/torchao handle arbitrary sizes; other methods
+        # (Marlin, FP8, …) require dimensions divisible by 64, which
+        # the vision tower (intermediate_size=4304) does not satisfy.
+        # TODO(mgoin): remove this by fixing kernel padding.
         if quant_config and quant_config.get_name() in [
             "bitsandbytes",
             "torchao",
             "compressed-tensors",
         ]:
-            # compressed-tensors falls back to an unquantized linear for tower
-            # layers that match no scheme (e.g. the dequantized audio
-            # ffw_layer_1 / linear_start / post), and its WNA8O8Int humming/torch
-            # path handles the non-64-aligned tower dimensions.
             tower_quant = quant_config
         else:
             vision_cfg = config.vision_config

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1081,12 +1081,13 @@ class Gemma4ForConditionalGeneration(
             # Some variants have hidden_size_per_layer_input=None (no PLE).
             ple_dim = config.text_config.hidden_size_per_layer_input
             if ple_dim is not None and ple_dim > 0:
+                embed = self.language_model.model.embed_tokens
                 self.per_layer_embeddings = torch.zeros(
                     vllm_config.scheduler_config.max_num_batched_tokens,
                     config.text_config.num_hidden_layers,
                     ple_dim,
-                    device=self.language_model.model.embed_tokens.weight.device,
-                    dtype=self.language_model.model.embed_tokens.weight.dtype,
+                    device=next(embed.parameters()).device,
+                    dtype=vllm_config.model_config.dtype,
                 )
             else:
                 self.per_layer_embeddings = None

--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -307,12 +307,13 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
                 None,
             )
             if ple_dim is not None and ple_dim > 0:
+                embed = self.language_model.model.embed_tokens
                 self.per_layer_embeddings = torch.zeros(
                     vllm_config.scheduler_config.max_num_batched_tokens,
                     config.text_config.num_hidden_layers,
                     ple_dim,
-                    device=self.language_model.model.embed_tokens.weight.device,
-                    dtype=self.language_model.model.embed_tokens.weight.dtype,
+                    device=next(embed.parameters()).device,
+                    dtype=vllm_config.model_config.dtype,
                 )
             else:
                 self.per_layer_embeddings = None


### PR DESCRIPTION



## Purpose

Requires compressed-tensors bump for embedding support with https://github.com/vllm-project/compressed-tensors/pull/718

Introduces two new specialized methods for compressed-tensors to dispatch to:
* `CompressedTensorsWNA8O8Int` to support any linear layer that has INT1-8 weights with static per-tensor scales for INT8 inputs and outputs. Currently we are running these as fake quants on the input+output, with a weight-only gemm in the middle using humming/marlin/various slower fallback methods.
* `CompressedTensorsEmbeddingWNA16Int` for supporting `VocabParallelEmbedding` layers that have been compressed to INT1-8 weights, with a trivial Triton kernel for efficient fused selection+dequant

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

