### PR TITLE
Add SM103 to Docker CUDA arch defaults

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -248,7 +248,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # Explicitly set the list to avoid issues with torch 2.2
 # See https://github.com/pytorch/pytorch/pull/123243
 # From versions.json: .torch.cuda_arch_list
-ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
+ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 10.3 11.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 #################### BUILD BASE IMAGE ####################
 
@@ -957,7 +957,7 @@ ARG PIP_EXTRA_INDEX_URL UV_EXTRA_INDEX_URL
 ENV UV_HTTP_TIMEOUT=500
 
 # install kv_connectors if requested
-ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
+ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 10.3 11.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 RUN --mount=type=cache,target=/opt/uv/cache \
     --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -20,7 +20,7 @@ variable "NVCC_THREADS" {
 }
 
 variable "TORCH_CUDA_ARCH_LIST" {
-  default = "8.0 8.9 9.0 10.0 11.0 12.0"
+  default = "8.0 8.9 9.0 10.0 10.3 11.0 12.0"
 }
 
 variable "COMMIT" {

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -35,7 +35,7 @@
       "default": "false"
     },
     "TORCH_CUDA_ARCH_LIST": {
-      "default": "7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX"
+      "default": "7.5 8.0 8.6 8.9 9.0 10.0 10.3 11.0 12.0+PTX"
     },
     "MAX_JOBS": {
       "default": "2"


### PR DESCRIPTION
## Summary

Add NVIDIA B300 / SM103 (`10.3`) to the default Docker CUDA architecture lists.

The vLLM CMake configuration already recognizes `10.3`, but the Docker defaults did not include it. As a result, stock Docker builds can omit native SM103 coverage from build-time CUDA extension paths even on images where some runtime/JIT components, such as FlashInfer artifacts, contain SM103-compatible cubins.

## Why

B300 deployments need `TORCH_CUDA_ARCH_LIST` to include compute capability `10.3` at image build time. Setting it only at container runtime is not equivalent, because already-built CUDA extensions are not rebuilt retroactively.

This updates:

- `docker/versions.json`
- `docker/Dockerfile`
- `docker/docker-bake.hcl`

## Validation

- Parsed `docker/versions.json` with `python3 -m json.tool`.
- Confirmed the updated Docker defaults include `10.3`.
- Built/tested an equivalent B300 image externally and confirmed it serves NVFP4/MTP workloads on B300 where stock images without `10.3` in the build arch list were unreliable.
