### PR TITLE
[BugFix] Fix sparse NCCL weight transfer test construction

### DIFF
--- a/docs/training/weight_transfer/base.md
+++ b/docs/training/weight_transfer/base.md
@@ -156,5 +156,6 @@ from vllm.distributed.weight_transfer.factory import WeightTransferEngineFactory
 engine = WeightTransferEngineFactory.create_engine(
     config=weight_transfer_config,
     parallel_config=parallel_config,
+    model=model,
 )
 ```

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -291,7 +291,9 @@ def test_nccl_receive_sparse_weights_without_init_raises():
 
     config = WeightTransferConfig(backend="nccl")
     parallel_config = create_mock_parallel_config()
-    engine = NCCLWeightTransferEngine(config, parallel_config)
+    engine = NCCLWeightTransferEngine(
+        config, parallel_config, MagicMock(spec=torch.nn.Module)
+    )
 
     update_info = NCCLWeightTransferUpdateInfo(
         names=["w"],
@@ -526,7 +528,9 @@ def inference_receive_sparse_tensor(
     parallel_config.data_parallel_rank = 0
     parallel_config.data_parallel_index = 0
 
-    engine = NCCLWeightTransferEngine(config, parallel_config)
+    engine = NCCLWeightTransferEngine(
+        config, parallel_config, MagicMock(spec=torch.nn.Module)
+    )
     engine.init_transfer_engine(
         NCCLWeightTransferInitInfo(
             master_address=master_address,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix https://github.com/vllm-project/vllm/pull/44272 forward for the tests that failed in the nightly CI.

The production path already passes the model through WeightTransferEngineFactory.create_engine(...); the breakage was in stale test/example-style call sites that still constructed NCCLWeightTransferEngine(config, parallel_config) directly which run only when >2 GPUs.

This updates:

```
tests/distributed/test_weight_transfer.py
docs/training/weight_transfer/base.md
```

## Test Plan

- Ran targeted sparse NCCL regression tests on a two-GPU L40 environment.
- Ran related sparse worker/model-runner tests.
- Ran the full distributed weight transfer suite covering NCCL dense, NCCL sparse, and IPC paths.
- Ran the sparse NCCL example to validate the real-model dense-vs-sparse update flow.

## Test Result

- Targeted sparse NCCL regression tests passed.
- Related sparse worker/model-runner tests passed.
- Full distributed weight transfer suite passed.
- Sparse NCCL example completed successfully with matching dense and sparse update behavior.

---
