### PR TITLE
[Bugfix] Fix unstreamed tool call args dropped in Responses API streaming

### DIFF
--- a/tests/parser/test_streaming.py
+++ b/tests/parser/test_streaming.py
@@ -58,7 +58,11 @@ def stream_text(parser, tokenizer, text, request, prompt_token_ids=None):
     for tid in token_ids:
         delta_text = tokenizer.decode([tid])
         result = parser.parse_delta(
-            delta_text, [tid], request, prompt_token_ids=prompt_token_ids
+            delta_text,
+            [tid],
+            request,
+            prompt_token_ids=prompt_token_ids,
+            finished=False,
         )
         prompt_token_ids = None
         results.append(result)
@@ -146,7 +150,11 @@ def stream_chunks(parser, tokenizer, chunks, request_obj):
     for chunk in chunks:
         delta_text = tokenizer.decode(chunk)
         result = parser.parse_delta(
-            delta_text, chunk, request_obj, prompt_token_ids=prompt_token_ids
+            delta_text,
+            chunk,
+            request_obj,
+            prompt_token_ids=prompt_token_ids,
+            finished=False,
         )
         prompt_token_ids = None
         results.append(result)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1408,6 +1408,7 @@ class OpenAIServingResponses(OpenAIServing):
                     delta_token_ids=delta_token_ids,
                     request=request,
                     prompt_token_ids=ctx.last_output.prompt_token_ids,
+                    finished=output.finish_reason is not None,
                 )
             else:
                 delta_message = DeltaMessage(content=output.text)

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -344,7 +344,8 @@ class Parser:
         delta_token_ids: list[int],
         request: ChatCompletionRequest | ResponsesRequest,
         prompt_token_ids: list[int] | None = None,
-        finished: bool = False,
+        *,
+        finished: bool,
     ) -> DeltaMessage | None:
         """Parse a single streaming delta, orchestrating reasoning then
         tool call extraction via internal stream state.
@@ -809,7 +810,8 @@ class DelegatingParser(Parser):
         delta_token_ids: list[int],
         request: ChatCompletionRequest | ResponsesRequest,
         prompt_token_ids: list[int] | None = None,
-        finished: bool = False,
+        *,
+        finished: bool,
     ) -> DeltaMessage | None:
         state = self._stream_state
 


### PR DESCRIPTION
## Purpose
When tool parsers stream arguments incrementally, they may buffer chunks that haven't been sent to the client yet. On the final streaming delta, parse_delta(finished=True) calls _append_unstreamed_tool_args(), which computes the diff between the fully-parsed arguments and what was actually streamed, and appends the remainder. Without this flush, the client receives truncated or empty tool call arguments.

The chat completions path already passes finished correctly. This PR extends the same fix to the Responses API path.

## Test Plan
Verify the final streamed event contains complete tool call arguments (e.g. {"location": "San Francisco"}) rather than truncated.
```
vllm serve Qwen/Qwen3-0.6B --enable-auto-tool-choice --tool-call-parser hermes

- Send a streaming Responses API request with a tool/function definition that produces multi-token arguments:
curl -X POST http://localhost:8000/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen3-0.6B",
    "stream": true,
    "input": "What is the weather in San Francisco?",
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "Get the current weather for a location",
        "parameters": {
          "type": "object",
          "properties": {
            "location": {"type": "string"}
          },
          "required": ["location"]
        }
      }
    }]
```
