### PR TITLE
[Tests] Gate Step3VL under Transformers v5

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1343,7 +1343,15 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         "HuggingFaceTB/SmolVLM2-2.2B-Instruct"
     ),
     "Step3VLForConditionalGeneration": _HfExamplesInfo(
-        "stepfun-ai/step3", trust_remote_code=True
+        "stepfun-ai/step3",
+        trust_remote_code=True,
+        max_transformers_version="5.3",
+        transformers_version_reason={
+            "hf": (
+                "Transformers v5.4 removed the ignore_keys param from "
+                "validate_rope(); vLLM has vendored the config and is unaffected"
+            )
+        },
     ),
     "StepVLForConditionalGeneration": _HfExamplesInfo(
         "stepfun-ai/Step3-VL-10B", trust_remote_code=True


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a Transformers v5 version cap (`max_transformers_version="5.3"`) for `Step3VLForConditionalGeneration` in the model test registry.

`validate_rope()` no longer accepts the `ignore_keys` parameter above Transformers v5.4, causing test failures when running against Transformers v5. This is listed as an open item in the tracker issue #38379.

This mirrors the identical fix already applied to `SarvamMLAForCausalLM` (same root cause, same fix pattern).

#### Why this is not a duplicate PR

Checked all open PRs against `#38379` — no existing PR covers `Step3VLForConditionalGeneration`. The two open PRs for this tracker (`#43305`, `#38821`) are for Tarsier2, a different model.

#### Does this PR introduce _any_ user-facing change?

No — test registry metadata only.

#### How was this patch tested?

- `pre-commit run ruff-check --files tests/models/registry.py` — passed
- Verified the version cap logic directly against the installed `transformers==5.9.0`:

```python
# check_transformers_version uses default check_version_reason="hf"
# (same path taken by multimodal generation tests via vlm_utils/core.py)
v5.2.0 → pass   (≤ cap, test runs)
v5.3.0 → pass   (= cap, test runs)
v5.4.0 → SKIP   (> cap, test skips ✓)
v5.9.0 → SKIP   (> cap, test skips ✓)
```

Behaviour is identical to `SarvamMLAForCausalLM` which uses the exact same pattern.

> **AI assistance disclosure:** This PR was developed with Claude (AI assistance). All changed lines have been reviewed and the fix has been manually verified as described above.

Refs #38379