### PR TITLE
[Bugfix] Fix broken test_parse.py after _WrappedParser removal

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -281,6 +281,7 @@ steps:
   - vllm/model_executor/layers/quantization/quark/
   - vllm/multimodal/
   - vllm/outputs.py
+  - vllm/parser/
   - vllm/platforms/
   - vllm/pooling_params.py
   - vllm/ray/

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.parser.abstract_parser import _WrappedParser
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
 
@@ -65,9 +65,11 @@ TOOLS = [
 
 
 def make_parser(tokenizer, reasoning=False, tool=False):
-    _WrappedParser.reasoning_parser_cls = ThinkReasoningParser if reasoning else None
-    _WrappedParser.tool_parser_cls = Hermes2ProToolParser if tool else None
-    return _WrappedParser(tokenizer)
+    class TestParser(DelegatingParser):
+        reasoning_parser_cls = ThinkReasoningParser if reasoning else None
+        tool_parser_cls = Hermes2ProToolParser if tool else None
+
+    return TestParser(tokenizer)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `test_parse.py` still imported `_WrappedParser`, which was removed in #44279. Updated to use `DelegatingParser` with a local subclass, matching the pattern already applied in `test_streaming.py`.
- Added `vllm/parser/` to `source_file_dependencies` in the `async-engine-inputs-utils-worker-config-cpu` CI job. This was missing, so changes to `vllm/parser/` source code didn't trigger the job that runs `pytest -v -s parser`, which is how #44279 merged without catching the breakage.

## Test plan
- [x] `pytest tests/parser/test_parse.py -v` — all 14 tests pass