### PR TITLE
[CI] Add missing vllm/parser/ CI trigger and fix test_parse.py 

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -281,6 +281,7 @@ steps:
   - vllm/model_executor/layers/quantization/quark/
   - vllm/multimodal/
   - vllm/outputs.py
+  - vllm/parser/
   - vllm/platforms/
   - vllm/pooling_params.py
   - vllm/ray/

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.parser.abstract_parser import _WrappedParser
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
 
@@ -65,9 +65,11 @@ TOOLS = [
 
 
 def make_parser(tokenizer, reasoning=False, tool=False):
-    _WrappedParser.reasoning_parser_cls = ThinkReasoningParser if reasoning else None
-    _WrappedParser.tool_parser_cls = Hermes2ProToolParser if tool else None
-    return _WrappedParser(tokenizer)
+    class TestParser(DelegatingParser):
+        reasoning_parser_cls = ThinkReasoningParser if reasoning else None
+        tool_parser_cls = Hermes2ProToolParser if tool else None
+
+    return TestParser(tokenizer)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose
#44279 removed `_WrappedParser` from `vllm/parser/abstract_parser.py` and updated `test_streaming.py` to use `DelegatingParser`, but `test_parse.py` was added by a separate PR around the same time and still referenced `_WrappedParser`. The CI didn't catch this because `vllm/parser/` wasn't listed as a trigger path for the job — only `tests/parser` was. So the job only ran when test files changed, not when the source code they test changed. 

In this PR, fix the failing test and CI trigger.

## Test Plan
```
pytest tests/parser/test_parse.py
```
