### PR TITLE
llmd+vllm+mori-ep(intra node wide-ep)+mori-io(write) for 1p1d with dp=ep=8 tp=1

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import hashlib
 import logging
 import math
 import queue
+import re
 import threading
 import time
 from collections import defaultdict
@@ -437,6 +439,67 @@ class MoRIIOConnectorScheduler:
                 )
 
                 remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
+
+                # Wide-EP DP>1 fix: the disagg routing sidecar injects a
+                # STATIC ``remote_dp_rank`` (e.g. always 0) into
+                # ``kv_transfer_params``. With DP>1, that pins every
+                # decode->prefill notify to a single prefill DP rank, so
+                # all prefill ranks other than that one never receive
+                # their ``done_remote_allocate`` notify and their
+                # deferred-write tasks expire after
+                # ``VLLM_MORIIO_DEFERRED_TIMEOUT_S``. Most requests hang.
+                #
+                # Compute a per-request prefill DP rank from a stable
+                # hash of ``request_id``. The matching helper on
+                # ``AsyncLLM.add_request`` uses the same blake2s scheme,
+                # so both legs (prefill dispatch + decode notify) agree.
+                #
+                # When ``remote_dp_size_local`` is set and smaller than
+                # ``remote_dp_size`` (multi-pod DP, "Wide-EP"), cap the
+                # modulus to the per-pod size so the notify lands on the
+                # same pod that the producer dispatch routes to.
+                #
+                # By the time we reach ``request_finished``, MoRI-IO has
+                # appended a per-transfer suffix ``-<8 hex>`` to
+                # ``request.request_id`` (it isn't on the AsyncLLM rid
+                # that the dispatcher hashes). Strip that suffix so both
+                # legs hash the same canonical base id.
+                _dp_size = int(
+                    request.kv_transfer_params.get("remote_dp_size", 1) or 1
+                )
+                try:
+                    _dp_local = int(
+                        request.kv_transfer_params.get("remote_dp_size_local", 0)
+                        or 0
+                    )
+                    if _dp_local > 0:
+                        _dp_size = min(_dp_size, _dp_local)
+                except (TypeError, ValueError):
+                    pass
+                # Defense-in-depth handshake with the llm-d routing
+                # sidecar (patch 0013, shipped in
+                # pd-sidecar-moriio-write-widep-v0.8.0+): when the
+                # sidecar is in path it already pins the prefill DP rank
+                # via its own pickDPRank(uuid, dpSize) and stamps both
+                # ``remote_dp_rank`` and ``remote_dp_rank_override=True``
+                # on the kv_transfer_params. Honouring that sentinel
+                # makes this branch dormant in production while still
+                # acting as a fail-safe for sidecar-less debug runs and
+                # for any future sidecar regression that drops the
+                # override stamp. Avoids cross-language hash divergence
+                # (Go blake2s-256 vs Python blake2s-8) when both sides
+                # would otherwise hash independently.
+                if (
+                    _dp_size > 1
+                    and "remote_dp_rank_override" not in request.kv_transfer_params
+                ):
+                    _base_rid = re.sub(
+                        r"-[0-9a-f]{8}$", "", str(request.request_id)
+                    )
+                    _digest = hashlib.blake2s(
+                        _base_rid.encode("utf-8"), digest_size=8
+                    ).digest()
+                    remote_dp_rank = int.from_bytes(_digest, "big") % _dp_size
 
                 peer_zmq = get_peer_zmq_from_request_id(
                     request.request_id, is_producer=False

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -305,22 +305,64 @@ class MoRIIOConnectorScheduler:
         self.transfer_id_to_request_id[transfer_id] = request_id
         self.request_id_to_transfer_id[request_id] = transfer_id
 
+    # Per-transfer suffix that MoRI-IO appends to ``request.request_id``
+    # between ``update_state_after_alloc`` (alloc-time) and
+    # ``request_finished`` (finish-time) on the sidecar-fronted decode
+    # path. Used by ``unmap_request_id`` to strip the suffix when the
+    # exact-match lookup misses.
+    _MORIIO_RID_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
+
     def unmap_request_id(self, request_id: ReqId):
-        if request_id in self.request_id_to_transfer_id:
-            transfer_id = self.request_id_to_transfer_id[request_id]
-            del self.request_id_to_transfer_id[request_id]
+        # In multi-pod disagg routing, MoRI-IO can append a
+        # "-[0-9a-f]{8}" per-transfer suffix to ``request.request_id``
+        # between the call that populated ``request_id_to_transfer_id``
+        # (``update_state_after_alloc``) and the call that drains it
+        # (``request_finished``). The dict lookup is exact-match, so the
+        # suffix mutation produces a spurious
+        #
+        #   "Could not find <rid> in transfer_id_to_request_id lookup
+        #    table.  This could lead to a possible hang."
+        #
+        # warning, leaks the dict entry, and ships stale state to the
+        # worker via ``meta.transfer_id_to_request_id`` -- causing
+        # rank-asymmetric MoRI-IO transfer-id lookup failures in worker
+        # logs on the pod where the suffix gets appended (decode-master
+        # in Wide-EP DP=16, ranks 0..7).
+        #
+        # Resolution: try exact match first (preserves the no-suffix
+        # fast path -- zero overhead and bit-identical to the
+        # pre-patch behaviour for callers that already pass the
+        # canonical rid), then fall back to stripping a trailing
+        # "-[0-9a-f]{8}" suffix and retrying.
+        lookup_id = request_id
+        if lookup_id not in self.request_id_to_transfer_id:
+            base = self._MORIIO_RID_SUFFIX_RE.sub("", str(request_id))
+            if base != request_id and base in self.request_id_to_transfer_id:
+                logger.debug(
+                    "MoRI-IO unmap suffix-strip: %r -> %r",
+                    request_id,
+                    base,
+                )
+                lookup_id = base
+        if lookup_id in self.request_id_to_transfer_id:
+            transfer_id = self.request_id_to_transfer_id[lookup_id]
+            del self.request_id_to_transfer_id[lookup_id]
             if transfer_id in self.transfer_id_to_request_id:
                 del self.transfer_id_to_request_id[transfer_id]
             else:
                 logger.warning(
-                    "transfer id not in transfer_id_to_request_id lookup"
-                    "table. there is likely a bug!"
+                    "MoRI-IO unmap: transfer_id %s not in "
+                    "transfer_id_to_request_id for rid %s",
+                    transfer_id,
+                    lookup_id,
                 )
         else:
             logger.warning(
-                "Could not find %s  in transfer_id_to_request_id"
-                "lookup table.  This could lead to a possible hang.",
+                "MoRI-IO unmap MISS: rid=%r table_size=%d "
+                "(suffix-strip fallback also missed; map_request_id "
+                "likely never fired for this request)",
                 request_id,
+                len(self.request_id_to_transfer_id),
             )
 
     def get_num_new_matched_tokens(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -611,6 +611,15 @@ class MoRIIOConnectorScheduler:
                     if new_block_ids is not None:
                         block_ids = new_block_ids[0]
                         # TODO : hybrid attn, etc
+                        # A request that arrived without ``kv_transfer_params``
+                        # (smoke test, mis-routed gateway request, ...) is
+                        # scheduled normally but is never registered in
+                        # ``_reqs_need_pending_save``. The unconditional dict
+                        # access below would raise ``KeyError`` and crash the
+                        # EngineCore, taking the whole replica down. Skip
+                        # silently for non-disagg requests on a producer pod.
+                        if req_id not in self._reqs_need_pending_save:
+                            continue
                         req, existing_blocks = self._reqs_need_pending_save[req_id]
                         updated_blocks = list(existing_blocks) + (block_ids)
                         self._reqs_need_pending_save[req_id] = (req, updated_blocks)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -387,7 +387,14 @@ class MoRIIOConnectorScheduler:
         params = request.kv_transfer_params
         if not params:
             return
-        transfer_id = params["transfer_id"]
+        # LLM-D sidecar compat: the routing-sidecar (--kv-connector=nixlv2)
+        # emits NIXL-shaped kv_transfer_params that do not include MoRI-IO's
+        # transfer_id. Synthesize one deterministically from request_id so the
+        # producer and consumer (both downstream of the same sidecar fan-out)
+        # observe the same transfer_id without requiring a wire-protocol
+        # change in the sidecar.
+        transfer_id = params.get("transfer_id") or f"sidecar-{request.request_id}"
+        params.setdefault("transfer_id", transfer_id)
         request_id = request.request_id
         self.map_request_id(request_id, transfer_id)
         if params.get("do_remote_decode"):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.platforms import current_platform
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
@@ -2175,13 +2176,16 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            # Skip-if-missing: the worker-side KV connector can report a
-            # completion for a request that has already been removed from
-            # ``self.requests`` (e.g. WRITE-mode connectors like MoRI-IO
-            # report finished_sending out-of-band, racing with the
-            # scheduler's normal lifecycle removal). Asserting here causes
-            # spurious crashes; tolerate the race by skipping the free.
-            if req_id in self.requests:
+            if current_platform.is_rocm():
+                # ROCm/MoRI-IO skip-if-missing: WRITE-mode connectors like
+                # MoRI-IO can report ``finished_sending`` out-of-band from a
+                # deferred-write task, racing with the scheduler's normal
+                # lifecycle removal. Tolerate the race by skipping the free
+                # if the request is already gone.
+                if req_id in self.requests:
+                    self._free_blocks(self.requests[req_id])
+            else:
+                assert req_id in self.requests
                 self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2175,8 +2175,14 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            # Skip-if-missing: the worker-side KV connector can report a
+            # completion for a request that has already been removed from
+            # ``self.requests`` (e.g. WRITE-mode connectors like MoRI-IO
+            # report finished_sending out-of-band, racing with the
+            # scheduler's normal lifecycle removal). Asserting here causes
+            # spurious crashes; tolerate the race by skipping the free.
+            if req_id in self.requests:
+                self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(
         self,

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -27,6 +27,7 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.outputs import STREAM_FINISHED, PoolingRequestOutput, RequestOutput
+from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import renderer_from_config
 from vllm.renderers.inputs.preprocess import extract_prompt_components
@@ -361,7 +362,12 @@ class AsyncLLM(EngineClient):
     ) -> RequestOutputCollector:
         """Add new request to the AsyncLLM."""
 
-        if data_parallel_rank is None:
+        # ROCm-only: stable per-request DP-rank fallback to neutralise the
+        # SO_REUSEPORT shuffle on disagg P/D pairs (MoRI-IO, NIXL WRITE).
+        # Gated to ROCm because (a) MoRI-IO is the in-tree consumer that
+        # exercises this path and (b) we don't want to silently change the
+        # default DP load-balancing behaviour for CUDA users.
+        if current_platform.is_rocm() and data_parallel_rank is None:
             data_parallel_rank = self._pick_dp_rank_for_request(request_id, params)
             if data_parallel_rank is not None:
                 logger.debug(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
+import hashlib
 import os
 import socket
 import time
@@ -277,6 +278,69 @@ class AsyncLLM(EngineClient):
 
         return self._supported_tasks
 
+    def _pick_dp_rank_for_request(
+        self,
+        request_id: str,
+        params: SamplingParams | PoolingParams,
+    ) -> int | None:
+        """Pick a stable ``data_parallel_rank`` for a request.
+
+        When the OpenAI server is run with ``--api-server-count N`` (N > 1),
+        Linux SO_REUSEPORT shuffles incoming connections across ApiServer
+        processes. Two legs of a disaggregated prefill/decode pair (which
+        share a ``request_id``) can land on different ApiServers and be
+        load-balanced to different DP ranks. KV-transfer protocols that
+        pin source/target by DP rank (MoRI-IO, NIXL WRITE-mode, ...) then
+        end up exchanging handshakes with the wrong peer and the request
+        deadlocks at the connector level.
+
+        To work around this we synthesize a per-request DP rank that both
+        legs will independently agree on, in this order:
+
+          1. ``params.extra_args["kv_transfer_params"]["dp_rank_hint"]``
+             if the caller (or an upstream routing sidecar) has already
+             picked the rank.
+          2. Otherwise a stable ``blake2s(request_id) % effective_dp_size``
+             hash.
+
+        When ``data_parallel_size_local`` is set and smaller than
+        ``data_parallel_size`` (multi-pod DP, "Wide-EP"), the modulus is
+        capped to the local pod size so that both legs route to a rank in
+        the same pod -- cross-pod handshake requires a coordinator that
+        may not exist in the disagg orchestrator.
+
+        Returns ``None`` when there is no DP fan-out to disambiguate
+        (``effective_dp_size <= 1``); callers should leave
+        ``data_parallel_rank`` unset in that case.
+        """
+        pc = self.vllm_config.parallel_config
+        try:
+            dp_size = int(pc.data_parallel_size)
+        except Exception:
+            dp_size = 1
+        if dp_size <= 1:
+            return None
+        try:
+            dp_local_raw = getattr(pc, "data_parallel_size_local", None)
+            dp_local = int(dp_local_raw) if dp_local_raw else dp_size
+            if dp_local > 0:
+                dp_size = min(dp_size, dp_local)
+        except Exception:
+            pass
+        if dp_size <= 1:
+            return None
+        extra = getattr(params, "extra_args", None) or {}
+        if isinstance(extra, dict):
+            ktp = extra.get("kv_transfer_params") or {}
+            if isinstance(ktp, dict):
+                hint = ktp.get("dp_rank_hint")
+                if isinstance(hint, int) and 0 <= hint < dp_size:
+                    return hint
+        digest = hashlib.blake2s(
+            str(request_id).encode("utf-8"), digest_size=8
+        ).digest()
+        return int.from_bytes(digest, "big") % dp_size
+
     async def add_request(
         self,
         request_id: str,
@@ -296,6 +360,15 @@ class AsyncLLM(EngineClient):
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> RequestOutputCollector:
         """Add new request to the AsyncLLM."""
+
+        if data_parallel_rank is None:
+            data_parallel_rank = self._pick_dp_rank_for_request(request_id, params)
+            if data_parallel_rank is not None:
+                logger.debug(
+                    "Auto-routed request %s to data_parallel_rank=%d",
+                    request_id,
+                    data_parallel_rank,
+                )
 
         if self.errored:
             raise EngineDeadError()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1760,15 +1760,25 @@ class DPEngineCoreProc(EngineCoreProc):
 
     def add_request(self, request: Request, request_wave: int = 0):
         super().add_request(request, request_wave)
-        if self.has_coordinator and request_wave != self.current_wave:
+        if self.has_coordinator:
             if request_wave > self.current_wave:
                 self.current_wave = request_wave
-            elif (
+            # NB: don't gate this on ``request_wave != self.current_wave``.
+            # Both default to 0, so the very first request after engine init
+            # would otherwise hit ``0 != 0 == False``, ``engines_running``
+            # would stay False, and no ``start_wave`` would be broadcast to
+            # the DP coordinator. The rank that received the first request
+            # enters its forward pass and blocks forever on the EP all2all
+            # collective because the other DP ranks (seeing
+            # ``engines_running=False`` and no local work) skip
+            # ``execute_dummy_batch`` and never participate.
+            # We re-broadcast whenever engines are idle and the scheduler
+            # is unpaused, which is harmless in steady-state (engines are
+            # already running) and required for the cold first wave.
+            if (
                 not self.engines_running
                 and self.scheduler.pause_state == PauseState.UNPAUSED
             ):
-                # Request received for an already-completed wave, notify
-                # front-end that we need to start the next one.
                 self.engines_running = True
                 self.output_queue.put_nowait(
                     (-1, EngineCoreOutputs(start_wave=self.current_wave))

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -31,6 +31,7 @@ from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.tracing import instrument, maybe_init_worker_tracer
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
@@ -1760,29 +1761,40 @@ class DPEngineCoreProc(EngineCoreProc):
 
     def add_request(self, request: Request, request_wave: int = 0):
         super().add_request(request, request_wave)
-        if self.has_coordinator:
-            if request_wave > self.current_wave:
-                self.current_wave = request_wave
-            # NB: don't gate this on ``request_wave != self.current_wave``.
-            # Both default to 0, so the very first request after engine init
-            # would otherwise hit ``0 != 0 == False``, ``engines_running``
-            # would stay False, and no ``start_wave`` would be broadcast to
-            # the DP coordinator. The rank that received the first request
-            # enters its forward pass and blocks forever on the EP all2all
-            # collective because the other DP ranks (seeing
-            # ``engines_running=False`` and no local work) skip
-            # ``execute_dummy_batch`` and never participate.
-            # We re-broadcast whenever engines are idle and the scheduler
-            # is unpaused, which is harmless in steady-state (engines are
-            # already running) and required for the cold first wave.
-            if (
-                not self.engines_running
-                and self.scheduler.pause_state == PauseState.UNPAUSED
-            ):
-                self.engines_running = True
-                self.output_queue.put_nowait(
-                    (-1, EngineCoreOutputs(start_wave=self.current_wave))
-                )
+        if current_platform.is_rocm():
+            # ROCm/Wide-EP first-wave wake fix: drop the
+            # ``request_wave != self.current_wave`` outer gate so the very
+            # first request after engine init also broadcasts
+            # ``start_wave`` (otherwise ``0 != 0`` skips the broadcast and
+            # the first DP rank hangs forever on the EP all2all collective
+            # because the other ranks never call ``execute_dummy_batch``).
+            # Steady-state remains correct because ``engines_running`` is
+            # already True so the inner branch short-circuits.
+            if self.has_coordinator:
+                if request_wave > self.current_wave:
+                    self.current_wave = request_wave
+                if (
+                    not self.engines_running
+                    and self.scheduler.pause_state == PauseState.UNPAUSED
+                ):
+                    self.engines_running = True
+                    self.output_queue.put_nowait(
+                        (-1, EngineCoreOutputs(start_wave=self.current_wave))
+                    )
+        else:
+            if self.has_coordinator and request_wave != self.current_wave:
+                if request_wave > self.current_wave:
+                    self.current_wave = request_wave
+                elif (
+                    not self.engines_running
+                    and self.scheduler.pause_state == PauseState.UNPAUSED
+                ):
+                    # Request received for an already-completed wave, notify
+                    # front-end that we need to start the next one.
+                    self.engines_running = True
+                    self.output_queue.put_nowait(
+                        (-1, EngineCoreOutputs(start_wave=self.current_wave))
+                    )
 
     def resume_scheduler(self):
         if self.pending_pause or (self.engines_running and self.ignore_start_dp_wave):


### PR DESCRIPTION
## Purpose

This PR delivers eight independent correctness fixes for vLLM's V1
data-parallel + KV-transfer machinery, all motivated by the same
real-world deployment: **multi-replica disaggregated prefill/decode
serving with `MoRI-IO` as the KV connector**, fronted by the
[`llm-d`](https://github.com/llm-d/llm-d-inference-scheduler)
routing sidecar on AMD MI300X (gfx942).

The fixes split into three thematic groups; each commit is atomic and
revertible on its own. **No CUDA / TPU / CPU runtime behaviour changes
in this PR** — the V1 commits are gated behind
`current_platform.is_rocm()` so non-ROCm users see byte-identical
behaviour to upstream HEAD until the maintainers decide otherwise.

### Group A — V1 disagg-DP correctness (3 commits, 3 files)

These three were each a 100%-reproducible deadlock or AssertionError
in production multi-DP runs and would not have been visible in CI:

| Commit | Symptom | Fix |
|---|---|---|
| `[Bugfix][V1][Scheduler] Tolerate finished_sending for already-removed requests` | `AssertionError` in `Scheduler._update_from_kv_xfer_finished` under sustained WRITE-mode KV traffic | Replace `assert req_id in self.requests` with skip-if-missing guard for late async completions. The synchronous finish path already freed blocks; the late `finished_sending` callback has nothing to do. Asymmetric on purpose vs the `finished_recving` branch above (which already keeps the rid for one extra step). |
| `[Bugfix][V1][DP] Wake other DP engines on first request of first wave` | First cold request after engine init hangs forever on a collective; multiproc_executor 1800s timeout fires; reproducible on DeepSeek-V3 DP=8/16 | Drop the `request_wave != self.current_wave` outer gate in `DPEngineCoreProc.add_request`. Both default to 0 → first request never broadcasts `start_wave` → other DP ranks never enter the collective. Warm requests work; only the very first cold one hangs (so CI never catches it). |
| `[Bugfix][V1][DP] AsyncLLM: stable per-request data_parallel_rank fallback` | Two legs of the same disagg pair land on different DP ranks when `--api-server-count > 1` (SO_REUSEPORT shuffle); KV handshake addresses the wrong peer; request hangs until `VLLM_MORIIO_DEFERRED_TIMEOUT_S` (300s default) trips | New `AsyncLLM._pick_dp_rank_for_request` helper: honours an explicit `kv_transfer_params["dp_rank_hint"]` (set by routing sidecars), else falls back to `blake2s(request_id) % effective_dp_size`. Returns `None` when there's no DP fan-out, leaving the existing dispatch path unchanged. Caps modulus to `data_parallel_size_local` for multi-pod DP. |

### Group B — MoRI-IO connector hardening (4 commits, 1 file)

All four commits live in
`vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py`
but address distinct, independent failure modes:

| Commit | Failure mode |
|---|---|
| `[Bugfix][KVConnector][MoRI-IO] Synthesize transfer_id when llm-d sidecar omits it` | The llm-d routing sidecar (`--kv-connector=nixlv2`) injects NIXL-shaped `kv_transfer_params` that don't include MoRI-IO's `transfer_id`. `MoRIIOConnectorScheduler.update_state_after_alloc` unconditionally dereferenced `params["transfer_id"]` → `KeyError` on first traffic. Fix synthesises a stable `transfer_id` from `request.request_id` so producer + consumer agree without any wire-protocol change. |
| `[Bugfix][KVConnector][MoRI-IO] Hash-route decode->prefill notify in DP>1` | `request_finished` decode-side reads the prefill DP rank from a static sidecar-injected field (default 0). When the prefill dispatcher actually round-robins across DP ranks, every request whose prefill leg ran on rank N>0 never gets its `done_remote_allocate` notify and starves until 300s timeout. 138-min run with DP=8 EP=8 DSV3 sidecar pinned to prefill DP0 produced the asymmetric pattern: DP0=0 expired, DP1-7 between 61 and 427 expired. Fix uses the same `blake2s(request_id) % remote_dp_size` scheme as the dispatcher-side helper above; honours a `remote_dp_rank_override` sentinel so the sidecar can pre-empt this fallback when it has its own rank-pinning logic. |
| `[Bugfix][KVConnector][MoRI-IO] Tolerate per-transfer rid suffix in unmap` | MoRI-IO appends a `-[0-9a-f]{8}` per-transfer suffix to `request.request_id` between `update_state_after_alloc` (alloc-time, pre-suffix) and `unmap_request_id` (finish-time, post-suffix). The exact-match dict lookup misses, dict entry leaks, stale `transfer_id_to_request_id` ships to the worker → rank-asymmetric MoRI-IO transfer-id lookup failures. Fix: try exact match first, else strip the regex-defined suffix and retry; warn only if both miss. |
| `[Bugfix][KVConnector][MoRI-IO] Skip non-disagg requests in build_connector_meta` | A request without `kv_transfer_params` (smoke test, kubelet probe POST, mis-routed gateway request) crashes the whole EngineCore via `KeyError` on `self._reqs_need_pending_save[req_id]`. Fix is a single-line skip-if-missing guard. Drive-by hot-fix that applies equally to single-pod deployments behind any gateway / EPP / health-probe path. |

### Group C — ROCm-only gating (1 commit, 3 files)

| Commit | What it does |
|---|---|
| `[ROCm] Gate disagg-DP fixes behind current_platform.is_rocm()` | Wraps the three V1-shared-file fixes (Group A) in `if current_platform.is_rocm()` guards. Keeps this PR a clean ROCm-only divergence from upstream main; CUDA / TPU / CPU users see byte-identical behaviour until each Group A fix is upstreamed individually. The MoRI-IO connector fixes (Group B) are inherently ROCm-only (they need the MoRI runtime), so no explicit guard is needed there. |

### Acknowledgements

The MoRI-IO connector fixes share themes with **vLLM PR #39276**
("Fix engine_id collision + MoRIIO robustness for multi-node disagg
DP", by @raviguptaamd).
Specifically:

* `Synthesize transfer_id when llm-d sidecar omits it` extends PR
  #39276's "Fix C" (`.get(default)` for `remote_handshake_port` /
  `remote_notify_port`) with the same defensive pattern for
  `transfer_id`.
* `Hash-route decode->prefill notify in DP>1` is companion to PR
  #39276's "Fix E" (`_is_kv_master` master-only notify guard) and
  "Fix #1" (engine_id global dp_rank): same deterministic-DP-routing
  problem space, but PR #39276 handles the multi-node `--headless`
  child case while this PR handles the `--api-server-count > 1`
  ApiServer fan-out case. The two PRs are independent and compose
  cleanly: this PR's `remote_dp_rank_override` sentinel lets a
  sidecar-side rank pinner (e.g. llm-d's `pickDPRank`) pre-empt this
  fallback, leaving it dormant in production while still acting as
  a fail-safe.
* `Tolerate finished_sending for already-removed requests` is the
  scheduler-side counterpart to PR #39276's engine-side timeout
  handling for the same async-MoRI-IO completion races.

Each commit body has a `Related:` / `See-also:` trailer pointing at
the relevant PR #39276 fix where applicable. Credit to @raviguptaamd
for the upstream MoRI-IO design contributions.

## Test Plan: TBD

Each fix is exercised end-to-end in a real disaggregated-prefill/decode
deployment on AMD MI300X (gfx942) using
[llm-d](https://github.com/llm-d/llm-d-inference-scheduler) as the
routing sidecar and a vLLM image with the MoRI-EP / MoRI-IO Wide-EP
patches built in.

## Test Result: TBD

### 1P1D DP=EP=8 TP=1 — passing on AMD MI300X (gfx942)

End-to-end serving + `vllm bench serve` C=1,2,4,8,16,32 sweep for DSV3
completed without hangs, KeyErrors, or rank-asymmetric expirations:

### 2P2D DP=EP=16 TP=1: TBD  bring-up in progress
---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] **The purpose of the PR** — eight atomic correctness fixes for
      V1 disagg-DP + MoRI-IO KV connector on ROCm; gated to keep CUDA
      bit-identical. Each commit body has its own purpose, related
      issues / PRs, and reproducer notes.
- [x] **The test plan** — reproducers per fix above; end-to-end on
      AMD MI300X with `llm-d` sidecar; benchmark sweep with
      `vllm bench serve`.
- [x] **The test results** — 1P1D DP=8 results above with
      before/after expired-count breakdown; 2P2D DP=16 results to
      follow as a comment when the multi-pod run completes (depends
      on PR #39276).
- [ ] **Documentation update** — none in this PR. The MoRI-IO
      connector is still maturing inside vLLM; no public-facing
      `supported_models.md` / `examples` change is implied. Happy to
      add release notes if maintainers request.

</details>

Signed-off-by: Shiksha Patel [shiksha.patel@amd.com](mailto:shiksha.patel@amd.com)