### PR TITLE
[Bugfix] Fix Deepseek v4 non-mega-moe model init error

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -637,6 +637,14 @@ class DeepseekV4MoE(nn.Module):
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
 
+        self.n_redundant_experts = 0
+        self.n_shared_experts = config.n_shared_experts or 0
+        self.n_logical_experts = self.n_routed_experts
+        self.n_physical_experts = self.n_logical_experts
+        self.n_local_physical_experts = self.n_local_experts
+        self.physical_expert_start = self.experts_start_idx
+        self.physical_expert_end = self.experts_end_idx
+
         self.experts = FusedMoE(
             shared_experts=self.shared_experts,
             gate=self.gate,


### PR DESCRIPTION
## Purpose
Fix the following init error, introduced by https://github.com/vllm-project/vllm/pull/43339, which only updated `_init_mega_moe_experts` but not `_init_fused_moe_experts`.
```
 ERROR 06-02 13:02:27 [multiproc_executor.py:868] Traceback (most recent call last):
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/v1/executor/multiproc_executor.py", line 835, in worker_main
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     worker = WorkerProc(*args, **kwargs)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     return func(*args, **kwargs)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]            ^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/v1/executor/multiproc_executor.py", line 614, in __init__
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     self.worker.load_model()
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/v1/worker/gpu_worker.py", line 345, in load_model
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     return func(*args, **kwargs)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]            ^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/v1/worker/gpu_model_runner.py", line 5105, in load_model
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     self.model = model_loader.load_model(
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]                  ^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     return func(*args, **kwargs)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]            ^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/model_executor/model_loader/base_loader.py", line 55, in load_model
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     model = initialize_model(
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]             ^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     return func(*args, **kwargs)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]            ^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/model_executor/model_loader/utils.py", line 61, in initialize_model
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     model = model_class(vllm_config=vllm_config, prefix=prefix)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/models/deepseek_v4/nvidia/model.py", line 1428, in __init__
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     self.set_moe_parameters()
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/models/deepseek_v4/nvidia/model.py", line 1448, in set_moe_parameters
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     self.extract_moe_parameters(example_moe)
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/vllm/models/deepseek_v4/nvidia/model.py", line 1373, in extract_moe_parameters
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     self.num_logical_experts = example_moe.n_logical_experts
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]   File "/vllm/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1968, in __getattr__
 ERROR 06-02 13:02:27 [multiproc_executor.py:868]     raise AttributeError(
 ERROR 06-02 13:02:27 [multiproc_executor.py:868] AttributeError: 'DeepseekV4MoE' object has no attribute 'n_logical_experts'. Did you mean: 'n_local_experts'?
```

## Test Plan

## Test Result
```
VLLM_ENGINE_READY_TIMEOUT_S=3600 vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --block-size 256 \
  --enable-prefix-caching \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
  --attention_config.use_fp4_indexer_cache True \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --max-cudagraph-capture-size 2048 \
  --max-num-batched-tokens 2048 \
  --no-enable-flashinfer-autotune \
  --tensor-parallel-size 8

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

