### PR TITLE
[docker] Stop using extra-index-url for flashinfer-jit-cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -760,7 +760,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 ARG FLASHINFER_VERSION=0.6.12
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
-        --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
+        --index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
 
 # ============================================================
 # OPENAI API SERVER DEPENDENCIES


### PR DESCRIPTION
`flashinfer-jit-cache` is currently quarantined on PyPI

Credit to @jstawinsky