### PR TITLE
[ROCm][CI] Fix stale wvSplitK GEMM fallback test for N=5

### DIFF
--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -41,8 +41,10 @@ def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     assert torch.allclose(out, ref, atol=1e-3, rtol=1e-3)
 
 
-def test_rocm_unquantized_gemm_gfx1x_n_gt_4_falls_back(monkeypatch):
-    x = torch.randn(5, 64, dtype=torch.float16)
+def test_rocm_unquantized_gemm_gfx1x_n_gt_5_falls_back(monkeypatch):
+    # wvSplitK skinny GEMM handles n in [1, 5] (see PR #40687); n > 5 must
+    # fall back to torch.nn.functional.linear.
+    x = torch.randn(6, 64, dtype=torch.float16)
     weight = torch.randn(128, 64, dtype=torch.float16)
 
     monkeypatch.setattr(utils, "use_aiter_triton_gemm", lambda *args: False)


### PR DESCRIPTION
PR #40687 raised the wvSplitK skinny-GEMM cutoff from n<=4 to n<=5, but test_rocm_unquantized_gemm_gfx1x_n_gt_4_falls_back still used n=5 and asserted a fallback, so it fails (wvSplitK is now called). Use n=6 and rename to ..._n_gt_5_falls_back to test the real fallback boundary.

Tested on gfx1100: fails before / passes after against the n<=5 impl.

@AndreasKaratzas 