### PR TITLE
[Bugfix] Preserve unloaded non-persistent buffers during layerwise reload

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -80,6 +80,13 @@ class _AliasedBufferWithUninitializedChildLayer(_AliasedBufferLayer):
         )
 
 
+class _NonPersistentBufferLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(2, 2))
+        self.register_buffer("scale", torch.tensor(0.25), persistent=False)
+
+
 def test_move_metatensors():
     tensor = torch.empty((1, 2, 3))
     meta_tensor = to_meta_tensor(tensor)
@@ -332,6 +339,73 @@ def test_layerwise_reload_skips_child_parameter_alias_buffers(monkeypatch):
     assert layer.conv_weights.untyped_storage().data_ptr() == (
         layer.conv1d.weight.untyped_storage().data_ptr()
     )
+
+
+def test_layerwise_reload_preserves_unloaded_non_persistent_buffers(monkeypatch):
+    layer = _NonPersistentBufferLayer()
+    model = torch.nn.Sequential(layer)
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+    original_scale = layer.scale.clone()
+
+    def materialize_with_sentinel(meta_tensor):
+        tensor = torch.empty_strided(
+            size=tuple(meta_tensor.size()),
+            stride=tuple(meta_tensor.stride()),
+            dtype=meta_tensor.dtype,
+            requires_grad=False,
+        )
+        tensor.fill_(-123.0)
+        tensor.__class__ = meta_tensor.__class__
+        tensor.__dict__ = meta_tensor.__dict__.copy()
+        return tensor
+
+    monkeypatch.setattr(
+        reload_meta, "materialize_meta_tensor", materialize_with_sentinel
+    )
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.weight, loaded_weight)
+    assert torch.equal(layer.scale, original_scale)
+    assert "scale" in layer._non_persistent_buffers_set
+    assert "0.scale" not in model.state_dict()
+
+
+def test_layerwise_reload_updates_loaded_non_persistent_buffers(monkeypatch):
+    layer = _NonPersistentBufferLayer()
+    model = torch.nn.Sequential(layer)
+    loaded_weight = torch.full_like(layer.weight, 7.0)
+    loaded_scale = torch.full_like(layer.scale, 0.5)
+
+    def materialize_with_sentinel(meta_tensor):
+        tensor = torch.empty_strided(
+            size=tuple(meta_tensor.size()),
+            stride=tuple(meta_tensor.stride()),
+            dtype=meta_tensor.dtype,
+            requires_grad=False,
+        )
+        tensor.fill_(-123.0)
+        tensor.__class__ = meta_tensor.__class__
+        tensor.__dict__ = meta_tensor.__dict__.copy()
+        return tensor
+
+    monkeypatch.setattr(
+        reload_meta, "materialize_meta_tensor", materialize_with_sentinel
+    )
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    layer.scale.weight_loader(layer.scale, loaded_scale)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.weight, loaded_weight)
+    assert torch.equal(layer.scale, loaded_scale)
+    assert "scale" in layer._non_persistent_buffers_set
+    assert "0.scale" not in model.state_dict()
 
 
 @pytest.mark.parametrize(

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -71,6 +71,18 @@ class _ParentAliasedChildBufferLayer(torch.nn.Module):
         )
 
 
+class _ChildAliasOnlyBufferLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1d = torch.nn.Linear(3, 2, bias=False)
+        self.conv1d.weight.data.copy_(
+            torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        )
+        self.register_buffer(
+            "conv_weights", self.conv1d.weight.detach().view(-1), persistent=False
+        )
+
+
 class _AliasedBufferWithUninitializedChildLayer(_AliasedBufferLayer):
     def __init__(self):
         super().__init__()
@@ -296,6 +308,8 @@ def test_layerwise_reload_skips_non_persistent_parameter_alias_buffers(monkeypat
     assert layer.weight_view.untyped_storage().data_ptr() == (
         layer.weight.untyped_storage().data_ptr()
     )
+    assert "weight_view" in layer._non_persistent_buffers_set
+    assert "0.weight_view" not in model.state_dict()
 
 
 def test_capture_layer_to_meta_skips_uninitialized_parameter_storage_ptrs():
@@ -339,6 +353,42 @@ def test_layerwise_reload_skips_child_parameter_alias_buffers(monkeypatch):
     assert layer.conv_weights.untyped_storage().data_ptr() == (
         layer.conv1d.weight.untyped_storage().data_ptr()
     )
+    assert "conv_weights" in layer._non_persistent_buffers_set
+    assert "0.conv_weights" not in model.state_dict()
+
+
+def test_layerwise_reload_restores_alias_buffer_on_zero_size_layer(monkeypatch):
+    layer = _ChildAliasOnlyBufferLayer()
+    model = torch.nn.Sequential(layer)
+    loaded_conv = torch.full_like(layer.conv1d.weight, 7.0)
+
+    def materialize_with_sentinel(meta_tensor):
+        tensor = torch.empty_strided(
+            size=tuple(meta_tensor.size()),
+            stride=tuple(meta_tensor.stride()),
+            dtype=meta_tensor.dtype,
+            requires_grad=False,
+        )
+        tensor.fill_(-123.0)
+        tensor.__class__ = meta_tensor.__class__
+        tensor.__dict__ = meta_tensor.__dict__.copy()
+        return tensor
+
+    monkeypatch.setattr(
+        reload_meta, "materialize_meta_tensor", materialize_with_sentinel
+    )
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    layer.conv1d.weight.weight_loader(layer.conv1d.weight, loaded_conv)
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.conv_weights, loaded_conv.view(-1))
+    assert layer.conv_weights.untyped_storage().data_ptr() == (
+        layer.conv1d.weight.untyped_storage().data_ptr()
+    )
+    assert "conv_weights" in layer._non_persistent_buffers_set
+    assert "0.conv_weights" not in model.state_dict()
 
 
 def test_layerwise_reload_preserves_unloaded_non_persistent_buffers(monkeypatch):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -388,10 +388,16 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
     kernel tensor references on the layer. Preserves cudagraph references."""
     assert info.kernel_tensors is not None
     parameters, buffers = info.kernel_tensors
+    loaded_tensor_names = {name for name, _ in info.loaded_weights}
     for name, param in parameters.items():
         param.data.copy_(getattr(layer, name))
     for name, buffer in buffers.items():
         if name not in layer._buffers:
+            continue
+        if (
+            name in layer._non_persistent_buffers_set
+            and name not in loaded_tensor_names
+        ):
             continue
         buffer.data.copy_(getattr(layer, name))
 
@@ -399,6 +405,7 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
 
 
 def _place_kernel_tensors(layer: torch.nn.Module, info: LayerReloadingInfo):
+    non_persistent_buffers = set(layer._non_persistent_buffers_set)
     for name in get_layer_tensors(layer):
         delattr(layer, name)
 
@@ -407,4 +414,8 @@ def _place_kernel_tensors(layer: torch.nn.Module, info: LayerReloadingInfo):
     for name, param in parameters.items():
         layer.register_parameter(name, param)
     for name, buffer in buffers.items():
-        layer.register_buffer(name, buffer)
+        layer.register_buffer(
+            name,
+            buffer,
+            persistent=name not in non_persistent_buffers,
+        )

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -109,6 +109,8 @@ def initialize_layerwise_reload(model: torch.nn.Module):
 
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
+        # snapshot now: restore_layer_on_meta drops alias buffers from the live set
+        info.kernel_non_persistent_buffers = set(layer._non_persistent_buffers_set)
 
         # Restore layer parameters/buffers onto meta device
         restore_layer_on_meta(layer, info)
@@ -259,10 +261,12 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
                 _layerwise_process(layer, info)
                 continue
 
-            # reloading: place kernel tensors back as a fallback
-            elif info.load_numel_total > 0:  # type: ignore[operator]
+            # reloading: place kernel tensors back as a fallback. Always place, even
+            # when nothing is loadable (load_numel_total == 0), so parameter-alias
+            # buffers on such layers are restored rather than left deleted.
+            if info.load_numel_total > 0:  # type: ignore[operator]
                 logger.warning("%s: Failed to load weights", layer.__class__.__name__)
-                _place_kernel_tensors(layer, info)
+            _place_kernel_tensors(layer, info)
 
         # Process non-attention layers which did not load all elements. This can happen
         # if the created weight has extra padding elements which are not loaded
@@ -388,16 +392,14 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
     kernel tensor references on the layer. Preserves cudagraph references."""
     assert info.kernel_tensors is not None
     parameters, buffers = info.kernel_tensors
+    non_persistent = info.kernel_non_persistent_buffers
     loaded_tensor_names = {name for name, _ in info.loaded_weights}
     for name, param in parameters.items():
         param.data.copy_(getattr(layer, name))
     for name, buffer in buffers.items():
         if name not in layer._buffers:
             continue
-        if (
-            name in layer._non_persistent_buffers_set
-            and name not in loaded_tensor_names
-        ):
+        if name in non_persistent and name not in loaded_tensor_names:
             continue
         buffer.data.copy_(getattr(layer, name))
 
@@ -405,17 +407,13 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
 
 
 def _place_kernel_tensors(layer: torch.nn.Module, info: LayerReloadingInfo):
-    non_persistent_buffers = set(layer._non_persistent_buffers_set)
     for name in get_layer_tensors(layer):
         delattr(layer, name)
 
     assert info.kernel_tensors is not None
     parameters, buffers = info.kernel_tensors
+    non_persistent = info.kernel_non_persistent_buffers
     for name, param in parameters.items():
         layer.register_parameter(name, param)
     for name, buffer in buffers.items():
-        layer.register_buffer(
-            name,
-            buffer,
-            persistent=name not in non_persistent_buffers,
-        )
+        layer.register_buffer(name, buffer, persistent=name not in non_persistent)

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -117,6 +117,7 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
     if layer.__class__.__name__ in SKIP_MODULES:
         return
 
+    non_persistent_buffers = set(layer._non_persistent_buffers_set)
     for name in get_layer_tensors(layer):
         if name not in SKIP_TENSORS:
             delattr(layer, name)
@@ -130,7 +131,11 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
     for name, buffer in restore_buffers.items():
         if name not in SKIP_TENSORS:
             buffer = restore_layer_refs(buffer, layer)
-            layer.register_buffer(name, buffer)
+            layer.register_buffer(
+                name,
+                buffer,
+                persistent=name not in non_persistent_buffers,
+            )
 
 
 def materialize_layer(layer: torch.nn.Module, info: LayerReloadingInfo):

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -117,7 +117,7 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
     if layer.__class__.__name__ in SKIP_MODULES:
         return
 
-    non_persistent_buffers = set(layer._non_persistent_buffers_set)
+    non_persistent = set(layer._non_persistent_buffers_set)
     for name in get_layer_tensors(layer):
         if name not in SKIP_TENSORS:
             delattr(layer, name)
@@ -131,11 +131,7 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
     for name, buffer in restore_buffers.items():
         if name not in SKIP_TENSORS:
             buffer = restore_layer_refs(buffer, layer)
-            layer.register_buffer(
-                name,
-                buffer,
-                persistent=name not in non_persistent_buffers,
-            )
+            layer.register_buffer(name, buffer, persistent=name not in non_persistent)
 
 
 def materialize_layer(layer: torch.nn.Module, info: LayerReloadingInfo):

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -29,6 +29,10 @@ class LayerReloadingInfo:
     # kernel formatted tensors, copied into by `_layerwise_process` when reloading
     kernel_tensors: LayerTensors | None = None
 
+    # non-persistent buffer names captured with `kernel_tensors`, so buffer
+    # persistence survives `_non_persistent_buffers_set` being mutated during reload
+    kernel_non_persistent_buffers: set[str] = field(default_factory=set)
+
     def reset(self):
         self.__init__(  # type: ignore[misc]
             restore_metadata=self.restore_metadata, restore_device=self.restore_device


### PR DESCRIPTION

## Purpose

Fix layerwise reload corrupting unloaded non-persistent direct buffers.

I hit this as a silent Gemma4 divergence in a warm weight-sync loop:
`google/gemma-4-26B-A4B-it` matched trainer-forward on cold load, but after warm
`/update_weights` calls the trainer-vs-vLLM KL jumped from about `0.01` to `>1.5`.
The corrupted tensor was `Gemma4Router.root_size`, a `persistent=False` runtime
buffer that changed from bf16 `0.018798828125` to `1.0`.

Layerwise reload restores each module to load-ready meta tensors, replays the cached
weight-loader calls, processes the materialized layer, and copies processed tensors back
into the original kernel tensor storage. That copy-back is correct for tensors loaded in
the current reload, but not for a non-persistent runtime/config buffer whose weight loader
never ran.

This PR:

- preserves `persistent=False` buffer metadata when restoring modules to meta and when
  placing original kernel tensors back;
- skips copy-back for non-persistent direct buffers that were not loaded in the current
  reload;
- still updates non-persistent buffers whose weight loader actually ran.

Before/after:

| case | before | after |
|---|---:|---:|
| Gemma4 `root_size` after warm reload | `1.0` | `0.018798828125` |
| step-3 trainer-vs-vLLM KL in the repro | `1.5236` | `0.0084` |
| focused reload tests | N/A | `4 passed, 27 deselected` |

This is adjacent to #42481, which fixed non-persistent parameter-alias buffers. It also
overlaps with the older open #40647 at the level of `_copy_and_restore_kernel_tensors`,
but it is not the same patch: #40647 proposes broader loaded-tensor-only copy-back and is
currently stale/needs-rebase; this PR is a narrower direct-buffer fix, preserves
`persistent=False` metadata, and includes a focused Gemma4 failure mode plus synthetic
regression tests.

Gemma4 context: #38826. cc @lucianommartins.

## Test Plan

- Add synthetic layerwise reload regression tests:
  - loaded direct parameter + unloaded non-persistent direct buffer preserves the buffer
    value and `persistent=False` behavior;
  - loaded direct parameter + loaded non-persistent direct buffer still updates both
    tensors.
- Run the existing alias-buffer reload tests from #42481 to guard the previous fix.
- Validate the motivating Gemma4 repro with focused replay and full weight-sync KL.

## Test Result

Focused reload tests:

```bash
uv run --with pytest --with tblib --no-sync \
  pytest tests/model_executor/model_loader/test_reload.py \
  -k "alias_buffers or non_persistent_buffers" -q
```

```text
4 passed, 27 deselected, 23 warnings in 2.77s
```

Targeted pre-commit on the changed files:

```bash
uv run --with pre-commit --no-sync pre-commit run --files \
  tests/model_executor/model_loader/test_reload.py \
  vllm/model_executor/model_loader/reload/layerwise.py \
  vllm/model_executor/model_loader/reload/meta.py
```

```text
ruff check: Passed
ruff format: Passed
typos: Passed
mypy hook: Passed
SPDX / root lazy imports / forbidden imports / config validation: Passed
```

Focused Gemma4 replay:

| probe | router `root_size` | mean abs replay-vs-trainer logprob |
|---|---:|---:|
| cold load | `0.018798828125` | `0.2171647858742523` |
| warm reload | `1.0` | `2.686207366607036` |
| warm reload + restore only `root_size` | `0.018798828125` | `0.2171647858742523` |

Full weight-sync validation:

| run | step 0 | step 1 | step 2 | step 3 | step 4 | step 5 |
|---|---:|---:|---:|---:|---:|---:|
| baseline warm reload | `0.0109` | `0.0148` | `0.0074` | `1.5236` | `2.5620` | `1.9653` |
| preserve `root_size` | `0.0508` | `0.0078` | `0.0050` | `0.0084` | `0.0229` | `0.0069` |

## Notes

- No user-facing docs change: this is a correctness fix for existing layerwise reload
  behavior.
- Duplicate-work check: searched open PRs/issues for `layerwise reload non-persistent
  buffer`, `Gemma4 root_size`, and `reload buffer model_loader`; no direct duplicate was
  found. See #40647 note above for the nearest open overlap.
- AI assistance disclosure: this PR includes AI-assisted debugging, PR drafting, and code
  drafting. I reviewed the changed lines and focused tests before submitting.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] AI assistance is disclosed.
- [x] Duplicate-work check is documented.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
