### PR TITLE
Refactor RMSNorm vectorized launch checks

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -10,6 +10,32 @@
 
 namespace vllm {
 
+namespace {
+
+constexpr int kRmsNormVectorWidth = 8;
+constexpr int kRmsNormAlignmentBytes =
+    kRmsNormVectorWidth * 2;  // 8 * sizeof(fp16/bf16)
+
+inline bool can_launch_vectorized_fused_rms_norm(const void* input_ptr,
+                                                 const void* residual_ptr,
+                                                 const void* weight_ptr,
+                                                 int hidden_size,
+                                                 int64_t input_stride) {
+  auto inp = reinterpret_cast<std::uintptr_t>(input_ptr);
+  auto res = reinterpret_cast<std::uintptr_t>(residual_ptr);
+  auto wt = reinterpret_cast<std::uintptr_t>(weight_ptr);
+  const bool ptrs_are_aligned = inp % kRmsNormAlignmentBytes == 0 &&
+                                res % kRmsNormAlignmentBytes == 0 &&
+                                wt % kRmsNormAlignmentBytes == 0;
+  const bool offsets_are_multiple_of_vector_width =
+      hidden_size % kRmsNormVectorWidth == 0 &&
+      input_stride % kRmsNormVectorWidth == 0;
+  return ptrs_are_aligned && offsets_are_multiple_of_vector_width &&
+         !vllm::vllm_is_batch_invariant();
+}
+
+}  // namespace
+
 // TODO(woosuk): Further optimize this kernel.
 template <typename scalar_t, int VEC_SIZE, int NUM_DIMS>
 __global__ void rms_norm_kernel(
@@ -276,21 +302,9 @@ void fused_add_rms_norm(torch::stable::Tensor& input,     // [..., hidden_size]
     However, this requires each tensor's data to be aligned to 16
     bytes.
    */
-  auto inp_ptr = reinterpret_cast<std::uintptr_t>(input.data_ptr());
-  auto res_ptr = reinterpret_cast<std::uintptr_t>(residual.data_ptr());
-  auto wt_ptr = reinterpret_cast<std::uintptr_t>(weight.data_ptr());
-  constexpr int vector_width = 8;
-  constexpr int req_alignment_bytes =
-      vector_width * 2;  // vector_width * sizeof(bfloat16 or float16) (float32
-                         // falls back to non-vectorized version anyway)
-  bool ptrs_are_aligned = inp_ptr % req_alignment_bytes == 0 &&
-                          res_ptr % req_alignment_bytes == 0 &&
-                          wt_ptr % req_alignment_bytes == 0;
-  bool offsets_are_multiple_of_vector_width =
-      hidden_size % vector_width == 0 && input_stride % vector_width == 0;
-  bool batch_invariant_launch = vllm::vllm_is_batch_invariant();
-  if (ptrs_are_aligned && offsets_are_multiple_of_vector_width &&
-      !batch_invariant_launch) {
+  if (vllm::can_launch_vectorized_fused_rms_norm(
+          input.data_ptr(), residual.data_ptr(), weight.data_ptr(), hidden_size,
+          input_stride)) {
     LAUNCH_FUSED_ADD_RMS_NORM(8);
   } else {
     LAUNCH_FUSED_ADD_RMS_NORM(0);

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -18,6 +18,31 @@
 
 namespace vllm {
 
+namespace {
+
+constexpr int kRmsNormQuantVectorWidth = 8;
+constexpr int kRmsNormQuantAlignmentBytes = 16;
+
+inline bool can_launch_vectorized_fused_rms_norm_quant(const void* input_ptr,
+                                                       const void* residual_ptr,
+                                                       const void* weight_ptr,
+                                                       int hidden_size,
+                                                       int input_stride) {
+  auto inp = reinterpret_cast<std::uintptr_t>(input_ptr);
+  auto res = reinterpret_cast<std::uintptr_t>(residual_ptr);
+  auto wt = reinterpret_cast<std::uintptr_t>(weight_ptr);
+  const bool ptrs_are_aligned = inp % kRmsNormQuantAlignmentBytes == 0 &&
+                                res % kRmsNormQuantAlignmentBytes == 0 &&
+                                wt % kRmsNormQuantAlignmentBytes == 0;
+  const bool offsets_are_multiple_of_vector_width =
+      hidden_size % kRmsNormQuantVectorWidth == 0 &&
+      input_stride % kRmsNormQuantVectorWidth == 0;
+  return ptrs_are_aligned && offsets_are_multiple_of_vector_width &&
+         !vllm::vllm_is_batch_invariant();
+}
+
+}  // namespace
+
 // TODO(woosuk): Further optimize this kernel.
 template <typename scalar_t, typename fp8_type, int VEC_SIZE>
 __global__ void rms_norm_static_fp8_quant_kernel(
@@ -280,14 +305,9 @@ void fused_add_rms_norm_static_fp8_quant(
     However, this requires each tensor's data to be aligned to 16
     bytes.
    */
-  auto inp_ptr = reinterpret_cast<std::uintptr_t>(input.data_ptr());
-  auto res_ptr = reinterpret_cast<std::uintptr_t>(residual.data_ptr());
-  auto wt_ptr = reinterpret_cast<std::uintptr_t>(weight.data_ptr());
-  bool ptrs_are_aligned =
-      inp_ptr % 16 == 0 && res_ptr % 16 == 0 && wt_ptr % 16 == 0;
-  bool batch_invariant_launch = vllm::vllm_is_batch_invariant();
-  if (ptrs_are_aligned && hidden_size % 8 == 0 && input_stride % 8 == 0 &&
-      !batch_invariant_launch) {
+  if (vllm::can_launch_vectorized_fused_rms_norm_quant(
+          input.data_ptr(), residual.data_ptr(), weight.data_ptr(), hidden_size,
+          input_stride)) {
     LAUNCH_FUSED_ADD_RMS_NORM(8);
   } else {
     LAUNCH_FUSED_ADD_RMS_NORM(0);

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -6,6 +6,7 @@ import torch
 
 from tests.kernels.quant_utils import FP8_DTYPE
 from tests.kernels.utils import opcheck
+from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -190,3 +191,61 @@ def test_gemma_rms_norm_mixed_input_weight_dtype(default_vllm_config) -> None:
 
     assert out.dtype == x.dtype
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("add_residual", [False, True])
+@pytest.mark.parametrize("strided_input", [False, True])
+@torch.inference_mode()
+def test_rms_norm_custom_op_toggle_parity(
+    dtype: torch.dtype,
+    add_residual: bool,
+    strided_input: bool,
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    device = CUDA_DEVICES[0]
+    torch.set_default_device(device)
+    set_random_seed(0)
+
+    num_tokens = 64
+    hidden_size = 1536
+    last_dim = hidden_size * 2 if strided_input else hidden_size
+
+    x_base = torch.randn(num_tokens, last_dim, dtype=dtype)
+    x = x_base[..., :hidden_size]
+    assert x.is_contiguous() != strided_input
+
+    residual = torch.randn_like(x) * (1 / (2 * hidden_size)) if add_residual else None
+
+    weight = torch.empty(hidden_size, dtype=dtype).normal_(mean=1.0, std=0.1)
+
+    enabled_cfg = VllmConfig(
+        compilation_config=CompilationConfig(custom_ops=["none", "+rms_norm"])
+    )
+    disabled_cfg = VllmConfig(compilation_config=CompilationConfig(custom_ops=["none"]))
+
+    with set_current_vllm_config(enabled_cfg):
+        layer_enabled = RMSNorm(hidden_size).to(dtype=dtype)
+        layer_enabled.weight.data.copy_(weight)
+        out_enabled = layer_enabled(
+            x.clone(), residual.clone() if residual is not None else None
+        )
+
+    with set_current_vllm_config(disabled_cfg):
+        layer_disabled = RMSNorm(hidden_size).to(dtype=dtype)
+        layer_disabled.weight.data.copy_(weight)
+        out_disabled = layer_disabled(
+            x.clone(), residual.clone() if residual is not None else None
+        )
+
+    if add_residual:
+        torch.testing.assert_close(
+            out_enabled[0], out_disabled[0], atol=1e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            out_enabled[1], out_disabled[1], atol=1e-2, rtol=1e-2
+        )
+    else:
+        torch.testing.assert_close(out_enabled, out_disabled, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
## Purpose
Refactor RMSNorm vectorized launch checks for fused RMSNorm paths.
Previously, the vectorized launch eligibility logic was duplicated inline between the standard fused RMSNorm kernel path and the fused RMSNorm + FP8 quant path. This change centralizes those checks into small helpers so alignment, hidden-size/stride divisibility, and batch-invariant gating stay consistent.

Python API and CustomOp dispatch behavior are unchanged.
Related to #19817.

## Test Plan

  
  # Unit regression
  `.venv/bin/python -m pytest tests/kernels/core/test_layernorm.py::test_rms_norm_custom_op_toggle_parity -v`


# RMSNorm benchmark correctness precheck
  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
    .venv/bin/python benchmarks/kernels/benchmark_rmsnorm.py \
      --batch-size 4 \
      --seq-len 128 \
      --hidden-size 4096 \
      --use-residual \
      --save-path /vllm-workspace/rmsnorm-results

  ## Test Result
* Added regression coverage for RMSNorm CustomOp enabled vs disabled output parity.
* Unit regression passed locally on NVIDIA A100 80GB PCIe.
* RMSNorm benchmark correctness precheck passed: naive, FlashInfer, and vLLM outputs matched for fused residual RMSNorm.