### PR TITLE
[Rust Frontend] Add /abort_requests endpoint

### DIFF
--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -1,3 +1,4 @@
+mod abort_requests;
 mod cache;
 mod collective_rpc;
 mod health;
@@ -91,6 +92,7 @@ fn build_router_with_options(
             .route("/reset_mm_cache", post(cache::reset_mm_cache))
             .route("/reset_encoder_cache", post(cache::reset_encoder_cache))
             .route("/collective_rpc", post(collective_rpc::collective_rpc))
+            .route("/abort_requests", post(abort_requests::abort_requests))
             .route("/sleep", post(sleep::sleep))
             .route("/wake_up", post(sleep::wake_up))
             .route("/is_sleeping", get(sleep::is_sleeping))

--- a/rust/src/server/src/routes/abort_requests.rs
+++ b/rust/src/server/src/routes/abort_requests.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::extract::rejection::JsonRejection;
+use axum::http::StatusCode;
+use serde::Deserialize;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+use crate::utils::utility_call_error;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AbortRequestsRequest {
+    request_ids: Option<Vec<String>>,
+}
+
+pub async fn abort_requests(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<AbortRequestsRequest>, JsonRejection>,
+) -> Result<StatusCode, ApiError> {
+    let Json(body) = body.map_err(|error| ApiError::json_parse_error(error.body_text()))?;
+    let request_ids = body.request_ids.ok_or_else(|| {
+        ApiError::invalid_request(
+            "Missing 'request_ids' in request body".to_string(),
+            Some("request_ids"),
+        )
+    })?;
+
+    state
+        .chat
+        .abort(&request_ids)
+        .await
+        .map_err(|error| utility_call_error("abort_requests", error))?;
+
+    Ok(StatusCode::OK)
+}

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -4627,6 +4627,111 @@ async fn is_paused_route_returns_json_payload() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn abort_requests_route_returns_ok_for_well_formed_body() {
+    let (app, engine_task) =
+        test_admin_app_with_engine_script(|_dealer, _push| boxed_test_future(async move {})).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/abort_requests")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"request_ids":["req-1","req-2"]}"#))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert!(body.is_empty());
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn abort_requests_route_rejects_missing_request_ids() {
+    let (app, engine_task) =
+        test_admin_app_with_engine_script(|_dealer, _push| boxed_test_future(async move {})).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/abort_requests")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{}"#))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["error"]["type"], "invalid_request_error");
+    assert_eq!(json["error"]["param"], "request_ids");
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn abort_requests_route_rejects_malformed_json() {
+    let (app, engine_task) =
+        test_admin_app_with_engine_script(|_dealer, _push| boxed_test_future(async move {})).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/abort_requests")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"request_ids": "#))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["error"]["type"], "invalid_request_error");
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn abort_requests_route_accepts_empty_id_list() {
+    let (app, engine_task) =
+        test_admin_app_with_engine_script(|_dealer, _push| boxed_test_future(async move {})).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/abort_requests")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"request_ids":[]}"#))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert!(body.is_empty());
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn admin_routes_are_hidden_when_dev_mode_is_disabled() {
     let (chat, engine_task) = test_chat_with_engine_handle().await;
     let app = build_router_with_dev_mode(
@@ -4645,6 +4750,7 @@ async fn admin_routes_are_hidden_when_dev_mode_is_disabled() {
         ("POST", "/pause"),
         ("POST", "/resume"),
         ("POST", "/collective_rpc"),
+        ("POST", "/abort_requests"),
         ("POST", "/reset_prefix_cache"),
         ("POST", "/reset_mm_cache"),
         ("POST", "/reset_encoder_cache"),


### PR DESCRIPTION


## Purpose

Adds a `POST /abort_requests` to Rust frontend, contributing to "RL / admin / lifecycle APIs" in the Rust frontend roadmap (#44280).

Cancels one or more in-flight requests by ID:

- Accepts a JSON body returns
  `200 OK`, mirroring the Python frontend's `/abort_requests`
  contract.
- Registered in the dev-mode `build_router_with_dev_mode`, alongside
  the other Rust admin routes (`/sleep`, `/collective_rpc`, `/reset_*_cache`).

## Test Plan

```bash
cargo fmt --all --check
cargo clippy -p vllm-server --all-targets -- -D warnings
cargo nextest run -p vllm-server 
cargo nextest run -p vllm-server abort_requests_route admin_routes_are_hidden
```

New tests in `rust/src/server/src/routes/tests.rs`:

- `abort_requests_route_returns_ok_for_well_formed_body` — valid body → `200`
- `abort_requests_route_rejects_missing_request_ids` — missing field → `400`,
  asserts error `type` and `param`
- `abort_requests_route_rejects_malformed_json` — invalid JSON → `400`
  (covers the `JsonRejection` branch)
- `abort_requests_route_accepts_empty_id_list` — `[]` → `200` no-op

## Test Result

```
cargo nextest run -p vllm-server abort_requests_route admin_routes_are_hidden
  → Starting 5 tests across 1 binary (154 tests skipped)
    PASS abort_requests_route_returns_ok_for_well_formed_body
    PASS abort_requests_route_rejects_missing_request_ids
    PASS abort_requests_route_rejects_malformed_json
    PASS abort_requests_route_accepts_empty_id_list
    PASS admin_routes_are_hidden_when_dev_mode_is_disabled
  → Summary: 5 tests run, 5 passed, 154 skipped
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. Not needed — this is Rust-frontend API wiring with no model/docs surface.
</details>
