### PR TITLE
[Bugfix][Model] Fix Qwen3 deepstack buffer device mismatch

### DIFF
--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+import torch
 from transformers import PretrainedConfig
 
 from vllm.multimodal.processing import InputProcessingContext
@@ -216,6 +218,62 @@ def test_qwen3_omni_get_updates_use_audio_in_video(
     assert len(updates) == expected_total, (
         f"Expected {expected_total} total tokens, got {len(updates)}"
     )
+
+
+def test_qwen3_omni_empty_deepstack_buffers_match_inputs_embeds():
+    from vllm.model_executor.models.qwen3_omni_moe_thinker import (
+        Qwen3OmniMoeThinkerForConditionalGeneration,
+    )
+
+    model = Qwen3OmniMoeThinkerForConditionalGeneration.__new__(
+        Qwen3OmniMoeThinkerForConditionalGeneration
+    )
+    model.config = SimpleNamespace(text_config=SimpleNamespace(hidden_size=8))
+    model.deepstack_num_level = 2
+    model.deepstack_input_embeds = [
+        torch.zeros(4, 8),
+        torch.zeros(4, 8),
+    ]
+    model.deepstack_input_embeds_num_tokens = 0
+    inputs_embeds = torch.empty(2, 8, device="meta", dtype=torch.float16)
+
+    deepstack_input_embeds = model._get_deepstack_input_embeds(
+        num_tokens=2, inputs_embeds=inputs_embeds
+    )
+
+    assert deepstack_input_embeds is not None
+    for tensor in deepstack_input_embeds.tensors.values():
+        assert tensor.shape == (2, 8)
+        assert tensor.device == inputs_embeds.device
+        assert tensor.dtype == inputs_embeds.dtype
+
+
+def test_qwen3_omni_deepstack_payload_matches_payload_dtype():
+    from vllm.model_executor.models.qwen3_omni_moe_thinker import (
+        Qwen3OmniMoeThinkerForConditionalGeneration,
+    )
+
+    model = Qwen3OmniMoeThinkerForConditionalGeneration.__new__(
+        Qwen3OmniMoeThinkerForConditionalGeneration
+    )
+    model.config = SimpleNamespace(text_config=SimpleNamespace(hidden_size=8))
+    model.deepstack_num_level = 2
+    model.deepstack_input_embeds = [
+        torch.zeros(4, 8),
+        torch.zeros(4, 8),
+    ]
+    model.deepstack_input_embeds_num_tokens = 0
+    payload = torch.arange(2 * 3 * 8, dtype=torch.float16).reshape(2, 3, 8)
+
+    model._set_deepstack_input_embeds(payload)
+    deepstack_input_embeds = model._get_deepstack_input_embeds(
+        num_tokens=3, inputs_embeds=torch.empty(3, 8, dtype=torch.float16)
+    )
+
+    assert deepstack_input_embeds is not None
+    for idx, tensor in enumerate(deepstack_input_embeds.tensors.values()):
+        assert tensor.dtype == payload.dtype
+        assert torch.equal(tensor, payload[idx])
 
 
 if __name__ == "__main__":

--- a/tests/model_executor/test_qwen3_vl_mrope.py
+++ b/tests/model_executor/test_qwen3_vl_mrope.py
@@ -3,6 +3,7 @@
 import dataclasses
 import random
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -30,6 +31,50 @@ IMAGE_TOKEN_ID = 999
 VIDEO_TOKEN_ID = 888
 VISION_START_TOKEN_ID = 777
 VISION_END_TOKEN_ID = 778
+
+
+def test_qwen3_vl_empty_deepstack_buffers_match_inputs_embeds():
+    model = Qwen3VLForConditionalGeneration.__new__(Qwen3VLForConditionalGeneration)
+    model.config = SimpleNamespace(text_config=SimpleNamespace(hidden_size=8))
+    model.deepstack_num_level = 2
+    model.deepstack_input_embeds = [
+        torch.zeros(4, 8),
+        torch.zeros(4, 8),
+    ]
+    model.deepstack_input_embeds_num_tokens = 0
+    inputs_embeds = torch.empty(2, 8, device="meta", dtype=torch.float16)
+
+    deepstack_input_embeds = model._get_deepstack_input_embeds(
+        num_tokens=2, inputs_embeds=inputs_embeds
+    )
+
+    assert deepstack_input_embeds is not None
+    for tensor in deepstack_input_embeds.tensors.values():
+        assert tensor.shape == (2, 8)
+        assert tensor.device == inputs_embeds.device
+        assert tensor.dtype == inputs_embeds.dtype
+
+
+def test_qwen3_vl_deepstack_payload_matches_payload_dtype():
+    model = Qwen3VLForConditionalGeneration.__new__(Qwen3VLForConditionalGeneration)
+    model.config = SimpleNamespace(text_config=SimpleNamespace(hidden_size=8))
+    model.deepstack_num_level = 2
+    model.deepstack_input_embeds = [
+        torch.zeros(4, 8),
+        torch.zeros(4, 8),
+    ]
+    model.deepstack_input_embeds_num_tokens = 0
+    payload = torch.arange(2 * 3 * 8, dtype=torch.float16).reshape(2, 3, 8)
+
+    model._set_deepstack_input_embeds(payload)
+    deepstack_input_embeds = model._get_deepstack_input_embeds(
+        num_tokens=3, inputs_embeds=torch.empty(3, 8, dtype=torch.float16)
+    )
+
+    assert deepstack_input_embeds is not None
+    for idx, tensor in enumerate(deepstack_input_embeds.tensors.values()):
+        assert tensor.dtype == payload.dtype
+        assert torch.equal(tensor, payload[idx])
 
 
 @dataclass

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1775,11 +1775,16 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
     def _get_deepstack_input_embeds(
         self,
         num_tokens: int,
+        inputs_embeds: torch.Tensor,
     ) -> IntermediateTensors | None:
         if not getattr(self, "deepstack_input_embeds", None):
             return None  # If vision tower is skipped
-        if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self._resize_deepstack_input_embeds(num_tokens)
+        if (
+            num_tokens > self.deepstack_input_embeds[0].size(0)
+            or self.deepstack_input_embeds[0].device != inputs_embeds.device
+            or self.deepstack_input_embeds[0].dtype != inputs_embeds.dtype
+        ):
+            self._resize_deepstack_input_embeds(num_tokens, inputs_embeds)
 
         # get deepstack_input_embeds from buffer, and clear the buffer
         return IntermediateTensors(
@@ -1791,13 +1796,15 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             }
         )
 
-    def _resize_deepstack_input_embeds(self, num_tokens: int) -> None:
+    def _resize_deepstack_input_embeds(
+        self, num_tokens: int, reference: torch.Tensor
+    ) -> None:
         self.deepstack_input_embeds = [
             torch.zeros(
                 num_tokens,
                 self.config.text_config.hidden_size,
-                device=self.deepstack_input_embeds[0].device,
-                dtype=self.deepstack_input_embeds[0].dtype,
+                device=reference.device,
+                dtype=reference.dtype,
             )
             for _ in range(self.deepstack_num_level)
         ]
@@ -1808,8 +1815,12 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
 
         # set deepstack_input_embeds to buffer
         num_tokens = deepstack_input_embeds.size(1)
-        if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self._resize_deepstack_input_embeds(num_tokens)
+        if (
+            num_tokens > self.deepstack_input_embeds[0].size(0)
+            or self.deepstack_input_embeds[0].device != deepstack_input_embeds.device
+            or self.deepstack_input_embeds[0].dtype != deepstack_input_embeds.dtype
+        ):
+            self._resize_deepstack_input_embeds(num_tokens, deepstack_input_embeds)
         for idx in range(self.deepstack_num_level):
             self.deepstack_input_embeds[idx][:num_tokens].copy_(
                 deepstack_input_embeds[idx]
@@ -2012,7 +2023,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
 
         if inputs_embeds is not None and get_pp_group().is_first_rank:
             deepstack_input_embeds = self._get_deepstack_input_embeds(
-                inputs_embeds.size(0)
+                inputs_embeds.size(0), inputs_embeds
             )
         else:
             deepstack_input_embeds = None

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1712,11 +1712,16 @@ class Qwen3VLForConditionalGeneration(
     def _get_deepstack_input_embeds(
         self,
         num_tokens: int,
+        inputs_embeds: torch.Tensor,
     ) -> IntermediateTensors | None:
         if not getattr(self, "deepstack_input_embeds", None):
             return None  # If vision tower is skipped
-        if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self._resize_deepstack_input_embeds(num_tokens)
+        if (
+            num_tokens > self.deepstack_input_embeds[0].size(0)
+            or self.deepstack_input_embeds[0].device != inputs_embeds.device
+            or self.deepstack_input_embeds[0].dtype != inputs_embeds.dtype
+        ):
+            self._resize_deepstack_input_embeds(num_tokens, inputs_embeds)
 
         # get deepstack_input_embeds from buffer, and clear the buffer
         return IntermediateTensors(
@@ -1728,13 +1733,15 @@ class Qwen3VLForConditionalGeneration(
             }
         )
 
-    def _resize_deepstack_input_embeds(self, num_tokens: int) -> None:
+    def _resize_deepstack_input_embeds(
+        self, num_tokens: int, reference: torch.Tensor
+    ) -> None:
         self.deepstack_input_embeds = [
             torch.zeros(
                 num_tokens,
                 self.config.text_config.hidden_size,
-                device=self.deepstack_input_embeds[0].device,
-                dtype=self.deepstack_input_embeds[0].dtype,
+                device=reference.device,
+                dtype=reference.dtype,
             )
             for _ in range(self.deepstack_num_level)
         ]
@@ -1745,8 +1752,12 @@ class Qwen3VLForConditionalGeneration(
 
         # set deepstack_input_embeds to buffer
         num_tokens = deepstack_input_embeds.size(1)
-        if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self._resize_deepstack_input_embeds(num_tokens)
+        if (
+            num_tokens > self.deepstack_input_embeds[0].size(0)
+            or self.deepstack_input_embeds[0].device != deepstack_input_embeds.device
+            or self.deepstack_input_embeds[0].dtype != deepstack_input_embeds.dtype
+        ):
+            self._resize_deepstack_input_embeds(num_tokens, deepstack_input_embeds)
         for idx in range(self.deepstack_num_level):
             self.deepstack_input_embeds[idx][:num_tokens].copy_(
                 deepstack_input_embeds[idx]
@@ -2822,7 +2833,7 @@ class Qwen3VLForConditionalGeneration(
 
         if inputs_embeds is not None and get_pp_group().is_first_rank:
             deepstack_input_embeds = self._get_deepstack_input_embeds(
-                inputs_embeds.size(0)
+                inputs_embeds.size(0), inputs_embeds
             )
         else:
             deepstack_input_embeds = None


### PR DESCRIPTION
## Purpose

Fix a Qwen3 deepstack profiling/serving crash caused by returning zero-backed deepstack buffers that were still on their initialization device/dtype.

PR #43617 intentionally made Qwen3-VL and Qwen3-Omni return zero-backed `IntermediateTensors` when no active deepstack payload exists. That preserves a stable decoder input structure for `torch.compile`/CUDA graph profiling and avoids skipping the deepstack branch for later real multimodal requests.

However, those buffers are initialized before model weights are moved to the active execution device. If the decoder dummy/profile path requests deepstack tensors before any vision payload has populated the buffer, `_get_deepstack_input_embeds()` can return stale CPU/float32 tensors while the decoder `inputs_embeds` are on the active model device/dtype. This can break audio-only or text-only profiling/serving paths for Qwen3-Omni and Qwen3-VL.

This PR keeps the #43617 contract: empty deepstack buffers still return zero-backed `IntermediateTensors`. The fix is narrower: recreate the buffers when their size, device, or dtype does not match the current `inputs_embeds`/deepstack payload tensor.

## Duplicate check

I searched for existing Qwen3 deepstack PRs/issues before updating this patch. The closest prior work is:

- #43617: merged; intentionally keeps zero-backed deepstack `IntermediateTensors` for compile stability.
- #40145: older deepstack buffer handling optimization.

This PR is not a duplicate of #43617. It is a follow-up that preserves #43617's stable-input behavior while fixing the stale buffer device/dtype mismatch noted in review of that PR.

## Test Plan

- Add regression coverage for Qwen3-Omni empty deepstack buffers matching the current `inputs_embeds` device/dtype.
- Add matching regression coverage for Qwen3-VL, since the same helper pattern exists there.
- Add payload-preservation coverage for `_set_deepstack_input_embeds()` so real deepstack payloads are copied into buffers with the payload dtype rather than later being dropped by a getter-side resize.
- Run affected model-executor test files.
- Run compile and ruff checks on changed files.

## Test Result

- `PYTHONPATH=/home/aomori/vllm XDG_CACHE_HOME=/tmp/$USER/.cache mamba run -n vllm-nightly pytest tests/model_executor/test_qwen3_omni.py tests/model_executor/test_qwen3_vl_mrope.py -q`
  - `101 passed, 16 warnings in 26.05s`
- `PYTHONPATH=/home/aomori/vllm XDG_CACHE_HOME=/tmp/$USER/.cache mamba run -n vllm-nightly python -m compileall vllm/model_executor/models/qwen3_omni_moe_thinker.py vllm/model_executor/models/qwen3_vl.py tests/model_executor/test_qwen3_omni.py tests/model_executor/test_qwen3_vl_mrope.py`
  - passed
- `PYTHONPATH=/home/aomori/vllm XDG_CACHE_HOME=/tmp/$USER/.cache mamba run -n vllm-nightly python -m ruff check vllm/model_executor/models/qwen3_omni_moe_thinker.py vllm/model_executor/models/qwen3_vl.py tests/model_executor/test_qwen3_omni.py tests/model_executor/test_qwen3_vl_mrope.py`
  - `All checks passed!`
- `PYTHONPATH=/home/aomori/vllm XDG_CACHE_HOME=/tmp/$USER/.cache mamba run -n vllm-nightly python -m ruff format --check vllm/model_executor/models/qwen3_omni_moe_thinker.py vllm/model_executor/models/qwen3_vl.py tests/model_executor/test_qwen3_omni.py tests/model_executor/test_qwen3_vl_mrope.py`
  - `4 files already formatted`

## Documentation

No docs update: this is an internal model-executor bugfix and does not change user-facing APIs or documented behavior.

## AI Assistance

This PR includes AI-assisted code changes. The commit includes an AI attribution trailer and a `Signed-off-by:` trailer for DCO compliance.

## CI note

The current `pre-commit` workflow failure is from vLLM's `pre-run-check`: PRs from authors with fewer than four merged PRs require a maintainer to add the `ready` or `verified` label before the actual pre-commit job runs. The workflow listens for `pull_request.labeled`, so applying either label should rerun and unblock that gate.