### PR TITLE
[Bugfix][Core] Filter reasoning boundary tokens before structured-output FSM advance

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -272,6 +272,9 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.connector = None
     scheduler.structured_output_manager = Mock()
     scheduler.structured_output_manager.should_advance.return_value = True
+    scheduler.structured_output_manager.filter_tokens_for_fsm_advance.side_effect = (
+        lambda _request, token_ids: token_ids
+    )
     scheduler.requests = {request.request_id: request}
     scheduler.running = [request]
     scheduler.waiting = Mock()

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2556,6 +2556,9 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.connector = None
     scheduler.structured_output_manager = Mock()
     scheduler.structured_output_manager.should_advance.return_value = True
+    scheduler.structured_output_manager.filter_tokens_for_fsm_advance.side_effect = (
+        lambda _request, token_ids: token_ids
+    )
     scheduler.requests = {request.request_id: request}
     scheduler.running = [request]
     scheduler.waiting = Mock()
@@ -2613,6 +2616,83 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     assert engine_core_output.request_id == request.request_id
     assert engine_core_output.new_token_ids == [123]
     assert engine_core_output.finish_reason == FinishReason.ERROR
+
+
+def test_structured_output_fsm_advance_filters_reasoning_boundary_tokens():
+    """Boundary tokens filtered before accept_tokens should not abort."""
+    from vllm.v1.structured_output import StructuredOutputManager
+
+    scheduler = object.__new__(Scheduler)
+    sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0, 1],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    request.structured_output_request = Mock()
+    request.structured_output_request.grammar = Mock()
+    request.structured_output_request.grammar.accept_tokens.return_value = True
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens
+
+    scheduler.perf_metrics = None
+    scheduler.connector = None
+    scheduler.structured_output_manager = Mock(spec=StructuredOutputManager)
+    scheduler.structured_output_manager.should_advance.return_value = True
+    scheduler.structured_output_manager.filter_tokens_for_fsm_advance.return_value = [
+        151644
+    ]
+    scheduler.requests = {request.request_id: request}
+    scheduler.running = [request]
+    scheduler.waiting = Mock()
+    scheduler.kv_cache_manager = Mock()
+    scheduler.kv_cache_manager.take_events.return_value = None
+    scheduler.kv_event_publisher = Mock()
+    scheduler.finished_req_ids = set()
+    scheduler.finished_req_ids_dict = None
+    scheduler.vllm_config = Mock()
+    scheduler.vllm_config.model_config.enable_return_routed_experts = False
+    scheduler.enable_return_routed_experts = False
+    scheduler.recompute_kv_load_failures = False
+    scheduler.make_stats = Mock(return_value=None)
+    scheduler.max_model_len = 128
+    scheduler._free_request = Mock()
+
+    output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    boundary_tokens = [198, 248069, 151644]
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[boundary_tokens],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_runner_output)
+
+    scheduler.structured_output_manager.filter_tokens_for_fsm_advance.assert_called_once_with(
+        request, boundary_tokens
+    )
+    request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
+        request.request_id, [151644]
+    )
+    assert request.status != RequestStatus.FINISHED_ERROR
+    assert request.status == RequestStatus.RUNNING
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -9,7 +9,10 @@ import pytest
 
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.v1.request import Request
-from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output import (
+    StructuredOutputManager,
+    filter_reasoning_boundary_tokens,
+)
 from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 
 
@@ -17,6 +20,14 @@ class MockReasoner:
     def __init__(self, tokenizer):
         self.is_reasoning_end = Mock(return_value=False)
         self.is_reasoning_end_streaming = Mock(return_value=False)
+        self.start_token_id = 248068
+        self.end_token_id = 248069
+
+    def get_boundary_token_ids(self):
+        return frozenset({self.start_token_id, self.end_token_id})
+
+    def get_transition_whitespace_token_ids(self):
+        return frozenset({198})
 
 
 class TestReasoningStructuredOutput:
@@ -258,3 +269,80 @@ class TestReasoningStructuredOutput:
 
         # Should return True since reasoning has ended
         assert result is True
+
+    def test_filter_reasoning_boundary_tokens_strips_end_and_whitespace(self):
+        """Boundary tokens must be removed before FSM advance."""
+        reasoner = MockReasoner(tokenizer=Mock())
+        tool_token = 151644
+        filtered = filter_reasoning_boundary_tokens(
+            [198, reasoner.end_token_id, 198, tool_token],
+            reasoner,
+        )
+        assert filtered == [tool_token]
+
+    def test_filter_reasoning_boundary_tokens_no_boundary_unchanged(self):
+        reasoner = MockReasoner(tokenizer=Mock())
+        tokens = [151644, 151645]
+        assert filter_reasoning_boundary_tokens(tokens, reasoner) == tokens
+
+    def test_filter_tokens_for_fsm_advance_structural_tag(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.STRUCTURAL_TAG,
+            "{}",
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        structured_req.reasoner = reasoner
+        tool_token = 151644
+
+        filtered = manager_with_reasoner.filter_tokens_for_fsm_advance(
+            mock_request_with_structured_output,
+            [198, reasoner.end_token_id, tool_token],
+        )
+        assert filtered == [tool_token]
+
+    def test_filter_tokens_for_fsm_advance_skipped_when_enable_in_reasoning(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        manager_with_reasoner.enable_in_reasoning = True
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.STRUCTURAL_TAG,
+            "{}",
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        structured_req.reasoner = reasoner
+        tokens = [198, reasoner.end_token_id, 151644]
+
+        assert (
+            manager_with_reasoner.filter_tokens_for_fsm_advance(
+                mock_request_with_structured_output, tokens
+            )
+            == tokens
+        )
+
+    def test_build_fsm_advance_skip_mask(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.STRUCTURAL_TAG,
+            "{}",
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        structured_req.reasoner = reasoner
+        tool_token = 151644
+        req_tokens = [198, reasoner.end_token_id, tool_token]
+
+        mask = manager_with_reasoner._build_fsm_advance_skip_mask(
+            mock_request_with_structured_output, req_tokens
+        )
+        assert mask == [False, False, True]

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -185,6 +185,17 @@ class ReasoningParser:
         """
         return None
 
+    def get_boundary_token_ids(self) -> frozenset[int]:
+        """Token ids that delimit reasoning and must not be FSM-advanced.
+
+        Subclasses with thinking start/end tokens should override this.
+        """
+        return frozenset()
+
+    def get_transition_whitespace_token_ids(self) -> frozenset[int]:
+        """Whitespace token ids that may appear around reasoning boundaries."""
+        return frozenset()
+
 
 class ReasoningParserManager:
     """

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -69,6 +69,17 @@ class BaseThinkingReasoningParser(ReasoningParser):
         self.start_token_id: int = start_token_id
         self.end_token_id: int = end_token_id
 
+    def get_boundary_token_ids(self) -> frozenset[int]:
+        return frozenset({self.start_token_id, self.end_token_id})
+
+    def get_transition_whitespace_token_ids(self) -> frozenset[int]:
+        transition: set[int] = set()
+        for text in ("\n", "\n\n", "\r\n", " ", "\t"):
+            token_id = self.vocab.get(text)
+            if token_id is not None:
+                transition.add(token_id)
+        return frozenset(transition)
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         start_token_id = self.start_token_id
         end_token_id = self.end_token_id

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1446,8 +1446,11 @@ class Scheduler(SchedulerInterface):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 assert struct_output_request.grammar is not None
-                if not struct_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
-                    req_id, new_token_ids
+                tokens = self.structured_output_manager.filter_tokens_for_fsm_advance(
+                    request, new_token_ids
+                )
+                if tokens and not struct_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
+                    req_id, tokens
                 ):
                     logger.error(
                         "Unexpected: grammar rejected tokens %s for request %s. "

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -33,6 +33,48 @@ else:
 logger = init_logger(__name__)
 
 
+def filter_reasoning_boundary_tokens(
+    token_ids: list[int],
+    reasoner: "ReasoningParser",
+) -> list[int]:
+    """Strip reasoning boundary tokens before advancing an xgrammar FSM.
+
+    When ``reasoning=False`` structural tags exclude thinking markers, tokens
+    such as ``</think>`` and adjacent whitespace must not be passed
+    to ``accept_tokens`` even if they appear in the same MTP-accepted batch as
+    valid suffix tokens (e.g. tool-call tokens).
+    """
+    end_id = getattr(reasoner, "end_token_id", None)
+    start_id = getattr(reasoner, "start_token_id", None)
+    transition_ids = reasoner.get_transition_whitespace_token_ids()
+
+    boundary_marker_ids = {tid for tid in (start_id, end_id) if tid is not None}
+    if not boundary_marker_ids or not any(
+        token in boundary_marker_ids for token in token_ids
+    ):
+        return token_ids
+
+    result: list[int] = []
+    i = 0
+    while i < len(token_ids):
+        token = token_ids[i]
+        if token in boundary_marker_ids:
+            i += 1
+            while i < len(token_ids) and token_ids[i] in transition_ids:
+                i += 1
+            continue
+        if token in transition_ids:
+            j = i
+            while j < len(token_ids) and token_ids[j] in transition_ids:
+                j += 1
+            if j < len(token_ids) and token_ids[j] in boundary_marker_ids:
+                i = j
+                continue
+        result.append(token)
+        i += 1
+    return result
+
+
 class StructuredOutputManager:
     """Engine-level manager for structured output requests."""
 
@@ -277,12 +319,23 @@ class StructuredOutputManager:
 
                 state_advancements = 0
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
-                for token in itertools.chain(req_tokens, (-1,)):
+                skip_advance = self._build_fsm_advance_skip_mask(
+                    request, list(req_tokens)
+                )
+                for token_index, token in enumerate(itertools.chain(req_tokens, (-1,))):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
                     if token == -1:
                         # Stop advancing the grammar once we hit a padding token.
                         apply_bitmask = False
-                    if apply_bitmask and not grammar.is_terminated():
+                    if (
+                        apply_bitmask
+                        and not grammar.is_terminated()
+                        and token != -1
+                        and (
+                            token_index >= len(skip_advance)
+                            or skip_advance[token_index]
+                        )
+                    ):
                         accepted = grammar.accept_tokens(req_id, [token])
                         assert accepted, (token, req_id, scheduled_spec_decode_tokens)
                         state_advancements += 1
@@ -368,6 +421,52 @@ class StructuredOutputManager:
                 return True
 
         return False
+
+    def _should_filter_reasoning_boundary_tokens(self, request: "Request") -> bool:
+        if self.enable_in_reasoning:
+            return False
+
+        reasoner = self._get_reasoner(request)
+        if reasoner is None:
+            return False
+
+        structured_req = request.structured_output_request
+        if structured_req is None:
+            return False
+
+        return (
+            structured_req.structured_output_key[0]
+            == StructuredOutputOptions.STRUCTURAL_TAG
+        )
+
+    def filter_tokens_for_fsm_advance(
+        self, request: "Request", token_ids: list[int]
+    ) -> list[int]:
+        if not self._should_filter_reasoning_boundary_tokens(request):
+            return token_ids
+
+        reasoner = self._get_reasoner(request)
+        assert reasoner is not None
+        return filter_reasoning_boundary_tokens(token_ids, reasoner)
+
+    def _build_fsm_advance_skip_mask(
+        self, request: "Request", token_ids: list[int]
+    ) -> list[bool]:
+        if not token_ids or not self._should_filter_reasoning_boundary_tokens(request):
+            return [True] * len(token_ids)
+
+        reasoner = self._get_reasoner(request)
+        assert reasoner is not None
+        filtered = filter_reasoning_boundary_tokens(token_ids, reasoner)
+        advance_mask: list[bool] = []
+        filtered_index = 0
+        for token in token_ids:
+            if filtered_index < len(filtered) and token == filtered[filtered_index]:
+                advance_mask.append(True)
+                filtered_index += 1
+            else:
+                advance_mask.append(False)
+        return advance_mask
 
     def clear_backend(self) -> None:
         if self.backend is not None:


### PR DESCRIPTION
## Purpose
Fixes [#44006](https://github.com/vllm-project/vllm/issues/44006).

When MTP speculative decoding, VLLM_ENFORCE_STRICT_TOOL_CALLING=1, and a reasoning model with tool calling are used together, tool-call requests intermittently fail (~40% of runs) with HTTP 500. The engine logs show xgrammar rejecting tokens such as [198, 248069]—whitespace plus the thinking end token (</think>)—because they are passed to accept_tokens even though structural_tag grammar already excludes those markers (reasoning=False).

With MTP, the transition out of the thinking phase can land boundary tokens and adjacent whitespace in the same accepted batch as valid suffix tokens (e.g. tool-call tokens). The scheduler and spec-decode FSM advance paths previously forwarded the full batch to xgrammar, so the FSM aborted the request (Failed to advance FSM … for token 248069).

This PR strips reasoning start/end boundary tokens and transition whitespace before advancing the xgrammar FSM, but only when:

structured output mode is STRUCTURAL_TAG (strict tool calling), and
reasoning is not enabled inside the grammar (enable_in_reasoning=False).
Changes:

Add filter_reasoning_boundary_tokens() and wire it through StructuredOutputManager.filter_tokens_for_fsm_advance() (scheduler accept_tokens path) and _build_fsm_advance_skip_mask() (MTP grammar_bitmask / per-draft-token advance path).
Extend ReasoningParser with get_boundary_token_ids() / get_transition_whitespace_token_ids() (implemented in basic_parsers for think start/end parsers).
Non-duplicate check: [#44292](https://github.com/vllm-project/vllm/pull/44292) / [#44297](https://github.com/vllm-project/vllm/pull/44297) targeted a different failure mode: the bonus-token bitmask row becoming unconstrained after padded invalid draft positions (-1) in grammar_bitmask. This PR fixes tokens that are already sampled and accepted but must not be FSM-advanced (reasoning boundary markers in the same MTP batch). The two fixes are complementary; this change does not modify the bonus-bitmask padding logic.

## Test Plan & Test Result
```
#!/usr/bin/env bash
set -euo pipefail

cd "$(dirname "$0")"

export VLLM_ENFORCE_STRICT_TOOL_CALLING=1

exec .venv/bin/python3.12 vllm/entrypoints/openai/api_server.py \
  --model /mnt/models/Qwen3.5-397B-A17B-FP8 \
  --served-model-name qwen \
  --tensor-parallel-size 8 \
  --enable-expert-parallel \
  --speculative-config.method mtp \
  --speculative-config.num_speculative_tokens 1 \
  --reasoning-parser qwen3 \
  --enable-auto-tool-choice \
  --tool-call-parser qwen3_coder \
  --enable-log-requests \
  --moe-backend triton \
  --linear-backend deep_gemm
```

request
The responses to multiple requests are normal.
```
#!/usr/bin/env python3
from openai import OpenAI

client = OpenAI(
    api_key="EMPTY",
    base_url="http://127.0.0.1:8000/v1",
    max_retries=0,
)

tool_list = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get the current weather information",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "City name, e.g., 'Beijing', 'Shanghai', 'New York'",
                    },
                    "unit": {
                        "type": "string",
                        "enum": ["celsius", "fahrenheit"],
                        "description": "Temperature unit",
                    },
                },
                "required": ["location"],
            },
        },
    },
    {
        "type": "function",
        "function": {
            "name": "getCurrentTime",
            "description": "Get the current time for a specified location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "City or country name",
                    },
                },
                "required": ["location"],
            },
        },
    },
]

messages = [{"role": "user", "content": "How is the weather in Beijing?"}]

response = client.chat.completions.create(
    model="qwen",
    messages=messages,
    tools=tool_list,
    tool_choice="auto",
)

print(response.model_dump_json(indent=2))

```
response
```
{
  "id": "chatcmpl-a7071d34e4a1ce72",
  "choices": [
    {
      "finish_reason": "tool_calls",
      "index": 0,
      "logprobs": null,
      "message": {
        "content": null,
        "refusal": null,
        "role": "assistant",
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [
          {
            "id": "chatcmpl-tool-a0ffe7d5fc54fa68",
            "function": {
              "arguments": "{\"location\": \"Beijing\"}",
              "name": "get_weather"
            },
            "type": "function"
          }
        ],
        "reasoning": "The user is asking about the weather in Beijing. I have a get_weather function that can get current weather information for a specified location. The function requires a \"location\" parameter and has an optional \"unit\" parameter for temperature (celsius or fahrenheit).\n\nSince the user asked about Beijing, I should use \"Beijing\" as the location. The unit parameter is optional, so I don't need to specify it - the function will likely use a default unit.\n\nLet me call the get_weather function with Beijing as the location.\n"
      },
      "stop_reason": null,
      "token_ids": null,
      "routed_experts": null
    }
  ],
  "created": 1780471166,
  "model": "qwen",
  "object": "chat.completion",
  "service_tier": null,
  "system_fingerprint": "vllm-0.21.0-tp8-ep-77a42e07",
  "usage": {
    "completion_tokens": 139,
    "prompt_tokens": 392,
    "total_tokens": 531,
    "completion_tokens_details": null,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "prompt_text": null,
  "kv_transfer_params": null
}

```
