### PR TITLE
[Bugfix] Add @register_fake for dsv3_fused_a_gemm

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -3137,6 +3137,17 @@ def dsv3_fused_a_gemm(
     torch.ops._C.dsv3_fused_a_gemm(output, mat_a, mat_b)
 
 
+if hasattr(torch.ops._C, "dsv3_fused_a_gemm"):
+
+    @register_fake("_C::dsv3_fused_a_gemm")
+    def dsv3_fused_a_gemm_fake(
+        output: torch.Tensor,
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+    ) -> None:
+        pass
+
+
 if hasattr(torch.ops._C, "weight_packed_linear"):
 
     @register_fake("_C::weight_packed_linear")


### PR DESCRIPTION
## Summary

The `dsv3_fused_a_gemm` custom op is missing a `@register_fake` registration, causing `torch.compile` tracing to fail with:

```
TypeError: Multiple dispatch failed for 'torch._ops.vllm.min_latency_fused_qkv_a_proj.default';
all __torch_dispatch__ handlers returned NotImplemented
```

When `torch.compile` traces `min_latency_fused_qkv_a_proj`, it enters the real impl which calls `torch.ops._C.dsv3_fused_a_gemm`. Under `FakeTensorMode`, this op has no fake impl registered, so dispatch fails. This only triggers for bf16 weights with shape `[2112, 7168]` on SM90+ GPUs (DeepSeek V2/V3 QKV A-projection).

## Fix

Adds a no-op `@register_fake("_C::dsv3_fused_a_gemm")` with the same `hasattr` guard pattern used by every other custom op in the file (`weight_packed_linear`, `fused_experts_cpu`, etc.). The fake impl is a `pass` since the C binding signature is `(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()` — in-place mutation, returns `None`.

This is additive and only affects tracing, not actual CUDA execution.

## Not a duplicate

Checked open PRs — no existing PR addresses this. This op was added recently and is the only one in `_custom_ops.py` missing its `@register_fake`.

## Test

Verified this fixes the crash in our nightly CI for bf16 ML3 model evals that use piecewise CUDA graph warmup with `torch.compile`.