### PR TITLE
[Performance]Improve use_cascade_attention mechanism

### DIFF
--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -333,10 +333,11 @@ def is_flash_attn_varlen_func_available() -> bool:
 
     return False
 
+
 def should_pack_gqa(seqlen_q: int, qhead_per_khead: int, blockM: int) -> bool:
     """
     Decide whether to pack GQA heads for decoding (fixed-length queries).
-
+    Same code as https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/hopper/heuristics.h#L16
     Args:
         seqlen_q: length of the query sequence (fixed)
         qhead_per_khead: number of Q heads per KV head
@@ -345,6 +346,7 @@ def should_pack_gqa(seqlen_q: int, qhead_per_khead: int, blockM: int) -> bool:
     Returns:
         True if PackGQA is beneficial
     """
+
     # Helper to round up to nearest multiple of blockM
     def round_up(a: int, b: int) -> int:
         return ((a + b - 1) // b) * b
@@ -353,7 +355,9 @@ def should_pack_gqa(seqlen_q: int, qhead_per_khead: int, blockM: int) -> bool:
     nopack_eff = seqlen_q / round_up(seqlen_q, blockM)
 
     # Efficiency if we pack multiple Q heads together
-    pack_eff = (seqlen_q * qhead_per_khead) / round_up(seqlen_q * qhead_per_khead, blockM)
+    pack_eff = (seqlen_q * qhead_per_khead) / round_up(
+        seqlen_q * qhead_per_khead, blockM
+    )
 
     # Heuristic: pack if it improves tile utilization by ~10%
     return nopack_eff < 0.9 * pack_eff

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -332,3 +332,28 @@ def is_flash_attn_varlen_func_available() -> bool:
         return _ROCM_FLASH_ATTN_AVAILABLE
 
     return False
+
+def should_pack_gqa(seqlen_q: int, qhead_per_khead: int, blockM: int) -> bool:
+    """
+    Decide whether to pack GQA heads for decoding (fixed-length queries).
+
+    Args:
+        seqlen_q: length of the query sequence (fixed)
+        qhead_per_khead: number of Q heads per KV head
+        blockM: FlashAttention tile size
+
+    Returns:
+        True if PackGQA is beneficial
+    """
+    # Helper to round up to nearest multiple of blockM
+    def round_up(a: int, b: int) -> int:
+        return ((a + b - 1) // b) * b
+
+    # Efficiency if we do NOT pack
+    nopack_eff = seqlen_q / round_up(seqlen_q, blockM)
+
+    # Efficiency if we pack multiple Q heads together
+    pack_eff = (seqlen_q * qhead_per_khead) / round_up(seqlen_q * qhead_per_khead, blockM)
+
+    # Heuristic: pack if it improves tile utilization by ~10%
+    return nopack_eff < 0.9 * pack_eff

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -1381,7 +1381,7 @@ def use_cascade_attention(
     # Too few queries. Probably not worth using cascade attention.
     # We use an arbitrary threshold of 8 queries. TODO: Tune this threshold.
     num_reqs = len(query_lens)
-    if num_reqs < 8:
+    if num_reqs <= 32:
         return False
     # disable cascade attention for DCP
     if dcp_world_size > 1:

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -1417,10 +1417,10 @@ def use_cascade_attention(
     num_prefix_tiles = cdiv(common_prefix_len, kv_tile_size)
 
     fa_version = get_flash_attn_version()
-    pack_gqa = should_pack_gqa(seqlen_q=1,
-                               qhead_per_khead=num_queries_per_kv,
-                               blockM=q_tile_size)
-    
+    pack_gqa = should_pack_gqa(
+        seqlen_q=1, qhead_per_khead=num_queries_per_kv, blockM=q_tile_size
+    )
+
     if fa_version == 3 and pack_gqa:
         # By using PackGQA
         # [Q_0, Q_1,...., Q_15] are packed together and is processed by one CTA
@@ -1428,7 +1428,12 @@ def use_cascade_attention(
         cascade_waves = cdiv(cascade_ctas, num_sms)
         cascade_time = cascade_waves * num_prefix_tiles
 
-        flash_decoding_ctas = num_prefix_tiles * num_kv_heads * cdiv(num_queries_per_kv * num_reqs, q_tile_size)
+        flash_decoding_ctas = (
+            num_prefix_tiles
+            * num_kv_heads
+            * cdiv(num_queries_per_kv * num_reqs, q_tile_size)
+        )
+
     else:
         cascade_ctas = num_query_heads * cdiv(num_tokens, q_tile_size)
         cascade_waves = cdiv(cascade_ctas, num_sms)
@@ -1438,13 +1443,17 @@ def use_cascade_attention(
             num_reqs * num_kv_heads * cdiv(num_queries_per_kv, q_tile_size)
         )
         flash_decoding_ctas *= num_prefix_tiles
-        
+
     # FA2 uses 128 threads per block, allowing each SM to run 2 blocks concurrently.
     # Therefore, the effective SM count is num_sms * 2
     # ref:https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/csrc/flash_attn/flash_api.cpp#L316
     # FA3 directly using num_sms pass to num_splits_heuristic
     # ref:https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/hopper/flash_api.cpp#L501
-    flash_decoding_time = cdiv(flash_decoding_ctas, 2 * num_sms) if fa_version == 2 else cdiv(flash_decoding_ctas, num_sms)
+    flash_decoding_time = (
+        cdiv(flash_decoding_ctas, 2 * num_sms)
+        if fa_version == 2
+        else cdiv(flash_decoding_ctas, num_sms)
+    )
     # Use cascade attention if it is faster than FlashDecoding.
     return cascade_time < flash_decoding_time
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -1444,16 +1444,7 @@ def use_cascade_attention(
         )
         flash_decoding_ctas *= num_prefix_tiles
 
-    # FA2 uses 128 threads per block, allowing each SM to run 2 blocks concurrently.
-    # Therefore, the effective SM count is num_sms * 2
-    # ref:https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/csrc/flash_attn/flash_api.cpp#L316
-    # FA3 directly using num_sms pass to num_splits_heuristic
-    # ref:https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/hopper/flash_api.cpp#L501
-    flash_decoding_time = (
-        cdiv(flash_decoding_ctas, 2 * num_sms)
-        if fa_version == 2
-        else cdiv(flash_decoding_ctas, num_sms)
-    )
+    flash_decoding_time = cdiv(flash_decoding_ctas, num_sms)
     # Use cascade attention if it is faster than FlashDecoding.
     return cascade_time < flash_decoding_time
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -1423,7 +1423,7 @@ def use_cascade_attention(
 
     if fa_version == 3 and pack_gqa:
         # By using PackGQA
-        # [Q_0, Q_1,...., Q_15] are packed together and is processed by one CTA
+        # [Q_0, Q_1,...., Q_n] are packed together and is processed by one CTA
         cascade_ctas = num_kv_heads * cdiv(num_tokens * num_queries_per_kv, q_tile_size)
         cascade_waves = cdiv(cascade_ctas, num_sms)
         cascade_time = cascade_waves * num_prefix_tiles

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -26,6 +26,7 @@ from vllm.v1.attention.backends.fa_utils import (
     get_flash_attn_version,
     is_fa_version_supported,
     is_flash_attn_varlen_func_available,
+    should_pack_gqa,
 )
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
@@ -1415,16 +1416,35 @@ def use_cascade_attention(
     kv_tile_size = 128
     num_prefix_tiles = cdiv(common_prefix_len, kv_tile_size)
 
-    cascade_ctas = num_query_heads * cdiv(num_tokens, q_tile_size)
-    cascade_waves = cdiv(cascade_ctas, num_sms)
-    cascade_time = cascade_waves * num_prefix_tiles
+    fa_version = get_flash_attn_version()
+    pack_gqa = should_pack_gqa(seqlen_q=1,
+                               qhead_per_khead=num_queries_per_kv,
+                               blockM=q_tile_size)
+    
+    if fa_version == 3 and pack_gqa:
+        # By using PackGQA
+        # [Q_0, Q_1,...., Q_15] are packed together and is processed by one CTA
+        cascade_ctas = num_kv_heads * cdiv(num_tokens * num_queries_per_kv, q_tile_size)
+        cascade_waves = cdiv(cascade_ctas, num_sms)
+        cascade_time = cascade_waves * num_prefix_tiles
 
-    flash_decoding_ctas = (
-        num_reqs * num_kv_heads * cdiv(num_queries_per_kv, q_tile_size)
-    )
-    flash_decoding_ctas *= num_prefix_tiles
-    flash_decoding_time = cdiv(flash_decoding_ctas, num_sms)
+        flash_decoding_ctas = num_prefix_tiles * num_kv_heads * cdiv(num_queries_per_kv * num_reqs, q_tile_size)
+    else:
+        cascade_ctas = num_query_heads * cdiv(num_tokens, q_tile_size)
+        cascade_waves = cdiv(cascade_ctas, num_sms)
+        cascade_time = cascade_waves * num_prefix_tiles
 
+        flash_decoding_ctas = (
+            num_reqs * num_kv_heads * cdiv(num_queries_per_kv, q_tile_size)
+        )
+        flash_decoding_ctas *= num_prefix_tiles
+        
+    # FA2 uses 128 threads per block, allowing each SM to run 2 blocks concurrently.
+    # Therefore, the effective SM count is num_sms * 2
+    # ref:https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/csrc/flash_attn/flash_api.cpp#L316
+    # FA3 directly using num_sms pass to num_splits_heuristic
+    # ref:https://github.com/vllm-project/flash-attention/blob/dd62dac706b1cf7895bd99b18c6cb7e7e117ee25/hopper/flash_api.cpp#L501
+    flash_decoding_time = cdiv(flash_decoding_ctas, 2 * num_sms) if fa_version == 2 else cdiv(flash_decoding_ctas, num_sms)
     # Use cascade attention if it is faster than FlashDecoding.
     return cascade_time < flash_decoding_time
 


### PR DESCRIPTION
## Purpose
Close #15647 
## Test Plan
Test Script
```
"""
Benchmark: cascade_attention vs flash_decoding across batch_size × prefix_len.

Goal: verify whether the default heuristic selects the faster attention method.

Columns:
  Flash(ms)    — forced FORCE_FLASH=1
  Cascade(ms)  — forced FORCE_CASCADE=1
  Default(ms)  — natural heuristic, no forcing
  Winner       — faster of Flash vs Cascade
  Gap          — how far Default deviates from the winner (%)

Usage:
    python debug_cascade_attention.py [--model PATH] [--max-tokens N]
"""

from __future__ import annotations

import argparse
import gc
import json
import os
import sys
import tempfile
import time
from typing import Any

import numpy as np
import torch

os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"


# ────────────────────────────────────────────────────────────────
# Step-level timing patch (decode TTOT only, excludes prefill)
# ────────────────────────────────────────────────────────────────

_STEP_TIMING_FILE: str | None = None


def _write_step_timing(step_type: str, elapsed: float, num_tokens: int) -> None:
    if _STEP_TIMING_FILE:
        with open(_STEP_TIMING_FILE, "a") as f:
            f.write(json.dumps({"type": step_type, "elapsed": elapsed,
                                "tokens": num_tokens}) + "\n")


_original_execute_model = None


def _patched_execute_model(self_runner, scheduler_output, intermediate_tensors=None):
    t0 = time.perf_counter()
    result = _original_execute_model(self_runner, scheduler_output, intermediate_tensors)
    elapsed = time.perf_counter() - t0

    ns = scheduler_output.num_scheduled_tokens
    if ns:
        total_tokens = sum(ns.values())
        num_reqs = len(ns)
        step_type = "decode" if total_tokens == num_reqs else "prefill"
        _write_step_timing(step_type, elapsed, num_reqs)

    return result


def _install_timing_patch() -> None:
    import vllm.v1.worker.gpu_model_runner as _gmr
    global _original_execute_model
    _original_execute_model = _gmr.GPUModelRunner.execute_model
    _gmr.GPUModelRunner.execute_model = _patched_execute_model


def _read_decode_ttot_ms() -> float:
    """Return average decode TTOT in ms/token from the step timing file."""
    total_time = 0.0
    total_tokens = 0
    if _STEP_TIMING_FILE and os.path.exists(_STEP_TIMING_FILE):
        with open(_STEP_TIMING_FILE) as f:
            for line in f:
                try:
                    e = json.loads(line.strip())
                    if e["type"] == "decode":
                        total_time += e["elapsed"]
                        total_tokens += e["tokens"]
                except Exception:
                    pass
    return (total_time / total_tokens * 1000) if total_tokens > 0 else float("inf")


# ────────────────────────────────────────────────────────────────
# Prompt builder
# ────────────────────────────────────────────────────────────────

def _build_prompts(tokenizer, prefix_len: int, batch_size: int) -> list[str]:
    pad_word = " hello"
    ids = tokenizer.encode(pad_word * (prefix_len * 3), add_special_tokens=False)
    prefix_text = tokenizer.decode(ids[:prefix_len], skip_special_tokens=True)
    return [
        f"{prefix_text}\n\nUser: request_{i}: Write a haiku about autumn.\n\nAssistant:"
        for i in range(batch_size)
    ]


# ────────────────────────────────────────────────────────────────
# Main
# ────────────────────────────────────────────────────────────────

def main() -> int:
    parser = argparse.ArgumentParser()
    parser.add_argument("--model", default="Qwen/Qwen3-14B")
    parser.add_argument("--max-tokens", type=int, default=32)
    parser.add_argument("--gpu-memory-utilization", type=float, default=0.80)
    parser.add_argument("--max-model-len", type=int, default=4608)
    args = parser.parse_args()

    _install_timing_patch()

    from vllm import LLM, SamplingParams
    from transformers import AutoTokenizer

    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)

    batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
    prefix_lens = [512, 1024, 2048, 4096]

    global _STEP_TIMING_FILE
    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False,
                                     prefix="step_timing_") as tmp:
        _STEP_TIMING_FILE = tmp.name

    llm_kwargs: dict[str, Any] = dict(
        model=args.model,
        disable_cascade_attn=False,
        attention_config={"backend": "FLASH_ATTN"},
        gpu_memory_utilization=args.gpu_memory_utilization,
        max_model_len=args.max_model_len,
        enforce_eager=True,
        enable_prefix_caching=True,
    )
    sampling_params = SamplingParams(temperature=0.0, max_tokens=args.max_tokens)

    # results[prefix_len][bs][force_mode] = decode_ms
    results: dict[int, dict[int, dict[str, float]]] = {}

    for force_mode in ("flash", "cascade", "default"):
        print(f"\n{'=' * 60}")
        print(f"  Mode: {force_mode.upper()}")
        print(f"{'=' * 60}")

        # Set env before fork so worker inherits the correct flag.
        os.environ.pop("FORCE_CASCADE", None)
        os.environ.pop("FORCE_FLASH", None)
        if force_mode == "cascade":
            os.environ["FORCE_CASCADE"] = "1"
        elif force_mode == "flash":
            os.environ["FORCE_FLASH"] = "1"

        llm = LLM(**llm_kwargs)

        # Warm-up: absorb CUDA kernel JIT latency.
        llm.generate(_build_prompts(tokenizer, 128, 1)[:1],
                     SamplingParams(temperature=0.0, max_tokens=4))

        for prefix_len in prefix_lens:
            prompts = _build_prompts(tokenizer, prefix_len, max(batch_sizes))

            for bs in batch_sizes:
                if prefix_len + args.max_tokens > args.max_model_len:
                    continue

                llm.reset_prefix_cache()
                open(_STEP_TIMING_FILE, "w").close()

                llm.generate(prompts[:bs], sampling_params)

                ms = _read_decode_ttot_ms()
                results.setdefault(prefix_len, {}).setdefault(bs, {})[force_mode] = ms
                print(f"  prefix={prefix_len:>5}  batch={bs:>3}  {ms:.3f} ms/tok")

        del llm
        gc.collect()
        torch.cuda.empty_cache()

    os.environ.pop("FORCE_CASCADE", None)
    os.environ.pop("FORCE_FLASH", None)

    # ── Print table ──────────────────────────────────────────────
    col = "| {:>5} | {:>7} | {:>11} | {:>13} | {:>13} | {:>10} | {:>14} |"
    sep = "|" + "|".join(["-" * w for w in [7, 9, 13, 15, 15, 12, 16]]) + "|"

    print(f"\n\n{'=' * 100}")
    print("  Benchmark Results")
    print(f"{'=' * 100}")
    print(col.format("Batch", "Prefix", "Flash(ms)", "Cascade(ms)", "Default(ms)", "Winner", "Default Gap"))
    print(sep)

    for prefix_len in prefix_lens:
        for bs in batch_sizes:
            entry = results.get(prefix_len, {}).get(bs)
            if not entry:
                print(col.format(bs, prefix_len, "skip", "skip", "skip", "-", "-"))
                continue

            flash_ms   = entry.get("flash",   float("inf"))
            cascade_ms = entry.get("cascade", float("inf"))
            default_ms = entry.get("default", float("inf"))

            winner   = "flash" if flash_ms <= cascade_ms else "cascade"
            best_ms  = min(flash_ms, cascade_ms)
            gap_pct  = (default_ms - best_ms) / best_ms * 100

            # Flag cases where default is meaningfully worse than the best.
            flag = " ⚠" if gap_pct > 5.0 else ""

            print(col.format(
                bs, prefix_len,
                f"{flash_ms:.3f}",
                f"{cascade_ms:.3f}",
                f"{default_ms:.3f}",
                winner,
                f"+{gap_pct:.1f}%{flag}",
            ))

    print(sep)
    print()
    print("  ⚠  = default deviates >5% from the optimal forced mode")
    print()

    if _STEP_TIMING_FILE and os.path.exists(_STEP_TIMING_FILE):
        os.unlink(_STEP_TIMING_FILE)
    return 0


if __name__ == "__main__":
    sys.exit(main())
```
## Test Result
```
====================================================================================================
FA3  Benchmark Results
====================================================================================================
| Batch |  Prefix |   Flash(ms) |   Cascade(ms) |   Default(ms) |     Winner |    Default Gap |
|-------|---------|-------------|---------------|---------------|------------|----------------|
|     1 |     512 |      19.269 |        23.315 |        19.835 |      flash |          +2.9% |
|     2 |     512 |       8.336 |        10.262 |         8.675 |      flash |          +4.1% |
|     4 |     512 |       4.174 |         5.053 |         4.303 |      flash |          +3.1% |
|     8 |     512 |       2.075 |         2.552 |         2.131 |      flash |          +2.7% |
|    16 |     512 |       1.057 |         1.292 |         1.089 |      flash |          +3.0% |
|    32 |     512 |       0.537 |         0.653 |         0.546 |      flash |          +1.6% |
|    64 |     512 |       0.279 |         0.321 |         0.291 |      flash |          +4.2% |
|   128 |     512 |       0.158 |         0.344 |         0.162 |      flash |          +2.5% |
|   256 |     512 |       0.095 |         0.236 |         0.097 |      flash |          +2.2% |
|   512 |     512 |       0.091 |         0.297 |         0.099 |      flash |        +8.4% ⚠ |
|     1 |    1024 |      18.755 |        26.904 |        19.302 |      flash |          +2.9% |
|     2 |    1024 |       8.457 |        10.170 |         8.732 |      flash |          +3.3% |
|     4 |    1024 |       4.223 |         5.039 |         4.344 |      flash |          +2.9% |
|     8 |    1024 |       2.103 |         2.546 |         2.164 |      flash |          +2.9% |
|    16 |    1024 |       1.062 |         1.308 |         1.100 |      flash |          +3.5% |
|    32 |    1024 |       0.526 |         0.693 |         0.538 |      flash |          +2.2% |
|    64 |    1024 |       0.291 |         0.407 |         0.295 |      flash |          +1.5% |
|   128 |    1024 |       0.149 |         0.273 |         0.149 |      flash |          +0.4% |
|   256 |    1024 |       0.105 |         0.297 |         0.098 |      flash |         +-6.5% |
|   512 |    1024 |       0.073 |         0.256 |         0.090 |      flash |       +23.8% ⚠ |
|     1 |    2048 |      22.725 |        33.332 |        23.183 |      flash |          +2.0% |
|     2 |    2048 |       8.349 |         9.997 |         8.596 |      flash |          +3.0% |
|     4 |    2048 |       4.183 |         4.958 |         4.302 |      flash |          +2.8% |
|     8 |    2048 |       2.163 |         2.527 |         2.201 |      flash |          +1.7% |
|    16 |    2048 |       1.059 |         1.328 |         1.082 |      flash |          +2.2% |
|    32 |    2048 |       0.536 |         0.704 |         0.543 |      flash |          +1.4% |
|    64 |    2048 |       0.297 |         0.407 |         0.301 |      flash |          +1.3% |
|   128 |    2048 |       0.190 |         0.286 |         0.192 |      flash |          +0.9% |
|   256 |    2048 |       0.106 |         0.271 |         0.090 |      flash |        +-15.5% |
|   512 |    2048 |       0.090 |         0.268 |         0.099 |      flash |        +9.7% ⚠ |
|     1 |    4096 |      30.810 |        47.741 |        30.705 |      flash |         +-0.3% |
|     2 |    4096 |       8.511 |        10.294 |         8.565 |      flash |          +0.6% |
|     4 |    4096 |       4.324 |         5.218 |         4.367 |      flash |          +1.0% |
|     8 |    4096 |       2.164 |         2.596 |         2.159 |      flash |         +-0.2% |
|    16 |    4096 |       1.097 |         1.356 |         1.110 |      flash |          +1.1% |
|    32 |    4096 |       0.554 |         0.734 |         0.572 |      flash |          +3.3% |
|    64 |    4096 |       0.310 |         0.427 |         0.311 |      flash |          +0.2% |
|   128 |    4096 |       0.277 |         0.316 |         0.275 |      flash |         +-0.9% |
|   256 |    4096 |       0.140 |         0.301 |         0.152 |      flash |        +8.5% ⚠ |
|   512 |    4096 |       0.149 |         0.281 |         0.214 |      flash |       +44.1% ⚠ |
|-------|---------|-------------|---------------|---------------|------------|----------------|
```


```
====================================================================================================
FA2  Benchmark Results
====================================================================================================
| Batch |  Prefix |   Flash(ms) |   Cascade(ms) |   Default(ms) |     Winner |    Default Gap |
|-------|---------|-------------|---------------|---------------|------------|----------------|
|     1 |     512 |      11.422 |        33.135 |        11.040 |      flash |         +-3.3% |
|     2 |     512 |       6.143 |        15.708 |         6.265 |      flash |          +2.0% |
|     4 |     512 |       2.835 |         8.170 |         2.925 |      flash |          +3.2% |
|     8 |     512 |       1.453 |         4.066 |         1.467 |      flash |          +1.0% |
|    16 |     512 |       0.724 |         2.058 |         0.738 |      flash |          +1.9% |
|    32 |     512 |       0.679 |         1.159 |         0.681 |      flash |          +0.3% |
|    64 |     512 |       0.360 |         0.639 |         0.646 |      flash |       +79.5% ⚠ |
|   128 |     512 |       0.240 |         0.342 |         0.368 |      flash |       +52.9% ⚠ |
|   256 |     512 |       0.200 |         0.276 |         0.276 |      flash |       +37.8% ⚠ |
|   512 |     512 |       0.204 |         0.267 |         0.273 |      flash |       +33.7% ⚠ |
|     1 |    1024 |      12.851 |        36.136 |        12.371 |      flash |         +-3.7% |
|     2 |    1024 |       5.818 |        16.344 |         5.764 |      flash |         +-0.9% |
|     4 |    1024 |       2.866 |         8.267 |         2.920 |      flash |          +1.9% |
|     8 |    1024 |       1.421 |         4.121 |         1.464 |      flash |          +3.0% |
|    16 |    1024 |       0.727 |         2.087 |         0.723 |      flash |         +-0.6% |
|    32 |    1024 |       0.707 |         1.176 |         0.709 |      flash |          +0.2% |
|    64 |    1024 |       0.425 |         0.668 |         0.667 |      flash |       +56.9% ⚠ |
|   128 |    1024 |       0.277 |         0.348 |         0.344 |      flash |       +24.4% ⚠ |
|   256 |    1024 |       0.225 |         0.288 |         0.240 |      flash |        +6.7% ⚠ |
|   512 |    1024 |       0.229 |         0.233 |         0.274 |      flash |       +19.9% ⚠ |
|     1 |    2048 |      14.034 |        42.228 |        13.800 |      flash |         +-1.7% |
|     2 |    2048 |       5.626 |        16.934 |         7.268 |      flash |       +29.2% ⚠ |
|     4 |    2048 |       2.849 |         8.571 |         3.720 |      flash |       +30.6% ⚠ |
|     8 |    2048 |       1.428 |         4.266 |         1.852 |      flash |       +29.6% ⚠ |
|    16 |    2048 |       0.953 |         2.167 |         0.945 |      flash |         +-0.8% |
|    32 |    2048 |       0.760 |         1.624 |         0.890 |      flash |       +17.1% ⚠ |
|    64 |    2048 |       0.479 |         0.690 |         0.692 |      flash |       +44.6% ⚠ |
|   128 |    2048 |       0.331 |         0.370 |         0.378 |      flash |       +14.3% ⚠ |
|   256 |    2048 |       0.287 |         0.275 |         0.272 |    cascade |         +-0.8% |
|   512 |    2048 |       0.285 |         0.252 |         0.248 |    cascade |         +-1.4% |
|     1 |    4096 |      18.124 |        55.134 |        17.780 |      flash |         +-1.9% |
|     2 |    4096 |       9.614 |        30.846 |         9.335 |      flash |         +-2.9% |
|     4 |    4096 |       4.728 |        15.366 |         4.667 |      flash |         +-1.3% |
|     8 |    4096 |       2.410 |         7.676 |         2.382 |      flash |         +-1.1% |
|    16 |    4096 |       1.259 |         3.876 |         1.261 |      flash |          +0.2% |
|    32 |    4096 |       1.122 |         2.101 |         1.127 |      flash |          +0.4% |
|    64 |    4096 |       0.708 |         1.129 |         0.740 |      flash |          +4.6% |
|   128 |    4096 |       0.509 |         0.591 |         0.432 |      flash |        +-15.1% |
|   256 |    4096 |       0.419 |         0.410 |         0.318 |    cascade |        +-22.4% |
|   512 |    4096 |       0.413 |         0.343 |         0.301 |    cascade |        +-12.3% |
|-------|---------|-------------|---------------|---------------|------------|----------------|
```


The previous heuristic incorrectly chose cascade attention at `16 < batch_size <= 32` where flash decoding is faster. 

The updated heuristic now correctly selects the faster method.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

