### PR TITLE
[Frontend] Report reasoning_tokens usage for chat completions; fix count for prompt-injected <think>

### DIFF
--- a/tests/reasoning/test_deepseekr1_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekr1_reasoning_parser.py
@@ -286,3 +286,24 @@ def test_reasoning(
     else:
         content = parser.extract_content_ids(output)
         assert content == []
+
+
+def test_count_reasoning_tokens(deepseek_r1_qwen_tokenizer):
+    """DeepSeek-R1 opens the reasoning block via the prompt template, so the
+    generated output has no ``<think>`` start token; reasoning runs from the
+    start of the output up to (excluding) ``</think>``."""
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        deepseek_r1_qwen_tokenizer
+    )
+    start = parser.start_token_id
+    end = parser.end_token_id
+
+    # No start token (injected via prompt) + </think> present -> count the
+    # tokens before </think> (excludes the delimiter).
+    assert parser.count_reasoning_tokens([10, 11, 12, end, 99, 98]) == 3
+    # No start and no end -> reasoning unfinished or disabled -> 0.
+    assert parser.count_reasoning_tokens([10, 11, 12]) == 0
+    # Immediate </think> -> no reasoning tokens.
+    assert parser.count_reasoning_tokens([end, 1, 2]) == 0
+    # Explicit <think> in the output -> defer to the base span counter.
+    assert parser.count_reasoning_tokens([start, 10, 11, end, 99]) == 2

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -39,6 +39,7 @@ from vllm.entrypoints.openai.chat_completion.stream_harmony import (
     extract_harmony_streaming_delta,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokenUsageInfo,
     DeltaMessage,
     ErrorResponse,
     FunctionCall,
@@ -883,6 +884,16 @@ class OpenAIServingChat(OpenAIServing):
                     final_usage.prompt_tokens_details = PromptTokenUsageInfo(
                         cached_tokens=num_cached_tokens
                     )
+                if reasoning_parser is not None and all_previous_token_ids is not None:
+                    num_reasoning_tokens = sum(
+                        reasoning_parser.count_reasoning_tokens(
+                            all_previous_token_ids[i]
+                        )
+                        for i in range(num_choices)
+                    )
+                    final_usage.completion_tokens_details = CompletionTokenUsageInfo(
+                        reasoning_tokens=num_reasoning_tokens
+                    )
 
                 final_usage_chunk = ChatCompletionStreamResponse(
                     id=request_id,
@@ -1306,6 +1317,18 @@ class OpenAIServingChat(OpenAIServing):
         if self.enable_prompt_tokens_details and final_res.num_cached_tokens:
             usage.prompt_tokens_details = PromptTokenUsageInfo(
                 cached_tokens=final_res.num_cached_tokens
+            )
+        if self.reasoning_parser_cls is not None:
+            reasoning_parser = self.reasoning_parser_cls(
+                tokenizer,
+                chat_template_kwargs=self._effective_chat_template_kwargs(request),
+            )
+            num_reasoning_tokens = sum(
+                reasoning_parser.count_reasoning_tokens(output.token_ids)
+                for output in final_res.outputs
+            )
+            usage.completion_tokens_details = CompletionTokenUsageInfo(
+                reasoning_tokens=num_reasoning_tokens
             )
 
         request_metadata.final_usage_info = usage

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -103,11 +103,16 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
 
 
+class CompletionTokenUsageInfo(OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
     prompt_tokens_details: PromptTokenUsageInfo | None = None
+    completion_tokens_details: CompletionTokenUsageInfo | None = None
 
 
 class RequestResponseMetadata(BaseModel):

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -25,6 +25,27 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
         """The token that ends reasoning content."""
         return "</think>"
 
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        """Count reasoning tokens in the generated output.
+
+        DeepSeek-R1-style models open the reasoning block via the prompt's
+        chat template, so the generated output usually does not contain the
+        ``<think>`` start token. The generic start/end span counter in the
+        base class would return ``0`` in that case because it never sees an
+        opening token. Here we count from the start of the output up to (but
+        excluding) the ``</think>`` end token instead.
+        """
+        # If the model emitted an explicit <think>, defer to the generic
+        # span counter (handles nested/explicit spans correctly).
+        if self.start_token_id in token_ids:
+            return super().count_reasoning_tokens(token_ids)
+        token_ids = list(token_ids)
+        if self.end_token_id in token_ids:
+            return token_ids.index(self.end_token_id)
+        # No </think> in the output: reasoning is either unfinished or was
+        # disabled. Return 0 rather than misattributing content as reasoning.
+        return 0
+
     def extract_reasoning_streaming(
         self,
         previous_text: str,


### PR DESCRIPTION
## Purpose

Report reasoning-token usage for the Chat Completions API and fix the
reasoning-token count for reasoning parsers that open the thinking block via
the prompt's chat template (DeepSeek-R1, Nemotron-V3).

Two related gaps today:

1. **Chat Completions never reports reasoning tokens.** `UsageInfo` has no
   `completion_tokens_details`, so `/v1/chat/completions` cannot tell a client
   how many of the completion tokens were reasoning — even though the Responses
   API already returns `output_tokens_details.reasoning_tokens`.

2. **`reasoning_tokens` is `0` for prompt-injected `<think>` models.**
   `BaseThinkingReasoningParser.count_reasoning_tokens` counts tokens *between*
   `<think>` and `</think>`. DeepSeek-R1 / Nemotron-V3 open the reasoning block
   via the chat template, so the generated output contains no `<think>` start
   token; the span counter never increments and returns `0`. This affects the
   Responses API's `output_tokens_details.reasoning_tokens` for these models.

## Changes

- `engine/protocol.py`: add `CompletionTokenUsageInfo { reasoning_tokens }` and
  `UsageInfo.completion_tokens_details` (mirrors OpenAI's
  `completion_tokens_details` and the existing Responses `OutputTokensDetails`).
- `chat_completion/serving.py`: populate `completion_tokens_details.reasoning_tokens`
  in both the streaming and non-streaming paths via
  `ReasoningParser.count_reasoning_tokens` (only when a reasoning parser is set).
- `reasoning/deepseek_r1_reasoning_parser.py`: override `count_reasoning_tokens`
  to count from the start of the output up to `</think>` when no `<think>` start
  token is present (prompt-injected reasoning), deferring to the base span
  counter when an explicit `<think>` is emitted. Nemotron-V3 inherits the fix.

## Test

- New unit test `tests/reasoning/test_deepseekr1_reasoning_parser.py::test_count_reasoning_tokens`
  covering: prompt-injected start (`</think>` present → tokens before it),
  unfinished/disabled reasoning (no start/end → 0), immediate `</think>` → 0,
  and explicit `<think>` in output → base span counter.

## Notes

- Behavior is unchanged when no reasoning parser is configured
  (`completion_tokens_details` stays unset) and for models that emit `<think>`
  in the output (the base span counter is still used).
