### PR TITLE
[Rust-fronted] add llm tokenizer crates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2442,6 +2442,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "llm-tokenizer"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4992c0d29fdf0e964a5a1446c4b61b74ce7148b064b18feabfb375f7717e5d96"
+dependencies = [
+ "aho-corasick",
+ "anyhow",
+ "base64 0.22.1",
+ "blake3",
+ "dashmap",
+ "futures",
+ "hf-hub 0.5.0",
+ "minijinja",
+ "minijinja-contrib",
+ "rayon",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tiktoken-rs 0.9.1",
+ "tokenizers",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5562,6 +5589,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5880,11 +5908,12 @@ dependencies = [
 name = "vllm-tokenizer"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "criterion",
- "dashmap",
  "fastokens",
  "hf-hub 0.5.0",
+ "llm-tokenizer",
  "riptoken",
  "rustc-hash 1.1.0",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1028,6 +1028,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,9 +2892,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5868,6 +5882,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "criterion",
+ "dashmap",
  "fastokens",
  "hf-hub 0.5.0",
  "riptoken",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,6 +46,7 @@ hf-hub = { version = "0.5.0", features = ["tokio"] }
 http-body = "1.0.1"
 itertools = "0.14.0"
 libc = "0.2.177"
+llm-tokenizer = "1.3.2"
 llm-multimodal = { git = "https://github.com/vllm-project/llm-multimodal", rev = "5b558989844d1c7af3e43d0f604069ffd9c06320" }
 mimalloc = "0.1.52"
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ byteorder = "1.5.0"
 bytes = "1.11.1"
 clap = { version = "4.5.38", features = ["derive", "env"] }
 criterion = "0.5.1"
+dashmap = "6.1.0"
 easy-ext = "1.0.3"
 educe = "0.6.0"
 enum-as-inner = "0.7.0"

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -27,18 +27,19 @@ use crate::error::Result;
 /// tokenizer.
 ///
 /// Optional tuning knobs (only effective when the cache is enabled):
-/// - `VLLM_RS_TOKENIZER_CACHE_SIZE`: max L0 entries (default 10 000)
-/// - `VLLM_RS_TOKENIZER_CACHE_ENABLE_L1=1`: enable L1 prefix cache
-const ENABLE_TOKENIZER_CACHE_ENV: &str = "VLLM_RS_ENABLE_TOKENIZER_CACHE";
-const TOKENIZER_CACHE_SIZE_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_SIZE";
-const TOKENIZER_CACHE_ENABLE_L1_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_ENABLE_L1";
+/// - `VLLM_RS_LLM_TOKENIZER_CACHE_SIZE`: max L0 entries (default 10 000)
+/// - `VLLM_RS_LLM_TOKENIZER_CACHE_ENABLE_L1=1`: enable L1 prefix cache
+const TOKENIZER_CACHE_SIZE_ENV: &str = "VLLM_RS_LLM_TOKENIZER_CACHE_SIZE";
+const TOKENIZER_CACHE_ENABLE_L1_ENV: &str = "VLLM_RS_LLM_TOKENIZER_CACHE_ENABLE_L1";
+const TOKENIZER_L1_CACHE_MAX_MEMORY_ENV: &str = "VLLM_RS_LLM_TOKENIZER_L1_CACHE_MAX_MEMORY";
+/// Environment variable to enable the experimental LLM tokenizer.
+const ENABLE_LLM_TOKENIZER: &str = "VLLM_RS_ENABLE_LLM_TOKENIZER";
 
 fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
-    let enable_cache = std::env::var_os(ENABLE_TOKENIZER_CACHE_ENV)
+    let enable_llm_tokenizer = std::env::var_os(ENABLE_LLM_TOKENIZER)
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
-
-    if enable_cache {
+    if enable_llm_tokenizer {
         let max_entries: usize = std::env::var(TOKENIZER_CACHE_SIZE_ENV)
             .ok()
             .and_then(|v| v.parse().ok())
@@ -46,30 +47,31 @@ fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
         let enable_l1 = std::env::var_os(TOKENIZER_CACHE_ENABLE_L1_ENV)
             .map(|v| v == "1" || v == "true")
             .unwrap_or(false);
+        let l1_max_memory: usize = std::env::var(TOKENIZER_L1_CACHE_MAX_MEMORY_ENV)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50 * 1024 * 1024);
         let cache_config = LlmCacheConfig {
             enable_l0: true,
             l0_max_entries: max_entries,
             enable_l1,
-            l1_max_memory: 50 * 1024 * 1024,
+            l1_max_memory,
         };
         tracing::info!(
             max_entries,
             enable_l1,
-            "llm-tokenizer cache enabled (set by {ENABLE_TOKENIZER_CACHE_ENV})"
+            "llm-tokenizer cache enabled (set by {ENABLE_LLM_TOKENIZER})"
         );
         match tokenizer {
-            TokenizerSource::HuggingFace(path) => Ok(Arc::new(LlmCachedTokenizer::new(
-                HuggingFaceTokenizer::new(path)?,
-                cache_config,
-            ))),
-            TokenizerSource::Tiktoken(path) => Ok(Arc::new(LlmCachedTokenizer::new(
-                TiktokenTokenizer::new(path)?,
-                cache_config,
-            ))),
-            TokenizerSource::Tekken(path) => Ok(Arc::new(LlmCachedTokenizer::new(
-                TekkenTokenizer::new(path)?,
-                cache_config,
-            ))),
+            TokenizerSource::HuggingFace(path) => {
+                Ok(Arc::new(LlmCachedTokenizer::new(path, cache_config)))
+            }
+            TokenizerSource::Tiktoken(path) => {
+                Ok(Arc::new(LlmCachedTokenizer::new(path, cache_config)))
+            }
+            TokenizerSource::Tekken(path) => {
+                Ok(Arc::new(LlmCachedTokenizer::new(path, cache_config)))
+            }
         }
     } else {
         match tokenizer {

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -25,10 +25,14 @@ use crate::error::Result;
 /// DashMap-based L0 whole-string cache (inspired by `llm-tokenizer`).
 /// Leave unset or set to `0` to use the original uncached tokenizer.
 ///
-/// When enabled, an optional `VLLM_RS_TOKENIZER_CACHE_SIZE` variable
-/// controls the maximum number of cached entries (default: 10 000).
+/// Optional tuning knobs (only effective when the cache is enabled):
+/// - `VLLM_RS_TOKENIZER_CACHE_SIZE`: max entries (default 10 000)
+/// - `VLLM_RS_TOKENIZER_CACHE_MAX_KEY_BYTES`: strings longer than this
+///   bypass the cache entirely to avoid overhead on long unique prompts
+///   (default 2048).
 const ENABLE_TOKENIZER_CACHE_ENV: &str = "VLLM_RS_ENABLE_TOKENIZER_CACHE";
 const TOKENIZER_CACHE_SIZE_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_SIZE";
+const TOKENIZER_CACHE_MAX_KEY_BYTES_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_MAX_KEY_BYTES";
 
 fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
     let enable_cache = std::env::var_os(ENABLE_TOKENIZER_CACHE_ENV)
@@ -36,16 +40,22 @@ fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
         .unwrap_or(false);
 
     if enable_cache {
-        let max_entries = std::env::var(TOKENIZER_CACHE_SIZE_ENV)
+        let max_entries: usize = std::env::var(TOKENIZER_CACHE_SIZE_ENV)
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(10_000);
+        let max_key_bytes: usize = std::env::var(TOKENIZER_CACHE_MAX_KEY_BYTES_ENV)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(2048);
         let cache_config = CacheConfig {
             enable_l0: true,
             l0_max_entries: max_entries,
+            l0_max_key_bytes: max_key_bytes,
         };
         tracing::info!(
             max_entries,
+            max_key_bytes,
             "tokenizer encode cache enabled (set by {ENABLE_TOKENIZER_CACHE_ENV})"
         );
         match tokenizer {

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use tracing::info;
 use vllm_tokenizer::{
-    CacheConfig, CachedTokenizer, DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer,
+    DynTokenizer, HuggingFaceTokenizer, LlmCacheConfig, LlmCachedTokenizer, TekkenTokenizer,
     TiktokenTokenizer,
 };
 
@@ -21,18 +21,17 @@ use crate::error::Result;
 
 /// Environment variable to enable the tokenizer encode cache.
 ///
-/// Set `VLLM_RS_ENABLE_TOKENIZER_CACHE=1` to wrap the tokenizer with a
-/// DashMap-based L0 whole-string cache (inspired by `llm-tokenizer`).
-/// Leave unset or set to `0` to use the original uncached tokenizer.
+/// Set `VLLM_RS_ENABLE_TOKENIZER_CACHE=1` to wrap the tokenizer with
+/// `llm-tokenizer`'s `CachedTokenizer` (L0 whole-string + optional L1
+/// prefix cache). Leave unset or set to `0` to use the original uncached
+/// tokenizer.
 ///
 /// Optional tuning knobs (only effective when the cache is enabled):
-/// - `VLLM_RS_TOKENIZER_CACHE_SIZE`: max entries (default 10 000)
-/// - `VLLM_RS_TOKENIZER_CACHE_MAX_KEY_BYTES`: strings longer than this
-///   bypass the cache entirely to avoid overhead on long unique prompts
-///   (default 2048).
+/// - `VLLM_RS_TOKENIZER_CACHE_SIZE`: max L0 entries (default 10 000)
+/// - `VLLM_RS_TOKENIZER_CACHE_ENABLE_L1=1`: enable L1 prefix cache
 const ENABLE_TOKENIZER_CACHE_ENV: &str = "VLLM_RS_ENABLE_TOKENIZER_CACHE";
 const TOKENIZER_CACHE_SIZE_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_SIZE";
-const TOKENIZER_CACHE_MAX_KEY_BYTES_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_MAX_KEY_BYTES";
+const TOKENIZER_CACHE_ENABLE_L1_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_ENABLE_L1";
 
 fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
     let enable_cache = std::env::var_os(ENABLE_TOKENIZER_CACHE_ENV)
@@ -44,30 +43,30 @@ fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(10_000);
-        let max_key_bytes: usize = std::env::var(TOKENIZER_CACHE_MAX_KEY_BYTES_ENV)
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(2048);
-        let cache_config = CacheConfig {
+        let enable_l1 = std::env::var_os(TOKENIZER_CACHE_ENABLE_L1_ENV)
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false);
+        let cache_config = LlmCacheConfig {
             enable_l0: true,
             l0_max_entries: max_entries,
-            l0_max_key_bytes: max_key_bytes,
+            enable_l1,
+            l1_max_memory: 50 * 1024 * 1024,
         };
         tracing::info!(
             max_entries,
-            max_key_bytes,
-            "tokenizer encode cache enabled (set by {ENABLE_TOKENIZER_CACHE_ENV})"
+            enable_l1,
+            "llm-tokenizer cache enabled (set by {ENABLE_TOKENIZER_CACHE_ENV})"
         );
         match tokenizer {
-            TokenizerSource::HuggingFace(path) => Ok(Arc::new(CachedTokenizer::new(
+            TokenizerSource::HuggingFace(path) => Ok(Arc::new(LlmCachedTokenizer::new(
                 HuggingFaceTokenizer::new(path)?,
                 cache_config,
             ))),
-            TokenizerSource::Tiktoken(path) => Ok(Arc::new(CachedTokenizer::new(
+            TokenizerSource::Tiktoken(path) => Ok(Arc::new(LlmCachedTokenizer::new(
                 TiktokenTokenizer::new(path)?,
                 cache_config,
             ))),
-            TokenizerSource::Tekken(path) => Ok(Arc::new(CachedTokenizer::new(
+            TokenizerSource::Tekken(path) => Ok(Arc::new(LlmCachedTokenizer::new(
                 TekkenTokenizer::new(path)?,
                 cache_config,
             ))),

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -19,21 +19,55 @@ pub use self::model_files::{ResolvedModelFiles, TokenizerSource};
 use crate::backend::{SamplingHints, TextBackend};
 use crate::error::Result;
 
+/// Environment variable to enable the tokenizer encode cache.
+///
+/// Set `VLLM_RS_ENABLE_TOKENIZER_CACHE=1` to wrap the tokenizer with a
+/// DashMap-based L0 whole-string cache (inspired by `llm-tokenizer`).
+/// Leave unset or set to `0` to use the original uncached tokenizer.
+///
+/// When enabled, an optional `VLLM_RS_TOKENIZER_CACHE_SIZE` variable
+/// controls the maximum number of cached entries (default: 10 000).
+const ENABLE_TOKENIZER_CACHE_ENV: &str = "VLLM_RS_ENABLE_TOKENIZER_CACHE";
+const TOKENIZER_CACHE_SIZE_ENV: &str = "VLLM_RS_TOKENIZER_CACHE_SIZE";
+
 fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
-    let cache_config = CacheConfig::default();
-    match tokenizer {
-        TokenizerSource::HuggingFace(path) => Ok(Arc::new(CachedTokenizer::new(
-            HuggingFaceTokenizer::new(path)?,
-            cache_config,
-        ))),
-        TokenizerSource::Tiktoken(path) => Ok(Arc::new(CachedTokenizer::new(
-            TiktokenTokenizer::new(path)?,
-            cache_config,
-        ))),
-        TokenizerSource::Tekken(path) => Ok(Arc::new(CachedTokenizer::new(
-            TekkenTokenizer::new(path)?,
-            cache_config,
-        ))),
+    let enable_cache = std::env::var_os(ENABLE_TOKENIZER_CACHE_ENV)
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+
+    if enable_cache {
+        let max_entries = std::env::var(TOKENIZER_CACHE_SIZE_ENV)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10_000);
+        let cache_config = CacheConfig {
+            enable_l0: true,
+            l0_max_entries: max_entries,
+        };
+        tracing::info!(
+            max_entries,
+            "tokenizer encode cache enabled (set by {ENABLE_TOKENIZER_CACHE_ENV})"
+        );
+        match tokenizer {
+            TokenizerSource::HuggingFace(path) => Ok(Arc::new(CachedTokenizer::new(
+                HuggingFaceTokenizer::new(path)?,
+                cache_config,
+            ))),
+            TokenizerSource::Tiktoken(path) => Ok(Arc::new(CachedTokenizer::new(
+                TiktokenTokenizer::new(path)?,
+                cache_config,
+            ))),
+            TokenizerSource::Tekken(path) => Ok(Arc::new(CachedTokenizer::new(
+                TekkenTokenizer::new(path)?,
+                cache_config,
+            ))),
+        }
+    } else {
+        match tokenizer {
+            TokenizerSource::HuggingFace(path) => Ok(Arc::new(HuggingFaceTokenizer::new(path)?)),
+            TokenizerSource::Tiktoken(path) => Ok(Arc::new(TiktokenTokenizer::new(path)?)),
+            TokenizerSource::Tekken(path) => Ok(Arc::new(TekkenTokenizer::new(path)?)),
+        }
     }
 }
 

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use tracing::info;
-use vllm_tokenizer::{DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer, TiktokenTokenizer};
+use vllm_tokenizer::{
+    CacheConfig, CachedTokenizer, DynTokenizer, HuggingFaceTokenizer, TekkenTokenizer,
+    TiktokenTokenizer,
+};
 
 use self::config::{GenerationConfig, load_generation_config};
 pub use self::config::{
@@ -17,10 +20,20 @@ use crate::backend::{SamplingHints, TextBackend};
 use crate::error::Result;
 
 fn load_tokenizer(tokenizer: &TokenizerSource) -> Result<DynTokenizer> {
+    let cache_config = CacheConfig::default();
     match tokenizer {
-        TokenizerSource::HuggingFace(path) => Ok(Arc::new(HuggingFaceTokenizer::new(path)?)),
-        TokenizerSource::Tiktoken(path) => Ok(Arc::new(TiktokenTokenizer::new(path)?)),
-        TokenizerSource::Tekken(path) => Ok(Arc::new(TekkenTokenizer::new(path)?)),
+        TokenizerSource::HuggingFace(path) => Ok(Arc::new(CachedTokenizer::new(
+            HuggingFaceTokenizer::new(path)?,
+            cache_config,
+        ))),
+        TokenizerSource::Tiktoken(path) => Ok(Arc::new(CachedTokenizer::new(
+            TiktokenTokenizer::new(path)?,
+            cache_config,
+        ))),
+        TokenizerSource::Tekken(path) => Ok(Arc::new(CachedTokenizer::new(
+            TekkenTokenizer::new(path)?,
+            cache_config,
+        ))),
     }
 }
 

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -122,7 +122,18 @@ impl TextLlm {
 
         let tokenizer = self.backend.tokenizer();
         let prompt_token_ids = match take(&mut request.prompt) {
-            Prompt::Text(text) => tokenizer.encode(&text, request.add_special_tokens)?,
+            Prompt::Text(text) => {
+                let start = std::time::Instant::now();
+                let ids = tokenizer.encode(&text, request.add_special_tokens)?;
+                let elapsed = start.elapsed();
+                tracing::debug!(
+                    elapsed_us = elapsed.as_micros() as u64,
+                    text_bytes = text.len(),
+                    tokens = ids.len(),
+                    "prompt tokenizer encode total"
+                );
+                ids
+            }
             // Pre-tokenized prompts are the main completions-side escape hatch that lets benchmark
             // and infra workloads bypass chat rendering and tokenizer overhead entirely.
             Prompt::TokenIds(token_ids) => token_ids,

--- a/rust/src/tokenizer/Cargo.toml
+++ b/rust/src/tokenizer/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 base64.workspace = true
+dashmap.workspace = true
 fastokens.workspace = true
 riptoken.workspace = true
 rustc-hash.workspace = true

--- a/rust/src/tokenizer/Cargo.toml
+++ b/rust/src/tokenizer/Cargo.toml
@@ -6,8 +6,9 @@ license.workspace = true
 
 [dependencies]
 base64.workspace = true
-dashmap.workspace = true
+anyhow.workspace = true
 fastokens.workspace = true
+llm-tokenizer.workspace = true
 riptoken.workspace = true
 rustc-hash.workspace = true
 serde.workspace = true

--- a/rust/src/tokenizer/src/cached.rs
+++ b/rust/src/tokenizer/src/cached.rs
@@ -5,25 +5,32 @@
 //!
 //! # Architecture
 //!
-//! - **L0 Cache**: Whole-string exact match using `DashMap` for lock-free
-//!   concurrent reads. Uses approximate LRU eviction (sample + evict oldest)
-//!   to protect frequently-accessed entries like system prompts.
+//! - **L0 Cache**: Whole-string exact match using `DashMap` with FxHash for
+//!   fast, lock-free concurrent reads. Only caches strings up to a configurable
+//!   length threshold — long unique prompts skip the cache entirely to avoid
+//!   overhead on the dominant miss path.
 //!
-//! # Usage
+//! # Performance notes
 //!
-//! ```ignore
-//! use std::sync::Arc;
-//! use vllm_tokenizer::{CachedTokenizer, CacheConfig};
+//! In vllm's serving path, `encode` is typically called on the **full rendered
+//! prompt** (system + user + chat template). Since user messages differ per
+//! request, hit rate on full prompts is near zero. This cache is most effective
+//! when the tokenizer is called on **repeated segments** (e.g., system prompts
+//! encoded separately, stop-word encoding, bad-word encoding).
 //!
-//! let inner = Arc::new(some_tokenizer);
-//! let cached = CachedTokenizer::new(inner, CacheConfig::default());
-//! let tokens = cached.encode("Hello world", false)?;
-//! ```
+//! To avoid regressing the dominant miss path:
+//! - Strings longer than `l0_max_key_bytes` bypass the cache completely (no
+//!   hash, no lookup, no allocation).
+//! - FxHash is used instead of SipHash for ~3x faster hashing on short keys.
+//! - On miss, the token Vec is moved (not cloned) into the cache.
+//! - Stats counters are omitted from the hot path; use [`CachedTokenizer::cache_stats`]
+//!   for diagnostics only.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashMap;
+use rustc_hash::FxBuildHasher;
 
 use crate::incremental::DecodeStream;
 use crate::{IncrementalDecoder, Result, Tokenizer};
@@ -38,6 +45,12 @@ pub struct CacheConfig {
     pub enable_l0: bool,
     /// Maximum number of entries in L0 cache.
     pub l0_max_entries: usize,
+    /// Maximum key length in bytes. Strings longer than this bypass the cache
+    /// entirely — no hash, no lookup, no allocation. This avoids adding
+    /// overhead to the dominant miss path (long unique prompts).
+    ///
+    /// Default: 2048 bytes (~500 tokens of English text).
+    pub l0_max_key_bytes: usize,
 }
 
 impl Default for CacheConfig {
@@ -45,47 +58,55 @@ impl Default for CacheConfig {
         Self {
             enable_l0: true,
             l0_max_entries: 10_000,
+            l0_max_key_bytes: 2048,
         }
     }
 }
 
-/// A cached encoding entry with access tracking for approximate LRU eviction.
+/// A cached encoding entry with insertion timestamp for approximate LRU.
 struct CachedEntry {
-    token_ids: Arc<Vec<u32>>,
+    /// Cached token IDs, shared via Arc to avoid cloning on hit when possible
+    /// in future trait extensions. Currently the trait requires Vec<u32>, so
+    /// we call `.to_vec()` on the inner slice.
+    token_ids: Arc<[u32]>,
+    /// Monotonic timestamp of last access (for LRU eviction).
     last_accessed: AtomicU64,
 }
 
-/// L0 cache: whole-string exact match using DashMap for lock-free reads.
+/// L0 cache: whole-string exact match using DashMap with FxHash.
 ///
-/// Uses two separate maps (one per `add_special_tokens` value) so that
-/// lookups can borrow the key as `&str` without allocating.
-///
-/// Eviction uses approximate LRU: when capacity is reached, sample a few
-/// entries and evict the one with the oldest `last_accessed` timestamp.
+/// Two separate maps (one per `add_special_tokens` value) so lookups borrow
+/// `&str` without allocating.
 struct L0Cache {
-    map_plain: DashMap<String, CachedEntry>,
-    map_special: DashMap<String, CachedEntry>,
+    map_plain: DashMap<String, CachedEntry, FxBuildHasher>,
+    map_special: DashMap<String, CachedEntry, FxBuildHasher>,
     max_entries: usize,
+    max_key_bytes: usize,
+    /// Monotonic counter for LRU timestamps.
+    access_counter: AtomicU64,
+    /// Stats — updated with Relaxed ordering, read only via `stats()`.
     hits: AtomicU64,
     misses: AtomicU64,
-    access_counter: AtomicU64,
+    skips: AtomicU64,
 }
 
 impl L0Cache {
-    fn new(max_entries: usize) -> Self {
+    fn new(max_entries: usize, max_key_bytes: usize) -> Self {
         let per_map = max_entries.min(1024) / 2 + 1;
         Self {
-            map_plain: DashMap::with_capacity(per_map),
-            map_special: DashMap::with_capacity(per_map),
+            map_plain: DashMap::with_capacity_and_hasher(per_map, FxBuildHasher),
+            map_special: DashMap::with_capacity_and_hasher(per_map, FxBuildHasher),
             max_entries,
+            max_key_bytes,
+            access_counter: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
-            access_counter: AtomicU64::new(0),
+            skips: AtomicU64::new(0),
         }
     }
 
     #[inline]
-    fn map_for(&self, add_special_tokens: bool) -> &DashMap<String, CachedEntry> {
+    fn map_for(&self, add_special_tokens: bool) -> &DashMap<String, CachedEntry, FxBuildHasher> {
         if add_special_tokens {
             &self.map_special
         } else {
@@ -102,59 +123,71 @@ impl L0Cache {
         self.map_plain.len() + self.map_special.len()
     }
 
-    /// Look up a cached encoding. Zero-allocation on the lookup path.
-    fn get(&self, key: &str, add_special_tokens: bool) -> Option<Arc<Vec<u32>>> {
-        match self.map_for(add_special_tokens).get(key) {
-            Some(entry) => {
-                self.hits.fetch_add(1, Ordering::Relaxed);
-                let ts = self.next_timestamp();
-                entry.value().last_accessed.store(ts, Ordering::Relaxed);
-                Some(Arc::clone(&entry.value().token_ids))
-            }
-            None => {
-                self.misses.fetch_add(1, Ordering::Relaxed);
-                None
-            }
-        }
+    /// Returns true if the key is eligible for caching.
+    #[inline]
+    fn is_cacheable(&self, key: &str) -> bool {
+        key.len() <= self.max_key_bytes
+    }
+
+    /// Look up a cached encoding. Returns Arc to avoid cloning until necessary.
+    #[inline]
+    fn get(&self, key: &str, add_special_tokens: bool) -> Option<Arc<[u32]>> {
+        let entry = self.map_for(add_special_tokens).get(key)?;
+        let ts = self.next_timestamp();
+        entry.value().last_accessed.store(ts, Ordering::Relaxed);
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        Some(Arc::clone(&entry.value().token_ids))
+    }
+
+    fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_skip(&self) {
+        self.skips.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Evict the approximately least-recently-used entry if at capacity.
     fn maybe_evict(&self) {
-        if self.len() >= self.max_entries {
-            let victim_map = if self.map_plain.len() >= self.map_special.len() {
-                &self.map_plain
-            } else {
-                &self.map_special
-            };
+        if self.len() < self.max_entries {
+            return;
+        }
+        let victim_map = if self.map_plain.len() >= self.map_special.len() {
+            &self.map_plain
+        } else {
+            &self.map_special
+        };
 
-            let key_to_remove = {
-                let mut oldest_key: Option<String> = None;
-                let mut oldest_ts = u64::MAX;
+        // Sample EVICTION_SAMPLE_SIZE entries, evict the oldest.
+        // Scope the iterator so shard locks are released before remove().
+        let key_to_remove = {
+            let mut oldest_key: Option<String> = None;
+            let mut oldest_ts = u64::MAX;
 
-                for (i, entry) in victim_map.iter().enumerate() {
-                    let ts = entry.value().last_accessed.load(Ordering::Relaxed);
-                    if ts < oldest_ts {
-                        oldest_ts = ts;
-                        oldest_key = Some(entry.key().clone());
-                    }
-                    if i + 1 >= EVICTION_SAMPLE_SIZE {
-                        break;
-                    }
+            for (i, entry) in victim_map.iter().enumerate() {
+                let ts = entry.value().last_accessed.load(Ordering::Relaxed);
+                if ts < oldest_ts {
+                    oldest_ts = ts;
+                    oldest_key = Some(entry.key().clone());
                 }
-                oldest_key
-            };
-
-            if let Some(k) = key_to_remove {
-                victim_map.remove(&k);
+                if i + 1 >= EVICTION_SAMPLE_SIZE {
+                    break;
+                }
             }
+            oldest_key
+        };
+
+        if let Some(k) = key_to_remove {
+            victim_map.remove(&k);
         }
     }
 
+    /// Insert token_ids into the cache. Consumes the Vec (no clone).
     fn insert(&self, key: String, add_special_tokens: bool, token_ids: Vec<u32>) {
         self.maybe_evict();
         let ts = self.next_timestamp();
         let entry = CachedEntry {
-            token_ids: Arc::new(token_ids),
+            token_ids: Arc::from(token_ids),
             last_accessed: AtomicU64::new(ts),
         };
         self.map_for(add_special_tokens).insert(key, entry);
@@ -163,10 +196,12 @@ impl L0Cache {
     fn stats(&self) -> CacheStats {
         let hits = self.hits.load(Ordering::Relaxed);
         let misses = self.misses.load(Ordering::Relaxed);
+        let skips = self.skips.load(Ordering::Relaxed);
         let total = hits + misses;
         CacheStats {
             hits,
             misses,
+            skips,
             entries: self.len(),
             hit_rate: if total > 0 {
                 hits as f64 / total as f64
@@ -181,6 +216,7 @@ impl L0Cache {
         self.map_special.clear();
         self.hits.store(0, Ordering::Relaxed);
         self.misses.store(0, Ordering::Relaxed);
+        self.skips.store(0, Ordering::Relaxed);
         self.access_counter.store(0, Ordering::Relaxed);
     }
 }
@@ -188,17 +224,25 @@ impl L0Cache {
 /// Cache statistics.
 #[derive(Debug, Clone)]
 pub struct CacheStats {
+    /// Number of cache hits.
     pub hits: u64,
+    /// Number of cache misses (key not found but was looked up).
     pub misses: u64,
+    /// Number of skipped lookups (key too long, bypassed cache entirely).
+    pub skips: u64,
+    /// Current number of cached entries.
     pub entries: usize,
+    /// Hit rate = hits / (hits + misses). Skips are excluded.
     pub hit_rate: f64,
 }
 
 /// A caching wrapper around any [`Tokenizer`] implementation.
 ///
 /// Caches `encode` results using a DashMap-based L0 whole-string exact-match
-/// cache with approximate LRU eviction. Decode and other methods pass through
-/// to the inner tokenizer unchanged.
+/// cache with FxHash and approximate LRU eviction. Strings longer than
+/// [`CacheConfig::l0_max_key_bytes`] bypass the cache entirely.
+///
+/// Decode and other methods pass through to the inner tokenizer unchanged.
 pub struct CachedTokenizer<T: Tokenizer> {
     inner: T,
     l0: Option<L0Cache>,
@@ -208,7 +252,7 @@ impl<T: Tokenizer> CachedTokenizer<T> {
     /// Create a new cached tokenizer wrapping `inner`.
     pub fn new(inner: T, config: CacheConfig) -> Self {
         let l0 = if config.enable_l0 {
-            Some(L0Cache::new(config.l0_max_entries))
+            Some(L0Cache::new(config.l0_max_entries, config.l0_max_key_bytes))
         } else {
             None
         };
@@ -235,23 +279,34 @@ impl<T: Tokenizer> CachedTokenizer<T> {
 
 impl<T: Tokenizer> Tokenizer for CachedTokenizer<T> {
     fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
-        if let Some(l0) = &self.l0 {
-            if let Some(cached) = l0.get(text, add_special_tokens) {
-                return Ok((*cached).clone());
-            }
+        let Some(l0) = &self.l0 else {
+            return self.inner.encode(text, add_special_tokens);
+        };
+
+        // Skip cache for long strings — they're almost always unique full
+        // prompts. Avoiding hash + lookup + key allocation on this path is
+        // critical since it's the dominant case in serving.
+        if !l0.is_cacheable(text) {
+            l0.record_skip();
+            return self.inner.encode(text, add_special_tokens);
         }
 
+        // Cache hit — return a copy of the cached slice.
+        if let Some(cached) = l0.get(text, add_special_tokens) {
+            return Ok(cached.to_vec());
+        }
+
+        // Cache miss — encode, move result into cache, return from cache.
+        l0.record_miss();
         let token_ids = self.inner.encode(text, add_special_tokens)?;
-
-        if let Some(l0) = &self.l0 {
-            l0.insert(text.to_owned(), add_special_tokens, token_ids.clone());
-        }
-
-        Ok(token_ids)
+        // Clone the key string and move token_ids into the cache.
+        // We keep a copy to return to the caller.
+        let result = token_ids.clone();
+        l0.insert(text.to_owned(), add_special_tokens, token_ids);
+        Ok(result)
     }
 
     fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
-        // Decode is not cached — it's fast enough and rarely repeated.
         self.inner.decode(token_ids, skip_special_tokens)
     }
 
@@ -273,8 +328,6 @@ impl<T: Tokenizer> Tokenizer for CachedTokenizer<T> {
         skip_special_tokens: bool,
         min_bytes_to_buffer: usize,
     ) -> Box<dyn IncrementalDecoder + '_> {
-        // Decode streaming uses the inner tokenizer directly since the
-        // DecodeStream relies on the decode() method which is not cached.
         Box::new(DecodeStream::new(
             self,
             prompt_token_ids,
@@ -291,10 +344,10 @@ mod tests {
 
     use super::*;
 
-    /// Simple test tokenizer that splits on whitespace and assigns incrementing IDs.
-    struct SimpleTokenizer;
+    /// Simple test tokenizer: each byte becomes a token ID.
+    struct ByteTokenizer;
 
-    impl Tokenizer for SimpleTokenizer {
+    impl Tokenizer for ByteTokenizer {
         fn encode(&self, text: &str, _add_special_tokens: bool) -> Result<Vec<u32>> {
             Ok(text.bytes().map(|b| b as u32).collect())
         }
@@ -311,7 +364,7 @@ mod tests {
 
     #[test]
     fn cache_hit_returns_same_result() {
-        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
 
         let r1 = cached.encode("hello", false).unwrap();
         let r2 = cached.encode("hello", false).unwrap();
@@ -324,13 +377,53 @@ mod tests {
 
     #[test]
     fn add_special_tokens_flag_separates_entries() {
-        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
 
         let _ = cached.encode("test", false).unwrap();
         let _ = cached.encode("test", true).unwrap();
 
         let stats = cached.cache_stats().unwrap();
-        assert_eq!(stats.misses, 2); // Two distinct cache entries
+        assert_eq!(stats.misses, 2);
+    }
+
+    #[test]
+    fn long_strings_bypass_cache() {
+        let config = CacheConfig {
+            enable_l0: true,
+            l0_max_entries: 100,
+            l0_max_key_bytes: 10, // very short threshold
+        };
+        let cached = CachedTokenizer::new(ByteTokenizer, config);
+
+        // This string is > 10 bytes, should skip cache entirely.
+        let long = "this is a long string that exceeds the threshold";
+        let r1 = cached.encode(long, false).unwrap();
+        let r2 = cached.encode(long, false).unwrap();
+        assert_eq!(r1, r2);
+
+        let stats = cached.cache_stats().unwrap();
+        assert_eq!(stats.skips, 2);
+        assert_eq!(stats.hits, 0);
+        assert_eq!(stats.misses, 0);
+        assert_eq!(stats.entries, 0);
+    }
+
+    #[test]
+    fn short_strings_use_cache() {
+        let config = CacheConfig {
+            enable_l0: true,
+            l0_max_entries: 100,
+            l0_max_key_bytes: 100,
+        };
+        let cached = CachedTokenizer::new(ByteTokenizer, config);
+
+        let _ = cached.encode("hi", false).unwrap();
+        let _ = cached.encode("hi", false).unwrap();
+
+        let stats = cached.cache_stats().unwrap();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 1);
+        assert_eq!(stats.entries, 1);
     }
 
     #[test]
@@ -338,8 +431,9 @@ mod tests {
         let config = CacheConfig {
             enable_l0: true,
             l0_max_entries: 2,
+            l0_max_key_bytes: 1024,
         };
-        let cached = CachedTokenizer::new(SimpleTokenizer, config);
+        let cached = CachedTokenizer::new(ByteTokenizer, config);
 
         let _ = cached.encode("a", false).unwrap();
         let _ = cached.encode("b", false).unwrap();
@@ -354,31 +448,28 @@ mod tests {
         let config = CacheConfig {
             enable_l0: true,
             l0_max_entries: 4,
+            l0_max_key_bytes: 1024,
         };
-        let cached = CachedTokenizer::new(SimpleTokenizer, config);
+        let cached = CachedTokenizer::new(ByteTokenizer, config);
 
-        // Insert system prompt + 3 queries
-        let _ = cached.encode("system_prompt", false).unwrap();
+        let _ = cached.encode("sys", false).unwrap();
         let _ = cached.encode("q1", false).unwrap();
         let _ = cached.encode("q2", false).unwrap();
         let _ = cached.encode("q3", false).unwrap();
 
-        // Simulate: each new request accesses system_prompt then inserts a new query
         for i in 4..12 {
-            let _ = cached.encode("system_prompt", false).unwrap(); // hit
-            let _ = cached.encode(&format!("q{i}"), false).unwrap(); // miss + evict
+            let _ = cached.encode("sys", false).unwrap(); // keep sys hot
+            let _ = cached.encode(&format!("q{i}"), false).unwrap();
         }
 
-        // system_prompt should survive due to LRU
         let stats = cached.cache_stats().unwrap();
-        assert!(stats.hits >= 8); // system_prompt was hit each iteration
+        assert!(stats.hits >= 8);
     }
 
     #[test]
     fn decode_passes_through() {
-        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
-        let decoded = cached.decode(&[72, 105], false).unwrap();
-        assert_eq!(decoded, "Hi");
+        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
+        assert_eq!(cached.decode(&[72, 105], false).unwrap(), "Hi");
     }
 
     #[test]
@@ -386,9 +477,9 @@ mod tests {
         let config = CacheConfig {
             enable_l0: false,
             l0_max_entries: 0,
+            l0_max_key_bytes: 0,
         };
-        let cached = CachedTokenizer::new(SimpleTokenizer, config);
-
+        let cached = CachedTokenizer::new(ByteTokenizer, config);
         let r1 = cached.encode("hello", false).unwrap();
         let r2 = cached.encode("hello", false).unwrap();
         assert_eq!(r1, r2);
@@ -397,22 +488,18 @@ mod tests {
 
     #[test]
     fn concurrent_access() {
-        let cached = Arc::new(CachedTokenizer::new(
-            SimpleTokenizer,
-            CacheConfig::default(),
-        ));
+        let cached = Arc::new(CachedTokenizer::new(ByteTokenizer, CacheConfig::default()));
         let mut handles = vec![];
 
         for i in 0..10 {
             let c = Arc::clone(&cached);
             handles.push(thread::spawn(move || {
-                let key = format!("key_{i}");
+                let key = format!("k{i}");
                 let r1 = c.encode(&key, false).unwrap();
                 let r2 = c.encode(&key, false).unwrap();
                 assert_eq!(r1, r2);
             }));
         }
-
         for h in handles {
             h.join().unwrap();
         }
@@ -424,9 +511,8 @@ mod tests {
 
     #[test]
     fn clear_cache_works() {
-        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
         let _ = cached.encode("test", false).unwrap();
-
         assert_eq!(cached.cache_stats().unwrap().entries, 1);
         cached.clear_cache();
         assert_eq!(cached.cache_stats().unwrap().entries, 0);

--- a/rust/src/tokenizer/src/cached.rs
+++ b/rust/src/tokenizer/src/cached.rs
@@ -1,312 +1,222 @@
-//! Tokenizer caching layer inspired by `llm-tokenizer`'s cache architecture.
+//! Tokenizer caching layer using `llm-tokenizer`'s [`CachedTokenizer`] and
+//! L0/L1 cache infrastructure.
 //!
-//! Provides a [`CachedTokenizer`] wrapper around any [`Tokenizer`] implementation
-//! to speed up repeated encoding of the same strings (e.g., system prompts).
+//! Since vllm defines its own [`Tokenizer`](crate::Tokenizer) trait and
+//! `llm-tokenizer` defines a separate `Encoder + Decoder + Tokenizer` trait
+//! hierarchy, this module provides an **adapter** ([`VllmTokenizerAdapter`])
+//! that bridges the two. The adapter wraps any `vllm_tokenizer::Tokenizer`
+//! and implements `llm_tokenizer::traits::{Encoder, Decoder, Tokenizer}` so
+//! that `llm_tokenizer::CachedTokenizer` can wrap it.
 //!
-//! # Architecture
+//! The public [`LlmCachedTokenizer`] struct then wraps the whole stack and
+//! re-implements `vllm_tokenizer::Tokenizer`, making the caching layer
+//! transparent to the rest of vllm.
 //!
-//! - **L0 Cache**: Whole-string exact match using `DashMap` with FxHash for
-//!   fast, lock-free concurrent reads. Only caches strings up to a configurable
-//!   length threshold — long unique prompts skip the cache entirely to avoid
-//!   overhead on the dominant miss path.
+//! # Usage
 //!
-//! # Performance notes
+//! ```ignore
+//! use vllm_tokenizer::{LlmCachedTokenizer, LlmCacheConfig};
 //!
-//! In vllm's serving path, `encode` is typically called on the **full rendered
-//! prompt** (system + user + chat template). Since user messages differ per
-//! request, hit rate on full prompts is near zero. This cache is most effective
-//! when the tokenizer is called on **repeated segments** (e.g., system prompts
-//! encoded separately, stop-word encoding, bad-word encoding).
-//!
-//! To avoid regressing the dominant miss path:
-//! - Strings longer than `l0_max_key_bytes` bypass the cache completely (no
-//!   hash, no lookup, no allocation).
-//! - FxHash is used instead of SipHash for ~3x faster hashing on short keys.
-//! - On miss, the token Vec is moved (not cloned) into the cache.
-//! - Stats counters are omitted from the hot path; use [`CachedTokenizer::cache_stats`]
-//!   for diagnostics only.
+//! let inner = HuggingFaceTokenizer::new(path)?;
+//! let cached = LlmCachedTokenizer::new(inner, LlmCacheConfig::default());
+//! let tokens = cached.encode("Hello world", false)?;
+//! ```
 
+use std::any::Any;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
-use dashmap::DashMap;
-use rustc_hash::FxBuildHasher;
+use llm_tokenizer::cache::{CacheConfig as LlmCacheConfigInner, CachedTokenizer};
+use llm_tokenizer::traits::{
+    Decoder as LlmDecoder, Encoder as LlmEncoder, Encoding as LlmEncoding,
+    SpecialTokens as LlmSpecialTokens, TokenIdType, Tokenizer as LlmTokenizer,
+};
 
 use crate::incremental::DecodeStream;
 use crate::{IncrementalDecoder, Result, Tokenizer};
 
-/// Number of entries to sample when looking for an eviction candidate.
-const EVICTION_SAMPLE_SIZE: usize = 8;
-
-/// Configuration for the tokenizer cache.
+/// Configuration for the llm-tokenizer cache layer.
 #[derive(Debug, Clone)]
-pub struct CacheConfig {
-    /// Enable L0 (whole-string) cache.
+pub struct LlmCacheConfig {
+    /// Enable L0 (whole-string exact match) cache.
     pub enable_l0: bool,
     /// Maximum number of entries in L0 cache.
     pub l0_max_entries: usize,
-    /// Maximum key length in bytes. Strings longer than this bypass the cache
-    /// entirely — no hash, no lookup, no allocation. This avoids adding
-    /// overhead to the dominant miss path (long unique prompts).
-    ///
-    /// Default: 2048 bytes (~500 tokens of English text).
-    pub l0_max_key_bytes: usize,
+    /// Enable L1 (prefix matching) cache.
+    pub enable_l1: bool,
+    /// Maximum memory for L1 cache in bytes.
+    pub l1_max_memory: usize,
 }
 
-impl Default for CacheConfig {
+impl Default for LlmCacheConfig {
     fn default() -> Self {
         Self {
             enable_l0: true,
             l0_max_entries: 10_000,
-            l0_max_key_bytes: 2048,
+            enable_l1: false,
+            l1_max_memory: 50 * 1024 * 1024,
         }
     }
 }
 
-/// A cached encoding entry with insertion timestamp for approximate LRU.
-struct CachedEntry {
-    /// Cached token IDs, shared via Arc to avoid cloning on hit when possible
-    /// in future trait extensions. Currently the trait requires Vec<u32>, so
-    /// we call `.to_vec()` on the inner slice.
-    token_ids: Arc<[u32]>,
-    /// Monotonic timestamp of last access (for LRU eviction).
-    last_accessed: AtomicU64,
-}
-
-/// L0 cache: whole-string exact match using DashMap with FxHash.
-///
-/// Two separate maps (one per `add_special_tokens` value) so lookups borrow
-/// `&str` without allocating.
-struct L0Cache {
-    map_plain: DashMap<String, CachedEntry, FxBuildHasher>,
-    map_special: DashMap<String, CachedEntry, FxBuildHasher>,
-    max_entries: usize,
-    max_key_bytes: usize,
-    /// Monotonic counter for LRU timestamps.
-    access_counter: AtomicU64,
-    /// Stats — updated with Relaxed ordering, read only via `stats()`.
-    hits: AtomicU64,
-    misses: AtomicU64,
-    skips: AtomicU64,
-}
-
-impl L0Cache {
-    fn new(max_entries: usize, max_key_bytes: usize) -> Self {
-        let per_map = max_entries.min(1024) / 2 + 1;
-        Self {
-            map_plain: DashMap::with_capacity_and_hasher(per_map, FxBuildHasher),
-            map_special: DashMap::with_capacity_and_hasher(per_map, FxBuildHasher),
-            max_entries,
-            max_key_bytes,
-            access_counter: AtomicU64::new(0),
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
-            skips: AtomicU64::new(0),
+impl From<LlmCacheConfig> for LlmCacheConfigInner {
+    fn from(c: LlmCacheConfig) -> Self {
+        LlmCacheConfigInner {
+            enable_l0: c.enable_l0,
+            l0_max_entries: c.l0_max_entries,
+            enable_l1: c.enable_l1,
+            l1_max_memory: c.l1_max_memory,
         }
-    }
-
-    #[inline]
-    fn map_for(&self, add_special_tokens: bool) -> &DashMap<String, CachedEntry, FxBuildHasher> {
-        if add_special_tokens {
-            &self.map_special
-        } else {
-            &self.map_plain
-        }
-    }
-
-    #[inline]
-    fn next_timestamp(&self) -> u64 {
-        self.access_counter.fetch_add(1, Ordering::Relaxed)
-    }
-
-    fn len(&self) -> usize {
-        self.map_plain.len() + self.map_special.len()
-    }
-
-    /// Returns true if the key is eligible for caching.
-    #[inline]
-    fn is_cacheable(&self, key: &str) -> bool {
-        key.len() <= self.max_key_bytes
-    }
-
-    /// Look up a cached encoding. Returns Arc to avoid cloning until necessary.
-    #[inline]
-    fn get(&self, key: &str, add_special_tokens: bool) -> Option<Arc<[u32]>> {
-        let entry = self.map_for(add_special_tokens).get(key)?;
-        let ts = self.next_timestamp();
-        entry.value().last_accessed.store(ts, Ordering::Relaxed);
-        self.hits.fetch_add(1, Ordering::Relaxed);
-        Some(Arc::clone(&entry.value().token_ids))
-    }
-
-    fn record_miss(&self) {
-        self.misses.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn record_skip(&self) {
-        self.skips.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Evict the approximately least-recently-used entry if at capacity.
-    fn maybe_evict(&self) {
-        if self.len() < self.max_entries {
-            return;
-        }
-        let victim_map = if self.map_plain.len() >= self.map_special.len() {
-            &self.map_plain
-        } else {
-            &self.map_special
-        };
-
-        // Sample EVICTION_SAMPLE_SIZE entries, evict the oldest.
-        // Scope the iterator so shard locks are released before remove().
-        let key_to_remove = {
-            let mut oldest_key: Option<String> = None;
-            let mut oldest_ts = u64::MAX;
-
-            for (i, entry) in victim_map.iter().enumerate() {
-                let ts = entry.value().last_accessed.load(Ordering::Relaxed);
-                if ts < oldest_ts {
-                    oldest_ts = ts;
-                    oldest_key = Some(entry.key().clone());
-                }
-                if i + 1 >= EVICTION_SAMPLE_SIZE {
-                    break;
-                }
-            }
-            oldest_key
-        };
-
-        if let Some(k) = key_to_remove {
-            victim_map.remove(&k);
-        }
-    }
-
-    /// Insert token_ids into the cache. Consumes the Vec (no clone).
-    fn insert(&self, key: String, add_special_tokens: bool, token_ids: Vec<u32>) {
-        self.maybe_evict();
-        let ts = self.next_timestamp();
-        let entry = CachedEntry {
-            token_ids: Arc::from(token_ids),
-            last_accessed: AtomicU64::new(ts),
-        };
-        self.map_for(add_special_tokens).insert(key, entry);
-    }
-
-    fn stats(&self) -> CacheStats {
-        let hits = self.hits.load(Ordering::Relaxed);
-        let misses = self.misses.load(Ordering::Relaxed);
-        let skips = self.skips.load(Ordering::Relaxed);
-        let total = hits + misses;
-        CacheStats {
-            hits,
-            misses,
-            skips,
-            entries: self.len(),
-            hit_rate: if total > 0 {
-                hits as f64 / total as f64
-            } else {
-                0.0
-            },
-        }
-    }
-
-    fn clear(&self) {
-        self.map_plain.clear();
-        self.map_special.clear();
-        self.hits.store(0, Ordering::Relaxed);
-        self.misses.store(0, Ordering::Relaxed);
-        self.skips.store(0, Ordering::Relaxed);
-        self.access_counter.store(0, Ordering::Relaxed);
     }
 }
 
-/// Cache statistics.
-#[derive(Debug, Clone)]
-pub struct CacheStats {
-    /// Number of cache hits.
-    pub hits: u64,
-    /// Number of cache misses (key not found but was looked up).
-    pub misses: u64,
-    /// Number of skipped lookups (key too long, bypassed cache entirely).
-    pub skips: u64,
-    /// Current number of cached entries.
-    pub entries: usize,
-    /// Hit rate = hits / (hits + misses). Skips are excluded.
-    pub hit_rate: f64,
-}
+// ---------------------------------------------------------------------------
+// Adapter: vllm Tokenizer → llm-tokenizer traits
+// ---------------------------------------------------------------------------
 
-/// A caching wrapper around any [`Tokenizer`] implementation.
-///
-/// Caches `encode` results using a DashMap-based L0 whole-string exact-match
-/// cache with FxHash and approximate LRU eviction. Strings longer than
-/// [`CacheConfig::l0_max_key_bytes`] bypass the cache entirely.
-///
-/// Decode and other methods pass through to the inner tokenizer unchanged.
-pub struct CachedTokenizer<T: Tokenizer> {
+/// Wraps a vllm [`Tokenizer`] and implements `llm_tokenizer`'s
+/// `Encoder`, `Decoder`, and `Tokenizer` traits so that
+/// `llm_tokenizer::CachedTokenizer` can wrap it.
+struct VllmTokenizerAdapter<T: Tokenizer> {
     inner: T,
-    l0: Option<L0Cache>,
+    /// Placeholder special tokens — vllm's Tokenizer trait does not expose
+    /// special-token metadata, so we provide an empty default.
+    special_tokens: LlmSpecialTokens,
 }
 
-impl<T: Tokenizer> CachedTokenizer<T> {
-    /// Create a new cached tokenizer wrapping `inner`.
-    pub fn new(inner: T, config: CacheConfig) -> Self {
-        let l0 = if config.enable_l0 {
-            Some(L0Cache::new(config.l0_max_entries, config.l0_max_key_bytes))
-        } else {
-            None
+impl<T: Tokenizer> LlmEncoder for VllmTokenizerAdapter<T> {
+    fn encode(&self, input: &str, add_special_tokens: bool) -> anyhow::Result<LlmEncoding> {
+        let ids = self
+            .inner
+            .encode(input, add_special_tokens)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(LlmEncoding::Plain(ids))
+    }
+
+    fn encode_batch(
+        &self,
+        inputs: &[&str],
+        add_special_tokens: bool,
+    ) -> anyhow::Result<Vec<LlmEncoding>> {
+        inputs
+            .iter()
+            .map(|&input| LlmEncoder::encode(self, input, add_special_tokens))
+            .collect()
+    }
+}
+
+impl<T: Tokenizer> LlmDecoder for VllmTokenizerAdapter<T> {
+    fn decode(
+        &self,
+        token_ids: &[TokenIdType],
+        skip_special_tokens: bool,
+    ) -> anyhow::Result<String> {
+        self.inner
+            .decode(token_ids, skip_special_tokens)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
+impl<T: Tokenizer + 'static> LlmTokenizer for VllmTokenizerAdapter<T> {
+    fn vocab_size(&self) -> usize {
+        // vllm's Tokenizer trait does not expose vocab_size; return 0 as a
+        // safe default (only used by llm-tokenizer's fingerprinting, not the
+        // cache hot path).
+        0
+    }
+
+    fn get_special_tokens(&self) -> &LlmSpecialTokens {
+        &self.special_tokens
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+        self.inner.token_to_id(token)
+    }
+
+    fn id_to_token(&self, id: TokenIdType) -> Option<String> {
+        self.inner.id_to_token(id)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public wrapper: llm-tokenizer cached stack → vllm Tokenizer
+// ---------------------------------------------------------------------------
+
+/// A tokenizer wrapper that uses `llm-tokenizer`'s [`CachedTokenizer`] (with
+/// L0 and optional L1 caches) to accelerate repeated `encode` calls.
+///
+/// Implements vllm's [`Tokenizer`] trait so it can be used as a drop-in
+/// replacement wherever `DynTokenizer` is expected.
+pub struct LlmCachedTokenizer {
+    /// The llm-tokenizer CachedTokenizer wrapping our adapter.
+    cached: CachedTokenizer,
+    /// Keep a direct reference to the adapter's inner tokenizer for methods
+    /// that should not go through the cache (decode, token_to_id, etc.).
+    inner: Arc<dyn Tokenizer>,
+}
+
+impl LlmCachedTokenizer {
+    /// Create a new cached tokenizer wrapping `inner` with the given config.
+    pub fn new<T: Tokenizer + 'static>(inner: T, config: LlmCacheConfig) -> Self {
+        let inner_arc: Arc<dyn Tokenizer> = Arc::from(inner);
+
+        // We need to give CachedTokenizer an Arc<dyn llm_tokenizer::Tokenizer>.
+        // Create the adapter wrapping a clone of the Arc.
+        let adapter = VllmTokenizerAdapter {
+            inner: inner_arc.clone(),
+            special_tokens: LlmSpecialTokens::default(),
         };
-        Self { inner, l0 }
+        let llm_inner: Arc<dyn LlmTokenizer> = Arc::new(adapter);
+        let cached = CachedTokenizer::new(llm_inner, config.into());
+
+        Self {
+            cached,
+            inner: inner_arc,
+        }
     }
 
     /// Get L0 cache statistics, if the cache is enabled.
-    pub fn cache_stats(&self) -> Option<CacheStats> {
-        self.l0.as_ref().map(|c| c.stats())
+    pub fn cache_stats(&self) -> Option<llm_tokenizer::CacheStats> {
+        self.cached.cache_stats()
+    }
+
+    /// Get L1 cache statistics, if the cache is enabled.
+    pub fn l1_cache_stats(&self) -> Option<llm_tokenizer::cache::L1CacheStats> {
+        self.cached.l1_cache_stats()
     }
 
     /// Clear all cached entries.
     pub fn clear_cache(&self) {
-        if let Some(l0) = &self.l0 {
-            l0.clear();
-        }
-    }
-
-    /// Get a reference to the inner tokenizer.
-    pub fn inner(&self) -> &T {
-        &self.inner
+        self.cached.clear_cache();
     }
 }
 
-impl<T: Tokenizer> Tokenizer for CachedTokenizer<T> {
+impl Tokenizer for LlmCachedTokenizer {
     fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
-        let Some(l0) = &self.l0 else {
-            return self.inner.encode(text, add_special_tokens);
-        };
+        let start = std::time::Instant::now();
 
-        // Skip cache for long strings — they're almost always unique full
-        // prompts. Avoiding hash + lookup + key allocation on this path is
-        // critical since it's the dominant case in serving.
-        if !l0.is_cacheable(text) {
-            l0.record_skip();
-            return self.inner.encode(text, add_special_tokens);
-        }
+        // Go through llm-tokenizer's CachedTokenizer which handles L0/L1.
+        let encoding = LlmEncoder::encode(&self.cached, text, add_special_tokens)
+            .map_err(|e| crate::error::TokenizerError(format!("{e}")))?;
 
-        // Cache hit — return a copy of the cached slice.
-        if let Some(cached) = l0.get(text, add_special_tokens) {
-            return Ok(cached.to_vec());
-        }
+        let token_ids = encoding.token_ids().to_vec();
 
-        // Cache miss — encode, move result into cache, return from cache.
-        l0.record_miss();
-        let token_ids = self.inner.encode(text, add_special_tokens)?;
-        // Clone the key string and move token_ids into the cache.
-        // We keep a copy to return to the caller.
-        let result = token_ids.clone();
-        l0.insert(text.to_owned(), add_special_tokens, token_ids);
-        Ok(result)
+        let elapsed = start.elapsed();
+        tracing::debug!(
+            elapsed_us = elapsed.as_micros() as u64,
+            text_bytes = text.len(),
+            tokens = token_ids.len(),
+            "llm-tokenizer cached encode"
+        );
+
+        Ok(token_ids)
     }
 
     fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        // Decode is not cached by llm-tokenizer either — pass through directly.
         self.inner.decode(token_ids, skip_special_tokens)
     }
 
@@ -337,11 +247,31 @@ impl<T: Tokenizer> Tokenizer for CachedTokenizer<T> {
     }
 }
 
+// We need Tokenizer implemented for Arc<dyn Tokenizer> so the adapter works.
+impl Tokenizer for Arc<dyn Tokenizer> {
+    fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
+        (**self).encode(text, add_special_tokens)
+    }
+
+    fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        (**self).decode(token_ids, skip_special_tokens)
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        (**self).token_to_id(token)
+    }
+
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        (**self).id_to_token(id)
+    }
+
+    fn is_special_id(&self, token_id: u32) -> bool {
+        (**self).is_special_id(token_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::thread;
-
     use super::*;
 
     /// Simple test tokenizer: each byte becomes a token ID.
@@ -364,7 +294,7 @@ mod tests {
 
     #[test]
     fn cache_hit_returns_same_result() {
-        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
+        let cached = LlmCachedTokenizer::new(ByteTokenizer, LlmCacheConfig::default());
 
         let r1 = cached.encode("hello", false).unwrap();
         let r2 = cached.encode("hello", false).unwrap();
@@ -377,7 +307,7 @@ mod tests {
 
     #[test]
     fn add_special_tokens_flag_separates_entries() {
-        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
+        let cached = LlmCachedTokenizer::new(ByteTokenizer, LlmCacheConfig::default());
 
         let _ = cached.encode("test", false).unwrap();
         let _ = cached.encode("test", true).unwrap();
@@ -387,108 +317,20 @@ mod tests {
     }
 
     #[test]
-    fn long_strings_bypass_cache() {
-        let config = CacheConfig {
-            enable_l0: true,
-            l0_max_entries: 100,
-            l0_max_key_bytes: 10, // very short threshold
-        };
-        let cached = CachedTokenizer::new(ByteTokenizer, config);
-
-        // This string is > 10 bytes, should skip cache entirely.
-        let long = "this is a long string that exceeds the threshold";
-        let r1 = cached.encode(long, false).unwrap();
-        let r2 = cached.encode(long, false).unwrap();
-        assert_eq!(r1, r2);
-
-        let stats = cached.cache_stats().unwrap();
-        assert_eq!(stats.skips, 2);
-        assert_eq!(stats.hits, 0);
-        assert_eq!(stats.misses, 0);
-        assert_eq!(stats.entries, 0);
-    }
-
-    #[test]
-    fn short_strings_use_cache() {
-        let config = CacheConfig {
-            enable_l0: true,
-            l0_max_entries: 100,
-            l0_max_key_bytes: 100,
-        };
-        let cached = CachedTokenizer::new(ByteTokenizer, config);
-
-        let _ = cached.encode("hi", false).unwrap();
-        let _ = cached.encode("hi", false).unwrap();
-
-        let stats = cached.cache_stats().unwrap();
-        assert_eq!(stats.hits, 1);
-        assert_eq!(stats.misses, 1);
-        assert_eq!(stats.entries, 1);
-    }
-
-    #[test]
-    fn eviction_respects_capacity() {
-        let config = CacheConfig {
-            enable_l0: true,
-            l0_max_entries: 2,
-            l0_max_key_bytes: 1024,
-        };
-        let cached = CachedTokenizer::new(ByteTokenizer, config);
-
-        let _ = cached.encode("a", false).unwrap();
-        let _ = cached.encode("b", false).unwrap();
-        let _ = cached.encode("c", false).unwrap();
-
-        let stats = cached.cache_stats().unwrap();
-        assert!(stats.entries <= 2);
-    }
-
-    #[test]
-    fn lru_eviction_keeps_frequently_accessed() {
-        let config = CacheConfig {
-            enable_l0: true,
-            l0_max_entries: 4,
-            l0_max_key_bytes: 1024,
-        };
-        let cached = CachedTokenizer::new(ByteTokenizer, config);
-
-        let _ = cached.encode("sys", false).unwrap();
-        let _ = cached.encode("q1", false).unwrap();
-        let _ = cached.encode("q2", false).unwrap();
-        let _ = cached.encode("q3", false).unwrap();
-
-        for i in 4..12 {
-            let _ = cached.encode("sys", false).unwrap(); // keep sys hot
-            let _ = cached.encode(&format!("q{i}"), false).unwrap();
-        }
-
-        let stats = cached.cache_stats().unwrap();
-        assert!(stats.hits >= 8);
-    }
-
-    #[test]
     fn decode_passes_through() {
-        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
+        let cached = LlmCachedTokenizer::new(ByteTokenizer, LlmCacheConfig::default());
         assert_eq!(cached.decode(&[72, 105], false).unwrap(), "Hi");
     }
 
     #[test]
-    fn cache_disabled_still_works() {
-        let config = CacheConfig {
-            enable_l0: false,
-            l0_max_entries: 0,
-            l0_max_key_bytes: 0,
-        };
-        let cached = CachedTokenizer::new(ByteTokenizer, config);
-        let r1 = cached.encode("hello", false).unwrap();
-        let r2 = cached.encode("hello", false).unwrap();
-        assert_eq!(r1, r2);
-        assert!(cached.cache_stats().is_none());
-    }
-
-    #[test]
     fn concurrent_access() {
-        let cached = Arc::new(CachedTokenizer::new(ByteTokenizer, CacheConfig::default()));
+        use std::sync::Arc;
+        use std::thread;
+
+        let cached = Arc::new(LlmCachedTokenizer::new(
+            ByteTokenizer,
+            LlmCacheConfig::default(),
+        ));
         let mut handles = vec![];
 
         for i in 0..10 {
@@ -507,14 +349,5 @@ mod tests {
         let stats = cached.cache_stats().unwrap();
         assert_eq!(stats.entries, 10);
         assert!(stats.hits >= 10);
-    }
-
-    #[test]
-    fn clear_cache_works() {
-        let cached = CachedTokenizer::new(ByteTokenizer, CacheConfig::default());
-        let _ = cached.encode("test", false).unwrap();
-        assert_eq!(cached.cache_stats().unwrap().entries, 1);
-        cached.clear_cache();
-        assert_eq!(cached.cache_stats().unwrap().entries, 0);
     }
 }

--- a/rust/src/tokenizer/src/cached.rs
+++ b/rust/src/tokenizer/src/cached.rs
@@ -1,38 +1,10 @@
-//! Tokenizer caching layer using `llm-tokenizer`'s [`CachedTokenizer`] and
-//! L0/L1 cache infrastructure.
-//!
-//! Since vllm defines its own [`Tokenizer`](crate::Tokenizer) trait and
-//! `llm-tokenizer` defines a separate `Encoder + Decoder + Tokenizer` trait
-//! hierarchy, this module provides an **adapter** ([`VllmTokenizerAdapter`])
-//! that bridges the two. The adapter wraps any `vllm_tokenizer::Tokenizer`
-//! and implements `llm_tokenizer::traits::{Encoder, Decoder, Tokenizer}` so
-//! that `llm_tokenizer::CachedTokenizer` can wrap it.
-//!
-//! The public [`LlmCachedTokenizer`] struct then wraps the whole stack and
-//! re-implements `vllm_tokenizer::Tokenizer`, making the caching layer
-//! transparent to the rest of vllm.
-//!
-//! # Usage
-//!
-//! ```ignore
-//! use vllm_tokenizer::{LlmCachedTokenizer, LlmCacheConfig};
-//!
-//! let inner = HuggingFaceTokenizer::new(path)?;
-//! let cached = LlmCachedTokenizer::new(inner, LlmCacheConfig::default());
-//! let tokens = cached.encode("Hello world", false)?;
-//! ```
+use std::path::PathBuf;
 
-use std::any::Any;
-use std::sync::Arc;
-
-use llm_tokenizer::cache::{CacheConfig as LlmCacheConfigInner, CachedTokenizer};
-use llm_tokenizer::traits::{
-    Decoder as LlmDecoder, Encoder as LlmEncoder, Encoding as LlmEncoding,
-    SpecialTokens as LlmSpecialTokens, TokenIdType, Tokenizer as LlmTokenizer,
+use crate::{Result, Tokenizer};
+use llm_tokenizer::cache::CacheConfig as LlmCacheConfigInner;
+use llm_tokenizer::{
+    CachedTokenizer, Decoder, Encoder, TokenizerTrait, create_tokenizer_from_file,
 };
-
-use crate::incremental::DecodeStream;
-use crate::{IncrementalDecoder, Result, Tokenizer};
 
 /// Configuration for the llm-tokenizer cache layer.
 #[derive(Debug, Clone)]
@@ -69,285 +41,57 @@ impl From<LlmCacheConfig> for LlmCacheConfigInner {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Adapter: vllm Tokenizer → llm-tokenizer traits
-// ---------------------------------------------------------------------------
-
-/// Wraps a vllm [`Tokenizer`] and implements `llm_tokenizer`'s
-/// `Encoder`, `Decoder`, and `Tokenizer` traits so that
-/// `llm_tokenizer::CachedTokenizer` can wrap it.
-struct VllmTokenizerAdapter<T: Tokenizer> {
-    inner: T,
-    /// Placeholder special tokens — vllm's Tokenizer trait does not expose
-    /// special-token metadata, so we provide an empty default.
-    special_tokens: LlmSpecialTokens,
-}
-
-impl<T: Tokenizer> LlmEncoder for VllmTokenizerAdapter<T> {
-    fn encode(&self, input: &str, add_special_tokens: bool) -> anyhow::Result<LlmEncoding> {
-        let ids = self
-            .inner
-            .encode(input, add_special_tokens)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        Ok(LlmEncoding::Plain(ids))
-    }
-
-    fn encode_batch(
-        &self,
-        inputs: &[&str],
-        add_special_tokens: bool,
-    ) -> anyhow::Result<Vec<LlmEncoding>> {
-        inputs
-            .iter()
-            .map(|&input| LlmEncoder::encode(self, input, add_special_tokens))
-            .collect()
-    }
-}
-
-impl<T: Tokenizer> LlmDecoder for VllmTokenizerAdapter<T> {
-    fn decode(
-        &self,
-        token_ids: &[TokenIdType],
-        skip_special_tokens: bool,
-    ) -> anyhow::Result<String> {
-        self.inner
-            .decode(token_ids, skip_special_tokens)
-            .map_err(|e| anyhow::anyhow!("{e}"))
-    }
-}
-
-impl<T: Tokenizer + 'static> LlmTokenizer for VllmTokenizerAdapter<T> {
-    fn vocab_size(&self) -> usize {
-        // vllm's Tokenizer trait does not expose vocab_size; return 0 as a
-        // safe default (only used by llm-tokenizer's fingerprinting, not the
-        // cache hot path).
-        0
-    }
-
-    fn get_special_tokens(&self) -> &LlmSpecialTokens {
-        &self.special_tokens
-    }
-
-    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
-        self.inner.token_to_id(token)
-    }
-
-    fn id_to_token(&self, id: TokenIdType) -> Option<String> {
-        self.inner.id_to_token(id)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Public wrapper: llm-tokenizer cached stack → vllm Tokenizer
-// ---------------------------------------------------------------------------
-
-/// A tokenizer wrapper that uses `llm-tokenizer`'s [`CachedTokenizer`] (with
-/// L0 and optional L1 caches) to accelerate repeated `encode` calls.
-///
-/// Implements vllm's [`Tokenizer`] trait so it can be used as a drop-in
-/// replacement wherever `DynTokenizer` is expected.
 pub struct LlmCachedTokenizer {
     /// The llm-tokenizer CachedTokenizer wrapping our adapter.
     cached: CachedTokenizer,
-    /// Keep a direct reference to the adapter's inner tokenizer for methods
-    /// that should not go through the cache (decode, token_to_id, etc.).
-    inner: Arc<dyn Tokenizer>,
 }
 
 impl LlmCachedTokenizer {
-    /// Create a new cached tokenizer wrapping `inner` with the given config.
-    pub fn new<T: Tokenizer + 'static>(inner: T, config: LlmCacheConfig) -> Self {
-        let inner_arc: Arc<dyn Tokenizer> = Arc::from(inner);
-
-        // We need to give CachedTokenizer an Arc<dyn llm_tokenizer::Tokenizer>.
-        // Create the adapter wrapping a clone of the Arc.
-        let adapter = VllmTokenizerAdapter {
-            inner: inner_arc.clone(),
-            special_tokens: LlmSpecialTokens::default(),
-        };
-        let llm_inner: Arc<dyn LlmTokenizer> = Arc::new(adapter);
-        let cached = CachedTokenizer::new(llm_inner, config.into());
-
-        Self {
-            cached,
-            inner: inner_arc,
-        }
-    }
-
-    /// Get L0 cache statistics, if the cache is enabled.
-    pub fn cache_stats(&self) -> Option<llm_tokenizer::CacheStats> {
-        self.cached.cache_stats()
-    }
-
-    /// Get L1 cache statistics, if the cache is enabled.
-    pub fn l1_cache_stats(&self) -> Option<llm_tokenizer::cache::L1CacheStats> {
-        self.cached.l1_cache_stats()
-    }
-
-    /// Clear all cached entries.
-    pub fn clear_cache(&self) {
-        self.cached.clear_cache();
+    pub fn new(tokenizer_path: &PathBuf, cache_config: LlmCacheConfig) -> Self {
+        let tokenizers_file_path = &tokenizer_path.to_string_lossy();
+        let base_tokenizer = create_tokenizer_from_file(tokenizers_file_path).unwrap_or_else(|_| {
+            panic!(
+                "Failed to create base tokenizer for LlmCachedTokenizer (path: {tokenizers_file_path})"
+            )
+            });
+        let llm_config: LlmCacheConfigInner = cache_config.into();
+        tracing::info!(
+            enable_l0 = llm_config.enable_l0,
+            l0_max_entries = llm_config.l0_max_entries,
+            enable_l1 = llm_config.enable_l1,
+            l1_max_memory = llm_config.l1_max_memory,
+            "LlmCachedTokenizer created with llm-tokenizer cache"
+        );
+        let cached = CachedTokenizer::new(base_tokenizer, llm_config);
+        Self { cached }
     }
 }
 
 impl Tokenizer for LlmCachedTokenizer {
     fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
-        let start = std::time::Instant::now();
-
-        // Go through llm-tokenizer's CachedTokenizer which handles L0/L1.
-        let encoding = LlmEncoder::encode(&self.cached, text, add_special_tokens)
+        let encoding = self
+            .cached
+            .encode(text, add_special_tokens)
             .map_err(|e| crate::error::TokenizerError(format!("{e}")))?;
-
         let token_ids = encoding.token_ids().to_vec();
-
-        let elapsed = start.elapsed();
-        tracing::debug!(
-            elapsed_us = elapsed.as_micros() as u64,
-            text_bytes = text.len(),
-            tokens = token_ids.len(),
-            "llm-tokenizer cached encode"
-        );
-
         Ok(token_ids)
     }
 
     fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
-        // Decode is not cached by llm-tokenizer either — pass through directly.
-        self.inner.decode(token_ids, skip_special_tokens)
+        self.cached
+            .decode(token_ids, skip_special_tokens)
+            .map_err(|e| crate::error::TokenizerError(format!("{e}")))
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.inner.token_to_id(token)
+        self.cached.token_to_id(token)
     }
 
     fn id_to_token(&self, id: u32) -> Option<String> {
-        self.inner.id_to_token(id)
+        self.cached.id_to_token(id)
     }
 
-    fn is_special_id(&self, token_id: u32) -> bool {
-        self.inner.is_special_id(token_id)
-    }
-
-    fn create_decode_stream(
-        &self,
-        prompt_token_ids: &[u32],
-        skip_special_tokens: bool,
-        min_bytes_to_buffer: usize,
-    ) -> Box<dyn IncrementalDecoder + '_> {
-        Box::new(DecodeStream::new(
-            self,
-            prompt_token_ids,
-            skip_special_tokens,
-            min_bytes_to_buffer,
-        ))
-    }
-}
-
-// We need Tokenizer implemented for Arc<dyn Tokenizer> so the adapter works.
-impl Tokenizer for Arc<dyn Tokenizer> {
-    fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
-        (**self).encode(text, add_special_tokens)
-    }
-
-    fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
-        (**self).decode(token_ids, skip_special_tokens)
-    }
-
-    fn token_to_id(&self, token: &str) -> Option<u32> {
-        (**self).token_to_id(token)
-    }
-
-    fn id_to_token(&self, id: u32) -> Option<String> {
-        (**self).id_to_token(id)
-    }
-
-    fn is_special_id(&self, token_id: u32) -> bool {
-        (**self).is_special_id(token_id)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Simple test tokenizer: each byte becomes a token ID.
-    struct ByteTokenizer;
-
-    impl Tokenizer for ByteTokenizer {
-        fn encode(&self, text: &str, _add_special_tokens: bool) -> Result<Vec<u32>> {
-            Ok(text.bytes().map(|b| b as u32).collect())
-        }
-
-        fn decode(&self, token_ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
-            let bytes: Vec<u8> = token_ids.iter().map(|&id| id as u8).collect();
-            Ok(String::from_utf8_lossy(&bytes).into_owned())
-        }
-
-        fn token_to_id(&self, _token: &str) -> Option<u32> {
-            None
-        }
-    }
-
-    #[test]
-    fn cache_hit_returns_same_result() {
-        let cached = LlmCachedTokenizer::new(ByteTokenizer, LlmCacheConfig::default());
-
-        let r1 = cached.encode("hello", false).unwrap();
-        let r2 = cached.encode("hello", false).unwrap();
-        assert_eq!(r1, r2);
-
-        let stats = cached.cache_stats().unwrap();
-        assert_eq!(stats.hits, 1);
-        assert_eq!(stats.misses, 1);
-    }
-
-    #[test]
-    fn add_special_tokens_flag_separates_entries() {
-        let cached = LlmCachedTokenizer::new(ByteTokenizer, LlmCacheConfig::default());
-
-        let _ = cached.encode("test", false).unwrap();
-        let _ = cached.encode("test", true).unwrap();
-
-        let stats = cached.cache_stats().unwrap();
-        assert_eq!(stats.misses, 2);
-    }
-
-    #[test]
-    fn decode_passes_through() {
-        let cached = LlmCachedTokenizer::new(ByteTokenizer, LlmCacheConfig::default());
-        assert_eq!(cached.decode(&[72, 105], false).unwrap(), "Hi");
-    }
-
-    #[test]
-    fn concurrent_access() {
-        use std::sync::Arc;
-        use std::thread;
-
-        let cached = Arc::new(LlmCachedTokenizer::new(
-            ByteTokenizer,
-            LlmCacheConfig::default(),
-        ));
-        let mut handles = vec![];
-
-        for i in 0..10 {
-            let c = Arc::clone(&cached);
-            handles.push(thread::spawn(move || {
-                let key = format!("k{i}");
-                let r1 = c.encode(&key, false).unwrap();
-                let r2 = c.encode(&key, false).unwrap();
-                assert_eq!(r1, r2);
-            }));
-        }
-        for h in handles {
-            h.join().unwrap();
-        }
-
-        let stats = cached.cache_stats().unwrap();
-        assert_eq!(stats.entries, 10);
-        assert!(stats.hits >= 10);
+    fn is_special_id(&self, _: u32) -> bool {
+        false
     }
 }

--- a/rust/src/tokenizer/src/cached.rs
+++ b/rust/src/tokenizer/src/cached.rs
@@ -1,0 +1,434 @@
+//! Tokenizer caching layer inspired by `llm-tokenizer`'s cache architecture.
+//!
+//! Provides a [`CachedTokenizer`] wrapper around any [`Tokenizer`] implementation
+//! to speed up repeated encoding of the same strings (e.g., system prompts).
+//!
+//! # Architecture
+//!
+//! - **L0 Cache**: Whole-string exact match using `DashMap` for lock-free
+//!   concurrent reads. Uses approximate LRU eviction (sample + evict oldest)
+//!   to protect frequently-accessed entries like system prompts.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use vllm_tokenizer::{CachedTokenizer, CacheConfig};
+//!
+//! let inner = Arc::new(some_tokenizer);
+//! let cached = CachedTokenizer::new(inner, CacheConfig::default());
+//! let tokens = cached.encode("Hello world", false)?;
+//! ```
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+
+use crate::incremental::DecodeStream;
+use crate::{IncrementalDecoder, Result, Tokenizer};
+
+/// Number of entries to sample when looking for an eviction candidate.
+const EVICTION_SAMPLE_SIZE: usize = 8;
+
+/// Configuration for the tokenizer cache.
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    /// Enable L0 (whole-string) cache.
+    pub enable_l0: bool,
+    /// Maximum number of entries in L0 cache.
+    pub l0_max_entries: usize,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            enable_l0: true,
+            l0_max_entries: 10_000,
+        }
+    }
+}
+
+/// A cached encoding entry with access tracking for approximate LRU eviction.
+struct CachedEntry {
+    token_ids: Arc<Vec<u32>>,
+    last_accessed: AtomicU64,
+}
+
+/// L0 cache: whole-string exact match using DashMap for lock-free reads.
+///
+/// Uses two separate maps (one per `add_special_tokens` value) so that
+/// lookups can borrow the key as `&str` without allocating.
+///
+/// Eviction uses approximate LRU: when capacity is reached, sample a few
+/// entries and evict the one with the oldest `last_accessed` timestamp.
+struct L0Cache {
+    map_plain: DashMap<String, CachedEntry>,
+    map_special: DashMap<String, CachedEntry>,
+    max_entries: usize,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    access_counter: AtomicU64,
+}
+
+impl L0Cache {
+    fn new(max_entries: usize) -> Self {
+        let per_map = max_entries.min(1024) / 2 + 1;
+        Self {
+            map_plain: DashMap::with_capacity(per_map),
+            map_special: DashMap::with_capacity(per_map),
+            max_entries,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            access_counter: AtomicU64::new(0),
+        }
+    }
+
+    #[inline]
+    fn map_for(&self, add_special_tokens: bool) -> &DashMap<String, CachedEntry> {
+        if add_special_tokens {
+            &self.map_special
+        } else {
+            &self.map_plain
+        }
+    }
+
+    #[inline]
+    fn next_timestamp(&self) -> u64 {
+        self.access_counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn len(&self) -> usize {
+        self.map_plain.len() + self.map_special.len()
+    }
+
+    /// Look up a cached encoding. Zero-allocation on the lookup path.
+    fn get(&self, key: &str, add_special_tokens: bool) -> Option<Arc<Vec<u32>>> {
+        match self.map_for(add_special_tokens).get(key) {
+            Some(entry) => {
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                let ts = self.next_timestamp();
+                entry.value().last_accessed.store(ts, Ordering::Relaxed);
+                Some(Arc::clone(&entry.value().token_ids))
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    /// Evict the approximately least-recently-used entry if at capacity.
+    fn maybe_evict(&self) {
+        if self.len() >= self.max_entries {
+            let victim_map = if self.map_plain.len() >= self.map_special.len() {
+                &self.map_plain
+            } else {
+                &self.map_special
+            };
+
+            let key_to_remove = {
+                let mut oldest_key: Option<String> = None;
+                let mut oldest_ts = u64::MAX;
+
+                for (i, entry) in victim_map.iter().enumerate() {
+                    let ts = entry.value().last_accessed.load(Ordering::Relaxed);
+                    if ts < oldest_ts {
+                        oldest_ts = ts;
+                        oldest_key = Some(entry.key().clone());
+                    }
+                    if i + 1 >= EVICTION_SAMPLE_SIZE {
+                        break;
+                    }
+                }
+                oldest_key
+            };
+
+            if let Some(k) = key_to_remove {
+                victim_map.remove(&k);
+            }
+        }
+    }
+
+    fn insert(&self, key: String, add_special_tokens: bool, token_ids: Vec<u32>) {
+        self.maybe_evict();
+        let ts = self.next_timestamp();
+        let entry = CachedEntry {
+            token_ids: Arc::new(token_ids),
+            last_accessed: AtomicU64::new(ts),
+        };
+        self.map_for(add_special_tokens).insert(key, entry);
+    }
+
+    fn stats(&self) -> CacheStats {
+        let hits = self.hits.load(Ordering::Relaxed);
+        let misses = self.misses.load(Ordering::Relaxed);
+        let total = hits + misses;
+        CacheStats {
+            hits,
+            misses,
+            entries: self.len(),
+            hit_rate: if total > 0 {
+                hits as f64 / total as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    fn clear(&self) {
+        self.map_plain.clear();
+        self.map_special.clear();
+        self.hits.store(0, Ordering::Relaxed);
+        self.misses.store(0, Ordering::Relaxed);
+        self.access_counter.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Cache statistics.
+#[derive(Debug, Clone)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub entries: usize,
+    pub hit_rate: f64,
+}
+
+/// A caching wrapper around any [`Tokenizer`] implementation.
+///
+/// Caches `encode` results using a DashMap-based L0 whole-string exact-match
+/// cache with approximate LRU eviction. Decode and other methods pass through
+/// to the inner tokenizer unchanged.
+pub struct CachedTokenizer<T: Tokenizer> {
+    inner: T,
+    l0: Option<L0Cache>,
+}
+
+impl<T: Tokenizer> CachedTokenizer<T> {
+    /// Create a new cached tokenizer wrapping `inner`.
+    pub fn new(inner: T, config: CacheConfig) -> Self {
+        let l0 = if config.enable_l0 {
+            Some(L0Cache::new(config.l0_max_entries))
+        } else {
+            None
+        };
+        Self { inner, l0 }
+    }
+
+    /// Get L0 cache statistics, if the cache is enabled.
+    pub fn cache_stats(&self) -> Option<CacheStats> {
+        self.l0.as_ref().map(|c| c.stats())
+    }
+
+    /// Clear all cached entries.
+    pub fn clear_cache(&self) {
+        if let Some(l0) = &self.l0 {
+            l0.clear();
+        }
+    }
+
+    /// Get a reference to the inner tokenizer.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T: Tokenizer> Tokenizer for CachedTokenizer<T> {
+    fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
+        if let Some(l0) = &self.l0 {
+            if let Some(cached) = l0.get(text, add_special_tokens) {
+                return Ok((*cached).clone());
+            }
+        }
+
+        let token_ids = self.inner.encode(text, add_special_tokens)?;
+
+        if let Some(l0) = &self.l0 {
+            l0.insert(text.to_owned(), add_special_tokens, token_ids.clone());
+        }
+
+        Ok(token_ids)
+    }
+
+    fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        // Decode is not cached — it's fast enough and rarely repeated.
+        self.inner.decode(token_ids, skip_special_tokens)
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.inner.token_to_id(token)
+    }
+
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.inner.id_to_token(id)
+    }
+
+    fn is_special_id(&self, token_id: u32) -> bool {
+        self.inner.is_special_id(token_id)
+    }
+
+    fn create_decode_stream(
+        &self,
+        prompt_token_ids: &[u32],
+        skip_special_tokens: bool,
+        min_bytes_to_buffer: usize,
+    ) -> Box<dyn IncrementalDecoder + '_> {
+        // Decode streaming uses the inner tokenizer directly since the
+        // DecodeStream relies on the decode() method which is not cached.
+        Box::new(DecodeStream::new(
+            self,
+            prompt_token_ids,
+            skip_special_tokens,
+            min_bytes_to_buffer,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    /// Simple test tokenizer that splits on whitespace and assigns incrementing IDs.
+    struct SimpleTokenizer;
+
+    impl Tokenizer for SimpleTokenizer {
+        fn encode(&self, text: &str, _add_special_tokens: bool) -> Result<Vec<u32>> {
+            Ok(text.bytes().map(|b| b as u32).collect())
+        }
+
+        fn decode(&self, token_ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
+            let bytes: Vec<u8> = token_ids.iter().map(|&id| id as u8).collect();
+            Ok(String::from_utf8_lossy(&bytes).into_owned())
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<u32> {
+            None
+        }
+    }
+
+    #[test]
+    fn cache_hit_returns_same_result() {
+        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+
+        let r1 = cached.encode("hello", false).unwrap();
+        let r2 = cached.encode("hello", false).unwrap();
+        assert_eq!(r1, r2);
+
+        let stats = cached.cache_stats().unwrap();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 1);
+    }
+
+    #[test]
+    fn add_special_tokens_flag_separates_entries() {
+        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+
+        let _ = cached.encode("test", false).unwrap();
+        let _ = cached.encode("test", true).unwrap();
+
+        let stats = cached.cache_stats().unwrap();
+        assert_eq!(stats.misses, 2); // Two distinct cache entries
+    }
+
+    #[test]
+    fn eviction_respects_capacity() {
+        let config = CacheConfig {
+            enable_l0: true,
+            l0_max_entries: 2,
+        };
+        let cached = CachedTokenizer::new(SimpleTokenizer, config);
+
+        let _ = cached.encode("a", false).unwrap();
+        let _ = cached.encode("b", false).unwrap();
+        let _ = cached.encode("c", false).unwrap();
+
+        let stats = cached.cache_stats().unwrap();
+        assert!(stats.entries <= 2);
+    }
+
+    #[test]
+    fn lru_eviction_keeps_frequently_accessed() {
+        let config = CacheConfig {
+            enable_l0: true,
+            l0_max_entries: 4,
+        };
+        let cached = CachedTokenizer::new(SimpleTokenizer, config);
+
+        // Insert system prompt + 3 queries
+        let _ = cached.encode("system_prompt", false).unwrap();
+        let _ = cached.encode("q1", false).unwrap();
+        let _ = cached.encode("q2", false).unwrap();
+        let _ = cached.encode("q3", false).unwrap();
+
+        // Simulate: each new request accesses system_prompt then inserts a new query
+        for i in 4..12 {
+            let _ = cached.encode("system_prompt", false).unwrap(); // hit
+            let _ = cached.encode(&format!("q{i}"), false).unwrap(); // miss + evict
+        }
+
+        // system_prompt should survive due to LRU
+        let stats = cached.cache_stats().unwrap();
+        assert!(stats.hits >= 8); // system_prompt was hit each iteration
+    }
+
+    #[test]
+    fn decode_passes_through() {
+        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+        let decoded = cached.decode(&[72, 105], false).unwrap();
+        assert_eq!(decoded, "Hi");
+    }
+
+    #[test]
+    fn cache_disabled_still_works() {
+        let config = CacheConfig {
+            enable_l0: false,
+            l0_max_entries: 0,
+        };
+        let cached = CachedTokenizer::new(SimpleTokenizer, config);
+
+        let r1 = cached.encode("hello", false).unwrap();
+        let r2 = cached.encode("hello", false).unwrap();
+        assert_eq!(r1, r2);
+        assert!(cached.cache_stats().is_none());
+    }
+
+    #[test]
+    fn concurrent_access() {
+        let cached = Arc::new(CachedTokenizer::new(
+            SimpleTokenizer,
+            CacheConfig::default(),
+        ));
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let c = Arc::clone(&cached);
+            handles.push(thread::spawn(move || {
+                let key = format!("key_{i}");
+                let r1 = c.encode(&key, false).unwrap();
+                let r2 = c.encode(&key, false).unwrap();
+                assert_eq!(r1, r2);
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let stats = cached.cache_stats().unwrap();
+        assert_eq!(stats.entries, 10);
+        assert!(stats.hits >= 10);
+    }
+
+    #[test]
+    fn clear_cache_works() {
+        let cached = CachedTokenizer::new(SimpleTokenizer, CacheConfig::default());
+        let _ = cached.encode("test", false).unwrap();
+
+        assert_eq!(cached.cache_stats().unwrap().entries, 1);
+        cached.clear_cache();
+        assert_eq!(cached.cache_stats().unwrap().entries, 0);
+    }
+}

--- a/rust/src/tokenizer/src/lib.rs
+++ b/rust/src/tokenizer/src/lib.rs
@@ -11,7 +11,7 @@ mod incremental;
 mod tekken;
 mod tiktoken;
 
-pub use cached::{CacheConfig, CacheStats, CachedTokenizer};
+pub use cached::{LlmCacheConfig, LlmCachedTokenizer};
 pub use error::{Result, TokenizerError};
 pub use hf::HuggingFaceTokenizer;
 pub use incremental::IncrementalDecoder;

--- a/rust/src/tokenizer/src/lib.rs
+++ b/rust/src/tokenizer/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::incremental::DecodeStream;
 
 mod byte_level_decode;
+mod cached;
 #[macro_use]
 mod error;
 mod hf;
@@ -10,6 +11,7 @@ mod incremental;
 mod tekken;
 mod tiktoken;
 
+pub use cached::{CacheConfig, CacheStats, CachedTokenizer};
 pub use error::{Result, TokenizerError};
 pub use hf::HuggingFaceTokenizer;
 pub use incremental::IncrementalDecoder;


### PR DESCRIPTION
## Purpose

By integrating `llm-tokenizer` (https://crates.io/crates/llm-tokenizer), we can leverage its caching capabilities to reduce the execution time of tokenizer encoding operations.

## Test Plan

Based on my testing, when not utilizing caching capabilities, the TTFT improves by approximately 20% compared to using Fasttoken; however, according to my specific test results, the improvement is sometimes limited to just 10%.

## Test Result

- vllm server
```
$ python -m vllm.entrypoints.cli.main serve --model /new-model/MiniMax-M2.7 --trust-remote-code --tensor-parallel-size 4 --no-enable-prefix-caching
```

- vllm bench server
```
vllm bench serve --served-model-name /new-model/MiniMax-M2.7   --model /new-model/MiniMax-M2.7   --backend openai-chat   --endpoint /v1/chat/completions   --dataset-name sharegpt   --num-prompts 100   --base-url http://127.0.0.1:8000   --dataset-path /new-model/dateset/ShareGPT_V4.3_unfiltered_cleaned_split.json
```

- Use llm-tokenizer
```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Benchmark duration (s):                  19.59
Total input tokens:                      26373
Total generated tokens:                  22963
Request throughput (req/s):              5.11
Output token throughput (tok/s):         1172.30
Peak output token throughput (tok/s):    2142.00
Peak concurrent requests:                100.00
Total token throughput (tok/s):          2518.69
---------------Time to First Token----------------
Mean TTFT (ms):                          877.91
Median TTFT (ms):                        587.87
P99 TTFT (ms):                           1753.59
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.71
Median TPOT (ms):                        37.60
P99 TPOT (ms):                           184.54
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.65
Median ITL (ms):                         28.91
P99 ITL (ms):                            140.55
==================================================
```

- Use current default tokenizer
```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Benchmark duration (s):                  19.17
Total input tokens:                      26373
Total generated tokens:                  22525
Request throughput (req/s):              5.22
Output token throughput (tok/s):         1175.07
Peak output token throughput (tok/s):    2233.00
Peak concurrent requests:                100.00
Total token throughput (tok/s):          2550.88
---------------Time to First Token----------------
Mean TTFT (ms):                          1189.75
Median TTFT (ms):                        1222.11
P99 TTFT (ms):                           1884.42
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.45
Median TPOT (ms):                        35.32
P99 TPOT (ms):                           186.49
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.31
Median ITL (ms):                         29.25
P99 ITL (ms):                            45.05
==================================================
```

---
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

