### PR TITLE
[Core] Implement request lifecycle spans and root span hierarchy

### DIFF
--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -134,6 +134,11 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_request(self, request_id: str) -> "Request | None":
+        """Get a request by its ID."""
+        raise NotImplementedError
+
+    @abstractmethod
     def finish_requests(
         self,
         request_ids: str | Iterable[str] | None,

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -244,6 +244,9 @@ class SchedulerOutput:
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int = 0
 
+    # Start time of the batch in nanoseconds (used for tracing metrics)
+    batch_start_time_ns: int | None = None
+
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -897,6 +897,7 @@ class Scheduler(SchedulerInterface):
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    request.async_kv_load_start_time_ns = time.time_ns()
                     step_skipped_waiting.prepend_request(request)
                     # Set num_computed_tokens even though KVs are not yet loaded.
                     # request.num_computed_tokens will not be used anywhere until
@@ -921,9 +922,15 @@ class Scheduler(SchedulerInterface):
                         EngineCoreEventType.SCHEDULED, scheduled_timestamp
                     )
                 if request.status == RequestStatus.WAITING:
+                    request.trace_end_queuing()
+                    if request.num_computed_tokens > 0:
+                        request.decode_start_time_ns = time.time_ns()
+                    else:
+                        request.prefill_start_time_ns = time.time_ns()
                     scheduled_new_reqs.append(request)
                 elif request.status == RequestStatus.PREEMPTED:
                     scheduled_resumed_reqs.append(request)
+                    request.prefill_start_time_ns = time.time_ns()
                 else:
                     raise RuntimeError(f"Invalid request status: {request.status}")
 
@@ -1085,6 +1092,10 @@ class Scheduler(SchedulerInterface):
         assert request.status == RequestStatus.RUNNING, (
             "Only running requests can be preempted"
         )
+
+        # Close active prefill or decode spans
+        request.trace_preempt()
+
         self._free_request_blocks(request)
         self.encoder_cache_manager.free(request)
         self._inflight_prefills.discard(request)
@@ -1517,6 +1528,11 @@ class Scheduler(SchedulerInterface):
             generated_token_ids = (
                 sampled_token_ids[req_index] if sampled_token_ids else []
             )
+
+            if generated_token_ids:
+                request.trace_end_prefill()
+                if request.decode_start_time_ns is None:
+                    request.decode_start_time_ns = time.time_ns()
 
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
@@ -1954,6 +1970,9 @@ class Scheduler(SchedulerInterface):
             if self.log_stats:
                 request.record_event(EngineCoreEventType.QUEUED)
 
+    def get_request(self, request_id: str) -> Request | None:
+        return self.requests.get(request_id)
+
     def finish_requests(
         self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
     ) -> list[tuple[str, int]]:
@@ -2021,6 +2040,9 @@ class Scheduler(SchedulerInterface):
         self, request: Request, delay_free_blocks: bool = False
     ) -> dict[str, Any] | None:
         assert request.is_finished()
+
+        # End active spans and clean up
+        request.trace_cleanup()
 
         self._inflight_prefills.discard(request)
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
@@ -2366,6 +2388,8 @@ class Scheduler(SchedulerInterface):
             if request.request_id not in self.finished_recving_kv_req_ids:
                 return False
             self._update_waiting_for_remote_kv(request)
+            request.trace_end_kv_transfer()
+
             if request.num_preemptions:
                 request.status = RequestStatus.PREEMPTED
             else:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -461,6 +461,8 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         scheduler_output = self.scheduler.schedule()
+
+        batch_start_time_ns = time.time_ns()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
@@ -470,6 +472,40 @@ class EngineCore:
             model_output = future.result()
             if model_output is None:
                 model_output = self.model_executor.sample_tokens(grammar_output)
+            batch_end_time_ns = time.time_ns()
+
+            # Emit per-request vllm_step_execution spans
+            step_attributes = {
+                "num_prefill_requests": len(scheduler_output.scheduled_new_reqs),
+                "num_decode_requests": len(
+                    scheduler_output.scheduled_cached_reqs.req_ids
+                ),
+                "total_scheduled_tokens": scheduler_output.total_num_scheduled_tokens,
+            }
+            prefill_attrs = {"phase": "prefill", **step_attributes}
+            decode_attrs = {"phase": "decode", **step_attributes}
+
+            for req_data in scheduler_output.scheduled_new_reqs:
+                req = self.scheduler.get_request(req_data.req_id)
+                if req and req.trace_headers:
+                    attrs = (
+                        decode_attrs if req.num_computed_tokens > 0 else prefill_attrs
+                    )
+                    req.emit_span(
+                        span_name="vllm_step_execution",
+                        start_time=batch_start_time_ns,
+                        end_time=batch_end_time_ns,
+                        attributes=attrs,
+                    )
+            for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
+                req = self.scheduler.get_request(req_id)
+                if req and req.trace_headers:
+                    req.emit_span(
+                        span_name="vllm_step_execution",
+                        start_time=batch_start_time_ns,
+                        end_time=batch_end_time_ns,
+                        attributes=decode_attrs,
+                    )
 
         # Before processing the model output, process any aborts that happened
         # during the model execution.
@@ -518,6 +554,8 @@ class EngineCore:
         deferred_scheduler_output = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule()
+
+            scheduler_output.batch_start_time_ns = time.time_ns()
             with self.log_error_detail(scheduler_output):
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True
@@ -561,6 +599,8 @@ class EngineCore:
 
         # Block until the next result is available.
         future, scheduler_output, exec_model_fut = batch_queue.pop()
+
+        batch_start_time_ns = scheduler_output.batch_start_time_ns
         with (
             self.log_error_detail(scheduler_output),
             self.log_iteration_details(scheduler_output),
@@ -571,6 +611,45 @@ class EngineCore:
                 # call failed - raise that exception.
                 exec_model_fut.result()
                 raise RuntimeError("unexpected error")
+            batch_end_time_ns = time.time_ns()
+
+            # Emit per-request vllm_step_execution spans
+            if batch_start_time_ns is not None:
+                step_attributes = {
+                    "num_prefill_requests": len(scheduler_output.scheduled_new_reqs),
+                    "num_decode_requests": len(
+                        scheduler_output.scheduled_cached_reqs.req_ids
+                    ),
+                    "total_scheduled_tokens": (
+                        scheduler_output.total_num_scheduled_tokens
+                    ),
+                }
+                prefill_attrs = {"phase": "prefill", **step_attributes}
+                decode_attrs = {"phase": "decode", **step_attributes}
+
+                for req_data in scheduler_output.scheduled_new_reqs:
+                    req = self.scheduler.get_request(req_data.req_id)
+                    if req and req.trace_headers:
+                        attrs = (
+                            decode_attrs
+                            if req.num_computed_tokens > 0
+                            else prefill_attrs
+                        )
+                        req.emit_span(
+                            span_name="vllm_step_execution",
+                            start_time=batch_start_time_ns,
+                            end_time=batch_end_time_ns,
+                            attributes=attrs,
+                        )
+                for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
+                    req = self.scheduler.get_request(req_id)
+                    if req and req.trace_headers:
+                        req.emit_span(
+                            span_name="vllm_step_execution",
+                            start_time=batch_start_time_ns,
+                            end_time=batch_end_time_ns,
+                            attributes=decode_attrs,
+                        )
 
         # Before processing the model output, process any aborts that happened
         # during the model execution.

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -101,6 +101,12 @@ class Request:
         # P/D: Connector-specific KV transfer parameters.
         self.kv_transfer_params: dict[str, Any] | None = None
 
+        # Distributed Tracing: Explicit state transition timing fields.
+        self.arrival_time_ns: int | None = int(self.arrival_time * 1e9)
+        self.async_kv_load_start_time_ns: int | None = None
+        self.prefill_start_time_ns: int | None = None
+        self.decode_start_time_ns: int | None = None
+
         if pooling_params is not None:
             # Pooling models.
             self.max_tokens = 1
@@ -318,6 +324,98 @@ class Request:
         if self.request_id != other.request_id:
             return self.request_id < other.request_id
         return id(self) < id(other)
+
+    def emit_span(
+        self,
+        span_name: str,
+        start_time: int,
+        end_time: int,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Helper to manually emit an OTel trace span linked to this request's
+        context."""
+        from vllm.tracing import extract_trace_context, instrument_manual
+
+        trace_context = (
+            extract_trace_context(self.trace_headers) if self.trace_headers else None
+        )
+
+        merged_attributes = {"request_id": self.request_id}
+        if attributes:
+            merged_attributes.update(attributes)
+
+        instrument_manual(
+            span_name=span_name,
+            start_time=start_time,
+            end_time=end_time,
+            context=trace_context,
+            attributes=merged_attributes,
+        )
+
+    def trace_end_queuing(self) -> None:
+        """Transition request out of the queue. Closes vllm_queue span."""
+        if self.arrival_time_ns is None:
+            return
+
+        now = time.time_ns()
+        self.emit_span("vllm_queue", self.arrival_time_ns, now)
+        self.arrival_time_ns = None  # prevent double queue spans
+
+    def trace_end_kv_transfer(self, aborted: bool = False) -> None:
+        """Transition request out of KV transfer. Closes vllm_async_kv_transfer span."""
+        if self.async_kv_load_start_time_ns is None:
+            return
+
+        now = time.time_ns()
+        attributes = {"aborted": True} if aborted else None
+        self.emit_span(
+            "vllm_async_kv_transfer", self.async_kv_load_start_time_ns, now, attributes
+        )
+        self.async_kv_load_start_time_ns = None
+
+    def trace_end_prefill(self, aborted: bool = False) -> None:
+        """Transition request out of prefill. Closes vllm_prefill span."""
+        if self.prefill_start_time_ns is None:
+            return
+
+        now = time.time_ns()
+        attributes = {"aborted": True} if aborted else None
+        self.emit_span("vllm_prefill", self.prefill_start_time_ns, now, attributes)
+        self.prefill_start_time_ns = None
+
+    def trace_end_decode(self, aborted: bool = False) -> None:
+        """Transition request out of decode. Closes vllm_decode span."""
+        if self.decode_start_time_ns is None:
+            return
+
+        now = time.time_ns()
+        attributes = {"aborted": True} if aborted else None
+        self.emit_span("vllm_decode", self.decode_start_time_ns, now, attributes)
+        self.decode_start_time_ns = None
+
+    def trace_preempt(self) -> None:
+        """Transition request to PREEMPTED. Closes active prefill or decode spans."""
+        now = time.time_ns()
+        attributes = {"preempted": True}
+
+        if self.prefill_start_time_ns is not None:
+            self.emit_span("vllm_prefill", self.prefill_start_time_ns, now, attributes)
+            self.prefill_start_time_ns = None
+
+        if self.decode_start_time_ns is not None:
+            self.emit_span("vllm_decode", self.decode_start_time_ns, now, attributes)
+            self.decode_start_time_ns = None
+
+    def trace_cleanup(self) -> None:
+        """Catch-all transition to clean up any lingering active spans when
+        request is freed."""
+        is_aborted = (
+            self.status == RequestStatus.FINISHED_ABORTED
+            or self.status == RequestStatus.FINISHED_ERROR
+        )
+        self.trace_end_kv_transfer(aborted=is_aborted)
+        self.trace_end_prefill(aborted=is_aborted)
+        self.trace_end_decode(aborted=is_aborted)
 
 
 class RequestStatus(enum.IntEnum):


### PR DESCRIPTION
- Add timing spans for request prefill, decode, and preempted phases.
- Track scheduler-level events including queuing, preemption, and async KV transfer.
- Add batch_start_time_ns field to SchedulerOutput to cache start time of the model execution.

Co-authored-by: gemini-code-assist




## Purpose
This PR exports request-level execution timing as separate spans for otel tracing. Specifically, it enables tracking the time each request spends in:
- **Queueing (`vllm_queue`):** time the request spends in the queue.
- **KV Prefetch (`vllm_async_kv_transfer`):** time spent in WAITING_FOR_REMOTE_KV.
- **Execution Phases (`vllm_prefill` / `vllm_decode`):** time spent in prefill and decode phase.

*No duplication:* This work is distinct from #32573. While #32573 focuses on fine-grained token-level tracing, this PR focuses on request lifecycle state transition/duration spans. Should the maintainers prefer #32573's approach for per-token/forward-pass latency telemetry, we can easily remove the per-forward-pass iteration span (`vllm_step_execution`) from this PR and keep the rest (`vllm_queue`, `vllm_async_kv_transfer`, `vllm_prefill`, and `vllm_decode`).

## Test Plan
Deploy vLLM and observe the aforementioned span in collected traces.

## Test Result
Verified span nesting and duration telemetry visually inside Jaeger during prefill and decode serving phases:
<img width="3430" height="1880" alt="BXGRhUcizhztvfc" src="https://github.com/user-attachments/assets/956ae849-2b89-4301-a2c1-f42f2048c3c2" />

(deployment using [llm-d's pd disaggregation guide](https://github.com/llm-d/llm-d/blob/main/guides/pd-disaggregation/README.md), so there are llm-d proxy traces visible in the screenshot)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

