### PR TITLE
Fix FlashInfer attention auto-selection on SM75 GPUs

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -14,6 +14,7 @@ from vllm.config import (
 )
 from vllm.platforms import current_platform
 from vllm.platforms.cpu import CpuPlatform
+from vllm.platforms.interface import DeviceCapability
 
 # CudaPlatform and RocmPlatform import their respective compiled C extensions
 # at module level, raising ModuleNotFoundError on incompatible builds.
@@ -220,6 +221,8 @@ def test_backend_selection(
                         expected = "TRITON_MLA"
                         assert backend.get_name() == expected
                 elif name == "FLASHINFER":
+                    if capability < (8, 0):
+                        pytest.skip("FlashInfer attention requires SM80 or higher")
                     backend = get_attn_backend(64, torch.float16, None, use_mla=use_mla)
                     expected = "FLASHINFER"
                     assert backend.get_name() == expected
@@ -366,6 +369,32 @@ def test_auto_backend_selection_behavior():
 
     # Both should select the same backend
     assert backend_auto.get_name() == backend_none.get_name()
+
+
+def test_cuda_sm75_auto_selects_triton_attn(monkeypatch: pytest.MonkeyPatch):
+    """FlashInfer native prefill can crash on Turing; auto-select Triton."""
+    if CudaPlatform is None:
+        pytest.skip("CudaPlatform not available")
+
+    def get_sm75_capability(cls, device_id: int = 0):
+        return DeviceCapability(major=7, minor=5)
+
+    monkeypatch.setattr(
+        CudaPlatform, "get_device_capability", classmethod(get_sm75_capability)
+    )
+
+    vllm_config = VllmConfig()
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
+    ):
+        backend = get_attn_backend(
+            head_size=128,
+            dtype=torch.float16,
+            kv_cache_dtype=None,
+        )
+
+    assert backend.get_name() == "TRITON_ATTN"
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -406,7 +406,7 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return capability >= DeviceCapability(7, 5) and capability <= DeviceCapability(
+        return capability >= DeviceCapability(8, 0) and capability <= DeviceCapability(
             12, 1
         )
 


### PR DESCRIPTION
## Purpose
Fixes #44379.
Avoid auto-selecting FlashInfer attention on SM75/Turing GPUs. In v0.22.0, the CUDA image upgraded FlashInfer from `0.6.8.post1` to `0.6.11.post2`; on T4/SM75 this can crash in the native FlashInfer paged prefill path with `BatchPrefillWithPagedKVCache failed with error invalid argument`.

With this change, SM75 falls back to `TRITON_ATTN` instead of entering the failing FlashInfer attention path.

## Test Plan
Run the new attention backend selection regression test:
```bash
python -m pytest tests/kernels/attention/test_attention_selector.py -k sm75_auto_selects_triton_attn -q
```
## Test Result

1 passed, 39 deselected, 20 warnings in 3.88s

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

