### PR TITLE
[Profiler] Get Detailed MultiModal Data Preprocessing Timing Stats

### DIFF
--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -42,43 +42,25 @@ else:
     LLMEngine = object
 
 
-def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, float]]:
-    """
-    Get all multimodal timing stats from the LLM engine.
-
-    Collects both preprocessing stats (HF processor, hashing, cache lookup,
-    prompt update) and encoder forward pass timing, merged by request_id.
+def merge_timing_stats(
+    preprocess_stats: dict[str, dict[str, float]],
+    encoder_results: list[dict[str, dict[str, float | int]] | None],
+) -> dict[str, dict[str, float]]:
+    """Merge preprocessing stats with encoder stats collected from workers.
 
     Args:
-        llm_engine: The LLM engine (has input_processor and workers).
+        preprocess_stats: Per-request preprocessing stats from
+            ``renderer._mm_timing_registry.stat()``.
+        encoder_results: List of per-worker results from
+            ``collective_rpc("get_encoder_timing_stats")``. Each element is
+            ``{request_id: {stage: value}}`` or ``None``.
 
     Returns:
-        Dictionary mapping request_id to merged stats dict containing
-        both preprocessing and encoder timing metrics.
-
-    Example:
-        {
-            'request-123': {
-                'get_mm_hashes_secs': 0.02,
-                'get_cache_missing_items_secs': 0.01,
-                'apply_hf_processor_secs': 0.45,
-                'merge_mm_kwargs_secs': 0.01,
-                'apply_prompt_updates_secs': 0.03,
-                'preprocessor_total_secs': 0.51,
-                'encoder_forward_secs': 0.23,
-                'num_encoder_calls': 1
-            }
-        }
+        Dictionary mapping request_id to merged stats dict.
     """
-    observability_config = llm_engine.vllm_config.observability_config
-    if not observability_config or not observability_config.enable_mm_processor_stats:
-        return {}
-
-    renderer = llm_engine.renderer
-    mm_processor_stats = renderer._mm_timing_registry.stat()
-
+    # Aggregate encoder stats across workers (take max)
     encoder_stats = dict[str, dict[str, float]]()
-    for worker_stats in llm_engine.collective_rpc("get_encoder_timing_stats"):
+    for worker_stats in encoder_results:
         if not worker_stats:
             continue
 
@@ -86,7 +68,6 @@ def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, f
             if request_id not in encoder_stats:
                 encoder_stats[request_id] = dict(stats_dict)
             else:
-                # Aggregate timing metrics across workers
                 current_time = encoder_stats[request_id].get(
                     "encoder_forward_secs", 0.0
                 )
@@ -101,9 +82,10 @@ def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, f
                     current_calls, new_calls
                 )
 
+    # Merge preprocessing + encoder by request_id
     merged_stats = dict[str, dict[str, float]]()
 
-    for request_id, prep_dict in mm_processor_stats.items():
+    for request_id, prep_dict in preprocess_stats.items():
         merged_stats[request_id] = dict(prep_dict)
 
     for request_id, enc_dict in encoder_stats.items():
@@ -122,6 +104,32 @@ def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, f
             merged_stats[request_id] = dict(enc_dict)
 
     return merged_stats
+
+
+def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, float]]:
+    """
+    Get all multimodal timing stats from the LLM engine.
+
+    Collects both preprocessing stats (HF processor, hashing, cache lookup,
+    prompt update) and encoder forward pass timing, merged by request_id.
+
+    Args:
+        llm_engine: The LLM engine (has input_processor and workers).
+
+    Returns:
+        Dictionary mapping request_id to merged stats dict containing
+        both preprocessing and encoder timing metrics.
+    """
+    observability_config = llm_engine.vllm_config.observability_config
+    if not observability_config or not observability_config.enable_mm_processor_stats:
+        return {}
+
+    renderer = llm_engine.renderer
+    mm_processor_stats = renderer._mm_timing_registry.stat()
+
+    encoder_results = llm_engine.collective_rpc("get_encoder_timing_stats")
+
+    return merge_timing_stats(mm_processor_stats, encoder_results)
 
 
 def collect_mm_processor_stats(llm_engine: LLMEngine) -> dict[str, list[float]]:

--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -42,25 +42,43 @@ else:
     LLMEngine = object
 
 
-def merge_timing_stats(
-    preprocess_stats: dict[str, dict[str, float]],
-    encoder_results: list[dict[str, dict[str, float | int]] | None],
-) -> dict[str, dict[str, float]]:
-    """Merge preprocessing stats with encoder stats collected from workers.
+def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, float]]:
+    """
+    Get all multimodal timing stats from the LLM engine.
+
+    Collects both preprocessing stats (HF processor, hashing, cache lookup,
+    prompt update) and encoder forward pass timing, merged by request_id.
 
     Args:
-        preprocess_stats: Per-request preprocessing stats from
-            ``renderer._mm_timing_registry.stat()``.
-        encoder_results: List of per-worker results from
-            ``collective_rpc("get_encoder_timing_stats")``. Each element is
-            ``{request_id: {stage: value}}`` or ``None``.
+        llm_engine: The LLM engine (has input_processor and workers).
 
     Returns:
-        Dictionary mapping request_id to merged stats dict.
+        Dictionary mapping request_id to merged stats dict containing
+        both preprocessing and encoder timing metrics.
+
+    Example:
+        {
+            'request-123': {
+                'get_mm_hashes_secs': 0.02,
+                'get_cache_missing_items_secs': 0.01,
+                'apply_hf_processor_secs': 0.45,
+                'merge_mm_kwargs_secs': 0.01,
+                'apply_prompt_updates_secs': 0.03,
+                'preprocessor_total_secs': 0.51,
+                'encoder_forward_secs': 0.23,
+                'num_encoder_calls': 1
+            }
+        }
     """
-    # Aggregate encoder stats across workers (take max)
+    observability_config = llm_engine.vllm_config.observability_config
+    if not observability_config or not observability_config.enable_mm_processor_stats:
+        return {}
+
+    renderer = llm_engine.renderer
+    mm_processor_stats = renderer._mm_timing_registry.stat()
+
     encoder_stats = dict[str, dict[str, float]]()
-    for worker_stats in encoder_results:
+    for worker_stats in llm_engine.collective_rpc("get_encoder_timing_stats"):
         if not worker_stats:
             continue
 
@@ -68,6 +86,7 @@ def merge_timing_stats(
             if request_id not in encoder_stats:
                 encoder_stats[request_id] = dict(stats_dict)
             else:
+                # Aggregate timing metrics across workers
                 current_time = encoder_stats[request_id].get(
                     "encoder_forward_secs", 0.0
                 )
@@ -82,10 +101,9 @@ def merge_timing_stats(
                     current_calls, new_calls
                 )
 
-    # Merge preprocessing + encoder by request_id
     merged_stats = dict[str, dict[str, float]]()
 
-    for request_id, prep_dict in preprocess_stats.items():
+    for request_id, prep_dict in mm_processor_stats.items():
         merged_stats[request_id] = dict(prep_dict)
 
     for request_id, enc_dict in encoder_stats.items():
@@ -104,32 +122,6 @@ def merge_timing_stats(
             merged_stats[request_id] = dict(enc_dict)
 
     return merged_stats
-
-
-def get_timing_stats_from_engine(llm_engine: LLMEngine) -> dict[str, dict[str, float]]:
-    """
-    Get all multimodal timing stats from the LLM engine.
-
-    Collects both preprocessing stats (HF processor, hashing, cache lookup,
-    prompt update) and encoder forward pass timing, merged by request_id.
-
-    Args:
-        llm_engine: The LLM engine (has input_processor and workers).
-
-    Returns:
-        Dictionary mapping request_id to merged stats dict containing
-        both preprocessing and encoder timing metrics.
-    """
-    observability_config = llm_engine.vllm_config.observability_config
-    if not observability_config or not observability_config.enable_mm_processor_stats:
-        return {}
-
-    renderer = llm_engine.renderer
-    mm_processor_stats = renderer._mm_timing_registry.stat()
-
-    encoder_results = llm_engine.collective_rpc("get_encoder_timing_stats")
-
-    return merge_timing_stats(mm_processor_stats, encoder_results)
 
 
 def collect_mm_processor_stats(llm_engine: LLMEngine) -> dict[str, list[float]]:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -2040,4 +2040,154 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
             json.dump(result_json, outfile)
         save_to_pytorch_benchmark_format(args, result_json, file_name)
 
+    # ---- MM Processor Stats Collection ----
+    # If the server was started with --enable-mm-processor-stats, collect
+    # per-request stage timings and display them alongside client metrics.
+    try:
+        from vllm.benchmarks.mm_processor import (
+            calculate_mm_processor_metrics,
+        )
+
+        async with (
+            aiohttp.ClientSession() as stats_session,
+            stats_session.get(f"{base_url}/mm_processor_stats") as resp,
+        ):
+            if resp.status == 200:
+                body = await resp.json()
+                per_request_stats = body.get("mm_processor_stats", {})
+                if per_request_stats:
+                    # Flatten per-request data to stage-keyed lists
+                    stats_by_stage: dict[str, list[float]] = {}
+                    for _req_id, stages in per_request_stats.items():
+                        for stage, value in stages.items():
+                            stats_by_stage.setdefault(stage, []).append(value)
+
+                    selected_percentiles = [
+                        float(p) for p in args.metric_percentiles.split(",")
+                    ]
+                    mm_metrics = calculate_mm_processor_metrics(
+                        stats_by_stage,
+                        selected_percentiles,
+                    )
+
+                    print()
+                    print(
+                        "{s:{c}^{n}}".format(
+                            s=" MM Processor Stage Latency ", n=50, c="="
+                        )
+                    )
+
+                    # Pipeline-ordered stage names (keys from
+                    # calculate_mm_processor_metrics: _secs -> _ms)
+                    preprocess_stages = [
+                        "video_decode_ms",
+                        "image_decode_ms",
+                        "audio_decode_ms",
+                        "video_fetch_bytes_ms",
+                        "image_fetch_bytes_ms",
+                        "audio_fetch_bytes_ms",
+                        "get_mm_hashes_ms",
+                        "get_cache_missing_items_ms",
+                        "hf_data_prep_ms",
+                        "hf_processor_call_ms",
+                        "hf_postprocess_ms",
+                        "merge_mm_kwargs_ms",
+                        "apply_prompt_updates_ms",
+                    ]
+                    encoder_stages = [
+                        "encoder_forward_ms",
+                        "num_encoder_calls",
+                        "embedding_gather_ms",
+                        "embedding_merge_ms",
+                        "prefill_forward_ms",
+                    ]
+
+                    found_preprocess = [s for s in preprocess_stages if s in mm_metrics]
+                    found_encoder = [s for s in encoder_stages if s in mm_metrics]
+                    has_total = "preprocessor_total_ms" in mm_metrics
+
+                    if not (has_total or found_preprocess or found_encoder):
+                        print("=" * 50)
+                    else:
+                        # Column layout: label | mean | median | pXX
+                        col_labels = ["mean", "median"]
+                        for p in selected_percentiles:
+                            p_word = str(int(p)) if int(p) == p else str(p)
+                            col_labels.append(f"p{p_word}")
+
+                        # Collect display labels to compute column width
+                        all_display: list[str] = []
+                        if has_total:
+                            all_display.append("preprocessor_total_ms:")
+                        all_display.extend(f"  {s}:" for s in found_preprocess)
+                        all_display.extend(f"  {s}:" for s in found_encoder)
+                        label_w = max(len(d) for d in all_display)
+                        col_w = 10  # match serving benchmark style
+
+                        def _fmt_row(label: str, metrics: dict) -> str:
+                            vals = [f"{metrics['mean']:.2f}"]
+                            vals.append(f"{metrics['median']:.2f}")
+                            for p in selected_percentiles:
+                                vals.append(f"{metrics.get(f'p{p}', 0.0):.2f}")
+                            val_strs = [f"{v:>{col_w}}" for v in vals]
+                            return f"{label:<{label_w}}{''.join(val_strs)}"
+
+                        # Print header row right above data
+                        print()
+                        header_vals = "".join(f"{c:>{col_w}}" for c in col_labels)
+                        print(f"{'':{label_w}}{header_vals}")
+
+                        # Preprocess total (top-level summary)
+                        if has_total:
+                            print(
+                                _fmt_row(
+                                    "preprocessor_total_ms:",
+                                    mm_metrics["preprocessor_total_ms"],
+                                )
+                            )
+
+                        # Preprocessing stages
+                        if found_preprocess:
+                            print(
+                                "{s:{c}^{n}}".format(s=" Preprocessing ", n=50, c="-")
+                            )
+                            for s in found_preprocess:
+                                print(
+                                    _fmt_row(
+                                        f"  {s}:",
+                                        mm_metrics[s],
+                                    )
+                                )
+
+                        # Encoder stages
+                        if found_encoder:
+                            print("{s:{c}^{n}}".format(s=" Encoding ", n=50, c="-"))
+                            for s in found_encoder:
+                                print(
+                                    _fmt_row(
+                                        f"  {s}:",
+                                        mm_metrics[s],
+                                    )
+                                )
+
+                        print("=" * 50)
+
+                    result_json["mm_processor_stats"] = mm_metrics
+                else:
+                    print(
+                        "MM Processor Stats: endpoint returned empty data. "
+                        "Make sure the server was started with "
+                        "--enable-mm-processor-stats."
+                    )
+            else:
+                print(
+                    f"MM Processor Stats: endpoint returned status "
+                    f"{resp.status}. To enable, start the server with "
+                    f"--enable-mm-processor-stats."
+                )
+    except aiohttp.ClientError as e:
+        print(f"MM Processor Stats: failed to connect ({e}).")
+    except Exception as e:
+        print(f"MM Processor Stats: unexpected error ({type(e).__name__}: {e}).")
+
     return result_json

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -358,6 +358,7 @@ class ModelConfig:
     skip_mm_profiling: InitVar[bool | None] = None
     video_pruning_rate: InitVar[float | None] = None
     mm_tensor_ipc: InitVar[MMTensorIPC] = None
+    mm_ipc_gpu_memory_gb: InitVar[float | None] = None
 
     def compute_hash(self) -> str:
         """
@@ -404,6 +405,7 @@ class ModelConfig:
             "mm_encoder_tp_mode",
             "interleave_mm_strings",
             "skip_mm_profiling",
+            "mm_ipc_gpu_memory_gb",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors
@@ -484,6 +486,7 @@ class ModelConfig:
         skip_mm_profiling: bool | None,
         video_pruning_rate: float | None,
         mm_tensor_ipc: MMTensorIPC,
+        mm_ipc_gpu_memory_gb: float | None,
     ) -> None:
         # Keep set served_model_name before maybe_model_redirect(self.model)
         self.served_model_name = get_served_model_name(
@@ -706,6 +709,7 @@ class ModelConfig:
                 skip_mm_profiling=skip_mm_profiling,
                 video_pruning_rate=video_pruning_rate,
                 mm_tensor_ipc=mm_tensor_ipc,
+                mm_ipc_gpu_memory_gb=mm_ipc_gpu_memory_gb,
             )
 
             mm_config_kwargs = {

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -197,6 +197,16 @@ class MultiModalConfig:
     - "direct_rpc": Use msgspec serialization via RPC
     - "torch_shm": Use torch.multiprocessing shared memory for zero-copy IPC
     Defaults to "direct_rpc". """
+    mm_ipc_gpu_memory_gb: float = Field(default=0, ge=0)
+    """Amount of GPU memory (in GiB) sequestered on the engine's device for
+    GPU-side multimodal work in the API-server (frontend) process, such as
+    hardware video decoding.
+
+    This budget is carved out of the engine's KV-cache memory so the headroom
+    physically exists, and frontend GPU decode paths acquire from a blocking
+    byte-counting semaphore of this size before allocating on the device.
+
+    Set to `0` (default) to disable frontend GPU multimodal memory gating."""
 
     @field_validator("limit_per_prompt", mode="before")
     @classmethod

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -67,8 +67,7 @@ class ObservabilityConfig:
 
     enable_mm_processor_stats: bool = False
     """Enable collection of timing statistics for multimodal processor operations.
-    This is for internal use only (e.g., benchmarks) and is not exposed as a CLI
-    argument."""
+    Exposed as ``--enable-mm-processor-stats`` CLI flag."""
 
     enable_logging_iteration_details: bool = False
     """Enable detailed logging of iteration details.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1354,6 +1354,10 @@ class EngineArgs:
             "--enable-logging-iteration-details",
             **observability_kwargs["enable_logging_iteration_details"],
         )
+        observability_group.add_argument(
+            "--enable-mm-processor-stats",
+            **observability_kwargs["enable_mm_processor_stats"],
+        )
 
         # Scheduler arguments
         scheduler_kwargs = get_kwargs(SchedulerConfig)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -577,6 +577,8 @@ class EngineArgs:
     skip_mm_profiling: bool = MultiModalConfig.skip_mm_profiling
     video_pruning_rate: float | None = MultiModalConfig.video_pruning_rate
     mm_tensor_ipc: MMTensorIPC = MultiModalConfig.mm_tensor_ipc
+    mm_ipc_gpu_memory_gb: float = MultiModalConfig.mm_ipc_gpu_memory_gb
+
     # LoRA fields
     enable_lora: bool = False
     max_loras: int = LoRAConfig.max_loras
@@ -1269,6 +1271,10 @@ class EngineArgs:
         multimodal_group.add_argument(
             "--mm-tensor-ipc", **multimodal_kwargs["mm_tensor_ipc"]
         )
+        multimodal_group.add_argument(
+            "--mm-ipc-gpu-memory-gb",
+            **multimodal_kwargs["mm_ipc_gpu_memory_gb"],
+        )
 
         # LoRA related configs
         lora_kwargs = get_kwargs(LoRAConfig)
@@ -1626,6 +1632,7 @@ class EngineArgs:
             logits_processors=self.logits_processors,
             video_pruning_rate=self.video_pruning_rate,
             mm_tensor_ipc=self.mm_tensor_ipc,
+            mm_ipc_gpu_memory_gb=self.mm_ipc_gpu_memory_gb,
             io_processor_plugin=self.io_processor_plugin,
             renderer_num_workers=self.renderer_num_workers,
         )

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -779,6 +779,16 @@ def _resolve_items(
 
 
 class MultiModalItemTracker(BaseMultiModalItemTracker[tuple[object, str | None]]):
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        *,
+        media_io_kwargs: dict[str, dict[str, Any]] | None = None,
+        timing_ctx: Any | None = None,
+    ):
+        super().__init__(model_config, media_io_kwargs=media_io_kwargs)
+        self._timing_ctx = timing_ctx
+
     def resolve_items(
         self,
     ) -> tuple[MultiModalDataDict | None, MultiModalUUIDDict | None]:
@@ -806,6 +816,10 @@ class MultiModalItemTracker(BaseMultiModalItemTracker[tuple[object, str | None]]
 class AsyncMultiModalItemTracker(
     BaseMultiModalItemTracker[Awaitable[tuple[object, str | None]]]
 ):
+    def __init__(self, model_config, *, media_io_kwargs=None, timing_ctx=None):
+        super().__init__(model_config, media_io_kwargs=media_io_kwargs)
+        self._timing_ctx = timing_ctx
+
     async def resolve_items(
         self,
     ) -> tuple[MultiModalDataDict | None, MultiModalUUIDDict | None]:
@@ -944,7 +958,14 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("prompt_embeds", PROMPT_EMBEDS_PLACEHOLDER_TOKEN)
 
     def parse_image(self, image_url: str | None, uuid: str | None = None) -> None:
-        image = self._connector.fetch_image(image_url) if image_url else None
+        timing_ctx = self._tracker._timing_ctx
+        if image_url:
+            image = self._connector.fetch_image(
+                image_url,
+                timing_ctx=timing_ctx,
+            )
+        else:
+            image = None
 
         placeholder = self._tracker.add("image", (image, uuid))
         self._add_placeholder("image", placeholder)
@@ -1008,7 +1029,14 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("image", placeholder)
 
     def parse_audio(self, audio_url: str | None, uuid: str | None = None) -> None:
-        audio = self._connector.fetch_audio(audio_url) if audio_url else None
+        timing_ctx = self._tracker._timing_ctx
+        if audio_url:
+            audio = self._connector.fetch_audio(
+                audio_url,
+                timing_ctx=timing_ctx,
+            )
+        else:
+            audio = None
 
         placeholder = self._tracker.add("audio", (audio, uuid))
         self._add_placeholder("audio", placeholder)
@@ -1030,14 +1058,15 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         return self.parse_audio(audio_url, uuid)
 
     def parse_video(self, video_url: str | None, uuid: str | None = None) -> None:
-        video = (
-            self._connector.fetch_video(
+        timing_ctx = self._tracker._timing_ctx
+        if video_url:
+            video = self._connector.fetch_video(
                 video_url=video_url,
                 video_processor=self._tracker.video_processor_name,
+                timing_ctx=timing_ctx,
             )
-            if video_url
-            else None
-        )
+        else:
+            video = None
 
         placeholder = self._tracker.add("video", (video, uuid))
         self._add_placeholder("video", placeholder)
@@ -1048,7 +1077,10 @@ class MultiModalContentParser(BaseMultiModalContentParser):
             and self._mm_processor_kwargs
             and self._mm_processor_kwargs.get("use_audio_in_video", False)
         ):
-            audio = self._connector.fetch_audio(video_url) if video_url else None
+            audio = self._connector.fetch_audio(
+                video_url,
+                timing_ctx=timing_ctx,
+            )
             audio_placeholder = self._tracker.add("audio", (audio, uuid))
             self._add_placeholder("audio", audio_placeholder)
 
@@ -1098,9 +1130,14 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return tensor, None
 
     async def _image_with_uuid_async(self, image_url: str | None, uuid: str | None):
-        image = (
-            await self._connector.fetch_image_async(image_url) if image_url else None
-        )
+        timing_ctx = self._tracker._timing_ctx
+        if image_url:
+            image = await self._connector.fetch_image_async(
+                image_url,
+                timing_ctx=timing_ctx,
+            )
+        else:
+            image = None
         return image, uuid
 
     def parse_image(self, image_url: str | None, uuid: str | None = None) -> None:
@@ -1188,9 +1225,14 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("image", placeholder)
 
     async def _audio_with_uuid_async(self, audio_url: str | None, uuid: str | None):
-        audio = (
-            await self._connector.fetch_audio_async(audio_url) if audio_url else None
-        )
+        timing_ctx = self._tracker._timing_ctx
+        if audio_url:
+            audio = await self._connector.fetch_audio_async(
+                audio_url,
+                timing_ctx=timing_ctx,
+            )
+        else:
+            audio = None
         return audio, uuid
 
     def parse_audio(self, audio_url: str | None, uuid: str | None = None) -> None:
@@ -1216,14 +1258,15 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return self.parse_audio(audio_url, uuid)
 
     async def _video_with_uuid_async(self, video_url: str | None, uuid: str | None):
-        video = (
-            await self._connector.fetch_video_async(
+        timing_ctx = self._tracker._timing_ctx
+        if video_url:
+            video = await self._connector.fetch_video_async(
                 video_url,
                 video_processor=self._tracker.video_processor_name,
+                timing_ctx=timing_ctx,
             )
-            if video_url
-            else None
-        )
+        else:
+            video = None
         return video, uuid
 
     def parse_video(self, video_url: str | None, uuid: str | None = None) -> None:
@@ -1865,6 +1908,8 @@ def parse_chat_messages(
     content_format: ChatTemplateContentFormat,
     media_io_kwargs: dict[str, dict[str, Any]] | None = None,
     mm_processor_kwargs: dict[str, Any] | None = None,
+    *,
+    timing_ctx: Any | None = None,
 ) -> tuple[
     list[ConversationMessage],
     MultiModalDataDict | None,
@@ -1874,6 +1919,7 @@ def parse_chat_messages(
     mm_tracker = MultiModalItemTracker(
         model_config,
         media_io_kwargs=media_io_kwargs,
+        timing_ctx=timing_ctx,
     )
 
     for msg in messages:
@@ -1904,6 +1950,8 @@ async def parse_chat_messages_async(
     content_format: ChatTemplateContentFormat,
     media_io_kwargs: dict[str, dict[str, Any]] | None = None,
     mm_processor_kwargs: dict[str, Any] | None = None,
+    *,
+    timing_ctx: Any | None = None,
 ) -> tuple[
     list[ConversationMessage],
     MultiModalDataDict | None,
@@ -1913,6 +1961,7 @@ async def parse_chat_messages_async(
     mm_tracker = AsyncMultiModalItemTracker(
         model_config,
         media_io_kwargs=media_io_kwargs,
+        timing_ctx=timing_ctx,
     )
 
     for msg in messages:

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -25,6 +25,12 @@ def register_vllm_serve_api_routers(app: FastAPI):
 
     attach_profile_router(app)
 
+    from vllm.entrypoints.serve.mm_processor.api_router import (
+        attach_router as attach_mm_processor_router,
+    )
+
+    attach_mm_processor_router(app)
+
     from vllm.entrypoints.serve.tokenize.api_router import (
         attach_router as attach_tokenize_router,
     )
@@ -41,12 +47,6 @@ def register_vllm_dev_api_routers(app: FastAPI):
     from .dev.cache.api_router import attach_router as attach_cache_router
 
     attach_cache_router(app)
-
-    from vllm.entrypoints.serve.mm_processor.api_router import (
-        attach_router as attach_mm_processor_router,
-    )
-
-    attach_mm_processor_router(app)
 
     from .dev.rlhf.api_router import attach_router as attach_rlhf_router
 

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -42,6 +42,12 @@ def register_vllm_dev_api_routers(app: FastAPI):
 
     attach_cache_router(app)
 
+    from vllm.entrypoints.serve.mm_processor.api_router import (
+        attach_router as attach_mm_processor_router,
+    )
+
+    attach_mm_processor_router(app)
+
     from .dev.rlhf.api_router import attach_router as attach_rlhf_router
 
     attach_rlhf_router(app)

--- a/vllm/entrypoints/serve/mm_processor/__init__.py
+++ b/vllm/entrypoints/serve/mm_processor/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/serve/mm_processor/api_router.py
+++ b/vllm/entrypoints/serve/mm_processor/api_router.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/mm_processor_stats")
+async def get_mm_processor_stats(request: Request):
+    """Return per-request multimodal processor timing stats.
+
+    Collects preprocessing stats from the renderer's timing registry and
+    encoder stats from GPU workers via collective_rpc, then merges them
+    by request_id.
+
+    This endpoint is only available when ``--enable-mm-processor-stats``
+    is set on the server. Both registries use clear-on-read semantics,
+    so calling this endpoint drains accumulated stats.
+    """
+    # 1. Preprocessing stats (API process, clear-on-read)
+    renderer = request.app.state.openai_serving_render.renderer
+    preprocess_stats = renderer._mm_timing_registry.stat()
+
+    # 2. Encoder stats (worker process, via collective_rpc, clear-on-read)
+    engine_client = request.app.state.engine_client
+    encoder_results = await engine_client.collective_rpc("get_encoder_timing_stats")
+
+    # 3. Merge preprocessing + encoder stats
+    # Import here to avoid circular imports at module level
+    from vllm.benchmarks.mm_processor import merge_timing_stats
+
+    merged = merge_timing_stats(preprocess_stats, encoder_results)
+
+    return JSONResponse(content={"mm_processor_stats": merged})
+
+
+def attach_router(app: FastAPI):
+    if getattr(app.state.args, "enable_mm_processor_stats", False):
+        app.include_router(router)

--- a/vllm/entrypoints/serve/mm_processor/api_router.py
+++ b/vllm/entrypoints/serve/mm_processor/api_router.py
@@ -11,6 +11,69 @@ logger = init_logger(__name__)
 router = APIRouter()
 
 
+def _merge_timing_stats(
+    preprocess_stats: dict[str, dict[str, float]],
+    encoder_results: list[dict[str, dict[str, float | int]] | None],
+) -> dict[str, dict[str, float]]:
+    """Merge preprocessing stats with encoder stats collected from workers.
+
+    Args:
+        preprocess_stats: Per-request preprocessing stats from
+            ``renderer._mm_timing_registry.stat()``.
+        encoder_results: List of per-worker results from
+            ``collective_rpc("get_encoder_timing_stats")``.
+
+    Returns:
+        Dictionary mapping request_id to merged stats dict.
+    """
+    # Aggregate encoder stats across workers (take max)
+    encoder_stats: dict[str, dict[str, float]] = {}
+    for worker_stats in encoder_results:
+        if not worker_stats:
+            continue
+
+        for request_id, stats_dict in worker_stats.items():
+            if request_id not in encoder_stats:
+                encoder_stats[request_id] = dict(stats_dict)
+            else:
+                current_time = encoder_stats[request_id].get(
+                    "encoder_forward_secs", 0.0
+                )
+                new_time = stats_dict.get("encoder_forward_secs", 0.0)
+                encoder_stats[request_id]["encoder_forward_secs"] = max(
+                    current_time, new_time
+                )
+
+                current_calls = encoder_stats[request_id].get("num_encoder_calls", 0)
+                new_calls = stats_dict.get("num_encoder_calls", 0)
+                encoder_stats[request_id]["num_encoder_calls"] = max(
+                    current_calls, new_calls
+                )
+
+    # Merge preprocessing + encoder by request_id
+    merged_stats: dict[str, dict[str, float]] = {}
+
+    for request_id, prep_dict in preprocess_stats.items():
+        merged_stats[request_id] = dict(prep_dict)
+
+    for request_id, enc_dict in encoder_stats.items():
+        if request_id in merged_stats:
+            merged_stats[request_id].update(enc_dict)
+        else:
+            # V1 engine may append worker suffix to request_id
+            # (e.g., "req-123" -> "req-123-0"), try suffix-stripping
+            matched = False
+            for existing_id in list(merged_stats.keys()):
+                if existing_id.startswith(request_id):
+                    merged_stats[existing_id].update(enc_dict)
+                    matched = True
+                    break
+            if not matched:
+                merged_stats[request_id] = dict(enc_dict)
+
+    return merged_stats
+
+
 @router.get("/mm_processor_stats")
 async def get_mm_processor_stats(request: Request):
     """Return per-request multimodal processor timing stats.
@@ -32,10 +95,7 @@ async def get_mm_processor_stats(request: Request):
     encoder_results = await engine_client.collective_rpc("get_encoder_timing_stats")
 
     # 3. Merge preprocessing + encoder stats
-    # Import here to avoid circular imports at module level
-    from vllm.benchmarks.mm_processor import merge_timing_stats
-
-    merged = merge_timing_stats(preprocess_stats, encoder_results)
+    merged = _merge_timing_stats(preprocess_stats, encoder_results)
 
     return JSONResponse(content={"mm_processor_stats": merged})
 

--- a/vllm/multimodal/gpu_ipc_memory.py
+++ b/vllm/multimodal/gpu_ipc_memory.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Admission control for frontend GPU-side multimodal work.
+
+When multimodal media is decoded on the GPU in the API-server (frontend)
+process, the decoded buffers compete for the same device memory that the
+engine reserves for weights, activations, and the KV cache. To keep the
+frontend's GPU usage within a sequestered budget (see
+``MultiModalConfig.mm_ipc_gpu_memory_gb``), decode paths acquire the number of
+bytes they need from a process-global :class:`MultiModalGPUMemoryPool` before
+allocating on the device and release them once the device memory is freed.
+
+The pool is a simple byte-counting semaphore: ``acquire`` blocks until enough
+budget is free, so concurrent requests serialize rather than oversubscribe the
+GPU. It lives only in the frontend process; the engine carves the matching
+amount out of its KV-cache budget so the headroom physically exists.
+"""
+
+import threading
+
+from vllm.logger import init_logger
+from vllm.utils.mem_constants import GiB_bytes
+
+logger = init_logger(__name__)
+
+
+class MultiModalGPUMemoryLease:
+    """A handle for bytes acquired from a :class:`MultiModalGPUMemoryPool`.
+
+    Releasing is idempotent and the lease doubles as a context manager so the
+    budget is returned even if the decode raises.
+    """
+
+    def __init__(self, pool: "MultiModalGPUMemoryPool", lease_id: int, nbytes: int):
+        self.lease_id = lease_id
+        self.nbytes = nbytes
+        self._pool = pool
+
+    def release(self) -> None:
+        self._pool._release(self)
+
+    def __enter__(self) -> "MultiModalGPUMemoryLease":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.release()
+
+
+class MultiModalGPUMemoryPool:
+    """Blocking byte-counting semaphore for frontend GPU multimodal memory.
+
+    Thread-safe in both directions: ``acquire`` (blocking) and ``release`` are
+    typically called from the renderer's multimodal executor threads.
+    """
+
+    def __init__(self, total_bytes: int):
+        if total_bytes <= 0:
+            raise ValueError(f"total_bytes must be positive, got {total_bytes}")
+        self._total_bytes = total_bytes
+        self._available = total_bytes
+        self._cond = threading.Condition()
+        self._next_lease_id = 0
+        # Outstanding lease ids, so a double release is a no-op.
+        self._outstanding: set[int] = set()
+
+    @property
+    def total_bytes(self) -> int:
+        return self._total_bytes
+
+    @property
+    def available_bytes(self) -> int:
+        with self._cond:
+            return self._available
+
+    def acquire(self, nbytes: int) -> MultiModalGPUMemoryLease:
+        """Reserve ``nbytes``, blocking until that much budget is free.
+
+        Raises ``ValueError`` if ``nbytes`` exceeds the pool's total capacity,
+        since such a request could never be satisfied.
+        """
+        if nbytes < 0:
+            raise ValueError(f"Cannot acquire negative bytes: {nbytes}")
+        if nbytes > self._total_bytes:
+            raise ValueError(
+                f"Multimodal GPU decode requested {nbytes} bytes, which exceeds "
+                f"the total pool size of {self._total_bytes} bytes. Increase "
+                f"--mm-ipc-gpu-memory-gb or reduce the multimodal input size."
+            )
+        with self._cond:
+            while self._available < nbytes:
+                self._cond.wait()
+            self._available -= nbytes
+            lease_id = self._next_lease_id
+            self._next_lease_id += 1
+            self._outstanding.add(lease_id)
+        return MultiModalGPUMemoryLease(self, lease_id, nbytes)
+
+    def _release(self, lease: MultiModalGPUMemoryLease) -> None:
+        with self._cond:
+            if lease.lease_id not in self._outstanding:
+                # Already released — idempotent.
+                return
+            self._outstanding.discard(lease.lease_id)
+            self._available += lease.nbytes
+            self._cond.notify_all()
+
+
+_GLOBAL_POOL: MultiModalGPUMemoryPool | None = None
+
+
+def set_mm_gpu_ipc_pool(pool: MultiModalGPUMemoryPool | None) -> None:
+    """Install the process-global pool (frontend process only)."""
+    global _GLOBAL_POOL
+    _GLOBAL_POOL = pool
+
+
+def get_mm_gpu_ipc_pool() -> MultiModalGPUMemoryPool | None:
+    """Return the process-global pool, or ``None`` when gating is disabled."""
+    return _GLOBAL_POOL
+
+
+def maybe_init_mm_gpu_ipc_pool(
+    mm_ipc_gpu_memory_gb: float,
+    api_process_count: int = 1,
+) -> MultiModalGPUMemoryPool | None:
+    """Create and install the global pool from the configured GiB budget.
+
+    Returns ``None`` (and leaves gating disabled) when the budget is 0. When
+    multiple API-server processes share one engine, each process gets an equal
+    slice of the user-provided frontend budget.
+    """
+    if mm_ipc_gpu_memory_gb <= 0:
+        set_mm_gpu_ipc_pool(None)
+        return None
+    if api_process_count <= 0:
+        raise ValueError(f"api_process_count must be positive, got {api_process_count}")
+    total_bytes = int(mm_ipc_gpu_memory_gb * GiB_bytes) // api_process_count
+    pool = MultiModalGPUMemoryPool(total_bytes)
+    set_mm_gpu_ipc_pool(pool)
+    logger.info(
+        "Initialized multimodal GPU IPC memory pool with %d bytes for this API "
+        "process (%.2f GiB total budget across %d API process(es)).",
+        total_bytes,
+        mm_ipc_gpu_memory_gb,
+        api_process_count,
+    )
+    return pool

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -289,9 +289,17 @@ class MediaConnector:
         media_io: MediaIO[_M],
         *,
         fetch_timeout: int | None = None,
+        timing_ctx: Any | None = None,
+        stage_prefix: str | None = None,
     ) -> _M:  # type: ignore[type-var]
         if url[:5].lower() == "data:":
-            return self._load_data_url(url, media_io)
+            decode_cm = (
+                timing_ctx.record(f"{stage_prefix}_decode")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
+            )
+            with decode_cm:
+                return self._load_data_url(url, media_io)
 
         url_spec = parse_url(url)
 
@@ -300,20 +308,51 @@ class MediaConnector:
 
             cached = self._get_cached_bytes(url)
             if cached is not None:
-                return media_io.load_bytes(cached)
+                fetch_cm = (
+                    timing_ctx.record(f"{stage_prefix}_fetch_bytes")
+                    if timing_ctx and stage_prefix
+                    else contextlib.nullcontext()
+                )
+                with fetch_cm:
+                    pass  # cache hit, negligible time
+                decode_cm = (
+                    timing_ctx.record(f"{stage_prefix}_decode")
+                    if timing_ctx and stage_prefix
+                    else contextlib.nullcontext()
+                )
+                with decode_cm:
+                    return media_io.load_bytes(cached)
 
             connection = self.connection
-            data = connection.get_bytes(
-                url_spec.url,
-                timeout=fetch_timeout,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+            fetch_cm = (
+                timing_ctx.record(f"{stage_prefix}_fetch_bytes")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
             )
+            with fetch_cm:
+                data = connection.get_bytes(
+                    url_spec.url,
+                    timeout=fetch_timeout,
+                    allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                )
+                self._put_cached_bytes(url, data)
 
-            self._put_cached_bytes(url, data)
-            return media_io.load_bytes(data)
+            decode_cm = (
+                timing_ctx.record(f"{stage_prefix}_decode")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
+            )
+            with decode_cm:
+                return media_io.load_bytes(data)
 
         if url_spec.scheme == "file":
-            return self._load_file_url(url_spec, media_io)
+            decode_cm = (
+                timing_ctx.record(f"{stage_prefix}_decode")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
+            )
+            with decode_cm:
+                return self._load_file_url(url_spec, media_io)
 
         msg = "The URL must be either a HTTP, data or file URL."
         raise ValueError(msg)
@@ -324,14 +363,22 @@ class MediaConnector:
         media_io: MediaIO[_M],
         *,
         fetch_timeout: int | None = None,
+        timing_ctx: Any | None = None,
+        stage_prefix: str | None = None,
     ) -> _M:
         loop = asyncio.get_running_loop()
 
         if url[:5].lower() == "data:":
-            future = loop.run_in_executor(
-                global_thread_pool, self._load_data_url, url, media_io
+            decode_cm = (
+                timing_ctx.record(f"{stage_prefix}_decode")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
             )
-            return await future
+            with decode_cm:
+                future = loop.run_in_executor(
+                    global_thread_pool, self._load_data_url, url, media_io
+                )
+                return await future
 
         url_spec = parse_url(url)
 
@@ -342,35 +389,63 @@ class MediaConnector:
                 global_thread_pool, self._get_cached_bytes, url
             )
             if cached is not None:
+                decode_cm = (
+                    timing_ctx.record(f"{stage_prefix}_decode")
+                    if timing_ctx and stage_prefix
+                    else contextlib.nullcontext()
+                )
+                with decode_cm:
+                    future = loop.run_in_executor(
+                        global_thread_pool, media_io.load_bytes, cached
+                    )
+                    return await future
+
+            connection = self.connection
+            fetch_cm = (
+                timing_ctx.record(f"{stage_prefix}_fetch_bytes")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
+            )
+            with fetch_cm:
+                data = await connection.async_get_bytes(
+                    url_spec.url,
+                    timeout=fetch_timeout,
+                    allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                )
+                await loop.run_in_executor(
+                    global_thread_pool, self._put_cached_bytes, url, data
+                )
+
+            decode_cm = (
+                timing_ctx.record(f"{stage_prefix}_decode")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
+            )
+            with decode_cm:
                 future = loop.run_in_executor(
-                    global_thread_pool, media_io.load_bytes, cached
+                    global_thread_pool, media_io.load_bytes, data
                 )
                 return await future
 
-            connection = self.connection
-            data = await connection.async_get_bytes(
-                url_spec.url,
-                timeout=fetch_timeout,
-                allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
-            )
-
-            await loop.run_in_executor(
-                global_thread_pool, self._put_cached_bytes, url, data
-            )
-            future = loop.run_in_executor(global_thread_pool, media_io.load_bytes, data)
-            return await future
-
         if url_spec.scheme == "file":
-            future = loop.run_in_executor(
-                global_thread_pool, self._load_file_url, url_spec, media_io
+            decode_cm = (
+                timing_ctx.record(f"{stage_prefix}_decode")
+                if timing_ctx and stage_prefix
+                else contextlib.nullcontext()
             )
-            return await future
+            with decode_cm:
+                future = loop.run_in_executor(
+                    global_thread_pool, self._load_file_url, url_spec, media_io
+                )
+                return await future
         msg = "The URL must be either a HTTP, data or file URL."
         raise ValueError(msg)
 
     def fetch_audio(
         self,
         audio_url: str,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[np.ndarray, int | float]:
         """
         Load audio from a URL.
@@ -381,11 +456,15 @@ class MediaConnector:
             audio_url,
             audio_io,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
+            timing_ctx=timing_ctx,
+            stage_prefix="audio",
         )
 
     async def fetch_audio_async(
         self,
         audio_url: str,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[np.ndarray, int | float]:
         """
         Asynchronously fetch audio from a URL.
@@ -396,6 +475,8 @@ class MediaConnector:
             audio_url,
             audio_io,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
+            timing_ctx=timing_ctx,
+            stage_prefix="audio",
         )
 
     def fetch_image(
@@ -403,6 +484,7 @@ class MediaConnector:
         image_url: str,
         *,
         image_mode: str = "RGB",
+        timing_ctx: Any | None = None,
     ) -> Image.Image:
         """
         Load a PIL image from an HTTP or base64 data URL.
@@ -418,6 +500,8 @@ class MediaConnector:
                 image_url,
                 image_io,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
+                timing_ctx=timing_ctx,
+                stage_prefix="image",
             )
         except UnidentifiedImageError as e:
             # convert to ValueError to be properly caught upstream
@@ -428,6 +512,7 @@ class MediaConnector:
         image_url: str,
         *,
         image_mode: str = "RGB",
+        timing_ctx: Any | None = None,
     ) -> Image.Image:
         """
         Asynchronously load a PIL image from an HTTP or base64 data URL.
@@ -443,6 +528,8 @@ class MediaConnector:
                 image_url,
                 image_io,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
+                timing_ctx=timing_ctx,
+                stage_prefix="image",
             )
         except UnidentifiedImageError as e:
             # convert to ValueError to be properly caught upstream
@@ -454,6 +541,7 @@ class MediaConnector:
         *,
         image_mode: str = "RGB",
         video_processor: str | None = None,
+        timing_ctx: Any | None = None,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         """
         Load video from an HTTP or base64 data URL.
@@ -472,6 +560,8 @@ class MediaConnector:
             video_url,
             video_io,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
+            timing_ctx=timing_ctx,
+            stage_prefix="video",
         )
 
     async def fetch_video_async(
@@ -480,6 +570,7 @@ class MediaConnector:
         *,
         image_mode: str = "RGB",
         video_processor: str | None = None,
+        timing_ctx: Any | None = None,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         """
         Asynchronously load video from an HTTP or base64 data URL.
@@ -500,6 +591,8 @@ class MediaConnector:
             video_url,
             video_io,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
+            timing_ctx=timing_ctx,
+            stage_prefix="video",
         )
 
     def fetch_image_embedding(

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, ItemsView, Iterable, Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from functools import lru_cache, partial
@@ -1138,6 +1139,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         mm_items: MultiModalDataItems,
         hf_processor_mm_kwargs: Mapping[str, object],
         tokenization_kwargs: Mapping[str, object],
+        *,
+        timing_ctx: TimingContext | None = None,
     ) -> tuple[list[int], BatchFeature, bool]:
         """
         Apply the HF processor on the prompt text and multi-modal data
@@ -1148,14 +1151,17 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         valid_mm_items = mm_items.select(
             {k for k, c in mm_items.get_all_counts().items() if c > 0}
         )
-        processor_data, passthrough_data = self._get_hf_mm_data(valid_mm_items)
 
-        processed_data = self._call_hf_processor(
-            prompt=prompt_text,
-            mm_data=processor_data,
-            mm_kwargs=hf_processor_mm_kwargs,
-            tok_kwargs=tokenization_kwargs,
-        )
+        with timing_ctx.record("hf_data_prep") if timing_ctx else nullcontext():
+            processor_data, passthrough_data = self._get_hf_mm_data(valid_mm_items)
+
+        with timing_ctx.record("hf_processor_call") if timing_ctx else nullcontext():
+            processed_data = self._call_hf_processor(
+                prompt=prompt_text,
+                mm_data=processor_data,
+                mm_kwargs=hf_processor_mm_kwargs,
+                tok_kwargs=tokenization_kwargs,
+            )
         processed_data.update(passthrough_data)
 
         input_ids = processed_data.pop("input_ids")
@@ -1216,6 +1222,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         mm_items: MultiModalDataItems,
         hf_processor_mm_kwargs: Mapping[str, object],
         tokenization_kwargs: Mapping[str, object],
+        *,
+        timing_ctx: TimingContext | None = None,
     ) -> BatchFeature:
         """
         Apply the HF processor on the multi-modal data only.
@@ -1234,6 +1242,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                 mm_items=mm_items,
                 hf_processor_mm_kwargs=hf_processor_mm_kwargs,
                 tokenization_kwargs=tokenization_kwargs,
+                timing_ctx=timing_ctx,
             )
 
             return mm_processed_data
@@ -1241,16 +1250,19 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         valid_mm_items = mm_items.select(
             {k for k, c in mm_items.get_all_counts().items() if c > 0}
         )
-        processor_data, passthrough_data = self._get_hf_mm_data(valid_mm_items)
 
-        processed_data = self.info.ctx.call_hf_processor(
-            partial(
-                call_hf_processor_mm_only,
-                self.info.get_hf_processor(**hf_processor_mm_kwargs),
-            ),
-            processor_data,
-            dict(**hf_processor_mm_kwargs, **tokenization_kwargs),
-        )
+        with timing_ctx.record("hf_data_prep") if timing_ctx else nullcontext():
+            processor_data, passthrough_data = self._get_hf_mm_data(valid_mm_items)
+
+        with timing_ctx.record("hf_processor_call") if timing_ctx else nullcontext():
+            processed_data = self.info.ctx.call_hf_processor(
+                partial(
+                    call_hf_processor_mm_only,
+                    self.info.get_hf_processor(**hf_processor_mm_kwargs),
+                ),
+                processor_data,
+                dict(**hf_processor_mm_kwargs, **tokenization_kwargs),
+            )
         processed_data.update(passthrough_data)
 
         return processed_data
@@ -1263,6 +1275,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         tokenization_kwargs: Mapping[str, object],
         *,
         enable_hf_prompt_update: bool,
+        timing_ctx: TimingContext | None = None,
     ) -> tuple[list[int], BatchFeature, bool]:
         """
         Apply the HF processor on the prompt text and multi-modal data.
@@ -1282,6 +1295,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                     mm_items=mm_items,
                     hf_processor_mm_kwargs=hf_processor_mm_kwargs,
                     tokenization_kwargs=tokenization_kwargs,
+                    timing_ctx=timing_ctx,
                 )
 
             prompt_ids = self._apply_hf_processor_text_only(prompt, tokenization_kwargs)
@@ -1292,6 +1306,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_items=mm_items,
             hf_processor_mm_kwargs=hf_processor_mm_kwargs,
             tokenization_kwargs=tokenization_kwargs,
+            timing_ctx=timing_ctx,
         )
 
         return prompt_ids, mm_processed_data, False
@@ -1400,25 +1415,26 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         inputs: ProcessorInputs,
         timing_ctx: TimingContext,
     ) -> tuple[list[int], MultiModalProcessingInfo, bool]:
-        with timing_ctx.record("apply_hf_processor"):
-            (
-                prompt_ids,
-                mm_processed_data,
-                is_update_applied,
-            ) = self._apply_hf_processor_main(
-                prompt=inputs.prompt,
-                mm_items=inputs.mm_data_items,
-                hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
-                tokenization_kwargs=inputs.tokenization_kwargs,
-                enable_hf_prompt_update=True,
-            )
-
-        mm_kwargs = MultiModalKwargsItems.from_hf_inputs(
+        (
+            prompt_ids,
             mm_processed_data,
-            self._get_mm_fields_config(
-                mm_processed_data, inputs.hf_processor_mm_kwargs
-            ),
+            is_update_applied,
+        ) = self._apply_hf_processor_main(
+            prompt=inputs.prompt,
+            mm_items=inputs.mm_data_items,
+            hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
+            tokenization_kwargs=inputs.tokenization_kwargs,
+            enable_hf_prompt_update=True,
+            timing_ctx=timing_ctx,
         )
+
+        with timing_ctx.record("hf_postprocess") if timing_ctx else nullcontext():
+            mm_kwargs = MultiModalKwargsItems.from_hf_inputs(
+                mm_processed_data,
+                self._get_mm_fields_config(
+                    mm_processed_data, inputs.hf_processor_mm_kwargs
+                ),
+            )
 
         # Use overrides if provided; fallback to data-dependent hashing.
         with timing_ctx.record("get_mm_hashes"):
@@ -1466,25 +1482,26 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         # NOTE: `prompt` does not correspond to `mm_missing_data_items`,
         # so we can't apply prompt updates until the new multimodal
         # items are combined with the cached multimodal items
-        with timing_ctx.record("apply_hf_processor"):
-            (
-                prompt_ids,
-                mm_missing_processed_data,
-                is_update_applied,
-            ) = self._apply_hf_processor_main(
-                prompt=inputs.prompt,
-                mm_items=mm_missing_data_items,
-                hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
-                tokenization_kwargs=inputs.tokenization_kwargs,
-                enable_hf_prompt_update=False,
-            )
-
-        mm_missing_kwargs = MultiModalKwargsItems.from_hf_inputs(
+        (
+            prompt_ids,
             mm_missing_processed_data,
-            self._get_mm_fields_config(
-                mm_missing_processed_data, inputs.hf_processor_mm_kwargs
-            ),
+            is_update_applied,
+        ) = self._apply_hf_processor_main(
+            prompt=inputs.prompt,
+            mm_items=mm_missing_data_items,
+            hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
+            tokenization_kwargs=inputs.tokenization_kwargs,
+            enable_hf_prompt_update=False,
+            timing_ctx=timing_ctx,
         )
+
+        with timing_ctx.record("hf_postprocess") if timing_ctx else nullcontext():
+            mm_missing_kwargs = MultiModalKwargsItems.from_hf_inputs(
+                mm_missing_processed_data,
+                self._get_mm_fields_config(
+                    mm_missing_processed_data, inputs.hf_processor_mm_kwargs
+                ),
+            )
 
         mm_missing_prompt_updates = self._get_mm_prompt_updates(
             mm_missing_data_items,

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -801,6 +801,130 @@ class GLMGAVideoBackend(VideoBackend):
 
 
 @VIDEO_LOADER_REGISTRY.register(
+    "glm46v",
+    video_processor="Glm46VVideoProcessor",
+)
+class GLM46VVideoBackend(VideoBackend):
+    """GLM-4.6V dynamic FPS video backend.
+
+    Faithfully replicates the frame sampling logic from transformers'
+    ``Glm46VVideoProcessor.sample_frames``:
+
+    - Dynamic FPS thresholds based on effective video duration:
+      ``{≤30s: 3fps, ≤300s: 1fps, >300s: 0.5fps}``
+    - ``temporal_patch_size`` multiplier (default 2) applied to extract count
+    - Duration capped at 2400s, frame count capped at 640
+    - Even frame count enforced (append last frame if odd)
+    """
+
+    # Match transformers defaults
+    _DYNAMIC_FPS_THRESHOLDS: ClassVar[dict[int, float]] = {
+        30: 3.0,
+        300: 1.0,
+        2400: 0.5,
+    }
+    _MAX_FRAME_COUNT_DYNAMIC: ClassVar[int] = 640
+    _MAX_DURATION: ClassVar[int] = 2400
+
+    @classmethod
+    def compute_frames_index_to_sample(
+        cls,
+        source: VideoSourceMetadata,
+        target: VideoTargetMetadata,
+        **kwargs,
+    ) -> list[int]:
+        total_frames_num = source.total_frames_num
+        original_fps = source.original_fps
+        duration = source.duration
+        temporal_patch_size = kwargs.get("temporal_patch_size", 2)
+
+        max_frame_idx = total_frames_num - 1
+
+        # Estimate duration from frame count and fps when not reported
+        if not duration and original_fps > 0:
+            duration = round(max_frame_idx / original_fps) + 1
+
+        effective_duration = min(duration, cls._MAX_DURATION)
+
+        # Select target_fps from dynamic thresholds
+        if effective_duration <= 30:
+            target_fps = cls._DYNAMIC_FPS_THRESHOLDS[30]
+        elif effective_duration <= 300:
+            target_fps = cls._DYNAMIC_FPS_THRESHOLDS[300]
+        else:
+            target_fps = cls._DYNAMIC_FPS_THRESHOLDS[2400]
+
+        extract_t = int(effective_duration * target_fps * temporal_patch_size)
+        extract_t = min(extract_t, cls._MAX_FRAME_COUNT_DYNAMIC)
+
+        duration_per_frame = 1 / original_fps if original_fps > 0 else 0
+        timestamps = [i * duration_per_frame for i in range(total_frames_num)]
+        max_second = int(duration) if duration else 0
+
+        if total_frames_num < extract_t:
+            frame_indices = np.linspace(
+                0, total_frames_num - 1, extract_t, dtype=int
+            ).tolist()
+        else:
+            frame_indices = []
+            current_second = 0.0
+            inv_fps = 1 / (temporal_patch_size * target_fps)
+            for frame_index in range(total_frames_num):
+                if timestamps[frame_index] >= current_second:
+                    current_second += inv_fps
+                    frame_indices.append(frame_index)
+                    if current_second >= max_second:
+                        break
+
+        if len(frame_indices) < extract_t:
+            if len(frame_indices) == 0:
+                start, end = 0, max(total_frames_num - 1, 0)
+            else:
+                start, end = frame_indices[0], frame_indices[-1]
+            frame_indices = np.linspace(start, end, extract_t, dtype=int).tolist()
+        elif len(frame_indices) > extract_t:
+            frame_indices = np.linspace(
+                0, total_frames_num - 1, extract_t, dtype=int
+            ).tolist()
+
+        # Deduplicate
+        seen: set[int] = set()
+        uniq: list[int] = []
+        for idx in frame_indices:
+            if idx not in seen:
+                seen.add(idx)
+                uniq.append(idx)
+
+        # Ensure even frame count
+        if len(uniq) & 1:
+            uniq.append(uniq[-1])
+
+        return uniq
+
+    @classmethod
+    def load_bytes(
+        cls,
+        data: bytes,
+        num_frames: int = -1,
+        fps: int = -1,
+        max_duration: int = 300,
+        frame_recovery: bool = False,
+        *,
+        backend: Literal["opencv", "pyav"] = "opencv",
+        **kwargs,
+    ) -> tuple[npt.NDArray, dict[str, Any]]:
+        return super().load_bytes(
+            data,
+            num_frames=num_frames,
+            fps=fps,
+            max_duration=max_duration,
+            frame_recovery=frame_recovery,
+            backend=backend,
+            **kwargs,
+        )
+
+
+@VIDEO_LOADER_REGISTRY.register(
     "molmo2",
     video_processor="Molmo2VideoProcessor",
 )

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import gc
 import math
+import os
+import tempfile
+import threading
 from abc import abstractmethod
+from contextlib import contextmanager, suppress
 from io import BytesIO
 from typing import Any, ClassVar, Literal, NamedTuple, cast
 
@@ -10,6 +15,7 @@ import numpy.typing as npt
 
 from vllm.logger import init_logger
 from vllm.utils.import_utils import PlaceholderModule
+from vllm.utils.mem_constants import MiB_bytes
 from vllm.utils.registry import ExtensionManager
 
 try:
@@ -129,6 +135,14 @@ class VideoSourceMetadata(NamedTuple):
     duration: float
 
 
+class PyNvVideoCodecSourceMetadata(NamedTuple):
+    """Metadata needed before GPU video decode."""
+
+    source: VideoSourceMetadata
+    width: int
+    height: int
+
+
 class VideoLoader:
     @classmethod
     def compute_frames_index_to_sample(
@@ -168,6 +182,21 @@ class VideoLoader:
 
 
 VIDEO_LOADER_REGISTRY = VideoLoaderRegistry()
+
+PYNVVIDEOCODEC_VIDEO_BACKEND: Literal["pynvvideocodec"] = "pynvvideocodec"
+# Fixed upper bound reserved for persistent PyNvVideoCodec decoder surfaces.
+PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES = 128 * MiB_bytes
+PYNVVIDEOCODEC_DECODER_CACHE_SIZE = 2
+PYNVVIDEOCODEC_MAX_RETAINED_DECODERS = 2
+
+
+class PyNvVideoCodecDecoderSlot:
+    """A retained PyNv decoder slot and its CUDA stream."""
+
+    def __init__(self, stream) -> None:
+        self.stream = stream
+        self.decoder = None
+        self.source_path: str | None = None
 
 
 class OpenCVVideoBackendMixin:
@@ -414,6 +443,256 @@ class OpenCVVideoBackendMixin:
         return frames, valid_frame_indices
 
 
+class PyNvVideoCodecVideoBackendMixin:
+    """PyNvVideoCodec utilities for GPU-backed frame decode."""
+
+    _decoder_slots: ClassVar[list[PyNvVideoCodecDecoderSlot]] = []
+    _active_decoder_slots: ClassVar[int] = 0
+    _decoder_slot_cond: ClassVar[threading.Condition] = threading.Condition()
+    _DEVICE_INDEX: ClassVar[int] = 0
+
+    @classmethod
+    @abstractmethod
+    def compute_frames_index_to_sample(
+        cls,
+        source: VideoSourceMetadata,
+        target: VideoTargetMetadata,
+        **kwargs,
+    ) -> list[int]:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def _prepare_source(cls, source: VideoSourceMetadata) -> VideoSourceMetadata:
+        raise NotImplementedError
+
+    @classmethod
+    def _create_decoder_slot(cls) -> PyNvVideoCodecDecoderSlot:
+        import torch
+
+        return PyNvVideoCodecDecoderSlot(torch.cuda.Stream(device=cls._DEVICE_INDEX))
+
+    @staticmethod
+    @contextmanager
+    def _torch_stream_context(stream):
+        import torch
+
+        previous_stream = torch.accelerator.current_stream()
+        torch.accelerator.set_stream(stream)
+        try:
+            yield
+        finally:
+            torch.accelerator.set_stream(previous_stream)
+
+    @staticmethod
+    def _drop_decoder_slot_decoder(decoder_slot: PyNvVideoCodecDecoderSlot) -> None:
+        decoder = decoder_slot.decoder
+        decoder_slot.decoder = None
+        decoder_slot.source_path = None
+        if decoder is None:
+            return
+        try:
+            decoder.stop()
+        except Exception:
+            logger.debug("Stopping PyNvVideoCodec decoder", exc_info=True)
+        del decoder
+        gc.collect()
+
+    @classmethod
+    @contextmanager
+    def _borrow_decoder_slot(cls):
+        create_slot = False
+        with cls._decoder_slot_cond:
+            while True:
+                if cls._decoder_slots:
+                    slot = cls._decoder_slots.pop()
+                    break
+                if cls._active_decoder_slots < PYNVVIDEOCODEC_MAX_RETAINED_DECODERS:
+                    cls._active_decoder_slots += 1
+                    create_slot = True
+                    break
+                cls._decoder_slot_cond.wait()
+
+        if create_slot:
+            try:
+                slot = cls._create_decoder_slot()
+            except Exception:
+                with cls._decoder_slot_cond:
+                    cls._active_decoder_slots -= 1
+                    cls._decoder_slot_cond.notify()
+                raise
+
+        try:
+            yield slot
+        finally:
+            with cls._decoder_slot_cond:
+                cls._decoder_slots.append(slot)
+                cls._decoder_slot_cond.notify()
+
+    @staticmethod
+    def _metadata_value(metadata, *names: str, default=None):
+        for name in names:
+            value = getattr(metadata, name, None)
+            if value is not None:
+                return value
+        return default
+
+    @classmethod
+    def _read_source_metadata(
+        cls,
+        file_path: str,
+        nvc,
+    ) -> PyNvVideoCodecSourceMetadata:
+        metadata_decoder = nvc.SimpleDecoder(
+            file_path,
+            output_color_type=nvc.OutputColorType.RGB,
+            use_device_memory=False,
+            need_scanned_stream_metadata=True,
+            decoder_cache_size=PYNVVIDEOCODEC_DECODER_CACHE_SIZE,
+        )
+        metadata = metadata_decoder.get_stream_metadata()
+        total_frames_num = len(metadata_decoder)
+        width = int(cls._metadata_value(metadata, "width", default=0))
+        height = int(cls._metadata_value(metadata, "height", default=0))
+        original_fps = float(
+            cls._metadata_value(
+                metadata,
+                "average_fps",
+                "avg_frame_rate",
+                "frame_rate",
+                "frameRate",
+                default=0.0,
+            )
+        )
+        duration = float(
+            cls._metadata_value(metadata, "duration", default=0.0)
+            or (total_frames_num / original_fps if original_fps > 0 else 0.0)
+        )
+        if total_frames_num <= 0:
+            raise ValueError("Could not determine video frame count")
+        if width <= 0 or height <= 0:
+            raise ValueError("Could not determine video dimensions")
+        return PyNvVideoCodecSourceMetadata(
+            source=VideoSourceMetadata(total_frames_num, original_fps, duration),
+            width=width,
+            height=height,
+        )
+
+    @classmethod
+    def _decode_to_pinned_host(
+        cls,
+        file_path: str,
+        frame_idx: list[int],
+        nvc,
+    ) -> npt.NDArray:
+        import torch
+
+        if not frame_idx:
+            return np.empty((0,), dtype=np.uint8)
+
+        with cls._borrow_decoder_slot() as decoder_slot:
+            stream = decoder_slot.stream
+            with cls._torch_stream_context(stream):
+                decoder = decoder_slot.decoder
+                if decoder is not None and decoder_slot.source_path != file_path:
+                    try:
+                        decoder.reconfigure_decoder(file_path)
+                        decoder_slot.source_path = file_path
+                    except Exception:
+                        logger.debug("Recreating PyNvVideoCodec decoder", exc_info=True)
+                        cls._drop_decoder_slot_decoder(decoder_slot)
+                        decoder = None
+                if decoder is None:
+                    decoder = nvc.SimpleDecoder(
+                        file_path,
+                        output_color_type=nvc.OutputColorType.RGB,
+                        use_device_memory=True,
+                        need_scanned_stream_metadata=False,
+                        gpu_id=cls._DEVICE_INDEX,
+                        cuda_stream=stream.cuda_stream,
+                        decoder_cache_size=PYNVVIDEOCODEC_DECODER_CACHE_SIZE,
+                    )
+                    decoder_slot.decoder = decoder
+                    decoder_slot.source_path = file_path
+
+                try:
+                    decoded_frames = decoder.get_batch_frames_by_index(frame_idx)
+                except Exception:
+                    cls._drop_decoder_slot_decoder(decoder_slot)
+                    raise
+                if len(decoded_frames) < len(frame_idx):
+                    logger.warning(
+                        "pynvvideocodec video loading: expected %d frames but got %d.",
+                        len(frame_idx),
+                        len(decoded_frames),
+                    )
+                torch_frames = [torch.from_dlpack(frame) for frame in decoded_frames]
+                if not torch_frames:
+                    return np.empty((0,), dtype=np.uint8)
+                device_frames = torch.stack(torch_frames)
+                if device_frames.ndim != 4:
+                    raise ValueError(
+                        "PyNvVideoCodec returned frames with unexpected shape "
+                        f"{tuple(device_frames.shape)}"
+                    )
+                if device_frames.shape[-1] == 3:
+                    device_frames = device_frames.contiguous()
+                elif device_frames.shape[1] == 3:
+                    device_frames = device_frames.permute(0, 2, 3, 1).contiguous()
+                else:
+                    raise ValueError(
+                        "PyNvVideoCodec returned RGB frames with unexpected shape "
+                        f"{tuple(device_frames.shape)}"
+                    )
+                host_frames = torch.empty(
+                    device_frames.shape,
+                    dtype=device_frames.dtype,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                host_frames.copy_(device_frames, non_blocking=True)
+                stream.synchronize()
+                host_array = host_frames.numpy()
+                del decoded_frames, torch_frames, device_frames
+                torch.accelerator.empty_cache()
+                return host_array
+
+    @classmethod
+    def decode_frames_pynvvideocodec(
+        cls,
+        data: bytes,
+        target: VideoTargetMetadata,
+        **kwargs,
+    ) -> tuple[npt.NDArray, VideoSourceMetadata, list[int], list[int]]:
+        import PyNvVideoCodec as nvc
+
+        from vllm.multimodal.gpu_ipc_memory import get_mm_gpu_ipc_pool
+
+        temp_fd, temp_path = tempfile.mkstemp(suffix=".mp4")
+        try:
+            with os.fdopen(temp_fd, "wb") as temp_file:
+                temp_file.write(data)
+
+            gpu_source = cls._read_source_metadata(temp_path, nvc)
+            source = cls._prepare_source(gpu_source.source)
+            frame_idx = cls.compute_frames_index_to_sample(
+                source=source, target=target, **kwargs
+            )
+            raw_frame_bytes = len(frame_idx) * gpu_source.height * gpu_source.width * 3
+            pool = get_mm_gpu_ipc_pool()
+            if pool is None or raw_frame_bytes == 0:
+                frames = cls._decode_to_pinned_host(temp_path, frame_idx, nvc)
+            else:
+                with pool.acquire(raw_frame_bytes):
+                    frames = cls._decode_to_pinned_host(temp_path, frame_idx, nvc)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temp_path)
+
+        valid_frame_indices = frame_idx[: int(frames.shape[0])]
+        return frames, source, frame_idx, valid_frame_indices
+
+
 class PyAVVideoBackendMixin:
     """PyAV (in-process FFmpeg bindings) codec utilities.
 
@@ -485,14 +764,19 @@ class PyAVVideoBackendMixin:
 
 
 @VIDEO_LOADER_REGISTRY.register("opencv")
-class VideoBackend(VideoLoader, OpenCVVideoBackendMixin, PyAVVideoBackendMixin):
+class VideoBackend(
+    VideoLoader,
+    OpenCVVideoBackendMixin,
+    PyAVVideoBackendMixin,
+    PyNvVideoCodecVideoBackendMixin,
+):
     """Uniform-sampling video backend.
 
     Samples ``num_frames`` uniformly across the video (or one frame every
     ``1/fps`` seconds, whichever produces fewer frames). The decoding codec
-    is selected via the ``backend`` kwarg (``"opencv"`` or ``"pyav"``),
-    which can be passed through ``--media-io-kwargs``. Defaults to
-    ``"pyav"`` for concurrent decoding.
+    is selected via the ``backend`` kwarg (``"opencv"``, ``"pyav"``, or
+    ``"pynvvideocodec"``), which can be passed through ``--media-io-kwargs``.
+    Defaults to ``"pyav"`` for concurrent decoding.
     """
 
     _sampling_suffix: ClassVar[str] = ""
@@ -537,7 +821,7 @@ class VideoBackend(VideoLoader, OpenCVVideoBackendMixin, PyAVVideoBackendMixin):
         max_duration: int = 300,
         frame_recovery: bool = False,
         *,
-        backend: Literal["opencv", "pyav"] = "opencv",
+        backend: Literal["opencv", "pyav", "pynvvideocodec"] = "opencv",
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         """Load sampled frames from raw video bytes.
@@ -550,7 +834,7 @@ class VideoBackend(VideoLoader, OpenCVVideoBackendMixin, PyAVVideoBackendMixin):
                 dynamic subclass; ignored here.
             frame_recovery: Enable forward-scan recovery for failed frames.
                 Only honored by the OpenCV codec.
-            backend: Decoding codec — ``"opencv"`` or ``"pyav"`` .
+            backend: Decoding codec — ``"opencv"``, ``"pyav"`` or ``"pynvvideocodec"``.
 
         Returns:
             Tuple of ``(frames_array, metadata_dict)``.
@@ -583,10 +867,21 @@ class VideoBackend(VideoLoader, OpenCVVideoBackendMixin, PyAVVideoBackendMixin):
                 frames, valid = cls.decode_frames(
                     container, frame_idx, source.original_fps, source.duration
                 )
+        elif backend == PYNVVIDEOCODEC_VIDEO_BACKEND:
+            if frame_recovery:
+                raise ValueError(
+                    "frame_recovery is not supported for "
+                    f"`{PYNVVIDEOCODEC_VIDEO_BACKEND}` backend"
+                )
+            frames, source, frame_idx, valid = cls.decode_frames_pynvvideocodec(
+                data,
+                target,
+                **kwargs,
+            )
         else:
             raise ValueError(
                 f"Unknown video codec backend {backend!r}; "
-                "valid options: 'opencv', 'pyav'."
+                "valid options: 'opencv', 'pyav', 'pynvvideocodec'."
             )
 
         if len(valid) < len(frame_idx):
@@ -601,6 +896,39 @@ class VideoBackend(VideoLoader, OpenCVVideoBackendMixin, PyAVVideoBackendMixin):
             source=source,
             video_backend=f"{backend}{cls._sampling_suffix}",
             valid_frame_indices=valid,
+        )
+
+
+@VIDEO_LOADER_REGISTRY.register(PYNVVIDEOCODEC_VIDEO_BACKEND)
+class PyNvVideoCodecVideoBackend(VideoBackend):
+    """Hardware-accelerated video backend using PyNvVideoCodec.
+    The backend first opens the stream only to read metadata and compute the
+    sampled frame indices. It then acquires the raw decoded RGB byte count from
+    the process-local multimodal GPU memory pool before decoding the selected
+    frames into VRAM. Decoded frames are copied into pinned host memory before
+    the lease is released, so downstream preprocessing continues to receive a
+    CPU ``np.ndarray`` in NHWC RGB format.
+    """
+
+    @classmethod
+    def load_bytes(
+        cls,
+        data: bytes,
+        num_frames: int = -1,
+        fps: int = -1,
+        max_duration: int = 300,
+        frame_recovery: bool = False,
+        **kwargs,
+    ) -> tuple[npt.NDArray, dict[str, Any]]:
+        kwargs.pop("backend", None)
+        return super().load_bytes(
+            data,
+            num_frames=num_frames,
+            fps=fps,
+            max_duration=max_duration,
+            frame_recovery=frame_recovery,
+            backend=PYNVVIDEOCODEC_VIDEO_BACKEND,
+            **kwargs,
         )
 
 
@@ -682,7 +1010,7 @@ class DynamicVideoBackend(VideoBackend):
         max_duration: int = 300,
         frame_recovery: bool = False,
         *,
-        backend: Literal["opencv", "pyav"] = "opencv",
+        backend: Literal["opencv", "pyav", "pynvvideocodec"] = "opencv",
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         return super().load_bytes(
@@ -781,7 +1109,7 @@ class GLMGAVideoBackend(VideoBackend):
         max_duration: int = 300,
         frame_recovery: bool = False,
         *,
-        backend: Literal["opencv", "pyav"] = "opencv",
+        backend: Literal["opencv", "pyav", "pynvvideocodec"] = "opencv",
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         frames, metadata = super().load_bytes(
@@ -910,7 +1238,7 @@ class GLM46VVideoBackend(VideoBackend):
         max_duration: int = 300,
         frame_recovery: bool = False,
         *,
-        backend: Literal["opencv", "pyav"] = "opencv",
+        backend: Literal["opencv", "pyav", "pynvvideocodec"] = "opencv",
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         return super().load_bytes(
@@ -1224,7 +1552,7 @@ class NemotronVLVideoBackend(VideoBackend):
         max_duration: int = 300,
         frame_recovery: bool = False,
         *,
-        backend: Literal["opencv", "pyav"] = "opencv",
+        backend: Literal["opencv", "pyav", "pynvvideocodec"] = "opencv",
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
         frames, metadata = super().load_bytes(

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -407,6 +407,8 @@ class BaseRenderer(ABC, Generic[_T]):
         self,
         messages: list["ChatCompletionMessageParam"],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list["ConversationMessage"], DictPrompt]:
         raise NotImplementedError
 
@@ -414,6 +416,8 @@ class BaseRenderer(ABC, Generic[_T]):
         self,
         messages: list["ChatCompletionMessageParam"],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list["ConversationMessage"], DictPrompt]:
         return self.render_messages(messages, params)
 
@@ -692,19 +696,30 @@ class BaseRenderer(ABC, Generic[_T]):
         tokenization_kwargs: dict[str, Any] | None,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> "MultiModalInput":
-        mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
-
         if skip_mm_cache and self._readonly_mm_processor is not None:
             mm_processor = self._readonly_mm_processor
         else:
             mm_processor = self.get_mm_processor()
 
+        # If no external timing_ctx provided, create one (offline LLM path).
+        if timing_ctx is None:
+            mm_req_id = (
+                f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
+            )
+            timing_ctx = self._mm_timing_registry.get(mm_req_id)
+
         mm_data_items = mm_processor.info.parse_mm_data(mm_data)
         mm_uuid_items = parse_mm_uuids(mm_uuids)
 
+        assert mm_req_id is not None
         mm_uuid_items = self._process_mm_uuids(
-            mm_data, mm_data_items, mm_uuid_items, mm_req_id
+            mm_data,
+            mm_data_items,
+            mm_uuid_items,
+            mm_req_id,
         )
 
         mm_processor_inputs = MMProcessorInputs(
@@ -714,10 +729,9 @@ class BaseRenderer(ABC, Generic[_T]):
             hf_processor_mm_kwargs=mm_processor_kwargs or {},
             tokenization_kwargs=tokenization_kwargs or {},
         )
-        mm_timing_ctx = self._mm_timing_registry.get(mm_req_id)
 
         with set_default_torch_num_threads():
-            mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)
+            mm_inputs = mm_processor.apply(mm_processor_inputs, timing_ctx)
 
         self.update_mm_cache_stats()
 
@@ -728,6 +742,8 @@ class BaseRenderer(ABC, Generic[_T]):
         prompt: TokensPrompt,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> TokensInput | MultiModalInput:
         """Process token inputs, with multimodal preprocessing offloaded
         to the shared thread pool in the async variant.
@@ -743,6 +759,8 @@ class BaseRenderer(ABC, Generic[_T]):
                 tokenization_kwargs=None,  # Tokenization already done in Step 2
                 mm_uuids=prompt.get("multi_modal_uuids"),
                 skip_mm_cache=skip_mm_cache,
+                timing_ctx=timing_ctx,
+                mm_req_id=mm_req_id,
             )
         else:
             engine_input = tokens_input(prompt_token_ids)
@@ -789,6 +807,8 @@ class BaseRenderer(ABC, Generic[_T]):
         prompt: TokensPrompt,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> TokensInput | MultiModalInput:
         prompt_token_ids = prompt["prompt_token_ids"]
 
@@ -801,6 +821,8 @@ class BaseRenderer(ABC, Generic[_T]):
                 tokenization_kwargs=None,
                 mm_uuids=prompt.get("multi_modal_uuids"),
                 skip_mm_cache=skip_mm_cache,
+                timing_ctx=timing_ctx,
+                mm_req_id=mm_req_id,
             )
         else:
             engine_input = tokens_input(prompt_token_ids)
@@ -817,22 +839,36 @@ class BaseRenderer(ABC, Generic[_T]):
         prompt: SingletonTokPrompt,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> SingletonInput:
         if "prompt_embeds" in prompt:
             return self._process_embeds(prompt)  # type: ignore[arg-type]
 
-        return self._process_tokens(prompt, skip_mm_cache=skip_mm_cache)  # type: ignore[arg-type]
+        return self._process_tokens(
+            prompt,  # type: ignore[arg-type]
+            skip_mm_cache=skip_mm_cache,
+            timing_ctx=timing_ctx,
+            mm_req_id=mm_req_id,
+        )
 
     async def _process_singleton_async(
         self,
         prompt: SingletonTokPrompt,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> SingletonInput:
         if "prompt_embeds" in prompt:
             return self._process_embeds(prompt)  # type: ignore[arg-type]
 
-        return await self._process_tokens_async(prompt, skip_mm_cache=skip_mm_cache)  # type: ignore[arg-type]
+        return await self._process_tokens_async(
+            prompt,  # type: ignore[arg-type]
+            skip_mm_cache=skip_mm_cache,
+            timing_ctx=timing_ctx,
+            mm_req_id=mm_req_id,
+        )
 
     def _process_enc_dec(
         self,
@@ -895,12 +931,19 @@ class BaseRenderer(ABC, Generic[_T]):
         arrival_time: float,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> EngineInput:
         engine_input: EngineInput
         if "encoder_prompt" in prompt:
             engine_input = self._process_enc_dec(prompt, skip_mm_cache=skip_mm_cache)  # type: ignore[arg-type]
         else:
-            engine_input = self._process_singleton(prompt, skip_mm_cache=skip_mm_cache)
+            engine_input = self._process_singleton(
+                prompt,
+                skip_mm_cache=skip_mm_cache,
+                timing_ctx=timing_ctx,
+                mm_req_id=mm_req_id,
+            )
 
         engine_input["arrival_time"] = arrival_time
 
@@ -912,6 +955,8 @@ class BaseRenderer(ABC, Generic[_T]):
         arrival_time: float,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> EngineInput:
         engine_input: EngineInput
         if "encoder_prompt" in prompt:
@@ -921,7 +966,10 @@ class BaseRenderer(ABC, Generic[_T]):
             )
         else:
             engine_input = await self._process_singleton_async(
-                prompt, skip_mm_cache=skip_mm_cache
+                prompt,
+                skip_mm_cache=skip_mm_cache,
+                timing_ctx=timing_ctx,
+                mm_req_id=mm_req_id,
             )
 
         engine_input["arrival_time"] = arrival_time
@@ -993,8 +1041,11 @@ class BaseRenderer(ABC, Generic[_T]):
         if tok_params is None:
             tok_params = self.default_chat_tok_params
 
+        mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
+        timing_ctx = self._mm_timing_registry.get(mm_req_id)
+
         rendered = [
-            self.render_messages(conversation, chat_params)
+            self.render_messages(conversation, chat_params, timing_ctx=timing_ctx)
             for conversation in conversations
         ]
 
@@ -1009,7 +1060,13 @@ class BaseRenderer(ABC, Generic[_T]):
         self._apply_prompt_extras(tok_prompts, prompt_extras)
 
         eng_prompts = [
-            self.process_for_engine(prompt, arrival_time, skip_mm_cache=skip_mm_cache)
+            self.process_for_engine(
+                prompt,
+                arrival_time,
+                skip_mm_cache=skip_mm_cache,
+                timing_ctx=timing_ctx,
+                mm_req_id=mm_req_id,
+            )
             for prompt in tok_prompts
         ]
 
@@ -1029,8 +1086,18 @@ class BaseRenderer(ABC, Generic[_T]):
         if tok_params is None:
             tok_params = self.default_chat_tok_params
 
+        # Create TimingContext early so media loading can be timed.
+        # This TimingContext is shared across all stages of this request.
+        timing_ctx = None
+        mm_req_id = None
+        if self._mm_timing_registry is not None:
+            mm_req_id = (
+                f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
+            )
+            timing_ctx = self._mm_timing_registry.get(mm_req_id)
+
         rendered = [
-            self.render_messages_async(conversation, chat_params)
+            self.render_messages_async(conversation, chat_params, timing_ctx=timing_ctx)
             for conversation in conversations
         ]
 
@@ -1047,7 +1114,11 @@ class BaseRenderer(ABC, Generic[_T]):
         eng_prompts = await asyncio.gather(
             *(
                 self.process_for_engine_async(
-                    p, arrival_time, skip_mm_cache=skip_mm_cache
+                    p,
+                    arrival_time,
+                    skip_mm_cache=skip_mm_cache,
+                    timing_ctx=timing_ctx,
+                    mm_req_id=mm_req_id,
                 )
                 for p in tok_prompts
             )

--- a/vllm/renderers/deepseek_v32.py
+++ b/vllm/renderers/deepseek_v32.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 from vllm.config import VllmConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -39,6 +41,8 @@ class DeepseekV32Renderer(BaseRenderer[DeepseekV32Tokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = parse_chat_messages(
             messages,
@@ -66,6 +70,8 @@ class DeepseekV32Renderer(BaseRenderer[DeepseekV32Tokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
             messages,

--- a/vllm/renderers/deepseek_v4.py
+++ b/vllm/renderers/deepseek_v4.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 from vllm.config import VllmConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -39,6 +41,8 @@ class DeepseekV4Renderer(BaseRenderer[DeepseekV4Tokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = parse_chat_messages(
             messages,
@@ -66,6 +70,8 @@ class DeepseekV4Renderer(BaseRenderer[DeepseekV4Tokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
             messages,

--- a/vllm/renderers/grok2.py
+++ b/vllm/renderers/grok2.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 from vllm.config import VllmConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -39,6 +41,8 @@ class Grok2Renderer(BaseRenderer[Grok2Tokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = parse_chat_messages(
             messages,
@@ -66,6 +70,8 @@ class Grok2Renderer(BaseRenderer[Grok2Tokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
             messages,

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -818,6 +818,8 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         model_config = self.model_config
         tokenizer = self.get_tokenizer()
@@ -840,6 +842,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             ),
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            timing_ctx=timing_ctx,
         )
 
         # prompt_embeds tensors are carried by the tracker through mm_data,
@@ -925,6 +928,8 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         model_config = self.model_config
         tokenizer = self.get_tokenizer()
@@ -947,6 +952,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             ),
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            timing_ctx=timing_ctx,
         )
 
         prompt_embeds_tensors: list[torch.Tensor] | None = None
@@ -1024,6 +1030,8 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         prompt: TokensPrompt,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> TokensInput | MultiModalInput:
         """Pre-expand `prompt_embeds` sentinels before delegating to the MM
         processor, then attach `prompt_embeds` modality data to the result.
@@ -1042,7 +1050,12 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             cast(dict, prompt)["prompt_token_ids"] = _expand_prompt_embeds_placeholders(
                 list(prompt["prompt_token_ids"]), mm_updates
             )
-        engine_input = super()._process_tokens(prompt, skip_mm_cache=skip_mm_cache)
+        engine_input = super()._process_tokens(
+            prompt,
+            skip_mm_cache=skip_mm_cache,
+            timing_ctx=timing_ctx,
+            mm_req_id=mm_req_id,
+        )
         if prompt_embeds_info is not None:
             tensors, _ = prompt_embeds_info
             self._apply_prompt_embeds_to_engine_input(
@@ -1058,6 +1071,8 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         prompt: TokensPrompt,
         *,
         skip_mm_cache: bool = False,
+        timing_ctx: Any | None = None,
+        mm_req_id: str | None = None,
     ) -> TokensInput | MultiModalInput:
         """Async equivalent of `_process_tokens`."""
         prompt_embeds_info = cast(dict, prompt).pop("_prompt_embeds", None)
@@ -1068,7 +1083,10 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 list(prompt["prompt_token_ids"]), mm_updates
             )
         engine_input = await super()._process_tokens_async(
-            prompt, skip_mm_cache=skip_mm_cache
+            prompt,
+            skip_mm_cache=skip_mm_cache,
+            timing_ctx=timing_ctx,
+            mm_req_id=mm_req_id,
         )
         if prompt_embeds_info is not None:
             tensors, _ = prompt_embeds_info

--- a/vllm/renderers/mistral.py
+++ b/vllm/renderers/mistral.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 from vllm.config import VllmConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -63,6 +65,8 @@ class MistralRenderer(BaseRenderer[MistralTokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         tokenizer = self.get_tokenizer()
         conversation, mm_data, mm_uuids = parse_chat_messages(
@@ -91,6 +95,8 @@ class MistralRenderer(BaseRenderer[MistralTokenizer]):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         tokenizer = self.get_tokenizer()
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(

--- a/vllm/renderers/terratorch.py
+++ b/vllm/renderers/terratorch.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
@@ -22,6 +24,8 @@ class TerratorchRenderer(BaseRenderer):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         model_config = self.model_config
 
@@ -45,6 +49,8 @@ class TerratorchRenderer(BaseRenderer):
         self,
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
+        *,
+        timing_ctx: Any | None = None,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         model_config = self.model_config
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3430,25 +3430,53 @@ class GPUModelRunner(
         ec_connector_output = None
 
         if self.supports_mm_inputs and is_first_rank and not is_encoder_decoder:
+            # Determine whether to time GPU stages for this step.
+            should_time_mm = bool(
+                self.observability_config
+                and self.observability_config.enable_mm_processor_stats
+                and scheduler_output.scheduled_encoder_inputs
+            )
+            # Collect unique request IDs that have encoder inputs for timing.
+            mm_req_ids = (
+                set(scheduler_output.scheduled_encoder_inputs.keys())
+                if should_time_mm
+                else set()
+            )
+
             # Run the multimodal encoder if any.
             with self.maybe_get_ec_connector_output(
                 scheduler_output,
                 encoder_cache=self.encoder_cache,
             ) as ec_connector_output:
                 self._execute_mm_encoder(scheduler_output)
-                mm_embeds, is_mm_embed = self._gather_mm_embeddings(scheduler_output)
+
+            with self._timed_gpu_stage(
+                should_time_mm,
+                "embedding_gather_secs",
+                mm_req_ids,
+            ):
+                mm_embeds, is_mm_embed = self._gather_mm_embeddings(
+                    scheduler_output,
+                )
 
             # NOTE(woosuk): To unify token ids and soft tokens (vision
             # embeddings), we always use embeddings (rather than token ids)
             # as input to the multimodal model, even when the input is text.
-            inputs_embeds_scheduled = self.model.embed_input_ids(
-                self.input_ids.gpu[:num_scheduled_tokens],
-                multimodal_embeddings=mm_embeds,
-                is_multimodal=is_mm_embed,
-            )
+            with self._timed_gpu_stage(
+                should_time_mm,
+                "embedding_merge_secs",
+                mm_req_ids,
+            ):
+                inputs_embeds_scheduled = self.model.embed_input_ids(
+                    self.input_ids.gpu[:num_scheduled_tokens],
+                    multimodal_embeddings=mm_embeds,
+                    is_multimodal=is_mm_embed,
+                )
 
-            # TODO(woosuk): Avoid the copy. Optimize.
-            self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(inputs_embeds_scheduled)
+                # TODO(woosuk): Avoid the copy. Optimize.
+                self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(
+                    inputs_embeds_scheduled,
+                )
 
             input_ids, inputs_embeds = self._prepare_mm_inputs(num_input_tokens)
             model_kwargs = {
@@ -4257,6 +4285,21 @@ class GPUModelRunner(
         # When spec decode is enabled, defer connector finalization
         # (wait_for_save + clear metadata) until after draft model runs.
         defer_kv_connector_finalize = self.speculative_config is not None
+
+        # Identify prefill requests for timing.
+        should_time_prefill = bool(
+            self.observability_config
+            and self.observability_config.enable_mm_processor_stats
+            and scheduler_output.scheduled_encoder_inputs
+        )
+        prefill_req_ids: set[str] = set()
+        if should_time_prefill and num_reqs > 0:
+            num_computed = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+            num_prompt = self.input_batch.num_prompt_tokens_cpu_tensor[:num_reqs]
+            for i, req_id in enumerate(req_ids):
+                if num_computed[i] < num_prompt[i]:
+                    prefill_req_ids.add(req_id)
+
         with (
             set_forward_context(
                 attn_metadata,
@@ -4274,6 +4317,11 @@ class GPUModelRunner(
                 scheduler_output,
                 defer_finalize=defer_kv_connector_finalize,
             ) as kv_connector_output,
+            self._timed_gpu_stage(
+                should_time_prefill and len(prefill_req_ids) > 0,
+                "prefill_forward_secs",
+                prefill_req_ids,
+            ),
         ):
             model_output = self._model_forward(
                 input_ids=input_ids,
@@ -7535,6 +7583,44 @@ class GPUModelRunner(
                     stats.encoder_forward_secs += per_request_time
                     stats.num_encoder_calls += 1
 
+    @contextmanager
+    def _timed_gpu_stage(
+        self,
+        should_time: bool,
+        stage_attr: str,
+        req_ids: set[str],
+    ):
+        """Context manager to time a GPU-side stage and record per-request.
+
+        Args:
+            should_time: Whether timing is enabled.
+            stage_attr: Attribute name on EncoderTimingStats to accumulate into.
+            req_ids: Set of request IDs to attribute the time to.
+        """
+        if not should_time or not req_ids:
+            yield
+            return
+
+        torch.accelerator.synchronize()
+        start_time = time.perf_counter()
+
+        try:
+            yield
+        finally:
+            torch.accelerator.synchronize()
+            elapsed = time.perf_counter() - start_time
+
+            per_request_time = elapsed / max(len(req_ids), 1)
+
+            with self._encoder_timing_lock:
+                for req_id in req_ids:
+                    if req_id not in self.encoder_timing_registry:
+                        self.encoder_timing_registry[req_id] = EncoderTimingStats()
+
+                    stats = self.encoder_timing_registry[req_id]
+                    current = getattr(stats, stage_attr, 0.0)
+                    setattr(stats, stage_attr, current + per_request_time)
+
 
 @dataclass
 class EncoderTimingStats:
@@ -7546,8 +7632,21 @@ class EncoderTimingStats:
     num_encoder_calls: int = 0
     """Number of times encoder was called for this request."""
 
+    # Extended timing for MM processing pipeline
+    embedding_gather_secs: float = 0.0
+    """Time spent in _gather_mm_embeddings (seconds)."""
+
+    embedding_merge_secs: float = 0.0
+    """Time spent in embed_input_ids + embedding copy (seconds)."""
+
+    prefill_forward_secs: float = 0.0
+    """Time spent in LLM forward pass for prefill requests (seconds)."""
+
     def to_dict(self) -> dict[str, float | int]:
         return {
             "encoder_forward_secs": self.encoder_forward_secs,
             "num_encoder_calls": self.num_encoder_calls,
+            "embedding_gather_secs": self.embedding_gather_secs,
+            "embedding_merge_secs": self.embedding_merge_secs,
+            "prefill_forward_secs": self.prefill_forward_secs,
         }

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -46,6 +46,11 @@ from vllm.distributed.weight_transfer import (
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
+from vllm.multimodal.video import (
+    PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
+    PYNVVIDEOCODEC_MAX_RETAINED_DECODERS,
+    PYNVVIDEOCODEC_VIDEO_BACKEND,
+)
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import CudaProfilerWrapper, TorchProfilerWrapper
 from vllm.sequence import IntermediateTensors
@@ -388,7 +393,7 @@ class Worker(WorkerBase):
                 "correspondingly."
             )
             logger.info(msg)
-            return kv_cache_memory_bytes
+            return self._reserve_mm_ipc_gpu_memory(kv_cache_memory_bytes)
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -510,7 +515,62 @@ class Worker(WorkerBase):
                     suggested_util,
                 )
 
-        return int(self.available_kv_cache_memory_bytes)
+        return self._reserve_mm_ipc_gpu_memory(
+            int(self.available_kv_cache_memory_bytes)
+        )
+
+    @staticmethod
+    def _uses_pynvvideocodec_video_backend(mm_config) -> bool:
+        video_backend = mm_config.media_io_kwargs.get("video", {}).get("video_backend")
+        return (
+            video_backend == PYNVVIDEOCODEC_VIDEO_BACKEND
+            or envs.VLLM_VIDEO_LOADER_BACKEND == PYNVVIDEOCODEC_VIDEO_BACKEND
+        )
+
+    def _reserve_mm_ipc_gpu_memory(self, available_kv_cache_memory_bytes: int) -> int:
+        """Carve frontend multimodal GPU memory out of the KV cache.
+        The frontend (API-server) process allocates GPU memory for hardware
+        multimodal decoding. Raw decoded frames are bounded by
+        ``mm_ipc_gpu_memory_gb`` and acquired by the frontend semaphore. Some
+        decoders also keep persistent surfaces around; reserve a fixed upper
+        bound for those when the corresponding backend is configured.
+        """
+        mm_config = self.model_config.multimodal_config
+        if mm_config is None:
+            return available_kv_cache_memory_bytes
+
+        raw_frame_reserved_bytes = int(mm_config.mm_ipc_gpu_memory_gb * GiB_bytes)
+        decoder_reserved_bytes = (
+            PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES
+            * PYNVVIDEOCODEC_MAX_RETAINED_DECODERS
+            if self._uses_pynvvideocodec_video_backend(mm_config)
+            else 0
+        )
+        reserved_bytes = raw_frame_reserved_bytes + decoder_reserved_bytes
+        if reserved_bytes <= 0:
+            return available_kv_cache_memory_bytes
+
+        remaining = available_kv_cache_memory_bytes - reserved_bytes
+        if remaining <= 0:
+            raise ValueError(
+                f"frontend multimodal GPU decoding reserves "
+                f"{format_gib(reserved_bytes)} GiB "
+                f"({format_gib(raw_frame_reserved_bytes)} GiB raw-frame budget, "
+                f"{format_gib(decoder_reserved_bytes)} GiB decoder cache budget), "
+                f"but only {format_gib(available_kv_cache_memory_bytes)} GiB is "
+                "available for the KV cache. Reduce mm_ipc_gpu_memory_gb, use a "
+                "different video backend, or increase gpu_memory_utilization."
+            )
+        logger.info_once(
+            "Reserving %s GiB of GPU memory for frontend multimodal decoding "
+            "(%s GiB raw-frame semaphore budget, %s GiB decoder cache budget); "
+            "KV cache memory reduced to %s GiB.",
+            format_gib(reserved_bytes),
+            format_gib(raw_frame_reserved_bytes),
+            format_gib(decoder_reserved_bytes),
+            format_gib(remaining),
+        )
+        return remaining
 
     def get_kv_connector_handshake_metadata(self) -> dict | None:
         """Get KV connector metadata from this worker if available."""


### PR DESCRIPTION
# Purpose
To get more detailed stats of the MM Processing Pipeline and find the real bottleneck when scaling the input size and concurrency

# Change List:
1. Move `timing_cxt` init from `_process_multimodal()` to `render_chat_async`, to catch MM data downlod and decode
2. Add encoder timing stats collection in GPU model runner
3. Add --enable-mm-processor-stats CLI flag and ObservabilityConfig
4. Add GET /mm_processor_stats server endpoint (clear-on-read)
5. Add timing instrumentation for `file://` and `data:` URL decode paths
6. Integrate stats collection into `vllm bench serve` output

## Results Summary

| Config | video_decode | hf_processor | preprocessor_total | Throughput | TTFT | TPOT |
|--------|-------------|-------------|-------------------|------------|------|------|
| 16 RPS, 1 API | 349ms | 2055ms | 2435ms | 0.48 req/s | 518s | 19ms |
| 32 RPS, 1 API | 4018ms | 2131ms | 6172ms | 0.46 req/s | 545s | 17ms |
| 32 RPS, 32 threads, 1 API | 6542ms | 2123ms | 8684ms | 0.46 req/s | 529s | 17ms |
| **32 RPS, 2 API servers** | **1681ms** | **2000ms** | **3703ms** | **0.69 req/s** | **352s** | 530ms |
| **32 RPS, 4 API servers** | **888ms** | **2124ms** | **3035ms** | **0.63 req/s** | **386s** | 586ms |

## Key Takeaways

### 1. video_decode is the sole bottleneck under concurrency

`hf_processor_call` (~2050ms), `encoder_forward` (~320ms), `prefill_forward` (~170ms) remain stable across all configs. Only `video_decode` degrades: **349ms → 4018ms → 6542ms** (18.8x). At 32 RPS with 1 API server, video_decode accounts for **65% of preprocessor_total**.

### 2. More threads = worse (GIL contention)

32 threads vs 8 threads (default): video_decode **worsened by 63%** (4018ms → 6542ms). The OpenCV-based `glm4_6v` backend holds the Python GIL during `grab()/retrieve()`. More threads competing for the GIL means more context switching overhead, not more parallelism. **`VLLM_MEDIA_LOADING_THREAD_COUNT` is not the right knob for GIL-bound workloads.**

### 3. `--api-server-count` is the effective fix

- 2 API servers: video_decode **3.9x faster** (6542ms → 1681ms), throughput **+50%** (0.46 → 0.69 req/s), TTFT **-34%** (529s → 352s)
- 4 API servers: video_decode **7.4x faster** (6542ms → 888ms)
- Each API server process has its own GIL, enabling true parallel preprocessing

### 4. Diminishing returns beyond 2 API servers

2 → 4 API servers: video_decode dropped further (1681ms → 888ms), but throughput actually **decreased** (0.69 → 0.63 req/s) and TTOT worsened (530ms → 586ms). The bottleneck shifted from CPU preprocessing to GPU inference — more API servers inject requests faster, increasing GPU batch sizes and per-token latency. **Further throughput gains require Data Parallelism, not more API servers.**

### 5. TPOT degradation is expected and orthogonal

TPOT went from ~17ms → 530–586ms with `--api-server-count ≥ 2`. This is because higher frontend throughput → larger GPU batch sizes → longer per-token latency. This is a GPU-side issue solvable independently via DP, not a regression from the preprocessing optimization.

### 6. Mid-term: PyAV backend would address the root cause

OpenCV's sequential `grab()/retrieve()` holds the GIL. PyAV uses `container.seek()` for direct frame access (O(target_frames) vs O(total_frames)) and **explicitly releases the GIL** during decode, enabling genuine thread-level parallelism without multi-process overhead.

### 7. Long-term: Rust frontend for preprocessing

A Rust-based frontend would fundamentally eliminate the GIL as a bottleneck by moving CPU-intensive preprocessing (video decode, image decode, HF processor call orchestration) out of the Python runtime entirely. Potential benefits:

- **True multi-threading without multi-process overhead** — no GIL, no `--api-server-count` workaround, no per-process memory duplication
- **Zero-copy media I/O** — Rust's ownership model enables efficient frame buffer sharing between decode and processor stages without serialization copies
- **Native async I/O** — `tokio`-style runtime avoids Python's `ThreadPoolExecutor` indirection; media fetch + decode can be pipelined in a single thread without context switching
- **Lower memory footprint** — no per-process Python interpreter overhead; video frame buffers can be memory-mapped and shared across requests
- **Consistent tail latency** — no GC pauses, no GIL-induced scheduling jitter; p99 latency would be much closer to median

# Detailed Tests and Benchmark Results on GLM-4.6V-Flash

> Will remove changes in `vllm/multimodal/video.py` when #44417 merged

Model: https://huggingface.co/zai-org/GLM-4.6V-Flash
Dataset: https://huggingface.co/datasets/yale-nlp/MMVU

## 16 Request Rate Baseline

```
# Model Server Side
vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 16       --base-url http://localhost:8091       --served-model-name glm

# Result
============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           16.00
Benchmark duration (s):                  1075.46
Total input tokens:                      10707622
Total generated tokens:                  58667
Request throughput (req/s):              0.48
Output token throughput (tok/s):         54.55
Peak output token throughput (tok/s):    641.00
Peak concurrent requests:                499.00
Total token throughput (tok/s):          10010.85
---------------Time to First Token----------------
Mean TTFT (ms):                          517885.88
Median TTFT (ms):                        518414.33
P99 TTFT (ms):                           1033775.04
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.39
Median TPOT (ms):                        15.16
P99 TPOT (ms):                           77.52
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.47
Median ITL (ms):                         5.95
P99 ITL (ms):                            508.33
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:       2434.55   2031.06   6590.23
----------------- Preprocessing ------------------
  video_decode_ms:            349.04    295.66   1064.06
  get_mm_hashes_ms:            23.95     20.42     62.30
  hf_data_prep_ms:              0.01      0.01      0.01
  hf_processor_call_ms:      2055.18   1751.59   5459.55
  hf_postprocess_ms:            0.46      0.39      1.42
  apply_prompt_updates_ms:     10.68      8.17     39.00
-------------------- Encoding --------------------
  encoder_forward_ms:         318.77    274.83    852.23
  num_encoder_calls:            1.00      1.00      1.00
  embedding_gather_ms:          0.18      0.17      0.39
  embedding_merge_ms:           1.62      1.14      2.44
  prefill_forward_ms:         168.92    154.35    305.81
==================================================
```

## 32 Request Rate Baseline

```
# Model Server Side
vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 32       --base-url http://localhost:8091       --served-model-name glm

# Result
============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           32.00
Benchmark duration (s):                  1115.02
Total input tokens:                      10707622
Total generated tokens:                  58988
Request throughput (req/s):              0.46
Output token throughput (tok/s):         52.90
Peak output token throughput (tok/s):    612.00
Peak concurrent requests:                508.00
Total token throughput (tok/s):          9655.94
---------------Time to First Token----------------
Mean TTFT (ms):                          544947.63
Median TTFT (ms):                        542727.62
P99 TTFT (ms):                           1081832.17
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.85
Median TPOT (ms):                        13.05
P99 TPOT (ms):                           56.63
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.06
Median ITL (ms):                         5.92
P99 ITL (ms):                            349.14
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:       6172.26   6092.26  12657.64
----------------- Preprocessing ------------------
  video_decode_ms:           4018.09   3944.00   7881.79
  get_mm_hashes_ms:            24.09     20.53     63.75
  hf_data_prep_ms:              0.01      0.01      0.01
  hf_processor_call_ms:      2130.90   1828.33   5617.52
  hf_postprocess_ms:            0.46      0.40      1.71
  apply_prompt_updates_ms:     10.77      8.30     38.57
-------------------- Encoding --------------------
  encoder_forward_ms:         316.42    274.25    830.42
  num_encoder_calls:            1.00      1.00      1.00
  embedding_gather_ms:          0.15      0.14      0.28
  embedding_merge_ms:           1.54      1.04      2.29
  prefill_forward_ms:         168.42    154.11    309.08
=================================================
```

## 32 Request Rate with `VLLM_MEDIA_LOADING_THREAD_COUNT=32`

```
# Model Server Side
VLLM_MEDIA_LOADING_THREAD_COUNT=32 vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 32       --base-url http://localhost:8091       --served-model-name glm

# Result
============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           32.00
Benchmark duration (s):                  1113.37
Total input tokens:                      10707622
Total generated tokens:                  58672
Request throughput (req/s):              0.46
Output token throughput (tok/s):         52.70
Peak output token throughput (tok/s):    688.00
Peak concurrent requests:                508.00
Total token throughput (tok/s):          9670.02
---------------Time to First Token----------------
Mean TTFT (ms):                          529069.76
Median TTFT (ms):                        532637.14
P99 TTFT (ms):                           1076394.70
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.78
Median TPOT (ms):                        12.74
P99 TPOT (ms):                           56.21
---------------Inter-token Latency----------------
Mean ITL (ms):                           16.99
Median ITL (ms):                         5.87
P99 ITL (ms):                            345.91
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:       8683.72   8847.91  17577.62
----------------- Preprocessing ------------------
  video_decode_ms:           6542.13   6607.76  12822.80
  get_mm_hashes_ms:            24.11     20.42     63.05
  hf_data_prep_ms:              0.01      0.01      0.01
  hf_processor_call_ms:      2122.94   1818.41   5555.13
  hf_postprocess_ms:            0.74      0.40     15.87
  apply_prompt_updates_ms:     10.75      8.16     38.62
-------------------- Encoding --------------------
  encoder_forward_ms:         316.89    274.14    844.94
  num_encoder_calls:            1.00      1.00      1.00
  embedding_gather_ms:          0.15      0.14      0.37
  embedding_merge_ms:           1.60      1.04      2.42
  prefill_forward_ms:         166.23    153.99    294.72
==================================================
```

## 16 Request Rate with PyAV Backend

```
# Model Server Side
vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0 --media-io-kwargs '{"video":{"backend":"pyav"}}'

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 16       --base-url http://localhost:8091       --served-model-name glm

# Result

============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           16.00
Benchmark duration (s):                  1130.90
Total input tokens:                      10707622
Total generated tokens:                  59258
Request throughput (req/s):              0.45
Output token throughput (tok/s):         52.40
Peak output token throughput (tok/s):    708.00
Peak concurrent requests:                500.00
Total token throughput (tok/s):          9520.61
---------------Time to First Token----------------
Mean TTFT (ms):                          554327.85
Median TTFT (ms):                        551709.47
P99 TTFT (ms):                           1081423.23
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.88
Median TPOT (ms):                        13.95
P99 TPOT (ms):                           76.66
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.79
Median ITL (ms):                         5.95
P99 ITL (ms):                            421.02
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:      36877.91  36311.93  72300.67
----------------- Preprocessing ------------------
  video_decode_ms:          34682.44  34604.98  69206.22
  get_mm_hashes_ms:            26.50     21.60     95.89
  hf_data_prep_ms:              0.01      0.01      0.01
  hf_processor_call_ms:      2157.70   1804.79   5788.46
  hf_postprocess_ms:            0.48      0.40      2.59
  apply_prompt_updates_ms:     10.79      8.32     38.71
-------------------- Encoding --------------------
  encoder_forward_ms:         317.00    274.82    866.52
  num_encoder_calls:            1.00      1.00      1.00
  embedding_gather_ms:          0.17      0.15      0.40
  embedding_merge_ms:           1.16      1.05      2.69
  prefill_forward_ms:         168.30    154.50    295.81
==================================================
```


## 32 Request Rate with PyAV Backend

```
# Model Server Side
vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0 --media-io-kwargs '{"video":{"backend":"pyav"}}'

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 32       --base-url http://localhost:8091       --served-model-name glm

# Result
============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           32.00
Benchmark duration (s):                  1138.40
Total input tokens:                      10707622
Total generated tokens:                  58501
Request throughput (req/s):              0.45
Output token throughput (tok/s):         51.39
Peak output token throughput (tok/s):    605.00
Peak concurrent requests:                507.00
Total token throughput (tok/s):          9457.26
---------------Time to First Token----------------
Mean TTFT (ms):                          566077.55
Median TTFT (ms):                        565559.49
P99 TTFT (ms):                           1104116.11
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.36
Median TPOT (ms):                        13.12
P99 TPOT (ms):                           63.26
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.19
Median ITL (ms):                         5.91
P99 ITL (ms):                            345.53
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:      45184.41  44305.18  88323.93
----------------- Preprocessing ------------------
  video_decode_ms:          43063.01  42767.60  85789.70
  get_mm_hashes_ms:            27.25     21.51    116.19
  hf_data_prep_ms:              0.01      0.01      0.01
  hf_processor_call_ms:      2171.12   1821.71   5696.93
  hf_postprocess_ms:            0.50      0.40      2.37
  apply_prompt_updates_ms:     10.78      8.22     39.07
-------------------- Encoding --------------------
  encoder_forward_ms:         316.94    275.49    887.30
  num_encoder_calls:            1.00      1.00      1.00
  embedding_gather_ms:          0.17      0.15      0.42
  embedding_merge_ms:           1.51      1.05      2.57
  prefill_forward_ms:         168.18    154.03    295.07
==================================================
```

## 32 Request Rate with `--api-server-count 2`

```
# Model Server Side
vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0 --api-server-count 2 

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 32       --base-url http://localhost:8091       --served-model-name glm

# Result
============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           32.00
Benchmark duration (s):                  739.02
Total input tokens:                      10707622
Total generated tokens:                  58474
Request throughput (req/s):              0.69
Output token throughput (tok/s):         79.12
Peak output token throughput (tok/s):    1702.00
Peak concurrent requests:                504.00
Total token throughput (tok/s):          14568.05
---------------Time to First Token----------------
Mean TTFT (ms):                          351816.89
Median TTFT (ms):                        337547.65
P99 TTFT (ms):                           714405.88
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          530.29
Median TPOT (ms):                        535.63
P99 TPOT (ms):                           1003.16
---------------Inter-token Latency----------------
Mean ITL (ms):                           523.05
Median ITL (ms):                         301.31
P99 ITL (ms):                            2708.91
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:       3702.63   3642.90   8514.65
----------------- Preprocessing ------------------
  video_decode_ms:           1680.76   1703.98   3658.27
  get_mm_hashes_ms:            23.56     19.71     63.97
  hf_data_prep_ms:              0.01      0.01      0.01
  hf_processor_call_ms:      1999.52   1724.63   5352.05
  hf_postprocess_ms:            0.50      0.40      2.23
  apply_prompt_updates_ms:     10.30      7.63     38.94
-------------------- Encoding --------------------
  encoder_forward_ms:         318.75    275.21    819.43
  num_encoder_calls:            1.00      1.00      1.00
  embedding_gather_ms:          0.28      0.26      0.51
  embedding_merge_ms:           1.75      1.08      3.08
  prefill_forward_ms:         188.97    185.37    285.87
==================================================
```

## 32 Request Rate with `--api-server-count 4`

```
# Model Server Side
vllm serve /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/ --tensor-parallel 2 --port 8091 --host 0.0.0.0 --served-model-name glm --enable-mm-processor-stats --allowed-local-media-path / --mm-processor-cache-gb 0 --api-server-count 4

# Benchmark Client Side
vllm bench serve       --backend openai-chat       --endpoint /v1/chat/completions       --model /cloud/oss_checkpoints/zai-org/GLM-4.6V-Flash/       --dataset-name hf --dataset-path yale-nlp/MMVU       --num-prompts 512 --request-rate 32       --base-url http://localhost:8091       --served-model-name glm

# Result
============ Serving Benchmark Result ============
Successful requests:                     512
Failed requests:                         0
Request rate configured (RPS):           32.00
Benchmark duration (s):                  808.21
Total input tokens:                      10707622
Total generated tokens:                  58681
Request throughput (req/s):              0.63
Output token throughput (tok/s):         72.61
Peak output token throughput (tok/s):    1835.00
Peak concurrent requests:                512.00
Total token throughput (tok/s):          13321.24
---------------Time to First Token----------------
Mean TTFT (ms):                          386364.81
Median TTFT (ms):                        410111.24
P99 TTFT (ms):                           777916.82
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          585.75
Median TPOT (ms):                        545.53
P99 TPOT (ms):                           1207.15
---------------Inter-token Latency----------------
Mean ITL (ms):                           579.56
Median ITL (ms):                         320.32
P99 ITL (ms):                            2462.01
==================================================

=========== MM Processor Stage Latency ===========

                                mean    median       p99
preprocessor_total_ms:       3034.68   2563.82   7865.18
----------------- Preprocessing ------------------
  video_decode_ms:            887.72    852.04   1925.85
  get_mm_hashes_ms:            24.02     20.38     64.20
  hf_data_prep_ms:              0.03      0.01      0.02
  hf_processor_call_ms:      2123.57   1800.42   5879.49
  hf_postprocess_ms:            0.49      0.40      2.54
  apply_prompt_updates_ms:     10.88      8.03     39.09
-------------------- Encoding --------------------
  encoder_forward_ms:         329.51    283.61    915.70
  num_encoder_calls:            0.99      1.00      1.00
  embedding_gather_ms:          0.33      0.29      0.90
  embedding_merge_ms:           1.72      1.18      3.19
  prefill_forward_ms:         186.44    183.47    273.96
==================================================
```