### PR TITLE
fix: default-disable FlashInfer sampler on consumer Blackwell GPUs (SM120/SM121)

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -56,6 +56,8 @@ def flashinfer_sampler_supported() -> bool:
     # Default-disable on these archs; users can still explicitly opt in
     # with VLLM_USE_FLASHINFER_SAMPLER=1.
     # See https://github.com/vllm-project/vllm/issues/43885
+    # TODO: remove this workaround after FlashInfer fix
+    # https://github.com/flashinfer-ai/flashinfer/issues/361
     if unsupported_reason is None and capability[0] == 12:
         unsupported_reason = (
             "FlashInfer sampler default-disabled on Blackwell consumer GPUs "

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -51,6 +51,17 @@ def flashinfer_sampler_supported() -> bool:
             f"unsupported compute capability {capability.as_version_str()}"
         )
 
+    # FlashInfer top-k/top-p sampler can cause CUDA stream hangs on
+    # Blackwell consumer GPUs (SM120/SM121: GB10, RTX 5090, RTX 6000 Pro).
+    # Default-disable on these archs; users can still explicitly opt in
+    # with VLLM_USE_FLASHINFER_SAMPLER=1.
+    # See https://github.com/vllm-project/vllm/issues/43885
+    if unsupported_reason is None and capability[0] == 12:
+        unsupported_reason = (
+            "FlashInfer sampler default-disabled on Blackwell consumer GPUs "
+            "(SM120/SM121) due to potential CUDA stream hangs"
+        )
+
     if unsupported_reason is None:
         logger.info_once("Using FlashInfer for top-p & top-k sampling.", scope="global")
         return True


### PR DESCRIPTION
## Summary

Fixes [#43885](https://github.com/vllm-project/vllm/issues/43885) — CUDA stream hang with FlashInfer top-k/top-p sampler on **consumer Blackwell GPUs** (GB10, RTX 5090, RTX 6000 Pro).

## Root Cause

vLLM v0.21.0 enabled FlashInfer top-k/top-p sampling by default ([#40376](https://github.com/vllm-project/vllm/pull/40376)). On consumer Blackwell GPUs (SM120/SM121), the FlashInfer sampler occasionally causes a CUDA stream to stall indefinitely. Data center Blackwell (B200/B300/GB200/GB300 with SM100/SM110) is unaffected.

## Fix

Default-disable FlashInfer sampling on `capability[0] == 12` (SM120/SM121 consumer Blackwell). Users can still explicitly opt in with `VLLM_USE_FLASHINFER_SAMPLER=1`.

## Related

- Closes [#43885](https://github.com/vllm-project/vllm/issues/43885)
- TODO: remove this workaround after FlashInfer fix: link to flashinfer issue

## Testing

- Hardware: Gigabyte AI TOP ATOM (GB10), 128 GB unified VRAM
- Model: ibm-granite/granite-3.0-1b-a400m-base
- Config: enforce_eager=True, async_scheduling=True, speculative_config={draft_model, num_spec_tokens=4}
- Bug scenario (spec decode + keeper + 3 streaming chunks): PASS (34 outputs, finished)
- Baseline (no spec decode): PASS

---
*AI assistance used: Claude (code analysis). Human submitter reviewed and tested on real hardware.*