### PR TITLE
[Bugfix][V1] Don't resume scheduler on a partial wake_up (illegal memory access, #44395)

### DIFF
--- a/tests/v1/engine/test_engine_core_wake_up.py
+++ b/tests/v1/engine/test_engine_core_wake_up.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``EngineCore.wake_up`` scheduler-resume gating (issue #44395).
+
+These exercise only the pure branching logic of ``wake_up`` via a mock
+``self``, so they need no model, GPU, or engine construction and run on CPU.
+"""
+
+from unittest.mock import MagicMock
+
+from vllm.v1.engine.core import EngineCore
+
+
+def _run_wake_up(tags, executor_is_sleeping):
+    """Invoke the unbound ``EngineCore.wake_up`` on a mock self and return it.
+
+    ``model_executor.is_sleeping`` models whether the executor is still
+    (partially) asleep *after* ``model_executor.wake_up(tags)`` ran.
+    """
+    core = MagicMock()
+    core.model_executor.is_sleeping = executor_is_sleeping
+    EngineCore.wake_up(core, tags)
+    return core
+
+
+class TestWakeUpResumeScheduler:
+    def test_partial_weights_wake_does_not_resume_scheduler(self):
+        # tags=["weights"] restores weights but leaves the KV cache released,
+        # so the executor is still sleeping and the scheduler must stay paused.
+        core = _run_wake_up(["weights"], executor_is_sleeping=True)
+        core.model_executor.wake_up.assert_called_once_with(["weights"])
+        core.resume_scheduler.assert_not_called()
+
+    def test_final_kv_cache_wake_resumes_scheduler(self):
+        # The follow-up wake makes the executor fully resident -> resume.
+        core = _run_wake_up(["kv_cache"], executor_is_sleeping=False)
+        core.model_executor.wake_up.assert_called_once_with(["kv_cache"])
+        core.resume_scheduler.assert_called_once_with()
+
+    def test_full_wake_resumes_scheduler(self):
+        core = _run_wake_up(None, executor_is_sleeping=False)
+        core.model_executor.wake_up.assert_called_once_with(None)
+        core.resume_scheduler.assert_called_once_with()
+
+    def test_scheduling_only_wake_resumes_without_touching_executor(self):
+        # Level-0 wake: executor memory is untouched (not sleeping) and only
+        # scheduling resumes.
+        core = _run_wake_up(["scheduling"], executor_is_sleeping=False)
+        core.model_executor.wake_up.assert_not_called()
+        core.resume_scheduler.assert_called_once_with()
+
+    def test_weights_with_scheduling_tag_still_gated(self):
+        # "scheduling" is stripped, ["weights"] is processed; the executor is
+        # still sleeping so the scheduler stays paused.
+        core = _run_wake_up(["weights", "scheduling"], executor_is_sleeping=True)
+        core.model_executor.wake_up.assert_called_once_with(["weights"])
+        core.resume_scheduler.assert_not_called()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -775,8 +775,15 @@ class EngineCore:
         if tags is None or tags:
             self.model_executor.wake_up(tags)
 
-        # Resume scheduling (applies to all levels)
-        self.resume_scheduler()
+        # Only resume scheduling once the executor is fully awake. A partial
+        # wake (e.g. tags=["weights"]) restores weights but leaves the KV
+        # cache released, so resuming would run forward passes -- including
+        # the dummy decode that idle data-parallel ranks issue to stay in
+        # lockstep -- against freed KV cache memory, causing an illegal
+        # memory access. The scheduler is resumed by a later full wake or
+        # wake_up(tags=["kv_cache"]). See issue #44395.
+        if not self.model_executor.is_sleeping:
+            self.resume_scheduler()
 
     def is_sleeping(self) -> bool:
         """Check if engine is sleeping at any level."""


### PR DESCRIPTION
## Purpose

Fixes #44395.

`EngineCore.wake_up()` called `resume_scheduler()` **unconditionally**, even
for a *partial* wake such as `wake_up(tags=["weights"])`:

```python
if tags is None or tags:
    self.model_executor.wake_up(tags)
# Resume scheduling (applies to all levels)
self.resume_scheduler()          # fires even on a weights-only wake
```

A weights-only wake restores model weights but leaves the **KV cache
released** (level-1 sleep discarded it), and `model_executor.is_sleeping`
stays `True` until *every* tag is woken. Resuming the scheduler in that
window lets forward passes run against freed KV-cache memory and crash with:

```
CUDA error: an illegal memory access was encountered
```

In **data-parallel** deployments this triggers with no user request: idle
DP ranks run `execute_dummy_batch()` decodes to stay in lockstep, so the
dummy decode writes into the released KV cache and the crash surfaces
(often as an NCCL `all_gather` error). This breaks the staged-wake pattern
used by RLHF / colocate workflows.

## Fix

Gate `resume_scheduler()` on the executor being fully awake:

```python
if not self.model_executor.is_sleeping:
    self.resume_scheduler()
```

The scheduler is then resumed by a later full wake or
`wake_up(tags=["kv_cache"])`. Level-0 (`tags=["scheduling"]`) and full
wakes are unaffected — the executor is not sleeping in those cases, so the
guard still resumes.

## Test Plan

Added `tests/v1/engine/test_engine_core_wake_up.py` — CPU-only unit tests
that exercise the `wake_up` scheduler-gating logic via a mock `self` (no
GPU/model/engine construction), covering:

- weights-only partial wake → scheduler **stays paused**;
- `["weights", "scheduling"]` (scheduling stripped, executor still asleep)
  → scheduler stays paused;
- full wake (`None`), `["kv_cache"]`, and `["scheduling"]` → scheduler
  resumes.

```bash
python -m pytest tests/v1/engine/test_engine_core_wake_up.py -v
ruff check vllm/v1/engine/core.py tests/v1/engine/test_engine_core_wake_up.py
ruff format --check vllm/v1/engine/core.py tests/v1/engine/test_engine_core_wake_up.py
```

## Test Result

- `pytest` → **5 passed**. Verified the tests are effective: against the
  unpatched `wake_up`, the two "must stay paused" cases **fail** (scheduler
  resumed) and pass after the fix.
- `ruff check` → `All checks passed!`; `ruff format --check` → already
  formatted.

Tested on a CPU-only build (`VLLM_TARGET_DEVICE=empty`). I was not able to
reproduce the end-to-end CUDA illegal-memory-access locally (no GPU); the
unit tests pin the scheduler-resume contract that causes it. End-to-end
validation on the issue's sleep-mode + DP scenario would be appreciated
from a reviewer with GPU access.

## Not a duplicate

No open PR references #44395 (searched issue refs and `wake_up` /
`resume_scheduler` PRs); the issue is unassigned.

---

AI assistance was used to help locate and implement this change. The diff
has been reviewed line by line and the tests were run with the results
shown above.
