### PR TITLE
[Bugfix] Two-phase KV allocation for cross-group prefix cache hits (supersedes #33775)

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -22,7 +22,7 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256, sha256_cbor
 from vllm.v1.core.block_pool import BlockHashToBlockMap, BlockPool
-from vllm.v1.core.kv_cache_manager import KVCacheManager, Request
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager, Request
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashWithGroupId,
@@ -3517,6 +3517,180 @@ def test_can_fit_full_sequence_full_attention_still_gates_oversized():
     req = make_request("oversized", list(range(prompt_len)), block_size, sha256)
 
     assert manager.allocate_slots(req, block_size, full_sequence_must_fit=True) is None
+
+
+def test_cache_hit_local_and_external():
+    # Regression test for #33775: when a request hits the local prefix cache
+    # in one KV cache group and needs external (connector) blocks in another,
+    # the external allocation of an earlier group must not evict the local
+    # cache-hit blocks of a later group. Otherwise the same physical block can
+    # be handed out twice, producing duplicate block IDs / ref_cnt corruption.
+    block_size = 16
+    kv_cache_config = make_kv_cache_config_hybrid_model(block_size, 31, 100)
+    del kv_cache_config.kv_cache_groups[2:]
+    req_id = "test"
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    top_blocks = []
+    head = manager.block_pool.free_block_queue.fake_free_list_head
+    for _ in range(10):
+        top_blocks.append(head.next_free_block)
+        head = head.next_free_block
+    cache_hit = KVCacheBlocks((top_blocks[:5], top_blocks[5:]))
+
+    manager.allocate_slots(
+        make_request(req_id, [0] * (8 * block_size), block_size, sha256),
+        16,
+        5 * block_size,
+        cache_hit,
+        0,
+        2 * block_size,
+    )
+
+    req_blocks = manager.get_blocks(req_id)
+    req_block_ids = req_blocks.get_block_ids()
+    all_block_ids = req_block_ids[0] + req_block_ids[1]
+    assert len(set(all_block_ids)) == len(all_block_ids), "Block IDs are not unique"
+
+
+def _take_free_blocks(manager: KVCacheManager, num_blocks: int) -> list[KVCacheBlock]:
+    """Grab the first ``num_blocks`` blocks at the head of the free queue
+    without removing them. These ref_cnt==0 blocks stand in for evictable
+    cache-hit blocks left behind by a previous (e.g. preempted) request, and
+    sitting at the head guarantees a later group's external ``get_new_blocks``
+    would contend for them on unpatched code (issue #33775)."""
+    blocks: list[KVCacheBlock] = []
+    head = manager.block_pool.free_block_queue.fake_free_list_head
+    for _ in range(num_blocks):
+        head = head.next_free_block
+        blocks.append(head)
+    return blocks
+
+
+def _assert_no_double_allocation(manager: KVCacheManager, req_id: str) -> None:
+    """No physical block may be handed out twice across groups, and every
+    block referenced by the request must have a live ref_cnt."""
+    block_ids = manager.get_blocks(req_id).get_block_ids()
+    flat = [block_id for group in block_ids for block_id in group]
+    assert len(set(flat)) == len(flat), "Block IDs are not unique across groups"
+    null_id = manager.block_pool.null_block.block_id
+    for block_id in flat:
+        if block_id == null_id:
+            continue
+        assert manager.block_pool.blocks[block_id].ref_cnt >= 1, (
+            f"block {block_id} referenced by the request has ref_cnt 0"
+        )
+
+
+def _two_phase_block_size(manager: KVCacheManager) -> int:
+    return manager.kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
+
+
+def _cross_group_cache_hit(
+    manager: KVCacheManager,
+    req_id: str,
+    num_groups: int,
+    local_blocks_per_group: int = 5,
+    num_external_blocks: int = 2,
+    num_new_blocks: int = 1,
+) -> Request:
+    """Allocate ``req_id`` with a per-group local prefix hit plus external
+    (connector) computed tokens, driving the coordinator's two-phase path.
+    Returns the allocated request so callers can free it (e.g. to preempt)."""
+    block_size = _two_phase_block_size(manager)
+    hit_blocks = _take_free_blocks(manager, num_groups * local_blocks_per_group)
+    cache_hit = KVCacheBlocks(
+        tuple(
+            hit_blocks[i * local_blocks_per_group : (i + 1) * local_blocks_per_group]
+            for i in range(num_groups)
+        )
+    )
+    prompt_blocks = local_blocks_per_group + num_external_blocks + num_new_blocks
+    request = make_request(
+        req_id, [0] * (prompt_blocks * block_size), block_size, sha256
+    )
+    manager.allocate_slots(
+        request,
+        num_new_blocks * block_size,
+        local_blocks_per_group * block_size,
+        cache_hit,
+        0,
+        num_external_blocks * block_size,
+    )
+    return request
+
+
+def _make_two_phase_manager(num_groups: int) -> KVCacheManager:
+    assert num_groups in (2, 3)
+    block_size = 16
+    kv_cache_config = make_kv_cache_config_hybrid_model(block_size, 31, 100)
+    del kv_cache_config.kv_cache_groups[num_groups:]
+    return make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+
+def test_cache_hit_local_and_external_three_groups():
+    # Scenario 1 (issue #33775): SWA + full attention with *three* KV cache
+    # groups (1 full + 2 sliding-window). A local prefix hit in some groups
+    # combined with external (connector) blocks in others must not let one
+    # group's external `get_new_blocks` evict another group's not-yet-touched
+    # cache-hit blocks, which would hand the same physical block out twice.
+    manager = _make_two_phase_manager(num_groups=3)
+    _cross_group_cache_hit(manager, "test", num_groups=3)
+    _assert_no_double_allocation(manager, "test")
+
+
+def test_cache_hit_local_and_external_three_groups_preempt_and_reallocate():
+    # Scenario 2: the same 3-group hybrid config, but the request is preempted
+    # (freed) and then reallocated. After the free, the coordinator must treat
+    # the request as new again so external blocks are re-allocated, and the
+    # two-phase ordering must still prevent cross-group double allocation when
+    # reallocating against the now-evictable cache-hit blocks.
+    manager = _make_two_phase_manager(num_groups=3)
+
+    request = _cross_group_cache_hit(manager, "test", num_groups=3)
+    _assert_no_double_allocation(manager, "test")
+
+    # Preempt: free the request; its blocks return to the pool (full ones stay
+    # cached/evictable) and the coordinator forgets it.
+    manager.free(request)
+    assert manager.get_blocks("test").get_block_ids() == ([], [], [])
+
+    # Reallocate the same request id against fresh cache-hit blocks taken from
+    # the current free-queue head, mirroring a preempted request being
+    # scheduled again. Because the request is no longer known, the coordinator
+    # re-arms `is_new_request` and re-runs external allocation, which must still
+    # not double-allocate across groups.
+    _cross_group_cache_hit(manager, "test", num_groups=3)
+    _assert_no_double_allocation(manager, "test")
+    assert manager.get_blocks("test").get_block_ids() != ([], [], [])
+
+
+def test_cache_hit_local_and_external_two_groups_preempt_and_reallocate():
+    # Scenario 3: the minimal 2-group hybrid config (1 full + 1 sliding-window)
+    # exercised through the same preempt -> reallocate cycle as scenario 2.
+    manager = _make_two_phase_manager(num_groups=2)
+
+    request = _cross_group_cache_hit(manager, "test", num_groups=2)
+    _assert_no_double_allocation(manager, "test")
+
+    manager.free(request)
+    assert manager.get_blocks("test").get_block_ids() == ([], [])
+
+    _cross_group_cache_hit(manager, "test", num_groups=2)
+    _assert_no_double_allocation(manager, "test")
+    assert manager.get_blocks("test").get_block_ids() != ([], [])
 
 
 def test_swa_free_split_keeps_cached_tail_ahead_of_scratch(monkeypatch):

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -390,7 +390,7 @@ def test_evictable_cached_blocks_not_double_allocated():
     # should only allocate the truly new block.
     assert num_blocks_to_allocate == 2
 
-    manager.allocate_new_computed_blocks(
+    manager.add_local_computed_blocks(
         request_id,
         [evictable_block],
         num_local_computed_tokens=block_size,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -201,13 +201,33 @@ class KVCacheCoordinator(ABC):
             num_local_computed_tokens: The number of local computed tokens.
             num_external_computed_tokens: The number of external computed tokens.
         """
+        # A request is being allocated for the first time iff no group holds any
+        # blocks for it yet. Running requests hit the per-manager fast path and
+        # never allocate external blocks (matching the previous single-pass
+        # behavior), so external allocation is gated on this.
+        is_new_request = all(
+            len(manager.req_to_blocks.get(request_id, ())) == 0
+            for manager in self.single_type_managers
+        )
+
+        # Two-phase allocation (issue #33775): first touch every group's local
+        # cache-hit blocks, then allocate external blocks for every group. This
+        # ensures an earlier group's external `get_new_blocks` cannot evict a
+        # later group's not-yet-touched cache-hit blocks.
         for i, manager in enumerate(self.single_type_managers):
-            manager.allocate_new_computed_blocks(
+            manager.add_local_computed_blocks(
                 request_id,
                 new_computed_blocks[i],
                 num_local_computed_tokens,
                 num_external_computed_tokens,
             )
+        if is_new_request and num_external_computed_tokens > 0:
+            for manager in self.single_type_managers:
+                manager.allocate_external_computed_blocks(
+                    request_id,
+                    num_local_computed_tokens,
+                    num_external_computed_tokens,
+                )
 
     def allocate_new_blocks(
         self,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -201,17 +201,12 @@ class KVCacheCoordinator(ABC):
             num_local_computed_tokens: The number of local computed tokens.
             num_external_computed_tokens: The number of external computed tokens.
         """
-        # A request is being allocated for the first time iff no group has
-        # registered it yet. Key this on `num_cached_block` (the same signal the
-        # pre-split code used for its fast path), which gated external
-        # allocation on exactly this condition. A running request won't have any
-        # new prefix-cache hits and never allocates external blocks, so it is a
-        # no-op here.
-        is_new_request = all(
-            request_id not in manager.num_cached_block
+        # A running request is already tracked in num_cached_block and won't
+        # have new prefix-cache hits, so this is a no-op for it.
+        if any(
+            request_id in manager.num_cached_block
             for manager in self.single_type_managers
-        )
-        if not is_new_request:
+        ):
             assert all(len(blocks) == 0 for blocks in new_computed_blocks)
             return
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -201,14 +201,19 @@ class KVCacheCoordinator(ABC):
             num_local_computed_tokens: The number of local computed tokens.
             num_external_computed_tokens: The number of external computed tokens.
         """
-        # A request is being allocated for the first time iff no group holds any
-        # blocks for it yet. Running requests hit the per-manager fast path and
-        # never allocate external blocks (matching the previous single-pass
-        # behavior), so external allocation is gated on this.
+        # A request is being allocated for the first time iff no group has
+        # registered it yet. Key this on `num_cached_block` (the same signal the
+        # pre-split code used for its fast path), which gated external
+        # allocation on exactly this condition. A running request won't have any
+        # new prefix-cache hits and never allocates external blocks, so it is a
+        # no-op here.
         is_new_request = all(
-            len(manager.req_to_blocks.get(request_id, ())) == 0
+            request_id not in manager.num_cached_block
             for manager in self.single_type_managers
         )
+        if not is_new_request:
+            assert all(len(blocks) == 0 for blocks in new_computed_blocks)
+            return
 
         # Two-phase allocation (issue #33775): first touch every group's local
         # cache-hit blocks, then allocate external blocks for every group. This
@@ -221,7 +226,7 @@ class KVCacheCoordinator(ABC):
                 num_local_computed_tokens,
                 num_external_computed_tokens,
             )
-        if is_new_request and num_external_computed_tokens > 0:
+        if num_external_computed_tokens > 0:
             for manager in self.single_type_managers:
                 manager.allocate_external_computed_blocks(
                     request_id,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -179,7 +179,7 @@ class SingleTypeKVCacheManager(ABC):
         )
         return num_new_blocks + num_evictable_blocks
 
-    def allocate_new_computed_blocks(
+    def add_local_computed_blocks(
         self,
         request_id: str,
         new_computed_blocks: Sequence[KVCacheBlock],
@@ -187,12 +187,11 @@ class SingleTypeKVCacheManager(ABC):
         num_external_computed_tokens: int,
     ) -> None:
         """
-        Add the new computed blocks to the request. This involves three steps:
-        1. Touch the computed blocks to make sure they won't be evicted.
-        1.5. (Optional) For sliding window, skip blocks are padded with null blocks.
+        Add the locally cached (prefix-hit) blocks to the request:
+        1. Touch the computed blocks (paired with adding them to `req_blocks`)
+           so their ref_cnt exactly tracks the referencing requests.
+        1.5. (Optional) For sliding window, skipped blocks are padded with nulls.
         2. Add the remaining computed blocks.
-        3. (Optional) For KV connectors, allocate new blocks for external computed
-            tokens (if any).
 
         Args:
             request_id: The request ID.
@@ -220,11 +219,6 @@ class SingleTypeKVCacheManager(ABC):
             # It is possible that all new computed blocks are skipped when
             # num_skipped_blocks > len(new_computed_blocks).
             new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
-            # Some external computed tokens may be skipped too.
-            num_external_computed_tokens = min(
-                num_total_computed_tokens - num_skipped_tokens,
-                num_external_computed_tokens,
-            )
 
         # Touch the computed blocks to make sure they won't be evicted.
         if self.enable_caching:
@@ -243,18 +237,48 @@ class SingleTypeKVCacheManager(ABC):
         # have a block_hash set.
         self.num_cached_block[request_id] = len(req_blocks)
 
-        if num_external_computed_tokens > 0:
-            # Allocate new blocks for external computed tokens.
-            allocated_blocks = self.block_pool.get_new_blocks(
-                cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Allocate new blocks for external (KV-connector) computed tokens.
+
+        Must run only after every group's local blocks have been touched via
+        `add_local_computed_blocks`, so this group's `get_new_blocks` cannot
+        evict another group's cache-hit blocks (issue #33775).
+
+        Args:
+            request_id: The request ID.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        if num_skipped_tokens > 0:
+            # Some external computed tokens may be skipped too.
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
             )
-            req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) in (
-                FullAttentionSpec,
-                TQFullAttentionSpec,
-                MLAAttentionSpec,
-            ):
-                self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+        if num_external_computed_tokens <= 0:
+            return
+
+        req_blocks = self.req_to_blocks[request_id]
+        allocated_blocks = self.block_pool.get_new_blocks(
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+        )
+        req_blocks.extend(allocated_blocks)
+        if type(self.kv_cache_spec) in (
+            FullAttentionSpec,
+            TQFullAttentionSpec,
+            MLAAttentionSpec,
+        ):
+            self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
         self, request_id: str, num_tokens: int, num_tokens_main_model: int
@@ -1233,7 +1257,7 @@ class MambaManager(SingleTypeKVCacheManager):
 class CrossAttentionManager(SingleTypeKVCacheManager):
     """Manager for cross-attention KV cache in encoder-decoder models."""
 
-    def allocate_new_computed_blocks(
+    def add_local_computed_blocks(
         self,
         request_id: str,
         new_computed_blocks: Sequence[KVCacheBlock],
@@ -1243,6 +1267,15 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         # We do not cache blocks for cross-attention to be shared between
         # requests, so  `new_computed_blocks` should always be empty.
         assert len(new_computed_blocks) == 0
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # Cross-attention does not use prefix caching / external KV loads.
+        return
 
     def cache_blocks(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -200,14 +200,8 @@ class SingleTypeKVCacheManager(ABC):
             num_local_computed_tokens: The number of local computed tokens.
             num_external_computed_tokens: The number of external computed tokens.
         """
-
-        if request_id in self.num_cached_block:
-            # Fast-path: a running request won't have any new prefix-cache hits.
-            # It should not have any new computed blocks.
-            assert len(new_computed_blocks) == 0
-            return
-
-        # A new request.
+        # The coordinator only calls this for first-time allocations (running
+        # requests are short-circuited there), so the request has no blocks yet.
         req_blocks = self.req_to_blocks[request_id]
         assert len(req_blocks) == 0
         num_total_computed_tokens = (


### PR DESCRIPTION
## Summary
Hybrid models (e.g. Gemma-4) with **local prefix hits + external KV** could assign the same physical block twice: per-group `touch → extend → get_new_blocks(external)` let group *i*'s external alloc evict group *j*'s untouched hit blocks → bad `ref_cnt` / duplicate block IDs → downstream **#43884** assert in `OffloadingConnectorScheduler`.

**Fix:** coordinator runs **all groups' local** (`add_local_computed_blocks`, touch paired with `extend`) **before any group's external** (`allocate_external_computed_blocks`). Implements #33775 intent per **@orozery**'s review (no bulk touch of SWA-skipped blocks; original evictable accounting).

**Not** #44329 connector clamp. Manual soak: RedHat `gemma-4-31B-it-NVFP4`, offload + MTP-3, without #44329 — no ASSERT_581 / engine crash (~900 reqs).

Fixes #43884 (root cause). Supersedes #33775 — credits @heheda12345 for the original approach.

## Relation to other PRs
- **Supersedes #33775** (@heheda12345) — stale/conflicting; same bug, two-phase split + review feedback.
- **Fixes root cause behind #43884**; does not include #44329 band-aid.
- Not duplicating open work on connector-only clamp.

## Test plan
- [x] `pre-commit` on changed files
- [x] `pytest tests/v1/core/test_prefix_caching.py -k test_cache_hit_local_and_external` (fails on unpatched main)
- [x] `pytest tests/v1/core/test_prefix_caching.py` (62 passed, patched)
- [x] `pytest tests/v1/core/test_single_type_kv_cache_manager.py::test_evictable_cached_blocks_not_double_allocated`