### PR TITLE
[LoRA] Fix dedup for post-replacement module aliases

### DIFF
--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -451,6 +451,7 @@ class LoRAModelManager:
             )
             if isinstance(new_module, BaseLayerWithLoRA):
                 wrapped_by_id[id(module)] = new_module
+                wrapped_by_id[id(new_module)] = new_module
 
             # (yard1): TODO make this more robust
             if "lm_head" in module_name:


### PR DESCRIPTION

Follow up on #42757 by fixing another shared-alias LoRA registration case.

#42757 deduplicated LoRA wrapping when the same original module is reachable
through multiple attribute paths, such as the MoE gate alias. However, it only
tracked the id of the original module before replacement.

This misses alias paths that resolve to the already-replaced LoRA wrapper. For
example, in Gemma4, `self_decoder.decoder_layers` aliases `layers`. After the
canonical `layers.*` path is wrapped, the alias path later sees the new
`BaseLayerWithLoRA` object, not the original module. Since the wrapper id was
not tracked, the same wrapper could still be registered twice.

During adapter activation, the canonical module name loads the LoRA weights, but
the alias module name has no matching adapter key and resets the same wrapper,
effectively clearing the LoRA weights.

This PR records both the original module id and the replacement wrapper id, so
both pre-replacement and post-replacement alias paths reuse the existing wrapper
without adding a second `self.modules` entry.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

