### PR TITLE
[BugFix] Fix Traceback due to malformed MessagePack (#24655)

### DIFF
--- a/tests/v1/engine/test_zmq_buffer_race.py
+++ b/tests/v1/engine/test_zmq_buffer_race.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ZMQ zero-copy buffer race condition fix.
+
+The old process_output_sockets code reused bytearray buffers for zero-copy
+ZMQ sends.  Under high concurrency the tracker could report ``done`` before
+ZMQ's I/O thread had fully released the memory, allowing the buffer to be
+overwritten while still in flight — producing garbled msgpack frames on the
+receiving end.
+
+These tests verify:
+1. The aliasing mechanism that enables the corruption.
+2. That buffer reuse *does* corrupt data for messages that hit ZMQ's
+   zero-copy path (>= 65 536 bytes in pyzmq/libzmq 4.x).
+3. That allocating a fresh buffer each time prevents the corruption.
+
+See: https://github.com/vllm-project/vllm/issues/24655
+"""
+
+import msgspec
+import pytest
+import zmq
+
+pytestmark = pytest.mark.cpu_test
+
+# pyzmq / libzmq stores messages < 65536 bytes inline in the zmq_msg_t
+# struct (effectively copying them), but uses true zero-copy for larger
+# messages.  The corruption only manifests on the zero-copy path.
+ZMQ_ZERO_COPY_THRESHOLD = 65536
+
+
+class LargeOutput(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    omit_defaults=True,  # type: ignore[call-arg]
+):
+    """Minimal msgspec type whose encoding exceeds ZMQ_ZERO_COPY_THRESHOLD."""
+
+    request_id: str
+    data: list[int] = []
+
+
+def _make_large_msg(
+    tag: str, *, min_size: int = ZMQ_ZERO_COPY_THRESHOLD
+) -> LargeOutput:
+    """Return a LargeOutput whose msgpack encoding is >= *min_size* bytes."""
+    # Each int element encodes to ~1-5 bytes in msgpack.  Overshoot a bit
+    # to guarantee we cross the threshold.
+    n_items = min_size  # list[int] with small ints → ~1 byte each + overhead
+    return LargeOutput(request_id=tag, data=list(range(n_items)))
+
+
+@pytest.fixture
+def zmq_push_pull():
+    """Yield a (push, pull) inproc socket pair and clean up afterwards."""
+    ctx = zmq.Context()
+    push = ctx.socket(zmq.PUSH)
+    pull = ctx.socket(zmq.PULL)
+    addr = "inproc://test-zmq-buffer-race"
+    push.bind(addr)
+    pull.connect(addr)
+    yield push, pull
+    push.close(linger=0)
+    pull.close(linger=0)
+    ctx.term()
+
+
+# ── 1. Mechanism proof ──────────────────────────────────────────────
+
+
+def test_zmq_frame_aliases_mutable_buffer():
+    """zmq.Frame(bytearray, copy=False) directly references the buffer.
+
+    Mutating the bytearray after Frame creation changes what the Frame
+    reports.  This aliasing is the prerequisite for the race.
+    """
+    buf = bytearray(b"original message content!")
+    frame = zmq.Frame(buf, copy=False)
+    assert bytes(frame) == b"original message content!"
+
+    buf[:8] = b"CORRUPT!"
+    assert bytes(frame) == b"CORRUPT! message content!"
+
+
+def test_large_bytearray_is_zero_copied_by_zmq(zmq_push_pull):
+    """pyzmq does true zero-copy for raw bytearrays >= 65536 bytes.
+
+    Below this threshold, data is copied into the zmq_msg_t inline
+    storage, making the aliasing harmless.  At or above the threshold
+    the bytearray's memory is shared — mutations after send are visible
+    to the receiver.
+    """
+    push, pull = zmq_push_pull
+
+    # Below threshold: safe (pyzmq copies internally).
+    small = bytearray(b"A" * (ZMQ_ZERO_COPY_THRESHOLD - 1))
+    push.send_multipart([small], copy=False)
+    small[:4] = b"ZZZZ"
+    received = pull.recv_multipart()
+    assert received[0][:4] == b"AAAA", "small buffer should NOT be aliased"
+
+    # At threshold: zero-copy (aliased).
+    large = bytearray(b"B" * ZMQ_ZERO_COPY_THRESHOLD)
+    push.send_multipart([large], copy=False)
+    large[:4] = b"ZZZZ"
+    received = pull.recv_multipart()
+    assert received[0][:4] == b"ZZZZ", "large buffer SHOULD be aliased"
+
+
+# ── 2. Corruption with buffer reuse ────────────────────────────────
+
+
+def test_buffer_reuse_corrupts_large_messages(zmq_push_pull):
+    """Reusing the encode_into buffer corrupts large in-flight messages.
+
+    This reproduces the mechanism behind the race condition: the encoder
+    clears and rewrites the same bytearray, and because the message is
+    large enough to hit ZMQ's zero-copy path, the receiver sees the
+    *second* encoding instead of the first.
+    """
+    push, pull = zmq_push_pull
+    encoder = msgspec.msgpack.Encoder()
+    decoder = msgspec.msgpack.Decoder(LargeOutput)
+
+    msg1 = _make_large_msg("msg1")
+    msg2 = _make_large_msg("msg2")
+
+    buffer = bytearray()
+    encoder.encode_into(msg1, buffer)
+    assert len(buffer) >= ZMQ_ZERO_COPY_THRESHOLD
+
+    snapshot = bytes(buffer)
+    push.send_multipart([buffer], copy=False)
+
+    # Reuse the buffer immediately — overwrites in-flight data.
+    encoder.encode_into(msg2, buffer)
+
+    frames = pull.recv_multipart()
+    received = bytes(frames[0])
+
+    # The received data should NOT match the original msg1 encoding.
+    assert received != snapshot, (
+        "Expected corruption from buffer reuse, "
+        "but the data was intact — the zero-copy aliasing "
+        "did not occur on this platform/pyzmq combination."
+    )
+
+    # Decoding should give msg2's content or fail entirely.
+    try:
+        result = decoder.decode(received)
+        assert result.request_id != "msg1", (
+            "Received msg1 intact despite buffer overwrite"
+        )
+    except msgspec.DecodeError:
+        pass  # garbled data — confirms corruption
+
+
+# ── 3. Fresh buffers prevent corruption ─────────────────────────────
+
+
+def test_fresh_buffers_prevent_corruption(zmq_push_pull):
+    """Allocating a fresh bytearray per send prevents corruption.
+
+    This verifies the fix: even with large messages that cross the
+    zero-copy threshold, each message is encoded into its own buffer,
+    so no aliasing can occur.
+    """
+    push, pull = zmq_push_pull
+    encoder = msgspec.msgpack.Encoder()
+    decoder = msgspec.msgpack.Decoder(LargeOutput)
+
+    messages = [_make_large_msg(f"msg{i}") for i in range(20)]
+
+    for msg in messages:
+        buffer = bytearray()  # fresh buffer — the fix
+        encoder.encode_into(msg, buffer)
+        push.send_multipart([buffer], copy=False)
+
+    for expected in messages:
+        frames = pull.recv_multipart()
+        result = decoder.decode(frames[0])
+        assert result.request_id == expected.request_id
+        assert result.data == expected.data

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1521,12 +1521,10 @@ class EngineCoreProc(EngineCore):
 
         # Msgpack serialization encoding.
         encoder = MsgpackEncoder()
-        # Send buffers to reuse.
-        reuse_buffers: list[bytearray] = []
-        # Keep references to outputs and buffers until zmq is finished
-        # with them (outputs may contain tensors/np arrays whose
-        # backing buffers were extracted for zero-copy send).
-        pending = deque[tuple[zmq.MessageTracker, Any, bytearray]]()
+        # Keep references to outputs until zmq is finished with them
+        # (outputs may contain tensors/np arrays whose backing buffers
+        # were extracted for zero-copy send).
+        pending = deque[tuple[zmq.MessageTracker, Any]]()
 
         # We must set linger to ensure the ENGINE_CORE_DEAD
         # message is sent prior to closing the socket.
@@ -1546,8 +1544,6 @@ class EngineCoreProc(EngineCore):
                 if coord_output_path is not None
                 else None
             )
-            max_reuse_bufs = len(sockets) + 1
-
             while True:
                 output = self.output_queue.get()
                 if output == EngineCoreProc.ENGINE_CORE_DEAD:
@@ -1559,27 +1555,31 @@ class EngineCoreProc(EngineCore):
                 outputs.engine_index = engine_index
 
                 if client_index == -1:
-                    # Don't reuse buffer for coordinator message
-                    # which will be very small.
                     assert coord_socket is not None
                     coord_socket.send_multipart(encoder.encode(outputs))
                     continue
 
-                # Reclaim buffers that zmq is finished with.
+                # Release references for completed sends.
                 while pending and pending[-1][0].done:
-                    reuse_buffers.append(pending.pop()[2])
+                    pending.pop()
 
-                buffer = reuse_buffers.pop() if reuse_buffers else bytearray()
+                # Always allocate a fresh buffer to avoid reuse
+                # race with zmq's async I/O thread.
+                buffer = bytearray()
                 buffers = encoder.encode_into(outputs, buffer)
-                tracker = sockets[client_index].send_multipart(
-                    buffers, copy=False, track=True
-                )
-                if not tracker.done:
-                    ref = outputs if len(buffers) > 1 else None
-                    pending.appendleft((tracker, ref, buffer))
-                elif len(reuse_buffers) < max_reuse_bufs:
-                    # Limit the number of buffers to reuse.
-                    reuse_buffers.append(buffer)
+                if len(buffers) > 1:
+                    # Tensor/numpy backing buffers: track to prevent
+                    # GC of outputs while zmq reads tensor memory.
+                    tracker = sockets[client_index].send_multipart(
+                        buffers, copy=False, track=True
+                    )
+                    if not tracker.done:
+                        pending.appendleft((tracker, outputs))
+                else:
+                    # Common path (single msgpack frame): the zmq
+                    # Frame holds a ref to the unique buffer, so no
+                    # tracker is needed.
+                    sockets[client_index].send(buffers[0], copy=False)
 
     def _handle_request_preproc_error(self, request: EngineCoreRequest) -> None:
         """Log and return a request-scoped error response for exceptions raised


### PR DESCRIPTION
## Summary

Fixes #24655.

Problem: vLLM ApiServer fails to receive a message from EngineCore, since message is malformed. In some cases just a traceback is printed. In other cases vLLM processes are terminated.
Problem can be reconstructed in latest main branch and in v0.19.0

Overview:
`process_output_sockets` in `vllm/v1/engine/core.py` reuses a pool of `bytearray` buffers and sends ZMQ frames with `copy=False`, relying on `zmq.MessageTracker.done` to know when a buffer is safe to recycle. Under sustained high-throughput workloads, the tracker can report completion before ZMQ's I/O thread has fully released the underlying memory. The buffer is then overwritten by `encode_into` while still in flight, producing garbled msgpack on the receiving end:

```
msgspec.DecodeError: MessagePack data is malformed: trailing characters (byte 198)
```

**Root cause:** pyzmq/libzmq uses true zero-copy (direct memory aliasing) for buffers >= 65,536 bytes when `copy=False` is set. The `bytearray` passed to `send_multipart` is not copied — the ZMQ frame points directly into the buffer's memory. When the buffer is recycled and `encode_into` clears and rewrites it, any in-flight frame referencing that memory sees corrupted data. Large output messages (e.g. beam-search with logprobs, scoring/embedding batches) routinely exceed this 64 KB threshold, which is why the bug manifests only under heavy production load.

**Fix:** Replace the buffer-reuse pool with a fresh `bytearray()` allocation per iteration. Additionally split the send path:

- **Multi-buffer path** (`len(buffers) > 1`): outputs contain tensor/numpy backing buffers extracted for zero-copy. Use `send_multipart(..., copy=False, track=True)` and hold a reference to `outputs` in `pending` to prevent GC while ZMQ reads tensor memory.
- **Single-buffer path** (`len(buffers) == 1`, common case): only one msgpack frame. Use `send(..., copy=False)` with no tracker — the ZMQ Frame itself holds a reference to the unique buffer, preventing it from being freed until transmission completes.

This trades a minor allocation cost (fresh `bytearray()` per send) for correctness. The allocation is cheap — Python's allocator reuses recently-freed small blocks — while the corruption causes hard-to-diagnose production crashes.

In performance tests in beam search use case, no performance degradation is seen.

## Duplicate-work check

```bash
gh pr list --repo vllm-project/vllm --state open --search "24655 in:body"
# No results — no open PR addresses this issue.
gh pr list --repo vllm-project/vllm --state open --search "malformed msgpack buffer reuse"
# No results.
```

## Test plan

New test file `tests/v1/engine/test_zmq_buffer_race.py` with 4 deterministic, CPU-only tests:

| Test | What it verifies |
|---|---|
| `test_zmq_frame_aliases_mutable_buffer` | `zmq.Frame(bytearray, copy=False)` shares memory — mutating the buffer changes the frame's view |
| `test_large_bytearray_is_zero_copied_by_zmq` | Below 65 536 B pyzmq copies internally (safe); at/above the threshold it does true zero-copy (aliased) |
| `test_buffer_reuse_corrupts_large_messages` | `encode_into` on a reused buffer overwrites the in-flight ZMQ message — **deterministically reproduces the corruption** |
| `test_fresh_buffers_prevent_corruption` | Allocating a fresh `bytearray()` per send prevents corruption — **validates the fix** |

```bash
pre-commit run --files vllm/v1/engine/core.py tests/v1/engine/test_zmq_buffer_race.py
pytest tests/v1/engine/test_zmq_buffer_race.py -v   # 4 passed
```

## Test Results

### Traceback reconstruction (with and w/o fix)

### server command
```bash
vllm serve OpenOneRec/OneRec-1.7B --trust-remote-code --default-chat-template-kwargs '{"enable_thinking": false}' --max-logprobs 4096 --max_num_seqs 1024 --gpu-memory-utilization 0.4 --max_num_batched_tokens 16384
```

### client command

place this script [client_long_en.sh](https://github.com/user-attachments/files/28676590/client_long_en.sh) in your server and then run

```bash
for i in {1..100}; do
    for j in {1..5}; do
        bash client_long_en.sh &
    done
    wait
done

```

This script runs 100 cycles, where each cycle launches 5 concurrent beam search clients with beam width 512.
The model used is OpenOneRec/OneRec-1.7B

### server output w/o code fix
[vllm_serve_v17_2_branch_main_traceback_occur.log](https://github.com/user-attachments/files/28550439/vllm_serve_v17_2_branch_main_traceback_occur.log)


### server output with code fix
[vllm_serve_v17_2_branch_main_with_pr_44414_fix_no_traceback.log](https://github.com/user-attachments/files/28550447/vllm_serve_v17_2_branch_main_with_pr_44414_fix_no_traceback.log)


### UT

```bash
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ehaleva/workspace/git-proj/vllm-gr/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/ehaleva/workspace/git-proj/vllm_vanilla_main/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, cov-7.1.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 4 items

tests/v1/engine/test_zmq_buffer_race.py::test_zmq_frame_aliases_mutable_buffer PASSED [ 25%]
tests/v1/engine/test_zmq_buffer_race.py::test_large_bytearray_is_zero_copied_by_zmq PASSED [ 50%]
tests/v1/engine/test_zmq_buffer_race.py::test_buffer_reuse_corrupts_large_messages PASSED [ 75%]
tests/v1/engine/test_zmq_buffer_race.py::test_fresh_buffers_prevent_corruption PASSED [100%]

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/v1/engine/test_zmq_buffer_race.py: 14 warnings
  /home/ehaleva/workspace/git-proj/vllm-gr/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 4 passed, 16 warnings in 1.68s ========================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

# Pre-commit

```bash
# pre-commit run -a 

ruff check..........................................................................................Passed
ruff format.........................................................................................Passed
typos...............................................................................................Passed
clang-format........................................................................................Passed
markdownlint-cli2...................................................................................Passed
Lint GitHub Actions workflow files..................................................................Passed
pip-compile.........................................................................................Passed
pip-compile-rocm....................................................................................Passed
pip-compile-xpu.....................................................................................Passed
pip-compile-docs....................................................................................Passed
reformat test/nightly-torch.txt to be in sync with test/cuda.in.....................................Passed
Run mypy locally for lowest supported Python version................................................Passed
Lint shell scripts..................................................................................Passed
Lint PNG exports from excalidraw....................................................................Passed
Check SPDX headers..................................................................................Passed
Check root lazy imports.............................................................................Passed
Check for spaces in all filenames...................................................................Passed
Update Dockerfile dependency graph..................................................................Passed
Test non-root entrypoint wrapper....................................................................Passed
Check for forbidden imports.........................................................................Passed
Prevent new 'torch.cuda' APIs call..................................................................Passed
Validate configuration has default values and that each field has a docstring.......................Passed
Validate docker/versions.json matches Dockerfile....................................................Passed
Check attention backend documentation is up to date.................................................Passed
Check for boolean ops in with-statements............................................................Passed
Rust - Normalize Cargo manifests with autoinherit...................................................Passed
Rust - Sort Cargo manifest sections.................................................................Passed
Rust - Format code..................................................................................Passed
Suggestion..........................................................................................Passed
- hook id: suggestion
- duration: 0s

To bypass all the pre-commit hooks, add --no-verify to git commit. To skip a specific hook, prefix the commit command with SKIP=<hook-id>.

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

