### PR TITLE
Revert "[CI/Build] Bump flashinfer to v0.6.12" (#44036)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -757,7 +757,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.12
+ARG FLASHINFER_VERSION=0.6.11.post2
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -256,13 +256,13 @@ RUN pip install setuptools==75.6.0 packaging==23.2 ninja==1.11.1.3 build==1.2.2.
 
 
 # build flashinfer for torch nightly from source around 10 mins
-# release version: v0.6.12
+# release version: v0.6.11.post2
 # todo(elainewy): cache flashinfer build result for faster build
 ENV CCACHE_DIR=/root/.cache/ccache
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/uv \
     echo "git clone flashinfer..." \
-    && git clone --depth 1 --branch v0.6.12 --recursive https://github.com/flashinfer-ai/flashinfer.git \
+    && git clone --depth 1 --branch v0.6.11.post2 --recursive https://github.com/flashinfer-ai/flashinfer.git \
     && cd flashinfer \
     && git submodule update --init --recursive \
     && echo "finish git clone flashinfer..." \

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.12"
+      "default": "0.6.11.post2"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,8 @@ torchaudio==2.11.0
 # These must be updated alongside torch
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.12
-flashinfer-cubin==0.6.12
+flashinfer-python==0.6.11.post2
+flashinfer-cubin==0.6.11.post2
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
 # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to


### PR DESCRIPTION
## Revert of #44036

This reverts commit 8b3b71ee9db164dd236f20250e5b34e84b75de80 (PR https://github.com/vllm-project/vllm/pull/44036).

### Reason

The flashinfer v0.6.12 bump introduced in #44036 is linked to **3 new CI failures** in nightly build [#69683](https://buildkite.com/vllm/ci/builds/69683):

- **LM Eval Large Models (B200, EP)**: GSM8K accuracy dropped to 39% vs 67% threshold for `Qwen3-Next-80B-A3B-NVFP4-EP2` (severe accuracy regression)
- **LM Eval Qwen3.5 Models (B200)**: Server exits unexpectedly for TurboQuant models on B200
- **LM Eval TurboQuant KV Cache**: Server exits unexpectedly for TurboQuant KV cache tests

### Files changed
- `docker/Dockerfile`
- `docker/Dockerfile.nightly_torch`
- `docker/versions.json`
- `requirements/cuda.txt`

---
*Auto-generated by CI failure analyzer. Build [#69683](https://buildkite.com/vllm/ci/builds/69683).*