### PR TITLE
[XPU] skip UT test_with_ngram_gpu_spec_decoding

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -158,6 +158,10 @@ def test_with_eagle3_spec_decoding(sample_json_schema, monkeypatch: pytest.Monke
 
 
 @pytest.mark.flaky(reruns=2, only_on=current_platform.is_rocm())
+@pytest.mark.skipif(
+    current_platform.is_xpu(),
+    reason=("XPU matmul/attention kernels are not batch-invariant"),
+)
 def test_with_ngram_gpu_spec_decoding(monkeypatch: pytest.MonkeyPatch):
     """Test ngram_gpu speculative decoding with different configurations.
 


### PR DESCRIPTION
 XPU matmul/attention kernels are not batch-invariant across chunked-vs-non-chunked prefill and sync-vs-async scheduling shapes, so token outputs can diverge slightly between configs.