### PR TITLE
[Bugfix] Fix CPU memory leak related to not cleaning up old remotes data

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -20,6 +20,7 @@ import torch
 from vllm import LLM
 from vllm.config import KVTransferConfig, set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.utils import (
+    EngineTransferInfo,
     KVOutputAggregator,
     TransferTopology,
     get_current_attn_backend,
@@ -1844,6 +1845,11 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         worker.src_xfer_handles_by_tp_ratio = {-2: [456, 457]}
         worker.dst_xfer_side_handles = {"engine1": {0: 789}}
         worker._remote_agents = {"engine1": {0: "agent1"}}
+        # _cleanup_remote_engine (called by shutdown) also clears these:
+        worker.kv_caches_base_addr["engine1"] = {0: [0xABC]}
+        worker.dst_num_blocks["engine1"] = 50
+        worker.tp_mappings["engine1"] = MagicMock()
+        worker._engine_last_active["engine1"] = time.perf_counter()
         worker._registered_descs = ["desc1", "desc2"]
 
         mock_listener.is_alive.return_value = False
@@ -1872,6 +1878,118 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         assert mock_dereg.call_count == 2
         mock_dereg.assert_any_call("desc1")
         mock_dereg.assert_any_call("desc2")
+
+
+# ── TTL-based remote engine eviction tests ──────────────────────────
+
+
+def _setup_worker_with_remote_engine(
+    engine_ttl: float = 10.0,
+) -> tuple[Any, str]:
+    """Create a worker with one remote engine registered."""
+    vllm_config = create_vllm_config(
+        kv_connector_extra_config={"engine_ttl": engine_ttl},
+    )
+    worker = NixlConnectorWorker(
+        vllm_config,
+        vllm_config.kv_transfer_config.engine_id,
+        make_kv_cache_config(block_size=16),
+    )
+
+    engine_id = "remote-engine-1"
+    worker._remote_agents[engine_id] = {0: "agent_0", 1: "agent_1"}
+    worker.dst_xfer_side_handles[engine_id] = {0: 100, 1: 200}
+    worker.kv_caches_base_addr[engine_id] = {0: [0xABC]}
+    worker.dst_num_blocks[engine_id] = 50
+    worker.tp_mappings[engine_id] = MagicMock()
+    worker._engine_last_active[engine_id] = time.perf_counter()
+
+    worker.transfer_topo = MagicMock()
+
+    return worker, engine_id
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_engine_ttl_eviction(default_vllm_config, dist_init):
+    """Stale engines are evicted when TTL expires."""
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=10.0)
+    nixl_wrapper = worker.nixl_wrapper
+
+    with (
+        patch.object(nixl_wrapper, "release_dlist_handle") as mock_rel,
+        patch.object(nixl_wrapper, "remove_remote_agent") as mock_rem,
+    ):
+        # Make the engine stale.
+        worker._engine_last_active[engine_id] = time.perf_counter() - 20.0
+
+        worker._evict_stale_engines()
+
+        assert engine_id not in worker._remote_agents
+        assert engine_id not in worker.dst_xfer_side_handles
+        assert engine_id not in worker.kv_caches_base_addr
+        assert engine_id not in worker.dst_num_blocks
+        assert engine_id not in worker.tp_mappings
+        assert engine_id not in worker._engine_last_active
+        worker.transfer_topo.unregister_remote_engine.assert_called_with(engine_id)
+
+        assert mock_rel.call_count == 2
+        mock_rel.assert_any_call(100)
+        mock_rel.assert_any_call(200)
+
+        assert mock_rem.call_count == 2
+        mock_rem.assert_any_call("agent_0")
+        mock_rem.assert_any_call("agent_1")
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_engine_ttl_disabled(default_vllm_config, dist_init):
+    """Eviction is disabled when engine_ttl <= 0."""
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=0.0)
+
+    # Make the engine stale.
+    worker._engine_last_active[engine_id] = time.perf_counter() - 9999.0
+
+    worker._evict_stale_engines()
+
+    # Nothing should be evicted.
+    assert engine_id in worker._remote_agents
+    assert engine_id in worker.dst_xfer_side_handles
+
+
+def test_transfer_topology_unregister():
+    """TransferTopology.unregister_remote_engine removes the engine."""
+    topo = TransferTopology(
+        tp_rank=0,
+        tp_size=1,
+        block_size=16,
+        engine_id="local",
+        is_mla=False,
+        is_mamba=False,
+        total_num_kv_heads=4,
+        attn_backends=[FlashAttentionBackend],
+    )
+
+    info = EngineTransferInfo(
+        remote_tp_size=1,
+        remote_block_size=16,
+        remote_block_len=64,
+        remote_physical_blocks_per_logical=1,
+    )
+    topo.register_remote_engine("remote-1", info)
+    assert topo.get_engine_info("remote-1") is info
+
+    topo.unregister_remote_engine("remote-1")
+    with pytest.raises(KeyError):
+        topo.get_engine_info("remote-1")
+
+    # Idempotent: no error on double-unregister
+    topo.unregister_remote_engine("remote-1")
 
 
 @patch(

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -258,7 +258,7 @@ def test_apply_prefix_caching_mamba_hybrid(
     )
     from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
 
-    worker = object.__new__(cls=NixlConnectorWorker)
+    worker = object.__new__(NixlConnectorWorker)
     worker._has_mamba = True
     worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
     worker._group_spec_types = (FullAttentionSpec, MambaSpec)

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -162,6 +162,7 @@ def test_read_blocks_for_req_expands_remote_ids(
 
     worker = object.__new__(NixlConnectorWorker)
     worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
+    worker._engine_last_active = {}
 
     has_mamba = any(t is MambaSpec for t in resolved_types)
     has_swa = any(t is SlidingWindowSpec for t in resolved_types)
@@ -257,7 +258,7 @@ def test_apply_prefix_caching_mamba_hybrid(
     )
     from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
 
-    worker = object.__new__(NixlConnectorWorker)
+    worker = object.__new__(cls=NixlConnectorWorker)
     worker._has_mamba = True
     worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
     worker._group_spec_types = (FullAttentionSpec, MambaSpec)

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -482,7 +482,9 @@ class TransferTopology:
         return self._engines[(remote_engine_id, remote_pp_rank)]
 
     def unregister_remote_engine(self, remote_engine_id: EngineId) -> None:
-        self._engines.pop(remote_engine_id, None)  # type: ignore[call-overload]
+        # Remove all pp_rank entries for the remote engine.
+        for key in [k for k in self._engines if k[0] == remote_engine_id]:
+            del self._engines[key]
 
     # ============================================================
     # Layout properties

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -482,7 +482,7 @@ class TransferTopology:
         return self._engines[(remote_engine_id, remote_pp_rank)]
 
     def unregister_remote_engine(self, remote_engine_id: EngineId) -> None:
-        self._engines.pop(remote_engine_id, None)
+        self._engines.pop(remote_engine_id, None)  # type: ignore[call-overload]
 
     # ============================================================
     # Layout properties

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -481,6 +481,9 @@ class TransferTopology:
     ) -> EngineTransferInfo:
         return self._engines[(remote_engine_id, remote_pp_rank)]
 
+    def unregister_remote_engine(self, remote_engine_id: EngineId) -> None:
+        self._engines.pop(remote_engine_id, None)
+
     # ============================================================
     # Layout properties
     # ============================================================

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -411,7 +411,7 @@ class NixlConnectorWorker:
         # TTL-based eviction of stale remote engine state.
         self._engine_last_active: dict[EngineId, float] = {}
         self._engine_ttl: float = vllm_config.kv_transfer_config.get_from_extra_config(
-            "engine_ttl", 600.0
+            "engine_ttl", 3600.0
         )
 
         self.block_size = vllm_config.cache_config.block_size

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -2036,7 +2036,8 @@ class NixlConnectorWorker:
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        # Update last activity from this remote.
+        # Update last activity from this remote. Mind that cleanup is done on main
+        # thread (this one), so we don't race on this structure.
         self._engine_last_active[engine_id] = time.perf_counter()
         plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -408,6 +408,12 @@ class NixlConnectorWorker:
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
 
+        # TTL-based eviction of stale remote engine state.
+        self._engine_last_active: dict[EngineId, float] = {}
+        self._engine_ttl: float = vllm_config.kv_transfer_config.get_from_extra_config(
+            "engine_ttl", 600.0
+        )
+
         self.block_size = vllm_config.cache_config.block_size
         self.model_config = vllm_config.model_config
 
@@ -711,6 +717,7 @@ class NixlConnectorWorker:
         returned future.
         Failures to handshake are logged and the request is marked as failed.
         """
+        self._evict_stale_engines()
         with self._handshake_lock:
             if engine_id in self._remote_agents:
                 return None
@@ -731,6 +738,7 @@ class NixlConnectorWorker:
                     del self._handshake_futures[eid]
                     try:
                         self._remote_agents[eid] = f.result()
+                        self._engine_last_active[eid] = time.perf_counter()
                     except Exception as e:
                         self._log_failure(
                             failure_type="handshake_setup_failed",
@@ -2028,6 +2036,8 @@ class NixlConnectorWorker:
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
+        # Update last activity from this remote.
+        self._engine_last_active[engine_id] = time.perf_counter()
         plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
@@ -2473,6 +2483,61 @@ class NixlConnectorWorker:
                 break
         return result
 
+    def _evict_stale_engines(self) -> None:
+        """Scan for and evict remote engines that have exceeded their TTL.
+
+        Called from the main thread in when a new remote engine appears.
+        We can only go OOM as we discover and register a new remote, therefore we make
+        sure we clean up stale engine data structures before then. This invariant
+        prevents us from using background threads, though memory usage is not guaranteed
+        to be "optimal" until a new handshake is performed.
+
+        Engines with active transfers or pending handshakes cannot be stale:
+        - Active transfers touch _engine_last_active in start_load_kv.
+        - Pending handshakes don't have an _engine_last_active entry yet
+        """
+        # NOTE (NickLucche): This does NOT currently prevent OOMing if a huge number
+        # of remote engines is registered all at once (adding a background cleanup
+        # thread wouldnt help either).
+        # If that scenario is plausible, we can follow up with an LRU eviction policy.
+        if self._engine_ttl <= 0:
+            return
+
+        now = time.perf_counter()
+        for eid, last_active in list(self._engine_last_active.items()):
+            if now - last_active > self._engine_ttl:
+                self._cleanup_remote_engine(eid)
+
+    def _cleanup_remote_engine(
+        self, engine_id: EngineId, *, log_eviction: bool = True
+    ) -> None:
+        """Remove all state for a single remote engine.
+
+        Releases NIXL resources (dlist handles, remote agents) and clears
+        all per-engine data structures. Used by both TTL eviction and
+        shutdown.
+        """
+        assert engine_id in self._remote_agents
+
+        for handle in self.dst_xfer_side_handles.pop(engine_id).values():
+            self.nixl_wrapper.release_dlist_handle(handle)
+        for agent_name in self._remote_agents.pop(engine_id).values():
+            self.nixl_wrapper.remove_remote_agent(agent_name)
+
+        del self.kv_caches_base_addr[engine_id]
+        del self.dst_num_blocks[engine_id]
+        del self.tp_mappings[engine_id]
+        if self.transfer_topo is not None:
+            self.transfer_topo.unregister_remote_engine(engine_id)
+
+        last_active = self._engine_last_active.pop(engine_id)
+        if log_eviction:
+            logger.info(
+                "Evicted stale remote engine %s (inactive for %.1fs).",
+                engine_id,
+                time.perf_counter() - last_active,
+            )
+
     def __del__(self):
         self.shutdown()
 
@@ -2493,14 +2558,8 @@ class NixlConnectorWorker:
             for handle in handles:
                 self.nixl_wrapper.release_dlist_handle(handle)
         self.src_xfer_handles_by_tp_ratio.clear()
-        for dst_xfer_side_handles in self.dst_xfer_side_handles.values():
-            for dst_xfer_side_handle in dst_xfer_side_handles.values():
-                self.nixl_wrapper.release_dlist_handle(dst_xfer_side_handle)
-        self.dst_xfer_side_handles.clear()
-        for remote_agents in self._remote_agents.values():
-            for agent_name in remote_agents.values():
-                self.nixl_wrapper.remove_remote_agent(agent_name)
-        self._remote_agents.clear()
+        for engine_id in list(self._remote_agents):
+            self._cleanup_remote_engine(engine_id, log_eviction=False)
         for desc in self._registered_descs:
             self.nixl_wrapper.deregister_memory(desc)
         self._registered_descs.clear()


### PR DESCRIPTION
 ## Problem

When a Prefill pod dies, the Decode pod never cleans up per-engine state accumulated during handshake (D has no way to know when a P dies/is not used anymore right now).
These grow monotonically until D shuts down, leaking both NIXL resources and memory.

## Approach

This PR adds a **TTL-based eviction** policy: if D hasn't read from a remote engine for `engine_ttl` seconds (default 600, configurable via kv_connector_extra_config), all its state is released.

The eviction check runs inline on the main thread in _ensure_handshake, right before registering a new remote — not on a background thread. 
This is the only place memory grows, so checking there is **sufficient to prevent OOM**, similar to how
some data structures check eviction on insert.

The alternative approach considered is to use a background thread, but that would add extra complexity and contention on NIXL calls (not thread-safe), with little benefits since handshakes are already rare.
The trade-off is that the approach proposed here does not guarantee _optimal_ memory usage until the next handshake is performed. But this in my view less important, because both methods only guarantee cleaning up within a time window >  `engine_ttl`, and more importantly other primary use of memory like offloading already allocate/reserve memory ahead of time.


Furthermore, please note that the minimal approach proposed here naturally extends to LRU eviction if we ever need to handle surges of simultaneous remote registrations (and want to only allow N at a time). 

## Validating
---
Here's a simple script I used to validate the TTL
<details>

```python3
from __future__ import annotations

import argparse
import contextlib
import gc
import os
import sys
import tempfile
import time
os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")

try:
    import msgspec  # noqa: E402
    import torch  # noqa: E402
except ModuleNotFoundError as exc:
    print(
        "Missing dependency. Run with the project venv, e.g.\n"
        "  chg run -- /path/to/.venv/bin/python "
        "tests/v1/kv_connector/unit/test_mem_leak.py",
        file=sys.stderr,
    )
    raise SystemExit(1) from exc

from vllm.config import (  # noqa: E402
    AttentionConfig,
    CacheConfig,
    DeviceConfig,
    KVTransferConfig,
    ModelConfig,
    SchedulerConfig,
    VllmConfig,
    set_current_vllm_config,
)
from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (  # noqa: E402
    NixlAgentMetadata,
    NixlConnectorWorker,
    NixlHandshakePayload,
)
from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (  # noqa: E402
    GET_META_MSG,
)
from vllm.distributed.nixl_utils import NixlWrapper  # noqa: E402
from vllm.v1.kv_cache_interface import (  # noqa: E402
    FullAttentionSpec,
    KVCacheConfig,
    KVCacheGroupSpec,
)

import zmq  # noqa: E402


# ── Config helpers ───────────────────────────────────────────────────


BLOCK_SIZE = 16
NUM_KV_HEADS = 4
HEAD_SIZE = 16
NUM_LAYERS = 50
DTYPE = torch.float16
MODEL = "facebook/opt-125m"


def create_vllm_config(
    kv_connector_extra_config: dict | None = None,
) -> VllmConfig:
    model_config = ModelConfig(
        model=MODEL,
        trust_remote_code=True,
        dtype="float16",
        seed=42,
    )
    scheduler_config = SchedulerConfig(
        max_num_seqs=16,
        max_num_batched_tokens=64,
        max_model_len=10000,
        enable_chunked_prefill=True,
        is_encoder_decoder=model_config.is_encoder_decoder,
    )
    cache_config = CacheConfig(
        block_size=BLOCK_SIZE,
        gpu_memory_utilization=0.9,
        cache_dtype="auto",
        enable_prefix_caching=True,
    )
    kv_transfer_config = KVTransferConfig(
        kv_connector="NixlConnector",
        kv_role="kv_both",
        kv_connector_extra_config=kv_connector_extra_config or {},
    )
    return VllmConfig(
        scheduler_config=scheduler_config,
        model_config=model_config,
        cache_config=cache_config,
        kv_transfer_config=kv_transfer_config,
        device_config=DeviceConfig("cuda"),
        attention_config=AttentionConfig(),
    )


def make_kv_caches(num_blocks: int, num_layers: int) -> dict[str, torch.Tensor]:
    from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend

    logical_shape = FlashAttentionBackend.get_kv_cache_shape(
        num_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE
    )
    stride_order = FlashAttentionBackend.get_kv_cache_stride_order()
    physical_shape = tuple(logical_shape[i] for i in stride_order)
    inv_order = [stride_order.index(i) for i in range(len(stride_order))]
    kv_caches = {}
    for layer_name in [f"layer{i}" for i in range(num_layers)]:
        raw = torch.zeros(physical_shape, dtype=DTYPE, device="cuda")
        kv_caches[layer_name] = raw.permute(*inv_order)
    return kv_caches


def make_kv_cache_config(num_blocks: int, num_layers: int) -> KVCacheConfig:
    return KVCacheConfig(
        num_blocks=num_blocks,
        kv_cache_tensors=[],
        kv_cache_groups=[
            KVCacheGroupSpec(
                [f"layer{i}" for i in range(num_layers)],
                FullAttentionSpec(
                    block_size=BLOCK_SIZE,
                    num_kv_heads=NUM_KV_HEADS,
                    head_size=HEAD_SIZE,
                    dtype=DTYPE,
                ),
            )
        ],
    )


# ── Distributed bootstrap ───────────────────────────────────────────


@contextlib.contextmanager
def _init_distributed():
    from vllm.distributed.parallel_state import (
        cleanup_dist_env_and_memory,
        init_distributed_environment,
        initialize_model_parallel,
    )

    fd, temp_file = tempfile.mkstemp()
    os.close(fd)
    try:
        init_distributed_environment(
            world_size=1,
            rank=0,
            distributed_init_method=f"file://{temp_file}",
            local_rank=0,
            backend="nccl",
        )
        initialize_model_parallel(1, 1)
        yield
        cleanup_dist_env_and_memory()
    finally:
        with contextlib.suppress(OSError):
            os.unlink(temp_file)


Measurement = tuple[float, int, float, float, float, int, str]
# (elapsed_s, engines_registered, uss_mib, rss_mib, cumulative_uss_mib,
#  active_engines, phase)


@contextlib.contextmanager
def _quiet_logs():
    import logging

    root = logging.getLogger()
    prev = root.level
    root.setLevel(logging.ERROR)
    for name in ("vllm", "nixl", "NIXL"):
        logging.getLogger(name).setLevel(logging.ERROR)
    try:
        yield
    finally:
        root.setLevel(prev)


def _malloc_trim() -> None:
    try:
        import ctypes
        ctypes.CDLL("libc.so.6").malloc_trim(0)
    except (OSError, AttributeError):
        pass


def _stabilize_mem() -> None:
    gc.collect()
    _malloc_trim()
    time.sleep(0.05)


class ProcMem:
    __slots__ = ("rss_mib", "uss_mib", "private_mib")

    def __init__(self, rss_mib: float, uss_mib: float, private_mib: float):
        self.rss_mib = rss_mib
        self.uss_mib = uss_mib
        self.private_mib = private_mib


def get_proc_mem() -> ProcMem:
    """Process memory stats for *this* Python process only."""
    rss_mib = uss_mib = private_mib = 0.0

    try:
        with open("/proc/self/smaps_rollup") as f:
            for line in f:
                parts = line.split()
                if len(parts) < 2:
                    continue
                key, kb = parts[0].rstrip(":"), int(parts[1])
                if key == "Rss":
                    rss_mib = kb / 1024
                elif key == "Pss":
                    # smaps_rollup has no USS; Pss is a decent proxy on Linux.
                    uss_mib = kb / 1024
                elif key in ("Private_Clean", "Private_Dirty"):
                    private_mib += kb / 1024
    except (FileNotFoundError, ValueError, OSError):
        pass

    if rss_mib == 0.0:
        try:
            with open("/proc/self/status") as f:
                for line in f:
                    if line.startswith("VmRSS:"):
                        rss_mib = int(line.split()[1]) / 1024
        except (FileNotFoundError, ValueError, OSError):
            pass

    try:
        import psutil

        info = psutil.Process().memory_full_info()
        rss_mib = info.rss / (1024 * 1024)
        uss_mib = getattr(info, "uss", info.rss) / (1024 * 1024)
        private_mib = max(private_mib, uss_mib)
    except (ImportError, AttributeError):
        if uss_mib == 0.0:
            uss_mib = rss_mib

    return ProcMem(rss_mib=rss_mib, uss_mib=uss_mib, private_mib=private_mib)


# ── Fake P (prefill) engine ──────────────────────────────────────────


class FakePrefillEngine:
    """A minimal NIXL agent pretending to be a P engine.

    Allocates GPU KV caches matching D's layout, registers them with a
    real NIXL agent, and serves handshake metadata over ZMQ — just enough
    for D to call add_remote_agent() and allocate real memory on its side.
    """

    def __init__(
        self,
        engine_id: str,
        num_blocks: int,
        compat_hash: str,
        d_worker: NixlConnectorWorker,
    ):
        self.engine_id = engine_id
        self.num_blocks = num_blocks

        # Create a real NIXL agent for this fake P.
        self.nixl_agent = NixlWrapper(f"fake-p-{engine_id}")

        # Match D's KV layout and block lengths exactly.
        block_lens = list(d_worker.block_len_per_layer)
        kv_caches = make_kv_caches(num_blocks, NUM_LAYERS)
        device_id = max(next(iter(kv_caches.values())).get_device(), 0)

        caches_data = []
        base_addrs = []
        for layer_name in [f"layer{i}" for i in range(NUM_LAYERS)]:
            cache = kv_caches[layer_name]
            tensor_size_bytes = cache.numel() * cache.element_size()
            caches_data.append(
                (cache.data_ptr(), tensor_size_bytes, device_id, "")
            )
            base_addrs.append(cache.data_ptr())

        descs = self.nixl_agent.get_reg_descs(caches_data, "VRAM")
        self.nixl_agent.register_memory(descs, backends=["UCX"])

        # Build handshake payload.
        agent_meta = NixlAgentMetadata(
            engine_id=engine_id,
            agent_metadata=self.nixl_agent.get_agent_metadata(),
            kv_caches_base_addr=base_addrs,
            device_id=device_id,
            num_blocks=num_blocks,
            block_lens=block_lens,
            kv_cache_layout=d_worker.kv_cache_layout,
            block_size=BLOCK_SIZE,
            ssm_sizes=(0, 0),
            attn_backend_name=d_worker.backend_name,
            physical_blocks_per_logical_kv_block=1,
        )
        encoder = msgspec.msgpack.Encoder()
        payload = NixlHandshakePayload(
            compatibility_hash=compat_hash,
            agent_metadata_bytes=encoder.encode(agent_meta),
        )
        self._encoded_payload = encoder.encode(payload)


# ── D worker setup ───────────────────────────────────────────────────


def create_decode_worker(
    vllm_config: VllmConfig,
    num_blocks: int,
) -> NixlConnectorWorker:
    kv_cache_config = make_kv_cache_config(num_blocks=num_blocks, num_layers=NUM_LAYERS)

    with set_current_vllm_config(vllm_config):
        worker = NixlConnectorWorker(
            vllm_config,
            vllm_config.kv_transfer_config.engine_id,
            kv_cache_config,
        )

        worker.register_kv_caches(make_kv_caches(num_blocks, NUM_LAYERS))

    return worker


# ── ZMQ fake-P server ────────────────────────────────────────────────


@contextlib.contextmanager
def fake_p_zmq_server(fake_p: FakePrefillEngine, port: int):
    """Run a ZMQ ROUTER that serves one fake P's handshake metadata."""
    import threading

    stop = threading.Event()
    ready = threading.Event()
    addr = f"tcp://127.0.0.1:{port}"

    def serve():
        ctx = zmq.Context()
        sock = ctx.socket(zmq.ROUTER)
        sock.bind(addr)
        sock.setsockopt(zmq.RCVTIMEO, 200)
        ready.set()
        while not stop.is_set():
            try:
                identity, _, msg = sock.recv_multipart()
            except zmq.Again:
                continue
            sock.send_multipart(
                (identity, b"", fake_p._encoded_payload)
            )
        sock.close()
        ctx.destroy(linger=0)

    t = threading.Thread(target=serve, daemon=True)
    t.start()
    ready.wait()
    try:
        yield
    finally:
        stop.set()
        t.join(timeout=2)


# ── Core loop ────────────────────────────────────────────────────────


def _register_fake_p(
    worker: NixlConnectorWorker,
    engine_id: str,
    port: int,
    p_num_blocks: int,
) -> float:
    """Register one fake P; return USS delta (MiB) for the D-side handshake only."""
    fake_p = FakePrefillEngine(
        engine_id=engine_id,
        num_blocks=p_num_blocks,
        compat_hash=worker.compat_hash,  # type: ignore[arg-type]
        d_worker=worker,
    )
    with fake_p_zmq_server(fake_p, port):
        _stabilize_mem()
        mem_before = get_proc_mem()
        fut = worker._ensure_handshake(engine_id, "127.0.0.1", port, tp_size=1)
        if fut is not None:
            fut.result(timeout=30)
        _stabilize_mem()
        mem_after = get_proc_mem()
        step_delta = mem_after.uss_mib - mem_before.uss_mib
    del fake_p
    _stabilize_mem()
    return step_delta


def _record(
    measurements: list[Measurement],
    t0: float,
    engines: int,
    mem: ProcMem,
    baseline_uss: float,
    cumulative_uss: float,
    active: int,
    phase: str,
    *,
    verbose: bool,
) -> None:
    elapsed = time.perf_counter() - t0
    measurements.append(
        (elapsed, engines, mem.uss_mib, mem.rss_mib, cumulative_uss, active, phase)
    )
    if verbose:
        print(
            f"{elapsed:8.1f}s  {engines:>8}  {active:>8}  {mem.uss_mib:>12.1f}  "
            f"{mem.uss_mib - baseline_uss:>+12.1f}  {cumulative_uss:>+12.1f}  "
            f"{phase}"
        )


def run_scenario(
    name: str,
    engine_ttl: float,
    num_engines: int,
    d_num_blocks: int,
    p_num_blocks: int,
    vllm_config: VllmConfig,
    zmq_base_port: int,
    *,
    gap_seconds: float,
    verbose: bool,
) -> list[Measurement]:
    print(f"\n--- {name} (engine_ttl={engine_ttl}s, gap={gap_seconds}s) ---")

    with _quiet_logs():
        worker = create_decode_worker(vllm_config, d_num_blocks)
        assert worker.compat_hash is not None

        _stabilize_mem()
        torch.cuda.empty_cache()
        _stabilize_mem()
        init_mem = get_proc_mem()
        baseline_uss = init_mem.uss_mib
        cumulative_uss = 0.0
        measurements: list[Measurement] = []
        hdr = (
            f"{'Elapsed':>10}  {'Engines':>8}  {'Active':>8}  {'USS (MiB)':>12}  "
            f"{'Δ USS':>12}  {'Cumul Δ':>12}  Phase"
        )
        print(hdr)
        print(
            f"{'─' * 10}  {'─' * 8}  {'─' * 8}  {'─' * 12}  "
            f"{'─' * 12}  {'─' * 12}  {'─' * 8}"
        )
        t0 = time.perf_counter()
        _record(
            measurements, t0, 0, init_mem, baseline_uss, cumulative_uss, 0, "start",
            verbose=verbose,
        )

        for i in range(num_engines):
            if i > 0:
                time.sleep(gap_seconds)
                _stabilize_mem()
                _record(
                    measurements,
                    t0,
                    i,
                    get_proc_mem(),
                    baseline_uss,
                    cumulative_uss,
                    len(worker._remote_agents),
                    "wait",
                    verbose=verbose,
                )

            step_delta = _register_fake_p(
                worker,
                engine_id=f"prefill-{i}",
                port=zmq_base_port + i,
                p_num_blocks=p_num_blocks,
            )
            cumulative_uss += step_delta
            _record(
                measurements,
                t0,
                i + 1,
                get_proc_mem(),
                baseline_uss,
                cumulative_uss,
                len(worker._remote_agents),
                "register",
                verbose=verbose,
            )

        elapsed = time.perf_counter() - t0
        worker.shutdown()
        del worker
        torch.cuda.empty_cache()
        _stabilize_mem()
    print(f"  ({elapsed:.1f}s elapsed, cumulative USS delta={cumulative_uss:+.1f} MiB)")
    return measurements


# ── Output ───────────────────────────────────────────────────────────


def print_summary(
    with_ttl: list[Measurement],
    baseline: list[Measurement],
    *,
    engine_ttl: float,
    baseline_engine_ttl: float,
) -> None:
    ttl_init = with_ttl[0][2]
    baseline_init = baseline[0][2]
    ttl_reg = [m for m in with_ttl if m[6] == "register"]
    baseline_reg = [m for m in baseline if m[6] == "register"]

    print("\n" + "=" * 50)
    print("Summary (USS, measured after worker init):")
    print(
        f"  Short TTL ({engine_ttl}s):  "
        f"cumulative net = {with_ttl[-1][4]:+.1f} MiB, "
        f"final USS Δ = {with_ttl[-1][2] - ttl_init:+.1f} MiB, "
        f"active engines = {with_ttl[-1][5]}"
    )
    print(
        f"  High TTL ({baseline_engine_ttl}s): "
        f"cumulative net = {baseline[-1][4]:+.1f} MiB, "
        f"final USS Δ = {baseline[-1][2] - baseline_init:+.1f} MiB, "
        f"active engines = {baseline[-1][5]}"
    )
    if ttl_reg and baseline_reg:
        print(
            f"  Per-register avg step: short TTL "
            f"{with_ttl[-1][4] / len(ttl_reg):+.2f} MiB, "
            f"high TTL {baseline[-1][4] / len(baseline_reg):+.2f} MiB"
        )
    print("=" * 50)


def plot_results(
    with_ttl: list[Measurement],
    baseline: list[Measurement],
    output_path: str,
    engine_ttl: float,
    baseline_engine_ttl: float,
    gap_seconds: float,
) -> None:
    try:
        import matplotlib
        matplotlib.use("Agg")
        import matplotlib.pyplot as plt
    except ImportError:
        print(f"\nmatplotlib not available, skipping plot ({output_path})")
        return

    ttl_init = with_ttl[0][2]
    baseline_init = baseline[0][2]
    baseline_label = f"High TTL ({baseline_engine_ttl}s)"

    fig, (ax_uss, ax_active) = plt.subplots(
        2, 1, figsize=(11, 7), sharex=True, gridspec_kw={"height_ratios": [3, 1]}
    )

    def plot_uss_delta(ax, data, init_uss, label, color):
        xs = [elapsed for elapsed, _, _, _, _, _, _ in data]
        ys = [uss - init_uss for _, _, uss, _, _, _, _ in data]
        ax.plot(
            xs, ys, f"{color}-", linewidth=1.5, drawstyle="steps-post", alpha=0.85,
            label=label,
        )
        reg_x = [e for e, _, _, _, _, _, ph in data if ph == "register"]
        reg_y = [uss - init_uss for _, _, uss, _, _, _, ph in data if ph == "register"]
        ax.plot(reg_x, reg_y, f"{color}o", markersize=4)

    plot_uss_delta(ax_uss, baseline, baseline_init, baseline_label, "r")
    plot_uss_delta(
        ax_uss, with_ttl, ttl_init, f"Short TTL ({engine_ttl}s)", "g",
    )
    ax_uss.set_ylabel("USS delta from D init (MiB)")
    ax_uss.set_title(
        "Sequential P registrations: register → wait → register → …\n"
        "(USS = process-unique memory; baseline = after D worker init)"
    )
    ax_uss.legend(loc="upper left", fontsize=9)
    ax_uss.grid(True, alpha=0.3)

    ax_active.plot(
        [e for e, _, _, _, _, _, _ in baseline],
        [active for _, _, _, _, _, active, _ in baseline],
        "r-", drawstyle="steps-post", linewidth=1.5, label=baseline_label,
    )
    ax_active.plot(
        [e for e, _, _, _, _, _, _ in with_ttl],
        [active for _, _, _, _, _, active, _ in with_ttl],
        "g-", drawstyle="steps-post", linewidth=1.5,
        label=f"Short TTL ({engine_ttl}s)",
    )
    ax_active.set_xlabel(
        f"Elapsed time (s) — gap={gap_seconds}s between registrations"
    )
    ax_active.set_ylabel("Active remote engines on D")
    ax_active.legend(loc="upper left")
    ax_active.grid(True, alpha=0.3)

    fig.tight_layout()
    fig.savefig(output_path, dpi=150)
    print(f"\nPlot saved to {output_path}")
    plt.close(fig)


# ── Main ─────────────────────────────────────────────────────────────


def main():
    parser = argparse.ArgumentParser(
        description="Demo: NIXL TTL eviction prevents memory leaks"
    )
    parser.add_argument(
        "--num-engines", type=int, default=30,
        help="P engines to simulate (one at a time)",
    )
    parser.add_argument(
        "--d-num-blocks", type=int, default=200,
        help="KV cache blocks on D side",
    )
    parser.add_argument(
        "--p-num-blocks", type=int, default=200,
        help="KV cache blocks per fake P engine",
    )
    parser.add_argument(
        "--gap-seconds", type=float, default=2.0,
        help="Wait between registrations (must exceed --engine-ttl for TTL)",
    )
    parser.add_argument(
        "--plot", type=str, default="ttl_eviction_memory.png",
        help="Output plot path (empty to skip)",
    )
    parser.add_argument(
        "--engine-ttl", type=float, default=1.0,
        help="TTL for the short-TTL D worker (seconds)",
    )
    parser.add_argument(
        "--baseline-engine-ttl", type=float, default=10000.0,
        help="TTL for the separate baseline D worker (never expires in demo)",
    )
    parser.add_argument(
        "--zmq-base-port", type=int, default=15000,
        help="Starting port for fake-P ZMQ servers",
    )
    parser.add_argument(
        "--verbose", action="store_true",
        help="Print every measurement row",
    )
    args = parser.parse_args()

    if args.gap_seconds <= args.engine_ttl:
        print(
            f"Warning: gap ({args.gap_seconds}s) should exceed --engine-ttl "
            f"({args.engine_ttl}s) so stale engines are evicted on the next "
            f"registration.",
            file=sys.stderr,
        )

    print("=== NIXL TTL Eviction Memory Demo ===")
    print(
        f"Config: {args.num_engines} engines, "
        f"D blocks={args.d_num_blocks}, P blocks={args.p_num_blocks}, "
        f"gap={args.gap_seconds}s, "
        f"short TTL={args.engine_ttl}s, "
        f"baseline TTL={args.baseline_engine_ttl}s"
    )

    vllm_config_ttl = create_vllm_config(
        kv_connector_extra_config={
            "engine_ttl": args.engine_ttl,
            "enforce_handshake_compat": False,
        },
    )
    vllm_config_baseline = create_vllm_config(
        kv_connector_extra_config={
            "engine_ttl": args.baseline_engine_ttl,
            "enforce_handshake_compat": False,
        },
    )

    with set_current_vllm_config(vllm_config_ttl), _init_distributed():
        # Run baseline first so short-TTL scenario isn't warmed up by leaks.
        with set_current_vllm_config(vllm_config_baseline):
            baseline = run_scenario(
                name=f"High TTL baseline ({args.baseline_engine_ttl}s)",
                engine_ttl=args.baseline_engine_ttl,
                num_engines=args.num_engines,
                d_num_blocks=args.d_num_blocks,
                p_num_blocks=args.p_num_blocks,
                vllm_config=vllm_config_baseline,
                zmq_base_port=args.zmq_base_port,
                gap_seconds=args.gap_seconds,
                verbose=args.verbose,
            )

        with set_current_vllm_config(vllm_config_ttl):
            with_ttl = run_scenario(
                name=f"Short TTL ({args.engine_ttl}s)",
                engine_ttl=args.engine_ttl,
                num_engines=args.num_engines,
                d_num_blocks=args.d_num_blocks,
                p_num_blocks=args.p_num_blocks,
                vllm_config=vllm_config_ttl,
                zmq_base_port=args.zmq_base_port + args.num_engines,
                gap_seconds=args.gap_seconds,
                verbose=args.verbose,
            )

    print_summary(
        with_ttl,
        baseline,
        engine_ttl=args.engine_ttl,
        baseline_engine_ttl=args.baseline_engine_ttl,
    )

    if args.plot:
        plot_results(
            with_ttl,
            baseline,
            args.plot,
            args.engine_ttl,
            args.baseline_engine_ttl,
            args.gap_seconds,
        )


if __name__ == "__main__":
    main()

```

</details>

This is instantiating a NixlConnectorWorker (the "D" receiver) while spinning up multiple "fake" P agents, that mimic a prefiller workflow by creating a bunch of KVTensor, registering memory with nixl and have D add them as new remote engines. This happens incrementally (every 10s a new P comes in).

These results clearly show memory behavior with and without ("High TTL") the eviction logic.
<img width="1650" height="1050" alt="image" src="https://github.com/user-attachments/assets/41071e63-d2c8-4d05-b593-a0e0de6a8b8b" />


### Test with

Tests added in `test_nixl_connector.py`

cc @hasB4K