### PR TITLE
[XPU] Enable v1 sample tests on XPU CI

### DIFF
--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -13,7 +13,7 @@ pytest-shard
 absl-py
 accelerate
 arctic-inference
-lm_eval[api]
+lm-eval[api]>=0.4.12
 modelscope
 
 # --- Audio Processing ---

--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -42,11 +42,17 @@ SAMPLE_PROMPT = BatchLogprobsComposition.SAMPLE_PROMPT
 #
 # Force LLM instances into an identical, deterministic execution
 # mode so the test isolates spec-decode correctness only:
-ROCM_DETERMINISM_KWARGS: dict = (
-    dict(max_num_seqs=1, attention_backend="TRITON_ATTN")
-    if current_platform.is_rocm()
-    else {}
-)
+#
+# ROCm: TRITON_ATTN eliminates non-determinism from skinny GEMM scheduling.
+# XPU:  FLASH_ATTN (Intel IPEX SYCL kernel) is more numerically stable across
+#       different batch geometries (single decode vs. spec-decode verification)
+#       than the Triton attention implementation on XPU.
+if current_platform.is_rocm():
+    GPU_DETERMINISM_KWARGS: dict = dict(max_num_seqs=1, attention_backend="TRITON_ATTN")
+elif current_platform.is_xpu():
+    GPU_DETERMINISM_KWARGS = dict(max_num_seqs=1, attention_backend="FLASH_ATTN")
+else:
+    GPU_DETERMINISM_KWARGS = {}
 
 
 @pytest.fixture(
@@ -1127,7 +1133,7 @@ def test_spec_decode_logprobs(
         enable_chunked_prefill=True,
         max_num_batched_tokens=32,
         enable_prefix_caching=False,
-        **ROCM_DETERMINISM_KWARGS,
+        **GPU_DETERMINISM_KWARGS,
     )
 
     # Run base LLM.


### PR DESCRIPTION
## Purpose

Enable `tests/v1/sample` on XPU CI by fixing two blocking test failures.

### 1. Fix `test_spec_decode_logprobs` — logprob mismatch

The Triton attention implementation on XPU produces different numerical results across batch geometries (single-token decode vs. multi-token spec-decode verification), causing logprob mismatch beyond `abs_tol=0.1`.

Use `FLASH_ATTN` (Intel IPEX SYCL kernel) for XPU in `GPU_DETERMINISM_KWARGS`, which is numerically stable across batch sizes. ROCm continues to use `TRITON_ATTN` (unchanged).

### 2. Fix `test_logprobs_e2e` — lm-eval ImportError

Pin `lm-eval[api]>=0.4.12` in `requirements/test/xpu.in` to align with `cuda.in` and `rocm.in`. The previously unpinned entry resolved to `0.4.11`, which causes an `ImportError` at test collection time.

## Test Plan

```bash
pytest -s -v tests/v1/sample/test_logprobs.py::test_spec_decode_logprobs
pytest -s -v tests/v1/sample/test_logprobs_e2e.py::test_prompt_logprobs_e2e
```

---

Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
