### PR TITLE
[Feature] Add fault tolerance framework (simplified) for DP+EP external LB deployments

### DIFF
--- a/.buildkite/test_areas/fault_tolerance.yaml
+++ b/.buildkite/test_areas/fault_tolerance.yaml
@@ -1,0 +1,26 @@
+group: Fault Tolerance
+depends_on:
+  - image-build
+steps:
+- label: Fault Tolerance E2E (2xH100)
+  key: fault-tolerance-e2e-2xh100
+  timeout_in_minutes: 35
+  device: h100
+  num_devices: 2
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/v1/fault_tolerance/
+  - vllm/v1/worker/sentinel/
+  - vllm/entrypoints/serve/fault_tolerance/
+  - vllm/distributed/elastic_ep/
+  - vllm/distributed/device_communicators/
+  - vllm/v1/engine/
+  - vllm/v1/worker/
+  - tests/v1/fault_tolerance/
+  - tests/v1/distributed/test_external_lb_dp.py
+  commands:
+  # Base image has no nixl; install it or has_nixl_ep() skips the tests.
+  - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
+  # https://github.com/NVIDIA/nccl/issues/1838
+  - export NCCL_CUMEM_HOST_ENABLE=0
+  - pytest -v -s v1/fault_tolerance/test_fault_tolerance_e2e.py

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1547,6 +1547,16 @@ def test_needs_dp_coordination(
     assert vllm_config.needs_dp_coordinator == expected_needs_coordinator
 
 
+def test_fault_tolerance_requires_single_api_server():
+    """Fault tolerance assumes one AsyncMPClient manages all engines, so it
+    is incompatible with API server scale-out (_api_process_count > 1)."""
+    with pytest.raises(ValueError, match="single API server"):
+        ParallelConfig(enable_fault_tolerance=True, _api_process_count=2)
+
+    # Single API server (the FT-supported topology) is accepted.
+    ParallelConfig(enable_fault_tolerance=True, _api_process_count=1)
+
+
 def test_renderer_num_workers_with_mm_cache():
     """Disallow renderer_num_workers > 1 when mm processor cache is enabled,
     since neither cache type is thread-safe."""

--- a/tests/v1/fault_tolerance/__init__.py
+++ b/tests/v1/fault_tolerance/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end tests for the elastic fault-tolerance framework.
+
+Requires nixl_ep FT hardware; gated behind ``has_nixl_ep()``.
+"""
+
+import contextlib
+import os
+import threading
+import time
+
+import psutil
+import pytest
+import requests
+
+from tests.utils import multi_gpu_test
+from vllm.utils.import_utils import has_nixl_ep
+
+MODEL_NAME = os.getenv("MODEL_NAME", "ibm-research/PowerMoE-3b")
+DP_SIZE = int(os.getenv("DP_SIZE", "2"))
+
+# Fault-detection timeout budget:
+# - CPU: Gloo DP allreduce timeout (10s) detects the dead peer.
+# - nixl_ep: kernel masks the dead rank after Buffer's default timeout_ms=30000 (30s).
+# - Deadline (45s): slowest fallback (30s) + margin.
+CPU_DISTRIBUTED_TIMEOUT_S = 10
+FAULT_DETECTION_DEADLINE_S = 45
+
+
+def _ft_server_args() -> list[str]:
+    return [
+        "--enforce-eager",
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "128",
+        "--enable-expert-parallel",
+        "--all2all-backend",
+        "nixl_ep",
+        "--enable-fault-tolerance",
+        "--cpu-distributed-timeout-seconds",
+        str(CPU_DISTRIBUTED_TIMEOUT_S),
+        "--fault-tolerance-config",
+        '{"engine_recovery_timeout_sec": 120}',
+    ]
+
+
+def _server_for_rank(servers, rank: int):
+    """Locate the server for a DP rank."""
+    for server, sargs in servers:
+        if "--data-parallel-rank" in sargs:
+            idx = sargs.index("--data-parallel-rank")
+            if int(sargs[idx + 1]) == rank:
+                return server
+    raise AssertionError(f"no server found for DP rank {rank}")
+
+
+def _get_ft_status(server) -> dict:
+    resp = requests.get(server.url_for("fault_tolerance/status"), timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _kill_worker_process(server) -> None:
+    """SIGKILL only the worker proc, leaving EngineCore and API server alive."""
+    workers = [
+        p
+        for p in psutil.Process(server.proc.pid).children(recursive=True)
+        if "Worker" in " ".join(p.cmdline())
+    ]
+    assert len(workers) == 1, f"expected 1 worker proc, found: {workers}"
+    workers[0].kill()
+
+
+def _poll_status(server, deadline_s: int, predicate):
+    """Poll ``/fault_tolerance/status`` until ``predicate(engine)`` is true.
+
+    Returns the first matching engine dict, or ``None`` on timeout. Request
+    errors are suppressed so a briefly-unreachable server doesn't abort the poll.
+    """
+    start = time.time()
+    while time.time() - start < deadline_s:
+        with contextlib.suppress(Exception):
+            for engine in _get_ft_status(server)["engines"]:
+                if predicate(engine):
+                    return engine
+        time.sleep(1.0)
+    return None
+
+
+def _wait_for_engine_fault(server, client, deadline_s: int):
+    """Drive the server and wait until an engine reports ``dead``/``unhealthy``.
+
+    Requests run in the background so the engine keeps stepping into the failed
+    component. Both statuses match, so an unexpected one fails the caller's
+    assertion instead of looking like a hang. Returns the faulted engine dict,
+    or ``None`` on timeout.
+    """
+    stop = threading.Event()
+
+    def _drive():
+        while not stop.is_set():
+            with contextlib.suppress(Exception):  # errors once faulted -- expected
+                client.completions.create(
+                    model=MODEL_NAME,
+                    prompt="Hello, my name is",
+                    max_tokens=5,
+                    temperature=0.0,
+                )
+            time.sleep(1.0)
+
+    driver = threading.Thread(target=_drive, daemon=True)
+    driver.start()
+    try:
+        return _poll_status(
+            server,
+            deadline_s,
+            lambda engine: engine["status"] in ("dead", "unhealthy"),
+        )
+    finally:
+        stop.set()
+        driver.join(timeout=5)
+
+
+def _wait_for_ft_apply_outcome(server, request_id: str, deadline_s: int) -> str | None:
+    """Wait until ``/status`` records the outcome of the given FT apply request.
+
+    ``/apply`` dispatches recovery in a background task; once the engine records
+    the request id, its ``ft_error`` field holds the rejection reason (``None``
+    on success). Returns that error, or ``None`` if the request succeeded or was
+    never recorded before the deadline (indistinguishable here).
+    """
+    engine = _poll_status(
+        server,
+        deadline_s,
+        lambda engine: engine.get("last_ft_request_id") == request_id,
+    )
+    return engine.get("ft_error") if engine else None
+
+
+@pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")
+@multi_gpu_test(num_gpus=2)
+def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
+    """One worker kill surfaces two status transitions at once.
+
+    SIGKILLing only rank 1's worker leaves both EngineCores alive, so the same
+    fault is seen two ways:
+
+    - Survivor (rank 0): detects the dead peer via Gloo allreduce / nixl_ep
+      kernel timeout. Its own executor is fine, so ``on_fault`` marks it
+      UNHEALTHY with a ``fault_info``.
+    - Victim (rank 1): detects its own executor failure and marks itself DEAD.
+
+    Recovery is gated on UNHEALTHY: the DEAD engine accepts ``retry`` at the
+    HTTP layer (202 = background dispatch) but rejects it in the engine,
+    recording the reason as ``ft_error``.
+    """
+    from tests.v1.distributed.test_external_lb_dp import ExternalLBServerManager
+
+    manager = ExternalLBServerManager(
+        MODEL_NAME,
+        DP_SIZE,
+        api_server_count=1,  # FT requires a single API server per engine
+        base_server_args=_ft_server_args(),
+        tp_size=1,
+    )
+
+    with manager as servers:
+        assert len(servers) == DP_SIZE
+        survivor = _server_for_rank(servers, 0)
+        victim = _server_for_rank(servers, 1)
+
+        # 1. Confirm both engines are healthy and serving.
+        for server in (survivor, victim):
+            client = server.get_client()
+            client.completions.create(
+                model=MODEL_NAME,
+                prompt="Hello, my name is",
+                max_tokens=5,
+                temperature=0.0,
+            )
+            status = _get_ft_status(server)
+            assert status["schema_version"] == 1, status
+            assert status["total_engines"] == 1, status  # one engine per server
+            assert all(e["status"] == "healthy" for e in status["engines"]), status
+
+        # 2. Kill only the victim's worker; both EngineCores stay alive.
+        _kill_worker_process(victim)
+
+        # 3. Drive both engines so each keeps stepping into the failed
+        #    component; poll in parallel so the deadline applies independently.
+        results: dict = {}
+
+        def _wait(server, client, key):
+            results[key] = _wait_for_engine_fault(
+                server, client, FAULT_DETECTION_DEADLINE_S
+            )
+
+        pollers = [
+            threading.Thread(
+                target=_wait, args=(survivor, survivor.get_client(), "survivor")
+            ),
+            threading.Thread(
+                target=_wait, args=(victim, victim.get_client(), "victim")
+            ),
+        ]
+        for p in pollers:
+            p.start()
+        for p in pollers:
+            p.join()
+        survivor_faulted = results["survivor"]
+        victim_faulted = results["victim"]
+
+        assert survivor_faulted is not None, (
+            "survivor did not report the peer fault within "
+            f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+        )
+        # The survivor's own executor is fine, so it must be UNHEALTHY, not DEAD.
+        assert survivor_faulted["status"] == "unhealthy", survivor_faulted
+        assert survivor_faulted.get("fault_info"), survivor_faulted
+
+        assert victim_faulted is not None, (
+            "victim did not report its worker's death within "
+            f"{FAULT_DETECTION_DEADLINE_S}s"
+        )
+        assert victim_faulted["status"] == "dead", victim_faulted
+
+        # 4. retry is accepted at the HTTP layer (202 = background dispatch)...
+        resp = requests.post(
+            victim.url_for("fault_tolerance/apply"),
+            json={"instruction": "retry", "params": {}},
+            timeout=10,
+        )
+        assert resp.status_code == 202, resp.text
+        request_id = resp.json()["request_id"]
+
+        # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
+        ft_error = _wait_for_ft_apply_outcome(
+            victim, request_id, FAULT_DETECTION_DEADLINE_S
+        )
+        assert ft_error is not None, (
+            "rejection was never recorded in /fault_tolerance/status"
+        )
+        assert "status is DEAD" in ft_error, ft_error

--- a/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
@@ -23,10 +23,10 @@ MODEL_NAME = os.getenv("MODEL_NAME", "ibm-research/PowerMoE-3b")
 DP_SIZE = 2
 
 # Fault-detection timeout budget:
-# - CPU: Gloo DP allreduce timeout (10s) detects the dead peer.
+# - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
 # - nixl_ep: kernel masks the dead rank after Buffer's default timeout_ms=30000 (30s).
 # - Deadline (45s): slowest fallback (30s) + margin.
-CPU_DISTRIBUTED_TIMEOUT_S = 10
+CPU_DISTRIBUTED_TIMEOUT_S = 30
 FAULT_DETECTION_DEADLINE_S = 45
 
 

--- a/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
@@ -28,6 +28,78 @@ CPU_DISTRIBUTED_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
 
+# Patches ``gpu.dp_utils.sync_cudagraph_and_dp_padding`` to raise on ``rank`` at
+# a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
+_FAULT_INJECT_SITECUSTOMIZE = """\
+import builtins
+import os
+import sys
+
+_SPEC = os.environ.get("VLLM_FT_TEST_INJECT_FAULT")
+_MODULE = "vllm.v1.worker.gpu.dp_utils"
+_ATTR = "sync_cudagraph_and_dp_padding"
+
+if _SPEC:
+    _f = dict(kv.split("=", 1) for kv in _SPEC.split(","))
+    _RANK, _STEP = int(_f["rank"]), int(_f["step"])
+    _steps = [0]
+
+    def _patch(m):
+        import inspect
+        _orig = getattr(m, _ATTR)
+        _sig = inspect.signature(_orig)
+        def _wrapped(*args, **kwargs):
+            result = _orig(*args, **kwargs)
+            bound = _sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            dp_rank = bound.arguments.get("dp_rank")
+            if dp_rank == _RANK:
+                _steps[0] += 1
+                if _steps[0] == _STEP:
+                    raise RuntimeError(
+                        "FT test fault injection (rank=%d step=%d)" % (_RANK, _STEP)
+                    )
+            return result
+
+        setattr(m, _ATTR, _wrapped)
+
+    _real_import = builtins.__import__
+
+    def _hook(name, *a, **k):
+        module = _real_import(name, *a, **k)
+        m = sys.modules.get(_MODULE)
+        # During vLLM's circular import the module lands in sys.modules before
+        # its functions are defined; hasattr guards against patching too early.
+        if (
+            m is not None
+            and hasattr(m, _ATTR)
+            and not getattr(m, "_ft_patched", False)
+        ):
+            m._ft_patched = True
+            _patch(m)
+        return module
+
+    builtins.__import__ = _hook
+"""
+
+
+def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> None:
+    """Arrange for the DP-sync fn to raise on ``rank`` at serving ``step``.
+
+    Writes a ``sitecustomize.py`` and prepends its dir to PYTHONPATH so every
+    vLLM subprocess picks it up; the fault spec is read from the environment.
+    """
+    site_dir = tmp_path / "ft_inject"
+    site_dir.mkdir()
+    (site_dir / "sitecustomize.py").write_text(_FAULT_INJECT_SITECUSTOMIZE)
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        str(site_dir) + (os.pathsep + existing if existing else ""),
+    )
+    monkeypatch.setenv("VLLM_FT_TEST_INJECT_FAULT", f"rank={rank},step={step}")
+
+
 def _ft_server_args() -> list[str]:
     return [
         "--enforce-eager",
@@ -48,6 +120,19 @@ def _ft_server_args() -> list[str]:
     ]
 
 
+def _ft_manager():
+    """Build the shared DP+EP fault-tolerant server topology (one engine/server)."""
+    from tests.v1.distributed.test_external_lb_dp import ExternalLBServerManager
+
+    return ExternalLBServerManager(
+        MODEL_NAME,
+        DP_SIZE,
+        api_server_count=1,  # FT requires a single API server per engine
+        base_server_args=_ft_server_args(),
+        tp_size=1,
+    )
+
+
 def _server_for_rank(servers, rank: int):
     """Locate the server for a DP rank."""
     for server, sargs in servers:
@@ -58,9 +143,39 @@ def _server_for_rank(servers, rank: int):
     raise AssertionError(f"no server found for DP rank {rank}")
 
 
+def _complete(client):
+    """Issue the one standard completion the tests use everywhere."""
+    return client.completions.create(
+        model=MODEL_NAME,
+        prompt="Hello, my name is",
+        max_tokens=5,
+        temperature=0.0,
+        timeout=10.0,
+    )
+
+
 def _get_ft_status(server) -> dict:
     resp = requests.get(server.url_for("fault_tolerance/status"), timeout=10)
     resp.raise_for_status()
+    return resp.json()
+
+
+def _assert_serving_and_healthy(server) -> dict:
+    """Serve one request and assert every engine reports healthy. Returns status."""
+    _complete(server.get_client())
+    status = _get_ft_status(server)
+    assert all(e["status"] == "healthy" for e in status["engines"]), status
+    return status
+
+
+def _apply_ft(server, instruction: str, params: dict | None = None) -> dict:
+    """POST an FT instruction; assert it is accepted (202) and return the body."""
+    resp = requests.post(
+        server.url_for("fault_tolerance/apply"),
+        json={"instruction": instruction, "params": params or {}},
+        timeout=10,
+    )
+    assert resp.status_code == 202, resp.text
     return resp.json()
 
 
@@ -91,54 +206,110 @@ def _poll_status(server, deadline_s: int, predicate):
     return None
 
 
-def _wait_for_engine_fault(server, client, deadline_s: int):
-    """Drive the server and wait until an engine reports ``dead``/``unhealthy``.
+def _wait_for_status(server, statuses, deadline_s: int = FAULT_DETECTION_DEADLINE_S):
+    """Poll until an engine reports one of ``statuses`` (a set of status strings)."""
+    return _poll_status(server, deadline_s, lambda e: e["status"] in statuses)
 
-    Requests run in the background so the engine keeps stepping into the failed
-    component. Both statuses match, so an unexpected one fails the caller's
-    assertion instead of looking like a hang. Returns the faulted engine dict,
-    or ``None`` on timeout.
+
+@contextlib.contextmanager
+def _driving(*servers):
+    """Pump completions at each server in the background for the block's duration.
+
+    Keeps every engine stepping into its failed component so a fault surfaces,
+    and lets each ``retry`` reach its cross-rank collective. Errors are expected
+    once faulted and are ignored.
     """
     stop = threading.Event()
 
-    def _drive():
+    def _drive(server):
+        client = server.get_client()
         while not stop.is_set():
-            with contextlib.suppress(Exception):  # errors once faulted -- expected
-                client.completions.create(
-                    model=MODEL_NAME,
-                    prompt="Hello, my name is",
-                    max_tokens=5,
-                    temperature=0.0,
-                )
-            time.sleep(1.0)
+            with contextlib.suppress(Exception):
+                _complete(client)
+            time.sleep(0.2)
 
-    driver = threading.Thread(target=_drive, daemon=True)
-    driver.start()
+    threads = [threading.Thread(target=_drive, args=(s,), daemon=True) for s in servers]
+    for t in threads:
+        t.start()
     try:
-        return _poll_status(
-            server,
-            deadline_s,
-            lambda engine: engine["status"] in ("dead", "unhealthy"),
-        )
+        yield
     finally:
         stop.set()
-        driver.join(timeout=5)
+        for t in threads:
+            t.join(timeout=2)
 
 
 def _wait_for_ft_apply_outcome(server, request_id: str, deadline_s: int) -> str | None:
-    """Wait until ``/status`` records the outcome of the given FT apply request.
-
-    ``/apply`` dispatches recovery in a background task; once the engine records
-    the request id, its ``ft_error`` field holds the rejection reason (``None``
-    on success). Returns that error, or ``None`` if the request succeeded or was
-    never recorded before the deadline (indistinguishable here).
-    """
+    """Wait until ``/status`` records the outcome of the given FT apply request."""
     engine = _poll_status(
         server,
         deadline_s,
         lambda engine: engine.get("last_ft_request_id") == request_id,
     )
     return engine.get("ft_error") if engine else None
+
+
+@pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")
+@multi_gpu_test(num_gpus=2)
+def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
+    """An exception injected into the inference path drives full retry recovery.
+
+    Injecting an exception into ``sync_cudagraph_and_dp_padding`` at a chosen
+    step on rank 1.
+
+    - Rank 1 raises inside the busy loop and goes UNHEALTHY.
+    - Rank 0 detects the now-absent peer via the communication timeout and also
+      goes UNHEALTHY.
+
+    Both being UNHEALTHY is the precondition for ``retry``. The fault is patched
+    into the DP-sync fn from the test (via a generated ``sitecustomize``).
+    """
+    fault_step = int(os.getenv("FT_FAULT_STEP", "50"))
+    _install_fault_injection(monkeypatch, tmp_path, rank=1, step=fault_step)
+
+    with _ft_manager() as servers:
+        assert len(servers) == DP_SIZE
+        rank0 = _server_for_rank(servers, 0)
+        rank1 = _server_for_rank(servers, 1)
+
+        # 1. Both engines healthy and serving.
+        for server in (rank0, rank1):
+            status = _assert_serving_and_healthy(server)
+            assert status["schema_version"] == 1, status
+            assert status["total_engines"] == 1, status  # one engine per server
+
+        # 2. Drive both ranks so rank 1 accumulates execute_model steps and trips
+        #    the injected fault; rank 0 then times out on the DP allreduce.
+        with _driving(rank0, rank1):
+            faulted = {
+                rank: _wait_for_status(server, {"unhealthy"})
+                for rank, server in ((0, rank0), (1, rank1))
+            }
+
+        for rank, engine in faulted.items():
+            assert engine is not None, (
+                f"rank {rank} did not report UNHEALTHY within "
+                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
+        # The rank that raised carries the fault info from its own exception.
+        assert faulted[1].get("fault_info"), faulted[1]
+
+        # 3. retry both engines.
+        for server in (rank0, rank1):
+            _apply_ft(server, "retry")
+
+        # 4. Recovery completes: both engines return to healthy.
+        for rank, server in ((0, rank0), (1, rank1)):
+            healthy = _wait_for_status(server, {"healthy"})
+            assert healthy is not None, (
+                f"rank {rank} did not recover to healthy within "
+                f"{FAULT_DETECTION_DEADLINE_S}s"
+            )
+
+        # 5. Post-recovery inference works on both ranks.
+        for server in (rank0, rank1):
+            completion = _complete(server.get_client())
+            assert completion.choices[0].text is not None
 
 
 @pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")
@@ -158,61 +329,24 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
     HTTP layer (202 = background dispatch) but rejects it in the engine,
     recording the reason as ``ft_error``.
     """
-    from tests.v1.distributed.test_external_lb_dp import ExternalLBServerManager
-
-    manager = ExternalLBServerManager(
-        MODEL_NAME,
-        DP_SIZE,
-        api_server_count=1,  # FT requires a single API server per engine
-        base_server_args=_ft_server_args(),
-        tp_size=1,
-    )
-
-    with manager as servers:
+    with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
         survivor = _server_for_rank(servers, 0)
         victim = _server_for_rank(servers, 1)
 
         # 1. Confirm both engines are healthy and serving.
         for server in (survivor, victim):
-            client = server.get_client()
-            client.completions.create(
-                model=MODEL_NAME,
-                prompt="Hello, my name is",
-                max_tokens=5,
-                temperature=0.0,
-            )
-            status = _get_ft_status(server)
-            assert status["schema_version"] == 1, status
-            assert status["total_engines"] == 1, status  # one engine per server
-            assert all(e["status"] == "healthy" for e in status["engines"]), status
+            _assert_serving_and_healthy(server)
 
         # 2. Kill only the victim's worker; both EngineCores stay alive.
         _kill_worker_process(victim)
 
-        # 3. Drive both engines so each keeps stepping into the failed
-        #    component; poll in parallel so the deadline applies independently.
-        results: dict = {}
-
-        def _wait(server, client, key):
-            results[key] = _wait_for_engine_fault(
-                server, client, FAULT_DETECTION_DEADLINE_S
-            )
-
-        pollers = [
-            threading.Thread(
-                target=_wait, args=(survivor, survivor.get_client(), "survivor")
-            ),
-            threading.Thread(
-                target=_wait, args=(victim, victim.get_client(), "victim")
-            ),
-        ]
-        for p in pollers:
-            p.start()
-        for p in pollers:
-            p.join()
-        survivor_faulted = results["survivor"]
-        victim_faulted = results["victim"]
+        # 3. Drive both engines so each keeps stepping into the failed component.
+        #    Both fault ~together via timeout, so sequential polling under one
+        #    driving context still sees each within the deadline.
+        with _driving(survivor, victim):
+            survivor_faulted = _wait_for_status(survivor, {"dead", "unhealthy"})
+            victim_faulted = _wait_for_status(victim, {"dead", "unhealthy"})
 
         assert survivor_faulted is not None, (
             "survivor did not report the peer fault within "
@@ -229,13 +363,7 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
         assert victim_faulted["status"] == "dead", victim_faulted
 
         # 4. retry is accepted at the HTTP layer (202 = background dispatch)...
-        resp = requests.post(
-            victim.url_for("fault_tolerance/apply"),
-            json={"instruction": "retry", "params": {}},
-            timeout=10,
-        )
-        assert resp.status_code == 202, resp.text
-        request_id = resp.json()["request_id"]
+        request_id = _apply_ft(victim, "retry")["request_id"]
 
         # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
         ft_error = _wait_for_ft_apply_outcome(

--- a/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
@@ -9,16 +9,18 @@ import contextlib
 import os
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import psutil
 import pytest
 import requests
 
-from tests.utils import multi_gpu_test
+from tests.utils import RemoteOpenAIServer, multi_gpu_test
 from vllm.utils.import_utils import has_nixl_ep
 
 MODEL_NAME = os.getenv("MODEL_NAME", "ibm-research/PowerMoE-3b")
-DP_SIZE = int(os.getenv("DP_SIZE", "2"))
+DP_SIZE = 2
 
 # Fault-detection timeout budget:
 # - CPU: Gloo DP allreduce timeout (10s) detects the dead peer.
@@ -154,18 +156,25 @@ def _complete(client):
     )
 
 
+def _in_parallel(fn, servers) -> list:
+    """Run ``fn(server)`` for all servers concurrently; return results in order."""
+    with ThreadPoolExecutor(max_workers=len(servers)) as ex:
+        return list(ex.map(fn, servers))
+
+
 def _get_ft_status(server) -> dict:
     resp = requests.get(server.url_for("fault_tolerance/status"), timeout=10)
     resp.raise_for_status()
     return resp.json()
 
 
-def _assert_serving_and_healthy(server) -> dict:
-    """Serve one request and assert every engine reports healthy. Returns status."""
-    _complete(server.get_client())
-    status = _get_ft_status(server)
-    assert all(e["status"] == "healthy" for e in status["engines"]), status
-    return status
+def _assert_serving_and_healthy(servers) -> None:
+    """Wait until every engine is healthy, then serve one request per server."""
+    healthy = _wait_for_engines(
+        list(servers), match_key="status", match_values={"healthy"}
+    )
+    assert all(healthy), healthy
+    _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
 def _apply_ft(server, instruction: str, params: dict | None = None) -> dict:
@@ -190,34 +199,40 @@ def _kill_worker_process(server) -> None:
     workers[0].kill()
 
 
-def _poll_status(server, deadline_s: int, predicate):
-    """Poll ``/fault_tolerance/status`` until ``predicate(engine)`` is true.
+def _wait_for_engines(
+    servers: list[RemoteOpenAIServer],
+    match_key: str,
+    match_values: set[str],
+    deadline_s: int = FAULT_DETECTION_DEADLINE_S,
+) -> list[dict[str, Any] | None]:
+    """Poll ``/fault_tolerance/status`` until each server's engine status matches.
 
-    Returns the first matching engine dict, or ``None`` on timeout. Request
-    errors are suppressed so a briefly-unreachable server doesn't abort the poll.
+    A server matches when its engine-status dict has ``match_key`` equal to
+    one of ``match_values``. Returns one engine-status dict per server. Servers still
+    unmatched after ``deadline_s`` get None.
     """
+    results: dict[int, dict[str, Any]] = {}
+    pending = dict(enumerate(servers))
     start = time.time()
-    while time.time() - start < deadline_s:
-        with contextlib.suppress(Exception):
-            for engine in _get_ft_status(server)["engines"]:
-                if predicate(engine):
-                    return engine
-        time.sleep(1.0)
-    return None
-
-
-def _wait_for_status(server, statuses, deadline_s: int = FAULT_DETECTION_DEADLINE_S):
-    """Poll until an engine reports one of ``statuses`` (a set of status strings)."""
-    return _poll_status(server, deadline_s, lambda e: e["status"] in statuses)
+    while pending and time.time() - start < deadline_s:
+        for i, server in list(pending.items()):
+            with contextlib.suppress(Exception):
+                for engine_status in _get_ft_status(server)["engines"]:
+                    if engine_status.get(match_key) in match_values:
+                        results[i] = engine_status
+                        del pending[i]
+                        break
+        if pending:
+            time.sleep(1.0)
+    return [results.get(i) for i in range(len(servers))]
 
 
 @contextlib.contextmanager
 def _driving(*servers):
     """Pump completions at each server in the background for the block's duration.
 
-    Keeps every engine stepping into its failed component so a fault surfaces,
-    and lets each ``retry`` reach its cross-rank collective. Errors are expected
-    once faulted and are ignored.
+    Keeps every engine stepping into its failed component so a fault surfaces.
+    Errors are expected once faulted and are ignored.
     """
     stop = threading.Event()
 
@@ -240,13 +255,14 @@ def _driving(*servers):
 
 
 def _wait_for_ft_apply_outcome(server, request_id: str, deadline_s: int) -> str | None:
-    """Wait until ``/status`` records the outcome of the given FT apply request."""
-    engine = _poll_status(
-        server,
-        deadline_s,
-        lambda engine: engine.get("last_ft_request_id") == request_id,
-    )
-    return engine.get("ft_error") if engine else None
+    """Wait until ``/fault_tolerance/status`` records the FT apply outcome."""
+    engine_status = _wait_for_engines(
+        [server],
+        match_key="last_ft_request_id",
+        match_values={request_id},
+        deadline_s=deadline_s,
+    )[0]
+    return engine_status.get("ft_error") if engine_status else None
 
 
 @pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")
@@ -273,43 +289,30 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
         rank1 = _server_for_rank(servers, 1)
 
         # 1. Both engines healthy and serving.
-        for server in (rank0, rank1):
-            status = _assert_serving_and_healthy(server)
-            assert status["schema_version"] == 1, status
-            assert status["total_engines"] == 1, status  # one engine per server
+        _assert_serving_and_healthy((rank0, rank1))
 
         # 2. Drive both ranks so rank 1 accumulates execute_model steps and trips
         #    the injected fault; rank 0 then times out on the DP allreduce.
         with _driving(rank0, rank1):
-            faulted = {
-                rank: _wait_for_status(server, {"unhealthy"})
-                for rank, server in ((0, rank0), (1, rank1))
-            }
+            faulted = _wait_for_engines(
+                [rank0, rank1], match_key="status", match_values={"unhealthy"}
+            )
 
-        for rank, engine in faulted.items():
-            assert engine is not None, (
+        for rank, engine_status in enumerate(faulted):
+            assert engine_status is not None, (
                 f"rank {rank} did not report UNHEALTHY within "
                 f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
             )
         # The rank that raised carries the fault info from its own exception.
+        assert faulted[1] is not None
         assert faulted[1].get("fault_info"), faulted[1]
 
         # 3. retry both engines.
         for server in (rank0, rank1):
             _apply_ft(server, "retry")
 
-        # 4. Recovery completes: both engines return to healthy.
-        for rank, server in ((0, rank0), (1, rank1)):
-            healthy = _wait_for_status(server, {"healthy"})
-            assert healthy is not None, (
-                f"rank {rank} did not recover to healthy within "
-                f"{FAULT_DETECTION_DEADLINE_S}s"
-            )
-
-        # 5. Post-recovery inference works on both ranks.
-        for server in (rank0, rank1):
-            completion = _complete(server.get_client())
-            assert completion.choices[0].text is not None
+        # 4. Recovery completes: both engines return to healthy and serve again.
+        _assert_serving_and_healthy((rank0, rank1))
 
 
 @pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")
@@ -335,18 +338,18 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
         victim = _server_for_rank(servers, 1)
 
         # 1. Confirm both engines are healthy and serving.
-        for server in (survivor, victim):
-            _assert_serving_and_healthy(server)
+        _assert_serving_and_healthy((survivor, victim))
 
         # 2. Kill only the victim's worker; both EngineCores stay alive.
         _kill_worker_process(victim)
 
         # 3. Drive both engines so each keeps stepping into the failed component.
-        #    Both fault ~together via timeout, so sequential polling under one
-        #    driving context still sees each within the deadline.
         with _driving(survivor, victim):
-            survivor_faulted = _wait_for_status(survivor, {"dead", "unhealthy"})
-            victim_faulted = _wait_for_status(victim, {"dead", "unhealthy"})
+            survivor_faulted, victim_faulted = _wait_for_engines(
+                [survivor, victim],
+                match_key="status",
+                match_values={"dead", "unhealthy"},
+            )
 
         assert survivor_faulted is not None, (
             "survivor did not report the peer fault within "

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -13,6 +13,7 @@ from vllm.config.device import DeviceConfig
 from vllm.config.diffusion import DiffusionConfig
 from vllm.config.ec_manager_config import EncoderCacheManagerConfig
 from vllm.config.ec_transfer import ECTransferConfig
+from vllm.config.fault_tolerance import FaultToleranceConfig
 from vllm.config.kernel import KernelConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.config.kv_transfer import KVTransferConfig
@@ -124,6 +125,8 @@ __all__ = [
     "StructuredOutputsConfig",
     # From vllm.config.profiler
     "ProfilerConfig",
+    # From vllm.config.fault_tolerance
+    "FaultToleranceConfig",
     # From vllm.config.utils
     "ConfigType",
     "SupportsMetricsInfo",

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+from vllm.config.utils import config
+
+
+@config
+class FaultToleranceConfig:
+    """Configuration for fault tolerance."""
+
+    engine_recovery_timeout_sec: int = 120
+    """Timeout (in seconds) to wait for error handling instructions
+    before raising an exception. If the EngineCore encounters an
+    error, it waits up to this many seconds for instructions on how
+    to handle the error. If no instructions are received within this
+    time, the original error is raised.
+    """

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -12,7 +12,7 @@ class FaultToleranceConfig:
     engine_recovery_timeout_sec: int = 120
     """Timeout (in seconds) to wait for error handling instructions
     before raising an exception. If the EngineCore encounters an
-    error, it waits up to this many seconds for instructions on how
-    to handle the error. If no instructions are received within this
-    time, the original error is raised.
+    error, it waits up to this many seconds for vLLM to receive 
+    instructions on how to handle the error and then recover from the fault.
+    If vLLM does not recover during this time, the original error is raised.
     """

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -457,6 +457,13 @@ class ParallelConfig:
                 f"but found: {self._api_process_rank}"
             )
 
+        if self.enable_fault_tolerance and self._api_process_count > 1:
+            raise ValueError(
+                "Fault tolerance requires a single API server process "
+                f"(--api-server-count=1), but got {self._api_process_count}. "
+                "The FT system assumes one AsyncMPClient manages all engines."
+            )
+
         if self.all2all_backend in ["pplx", "naive"]:
             logger.warning(
                 "The '%s' all2all backend has been removed. "

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -13,6 +13,7 @@ from torch.distributed import ProcessGroup, ReduceOp, Store
 from typing_extensions import Self
 
 import vllm.envs as envs
+from vllm.config.fault_tolerance import FaultToleranceConfig
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from ray.runtime_env import RuntimeEnv
     from ray.util.placement_group import PlacementGroup
 
+    from vllm.config.fault_tolerance import FaultToleranceConfig
     from vllm.v1.executor import Executor
 else:
     RuntimeEnv = Any
@@ -392,6 +394,16 @@ class ParallelConfig:
         This is an internal config that is only valid for and
         should only be set by API server scale-out.
     """
+
+    enable_fault_tolerance: bool = False
+    """Enable fault tolerance for detailed error recovery,
+    such as scaling down fault DPEngineCore.
+    """
+
+    fault_tolerance_config: FaultToleranceConfig = Field(
+        default_factory=FaultToleranceConfig
+    )
+    """The configurations for fault tolerance."""
 
     @field_validator("disable_nccl_for_dp_synchronization", mode="wrap")
     @classmethod

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed as dist
 
 import vllm.envs as envs
+from vllm.config import get_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_pcp_group
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.forward_context import get_forward_context
@@ -278,7 +279,9 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
 
     def __init__(self, cpu_group, tcp_store_group=None):
         super().__init__(cpu_group, tcp_store_group)
-        self.support_fault_tolerance = False  # TODO: set to True when FT is supported.
+        self.support_fault_tolerance = (
+            get_current_vllm_config().parallel_config.enable_fault_tolerance
+        )
 
     def _make_all2all_kwargs(
         self,
@@ -359,6 +362,16 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
             DeepEPLLAll2AllManager._last_mask = torch.zeros_like(current)
         has_fault = (current != DeepEPLLAll2AllManager._last_mask).any()
         return has_fault
+
+    def clean_buffers(self) -> None:
+        buf = DeepEPLLAll2AllManager._buffer
+        if buf is None:
+            return
+        buf.get_local_buffer_tensor(dtype=torch.int8, use_rdma_buffer=True).zero_()
+        torch.accelerator.synchronize()
+        buf.low_latency_clean_mask_buffer()
+        torch.accelerator.synchronize()
+        DeepEPLLAll2AllManager._last_mask = None
 
 
 @dataclass
@@ -564,6 +577,16 @@ class NixlEPAll2AllManager(All2AllManagerBase):
             last = NixlEPAll2AllManager._last_mask
         has_fault = (current != last).any()
         return has_fault
+
+    def clean_buffers(self) -> None:
+        if NixlEPAll2AllManager._buffer is None:
+            return
+        state = NixlEPAll2AllManager._buffer
+        state.buffer.get_local_buffer_tensor(dtype=torch.int8).zero_()
+        torch.accelerator.synchronize()
+        state.buffer.clean_mask_buffer()
+        torch.accelerator.synchronize()
+        NixlEPAll2AllManager._last_active_mask = None
 
 
 class FlashInferNVLinkTwoSidedManager(All2AllManagerBase):

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -582,11 +582,13 @@ class NixlEPAll2AllManager(All2AllManagerBase):
         if NixlEPAll2AllManager._buffer is None:
             return
         state = NixlEPAll2AllManager._buffer
-        state.buffer.get_local_buffer_tensor(dtype=torch.int8).zero_()
+        state.buffer.get_local_buffer_tensor(
+            dtype=torch.int8, use_rdma_buffer=True
+        ).zero_()
         torch.accelerator.synchronize()
         state.buffer.clean_mask_buffer()
         torch.accelerator.synchronize()
-        NixlEPAll2AllManager._last_active_mask = None
+        NixlEPAll2AllManager._last_mask = None
 
 
 class FlashInferNVLinkTwoSidedManager(All2AllManagerBase):

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -111,6 +111,10 @@ class All2AllManagerBase:
         """Returns has_fault scalar."""
         raise NotImplementedError
 
+    def clean_buffers(self) -> None:
+        """Clean RDMA buffers and mask state during FT retry."""
+        raise NotImplementedError
+
     def set_num_sms(self, num_sms: int):
         pass
 

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -105,14 +105,30 @@ class All2AllManagerBase:
         raise NotImplementedError
 
     def query_active_mask(self) -> torch.Tensor:
+        """Return the all2all liveness mask for the EP ranks.
+
+        Returns:
+            An int32 device tensor where 0 marks a live rank and 1 marks a
+            masked (dead/unreachable) rank.
+        """
         raise NotImplementedError
 
     def query_fault(self) -> torch.Tensor:
-        """Returns has_fault scalar."""
+        """Return a scalar bool tensor, True if a new fault appeared.
+
+        Compares the current mask against the baseline recorded at the last
+        recovery point.
+        """
         raise NotImplementedError
 
     def clean_buffers(self) -> None:
-        """Clean RDMA buffers and mask state during FT retry."""
+        """Reset this rank's RDMA buffers and all2all mask state (rank-local).
+
+        Post-fault cleanup: a dispatch/combine that hit a dead peer or timed
+        out can leave partially-written or stale tokens in the RDMA receive
+        buffer, so it is zeroed to stop the next forward from reading that
+        contaminated data.
+        """
         raise NotImplementedError
 
     def set_num_sms(self, num_sms: int):

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -761,7 +761,12 @@ class EngineArgs:
                 **self.weight_transfer_config
             )
         if isinstance(self.fault_tolerance_config, dict):
-            self.enable_fault_tolerance = True
+            if not self.enable_fault_tolerance:
+                logger.warning(
+                    "--fault-tolerance-config was passed. Fault tolerance is being "
+                    "automatically enabled."
+                )
+                self.enable_fault_tolerance = True
             self.fault_tolerance_config = FaultToleranceConfig(
                 **self.fault_tolerance_config
             )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -42,6 +42,7 @@ from vllm.config import (
     DiffusionConfig,
     ECTransferConfig,
     EPLBConfig,
+    FaultToleranceConfig,
     KernelConfig,
     KVEventsConfig,
     KVTransferConfig,
@@ -722,6 +723,12 @@ class EngineArgs:
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
     performance_mode: PerformanceMode = VllmConfig.performance_mode
 
+    # fault tolerance fields (`None` means not explicitly provided).
+    fault_tolerance_config: FaultToleranceConfig | None = get_field(
+        ParallelConfig, "fault_tolerance_config"
+    )
+    enable_fault_tolerance: bool = ParallelConfig.enable_fault_tolerance
+
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
     kv_offloading_backend: KVOffloadingBackend = CacheConfig.kv_offloading_backend
     tokens_only: bool = False
@@ -753,6 +760,10 @@ class EngineArgs:
         if isinstance(self.weight_transfer_config, dict):
             self.weight_transfer_config = WeightTransferConfig(
                 **self.weight_transfer_config
+            )
+        if isinstance(self.fault_tolerance_config, dict):
+            self.fault_tolerance_config = FaultToleranceConfig(
+                **self.fault_tolerance_config
             )
         if isinstance(self.ir_op_priority, dict):
             self.ir_op_priority = IrOpPriorityConfig(**self.ir_op_priority)
@@ -1150,6 +1161,16 @@ class EngineArgs:
         parallel_group.add_argument("--worker-cls", **parallel_kwargs["worker_cls"])
         parallel_group.add_argument(
             "--worker-extension-cls", **parallel_kwargs["worker_extension_cls"]
+        )
+        parallel_group.add_argument(
+            "--enable-fault-tolerance", **parallel_kwargs["enable_fault_tolerance"]
+        )
+        parallel_group.add_argument(
+            "--fault-tolerance-config",
+            **{
+                **parallel_kwargs["fault_tolerance_config"],
+                "default": None,
+            },
         )
 
         # KV cache arguments
@@ -1617,6 +1638,13 @@ class EngineArgs:
     def from_cli_args(cls, args: argparse.Namespace):
         # Get the list of attributes of this dataclass.
         attrs = [attr.name for attr in dataclasses.fields(cls)]
+
+        # If --fault-tolerance-config is provided, enable fault tolerance by default.
+        if args.fault_tolerance_config is not None:
+            args.enable_fault_tolerance = True
+        if args.enable_fault_tolerance and args.fault_tolerance_config is None:
+            args.fault_tolerance_config = FaultToleranceConfig()
+
         # Set the attributes from the parsed arguments.
         engine_args = cls(
             **{attr: getattr(args, attr) for attr in attrs if hasattr(args, attr)}
@@ -2022,6 +2050,12 @@ class EngineArgs:
         data_parallel_external_lb = (
             self.data_parallel_external_lb or self.data_parallel_rank is not None
         )
+        if self.enable_fault_tolerance and not data_parallel_external_lb:
+            raise ValueError(
+                "Fault tolerance requires external load balancer mode "
+                "(--data-parallel-external-lb or --data-parallel-rank). "
+                "Internal LB mode is not supported."
+            )
         if (
             self.data_parallel_size > 1
             and data_parallel_external_lb
@@ -2179,6 +2213,10 @@ class EngineArgs:
             _api_process_count=self._api_process_count,
             _api_process_rank=self._api_process_rank,
             assigned_physical_gpu_ids=self._resolve_device_ids(),
+            enable_fault_tolerance=self.enable_fault_tolerance,
+            fault_tolerance_config=(
+                self.fault_tolerance_config or FaultToleranceConfig()
+            ),
             numa_bind=self.numa_bind,
             numa_bind_nodes=self.numa_bind_nodes,
             numa_bind_cpus=self.numa_bind_cpus,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -117,7 +117,6 @@ from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.network_utils import get_ip
 from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
-from vllm.v1.fault_tolerance.utils import FT_BACKEND_SET
 from vllm.v1.sample.logits_processor import LogitsProcessor
 from vllm.version import __version__ as VLLM_VERSION
 
@@ -2056,11 +2055,6 @@ class EngineArgs:
                 "Fault tolerance requires external load balancer mode "
                 "(--data-parallel-external-lb or --data-parallel-rank). "
                 "Internal LB mode is not supported."
-            )
-        if self.enable_fault_tolerance and self.all2all_backend not in FT_BACKEND_SET:
-            raise ValueError(
-                "Fault tolerance requires an FT-capable all2all backend "
-                f"(deepep_low_latency or nixl_ep), but got '{self.all2all_backend}'."
             )
         if (
             self.data_parallel_size > 1

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -723,8 +723,7 @@ class EngineArgs:
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
     performance_mode: PerformanceMode = VllmConfig.performance_mode
 
-    # fault tolerance fields (`None` means not explicitly provided).
-    fault_tolerance_config: FaultToleranceConfig | None = get_field(
+    fault_tolerance_config: FaultToleranceConfig = get_field(
         ParallelConfig, "fault_tolerance_config"
     )
     enable_fault_tolerance: bool = ParallelConfig.enable_fault_tolerance
@@ -762,6 +761,7 @@ class EngineArgs:
                 **self.weight_transfer_config
             )
         if isinstance(self.fault_tolerance_config, dict):
+            self.enable_fault_tolerance = True
             self.fault_tolerance_config = FaultToleranceConfig(
                 **self.fault_tolerance_config
             )
@@ -1166,11 +1166,7 @@ class EngineArgs:
             "--enable-fault-tolerance", **parallel_kwargs["enable_fault_tolerance"]
         )
         parallel_group.add_argument(
-            "--fault-tolerance-config",
-            **{
-                **parallel_kwargs["fault_tolerance_config"],
-                "default": None,
-            },
+            "--fault-tolerance-config", **parallel_kwargs["fault_tolerance_config"]
         )
 
         # KV cache arguments
@@ -1638,12 +1634,6 @@ class EngineArgs:
     def from_cli_args(cls, args: argparse.Namespace):
         # Get the list of attributes of this dataclass.
         attrs = [attr.name for attr in dataclasses.fields(cls)]
-
-        # If --fault-tolerance-config is provided, enable fault tolerance by default.
-        if args.fault_tolerance_config is not None:
-            args.enable_fault_tolerance = True
-        if args.enable_fault_tolerance and args.fault_tolerance_config is None:
-            args.fault_tolerance_config = FaultToleranceConfig()
 
         # Set the attributes from the parsed arguments.
         engine_args = cls(
@@ -2214,9 +2204,7 @@ class EngineArgs:
             _api_process_rank=self._api_process_rank,
             assigned_physical_gpu_ids=self._resolve_device_ids(),
             enable_fault_tolerance=self.enable_fault_tolerance,
-            fault_tolerance_config=(
-                self.fault_tolerance_config or FaultToleranceConfig()
-            ),
+            fault_tolerance_config=self.fault_tolerance_config,
             numa_bind=self.numa_bind,
             numa_bind_nodes=self.numa_bind_nodes,
             numa_bind_cpus=self.numa_bind_cpus,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -117,6 +117,7 @@ from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.network_utils import get_ip
 from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.fault_tolerance.utils import FT_BACKEND_SET
 from vllm.v1.sample.logits_processor import LogitsProcessor
 from vllm.version import __version__ as VLLM_VERSION
 
@@ -2055,6 +2056,11 @@ class EngineArgs:
                 "Fault tolerance requires external load balancer mode "
                 "(--data-parallel-external-lb or --data-parallel-rank). "
                 "Internal LB mode is not supported."
+            )
+        if self.enable_fault_tolerance and self.all2all_backend not in FT_BACKEND_SET:
+            raise ValueError(
+                "Fault tolerance requires an FT-capable all2all backend "
+                f"(deepep_low_latency or nixl_ep), but got '{self.all2all_backend}'."
             )
         if (
             self.data_parallel_size > 1

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -20,6 +20,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest, FaultToleranceResult
 
 if TYPE_CHECKING:
     from vllm.v1.engine import PauseMode
@@ -232,6 +233,16 @@ class EngineClient(ABC):
         kwargs: dict | None = None,
     ):
         """Perform a collective RPC call to the given path."""
+        raise NotImplementedError
+
+    async def handle_fault(
+        self, fault_tolerance_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        """send fault tolerance instruction to the engine"""
+        raise NotImplementedError
+
+    async def get_status(self):
+        """Get fault tolerance status of all engines."""
         raise NotImplementedError
 
     async def get_supported_tasks(self) -> tuple[SupportedTask, ...]:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -269,6 +269,13 @@ def build_app(
 
         register_pooling_api_routers(app, supported_tasks, model_config)
 
+    if args.enable_fault_tolerance:
+        from vllm.entrypoints.serve.fault_tolerance.api_router import (
+            register_fault_tolerance_api_router,
+        )
+
+        register_fault_tolerance_api_router(app)
+
     # Endpoint plugins are attached last so their routes are registered after all core
     # routers. This runs even for the CPU only render server. A plugin eligible for
     # the `render` task still gets its routes registered. It receives

--- a/vllm/entrypoints/serve/fault_tolerance/api_router.py
+++ b/vllm/entrypoints/serve/fault_tolerance/api_router.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import uuid
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.serve.utils.api_utils import validate_json_request
+from vllm.logger import init_logger
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+_ALLOWED_INSTRUCTIONS = {"retry"}
+
+
+def _validate_payload(body: dict) -> tuple[str, dict]:
+    instruction = body.get("instruction")
+    params = body.get("params")
+    if not instruction or not isinstance(params, dict):
+        raise HTTPException(400, "'instruction' and 'params' are required.")
+    if instruction not in _ALLOWED_INSTRUCTIONS:
+        raise HTTPException(400, f"Invalid instruction: '{instruction}'.")
+    if "timeout" not in params or not isinstance(params["timeout"], (int, float)):
+        raise HTTPException(400, "Missing or invalid 'timeout' parameter.")
+    return instruction, params
+
+
+@router.post(
+    "/fault_tolerance/apply",
+    dependencies=[Depends(validate_json_request)],
+    responses={
+        HTTPStatus.OK.value: {"model": dict},
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.REQUEST_TIMEOUT.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+async def process_fault_tolerance_instruction(raw_request: Request):
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError as e:
+        raise HTTPException(400, "Invalid JSON format") from e
+
+    instruction, params = _validate_payload(body)
+    ft_request = FaultToleranceRequest(
+        instruction=instruction,
+        params=params,
+        request_id=str(uuid.uuid4()),
+    )
+
+    client: EngineClient = raw_request.app.state.engine_client
+    try:
+        ft_result = await client.handle_fault(ft_request)
+    except Exception as e:
+        logger.error("Failed to handle fault: %s", e)
+        raise HTTPException(500, "Failed to handle fault.") from e
+
+    if ft_result.success:
+        return JSONResponse({"message": "Instruction executed successfully."})
+    raise HTTPException(500, f"Instruction failed: {ft_result.reason}")
+
+
+@router.get("/fault_tolerance/status")
+async def get_status(raw_request: Request):
+    client: EngineClient = raw_request.app.state.engine_client
+    return JSONResponse(content=await client.get_status())
+
+
+def register_fault_tolerance_api_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/entrypoints/serve/fault_tolerance/api_router.py
+++ b/vllm/entrypoints/serve/fault_tolerance/api_router.py
@@ -21,14 +21,16 @@ _ALLOWED_INSTRUCTIONS = {"retry"}
 
 
 def _validate_payload(body: dict) -> tuple[str, dict]:
+    if not isinstance(body, dict):
+        raise HTTPException(400, "Request body must be a JSON object.")
     instruction = body.get("instruction")
-    params = body.get("params")
-    if not instruction or not isinstance(params, dict):
-        raise HTTPException(400, "'instruction' and 'params' are required.")
+    if not instruction:
+        raise HTTPException(400, "'instruction' is required.")
     if instruction not in _ALLOWED_INSTRUCTIONS:
         raise HTTPException(400, f"Invalid instruction: '{instruction}'.")
-    if "timeout" not in params or not isinstance(params["timeout"], (int, float)):
-        raise HTTPException(400, "Missing or invalid 'timeout' parameter.")
+    params = body.get("params", {})
+    if not isinstance(params, dict):
+        raise HTTPException(400, "'params' must be an object.")
     return instruction, params
 
 

--- a/vllm/entrypoints/serve/fault_tolerance/api_router.py
+++ b/vllm/entrypoints/serve/fault_tolerance/api_router.py
@@ -4,7 +4,7 @@ import json
 import uuid
 from http import HTTPStatus
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from vllm.engine.protocol import EngineClient
@@ -38,13 +38,13 @@ def _validate_payload(body: dict) -> tuple[str, dict]:
     "/fault_tolerance/apply",
     dependencies=[Depends(validate_json_request)],
     responses={
-        HTTPStatus.OK.value: {"model": dict},
+        HTTPStatus.ACCEPTED.value: {"model": dict},
         HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
-        HTTPStatus.REQUEST_TIMEOUT.value: {"model": ErrorResponse},
-        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
     },
 )
-async def process_fault_tolerance_instruction(raw_request: Request):
+async def process_fault_tolerance_instruction(
+    raw_request: Request, background_tasks: BackgroundTasks
+):
     try:
         body = await raw_request.json()
     except json.JSONDecodeError as e:
@@ -58,15 +58,36 @@ async def process_fault_tolerance_instruction(raw_request: Request):
     )
 
     client: EngineClient = raw_request.app.state.engine_client
-    try:
-        ft_result = await client.handle_fault(ft_request)
-    except Exception as e:
-        logger.error("Failed to handle fault: %s", e)
-        raise HTTPException(500, "Failed to handle fault.") from e
+    # Recovery runs cross-rank collective ops that only complete once every rank
+    # has been dispatched. Run it in the background and return immediately so the
+    # orchestrator can dispatch to all ranks without blocking; completion is
+    # observed by polling GET /fault_tolerance/status.
+    background_tasks.add_task(_run_fault_recovery, client, ft_request)
+    return JSONResponse(
+        status_code=HTTPStatus.ACCEPTED.value,
+        content={
+            "message": "Request accepted; poll /fault_tolerance/status for updates.",
+            "request_id": ft_request.request_id,
+        },
+        background=background_tasks,
+    )
 
-    if ft_result.success:
-        return JSONResponse({"message": "Instruction executed successfully."})
-    raise HTTPException(500, f"Instruction failed: {ft_result.reason}")
+
+async def _run_fault_recovery(
+    client: EngineClient, ft_request: FaultToleranceRequest
+) -> None:
+    """Drive recovery to completion after the 202 response is sent."""
+    try:
+        result = await client.handle_fault(ft_request)
+    except Exception:
+        logger.exception("[FT] Recovery dispatch failed.")
+        return
+    if not result.success:
+        logger.error(
+            "[FT] Recovery failed for request %s: %s",
+            ft_request.request_id,
+            result.reason,
+        )
 
 
 @router.get("/fault_tolerance/status")

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -31,6 +31,8 @@ FINISH_REASON_STRINGS = ("stop", "length", "abort", "error", "repetition")
 
 EEP_NOTIFICATION_CALL_ID = -1
 
+FT_STATUS_CALL_ID = -2
+
 
 class EEPNotificationType(enum.Enum):
     NEW_CORE_ENGINES_INIT_READY = "NEW_CORE_ENGINES_INIT_READY"

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -282,3 +282,9 @@ class ReconfigureRankType(enum.IntEnum):
 
     KEEP_CURRENT_RANK = -1
     SHUTDOWN_CURRENT_RANK = -2
+
+
+class EngineStatusType(enum.IntEnum):
+    HEALTHY = 0
+    DEAD = 1
+    UNHEALTHY = 2

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -44,6 +44,7 @@ from vllm.v1.engine.input_processor import InputProcessor
 from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest, FaultToleranceResult
 from vllm.v1.metrics.loggers import (
     StatLoggerFactory,
     StatLoggerManager,
@@ -1040,6 +1041,15 @@ class AsyncLLM(EngineClient):
             self.vllm_config.parallel_config.data_parallel_size = new_data_parallel_size
         finally:
             set_scaling_elastic_ep(False)
+
+    async def handle_fault(
+        self, fault_tolerance_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        """send fault tolerance instruction to the engine"""
+        return await self.engine_core.handle_fault(fault_tolerance_request)
+
+    async def get_status(self):
+        return await self.engine_core.get_status()
 
     @property
     def is_running(self) -> bool:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -78,6 +78,11 @@ from vllm.v1.engine.utils import (
     get_physical_gpu_ids_for_local_dp_rank,
 )
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance.engine_core_sentinel import (
+    FT_UTILITY_METHOD,
+    EngineCoreSentinel,
+    fault_tolerant_wrapper,
+)
 from vllm.v1.kv_cache_interface import KVCacheConfig, get_kv_cache_spec_kind
 from vllm.v1.metrics.stats import SchedulerIterationDetails, SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
@@ -1070,6 +1075,16 @@ class EngineCoreProc(EngineCore):
                 internal_dp_balancing,
             )
 
+            # Initialize fault tolerance settings.
+            self.enable_fault_tolerance = (
+                vllm_config.parallel_config.enable_fault_tolerance
+            )
+            if self.enable_fault_tolerance:
+                self.ft_sentinel = EngineCoreSentinel(
+                    engine=self,
+                    parallel_config=vllm_config.parallel_config,
+                )
+
             # Background Threads and Queues for IO. These enable us to
             # overlap ZMQ socket IO with GPU since they release the GIL,
             # and to overlap some serialization/deserialization with the
@@ -1355,6 +1370,7 @@ class EngineCoreProc(EngineCore):
         """Returns true if shutdown has not been requested."""
         return self.shutdown_state == EngineShutdownState.RUNNING
 
+    @fault_tolerant_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore."""
         while self._handle_shutdown():
@@ -1671,6 +1687,14 @@ class EngineCoreProc(EngineCore):
                             request = self.preprocess_add_request(req)
                         except Exception:
                             self._handle_request_preproc_error(req)
+                            continue
+                    elif request_type == EngineCoreRequestType.UTILITY:
+                        request = generic_decoder.decode(data_frames)
+                        client_idx, call_id, method, args = request
+                        if method == FT_UTILITY_METHOD:
+                            self.ft_sentinel.handle_command(
+                                client_idx, call_id, args[0]
+                            )
                             continue
                     else:
                         request = generic_decoder.decode(data_frames)
@@ -2021,6 +2045,7 @@ class DPEngineCoreProc(EngineCoreProc):
             and self.step_counter % self.prefill_schedule_interval != 0
         )
 
+    @fault_tolerant_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore for data parallel case."""
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -56,6 +56,11 @@ from vllm.v1.engine.utils import (
     launch_core_engines,
 )
 from vllm.v1.executor import Executor
+from vllm.v1.fault_tolerance.engine_core_sentinel import FT_UTILITY_METHOD
+from vllm.v1.fault_tolerance.utils import (
+    FaultToleranceRequest,
+    FaultToleranceResult,
+)
 from vllm.v1.pool.late_interaction import get_late_interaction_engine_index
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
 
@@ -270,6 +275,14 @@ class EngineCoreClient(ABC):
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
     ) -> list[_R]:
+        raise NotImplementedError
+
+    async def handle_fault(
+        self, fault_tolerance_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        raise NotImplementedError
+
+    async def get_status(self):
         raise NotImplementedError
 
 
@@ -1195,6 +1208,24 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async(
             "collective_rpc", method, timeout, args, kwargs
         )
+
+    async def handle_fault(
+        self, ft_request: FaultToleranceRequest
+    ) -> FaultToleranceResult:
+        res = await self.call_utility_async(FT_UTILITY_METHOD, ft_request)
+        result = FaultToleranceResult(**res)
+        return result
+
+    async def get_status(self):
+        ft_request = FaultToleranceRequest(instruction="status", params={})
+        res = await self.call_utility_async(FT_UTILITY_METHOD, ft_request)
+        return {
+            "schema_version": 1,
+            "total_engines": len(self.engine_ranks_managed),
+            "engines": [
+                {"id": res["engine_id"], "status": res["status"]},
+            ],
+        }
 
 
 class DPAsyncMPClient(AsyncMPClient):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1222,9 +1222,7 @@ class AsyncMPClient(MPClient):
         return {
             "schema_version": 1,
             "total_engines": len(self.engine_ranks_managed),
-            "engines": [
-                {"id": res["engine_id"], "status": res["status"]},
-            ],
+            "engines": [res],
         }
 
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -35,6 +35,7 @@ from vllm.utils.network_utils import (
 )
 from vllm.v1.engine import (
     EEP_NOTIFICATION_CALL_ID,
+    FT_STATUS_CALL_ID,
     EEPNotificationType,
     EngineCoreOutputs,
     EngineCoreReadyResponse,
@@ -984,6 +985,14 @@ class AsyncMPClient(MPClient):
         self.client_count = client_count
         self.client_index = client_index
         self.outputs_queue = asyncio.Queue[EngineCoreOutputs | Exception]()
+
+        # locally-cached engine status
+        self._engine_status: dict[int, dict] = {}
+        if self.vllm_config.parallel_config.enable_fault_tolerance:
+            self._engine_status = {
+                rank: {"id": rank, "status": "healthy"}
+                for rank in self.engine_ranks_managed
+            }
         try:
             # If we are running in an asyncio event loop, start the queue task.
             # Otherwise, it will be started lazily. If it is not started here,
@@ -1007,7 +1016,7 @@ class AsyncMPClient(MPClient):
         output_handler: (
             Callable[[AsyncMPClient, EngineCoreOutputs], Awaitable[None]] | None
         ) = getattr(self.__class__, "process_engine_outputs", None)
-        _self_ref = weakref.ref(self) if output_handler else None
+        _self_ref = weakref.ref(self)
         output_socket = resources.output_socket
         assert output_socket is not None
 
@@ -1038,6 +1047,14 @@ class AsyncMPClient(MPClient):
                             asyncio.create_task(
                                 notification_callback_handler(_self, notification_data)
                             )
+                        elif outputs.utility_output.call_id == FT_STATUS_CALL_ID:
+                            _self = _self_ref()
+                            if not _self:
+                                return
+                            if outputs.utility_output.result is not None:
+                                _self._engine_status[outputs.engine_index] = (
+                                    outputs.utility_output.result.result
+                                )
                         else:
                             _process_utility_output(
                                 outputs.utility_output, utility_results
@@ -1217,12 +1234,10 @@ class AsyncMPClient(MPClient):
         return result
 
     async def get_status(self):
-        ft_request = FaultToleranceRequest(instruction="status", params={})
-        res = await self.call_utility_async(FT_UTILITY_METHOD, ft_request)
         return {
             "schema_version": 1,
             "total_engines": len(self.engine_ranks_managed),
-            "engines": [res],
+            "engines": list(self._engine_status.values()),
         }
 
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -16,6 +16,7 @@ from multiprocessing.queues import Queue
 from threading import Thread
 from typing import Any, TypeAlias, TypeVar
 
+import msgspec
 import msgspec.msgpack
 import zmq
 import zmq.asyncio
@@ -1230,8 +1231,7 @@ class AsyncMPClient(MPClient):
         self, ft_request: FaultToleranceRequest
     ) -> FaultToleranceResult:
         res = await self.call_utility_async(FT_UTILITY_METHOD, ft_request)
-        result = FaultToleranceResult(**res)
-        return result
+        return msgspec.convert(res, FaultToleranceResult)
 
     async def get_status(self):
         return {

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1231,7 +1231,13 @@ class AsyncMPClient(MPClient):
         self, ft_request: FaultToleranceRequest
     ) -> FaultToleranceResult:
         res = await self.call_utility_async(FT_UTILITY_METHOD, ft_request)
-        return msgspec.convert(res, FaultToleranceResult)
+        result = msgspec.convert(res, FaultToleranceResult)
+        if not result.success:
+            status = self._engine_status.get(self.engine_ranks_managed[0])
+            if status is not None:
+                status["last_ft_request_id"] = result.request_id
+                status["ft_error"] = result.reason
+        return result
 
     async def get_status(self):
         return {

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -234,9 +234,6 @@ class CoreEngineProcManager:
                 if exitcode != 0 and not self.manager_stopped.is_set():
                     self.failed_proc_name = proc.name
             if died_sentinels:
-                # Any engine exit currently triggers a shutdown. Future
-                # work (e.g., Elastic and fault-tolerant EP) will add finer-grained
-                # handling for different exit scenarios.
                 break
 
         self.shutdown()

--- a/vllm/v1/fault_tolerance/__init__.py
+++ b/vllm/v1/fault_tolerance/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .engine_core_sentinel import EngineCoreSentinel, fault_tolerant_wrapper
+
+__all__ = [
+    "EngineCoreSentinel",
+    "fault_tolerant_wrapper",
+]

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""EngineCoreSentinel and fault_tolerant_wrapper for the engine core."""
+
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from vllm.config import set_current_vllm_config
+from vllm.distributed import stateless_destroy_torch_distributed_process_group
+from vllm.distributed.utils import stateless_init_torch_distributed_process_group
+from vllm.logger import init_logger
+from vllm.utils.network_utils import get_open_port
+from vllm.v1.engine import EngineCoreOutputs, EngineStatusType, UtilityOutput
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+from vllm.v1.request import RequestStatus
+from vllm.v1.serial_utils import UtilityResult, run_method
+
+if TYPE_CHECKING:
+    from vllm.v1.engine.core import EngineCoreProc
+
+logger = init_logger(__name__)
+
+FT_UTILITY_METHOD = "handle_fault_tolerance"
+
+
+class EngineCoreSentinel:
+    """Manages fault tolerance state for a single engine core."""
+
+    def __init__(self, engine: "EngineCoreProc", parallel_config):
+        self.engine = engine
+        self.engine_index = engine.engine_index
+        self.parallel_config = parallel_config
+        ft_config = parallel_config.fault_tolerance_config
+        self.engine_recovery_timeout_sec = ft_config.engine_recovery_timeout_sec
+
+        self.resumed = threading.Event()
+        self.resumed.set()
+        self.status_type = EngineStatusType.HEALTHY
+        self._dp_reinit_epoch = 0
+
+    # ------------------------------------------------------------------
+    # Command dispatch (called from process_input_sockets thread)
+    # ------------------------------------------------------------------
+
+    def handle_command(self, client_idx: int, call_id: int, ft_args: dict):
+        """Dispatch an FT command by instruction name and enqueue result."""
+        ft_request = FaultToleranceRequest(**ft_args)
+        try:
+            result = run_method(self, ft_request.instruction, (ft_request,), {})
+        except Exception as e:
+            logger.exception("[FT] Instruction '%s' failed", ft_request.instruction)
+            result = {
+                "request_id": ft_request.request_id,
+                "success": False,
+                "reason": str(e),
+            }
+
+        uo = UtilityOutput(call_id)
+        uo.result = UtilityResult(result)
+        self.engine.output_queue.put_nowait(
+            (client_idx, EngineCoreOutputs(utility_output=uo))
+        )
+
+    # ------------------------------------------------------------------
+    # Fault handling (called by wrapper, runs in busy-loop thread)
+    # ------------------------------------------------------------------
+
+    def on_fault(self, exc: Exception):
+        """Called by the wrapper when the busy loop raises an exception."""
+        self.resumed.clear()
+        logger.warning(
+            "[FT] Busy loop raised %s. Waiting for recovery.", type(exc).__name__
+        )
+
+        engine = self.engine
+        aborted = engine.scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
+        engine._send_abort_outputs(aborted)
+        if engine.batch_queue is not None:
+            engine.batch_queue.clear()
+
+        self.status_type = EngineStatusType.UNHEALTHY
+        logger.info(
+            "[FT] Engine %d status -> UNHEALTHY:", self.engine_index, exc_info=exc
+        )
+
+    # ------------------------------------------------------------------
+    # Instruction handlers (method name == instruction string)
+    # ------------------------------------------------------------------
+
+    def status(self, ft_request: FaultToleranceRequest) -> dict:
+        return {
+            "request_id": ft_request.request_id,
+            "success": True,
+            "engine_id": self.engine_index,
+            "status": self.status_type.name.lower(),
+        }
+
+    def retry(self, ft_request: FaultToleranceRequest) -> dict:
+        engine = self.engine
+        executor = engine.model_executor
+
+        with set_current_vllm_config(engine.vllm_config):
+            ft_request.params.update(self._reinit_dp_group())
+        if hasattr(engine, "step_counter"):
+            engine.step_counter = 0
+
+        executor.collective_rpc("handle_ft_command", args=(ft_request,))
+
+        self.status_type = EngineStatusType.HEALTHY
+        logger.info("[FT] Engine %d status -> HEALTHY", self.engine_index)
+        self.resumed.set()
+        return {"request_id": ft_request.request_id, "success": True}
+
+    # ------------------------------------------------------------------
+    # Recovery helpers
+    # ------------------------------------------------------------------
+
+    def _reinit_dp_group(self) -> dict:
+        """Reinit DP process group if in DP mode. Returns worker params."""
+        engine = self.engine
+        if not hasattr(engine, "dp_group") or not hasattr(engine, "dp_store"):
+            return {}
+
+        parallel_config = engine.vllm_config.parallel_config
+        worker_key = f"ft_worker_dp_port_{self._dp_reinit_epoch}"
+        engine_key = f"ft_engine_dp_port_{self._dp_reinit_epoch}"
+        self._dp_reinit_epoch += 1
+
+        if parallel_config.data_parallel_rank == 0:
+            worker_port = get_open_port()
+            engine_port = get_open_port()
+            engine.dp_store.set(worker_key, str(worker_port).encode())
+            engine.dp_store.set(engine_key, str(engine_port).encode())
+        else:
+            worker_port = int(engine.dp_store.get(worker_key).decode())
+            engine_port = int(engine.dp_store.get(engine_key).decode())
+
+        stateless_destroy_torch_distributed_process_group(engine.dp_group)
+        engine.dp_group, engine.dp_store = (
+            stateless_init_torch_distributed_process_group(
+                parallel_config.data_parallel_master_ip,
+                engine_port,
+                parallel_config.data_parallel_rank,
+                parallel_config.data_parallel_size,
+                backend="gloo",
+                return_store=True,
+            )
+        )
+        return {"new_stateless_dp_group_port": worker_port}
+
+
+def fault_tolerant_wrapper(busy_loop_func: Callable):
+    """Wrap the busy loop to catch faults and delegate recovery."""
+
+    def run_with_fault_tolerance(self: "EngineCoreProc"):
+        while True:
+            try:
+                busy_loop_func(self)
+            except SystemExit:
+                raise
+            except Exception as exc:
+                if not self.enable_fault_tolerance:
+                    raise
+                self.ft_sentinel.on_fault(exc)
+                recovered = self.ft_sentinel.resumed.wait(
+                    timeout=self.ft_sentinel.engine_recovery_timeout_sec
+                )
+                if recovered:
+                    continue
+                logger.error(
+                    "[FT] No recovery within %ds timeout.",
+                    self.ft_sentinel.engine_recovery_timeout_sec,
+                )
+                raise
+
+    return run_with_fault_tolerance

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -39,10 +39,6 @@ class EngineCoreSentinel:
         self.status_type = EngineStatusType.HEALTHY
         self._dp_reinit_epoch = 0
 
-    # ------------------------------------------------------------------
-    # Command dispatch (called from process_input_sockets thread)
-    # ------------------------------------------------------------------
-
     def handle_command(self, client_idx: int, call_id: int, ft_args: dict):
         """Dispatch an FT command by instruction name and enqueue result."""
         ft_request = FaultToleranceRequest(**ft_args)
@@ -62,10 +58,6 @@ class EngineCoreSentinel:
             (client_idx, EngineCoreOutputs(utility_output=uo))
         )
 
-    # ------------------------------------------------------------------
-    # Fault handling (called by wrapper, runs in busy-loop thread)
-    # ------------------------------------------------------------------
-
     def on_fault(self, exc: Exception):
         """Called by the wrapper when the busy loop raises an exception."""
         self.resumed.clear()
@@ -83,10 +75,6 @@ class EngineCoreSentinel:
         logger.info(
             "[FT] Engine %d status -> UNHEALTHY:", self.engine_index, exc_info=exc
         )
-
-    # ------------------------------------------------------------------
-    # Instruction handlers (method name == instruction string)
-    # ------------------------------------------------------------------
 
     def status(self, ft_request: FaultToleranceRequest) -> dict:
         return {
@@ -111,10 +99,6 @@ class EngineCoreSentinel:
         logger.info("[FT] Engine %d status -> HEALTHY", self.engine_index)
         self.resumed.set()
         return {"request_id": ft_request.request_id, "success": True}
-
-    # ------------------------------------------------------------------
-    # Recovery helpers
-    # ------------------------------------------------------------------
 
     def _reinit_dp_group(self) -> dict:
         """Reinit DP process group if in DP mode. Returns worker params."""

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -37,6 +37,7 @@ class EngineCoreSentinel:
         self.resumed = threading.Event()
         self.resumed.set()
         self.status_type = EngineStatusType.HEALTHY
+        self.fault_info: str | None = None
         self._dp_reinit_epoch = 0
 
     def handle_command(self, client_idx: int, call_id: int, ft_args: dict):
@@ -72,17 +73,19 @@ class EngineCoreSentinel:
             engine.batch_queue.clear()
 
         self.status_type = EngineStatusType.UNHEALTHY
+        self.fault_info = f"{type(exc).__name__}: {exc}"
         logger.info(
             "[FT] Engine %d status -> UNHEALTHY:", self.engine_index, exc_info=exc
         )
 
     def status(self, ft_request: FaultToleranceRequest) -> dict:
-        return {
-            "request_id": ft_request.request_id,
-            "success": True,
-            "engine_id": self.engine_index,
+        result = {
+            "id": self.engine_index,
             "status": self.status_type.name.lower(),
         }
+        if self.status_type == EngineStatusType.UNHEALTHY:
+            result["fault_info"] = self.fault_info
+        return result
 
     def retry(self, ft_request: FaultToleranceRequest) -> dict:
         engine = self.engine

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -7,6 +7,8 @@ import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+import msgspec
+
 from vllm.config import set_current_vllm_config
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.utils import stateless_init_torch_distributed_process_group
@@ -18,7 +20,7 @@ from vllm.v1.engine import (
     EngineStatusType,
     UtilityOutput,
 )
-from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest, FaultToleranceResult
 from vllm.v1.request import RequestStatus
 from vllm.v1.serial_utils import UtilityResult, run_method
 
@@ -53,14 +55,12 @@ class EngineCoreSentinel:
             result = run_method(self, ft_request.instruction, (ft_request,), {})
         except Exception as e:
             logger.exception("[FT] Instruction '%s' failed", ft_request.instruction)
-            result = {
-                "request_id": ft_request.request_id,
-                "success": False,
-                "reason": str(e),
-            }
+            result = FaultToleranceResult(
+                request_id=ft_request.request_id, success=False, reason=str(e)
+            )
 
         uo = UtilityOutput(call_id)
-        uo.result = UtilityResult(result)
+        uo.result = UtilityResult(msgspec.structs.asdict(result))
         self.engine.output_queue.put_nowait(
             (client_idx, EngineCoreOutputs(utility_output=uo))
         )
@@ -99,7 +99,7 @@ class EngineCoreSentinel:
         outputs.engine_index = self.engine_index
         self.engine.output_queue.put_nowait((0, outputs))
 
-    def retry(self, ft_request: FaultToleranceRequest) -> dict:
+    def retry(self, ft_request: FaultToleranceRequest) -> FaultToleranceResult:
         engine = self.engine
         executor = engine.model_executor
 
@@ -114,7 +114,7 @@ class EngineCoreSentinel:
         logger.info("[FT] Engine %d status -> HEALTHY", self.engine_index)
         self.resumed.set()
         self._push_status()
-        return {"request_id": ft_request.request_id, "success": True}
+        return FaultToleranceResult(request_id=ft_request.request_id, success=True)
 
     def _reinit_dp_group(self) -> dict:
         """Reinit DP process group if in DP mode. Returns worker params."""

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -11,7 +11,12 @@ from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.utils import stateless_init_torch_distributed_process_group
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_open_port
-from vllm.v1.engine import EngineCoreOutputs, EngineStatusType, UtilityOutput
+from vllm.v1.engine import (
+    FT_STATUS_CALL_ID,
+    EngineCoreOutputs,
+    EngineStatusType,
+    UtilityOutput,
+)
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.request import RequestStatus
 from vllm.v1.serial_utils import UtilityResult, run_method
@@ -77,15 +82,21 @@ class EngineCoreSentinel:
         logger.info(
             "[FT] Engine %d status -> UNHEALTHY:", self.engine_index, exc_info=exc
         )
+        self._push_status()
 
-    def status(self, ft_request: FaultToleranceRequest) -> dict:
-        result = {
-            "id": self.engine_index,
-            "status": self.status_type.name.lower(),
-        }
+    def _push_status(self):
+        """Push current health to the client so it can refresh its cache."""
+        payload = {"id": self.engine_index, "status": self.status_type.name.lower()}
         if self.status_type == EngineStatusType.UNHEALTHY:
-            result["fault_info"] = self.fault_info
-        return result
+            payload["fault_info"] = self.fault_info
+        outputs = EngineCoreOutputs(
+            utility_output=UtilityOutput(
+                call_id=FT_STATUS_CALL_ID,
+                result=UtilityResult(payload),
+            )
+        )
+        outputs.engine_index = self.engine_index
+        self.engine.output_queue.put_nowait((0, outputs))
 
     def retry(self, ft_request: FaultToleranceRequest) -> dict:
         engine = self.engine
@@ -101,6 +112,7 @@ class EngineCoreSentinel:
         self.status_type = EngineStatusType.HEALTHY
         logger.info("[FT] Engine %d status -> HEALTHY", self.engine_index)
         self.resumed.set()
+        self._push_status()
         return {"request_id": ft_request.request_id, "success": True}
 
     def _reinit_dp_group(self) -> dict:

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -79,7 +79,7 @@ class EngineCoreSentinel:
             engine.batch_queue.clear()
 
         self.status_type = EngineStatusType.UNHEALTHY
-        self.fault_info = f"{type(exc).__name__}: {exc}"
+        self.fault_info = f"{type(exc).__name__}"
         logger.info(
             "[FT] Engine %d status -> UNHEALTHY:", self.engine_index, exc_info=exc
         )

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -49,15 +49,27 @@ class EngineCoreSentinel:
         self._dp_reinit_epoch = 0
 
     def handle_command(self, client_idx: int, call_id: int, ft_args: dict):
-        """Dispatch an FT command by instruction name and enqueue result."""
+        """Dispatch an FT command by instruction name."""
         ft_request = FaultToleranceRequest(**ft_args)
-        try:
-            result = run_method(self, ft_request.instruction, (ft_request,), {})
-        except Exception as e:
-            logger.exception("[FT] Instruction '%s' failed", ft_request.instruction)
-            result = FaultToleranceResult(
-                request_id=ft_request.request_id, success=False, reason=str(e)
+        if self.status_type != EngineStatusType.UNHEALTHY:
+            reason = (
+                f"[FT] Rejecting {ft_request.instruction} on engine "
+                f"{self.engine_index}: status is {self.status_type.name}"
             )
+            logger.warning(reason)
+            result = FaultToleranceResult(
+                request_id=ft_request.request_id,
+                success=False,
+                reason=reason,
+            )
+        else:
+            try:
+                result = run_method(self, ft_request.instruction, (ft_request,), {})
+            except Exception as e:
+                logger.exception("[FT] Instruction '%s' failed", ft_request.instruction)
+                result = FaultToleranceResult(
+                    request_id=ft_request.request_id, success=False, reason=str(e)
+                )
 
         uo = UtilityOutput(call_id)
         uo.result = UtilityResult(msgspec.structs.asdict(result))
@@ -77,11 +89,19 @@ class EngineCoreSentinel:
         engine._send_abort_outputs(aborted)
         if engine.batch_queue is not None:
             engine.batch_queue.clear()
-
-        self.status_type = EngineStatusType.UNHEALTHY
+        if (
+            hasattr(engine.model_executor, "is_failed")
+            and engine.model_executor.is_failed
+        ):
+            self.status_type = EngineStatusType.DEAD
+        else:
+            self.status_type = EngineStatusType.UNHEALTHY
         self.fault_info = f"{type(exc).__name__}"
         logger.info(
-            "[FT] Engine %d status -> UNHEALTHY:", self.engine_index, exc_info=exc
+            "[FT] Engine %d status -> %s:",
+            self.engine_index,
+            self.status_type.name,
+            exc_info=exc,
         )
         self._push_status()
 

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """EngineCoreSentinel and fault_tolerant_wrapper for the engine core."""
 
+import json
 import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -122,17 +123,17 @@ class EngineCoreSentinel:
             return {}
 
         parallel_config = engine.vllm_config.parallel_config
-        worker_key = f"ft_worker_dp_port_{self._dp_reinit_epoch}"
+        worker_key = f"ft_worker_dp_ports_{self._dp_reinit_epoch}"
         engine_key = f"ft_engine_dp_port_{self._dp_reinit_epoch}"
         self._dp_reinit_epoch += 1
 
         if parallel_config.data_parallel_rank == 0:
-            worker_port = get_open_port()
+            worker_ports = [get_open_port() for _ in range(parallel_config.world_size)]
             engine_port = get_open_port()
-            engine.dp_store.set(worker_key, str(worker_port).encode())
+            engine.dp_store.set(worker_key, json.dumps(worker_ports).encode())
             engine.dp_store.set(engine_key, str(engine_port).encode())
         else:
-            worker_port = int(engine.dp_store.get(worker_key).decode())
+            worker_ports = json.loads(engine.dp_store.get(worker_key).decode())
             engine_port = int(engine.dp_store.get(engine_key).decode())
 
         stateless_destroy_torch_distributed_process_group(engine.dp_group)
@@ -146,7 +147,7 @@ class EngineCoreSentinel:
                 return_store=True,
             )
         )
-        return {"new_stateless_dp_group_port": worker_port}
+        return {"new_stateless_dp_group_ports": worker_ports}
 
 
 def fault_tolerant_wrapper(busy_loop_func: Callable):

--- a/vllm/v1/fault_tolerance/utils.py
+++ b/vllm/v1/fault_tolerance/utils.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
+import msgspec
+
+
+class FaultToleranceResult(msgspec.Struct):
+    request_id: str
+    success: bool
+    reason: str | None = None
+
+
+class FaultToleranceRequest(msgspec.Struct):
+    instruction: str
+    params: dict[str, Any]
+    request_id: str = ""

--- a/vllm/v1/fault_tolerance/utils.py
+++ b/vllm/v1/fault_tolerance/utils.py
@@ -4,6 +4,10 @@ from typing import Any
 
 import msgspec
 
+# All2all backends that support fault-tolerant timeout + rank masking,
+# required for FT under DP+EP MoE deployments.
+FT_BACKEND_SET = frozenset({"deepep_low_latency", "nixl_ep"})
+
 
 class FaultToleranceResult(msgspec.Struct):
     request_id: str

--- a/vllm/v1/fault_tolerance/utils.py
+++ b/vllm/v1/fault_tolerance/utils.py
@@ -4,10 +4,6 @@ from typing import Any
 
 import msgspec
 
-# All2all backends that support fault-tolerant timeout + rank masking,
-# required for FT under DP+EP MoE deployments.
-FT_BACKEND_SET = frozenset({"deepep_low_latency", "nixl_ep"})
-
 
 class FaultToleranceResult(msgspec.Struct):
     request_id: str

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -5,6 +5,7 @@ import contextlib
 import numpy as np
 import torch
 
+from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsTensors, ModelRunnerOutput
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 
@@ -17,6 +18,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         num_sampled_tokens: torch.Tensor,
         main_stream: torch.cuda.Stream,
         copy_stream: torch.cuda.Stream,
+        check_ep_fault: bool = False,
     ):
         # NOTE(woosuk): We must retain references to the GPU tensors,
         # as the copy operations are performed on a different CUDA stream than
@@ -26,6 +28,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.num_sampled_tokens = num_sampled_tokens
         # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
         self.copy_event = torch.cuda.Event(blocking=True)
+        self._has_fault: torch.Tensor | None = None
 
         with stream(copy_stream, main_stream):
             copy_stream.wait_stream(main_stream)
@@ -44,6 +47,9 @@ class AsyncOutput(AsyncModelRunnerOutput):
                 k: v.to_cpu_nonblocking() if v is not None else None
                 for k, v in self.model_runner_output.prompt_logprobs_dict.items()
             }
+            if check_ep_fault:
+                has_fault = get_ep_all2all_manager().query_fault()
+                self._has_fault = has_fault.to("cpu", non_blocking=True)
             self.copy_event.record(copy_stream)
 
     def get_output(self) -> ModelRunnerOutput:
@@ -67,6 +73,15 @@ class AsyncOutput(AsyncModelRunnerOutput):
         if self.logprobs_tensors is not None:
             self.model_runner_output.logprobs = self.logprobs_tensors.tolists()
         self.model_runner_output.prompt_logprobs_dict = self.prompt_logprobs_dict
+
+        if self._has_fault is not None and self._has_fault.item():
+            mask = get_ep_all2all_manager().query_active_mask()
+            raise RuntimeError(
+                "Fault detected in EP all2all communication: "
+                "one or more ranks timed out during dispatch/combine. "
+                f"Mask: {mask.cpu().tolist()}"
+            )
+
         return self.model_runner_output
 
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -38,6 +38,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
@@ -174,6 +175,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Data parallelism.
         self.dp_size = self.parallel_config.data_parallel_size
         self.dp_rank = self.parallel_config.data_parallel_rank
+
+        # Detect EP all2all peer faults to prevent emitting corrupted output.
+        # Only meaningful for MoE + DP with an FT-capable all2all backend.
+        self.check_ep_fault = False
+        if self.dp_size > 1 and self.model_config.is_moe:
+            self.check_ep_fault = get_ep_all2all_manager().support_fault_tolerance
 
         # Decode context parallelism.
         self.dcp_size = self.parallel_config.decode_context_parallel_size
@@ -1488,6 +1495,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             num_sampled_tokens=num_sampled,
             main_stream=self.main_stream,
             copy_stream=self.output_copy_stream,
+            check_ep_fault=self.check_ep_fault,
         )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -149,7 +149,7 @@ class Worker(WorkerBase):
         self.elastic_ep_executor = ElasticEPScalingExecutor(self)
         self.worker_sentinel: WorkerSentinel | None = None
         if self.parallel_config.enable_fault_tolerance:
-            self.worker_sentinel = WorkerSentinel(worker=self, device=self.device)
+            self.worker_sentinel = WorkerSentinel(worker=self)
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
         self._sleep_rebuild_draft_metadata_buffers = False

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -70,6 +70,7 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
 )
 from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.worker.sentinel.gpu_worker_sentinel import WorkerSentinel
 from vllm.v1.worker.startup_plan import (
     maybe_apply_startup_plan,
     maybe_save_startup_plan,
@@ -146,7 +147,9 @@ class Worker(WorkerBase):
         from vllm.distributed.elastic_ep.elastic_execute import ElasticEPScalingExecutor
 
         self.elastic_ep_executor = ElasticEPScalingExecutor(self)
-
+        self.worker_sentinel: WorkerSentinel | None = None
+        if self.parallel_config.enable_fault_tolerance:
+            self.worker_sentinel = WorkerSentinel(worker=self, device=self.device)
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
         self._sleep_rebuild_draft_metadata_buffers = False
@@ -413,6 +416,10 @@ class Worker(WorkerBase):
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
+
+    def handle_ft_command(self, ft_request):
+        assert self.worker_sentinel is not None
+        return self.worker_sentinel.handle_command(ft_request)
 
     # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
     # to hijack tensor allocation.

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.config import set_current_vllm_config
+from vllm.distributed import (
+    get_dp_group,
+    get_ep_group,
+    stateless_init_torch_distributed_process_group,
+)
+from vllm.logger import init_logger
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+from vllm.v1.serial_utils import run_method
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_worker import Worker
+
+logger = init_logger(__name__)
+
+_FT_BACKEND_SET = {"deepep_low_latency", "nixl_ep"}
+
+
+class WorkerSentinel:
+    """Holds FT state for a single worker (mask tensors, DP config).
+
+    Methods are called via collective_rpc from EngineCoreSentinel.
+    """
+
+    def __init__(self, worker: "Worker", device: torch.device):
+        self.worker = worker
+        self.device = device
+        self.dp_rank = worker.parallel_config.data_parallel_rank
+        self.dp_size = worker.parallel_config.data_parallel_size
+        self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
+
+        self.use_ft_backend = (
+            worker.parallel_config.all2all_backend in _FT_BACKEND_SET
+            and self.dp_size > 1
+        )
+
+    def handle_command(self, ft_request: FaultToleranceRequest):
+        """Dispatch an FT command by instruction name."""
+        with set_current_vllm_config(self.worker.vllm_config):
+            return run_method(self, ft_request.instruction, (ft_request,), {})
+
+    def retry(self, ft_request: FaultToleranceRequest):
+        torch.accelerator.synchronize()
+        params = ft_request.params
+        self._clean_worker_state()
+        if self.dp_size > 1:
+            port = params["new_stateless_dp_group_port"]
+            get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
+                self.data_parallel_master_ip,
+                port,
+                self.dp_rank,
+                self.dp_size,
+                backend="gloo",
+            )
+            if self.use_ft_backend:
+                comm = get_ep_group().device_communicator
+                assert comm and comm.all2all_manager
+                mgr = comm.all2all_manager
+                mgr.clean_buffers()
+
+    def _clean_worker_state(self):
+        self.worker.model_runner.execute_model_state = None
+        self.worker.model_runner.kv_connector_output = None
+        input_batch = self.worker.model_runner.input_batch
+        cached_req_ids = input_batch.req_id_to_index.keys()
+        for req_id in list(cached_req_ids):
+            input_batch.remove_request(req_id)
+        input_batch.condense()
+        input_batch.refresh_metadata()
+        input_batch.req_prompt_embeds.clear()

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# All2all backends that support fault-tolerant timeout + rank masking,
+# required for FT under DP+EP MoE deployments.
+FT_BACKEND_SET = frozenset({"deepep_low_latency", "nixl_ep"})
+
 
 class WorkerSentinel:
     """Holds FT state for a single worker (mask tensors, DP config).
@@ -33,6 +37,11 @@ class WorkerSentinel:
         self.dp_rank = worker.parallel_config.data_parallel_rank
         self.dp_size = worker.parallel_config.data_parallel_size
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
+        all2all_backend = worker.parallel_config.all2all_backend
+        assert all2all_backend in FT_BACKEND_SET, (
+            f"Fault tolerance requires an FT-capable all2all backend "
+            f"(one of {sorted(FT_BACKEND_SET)}), but got '{all2all_backend}'."
+        )
 
     def handle_command(self, ft_request: FaultToleranceRequest):
         """Dispatch an FT command by instruction name."""

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -55,7 +55,8 @@ class WorkerSentinel:
         if self.dp_size > 1:
             old_cpu_group = get_dp_group().cpu_group
             stateless_destroy_torch_distributed_process_group(old_cpu_group)
-            port = params["new_stateless_dp_group_port"]
+            world_size = self.worker.parallel_config.world_size
+            port = params["new_stateless_dp_group_ports"][self.worker.rank % world_size]
             get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
                 self.data_parallel_master_ip,
                 port,

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -7,11 +7,11 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.distributed import (
     get_dp_group,
-    get_ep_group,
     stateless_destroy_torch_distributed_process_group,
     stateless_init_torch_distributed_process_group,
 )
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.serial_utils import run_method
 
@@ -63,12 +63,7 @@ class WorkerSentinel:
                 self.dp_size,
                 backend="gloo",
             )
-            self._get_all2all_manager().clean_buffers()
-
-    def _get_all2all_manager(self):
-        comm = get_ep_group().device_communicator
-        assert comm and comm.all2all_manager
-        return comm.all2all_manager
+            get_ep_all2all_manager().clean_buffers()
 
     def _clean_worker_state(self):
         self.worker.model_runner.execute_model_state = None

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -32,17 +32,17 @@ class WorkerSentinel:
     Methods are called via collective_rpc from EngineCoreSentinel.
     """
 
-    def __init__(self, worker: "Worker", device: torch.device):
+    def __init__(self, worker: "Worker"):
         self.worker = worker
-        self.device = device
         self.dp_rank = worker.parallel_config.data_parallel_rank
         self.dp_size = worker.parallel_config.data_parallel_size
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
         all2all_backend = worker.parallel_config.all2all_backend
-        assert all2all_backend in FT_BACKEND_SET, (
-            f"Fault tolerance requires an FT-capable all2all backend "
-            f"(one of {sorted(FT_BACKEND_SET)}), but got '{all2all_backend}'."
-        )
+        if all2all_backend not in FT_BACKEND_SET:
+            raise ValueError(
+                f"Fault tolerance requires an FT-capable all2all backend "
+                f"(one of {sorted(FT_BACKEND_SET)}), but got '{all2all_backend}'."
+            )
 
     def handle_command(self, ft_request: FaultToleranceRequest):
         """Dispatch an FT command by instruction name."""
@@ -54,6 +54,7 @@ class WorkerSentinel:
         params = ft_request.params
         self._clean_worker_state()
         if self.dp_size > 1:
+            get_ep_all2all_manager().clean_buffers()
             old_cpu_group = get_dp_group().cpu_group
             stateless_destroy_torch_distributed_process_group(old_cpu_group)
             world_size = self.worker.parallel_config.world_size
@@ -65,7 +66,6 @@ class WorkerSentinel:
                 self.dp_size,
                 backend="gloo",
             )
-            get_ep_all2all_manager().clean_buffers()
 
     def _clean_worker_state(self):
         model_runner = self.worker.model_runner
@@ -76,9 +76,14 @@ class WorkerSentinel:
                 runner._remove_request(req_id)
         else:
             model_runner.kv_connector_output = None
+
             input_batch = model_runner.input_batch
-            for req_id in list(input_batch.req_id_to_index):
+            cached_req_ids = list(input_batch.req_id_to_index)
+            for req_id in cached_req_ids:
+                model_runner.requests.pop(req_id, None)
+                model_runner.num_prompt_logprobs.pop(req_id, None)
                 input_batch.remove_request(req_id)
+
             input_batch.condense()
             input_batch.refresh_metadata()
             input_batch.req_prompt_embeds.clear()

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -8,6 +8,7 @@ from vllm.config import set_current_vllm_config
 from vllm.distributed import (
     get_dp_group,
     get_ep_group,
+    stateless_destroy_torch_distributed_process_group,
     stateless_init_torch_distributed_process_group,
 )
 from vllm.logger import init_logger
@@ -18,8 +19,6 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
 
 logger = init_logger(__name__)
-
-_FT_BACKEND_SET = {"deepep_low_latency", "nixl_ep"}
 
 
 class WorkerSentinel:
@@ -35,11 +34,6 @@ class WorkerSentinel:
         self.dp_size = worker.parallel_config.data_parallel_size
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
 
-        self.use_ft_backend = (
-            worker.parallel_config.all2all_backend in _FT_BACKEND_SET
-            and self.dp_size > 1
-        )
-
     def handle_command(self, ft_request: FaultToleranceRequest):
         """Dispatch an FT command by instruction name."""
         with set_current_vllm_config(self.worker.vllm_config):
@@ -50,6 +44,8 @@ class WorkerSentinel:
         params = ft_request.params
         self._clean_worker_state()
         if self.dp_size > 1:
+            old_cpu_group = get_dp_group().cpu_group
+            stateless_destroy_torch_distributed_process_group(old_cpu_group)
             port = params["new_stateless_dp_group_port"]
             get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
                 self.data_parallel_master_ip,
@@ -58,11 +54,12 @@ class WorkerSentinel:
                 self.dp_size,
                 backend="gloo",
             )
-            if self.use_ft_backend:
-                comm = get_ep_group().device_communicator
-                assert comm and comm.all2all_manager
-                mgr = comm.all2all_manager
-                mgr.clean_buffers()
+            self._get_all2all_manager().clean_buffers()
+
+    def _get_all2all_manager(self):
+        comm = get_ep_group().device_communicator
+        assert comm and comm.all2all_manager
+        return comm.all2all_manager
 
     def _clean_worker_state(self):
         self.worker.model_runner.execute_model_state = None

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import torch
 
@@ -16,6 +16,7 @@ from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.serial_utils import run_method
 
 if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.model_runner import GPUModelRunner as GPUModelRunnerV2
     from vllm.v1.worker.gpu_worker import Worker
 
 logger = init_logger(__name__)
@@ -67,12 +68,17 @@ class WorkerSentinel:
             get_ep_all2all_manager().clean_buffers()
 
     def _clean_worker_state(self):
-        self.worker.model_runner.execute_model_state = None
-        self.worker.model_runner.kv_connector_output = None
-        input_batch = self.worker.model_runner.input_batch
-        cached_req_ids = input_batch.req_id_to_index.keys()
-        for req_id in list(cached_req_ids):
-            input_batch.remove_request(req_id)
-        input_batch.condense()
-        input_batch.refresh_metadata()
-        input_batch.req_prompt_embeds.clear()
+        model_runner = self.worker.model_runner
+        model_runner.execute_model_state = None
+        if self.worker.use_v2_model_runner:
+            runner = cast("GPUModelRunnerV2", model_runner)
+            for req_id in list(runner.req_states.req_id_to_index):
+                runner._remove_request(req_id)
+        else:
+            model_runner.kv_connector_output = None
+            input_batch = model_runner.input_batch
+            for req_id in list(input_batch.req_id_to_index):
+                input_batch.remove_request(req_id)
+            input_batch.condense()
+            input_batch.refresh_metadata()
+            input_batch.req_prompt_embeds.clear()


### PR DESCRIPTION
## Purpose

Add fault tolerance (FT) framework for DP+EP (Data Parallelism + Expert Parallelism) MoE deployments. When one DP rank dies, the EP all2all operation on surviving ranks blocks indefinitely, causing a full cluster hang. This framework detects faults, aborts in-flight requests, and allows an external orchestrator to trigger coordinated recovery via a REST API.

<img width="538" height="618" alt="ft architecture drawio" src="https://github.com/user-attachments/assets/88473bb9-57b8-4a9c-9eee-2539889c85c6" />


Key design:
- **Sentinel pattern**: All FT state lives in dedicated `EngineCoreSentinel` and `WorkerSentinel` objects -- EngineCore and Worker hold only a reference
- **Externally-driven recovery**: Orchestrator can send `POST /fault_tolerance/apply` with `{"instruction": "xxx"}` for different recovery policies
- **External LB mode only**: FT targets the external load balancer topology. Client-side FT logic is minimal -- just forwarding instructions and reporting status
- **No extra control flow**: FT commands reuse existing `call_utility_async` (client -> engine) and `collective_rpc` (engine -> workers) mechanisms. No new communication channels or threads are introduced
- **Minimal hot-path intrusion**: The `fault_tolerant_wrapper` decorator on the busy loop is the only structural integration point

This is a simplified version -- redundant abstractions, unused config fields, and unnecessary manual state resets have been removed compared to earlier iterations.

### Details

1. **External LB mode only.** Per community feedback, external LB mode is the recommended topology for production deployments. This PR targets FT exclusively for external LB mode (`--data-parallel-external-lb` / `--data-parallel-rank`), which also significantly reduces implementation complexity.

2. **Fault detection prerequisites.** FT relies on each engine being able to detect peer failures instead of hanging indefinitely. This requires: (a) an FT-capable all2all backend (`nixl_ep` or `deepep_low_latency`) that supports timeout + rank masking, and (b) a configured Gloo timeout (`--cpu-distributed-timeout-seconds`) for the CPU allreduce used in DP batch synchronization.

3. **Status semantics during fault propagation.** After a DP rank fails, all other ranks will eventually raise exceptions too (via Gloo allreduce timeout and/or all2all kernel timeout). If the status API shows some ranks as `unhealthy` but others still as `healthy`, the "healthy" ranks are most likely still waiting inside a timeout window (e.g., the Gloo CPU group timeout or the all2all backend's kernel timeout) and have not yet raised their exception. The orchestrator should wait for **all** ranks to become `unhealthy` before issuing a recovery command.

4. **Retry recovery for transient faults.** The current implementation supports `retry` recovery for transiently recoverable faults such as network blips. On `retry`, the framework reinitializes the DP process group, cleans worker state (input batch, model runner state), and resets RDMA buffers and mask state in the all2all backend.

## Test Plan

**Model**: Qwen3-30B-A3B (MoE, 128 experts)
**Configuration**: DP=4, TP=1, EP=4, `deepep_low_latency` backend

### Launching the cluster

Each DP rank runs as a separate `vllm serve` process. The command below shows rank 0 -- launch one such process per GPU, incrementing `CUDA_VISIBLE_DEVICES`, `--data-parallel-rank`, and `--port` for each rank:

```bash
CUDA_VISIBLE_DEVICES=0 python -m vllm.entrypoints.cli.main serve \
    Qwen/Qwen3-30B-A3B \
    --data-parallel-size 4 \
    --data-parallel-size-local 1 \
    --data-parallel-rank 0 \
    --port 8100 \
    --enable-expert-parallel \
    --all2all-backend deepep_low_latency \
    --gpu-memory-utilization 0.5 \
    --max-model-len 1024 \
    --trust-remote-code \
    --cpu-distributed-timeout-seconds 3 \
    --enable-fault-tolerance \
    --fault-tolerance-config '{"engine_recovery_timeout_sec": 500}'
```

### Simulating faults

To simulate a transient device-side failure, inject a `RuntimeError` in the DP allreduce path (`_run_ar` in `vllm/v1/worker/dp_utils.py`). The patch adds a step counter and raises an exception at specific steps (250 and 5000) on a target rank (rank 1), **after** the allreduce completes:

```python
# After dist.all_reduce(tensor, group=group):
if (step_count in [250, 5000] and dp_rank == 1):
    raise RuntimeError("FAULT INJECTION: exception after allreduce")
```

### Sending inference requests

```bash
# Send a chat completion request to rank 0 (repeat for each rank's port: 8100, 8101, ...):
curl -s http://localhost:8100/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "Qwen/Qwen3-30B-A3B", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 64}'
```

### Querying FT status and issuing recovery

```bash
# Query engine status (repeat for each rank's port):
curl -s http://localhost:8100/fault_tolerance/status

# Issue retry to all ranks after all become unhealthy:
curl -s -X POST http://localhost:8100/fault_tolerance/apply \
  -H "Content-Type: application/json" \
  -d '{"instruction": "retry", "params": {"timeout": 120}}'
```

## Test Results
Run log: 
[test_inject_fault_and_retry.log](https://github.com/user-attachments/files/28876666/test_inject_fault_and_retry.log)


Tested with DP=4, EP=4, `deepep_low_latency` backend. Faults were injected at step 250 and step 5000 on DP rank 1. Both fault-recovery cycles completed successfully.

### Fault Injection # 1 -- Step 250

| Time | Event |
|------|-------|
| 16:49:15 | All 4 engines fully started. FT routes (`/fault_tolerance/apply`, `/fault_tolerance/status`) registered |
| 16:52:40 | **Fault injected on R1** -- `RuntimeError` raised after allreduce at step 250 |
| 16:52:40 | R1 EngineCore catches exception, **R1 -> UNHEALTHY** |
| 16:52:43 | R0, R2, R3 workers hit Gloo allreduce timeout (3s) on the next DP-sync batch (async scheduling overlaps host and device): `Timed out waiting 3000ms for recv operation` |
| 16:54:21 | R0, R2, R3 hit EP all2all kernel timeout -- fault mask: `[0, 1, 0, 0]` (rank 1 faulted) |
| 16:54:21 | **R0, R2, R3 -> UNHEALTHY**. All 4 engines now unhealthy |
| 16:54:21 | `GET /fault_tolerance/status` confirms all 4 engines are `unhealthy` |
| 16:54:44 | `POST /fault_tolerance/apply` (retry) sent to all 4 engines. **All 4 -> HEALTHY** |
| 16:54:45 | Normal serving resumes |

Key log lines:
```
[R1] ERROR 16:52:40 [dp_utils.py:67] FAULT INJECTION: exception after allreduce step 250 rank 1
[R1] WARNING 16:52:40 [engine_core_sentinel.py:72] [FT] Busy loop raised KeyError. Waiting for recovery.
[R1] INFO 16:52:40 [engine_core_sentinel.py:83] [FT] Engine 1 status -> UNHEALTHY

[R0] ERROR 16:52:43 RuntimeError: Timed out waiting 3000ms for recv operation to complete

[R0] ERROR 16:54:21 RuntimeError: Fault detected in EP all2all communication:
  one or more ranks timed out during dispatch/combine. Mask: [0, 1, 0, 0]
[R0] WARNING 16:54:21 [engine_core_sentinel.py:72] [FT] Busy loop raised RuntimeError. Waiting for recovery.
[R0] INFO 16:54:21 [engine_core_sentinel.py:83] [FT] Engine 0 status -> UNHEALTHY

[R0] INFO 16:54:44 [engine_core_sentinel.py:111] [FT] Engine 0 status -> HEALTHY
[R1] INFO 16:54:44 [engine_core_sentinel.py:111] [FT] Engine 1 status -> HEALTHY
[R2] INFO 16:54:44 [engine_core_sentinel.py:111] [FT] Engine 2 status -> HEALTHY
[R3] INFO 16:54:44 [engine_core_sentinel.py:111] [FT] Engine 3 status -> HEALTHY
```

### Fault Injection # 2 -- Step 5000

| Time | Event |
|------|-------|
| 16:54:55 | Normal serving continues after first recovery |
| 16:58:48 | **Fault injected on R1** -- `RuntimeError` at step 5000 |
| 16:58:48 | **R1 -> UNHEALTHY** |
| 16:58:51 | R0, R2, R3 hit Gloo allreduce timeout (3s) |
| 17:00:29 | R0, R2, R3 hit EP all2all kernel timeout -- mask: `[0, 1, 0, 0]` |
| 17:00:29 | **R0, R2, R3 -> UNHEALTHY**. All 4 engines unhealthy |
| 17:03:51 | `POST /fault_tolerance/apply` (retry) sent. **All 4 -> HEALTHY** |
| 17:03:55 | Serving resumes. Throughput ramps back to ~19 tok/s within seconds |
| 17:04:55 | Steady-state serving confirmed -- all 4 engines at ~19.4 tok/s, all requests returning 200 |

### Summary

- Both fault injection cycles followed the same detection -> status query -> retry -> resume pattern
- The faulted rank (R1) was correctly identified via the all2all fault mask `[0, 1, 0, 0]`
- Healthy ranks detected the fault via the EP all2all kernel timeout and entered the recovery flow
- After each `retry`, all 4 engines returned to `HEALTHY` and inference throughput was fully restored
- The service remained stable after the second recovery with no secondary crashes

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
