### PR TITLE
[Bugfix] Don't double-count local prefix cache stats on scheduling retries

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1934,6 +1934,193 @@ def test_external_prefix_cache_metrics(is_async: bool, local_cache_hits: bool):
     assert external_stats.preempted_requests == 0
 
 
+def test_local_prefix_cache_stats_not_double_counted_on_retry():
+    """Regression test for gh-43736.
+
+    A request that performs a local prefix cache lookup but then fails to
+    allocate KV slots stays in the waiting queue and is retried on later
+    scheduling steps. Local prefix cache stats must be recorded only when the
+    request is actually scheduled -- not once per lookup -- otherwise the
+    reported hit rate is inflated.
+
+    Here the request is larger than the entire KV cache, so it can never be
+    allocated. It is looked up on every schedule() call but never scheduled,
+    so it must contribute nothing to the prefix cache stats. Before the fix it
+    was counted once per lookup (requests == num_steps).
+    """
+    block_size = 16
+    # 5 blocks total, 1 reserved as the null block -> 4 usable (64 tokens).
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        enable_chunked_prefill=False,
+        num_blocks=5,
+        block_size=block_size,
+    )
+
+    # 8 blocks (128 tokens) cannot fit in the 4 usable blocks, so
+    # allocate_slots() returns None and the request is left in the waiting
+    # queue to be retried on subsequent steps.
+    request = create_requests(
+        num_requests=1,
+        num_tokens=block_size * 8,
+        block_size=block_size,
+    )[0]
+    scheduler.add_request(request)
+
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+
+    # Spy on allocate_slots to guarantee the test exercises the intended path:
+    # the request reaches allocation and is rejected (returns None), rather
+    # than exiting earlier (e.g. on a token-budget break).
+    orig_allocate_slots = scheduler.kv_cache_manager.allocate_slots
+    allocate_results: list = []
+
+    def spy_allocate_slots(*args, **kwargs):
+        result = orig_allocate_slots(*args, **kwargs)
+        allocate_results.append(result)
+        return result
+
+    scheduler.kv_cache_manager.allocate_slots = spy_allocate_slots
+
+    num_steps = 3
+    for _ in range(num_steps):
+        output = scheduler.schedule()
+        # The request never gets scheduled (cannot allocate KV slots) and
+        # stays in the waiting queue, re-doing the lookup on the next step.
+        assert len(output.scheduled_new_reqs) == 0
+        assert len(scheduler.waiting) == 1
+
+    # The request actually reached allocation every step and was rejected.
+    assert len(allocate_results) == num_steps
+    assert all(result is None for result in allocate_results)
+
+    # Looked up num_steps times but never scheduled -> not counted at all.
+    assert stats.requests == 0
+    assert stats.queries == 0
+    assert stats.hits == 0
+
+
+def test_local_prefix_cache_stats_empty_when_caching_disabled():
+    """Guard for the schedule-time recording gate (gh-43736).
+
+    When prefix caching is disabled, get_computed_blocks() takes its early-out
+    and performs no lookup, so the new schedule-time record_prefix_cache_stats()
+    must also record nothing -- otherwise a scheduled request would register a
+    phantom miss and the local hit rate would go from "empty" to a misleading
+    0%.
+    """
+    scheduler = create_scheduler(enable_prefix_caching=False)
+    requests = create_requests(num_requests=3, num_tokens=16)
+    for request in requests:
+        scheduler.add_request(request)
+
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+
+    output = scheduler.schedule()
+    # The requests are scheduled (plenty of blocks) ...
+    assert len(output.scheduled_new_reqs) == len(requests)
+    # ... but with caching off no local prefix cache lookup happened, so the
+    # stats stay empty rather than recording phantom misses.
+    assert stats.requests == 0
+    assert stats.queries == 0
+    assert stats.hits == 0
+
+
+def test_local_prefix_cache_stats_counted_once_for_retried_then_scheduled_request():
+    """Regression test for gh-43736.
+
+    The reported symptom: a request that hits the local prefix cache but fails
+    KV allocation is retried on a later step, and each retry re-counted its
+    query and hit, inflating the reported hit rate. After the fix the lookup is
+    recorded once -- when the request is actually scheduled.
+
+    Unlike the "never scheduled" test above (which checks a 0/0/0 result against
+    an empty cache), this drives the actual issue scenario: a genuine local
+    cache hit on a request that is rejected once and then admitted, so the query
+    and hit must appear exactly once.
+    """
+    block_size = 16
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        enable_chunked_prefill=False,
+        block_size=block_size,
+    )
+
+    # Seed the local prefix cache: run a request to completion so its blocks are
+    # cached and can be hit by a later request with the same prompt.
+    seed = create_requests(
+        num_requests=1,
+        num_tokens=block_size * 2,
+        max_tokens=2,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["seed"],
+    )[0]
+    scheduler.add_request(seed)
+    seed_output = scheduler.schedule()
+    _step_until_done(
+        scheduler,
+        seed_output,
+        ModelRunnerOutput(
+            req_ids=["seed"],
+            req_id_to_index={"seed": 0},
+            sampled_token_ids=[[1000]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # make_stats() during the seeding step swaps in a fresh accumulator, so
+    # re-read it now; the retried request's lookup must be the only thing
+    # recorded from here on.
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
+
+    # A request with the same prompt as the seed -> genuine local cache hit.
+    retried = create_requests(
+        num_requests=1,
+        num_tokens=block_size * 3,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["retried"],
+    )[0]
+    scheduler.add_request(retried)
+
+    # Force the first allocation attempt to fail so the request is retried, then
+    # delegate so it is admitted on the next step.
+    orig_allocate_slots = scheduler.kv_cache_manager.allocate_slots
+    allocate_results: list = []
+
+    def spy_allocate_slots(*args, **kwargs):
+        if not allocate_results:
+            allocate_results.append(None)
+            return None
+        result = orig_allocate_slots(*args, **kwargs)
+        allocate_results.append(result)
+        return result
+
+    scheduler.kv_cache_manager.allocate_slots = spy_allocate_slots
+
+    # Step 1: allocation rejected -> request retried, nothing recorded yet.
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 0
+    assert len(scheduler.waiting) == 1
+    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
+
+    # Step 2: admitted -> the lookup is recorded exactly once, with the hit.
+    output = scheduler.schedule()
+    assert "retried" in output.num_scheduled_tokens
+    assert allocate_results[0] is None and allocate_results[1] is not None
+    assert stats.requests == 1
+    assert stats.queries == retried.num_tokens
+    assert stats.hits == block_size * 2
+
+
 @pytest.mark.parametrize(
     "use_ec_connector, ec_role", [(False, None), (True, "ec_consumer")]
 )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -225,7 +225,7 @@ class KVCacheManager:
         # disabled or the request is marked as skipping kv cache read
         # (which happens when the request requires prompt logprobs
         # or calls a pooling model with all pooling).
-        if not self.enable_caching or request.skip_reading_prefix_cache:
+        if not self._prefix_cache_lookup_enabled(request):
             return self.empty_kv_cache_blocks, 0, 0
 
         # NOTE: When all tokens hit the cache, we must recompute the last token
@@ -269,16 +269,37 @@ class KVCacheManager:
             num_new_computed_tokens + num_uncached if num_uncached else 0
         )
 
-        if self.log_stats:
+        # NOTE: Prefix cache stats are intentionally NOT recorded here. The
+        # scheduler records them via record_prefix_cache_stats() only after
+        # the request is actually scheduled, so that requests which perform
+        # the lookup but fail to allocate KV slots (and are retried in a
+        # later step) are not counted multiple times.
+        blocks = self.create_kv_cache_blocks(computed_blocks)
+        return blocks, num_new_computed_tokens, shared_prefix_boundary
+
+    def _prefix_cache_lookup_enabled(self, request: Request) -> bool:
+        """Whether get_computed_blocks() performs a real local prefix cache
+        lookup for this request (i.e. did not take the early-out above)."""
+        return self.enable_caching and not request.skip_reading_prefix_cache
+
+    def record_prefix_cache_stats(self, request: Request, num_hits: int) -> None:
+        """Record a local prefix cache lookup into the running stats.
+
+        Called by the scheduler once a request is actually scheduled (after a
+        successful KV slot allocation), rather than at lookup time, to avoid
+        double-counting requests that are retried across scheduling steps.
+
+        Mirrors the early-out in get_computed_blocks(): nothing is recorded
+        when prefix caching is disabled or the request skips the lookup, so a
+        no-lookup request does not register a phantom miss.
+        """
+        if self.log_stats and self._prefix_cache_lookup_enabled(request):
             assert self.prefix_cache_stats is not None
             self.prefix_cache_stats.record(
                 num_tokens=request.num_tokens,
-                num_hits=num_new_computed_tokens,
+                num_hits=num_hits,
                 preempted=request.num_preemptions > 0,
             )
-
-        blocks = self.create_kv_cache_blocks(computed_blocks)
-        return blocks, num_new_computed_tokens, shared_prefix_boundary
 
     def allocate_slots(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -706,6 +706,7 @@ class Scheduler(SchedulerInterface):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                local_prefix_cache_queried = False
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
@@ -739,13 +740,6 @@ class Scheduler(SchedulerInterface):
                         # The per-group lookup does not detect an uncached shared
                         # prefix, so there is no junction to pin in this path.
                         request.shared_prefix_boundary = 0
-                        if self.kv_cache_manager.log_stats:
-                            assert self.kv_cache_manager.prefix_cache_stats is not None
-                            self.kv_cache_manager.prefix_cache_stats.record(
-                                num_tokens=request.num_tokens,
-                                num_hits=num_new_local_computed_tokens,
-                                preempted=request.num_preemptions > 0,
-                            )
                     else:
                         (
                             new_computed_blocks,
@@ -756,6 +750,9 @@ class Scheduler(SchedulerInterface):
                             # if no uncached shared prefix was detected.
                             request.shared_prefix_boundary,
                         ) = self.kv_cache_manager.get_computed_blocks(request)
+                    # The cached-token branch above ran a local prefix cache
+                    # lookup; it is recorded later, once the request is admitted.
+                    local_prefix_cache_queried = True
 
                     # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
@@ -950,6 +947,19 @@ class Scheduler(SchedulerInterface):
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
                     break
+
+                # Record the local prefix cache lookup now that the request is
+                # admitted (KV allocation succeeded; this includes the async
+                # remote-KV wait path below). A request that queries the cache
+                # but is not admitted this step (failed KV allocation, an
+                # encoder/mamba budget break, or a connector/mm-prefetch skip)
+                # is retried later and would otherwise be counted again,
+                # inflating the local hit rate -- mirroring the connector
+                # prefix cache stats recorded below.
+                if local_prefix_cache_queried:
+                    self.kv_cache_manager.record_prefix_cache_stats(
+                        request, num_new_local_computed_tokens
+                    )
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that


### PR DESCRIPTION
## Purpose

Fixes #43736.

This PR fixes local prefix-cache hit-rate over-counting when a request performs
a local prefix-cache lookup but is not actually scheduled until a later
scheduler step.

`KVCacheManager.get_computed_blocks()` used to record local prefix-cache stats
immediately at lookup time. However, a request can still fail to schedule after
that lookup and remain in the waiting queue to retry later, for example when:

- `allocate_slots()` returns `None` under KV pressure.
- encoder or mamba-aligned scheduling exits with `num_new_tokens == 0`.
- chunked prefill is disabled and the token budget causes a break.
- connector matched-token lookup or multimodal prefetch skips scheduling.

On each retry, the request repeated the lookup and incremented
`PrefixCacheStats` again, inflating `requests`, `queries`, and `hits`.

The fix moves local prefix-cache stat recording from lookup time to the
scheduler point where the request is confirmed scheduled, after successful KV
slot allocation. This mirrors the existing connector prefix-cache stat path.

Implementation summary:

- `get_computed_blocks()` now only performs the lookup and returns the cached
  blocks/token count.
- `KVCacheManager.record_prefix_cache_stats(request, num_hits)` records stats
  only after scheduling succeeds.
- The recording helper reuses the same `_prefix_cache_lookup_enabled()` guard as
  `get_computed_blocks()`, so requests with prefix caching disabled or
  `skip_reading_prefix_cache` set do not register phantom misses.

Intentional behavior change:

A request that is looked up but never scheduled now contributes zero to local
prefix-cache stats. A request retried and later scheduled is counted exactly
once. This makes local prefix-cache metrics reflect scheduled requests rather
than raw lookup attempts, matching connector prefix-cache stat semantics.

Related prior PRs on this issue:

- #43734 (open, by the issue author) takes the same approach — moving local
  prefix-cache stat recording out of `get_computed_blocks()` into a
  post-allocation `record_prefix_cache_stats()` call. It has been inactive
  since 2026-05-28.
- #43822 and #45202 are closed (the latter was ruled a duplicate of this PR by
  a maintainer).

Relative to #43734, this PR is rebased onto current `main` (so it also handles
the Mamba-hybrid prefix-cache branch added since), routes recording through a
shared `_prefix_cache_lookup_enabled()` guard (no phantom misses when caching is
disabled or `skip_reading_prefix_cache` is set), and adds three regression tests
(vs one), including a retried-then-scheduled real-cache-hit case verified to fail
against the unfixed code. Happy to defer to maintainers on which to carry
forward.

AI assistance disclosure:

AI assistance was used to help investigate and implement this change. The
submitter reviewed the change end-to-end, read every changed line, traced the
affected scheduler paths, and ran the relevant tests locally. The submitter
understands and stands behind the change.

## Test Plan

Added two regression tests in `tests/v1/core/test_scheduler.py`:

- `test_local_prefix_cache_stats_not_double_counted_on_retry`: verifies that a
  request larger than the available KV cache is looked up on repeated
  `schedule()` calls but never scheduled, and therefore contributes nothing to
  `prefix_cache_stats`.
- `test_local_prefix_cache_stats_empty_when_caching_disabled`: verifies that
  scheduled requests do not record phantom local prefix-cache misses when
  prefix caching is disabled.

Also checked existing related coverage:

- `test_external_prefix_cache_metrics`
- `tests/v1/core/test_prefix_caching.py`
- scheduler tests matching `prefix_cache`, `stats`, `metric`,
  `unable_to_allocate`, or `preempt`

## Test Result

Verified locally on Apple Silicon (M1, CPU-only, `VLLM_TARGET_DEVICE=empty`
build, no CUDA):

```bash
pytest tests/v1/core/test_scheduler.py \
  -k "test_local_prefix_cache_stats_not_double_counted_on_retry or \
      test_local_prefix_cache_stats_empty_when_caching_disabled or \
      test_external_prefix_cache_metrics"
```

Result: `6 passed`.

Red-green:

- `test_local_prefix_cache_stats_not_double_counted_on_retry` fails against the
  unfixed code (stats recorded at lookup time), and passes with the fix.
- `test_local_prefix_cache_stats_empty_when_caching_disabled` is a guard for the
  new schedule-time recording gate, not a red-green regression: it passes on
  `main` too (`get_computed_blocks()` already early-outs before recording when
  caching is disabled). It would fail if the schedule-time
  `record_prefix_cache_stats()` dropped its `_prefix_cache_lookup_enabled()`
  guard and recorded a phantom miss for a no-lookup request.

Additional checks:

```bash
pytest tests/v1/core/test_prefix_caching.py -q
```

Result: `64 passed`.

```bash
pytest tests/v1/core/test_scheduler.py -q \
  -k "prefix_cache or stats or metric or unable_to_allocate or preempt"
```

Result: `36 passed, 67 deselected`.

After rebasing onto latest `main` to resolve the merge conflict, the focused
regression tests still pass:

```bash
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_local_prefix_cache_stats_not_double_counted_on_retry tests/v1/core/test_scheduler.py::test_local_prefix_cache_stats_empty_when_caching_disabled -v
```

Result: `2 passed`.

Lint:

- `ruff check` passed on all changed files.
- `ruff format --check` passed on all changed files.


## Follow-up (review hardening)

Added a third regression test,
`test_local_prefix_cache_stats_counted_once_for_retried_then_scheduled_request`,
that drives the issue's actual scenario rather than only the "never scheduled"
case: a request with a genuine local cache hit that is rejected once (KV
allocation returns `None`) and admitted on the next step. It asserts the query
and hit are recorded exactly once (`requests == 1`, non-zero `hits`) and that
the rejected retry records nothing. Confirmed it fails against the unfixed code
with `assert (1, 48, 32) == (0, 0, 0)` (the rejected retry counted at lookup
time), and passes with the fix.

```bash
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py \
  -k "prefix_cache_stats or external_prefix_cache_metrics"
```

Result: `7 passed`. `ruff check` and `ruff format --check` pass on all changed
files.

Note on the hybrid path: the mamba/connector lookup branch records via
`record_prefix_cache_stats()` → `_prefix_cache_lookup_enabled()`, so a
`skip_reading_prefix_cache` hybrid request records nothing. That hybrid record
path is not directly unit-tested.


