### PR TITLE
[Bugfix] Fix DeepSeek-V4 init errors for compressed tensors

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -616,7 +616,14 @@ class DeepseekV4MoE(nn.Module):
         self.tp_rank = get_tensor_model_parallel_rank()
         assert config.n_routed_experts % self.tp_size == 0
 
+        self.n_routed_experts = config.n_routed_experts
+        self.n_shared_experts = config.n_shared_experts or 0
+        self.n_logical_experts = self.n_routed_experts
+        self.n_physical_experts = self.n_routed_experts
+        self.n_redundant_experts = 0
+
         self.n_local_experts = config.n_routed_experts // self.tp_size
+        self.n_local_physical_experts = self.n_local_experts
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
 
@@ -797,7 +804,6 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{prefix}.wo_b",
         )
         self.softmax_scale = self.head_dim**-0.5
-        self.scale_fmt = config.quantization_config["scale_fmt"]
 
         self.rope_parameters = config.rope_scaling
 


### PR DESCRIPTION
Two recent refactors introduced init-time errors for DeepSeek-V4 variants:

1. `1ff2b11e172` ("[DSv4] Refactor DeepseekV4Attention") left behind a dead `config.quantization_config["scale_fmt"]` access that crashes on checkpoints without that key (e.g. RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8). The real usage was moved to attention.py where it's hardcoded. Remove the dead line.

2. `24270941528` ("[Feature] Support EPLB for DeepSeek v4 Mega Moe") added `extract_moe_parameters` which reads `n_logical_experts` and related attributes, but only the MegaMoE init path sets them. The FusedMoE path (used by standard TP without expert-parallel) is missing them, causing AttributeError on any non-MegaMoE DeepSeek-V4 load.

