### PR TITLE
Fix Qwen3-Coder required tool parsing

### DIFF
--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.parser.parser_manager import ParserManager
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 from vllm.tool_parsers.qwen3coder_tool_parser import (
@@ -268,6 +269,63 @@ def test_extract_tool_calls_no_tools(qwen3_tool_parser_parametrized):
     assert not extracted_tool_calls.tools_called
     assert extracted_tool_calls.tool_calls == []
     assert extracted_tool_calls.content == model_output
+
+
+def test_required_tool_choice_uses_qwen3_xml_after_reasoning(
+    qwen3_tokenizer, sample_tools
+):
+    """Regression: qwen3 required tool choice must parse XML after </think>.
+
+    The generic required-tool parser expects JSON. Qwen3-Coder emits XML tool
+    calls, so required/named tool choice must route through this parser's XML
+    extraction path after reasoning extraction.
+    """
+    model_output = (
+        'The user asked for weather. I should call get_current_weather.</think>\n'
+        "<tool_call>\n"
+        "<function=get_current_weather>\n"
+        "<parameter=city>\n"
+        "Dallas\n"
+        "</parameter>\n"
+        "<parameter=state>\n"
+        "TX\n"
+        "</parameter>\n"
+        "<parameter=unit>\n"
+        "fahrenheit\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[],
+        tools=_as_chat_completion_tools(sample_tools),
+        tool_choice="required",
+    )
+
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="qwen3_coder",
+        reasoning_parser_name="nemotron_v3",
+        enable_auto_tools=True,
+        model_name=MODEL,
+    )
+    assert parser_cls is not None
+    parser = parser_cls(qwen3_tokenizer, sample_tools)
+
+    reasoning, content, tool_calls = parser.parse(
+        model_output, request, enable_auto_tools=True
+    )
+
+    assert reasoning == "The user asked for weather. I should call get_current_weather."
+    assert content is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_current_weather"
+    assert json.loads(tool_calls[0].arguments) == {
+        "city": "Dallas",
+        "state": "TX",
+        "unit": "fahrenheit",
+    }
 
 
 @pytest.mark.parametrize(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1244,6 +1244,7 @@ class OpenAIServingChat(OpenAIServing):
             is_finish_reason_tool_calls = auto_tools_called or (
                 request.tool_choice
                 and request.tool_choice == "required"
+                and message.tool_calls
                 and output.finish_reason == "stop"
             )
 

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -18,7 +18,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
-from vllm.envs import VLLM_ENFORCE_STRICT_TOOL_CALLING
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import (
@@ -39,7 +38,7 @@ logger = init_logger(__name__)
 
 
 class Qwen3CoderToolParser(ToolParser):
-    supports_required_and_named: bool = not VLLM_ENFORCE_STRICT_TOOL_CALLING
+    supports_required_and_named: bool = False
 
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)


### PR DESCRIPTION
## Summary

Fix `qwen3_coder` tool parsing for `tool_choice="required"` / named tool choices when the model emits Qwen3 XML tool-call syntax after reasoning output.

`qwen3_coder` currently advertises `supports_required_and_named` for the generic required-tool path. That path expects JSON tool-call output, but Qwen3-Coder emits XML like:

```xml
</think>
<tool_call>
<function=get_weather>
<parameter=location>
San Francisco, CA
</parameter>
</function>
</tool_call>
```

As a result, the reasoning parser can split out the reasoning text, but the required tool call is dropped and the response can return `finish_reason="tool_calls"` with `tool_calls=[]`.

This PR:

- routes required/named tool choices for `qwen3_coder` through its XML parser by setting `supports_required_and_named = False`
- avoids reporting `finish_reason="tool_calls"` for required tool choice unless a tool call was actually parsed
- adds a regression test for Qwen3 XML tool calls after `</think>` with `tool_choice="required"`

## Duplicate-work check

Checked open PR searches for:

- `qwen3 coder required tool parser`
- `qwen3 tool_choice required`
- `qwen3_coder tool_call XML`

Related open PRs exist, especially #35936, which implements a broader serving-layer fallback for non-JSON `tool_choice="required"` in streaming and non-streaming paths. This PR is a narrower alternative focused on `qwen3_coder` parser capability routing plus the guard that prevents `finish_reason="tool_calls"` when no tool call was parsed. Other related Qwen reasoning/XML parser PRs (#39055, #44141) address tool calls embedded inside reasoning rather than this required/named tool-choice path.

## Validation

- `.venv/bin/python -m py_compile vllm/tool_parsers/qwen3coder_tool_parser.py vllm/entrypoints/openai/chat_completion/serving.py tests/tool_parsers/test_qwen3coder_tool_parser.py` - passed
- `uvx --from ruff ruff check vllm/tool_parsers/qwen3coder_tool_parser.py vllm/entrypoints/openai/chat_completion/serving.py tests/tool_parsers/test_qwen3coder_tool_parser.py` - passed
- `uv run --with ruff ruff check ...` - attempted, but local dependency resolution failed on macOS because the project environment requires unavailable `torch==2.11.0+cpu` for a resolved split
- Manually validated against a patched vLLM 0.22.0 Ultra NVFP4 + MTP5 deployment: `tool_choice="required"` weather requests now return `get_weather` tool calls instead of empty `tool_calls`.

## AI assistance

AI assistance was used to inspect the PR comments/checks, amend the DCO signoff, run targeted local validation, and update this PR description. The human submitter is responsible for reviewing and defending the change end-to-end.