### PR TITLE
[Kernel][MoE] Delegate finalize output-buffer allocation to prepare_finalize

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -122,7 +122,6 @@ class TopKWeightAndReduce(ABC):
     @abstractmethod
     def apply(
         self,
-        output: torch.Tensor | None,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -130,8 +129,8 @@ class TopKWeightAndReduce(ABC):
     ) -> torch.Tensor:
         """
         Apply topk_weights to the fused_experts_outputs and/or reduce.
-        If an output tensor is not passed, it will be created in the
-        function.
+        The output buffer is always allocated (and owned) by the
+        implementation and returned to the caller.
         """
         raise NotImplementedError
 
@@ -353,17 +352,15 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
     @abstractmethod
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: TopKWeightAndReduce,
-    ) -> None:
+    ) -> torch.Tensor:
         """
         Perform any combine plus apply weights and perform a reduction on the
         fused experts output.
-        - output: The output tensor, written in place.  Must be (M, K) shape.
         - fused_expert_output: The unweighted, unreduced output of the fused
           experts, it will have (M, topk, K) shape.
         - topk_weights: The weights to be applied to the fused_experts_output.
@@ -372,12 +369,16 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
           fused_expert_output.
         - weight_and_reduce_impl: An optional TopKWeightAndReduce
           implementation.
+
+        Returns the (M, K) shaped output tensor.  The output shape is recovered
+        from topk_ids (M = topk_ids.shape[0]) and fused_expert_output
+        (K = fused_expert_output.shape[-1]); the implementation owns the
+        allocation of the returned buffer.
         """
         raise NotImplementedError
 
     def finalize_async(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -387,7 +388,6 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
         """
         Perform any combine plus apply weights and perform a reduction on the
         fused experts output but do not wait for results from other workers.
-        - output: The output tensor, written in place.  Must be (M, K) shape.
         - fused_expert_output: The unweighted, unreduced output of the fused
           experts, it will have (M, topk, K) shape.
         - topk_weights: The weights to be applied to the fused_experts_output.
@@ -397,23 +397,23 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
         - weight_and_reduce_impl: An optional TopKWeightAndReduce
           implementation.
 
-        Returns a callback or a hook callback pair that when invoked waits for
-        results from other workers and has the same return signature as
-        `finalize`, if a hook is returned this is more lightweight check that
-        the recv is complete without doing extra work (used by DBO, will be
-        refactored in the very near future)
+        Returns a receiver callback (or a hook/receiver pair) that, when
+        invoked, waits for results from other workers and returns the
+        (M, K) output tensor (same return contract as `finalize`).  If a hook
+        is returned it is a more lightweight check that the recv is complete
+        without doing extra work (used by DBO, will be refactored in the very
+        near future).
 
-        ret = obj.finalize_async(output, ...)
-        ... output not valid yet ...
+        ret = obj.finalize_async(...)
         if isinstance(ret, tuple):
             hook, receiver = ret
             hook()
-        receiver()
+        output = receiver()
         ... output valid here ...
 
         is equivalent to:
 
-        obj.finalize(output, ...)
+        output = obj.finalize(...)
         """
         raise NotImplementedError
 
@@ -1216,7 +1216,6 @@ class FusedMoEKernelModularImpl:
         expert_map: torch.Tensor | None,
         apply_router_weight_on_input: bool,
         expert_tokens_meta: ExpertTokensMetadata | None,
-        output_alias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         _, M_full, N, K, top_k = self.fused_experts.moe_problem_size(
             a1q, w1, w2, topk_ids
@@ -1245,23 +1244,9 @@ class FusedMoEKernelModularImpl:
             activation,
         )
 
-        # If caller's output buffer already matches fused_out shape/dtype, alias
-        # to skip the redundant copy in TopKWeightAndReduceNoOP.apply downstream.
-        # This eliminates ~94% of __amd_rocclr_copyBuffer events (Copy 2 of the
-        # double-copy MoE write-back path).
-        if current_platform.is_rocm():
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            if (
-                rocm_aiter_ops.is_fused_moe_enabled()
-                and output_alias is not None
-                and output_alias.shape == fused_out.shape
-                and output_alias.dtype == fused_out.dtype
-                and output_alias.device == fused_out.device
-                and output_alias.is_contiguous()
-            ):
-                fused_out = output_alias
-
+        # Output-buffer allocation is delegated to finalize (it owns and
+        # returns the result buffer), so no caller-provided output is aliased
+        # into the fused-experts op here.
         self.fused_experts.apply(
             output=fused_out,
             hidden_states=a1q,
@@ -1284,9 +1269,7 @@ class FusedMoEKernelModularImpl:
 
     def _finalize(
         self,
-        output: torch.Tensor,
         fused_out: torch.Tensor,
-        hidden_states: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
@@ -1295,7 +1278,8 @@ class FusedMoEKernelModularImpl:
     ) -> torch.Tensor:
         """
         The _finalize method is a wrapper around self.prepare_finalize.finalize
-        that handles DBO, async and shared expert overlap.
+        that handles DBO, async and shared expert overlap.  The output buffer
+        is allocated by the prepare_finalize implementation and returned.
 
         Args:
             shared_experts: SharedExperts | None. The shared experts if any.
@@ -1308,8 +1292,7 @@ class FusedMoEKernelModularImpl:
         if not self.prepare_finalize.supports_async():
             assert not dbo_enabled()
 
-            self.prepare_finalize.finalize(
-                output,
+            output = self.prepare_finalize.finalize(
                 fused_out,
                 topk_weights,
                 topk_ids,
@@ -1318,7 +1301,6 @@ class FusedMoEKernelModularImpl:
             )
         else:
             finalize_ret = self.prepare_finalize.finalize_async(
-                output,
                 fused_out,
                 topk_weights,
                 topk_ids,
@@ -1346,7 +1328,7 @@ class FusedMoEKernelModularImpl:
                 else:
                     hook()
 
-            receiver()
+            output = receiver()
 
         return output
 
@@ -1392,8 +1374,6 @@ class FusedMoEKernelModularImpl:
         Returns:
         - torch.Tensor: The output tensor after applying the MoE layer.
         """
-        output = torch.empty_like(hidden_states)
-
         local_num_experts = w1.shape[0]
         if global_num_experts == -1:
             global_num_experts = local_num_experts
@@ -1421,13 +1401,10 @@ class FusedMoEKernelModularImpl:
             expert_map=expert_map,
             apply_router_weight_on_input=apply_router_weight_on_input,
             expert_tokens_meta=expert_tokens_meta,
-            output_alias=output,
         )
 
         return self._finalize(
-            output,
             fused_out,
-            hidden_states,
             topk_weights,
             topk_ids,
             apply_router_weight_on_input,

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/batched.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/batched.py
@@ -153,17 +153,16 @@ class BatchedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
+    ) -> torch.Tensor:
         if isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate):
             weight_and_reduce_impl = TopKWeightAndReduceNaiveBatched(self.rank)
-        weight_and_reduce_impl.apply(
-            output=output,
+        # apply() allocates a fresh (num_tokens, K) buffer and returns it.
+        return weight_and_reduce_impl.apply(
             fused_expert_output=fused_expert_output,
             topk_weights=topk_weights,
             topk_ids=topk_ids,

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
@@ -335,14 +335,13 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def _finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
         do_async: bool,
-    ) -> Callable | None:
+    ) -> Callable | torch.Tensor:
         a2a_idx = dbo_current_ubatch_id()
         handle = self.handles[a2a_idx]
         assert handle is not None
@@ -353,7 +352,6 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             if isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate):
                 weight_and_reduce_impl = TopKWeightAndReduceContiguous()
             fused_expert_output = weight_and_reduce_impl.apply(
-                output=None,
                 fused_expert_output=fused_expert_output,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
@@ -379,26 +377,27 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         if do_async:
 
-            def _receiver():
+            def _receiver() -> torch.Tensor:
                 if event.event is not None:
                     event.current_stream_wait()
                 dbo_switch_to_comm()
-                output.copy_(combined_x, non_blocking=True)
 
                 # TODO(lucas): refactor the modular kernel so this will be
                 # handled there
                 dbo_yield_and_switch_from_comm_to_compute()
 
+                # combined_x is freshly allocated by the DeepEP combine kernel;
+                # return it directly instead of copying into a caller buffer.
+                return combined_x
+
             return _receiver
         else:
             # TODO(lucas): support this case with the refactored modular kernel
             assert not dbo_enabled()
-            output.copy_(combined_x, non_blocking=True)
-            return None
+            return combined_x
 
     def finalize_async(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -406,7 +405,6 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
     ) -> Callable:
         receiver = self._finalize(
-            output,
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -414,20 +412,18 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             weight_and_reduce_impl,
             True,
         )
-        assert receiver is not None
+        assert callable(receiver)
         return receiver
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
-        self._finalize(
-            output,
+    ) -> torch.Tensor:
+        out = self._finalize(
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -435,3 +431,5 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             weight_and_reduce_impl,
             False,
         )
+        assert isinstance(out, torch.Tensor)
+        return out

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
@@ -371,7 +371,6 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def _finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -393,6 +392,16 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             # weights have already been applied.
             combine_topk_weights = torch.ones_like(topk_weights)
 
+        # The combine kernel writes the per-token result in place, so allocate
+        # the (num_tokens, hidden_dim) output buffer for it here.
+        num_tokens = topk_ids.size(0)
+        hidden_dim = fused_expert_output.size(-1)
+        output = torch.empty(
+            (num_tokens, hidden_dim),
+            device=fused_expert_output.device,
+            dtype=fused_expert_output.dtype,
+        )
+
         combine_topk_ids = self._map_global_to_physical_ids(topk_ids)
         # TODO (varun) : Enable zero copy mode
         dbo_maybe_run_recv_hook()
@@ -407,11 +416,10 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             out=output,
         )
 
-        return recv_hook, lambda: None
+        return recv_hook, lambda: output
 
     def finalize_async(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -419,7 +427,6 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
     ) -> tuple[Callable, Callable]:
         return self._finalize(
-            output,
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -430,15 +437,13 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
-        self._finalize(
-            output,
+    ) -> torch.Tensor:
+        _, receiver = self._finalize(
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -446,3 +451,4 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             weight_and_reduce_impl,
             do_async=False,
         )
+        return receiver()

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_v2.py
@@ -315,14 +315,13 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def _finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
         do_async: bool,
-    ) -> Callable | None:
+    ) -> torch.Tensor:
         a2a_idx = dbo_current_ubatch_id()
         handle = self.handles[a2a_idx]
         assert handle is not None
@@ -331,7 +330,6 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             if isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate):
                 weight_and_reduce_impl = TopKWeightAndReduceContiguous()
             fused_expert_output = weight_and_reduce_impl.apply(
-                output=None,
                 fused_expert_output=fused_expert_output,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
@@ -351,20 +349,19 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             async_with_compute_stream=False,
         )
 
-        output.copy_(combined_x, non_blocking=True)
-        return None
+        # combine allocates combined_x ((M, K) bf16); return it directly
+        # instead of copying into a caller-provided buffer.
+        return combined_x
 
     def finalize_async(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
     ) -> Callable:
-        self._finalize(
-            output,
+        output = self._finalize(
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -372,19 +369,17 @@ class DeepEPV2PrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             weight_and_reduce_impl,
             False,
         )
-        return lambda: None
+        return lambda: output
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
-        self._finalize(
-            output,
+    ) -> torch.Tensor:
+        return self._finalize(
             fused_expert_output,
             topk_weights,
             topk_ids,

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -146,13 +146,12 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
+    ) -> torch.Tensor:
         assert self.all2all_manager.moe_alltoall is not None  # type: ignore[attr-defined]
 
         ep_size = self.all2all_manager.world_size
@@ -161,8 +160,8 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             ep_size, self.runtime_max_tokens_per_rank, hidden_size
         )
 
-        combined_output = self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
+        # combine() returns a fresh (M, K) tensor; return it directly.
+        return self.all2all_manager.moe_alltoall.combine(  # type: ignore[attr-defined]
             payload=fused_expert_output,
             runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
         )
-        output.copy_(combined_output)

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_two_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_two_sided.py
@@ -103,23 +103,22 @@ class FlashInferNVLinkTwoSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
+    ) -> torch.Tensor:
         top_k = topk_ids.size(1)
-        token_count = output.shape[0]
-        fused_expert_output = flashinfer_alltoall_combine(
+        token_count = topk_ids.size(0)
+        # combine() returns a fresh (token_count, K) tensor; return it directly.
+        return flashinfer_alltoall_combine(
             self.all2all_manager,
             fused_expert_output,
             top_k=top_k,
             token_count=token_count,
             alltoall_info=self.alltoall_info,
         )
-        output.copy_(fused_expert_output)
 
 
 def flashinfer_alltoall_dispatch(

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/mori.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/mori.py
@@ -108,17 +108,17 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
-        num_token = output.shape[0]
+    ) -> torch.Tensor:
+        num_token = topk_ids.shape[0]
         result = self.mori_op.combine(
             fused_expert_output,
             None,
             topk_ids,
         )[0]
-        output.copy_(result[:num_token])
+        # combine() returns a fresh buffer; return the token slice directly.
+        return result[:num_token]

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/naive_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/naive_dp_ep.py
@@ -186,26 +186,25 @@ class MoEPrepareAndFinalizeNaiveDPEPModular(mk.FusedMoEPrepareAndFinalizeModular
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
+    ) -> torch.Tensor:
         if isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate):
             weight_and_reduce_impl = TopKWeightAndReduceContiguous()
 
         out = weight_and_reduce_impl.apply(
-            output=None,
             fused_expert_output=fused_expert_output,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             apply_router_weight_on_input=apply_router_weight_on_input,
         )
 
-        output.copy_(
-            get_ep_group().combine(out, is_sequence_parallel=self.is_sequence_parallel)
+        # combine() returns a fresh tensor; return it directly (skips a copy).
+        return get_ep_group().combine(
+            out, is_sequence_parallel=self.is_sequence_parallel
         )
 
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
@@ -339,7 +339,6 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def _finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -361,6 +360,16 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             # weights have already been applied.
             combine_topk_weights = torch.ones_like(topk_weights)
 
+        # The combine kernel writes the per-token result in place, so allocate
+        # the (num_tokens, hidden_dim) output buffer for it here.
+        num_tokens = topk_ids.size(0)
+        hidden_dim = fused_expert_output.size(-1)
+        output = torch.empty(
+            (num_tokens, hidden_dim),
+            device=fused_expert_output.device,
+            dtype=fused_expert_output.dtype,
+        )
+
         combine_topk_ids = self._map_global_to_physical_ids(topk_ids)
         # TODO (varun) : Enable zero copy mode
         dbo_maybe_run_recv_hook()
@@ -375,11 +384,10 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             out=output,
         )
 
-        return recv_hook, lambda: None
+        return recv_hook, lambda: output
 
     def finalize_async(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -387,7 +395,6 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
     ) -> tuple[Callable, Callable]:
         return self._finalize(
-            output,
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -398,15 +405,13 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
-        self._finalize(
-            output,
+    ) -> torch.Tensor:
+        _, receiver = self._finalize(
             fused_expert_output,
             topk_weights,
             topk_ids,
@@ -414,3 +419,4 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             weight_and_reduce_impl,
             do_async=False,
         )
+        return receiver()

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
@@ -79,17 +79,15 @@ class MoEPrepareAndFinalizeNoDPEPModular(mk.FusedMoEPrepareAndFinalizeModular):
 
     def finalize(
         self,
-        output: torch.Tensor,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
+    ) -> torch.Tensor:
         if isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate):
             weight_and_reduce_impl = TopKWeightAndReduceContiguous()
-        weight_and_reduce_impl.apply(
-            output=output,
+        return weight_and_reduce_impl.apply(
             fused_expert_output=fused_expert_output,
             topk_weights=topk_weights,
             topk_ids=topk_ids,

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -29,7 +29,6 @@ class TopKWeightAndReduceDelegate(mk.TopKWeightAndReduce):
 
     def apply(
         self,
-        output: torch.Tensor | None,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -52,29 +51,14 @@ class TopKWeightAndReduceNoOP(mk.TopKWeightAndReduce):
 
     def apply(
         self,
-        output: torch.Tensor | None,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
     ) -> torch.Tensor:
-        # Weight application and reduction operations are already done.
-        if output is None:
-            return fused_expert_output
-
-        # Skip self-copy when caller aliased fused_out to output upstream.
-        if output is fused_expert_output:
-            return output
-
-        # MoEPrepareAndFinalizeNoDPEPModular needs the output to be in the `output`
-        # tensor.
-        assert output.size() == fused_expert_output.size(), (
-            "output shape is expected to match the fused_expert_output shape. "
-            f"But got output={output.size()}, "
-            f"used_expert_output={fused_expert_output.size()}"
-        )
-        output.copy_(fused_expert_output, non_blocking=True)
-        return output
+        # Weight application and reduction operations are already done; the
+        # fused_expert_output is the final result, return it directly.
+        return fused_expert_output
 
 
 class TopKWeightAndReduceContiguous(mk.TopKWeightAndReduce):
@@ -88,7 +72,6 @@ class TopKWeightAndReduceContiguous(mk.TopKWeightAndReduce):
 
     def apply(
         self,
-        output: torch.Tensor | None,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -107,16 +90,11 @@ class TopKWeightAndReduceContiguous(mk.TopKWeightAndReduce):
         if not apply_router_weight_on_input:
             fused_expert_output.mul_(topk_weights.view(m, -1, 1))
 
-        if output is None:
-            output = torch.empty(
-                (m, k),
-                device=fused_expert_output.device,
-                dtype=fused_expert_output.dtype,
-            )
-        assert output.size() == (m, k), (
-            f"Expected output size {(m, k)}. But got {output.size()}"
+        output = torch.empty(
+            (m, k),
+            device=fused_expert_output.device,
+            dtype=fused_expert_output.dtype,
         )
-
         ops.moe_sum(fused_expert_output, output)
         return output
 
@@ -137,7 +115,6 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
 
     def apply(
         self,
-        output: torch.Tensor | None,
         fused_expert_output: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -148,17 +125,10 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
         num_local_experts = fused_expert_output.size(0)
         K = fused_expert_output.size(-1)
 
-        if output is None:
-            output = torch.zeros(
-                (num_tokens, K),
-                device=fused_expert_output.device,
-                dtype=fused_expert_output.dtype,
-            )
-        else:
-            output.fill_(0)
-
-        assert output.size() == (num_tokens, K), (
-            f"Expected output size {(num_tokens, K)}, but got {output.size()}"
+        output = torch.zeros(
+            (num_tokens, K),
+            device=fused_expert_output.device,
+            dtype=fused_expert_output.dtype,
         )
 
         first_expert = num_local_experts * self.rank


### PR DESCRIPTION
## Summary

The modular MoE kernel (`FusedMoEKernelModularImpl.apply`) eagerly allocates
`output = torch.empty_like(hidden_states)` and passes it as an in-place
destination to `prepare_finalize.finalize()`. But several backends allocate
their own combine buffer and then `copy_()` into the caller's buffer, so the
eager allocation **and** the copy are redundant:

| backend | today | after |
|---|---|---|
| `deepep_ht` | combine → `combined_x`, then `output.copy_()` | return `combined_x` (skips copy) |
| `naive_dp_ep` | `output.copy_(ep_group.combine(...))` | return combine result |
| `flashinfer nvlink` one/two-sided | `output.copy_(combine(...))` | return combine result |
| `mori` | `output.copy_(result[:n])` | return `result[:n]` |
| `deepep_ll` / `nixl_ep` | combine writes `out=output` | allocate internally, receiver returns it |
| `no_dp_ep` / `batched` | `weight_and_reduce(output=...)` | impl allocates and returns |

The same `copy_` also lived inside `TopKWeightAndReduceNoOP.apply` whenever a
pre-allocated `output` was handed in.

## Change

Delegate output-buffer ownership to `finalize`:

- `FusedMoEPrepareAndFinalize.finalize(...) -> torch.Tensor` (was `None` +
  in-place `output` arg). Output shape is recovered from `topk_ids.shape[0]`
  (M) and `fused_expert_output.shape[-1]` (K) — both already passed in.
- `finalize_async(...)`'s receiver now **returns** the output tensor, mirroring
  `prepare_async` (whose receiver already returns tensors). In-place combine
  backends (`deepep_ll`, `nixl_ep`) allocate before launch and return the
  buffer from the receiver.
- `TopKWeightAndReduce.apply(...)` drops its `output` parameter; every impl
  allocates and returns (removing the `NoOP` `copy_`).
- `apply()` drops the eager `empty_like`; `_fused_experts` drops the
  `output_alias` plumbing.

## Testing

Run on B200/GB200 (sm100), `CUDA 13.1`, `torch 2.11+cu130`:

- **`tests/kernels/moe/test_deepep_moe.py`: 56/56 passed.** Validates both
  finalize paths this PR changes end-to-end against the reference MoE:
  `DeepEPHTPrepareAndFinalize` (HT — async receiver returns the combine buffer
  directly, the copy-skip) and `DeepEPLLPrepareAndFinalize` (LL — allocates the
  `out=` buffer internally and returns it from the receiver). *(Required
  building DeepEP locally with `TORCH_CUDA_ARCH_LIST=10.0`.)*
- **`test_modular_kernel_combinations_singlegpu`: 7 passed / 3 failed**; the 3
  failures (`FlashInferExperts`, `DeepGemmExperts`, `TritonOrDeepGemmExperts`)
  **reproduce identically on `main`** (pre-existing, unrelated). The 7 passes
  cover both reduce paths: `TritonExperts` (`NoOP` → returns the reduced buffer
  directly) and `CutlassExpertsFp8` (`Contiguous` → fresh allocation).
- `pre-commit run` (ruff, ruff-format, mypy) passes on all changed files.

### Environment-blocked / not yet validated

- **flashinfer nvlink** (`flashinfer_nvlink_one_sided` / `two_sided`): MNNVL
  needs the `SYS_PTRACE` capability; running the tests under that capability
  (e.g. `sudo`), **`tests/distributed/test_mnnvl_alltoall.py::test_two_sided_dispatch_combine`
  PASSES** — this directly exercises the `MnnvlMoe` two-sided combine that
  `flashinfer_nvlink_two_sided.finalize` now returns instead of copying into a
  caller buffer, so that edit is validated by proxy. `test_args_dispatch_combine`
  also passes. Remaining gaps are **not** in this PR: the one-sided dedicated
  test hits a pre-existing flashinfer workspace-sizing assertion
  (`workspace insufficient for combine payload region`, in the raw `MnnvlMoe`
  API), and the flashinfer-nvlink `test_modular_kernel_combinations_multigpu`
  cases fail identically on `main` with `ValueError: Unknown all2all backend:
  None` (a prepare-phase harness/config gap that aborts before `finalize` runs).
- **`test_deepep_deepgemm_moe.py`**: blocked by a pre-existing DeepGemm sm100
  assertion (`gemm.hpp:204: Unsupported architecture or scaling factor types`)
  in the experts kernel — aborts before `finalize` runs, unrelated to this PR.
- **`mori`**: backend not available in my environment.
- **Multi-layer workspace lifetime**: for `NoOP` backends `finalize` now returns
  a view into the shared fused-experts workspace. Single-call value correctness
  is verified (above); cross-layer reuse / CUDA-graph lifetime would be worth an
  e2e confirmation.
- **ROCm/AITER**: this removes the `output_alias` zero-copy path that #41315
  targets. On ROCm+AITER the `NoOP` finalize would re-introduce one copy.
  Feedback wanted on whether/how to preserve that alias under this scheme.

## Relation to existing PRs

Not a duplicate of #41315 ("Avoid redundant AITER MoE output copies"): that PR
is an AITER-specific alias to skip one copy; this is a general restructuring of
output-buffer ownership that removes the redundant alloc+copy across all
modular backends. The interaction with #41315 is the open ROCm question above.

## AI assistance

This change was developed with AI assistance (Claude Code). The diff has been
reviewed and the test results above were run locally.
