### PR TITLE
# Helion `scaled_mm` vs cutlass — benchmark command & result

### DIFF
--- a/vllm/kernels/helion/configs/scaled_mm/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/scaled_mm/nvidia_b200.json
@@ -1,0 +1,1266 @@
+[
+  {
+    "key": {
+      "n": 4096,
+      "k": 2048,
+      "numtokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        2048
+      ],
+      "loop_orders": [
+        [
+          2,
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        0
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 4096,
+      "k": 2048,
+      "numtokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        1,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 4096,
+      "k": 2048,
+      "numtokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        4,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 4096,
+      "k": 2048,
+      "numtokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 2048,
+      "numtokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 2048,
+      "numtokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 2048,
+      "numtokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 2048,
+      "numtokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 12288,
+      "k": 2048,
+      "numtokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 12288,
+      "k": 2048,
+      "numtokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [
+        null,
+        false
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 12288,
+      "k": 2048,
+      "numtokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [
+        null,
+        false
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 12288,
+      "k": 2048,
+      "numtokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        16,
+        32,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 6144,
+      "numtokens": 1
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 6144,
+      "numtokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 6144,
+      "numtokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 6144,
+      "numtokens": 16
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        0
+      ],
+      "range_multi_buffers": [
+        null,
+        false
+      ],
+      "range_flattens": [
+        null,
+        true
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 4096,
+      "k": 2048,
+      "numtokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0,
+          2
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        1
+      ],
+      "range_warp_specializes": [
+        false,
+        false
+      ],
+      "range_num_stages": [
+        1,
+        3
+      ],
+      "range_multi_buffers": [
+        true,
+        false
+      ],
+      "range_flattens": [
+        true,
+        true
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 64,
+      "maxnreg": 256,
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 2048,
+      "numtokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        false
+      ],
+      "range_num_stages": [
+        3,
+        2
+      ],
+      "range_multi_buffers": [
+        false,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 32,
+      "maxnreg": 64,
+      "split_k": 2
+    }
+  },
+  {
+    "key": {
+      "n": 12288,
+      "k": 2048,
+      "numtokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        32,
+        512
+      ],
+      "loop_orders": [
+        [
+          2,
+          0,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0,
+        2
+      ],
+      "range_warp_specializes": [
+        null,
+        null
+      ],
+      "range_num_stages": [
+        0,
+        3
+      ],
+      "range_multi_buffers": [
+        null,
+        null
+      ],
+      "range_flattens": [
+        null,
+        false
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat",
+      "split_k": 1
+    }
+  },
+  {
+    "key": {
+      "n": 2048,
+      "k": 6144,
+      "numtokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        8,
+        16,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0,
+        4
+      ],
+      "range_warp_specializes": [
+        null,
+        false
+      ],
+      "range_num_stages": [
+        0,
+        3
+      ],
+      "range_multi_buffers": [
+        null,
+        true
+      ],
+      "range_flattens": [
+        null,
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "split_k": 4
+    }
+  }
+]

--- a/vllm/kernels/helion/ops/scaled_mm.py
+++ b/vllm/kernels/helion/ops/scaled_mm.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FP8 RowWise ``scaled_mm`` Helion kernel (per-token act / per-channel weight).
+
+    out[m, n] = scale_a[m] * scale_b[n] * sum_k A[m, k] * B[k, n]
+
+A/B fp8 e4m3 (B column-major ``[K, N]`` as vLLM stores weights), out bf16,
+scale_a ``[M, 1]`` f32, scale_b ``[1, N]`` f32.
+
+This is the skinny-M (decode) regime: memory-bandwidth bound on reading B, so a
+split-K reduction (``split_k`` tunable) is used to fill the machine, with the
+rowwise scale folded into each K-split partial (linear across K) and partials
+accumulated via ``atomic_add`` into a pre-zeroed output. Beats / matches cutlass
+at M<=16; the caller routes only small M here (see the FP8 linear kernel).
+
+N and K are specialized (fixed per layer); M (num tokens) stays dynamic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.logger import init_logger
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "scaled_mm Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+import helion
+import helion.language as hl
+from helion.autotuner import PowerOfTwoFragment
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+# (N, K) of the FP8 W8A8 linear layers we tune for (Qwen3-1.7B); N=out, K=in.
+_LAYER_NK = [(4096, 2048), (2048, 2048), (12288, 2048), (2048, 6144)]
+# Decode num_tokens (M) where the split-K kernel matches/beats cutlass.
+_NUM_TOKENS = [1, 2, 4, 8, 16]
+
+
+def generate_scaled_mm_inputs() -> dict[CaseKey, tuple[Any, ...]]:
+    inputs: dict[CaseKey, tuple[Any, ...]] = {}
+    for n, k in _LAYER_NK:
+        for m in _NUM_TOKENS:
+            a = (torch.randn(m, k, device="cuda") * 0.3).to(torch.float8_e4m3fn)
+            # Column-major [K, N], matching how vLLM stores the fp8 weight.
+            b = (
+                (torch.randn(k, n, device="cuda") * 0.3)
+                .to(torch.float8_e4m3fn)
+                .T.contiguous()
+                .T
+            )
+            scale_a = (torch.rand(m, 1, device="cuda") + 0.5).to(torch.float32)
+            scale_b = (torch.rand(1, n, device="cuda") + 0.5).to(torch.float32)
+            inputs[CaseKey({"n": n, "k": k, "numtokens": m})] = (a, b, scale_a, scale_b)
+    return inputs
+
+
+_pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
+
+
+def pick_scaled_mm_config(
+    args: tuple[Any, ...], config_keys: list[CaseKey]
+) -> CaseKey | None:
+    """Pick the pre-tuned config: exact (n, k) match, then smallest tuned
+    num_tokens >= the input's M (fall back to the largest tuned M)."""
+    if not config_keys:
+        return None
+
+    a, b, _sa, _sb = args
+    m = int(a.shape[0])
+    k = int(a.shape[1])
+    n = int(b.shape[1])
+
+    cache_key = (m, n, k)
+    cached = _pick_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    by_nk: dict[tuple[int, int], list[int]] = {}
+    for key in config_keys:
+        if key.is_default():
+            continue
+        by_nk.setdefault((key["n"], key["k"]), []).append(key["numtokens"])
+
+    if (n, k) not in by_nk:
+        return None
+    available = sorted(by_nk[(n, k)])
+    best_m = next((x for x in available if x >= m), available[-1])
+    result = CaseKey({"n": n, "k": k, "numtokens": best_m})
+    _pick_cache[cache_key] = result
+    return result
+
+
+def _scaled_mm_fake(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty((A.shape[0], B.shape[1]), dtype=torch.bfloat16, device=A.device)
+
+
+@register_kernel(
+    config_picker=pick_scaled_mm_config,
+    input_generator=generate_scaled_mm_inputs,
+    fake_impl=_scaled_mm_fake,
+)
+def scaled_mm(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    m, k = A.shape
+    _, n = B.shape
+    n = hl.specialize(n)
+    k = hl.specialize(k)
+    split_k = hl.register_tunable("split_k", PowerOfTwoFragment(1, 32))
+    out = torch.zeros([m, n], dtype=torch.bfloat16, device=A.device)
+    k_block = helion.next_power_of_2(helion.cdiv(k, split_k))
+    for tile_m, tile_n, outer_k in hl.tile([m, n, k], block_size=[None, None, k_block]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for inner_k in hl.tile(outer_k.begin, outer_k.end):
+            acc = hl.dot(A[tile_m, inner_k], B[inner_k, tile_n], acc=acc)
+        # Rowwise scale is linear across K -> fold into each split-K partial.
+        acc = acc * scale_a[tile_m, :] * scale_b[:, tile_n]
+        hl.atomic_add(out, [tile_m, tile_n], acc.to(torch.bfloat16))
+    return out
+
+
+def scaled_mm_baseline(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    from vllm import _custom_ops as ops
+
+    return ops.cutlass_scaled_mm(
+        A, B, scale_a=scale_a, scale_b=scale_b, out_dtype=torch.bfloat16
+    )

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import os
+
 import torch
 
 from vllm import _custom_ops as ops
@@ -187,6 +189,27 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         bias: torch.Tensor | None,
         output_shape: list,
     ) -> torch.Tensor:
+        # EXPERIMENTAL: route the rowwise (per-token act / per-channel weight)
+        # FP8 GEMM to the Helion ``vllm_helion::scaled_mm`` kernel when
+        # VLLM_USE_HELION_SCALED_MM=1. Only the bf16-out, bias-free,
+        # per-token+per-channel, small-M (decode) case is routed; everything else
+        # falls through to cutlass (Helion only wins at M<=16). See
+        # vllm/kernels/helion/ops/scaled_mm.py.
+        M = A.shape[0]
+        if (
+            os.environ.get("VLLM_USE_HELION_SCALED_MM") == "1"
+            and bias is None
+            and out_dtype is torch.bfloat16
+            and As.numel() == M  # per-token activation scale
+            and Bs.numel() == B.shape[1]  # per-channel weight scale
+            and M <= 16
+        ):
+            import vllm.kernels.helion  # noqa: F401, registers vllm_helion ops
+
+            return torch.ops.vllm_helion.scaled_mm(
+                A, B, As.reshape(M, 1), Bs.reshape(1, B.shape[1])
+            ).view(*output_shape)
+
         # Per-tensor/Per-channel padding to use Cutlass instead of Triton.
         K, N = B.shape
         pad_k = (16 - K % 16) % 16


### PR DESCRIPTION
End-to-end vLLM serving A/B at **BS=1** comparing the Helion FP8 RowWise `scaled_mm` kernel against vLLM's cutlass kernel, under the production config (torch.compile + CUDA graph + FP8 fusion).

## Setup

| | |
|---|---|
| Model | `RedHatAI/Qwen3-1.7B-FP8-dynamic` (FP8, per-token act / per-channel weight) | | Hardware | 1× NVIDIA B200, `tensor-parallel-size 1` (shared box) | | Env | conda env `pytorch-3.12` (vLLM `0.20.2rc1.dev`) | | Input / Output | 512 / 600 tokens |
| Dataset | `random` |
| Batch size | 1 (`--max-num-seqs 1`); `--num-prompts 128`, `--num-warmups 16` | | Helion kernel | `vllm/kernels/helion/ops/scaled_mm.py` (`vllm_helion::scaled_mm`) | | Helion configs | `vllm/kernels/helion/configs/scaled_mm/nvidia_b200.json` | | Toggle | `VLLM_USE_HELION_SCALED_MM=1` (routes rowwise bf16, M≤16 → Helion) |

## Benchmark command

Driver: `run_bench.sh` in `/home/shangdiy/qwen3_fp8_bench/` (starts the server, then runs `vllm bench serve`). A **fresh `VLLM_CACHE_ROOT` per run is required**, otherwise a cached compiled graph is replayed and the Helion hook is bypassed.

```bash
cd /home/shangdiy/qwen3_fp8_bench

# ---- Baseline (cutlass) ----
VLLM_CACHE_ROOT=/home/shangdiy/helion/agent_space/vc_fw_base \
TRITON_CACHE_DIR=/home/shangdiy/helion/agent_space/fw_base_tc \
TMPDIR=/home/shangdiy/helion/agent_space/vllm_integ_tt \
TAG=fw_base GPU=1 BATCH_SIZES="1" bash run_bench.sh

# ---- Helion (vllm_helion::scaled_mm) ----
VLLM_USE_HELION_SCALED_MM=1 \
VLLM_CACHE_ROOT=/home/shangdiy/helion/agent_space/vc_fw_helion \
TRITON_CACHE_DIR=/home/shangdiy/helion/agent_space/fw_helion_tc \
TMPDIR=/home/shangdiy/helion/agent_space/vllm_integ_tt \
TAG=fw_helion GPU=1 BATCH_SIZES="1" bash run_bench.sh
```

Each invocation expands to (via `conda run -n pytorch-3.12 --no-capture-output`):

```bash
# 1. Serve
CUDA_VISIBLE_DEVICES=1 python3 -m vllm.entrypoints.openai.api_server \
  --model RedHatAI/Qwen3-1.7B-FP8-dynamic \
  --max-num-seqs 1 --tensor-parallel-size 1 --gpu-memory-utilization 0.3 --port 8000 \
  --compilation-config '{"max_cudagraph_capture_size": 8192, "custom_ops": ["+quant_fp8"], "pass_config": {"fuse_norm_quant": true, "fuse_act_quant": true, "enable_qk_norm_rope_fusion": true}}'

# 2. Benchmark
vllm bench serve \
  --backend vllm --model RedHatAI/Qwen3-1.7B-FP8-dynamic \
  --endpoint /v1/completions \
  --dataset-name random --input-len 512 --output-len 600 \
  --num-prompts 128 --max-concurrency 1 --num-warmups 16 \
  --disable-shuffle --save-result --result-dir results_fw_helion --result-filename result_bs1.json
```

Read the numbers out:

```bash
conda run -n pytorch-3.12 --no-capture-output python3 -c "
import json; d=json.load(open('results_fw_helion/result_bs1.json'))
print('out=%.1f tok/s  TPOT=%.3f ms'%(d['output_throughput'], d['mean_tpot_ms']))"
```

## Result (BS=1)

| | out tok/s (samples) | TPOT ms (samples) | median TPOT | 
|---|---|---|---|
| Baseline (cutlass) | 480.5, 490.5, 505.1, 512.7, 519.4 | 2.054, 2.010, 1.953, 1.924, 1.898 | **1.953** | 
| **Helion** | 548.7, 566.9, 575.9 | 1.795, 1.738, 1.708 | **1.738** |

**≈ +12% throughput / −11% TPOT at BS=1.** Every Helion sample (1.708–1.795 ms) is below every baseline sample (1.898–2.054 ms) — no overlap, so it is not clock noise. Correctness vs cutlass / `torch._scaled_mm`: rel-err ≤ 0.006.

Scope: the speedup is for low-concurrency decode (M ≤ 16). M ≥ 32/64 and prefill (M=512) fall back to cutlass (no regression).

## Regenerating the configs (per GPU)

```bash
CUDA_VISIBLE_DEVICES=1 TRITON_CACHE_DIR=/tmp/at_tc TMPDIR=/tmp/at_tt \
conda run -n pytorch-3.12 --no-capture-output \
  python scripts/autotune_helion_kernels.py --kernels scaled_mm --force --autotune-effort quick
# -> vllm/kernels/helion/configs/scaled_mm/<gpu>.json  (split_k bounded to <=32)
```




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

