### PR TITLE
[Bugfix][Voxtral Realtime] Fix token feedback timeout silent hang

### DIFF
--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -17,7 +17,6 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.speech_to_text import SpeechToTextParams
 from vllm.engine.protocol import StreamingInput
-from vllm.envs import VLLM_ENGINE_ITERATION_TIMEOUT_S
 from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings, SupportsRealtime
@@ -265,13 +264,11 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into buffer in background
+        # Feed output tokens back into the buffer. Idle waits are normal here;
+        # request cleanup still cancels this task through the finally block.
         async def feed_tokens():
             while True:
-                all_outputs = await asyncio.wait_for(
-                    input_stream.get(),
-                    timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
-                )
+                all_outputs = await input_stream.get()
                 await buffer.append_tokens(all_outputs[-1:])
 
         audio_task = asyncio.create_task(feed_audio())


### PR DESCRIPTION
## Purpose

Closes #36015.
Closes #35863.

Voxtral realtime has a background `feed_tokens()` task that moves engine output tokens from `input_stream` into the realtime transcription buffer. That task currently wraps `input_stream.get()` in `asyncio.wait_for(..., VLLM_ENGINE_ITERATION_TIMEOUT_S)`. A normal idle interval with no engine output can therefore raise `TimeoutError` and kill the feedback task while the websocket session remains open. Later audio keeps arriving, but no generated tokens are appended back into the realtime buffer, so the session silently stops producing transcription output.

This removes the timeout around `input_stream.get()`. Waiting for the next engine output on this queue is not itself a failure; the wait is still bounded by the request lifecycle. Client disconnect, session finalization, and real engine failures still cancel or unwind the generator, while legitimate silence, scheduler delay, or a temporarily starved session no longer aborts token feedback.

`#35863` is the same failure mode under concurrency: the first two sessions keep receiving output, while the third session can sit idle past the timeout, lose its feedback task, and keep an open websocket with no further transcription. This is not a duplicate of #36089, which kept the timeout and retried after `TimeoutError`; retrying still treats a normal idle queue wait as exceptional. #37483 only changed realtime test timeout / connection validation, not the production `feed_tokens()` path in `voxtral_realtime.py`.

## Test Plan

Run real `/v1/realtime` websocket E2E before and after the patch with `mistralai/Voxtral-Mini-4B-Realtime-2602` and the reporter serving flags. The original hang can take about a minute or longer to hit on a fast GPU, so the repro keeps the model and serving flags unchanged and accelerates only the idle window with `VLLM_ENGINE_ITERATION_TIMEOUT_S=3` plus a deliberate gap before more audio arrives.

Run both reported shapes:

- a single realtime session with a silence gap before more audio
- three concurrent realtime sessions, each in its own thread and event loop, where session 3 has the idle gap

Also run the existing realtime validation tests, existing Voxtral realtime tests, and changed-file pre-commit.

## Test Result

Real realtime websocket E2E:

| Reporter path | Before this PR | With this PR |
|---|---|---|
| #36015 single session, idle gap before more audio | `REPRO_TIMEOUT_NO_DONE`; no `transcription.done` | `REPRO_DONE`; full transcription completes |
| #35863 three concurrent sessions | s1=808 deltas + done, s2=808 + done, s3=1 delta, no done, no error, websocket still open | s1=808, s2=808, s3=808; all sessions emit `transcription.done` |

No-regression checks:

```text
VLLM_USE_FLASHINFER_SAMPLER=0 pytest tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py
# 4 passed

VLLM_USE_FLASHINFER_SAMPLER=0 pytest tests/models/multimodal/generation/test_voxtral_realtime.py
# 3 passed

pre-commit run --files vllm/model_executor/models/voxtral_realtime.py tests/models/multimodal/generation/test_voxtral_realtime.py
# passed
```

<details>
<summary>Realtime E2E repro script and commands</summary>

Environment used for the recorded run:

- GPU: NVIDIA RTX PRO 6000 (Blackwell, sm_120)
- CUDA: 13.0
- PyTorch: 2.11.0
- Python: 3.12
- vLLM source build, base `985c97a6a`
- Model: `mistralai/Voxtral-Mini-4B-Realtime-2602`
- `VLLM_USE_FLASHINFER_SAMPLER=0` because the FlashInfer sampler JIT does not build on sm_120 in this environment. This is unrelated to the realtime feedback queue path.

Save this as `/tmp/voxtral_realtime_timeout_repro.py` and run it from a vLLM checkout. It starts the server through `RemoteOpenAIServer`, uses the reporter model and serving flags, and accelerates only the idle timeout to make the failure deterministic.

```python
#!/usr/bin/env python3
# SPDX-License-Identifier: Apache-2.0
import asyncio
import json
import os
import sys
import threading
import time

import numpy as np
import pybase64 as base64
import websockets

from tests.utils import RemoteOpenAIServer
from vllm.assets.audio import AudioAsset
from vllm.multimodal.media.audio import load_audio

SERVED = "mistralai/Voxtral-Mini-4B-Realtime-2602"
LOCAL = "mistralai/Voxtral-Mini-4B-Realtime-2602"
MODE = os.environ.get("MODE", "concurrent")
EXPECT = os.environ.get("EXPECT", "broken")
RESULTS = {}


def chunks(loops):
    path = AudioAsset("mary_had_lamb").get_local_path()
    audio, _ = load_audio(str(path), sr=16000, mono=True)
    out = []
    for _ in range(loops):
        for start in range(0, len(audio), 1600):
            chunk = (audio[start:start + 1600] * 32767).astype(np.int16)
            out.append(base64.b64encode(chunk.tobytes()).decode())
    return out


async def session(url, name, audio_chunks, start_delay, gap):
    deltas = 0
    first_delta = None
    done = None
    exc = None
    try:
        async with websockets.connect(url, max_size=None, ping_interval=None) as ws:
            t0 = time.monotonic()
            json.loads(await asyncio.wait_for(ws.recv(), timeout=30))
            await ws.send(json.dumps({"type": "session.update", "model": SERVED}))
            await asyncio.sleep(start_delay)

            async def rx():
                nonlocal deltas, first_delta, done
                try:
                    while True:
                        event = json.loads(await asyncio.wait_for(ws.recv(), timeout=8))
                        typ = event.get("type")
                        if typ == "transcription.delta":
                            deltas += 1
                            if first_delta is None:
                                first_delta = time.monotonic() - t0
                        elif typ in ("transcription.done", "error"):
                            done = typ
                            return
                except TimeoutError:
                    return

            async def tx():
                await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
                if gap:
                    await asyncio.sleep(gap)
                for chunk in audio_chunks:
                    await ws.send(json.dumps({
                        "type": "input_audio_buffer.append",
                        "audio": chunk,
                    }))
                    await asyncio.sleep(0.08)
                await ws.send(json.dumps({
                    "type": "input_audio_buffer.commit",
                    "final": True,
                }))

            reader = asyncio.create_task(rx())
            writer = asyncio.create_task(tx())
            await asyncio.wait(
                {reader, writer},
                timeout=140,
                return_when=asyncio.ALL_COMPLETED,
            )
            for task in (reader, writer):
                if not task.done():
                    task.cancel()
    except Exception as e:
        exc = repr(e)
    RESULTS[name] = {
        "deltas": deltas,
        "first": first_delta,
        "done": done,
        "exc": exc,
    }


def run_session(url, name, audio_chunks, start_delay, gap):
    asyncio.run(session(url, name, audio_chunks, start_delay, gap))


def run_repro():
    audio_chunks = chunks(4)
    env = {
        "PYTHONPATH": os.getcwd(),
        "VLLM_ENGINE_ITERATION_TIMEOUT_S": "3",
    }
    args = [
        "--served-model-name", SERVED,
        "--tokenizer-mode", "mistral",
        "--config-format", "mistral",
        "--load-format", "mistral",
        "--trust-remote-code",
        "--compilation-config", '{"cudagraph_mode":"PIECEWISE"}',
        "--tensor-parallel-size", "1",
        "--max-model-len", "45000",
        "--max-num-batched-tokens", "8192",
        "--max-num-seqs", "16",
        "--gpu-memory-utilization", "0.9",
    ]
    with RemoteOpenAIServer(LOCAL, args, env_dict=env, max_wait_seconds=600) as server:
        url = server.url_root.replace("http://", "ws://") + "/v1/realtime"
        if MODE == "single":
            threads = [
                threading.Thread(
                    target=run_session,
                    args=(url, "s1", audio_chunks, 0.0, 6.0),
                )
            ]
        else:
            threads = [
                threading.Thread(
                    target=run_session,
                    args=(url, "s1", audio_chunks, 0.0, 0.0),
                ),
                threading.Thread(
                    target=run_session,
                    args=(url, "s2", audio_chunks, 0.0, 0.0),
                ),
                threading.Thread(
                    target=run_session,
                    args=(url, "s3", audio_chunks, 0.5, 6.0),
                ),
            ]
        for thread in threads:
            thread.start()
        for thread in threads:
            thread.join()


def main():
    run_repro()
    for name in sorted(RESULTS):
        print(name, RESULTS[name])

    if MODE == "single":
        s1 = RESULTS.get("s1", {})
        broken = s1.get("done") is None
        fixed = s1.get("done") == "transcription.done"
        if EXPECT == "broken" and broken:
            print("REPRO_TIMEOUT_NO_DONE")
            return 0
        if EXPECT == "fixed" and fixed:
            print("REPRO_DONE")
            return 0
        print("UNEXPECTED_SINGLE_RESULT")
        return 1

    s1 = RESULTS.get("s1", {})
    s2 = RESULTS.get("s2", {})
    s3 = RESULTS.get("s3", {})
    broken = (
        s1.get("deltas", 0) > 50
        and s2.get("deltas", 0) > 50
        and s3.get("deltas", 0) <= 5
        and s3.get("done") is None
    )
    fixed = (
        s1.get("deltas", 0) > 50
        and s2.get("deltas", 0) > 50
        and s3.get("deltas", 0) > 50
        and s1.get("done") == "transcription.done"
        and s2.get("done") == "transcription.done"
        and s3.get("done") == "transcription.done"
    )
    if EXPECT == "broken" and broken:
        print("WEDGE_REAL_SESSION3_SILENT_SEPARATE_LOOPS")
        return 0
    if EXPECT == "fixed" and fixed:
        print("NO_WEDGE_SESSION3_OK")
        return 0
    print("UNEXPECTED_CONCURRENT_RESULT")
    return 1


if __name__ == "__main__":
    raise SystemExit(main())
```

Commands:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export CUDA_VISIBLE_DEVICES=0
export VLLM_USE_FLASHINFER_SAMPLER=0

# Base/main. Expected to pass by reproducing the broken behavior.
MODE=single EXPECT=broken python /tmp/voxtral_realtime_timeout_repro.py
MODE=concurrent EXPECT=broken python /tmp/voxtral_realtime_timeout_repro.py

# This PR. Expected to pass by completing the realtime sessions.
MODE=single EXPECT=fixed python /tmp/voxtral_realtime_timeout_repro.py
MODE=concurrent EXPECT=fixed python /tmp/voxtral_realtime_timeout_repro.py
```

Observed output summary:

```text
# base/main
MODE=single      REPRO_TIMEOUT_NO_DONE
MODE=concurrent  WEDGE_REAL_SESSION3_SILENT_SEPARATE_LOOPS
                 s1=808 deltas + transcription.done
                 s2=808 deltas + transcription.done
                 s3=1 delta, done=None, websocket still open

# this PR
MODE=single      REPRO_DONE
MODE=concurrent  NO_WEDGE_SESSION3_OK
                 s1=808 deltas + transcription.done
                 s2=808 deltas + transcription.done
                 s3=808 deltas + transcription.done
```

</details>

AI assistance was used to prepare this PR.


