### PR TITLE
[CI] Resolve release V2 docker build after ROCm CI wheels change

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,4 @@ rust/target/
 docs/
 .github/
 .pre-commit-config.yaml
-.clang-format
-.gitattributes
 format.sh

--- a/tools/check_repo.sh
+++ b/tools/check_repo.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 # Checks whether the repo is clean and whether tags are available (necessary to correctly produce vllm version at build time)
 
+# Some Docker builds intentionally omit tracked, non-build files from the
+# context. Restore only those paths from the mounted .git object database before
+# checking cleanliness so release builds still see a coherent worktree.
+if [ -f /.dockerenv ]; then
+	git ls-files -z -- docs .github .pre-commit-config.yaml format.sh \
+		| git checkout-index -f -z --stdin
+fi
+
 if ! git diff --quiet; then
 	echo "Repo is dirty" >&2
 


### PR DESCRIPTION
Release Docker builds were failing with `Repo is dirty` because tracked files excluded by `.dockerignore` were missing from the container worktree while `.git` was still available for the cleanliness check. This keeps `.clang-format` and `.gitattributes` in the Docker context, while continuing to ignore non-build paths such as `docs/`, `.github/`, `.pre-commit-config.yaml`, and `format.sh`. To make that safe, `tools/check_repo.sh` restores only those intentionally omitted tracked paths from the Git index before running `git diff --quiet` inside Docker. This preserves the smaller Docker context for CI base builds without making release builds see false dirty-tree changes. Verified with `git diff --check`, `bash -n tools/check_repo.sh`, and a temp worktree simulation with the ignored tracked paths removed.