### PR TITLE
[Bugfix] RayExecutorV2: Defer `vllm_config` deserialization until after `CUDA_VISIBLE_DEVICES` is set

### DIFF
--- a/tests/distributed/test_ray_v2_executor.py
+++ b/tests/distributed/test_ray_v2_executor.py
@@ -8,6 +8,7 @@ and distributed execution with various TP/PP configurations.
 """
 
 import gc
+import os
 import threading
 from unittest.mock import patch
 
@@ -105,6 +106,53 @@ def test_ray_v2_executor(tp_size, pp_size):
     executor = RayExecutorV2(vllm_config=vllm_config)
     try:
         assert_executor(executor, tp_size, pp_size)
+    finally:
+        executor.shutdown()
+
+
+def test_ray_v2_config_deserialized_after_cuda_visible_devices():
+    """vllm_config must be deserialized only *after* CUDA_VISIBLE_DEVICES is set.
+
+    A probe attached to the real config records CUDA_VISIBLE_DEVICES at the exact
+    moment a worker deserializes it. The test asserts that recorded value matches
+    the worker's assigned GPUs, which holds only if deserialization happened after
+    the env var was set.
+    """
+    tp_size = 2
+    vllm_config = create_vllm_config(tensor_parallel_size=tp_size)
+
+    record_var = "RECORDED_CUDA_VISIBLE_DEVICES"
+
+    def record_env():
+        os.environ[record_var] = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+        return None
+
+    class Probe:
+        def __reduce__(self):
+            return (record_env, ())
+
+    # Attach to the real config so the probe fires when the config is deserialized.
+    vllm_config._probe = Probe()
+    executor = RayExecutorV2(vllm_config=vllm_config)
+    try:
+
+        def get_env(worker, name):
+            return os.environ.get(name, "")
+
+        recorded = executor.collective_rpc(get_env, args=(record_var,))
+        assigned = executor.collective_rpc(get_env, args=("CUDA_VISIBLE_DEVICES",))
+
+        assert len(recorded) == tp_size
+        assert len(assigned) == tp_size
+
+        for at_deserialize, final in zip(recorded, assigned):
+            assert at_deserialize == final
+
+            device_ids = at_deserialize.split(",")
+            assert all(tok.isdigit() for tok in device_ids)
+            assert len(device_ids) == tp_size
+
+        assert_executor(executor, tp_size=tp_size, pp_size=1)
     finally:
         executor.shutdown()
 

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -8,6 +8,8 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Any
 
+import torch
+
 import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed.device_communicators.shm_broadcast import (
@@ -159,6 +161,12 @@ class RayWorkerProc(WorkerProc):
         in missing vars but never overwrite node-local values.
         *env_vars* (e.g. CUDA_VISIBLE_DEVICES) always overwrite.
         """
+        if torch.cuda.is_initialized():
+            raise RuntimeError(
+                "CUDA context was already initialized in RayWorkerProc "
+                "before CUDA_VISIBLE_DEVICES was set."
+            )
+
         if driver_env_vars:
             for key, value in driver_env_vars.items():
                 os.environ.setdefault(key, value)

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -36,6 +36,7 @@ from vllm.v1.executor.ray_utils import (
 )
 
 if ray is not None:
+    import ray.cloudpickle  # noqa: F401
     from ray.actor import ActorHandle
     from ray.types import ObjectRef
     from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -98,11 +99,21 @@ class RayWorkerProc(WorkerProc):
     each instance is unaware which physical devices others hold, and the
     externally managed placement group avoids CUDA_VISIBLE_DEVICES conflicts
     by binding workers to specific placement group bundles.
+
+    Because CUDA_VISIBLE_DEVICES is only correct *after* step 3, __init__ must not
+    do anything that creates a CUDA context. In particular ``vllm_config`` is held
+    in serialized form and only deserialized inside ``initialize_worker`` once
+    CUDA_VISIBLE_DEVICES is set: deserializing it imports model/quantization
+    modules whose import side effects (e.g. AutoGPTQ -> fused_moe -> flashinfer)
+    create a CUDA context. If that happened at construction time, with
+    RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES set, the context would bind to
+    cuda:0 and every colocated worker would pile onto the same physical GPU regardless
+    of the CUDA_VISIBLE_DEVICES set later.
     """
 
     def __init__(
         self,
-        vllm_config: VllmConfig,
+        vllm_config_serialized: bytes,
         rank: int,
         distributed_init_method: str,
         input_shm_handle: Handle,
@@ -110,9 +121,14 @@ class RayWorkerProc(WorkerProc):
         is_driver_node: bool = False,
     ):
         # Defer WorkerProc.__init__ until GPU IDs are known.
+        #
+        # Keep vllm_config serialized here; it is deserialized in
+        # initialize_worker() after CUDA_VISIBLE_DEVICES is set so that any
+        # CUDA-context-creating imports (e.g. flashinfer) bind to this worker's
+        # assigned GPU rather than cuda:0.
         self._is_driver_node = is_driver_node
+        self._vllm_config_serialized = vllm_config_serialized
         self._init_kwargs = dict(
-            vllm_config=vllm_config,
             rank=rank,
             distributed_init_method=distributed_init_method,
             input_shm_handle=input_shm_handle,
@@ -149,8 +165,12 @@ class RayWorkerProc(WorkerProc):
         for key, value in env_vars.items():
             os.environ[key] = value
 
+        # Deserialize vllm_config only now, after CUDA_VISIBLE_DEVICES is set.
+        vllm_config = ray.cloudpickle.loads(self._vllm_config_serialized)
+
         self.local_rank = local_rank
         super().__init__(
+            vllm_config=vllm_config,
             local_rank=local_rank,
             **self._init_kwargs,
         )
@@ -323,6 +343,8 @@ class RayExecutorV2(MultiprocExecutor):
         runtime_env = self._build_runtime_env()
         resource_kwargs = self._get_actor_resource_kwargs()
 
+        vllm_config_serialized = ray.cloudpickle.dumps(self.vllm_config)
+
         for bundle_idx in range(self.world_size):
             bundle = bundle_assignments[bundle_idx]
             is_driver_worker = self._is_driver_worker(bundle["rank"])
@@ -347,7 +369,7 @@ class RayExecutorV2(MultiprocExecutor):
                     runtime_env=runtime_env,
                 )
                 .remote(
-                    vllm_config=self.vllm_config,
+                    vllm_config_serialized=vllm_config_serialized,
                     rank=bundle["rank"],
                     distributed_init_method=distributed_init_method,
                     input_shm_handle=scheduler_output_handle,


### PR DESCRIPTION



## Purpose
Deserializing `vllm_config` in the worker actor constructor imports quantization/model modules (e.g. AutoGPTQ/FP8 -> fused_moe -> flashinfer) that create a CUDA context. With `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES` set, that context binds to cuda:0, so all colocated workers pile onto the same physical GPU and OOM. Ship `vllm_config` as bytes and deserialize it in `initialize_worker()` after `CUDA_VISIBLE_DEVICES` is set.

Related to https://github.com/ray-project/ray/pull/63810.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

