### PR TITLE
[XPU] Cap topk/topp Triton BLOCK_SIZE to 4096 to fix Top-p mask difference failures

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -52,4 +52,5 @@ steps:
       pytest -v -s v1/logits_processors --ignore=v1/logits_processors/test_custom_online.py --ignore=v1/logits_processors/test_custom_offline.py &&
       pytest -v -s v1/test_oracle.py &&
       pytest -v -s v1/test_request.py &&
-      pytest -v -s v1/test_outputs.py'
+      pytest -v -s v1/test_outputs.py &&
+      pytest -v -s v1/sample/test_topk_topp_sampler.py'

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -929,8 +929,12 @@ def apply_top_k_top_p_triton(
         normal_cdf_to_sigma_table, percentile_to_std_table = tables
 
     # Smaller tiles compile and run faster on CPU; GPU benefits from larger tiles.
+    # On XPU, large BLOCK_SIZE causes precision loss in the single-pass pivot
+    # approximation; use smaller tiles for accurate top-p results.
     if logits.device.type == "cpu":
         block_size, block_size_trunc = 256, 128
+    elif logits.device.type == "xpu":
+        block_size, block_size_trunc = 4096, 2048
     else:
         block_size, block_size_trunc = 8192, 4096
 


### PR DESCRIPTION
## Summary

Cap the Triton `BLOCK_SIZE` to 4096 in `topk_topp_triton.py` on XPU to fix `Top-p mask difference too large` test failures.

## Changes
- `vllm/v1/sample/ops/topk_topp_triton.py`: limit XPU block size to 4096 for deterministic sampling
- `.buildkite/intel_jobs/misc_intel.yaml`: enable `test_topk_topp_sampler.py` on XPU CI