### PR TITLE
[XPU] Fix test_logprobs_e2e import error: pin lm-eval[api]>=0.4.12

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -64,7 +64,8 @@ steps:
       pytest -v -s v1/test_request.py &&
       pytest -v -s v1/test_outputs.py &&
       pytest -v -s v1/sample/test_topk_topp_sampler.py &&
-      pytest -v -s v1/sample/test_logprobs.py'
+      pytest -v -s v1/sample/test_logprobs.py &&
+      pytest -v -s v1/sample/test_logprobs_e2e.py'
 
 - label: XPU CPU Offload
   timeout_in_minutes: 60

--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -57,7 +57,8 @@ steps:
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
-      'export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+      'pip install lm_eval[api]>=0.4.12 &&
+      export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
       cd tests &&
       pytest -v -s v1/logits_processors --ignore=v1/logits_processors/test_custom_online.py --ignore=v1/logits_processors/test_custom_offline.py &&
       pytest -v -s v1/test_oracle.py &&

--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -13,7 +13,7 @@ pytest-shard
 absl-py
 accelerate
 arctic-inference
-lm_eval[api]
+lm_eval[api]>=0.4.12
 modelscope
 
 # --- Audio Processing ---

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -33,7 +33,6 @@ arctic-inference==0.1.1
 attrs==26.1.0
     # via
     #   aiohttp
-    #   jsonlines
     #   jsonschema
     #   referencing
 audioread==3.0.1
@@ -225,8 +224,6 @@ joblib==1.5.3
     #   librosa
     #   nltk
     #   scikit-learn
-jsonlines==4.0.0
-    # via lm-eval
 jsonschema==4.26.0
     # via
     #   -c requirements/common.txt
@@ -247,7 +244,7 @@ librosa==0.10.2.post1
     # via -r requirements/test/xpu.in
 llvmlite==0.47.0
     # via numba
-lm-eval==0.4.11
+lm-eval==0.4.12
     # via -r requirements/test/xpu.in
 lxml==6.0.2
     # via
@@ -734,5 +731,3 @@ xxhash==3.6.0
     #   evaluate
 yarl==1.23.0
     # via aiohttp
-zstandard==0.25.0
-    # via lm-eval


### PR DESCRIPTION
## Summary

Fix `ImportError` in `test_logprobs_e2e` caused by an incompatible `lm-eval` version on XPU CI.

## Changes
- `requirements/test/xpu.in`: pin `lm_eval[api]>=0.4.12`
- `.buildkite/intel_jobs/misc_intel.yaml`: install `lm_eval[api]>=0.4.12` before running `test_logprobs_e2e.py` on XPU CI