### PR TITLE
[Bugfix] Fix Eagle3LlamaModel assert to be torch.compile compatible

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -94,14 +94,6 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             return False, "XPUFp8BlockScaledMM only support on XPU"
         return True, None
 
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        super().process_weights_after_loading(layer)
-        scale_attr = (
-            "weight_scale_inv" if hasattr(layer, "weight_scale_inv") else "weight_scale"
-        )
-        scale = getattr(layer, scale_attr)
-        replace_parameter(layer, scale_attr, scale.data.t().contiguous())
-
     def apply_block_scaled_mm(
         self,
         A: torch.Tensor,
@@ -110,11 +102,15 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         Bs: torch.Tensor,
     ) -> torch.Tensor:
         # Weight is [N, K]. Use .t() to create a [K, N] view without copying.
+        # fp8_gemm expects scale in [K//block, N//block] (transposed) layout,
+        # so we transpose Bs here rather than in process_weights_after_loading,
+        # which keeps the stored scale in standard [N//block, K//block] format
+        # for use by get_and_maybe_dequant_weights (e.g., MLA kv_b_proj).
         return torch.ops._xpu_C.fp8_gemm(
             A,
             B.t(),
             self.config.out_dtype,
             As,
-            Bs,
+            Bs.t().contiguous(),
             torch.Tensor(),
         )

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -94,6 +94,14 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             return False, "XPUFp8BlockScaledMM only support on XPU"
         return True, None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module):
+        super().process_weights_after_loading(layer)
+        scale_attr = (
+            "weight_scale_inv" if hasattr(layer, "weight_scale_inv") else "weight_scale"
+        )
+        scale = getattr(layer, scale_attr)
+        replace_parameter(layer, scale_attr, scale.data.t().contiguous())
+
     def apply_block_scaled_mm(
         self,
         A: torch.Tensor,
@@ -102,15 +110,11 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         Bs: torch.Tensor,
     ) -> torch.Tensor:
         # Weight is [N, K]. Use .t() to create a [K, N] view without copying.
-        # fp8_gemm expects scale in [K//block, N//block] (transposed) layout,
-        # so we transpose Bs here rather than in process_weights_after_loading,
-        # which keeps the stored scale in standard [N//block, K//block] format
-        # for use by get_and_maybe_dequant_weights (e.g., MLA kv_b_proj).
         return torch.ops._xpu_C.fp8_gemm(
             A,
             B.t(),
             self.config.out_dtype,
             As,
-            Bs.t().contiguous(),
+            Bs,
             torch.Tensor(),
         )

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -236,7 +236,10 @@ class LlamaModel(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if input_embeds is None:
             input_embeds = self.embed_input_ids(input_ids)
-        assert hidden_states.shape[-1] == input_embeds.shape[-1]
+        torch._assert(
+            hidden_states.shape[-1] == input_embeds.shape[-1],
+            "hidden_states and input_embeds must have the same last dimension",
+        )
 
         residual = None
         for layer in self.layers:


### PR DESCRIPTION
## Summary

Replace the bare Python `assert` in `Eagle3LlamaModel` with `torch._assert()` so that the shape check is compatible with `torch.compile` / AOT compilation.

Under `torch.compile`, a bare `assert` on symbolic shapes can cause a `UserError`, while `torch._assert()` is lowered into the graph safely.

## Changes
- `vllm/model_executor/models/llama_eagle3.py`: replace `assert hidden_states.shape[-1] == input_embeds.shape[-1]` with `torch._assert(...)`