### PR TITLE
Fix sparse BlockStored event token/hash mapping

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2049,6 +2049,83 @@ def test_null_parent_block_hash():
     assert blocks[num_full_blocks - 1].block_hash is not None
 
 
+def test_block_stored_event_offsets_for_null_blocks():
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_null_event_offsets",
+        prompt_token_ids=list(range(2 * block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = [pool.null_block, *pool.get_new_blocks(1)]
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+
+    events = pool.take_events()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[1])
+    ]
+    assert event.extra_keys == [None]
+    assert event.token_ids == list(req.all_token_ids)
+    assert event.block_offsets == [1]
+
+
+def test_block_stored_event_offsets_for_masked_blocks():
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_masked_event_offsets",
+        prompt_token_ids=list(range(2 * block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = pool.get_new_blocks(2)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=0,
+        block_mask=[False, True],
+    )
+
+    events = pool.take_events()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[1])
+    ]
+    assert event.extra_keys == [None]
+    assert event.token_ids == list(req.all_token_ids)
+    assert event.block_offsets == [1]
+    assert blocks[0].block_hash is None
+    assert blocks[1].block_hash is not None
+
+
 @pytest.mark.parametrize("blocks_to_cache", [2, 3, 10])
 def test_kv_cache_events_with_lora(blocks_to_cache: int):
     """Test BlockStored events contain correct lora_id when using LoRA requests."""

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2267,6 +2267,191 @@ def test_null_parent_block_hash():
     assert blocks[num_full_blocks - 1].block_hash is not None
 
 
+def test_block_stored_event_splits_around_null_blocks():
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_null_event_split",
+        prompt_token_ids=list(range(2 * block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = [pool.null_block, *pool.get_new_blocks(1)]
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+
+    events = pool.take_events()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
+        req.block_hashes[0]
+    )
+    assert event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[1])
+    ]
+    assert event.extra_keys == [None]
+    assert event.token_ids == list(req.all_token_ids[block_size:])
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(req.all_token_ids[:block_size])
+    assert event.skipped_extra_keys == [None]
+    assert pool.null_block.block_hash is None
+    assert blocks[1].block_hash is not None
+
+
+def test_block_stored_event_splits_around_masked_blocks():
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_masked_event_split",
+        prompt_token_ids=list(range(2 * block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = pool.get_new_blocks(2)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=0,
+        block_mask=[False, True],
+    )
+
+    events = pool.take_events()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.parent_block_hash == kv_cache_utils.maybe_convert_block_hash(
+        req.block_hashes[0]
+    )
+    assert event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[1])
+    ]
+    assert event.extra_keys == [None]
+    assert event.token_ids == list(req.all_token_ids[block_size:])
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(req.all_token_ids[:block_size])
+    assert event.skipped_extra_keys == [None]
+    assert blocks[0].block_hash is None
+    assert blocks[1].block_hash is not None
+
+
+def test_block_stored_event_emits_dense_runs_around_masked_block():
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_contiguous_prefix_event",
+        prompt_token_ids=list(range(3 * block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = pool.get_new_blocks(3)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+        block_mask=[True, False, True],
+    )
+
+    events = pool.take_events()
+    assert len(events) == 2
+    first_event, second_event = events
+    assert isinstance(first_event, BlockStored)
+    assert first_event.parent_block_hash is None
+    assert first_event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[0])
+    ]
+    assert first_event.extra_keys == [None]
+    assert first_event.token_ids == list(req.all_token_ids[:block_size])
+    assert first_event.skipped_parent_block_hash is None
+    assert first_event.skipped_token_ids is None
+    assert first_event.skipped_extra_keys is None
+    assert isinstance(second_event, BlockStored)
+    expected_parent = kv_cache_utils.maybe_convert_block_hash(req.block_hashes[1])
+    assert second_event.parent_block_hash == expected_parent
+    assert second_event.block_hashes == [
+        kv_cache_utils.maybe_convert_block_hash(req.block_hashes[2])
+    ]
+    assert second_event.extra_keys == [None]
+    assert second_event.token_ids == list(req.all_token_ids[2 * block_size :])
+    expected_skipped_parent = kv_cache_utils.maybe_convert_block_hash(
+        req.block_hashes[0]
+    )
+    assert second_event.skipped_parent_block_hash == expected_skipped_parent
+    assert second_event.skipped_token_ids == list(
+        req.all_token_ids[block_size : 2 * block_size]
+    )
+    assert second_event.skipped_extra_keys == [None]
+    assert all(block.block_hash is not None for block in blocks[::2])
+    assert blocks[1].block_hash is None
+
+
+def test_block_stored_event_skipped_context_includes_extra_keys():
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_skipped_event_context_extra_keys",
+        prompt_token_ids=list(range(2 * block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+        cache_salt="salt",
+    )
+    blocks = pool.get_new_blocks(2)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=0,
+        block_mask=[False, True],
+    )
+
+    events = pool.take_events()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.extra_keys == [None]
+    assert event.skipped_parent_block_hash is None
+    assert event.skipped_token_ids == list(req.all_token_ids[:block_size])
+    assert event.skipped_extra_keys == [("salt",)]
+
+
 @pytest.mark.parametrize("blocks_to_cache", [2, 3, 10])
 def test_kv_cache_events_with_lora(blocks_to_cache: int):
     """Test BlockStored events contain correct lora_id when using LoRA requests."""

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -72,6 +72,13 @@ class BlockStored(KVCacheEvent):
     # filter groups as they are learned. Remove events only need group_idx+hash.
     kv_cache_spec_kind: str | None = None
     kv_cache_spec_sliding_window: int | None = None
+    block_offsets: list[int] | None = None
+    """Optional offsets mapping block_hashes to token_ids chunks.
+
+    When present, ``block_offsets[i]`` is the block-sized chunk index inside
+    ``token_ids`` for ``block_hashes[i]``. ``None`` means dense layout:
+    block_hashes are aligned with token_ids chunks from the beginning.
+    """
 
     def __hash__(self) -> int:
         return hash(
@@ -86,6 +93,7 @@ class BlockStored(KVCacheEvent):
                 self.group_idx,
                 self.kv_cache_spec_kind,
                 self.kv_cache_spec_sliding_window,
+                tuple(self.block_offsets) if self.block_offsets else None,
             )
         )
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -71,6 +71,16 @@ class BlockStored(KVCacheEvent):
     """Store events carry cache-spec metadata so consumers can classify and
     filter groups as they are learned. Remove events only need group_idx+hash.
     """
+
+    skipped_parent_block_hash: ExternalBlockHash | None = None
+    """Parent hash for skipped token context preceding this store event."""
+
+    skipped_token_ids: list[int] | None = None
+    """Logical token span for skipped blocks preceding this store event."""
+
+    skipped_extra_keys: list[tuple[Any, ...] | None] | None = None
+    """Extra keys for ``skipped_token_ids``, one entry per skipped block."""
+
     group_idx: int | None = None
     kv_cache_spec_kind: str | None = None
     kv_cache_spec_sliding_window: int | None = None
@@ -95,6 +105,9 @@ class BlockStored(KVCacheEvent):
                 self.lora_id,
                 self.medium,
                 tuple(self.extra_keys) if self.extra_keys else None,
+                self.skipped_parent_block_hash,
+                tuple(self.skipped_token_ids) if self.skipped_token_ids else None,
+                tuple(self.skipped_extra_keys) if self.skipped_extra_keys else None,
                 self.group_idx,
                 self.kv_cache_spec_kind,
                 self.kv_cache_spec_sliding_window,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -264,6 +264,9 @@ class BlockPool:
         new_hashes: list[ExternalBlockHash] | None = (
             [] if self.enable_kv_cache_events else None
         )
+        new_block_offsets: list[int] | None = (
+            [] if self.enable_kv_cache_events else None
+        )
         for i, blk in enumerate(new_full_blocks):
             # Some blocks may be null or masked out when enabling sparse attention
             # like sliding window attention, or Mamba models with prefix-caching
@@ -281,6 +284,8 @@ class BlockPool:
             self.cached_block_hash_to_block.insert(block_hash_with_group_id, blk)
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
+                assert new_block_offsets is not None
+                new_block_offsets.append(i)
 
         if self.enable_kv_cache_events:
             if num_cached_blocks == 0:
@@ -293,6 +298,12 @@ class BlockPool:
             # Calculate token range for the blocks being cached
             start_token_idx = num_cached_blocks * block_size
             end_token_idx = num_full_blocks * block_size
+            assert new_block_offsets is not None
+            block_offsets = (
+                None
+                if new_block_offsets == list(range(len(new_full_blocks)))
+                else new_block_offsets
+            )
 
             # Generate extra keys for each block individually.
             # Each block may have different extra_keys (e.g., different MM
@@ -327,6 +338,7 @@ class BlockPool:
                     else None,
                     extra_keys=extra_keys_list if extra_keys_list else None,
                     group_idx=kv_cache_group_id,
+                    block_offsets=block_offsets,
                 )
             )
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -265,14 +265,26 @@ class BlockPool:
         )
 
         new_block_hashes = block_hashes[num_cached_blocks:]
-        new_hashes: list[ExternalBlockHash] | None = (
-            [] if self.enable_kv_cache_events else None
-        )
+        # KV events must stay dense: split around skipped logical blocks so each
+        # event's parent is the immediate predecessor of its first block.
+        event_runs: list[tuple[int, int, list[ExternalBlockHash]]] = []
+        event_start_idx: int | None = None
+        event_hashes: list[ExternalBlockHash] = []
         for i, blk in enumerate(new_full_blocks):
             # Some blocks may be null or masked out when enabling sparse attention
             # like sliding window attention, or Mamba models with prefix-caching
             # in align mode. We skip null blocks here.
             if blk.is_null or (block_mask is not None and not block_mask[i]):
+                if self.enable_kv_cache_events and event_start_idx is not None:
+                    event_runs.append(
+                        (
+                            event_start_idx,
+                            num_cached_blocks + i,
+                            event_hashes,
+                        )
+                    )
+                    event_start_idx = None
+                    event_hashes = []
                 continue
             block_hash = new_block_hashes[i]
             num_hash_tokens = (num_cached_blocks + i + 1) * block_size
@@ -295,51 +307,92 @@ class BlockPool:
                 blk,
                 num_tokens=num_hash_tokens,
             )
-            if new_hashes is not None:
-                new_hashes.append(maybe_convert_block_hash(block_hash))
+            if self.enable_kv_cache_events:
+                if event_start_idx is None:
+                    event_start_idx = num_cached_blocks + i
+                event_hashes.append(maybe_convert_block_hash(block_hash))
 
-        if self.enable_kv_cache_events:
-            if num_cached_blocks == 0:
+        if self.enable_kv_cache_events and event_start_idx is not None:
+            event_runs.append((event_start_idx, num_full_blocks, event_hashes))
+
+        last_event_end_idx = num_cached_blocks
+        for event_start_idx, event_end_idx, event_hashes in event_runs:
+            if event_start_idx == 0:
                 parent_block_hash: ExternalBlockHash | None = None
             else:
                 parent_block_hash = maybe_convert_block_hash(
-                    block_hashes[num_cached_blocks - 1]
+                    block_hashes[event_start_idx - 1]
                 )
 
+            if event_start_idx > last_event_end_idx:
+                skipped_parent_block_hash = (
+                    None
+                    if last_event_end_idx == 0
+                    else maybe_convert_block_hash(block_hashes[last_event_end_idx - 1])
+                )
+                skipped_start_token_idx = last_event_end_idx * block_size
+                skipped_end_token_idx = event_start_idx * block_size
+                skipped_extra_keys = self._generate_block_extra_keys(
+                    request,
+                    last_event_end_idx,
+                    event_start_idx,
+                    block_size,
+                )
+            else:
+                skipped_parent_block_hash = None
+                skipped_start_token_idx = None
+                skipped_end_token_idx = None
+                skipped_extra_keys = None
+
             # Calculate token range for the blocks being cached
-            start_token_idx = num_cached_blocks * block_size
-            end_token_idx = num_full_blocks * block_size
+            start_token_idx = event_start_idx * block_size
+            end_token_idx = event_end_idx * block_size
 
             # Generate extra keys for each block individually.
             # Each block may have different extra_keys (e.g., different MM
             # features, or cache_salt only for the first block).
-            # Skip null/masked-out blocks to match the length of new_hashes.
-            extra_keys_list: list[tuple[Any, ...] | None] = []
-            curr_mm_idx = 0
-            for i in range(num_cached_blocks, num_full_blocks):
-                if blocks[i].is_null:
-                    continue
-                if block_mask is not None and not block_mask[i - num_cached_blocks]:
-                    continue
-                block_start = i * block_size
-                block_end = block_start + block_size
-                extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
-                    request, block_start, block_end, curr_mm_idx
-                )
-                extra_keys_list.append(extra_keys)
+            extra_keys_list = self._generate_block_extra_keys(
+                request,
+                event_start_idx,
+                event_end_idx,
+                block_size,
+            )
 
             self.kv_event_queue.append(
                 self._build_block_stored_event(
                     request,
-                    block_hashes=new_hashes,
+                    block_hashes=event_hashes,
                     parent_block_hash=parent_block_hash,
                     start_token_idx=start_token_idx,
                     end_token_idx=end_token_idx,
                     block_size=block_size,
                     kv_cache_group_id=kv_cache_group_id,
                     extra_keys_list=extra_keys_list,
+                    skipped_parent_block_hash=skipped_parent_block_hash,
+                    skipped_start_token_idx=skipped_start_token_idx,
+                    skipped_end_token_idx=skipped_end_token_idx,
+                    skipped_extra_keys=skipped_extra_keys,
                 )
             )
+            last_event_end_idx = event_end_idx
+
+    def _generate_block_extra_keys(
+        self,
+        request: Request,
+        start_block_idx: int,
+        end_block_idx: int,
+        block_size: int,
+    ) -> list[tuple[Any, ...] | None]:
+        extra_keys_list: list[tuple[Any, ...] | None] = []
+        curr_mm_idx = 0
+        for i in range(start_block_idx, end_block_idx):
+            block_start = i * block_size
+            block_end = block_start + block_size
+            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
+                request, block_start, block_end, curr_mm_idx
+            )
+            extra_keys_list.append(extra_keys)
+        return extra_keys_list
 
     def _build_block_stored_event(
         self,
@@ -351,6 +404,10 @@ class BlockPool:
         block_size: int,
         kv_cache_group_id: int,
         extra_keys_list: list[tuple[Any, ...] | None],
+        skipped_parent_block_hash: ExternalBlockHash | None = None,
+        skipped_start_token_idx: int | None = None,
+        skipped_end_token_idx: int | None = None,
+        skipped_extra_keys: list[tuple[Any, ...] | None] | None = None,
     ) -> BlockStored:
         """Build a ``BlockStored`` KV event for ``request``.
 
@@ -367,6 +424,14 @@ class BlockPool:
             medium=MEDIUM_GPU,
             lora_name=request.lora_request.name if request.lora_request else None,
             extra_keys=extra_keys_list if extra_keys_list else None,
+            skipped_parent_block_hash=skipped_parent_block_hash,
+            skipped_token_ids=request.all_token_ids[
+                skipped_start_token_idx:skipped_end_token_idx
+            ]
+            if skipped_start_token_idx is not None
+            and skipped_end_token_idx is not None
+            else None,
+            skipped_extra_keys=skipped_extra_keys,
             group_idx=kv_cache_group_id,
             session_id=request.session_id,
         )


### PR DESCRIPTION



## Purpose
Fixes #44451.
`BlockStored` events can become ambiguous when a KV cache group skips logical blocks, such as Mamba groups with `--mamba-cache-mode align`.
Before this change, `block_hashes` and `extra_keys` only included emitted non-null blocks, while `token_ids` still covered the full logical token range. This could produce sparse events like one block hash with multiple block-sized token chunks, without enough metadata for external KV event consumers to determine which token chunk belongs to the emitted hash.
This PR adds optional `BlockStored.block_offsets`. When present, `block_offsets[i]` identifies the block-sized chunk in `token_ids` corresponding to `block_hashes[i]`. Dense events keep `block_offsets=None`.
## Test Plan
Unit tests:
```bash
python -m pytest \
  tests/v1/core/test_prefix_caching.py::test_block_stored_event_offsets_for_null_blocks \
  tests/v1/core/test_prefix_caching.py::test_block_stored_event_offsets_for_masked_blocks \
  -q
```
End-to-end validation used a Qwen3.5 Mamba align server with KV events enabled:
```bash
vllm serve /mnt/models/Qwen/Qwen3.5-4B \
  --trust-remote-code \
  --enable-prefix-caching \
  --mamba-cache-mode align \
  --max-num-seqs 1 \
  --gpu-memory-utilization 0.90 \
  --enforce-eager \
  --skip-mm-profiling \
  --limit-mm-per-prompt '{"image": 0, "video": 0}' \
  --kv-events-config '{"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:8100"}'
```
The e2e verifier subscribes to the ZMQ KV event stream, sends OpenAI-compatible completion requests, and checks that every sparse BlockStored event has reconstructable hash-to-token mapping:
```bash
import threading
import time
from collections import Counter
from typing import Any

import msgspec
import requests
import zmq
from msgspec.msgpack import Decoder


class EventBatch(msgspec.Struct, array_like=True, omit_defaults=True, gc=False):
    ts: float
    events: list[Any]
    data_parallel_rank: int | None = None


class KVCacheEvent(
    msgspec.Struct, array_like=True, omit_defaults=True, gc=False, tag=True
):
    pass


class BlockStored(KVCacheEvent):
    block_hashes: list[Any]
    parent_block_hash: Any | None
    token_ids: list[int]
    block_size: int
    lora_id: int | None
    medium: str | None
    lora_name: str | None
    extra_keys: list[tuple[Any, ...] | None] | None = None
    group_idx: int | None = None
    kv_cache_spec_kind: str | None = None
    kv_cache_spec_sliding_window: int | None = None
    block_offsets: list[int] | None = None


class BlockRemoved(KVCacheEvent):
    block_hashes: list[Any]
    medium: str | None
    group_idx: int | None = None


class AllBlocksCleared(KVCacheEvent):
    pass


class KVEventBatch(EventBatch):
    events: list[BlockStored | BlockRemoved | AllBlocksCleared]


stats = Counter()
bad_events = []
sparse_events = []


def listen(stop_event):
    decoder = Decoder(type=KVEventBatch)

    ctx = zmq.Context()
    sub = ctx.socket(zmq.SUB)
    sub.connect("tcp://<server-host>:8100")
    sub.setsockopt(zmq.SUBSCRIBE, b"")

    poller = zmq.Poller()
    poller.register(sub, zmq.POLLIN)

    while not stop_event.is_set():
        if not poller.poll(500):
            continue

        frames = sub.recv_multipart()
        stats["raw_zmq"] += 1

        try:
            _, _, payload = frames
            batch = decoder.decode(payload)
        except Exception:
            stats["decode_error"] += 1
            continue

        for event in batch.events:
            if not isinstance(event, BlockStored):
                continue

            stats["block_stored"] += 1
            token_blocks = len(event.token_ids) // event.block_size
            hash_blocks = len(event.block_hashes)

            if event.kv_cache_spec_kind:
                stats[f"kind:{event.kv_cache_spec_kind}"] += 1

            if token_blocks > hash_blocks:
                stats["sparse"] += 1
                record = {
                    "group_idx": event.group_idx,
                    "kind": event.kv_cache_spec_kind,
                    "block_size": event.block_size,
                    "token_blocks": token_blocks,
                    "hash_blocks": hash_blocks,
                    "len_token_ids": len(event.token_ids),
                    "block_offsets": event.block_offsets,
                }
                sparse_events.append(record)

                ok = (
                    event.block_offsets is not None
                    and len(event.block_offsets) == hash_blocks
                    and all(0 <= off < token_blocks for off in event.block_offsets)
                )
                if not ok:
                    bad_events.append(record)


def send_requests():
    base_url = "http://<server-host>:8000"
    model = "/mnt/models/Qwen/Qwen3.5-4B"
    url = f"{base_url}/v1/completions"

    lengths = [500, 527, 529, 800, 1055, 1057, 1584, 2112, 2500, 3168]
    salts = ["same-salt", "tenant-A", "tenant-B"]

    for salt in salts:
        for n in lengths:
            prompt = f"{salt}\n" + " ".join(f"tok{i}" for i in range(n))
            r = requests.post(
                url,
                json={
                    "model": model,
                    "prompt": prompt,
                    "temperature": 0,
                    "max_tokens": 16,
                },
                timeout=120,
            )
            r.raise_for_status()


def main():
    stop_event = threading.Event()
    t = threading.Thread(target=listen, args=(stop_event,), daemon=True)
    t.start()

    time.sleep(1)
    send_requests()
    time.sleep(3)

    stop_event.set()
    t.join(timeout=2)

    print("Summary:", dict(stats))
    print("Sparse events:")
    for event in sparse_events:
        print(event)

    if bad_events:
        print("BAD sparse events:")
        for event in bad_events:
            print(event)
        raise SystemExit(1)

    if not sparse_events:
        print("No sparse events observed.")
        raise SystemExit(2)

    print("PASS: sparse BlockStored events are reconstructable.")


if __name__ == "__main__":
    main()
```
## Test Result
```
Unit tests pass.
```
Before the fix, reverting the code reproduces ambiguous sparse Mamba events:
BAD sparse events:
```
{'group_idx': 0, 'kind': 'mamba', 'block_size': 528, 'token_blocks': 3, 'hash_blocks': 1, 'len_token_ids': 1584, 'block_offsets': None}
{'group_idx': 1, 'kind': 'mamba', 'block_size': 528, 'token_blocks': 3, 'hash_blocks': 1, 'len_token_ids': 1584, 'block_offsets': None}
{'group_idx': 2, 'kind': 'mamba', 'block_size': 528, 'token_blocks': 2, 'hash_blocks': 1, 'len_token_ids': 1056, 'block_offsets': None}
```
After the fix, sparse Mamba events include offsets and pass validation:
```
{'group_idx': 0, 'kind': 'mamba', 'block_size': 528, 'token_blocks': 3, 'hash_blocks': 1, 'len_token_ids': 1584, 'block_offsets': [2]}
{'group_idx': 1, 'kind': 'mamba', 'block_size': 528, 'token_blocks': 3, 'hash_blocks': 1, 'len_token_ids': 1584, 'block_offsets': [2]}
{'group_idx': 2, 'kind': 'mamba', 'block_size': 528, 'token_blocks': 3, 'hash_blocks': 1, 'len_token_ids': 1584, 'block_offsets': [2]}
PASS: sparse BlockStored events are reconstructable.
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

