### PR TITLE
[Bugfix] Fix ZMQ port TOCTOU race in shm_broadcast.py

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -32,7 +32,6 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import (
     get_ip,
-    get_open_port,
     get_open_zmq_inproc_path,
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,
@@ -425,14 +424,16 @@ class MessageQueue:
                 connect_ip = get_ip()
             self.remote_socket = context.socket(XPUB)
             self.remote_socket.setsockopt(XPUB_VERBOSE, True)
-            remote_subscribe_port = get_open_port()
             if is_valid_ipv6_address(connect_ip):
                 self.remote_socket.setsockopt(IPV6, 1)
                 remote_addr_ipv6 = True
                 connect_ip = f"[{connect_ip}]"
-            socket_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
-            self.remote_socket.bind(socket_addr)
-            remote_subscribe_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
+            # Bind to port 0 so the OS assigns a port atomically,
+            # avoiding TOCTOU race with get_open_port(). (See #28498)
+            self.remote_socket.bind(f"tcp://{connect_ip}:0")
+            remote_subscribe_addr = (
+                self.remote_socket.getsockopt(zmq.LAST_ENDPOINT).decode()
+            )
         else:
             remote_subscribe_addr = None
             self.remote_socket = None


### PR DESCRIPTION
 ## Summary

  - Fix TOCTOU (time-of-check-time-of-use) race condition in `MessageQueue.__init__` where `get_open_port()` discovers a port, but another process (e.g., Ray) can claim it 
  before the ZMQ XPUB socket binds — causing `zmq.error.ZMQError: Address already in use`
  - Replace with late binding (`port=0`), letting the OS assign the port atomically at `bind()` time, then read back the real address via `zmq.LAST_ENDPOINT`
  - Follows the same pattern already merged in the DP coordinator (PR #37452)

  ## Motivation

  In multi-node deployments (e.g., 2P 4D with DeepSeek-V3), engine startup takes ~5 minutes after port selection. During this window, other services can claim the
  pre-selected port. This fix eliminates that race window entirely.

  ## Changes

  - `vllm/distributed/device_communicators/shm_broadcast.py`:
    - Removed `get_open_port()` call for remote subscriber socket
    - Bind to `tcp://{connect_ip}:0` instead of a pre-selected port
    - Read actual bound endpoint via `self.remote_socket.getsockopt(zmq.LAST_ENDPOINT).decode()`
    - Removed unused `get_open_port` import

  ## Existing PRs

  PRs #30520, #35977, and #39496 address the same issue but have been stalled with merge conflicts for 3+ months. This PR is a minimal, focused fix for the one remaining   
  TOCTOU site (`shm_broadcast.py`), since the coordinator side was already fixed by PR #37452.

  ## Test plan

  - [x] Existing `shm_broadcast` tests pass (the fix is a drop-in replacement — same bind semantics, same address format from `LAST_ENDPOINT`)
  - [x] Multi-node deployments no longer hit `Address already in use` on the remote XPUB socket

  ## AI disclosure

  This PR was developed with AI assistance (Claude). All code has been reviewed and understood by the human submitter.

  Closes #28498