### PR TITLE
Fix fastsafetensors installation issue on non-x86_64 platforms

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -18,7 +18,7 @@ tilelang==0.1.9
 nvidia-cudnn-frontend>=1.13.0,<1.19.0
 
 # Required for faster safetensors model loading
-fastsafetensors >= 0.2.2
+fastsafetensors >= 0.2.2; platform_machine == "x86_64"
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
 nvidia-cutlass-dsl[cu13]==4.5.2

--- a/requirements/test/nightly-torch.txt
+++ b/requirements/test/nightly-torch.txt
@@ -43,6 +43,6 @@ tritonclient>=2.51.0
 numba == 0.65.0 # Required for N-gram speculative decoding
 numpy
 runai-model-streamer[s3,gcs,azure]==0.15.7
-fastsafetensors>=0.2.2
+fastsafetensors>=0.2.2; platform_machine == "x86_64"
 instanttensor>=0.1.5
 pydantic>=2.12 # 2.11 leads to error on python 3.13


### PR DESCRIPTION



## Purpose(closes #44407)

Fix installation issues on aarch64 platforms by restricting `fastsafetensors` to x86_64 environments in:

* `requirements/cuda.txt`
* `requirements/test/nightly-torch.txt`

`fastsafetensors` currently only provides x86_64 wheels on PyPI. On aarch64, package managers attempt a source build, which fails due to an upstream packaging issue (missing `pybind11` in build requirements).

This change is consistent with the existing guard already present in `requirements/test/cuda.in`.

## Test Plan

* Verified the dependency changes in both requirements files.
* Confirmed that `weight_utils.py` already handles missing `fastsafetensors` imports through the existing `try/except ImportError` fallback.

## Test Result

* x86_64 installations remain unchanged.
* aarch64 environments no longer attempt to install `fastsafetensors` through these requirements, avoiding the known source-build failure.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

