### PR TITLE
[WIP][Kernel][CuTeDSL] Quant Scaled MM Per (Tensor/token/channel) FP8/INT8 kernel in CuTeDSL

### DIFF
--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -15,6 +15,9 @@ from utils import make_rand_tensors
 from weight_shapes import WEIGHT_SHAPES
 
 from vllm import _custom_ops as ops
+from vllm.kernels.quantization.cutedsl.scaled_mm_dispatch import (
+    cutedsl_scaled_mm,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     w8a8_triton_block_scaled_mm,
 )
@@ -30,7 +33,7 @@ DEFAULT_TP_SIZES = [1]
 def bench_fn(
     label: str, sub_label: str, description: str, fn: Callable, *args, **kwargs
 ) -> TMeasurement:
-    min_run_time = 1
+    min_run_time = 2
 
     globals = {
         "args": args,
@@ -60,9 +63,20 @@ def bench_int8(
     a, b = make_rand_tensors(torch.int8, m, n, k)
     scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
     scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    per_token_scale_a = torch.rand((m, 1), device="cuda", dtype=torch.float32)
+    per_channel_scale_b = torch.rand(
+        (1, n), device="cuda", dtype=torch.float32
+    )
     bias = torch.zeros((n,), device="cuda", dtype=torch.bfloat16)
     azp = torch.zeros((m,), device="cuda", dtype=torch.int32)
     azp_adj = torch.zeros((n,), device="cuda", dtype=torch.int32)
+
+    # Pre-compile once so the benchmark measures steady-state, not
+    # torch.compile's JIT tracing/compilation overhead.
+    cutedsl_compiled_per_token_channel = torch.compile(
+        cutedsl_scaled_mm, dynamic=True)
+    cutedsl_compiled_per_token_channel(
+        a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16)
 
     bench_fns = {
         "pytorch_bf16_bf16_bf16_matmul-no-scales": lambda: torch.mm(
@@ -89,12 +103,33 @@ def bench_int8(
         "cutlass_i8_i8_bf16_scaled_mm_azp_pt_bias": lambda: ops.cutlass_scaled_mm_azp(
             a, b, scale_a, scale_b, torch.bfloat16, azp_adj, azp, bias
         ),
+        "cutedsl_i8_i8_bf16_scaled_mm": lambda: cutedsl_scaled_mm(
+            a, b, scale_a, scale_b, torch.bfloat16
+        ),
+        "cutedsl_i8_i8_bf16_scaled_mm_bias": lambda: cutedsl_scaled_mm(
+            a, b, scale_a, scale_b, torch.bfloat16, bias
+        ),
+        "cutedsl_i8_i8_bf16_scaled_mm_per_token_channel": lambda: cutedsl_scaled_mm(
+            a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16
+        ),
+        "cutedsl_i8_i8_bf16_compiled_per_token_channel": lambda: cutedsl_compiled_per_token_channel(
+            a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16
+        ),
+        "cutlass_i8_i8_bf16_scaled_mm_per_token_channel": lambda: ops.cutlass_scaled_mm(
+            a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16
+        ),
     }
 
     timers = []
     for name, fn in bench_fns.items():
         # If bench_kernels is None, run all. Otherwise, run only exact matches.
         if bench_kernels is None or name in bench_kernels:
+            # Skip CuTe DSL benchmarks when unsupported (returns None).
+            if name.startswith("cutedsl_"):
+                result = fn()
+                if result is None:
+                    print(f"Skipping {name} (not supported on this GPU)")
+                    continue
             print(f"Running {name}")
             timers.append(bench_fn(label, sub_label, name, fn))
 
@@ -116,6 +151,10 @@ def bench_fp8(
     a_cont = a.contiguous()
     scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
     scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    per_token_scale_a = torch.rand((m, 1), device="cuda", dtype=torch.float32)
+    per_channel_scale_b = torch.rand(
+        (1, n), device="cuda", dtype=torch.float32
+    )
 
     block_scale_a = torch.rand((m, cdiv(k, 128)), device="cuda", dtype=torch.float32)
     block_scale_b = torch.rand(
@@ -126,6 +165,13 @@ def bench_fp8(
     bias = torch.zeros((n,), device="cuda", dtype=torch.bfloat16)
 
     print(m, k, n)
+
+    # Pre-compile once so the benchmark measures steady-state, not
+    # torch.compile's JIT tracing/compilation overhead.
+    cutedsl_compiled_per_token_channel = torch.compile(
+        cutedsl_scaled_mm, dynamic=True)
+    cutedsl_compiled_per_token_channel(
+        a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16)
 
     bench_fns = {
         "pytorch_bf16_bf16_bf16_matmul-no-scales": lambda: torch.mm(
@@ -164,12 +210,39 @@ def bench_fp8(
         "cutlass_fp8_fp8_fp16_scaled_mm_blockwise": lambda: ops.cutlass_scaled_mm(
             a, b, block_scale_a_M_major, block_scale_b_K_major, torch.float16
         ),
+        "cutedsl_fp8_fp8_bf16_scaled_mm": lambda: cutedsl_scaled_mm(
+            a, b, scale_a, scale_b, torch.bfloat16
+        ),
+        "cutedsl_fp8_fp8_fp16_scaled_mm": lambda: cutedsl_scaled_mm(
+            a, b, scale_a, scale_b, torch.float16
+        ),
+        "cutedsl_fp8_fp8_bf16_scaled_mm_bias": lambda: cutedsl_scaled_mm(
+            a, b, scale_a, scale_b, torch.bfloat16, bias
+        ),
+        "cutedsl_fp8_fp8_fp16_scaled_mm_bias": lambda: cutedsl_scaled_mm(
+            a, b, scale_a, scale_b, torch.float16, bias.to(dtype=torch.float16)
+        ),
+        "cutedsl_fp8_fp8_bf16_scaled_mm_per_token_channel": lambda: cutedsl_scaled_mm(
+            a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16
+        ),
+        "cutedsl_fp8_fp8_bf16_compiled_per_token_channel": lambda: cutedsl_compiled_per_token_channel(
+            a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16
+        ),
+        "cutlass_fp8_fp8_bf16_scaled_mm_per_token_channel": lambda: ops.cutlass_scaled_mm(
+            a, b, per_token_scale_a, per_channel_scale_b, torch.bfloat16
+        ),
     }
 
     timers = []
     for name, fn in bench_fns.items():
         # If bench_kernels is None, run all. Otherwise, run only exact matches.
         if bench_kernels is None or name in bench_kernels:
+            # Skip CuTe DSL benchmarks when unsupported (returns None).
+            if name.startswith("cutedsl_"):
+                result = fn()
+                if result is None:
+                    print(f"Skipping {name} (not supported on this GPU)")
+                    continue
             print(f"Running {name}")
             timers.append(bench_fn(label, sub_label, name, fn))
 
@@ -273,7 +346,6 @@ def run_model_bench(args):
         for m in Ms:
             for k, n in KNs:
                 MKNs.append((m, k, n))
-
         data = run(args.dtype, MKNs, bench_kernels=args.kernels)
         model_bench_data.append(data)
 
@@ -308,13 +380,13 @@ Benchmark Cutlass GEMM.
 
     To run square GEMMs:
         python3 ./benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype fp8 square_bench --dim-start 128 --dim-end 512 --dim-increment 64
-    
+
     To run constant N and K and sweep M:
         python3 ./benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype fp8 range_bench --dim-start 128 --dim-end 512 --dim-increment 64 --n-constant 16384 --k-constant 16384
-    
+
     To run dimensions from a model:
         python3 ./benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype fp8 model_bench --models meta-llama/Llama-2-7b-hf --batch-sizes 16 --tp-sizes 1
-    
+
     Output:
         - a .pkl file, that is a list of raw torch.benchmark.utils.Measurements for the pytorch and cutlass implementations for the various GEMMs.
             """,  # noqa: E501

--- a/scripts/benchmark_cutedsl_kernel.py
+++ b/scripts/benchmark_cutedsl_kernel.py
@@ -1,0 +1,219 @@
+"""
+This script benchmarks the cutedsl kernel against the cutlass kernel for 
+various input sizes and configurations. It uses triton.do_bench tool for benchmarking.
+It generates random input tensors, runs both kernels multiple times, and measures 
+their execution time. The results are printed in a tabular format, showing the 
+average execution time for each kernel and the speedup achieved by the cutedsl 
+kernel over the cutlass kernel.
+"""
+import copy
+import math
+from dataclasses import dataclass
+from itertools import product
+from typing import Any
+
+import torch
+import triton
+
+from vllm.kernels.helion.case_key import CaseKey
+from vllm.kernels.quantization.cutedsl.scaled_mm_dispatch import (
+    cutedsl_scaled_mm,
+)
+from vllm.platforms import current_platform
+
+
+@dataclass
+class Row:
+    case: str
+    cutedsl_ms: float
+    cutlass_ms: float
+    speedup_x: float
+
+
+def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
+    m_size_list = [1, 2, 4, 8, 16, 32, 64, 128]
+    b_shape_list = [
+        # qwen3-1.7B
+        # TP=1
+        # (2048, 4096),
+        # (2048, 2048),
+        # (2048, 12288),
+        # (6144, 2048),
+        # # qwen3-8B
+        # # TP=1
+        # (4096, 6144),
+        (4096, 4096),
+        # (4096, 24576),
+        # (12288, 4096),
+        # # qwen3-32B
+        # # TP=1
+        # (5120, 10240),
+        # (5120, 5120),
+        # (5120, 51200),
+        # (25600, 5120),
+    ]
+
+    in_dtype: torch.dtype = current_platform.fp8_dtype()
+    scale_dtype: torch.dtype = torch.float32
+    out_dtype: torch.dtype = torch.bfloat16
+    inputs = {}
+    for M, (K, N) in product(m_size_list, b_shape_list):
+        scale = 1.0 / math.sqrt(K)
+        a = (scale * (0.5 + torch.rand(M, K, dtype=torch.float32, device="cuda"))).to(
+            in_dtype
+        )
+        b = (scale * (0.5 + torch.rand(N, K, dtype=torch.float32, device="cuda"))).to(
+            in_dtype
+        )
+        b = b.t()
+        c = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        # per token
+        scale_a = 0.5 + torch.rand((1, M), dtype=scale_dtype, device="cuda")
+        scale_a = scale_a.t()
+        # per tensor
+        # scale_a = 0.5 + torch.rand((1, 1), dtype=scale_dtype, device="cuda")
+        # per tensor
+        scale_b = 0.5 + torch.rand((1, 1), dtype=scale_dtype, device="cuda")
+        bias = 0.5 * (torch.rand(N, dtype=out_dtype, device="cuda") - 0.5)
+
+        config_key = CaseKey(
+            {
+                "K": K,
+                "N": N,
+                "M": M,
+            }
+        )
+        inputs[config_key] = (c, a, b, scale_a, scale_b, bias)
+
+    return inputs
+
+
+def baseline_cutedsl(
+    c: torch.Tensor,  # [M, N]
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    bias: torch.Tensor | None = None,  # [N]
+):
+    return cutedsl_scaled_mm(a, b, scale_a, scale_b, c.dtype, bias)
+
+
+def baseline_cutlass(
+    c: torch.Tensor,  # [M, N]
+    a: torch.Tensor,  # [M, K]
+    b: torch.Tensor,  # [K, N]
+    scale_a: torch.Tensor,  # [1]/[1, 1]/[M]/[M, 1]
+    scale_b: torch.Tensor,  # [1]/[1, 1]/[N]/[N, 1]
+    bias: torch.Tensor | None = None,  # [N]
+):
+    # re-initialize tensor c to get a fair comparison with cutlass
+    c = torch.empty((a.shape[0], b.shape[1]), dtype=c.dtype, device=a.device)
+    torch.ops._C.cutlass_scaled_mm(c, a, b, scale_a, scale_b, bias)
+    return c
+
+
+def print_table(rows: list[Row]) -> None:
+    headers = [
+        "case",
+        "cutedsl_ms",
+        "cutlass_ms",
+        "speedup(x)",
+    ]
+
+    data = [
+        [
+            r.case,
+            f"{r.cutedsl_ms:.3f}",
+            f"{r.cutlass_ms:.3f}",
+            f"{r.speedup_x:.3f}",
+        ]
+        for r in rows
+    ]
+
+    cols = list(zip(*([headers] + data)))
+    widths = [max(len(cell) for cell in col) for col in cols]
+
+    def fmt(row: list[str]) -> str:
+        return " | ".join(cell.ljust(w) for cell, w in zip(row, widths))
+
+    print(fmt(headers))
+    print("-+-".join("-" * w for w in widths))
+    for row in data:
+        print(fmt(row))
+
+
+def cleanup_gpu_resources():
+    import gc
+
+    try:
+        if torch.cuda.is_available():
+            # Clear GPU memory cache
+            torch.cuda.empty_cache()
+
+            # Force garbage collection
+            gc.collect()
+
+            # Clear torch compilation cache
+            if hasattr(torch, "_dynamo"):
+                torch._dynamo.reset()
+
+            # Synchronize all CUDA streams
+            torch.cuda.synchronize()
+
+            # Reset peak memory stats for clean measurements
+            torch.cuda.reset_peak_memory_stats()
+
+            print("GPU resources cleaned up successfully")
+
+    except Exception as e:
+        print(f"Failed to cleanup GPU resources: {e}")
+
+
+@torch.inference_mode()
+def benchmark(cutlass_kernel, cutedsl_kernel, repeat=1000, cudagraph=True):
+    rows: list[Row] = []
+    benchmark_fn = (
+        triton.testing.do_bench_cudagraph if cudagraph else triton.testing.do_bench
+    )
+
+    inputs_dict = generate_inputs()
+
+    for key, inputs in inputs_dict.items():
+        try:
+            print(f"Start benchmarking with key {key}")
+
+            inputs_clone = copy.deepcopy(inputs)
+
+            cutlass_fn = lambda: cutlass_kernel(*inputs)
+            cutedsl_fn = lambda: cutedsl_kernel(*inputs_clone)
+
+            cutlass_latency = benchmark_fn(cutlass_fn, rep=repeat, return_mode="mean")
+
+            cutedsl_latency = benchmark_fn(
+                cutedsl_fn, rep=repeat, return_mode="mean"
+            )
+
+            speedup = cutedsl_latency / cutlass_latency
+
+            rows.append(
+                Row(
+                    case=str(key),
+                    cutedsl_ms=cutedsl_latency,
+                    cutlass_ms=cutlass_latency,
+                    speedup_x=speedup,
+                )
+            )
+
+            cleanup_gpu_resources()
+
+        except Exception as e:
+            raise e
+            print(f"Benchmarking failed for key {key}: {e}")
+            continue
+
+    print_table(rows)
+
+
+if __name__ == "__main__":
+    benchmark(baseline_cutlass, baseline_cutedsl)

--- a/scripts/benchmark_cutedsl_kernel_raw.py
+++ b/scripts/benchmark_cutedsl_kernel_raw.py
@@ -1,0 +1,554 @@
+"""
+Benchmark: CuTe DSL kernel vs CUTLASS C++ kernel for per-tensor FP8 scaled GEMM
+on NVIDIA Hopper (SM90).
+
+Compares:
+  1. CuTe DSL  - vllm/kernels/quantization/cutedsl/scaled_mm_sm90_fp8.py
+                 (ScaledMmSm90Fp8Kernel)
+  2. CUTLASS   - called via vllm._custom_ops.cutlass_scaled_mm
+                 (csrc/quantization/w8a8/cutlass/c3x/scaled_mm_sm90_fp8_dispatch.cuh)
+
+Both kernels compute:  D = scale_a * scale_b * (A @ B^T)
+  - A: (M, K) FP8 e4m3, row-major
+  - B: (N, K) FP8 e4m3, col-major  (stored as (N, K).T for CUTLASS C++)
+  - D: (M, N) BF16 or FP16
+  - scale_a, scale_b: per-tensor FP32 scalars
+
+Usage:
+    python scripts/benchmark_cutedsl_kernel_raw.py
+
+    # Custom sizes
+    python scripts/benchmark_cutedsl_kernel_raw.py \
+        --m 128,256,512,1024 --k 4096 --n 4096
+
+    # Use auto tile selection (mirrors C++ dispatch logic)
+    python scripts/benchmark_cutedsl_kernel_raw.py \
+        --auto-tile
+
+    # Override CuTe DSL tile/cluster
+    python scripts/benchmark_cutedsl_kernel_raw.py \
+        --tile-shape-mn 128,128 --cluster-shape-mn 2,1
+"""
+
+import argparse
+import os
+import sys
+import time
+from typing import Callable, List, Tuple
+
+import torch
+
+# ---------------------------------------------------------------------------
+# CuTe DSL imports (may not be installed everywhere)
+# ---------------------------------------------------------------------------
+_cute_dsl_available = False
+try:
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.torch as cutlass_torch
+
+    _cute_dsl_available = True
+except ImportError:
+    pass
+
+# ---------------------------------------------------------------------------
+# CUTLASS via vLLM custom ops
+# ---------------------------------------------------------------------------
+_cutlass_ops_available = False
+try:
+    from vllm import _custom_ops as ops
+
+    _cutlass_ops_available = True
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+OUT_DTYPE_MAP = {
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+}
+
+CUTE_C_DTYPE_MAP = {}
+if _cute_dsl_available:
+    CUTE_C_DTYPE_MAP = {
+        "bf16": cutlass.BFloat16,
+        "fp16": cutlass.Float16,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tensor creation: CUTLASS C++ path (PyTorch tensors)
+# ---------------------------------------------------------------------------
+def make_tensors_cutlass(
+    m: int, n: int, k: int, out_dtype: torch.dtype
+) -> Tuple[torch.Tensor, ...]:
+    """Create FP8 A/B and per-tensor FP32 scales for the CUTLASS C++ kernel.
+
+    CUTLASS expects:
+      a: (M, K) fp8, row-major (contiguous)
+      b: (N, K).T -> (K, N) fp8, column-major
+      scale_a: scalar fp32 (per-tensor)
+      scale_b: scalar fp32 (per-tensor)
+    """
+    a = torch.randn((m, k), device="cuda").to(torch.float8_e4m3fn)
+    # B stored as (N, K) transposed to (K, N) column-major
+    b = torch.randn((n, k), device="cuda").to(torch.float8_e4m3fn).t()
+
+    scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+
+    out = torch.empty((m, n), device="cuda", dtype=out_dtype)
+    return a, b, scale_a, scale_b, out
+
+
+# ---------------------------------------------------------------------------
+# Tensor creation: CuTe DSL path (CuTe tensors)
+# ---------------------------------------------------------------------------
+def make_tensors_cutedsl(m: int, n: int, k: int, c_dtype_str: str):
+    """Create CuTe-style 3D tensors for the CuTe DSL kernel.
+
+    A: (M, K, 1) K-major, B: (N, K, 1) K-major, C: (M, N, 1) N-major.
+    scale_a: (M, 1, 1) per-token FP32 (filled with 1.0 for per-tensor).
+    scale_b: (1, 1, 1) scalar FP32.
+    """
+    ab_dtype = cutlass.Float8E4M3FN
+    c_dtype = CUTE_C_DTYPE_MAP[c_dtype_str]
+    scale_dtype = cutlass.Float32
+    l = 1
+
+    torch.manual_seed(42)
+    a_cpu = cutlass_torch.matrix(l, m, k, False, ab_dtype)
+    b_cpu = cutlass_torch.matrix(l, n, k, False, ab_dtype)
+    c_cpu = cutlass_torch.matrix(l, m, n, False, c_dtype)
+    # scale_a is per-token (M, 1, 1) — uniform 1.0 for per-tensor benchmarking
+    sfa_cpu = cutlass_torch.matrix(1, m, 1, False, scale_dtype)
+    sfb_cpu = cutlass_torch.matrix(1, 1, 1, False, scale_dtype)
+
+    a_tensor, _ = cutlass_torch.cute_tensor_like(
+        a_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, _ = cutlass_torch.cute_tensor_like(
+        b_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    c_tensor, _ = cutlass_torch.cute_tensor_like(
+        c_cpu, c_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    sfa_tensor, _ = cutlass_torch.cute_tensor_like(
+        sfa_cpu, scale_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    sfb_tensor, _ = cutlass_torch.cute_tensor_like(
+        sfb_cpu, scale_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    return a_tensor, b_tensor, c_tensor, sfa_tensor, sfb_tensor
+
+
+# ---------------------------------------------------------------------------
+# CUDA-event based timing
+# ---------------------------------------------------------------------------
+def bench_cuda_events(
+    fn: Callable, warmup: int = 10, iters: int = 100
+) -> Tuple[float, float, float]:
+    """Time *fn* with CUDA events. Returns (median_ms, mean_ms, min_ms)."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+
+    for i in range(iters):
+        starts[i].record()
+        fn()
+        ends[i].record()
+    torch.cuda.synchronize()
+
+    times = sorted(s.elapsed_time(e) for s, e in zip(starts, ends))
+    median = times[len(times) // 2]
+    mean = sum(times) / len(times)
+    minimum = times[0]
+    return median, mean, minimum
+
+
+# ---------------------------------------------------------------------------
+# CuTe DSL kernel wrapper (compile once, launch many)
+# ---------------------------------------------------------------------------
+class CuteDslBenchWrapper:
+    """Wraps the CuTe DSL ScaledMmSm90Fp8Kernel for benchmarking.
+
+    Compiles the kernel once during __init__ and re-launches on each __call__.
+    """
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        c_dtype_str: str,
+        tile_shape_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ):
+        # Ensure the kernel module is importable
+        dsl_dir = os.path.join(
+            os.path.dirname(__file__), "..", "vllm", "kernels", "quantization", "cutedsl"
+        )
+        dsl_dir = os.path.abspath(dsl_dir)
+        if dsl_dir not in sys.path:
+            sys.path.insert(0, dsl_dir)
+
+        from scaled_mm_sm90_fp8 import ScaledMmSm90Fp8Kernel
+
+        self.tensors = make_tensors_cutedsl(m, n, k, c_dtype_str)
+        a_t, b_t, c_t, sfa_t, sfb_t = self.tensors
+
+        self.gemm = ScaledMmSm90Fp8Kernel(
+            acc_dtype=cutlass.Float32,
+            tile_shape_mn=tile_shape_mn,
+            cluster_shape_mn=cluster_shape_mn,
+        )
+
+        torch_stream = torch.cuda.current_stream()
+        self.stream = cuda.CUstream(torch_stream.cuda_stream)
+
+        # Determine compilation opt level
+        try:
+            from cutlass import CUDA_VERSION
+
+            opt_level = (
+                3
+                if CUDA_VERSION.major < 13
+                or (CUDA_VERSION.major == 13 and CUDA_VERSION.minor < 1)
+                else 2
+            )
+        except ImportError:
+            opt_level = 3
+
+        # Compile once
+        print(
+            f"      [CuTe DSL] Compiling kernel "
+            f"(tile={tile_shape_mn}, cluster={cluster_shape_mn}) ... ",
+            end="",
+            flush=True,
+        )
+        t0 = time.time()
+        self.compiled = cute.compile(
+            self.gemm,
+            a_t,
+            b_t,
+            c_t,
+            sfa_t,
+            sfb_t,
+            self.stream,
+            options=f"--opt-level {opt_level}",
+        )
+        print(f"done ({time.time() - t0:.1f}s)")
+
+    def __call__(self):
+        a_t, b_t, c_t, sfa_t, sfb_t = self.tensors
+        self.compiled(a_t, b_t, c_t, sfa_t, sfb_t, self.stream)
+
+
+# ---------------------------------------------------------------------------
+# Main benchmark runner
+# ---------------------------------------------------------------------------
+def run_benchmarks(
+    m_sizes: List[int],
+    k_sizes: List[int],
+    n_sizes: List[int],
+    out_dtype_str: str,
+    warmup: int,
+    iters: int,
+    tile_shape_mn: Tuple[int, int] | None,
+    cluster_shape_mn: Tuple[int, int] | None,
+    auto_tile: bool,
+):
+    out_dtype = OUT_DTYPE_MAP[out_dtype_str]
+
+    header = (
+        f"{'M':>6}  {'N':>6}  {'K':>6}  "
+        f"{'Kernel':<45}  "
+        f"{'Median(ms)':>11}  {'Mean(ms)':>11}  {'Min(ms)':>10}  {'TFLOPS':>8}"
+    )
+    sep = "-" * len(header)
+    print(sep)
+    print(header)
+    print(sep)
+
+    for m in m_sizes:
+        for n in n_sizes:
+            for k in k_sizes:
+                flops = 2.0 * m * n * k
+                results: List[Tuple[str, float, float, float, float]] = []
+
+                # ---- CUTLASS C++ (via vLLM ops) ----
+                if _cutlass_ops_available:
+                    a, b, sa, sb, out = make_tensors_cutlass(m, n, k, out_dtype)
+
+                    def cutlass_fn(_a=a, _b=b, _sa=sa, _sb=sb, _dt=out_dtype):
+                        ops.cutlass_scaled_mm(_a, _b, _sa, _sb, _dt)
+
+                    try:
+                        med, mean, mn = bench_cuda_events(
+                            cutlass_fn, warmup, iters
+                        )
+                        tflops = flops / (med * 1e-3) / 1e12
+                        results.append(
+                            ("CUTLASS C++ (vllm ops)", med, mean, mn, tflops)
+                        )
+                    except Exception as e:
+                        results.append(
+                            (f"CUTLASS C++ [ERR: {e}]", -1, -1, -1, 0)
+                        )
+                else:
+                    results.append(
+                        ("CUTLASS C++ [NOT AVAILABLE]", -1, -1, -1, 0)
+                    )
+
+                # ---- CuTe DSL ----
+                if _cute_dsl_available:
+                    # Resolve tile/cluster config
+                    if auto_tile:
+                        from scaled_mm_sm90_fp8 import select_tile_config
+
+                        t_mn, c_mn = select_tile_config(m, n, k)
+                    elif tile_shape_mn is not None and cluster_shape_mn is not None:
+                        t_mn, c_mn = tile_shape_mn, cluster_shape_mn
+
+                    else:
+                        # Default
+                        t_mn, c_mn = (128, 128), (2, 1)
+
+                    try:
+                        wrapper = CuteDslBenchWrapper(
+                            m,
+                            n,
+                            k,
+                            out_dtype_str,
+                            tile_shape_mn=t_mn,
+                            cluster_shape_mn=c_mn,
+                        )
+                        med, mean, mn = bench_cuda_events(
+                            wrapper, warmup, iters
+                        )
+                        tflops = flops / (med * 1e-3) / 1e12
+                        label = f"CuTe DSL (tile={t_mn}, cl={c_mn})"
+                        results.append((label, med, mean, mn, tflops))
+                    except Exception as e:
+                        results.append(
+                            (f"CuTe DSL [ERR: {e}]", -1, -1, -1, 0)
+                        )
+                else:
+                    results.append(
+                        ("CuTe DSL [NOT AVAILABLE]", -1, -1, -1, 0)
+                    )
+
+                # ---- PyTorch _scaled_mm baseline (optional) ----
+                try:
+                    a_pt = torch.randn((m, k), device="cuda").to(
+                        torch.float8_e4m3fn
+                    )
+                    b_pt = torch.randn((n, k), device="cuda").to(
+                        torch.float8_e4m3fn
+                    ).t()
+                    sa_pt = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+                    sb_pt = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+
+                    def pytorch_fn(
+                        _a=a_pt, _b=b_pt, _sa=sa_pt, _sb=sb_pt, _dt=out_dtype
+                    ):
+                        torch._scaled_mm(
+                            _a, _b, _sa, _sb, out_dtype=_dt, use_fast_accum=True
+                        )
+
+                    med, mean, mn = bench_cuda_events(
+                        pytorch_fn, warmup, iters
+                    )
+                    tflops = flops / (med * 1e-3) / 1e12
+                    results.append(
+                        ("PyTorch _scaled_mm (fast_accum)", med, mean, mn, tflops)
+                    )
+                except Exception as e:
+                    results.append(
+                        (f"PyTorch _scaled_mm [ERR: {e}]", -1, -1, -1, 0)
+                    )
+
+                # Print results for this (M, N, K)
+                for name, med, mean, mn, tflops in results:
+                    if med < 0:
+                        print(
+                            f"{m:>6}  {n:>6}  {k:>6}  {name:<45}  "
+                            f"{'N/A':>11}  {'N/A':>11}  {'N/A':>10}  {'N/A':>8}"
+                        )
+                    else:
+                        print(
+                            f"{m:>6}  {n:>6}  {k:>6}  {name:<45}  "
+                            f"{med:>11.4f}  {mean:>11.4f}  {mn:>10.4f}  "
+                            f"{tflops:>8.2f}"
+                        )
+
+                # Speedup summary
+                cutlass_med = next(
+                    (r[1] for r in results if "CUTLASS C++" in r[0] and r[1] > 0),
+                    None,
+                )
+                cute_med = next(
+                    (r[1] for r in results if "CuTe DSL" in r[0] and r[1] > 0),
+                    None,
+                )
+                if cutlass_med and cute_med:
+                    speedup = cutlass_med / cute_med
+                    faster = "CuTe DSL" if speedup > 1 else "CUTLASS C++"
+                    ratio = speedup if speedup > 1 else 1.0 / speedup
+                    print(
+                        f"{'':>6}  {'':>6}  {'':>6}  "
+                        f"{'>> ' + faster + f' is {ratio:.2f}x faster':<45}"
+                    )
+                print()
+
+    print(sep)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def parse_int_list(s: str) -> List[int]:
+    return [int(x.strip()) for x in s.split(",")]
+
+
+def parse_int_tuple(s: str) -> Tuple[int, int]:
+    parts = [int(x.strip()) for x in s.split(",")]
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Expected two comma-separated ints")
+    return (parts[0], parts[1])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark CuTe DSL vs CUTLASS C++ per-tensor FP8 scaled GEMM "
+            "on NVIDIA Hopper (SM90)"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--m",
+        type=parse_int_list,
+        default=[16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192],
+        help="Comma-separated M dimensions (default: 128,256,...,8192)",
+    )
+    parser.add_argument(
+        "--n",
+        type=parse_int_list,
+        default=[4096],
+        help="Comma-separated N dimensions (default: 4096)",
+    )
+    parser.add_argument(
+        "--k",
+        type=parse_int_list,
+        default=[4096],
+        help="Comma-separated K dimensions (default: 4096)",
+    )
+    parser.add_argument(
+        "--out-dtype",
+        choices=["bf16", "fp16"],
+        default="bf16",
+        help="Output dtype (default: bf16)",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=10,
+        help="Number of warmup iterations (default: 10)",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=100,
+        help="Number of timed iterations (default: 100)",
+    )
+    parser.add_argument(
+        "--auto-tile",
+        action="store_true",
+        default=True,
+        help="Auto-select CuTe DSL tile/cluster using select_tile_config() "
+        "(mirrors C++ dispatch, default: True)",
+    )
+    parser.add_argument(
+        "--tile-shape-mn",
+        type=parse_int_tuple,
+        default=None,
+        help="Override CuTe DSL tile shape M,N (e.g. 128,128). "
+        "Disables --auto-tile.",
+    )
+    parser.add_argument(
+        "--cluster-shape-mn",
+        type=parse_int_tuple,
+        default=None,
+        help="Override CuTe DSL cluster shape M,N (e.g. 2,1). "
+        "Disables --auto-tile.",
+    )
+
+    args = parser.parse_args()
+
+    # If user explicitly sets tile/cluster, disable auto-tile
+    if args.tile_shape_mn is not None or args.cluster_shape_mn is not None:
+        args.auto_tile = False
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA GPU is required to run this benchmark.")
+
+    cap = torch.cuda.get_device_capability()
+    if cap[0] < 9:
+        raise RuntimeError(
+            f"SM90+ (Hopper) GPU required, got sm_{cap[0]}{cap[1]}"
+        )
+
+    # Ensure CuTe DSL kernel module is importable
+    if _cute_dsl_available:
+        dsl_dir = os.path.join(
+            os.path.dirname(__file__), "..", "vllm", "kernels", "quantization", "cutedsl"
+        )
+        dsl_dir = os.path.abspath(dsl_dir)
+        if dsl_dir not in sys.path:
+            sys.path.insert(0, dsl_dir)
+
+    print()
+    print("=" * 70)
+    print("  Per-Tensor FP8 Scaled GEMM Benchmark: CuTe DSL vs CUTLASS C++")
+    print("  Target: NVIDIA Hopper (SM90)")
+    print("=" * 70)
+    print(f"  GPU             : {torch.cuda.get_device_name()}")
+    print(f"  Compute cap     : {cap[0]}.{cap[1]}")
+    print(f"  M sizes         : {args.m}")
+    print(f"  N sizes         : {args.n}")
+    print(f"  K sizes         : {args.k}")
+    print(f"  Output dtype    : {args.out_dtype}")
+    print(f"  Warmup iters    : {args.warmup}")
+    print(f"  Timed iters     : {args.iters}")
+    print(f"  Auto tile select: {args.auto_tile}")
+    if not args.auto_tile:
+        print(f"  Tile shape MN   : {args.tile_shape_mn}")
+        print(f"  Cluster shape MN: {args.cluster_shape_mn}")
+    print(f"  CuTe DSL avail  : {_cute_dsl_available}")
+    print(f"  CUTLASS ops avail: {_cutlass_ops_available}")
+    print()
+
+    run_benchmarks(
+        m_sizes=args.m,
+        k_sizes=args.k,
+        n_sizes=args.n,
+        out_dtype_str=args.out_dtype,
+        warmup=args.warmup,
+        iters=args.iters,
+        tile_shape_mn=args.tile_shape_mn,
+        cluster_shape_mn=args.cluster_shape_mn,
+        auto_tile=args.auto_tile,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/quantization/test_cutedsl_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutedsl_scaled_mm.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CuTe DSL scaled GEMM kernels (FP8 and INT8) on SM90.
+
+Run `pytest tests/kernels/quantization/test_cutedsl_scaled_mm.py`.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.utils import baseline_scaled_mm, to_fp8, to_int8
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip("CuTe DSL kernels require CUDA", allow_module_level=True)
+
+MNK_FACTORS = [
+    (1, 256, 128),
+    (1, 16384, 1024),
+    (1, 24576, 4096),
+    (16, 256, 4096),
+    (16, 16384, 128),
+    (16, 24576, 4096),
+    (32, 8192, 4096),
+    (32, 16384, 4096),
+    (33, 1024, 1024),
+    (33, 8192, 128),
+    (64, 2048, 4096),
+    (64, 16384, 1024),
+    (100, 8192, 496),
+    (128, 32768, 4096),
+    (256, 4096, 4096),
+    (512, 256, 1024),
+    (512, 8192, 4096),
+    (512, 16384, 128),
+    (512, 24576, 128),
+]
+
+CUDA_DEVICES = [
+    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+]
+
+SCALE_COMBOS = [
+    ("tensor_tensor", lambda m, n: (1, 1), lambda m, n: (1, 1)),
+    ("token_tensor", lambda m, n: (m, 1), lambda m, n: (1, 1)),
+    ("tensor_channel", lambda m, n: (1, 1), lambda m, n: (1, n)),
+    ("token_channel", lambda m, n: (m, 1), lambda m, n: (1, n)),
+]
+
+
+def _cutedsl_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias=None):
+    """Call CuTe DSL scaled MM dispatch, skipping unsupported configs."""
+    from vllm.kernels.quantization.cutedsl.scaled_mm_dispatch import (
+        cutedsl_scaled_mm,
+    )
+
+    result = cutedsl_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias=bias)
+    if result is None:
+        pytest.skip("CuTe DSL does not support this configuration")
+    return result
+
+# FP8 helpers
+def cutedsl_fp8_gemm_helper(
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: type[torch.dtype] = torch.bfloat16,
+    device: str = "cuda",
+    scale_a_shape=(1, 1),
+    scale_b_shape=(1, 1),
+    use_bias: bool = False,
+):
+    a = to_fp8(torch.randn((m, k), device=device))
+    b = to_fp8(torch.randn((n, k), device=device).t())
+
+    scale_a = torch.randn(scale_a_shape, device=device, dtype=torch.float32)
+    scale_b = torch.randn(scale_b_shape, device=device, dtype=torch.float32)
+    bias = torch.randn(n, device=device, dtype=out_dtype) if use_bias else None
+
+    out = _cutedsl_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias=bias)
+    baseline = baseline_scaled_mm(a, b, scale_a, scale_b, out_dtype)
+    if bias is not None:
+        baseline = baseline + bias
+
+    torch.testing.assert_close(out, baseline, rtol=5e-1, atol=1.5e-1)
+
+# INT8 helpers
+def cutedsl_int8_gemm_helper(
+    m: int,
+    n: int,
+    k: int,
+    out_dtype: type[torch.dtype] = torch.bfloat16,
+    device: str = "cuda",
+    scale_a_shape=(1, 1),
+    scale_b_shape=(1, 1),
+    use_bias: bool = False,
+):
+    a = to_int8(torch.randn((m, k), device=device) * 5)
+    b = to_int8(torch.randn((n, k), device=device).t() * 5)
+
+    scale_a = torch.randn(scale_a_shape, device=device, dtype=torch.float32)
+    scale_b = torch.randn(scale_b_shape, device=device, dtype=torch.float32)
+    bias = torch.randn(n, device=device, dtype=out_dtype) if use_bias else None
+
+    out = _cutedsl_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias=bias)
+    baseline = baseline_scaled_mm(a, b, scale_a, scale_b, out_dtype)
+    if bias is not None:
+        baseline = baseline + bias
+
+    torch.testing.assert_close(out, baseline, rtol=1e-1, atol=1e0)
+
+# Per-tensor scale tests (regression)
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_fp8_gemm(m: int, n: int, k: int):
+    cutedsl_fp8_gemm_helper(m, n, k)
+
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_int8_gemm(m: int, n: int, k: int):
+    cutedsl_int8_gemm_helper(m, n, k)
+
+# Scale combination tests
+@pytest.mark.parametrize(
+    "desc,sa_fn,sb_fn",
+    [(c[0], c[1], c[2]) for c in SCALE_COMBOS],
+    ids=[c[0] for c in SCALE_COMBOS],
+)
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS[:6])
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_fp8_gemm_scales(m, n, k, desc, sa_fn, sb_fn):
+    cutedsl_fp8_gemm_helper(
+        m, n, k, scale_a_shape=sa_fn(m, n), scale_b_shape=sb_fn(m, n))
+
+@pytest.mark.parametrize(
+    "desc,sa_fn,sb_fn",
+    [(c[0], c[1], c[2]) for c in SCALE_COMBOS],
+    ids=[c[0] for c in SCALE_COMBOS],
+)
+@pytest.mark.parametrize("m,n,k", MNK_FACTORS[:6])
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_int8_gemm_scales(m, n, k, desc, sa_fn, sb_fn):
+    cutedsl_int8_gemm_helper(
+        m, n, k, scale_a_shape=sa_fn(m, n), scale_b_shape=sb_fn(m, n))
+
+# Bias tests
+@pytest.mark.parametrize("m,n,k", [(64, 256, 128), (128, 512, 256),
+                                     (256, 4096, 4096)])
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_fp8_gemm_bias(m, n, k):
+    cutedsl_fp8_gemm_helper(m, n, k, use_bias=True)
+
+@pytest.mark.parametrize("m,n,k", [(64, 256, 128), (128, 512, 256),
+                                     (256, 4096, 4096)])
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_int8_gemm_bias(m, n, k):
+    cutedsl_int8_gemm_helper(m, n, k, use_bias=True)
+
+# Output dtype tests
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_fp8_gemm_output_dtype(out_dtype: type[torch.dtype]):
+    cutedsl_fp8_gemm_helper(512, 512, 512, out_dtype=out_dtype)
+
+
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_int8_gemm_output_dtype(out_dtype: type[torch.dtype]):
+    cutedsl_int8_gemm_helper(512, 512, 512, out_dtype=out_dtype)
+
+# Multi-device tests
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_fp8_gemm_devices(device: str):
+    cutedsl_fp8_gemm_helper(512, 512, 512, device=device)
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_int8_gemm_devices(device: str):
+    cutedsl_int8_gemm_helper(512, 512, 512, device=device)
+
+# M-sweep tests
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_fp8_gemm_m_sweep():
+    for nk in range(32, 128, 32):
+        for m in range(1, 128):
+            cutedsl_fp8_gemm_helper(m, nk, nk)
+
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90),
+    reason="CuTe DSL SM90 kernels require Hopper or later.",
+)
+def test_cutedsl_int8_gemm_m_sweep():
+    for nk in range(32, 128, 32):
+        for m in range(1, 128):
+            cutedsl_int8_gemm_helper(m, nk, nk)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -766,6 +766,19 @@ def cutlass_scaled_mm(
         )
 
         out = triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
+    elif envs.VLLM_SWITCH_TO_CUTEDSL:
+        from vllm.kernels.quantization.cutedsl.scaled_mm_dispatch import (
+            cutedsl_scaled_mm,
+        )
+
+        out = cutedsl_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias)
+        if out is None:
+            # CuTe DSL does not support this config (blockwise scales,
+            # bias, non-Hopper, etc.) — fall back to CUTLASS C++.
+            out = torch.empty((a.shape[0], b.shape[1]),
+                              dtype=out_dtype, device=a.device)
+            torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b,
+                                           bias)
     else:
         out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
         torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: int | None = None
     VLLM_TPU_USING_PATHWAYS: bool = False
+    VLLM_SWITCH_TO_CUTEDSL: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
     VLLM_MOE_USE_DEEP_GEMM: bool = True
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
@@ -1471,6 +1472,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether using Pathways
     "VLLM_TPU_USING_PATHWAYS": lambda: bool(
         "proxy" in os.getenv("JAX_PLATFORMS", "").lower()
+    ),
+    # Switch per-tensor scaled GEMM (FP8/INT8) to CuTe DSL kernels instead of
+    # the default CUTLASS C++ kernels on Hopper (SM90). Requires the CUTLASS
+    # Python (CuTe DSL) package to be installed.
+    "VLLM_SWITCH_TO_CUTEDSL": lambda: bool(
+        int(os.getenv("VLLM_SWITCH_TO_CUTEDSL", "0"))
     ),
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM": lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "1"))),

--- a/vllm/kernels/quantization/cutedsl/__init__.py
+++ b/vllm/kernels/quantization/cutedsl/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CuTe DSL kernel implementations for vLLM."""

--- a/vllm/kernels/quantization/cutedsl/scaled_mm_dispatch.py
+++ b/vllm/kernels/quantization/cutedsl/scaled_mm_dispatch.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+CuTe DSL dispatch layer for scaled GEMM (FP8 / INT8) on SM90.
+
+Provides ``cutedsl_scaled_mm`` as a drop-in replacement for the CUTLASS C++
+path used by ``torch.ops._C.cutlass_scaled_mm``. The function is only called
+when ``VLLM_SWITCH_TO_CUTEDSL=1`` is set and the inputs are FP8 or INT8 on a
+Hopper GPU.
+
+Supports per-tensor, per-token (row-wise), and per-channel (column-wise)
+scales.  The dispatch layer pre-combines ``scale_a * scale_b`` into an
+``(M, N)`` tensor which is fused into the kernel epilogue via partition_C,
+eliminating any post-kernel scaling passes.
+
+Uses ``from_dlpack`` + ``mark_compact_shape_dynamic`` for zero-copy
+wrapping of PyTorch GPU tensors as dynamic-layout CuTe tensors at runtime.
+
+Kernels are JIT-compiled on first use and cached for subsequent calls.
+"""
+
+import logging
+from typing import Optional, Tuple
+
+import cuda.bindings.driver as cuda
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Compiled-kernel cache
+# ---------------------------------------------------------------------------
+class _KernelCache:
+    """Cache for compiled CuTe DSL kernels.
+
+    Cache key: ``(tile_mn, cluster_mn, input_dtype, output_dtype)``
+    Each unique tile/cluster/dtype combination is compiled once and reused for
+    all matrix sizes (the kernels are compiled with ``is_dynamic_layout=True``).
+    """
+
+    def __init__(self):
+        self._cache: dict[tuple, object] = {}
+
+    def get_or_compile(self, key: tuple, compile_fn):
+        if key not in self._cache:
+            self._cache[key] = compile_fn()
+        return self._cache[key]
+
+
+_kernel_cache = _KernelCache()
+
+# CuTe tensor caches — keyed by (data_ptr, shape, dtype) so the CuTe
+# wrapper (from_dlpack + dynamic-layout marking) can be computed once and
+# reused for subsequent calls with the same tensor, saving ~5 C++ interop
+# calls per cached hit.
+_weight_cute_cache: dict[int, object] = {}
+_cute_tensor_cache: dict[tuple, object] = {}
+
+
+def _get_or_wrap_cute(pt_tensor: torch.Tensor) -> object:
+    """Return a cached CuTe dynamic-layout tensor, or create and cache one."""
+    key = (pt_tensor.data_ptr(), pt_tensor.shape, pt_tensor.dtype)
+    cached = _cute_tensor_cache.get(key)
+    if cached is not None:
+        return cached
+    ct = _to_cute_dynamic(pt_tensor)
+    _cute_tensor_cache[key] = ct
+    return ct
+
+
+# PyTorch <-> CUTLASS dtype helpers
+_TORCH_TO_CUTLASS: dict[torch.dtype, object] = {}
+
+
+def _cutlass_dtype(torch_dtype: torch.dtype):
+    """Map a PyTorch dtype to its CUTLASS equivalent (lazy init)."""
+    global _TORCH_TO_CUTLASS
+    if not _TORCH_TO_CUTLASS:
+        import cutlass
+        _TORCH_TO_CUTLASS = {
+            torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+            torch.int8: cutlass.Int8,
+            torch.bfloat16: cutlass.BFloat16,
+            torch.float16: cutlass.Float16,
+            torch.float32: cutlass.Float32,
+        }
+    return _TORCH_TO_CUTLASS[torch_dtype]
+
+
+def _opt_level() -> int:
+    """Select nvcc optimisation level for CuTe DSL compilation."""
+    try:
+        from cutlass import CUDA_VERSION
+        if (CUDA_VERSION.major < 13
+                or (CUDA_VERSION.major == 13 and CUDA_VERSION.minor < 1)):
+            return 3
+        return 2
+    except ImportError:
+        return 3
+
+
+# Kernel compilation helpers
+def _compile_kernel(
+    is_fp8: bool,
+    tile_mn: Tuple[int, int],
+    cluster_mn: Tuple[int, int],
+    template_m: int,
+    template_n: int,
+    template_k: int,
+    out_dtype_torch: torch.dtype,
+):
+    """JIT-compile a CuTe DSL scaled MM kernel and return the callable."""
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.torch as cutlass_torch
+
+    if is_fp8:
+        from vllm.kernels.quantization.cutedsl.scaled_mm_sm90_fp8 import (
+            ScaledMmSm90Fp8Kernel,
+        )
+        ab_dtype = cutlass.Float8E4M3FN
+        acc_dtype = cutlass.Float32
+        KernelClass = ScaledMmSm90Fp8Kernel
+    else:
+        from vllm.kernels.quantization.cutedsl.scaled_mm_sm90_int8 import (
+            ScaledMmSm90Int8Kernel,
+        )
+        ab_dtype = cutlass.Int8
+        acc_dtype = cutlass.Int32
+        KernelClass = ScaledMmSm90Int8Kernel
+
+    c_dtype = _cutlass_dtype(out_dtype_torch)
+    scale_dtype = cutlass.Float32
+
+    # Create template tensors for compilation with is_dynamic_layout=True
+    # so the compiled kernel works for any M, N, K at runtime.
+    m = max(template_m, tile_mn[0])
+    n = max(template_n, tile_mn[1])
+    k = max(template_k, 128)
+    l = 1
+
+    a_cpu = cutlass_torch.matrix(l, m, k, False, ab_dtype)
+    b_cpu = cutlass_torch.matrix(l, n, k, False, ab_dtype)
+    c_cpu = cutlass_torch.matrix(l, m, n, False, c_dtype)
+    sa_cpu = cutlass_torch.matrix(1, m, n, False, scale_dtype)
+    sb_cpu = cutlass_torch.matrix(1, 1, 1, False, scale_dtype)
+
+    a_cute, _ = cutlass_torch.cute_tensor_like(
+        a_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16)
+    b_cute, _ = cutlass_torch.cute_tensor_like(
+        b_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16)
+    c_cute, _ = cutlass_torch.cute_tensor_like(
+        c_cpu, c_dtype, is_dynamic_layout=True, assumed_align=16)
+    sa_cute, _ = cutlass_torch.cute_tensor_like(
+        sa_cpu, scale_dtype, is_dynamic_layout=True, assumed_align=16)
+    sb_cute, _ = cutlass_torch.cute_tensor_like(
+        sb_cpu, scale_dtype, is_dynamic_layout=True, assumed_align=16)
+
+    scaled_mm = KernelClass(
+        acc_dtype=acc_dtype,
+        tile_shape_mn=tile_mn,
+        cluster_shape_mn=cluster_mn,
+    )
+
+    torch_stream = torch.cuda.current_stream()
+    stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    compiled = cute.compile(
+        scaled_mm,
+        a_cute, b_cute, c_cute, sa_cute, sb_cute, stream,
+        options=f"--opt-level {_opt_level()} --enable-tvm-ffi --ptxas-options -maxrregcount=64",
+    )
+
+    return compiled
+
+
+# Runtime tensor helpers
+def _to_cute_dynamic(pt_tensor: torch.Tensor) -> object:
+    """Wrap a PyTorch GPU tensor as a dynamic-layout CuTe tensor (zero-copy).
+
+    Uses ``from_dlpack`` for zero-copy wrapping, then
+    ``mark_compact_shape_dynamic`` on all modes to match the dynamic layout
+    produced by ``cute_tensor_like(is_dynamic_layout=True)`` at compile time.
+    """
+
+    ct = (
+        from_dlpack(pt_tensor, assumed_align=16, enable_tvm_ffi=True)
+        .mark_layout_dynamic(leading_dim=1)
+    )
+
+    return ct
+
+# PyTorch custom op - raw GEMM only, opaque to torch.compile
+@torch.library.custom_op(
+    "vllm::cutedsl_scaled_mm",
+    mutates_args=[],
+    device_types="cuda",
+)
+def _cutedsl_scaled_mm_op(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Custom op: CuTe DSL Scaled MM with fused scaling.
+
+    Computes ``scale_a * scale_b * (A @ B)``. All scale types (per-tensor,
+    per-token, per-channel) are pre-combined into an (M, N) scale tensor
+    and fused into the kernel epilogue via partition_C.
+
+    Uses from_dlpack + mark_compact_shape_dynamic for zero-copy input
+    wrapping with dynamic layouts.  No torch.cuda.synchronize().
+    """
+
+    M, K = a.shape
+    N = b.shape[1]
+    is_fp8 = a.dtype == torch.float8_e4m3fn
+
+    # select tile / cluster config
+    if is_fp8:
+        from vllm.kernels.quantization.cutedsl.scaled_mm_sm90_fp8 import (
+            select_tile_config,
+        )
+    else:
+        from vllm.kernels.quantization.cutedsl.scaled_mm_sm90_int8 import (
+            select_tile_config,
+        )
+    tile_mn, cluster_mn = select_tile_config(M, N, K)
+
+    # get or compile kernel
+    cache_key = (tile_mn, cluster_mn, a.dtype, out_dtype)
+    compiled = _kernel_cache.get_or_compile(
+        cache_key,
+        lambda: _compile_kernel(
+            is_fp8, tile_mn, cluster_mn, M, N, K, out_dtype,
+        ),
+    )
+
+    # pre-combine scales into (M, N) for fused epilogue
+    # Pad to tile boundaries so partial-tile element reads don't go OOB.
+    tile_m, tile_n = tile_mn
+    padded_M = ((M + tile_m - 1) // tile_m) * tile_m
+    padded_N = ((N + tile_n - 1) // tile_n) * tile_n
+    if padded_M == M and padded_N == N:
+        scale_combined = (
+            scale_a.float() * scale_b.float()
+        ).expand(M, N).contiguous()
+    else:
+        scale_combined = torch.ones(
+            padded_M, padded_N, device=a.device, dtype=torch.float32)
+        scale_combined[:M, :N] = (
+            scale_a.float() * scale_b.float()
+        ).expand(M, N)
+    scale_combined_3d = scale_combined.unsqueeze(-1)
+    dummy_sb = torch.ones(1, 1, 1, device=a.device, dtype=torch.float32)
+
+    # from_dlpack requires the current CUDA device to match the tensor's
+    # device, so set it explicitly for multi-GPU correctness.
+    with torch.cuda.device(a.device):
+        # zero-copy wrap inputs as dynamic-layout CuTe tensors
+        # Kernel expects 3D: A (M,K,1), B (N,K,1), C (M,N,1), scale (M,N,1).
+        # b is (K,N) column-major from weight loading; b.t() yields a
+        # contiguous (N,K) view — no data copy.  unsqueeze is also a view.
+        a_3d = a.contiguous().unsqueeze(-1)
+        c_3d = torch.empty(M, N, 1, dtype=out_dtype, device=a.device)
+
+        a_cute = _get_or_wrap_cute(a_3d)
+        c_cute = _to_cute_dynamic(c_3d)  # new alloc each call, can't cache
+
+        # B (weight) CuTe tensor is cached — weights are persistent
+        # nn.Parameters whose data pointer never changes during serving.
+        b_ptr = b.data_ptr()
+        if b_ptr in _weight_cute_cache:
+            b_cute = _weight_cute_cache[b_ptr]
+        else:
+            b_3d = b.t().unsqueeze(-1)
+            b_cute = _to_cute_dynamic(b_3d)
+            _weight_cute_cache[b_ptr] = b_cute
+
+        sc_cute = _to_cute_dynamic(scale_combined_3d)
+        # sb_cute = _to_cute_dynamic(dummy_sb)
+
+        # launch kernel — use CUDA events for true GPU execution time
+        torch_stream = torch.cuda.current_stream()
+        stream = cuda.CUstream(torch_stream.cuda_stream)
+        compiled(a_cute, b_cute, c_cute, sc_cute, dummy_sb, stream)
+
+    return c_3d.squeeze(-1)
+
+
+@torch.library.register_fake("vllm::cutedsl_scaled_mm")
+def _cutedsl_scaled_mm_fake(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Fake impl for torch.compile shape inference."""
+    return torch.empty(
+        a.shape[0], b.shape[1],
+        dtype=out_dtype,
+        device=a.device,
+    )
+
+
+def cutedsl_scaled_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: Optional[torch.Tensor] = None,
+) -> Optional[torch.Tensor]:
+    """Run scaled GEMM using the CuTe DSL kernel.
+
+    This is a drop-in replacement for the ``torch.ops._C.cutlass_scaled_mm``
+    path inside ``vllm._custom_ops.cutlass_scaled_mm``.
+
+    Supports per-tensor, per-token (row-wise), and per-channel (column-wise)
+    scales.  The dispatch layer pre-combines ``scale_a * scale_b`` into an
+    ``(M, N)`` tensor fused into the kernel epilogue via partition_C.
+
+    Returns ``None`` if the inputs are not supported (unsupported dtype,
+    non-Hopper GPU, missing dependencies).
+
+    Args:
+        a: (M, K) FP8-e4m3 or INT8 input, contiguous, on CUDA.
+        b: (K, N) FP8-e4m3 or INT8 weight, column-major, on CUDA.
+        scale_a: FP32 scale for *a* -- scalar (per-tensor) or (M, 1)
+            (per-token).
+        scale_b: FP32 scale for *b* -- scalar (per-tensor) or (N, 1) / (1, N)
+            (per-channel).
+        out_dtype: ``torch.bfloat16`` or ``torch.float16``.
+        bias: optional per-channel bias tensor of shape ``(N,)`` in
+            ``out_dtype``.
+
+    Returns:
+        ``(M, N)`` output tensor, or ``None`` on unsupported config.
+    """
+
+    # dtype must be FP8 or INT8
+    is_fp8 = a.dtype == torch.float8_e4m3fn
+    is_int8 = a.dtype == torch.int8
+    if not (is_fp8 or is_int8):
+        return None
+
+    # raw GEMM via custom op (opaque to torch.compile)
+    # All scale types (scalar, per-token, per-channel) are fused into
+    # the kernel epilogue.
+    raw_output = torch.ops.vllm.cutedsl_scaled_mm(
+        a, b, scale_a, scale_b, out_dtype)
+
+    result = raw_output
+    if bias is not None:
+        result = result + bias
+
+    return result

--- a/vllm/kernels/quantization/cutedsl/scaled_mm_sm90_fp8.py
+++ b/vllm/kernels/quantization/cutedsl/scaled_mm_sm90_fp8.py
@@ -1,0 +1,715 @@
+"""
+CuTe DSL implementation of the scaled FP8 GEMM kernel for NVIDIA Hopper (SM90).
+
+Rewrite of the CUTLASS C++ kernel in
+csrc/quantization/w8a8/cutlass/c3x/scaled_mm_sm90_fp8_dispatch.cuh
+
+Computes: D = scale_a * scale_b * (A @ B^T)
+  - A is MxK  (FP8 e4m3, row-major / K-major)
+  - B is NxK  (FP8 e4m3, col-major / K-major)
+  - D is MxN  (BF16 or FP16, row-major / N-major)
+  - scale_a: per-tensor (1,1) or per-token (M,1) FP32
+  - scale_b: per-tensor (1,1) or per-channel (1,N) FP32
+
+This kernel targets the NVIDIA Hopper GPU and uses:
+  - Tensor Memory Access (TMA) for global<->shared memory transfers
+  - WGMMA (Warp Group MMA) for FP8 matrix multiply-accumulate
+  - Multi-stage async pipeline for latency hiding
+  - TMA multicast with clusters to reduce L2 traffic
+  - Per-tensor scaling applied in the epilogue (scalar path)
+  - Per-token/per-channel scaling via broadcast-stride partition_C (broadcast path)
+"""
+
+import math
+from typing import Tuple, Type
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.hopper_helpers as sm90_utils
+
+
+class ScaledMmSm90Fp8Kernel:
+    """Hopper FP8 scaled GEMM kernel: D = scale_a * scale_b * (A @ B^T).
+
+    Mirrors the tile/cluster configurations from the C++ dispatch in
+    scaled_mm_sm90_fp8_dispatch.cuh.
+
+    :param acc_dtype: Accumulator data type (must be Float32).
+    :param tile_shape_mn: CTA tile shape (M, N).
+    :param cluster_shape_mn: Cluster shape (M, N).
+    The dispatch layer pre-combines ``scale_a * scale_b`` into an (M, N)
+    tensor which is tiled and partitioned like the output, then fused into
+    the epilogue via a single element-wise multiply.
+    """
+
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        tile_shape_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ):
+        self.acc_dtype = acc_dtype
+        self.cluster_shape_mn = cluster_shape_mn
+        self.tile_shape_mnk = (*tile_shape_mn, 1)
+        self.atom_layout_mnk = (
+            (2, 1, 1)
+            if self.tile_shape_mnk[0] > 64 and self.tile_shape_mnk[1] > 128
+            else (1, 1, 1)
+        )
+        self.num_mcast_ctas_a = None
+        self.num_mcast_ctas_b = None
+        self.is_a_mcast = False
+        self.is_b_mcast = False
+        self.tiled_mma = None
+
+        self.occupancy = 1
+        self.mma_warp_groups = math.prod(self.atom_layout_mnk)
+        self.num_threads_per_warp_group = 128
+        self.threads_per_cta = self.mma_warp_groups * self.num_threads_per_warp_group
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_90")
+
+        self.ab_stage = None
+        self.epi_stage = None
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+        self.epi_tile = None
+        self.shared_storage = None
+        self.buffer_align_bytes = 1024
+
+    def _setup_attributes(self):
+        """Configure kernel attributes from input tensor properties."""
+        if self.tile_shape_mnk[0] not in [64, 128, 256]:
+            raise ValueError("CTA tile shape M must be 64/128/256")
+        if self.tile_shape_mnk[1] not in [16, 64, 128, 256]:
+            raise ValueError("CTA tile shape N must be 16/64/128/256")
+
+        mma_tiler_m = min(64, self.tile_shape_mnk[0])
+        mma_tiler_n = self.tile_shape_mnk[1]
+
+        self.tiled_mma = sm90_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_layout.sm90_mma_major_mode(),
+            self.b_layout.sm90_mma_major_mode(),
+            self.acc_dtype,
+            self.atom_layout_mnk,
+            tiler_mn=(mma_tiler_m, mma_tiler_n),
+        )
+        mma_inst_shape_k = cute.size(self.tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.tile_shape_mnk = (
+            self.tile_shape_mnk[0],
+            self.tile_shape_mnk[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_layout_mnk = cute.make_layout((*self.cluster_shape_mn, 1))
+        self.num_mcast_ctas_a = self.cluster_shape_mn[1]
+        self.num_mcast_ctas_b = self.cluster_shape_mn[0]
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        is_cooperative = self.atom_layout_mnk == (2, 1, 1)
+        self.epi_tile = sm90_utils.compute_tile_shape_or_override(
+            self.tile_shape_mnk, self.c_dtype, is_cooperative=is_cooperative
+        )
+
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        scale_a: cute.Tensor,
+        scale_b: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        """Launch the scaled FP8 GEMM kernel.
+
+        :param a: Input FP8 tensor A (MxKxL).
+        :param b: Input FP8 tensor B (NxKxL).
+        :param c: Output tensor D (MxNxL).
+        :param scale_a: Per-tensor scale for A (scalar FP32).
+        :param scale_b: Per-tensor scale for B (scalar FP32).
+        :param stream: CUDA stream.
+        """
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        self._setup_attributes()
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[1],
+        )
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[0],
+        )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        grid = self._compute_grid(c, self.tile_shape_mnk, self.cluster_shape_mn)
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            scale_a,
+            scale_b,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        gScaleA: cute.Tensor,
+        gScaleB: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+    ):
+        """Device kernel: TMA load -> WGMMA mainloop -> scaled epilogue."""
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_b)
+
+        # Thread / block / cluster indices
+        bidx, bidy, bidz = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        cidx, cidy, _ = cute.arch.cluster_idx()
+        cdimx, cdimy, _ = cute.arch.cluster_dim()
+        cluster_id = cidx + cdimx * cidy
+
+        # CTA swizzle for L2 reuse
+        group_size_m = 8
+        s_shape = ((group_size_m, cdimx // group_size_m), cdimy)
+        s_stride = ((1, cdimy * group_size_m), group_size_m)
+        s_layout = cute.make_layout(s_shape, stride=s_stride)
+        num_reg_cids = cute.size(s_shape)
+        cid_m, cid_n = s_layout.get_flat_coord(cluster_id % num_reg_cids)
+
+        if cluster_id >= num_reg_cids:
+            tail_size_m = cdimx % group_size_m
+            tail_layout = cute.make_layout(
+                (tail_size_m, cdimy), stride=(1, tail_size_m)
+            )
+            tail_cid = cluster_id - num_reg_cids
+            tail_cid_m, tail_cid_n = tail_layout.get_flat_coord(tail_cid)
+            cid_m = cute.size(s_shape, mode=[0]) + tail_cid_m
+            cid_n = tail_cid_n
+
+        bidx_in_cluster = cute.arch.block_in_cluster_idx()
+        pid_m = cid_m * self.cluster_shape_mn[0] + bidx_in_cluster[0]
+        pid_n = cid_n * self.cluster_shape_mn[1] + bidx_in_cluster[1]
+
+        tile_coord_mnkl = (pid_m, pid_n, None, bidz)
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        # Multicast masks
+        a_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=1
+        )
+        b_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=0
+        )
+        a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+        b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(
+            self.a_dtype, a_smem_layout
+        ) + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+
+        # Shared memory allocation & pipeline init
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mcast_size = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        num_warps = self.threads_per_cta // 32
+        consumer_arrive_cnt = mcast_size * num_warps
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, consumer_arrive_cnt
+        )
+
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=mainloop_pipeline_array_ptr,
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # SMEM tensors
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC_ptr = cute.recast_ptr(
+            sA.iterator, epi_smem_layout_staged.inner, dtype=self.c_dtype
+        )
+        sC = cute.make_tensor(sC_ptr, epi_smem_layout_staged.outer)
+
+        # Global tile partitioning
+        gA_mkl = cute.local_tile(
+            mA_mkl, self.tile_shape_mnk, tile_coord_mnkl, proj=(1, None, 1)
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl, self.tile_shape_mnk, tile_coord_mnkl, proj=(None, 1, 1)
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl, self.tile_shape_mnk, tile_coord_mnkl, proj=(1, 1, None)
+        )
+
+        # Combined scale tiling (gScaleA = pre-combined M×N scale)
+        mSC_mnl = cute.make_tensor(gScaleA.iterator, gScaleA.layout)
+        gSC_mnl = cute.local_tile(
+            mSC_mnl, self.tile_shape_mnk,
+            tile_coord_mnkl, proj=(1, 1, None))
+
+        # MMA partitioning
+        warp_group_idx = cute.arch.make_warp_uniform(
+            tidx // self.num_threads_per_warp_group
+        )
+        warp_group_thread_layout = cute.make_layout(
+            self.mma_warp_groups, stride=self.num_threads_per_warp_group
+        )
+        thr_mma = tiled_mma.get_slice(warp_group_thread_layout(warp_group_idx))
+        tCgC = thr_mma.partition_C(gC_mnl)
+        tCgSC = thr_mma.partition_C(gSC_mnl)
+
+        # TMA partitions
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        sA_for_tma_partition = cute.group_modes(sA, 0, 2)
+        gA_for_tma_partition = cute.group_modes(gA_mkl, 0, 2)
+        tAsA, tAgA_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_a, a_cta_crd, a_cta_layout,
+            sA_for_tma_partition, gA_for_tma_partition,
+        )
+
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        sB_for_tma_partition = cute.group_modes(sB, 0, 2)
+        gB_for_tma_partition = cute.group_modes(gB_nkl, 0, 2)
+        tBsB, tBgB_nkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_b, b_cta_crd, b_cta_layout,
+            sB_for_tma_partition, gB_for_tma_partition,
+        )
+
+        # MMA fragments
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+        tCrA = tiled_mma.make_fragment_A(tCsA)
+        tCrB = tiled_mma.make_fragment_B(tCsB)
+        acc_shape = tCgC.shape
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        # Cluster sync after barrier init
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        # Prefetch TMA loads
+        k_tile_cnt = cute.size(gA_mkl, mode=[2])
+        prefetch_k_tile_cnt = cutlass.max(cutlass.min(self.ab_stage, k_tile_cnt), 0)
+
+        mainloop_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        if warp_idx == 0:
+            for prefetch_idx in cutlass.range(prefetch_k_tile_cnt, unroll=1):
+                mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+                tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                cute.copy(
+                    tma_atom_a, tAgA_k, tAsA_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(mainloop_producer_state),
+                    mcast_mask=a_mcast_mask,
+                )
+                cute.copy(
+                    tma_atom_b, tBgB_k, tBsB_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(mainloop_producer_state),
+                    mcast_mask=b_mcast_mask,
+                )
+                mainloop_pipeline.producer_commit(mainloop_producer_state)
+                mainloop_producer_state.advance()
+
+        # Prologue MMA
+        k_pipe_mmas = 1
+
+        mainloop_consumer_read_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        mainloop_consumer_release_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        peek_ab_full_status = cutlass.Boolean(1)
+        if mainloop_consumer_read_state.count < k_tile_cnt:
+            peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                mainloop_consumer_read_state
+            )
+
+        tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, False)
+        num_k_blocks = cute.size(tCrA, mode=[2])
+
+        for k_tile in cutlass.range_constexpr(k_pipe_mmas):
+            mainloop_pipeline.consumer_wait(
+                mainloop_consumer_read_state, peek_ab_full_status
+            )
+            cute.nvgpu.warpgroup.fence()
+            for k_block_idx in cutlass.range(num_k_blocks, unroll_full=True):
+                k_block_coord = (
+                    None, None, k_block_idx,
+                    mainloop_consumer_read_state.index,
+                )
+                cute.gemm(
+                    tiled_mma, accumulators,
+                    tCrA[k_block_coord], tCrB[k_block_coord],
+                    accumulators,
+                )
+                tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+            cute.nvgpu.warpgroup.commit_group()
+            mainloop_consumer_read_state.advance()
+            peek_ab_full_status = cutlass.Boolean(1)
+            if mainloop_consumer_read_state.count < k_tile_cnt:
+                peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                    mainloop_consumer_read_state
+                )
+
+        for k_tile in cutlass.range(k_pipe_mmas, k_tile_cnt, 1, unroll=1):
+            mainloop_pipeline.consumer_wait(
+                mainloop_consumer_read_state, peek_ab_full_status
+            )
+            cute.nvgpu.warpgroup.fence()
+            for k_block_idx in cutlass.range(num_k_blocks, unroll_full=True):
+                k_block_coord = (
+                    None, None, k_block_idx,
+                    mainloop_consumer_read_state.index,
+                )
+                cute.gemm(
+                    tiled_mma, accumulators,
+                    tCrA[k_block_coord], tCrB[k_block_coord],
+                    accumulators,
+                )
+
+            cute.nvgpu.warpgroup.commit_group()
+            cute.nvgpu.warpgroup.wait_group(k_pipe_mmas)
+
+            mainloop_pipeline.consumer_release(mainloop_consumer_release_state)
+            mainloop_consumer_read_state.advance()
+            mainloop_consumer_release_state.advance()
+
+            peek_ab_full_status = cutlass.Boolean(1)
+            if mainloop_consumer_read_state.count < k_tile_cnt:
+                peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                    mainloop_consumer_read_state
+                )
+
+            # Overlap TMA load with MMA
+            if warp_idx == 0 and mainloop_producer_state.count < k_tile_cnt:
+                mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+                tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                cute.copy(
+                    tma_atom_a, tAgA_k, tAsA_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(mainloop_producer_state),
+                    mcast_mask=a_mcast_mask,
+                )
+                cute.copy(
+                    tma_atom_b, tBgB_k, tBsB_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(mainloop_producer_state),
+                    mcast_mask=b_mcast_mask,
+                )
+                mainloop_pipeline.producer_commit(mainloop_producer_state)
+                mainloop_producer_state.advance()
+
+        # Epilouge: scale accumulators and write back
+        cute.nvgpu.warpgroup.wait_group(0)
+
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive()
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.sync_threads()
+
+        copy_atom_r2s = sm90_utils.sm90_get_smem_store_op(
+            self.c_layout,
+            elem_ty_d=self.c_dtype,
+            elem_ty_acc=self.acc_dtype,
+        )
+        copy_atom_C = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(self.c_layout.is_m_major_c(), 4),
+            self.c_dtype,
+        )
+        tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+        tiled_copy_r2s = cute.make_tiled_copy_S(copy_atom_r2s, tiled_copy_C_Atom)
+
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sD = thr_copy_r2s.partition_D(sC)
+        tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+        scale_regs = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        num_scale_elems = cute.size(scale_regs)
+        for i in cutlass.range_constexpr(num_scale_elems):
+            scale_regs[i] = tCgSC[i]
+        tRS_rS = tiled_copy_r2s.retile(scale_regs)
+
+        rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+        tRS_rD_layout = cute.make_layout(rD_shape[:3])
+        tRS_rD = cute.make_rmem_tensor_like(tRS_rD_layout, self.acc_dtype)
+        size_tRS_rD = cute.size(tRS_rD)
+
+        sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+        tCgC_for_tma_partition = cute.zipped_divide(gC_mnl, self.epi_tile)
+
+        bSG_sD, bSG_gD = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_c, 0, cute.make_layout(1),
+            sepi_for_tma_partition, tCgC_for_tma_partition,
+        )
+
+        epi_tile_num = cute.size(tCgC_for_tma_partition, mode=[1])
+        epi_tile_shape = tCgC_for_tma_partition.shape[1]
+        epi_tile_layout = cute.make_layout(
+            epi_tile_shape, stride=(epi_tile_shape[1], 1)
+        )
+
+        c_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.threads_per_cta
+        )
+        c_pipeline = pipeline.PipelineTmaStore.create(
+            num_stages=self.epi_stage,
+            producer_group=c_producer_group,
+        )
+
+        tRS_rD_s = cute.make_rmem_tensor_like(
+            tRS_rD_layout, cutlass.Float32)
+
+        for epi_idx in cutlass.range_constexpr(epi_tile_num):
+            # Copy accumulator fragment to D registers
+            for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                tRS_rD[epi_v] = tRS_rAcc[epi_idx * size_tRS_rD + epi_v]
+
+            acc_vec = tRS_rD.load()
+            for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                tRS_rD_s[epi_v] = tRS_rS[
+                    epi_idx * size_tRS_rD + epi_v]
+            s_vec = tRS_rD_s.load()
+            scaled_vec = acc_vec * s_vec
+
+            # Type convert to output dtype and store
+            tRS_rD_out = cute.make_rmem_tensor_like(tRS_rD_layout, self.c_dtype)
+            tRS_rD_out.store(scaled_vec.to(self.c_dtype))
+
+            epi_buffer = epi_idx % cute.size(tRS_sD, mode=[3])
+            cute.copy(
+                tiled_copy_r2s, tRS_rD_out, tRS_sD[(None, None, None, epi_buffer)]
+            )
+
+            cute.arch.fence_proxy("async.shared", space="cta")
+            
+            pipeline.sync(barrier_id=1)
+
+            gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
+            if warp_idx == 0:
+                cute.copy(
+                    tma_atom_c,
+                    bSG_sD[(None, epi_buffer)],
+                    bSG_gD[(None, gmem_coord)],
+                )
+                c_pipeline.producer_commit()
+                c_pipeline.producer_acquire()
+
+            pipeline.sync(barrier_id=1)
+
+        if warp_idx == 0:
+            c_pipeline.producer_tail()
+
+        return
+
+    @staticmethod
+    def _compute_stages(tile_shape_mnk, a_dtype, b_dtype, smem_capacity, occupancy):
+        epi_stage = 4
+        epi_bytes = 0
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        mbar_helpers_bytes = 1024
+        ab_stage = (
+            smem_capacity // occupancy - mbar_helpers_bytes - epi_bytes
+        ) // ab_bytes_per_stage
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk, epi_tile, a_dtype, a_layout, b_dtype, b_layout,
+        ab_stage, c_dtype, c_layout, epi_stage,
+    ):
+        a_smem = sm90_utils.make_smem_layout_a(a_layout, tile_shape_mnk, a_dtype, ab_stage)
+        b_smem = sm90_utils.make_smem_layout_b(b_layout, tile_shape_mnk, b_dtype, ab_stage)
+        epi_smem = sm90_utils.make_smem_layout_epi(c_dtype, c_layout, epi_tile, epi_stage)
+        return a_smem, b_smem, epi_smem
+
+    @staticmethod
+    def _compute_grid(c, tile_shape_mnk, cluster_shape_mn):
+        c_shape = (tile_shape_mnk[0], tile_shape_mnk[1])
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+        clusters = cute.ceil_div(cute.get(gc.layout, mode=[1]).shape, cluster_shape_mnl)
+        grid = tuple(x * y for x, y in zip(clusters, cluster_shape_mnl))
+        return grid
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(tensor, smem_layout_staged, smem_tile, mcast_dim):
+        op = (
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cute.nvgpu.cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            op, tensor, smem_layout, smem_tile, num_multicast=mcast_dim,
+        )
+        return tma_atom, tma_tensor
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(tensor_c, epi_smem_layout_staged, epi_tile):
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c, epi_smem_layout, epi_tile,
+        )
+        return tma_atom_c, tma_tensor_c
+
+
+# Dispatch helper — mirrors the C++ tile/cluster selection logic
+def select_tile_config(m: int, n: int, k: int) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Select (tile_shape_mn, cluster_shape_mn) matching the C++ dispatch.
+
+    Returns the same tile/cluster configurations as
+    scaled_mm_sm90_fp8_dispatch.cuh::cutlass_gemm_sm90_fp8_dispatch.
+    """
+    if m <= 16:
+        if n <= 1280:
+            return (64, 16), (1, 2)
+        return (64, 16), (1, 1)
+    elif m <= 64:
+        if n <= 1280:
+            return (64, 16), (1, 4)
+        return (64, 64), (1, 1)
+    elif m <= 128:
+        return (64, 128), (2, 1)
+    elif m >= 8192 and k >= 6144:
+        return (256, 128), (2, 1)
+    else:
+        return (128, 128), (2, 1)

--- a/vllm/kernels/quantization/cutedsl/scaled_mm_sm90_int8.py
+++ b/vllm/kernels/quantization/cutedsl/scaled_mm_sm90_int8.py
@@ -1,0 +1,757 @@
+"""
+CuTe DSL implementation of the scaled INT8 GEMM kernel for NVIDIA Hopper (SM90).
+
+Rewrite of the CUTLASS C++ kernel in
+csrc/quantization/w8a8/cutlass/c3x/scaled_mm_sm90_int8_dispatch.cuh
+
+Computes: D = scale_a * scale_b * (A @ B^T)
+  - A is MxK  (INT8, row-major / K-major)
+  - B is NxK  (INT8, col-major / K-major)
+  - D is MxN  (BF16 or FP16, row-major / N-major)
+  - scale_a: per-tensor (1,1) or per-token (M,1) FP32
+  - scale_b: per-tensor (1,1) or per-channel (1,N) FP32
+  - Accumulator is INT32, converted to FP32 for scaling before output
+
+This kernel targets the NVIDIA Hopper GPU and uses:
+  - Tensor Memory Access (TMA) for global<->shared memory transfers
+  - WGMMA (Warp Group MMA) for INT8 matrix multiply-accumulate (MmaI8Op)
+  - Multi-stage async pipeline for latency hiding
+  - TMA multicast with clusters to reduce L2 traffic
+  - Per-tensor scaling applied in the epilogue (scalar path)
+  - Per-token/per-channel scaling via broadcast-stride partition_C (broadcast path)
+
+Tile/cluster configurations mirror the C++ dispatch:
+  - M > 128:             (128, 128) tile, (2, 1) cluster  (Pingpong)
+  - M in (64, 128]:      (64, 128)  tile, (2, 1) cluster  (Pingpong)
+  - M in (32, 64]:       (64, 64)   tile, (1, 1) cluster
+  - M in [1, 32], N>=8K: (64, 128)  tile, (1, 4) cluster
+  - M in [1, 32], N<8K:  (64, 64)   tile, (1, 8) cluster
+
+"""
+
+import math
+from typing import Tuple, Type
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.hopper_helpers as sm90_utils
+
+
+class ScaledMmSm90Int8Kernel:
+    """Hopper INT8 scaled GEMM kernel: D = scale_a * scale_b * (A @ B^T).
+
+    Mirrors the tile/cluster configurations from the C++ dispatch in
+    scaled_mm_sm90_int8_dispatch.cuh.
+
+    :param acc_dtype: Accumulator data type (must be Int32 for INT8 WGMMA).
+    :param tile_shape_mn: CTA tile shape (M, N).
+    :param cluster_shape_mn: Cluster shape (M, N).
+    The dispatch layer pre-combines ``scale_a * scale_b`` into an (M, N)
+    tensor which is tiled and partitioned like the output, then fused into
+    the epilogue via a single element-wise multiply.
+    """
+
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        tile_shape_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ):
+        self.acc_dtype = acc_dtype
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.tile_shape_mnk = (*tile_shape_mn, 1)
+        self.atom_layout_mnk = (
+            (2, 1, 1)
+            if self.tile_shape_mnk[0] > 64 and self.tile_shape_mnk[1] > 128
+            else (1, 1, 1)
+        )
+        self.num_mcast_ctas_a = None
+        self.num_mcast_ctas_b = None
+        self.is_a_mcast = False
+        self.is_b_mcast = False
+        self.tiled_mma = None
+
+        self.occupancy = 1
+        self.mma_warp_groups = math.prod(self.atom_layout_mnk)
+        self.num_threads_per_warp_group = 128
+        self.threads_per_cta = self.mma_warp_groups * self.num_threads_per_warp_group
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_90")
+
+        self.ab_stage = None
+        self.epi_stage = None
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+        self.epi_tile = None
+        self.shared_storage = None
+        self.buffer_align_bytes = 1024
+
+    def _setup_attributes(self):
+        """Configure kernel attributes from input tensor properties."""
+        if self.tile_shape_mnk[0] not in [64, 128]:
+            raise ValueError("CTA tile shape M must be 64/128")
+        if self.tile_shape_mnk[1] not in [64, 128, 256]:
+            raise ValueError("CTA tile shape N must be 64/128/256")
+
+        mma_tiler_m = min(64, self.tile_shape_mnk[0])
+        mma_tiler_n = self.tile_shape_mnk[1]
+
+        self.tiled_mma = sm90_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_layout.sm90_mma_major_mode(),
+            self.b_layout.sm90_mma_major_mode(),
+            self.acc_dtype,
+            self.atom_layout_mnk,
+            tiler_mn=(mma_tiler_m, mma_tiler_n),
+        )
+        mma_inst_shape_k = cute.size(self.tiled_mma.shape_mnk, mode=[2])
+        # INT8 WGMMA uses K=32 per instruction; tile 4 for deeper K
+        mma_inst_tile_k = 4
+        self.tile_shape_mnk = (
+            self.tile_shape_mnk[0],
+            self.tile_shape_mnk[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_layout_mnk = cute.make_layout((*self.cluster_shape_mn, 1))
+        self.num_mcast_ctas_a = self.cluster_shape_mn[1]
+        self.num_mcast_ctas_b = self.cluster_shape_mn[0]
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        is_cooperative = self.atom_layout_mnk == (2, 1, 1)
+        self.epi_tile = sm90_utils.compute_tile_shape_or_override(
+            self.tile_shape_mnk, self.c_dtype, is_cooperative=is_cooperative
+        )
+
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        scale_a: cute.Tensor,
+        scale_b: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        """Launch the scaled INT8 GEMM kernel.
+
+        :param a: Input INT8 tensor A (MxKxL).
+        :param b: Input INT8 tensor B (NxKxL).
+        :param c: Output tensor D (MxNxL).
+        :param scale_a: Per-tensor scale for A (scalar FP32).
+        :param scale_b: Per-tensor scale for B (scalar FP32).
+        :param stream: CUDA stream.
+        """
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        self._setup_attributes()
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[1],
+        )
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[0],
+        )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        grid = self._compute_grid(c, self.tile_shape_mnk, self.cluster_shape_mn)
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            scale_a,
+            scale_b,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        gScaleA: cute.Tensor,
+        gScaleB: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+    ):
+        """Device kernel: TMA load -> WGMMA mainloop -> scaled epilogue.
+
+        The epilogue converts the INT32 accumulators to FP32, applies
+        per-tensor scaling (scale_a * scale_b), and converts to the output
+        data type (BF16 / FP16).
+        """
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_b)
+
+        # Thread / block / cluster indices
+        bidx, bidy, bidz = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        cidx, cidy, _ = cute.arch.cluster_idx()
+        cdimx, cdimy, _ = cute.arch.cluster_dim()
+        cluster_id = cidx + cdimx * cidy
+
+        # CTA swizzle for L2 reuse
+        group_size_m = 8
+        s_shape = ((group_size_m, cdimx // group_size_m), cdimy)
+        s_stride = ((1, cdimy * group_size_m), group_size_m)
+        s_layout = cute.make_layout(s_shape, stride=s_stride)
+        num_reg_cids = cute.size(s_shape)
+        cid_m, cid_n = s_layout.get_flat_coord(cluster_id % num_reg_cids)
+
+        if cluster_id >= num_reg_cids:
+            tail_size_m = cdimx % group_size_m
+            tail_layout = cute.make_layout(
+                (tail_size_m, cdimy), stride=(1, tail_size_m)
+            )
+            tail_cid = cluster_id - num_reg_cids
+            tail_cid_m, tail_cid_n = tail_layout.get_flat_coord(tail_cid)
+            cid_m = cute.size(s_shape, mode=[0]) + tail_cid_m
+            cid_n = tail_cid_n
+
+        bidx_in_cluster = cute.arch.block_in_cluster_idx()
+        pid_m = cid_m * self.cluster_shape_mn[0] + bidx_in_cluster[0]
+        pid_n = cid_n * self.cluster_shape_mn[1] + bidx_in_cluster[1]
+
+        tile_coord_mnkl = (pid_m, pid_n, None, bidz)
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        # Multicast masks
+        a_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=1
+        )
+        b_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=0
+        )
+        a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+        b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(
+            self.a_dtype, a_smem_layout
+        ) + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+
+        # Shared memory allocation & pipeline init
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mcast_size = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        num_warps = self.threads_per_cta // 32
+        consumer_arrive_cnt = mcast_size * num_warps
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, consumer_arrive_cnt
+        )
+
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=mainloop_pipeline_array_ptr,
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # SMEM tensors
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC_ptr = cute.recast_ptr(
+            sA.iterator, epi_smem_layout_staged.inner, dtype=self.c_dtype
+        )
+        sC = cute.make_tensor(sC_ptr, epi_smem_layout_staged.outer)
+
+        # Global tile partitioning
+        gA_mkl = cute.local_tile(
+            mA_mkl, self.tile_shape_mnk, tile_coord_mnkl, proj=(1, None, 1)
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl, self.tile_shape_mnk, tile_coord_mnkl, proj=(None, 1, 1)
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl, self.tile_shape_mnk, tile_coord_mnkl, proj=(1, 1, None)
+        )
+
+        # Combined scale tiling (gScaleA = pre-combined M×N scale)
+        mSC_mnl = cute.make_tensor(gScaleA.iterator, gScaleA.layout)
+        gSC_mnl = cute.local_tile(
+            mSC_mnl, self.tile_shape_mnk,
+            tile_coord_mnkl, proj=(1, 1, None))
+
+        # MMA partitioning
+        warp_group_idx = cute.arch.make_warp_uniform(
+            tidx // self.num_threads_per_warp_group
+        )
+        warp_group_thread_layout = cute.make_layout(
+            self.mma_warp_groups, stride=self.num_threads_per_warp_group
+        )
+        thr_mma = tiled_mma.get_slice(warp_group_thread_layout(warp_group_idx))
+        tCgC = thr_mma.partition_C(gC_mnl)
+        tCgSC = thr_mma.partition_C(gSC_mnl)
+
+        # TMA partitions for A
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        sA_for_tma_partition = cute.group_modes(sA, 0, 2)
+        gA_for_tma_partition = cute.group_modes(gA_mkl, 0, 2)
+        tAsA, tAgA_mkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_a, a_cta_crd, a_cta_layout,
+            sA_for_tma_partition, gA_for_tma_partition,
+        )
+
+        # TMA partitions for B
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        sB_for_tma_partition = cute.group_modes(sB, 0, 2)
+        gB_for_tma_partition = cute.group_modes(gB_nkl, 0, 2)
+        tBsB, tBgB_nkl = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_b, b_cta_crd, b_cta_layout,
+            sB_for_tma_partition, gB_for_tma_partition,
+        )
+
+        # MMA fragments
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+        tCrA = tiled_mma.make_fragment_A(tCsA)
+        tCrB = tiled_mma.make_fragment_B(tCsB)
+        acc_shape = tCgC.shape
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        # Cluster sync after barrier init
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        # Prefetch TMA loads
+        k_tile_cnt = cute.size(gA_mkl, mode=[2])
+        prefetch_k_tile_cnt = cutlass.max(cutlass.min(self.ab_stage, k_tile_cnt), 0)
+
+        mainloop_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        if warp_idx == 0:
+            for prefetch_idx in cutlass.range(prefetch_k_tile_cnt, unroll=1):
+                mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+                tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                cute.copy(
+                    tma_atom_a, tAgA_k, tAsA_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                        mainloop_producer_state
+                    ),
+                    mcast_mask=a_mcast_mask,
+                )
+                cute.copy(
+                    tma_atom_b, tBgB_k, tBsB_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                        mainloop_producer_state
+                    ),
+                    mcast_mask=b_mcast_mask,
+                )
+                mainloop_pipeline.producer_commit(mainloop_producer_state)
+                mainloop_producer_state.advance()
+
+        # Prologue MMA
+        k_pipe_mmas = 1
+
+        mainloop_consumer_read_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+        mainloop_consumer_release_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        peek_ab_full_status = cutlass.Boolean(1)
+        if mainloop_consumer_read_state.count < k_tile_cnt:
+            peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                mainloop_consumer_read_state
+            )
+
+        tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, False)
+        num_k_blocks = cute.size(tCrA, mode=[2])
+
+        for k_tile in cutlass.range_constexpr(k_pipe_mmas):
+            mainloop_pipeline.consumer_wait(
+                mainloop_consumer_read_state, peek_ab_full_status
+            )
+            cute.nvgpu.warpgroup.fence()
+            for k_block_idx in cutlass.range(num_k_blocks, unroll_full=True):
+                k_block_coord = (
+                    None, None, k_block_idx,
+                    mainloop_consumer_read_state.index,
+                )
+                cute.gemm(
+                    tiled_mma, accumulators,
+                    tCrA[k_block_coord], tCrB[k_block_coord],
+                    accumulators,
+                )
+                tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+            cute.nvgpu.warpgroup.commit_group()
+            mainloop_consumer_read_state.advance()
+            peek_ab_full_status = cutlass.Boolean(1)
+            if mainloop_consumer_read_state.count < k_tile_cnt:
+                peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                    mainloop_consumer_read_state
+                )
+
+        for k_tile in cutlass.range(k_pipe_mmas, k_tile_cnt, 1, unroll=1):
+            mainloop_pipeline.consumer_wait(
+                mainloop_consumer_read_state, peek_ab_full_status
+            )
+            cute.nvgpu.warpgroup.fence()
+            for k_block_idx in cutlass.range(num_k_blocks, unroll_full=True):
+                k_block_coord = (
+                    None, None, k_block_idx,
+                    mainloop_consumer_read_state.index,
+                )
+                cute.gemm(
+                    tiled_mma, accumulators,
+                    tCrA[k_block_coord], tCrB[k_block_coord],
+                    accumulators,
+                )
+
+            cute.nvgpu.warpgroup.commit_group()
+            cute.nvgpu.warpgroup.wait_group(k_pipe_mmas)
+
+            mainloop_pipeline.consumer_release(mainloop_consumer_release_state)
+            mainloop_consumer_read_state.advance()
+            mainloop_consumer_release_state.advance()
+
+            peek_ab_full_status = cutlass.Boolean(1)
+            if mainloop_consumer_read_state.count < k_tile_cnt:
+                peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                    mainloop_consumer_read_state
+                )
+
+            # Overlap TMA load with MMA
+            if warp_idx == 0 and mainloop_producer_state.count < k_tile_cnt:
+                mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+                tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                cute.copy(
+                    tma_atom_a, tAgA_k, tAsA_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                        mainloop_producer_state
+                    ),
+                    mcast_mask=a_mcast_mask,
+                )
+                cute.copy(
+                    tma_atom_b, tBgB_k, tBsB_pipe,
+                    tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                        mainloop_producer_state
+                    ),
+                    mcast_mask=b_mcast_mask,
+                )
+                mainloop_pipeline.producer_commit(mainloop_producer_state)
+                mainloop_producer_state.advance()
+
+        # Epilogue: Int32 -> Float32, scale, convert to output type, write
+        cute.nvgpu.warpgroup.wait_group(0)
+
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive()
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.sync_threads()
+
+        copy_atom_r2s = sm90_utils.sm90_get_smem_store_op(
+            self.c_layout,
+            elem_ty_d=self.c_dtype,
+            elem_ty_acc=self.acc_dtype,
+        )
+        copy_atom_C = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(self.c_layout.is_m_major_c(), 4),
+            self.c_dtype,
+        )
+        tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+        tiled_copy_r2s = cute.make_tiled_copy_S(copy_atom_r2s, tiled_copy_C_Atom)
+
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sD = thr_copy_r2s.partition_D(sC)
+        tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+        scale_regs = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        num_scale_elems = cute.size(scale_regs)
+        for i in cutlass.range_constexpr(num_scale_elems):
+            scale_regs[i] = tCgSC[i]
+        tRS_rS = tiled_copy_r2s.retile(scale_regs)
+
+        rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+        tRS_rD_layout = cute.make_layout(rD_shape[:3])
+        tRS_rD = cute.make_rmem_tensor_like(tRS_rD_layout, self.acc_dtype)
+        size_tRS_rD = cute.size(tRS_rD)
+
+        sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+        tCgC_for_tma_partition = cute.zipped_divide(gC_mnl, self.epi_tile)
+
+        bSG_sD, bSG_gD = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_c, 0, cute.make_layout(1),
+            sepi_for_tma_partition, tCgC_for_tma_partition,
+        )
+
+        epi_tile_num = cute.size(tCgC_for_tma_partition, mode=[1])
+        epi_tile_shape = tCgC_for_tma_partition.shape[1]
+        epi_tile_layout = cute.make_layout(
+            epi_tile_shape, stride=(epi_tile_shape[1], 1)
+        )
+
+        c_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.threads_per_cta
+        )
+        c_pipeline = pipeline.PipelineTmaStore.create(
+            num_stages=self.epi_stage,
+            producer_group=c_producer_group,
+        )
+
+        tRS_rD_s = cute.make_rmem_tensor_like(
+            tRS_rD_layout, cutlass.Float32)
+
+        for epi_idx in cutlass.range_constexpr(epi_tile_num):
+            # Copy accumulator fragment to D registers (Int32)
+            for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                tRS_rD[epi_v] = tRS_rAcc[epi_idx * size_tRS_rD + epi_v]
+
+            # Int32 accumulator -> Float32 -> scale -> output dtype
+            acc_vec = tRS_rD.load()
+            float_vec = acc_vec.to(cutlass.Float32)
+            for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                tRS_rD_s[epi_v] = tRS_rS[
+                    epi_idx * size_tRS_rD + epi_v]
+            s_vec = tRS_rD_s.load()
+            scaled_vec = float_vec * s_vec
+
+            tRS_rD_out = cute.make_rmem_tensor_like(tRS_rD_layout, self.c_dtype)
+            tRS_rD_out.store(scaled_vec.to(self.c_dtype))
+
+            epi_buffer = epi_idx % cute.size(tRS_sD, mode=[3])
+            cute.copy(
+                tiled_copy_r2s, tRS_rD_out, tRS_sD[(None, None, None, epi_buffer)]
+            )
+
+            cute.arch.fence_proxy("async.shared", space="cta")
+            pipeline.sync(barrier_id=1)
+
+            gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
+            if warp_idx == 0:
+                cute.copy(
+                    tma_atom_c,
+                    bSG_sD[(None, epi_buffer)],
+                    bSG_gD[(None, gmem_coord)],
+                )
+                c_pipeline.producer_commit()
+                c_pipeline.producer_acquire()
+
+            pipeline.sync(barrier_id=1)
+
+        if warp_idx == 0:
+            c_pipeline.producer_tail()
+
+        return
+
+    @staticmethod
+    def _compute_stages(tile_shape_mnk, a_dtype, b_dtype, smem_capacity, occupancy):
+        epi_stage = 4
+        epi_bytes = 0
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        mbar_helpers_bytes = 1024
+        ab_stage = (
+            smem_capacity // occupancy - mbar_helpers_bytes - epi_bytes
+        ) // ab_bytes_per_stage
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk, epi_tile, a_dtype, a_layout, b_dtype, b_layout,
+        ab_stage, c_dtype, c_layout, epi_stage,
+    ):
+        a_smem = sm90_utils.make_smem_layout_a(
+            a_layout, tile_shape_mnk, a_dtype, ab_stage
+        )
+        b_smem = sm90_utils.make_smem_layout_b(
+            b_layout, tile_shape_mnk, b_dtype, ab_stage
+        )
+        epi_smem = sm90_utils.make_smem_layout_epi(
+            c_dtype, c_layout, epi_tile, epi_stage
+        )
+        return a_smem, b_smem, epi_smem
+
+    @staticmethod
+    def _compute_grid(c, tile_shape_mnk, cluster_shape_mn):
+        c_shape = (tile_shape_mnk[0], tile_shape_mnk[1])
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+        clusters = cute.ceil_div(
+            cute.get(gc.layout, mode=[1]).shape, cluster_shape_mnl
+        )
+        grid = tuple(x * y for x, y in zip(clusters, cluster_shape_mnl))
+        return grid
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(tensor, smem_layout_staged, smem_tile, mcast_dim):
+        op = (
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cute.nvgpu.cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            op, tensor, smem_layout, smem_tile, num_multicast=mcast_dim,
+        )
+        return tma_atom, tma_tensor
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(tensor_c, epi_smem_layout_staged, epi_tile):
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c, epi_smem_layout, epi_tile,
+        )
+        return tma_atom_c, tma_tensor_c
+
+
+# Dispatch helper — mirrors the C++ tile/cluster selection logic
+def select_tile_config(m: int, n: int, k: int) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Select (tile_shape_mn, cluster_shape_mn) matching the C++ dispatch.
+
+    Returns the same tile/cluster configurations as
+    scaled_mm_sm90_int8_dispatch.cuh::cutlass_gemm_sm90_int8_dispatch.
+
+    The C++ dispatch uses next_pow_2(max(32, m)) for bucketing:
+      mp2 <= 32  => M in [1, 32]
+      mp2 <= 64  => M in (32, 64]
+      mp2 <= 128 => M in (64, 128]
+      else       => M in (128, inf)
+    """
+    mp2 = max(32, 1 << (m - 1).bit_length()) if m > 0 else 32
+
+    if mp2 <= 32:
+        # M in [1, 32]
+        if n < 8192:
+            return (64, 64), (1, 8)
+        else:
+            return (64, 128), (1, 4)
+    elif mp2 <= 64:
+        # M in (32, 64]
+        return (64, 64), (1, 1)
+    elif mp2 <= 128:
+        # M in (64, 128]
+        return (64, 128), (2, 1)
+    else:
+        # M in (128, inf)
+        return (128, 128), (2, 1)


### PR DESCRIPTION


## Purpose
Evaluating performance of Quant Scaled MM Per (Tensor/token/channel) FP8 kernel written in CuTeDSL against the Cutlass version. Evaluating the kernel for Hopper GPU (SM_90).

## Test Plan
PR contains the detail unit test to cover most of the scenarios.

## Test Result
Executing the kernel directly with expected tensor input gives the following kernel execution time. CuTe DSL performs better for M <1024, but performance declines after that.

M (N,K=4096) | CUTLASS C++ (ms) | CuTe DSL (ms) | PyTorch  (Mean ms) | CuTe DSL Speedup vs. CUTLASS
-- | -- | -- | -- | --
16 | 0.0247 | 0.0226 | 0.0230 | 1.09x
32 | 0.0248 | 0.0178 | 0.0229 | 1.39x
64 | 0.0246 | 0.0178 | 0.0231 | 1.38x
128 | 0.0255 | 0.0183 | 0.0230 | 1.39x
256 | 0.0290 | 0.0181 | 0.0260 | 1.60x
512 | 0.0291 | 0.0184 | 0.0266 | 1.58x
1024 | 0.0295 | 0.0347 | 0.0275 | 0.85x
2048 | 0.0560 | 0.0675 | 0.0498 | 0.83x
4096 | 0.0979 | 0.1276 | 0.0970 | 0.77x
8192 | 0.2094 | 0.2467 | 0.2060 | 0.85x

---
### Work in progress
- [ ] Debugging the performance issue related to M > 1024
- [ ] Calling the kernel through dispatch code (in the w8a8_benchmark) declines performance.

