### PR TITLE
fix: logprobs values change with requested count due to token-string collision

### DIFF
--- a/tests/tokenizers_/test_detokenize.py
+++ b/tests/tokenizers_/test_detokenize.py
@@ -70,6 +70,36 @@ class MockLogprobsTokenizer:
         return "".join(self.decoded_tokens[token_id] for token_id in ids)
 
 
+class MockSentencePieceBackend:
+    def __init__(self, raw_tokens: dict[int, str]):
+        self.raw_tokens = raw_tokens
+
+    def id_to_piece(self, token_id: int) -> str:
+        return self.raw_tokens[token_id]
+
+
+class MockSentencePieceLogprobsTokenizer(MockLogprobsTokenizer):
+    is_spm = True
+
+    def __init__(
+        self,
+        raw_tokens: dict[int, str],
+        decoded_tokens: dict[int, str],
+        sentencepiece_pieces: dict[int, str],
+    ):
+        super().__init__(raw_tokens, decoded_tokens)
+        self.tokenizer = MockSentencePieceBackend(sentencepiece_pieces)
+        self.convert_ids_to_tokens_call_count = 0
+
+    def convert_ids_to_tokens(
+        self,
+        ids: list[int],
+        skip_special_tokens: bool = False,
+    ) -> list[str]:
+        self.convert_ids_to_tokens_call_count += 1
+        return super().convert_ids_to_tokens(ids, skip_special_tokens)
+
+
 def _make_top_logprobs(
     tokenizer: MockLogprobsTokenizer,
     token_ids: list[int],
@@ -291,6 +321,17 @@ def test_convert_ids_list_to_tokens_preserves_sentencepiece_boundaries():
     assert len(top_logprobs) == 4
 
 
+def test_convert_ids_list_to_tokens_prefers_sentencepiece_backend_pieces():
+    tokenizer = MockSentencePieceLogprobsTokenizer(
+        raw_tokens={0: "true", 1: "true"},
+        decoded_tokens={0: "true", 1: "true"},
+        sentencepiece_pieces={0: "▁true", 1: "true"},
+    )
+
+    assert convert_ids_list_to_tokens(tokenizer, [0, 1]) == [" true", "true"]
+    assert tokenizer.convert_ids_to_tokens_call_count == 0
+
+
 def test_convert_ids_list_to_tokens_preserves_readable_space_tokens():
     byte_level_tokenizer = MockLogprobsTokenizer(
         raw_tokens={0: "Ġword", 1: "word", 2: "Ġ", 3: "Ċ"},
@@ -343,12 +384,8 @@ def test_convert_ids_list_to_tokens_keeps_logprobs_count_and_values_stable():
     token_ids = list(range(10))
     logprobs = [-0.1 * (idx + 1) for idx in range(10)]
 
-    top4 = _make_top_logprobs(
-        tokenizer, token_ids, logprobs, requested_logprobs=4
-    )
-    top10 = _make_top_logprobs(
-        tokenizer, token_ids, logprobs, requested_logprobs=10
-    )
+    top4 = _make_top_logprobs(tokenizer, token_ids, logprobs, requested_logprobs=4)
+    top10 = _make_top_logprobs(tokenizer, token_ids, logprobs, requested_logprobs=10)
 
     assert len(top4) == 4
     assert len(top10) == 10

--- a/tests/tokenizers_/test_detokenize.py
+++ b/tests/tokenizers_/test_detokenize.py
@@ -8,6 +8,7 @@ import pytest
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from vllm.sampling_params import SamplingParams
+from vllm.tokenizers.detokenizer_utils import convert_ids_list_to_tokens
 from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.detokenizer import (
@@ -45,6 +46,39 @@ TOKENIZERS = [
     "codellama/CodeLlama-7b-hf",
     "mistralai/Pixtral-12B-2409",
 ]
+
+
+class MockLogprobsTokenizer:
+    def __init__(self, raw_tokens: dict[int, str], decoded_tokens: dict[int, str]):
+        self.raw_tokens = raw_tokens
+        self.decoded_tokens = decoded_tokens
+
+    def convert_ids_to_tokens(
+        self,
+        ids: list[int],
+        skip_special_tokens: bool = False,
+    ) -> list[str]:
+        del skip_special_tokens
+        return [self.raw_tokens[token_id] for token_id in ids]
+
+    def decode(
+        self,
+        ids: list[int],
+        skip_special_tokens: bool = False,
+    ) -> str:
+        del skip_special_tokens
+        return "".join(self.decoded_tokens[token_id] for token_id in ids)
+
+
+def _make_top_logprobs(
+    tokenizer: MockLogprobsTokenizer,
+    token_ids: list[int],
+    logprobs: list[float],
+    requested_logprobs: int,
+) -> dict[str, float]:
+    requested_token_ids = token_ids[:requested_logprobs]
+    decoded_tokens = convert_ids_list_to_tokens(tokenizer, requested_token_ids)
+    return dict(zip(decoded_tokens, logprobs[:requested_logprobs]))
 
 
 def _run_incremental_decode(
@@ -239,3 +273,84 @@ def test_oov_decode(tokenizer, fast):
 
     assert decoded_text == ""
     assert out_ids == [len(tokenizer)]
+
+
+def test_convert_ids_list_to_tokens_preserves_sentencepiece_boundaries():
+    tokenizer = MockLogprobsTokenizer(
+        raw_tokens={0: "▁true", 1: "true", 2: "▁false", 3: "false"},
+        decoded_tokens={0: "true", 1: "true", 2: "false", 3: "false"},
+    )
+    token_ids = [0, 1, 2, 3]
+
+    decoded_tokens = convert_ids_list_to_tokens(tokenizer, token_ids)
+
+    assert decoded_tokens == [" true", "true", " false", "false"]
+    top_logprobs = _make_top_logprobs(
+        tokenizer, token_ids, [-0.1, -0.2, -0.3, -0.4], requested_logprobs=4
+    )
+    assert len(top_logprobs) == 4
+
+
+def test_convert_ids_list_to_tokens_preserves_readable_space_tokens():
+    byte_level_tokenizer = MockLogprobsTokenizer(
+        raw_tokens={0: "Ġword", 1: "word", 2: "Ġ", 3: "Ċ"},
+        decoded_tokens={0: " word", 1: "word", 2: " ", 3: "\n"},
+    )
+    sentencepiece_tokenizer = MockLogprobsTokenizer(
+        raw_tokens={0: "▁", 1: "▁▁"},
+        decoded_tokens={0: "", 1: " "},
+    )
+
+    assert convert_ids_list_to_tokens(byte_level_tokenizer, [0, 1, 2, 3]) == [
+        " word",
+        "word",
+        " ",
+        "\n",
+    ]
+    assert convert_ids_list_to_tokens(sentencepiece_tokenizer, [0, 1]) == [
+        " ",
+        "  ",
+    ]
+
+
+def test_convert_ids_list_to_tokens_keeps_logprobs_count_and_values_stable():
+    tokenizer = MockLogprobsTokenizer(
+        raw_tokens={
+            0: "▁true",
+            1: "alpha",
+            2: "beta",
+            3: "gamma",
+            4: "true",
+            5: "delta",
+            6: "epsilon",
+            7: "zeta",
+            8: "eta",
+            9: "theta",
+        },
+        decoded_tokens={
+            0: "true",
+            1: "alpha",
+            2: "beta",
+            3: "gamma",
+            4: "true",
+            5: "delta",
+            6: "epsilon",
+            7: "zeta",
+            8: "eta",
+            9: "theta",
+        },
+    )
+    token_ids = list(range(10))
+    logprobs = [-0.1 * (idx + 1) for idx in range(10)]
+
+    top4 = _make_top_logprobs(
+        tokenizer, token_ids, logprobs, requested_logprobs=4
+    )
+    top10 = _make_top_logprobs(
+        tokenizer, token_ids, logprobs, requested_logprobs=10
+    )
+
+    assert len(top4) == 4
+    assert len(top10) == 10
+    assert top4[" true"] == top10[" true"] == logprobs[0]
+    assert top10["true"] == logprobs[4]

--- a/vllm/tokenizers/detokenizer_utils.py
+++ b/vllm/tokenizers/detokenizer_utils.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from collections.abc import Callable, Sequence
+
 from vllm.tokenizers import TokenizerLike
 
 
@@ -55,7 +57,58 @@ def _convert_tokens_to_string_with_added_encoders(
 # tokenizers (bigger = more conservative).
 INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 
-_LEADING_SPACE_MARKERS = frozenset(("▁", "Ġ"))
+_SENTENCEPIECE_LEADING_SPACE_MARKER = "▁"
+_BYTE_LEVEL_BPE_LEADING_SPACE_MARKER = "Ġ"
+# id_to_piece/convert_ids_to_tokens exposes raw tokenizer pieces, but there is
+# no tokenizer-agnostic API that says whether decode normalized away a leading
+# space. Keep recognition limited to the canonical SentencePiece and byte-level
+# BPE leading-space markers used in raw vocab pieces.
+_LEADING_SPACE_MARKERS = frozenset(
+    (
+        _SENTENCEPIECE_LEADING_SPACE_MARKER,
+        _BYTE_LEVEL_BPE_LEADING_SPACE_MARKER,
+    )
+)
+
+
+def _get_sentencepiece_id_to_piece(
+    tokenizer: TokenizerLike,
+) -> Callable[[int], object] | None:
+    # MistralTokenizer stores its SentencePiece tokenizer on `.tokenizer` and
+    # marks that path with `is_spm`; do not use the same attribute for Tekken.
+    if getattr(tokenizer, "is_spm", False):
+        id_to_piece = getattr(
+            getattr(tokenizer, "tokenizer", None), "id_to_piece", None
+        )
+        if callable(id_to_piece):
+            return id_to_piece
+
+    id_to_piece = getattr(tokenizer, "id_to_piece", None)
+    if callable(id_to_piece):
+        return id_to_piece
+
+    sp_model = getattr(tokenizer, "sp_model", None)
+    id_to_piece = getattr(sp_model, "id_to_piece", None)
+    if callable(id_to_piece):
+        return id_to_piece
+    id_to_piece = getattr(sp_model, "IdToPiece", None)
+    if callable(id_to_piece):
+        return id_to_piece
+    return None
+
+
+def _convert_ids_to_raw_tokens(
+    tokenizer: TokenizerLike,
+    token_ids: list[int],
+) -> Sequence[object]:
+    id_to_piece = _get_sentencepiece_id_to_piece(tokenizer)
+    if id_to_piece is not None:
+        return [id_to_piece(token_id) for token_id in token_ids]
+
+    raw_tokens = tokenizer.convert_ids_to_tokens(token_ids)
+    if isinstance(raw_tokens, str):
+        return [raw_tokens]
+    return raw_tokens
 
 
 def _restore_leading_spaces(raw_token: object, token_str: str) -> str:
@@ -119,9 +172,7 @@ def convert_ids_list_to_tokens(
     if not token_ids:
         return []
 
-    raw_tokens = tokenizer.convert_ids_to_tokens(token_ids)
-    if isinstance(raw_tokens, str):
-        raw_tokens = [raw_tokens]
+    raw_tokens = _convert_ids_to_raw_tokens(tokenizer, token_ids)
 
     token_str_lst = []
     for idx, token_id in enumerate(token_ids):

--- a/vllm/tokenizers/detokenizer_utils.py
+++ b/vllm/tokenizers/detokenizer_utils.py
@@ -55,6 +55,28 @@ def _convert_tokens_to_string_with_added_encoders(
 # tokenizers (bigger = more conservative).
 INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 
+_LEADING_SPACE_MARKERS = frozenset(("▁", "Ġ"))
+
+
+def _restore_leading_spaces(raw_token: object, token_str: str) -> str:
+    if not isinstance(raw_token, str):
+        return token_str
+
+    num_leading_spaces = 0
+    for char in raw_token:
+        if char not in _LEADING_SPACE_MARKERS:
+            break
+        num_leading_spaces += 1
+
+    if num_leading_spaces == 0:
+        return token_str
+
+    decoded_leading_spaces = len(token_str) - len(token_str.lstrip(" "))
+    num_missing_spaces = num_leading_spaces - decoded_leading_spaces
+    if num_missing_spaces <= 0:
+        return token_str
+    return " " * num_missing_spaces + token_str
+
 
 def convert_prompt_ids_to_tokens(
     tokenizer: TokenizerLike,
@@ -94,12 +116,21 @@ def convert_ids_list_to_tokens(
       Python list of token string representations
 
     """
+    if not token_ids:
+        return []
+
+    raw_tokens = tokenizer.convert_ids_to_tokens(token_ids)
+    if isinstance(raw_tokens, str):
+        raw_tokens = [raw_tokens]
+
     token_str_lst = []
-    for token_id in token_ids:
+    for idx, token_id in enumerate(token_ids):
         # use default skip_special_tokens.
         token_str = tokenizer.decode([token_id])
         if token_str is None:
             token_str = ""
+        raw_token = raw_tokens[idx] if idx < len(raw_tokens) else None
+        token_str = _restore_leading_spaces(raw_token, token_str)
         token_str_lst.append(token_str)
     return token_str_lst
 


### PR DESCRIPTION


## Summary

Fixes dropped `top_logprobs` entries by keeping distinct token strings distinct, so an N-entry `logprobs=N` request returns N entries again.

## Why

Requesting `logprobs=N` on the OpenAI Completions API returned fewer than N entries, and a token's logprob appeared to change as N changed. Issue #44319 reports this as a logprob instability, but the values are stable at temperature=0; the real defect is that two distinct token ids render to the same string in `top_logprobs`, and because `top_logprobs` is keyed as `dict[str, float]` the colliding keys collapse and silently drop entries.

## Purpose

Fixes #44319, where requesting `logprobs=N` on the OpenAI Completions API returns fewer than N entries and a token's logprob appears to change as N changes. The values are stable at temperature=0; the real defect is that two distinct token ids render to the same string in `top_logprobs`, and because `top_logprobs` is keyed as `dict[str, float]` the colliding keys collapse and drop entries. The collision was introduced by PR #19209, which switched `convert_ids_list_to_tokens` in `vllm/tokenizers/detokenizer_utils.py` from `convert_ids_to_tokens()` to `decode([token_id])`, so the SentencePiece `▁` word-boundary marker is stripped and `▁true` and `true` both become `"true"`. This change decodes each id but keeps the leading-space signal when the underlying raw piece carries a word-boundary marker, so `" true"` and `"true"` stay distinct while output remains human-readable. `convert_prompt_ids_to_tokens` and `detokenize_incrementally` in the same module are unaffected.

## Test Plan

Added cases to `tests/tokenizers_/test_detokenize.py`: a tokenizer where one id decodes to `▁true` and another to `true` must return two distinct strings and keep all N keys in an N-entry `top_logprobs`; byte-level (`Ġ`) and pure-whitespace pieces must stay readable and distinct; logprobs=4 vs logprobs=10 must return 4 and 10 entries with a shared token's value identical across both at temperature=0.

## Test Result

The new tests in `tests/tokenizers_/test_detokenize.py` pass locally. Full tokenizer suite runs in CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
