### PR TITLE
fix: validate logits processor fqcn format

### DIFF
--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -23,6 +23,7 @@ from vllm.v1.sample.logits_processor import (
     STR_POOLING_REJECTS_LOGITSPROCS,
     STR_SPEC_DEC_REJECTS_LOGITSPROCS,
     LogitsProcessor,
+    _load_logitsprocs_by_fqcns,
 )
 
 # Create a mixture of requests which do and don't utilize the dummy logitproc
@@ -40,6 +41,20 @@ sampling_params_list = [
     ),
     SamplingParams(temperature=TEMP_GREEDY, max_tokens=MAX_TOKENS),
 ]
+
+
+@pytest.mark.parametrize(
+    "fqcn",
+    [
+        "tests.v1.logits_processors.utils.DummyLogitsProcessor",
+        "tests.v1.logits_processors.utils:DummyLogitsProcessor:extra",
+        ":DummyLogitsProcessor",
+        "tests.v1.logits_processors.utils:",
+    ],
+)
+def test_rejects_malformed_logits_processor_fqcn(fqcn: str):
+    with pytest.raises(ValueError, match="Expected format '<module>:<type>'"):
+        _load_logitsprocs_by_fqcns([fqcn])
 
 
 def _run_test(kwargs: dict, logitproc_loaded: bool) -> None:

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -125,7 +125,17 @@ def _load_logitsprocs_by_fqcns(
             continue
 
         logger.debug("- Loading logits processor %s", logitproc)
+        if logitproc.count(":") != 1:
+            raise ValueError(
+                f"Invalid logits processor FQCN {logitproc!r}. "
+                "Expected format '<module>:<type>'."
+            )
         module_path, qualname = logitproc.split(":")
+        if not module_path or not qualname:
+            raise ValueError(
+                f"Invalid logits processor FQCN {logitproc!r}. "
+                "Expected format '<module>:<type>'."
+            )
 
         try:
             # Load module


### PR DESCRIPTION
## Purpose

Fixes #44156.
Closes #44154.

`_load_logitsprocs_by_fqcns()` currently unpacks `logitproc.split(":")` directly. A malformed FQCN such as `mypackage.module.MyProcessor` or `a:b:c` raises Python's unpacking `ValueError`, which does not tell the user that vLLM expects `<module>:<type>`.

This PR validates the FQCN shape before unpacking. It rejects strings that do not contain exactly one colon, and also rejects empty module/type halves.

## Test Plan

Targeted behavior and static checks:

- Add a unit test for malformed logits processor FQCN strings.
- Run `py_compile` on the changed Python files.
- Run `ruff check` and `ruff format --check` on the changed files.
- Run `git diff --check`.
- Run a direct Python probe for the malformed FQCN cases without loading pytest's repo-level `conftest.py`.

I also attempted the targeted pytest invocation locally, but this Windows checkout cannot import the test conftest because `uvloop` is not available on Windows:

```text
ModuleNotFoundError: No module named 'uvloop'
```

## Test Result

Passed locally:

```powershell
python -m py_compile vllm\v1\sample\logits_processor\__init__.py tests\v1\logits_processors\test_custom_offline.py
python -m ruff check vllm\v1\sample\logits_processor\__init__.py tests\v1\logits_processors\test_custom_offline.py
python -m ruff format --check vllm\v1\sample\logits_processor\__init__.py tests\v1\logits_processors\test_custom_offline.py
git diff --check
```

Direct behavior probe result:

```text
ok
```

The probe covered:

- missing colon
- more than one colon
- empty module half
- empty type half
