### PR TITLE
[Bugfix] MiniCPM-V-4.6 video inference crash: placeholder count mismatches visual embedding count

### DIFF
--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,

--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -25,7 +25,6 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
@@ -268,9 +267,7 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
                         h, w = h_d.item(), w_d.item()
                 else:
                     raise TypeError(f"Unsupported frame type: {type(frame)}")
-                frame_sizes.append(
-                    torch.tensor([w, h], dtype=torch.long, device="cpu")
-                )
+                frame_sizes.append(torch.tensor([w, h], dtype=torch.long, device="cpu"))
 
                 ip_out = image_processor([frame], **video_mm_kwargs)
                 pv = ip_out["pixel_values"]  # (1, C, P, sum_W)

--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -262,10 +262,9 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
                         _, h, w = frame.shape
                 elif isinstance(frame, torch.Tensor):
                     if frame.ndim == 3 and frame.shape[-1] in (1, 3, 4):
-                        h, w = frame.shape[0].item(), frame.shape[1].item()
+                        h, w = frame.shape[0], frame.shape[1]
                     else:
-                        _, h_d, w_d = frame.shape
-                        h, w = h_d.item(), w_d.item()
+                        _, h, w = frame.shape
                 else:
                     raise TypeError(f"Unsupported frame type: {type(frame)}")
                 frame_sizes.append(torch.tensor([w, h], dtype=torch.long, device="cpu"))

--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -5,7 +5,9 @@
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+import numpy as np
 import torch
+from PIL import Image as PILImage
 from torch import nn
 from transformers import MiniCPMV4_6Config
 
@@ -30,7 +32,7 @@ from vllm.multimodal.inputs import (
     MultiModalFieldConfig,
     NestedTensors,
 )
-from vllm.multimodal.parse import ImageProcessorItems, VideoProcessorItems
+from vllm.multimodal.parse import ImageProcessorItems, ImageSize, VideoProcessorItems
 from vllm.multimodal.processing.processor import (
     PromptReplacement,
     PromptUpdateDetails,
@@ -239,12 +241,37 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
 
         per_video_pixel_values: list[torch.Tensor] = []
         per_video_tgt_sizes: list[torch.Tensor] = []
+        per_video_image_sizes: list[torch.Tensor] = []
 
         for video in parsed_videos:
             # video is iterable of frames (PIL Image or numpy array).
             all_slices: list[torch.Tensor] = []
             ts_list: list[torch.Tensor] = []
+            frame_sizes: list[torch.Tensor] = []
             for frame in video:
+                # Record per-frame (W, H) for video_image_sizes so that
+                # get_video_prompt_texts can consume a consistent frame size.
+                if isinstance(frame, PILImage.Image):
+                    w, h = frame.size
+                elif isinstance(frame, np.ndarray):
+                    if frame.ndim == 3 and frame.shape[-1] in (1, 3, 4):
+                        # HWC (e.g. from np.array(PIL.Image))
+                        h, w = frame.shape[0], frame.shape[1]
+                    else:
+                        # CHW
+                        _, h, w = frame.shape
+                elif isinstance(frame, torch.Tensor):
+                    if frame.ndim == 3 and frame.shape[-1] in (1, 3, 4):
+                        h, w = frame.shape[0].item(), frame.shape[1].item()
+                    else:
+                        _, h_d, w_d = frame.shape
+                        h, w = h_d.item(), w_d.item()
+                else:
+                    raise TypeError(f"Unsupported frame type: {type(frame)}")
+                frame_sizes.append(
+                    torch.tensor([w, h], dtype=torch.long, device="cpu")
+                )
+
                 ip_out = image_processor([frame], **video_mm_kwargs)
                 pv = ip_out["pixel_values"]  # (1, C, P, sum_W)
                 ts = ip_out["target_sizes"]  # (n_slices, 2)
@@ -275,6 +302,7 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
 
             per_video_pixel_values.append(out)
             per_video_tgt_sizes.append(torch.cat(ts_list, dim=0))
+            per_video_image_sizes.append(torch.stack(frame_sizes))
 
         if not per_video_pixel_values:
             return {}
@@ -282,6 +310,7 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
         return {
             "video_pixel_values": per_video_pixel_values,
             "video_tgt_sizes": per_video_tgt_sizes,
+            "video_image_sizes": per_video_image_sizes,
         }
 
     def _get_prompt_updates(
@@ -327,6 +356,31 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
             )
 
         def get_video_replacement(item_idx: int):
+            # Prefer video_image_sizes from processed data so that the
+            # placeholder count is driven by the same frame sizes that the
+            # vision tower will actually consume.
+            video_mm_kwargs = out_mm_kwargs.get("video")
+            if video_mm_kwargs is not None and item_idx < len(video_mm_kwargs):
+                video_item = video_mm_kwargs[item_idx]
+                image_sizes_elem = video_item.get("video_image_sizes")
+                if image_sizes_elem is not None and image_sizes_elem.data is not None:
+                    # image_sizes_elem.data: (num_frames, 2) – each row is [W, H]
+                    image_sizes = image_sizes_elem.data
+                    num_frames = image_sizes.shape[0]
+                    frame_size = ImageSize(
+                        width=int(image_sizes[0, 0].item()),
+                        height=int(image_sizes[0, 1].item()),
+                    )
+                    return PromptUpdateDetails.select_text(
+                        self.get_video_prompt_texts(
+                            frame_size,
+                            num_frames,
+                            downsample_mode=ds_mode,
+                            video_idx=item_idx,
+                        ),
+                        video_embed_text,
+                    )
+
             videos = mm_items.get_items(
                 "video",
                 (MiniCPMVVideoEmbeddingItems, VideoProcessorItems),

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -378,7 +378,14 @@ class VideoProcessorItems(ProcessorBatchItems[HfVideoItem | None]):
         if isinstance(image, PILImage.Image):
             return ImageSize(*image.size)
         if isinstance(image, (np.ndarray, torch.Tensor)):
-            _, h, w = image.shape
+            if image.ndim == 3 and image.shape[-1] in (1, 3, 4):
+                # HWC format (e.g. from np.array(PIL.Image) via
+                # _get_video_with_metadata).  PIL images are always
+                # channels-last.
+                h, w = image.shape[0], image.shape[1]
+            else:
+                # CHW format (standard PyTorch / numpy convention).
+                _, h, w = image.shape
             return ImageSize(w, h)
 
         assert_never(image)


### PR DESCRIPTION
## Summary

Sending a video request to `openbmb/MiniCPM-V-4_6` causes `EngineDeadError` — the engine core crashes because the number of `<|video_pad|>` placeholder tokens does not match the number of visual embeddings produced by the vision tower. Image inference works correctly; only video triggers this.

## Root Cause

Three issues conspire:

1. **`VideoProcessorItems.get_frame_size` (`parse.py`)** hardcodes `(C, H, W)` shape unpacking. When `_get_video_with_metadata` converts a list of PIL images via `np.array(...)`, the result is `(N, H, W, C)` (HWC). The existing code interprets channel-dim as width and height-dim as width, returning a bogus `ImageSize(3, W)` instead of `ImageSize(W, H)`.

2. **`process_videos` (`minicpmv4_6.py`)** manually calls the image processor per-frame and returns `video_pixel_values` + `video_tgt_sizes`, but never produces `video_image_sizes`. The upstream `MiniCPMVMultiModalProcessor.process_videos` would usually produce this field.

3. **`_get_prompt_updates`** reads frame size/count from raw `mm_items` (`VideoProcessorItems`), which has no access to the processed data. The placeholder count is therefore driven by broken frame sizes from issue (1).

Result: placeholder count ≠ actual embedding count → `_merge_multimodal_embeddings` raises `ValueError`.

## Fix

Three changes (all in Python, no C++/CUDA rebuild needed):

- **`vllm/model_executor/models/minicpmv4_6.py`**:
  - `process_videos`: record per-frame `(W, H)` and return `video_image_sizes` alongside the existing outputs.
  - `_get_prompt_updates` / `get_video_replacement`: prefer `video_image_sizes` from processed kwargs (via `out_mm_kwargs`) to drive placeholder counting; fall back to the old path if unavailable.

- **`vllm/multimodal/parse.py`**:
  - `VideoProcessorItems.get_frame_size`: detect HWC vs CHW array format before unpacking dimensions, so the fallback path (when `video_image_sizes` is unavailable) also produces correct frame sizes.

## Test

- 2× GPU (NVIDIA 4090), `tensor-parallel-size 2`, vLLM 0.22.0 patched with this fix.
- Sent a 4-second 320×240 video via `/v1/chat/completions`. Server returned a valid text description of the video content without any crash.

## Misc

- Only video inference triggers the crash; image inference is unaffected.
- Not a regression — the video path has never worked for MiniCPM-V-4.6 on vLLM.
- Change size: 2 files, +64/−2 lines.