### PR TITLE
[XPU] Add online fp8 quantization test

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -145,7 +145,8 @@ steps:
       - >-
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'cd tests &&
-        pytest -v -s quantization/test_auto_round.py'
+        pytest -v -s quantization/test_auto_round.py &&
+        pytest -v -s quantization/test_online.py'
   - label: "XPU compressed tensors FP8 test"
     depends_on:
       - image-build-xpu

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -88,6 +88,7 @@ _XPU_EXCLUDED_MODEL_IDS = {
     "baidu/Unlimited-OCR",
     "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",
     "Qwen/Qwen2.5-Omni-7B-AWQ",
+    "thinkingmachines/Inkling-NVFP4",
 }
 
 

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -121,7 +121,7 @@ def test_online_quantization(
             if moe is not None:
                 assert isinstance(moe._quant_method, expected_moe_cls)
 
-            if current_platform.is_cuda():
+            if current_platform.is_cuda() or current_platform.is_xpu():
                 assert o_proj.weight.dtype == torch.float8_e4m3fn
             elif current_platform.is_rocm():
                 assert o_proj.weight.dtype == current_platform.fp8_dtype()

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -89,6 +89,9 @@ def test_online_quantization(
     if use_rocm_aiter:
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 
+    if current_platform.is_xpu() and quant_scheme == "fp8_per_block":
+        pytest.skip("Skip test for online fp8_per_block on XPU platform.")
+
     # `LLM.apply_model` requires pickling a function.
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 

--- a/tests/quantization/utils.py
+++ b/tests/quantization/utils.py
@@ -10,15 +10,12 @@ from vllm.platforms import current_platform
 
 
 def is_quant_method_supported(quant_method: str) -> bool:
-    # Currently, all quantization methods require Nvidia or AMD GPUs
-    if not (current_platform.is_cuda() or current_platform.is_rocm()):
-        return False
-
     try:
         current_platform.verify_quantization(quant_method)
     except ValueError:
         return False
-
+    if current_platform.is_xpu():
+        return True
     capability = current_platform.get_device_capability()
     assert capability is not None
 

--- a/tests/quantization/utils.py
+++ b/tests/quantization/utils.py
@@ -10,6 +10,9 @@ from vllm.platforms import current_platform
 
 
 def is_quant_method_supported(quant_method: str) -> bool:
+    # Currently, quantization tests only run GPUs
+    if current_platform.is_cpu():
+        return False
     try:
         current_platform.verify_quantization(quant_method)
     except ValueError:

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -14,6 +14,7 @@ from vllm.model_executor.model_loader.utils import (
     initialize_model,
     process_weights_after_loading,
 )
+from vllm.platforms import current_platform
 from vllm.tracing import instrument
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import set_default_torch_dtype

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -14,7 +14,6 @@ from vllm.model_executor.model_loader.utils import (
     initialize_model,
     process_weights_after_loading,
 )
-from vllm.platforms import current_platform
 from vllm.tracing import instrument
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import set_default_torch_dtype

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -110,6 +110,19 @@ class XPUPlatform(Platform):
     ray_device_key: str = "GPU"
     dist_backend: str = "xccl"  # xccl only
     device_control_env_var: str = "ZE_AFFINITY_MASK"
+    supported_quantization: list[str] = [
+        "awq",
+        "gptq",
+        "fp8",
+        "mxfp4",
+        "mxfp8",
+        "fp8_per_tensor",
+        "fp8_per_block",
+        "online",
+        "gpt_oss_mxfp4",
+        "modelopt",
+        "compressed-tensors",
+    ]
 
     @classmethod
     def import_kernels(cls) -> None:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -113,6 +113,9 @@ class XPUPlatform(Platform):
     supported_quantization: list[str] = [
         "awq",
         "gptq",
+        "auto_awq",
+        "auto_gptq",
+        "inc",
         "fp8",
         "mxfp4",
         "mxfp8",


### PR DESCRIPTION



## Purpose
vLLM adopted new fp8 online frontend by PR #38318 and #40152, which provides more quantization configs including `fp8_per_tensor`, `fp8_per_block` and `mxfp8`. XPU platform supports all of these configs as verified. This PR adds the test for XPU platform.
| Model | fp8_per_tensor | fp8_per_block | mxfp8 | Notes |
|---|---|---|---|---|
| Dense model | Y | Y | Y |  |
| MoE model | Y | Y | Y | For pure per block, depends on PR [vllm-xpu-kernels#372](https://github.com/vllm-project/vllm-xpu-kernels/pull/372)/#44763 and moe_gemm falls back to triton by default and can use `VLLM_XPU_FUSED_MOE_USE_REF=1` to use ref impl |

## Test Plan
```
VLLM_LOG_MODEL_INSPECTION=1 VLLM_LOGGING_LEVEL=DEBUG python3 examples/basic/offline_inference/generate.py --model Qwen/Qwen3-30B-A3B  --enforce-eager --dtype=bfloat16 --block-size=64 --max_model_len=2048 --gpu-memory-utilization=0.8 --trust-remote-code --quantization=fp8_per_block -tp=4
VLLM_LOG_MODEL_INSPECTION=1 VLLM_LOGGING_LEVEL=DEBUG python3 examples/basic/offline_inference/generate.py --model Qwen/Qwen3-30B-A3B  --enforce-eager --dtype=bfloat16 --block-size=64 --max_model_len=2048 --gpu-memory-utilization=0.8 --trust-remote-code --quantization=mxfp8 -tp=4
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

