### PR TITLE
fix benchmarks: chat_template_kwargs ignored in spec_bench/custom_audio, causing distorted thinking-model metrics

### DIFF
--- a/tests/benchmarks/test_custom_dataset_chat_template_kwargs.py
+++ b/tests/benchmarks/test_custom_dataset_chat_template_kwargs.py
@@ -73,3 +73,72 @@ def test_chat_template_kwargs_default_is_noop(tmp_path: Path) -> None:
     get_samples(_args(str(jsonl), None), tok)
 
     assert tok.captured_kwargs == {}
+
+
+@pytest.mark.benchmark
+def test_custom_audio_chat_template_kwargs_forwarded(tmp_path: Path) -> None:
+    """--chat-template-kwargs must reach CustomAudioDataset."""
+    jsonl = tmp_path / "data.jsonl"
+    jsonl.write_text(
+        json.dumps(
+            {
+                "prompt": "hello audio",
+                "audio": {"array": [0.0, 0.0], "sampling_rate": 16000},
+            }
+        )
+        + "\n"
+    )
+
+    args = argparse.Namespace(
+        dataset_name="custom_audio",
+        dataset_path=str(jsonl),
+        disable_shuffle=True,
+        num_prompts=1,
+        custom_output_len=32,
+        skip_chat_template=False,
+        chat_template_kwargs={"thinking": True},
+        no_oversample=False,
+        seed=0,
+        request_id_prefix="",
+        enable_multimodal_chat=False,
+    )
+
+    tok = _RecordingTokenizer()
+    get_samples(args, tok)
+
+    assert tok.captured_kwargs == {"thinking": True}
+
+
+@pytest.mark.benchmark
+def test_spec_bench_chat_template_kwargs_forwarded(tmp_path: Path) -> None:
+    """--chat-template-kwargs must reach SpecBench."""
+    jsonl = tmp_path / "data.jsonl"
+    jsonl.write_text(
+        json.dumps(
+            {
+                "turns": ["hello spec_bench"],
+                "category": "test_cat",
+            }
+        )
+        + "\n"
+    )
+
+    args = argparse.Namespace(
+        dataset_name="spec_bench",
+        dataset_path=str(jsonl),
+        disable_shuffle=True,
+        num_prompts=1,
+        spec_bench_category="test_cat",
+        spec_bench_output_len=32,
+        skip_chat_template=False,
+        chat_template_kwargs={"thinking": True},
+        no_oversample=False,
+        seed=0,
+        request_id_prefix="",
+        enable_multimodal_chat=False,
+    )
+
+    tok = _RecordingTokenizer()
+    get_samples(args, tok)
+
+    assert tok.captured_kwargs == {"thinking": True}

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -2121,6 +2121,8 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             enable_multimodal_chat=args.enable_multimodal_chat,
             request_id_prefix=args.request_id_prefix,
             no_oversample=args.no_oversample,
+            skip_chat_template=args.skip_chat_template,
+            chat_template_kwargs=getattr(args, "chat_template_kwargs", None),
         )
 
     elif args.dataset_name == "sonnet":
@@ -2317,6 +2319,8 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
                 enable_multimodal_chat=args.enable_multimodal_chat,
                 request_id_prefix=args.request_id_prefix,
                 no_oversample=args.no_oversample,
+                skip_chat_template=args.skip_chat_template,
+                chat_template_kwargs=getattr(args, "chat_template_kwargs", None),
             ),
             "sharegpt": lambda: ShareGPTDataset(
                 random_seed=args.seed,
@@ -2867,6 +2871,7 @@ class CustomAudioDataset(CustomDataset):
         no_oversample: bool = False,
         skip_chat_template: bool = False,
         enable_multimodal_chat: bool = False,
+        chat_template_kwargs: dict | None = None,
         **kwargs,
     ) -> list[SampleRequest]:
         self.num_available_samples = len(self.data)
@@ -2916,6 +2921,7 @@ class CustomAudioDataset(CustomDataset):
                             [{"role": "user", "content": prompt}],
                             add_generation_prompt=True,
                             tokenize=False,
+                            **(chat_template_kwargs or {}),
                         )
                     # else: plain prompt for Whisper-style models
                 prompt_len = (


### PR DESCRIPTION
 

## Purpose

Trigger Scenario: 
User runs  vllm bench serve --dataset-name spec_bench  or  --dataset-name custom_audio  specifying  
--chat-template-kwargs .
 
Symptoms: 
Specified CLI arguments fail to apply. Reasoning models generate prompts  without thinking blocks, distorting speculative decoding acceptance length, throughput,  benchmark metrics.

Expected Behavior: 
CLI template arguments reach  apply_chat_template  during dataset  sampling.

 Root Cause:  
SpecBench  call point and  CustomAudioDataset.sample  interface did not  accept or forward  skip_chat_template  and  chat_template_kwargs .

 Fix Method: 
Updated datasets.py to accept and forward arguments. Added unit tests  in test_custom_dataset_chat_template_kwargs.py.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

