### PR TITLE
[Bugfix] Clamp num_computed_tokens after streaming session rebuild

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -696,6 +696,13 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
+                    # num_new_tokens can be 0 for streaming requests rebuilt
+                    # via _update_request_as_session() where num_computed_tokens
+                    # has been clamped to num_prompt_tokens.
+                    # Skip the request gracefully rather than asserting.
+                    # See https://github.com/vllm-project/vllm/issues/42760
+                    if num_new_tokens <= 0:
+                        break
                     assert num_new_tokens > 0
 
                     # Schedule encoder inputs.
@@ -1054,6 +1061,15 @@ class Scheduler(SchedulerInterface):
         # Update block hashes for the new tokens.
         session.update_block_hashes()
         session.num_prompt_tokens = len(session.prompt_token_ids)
+        # Clamp num_computed_tokens after session rebuild so
+        # num_new_tokens = num_tokens - num_computed_tokens > 0.
+        # After extending the prompt with kept output tokens and new
+        # streaming update tokens, num_computed_tokens can exceed
+        # num_prompt_tokens if spec decode tokens were counted.
+        # See https://github.com/vllm-project/vllm/issues/42760
+        session.num_computed_tokens = min(
+            session.num_computed_tokens, session.num_prompt_tokens
+        )
         session.arrival_time = update.arrival_time
         session.sampling_params = update.sampling_params
         if session.status == RequestStatus.WAITING_FOR_STREAMING_REQ:


### PR DESCRIPTION
When `_update_request_as_session()` rebuilds a streaming request's prompt
after a streaming update arrives, `num_computed_tokens` can stay at the old
value which exceeds the new prompt size. This causes
`num_new_tokens = num_tokens - num_computed_tokens` to become <= 0 in
`schedule()`, triggering `assert num_new_tokens > 0`.

## Root Cause

After a streaming request finishes its current sub-request and a new
chunk arrives, `_update_request_as_session()` rebuilds the prompt by
extending it with:
1. Output tokens generated by the previous sub-request
2. New tokens from the streaming update

However, `num_computed_tokens` is not adjusted to reflect the new prompt
size. With spec decode enabled, `num_computed_tokens` can include draft
tokens that push it beyond `num_prompt_tokens`, making
`num_new_tokens = num_tokens - num_computed_tokens` evaluate to 0 or
negative.

## Changes

Two changes in `vllm/v1/core/sched/scheduler.py`:

1. **Clamp `num_computed_tokens`** in `_update_request_as_session()` after
the prompt is rebuilt:
   ```python
   session.num_computed_tokens = min(
       session.num_computed_tokens, session.num_prompt_tokens
   )
   ```

2. **Guard the assertion** in `schedule()` with a graceful break when
`num_new_tokens <= 0`, which can still occur when
`num_computed_tokens == num_tokens` after the clamp:
   ```python
   if num_new_tokens <= 0:
       break
   ```

## Testing

- **Hardware**: DGX GB10 (NVIDIA GB10, 120 GB VRAM)
- **Model**: `ibm-granite/granite-3.0-1b-a400m-base`
- **Config**: `enforce_eager=True`, `async_scheduling=True`,
  `speculative_config={draft_model, num_spec_tokens=4}`
- **Baseline** (no spec decode, no keeper): PASS
- **Bug scenario** (spec decode + keeper + 3 streaming chunks):
  **PASS** (34 outputs, finished successfully)

## Related

Fixes #42760

---
*AI assistance used: Claude (code analysis, debugging, testing strategy).
Human submitter has reviewed every changed line and tested on real hardware.*