### PR TITLE
Perf/wna16 batched marlin block size

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -91,6 +91,7 @@ def _fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    batched_experts: bool = False,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
     M, K = hidden_states.size()
@@ -172,7 +173,9 @@ def _fused_marlin_moe(
     if output is None:
         output = intermediate_cache3
 
-    if expert_map is not None:
+    # BatchedExperts writes into pre-grouped expert output slices directly,
+    # so the extra zero-fill is only needed on the standard routed path.
+    if expert_map is not None and not batched_experts:
         output.zero_()
 
     a_scales2 = None
@@ -370,6 +373,7 @@ def fused_marlin_moe(
         clamp_limit=clamp_limit,
         gemm1_alpha=gemm1_alpha,
         gemm1_beta=gemm1_beta,
+        batched_experts=False,
     ).view(-1, topk, K)
 
     if output is None:
@@ -569,6 +573,7 @@ def batched_fused_marlin_moe(
         clamp_limit=clamp_limit,
         gemm1_alpha=gemm1_alpha,
         gemm1_beta=gemm1_beta,
+        batched_experts=True,
     )
 
     output = output.view(B, BATCH_TOKENS_MAX, K)

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -381,6 +381,34 @@ def fused_marlin_moe(
         return moe_sum(moe_output, output)
 
 
+def _select_batched_marlin_moe_block_size(
+    max_tokens_per_batch: int,
+    num_experts: int,
+    input_dtype: torch.dtype | None,
+    expert_num_tokens_cpu: torch.Tensor | None = None,
+) -> int:
+    # Batched expert tensors reserve max_tokens_per_batch for every expert.
+    # Decode usually distributes one rank's small token budget across many
+    # local experts, so using the full capacity here over-pads tiny-M GEMMs.
+    has_cpu_metadata = expert_num_tokens_cpu is not None
+    if expert_num_tokens_cpu is not None:
+        effective_tokens_per_expert = int(expert_num_tokens_cpu.max().item())
+    else:
+        effective_tokens_per_expert = max_tokens_per_batch / max(num_experts, 1)
+    block_size_m = 64
+    for b_m in [8, 16, 32, 48, 64]:
+        if effective_tokens_per_expert / b_m < 0.9:
+            block_size_m = b_m
+            break
+
+    if input_dtype is not None and input_dtype.itemsize == 1:
+        block_size_m = max(block_size_m, 16)
+    if not has_cpu_metadata:
+        block_size_m = max(block_size_m, 32)
+
+    return block_size_m
+
+
 def batched_fused_marlin_moe(
     hidden_states: torch.Tensor,
     expert_num_tokens: torch.Tensor,
@@ -414,6 +442,7 @@ def batched_fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    expert_num_tokens_cpu: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     This function massages the inputs so the batched hidden_states can be
@@ -484,17 +513,12 @@ def batched_fused_marlin_moe(
     # [B * MAX_TOKENS, K] and top_k can be interpreted as just 1.
     topk = 1
 
-    # TODO(varun) : Choose a decent block size like in fused_marlin_moe
-    # Tune block_size_m based on expert capacity to reduce padding overhead.
-    block_size_m = 64
-    for b_m in [8, 16, 32, 48, 64]:
-        if BATCH_TOKENS_MAX / b_m < 0.9:
-            block_size_m = b_m
-            break
-
-    if input_dtype is not None and input_dtype.itemsize == 1:
-        block_size_m = max(block_size_m, 16)
-
+    block_size_m = _select_batched_marlin_moe_block_size(
+        BATCH_TOKENS_MAX,
+        E,
+        input_dtype,
+        expert_num_tokens_cpu,
+    )
     sorted_token_ids, expert_ids, num_tokens_post_padded = batched_moe_align_block_size(
         max_tokens_per_batch=BATCH_TOKENS_MAX,
         block_size=block_size_m,
@@ -1024,4 +1048,5 @@ class BatchedMarlinExperts(MarlinExpertsBase):
             clamp_limit=self.gemm1_clamp_limit,
             gemm1_alpha=self.gemm1_alpha,
             gemm1_beta=self.gemm1_beta,
+            expert_num_tokens_cpu=expert_tokens_meta.expert_num_tokens_cpu,
         )


### PR DESCRIPTION
## Purpose

Profiling shows that `output.zero_()` is a hot operation on the Marlin `BatchedExperts` path and contributes noticeable overhead. Removing it can improve the output-side performance of this path by about 10%.

This PR skips that zero-fill only for the Marlin `BatchedExperts` path.

This is safe because, on the batched-experts path, outputs are written into pre-grouped expert slices and only valid rows produced by `batched_moe_align_block_size()` are consumed. Unlike the standard routed path, this path does not rely on the extra zero-fill to mask invalid expert outputs.

## Test Plan & Results

### Profile
TODO

### Benchmark
TODO

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

