### PR TITLE
[Performance] Remove output.zero_() hotspot on the Marlin BatchedExperts path

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -91,6 +91,7 @@ def _fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    batched_experts: bool = False,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
     M, K = hidden_states.size()
@@ -172,7 +173,9 @@ def _fused_marlin_moe(
     if output is None:
         output = intermediate_cache3
 
-    if expert_map is not None:
+    # BatchedExperts writes into pre-grouped expert output slices directly,
+    # so the extra zero-fill is only needed on the standard routed path.
+    if expert_map is not None and not batched_experts:
         output.zero_()
 
     a_scales2 = None
@@ -370,6 +373,7 @@ def fused_marlin_moe(
         clamp_limit=clamp_limit,
         gemm1_alpha=gemm1_alpha,
         gemm1_beta=gemm1_beta,
+        batched_experts=False,
     ).view(-1, topk, K)
 
     if output is None:
@@ -545,6 +549,7 @@ def batched_fused_marlin_moe(
         clamp_limit=clamp_limit,
         gemm1_alpha=gemm1_alpha,
         gemm1_beta=gemm1_beta,
+        batched_experts=True,
     )
 
     output = output.view(B, BATCH_TOKENS_MAX, K)


### PR DESCRIPTION
## Purpose

Profiling shows that `output.zero_()` is a hot operation on the Marlin `BatchedExperts` path and contributes noticeable overhead. Removing it can improve the output-side performance of this path by about 10%.

This PR skips that zero-fill only for the Marlin `BatchedExperts` path.

This is safe because, on the batched-experts path, outputs are written into pre-grouped expert slices and only valid rows produced by `batched_moe_align_block_size()` are consumed. Unlike the standard routed path, this path does not rely on the extra zero-fill to mask invalid expert outputs.

## Test Plan & Results

### Profile
TODO

### Benchmark
TODO

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

