### PR TITLE
Add ColBERT embedding_mode for asymmetric query/document encoding

### DIFF
--- a/tests/models/pooling/test_colbert_embedding_mode.py
+++ b/tests/models/pooling/test_colbert_embedding_mode.py
@@ -1,0 +1,877 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ColBERT embedding_mode query/document encoding.
+
+Reviewer-facing coverage map:
+- A correctness: marker/truncation/expansion + GPU asymmetry + ranking parity
+- B API safety: validate_colbert_embedding_mode + PoolingParams.verify
+- C cache: template/config hash + canonical pre-tokenization text + config change
+- D batch: batch independence (stateless) + mixed-mode stress + batch-vs-single
+- E IO: finalize immutability (no shared EngineInput mutation)
+- Gate: pylate ranking parity — exact top-k order (no score tolerance)
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+
+# bf16 GPU embeddings are not bitwise-stable; use relaxed checks here.
+# Ranking parity (merge gate) compares order only, not embedding values.
+COLBERT_GPU_EMBED_RTOL = 1e-2
+COLBERT_GPU_EMBED_ATOL = 1e-2
+COLBERT_PYLATE_EMBED_COS_MIN = 0.95
+
+from vllm.model_executor.models.colbert_encoding import (  # noqa: E402
+    COLBERT_ATTENTION_MASK_ENFORCED_IN_FORWARD,
+    ColBERTEncoder,
+    ColBERTEncodingConfig,
+    build_colbert_attention_mask,
+    canonicalize_colbert_input_text,
+    compute_colbert_cache_key,
+    compute_colbert_cache_salt,
+    compute_colbert_config_hash,
+    finalize_colbert_engine_input,
+    is_colbert_pooling_model,
+    resolve_colbert_chat_template_hash,
+    validate_colbert_embedding_mode,
+    validate_colbert_engine_inputs,
+)
+
+pytest.importorskip("transformers")
+
+
+def _import_pylate_models():
+    import importlib
+
+    pylate = pytest.importorskip("pylate")
+    if hasattr(pylate, "models"):
+        return pylate.models
+    return importlib.import_module("pylate.models")
+
+
+def _pooling_params(*args, **kwargs):
+    """Defer import so CPU-only tests can collect without loading vllm._C."""
+    from vllm.pooling_params import PoolingParams
+
+    return PoolingParams(*args, **kwargs)
+
+
+def _colbert_encode(llm, prompts, pooling_params):
+    """ColBERT models expose token_embed only; vLLM 0.22+ requires pooling_task."""
+    return llm.encode(prompts, pooling_params, pooling_task="token_embed")
+
+
+def _mean_per_token_cosine(a: torch.Tensor, b: torch.Tensor) -> float:
+    n = min(a.shape[0], b.shape[0])
+    if n == 0:
+        return 1.0
+    return F.cosine_similarity(a[:n].float(), b[:n].float(), dim=-1).mean().item()
+
+
+JINA_MODEL = "jinaai/jina-colbert-v2"
+JINA_OVERRIDES = {"hf_overrides": {"architectures": ["ColBERTJinaRobertaModel"]}}
+QUERY_TEXT = "What is the capital of France?"
+DOC_TEXT = "The capital of France is Paris."
+
+
+def set_seed(seed: int = 1234) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+@pytest.fixture(autouse=True)
+def _colbert_test_seed():
+    set_seed(1234)
+
+
+def test_colbert_attention_mask_not_enforced_constant():
+    assert COLBERT_ATTENTION_MASK_ENFORCED_IN_FORWARD is False
+
+
+def test_pooling_params_verify_rejects_embedding_mode_on_non_colbert():
+    from vllm.config import ModelConfig
+
+    model_config = ModelConfig(
+        model="sentence-transformers/all-MiniLM-L6-v2",
+        runner="pooling",
+    )
+    params = _pooling_params(task="token_embed", embedding_mode="query")
+    with pytest.raises(ValueError, match="only supported for ColBERT"):
+        params.verify(model_config)
+
+
+def test_validate_colbert_embedding_mode_rejects_non_colbert():
+    from vllm.config import ModelConfig
+
+    model_config = ModelConfig(
+        model="sentence-transformers/all-MiniLM-L6-v2",
+        runner="pooling",
+    )
+    with pytest.raises(ValueError, match="only supported for ColBERT"):
+        validate_colbert_embedding_mode(model_config, "query")
+
+    validate_colbert_embedding_mode(model_config, None)
+
+
+def test_is_colbert_pooling_model_detects_jina():
+    from vllm.config import ModelConfig
+
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    assert is_colbert_pooling_model(model_config)
+
+
+def test_colbert_insert_prefix_token():
+    assert ColBERTEncoder.insert_prefix_token([10, 20, 30], 99) == [10, 99, 20, 30]
+
+
+def test_colbert_marker_tokens_in_encoded_ids():
+    """Query vs document encodings must insert distinct marker token ids."""
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    encoder = ColBERTEncoder(cfg)
+    base_ids = tokenizer.encode(QUERY_TEXT, add_special_tokens=True)
+
+    q_ids = encoder.encode_token_ids(list(base_ids), "query")
+    d_ids = encoder.encode_token_ids(list(base_ids), "document")
+
+    assert cfg.query_prefix_id in q_ids
+    assert cfg.document_prefix_id in d_ids
+    assert cfg.query_prefix_id not in d_ids
+    assert cfg.document_prefix_id not in q_ids
+
+
+def test_colbert_query_expansion_padding_only_for_query():
+    """Query mode pads with mask tokens to query_length; document does not expand."""
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    encoder = ColBERTEncoder(cfg)
+    short_ids = tokenizer.encode("hello", add_special_tokens=True)
+
+    q_ids = encoder.encode_token_ids(list(short_ids), "query")
+    d_ids = encoder.encode_token_ids(list(short_ids), "document")
+
+    assert len(q_ids) == cfg.query_length
+    assert q_ids.count(cfg.mask_token_id) > 0
+    assert len(d_ids) <= cfg.document_length
+    assert len(d_ids) < len(q_ids)
+
+
+def test_pooling_params_embedding_mode_extra_kwargs():
+    params = _pooling_params(task="token_embed", embedding_mode="query")
+    assert params.extra_kwargs is not None
+    assert params.extra_kwargs["colbert_embedding_mode"] == "query"
+
+
+def test_colbert_config_hash_changes_cache_key():
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    template_hash = resolve_colbert_chat_template_hash(None, model_config=model_config)
+    config_hash_a = compute_colbert_config_hash(cfg, model_config=model_config)
+
+    cfg_mutated = ColBERTEncodingConfig(
+        query_prefix=cfg.query_prefix,
+        document_prefix=cfg.document_prefix,
+        query_prefix_id=cfg.query_prefix_id,
+        document_prefix_id=cfg.document_prefix_id,
+        query_length=cfg.query_length + 1,
+        document_length=cfg.document_length,
+        mask_token_id=cfg.mask_token_id,
+        pad_token_id=cfg.pad_token_id,
+        do_query_expansion=cfg.do_query_expansion,
+        attend_to_expansion_tokens=cfg.attend_to_expansion_tokens,
+    )
+    config_hash_b = compute_colbert_config_hash(cfg_mutated, model_config=model_config)
+    assert config_hash_a != config_hash_b
+
+    key_a = compute_colbert_cache_key(
+        model_name=JINA_MODEL,
+        embedding_mode="query",
+        raw_text=QUERY_TEXT,
+        chat_template_hash=template_hash,
+        colbert_config_hash=config_hash_a,
+    )
+    key_b = compute_colbert_cache_key(
+        model_name=JINA_MODEL,
+        embedding_mode="query",
+        raw_text=QUERY_TEXT,
+        chat_template_hash=template_hash,
+        colbert_config_hash=config_hash_b,
+    )
+    assert key_a != key_b
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_same_text_query_vs_document_embeddings_differ(
+    vllm_runner,
+    colbert_model: str,
+):
+    """Same text must encode differently under query vs document (not cosine-only)."""
+    text = "identical passage for asymmetry check"
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=512,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        llm = vllm_model.get_llm()
+        q = _colbert_encode(
+            llm,
+            [text],
+            _pooling_params(task="token_embed", embedding_mode="query"),
+        )[0].outputs.data
+        d = _colbert_encode(
+            llm,
+            [text],
+            _pooling_params(task="token_embed", embedding_mode="document"),
+        )[0].outputs.data
+
+    q_t = torch.as_tensor(q).float()
+    d_t = torch.as_tensor(d).float()
+    assert q_t.shape != d_t.shape or not torch.allclose(q_t, d_t, atol=1e-3)
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_query_differs_from_document(
+    vllm_runner,
+    colbert_model: str,
+):
+    """Query and document modes must produce different embeddings."""
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=512,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        llm = vllm_model.get_llm()
+        q_out = _colbert_encode(
+            llm,
+            [QUERY_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="query"),
+        )
+        d_out = _colbert_encode(
+            llm,
+            [DOC_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="document"),
+        )
+
+    q_emb = torch.as_tensor(q_out[0].outputs.data).float()
+    d_emb = torch.as_tensor(d_out[0].outputs.data).float()
+    assert q_emb.shape != d_emb.shape or not torch.allclose(q_emb, d_emb, atol=1e-3)
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_query_length_fixed(
+    vllm_runner,
+    colbert_model: str,
+):
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=512,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        llm = vllm_model.get_llm()
+        outputs = _colbert_encode(
+            llm,
+            [QUERY_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="query"),
+        )
+
+    q_emb = torch.as_tensor(outputs[0].outputs.data)
+    assert q_emb.shape[0] <= 32
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_batch_modes_no_cross_contamination(
+    vllm_runner,
+    colbert_model: str,
+):
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=512,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        llm = vllm_model.get_llm()
+        single_q = _colbert_encode(
+            llm,
+            [QUERY_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="query"),
+        )[0].outputs.data
+        single_d = _colbert_encode(
+            llm,
+            [DOC_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="document"),
+        )[0].outputs.data
+
+        batch = _colbert_encode(
+            llm,
+            [QUERY_TEXT, DOC_TEXT, QUERY_TEXT],
+            [
+                _pooling_params(task="token_embed", embedding_mode="query"),
+                _pooling_params(task="token_embed", embedding_mode="document"),
+                _pooling_params(task="token_embed", embedding_mode="query"),
+            ],
+        )
+
+    q0 = torch.as_tensor(batch[0].outputs.data).float()
+    d1 = torch.as_tensor(batch[1].outputs.data).float()
+    q2 = torch.as_tensor(batch[2].outputs.data).float()
+    ref_q = torch.as_tensor(single_q).float()
+    ref_d = torch.as_tensor(single_d).float()
+
+    torch.testing.assert_close(q0, ref_q, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(q2, ref_q, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(d1, ref_d, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_pylate_parity(
+    vllm_runner,
+    colbert_model: str,
+):
+    pylate_models = _import_pylate_models()
+
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=8192,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        llm = vllm_model.get_llm()
+        v_q = _colbert_encode(
+            llm,
+            [QUERY_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="query"),
+        )[0].outputs.data
+        v_d = _colbert_encode(
+            llm,
+            [DOC_TEXT],
+            _pooling_params(task="token_embed", embedding_mode="document"),
+        )[0].outputs.data
+
+    model = pylate_models.ColBERT(
+        model_name_or_path=colbert_model,
+        query_prefix="[QueryMarker]",
+        document_prefix="[DocumentMarker]",
+        attend_to_expansion_tokens=True,
+        trust_remote_code=True,
+    )
+    p_q = model.encode([QUERY_TEXT], is_query=True, convert_to_tensor=True)[0].float()
+    p_d = model.encode([DOC_TEXT], is_query=False, convert_to_tensor=True)[0].float()
+
+    v_q_t = torch.as_tensor(v_q).float().cpu()
+    v_d_t = torch.as_tensor(v_d).float().cpu()
+    p_q = p_q.detach().cpu()
+    p_d = p_d.detach().cpu()
+
+    assert _mean_per_token_cosine(v_q_t, p_q) > COLBERT_PYLATE_EMBED_COS_MIN
+    assert _mean_per_token_cosine(v_d_t, p_d) > COLBERT_PYLATE_EMBED_COS_MIN
+
+
+def test_colbert_cache_key_aligns_with_pre_tokenization():
+    from vllm.config import ModelConfig
+    from vllm.renderers.params import TokenizeParams
+    from vllm.tokenizers.registry import cached_tokenizer_from_config
+
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    tokenizer = cached_tokenizer_from_config(model_config)
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    encoder = ColBERTEncoder(cfg)
+    base = TokenizeParams(max_total_tokens=8192, do_lower_case=True)
+    colbert_tok = encoder.build_tokenize_params("query", base)
+
+    assert canonicalize_colbert_input_text("Hello", colbert_tok, tokenizer) == "hello"
+
+    template_hash = resolve_colbert_chat_template_hash(None, model_config=model_config)
+    config_hash = compute_colbert_config_hash(cfg, model_config=model_config)
+    key_hello = compute_colbert_cache_key(
+        model_name=JINA_MODEL,
+        embedding_mode="query",
+        raw_text="hello",
+        chat_template_hash=template_hash,
+        colbert_config_hash=config_hash,
+    )
+    key_canonical = compute_colbert_cache_key(
+        model_name=JINA_MODEL,
+        embedding_mode="query",
+        raw_text=canonicalize_colbert_input_text("Hello", colbert_tok, tokenizer),
+        chat_template_hash=template_hash,
+        colbert_config_hash=config_hash,
+    )
+    key_request_casing = compute_colbert_cache_key(
+        model_name=JINA_MODEL,
+        embedding_mode="query",
+        raw_text="Hello",
+        chat_template_hash=template_hash,
+        colbert_config_hash=config_hash,
+    )
+    assert key_hello == key_canonical
+    assert key_hello != key_request_casing
+
+
+def test_colbert_batch_independence_is_stateless():
+    """Same (text, mode) tokenizes identically across batch position and grouping."""
+    from vllm.config import ModelConfig, VllmConfig
+    from vllm.entrypoints.chat_utils import ChatTemplateConfig
+    from vllm.entrypoints.pooling.embed.io_processor import (
+        ColBERTTokenEmbedIOProcessor,
+    )
+    from vllm.entrypoints.pooling.pooling.protocol import PoolingCompletionRequest
+    from vllm.renderers.hf import HfRenderer
+    from vllm.tokenizers.registry import cached_tokenizer_from_config
+
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+        max_model_len=512,
+    )
+    vllm_config = VllmConfig(model_config=model_config)
+    renderer = HfRenderer(vllm_config, cached_tokenizer_from_config(model_config))
+    processor = ColBERTTokenEmbedIOProcessor(
+        vllm_config,
+        renderer,
+        ChatTemplateConfig(),
+    )
+    proxy = PoolingCompletionRequest(
+        model=None,
+        input="",
+        add_special_tokens=True,
+    )
+    tok_params = proxy.build_tok_params(model_config)
+
+    items: list[tuple[str, str]] = [
+        ("query", "What is ML?"),
+        ("document", "Machine learning is a field of study."),
+        ("query", "What is ML?"),
+        ("document", "Deep learning uses neural networks."),
+        ("query", "What is DL?"),
+    ]
+    prompts = [text for _, text in items]
+    modes = [mode for mode, _ in items]
+
+    batch_inputs = processor._render_colbert_cmpl_batch(
+        proxy, prompts, modes, tok_params=tok_params
+    )
+    assert len(batch_inputs) == len(items)
+
+    singles = [
+        processor._render_colbert_cmpl(proxy, [text], mode, tok_params=tok_params)[0]
+        for mode, text in items
+    ]
+
+    for i, (batched, single) in enumerate(zip(batch_inputs, singles)):
+        assert batched["prompt_token_ids"] == single["prompt_token_ids"], (
+            f"token ids differ at index {i} (batch vs single)"
+        )
+        assert batched.get("colbert_cache_key") == single.get("colbert_cache_key"), (
+            f"cache key differ at index {i}"
+        )
+
+    assert batch_inputs[0]["prompt_token_ids"] == batch_inputs[2]["prompt_token_ids"]
+    assert batch_inputs[0]["colbert_cache_key"] == batch_inputs[2]["colbert_cache_key"]
+
+    perm = [4, 1, 0, 3, 2]
+    perm_prompts = [prompts[i] for i in perm]
+    perm_modes = [modes[i] for i in perm]
+    perm_batch = processor._render_colbert_cmpl_batch(
+        proxy, perm_prompts, perm_modes, tok_params=tok_params
+    )
+    for out_j, orig_i in enumerate(perm):
+        perm_ids = perm_batch[out_j]["prompt_token_ids"]
+        single_ids = singles[orig_i]["prompt_token_ids"]
+        assert perm_ids == single_ids
+        perm_key = perm_batch[out_j]["colbert_cache_key"]
+        single_key = singles[orig_i]["colbert_cache_key"]
+        assert perm_key == single_key
+
+
+def test_colbert_cache_key_uses_template_hash():
+    text = QUERY_TEXT
+    template_hash = resolve_colbert_chat_template_hash("my-template")
+    assert len(template_hash) == 64
+    from vllm.config import ModelConfig
+    from vllm.tokenizers.registry import cached_tokenizer_from_config
+
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    tokenizer = cached_tokenizer_from_config(model_config)
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    config_hash = compute_colbert_config_hash(cfg, model_config=model_config)
+    base_kwargs = dict(
+        model_name=JINA_MODEL,
+        raw_text=text,
+        chat_template_hash=template_hash,
+        colbert_config_hash=config_hash,
+    )
+    q_key = compute_colbert_cache_key(embedding_mode="query", **base_kwargs)
+    d_key = compute_colbert_cache_key(embedding_mode="document", **base_kwargs)
+    same_key_again = compute_colbert_cache_key(embedding_mode="query", **base_kwargs)
+    other_hash = resolve_colbert_chat_template_hash("other-template")
+    other_template = compute_colbert_cache_key(
+        embedding_mode="query",
+        model_name=JINA_MODEL,
+        raw_text=text,
+        chat_template_hash=other_hash,
+        colbert_config_hash=config_hash,
+    )
+    assert q_key != d_key
+    assert q_key == same_key_again
+    assert q_key != other_template
+
+    assert (
+        compute_colbert_cache_salt(
+            "query",
+            text,
+            model_name=JINA_MODEL,
+            chat_template_hash=template_hash,
+            colbert_config_hash=config_hash,
+        )
+        == q_key
+    )
+
+
+def test_colbert_token_truncation_query_shorter_than_document():
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+        max_model_len=512,
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    encoder = ColBERTEncoder(cfg)
+    long_text = "word " * 5000
+    token_ids = tokenizer.encode(long_text, add_special_tokens=True)
+    q_ids = encoder.encode_token_ids(token_ids, "query")
+    d_ids = encoder.encode_token_ids(token_ids, "document")
+    assert len(q_ids) <= cfg.query_length
+    assert len(d_ids) <= cfg.document_length
+    assert len(q_ids) < len(d_ids)
+
+
+def test_colbert_engine_input_finalize_is_immutable():
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+
+    base = {
+        "type": "token",
+        "prompt_token_ids": [1, 2, 3],
+        "cache_salt": "shared",
+    }
+    a = finalize_colbert_engine_input(
+        base, mode="query", cache_key="salt-a", config=cfg
+    )
+    b = finalize_colbert_engine_input(
+        base, mode="document", cache_key="salt-b", config=cfg
+    )
+    assert a["colbert_embedding_mode"] == "query"
+    assert b["colbert_embedding_mode"] == "document"
+    assert a["cache_salt"] == "salt-a"
+    assert a["colbert_cache_key"] == "salt-a"
+    assert b["cache_salt"] == "salt-b"
+    assert a["colbert_attention_mask"] == build_colbert_attention_mask(
+        [1, 2, 3], "query", cfg
+    )
+    a["prompt_token_ids"].append(99)
+    assert base["prompt_token_ids"] == [1, 2, 3]
+
+
+def test_colbert_query_attention_mask_all_ones():
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    token_ids = [0, 1, 2, cfg.mask_token_id, cfg.mask_token_id]
+    mask = build_colbert_attention_mask(token_ids, "query", cfg)
+    assert mask == [1] * len(token_ids)
+
+
+def test_colbert_parity_check_env(monkeypatch):
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    monkeypatch.setenv("VLLM_COLBERT_PARITY_CHECK", "1")
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    engine_inputs = [
+        {
+            "type": "token",
+            "prompt_token_ids": [0] * 40,
+            "colbert_embedding_mode": "query",
+            "colbert_cache_key": "k1",
+        }
+    ]
+    with pytest.raises(ValueError, match="query length"):
+        validate_colbert_engine_inputs(engine_inputs, cfg)
+
+
+def test_colbert_encoding_config_from_tokenizer():
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    model_config = ModelConfig(
+        model=JINA_MODEL,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    assert cfg.query_prefix == "[QueryMarker]" or cfg.query_prefix_id is not None
+    assert (
+        cfg.document_prefix == "[DocumentMarker]" or cfg.document_prefix_id is not None
+    )
+
+
+STRESS_BATCH = [
+    ("query", "What is ML?"),
+    ("document", "Machine learning is ..."),
+    ("query", "What is DL?"),
+    ("document", "Deep learning is ..."),
+]
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_mixed_mode_stress_batch(
+    vllm_runner,
+    colbert_model: str,
+):
+    """Stress: interleaved query/doc batch — no cross-contamination."""
+    texts = [text for _, text in STRESS_BATCH]
+    modes = [mode for mode, _ in STRESS_BATCH]
+    params = [
+        _pooling_params(task="token_embed", embedding_mode=mode) for mode in modes
+    ]
+
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=512,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        llm = vllm_model.get_llm()
+
+        singles = []
+        for mode, text in STRESS_BATCH:
+            singles.append(
+                _colbert_encode(
+                    llm,
+                    [text],
+                    _pooling_params(task="token_embed", embedding_mode=mode),
+                )[0].outputs.data
+            )
+
+        batch_out = _colbert_encode(llm, texts, params)
+
+        for _ in range(3):
+            repeat = _colbert_encode(llm, texts, params)
+            for i, (a, b) in enumerate(zip(batch_out, repeat)):
+                ta = torch.as_tensor(a.outputs.data).float()
+                tb = torch.as_tensor(b.outputs.data).float()
+                torch.testing.assert_close(
+                    ta,
+                    tb,
+                    rtol=COLBERT_GPU_EMBED_RTOL,
+                    atol=COLBERT_GPU_EMBED_ATOL,
+                    msg=f"deterministic replay failed index {i}",
+                )
+
+    from transformers import AutoTokenizer
+
+    from vllm.config import ModelConfig
+
+    model_config = ModelConfig(
+        model=colbert_model,
+        runner="pooling",
+        trust_remote_code=True,
+        hf_overrides=JINA_OVERRIDES["hf_overrides"],
+    )
+    tokenizer = AutoTokenizer.from_pretrained(JINA_MODEL, trust_remote_code=True)
+    cfg = ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+    chat_hash = resolve_colbert_chat_template_hash(None, model_config=model_config)
+    config_hash = compute_colbert_config_hash(cfg, model_config=model_config)
+    cache_keys = [
+        compute_colbert_cache_key(
+            model_name=colbert_model,
+            embedding_mode=mode,
+            raw_text=text,
+            chat_template_hash=chat_hash,
+            colbert_config_hash=config_hash,
+        )
+        for mode, text in STRESS_BATCH
+    ]
+    assert len(cache_keys) == len(set(cache_keys))
+
+    for i, (single, batched) in enumerate(zip(singles, batch_out)):
+        ref = torch.as_tensor(single).float()
+        got = torch.as_tensor(batched.outputs.data).float()
+        torch.testing.assert_close(
+            ref,
+            got,
+            rtol=COLBERT_GPU_EMBED_RTOL,
+            atol=COLBERT_GPU_EMBED_ATOL,
+            msg=f"batch vs single index {i}",
+        )
+
+
+RANKING_QUERY = "What is machine learning?"
+RANKING_DOCS = [
+    "Machine learning is a subset of artificial intelligence.",
+    "Python is a popular programming language.",
+    "Deep learning uses neural networks with many layers.",
+]
+
+
+@pytest.mark.parametrize("colbert_model", [JINA_MODEL])
+def test_colbert_pylate_ranking_parity(vllm_runner, colbert_model: str):
+    """CI correctness gate: vLLM /score top-k order must match PyLate exactly.
+
+    Uses strict list equality on rankings only (no cosine checks, no score tolerance).
+    """
+    pylate_models = _import_pylate_models()
+
+    with vllm_runner(
+        colbert_model,
+        runner="pooling",
+        max_model_len=512,
+        enforce_eager=True,
+        trust_remote_code=True,
+        **JINA_OVERRIDES,
+    ) as vllm_model:
+        vllm_scores = vllm_model.score(RANKING_QUERY, RANKING_DOCS)
+
+    assert len(vllm_scores) == len(RANKING_DOCS)
+    vllm_ranking = sorted(
+        range(len(RANKING_DOCS)), key=lambda i: vllm_scores[i], reverse=True
+    )
+
+    pylate_model = pylate_models.ColBERT(
+        model_name_or_path=colbert_model,
+        query_prefix="[QueryMarker]",
+        document_prefix="[DocumentMarker]",
+        attend_to_expansion_tokens=True,
+        trust_remote_code=True,
+    )
+    q_emb = pylate_model.encode([RANKING_QUERY], is_query=True, convert_to_tensor=True)[
+        0
+    ].float()
+    pylate_scores = []
+    from vllm.entrypoints.pooling.scoring.utils import compute_maxsim_score
+
+    for doc in RANKING_DOCS:
+        d_emb = pylate_model.encode([doc], is_query=False, convert_to_tensor=True)[
+            0
+        ].float()
+        pylate_scores.append(compute_maxsim_score(q_emb, d_emb).item())
+
+    pylate_ranking = sorted(
+        range(len(RANKING_DOCS)), key=lambda i: pylate_scores[i], reverse=True
+    )
+
+    assert list(vllm_ranking) == list(pylate_ranking), (
+        f"vLLM ranking {vllm_ranking} != PyLate ranking {pylate_ranking}; "
+        f"vLLM scores={vllm_scores}, PyLate scores={pylate_scores}"
+    )
+    assert torch.equal(
+        torch.tensor(vllm_ranking),
+        torch.tensor(pylate_ranking),
+    )
+
+    k = min(5, len(RANKING_DOCS))
+    assert vllm_ranking[:k] == pylate_ranking[:k]

--- a/vllm/entrypoints/pooling/base/io_processor.py
+++ b/vllm/entrypoints/pooling/base/io_processor.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 from vllm import PoolingParams, PoolingRequestOutput, PromptType
 from vllm.config import VllmConfig
@@ -117,6 +117,30 @@ class PoolingIOProcessor:
 
     #######################################
     # helpers
+
+    @staticmethod
+    def _colbert_renderer_prompt_extras(
+        embedding_mode: Literal["query", "document"],
+        raw_text: str,
+        *,
+        config,
+        model_name: str,
+        chat_template_hash: str,
+        colbert_config_hash: str,
+    ) -> dict[str, Any]:
+        """Renderer-safe ColBERT cache isolation metadata (prefix-cache safe)."""
+        from vllm.model_executor.models.colbert_encoding import (
+            build_colbert_prompt_extras,
+        )
+
+        return build_colbert_prompt_extras(
+            embedding_mode,
+            config,
+            model_name=model_name,
+            raw_text=raw_text,
+            chat_template_hash=chat_template_hash,
+            colbert_config_hash=colbert_config_hash,
+        )
 
     def _preprocess_cmpl_online(
         self,

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -17,6 +17,8 @@ from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
 from vllm.utils import random_uuid
 from vllm.utils.serial_utils import EmbedDType, EncodingFormat, Endianness
 
+ColBERTEmbeddingMode = Literal["query", "document"]
+
 
 class PoolingBasicRequestMixin(OpenAIBaseModel):
     # --8<-- [start:pooling-common-params]
@@ -293,6 +295,29 @@ class EmbedRequestMixin(EncodingRequestMixin):
         "`None` uses the pooler's default, which is `True` in most cases.",
     )
     # --8<-- [end:embed-extra-params]
+
+
+def validate_colbert_embedding_mode(
+    model_config,
+    embedding_mode: ColBERTEmbeddingMode | None,
+) -> None:
+    """Validate ``embedding_mode`` before pooling IO (ColBERT architectures only)."""
+    from vllm.model_executor.models.colbert_encoding import (
+        validate_colbert_embedding_mode as _validate_colbert_embedding_mode,
+    )
+
+    _validate_colbert_embedding_mode(model_config, embedding_mode)
+
+
+class ColBERTEmbeddingModeMixin(OpenAIBaseModel):
+    embedding_mode: ColBERTEmbeddingMode | None = Field(
+        default=None,
+        description=(
+            "ColBERT asymmetric encoding mode. Use 'query' for query embeddings "
+            "and 'document' for document embeddings. When omitted, legacy "
+            "token_embed behavior is preserved."
+        ),
+    )
 
 
 class ClassifyRequestMixin(OpenAIBaseModel):

--- a/vllm/entrypoints/pooling/base/serving.py
+++ b/vllm/entrypoints/pooling/base/serving.py
@@ -16,9 +16,9 @@ from vllm import PoolingParams, PoolingRequestOutput, envs
 from vllm.config import VllmConfig
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import ChatTemplateConfig
+from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.exceptions import VLLMNotFoundError
 from vllm.inputs import EngineInput
 from vllm.lora.request import LoRARequest
@@ -109,6 +109,11 @@ class PoolingServingBase(ABC):
         await self._check_model(request)
 
         pooling_params = io_processor.create_pooling_params(request)
+        if isinstance(pooling_params, list):
+            for params in pooling_params:
+                params.verify(self.model_config)
+        else:
+            pooling_params.verify(self.model_config)
         ctx = PoolingServeContext(
             request=request,
             raw_request=raw_request,
@@ -283,7 +288,6 @@ class PoolingServingBase(ABC):
         request = ctx.request
         if request.model in self.models.lora_requests:
             ctx.lora_request = self.models.lora_requests[request.model]
-            return None
 
         # Currently only support default modality specific loras
         # if we have exactly one lora matched on the request.

--- a/vllm/entrypoints/pooling/colbert_io_mixin.py
+++ b/vllm/entrypoints/pooling/colbert_io_mixin.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ColBERT IO mixin (isolated to avoid embed <-> scoring circular imports)."""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+from vllm import PoolingParams
+from vllm.inputs import EngineInput, PromptType, TextPrompt
+from vllm.model_executor.models.colbert_encoding import (
+    ColBERTEmbeddingMode,
+    ColBERTEncoder,
+    apply_embedding_mode_to_pooling_params,
+    canonicalize_colbert_input_text,
+    compute_colbert_cache_key,
+    compute_colbert_config_hash,
+    finalize_colbert_engine_input,
+    resolve_colbert_chat_template_hash,
+    validate_colbert_engine_inputs,
+)
+from vllm.renderers import TokenizeParams
+from vllm.renderers.inputs.preprocess import prompt_to_seq
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+    from vllm.renderers import BaseRenderer
+
+
+class ColBERTIOProcessorMixin:
+    model_config: ModelConfig
+    renderer: BaseRenderer
+    chat_template: str | None
+    """Apply PyLate-compatible ColBERT encoding via renderer (per-request isolation).
+
+    Mode-group batch rendering is execution-only: it groups ``render_cmpl`` calls
+    by mode for efficiency and does not change tokenization semantics or outputs.
+    Each prompt still becomes an independent :class:`~vllm.inputs.EngineInput`
+    after render. Grouping does not couple KV-cache boundaries, attention graphs,
+    position encoding continuity, or scheduler batch semantics.
+    """
+
+    _colbert_encoder: ColBERTEncoder | None = None
+
+    def _colbert_chat_template_hash(self, request) -> str:
+        chat_template = getattr(request, "chat_template", None)
+        if chat_template is None:
+            chat_template = self.chat_template
+        return resolve_colbert_chat_template_hash(
+            chat_template,
+            model_config=self.model_config,
+        )
+
+    @staticmethod
+    def _extract_prompt_text(prompt: PromptType) -> str:
+        if isinstance(prompt, str):
+            return prompt
+        if isinstance(prompt, dict):
+            prompt_text = prompt.get("prompt")
+            if isinstance(prompt_text, str):
+                return prompt_text
+        raise ValueError(
+            "ColBERT embedding_mode requires text prompts; "
+            "token prompts are not supported."
+        )
+
+    def _get_colbert_encoder(self) -> ColBERTEncoder:
+        if self._colbert_encoder is None:
+            self._colbert_encoder = ColBERTEncoder.from_model_config(
+                self.model_config,
+                self.renderer.get_tokenizer(),
+            )
+        return self._colbert_encoder
+
+    def _resolve_colbert_mode(
+        self,
+        request_mode: ColBERTEmbeddingMode | None,
+        pooling_params: PoolingParams | None,
+    ) -> ColBERTEmbeddingMode | None:
+        if request_mode is not None:
+            return request_mode
+        if pooling_params is None:
+            return None
+        if pooling_params.embedding_mode is not None:
+            return pooling_params.embedding_mode
+        extra = pooling_params.extra_kwargs or {}
+        mode = extra.get("embedding_mode") or extra.get("colbert_embedding_mode")
+        if mode in ("query", "document"):
+            return mode
+        return None
+
+    def _render_colbert_cmpl(
+        self,
+        request,
+        prompts: Sequence[PromptType],
+        mode: ColBERTEmbeddingMode,
+        pooling_params: PoolingParams | None = None,
+        *,
+        tok_params: TokenizeParams | None = None,
+        chat_template_hash: str | None = None,
+    ) -> list[EngineInput]:
+        """Render one mode-homogeneous group via a single ``render_cmpl`` batch call."""
+        encoder = self._get_colbert_encoder()
+        config = encoder.config
+
+        if tok_params is None:
+            tok_params = request.build_tok_params(self.model_config)
+        colbert_tok_params = encoder.build_tokenize_params(mode, tok_params)
+
+        if chat_template_hash is None:
+            chat_template_hash = self._colbert_chat_template_hash(request)
+        model_name = self.model_config.model
+        colbert_config_hash = compute_colbert_config_hash(
+            config, model_config=self.model_config
+        )
+
+        tokenizer = self.renderer.get_tokenizer()
+        text_prompts: list[TextPrompt] = []
+        cache_keys: list[str] = []
+        for prompt in prompt_to_seq(prompts):
+            request_text = self._extract_prompt_text(prompt)
+            input_text = canonicalize_colbert_input_text(
+                request_text, colbert_tok_params, tokenizer
+            )
+            cache_key = compute_colbert_cache_key(
+                model_name=model_name,
+                embedding_mode=mode,
+                raw_text=input_text,
+                chat_template_hash=chat_template_hash,
+                colbert_config_hash=colbert_config_hash,
+            )
+            cache_keys.append(cache_key)
+
+            text_prompt: TextPrompt = {
+                "prompt": input_text,
+                "colbert_embedding_mode": mode,
+                "colbert_cache_key": cache_key,
+                "colbert_cache_salt": cache_key,
+                "cache_salt": cache_key,
+            }
+            if mode == "query" and config.attend_to_expansion_tokens:
+                text_prompt["colbert_attend_to_expansion"] = True
+                text_prompt["colbert_full_attention_mask"] = True
+            if isinstance(prompt, dict):
+                if mm := prompt.get("mm_processor_kwargs"):
+                    text_prompt["mm_processor_kwargs"] = cast(Any, mm)
+                if mm_uuids := prompt.get("multi_modal_uuids"):
+                    text_prompt["multi_modal_uuids"] = cast(Any, mm_uuids)
+                if mm_data := prompt.get("multi_modal_data"):
+                    text_prompt["multi_modal_data"] = cast(Any, mm_data)
+            text_prompts.append(text_prompt)
+
+        prompt_extras: dict[str, Any] | None = None
+        if mm_kwargs := getattr(request, "mm_processor_kwargs", None):
+            prompt_extras = {"mm_processor_kwargs": mm_kwargs}
+
+        rendered = self.renderer.render_cmpl(
+            text_prompts,
+            cast(TokenizeParams, colbert_tok_params),
+            prompt_extras=prompt_extras,
+        )
+        if len(rendered) != len(cache_keys):
+            raise ValueError(
+                "ColBERT batch render returned "
+                f"{len(rendered)} engine inputs for {len(cache_keys)} prompts"
+            )
+
+        finalized_inputs: list[EngineInput] = []
+        for engine_input, cache_key in zip(rendered, cache_keys):
+            finalized_inputs.append(
+                finalize_colbert_engine_input(
+                    engine_input,
+                    mode=mode,
+                    cache_key=cache_key,
+                    config=config,
+                )
+            )
+        if pooling_params is not None and len(finalized_inputs) == 1:
+            apply_embedding_mode_to_pooling_params(pooling_params, mode, config)
+        validate_colbert_engine_inputs(finalized_inputs, config)
+        return finalized_inputs
+
+    def _render_colbert_cmpl_batch(
+        self,
+        request,
+        prompts: Sequence[PromptType],
+        modes: Sequence[ColBERTEmbeddingMode],
+        pooling_params: PoolingParams | Sequence[PoolingParams] | None = None,
+        *,
+        tok_params: TokenizeParams | None = None,
+    ) -> list[EngineInput]:
+        if len(prompts) != len(modes):
+            raise ValueError("prompts and embedding modes must have the same length")
+
+        chat_template_hash = self._colbert_chat_template_hash(request)
+        indexed = list(enumerate(zip(prompts, modes)))
+        results: list[EngineInput | None] = [None] * len(prompts)
+
+        # NOTE: Batch grouping is strictly a PRE-TOKENIZATION rendering optimization.
+        # It does NOT affect:
+        # - KV cache reuse boundaries
+        # - attention computation graph
+        # - positional encoding continuity
+        # - model forward batching semantics
+        #
+        # Each EngineInput remains fully isolated after render.
+        for mode in ("query", "document"):
+            group = [(i, p) for i, (p, m) in indexed if m == mode]
+            if not group:
+                continue
+            group_prompts = [p for _, p in group]
+            group_params = None
+            if isinstance(pooling_params, Sequence):
+                group_params = [pooling_params[i] for i, _ in group]
+            elif pooling_params is not None:
+                group_params = pooling_params
+
+            rendered = self._render_colbert_cmpl(
+                request,
+                group_prompts,
+                mode,
+                group_params if not isinstance(group_params, list) else None,
+                tok_params=tok_params,
+                chat_template_hash=chat_template_hash,
+            )
+            if isinstance(group_params, list):
+                encoder_config = self._get_colbert_encoder().config
+                for params, engine_input in zip(group_params, rendered):
+                    apply_embedding_mode_to_pooling_params(
+                        params,
+                        mode,
+                        encoder_config,
+                    )
+            if len(rendered) != len(group):
+                raise ValueError(
+                    "ColBERT mode-group render size mismatch for "
+                    f"mode={mode}: {len(rendered)} vs {len(group)}"
+                )
+            for (idx, _), engine_input in zip(group, rendered):
+                results[idx] = engine_input
+
+        if any(r is None for r in results):
+            raise ValueError("ColBERT batch rendering failed to produce all inputs")
+
+        engine_inputs = [r for r in results if r is not None]
+        validate_colbert_engine_inputs(
+            engine_inputs,
+            self._get_colbert_encoder().config,
+        )
+        return engine_inputs

--- a/vllm/entrypoints/pooling/embed/io_processor.py
+++ b/vllm/entrypoints/pooling/embed/io_processor.py
@@ -18,14 +18,23 @@ from vllm.entrypoints.chat_utils import (
 )
 from vllm.inputs import EngineInput, tokens_input
 from vllm.logger import init_logger
+from vllm.model_executor.models.colbert_encoding import (
+    ColBERTEmbeddingMode,
+    apply_embedding_mode_to_pooling_params,
+    validate_colbert_embedding_mode,
+)
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
 from vllm.renderers import merge_kwargs
 from vllm.renderers.hf import resolve_chat_template
+from vllm.renderers.inputs.preprocess import prompt_to_seq
 from vllm.utils.collection_utils import chunk_list
 from vllm.utils.mistral import is_mistral_tokenizer
 
 from ..base.io_processor import PoolingIOProcessor
+from ..colbert_io_mixin import ColBERTIOProcessorMixin
+from ..pooling.protocol import PoolingCompletionRequest
 from ..scoring.io_processor import JinaRankingIOProcessorMixin
+from ..scoring.typing import ScoringData
 from ..typing import (
     OfflineInputsContext,
     PoolingChatLikeRequest,
@@ -560,6 +569,130 @@ class EmbedIOProcessor(PoolingIOProcessor):
 
 class TokenEmbedIOProcessor(PoolingIOProcessor):
     name = "token_embed"
+
+
+class ColBERTTokenEmbedIOProcessor(ColBERTIOProcessorMixin, TokenEmbedIOProcessor):
+    name = "token_embed"
+
+    def create_pooling_params(self, request):
+        mode = getattr(request, "embedding_mode", None)
+        validate_colbert_embedding_mode(self.model_config, mode)
+        params = super().create_pooling_params(request)
+        if mode is not None:
+            params.embedding_mode = mode
+            params.sync_colbert_extra_kwargs()
+        return params
+
+    def pre_process_online(self, ctx: PoolingServeContext) -> None:
+        request_mode = getattr(ctx.request, "embedding_mode", None)
+        validate_colbert_embedding_mode(self.model_config, request_mode)
+        mode = self._resolve_colbert_mode(
+            request_mode,
+            ctx.pooling_params if not isinstance(ctx.pooling_params, list) else None,
+        )
+        if mode is None:
+            return super().pre_process_online(ctx)
+
+        request = ctx.request
+        if isinstance(request, PoolingCompletionLikeRequest):
+            prompts = prompt_to_seq(request.input)
+            if isinstance(ctx.pooling_params, list):
+                modes_list = [
+                    self._resolve_colbert_mode(
+                        getattr(request, "embedding_mode", None), p
+                    )
+                    for p in ctx.pooling_params
+                ]
+                if any(m is None for m in modes_list):
+                    raise ValueError(
+                        "Each pooling param must specify ColBERT embedding_mode."
+                    )
+                ctx.engine_inputs = self._render_colbert_cmpl_batch(
+                    request,
+                    prompts,
+                    cast(list[ColBERTEmbeddingMode], modes_list),
+                    ctx.pooling_params,
+                )
+            else:
+                ctx.engine_inputs = self._render_colbert_cmpl(
+                    request,
+                    prompts,
+                    mode,
+                    ctx.pooling_params,
+                )
+            return
+        if isinstance(request, PoolingChatLikeRequest):
+            raise ValueError(
+                "ColBERT embedding_mode on chat requests is not supported yet."
+            )
+        return super().pre_process_online(ctx)
+
+    def pre_process_offline(self, ctx: OfflineInputsContext) -> Sequence[EngineInput]:
+        assert not isinstance(ctx.prompts, ScoringData) and not (
+            isinstance(ctx.prompts, dict) and "data" in ctx.prompts
+        )
+
+        pooling_params = ctx.pooling_params
+        if isinstance(pooling_params, Sequence):
+            for params in pooling_params:
+                validate_colbert_embedding_mode(
+                    self.model_config, params.embedding_mode
+                )
+        else:
+            validate_colbert_embedding_mode(
+                self.model_config, pooling_params.embedding_mode
+            )
+        prompts = prompt_to_seq(ctx.prompts)
+        tok_params = self.renderer.default_cmpl_tok_params.with_kwargs(
+            **(ctx.tokenization_kwargs or {})
+        )
+        proxy = PoolingCompletionRequest(
+            model=None,
+            input=cast(Any, prompts[0] if len(prompts) == 1 else prompts),
+            add_special_tokens=True,
+        )
+
+        if isinstance(pooling_params, Sequence):
+            modes: list[ColBERTEmbeddingMode | None] = [
+                self._resolve_colbert_mode(None, p) for p in pooling_params
+            ]
+            if any(m is not None for m in modes):
+                if len(modes) != len(prompts):
+                    raise ValueError(
+                        "Number of pooling params must match number of prompts "
+                        "when using ColBERT embedding_mode."
+                    )
+                if any(m is None for m in modes):
+                    raise ValueError(
+                        "Mixed ColBERT and non-ColBERT embedding_mode in one "
+                        "offline batch is not supported."
+                    )
+                resolved_modes = cast(list[ColBERTEmbeddingMode], modes)
+                encoder_config = self._get_colbert_encoder().config
+                for params, colbert_mode in zip(pooling_params, resolved_modes):
+                    apply_embedding_mode_to_pooling_params(
+                        params, colbert_mode, encoder_config
+                    )
+                return self._render_colbert_cmpl_batch(
+                    proxy,
+                    prompts,
+                    resolved_modes,
+                    pooling_params,
+                    tok_params=tok_params,
+                )
+            return super().pre_process_offline(ctx)
+
+        resolved_mode = self._resolve_colbert_mode(None, pooling_params)
+        if resolved_mode is None:
+            return super().pre_process_offline(ctx)
+
+        return self._render_colbert_cmpl(
+            proxy,
+            prompts,
+            resolved_mode,
+            pooling_params,
+            tok_params=tok_params,
+        )
 
 
 class JinaRankingTokenEmbedIOProcessor(

--- a/vllm/entrypoints/pooling/factories.py
+++ b/vllm/entrypoints/pooling/factories.py
@@ -21,12 +21,12 @@ if TYPE_CHECKING:
     from starlette.datastructures import State
 
     from vllm.engine.protocol import EngineClient
-    from vllm.entrypoints.serve.sagemaker.api_router import (
+    from vllm.entrypoints.logger import RequestLogger
+    from vllm.entrypoints.sagemaker.api_router import (
         EndpointFn,
         GetHandlerFn,
         RequestType,
     )
-    from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 
 else:
     RequestLogger = object
@@ -61,9 +61,18 @@ def init_pooling_io_processors(
         processors["embed"] = EmbedIOProcessor
 
     if pooling_task == "token_embed":
-        from .embed.io_processor import TokenEmbedIOProcessor
+        from vllm.model_executor.models.colbert_encoding import is_colbert_pooling_model
 
-        processors["token_embed"] = TokenEmbedIOProcessor
+        from .embed.io_processor import (
+            ColBERTTokenEmbedIOProcessor,
+            TokenEmbedIOProcessor,
+        )
+
+        processors["token_embed"] = (
+            ColBERTTokenEmbedIOProcessor
+            if is_colbert_pooling_model(model_config)
+            else TokenEmbedIOProcessor
+        )
 
     if has_io_processor(
         vllm_config,
@@ -78,11 +87,21 @@ def init_pooling_io_processors(
         processors["plugin"] = PluginWithoutIOProcessorPlugins
 
     if enable_scoring_api(supported_tasks, model_config):
-        from .scoring.io_processor import ScoringIOProcessors
+        from vllm.model_executor.models.colbert_encoding import is_colbert_pooling_model
+
+        from .scoring.io_processor import (
+            ColBERTLateInteractionIOProcessor,
+            ScoringIOProcessors,
+        )
 
         score_type: str | None = SCORE_TYPE_MAP.get(pooling_task, None)  # type: ignore[arg-type]
         if score_type is not None and score_type in ScoringIOProcessors:
-            processors[score_type] = ScoringIOProcessors[score_type]
+            if score_type == "late-interaction" and is_colbert_pooling_model(
+                model_config
+            ):
+                processors[score_type] = ColBERTLateInteractionIOProcessor
+            else:
+                processors[score_type] = ScoringIOProcessors[score_type]
 
     if model_config.architecture == "JinaForRanking":
         from .embed.io_processor import JinaRankingTokenEmbedIOProcessor

--- a/vllm/entrypoints/pooling/pooling/protocol.py
+++ b/vllm/entrypoints/pooling/pooling/protocol.py
@@ -15,6 +15,7 @@ from vllm.utils import random_uuid
 from ..base.protocol import (
     ChatRequestMixin,
     ClassifyRequestMixin,
+    ColBERTEmbeddingModeMixin,
     CompletionRequestMixin,
     EmbedRequestMixin,
     EncodingRequestMixin,
@@ -28,16 +29,20 @@ class PoolingCompletionRequest(
     CompletionRequestMixin,
     EmbedRequestMixin,
     ClassifyRequestMixin,
+    ColBERTEmbeddingModeMixin,
     FixedMaxLenTokenizeParamsMixin,
 ):
     task: PoolingTask | None = None
 
     def to_pooling_params(self):
-        return PoolingParams(
+        params = PoolingParams(
             task=self.task,
             use_activation=self.use_activation,
             dimensions=self.dimensions,
+            embedding_mode=self.embedding_mode,
         )
+        params.sync_colbert_extra_kwargs()
+        return params
 
 
 class PoolingChatRequest(
@@ -45,16 +50,20 @@ class PoolingChatRequest(
     ChatRequestMixin,
     EmbedRequestMixin,
     ClassifyRequestMixin,
+    ColBERTEmbeddingModeMixin,
     FixedMaxLenTokenizeParamsMixin,
 ):
     task: PoolingTask | None = None
 
     def to_pooling_params(self):
-        return PoolingParams(
+        params = PoolingParams(
             task=self.task,
             use_activation=self.use_activation,
             dimensions=self.dimensions,
+            embedding_mode=self.embedding_mode,
         )
+        params.sync_colbert_extra_kwargs()
+        return params
 
 
 T = TypeVar("T")

--- a/vllm/entrypoints/pooling/scoring/io_processor.py
+++ b/vllm/entrypoints/pooling/scoring/io_processor.py
@@ -15,6 +15,8 @@ from vllm.utils.mistral import is_mistral_tokenizer
 
 from ...chat_utils import ChatTemplateResolutionError
 from ..base.io_processor import PoolingIOProcessor
+from ..colbert_io_mixin import ColBERTIOProcessorMixin
+from ..pooling.protocol import PoolingCompletionRequest
 from ..typing import (
     OfflineInputsContext,
     OfflineOutputsContext,
@@ -294,6 +296,76 @@ class LateInteractionIOProcessor(BiEncoderIOProcessor):
                 )
             )
         return final_res_batch
+
+
+class ColBERTLateInteractionIOProcessor(
+    ColBERTIOProcessorMixin, LateInteractionIOProcessor
+):
+    name = "late-interaction"
+    pooling_task: PoolingTask = "token_embed"
+
+    def pre_process_online(self, ctx: ScoringServeContext):
+        request = ctx.request
+
+        if isinstance(request, ScoreRequest):
+            data_1 = request.data_1
+            data_2 = request.data_2
+        elif isinstance(request, RerankRequest):
+            data_1 = request.query
+            data_2 = request.documents
+        else:
+            raise ValueError(f"Invalid {self.name} request type")
+
+        scoring_data = self.valid_inputs(data_1, data_2)
+
+        max_tokens_per_query, max_tokens_per_doc = self._get_token_limits(
+            request=request
+        )
+        if max_tokens_per_query > 0 or max_tokens_per_doc > 0:
+            scoring_data = self._truncate_scoring_data(
+                scoring_data, max_tokens_per_query, max_tokens_per_doc
+            )
+
+        tok_params = request.build_tok_params(self.model_config)
+        ctx.engine_inputs = self._pre_process(
+            scoring_data,
+            tok_params,
+            prompt_extras={
+                k: v
+                for k in ("mm_processor_kwargs", "cache_salt", "chat_template_kwargs")
+                if (v := getattr(request, k, None)) is not None
+            },
+        )
+        ctx.n_queries = len(scoring_data.data_1)
+
+    def _pre_process(
+        self,
+        scoring_data: ScoringData,
+        tok_params: TokenizeParams,
+        prompt_extras: dict[str, Any] | None = None,
+    ) -> Sequence[EngineInput]:
+        data_1 = score_data_to_prompts(scoring_data.data_1, "query", self.model_config)
+        data_2 = score_data_to_prompts(
+            scoring_data.data_2, "document", self.model_config
+        )
+        proxy = PoolingCompletionRequest(
+            model=None,
+            input="",
+            add_special_tokens=True,
+        )
+        if prompt_extras:
+            for key in ("mm_processor_kwargs", "cache_salt"):
+                if key in prompt_extras:
+                    setattr(proxy, key, prompt_extras[key])
+
+        prompts = data_1 + data_2
+        modes: list[str] = ["query"] * len(data_1) + ["document"] * len(data_2)
+        return self._render_colbert_cmpl_batch(
+            proxy,
+            prompts,
+            modes,  # type: ignore[arg-type]
+            tok_params=tok_params,
+        )
 
 
 class FlashLateInteractionIOProcessor(LateInteractionIOProcessor):

--- a/vllm/inputs/engine.py
+++ b/vllm/inputs/engine.py
@@ -25,6 +25,24 @@ class _InputOptions(TypedDict):
     cache_salt: NotRequired[str]
     """Optional cache salt to be used for prefix caching."""
 
+    colbert_embedding_mode: NotRequired[Literal["query", "document"]]
+    """ColBERT asymmetric encoding mode for this engine input."""
+
+    colbert_attend_to_expansion: NotRequired[bool]
+    """When true, query expansion tokens use full attention (ColBERT)."""
+
+    colbert_cache_salt: NotRequired[str]
+    """Per-request renderer/prefix-cache isolation key for ColBERT encoding."""
+
+    colbert_cache_key: NotRequired[str]
+    """Canonical ColBERT cache isolation key for this engine input."""
+
+    colbert_full_attention_mask: NotRequired[bool]
+    """When true, query expansion tokens use full attention (PyLate parity metadata)."""
+
+    colbert_attention_mask: NotRequired[list[int]]
+    """Per-token ColBERT attention mask for the model input builder."""
+
 
 class TokensInput(_InputOptions):
     """Represents token-based input to the engine."""

--- a/vllm/inputs/llm.py
+++ b/vllm/inputs/llm.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, final
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar, final
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -94,6 +94,23 @@ class _PromptOptions(TypedDict):
     """
     Optional cache salt to be used for prefix caching.
     """
+
+    colbert_embedding_mode: NotRequired[Literal["query", "document"]]
+    """ColBERT asymmetric encoding mode for this prompt."""
+
+    colbert_attend_to_expansion: NotRequired[bool]
+    """When true, query expansion tokens use full attention (ColBERT)."""
+
+    colbert_cache_salt: NotRequired[str]
+    """Per-request renderer/prefix-cache isolation key for ColBERT encoding."""
+
+    colbert_cache_key: NotRequired[str]
+    """Canonical ColBERT cache isolation key (mirrors cache_salt when set)."""
+
+    colbert_full_attention_mask: NotRequired[bool]
+
+    colbert_attention_mask: NotRequired[list[int]]
+    """When true, query expansion tokens use full attention (PyLate parity metadata)."""
 
 
 class TextPrompt(_PromptOptions):

--- a/vllm/model_executor/models/colbert.py
+++ b/vllm/model_executor/models/colbert.py
@@ -6,6 +6,12 @@ ColBERT late interaction model for retrieval and reranking.
 ColBERT uses per-token embeddings and late interaction (MaxSim) scoring
 instead of single-vector representations or cross-encoder concatenation.
 
+ColBERT correctness for ``embedding_mode`` (query vs document markers, lengths,
+expansion padding) is enforced at **IO/tokenization** in
+``vllm.model_executor.models.colbert_encoding`` and pooling IO processors.
+**Forward passes in this module are unchanged by design** for compatibility with
+vLLM BERT kernels and existing pooling paths.
+
 This module provides:
 
 - :class:`ColBERTMixin` — mixin that adds ColBERT late-interaction support
@@ -27,6 +33,11 @@ from vllm.model_executor.layers.pooler import Pooler
 from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_embed
 
 from .bert import BertEmbeddingModel, BertModel
+from .colbert_encoding import (
+    ColBERTEncoder,
+    ColBERTEncodingConfig,
+    is_colbert_pooling_model,
+)
 from .interfaces import HasInnerState, IsHybrid, SupportsLateInteraction
 from .interfaces_base import default_pooling_type
 from .lfm2 import Lfm2ForCausalLM, Lfm2Model
@@ -96,6 +107,24 @@ class ColBERTMixin(nn.Module, SupportsLateInteraction):
         )
 
     # ---------------------------------------------------------------- pooler
+
+    @classmethod
+    def get_colbert_encoding_config(
+        cls,
+        model_config,
+        tokenizer,
+    ) -> ColBERTEncodingConfig:
+        """Build ColBERT encoding settings for the given tokenizer."""
+        return ColBERTEncodingConfig.from_model_config(model_config, tokenizer)
+
+    @classmethod
+    def get_colbert_encoder(cls, model_config, tokenizer) -> ColBERTEncoder:
+        """Return a ColBERT text encoder (PyLate-compatible preprocessing)."""
+        return ColBERTEncoder.from_model_config(model_config, tokenizer)
+
+    @classmethod
+    def is_colbert_pooling_model(cls, model_config) -> bool:
+        return is_colbert_pooling_model(model_config)
 
     def _build_colbert_pooler(self, pooler_config: PoolerConfig) -> Pooler:
         """Build pooler for ColBERT token embeddings.

--- a/vllm/model_executor/models/colbert_encoding.py
+++ b/vllm/model_executor/models/colbert_encoding.py
@@ -1,0 +1,598 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ColBERT query/document encoding for vLLM pooling (PyLate-compatible)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, cast
+
+from vllm.inputs import EngineInput
+from vllm.inputs.engine import TokensInput
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+    from vllm.inputs import EngineInput, TextPrompt, TokensPrompt
+    from vllm.renderers import TokenizeParams
+    from vllm.renderers.tokenizer import TokenizerLike
+
+logger = init_logger(__name__)
+
+ColBERTEmbeddingMode = Literal["query", "document"]
+
+# ColBERT ``colbert_attention_mask`` on EngineInput is metadata for parity checks
+# and observability only; vLLM pooling ColBERT forwards do not consume it.
+COLBERT_ATTENTION_MASK_ENFORCED_IN_FORWARD = False
+
+COLBERT_MODEL_ARCHITECTURES = frozenset(
+    {
+        "HF_ColBERT",
+        "ColBERTModel",
+        "ColBERTModernBertModel",
+        "ColBERTJinaRobertaModel",
+        "ColBERTLfm2Model",
+    }
+)
+
+DEFAULT_QUERY_PREFIX = "[unused0]"
+DEFAULT_DOCUMENT_PREFIX = "[unused1]"
+JINA_QUERY_PREFIX = "[QueryMarker]"
+JINA_DOCUMENT_PREFIX = "[DocumentMarker]"
+
+
+def is_colbert_pooling_model(model_config: ModelConfig) -> bool:
+    """Return True if the served model is a ColBERT late-interaction encoder."""
+    arch = model_config.architecture
+    if arch in COLBERT_MODEL_ARCHITECTURES:
+        return True
+    hf_archs = getattr(model_config.hf_config, "architectures", None) or []
+    return any(a in COLBERT_MODEL_ARCHITECTURES for a in hf_archs)
+
+
+def colbert_parity_check_enabled() -> bool:
+    return os.getenv("VLLM_COLBERT_PARITY_CHECK", "0") == "1"
+
+
+def colbert_strict_mode_enabled() -> bool:
+    return os.getenv("VLLM_COLBERT_STRICT_MODE", "0") == "1"
+
+
+def is_colbert_late_interaction(model_config: ModelConfig) -> bool:
+    """Return True if the model supports ColBERT late-interaction encoding."""
+    return is_colbert_pooling_model(model_config)
+
+
+def validate_colbert_embedding_mode(
+    model_config: ModelConfig,
+    embedding_mode: ColBERTEmbeddingMode | None,
+) -> None:
+    """Reject embedding_mode on non-ColBERT late-interaction models."""
+    if embedding_mode is None:
+        return
+    if not is_colbert_late_interaction(model_config):
+        raise ValueError(
+            "embedding_mode is only supported for ColBERT / late interaction models"
+        )
+
+
+def _warn_colbert_attention_mask_not_enforced() -> None:
+    if colbert_strict_mode_enabled():
+        logger.warning_once(
+            "ColBERT attention_mask is not enforced in transformer forward; "
+            "running in validation mode only."
+        )
+
+
+def _resolve_token_id(tokenizer: TokenizerLike, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if token_id is None or (unk_id is not None and token_id == unk_id):
+        raise ValueError(
+            f"ColBERT marker token {token!r} is not in the tokenizer vocabulary."
+        )
+    return int(token_id)
+
+
+def _load_artifact_metadata(model: str, revision: str | None) -> dict:
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        return {}
+
+    try:
+        path = hf_hub_download(model, filename="artifact.metadata", revision=revision)
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _load_st_colbert_config(model: str, revision: str | None) -> dict:
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        return {}
+
+    for filename in ("config_sentence_transformers.json", "modules.json"):
+        try:
+            path = hf_hub_download(model, filename=filename, revision=revision)
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if filename == "modules.json" and isinstance(data, list):
+                for entry in data:
+                    if entry.get("type") == "sentence_transformers.models.ColBERT":
+                        return entry.get("kwargs", {})
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            continue
+    return {}
+
+
+def resolve_colbert_chat_template_hash(
+    chat_template: str | None,
+    *,
+    model_config: ModelConfig | None = None,
+) -> str:
+    """SHA-256 hash of chat template (or model fallback) for cache keys."""
+    if chat_template is not None:
+        return hashlib.sha256(chat_template.encode("utf-8")).hexdigest()
+    if model_config is not None:
+        payload = f"{model_config.model}\0{model_config.revision or ''}"
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return hashlib.sha256(b"none").hexdigest()
+
+
+def resolve_colbert_chat_template_version(
+    chat_template: str | None,
+    *,
+    model_config: ModelConfig | None = None,
+) -> str:
+    """Deprecated alias for :func:`resolve_colbert_chat_template_hash`."""
+    return resolve_colbert_chat_template_hash(chat_template, model_config=model_config)
+
+
+def compute_colbert_config_hash(
+    config: ColBERTEncodingConfig,
+    *,
+    model_config: ModelConfig | None = None,
+) -> str:
+    """Hash ColBERT tokenization settings that affect encoded token sequences."""
+    parts = [
+        config.query_prefix,
+        config.document_prefix,
+        str(config.query_length),
+        str(config.document_length),
+        str(config.mask_token_id),
+        str(config.pad_token_id),
+        str(config.do_query_expansion),
+        str(config.attend_to_expansion_tokens),
+    ]
+    if model_config is not None:
+        parts.extend([model_config.model, model_config.revision or ""])
+    payload = "\0".join(parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def canonicalize_colbert_input_text(
+    text: str,
+    tok_params: ColBERTTokenizeParams,
+    tokenizer: TokenizerLike,
+) -> str:
+    """Return the exact string passed to ``tokenizer.encode`` for ColBERT paths.
+
+    Cache keys must use this value (not the raw API string) so prefix-cache
+    isolation matches tokenization when the renderer applies ``do_lower_case`` or
+    other pre-tokenization validators.
+    """
+
+    prompt: TextPrompt = {"prompt": text}
+    prepared = tok_params.apply_pre_tokenization(tokenizer, prompt)
+    return prepared["prompt"]
+
+
+def compute_colbert_cache_key(
+    *,
+    model_name: str,
+    embedding_mode: ColBERTEmbeddingMode | None,
+    raw_text: str,
+    chat_template_hash: str,
+    colbert_config_hash: str | None = None,
+) -> str:
+    """Canonical prefix-cache isolation key for ColBERT renderer paths.
+
+    ``raw_text`` must be the post-``apply_pre_tokenization`` prompt string (see
+    :func:`canonicalize_colbert_input_text`), not the unnormalized API payload.
+    ColBERT marker/truncate/pad steps run after tokenization and are represented
+    in ``prompt_token_ids`` plus ``embedding_mode`` / ``colbert_config_hash``.
+    """
+    # NOTE: cache key is defined over canonical pre-tokenization text to match
+    # the tokenizer input contract (not over token ids).
+    config_hash = colbert_config_hash if embedding_mode is not None else "none"
+    mode_part = "" if embedding_mode is None else embedding_mode
+    payload = "\0".join(
+        [model_name, mode_part, raw_text, chat_template_hash, config_hash]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def compute_colbert_cache_salt(
+    embedding_mode: ColBERTEmbeddingMode,
+    input_text: str,
+    *,
+    model_name: str = "",
+    chat_template_hash: str | None = None,
+    chat_template_version: str | None = None,
+    colbert_config_hash: str | None = None,
+    request_id: str | None = None,  # noqa: ARG001 — deprecated, ignored
+) -> str:
+    """Backward-compatible alias for :func:`compute_colbert_cache_key`."""
+    del request_id
+    template_hash = chat_template_hash
+    if template_hash is None:
+        if chat_template_version is not None:
+            template_hash = hashlib.sha256(
+                chat_template_version.encode("utf-8")
+            ).hexdigest()
+        else:
+            template_hash = resolve_colbert_chat_template_hash(None)
+    return compute_colbert_cache_key(
+        model_name=model_name,
+        embedding_mode=embedding_mode,
+        raw_text=input_text,
+        chat_template_hash=template_hash,
+        colbert_config_hash=colbert_config_hash,
+    )
+
+
+def build_colbert_attention_mask(
+    token_ids: list[int],
+    mode: ColBERTEmbeddingMode,
+    config: ColBERTEncodingConfig,
+) -> list[int]:
+    """Build per-token attention mask metadata for ColBERT engine inputs.
+
+    This mask is **not** consumed by the vLLM ColBERT transformer forward pass
+    (see :data:`COLBERT_ATTENTION_MASK_ENFORCED_IN_FORWARD`). Correctness relies
+    on preprocessing (markers, truncation, expansion) and ranking parity tests.
+    The mask is attached for validation, observability, and PyLate parity tooling.
+    """
+    _warn_colbert_attention_mask_not_enforced()
+    if mode == "query" and config.attend_to_expansion_tokens:
+        return [1] * len(token_ids)
+    return [0 if tid == config.pad_token_id else 1 for tid in token_ids]
+
+
+def finalize_colbert_engine_input(
+    engine_input: EngineInput,
+    *,
+    mode: ColBERTEmbeddingMode,
+    cache_key: str,
+    config: ColBERTEncodingConfig,
+) -> EngineInput:
+    """Return a fresh, immutable ColBERT engine input (no shared mutable token lists).
+
+    Attaches ``colbert_attention_mask`` as metadata only; it is not applied inside
+    the model forward pass. See :data:`COLBERT_ATTENTION_MASK_ENFORCED_IN_FORWARD`.
+    """
+    _warn_colbert_attention_mask_not_enforced()
+    if engine_input.get("type") != "token":
+        raise ValueError("ColBERT encoding requires token engine inputs")
+
+    token_ids = list(engine_input["prompt_token_ids"])
+    result: TokensInput = {
+        "type": "token",
+        "prompt_token_ids": token_ids,
+        "cache_salt": cache_key,
+        "colbert_embedding_mode": mode,
+        "colbert_cache_key": cache_key,
+        "colbert_cache_salt": cache_key,
+    }
+    if prompt := engine_input.get("prompt"):
+        result["prompt"] = prompt
+    if arrival_time := engine_input.get("arrival_time"):
+        result["arrival_time"] = arrival_time
+    if mode == "query" and config.attend_to_expansion_tokens:
+        result["colbert_attend_to_expansion"] = True
+        result["colbert_full_attention_mask"] = True
+    result["colbert_attention_mask"] = build_colbert_attention_mask(
+        token_ids, mode, config
+    )
+    return result
+
+
+@dataclass(frozen=True)
+class ColBERTEncodingConfig:
+    query_prefix: str
+    document_prefix: str
+    query_prefix_id: int
+    document_prefix_id: int
+    query_length: int
+    document_length: int
+    mask_token_id: int
+    pad_token_id: int
+    do_query_expansion: bool
+    attend_to_expansion_tokens: bool
+
+    @classmethod
+    def from_model_config(
+        cls,
+        model_config: ModelConfig,
+        tokenizer: TokenizerLike,
+    ) -> ColBERTEncodingConfig:
+        model = model_config.model
+        revision = model_config.revision
+        metadata = _load_artifact_metadata(model, revision)
+        st_cfg = _load_st_colbert_config(model, revision)
+
+        is_jina = "jina-colbert" in model.lower() or any(
+            a == "ColBERTJinaRobertaModel"
+            for a in (getattr(model_config.hf_config, "architectures", None) or [])
+        )
+
+        query_prefix = (
+            st_cfg.get("query_prefix")
+            or metadata.get("query_token_id")
+            or (JINA_QUERY_PREFIX if is_jina else DEFAULT_QUERY_PREFIX)
+        )
+        if isinstance(query_prefix, int):
+            query_prefix = tokenizer.convert_ids_to_tokens(query_prefix) or str(
+                query_prefix
+            )
+
+        document_prefix = (
+            st_cfg.get("document_prefix")
+            or metadata.get("doc_token_id")
+            or (JINA_DOCUMENT_PREFIX if is_jina else DEFAULT_DOCUMENT_PREFIX)
+        )
+        if isinstance(document_prefix, int):
+            document_prefix = tokenizer.convert_ids_to_tokens(document_prefix) or str(
+                document_prefix
+            )
+
+        query_length = (
+            st_cfg.get("query_length")
+            or metadata.get("query_maxlen")
+            or (32 if is_jina else 32)
+        )
+        document_length = (
+            st_cfg.get("document_length")
+            or metadata.get("doc_maxlen")
+            or model_config.max_model_len
+        )
+
+        attend_to_expansion = st_cfg.get("attend_to_expansion_tokens")
+        if attend_to_expansion is None:
+            attend_meta = metadata.get("attend_to_mask_tokens")
+            attend_to_expansion = (
+                bool(attend_meta) if attend_meta is not None else is_jina
+            )
+
+        do_query_expansion = st_cfg.get("do_query_expansion")
+        if do_query_expansion is None:
+            do_query_expansion = True
+
+        mask_token = tokenizer.mask_token or tokenizer.pad_token or "<mask>"
+        if mask_token is None:
+            raise ValueError(
+                "Tokenizer must define mask_token or pad_token for ColBERT."
+            )
+        mask_token_id = _resolve_token_id(tokenizer, mask_token)
+
+        pad_token = tokenizer.pad_token or mask_token
+        pad_token_id = _resolve_token_id(tokenizer, pad_token)
+
+        return cls(
+            query_prefix=str(query_prefix),
+            document_prefix=str(document_prefix),
+            query_prefix_id=_resolve_token_id(tokenizer, str(query_prefix)),
+            document_prefix_id=_resolve_token_id(tokenizer, str(document_prefix)),
+            query_length=int(query_length),
+            document_length=int(document_length),
+            mask_token_id=mask_token_id,
+            pad_token_id=pad_token_id,
+            do_query_expansion=bool(do_query_expansion),
+            attend_to_expansion_tokens=bool(attend_to_expansion),
+        )
+
+    def max_sequence_length_for_mode(self, mode: ColBERTEmbeddingMode) -> int:
+        if mode == "query":
+            return self.query_length
+        return self.document_length
+
+
+@dataclass(frozen=True)
+class ColBERTTokenizeParams:
+    """TokenizeParams wrapper that applies ColBERT post-tokenization hooks."""
+
+    base: TokenizeParams
+    config: ColBERTEncodingConfig
+    mode: ColBERTEmbeddingMode
+
+    def __getattr__(self, name: str):
+        return getattr(self.base, name)
+
+    def with_kwargs(self, **tokenization_kwargs):
+        return ColBERTTokenizeParams(
+            base=self.base.with_kwargs(**tokenization_kwargs),
+            config=self.config,
+            mode=self.mode,
+        )
+
+    def get_encode_kwargs(self) -> dict:
+        return dict(
+            truncation=False,
+            add_special_tokens=self.base.add_special_tokens,
+        )
+
+    def apply_pre_tokenization(
+        self,
+        tokenizer: TokenizerLike | None,
+        prompt: TextPrompt,
+    ) -> TextPrompt:
+        prompt = dict(prompt)
+        prompt = self.base.apply_pre_tokenization(tokenizer, prompt)
+        prompt["colbert_embedding_mode"] = self.mode
+        return cast("TextPrompt", prompt)
+
+    def apply_post_tokenization(
+        self,
+        tokenizer: TokenizerLike | None,
+        prompt: TokensPrompt,
+    ) -> TokensPrompt:
+        if tokenizer is None:
+            return prompt
+        prompt = dict(prompt)
+        token_ids = list(prompt["prompt_token_ids"])
+        encoder = ColBERTEncoder(self.config)
+        token_ids = encoder.encode_token_ids(token_ids, self.mode)
+        prompt["prompt_token_ids"] = token_ids
+        prompt["colbert_embedding_mode"] = self.mode
+        if self.mode == "query" and self.config.attend_to_expansion_tokens:
+            prompt["colbert_attend_to_expansion"] = True
+            prompt["colbert_full_attention_mask"] = True
+        return cast("TokensPrompt", prompt)
+
+
+class ColBERTEncoder:
+    """PyLate-compatible ColBERT token pipeline (marker → truncate → pad)."""
+
+    def __init__(self, config: ColBERTEncodingConfig) -> None:
+        self.config = config
+
+    @classmethod
+    def from_model_config(
+        cls,
+        model_config: ModelConfig,
+        tokenizer: TokenizerLike,
+    ) -> ColBERTEncoder:
+        return cls(ColBERTEncodingConfig.from_model_config(model_config, tokenizer))
+
+    def build_tokenize_params(
+        self,
+        mode: ColBERTEmbeddingMode,
+        base: TokenizeParams,
+    ) -> ColBERTTokenizeParams:
+        wrapped = base.with_kwargs(
+            truncation=False,
+            truncate_prompt_tokens=None,
+            pad_prompt_tokens=None,
+        )
+        return ColBERTTokenizeParams(base=wrapped, config=self.config, mode=mode)
+
+    @staticmethod
+    def insert_prefix_token(token_ids: list[int], prefix_id: int) -> list[int]:
+        if not token_ids:
+            return [prefix_id]
+        return [token_ids[0], prefix_id, *token_ids[1:]]
+
+    def encode_token_ids(
+        self,
+        token_ids: list[int],
+        mode: ColBERTEmbeddingMode,
+    ) -> list[int]:
+        """PyLate order: tokenize (done) → marker → length truncate → query pad."""
+        prefix_id = (
+            self.config.query_prefix_id
+            if mode == "query"
+            else self.config.document_prefix_id
+        )
+        encoded = self.insert_prefix_token(token_ids, prefix_id)
+        max_len = self.config.max_sequence_length_for_mode(mode)
+        if len(encoded) > max_len:
+            encoded = encoded[:max_len]
+        if mode == "query" and self.config.do_query_expansion:
+            pad_id = self.config.mask_token_id
+            if len(encoded) < max_len:
+                encoded = encoded + [pad_id] * (max_len - len(encoded))
+        return encoded
+
+
+def build_colbert_prompt_extras(
+    mode: ColBERTEmbeddingMode,
+    config: ColBERTEncodingConfig,
+    *,
+    model_name: str,
+    raw_text: str,
+    chat_template_hash: str,
+    colbert_config_hash: str,
+) -> dict:
+    cache_key = compute_colbert_cache_key(
+        model_name=model_name,
+        embedding_mode=mode,
+        raw_text=raw_text,
+        chat_template_hash=chat_template_hash,
+        colbert_config_hash=colbert_config_hash,
+    )
+    extras = {
+        "colbert_embedding_mode": mode,
+        "colbert_cache_key": cache_key,
+        "colbert_cache_salt": cache_key,
+        "cache_salt": cache_key,
+    }
+    if mode == "query" and config.attend_to_expansion_tokens:
+        extras["colbert_attend_to_expansion"] = True
+        extras["colbert_full_attention_mask"] = True
+    return extras
+
+
+def apply_embedding_mode_to_pooling_params(
+    pooling_params,
+    mode: ColBERTEmbeddingMode | None,
+    config: ColBERTEncodingConfig | None,
+) -> None:
+    if mode is None:
+        return
+    extra = dict(pooling_params.extra_kwargs or {})
+    extra["embedding_mode"] = mode
+    extra["colbert_embedding_mode"] = mode
+    if config is not None and mode == "query" and config.attend_to_expansion_tokens:
+        extra["colbert_attend_to_expansion"] = True
+        extra["colbert_full_attention_mask"] = True
+    pooling_params.extra_kwargs = extra
+
+
+def validate_colbert_engine_inputs(
+    engine_inputs: list[EngineInput],
+    config: ColBERTEncodingConfig,
+) -> None:
+    """Debug-only shape checks (``VLLM_COLBERT_PARITY_CHECK=1``)."""
+    if not colbert_parity_check_enabled():
+        return
+
+    seen_keys: set[str] = set()
+    for engine_input in engine_inputs:
+        mode = engine_input.get("colbert_embedding_mode")
+        if mode not in ("query", "document"):
+            raise ValueError(
+                "ColBERT parity check: missing colbert_embedding_mode on "
+                f"{engine_input!r}"
+            )
+        token_ids = engine_input.get("prompt_token_ids")
+        if token_ids is None:
+            continue
+        seq_len = len(token_ids)
+        if mode == "query" and seq_len > config.query_length:
+            raise ValueError(
+                f"ColBERT parity check: query length {seq_len} > {config.query_length}"
+            )
+        if mode == "document" and seq_len > config.document_length:
+            raise ValueError(
+                f"ColBERT parity check: document length {seq_len} > "
+                f"{config.document_length}"
+            )
+        cache_key = engine_input.get("colbert_cache_key") or engine_input.get(
+            "colbert_cache_salt"
+        )
+        if cache_key is None:
+            raise ValueError("ColBERT parity check: missing colbert_cache_key")
+        if cache_key in seen_keys:
+            logger.warning(
+                "ColBERT parity check: duplicate cache key %s (may be intentional)",
+                cache_key,
+            )
+        seen_keys.add(cache_key)

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -993,6 +993,16 @@ class SupportsLateInteraction(Protocol):
 
     score_type: ClassVar[ScoreType] = "late-interaction"
 
+    @classmethod
+    def is_colbert_pooling_model(cls, model_config: object) -> bool:
+        """Return True when asymmetric ColBERT encoding applies."""
+        ...
+
+    @classmethod
+    def get_colbert_encoder(cls, model_config: object, tokenizer: object):
+        """Return ColBERT query/document text encoder for IO processors."""
+        ...
+
 
 class SupportsQuant:
     """The interface required for all models that support quantization."""
@@ -1623,7 +1633,8 @@ class SupportsEncoderCudaGraph(Protocol):
 
     def encoder_cudagraph_forward(
         self,
-        inputs: dict[str, torch.Tensor],
+        mm_kwargs: dict[str, Any],
+        buffers: dict[str, torch.Tensor],
     ) -> torch.Tensor:
         """Run the encoder forward pass with precomputed buffers.
 

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, Literal
 
 import msgspec
 
@@ -61,6 +61,9 @@ class PoolingParams(
     step_tag_id: int | None = None
     returned_token_ids: list[int] | None = None
 
+    ## ColBERT asymmetric encoding (token_embed)
+    embedding_mode: Literal["query", "document"] | None = None
+
     ## Internal use only
     task: PoolingTask | None = None
     requires_token_ids: bool = False
@@ -87,6 +90,12 @@ class PoolingParams(
         return deepcopy(self)
 
     def verify(self, model_config: ModelConfig) -> None:
+        from vllm.model_executor.models.colbert_encoding import (
+            validate_colbert_embedding_mode,
+        )
+
+        validate_colbert_embedding_mode(model_config, self.embedding_mode)
+
         # plugin task uses io_processor.parse_request to verify inputs,
         # skipping PoolingParams verify
         if self.task == "plugin":
@@ -219,8 +228,17 @@ class PoolingParams(
             f"requires_token_ids={self.requires_token_ids}, "
             f"skip_reading_prefix_cache={self.skip_reading_prefix_cache}, "
             f"late_interaction_params={self.late_interaction_params}, "
+            f"embedding_mode={self.embedding_mode}, "
             f"extra_kwargs={self.extra_kwargs})"
         )
+
+    def sync_colbert_extra_kwargs(self) -> None:
+        if self.embedding_mode is None:
+            return
+        extra = dict(self.extra_kwargs or {})
+        extra["embedding_mode"] = self.embedding_mode
+        extra["colbert_embedding_mode"] = self.embedding_mode
+        self.extra_kwargs = extra
 
     def __post_init__(self) -> None:
         if self.output_kind != RequestOutputKind.FINAL_ONLY:
@@ -228,3 +246,4 @@ class PoolingParams(
                 "For pooling output_kind has to be FINAL_ONLY, "
                 f"got {self.output_kind!r}"
             )
+        self.sync_colbert_extra_kwargs()

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -104,9 +104,6 @@ class BaseRenderer(ABC, Generic[_T]):
         self._process_multimodal_async = make_async(
             self._process_multimodal, executor=self._mm_executor
         )
-        self._safe_load_prompt_embeds_async = make_async(
-            safe_load_prompt_embeds, executor=self._executor
-        )
         if mm_registry.supports_multimodal_inputs(config.model_config):
             mm_processor_cache = mm_registry.processor_cache_from_config(config)
 
@@ -379,28 +376,11 @@ class BaseRenderer(ABC, Generic[_T]):
 
         return [self.render_prompt(prompt) for prompt in prompts]
 
-    async def _render_prompt_async(
-        self,
-        prompt: DictPrompt | bytes,
-    ) -> DictPrompt:
-        if isinstance(prompt, bytes):
-            embeds = await self._safe_load_prompt_embeds_async(
-                self.model_config, prompt
-            )
-            return EmbedsPrompt(prompt_embeds=embeds)
-
-        return prompt
-
     async def render_prompts_async(
         self,
         prompts: Sequence[DictPrompt | bytes],
     ) -> list[DictPrompt]:
-        if len(prompts) == 0:
-            raise ValueError("You must pass at least one prompt")
-
-        return await asyncio.gather(
-            *(self._render_prompt_async(prompt) for prompt in prompts)
-        )
+        return self.render_prompts(prompts)
 
     @abstractmethod
     def render_messages(
@@ -615,7 +595,13 @@ class BaseRenderer(ABC, Generic[_T]):
 
         for prompt in prompts:
             target_prompt = extract_target_prompt(self.model_config, prompt)
-            target_prompt.update(prompt_extras)  # type: ignore[arg-type]
+            extras = dict(prompt_extras)
+            colbert_key = extras.pop("colbert_cache_key", None)
+            if colbert_key is not None:
+                extras.setdefault("colbert_cache_key", colbert_key)
+                extras.setdefault("colbert_cache_salt", colbert_key)
+                extras.setdefault("cache_salt", colbert_key)
+            target_prompt.update(extras)  # type: ignore[arg-type]
 
     # Step 4: Convert to engine inputs
     def _validate_mm_uuids(
@@ -751,6 +737,18 @@ class BaseRenderer(ABC, Generic[_T]):
             engine_input["prompt"] = prompt_text
         if cache_salt := prompt.get("cache_salt"):
             engine_input["cache_salt"] = cache_salt
+        if mode := prompt.get("colbert_embedding_mode"):
+            engine_input["colbert_embedding_mode"] = mode
+        if prompt.get("colbert_attend_to_expansion"):
+            engine_input["colbert_attend_to_expansion"] = True
+        if colbert_salt := prompt.get("colbert_cache_salt"):
+            engine_input["colbert_cache_salt"] = colbert_salt
+        if colbert_key := prompt.get("colbert_cache_key"):
+            engine_input["colbert_cache_key"] = colbert_key
+        if prompt.get("colbert_full_attention_mask"):
+            engine_input["colbert_full_attention_mask"] = True
+        if colbert_attn := prompt.get("colbert_attention_mask"):
+            engine_input["colbert_attention_mask"] = list(colbert_attn)
 
         return engine_input
 
@@ -809,6 +807,18 @@ class BaseRenderer(ABC, Generic[_T]):
             engine_input["prompt"] = prompt_text
         if cache_salt := prompt.get("cache_salt"):
             engine_input["cache_salt"] = cache_salt
+        if mode := prompt.get("colbert_embedding_mode"):
+            engine_input["colbert_embedding_mode"] = mode
+        if prompt.get("colbert_attend_to_expansion"):
+            engine_input["colbert_attend_to_expansion"] = True
+        if colbert_salt := prompt.get("colbert_cache_salt"):
+            engine_input["colbert_cache_salt"] = colbert_salt
+        if colbert_key := prompt.get("colbert_cache_key"):
+            engine_input["colbert_cache_key"] = colbert_key
+        if prompt.get("colbert_full_attention_mask"):
+            engine_input["colbert_full_attention_mask"] = True
+        if colbert_attn := prompt.get("colbert_attention_mask"):
+            engine_input["colbert_attention_mask"] = list(colbert_attn)
 
         return engine_input
 


### PR DESCRIPTION
## Summary

Adds `embedding_mode` (`query` | `document`) for ColBERT / late-interaction pooling models so query vs document tokenization happens at **pooling IO** (markers, query expansion, length limits), not in model `forward()`.

- Use **`POST /pooling`** with `task: "token_embed"` and top-level **`embedding_mode`**.
- Do **not** use `/v1/embeddings`, `pooling_params.embedding_mode`, or `input_type` for this flow.
- `/score` and `/rerank` continue to apply query/document encoding automatically via API fields.
- Omitting `embedding_mode` keeps the legacy symmetric `token_embed` path (backward compatible; not recommended for retrieval).

Fixes #42234

## Design

- Asymmetry at **text/tokenization** only (`ColBERTIOProcessorMixin`, `colbert_encoding.py`).
- `COLBERT_ATTENTION_MASK_ENFORCED_IN_FORWARD = False` — mask metadata only.
- Prefix-cache keys: canonical pre-tokenization text + model + mode + template/config hashes.
- Regression tests: `tests/models/pooling/test_colbert_embedding_mode.py`

## GPU validation (RunPod, `jinaai/jina-colbert-v2`, vLLM 0.22.0 + PR file overlay)

**Verdict:** READY TO MERGE — **19 PASS**, **0 FAIL**, **0 WARN**, **3 SKIP**

| Check | Result |
|-------|--------|
| Health | PASS |
| Pooling query / document / legacy | PASS |
| Score / rerank | PASS |
| Batch / cache / negatives / asymmetry | PASS |
| `pytest tests/models/pooling/test_colbert_embedding_mode.py` | **24/24 PASS** |

**Manual token counts** (`"machine learning"`):

| Mode | Tokens |
|------|--------|
| `embedding_mode: query` | 32 |
| `embedding_mode: document` | 5 |
| legacy (no mode) | 4 |

**Retrieval sanity:** query↔relevant doc **6.37** vs query↔irrelevant **2.41**.

