### PR TITLE
[Bugfix] Fix infinite loop from orphan keys in LRUCache multimodal cache

### DIFF
--- a/tests/utils_/test_cache.py
+++ b/tests/utils_/test_cache.py
@@ -123,3 +123,74 @@ def test_lru_cache():
     assert 2 in cache
     assert 4 in cache
     assert 6 in cache
+
+
+def test_touch_nonexistent_key_does_not_create_orphan():
+    """Regression test for https://github.com/vllm-project/vllm/issues/43941
+
+    Calling touch() on a key that doesn't exist in the cache must NOT add it
+    to __order, because that creates an "orphan" entry that causes popitem()
+    to loop infinitely during eviction.
+    """
+    cache = LRUCache(3)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    # Touch a key that was never inserted
+    cache.touch("ghost")
+
+    # "ghost" must NOT appear in the order
+    assert "ghost" not in cache.order
+    assert "ghost" not in cache
+    assert len(cache) == 2
+
+    # Eviction should still work normally
+    cache.put("c", 3)
+    cache.put("d", 4)  # triggers eviction of "a"
+    assert len(cache) == 3
+    assert "a" not in cache
+    assert set(cache.cache) == {"b", "c", "d"}
+
+
+def test_popitem_cleans_orphan_keys_no_infinite_loop():
+    """Regression test for https://github.com/vllm-project/vllm/issues/43941
+
+    If an orphan key somehow ends up in __order (e.g. from a prior bug),
+    popitem() must clean it up rather than looping forever.
+    """
+    cache = LRUCache(3)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    cache.put("c", 3)
+
+    # Manually inject an orphan key into __order (simulating the old bug)
+    cache._LRUCache__order["orphan"] = None  # type: ignore
+    # Move orphan to front (oldest position)
+    cache._LRUCache__order.move_to_end("orphan", last=False)  # type: ignore
+
+    # Now insert a new item, which requires eviction
+    # Without the fix, this would loop forever on the orphan
+    cache.put("d", 4)
+
+    # The orphan should have been cleaned, and "a" evicted as the real LRU
+    assert "orphan" not in cache.order
+    assert "a" not in cache
+    assert len(cache) == 3
+    assert set(cache.cache) == {"b", "c", "d"}
+
+
+def test_touch_existing_key_updates_lru_order():
+    """touch() on an existing key should move it to the end (most recent)."""
+    cache = LRUCache(3)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    cache.put("c", 3)
+
+    # Touch "a" to make it most recently used
+    cache.touch("a")
+
+    # Now "b" should be the oldest - evicted next
+    cache.put("d", 4)
+    assert "b" not in cache
+    assert "a" in cache
+    assert set(cache.cache) == {"a", "c", "d"}

--- a/vllm/utils/cache.py
+++ b/vllm/utils/cache.py
@@ -121,7 +121,11 @@ class LRUCache(cachetools.LRUCache[_K, _V]):
         try:
             self._LRUCache__order.move_to_end(key)  # type: ignore
         except KeyError:
-            self._LRUCache__order[key] = None  # type: ignore
+            # Only add to __order if the key actually exists in the cache.
+            # Otherwise we create an "orphan" key that can cause infinite
+            # loops during eviction (see github.com/vllm-project/vllm/issues/43941).
+            if key in self:
+                self._LRUCache__order[key] = None  # type: ignore
 
     @overload
     def get(self, key: _K, /) -> _V | None: ...
@@ -190,6 +194,18 @@ class LRUCache(cachetools.LRUCache[_K, _V]):
 
     def popitem(self, remove_pinned: bool = False):
         """Remove and return the `(key, value)` pair least recently used."""
+        order = self._LRUCache__order  # type: ignore
+
+        # Defensive cleanup: remove orphan keys from the head of __order
+        # that exist in __order but not in __data. This prevents infinite
+        # loops if an orphan was introduced by a prior bug or race condition.
+        # See github.com/vllm-project/vllm/issues/43941
+        while order:
+            first_key = next(iter(order))
+            if first_key in self:
+                break
+            del order[first_key]
+
         if not remove_pinned:
             # pop the oldest item in the cache that is not pinned
             lru_key = next(


### PR DESCRIPTION
## Purpose

Fix infinite loop in `LRUCache.popitem()` caused by orphan keys in `__order` (#43941).

`LRUCache.touch()` unconditionally adds a key to `__order` on `KeyError`, even when the key doesn't exist in `__data`. In the multimodal P0/P1 cache architecture, when P0 caches an `mm_hash` but the request is rejected (e.g. token count exceeds `max_model_len`) before reaching P1, subsequent requests trigger `touch()` on P1 for a key never stored there — creating an orphan entry in `__order`.

During eviction, `popitem()` finds the orphan as the LRU candidate, but `pop()` returns `None` (key not in `__data`) without removing it from `__order`, causing an infinite loop that hangs the engine.

**This differs from #44068** which only fixes `popitem()` (symptom). This PR additionally fixes `touch()` (root cause), providing two layers of protection:

1. **`touch()`**: Only add to `__order` if `key in self` — prevents orphan creation.
2. **`popitem()`**: Clean orphan keys from the head of `__order` before eviction — prevents infinite loop even if orphans exist from prior bugs.

## Test Plan

```bash
python -m pytest tests/utils_/test_cache.py -v
```

Three new regression tests added:
- `test_touch_nonexistent_key_does_not_create_orphan` — verifies touch on missing key doesn't pollute `__order`
- `test_popitem_cleans_orphan_keys_no_infinite_loop` — verifies eviction handles injected orphans without hanging
- `test_touch_existing_key_updates_lru_order` — verifies normal touch behavior is unaffected

## Test Result

```
tests/utils_/test_cache.py::test_lru_cache PASSED
tests/utils_/test_cache.py::test_touch_nonexistent_key_does_not_create_orphan PASSED
tests/utils_/test_cache.py::test_popitem_cleans_orphan_keys_no_infinite_loop PASSED
tests/utils_/test_cache.py::test_touch_existing_key_updates_lru_order PASSED

4 passed in 2.58s
```

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
