### PR TITLE
Add GH token to docs build pre run check

### DIFF
--- a/docs/pre_run_check.sh
+++ b/docs/pre_run_check.sh
@@ -24,8 +24,14 @@ echo "Checking pre-commit/pre-run-check status..."
 MAX_WAIT=300
 INTERVAL=60
 ELAPSED=0
+# Use a GitHub token if provided to raise the API rate limit (60 -> 5000
+# requests/hour). Set GITHUB_TOKEN in the Read the Docs environment variables.
+CURL_AUTH=()
+if [ -n "$GITHUB_TOKEN" ]; then
+  CURL_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
 while :; do
-  RAW=$(curl -sS -w "\n%{http_code}" "https://api.github.com/repos/vllm-project/vllm/commits/${READTHEDOCS_GIT_COMMIT_HASH}/check-runs?check_name=pre-run-check&filter=latest")
+  RAW=$(curl -sS "${CURL_AUTH[@]}" -w "\n%{http_code}" "https://api.github.com/repos/vllm-project/vllm/commits/${READTHEDOCS_GIT_COMMIT_HASH}/check-runs?check_name=pre-run-check&filter=latest")
   HTTP_CODE=$(printf %s "$RAW" | tail -n1)
   BODY=$(printf %s "$RAW" | sed '$d')
   if [ "$HTTP_CODE" != "200" ]; then


### PR DESCRIPTION
Increase the rate limit for the docs build skip check from 60/hour to 5000/hour