### PR TITLE
[Profiler] Support multiple profiling windows

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -85,6 +85,28 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 $ curl -X POST http://localhost:8000/stop_profile
 ```
 
+## Capturing Multiple Discontinuous Ranges
+
+`delay_iterations` and `max_iterations` can be comma-separated strings to
+capture multiple profiling windows after `/start_profile`. Each value in
+`delay_iterations` is paired with the value at the same position in
+`max_iterations`, and both are measured in worker steps relative to
+`/start_profile`.
+
+For example, this captures steps 10-29 and 100-199:
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --profiler-config '{"profiler":"cuda",
+                        "delay_iterations":"10,100",
+                        "max_iterations":"20,100"}'
+```
+
+The windows must be ordered and non-overlapping. Every non-final
+`max_iterations` value must be greater than 0. A final value of 0 keeps the last
+window open until `/stop_profile`, preserving the scalar `max_iterations=0`
+behavior.
+
 ## Profile with NVIDIA Nsight Systems
 
 Nsight systems is an advanced tool that exposes more profiling details, such as register and shared memory usage, annotated code regions and low-level CUDA APIs and events.

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -107,6 +107,21 @@ The windows must be ordered and non-overlapping. Every non-final
 window open until `/stop_profile`, preserving the scalar `max_iterations=0`
 behavior.
 
+The same syntax is supported by the torch profiler:
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --profiler-config '{"profiler":"torch",
+                        "torch_profiler_dir":"./vllm_profile",
+                        "delay_iterations":"10,100",
+                        "max_iterations":"20,100"}'
+```
+
+When using torch profiler schedule options such as `wait_iterations` or
+`warmup_iterations`, the schedule is applied inside each profiling window. vLLM
+creates a fresh torch profiler instance for every window, so torch outputs one
+trace per captured range.
+
 ## Profile with NVIDIA Nsight Systems
 
 Nsight systems is an advanced tool that exposes more profiling details, such as register and shared memory usage, annotated code regions and low-level CUDA APIs and events.

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -88,10 +88,6 @@ def test_max_iterations(default_profiler_config):
 
     # Iteration 2
     profiler.step()  # profiling_count becomes 2
-    assert profiler._running is True
-
-    # Iteration 3 (Exceeds max)
-    profiler.step()  # profiling_count becomes 3
 
     # Should have stopped now
     assert profiler._running is False
@@ -119,10 +115,6 @@ def test_delayed_start_and_max_iters(default_profiler_config):
     # Next iteration
     profiler.step()
     assert profiler._profiling_for_iters == 2
-    assert profiler._running is True
-
-    # Iteration 2 (exceeds max)
-    profiler.step()
 
     # Should have stopped now
     assert profiler._running is False
@@ -203,6 +195,243 @@ def test_mixed_delay_and_stop(default_profiler_config):
     profiler.step()
 
     assert profiler.start_call_count == 0
+
+
+def _multi_window_config(windows: list[tuple[int, int]]) -> ProfilerConfig:
+    """Build a ProfilerConfig with multiple (delay, max) windows."""
+    delays = ",".join(str(d) for d, _ in windows)
+    maxes = ",".join(str(m) for _, m in windows)
+    return ProfilerConfig(
+        profiler="cuda",
+        delay_iterations=delays,
+        max_iterations=maxes,
+    )
+
+
+@pytest.mark.parametrize(
+    ("windows", "idle_steps_after_first_window", "second_window_extra_steps"),
+    [
+        ([(0, 2), (5, 3)], 2, 2),
+        ([(0, 2), (3, 2)], 0, 1),
+    ],
+)
+def test_multi_window_two_windows(
+    windows: list[tuple[int, int]],
+    idle_steps_after_first_window: int,
+    second_window_extra_steps: int,
+):
+    """Two profiling windows fire in order, with or without an idle gap."""
+    config = _multi_window_config(windows)
+    profiler = ConcreteWorkerProfiler(config)
+
+    # First window: delay=0, max=2. Starts immediately on start().
+    profiler.start()
+    assert profiler._running is True
+    assert profiler.start_call_count == 1
+
+    profiler.step()  # iter 1, active iter 1
+    profiler.step()  # iter 2, active iter 2
+    assert profiler._running is False
+    assert profiler.stop_call_count == 1
+    assert profiler._active is True
+
+    for _ in range(idle_steps_after_first_window):
+        profiler.step()
+        assert profiler._running is False
+
+    profiler.step()  # Window 1 reaches its delay and starts.
+    assert profiler._running is True
+    assert profiler.start_call_count == 2
+
+    for _ in range(second_window_extra_steps):
+        profiler.step()
+    assert profiler._running is False
+    assert profiler.stop_call_count == 2
+
+
+def test_multi_window_three_windows_with_delayed_first_window():
+    """Three windows can fire in order when the first one is delayed."""
+    config = _multi_window_config([(1, 1), (3, 2), (6, 1)])
+    profiler = ConcreteWorkerProfiler(config)
+
+    profiler.start()
+    assert profiler._running is False
+    assert profiler.start_call_count == 0
+
+    profiler.step()  # iter 1: window 0 starts and completes
+    assert profiler._running is False
+    assert profiler.start_call_count == 1
+    assert profiler.stop_call_count == 1
+
+    profiler.step()  # iter 2: gap before window 1
+    assert profiler._running is False
+
+    profiler.step()  # iter 3: window 1 starts
+    assert profiler._running is True
+    assert profiler.start_call_count == 2
+
+    profiler.step()  # iter 4: window 1 completes
+    assert profiler._running is False
+    assert profiler.stop_call_count == 2
+
+    profiler.step()  # iter 5: gap before window 2
+    assert profiler._running is False
+
+    profiler.step()  # iter 6: window 2 starts and completes
+    assert profiler._running is False
+    assert profiler.start_call_count == 3
+    assert profiler.stop_call_count == 3
+
+
+def test_multi_window_stop_mid_sequence():
+    """Manual stop during window 0 cancels remaining windows."""
+    config = _multi_window_config([(0, 5), (10, 3)])
+    profiler = ConcreteWorkerProfiler(config)
+
+    profiler.start()
+    profiler.step()
+    profiler.step()
+
+    profiler.stop()
+    assert profiler._active is False
+    assert profiler.stop_call_count == 1
+
+    # Subsequent steps must not start window 1.
+    for _ in range(15):
+        profiler.step()
+    assert profiler.start_call_count == 1
+
+
+def test_multi_window_stop_during_later_window_cancels_remaining_windows():
+    """Manual stop during a later window cancels remaining windows."""
+    config = _multi_window_config([(0, 1), (3, 5), (10, 1)])
+    profiler = ConcreteWorkerProfiler(config)
+
+    profiler.start()
+    profiler.step()  # window 0 completes
+    profiler.step()  # gap before window 1
+    profiler.step()  # window 1 starts
+    profiler.step()  # window 1 is still running
+    assert profiler._running is True
+    assert profiler._current_window == 1
+
+    profiler.stop()
+    assert profiler._active is False
+    assert profiler._running is False
+    assert profiler._current_window == 1
+    assert profiler.stop_call_count == 2
+
+    for _ in range(10):
+        profiler.step()
+    assert profiler.start_call_count == 2
+    assert profiler.stop_call_count == 2
+
+
+def test_multi_window_parses_comma_separated_strings():
+    """Comma-separated strings should normalize to list[int] windows."""
+    config = ProfilerConfig(
+        profiler="cuda",
+        delay_iterations="30,100",
+        max_iterations="10,20",
+    )
+    assert config.get_iteration_windows() == [(30, 10), (100, 20)]
+
+
+def test_multi_window_rejects_torch_profiler(tmp_path):
+    """Multi-window is currently restricted to the cuda profiler."""
+    with pytest.raises(ValueError, match="Multiple profiling windows"):
+        ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir=str(tmp_path),
+            delay_iterations="0,50",
+            max_iterations="5,5",
+        )
+
+
+def test_multi_window_rejects_length_mismatch():
+    with pytest.raises(ValueError, match="same number"):
+        ProfilerConfig(
+            profiler="cuda",
+            delay_iterations="0,50",
+            max_iterations="5",
+        )
+
+
+def test_multi_window_rejects_overlap():
+    """Window 1 must not start before window 0 finishes."""
+    with pytest.raises(ValueError, match="must not overlap"):
+        ProfilerConfig(
+            profiler="cuda",
+            delay_iterations="0,4",
+            max_iterations="5,3",
+        )
+
+
+def test_multi_window_rejects_non_monotonic_delay():
+    with pytest.raises(ValueError, match="must not overlap"):
+        ProfilerConfig(
+            profiler="cuda",
+            delay_iterations="10,5",
+            max_iterations="2,2",
+        )
+
+
+def test_multi_window_rejects_negative_element():
+    with pytest.raises(ValueError, match="must be non-negative"):
+        ProfilerConfig(
+            profiler="cuda",
+            delay_iterations="0,-5",
+            max_iterations="2,2",
+        )
+
+
+def test_multi_window_rejects_zero_max_before_last_window():
+    """Only the final multi-window max can be 0 (unlimited)."""
+    with pytest.raises(ValueError, match="must be > 0 in multi-window mode"):
+        ProfilerConfig(
+            profiler="cuda",
+            delay_iterations="0,10",
+            max_iterations="0,5",
+        )
+
+
+def test_multi_window_allows_zero_max_for_last_window():
+    """The final window may run until stop_profile is called."""
+    config = _multi_window_config([(0, 2), (5, 0)])
+    assert config.get_iteration_windows() == [(0, 2), (5, 0)]
+
+    profiler = ConcreteWorkerProfiler(config)
+
+    profiler.start()
+    profiler.step()  # window 0 iter 1
+    profiler.step()  # window 0 iter 2, then stop
+    assert profiler._running is False
+    assert profiler.stop_call_count == 1
+
+    profiler.step()  # iter 3, still waiting for delay=5
+    profiler.step()  # iter 4, still waiting for delay=5
+    profiler.step()  # iter 5, final unlimited window starts
+    assert profiler._running is True
+    assert profiler.start_call_count == 2
+
+    for _ in range(5):
+        profiler.step()
+    assert profiler._running is True
+    assert profiler.stop_call_count == 1
+
+    profiler.stop()
+    assert profiler._running is False
+    assert profiler.stop_call_count == 2
+
+
+def test_single_window_via_string():
+    """A single-value string should behave identically to a scalar."""
+    config = ProfilerConfig(
+        profiler="cuda",
+        delay_iterations="2",
+        max_iterations="2",
+    )
+    assert config.get_iteration_windows() == [(2, 2)]
 
 
 class TestIsUriPath:

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -4,7 +4,7 @@ import pytest
 
 from vllm.config import ProfilerConfig
 from vllm.config.profiler import _is_uri_path
-from vllm.profiler.wrapper import WorkerProfiler
+from vllm.profiler.wrapper import TorchProfilerWrapper, WorkerProfiler
 
 
 class ConcreteWorkerProfiler(WorkerProfiler):
@@ -25,6 +25,29 @@ class ConcreteWorkerProfiler(WorkerProfiler):
 
     def _stop(self) -> None:
         self.stop_call_count += 1
+
+
+class FakeTorchProfile:
+    def __init__(self, kwargs: dict[str, object] | None = None) -> None:
+        self.kwargs = kwargs or {}
+        self.start_call_count = 0
+        self.stop_call_count = 0
+        self.step_call_count = 0
+
+    def start(self) -> None:
+        self.start_call_count += 1
+
+    def stop(self) -> None:
+        self.stop_call_count += 1
+
+    def step(self) -> None:
+        self.step_call_count += 1
+
+    def key_averages(self) -> "FakeTorchProfile":
+        return self
+
+    def table(self, sort_by: str, row_limit: int | None = None) -> str:
+        return f"{sort_by}:{row_limit}"
 
 
 @pytest.fixture
@@ -337,15 +360,112 @@ def test_multi_window_parses_comma_separated_strings():
     assert config.get_iteration_windows() == [(30, 10), (100, 20)]
 
 
-def test_multi_window_rejects_torch_profiler(tmp_path):
-    """Multi-window is currently restricted to the cuda profiler."""
-    with pytest.raises(ValueError, match="Multiple profiling windows"):
-        ProfilerConfig(
-            profiler="torch",
-            torch_profiler_dir=str(tmp_path),
-            delay_iterations="0,50",
-            max_iterations="5,5",
-        )
+def test_multi_window_allows_torch_profiler(tmp_path):
+    """Multi-window profiling is supported by the torch profiler."""
+    config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir=str(tmp_path),
+        delay_iterations="0,50",
+        max_iterations="5,5",
+    )
+    assert config.get_iteration_windows() == [(0, 5), (50, 5)]
+
+
+def test_torch_multi_window_uses_new_profiler_per_window(tmp_path, monkeypatch):
+    """Each torch profiling window needs a fresh profiler object."""
+    fake_profiles: list[FakeTorchProfile] = []
+
+    def fake_profile(**kwargs: object) -> FakeTorchProfile:
+        assert "activities" in kwargs
+        profile = FakeTorchProfile(kwargs)
+        fake_profiles.append(profile)
+        return profile
+
+    monkeypatch.setattr("vllm.profiler.wrapper.torch.profiler.profile", fake_profile)
+
+    config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir=str(tmp_path),
+        torch_profiler_dump_cuda_time_total=False,
+        delay_iterations="0,3",
+        max_iterations="2,2",
+    )
+    profiler = TorchProfilerWrapper(
+        config,
+        worker_name="worker",
+        local_rank=1,
+        activities=["CPU"],
+        on_trace_ready=lambda _: None,
+    )
+
+    profiler.start()
+    profiler.step()
+    profiler.step()
+    assert len(fake_profiles) == 1
+    assert fake_profiles[0].stop_call_count == 1
+    assert (tmp_path / "profiler_out_1_window_0.txt").exists()
+    assert profiler.profiler is None
+
+    profiler.step()
+    assert len(fake_profiles) == 2
+    assert fake_profiles[1].start_call_count == 1
+
+    profiler.step()
+    assert fake_profiles[1].stop_call_count == 1
+    assert (tmp_path / "profiler_out_1_window_1.txt").exists()
+    assert profiler.profiler is None
+
+
+def test_torch_multi_window_resets_schedule_per_window(tmp_path, monkeypatch):
+    """Torch wait/warmup schedule accounting resets for every profiling window."""
+    fake_profiles: list[FakeTorchProfile] = []
+
+    def fake_profile(**kwargs: object) -> FakeTorchProfile:
+        profile = FakeTorchProfile(kwargs)
+        fake_profiles.append(profile)
+        return profile
+
+    monkeypatch.setattr("vllm.profiler.wrapper.torch.profiler.profile", fake_profile)
+
+    config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir=str(tmp_path),
+        torch_profiler_dump_cuda_time_total=False,
+        delay_iterations="0,3",
+        max_iterations="1,1",
+        wait_iterations=1,
+        warmup_iterations=1,
+    )
+    profiler = TorchProfilerWrapper(
+        config,
+        worker_name="worker",
+        local_rank=1,
+        activities=["CPU"],
+        on_trace_ready=lambda _: None,
+    )
+
+    profiler.start()
+    profiler.step()
+    assert len(fake_profiles) == 1
+    assert fake_profiles[0].step_call_count == 1
+    assert fake_profiles[0].stop_call_count == 0
+    assert fake_profiles[0].kwargs["schedule"] is not None
+
+    profiler.step()
+    assert fake_profiles[0].step_call_count == 2
+    assert fake_profiles[0].stop_call_count == 1
+    assert profiler.profiler is None
+
+    profiler.step()
+    assert len(fake_profiles) == 2
+    assert fake_profiles[1].step_call_count == 1
+    assert fake_profiles[1].stop_call_count == 0
+    assert fake_profiles[1].kwargs["schedule"] is not None
+
+    profiler.step()
+    assert fake_profiles[1].step_call_count == 2
+    assert fake_profiles[1].stop_call_count == 1
+    assert profiler.profiler is None
 
 
 def test_multi_window_rejects_length_mismatch():

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -73,14 +73,23 @@ class ProfilerConfig:
     entire range.
     """
 
-    delay_iterations: int = Field(default=0, ge=0)
+    delay_iterations: int | str = Field(default=0)
     """Number of engine iterations to skip before starting profiling.
     Defaults to 0, meaning profiling starts immediately after receiving /start_profile.
+
+    May also be a comma-separated string (e.g. `"30,100"`) to define multiple
+    profiling windows. Each value is paired positionally with `max_iterations`,
+    and each value is measured from `/start_profile`.
+    Multi-window mode requires `profiler='cuda'`.
     """
 
-    max_iterations: int = Field(default=0, ge=0)
+    max_iterations: int | str = Field(default=0)
     """Maximum number of engine iterations to profile after starting profiling.
     Defaults to 0, meaning no limit.
+
+    May also be a comma-separated string (e.g. `"10,20"`), paired positionally
+    with `delay_iterations`. In multi-window mode, each entry except the final
+    one must be > 0. A final value of 0 means profile until `/stop_profile`.
     """
 
     warmup_iterations: int = Field(default=0, ge=0)
@@ -122,9 +131,83 @@ class ProfilerConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
+    def get_iteration_windows(self) -> list[tuple[int, int]]:
+        """Return profiling windows as a list of (delay, max) pairs.
+
+        Normalizes scalar `delay_iterations`/`max_iterations` to single-element
+        lists so callers can iterate uniformly.
+        """
+        delays = self._parse_iteration_values("delay_iterations", self.delay_iterations)
+        maxes = self._parse_iteration_values("max_iterations", self.max_iterations)
+        if len(delays) != len(maxes):
+            raise ValueError(
+                "delay_iterations and max_iterations must have the same number "
+                f"of values, got {len(delays)} and {len(maxes)}"
+            )
+        return list(zip(delays, maxes))
+
+    @staticmethod
+    def _parse_iteration_values(field_name: str, value: int | str) -> list[int]:
+        if isinstance(value, int):
+            return [value]
+        if not isinstance(value, str):
+            raise ValueError(
+                f"{field_name} must be an integer or comma-separated integers"
+            )
+
+        parts = [part.strip() for part in value.split(",")]
+        if not parts or any(part == "" for part in parts):
+            raise ValueError(
+                f"{field_name} must be an integer or comma-separated integers"
+            )
+
+        try:
+            return [int(part) for part in parts]
+        except ValueError as e:
+            raise ValueError(
+                f"{field_name} must be an integer or comma-separated integers"
+            ) from e
+
+    def _validate_multi_window_config(self, windows: list[tuple[int, int]]) -> None:
+        if self.profiler != "cuda":
+            raise ValueError(
+                "Multiple profiling windows are only supported when "
+                f"profiler='cuda', got profiler={self.profiler!r}"
+            )
+
+        for i, (delay, max_iters) in enumerate(windows):
+            is_last_window = i == len(windows) - 1
+            if max_iters == 0 and not is_last_window:
+                raise ValueError(
+                    f"max_iterations[{i}] must be > 0 in multi-window mode "
+                    "(0 means unlimited, which is incompatible with later "
+                    "windows)"
+                )
+            if i > 0:
+                previous_delay, previous_max_iters = windows[i - 1]
+                previous_end = previous_delay + previous_max_iters
+                if delay < previous_end:
+                    raise ValueError(
+                        "Profiling windows must not overlap: window "
+                        f"{i - 1} ends at iteration {previous_end} but window "
+                        f"{i} starts at iteration {delay}"
+                    )
+
     @model_validator(mode="after")
     def _validate_profiler_config(self) -> Self:
-        has_delay_or_limit = self.delay_iterations > 0 or self.max_iterations > 0
+        windows = self.get_iteration_windows()
+
+        if any(delay < 0 for delay, _ in windows):
+            raise ValueError("delay_iterations values must be non-negative")
+        if any(max_iters < 0 for _, max_iters in windows):
+            raise ValueError("max_iterations values must be non-negative")
+
+        if len(windows) > 1:
+            self._validate_multi_window_config(windows)
+
+        has_delay_or_limit = any(
+            delay > 0 or max_iters > 0 for delay, max_iters in windows
+        )
         if self.profiler == "torch" and has_delay_or_limit and not self.ignore_frontend:
             logger.warning_once(
                 "Using 'torch' profiler with delay_iterations or max_iterations "

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -80,7 +80,7 @@ class ProfilerConfig:
     May also be a comma-separated string (e.g. `"30,100"`) to define multiple
     profiling windows. Each value is paired positionally with `max_iterations`,
     and each value is measured from `/start_profile`.
-    Multi-window mode requires `profiler='cuda'`.
+    Multi-window mode is supported for `profiler='cuda'` and `profiler='torch'`.
     """
 
     max_iterations: int | str = Field(default=0)
@@ -169,10 +169,10 @@ class ProfilerConfig:
             ) from e
 
     def _validate_multi_window_config(self, windows: list[tuple[int, int]]) -> None:
-        if self.profiler != "cuda":
+        if self.profiler not in ("cuda", "torch"):
             raise ValueError(
                 "Multiple profiling windows are only supported when "
-                f"profiler='cuda', got profiler={self.profiler!r}"
+                f"profiler is 'cuda' or 'torch', got profiler={self.profiler!r}"
             )
 
         for i, (delay, max_iters) in enumerate(windows):

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -59,6 +59,15 @@ class ProfilerConfig:
     torch_profiler_dump_cuda_time_total: bool = True
     """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
 
+    cuda_profiler_control_dp_rank: int = Field(default=0, ge=-1)
+    """Data-parallel rank that controls CUDA profiler API start/stop calls.
+    Set to -1 to let every data-parallel rank call the CUDA profiler API."""
+
+    cuda_profiler_control_worker_rank: int = Field(default=0, ge=-1)
+    """Worker rank, within the selected data-parallel rank, that controls CUDA
+    profiler API start/stop calls. Set to -1 to let every worker in the
+    selected data-parallel rank call the CUDA profiler API."""
+
     torch_profiler_record_shapes: bool = False
     """If `True`, records tensor shapes in the torch profiler. Disabled by default."""
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -18,26 +18,19 @@ logger = init_logger(__name__)
 
 class WorkerProfiler(ABC):
     def __init__(self, profiler_config: ProfilerConfig) -> None:
-        self._delay_iters = profiler_config.delay_iterations
-        if self._delay_iters > 0:
-            logger.info_once(
-                "GPU profiling will start "
-                f"{self._delay_iters} steps after start_profile."
-            )
+        self._windows: list[tuple[int, int]] = profiler_config.get_iteration_windows()
+        logger.info_once(
+            "GPU profiling configured for following windows (start_iter, n_iters): %s",
+            str(self._windows),
+        )
 
-        self._max_iters = profiler_config.max_iterations
-        if self._max_iters > 0:
-            logger.info_once(
-                "GPU profiling will stop "
-                f"after {self._max_iters} worker steps, "
-                "or when stop_profile is received."
-            )
+        self._current_window = 0
 
         # Track when the profiler gets triggered by start_profile
         self._active_iteration_count = 0
         self._active = False
 
-        # Track when the profiler is actually running
+        # Track active-profiling iters within the current window
         self._profiling_for_iters = 0
         self._running = False
 
@@ -77,41 +70,47 @@ class WorkerProfiler(ABC):
             )
             return
         self._active = True
-        if self._delay_iters == 0:
-            self._call_start()
+        if self._current_window < len(self._windows):
+            delay, _ = self._windows[self._current_window]
+            if delay == 0:
+                self._call_start()
 
     def step(self) -> None:
         """Update the profiler state at each worker step,
-        to handle delayed starts and max iteration limits."""
-        if not self._active:
+        to handle delayed starts and max iteration limits across one or more
+        profiling windows."""
+        if not self._active or self._current_window >= len(self._windows):
             return
 
         self._active_iteration_count += 1
 
-        if (
-            not self._running
-            and self._delay_iters > 0
-            and self._active_iteration_count == self._delay_iters
-        ):
-            logger.info_once("Starting profiler after delay...")
+        delay, max_iters = self._windows[self._current_window]
+
+        if not self._running and self._active_iteration_count == delay:
+            logger.info_once(
+                "Starting profiler for window %d (delay=%d, max_iters=%d)...",
+                self._current_window,
+                delay,
+                max_iters,
+            )
             self._call_start()
 
-        # Call profiler step for schedule-based profiling
-        # Only count iterations where data is actually recorded (not warmup)
+        # Call profiler step for schedule-based profiling.
+        # Only count iterations where data is actually recorded (not warmup).
         if self._running and self._profiler_step():
             self._profiling_for_iters += 1
 
-        if (
-            self._max_iters > 0
-            and self._running
-            and self._profiling_for_iters > self._max_iters
-        ):
-            # Automatically stop the profiler after max iters
-            # will be marked as not running, but leave as active so that stop
-            # can clean up properly
-            logger.info_once("Max profiling iterations reached. Stopping profiler...")
+        if self._running and self._profiling_for_iters == max_iters:
+            logger.info_once(
+                "Profiling window %d complete (%d iters). Stopping profiler...",
+                self._current_window,
+                max_iters,
+            )
             self._call_stop()
-            return
+
+            # Reset and move to next window
+            self._profiling_for_iters = 0
+            self._current_window += 1
 
     def _profiler_step(self) -> bool:
         """Called each step when profiler is running.

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -338,8 +338,13 @@ class TorchProfilerWrapper(WorkerProfiler):
 
 
 class CudaProfilerWrapper(WorkerProfiler):
-    def __init__(self, profiler_config: ProfilerConfig) -> None:
+    def __init__(
+        self,
+        profiler_config: ProfilerConfig,
+        enable_cuda_profiler_api: bool = True,
+    ) -> None:
         super().__init__(profiler_config)
+        self.enable_cuda_profiler_api = enable_cuda_profiler_api
         # Note: lazy import to avoid dependency issues if CUDA is not available.
         import torch.cuda.profiler as cuda_profiler
 
@@ -347,11 +352,13 @@ class CudaProfilerWrapper(WorkerProfiler):
 
     @override
     def _start(self) -> None:
-        self._cuda_profiler.start()
+        if self.enable_cuda_profiler_api:
+            self._cuda_profiler.start()
 
     @override
     def _stop(self) -> None:
-        self._cuda_profiler.stop()
+        if self.enable_cuda_profiler_api:
+            self._cuda_profiler.stop()
 
     @override
     def annotate_context_manager(self, name: str):

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -20,7 +20,7 @@ class WorkerProfiler(ABC):
     def __init__(self, profiler_config: ProfilerConfig) -> None:
         self._windows: list[tuple[int, int]] = profiler_config.get_iteration_windows()
         logger.info_once(
-            "GPU profiling configured for following windows (start_iter, n_iters): %s",
+            "Profiling configured for following windows (start_iter, n_iters): %s",
             str(self._windows),
         )
 
@@ -100,7 +100,7 @@ class WorkerProfiler(ABC):
         if self._running and self._profiler_step():
             self._profiling_for_iters += 1
 
-        if self._running and self._profiling_for_iters == max_iters:
+        if max_iters > 0 and self._running and self._profiling_for_iters == max_iters:
             logger.info_once(
                 "Profiling window %d complete (%d iters). Stopping profiler...",
                 self._current_window,
@@ -186,53 +186,66 @@ class TorchProfilerWrapper(WorkerProfiler):
         # Determine trace handler: use custom handler if provided,
         # otherwise default to tensorboard trace handler
         if on_trace_ready is not None:
-            trace_handler = on_trace_ready
+            self._trace_handler = on_trace_ready
         else:
-            trace_handler = torch.profiler.tensorboard_trace_handler(
+            self._trace_handler = torch.profiler.tensorboard_trace_handler(
                 torch_profiler_trace_dir,
                 worker_name=worker_name,
                 use_gzip=profiler_config.torch_profiler_use_gzip,
             )
 
         self.dump_cpu_time_total = "CPU" in activities and len(activities) == 1
+        self._activities = [
+            TorchProfilerActivityMap[activity] for activity in activities
+        ]
 
         # Create profiler schedule if warmup or wait iterations are configured
-        profiler_schedule = None
-        if profiler_config.warmup_iterations > 0 or profiler_config.wait_iterations > 0:
-            profiler_schedule = torch.profiler.schedule(
-                skip_first=0,
-                wait=profiler_config.wait_iterations,
-                warmup=profiler_config.warmup_iterations,
-                active=profiler_config.active_iterations,
-                repeat=1,
-            )
-            if local_rank in (None, 0):
-                logger.info_once(
-                    "Profiler schedule configured: wait=%d, warmup=%d, active=%d",
-                    profiler_config.wait_iterations,
-                    profiler_config.warmup_iterations,
-                    profiler_config.active_iterations,
-                )
-
-        self.profiler = torch.profiler.profile(
-            activities=[TorchProfilerActivityMap[activity] for activity in activities],
-            schedule=profiler_schedule,
-            record_shapes=profiler_config.torch_profiler_record_shapes,
-            profile_memory=profiler_config.torch_profiler_with_memory,
-            with_stack=profiler_config.torch_profiler_with_stack,
-            with_flops=profiler_config.torch_profiler_with_flops,
-            on_trace_ready=trace_handler,
+        self._uses_schedule = (
+            profiler_config.warmup_iterations > 0 or profiler_config.wait_iterations > 0
         )
+        if self._uses_schedule and local_rank in (None, 0):
+            logger.info_once(
+                "Profiler schedule configured: wait=%d, warmup=%d, active=%d",
+                profiler_config.wait_iterations,
+                profiler_config.warmup_iterations,
+                profiler_config.active_iterations,
+            )
 
-        # Track if we're using a schedule (need to call step())
-        self._uses_schedule = profiler_schedule is not None
         self._warmup_iterations = profiler_config.warmup_iterations
         # Subtract 1 because profiler.start() already consumes step 0
         # (WAIT or WARMUP), so only wait + warmup - 1 non-active steps
         # remain to be advanced through via profiler.step() calls.
-        self._warmup_steps_remaining = max(
+        self._warmup_steps_per_window = max(
             profiler_config.wait_iterations + profiler_config.warmup_iterations - 1,
             0,
+        )
+        self._warmup_steps_remaining = self._warmup_steps_per_window
+        self.profiler: torch.profiler.profile | None = None
+
+    def _create_profiler_schedule(
+        self,
+    ) -> Callable[[int], torch.profiler.ProfilerAction] | None:
+        if not self._uses_schedule:
+            return None
+        profiler_config = self.profiler_config
+        return torch.profiler.schedule(
+            skip_first=0,
+            wait=profiler_config.wait_iterations,
+            warmup=profiler_config.warmup_iterations,
+            active=profiler_config.active_iterations,
+            repeat=1,
+        )
+
+    def _create_profiler(self) -> torch.profiler.profile:
+        profiler_config = self.profiler_config
+        return torch.profiler.profile(
+            activities=self._activities,
+            schedule=self._create_profiler_schedule(),
+            record_shapes=profiler_config.torch_profiler_record_shapes,
+            profile_memory=profiler_config.torch_profiler_with_memory,
+            with_stack=profiler_config.torch_profiler_with_stack,
+            with_flops=profiler_config.torch_profiler_with_flops,
+            on_trace_ready=self._trace_handler,
         )
 
     def _build_profiler_table(
@@ -240,6 +253,7 @@ class TorchProfilerWrapper(WorkerProfiler):
         sort_key: str,
         row_limit: int | None = None,
     ) -> str:
+        assert self.profiler is not None
         if row_limit is None:  # use profiler default row limit of 100
             return self.profiler.key_averages().table(sort_by=sort_key)
         return self.profiler.key_averages().table(
@@ -253,37 +267,53 @@ class TorchProfilerWrapper(WorkerProfiler):
         # Skip file write for URI paths (gs://, s3://, etc.)
         # as standard file I/O doesn't work with URI schemes
         if not _is_uri_path(profiler_dir):
-            profiler_out_file = f"{profiler_dir}/profiler_out_{rank}.txt"
+            window_suffix = ""
+            if len(self._windows) > 1:
+                window_suffix = f"_window_{self._current_window}"
+            profiler_out_file = f"{profiler_dir}/profiler_out_{rank}"
+            profiler_out_file += f"{window_suffix}.txt"
             with open(profiler_out_file, "w") as f:
                 print(table, file=f)
 
     @override
     def _start(self) -> None:
-        self.profiler.start()
+        assert self.profiler is None
+        profiler = self._create_profiler()
+        self.profiler = profiler
+        self._warmup_steps_remaining = self._warmup_steps_per_window
+        try:
+            profiler.start()
+        except Exception:
+            self.profiler = None
+            raise
 
     @override
     def _stop(self) -> None:
-        self.profiler.stop()
+        assert self.profiler is not None
+        try:
+            self.profiler.stop()
 
-        profiler_config = self.profiler_config
-        rank = self.local_rank
-        if profiler_config.torch_profiler_dump_cuda_time_total:
-            table = self._build_profiler_table(sort_key="self_cuda_time_total")
-            self._write_profiler_table(rank, table)
+            profiler_config = self.profiler_config
+            rank = self.local_rank
+            if profiler_config.torch_profiler_dump_cuda_time_total:
+                table = self._build_profiler_table(sort_key="self_cuda_time_total")
+                self._write_profiler_table(rank, table)
 
-            # only print profiler results on rank 0
-            if rank == 0:
-                print(table)
+                # only print profiler results on rank 0
+                if rank == 0:
+                    print(table)
 
-        if self.dump_cpu_time_total:
-            table = self._build_profiler_table(
-                sort_key="self_cpu_time_total", row_limit=50
-            )
-            self._write_profiler_table(rank, table)
+            if self.dump_cpu_time_total:
+                table = self._build_profiler_table(
+                    sort_key="self_cpu_time_total", row_limit=50
+                )
+                self._write_profiler_table(rank, table)
 
-            # only print profiler results on rank 0
-            if rank == 0:
-                print(table)
+                # only print profiler results on rank 0
+                if rank == 0:
+                    print(table)
+        finally:
+            self.profiler = None
 
     @override
     def _profiler_step(self) -> bool:
@@ -294,6 +324,7 @@ class TorchProfilerWrapper(WorkerProfiler):
             False if the step was a warmup step (data discarded).
         """
         if self._uses_schedule:
+            assert self.profiler is not None
             self.profiler.step()
             # Track warmup steps - only count active steps toward max_iterations
             if self._warmup_steps_remaining > 0:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -771,6 +771,36 @@ class Worker(WorkerBase):
         )
         return self.profiler.annotate_context_manager(annotation)
 
+    def _data_parallel_index(self) -> int:
+        return getattr(
+            self.parallel_config,
+            "data_parallel_index",
+            self.parallel_config.data_parallel_rank,
+        )
+
+    def _worker_rank_within_dp(self) -> int:
+        parallel_config = self.parallel_config
+        world_size_within_dp = (
+            parallel_config.pipeline_parallel_size
+            * parallel_config.tensor_parallel_size
+            * parallel_config.prefill_context_parallel_size
+        )
+        return self.rank % world_size_within_dp
+
+    def _is_cuda_profiler_control_worker(self) -> bool:
+        profiler_config = self.profiler_config
+
+        control_dp_rank = profiler_config.cuda_profiler_control_dp_rank
+        dp_rank = self._data_parallel_index()
+        if control_dp_rank >= 0 and dp_rank != control_dp_rank:
+            return False
+
+        control_worker_rank = profiler_config.cuda_profiler_control_worker_rank
+        return (
+            control_worker_rank < 0
+            or self._worker_rank_within_dp() == control_worker_rank
+        )
+
     @torch.inference_mode()
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
@@ -907,8 +937,20 @@ class Worker(WorkerBase):
                         "Starting torch profiler with trace name: %s", trace_name
                     )
                 elif profiler_type == "cuda":
-                    self.profiler = CudaProfilerWrapper(self.profiler_config)
-                    logger.debug("Starting CUDA profiler")
+                    enable_cuda_profiler_api = self._is_cuda_profiler_control_worker()
+                    self.profiler = CudaProfilerWrapper(
+                        self.profiler_config,
+                        enable_cuda_profiler_api=enable_cuda_profiler_api,
+                    )
+                    if enable_cuda_profiler_api:
+                        logger.debug("Starting CUDA profiler")
+                    else:
+                        logger.debug(
+                            "Skipping CUDA profiler API calls on worker rank %s in "
+                            "DP rank %s.",
+                            self._worker_rank_within_dp(),
+                            self._data_parallel_index(),
+                        )
                 else:
                     # Config validation should prevent this code being reached
                     raise ValueError(


### PR DESCRIPTION
## Purpose
Currently only a single profiling window is supported, this PR extends `delay_iterations` and `max_iterations` to accept multiple disjoint profiling windows.

Example command:
```
nsys profile --trace-fork-before-exec=true --cuda-graph-trace=node --capture-range=cudaProfilerApi --capture-range-end=[:2] vllm serve $MODEL --profiler-config.profiler=cuda --profiler-config.delay_iterations=2000,3000 --profiler-config.max_iterations=100,100
```

## Test Plan
Added some unit tests to cover new feature.
