### PR TITLE
[Bugfix] Reject non-object structured_outputs with HTTP 400

### DIFF
--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -181,3 +181,25 @@ def test_multiple_structured_outputs_rejected():
                 },
             }
         )
+
+
+@pytest.mark.parametrize(
+    "structured_outputs",
+    [True, False, 123, 1.5, "json", ["json"]],
+)
+def test_structured_outputs_non_object_rejected(structured_outputs):
+    """A non-object `structured_outputs` (e.g. a bool/number/string/list) must
+    be rejected with a clear validation error (HTTP 400) instead of crashing
+    with `AttributeError: '<type>' object has no attribute 'get'`, which would
+    otherwise surface as an HTTP 500 Internal Server Error."""
+    with pytest.raises(
+        ValueError,
+        match="`structured_outputs` must be a JSON object",
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "structured_outputs": structured_outputs,
+            }
+        )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -734,6 +734,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
         # structured_outputs may arrive as a dict (from JSON/raw kwargs) or
         # as a StructuredOutputsParams dataclass instance.
         is_dataclass = isinstance(structured_outputs_kwargs, StructuredOutputsParams)
+        if not is_dataclass and not isinstance(structured_outputs_kwargs, dict):
+            # A malformed value (e.g. a bool/str/number) must be rejected with
+            # HTTP 400 here; otherwise the `.get()` call below raises an
+            # AttributeError that escapes as a 500 Internal Server Error.
+            raise VLLMValidationError(
+                "`structured_outputs` must be a JSON object, got "
+                f"'{type(structured_outputs_kwargs).__name__}'.",
+                parameter="structured_outputs",
+            )
         count = sum(
             (
                 getattr(structured_outputs_kwargs, k, None)


### PR DESCRIPTION
## Purpose

A chat completion request that sends `structured_outputs` as a **non-object**
JSON value (e.g. `true`/`false`, a number, a string, or an array) currently
crashes the `check_structured_outputs_count` model validator. The validator
assumes `structured_outputs` is a `dict` or a `StructuredOutputsParams`
dataclass and calls `.get()` on it:

```python
count = sum(
    (getattr(structured_outputs_kwargs, k, None)
     if is_dataclass
     else structured_outputs_kwargs.get(k))  # <- crashes on a non-object value
    is not None
    for k in ("json", "regex", "choice")
)
```

A scalar/list value has no `.get()`, so it raises:

```
AttributeError: 'bool' object has no attribute 'get'
```

Because that is **not** a `ValueError`, Pydantic does not capture it as a
validation error — it escapes to the generic exception handler and is returned
as **HTTP 500 Internal Server Error**, even though the cause is a malformed
client request that should be **HTTP 400 Bad Request**.

Observed in production serving (request body was a valid object, but the
`structured_outputs` field was a bool):

```
"POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
...
  File ".../chat_completion/protocol.py", in check_structured_outputs_count
    else structured_outputs_kwargs.get(k)
AttributeError: 'bool' object has no attribute 'get'
```

### Fix

Add a type guard in `check_structured_outputs_count`: any `structured_outputs`
value that is neither a `dict` nor a `StructuredOutputsParams` instance is
rejected with a `VLLMValidationError` (a `ValueError` subclass that Pydantic
captures → `RequestValidationError` → HTTP 400) **before** the `.get()` call is
reached. Valid `dict` and dataclass inputs are unaffected.

### Relationship to #42961 (not a duplicate)

This is **distinct from** #42961 (*Reject non-object JSON bodies with HTTP 400*).
That PR rejects requests whose **entire body** is a non-object (`[]`, `true`,
`123`) at the `validate_json_request` dependency. This PR handles the case where
the **body is a valid object** but the **`structured_outputs` field** within it
is a non-object — that input passes the top-level body guard and still reaches
this validator. The two fixes are complementary and do not overlap. No other
open issue/PR addresses the `structured_outputs` field-type case.

## Test Plan

New parametrized unit test in
`tests/tool_use/test_chat_completion_request_validations.py::test_structured_outputs_non_object_rejected`
covers `structured_outputs` set to `True`, `False`, `123`, `1.5`, `"json"`, and
`["json"]`, asserting each raises a validation error rather than crashing.
Existing tests cover valid `dict` inputs (no regression).

```bash
pytest tests/tool_use/test_chat_completion_request_validations.py -v
```

## Test Result

The full pytest suite could not be run on the development machine (macOS,
without a CUDA build of vLLM, so `import vllm` is unavailable). The fix logic
was validated with a minimal standalone reproducer that mirrors the exact
validator body + a Pydantic `model_validator(mode="before")` + the real
`VLLMValidationError` semantics, comparing pre-fix vs post-fix behavior:

| `structured_outputs` | Before fix | After fix |
|---|---|---|
| `true` / `false` | **500** `'bool' object has no attribute 'get'` | **400** `... must be a JSON object` |
| `123` | **500** `'int' object has no attribute 'get'` | **400** `... must be a JSON object` |
| `"json"` | **500** `'str' object has no attribute 'get'` | **400** `... must be a JSON object` |
| `["json"]` | **500** `'list' object has no attribute 'get'` | **400** `... must be a JSON object` |
| `{"json": {...}}` (valid) | 200 | 200 — no regression |
| `{"json": ..., "regex": ...}` | 400 (one-kind rule) | 400 — unchanged |

`ruff check` and `ruff format --check` (v0.14.0, per `.pre-commit-config.yaml`)
pass on both changed files.

## AI Assistance Disclosure

This change was developed with AI assistance (Claude). The human submitter
reviewed every changed line, reproduced the original 500 from production logs,
validated pre/post behavior with the standalone reproducer above, and confirmed
`ruff check` / `ruff format` pass on the modified files. Attribution is included
as a `Co-authored-by: Claude` commit trailer per the vLLM CONTRIBUTING guide.
