### PR TITLE
[Bugfix] Two independent fixes uncovered while running Quark-quantized MoE checkpoints on ROCm.

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -577,6 +577,7 @@ class QuarkConfig(QuantizationConfig):
             # when 2D per-block scales are loaded into 0D per-tensor slots.
             try:
                 from vllm.model_executor.layers.fused_moe import FusedMoE
+
                 _is_fused_moe = isinstance(module, FusedMoE)
             except Exception:
                 _is_fused_moe = False

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -569,6 +569,27 @@ class QuarkConfig(QuantizationConfig):
                 if _matches_pattern(layer_name, name_pattern):
                     return config
 
+            # FusedMoE fallback: a folded Quark recipe may list only per-expert
+            # per-projection patterns (e.g. ``...experts.0.down_proj``) without
+            # an entry for the FusedMoE parent path itself. Without this probe,
+            # the parent layer falls through to global_quant_config (typically
+            # fp8 per-tensor) and dispatches to the wrong MoE method, crashing
+            # when 2D per-block scales are loaded into 0D per-tensor slots.
+            try:
+                from vllm.model_executor.layers.fused_moe import FusedMoE
+                _is_fused_moe = isinstance(module, FusedMoE)
+            except Exception:
+                _is_fused_moe = False
+            if _is_fused_moe:
+                for proj in ("down_proj", "gate_proj", "up_proj", "gate_up_proj"):
+                    for probe in (
+                        f"{layer_name}.0.{proj}",
+                        f"{layer_name}.{proj}",
+                    ):
+                        for name_pattern, config in layer_quant_config.items():
+                            if _matches_pattern(probe, name_pattern):
+                                return config
+
             layer_type = cast(str, type(module))
             layer_type_quant_config = cast(
                 dict[str, Any], self.quant_config.get("layer_type_quant_config")

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -103,7 +103,10 @@ def _dequant_mxfp4(
             "amd-quark`."
         ) from err
 
-    return mx.dq_mxfp4(x, scale, float_dtype)
+    # MLA chunked-prefill passes non-contiguous slices of kv_b_proj.weight /
+    # scale; the Quark HIP kernel asserts on non-contiguous inputs. Make them
+    # contiguous to satisfy the kernel without affecting numerics.
+    return mx.dq_mxfp4(x.contiguous(), scale.contiguous(), float_dtype)
 
 
 def _dequant_mxfp4_fake(
@@ -126,7 +129,9 @@ def _quant_dequant_mxfp4(
             "amd-quark`."
         ) from err
 
-    return mx.qdq_mxfp4(x, scale_calculation_mode)
+    # Same contiguous guard as _dequant_mxfp4: chunked-prefill non-contiguous
+    # slices crash the HIP kernel's assertion otherwise.
+    return mx.qdq_mxfp4(x.contiguous(), scale_calculation_mode)
 
 
 def _quant_dequant_mxfp4_fake(


### PR DESCRIPTION
### 1. `mxfp4_utils.py`: ensure dq/qdq inputs are contiguous                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                
  The Quark HIP kernel `mx.dq_mxfp4` / `mx.qdq_mxfp4` asserts contiguity on its
  tensor inputs. Under MLA chunked-prefill, `kv_b_proj.weight` / `scale` are
  sliced into non-contiguous views before being passed in, tripping the
  assertion. Adding `.contiguous()` at the call site fixes it without affecting
  numerics.
                                                                                                                                                                  
  ### 2. `quark.py`: FusedMoE expert-probe fallback in `_find_matched_config`
 
  A folded Quark recipe lists only per-expert per-projection patterns (e.g.
  `...experts.*.down_proj`) without an entry for the FusedMoE parent path
  (`...mlp.experts`). `_matches_pattern` then misses → falls through to
  `global_quant_config` (typically fp8 per-tensor) → MoE dispatch picks the
  wrong method → 2D per-block scales get loaded into 0D per-tensor slots and
  crash. The fallback probes child paths (`{layer_name}.{0.,}{down,gate,up,gate_up}_proj`)
  to inherit the correct scheme.                                                 
 
  ## Test Plan
                                                                                                                                                                  
  - Loaded DeepSeek-R1-0528 (mxfp4 + chunked-prefill on MI325)
    and Qwen3.5-397B (mxfp4 FusedMoE) on a folded recipe; both load and produce                                                                                   
    expected GSM8K accuracy (DSR1 0.97, Q3.5 0.94 on lm-eval flexible-extract,
    matching baselines).
  - Two commits, each self-contained and independently revertable.
                                                                                                                                                                  
  ## Test Result
                                                                                                                                                                  
  Both checkpoints load and evaluate without crashes; numerical match against
  the fake-quant reference is within noise