### PR TITLE
[Bugfix] Couple audio+video in mm processor cache for use_audio_in_video (fixes #44538)

### DIFF
--- a/tests/models/multimodal/processing/test_audio_in_video.py
+++ b/tests/models/multimodal/processing/test_audio_in_video.py
@@ -149,10 +149,11 @@ def test_audio_in_video_same_audio_different_video(model_id: str) -> None:
     The existing ``test_audio_in_video_cache_correctness`` reuses a single
     video across turns, so this cross-request collision is not covered there.
 
-    The fix couples ``video[i]`` with ``audio[i]`` (via
-    ``_get_mm_cache_coupled_groups``) so a cache-missed video drags its paired
-    audio back through the HF processor even when the audio is individually
-    cached. This test asserts the second request neither raises nor produces
+    The fix couples ``video[i]`` with ``audio[i]`` (via the Qwen-Omni
+    ``_cached_apply_hf_processor`` override) so a cache-missed video drags its
+    paired audio back through the HF processor even when the audio is
+    individually cached. This test asserts the second request neither raises
+    nor produces
     wrong tokens.
     """
     ctx = build_model_context(
@@ -292,19 +293,11 @@ def test_audio_in_video_cache_keys_do_not_change_semantic_hashes(
 
 
 @pytest.mark.parametrize("model_id", MODELS)
-def test_audio_in_video_partial_residency_reprocesses_whole_group(
-    model_id: str,
-) -> None:
-    """Group-aware keys alone are not enough: a coupled group's members are
-    still stored as independent cache entries, so LRU eviction can drop one
-    member while the other survives. If only the video is evicted, a later
-    request would otherwise get video-miss / audio-hit and run the HF processor
-    on the video without its paired audio (the #44538 StopIteration).
-
-    Group-miss expansion in ``_get_cache_missing_items`` must therefore drag the
-    still-resident audio back into the reprocessed set. This drives that method
-    directly with a fake cache simulating audio-resident / video-evicted, which
-    is deterministic (no reliance on LRU eviction order).
+def test_coupled_cache_keys_are_group_aware(model_id: str) -> None:
+    """The fix's processor-cache keys make each coupled member's key depend on
+    *all* members' content hashes, so a member is reused only when its whole
+    pairing matches (fixing both #44538 polarities) and an unpaired group is
+    left untouched. This unit-tests that key derivation directly.
     """
     ctx = build_model_context(
         model_id,
@@ -313,33 +306,43 @@ def test_audio_in_video_partial_residency_reprocesses_whole_group(
     )
     processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config, cache=None)
 
-    mm_data = create_paired_mm_data(video_seed=5, audio_seed=6)
-    mm_items = processor.info.parse_mm_data(mm_data)
+    groups = [[("video", 0), ("audio", 0)]]
+    keys_AX = processor._coupled_cache_keys({"video": ["vA"], "audio": ["aX"]}, groups)
+    keys_AX_again = processor._coupled_cache_keys(
+        {"video": ["vA"], "audio": ["aX"]}, groups
+    )
+    keys_BX = processor._coupled_cache_keys({"video": ["vB"], "audio": ["aX"]}, groups)
+    keys_AY = processor._coupled_cache_keys({"video": ["vA"], "audio": ["aY"]}, groups)
 
-    coupled_groups = processor._get_mm_cache_coupled_groups(
+    # Same pairing -> identical keys (full reuse).
+    assert keys_AX == keys_AX_again
+    # Different video -> the AUDIO key also changes (reported polarity: a shared
+    # audio is not reused across different videos).
+    assert keys_AX["audio"][0] != keys_BX["audio"][0]
+    # Different audio -> the VIDEO key also changes (reverse polarity).
+    assert keys_AX["video"][0] != keys_AY["video"][0]
+    # Members stay distinct within a group.
+    assert keys_AX["video"][0] != keys_AX["audio"][0]
+    # No coupling -> keys are returned unchanged.
+    assert processor._coupled_cache_keys({"video": ["vA"], "audio": ["aX"]}, []) == {
+        "video": ["vA"],
+        "audio": ["aX"],
+    }
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_coupling_only_active_for_use_audio_in_video(model_id: str) -> None:
+    """Coupling (and therefore the custom cache path) must engage only when
+    ``use_audio_in_video=True``; otherwise the base cache path is used."""
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"audio": 1, "image": 0, "video": 1},
+        mm_processor_cache_gb=1,
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config, cache=None)
+    mm_items = processor.info.parse_mm_data(create_paired_mm_data(5, 6))
+
+    assert processor._get_audio_in_video_coupled_groups(
         mm_items, {"use_audio_in_video": True}
-    )
-    assert coupled_groups, "coupling must be active for use_audio_in_video"
-
-    class _AudioResidentVideoEvictedCache:
-        """Simulates the audio member surviving in cache while the video member
-        was evicted (partial residency)."""
-
-        def is_cached(self, keys: list[str]) -> list[bool]:
-            return [key.startswith("audio:") for key in keys]
-
-    mm_cache_keys = {"video": ["video:0"], "audio": ["audio:0"]}
-
-    mm_needs_processing, mm_missing_items = processor._get_cache_missing_items(
-        cache=_AudioResidentVideoEvictedCache(),
-        mm_data_items=mm_items,
-        mm_cache_keys=mm_cache_keys,
-        coupled_groups=coupled_groups,
-    )
-
-    # Video missed; the resident audio is dragged back in by group expansion.
-    assert mm_needs_processing["video"] == [True]
-    assert mm_needs_processing["audio"] == [True]
-    # Both must be present in the data fed to the HF processor.
-    assert mm_missing_items.get_count("video", strict=False) == 1
-    assert mm_missing_items.get_count("audio", strict=False) == 1
+    ) == [[("video", 0), ("audio", 0)]]
+    assert processor._get_audio_in_video_coupled_groups(mm_items, {}) == []

--- a/tests/models/multimodal/processing/test_audio_in_video.py
+++ b/tests/models/multimodal/processing/test_audio_in_video.py
@@ -47,6 +47,25 @@ def create_mm_data(num_videos: int) -> dict[str, list]:
     return mm_data
 
 
+def create_paired_mm_data(video_seed: int, audio_seed: int) -> dict[str, list]:
+    """One video + one audio with independently controllable content. Use the
+    same ``audio_seed`` across requests to get a byte-identical audio track."""
+    video = random_video(
+        np.random.RandomState(video_seed),
+        min_frames=8,
+        max_frames=9,
+        min_wh=64,
+        max_wh=65,
+    )
+    audio, sr = random_audio(
+        np.random.RandomState(audio_seed),
+        min_len=8000,
+        max_len=8001,
+        sr=16000,
+    )
+    return dict[str, list](video=[video], audio=[(audio, sr)])
+
+
 @pytest.mark.parametrize("model_id", MODELS)
 @pytest.mark.parametrize("num_videos", [1, 2])
 def test_audio_in_video_cache_correctness(model_id: str, num_videos: int) -> None:
@@ -113,3 +132,214 @@ def test_audio_in_video_cache_correctness(model_id: str, num_videos: int) -> Non
         f"  baseline : {baseline_ids}\n"
         f"  cache-hit: {second_ids}"
     )
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_audio_in_video_same_audio_different_video(model_id: str) -> None:
+    """Regression test for https://github.com/vllm-project/vllm/issues/44538
+
+    With ``use_audio_in_video=True`` the audio track is extracted from the
+    video into a separate multimodal item that the processor cache hashes by
+    content. Two requests with *different* videos but a *byte-identical* audio
+    track collide on the audio cache entry: the second request's video misses
+    the cache while its audio hits, so the HF processor is run on the video
+    alone — but with ``use_audio_in_video=True`` it expects the audio
+    interleaved and raises ``StopIteration`` (HTTP 400 in serving).
+
+    The existing ``test_audio_in_video_cache_correctness`` reuses a single
+    video across turns, so this cross-request collision is not covered there.
+
+    The fix couples ``video[i]`` with ``audio[i]`` (via
+    ``_get_mm_cache_coupled_groups``) so a cache-missed video drags its paired
+    audio back through the HF processor even when the audio is individually
+    cached. This test asserts the second request neither raises nor produces
+    wrong tokens.
+    """
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"audio": 1, "image": 0, "video": 1},
+        mm_processor_cache_gb=1,
+    )
+
+    baseline_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=None
+    )
+    sender_cache = MultiModalProcessorSenderCache(ctx.model_config)
+    cached_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=sender_cache
+    )
+
+    video_token_id = baseline_processor.info.get_hf_config().video_token_id
+    hf_processor_mm_kwargs = {"use_audio_in_video": True}
+
+    # Different videos, byte-identical audio track (same audio_seed).
+    mm_data_a = create_paired_mm_data(video_seed=1, audio_seed=99)
+    mm_data_b = create_paired_mm_data(video_seed=2, audio_seed=99)
+
+    def run(processor, mm_data):
+        return processor(
+            [video_token_id],
+            mm_items=baseline_processor.info.parse_mm_data(mm_data),
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+        )["prompt_token_ids"]
+
+    baseline_b_ids = run(baseline_processor, mm_data_b)
+
+    # Warm the cache with request A (video A + audio X).
+    run(cached_processor, mm_data_a)
+
+    # Request B: different video, SAME audio. Audio is a cache hit; video is a
+    # miss. Without the coupling fix the HF processor receives the video with
+    # no paired audio and raises StopIteration; with it, the audio is
+    # reprocessed alongside the video and the tokens match the baseline.
+    second_ids = run(cached_processor, mm_data_b)
+    assert second_ids == baseline_b_ids, (
+        "Same-audio/different-video cache-hit produced different "
+        "prompt_token_ids than baseline (issue #44538).\n"
+        f"  baseline : {baseline_b_ids}\n"
+        f"  cache-hit: {second_ids}"
+    )
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_audio_in_video_same_video_different_audio(model_id: str) -> None:
+    """Reverse-polarity companion to the #44538 regression: *same* video,
+    *different* audio.
+
+    Here the video is a cache hit while the audio misses. The video's
+    interleaved placeholder layout depends on the paired audio's length, so
+    serving the cached (stale) video layout for the new audio would yield wrong
+    prompt_token_ids. The coupling fix reprocesses the whole group, so the
+    video layout is rebuilt for the new audio.
+    """
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"audio": 1, "image": 0, "video": 1},
+        mm_processor_cache_gb=1,
+    )
+
+    baseline_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=None
+    )
+    sender_cache = MultiModalProcessorSenderCache(ctx.model_config)
+    cached_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=sender_cache
+    )
+
+    video_token_id = baseline_processor.info.get_hf_config().video_token_id
+    hf_processor_mm_kwargs = {"use_audio_in_video": True}
+
+    # Same video, different audio (different length → different layout).
+    mm_data_a = create_paired_mm_data(video_seed=7, audio_seed=1)
+    mm_data_b = create_paired_mm_data(video_seed=7, audio_seed=2)
+
+    def run(processor, mm_data):
+        return processor(
+            [video_token_id],
+            mm_items=baseline_processor.info.parse_mm_data(mm_data),
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+        )["prompt_token_ids"]
+
+    baseline_b_ids = run(baseline_processor, mm_data_b)
+
+    run(cached_processor, mm_data_a)  # warm cache with (video, audio A)
+    second_ids = run(cached_processor, mm_data_b)  # video hit, audio miss
+    assert second_ids == baseline_b_ids, (
+        "Same-video/different-audio cache-hit reused a stale interleaved video "
+        "layout (issue #44538, reverse polarity).\n"
+        f"  baseline : {baseline_b_ids}\n"
+        f"  cache-hit: {second_ids}"
+    )
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_audio_in_video_cache_keys_do_not_change_semantic_hashes(
+    model_id: str,
+) -> None:
+    """The coupling fix rewrites *processor-cache keys* only; the semantic
+    ``mm_info.hashes`` (which feed the encoder-output and prefix caches) must
+    stay identical between the cached and uncached paths, or cached vs uncached
+    runs would diverge in downstream cache identity."""
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"audio": 1, "image": 0, "video": 1},
+        mm_processor_cache_gb=1,
+    )
+
+    baseline_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=None
+    )
+    sender_cache = MultiModalProcessorSenderCache(ctx.model_config)
+    cached_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=sender_cache
+    )
+
+    video_token_id = baseline_processor.info.get_hf_config().video_token_id
+    hf_processor_mm_kwargs = {"use_audio_in_video": True}
+    mm_data = create_paired_mm_data(video_seed=3, audio_seed=4)
+
+    def hashes(processor):
+        return processor(
+            [video_token_id],
+            mm_items=baseline_processor.info.parse_mm_data(mm_data),
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+        )["mm_hashes"]
+
+    assert hashes(baseline_processor) == hashes(cached_processor), (
+        "Coupling fix must not change the semantic mm_hashes; only the internal "
+        "processor-cache keys are group-aware."
+    )
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_audio_in_video_partial_residency_reprocesses_whole_group(
+    model_id: str,
+) -> None:
+    """Group-aware keys alone are not enough: a coupled group's members are
+    still stored as independent cache entries, so LRU eviction can drop one
+    member while the other survives. If only the video is evicted, a later
+    request would otherwise get video-miss / audio-hit and run the HF processor
+    on the video without its paired audio (the #44538 StopIteration).
+
+    Group-miss expansion in ``_get_cache_missing_items`` must therefore drag the
+    still-resident audio back into the reprocessed set. This drives that method
+    directly with a fake cache simulating audio-resident / video-evicted, which
+    is deterministic (no reliance on LRU eviction order).
+    """
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"audio": 1, "image": 0, "video": 1},
+        mm_processor_cache_gb=1,
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config, cache=None)
+
+    mm_data = create_paired_mm_data(video_seed=5, audio_seed=6)
+    mm_items = processor.info.parse_mm_data(mm_data)
+
+    coupled_groups = processor._get_mm_cache_coupled_groups(
+        mm_items, {"use_audio_in_video": True}
+    )
+    assert coupled_groups, "coupling must be active for use_audio_in_video"
+
+    class _AudioResidentVideoEvictedCache:
+        """Simulates the audio member surviving in cache while the video member
+        was evicted (partial residency)."""
+
+        def is_cached(self, keys: list[str]) -> list[bool]:
+            return [key.startswith("audio:") for key in keys]
+
+    mm_cache_keys = {"video": ["video:0"], "audio": ["audio:0"]}
+
+    mm_needs_processing, mm_missing_items = processor._get_cache_missing_items(
+        cache=_AudioResidentVideoEvictedCache(),
+        mm_data_items=mm_items,
+        mm_cache_keys=mm_cache_keys,
+        coupled_groups=coupled_groups,
+    )
+
+    # Video missed; the resident audio is dragged back in by group expansion.
+    assert mm_needs_processing["video"] == [True]
+    assert mm_needs_processing["audio"] == [True]
+    # Both must be present in the data fed to the HF processor.
+    assert mm_missing_items.get_count("video", strict=False) == 1
+    assert mm_missing_items.get_count("audio", strict=False) == 1

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -461,6 +461,33 @@ class Qwen2_5OmniThinkerDummyInputsBuilder(
 class Qwen2_5OmniThinkerMultiModalProcessor(
     BaseMultiModalProcessor[Qwen2_5OmniThinkerProcessingInfo]
 ):
+    def _get_mm_cache_coupled_groups(
+        self,
+        mm_data_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Sequence[Sequence[tuple[str, int]]]:
+        """With ``use_audio_in_video=True`` the audio track is interleaved into
+        the video by the HF processor, so each video and its paired audio form
+        one indivisible processing unit. Couple ``video[i]`` with ``audio[i]``
+        so the processor cache reuses the pair only when *both* match and
+        reprocesses them together otherwise; this fixes both the
+        ``StopIteration`` (video re-run without its cached audio) and the stale
+        interleaved layout (video served from the cache for a different audio).
+        See https://github.com/vllm-project/vllm/issues/44538.
+
+        Inherited by ``Qwen3OmniMoeThinkerMultiModalProcessor``.
+        """
+        if not hf_processor_mm_kwargs.get("use_audio_in_video", False):
+            return ()
+
+        num_videos = mm_data_items.get_count("video", strict=False)
+        num_audios = mm_data_items.get_count("audio", strict=False)
+        # use_audio_in_video pairs each video with exactly one audio item
+        # (extracted from that video); guard with min() in case the counts
+        # ever disagree.
+        num_pairs = min(num_videos, num_audios)
+        return [[("video", i), ("audio", i)] for i in range(num_pairs)]
+
     def _call_hf_processor(
         self,
         prompt: str,

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -22,6 +22,8 @@
 # limitations under the License.
 """Inference-only Qwen2.5-Omni model (thinker part)."""
 
+import hashlib
+from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from functools import partial
 from typing import Annotated, Any, Literal
@@ -46,7 +48,7 @@ from transformers.models.whisper import WhisperFeatureExtractor
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.forward_context import set_forward_context
-from vllm.inputs import ModalityData, MultiModalDataDict
+from vllm.inputs import ModalityData, MultiModalDataDict, MultiModalHashes
 from vllm.logger import init_logger
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.qwen2_5_vl import (
@@ -80,8 +82,11 @@ from vllm.multimodal.parse import (
 from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
 )
+from vllm.multimodal.processing.context import TimingContext
+from vllm.multimodal.processing.inputs import ProcessorInputs
 from vllm.multimodal.processing.processor import (
     BaseMultiModalProcessor,
+    MultiModalProcessingInfo,
     MultiModalPromptUpdates,
     PlaceholderFeaturesInfo,
     PromptReplacement,
@@ -461,24 +466,23 @@ class Qwen2_5OmniThinkerDummyInputsBuilder(
 class Qwen2_5OmniThinkerMultiModalProcessor(
     BaseMultiModalProcessor[Qwen2_5OmniThinkerProcessingInfo]
 ):
-    def _get_mm_cache_coupled_groups(
+    def _get_audio_in_video_coupled_groups(
         self,
         mm_data_items: MultiModalDataItems,
         hf_processor_mm_kwargs: Mapping[str, object],
-    ) -> Sequence[Sequence[tuple[str, int]]]:
-        """With ``use_audio_in_video=True`` the audio track is interleaved into
-        the video by the HF processor, so each video and its paired audio form
-        one indivisible processing unit. Couple ``video[i]`` with ``audio[i]``
-        so the processor cache reuses the pair only when *both* match and
-        reprocesses them together otherwise; this fixes both the
-        ``StopIteration`` (video re-run without its cached audio) and the stale
-        interleaved layout (video served from the cache for a different audio).
-        See https://github.com/vllm-project/vllm/issues/44538.
+    ) -> list[list[tuple[str, int]]]:
+        """Groups of ``(modality, item_idx)`` that the HF processor handles as
+        one indivisible unit.
 
-        Inherited by ``Qwen3OmniMoeThinkerMultiModalProcessor``.
+        With ``use_audio_in_video=True`` the audio track is interleaved into
+        the video by the HF processor, so ``video[i]`` and its paired
+        ``audio[i]`` cannot be processed independently. Returns no groups when
+        the flag is off, in which case the standard base-class cache path is
+        used unchanged. Inherited by ``Qwen3OmniMoeThinkerMultiModalProcessor``.
+        See https://github.com/vllm-project/vllm/issues/44538.
         """
         if not hf_processor_mm_kwargs.get("use_audio_in_video", False):
-            return ()
+            return []
 
         num_videos = mm_data_items.get_count("video", strict=False)
         num_audios = mm_data_items.get_count("audio", strict=False)
@@ -487,6 +491,203 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         # ever disagree.
         num_pairs = min(num_videos, num_audios)
         return [[("video", i), ("audio", i)] for i in range(num_pairs)]
+
+    @staticmethod
+    def _coupled_cache_keys(
+        mm_hashes: "MultiModalHashes",
+        coupled_groups: list[list[tuple[str, int]]],
+    ) -> "MultiModalHashes":
+        """Derive processor-cache keys in which every coupled member's key
+        incorporates the content hash of *all* members of its group.
+
+        A group is therefore reused only when all its members match, and any
+        change to any member misses the whole group together. This keeps the
+        cached ``(kwargs, prompt_updates)`` valid even though a coupled item's
+        prompt-update layout depends on the whole group. The semantic
+        ``mm_hashes`` (which become ``MultiModalFeatureSpec.identifier`` and
+        feed the encoder-output / prefix caches) are left untouched.
+        """
+        mm_cache_keys = {
+            modality: list(hashes) for modality, hashes in mm_hashes.items()
+        }
+        for group in coupled_groups:
+            members = [
+                (modality, idx)
+                for modality, idx in group
+                if 0 <= idx < len(mm_cache_keys.get(modality, ()))
+            ]
+            if len(members) < 2:
+                continue
+            group_token = hashlib.sha256(
+                "\0".join(
+                    f"{modality}:{mm_hashes[modality][idx]}"
+                    for modality, idx in sorted(members)
+                ).encode("utf-8")
+            ).hexdigest()[:16]
+            for modality, idx in members:
+                mm_cache_keys[modality][idx] = (
+                    f"{mm_hashes[modality][idx]}-aiv-{group_token}"
+                )
+        return mm_cache_keys
+
+    def _cached_apply_hf_processor(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> tuple[list[int], MultiModalProcessingInfo, bool]:
+        """Cache-aware processing that couples ``use_audio_in_video`` audio
+        with its paired video (issue #44538).
+
+        When no coupling applies (the common case, including
+        ``use_audio_in_video=False``) this defers entirely to the base
+        implementation, so non-omni behavior is unchanged. When the audio is
+        interleaved into the video, the audio item extracted from the video is
+        hashed independently by the processor cache, so two requests with
+        different videos but a byte-identical audio track would otherwise
+        collide on the audio entry: the second request's video misses while its
+        audio hits, the HF processor is run on the video alone, and it raises
+        ``StopIteration``. The reverse polarity (same video, different audio)
+        reuses a stale interleaved layout.
+
+        Both are fixed by (1) group-aware cache keys so a member is never reused
+        for a different pairing, and (2) reprocessing the whole group whenever
+        any member is missing — including when LRU eviction drops one member but
+        not its partner.
+        """
+        cache = self.cache
+        _, passthrough_data = self._get_hf_mm_data(inputs.mm_data_items)
+        coupled_groups = self._get_audio_in_video_coupled_groups(
+            inputs.mm_data_items, inputs.hf_processor_mm_kwargs
+        )
+        if cache is None or passthrough_data or not coupled_groups:
+            return super()._cached_apply_hf_processor(inputs, timing_ctx)
+
+        with timing_ctx.record("get_mm_hashes"):
+            mm_hashes = inputs.get_mm_hashes(self.info.model_id)
+
+        mm_cache_keys = self._coupled_cache_keys(mm_hashes, coupled_groups)
+
+        with timing_ctx.record("get_cache_missing_items"):
+            mm_is_cached = {
+                modality: cache.is_cached(keys)
+                for modality, keys in mm_cache_keys.items()
+            }
+            # Expand the cache-miss set over coupling groups: if any member of
+            # a group needs processing, every member does (covers both a
+            # different-pairing miss and LRU evicting one member of the pair).
+            mm_needs_processing = {
+                modality: [not c for c in items_is_cached]
+                for modality, items_is_cached in mm_is_cached.items()
+            }
+            for group in coupled_groups:
+                members = [
+                    (modality, idx)
+                    for modality, idx in group
+                    if 0 <= idx < len(mm_needs_processing.get(modality, ()))
+                ]
+                if any(mm_needs_processing[m][i] for m, i in members):
+                    for m, i in members:
+                        mm_needs_processing[m][i] = True
+
+            mm_missing_data = {}
+            for modality, needs in mm_needs_processing.items():
+                missing_modality_data = []
+                for idx, item_needs_processing in enumerate(needs):
+                    if not item_needs_processing:
+                        continue
+                    data = inputs.mm_data_items[modality][idx]
+                    if data is None:
+                        raise ValueError(
+                            f"Cache miss for {modality} at index {idx} "
+                            f"but data is not provided."
+                        )
+                    missing_modality_data.append(data)
+                mm_missing_data[modality] = missing_modality_data
+            mm_missing_data_items = self.info.parse_mm_data(
+                mm_missing_data, validate=False
+            )
+
+        with timing_ctx.record("apply_hf_processor"):
+            (
+                prompt_ids,
+                mm_missing_processed_data,
+                is_update_applied,
+            ) = self._apply_hf_processor_main(
+                prompt=inputs.prompt,
+                mm_items=mm_missing_data_items,
+                hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
+                tokenization_kwargs=inputs.tokenization_kwargs,
+                enable_hf_prompt_update=False,
+            )
+
+        mm_missing_kwargs = MultiModalKwargsItems.from_hf_inputs(
+            mm_missing_processed_data,
+            self._get_mm_fields_config(
+                mm_missing_processed_data, inputs.hf_processor_mm_kwargs
+            ),
+        )
+        mm_missing_prompt_updates = self._get_mm_prompt_updates(
+            mm_missing_data_items,
+            inputs.hf_processor_mm_kwargs,
+            mm_missing_kwargs,
+        )
+
+        with timing_ctx.record("merge_mm_kwargs"):
+            mm_kwargs, mm_prompt_updates = self._merge_coupled_mm_kwargs(
+                cache,
+                mm_cache_keys=mm_cache_keys,
+                mm_needs_processing=mm_needs_processing,
+                mm_missing_kwargs=mm_missing_kwargs,
+                mm_missing_prompt_updates=mm_missing_prompt_updates,
+            )
+
+        # ``mm_info.hashes`` uses the unchanged semantic hashes, not the
+        # group-aware cache keys, so downstream identity matches the base path.
+        mm_info = MultiModalProcessingInfo(
+            kwargs=mm_kwargs,
+            hashes=mm_hashes,
+            prompt_updates=mm_prompt_updates,
+        )
+        return prompt_ids, mm_info, is_update_applied
+
+    def _merge_coupled_mm_kwargs(
+        self,
+        cache,
+        mm_cache_keys: "MultiModalHashes",
+        mm_needs_processing: dict[str, list[bool]],
+        mm_missing_kwargs: MultiModalKwargsItems,
+        mm_missing_prompt_updates: MultiModalPromptUpdates,
+    ):
+        """Like the base ``_merge_mm_kwargs`` but keyed off
+        ``mm_needs_processing`` (the group-expanded mask) and the group-aware
+        cache keys: every reprocessed item consumes one HF output slot and is
+        stored/served under its group key."""
+        for keys in mm_cache_keys.values():
+            for item_hash in keys:
+                cache.touch_sender_cache_item(item_hash)
+
+        mm_missing_next_idx: dict[str, int] = defaultdict(int)
+        merged_kwargs = defaultdict(list)
+        merged_prompt_updates = defaultdict(list)
+        for modality, keys in mm_cache_keys.items():
+            missing_kwargs = mm_missing_kwargs.get(modality, [])
+            missing_prompt_updates = mm_missing_prompt_updates.get(modality, [])
+            for item_idx, item_hash in enumerate(keys):
+                if mm_needs_processing[modality][item_idx]:
+                    next_idx = mm_missing_next_idx[modality]
+                    item = (missing_kwargs[next_idx], missing_prompt_updates[next_idx])
+                    mm_missing_next_idx[modality] += 1
+                else:
+                    item = None
+                kwargs, updates = cache.get_and_update_item(item, item_hash)
+                merged_kwargs[modality].append(kwargs)
+                merged_prompt_updates[modality].append(
+                    [
+                        self._recompute_cached_prompt_update(update, item_idx)
+                        for update in updates
+                    ]
+                )
+        return MultiModalKwargsItems(merged_kwargs), dict(merged_prompt_updates)
 
     def _call_hf_processor(
         self,

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1315,9 +1315,9 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         video's interleaved placeholder layout is a function of the paired
         audio (and vice versa). Coupling is enforced two ways that work
         together: group-aware cache keys (see
-        :meth:`_apply_coupled_mm_cache_keys`) stop a member from being reused
+        `_apply_coupled_mm_cache_keys`) stop a member from being reused
         for a *different* pairing, and group-miss expansion (see
-        :meth:`_get_cache_missing_items`) reprocesses the whole group whenever
+        `_get_cache_missing_items`) reprocesses the whole group whenever
         any member is missing — including when LRU eviction drops one member
         but not the other. Without both, the per-item processor cache can serve
         one member while the other misses, producing either a ``StopIteration``
@@ -1342,7 +1342,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         ``prompt_updates`` depend on the whole group. It does **not** by itself
         keep a group atomically resident — LRU eviction can still drop one
         member but not the other; that partial-residency case is handled by
-        group-miss expansion in :meth:`_get_cache_missing_items`.
+        group-miss expansion in `_get_cache_missing_items`.
 
         These keys are used **only** for processor-cache membership and
         storage. The semantic ``mm_hashes`` (which become

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import hashlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, ItemsView, Iterable, Mapping, Sequence
@@ -1297,125 +1296,29 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         return prompt_ids, mm_processed_data, False
 
-    def _get_mm_cache_coupled_groups(
-        self,
-        mm_data_items: MultiModalDataItems,
-        hf_processor_mm_kwargs: Mapping[str, object],
-    ) -> Sequence[Sequence[tuple[str, int]]]:
-        """Groups of ``(modality, item_idx)`` whose HF processing is
-        indivisible: the processed result of one member (including its
-        prompt-update placeholder layout) depends on the *raw* data of the
-        other members in the same request.
-
-        The default is no coupling — every item is processed and cached
-        independently, which is what the per-modality processor cache assumes.
-
-        The motivating case is Qwen-Omni with ``use_audio_in_video=True``: the
-        audio track is interleaved into the video by the HF processor, so the
-        video's interleaved placeholder layout is a function of the paired
-        audio (and vice versa). Coupling is enforced two ways that work
-        together: group-aware cache keys (see
-        `_apply_coupled_mm_cache_keys`) stop a member from being reused
-        for a *different* pairing, and group-miss expansion (see
-        `_get_cache_missing_items`) reprocesses the whole group whenever
-        any member is missing — including when LRU eviction drops one member
-        but not the other. Without both, the per-item processor cache can serve
-        one member while the other misses, producing either a ``StopIteration``
-        in the HF processor (video re-run without its paired audio) or a stale
-        interleaved layout. See
-        https://github.com/vllm-project/vllm/issues/44538.
-        """
-        return ()
-
-    def _apply_coupled_mm_cache_keys(
-        self,
-        mm_hashes: MultiModalHashes,
-        coupled_groups: Sequence[Sequence[tuple[str, int]]],
-    ) -> MultiModalHashes:
-        """Derive the *processor-cache* keys from the semantic ``mm_hashes``.
-
-        Returns ``mm_hashes`` unchanged when there is no coupling. For each
-        coupled group, every member's cache key is rewritten to incorporate
-        the content hash of *every* member, so a member is never reused for a
-        different pairing (which would give a stale interleaved layout). This
-        keeps any cached ``(kwargs, prompt_updates)`` valid even though
-        ``prompt_updates`` depend on the whole group. It does **not** by itself
-        keep a group atomically resident — LRU eviction can still drop one
-        member but not the other; that partial-residency case is handled by
-        group-miss expansion in `_get_cache_missing_items`.
-
-        These keys are used **only** for processor-cache membership and
-        storage. The semantic ``mm_hashes`` (which become
-        ``MultiModalFeatureSpec.identifier`` and feed the encoder-output and
-        prefix caches) are left untouched, so cached and uncached runs produce
-        identical downstream identities.
-        """
-        if not coupled_groups:
-            return mm_hashes
-
-        mm_cache_keys = {
-            modality: list(hashes) for modality, hashes in mm_hashes.items()
-        }
-        for group in coupled_groups:
-            members = [
-                (modality, idx)
-                for modality, idx in group
-                if 0 <= idx < len(mm_cache_keys.get(modality, ()))
-            ]
-            if len(members) < 2:
-                # A group of fewer than two present items needs no coupling.
-                continue
-            group_token = hashlib.sha256(
-                "\0".join(
-                    f"{modality}:{mm_hashes[modality][idx]}"
-                    for modality, idx in sorted(members)
-                ).encode("utf-8")
-            ).hexdigest()[:16]
-            for modality, idx in members:
-                mm_cache_keys[modality][idx] = (
-                    f"{mm_hashes[modality][idx]}-aiv-{group_token}"
-                )
-        return mm_cache_keys
-
     def _get_cache_missing_items(
         self,
         cache: BaseMultiModalProcessorCache,
         mm_data_items: MultiModalDataItems,
         mm_hashes: MultiModalHashes,
-        coupled_groups: Sequence[Sequence[tuple[str, int]]],
     ) -> tuple[MultiModalIsCached, MultiModalDataItems]:
         mm_is_cached = {
             modality: cache.is_cached(hashes) for modality, hashes in mm_hashes.items()
         }
 
-        # An item needs (re)processing if it is not cached. Expand that miss
-        # state over coupling groups: if any member of a group needs
-        # processing, every member does. This handles a group becoming
-        # partially resident — not only when members are missed for different
-        # content (group-aware keys already prevent cross-pairing reuse) but
-        # also when LRU eviction drops one member while another survives. The
-        # HF processor is then always given the whole coupled group, so it
-        # never runs on, say, a video without its paired audio.
-        mm_needs_processing = {
-            modality: list(not c for c in items_is_cached)
+        mm_missing_idxs = {
+            modality: [
+                idx
+                for idx, item_is_cached in enumerate(items_is_cached)
+                if not item_is_cached
+            ]
             for modality, items_is_cached in mm_is_cached.items()
         }
-        for group in coupled_groups:
-            members = [
-                (modality, idx)
-                for modality, idx in group
-                if 0 <= idx < len(mm_needs_processing.get(modality, ()))
-            ]
-            if any(mm_needs_processing[m][i] for m, i in members):
-                for m, i in members:
-                    mm_needs_processing[m][i] = True
 
         mm_missing_data = {}
-        for modality, needs in mm_needs_processing.items():
+        for modality, idxs in mm_missing_idxs.items():
             missing_modality_data = []
-            for idx, item_needs_processing in enumerate(needs):
-                if not item_needs_processing:
-                    continue
+            for idx in idxs:
                 data = mm_data_items[modality][idx]
                 if data is None:
                     raise ValueError(
@@ -1428,7 +1331,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         mm_missing_items = self.info.parse_mm_data(mm_missing_data, validate=False)
 
-        return mm_needs_processing, mm_missing_items
+        return mm_is_cached, mm_missing_items
 
     def _recompute_cached_prompt_update(
         self,
@@ -1445,7 +1348,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         self,
         cache: BaseMultiModalProcessorCache,
         mm_hashes: MultiModalHashes,
-        mm_needs_processing: MultiModalIsCached,
+        mm_is_cached: MultiModalIsCached,
         mm_missing_kwargs: MultiModalKwargsItems,
         mm_missing_prompt_updates: MultiModalPromptUpdates,
     ) -> tuple[MultiModalKwargsOptionalItems, MultiModalPromptUpdates]:
@@ -1466,15 +1369,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             missing_prompt_updates = mm_missing_prompt_updates.get(modality, [])
 
             for item_idx, item_hash in enumerate(hashes):
-                # Every item the HF processor reprocessed (``needs_processing``)
-                # has a freshly computed output; pass it to the cache. For a
-                # genuinely-missing item this stores the new entry; for a
-                # coupling-induced reprocess of a still-resident member the
-                # cache returns the existing entry unchanged (the group-aware
-                # key pins the exact pairing, so the resident value is
-                # equivalent). Items that did not need processing are served
-                # straight from the cache.
-                if mm_needs_processing[modality][item_idx]:
+                if not mm_is_cached[modality][item_idx]:
                     missing_next_idx = mm_missing_next_idx[modality]
                     missing_kwargs_item = missing_kwargs[missing_next_idx]
                     missing_updates_item = missing_prompt_updates[missing_next_idx]
@@ -1561,22 +1456,11 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         with timing_ctx.record("get_mm_hashes"):
             mm_hashes = inputs.get_mm_hashes(self.info.model_id)
 
-        # Derive the processor-cache keys from the semantic hashes. These are
-        # identical to ``mm_hashes`` unless the model couples items (e.g.
-        # Qwen-Omni use_audio_in_video), in which case coupled members share a
-        # group-aware key so the cache never serves a partial group. The
-        # semantic ``mm_hashes`` are kept unchanged for ``mm_info`` below.
-        coupled_groups = self._get_mm_cache_coupled_groups(
-            inputs.mm_data_items, inputs.hf_processor_mm_kwargs
-        )
-        mm_cache_keys = self._apply_coupled_mm_cache_keys(mm_hashes, coupled_groups)
-
         with timing_ctx.record("get_cache_missing_items"):
-            mm_needs_processing, mm_missing_data_items = self._get_cache_missing_items(
+            mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
                 cache=cache,
                 mm_data_items=inputs.mm_data_items,
-                mm_hashes=mm_cache_keys,
-                coupled_groups=coupled_groups,
+                mm_hashes=mm_hashes,
             )
 
         # NOTE: `prompt` does not correspond to `mm_missing_data_items`,
@@ -1611,8 +1495,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         with timing_ctx.record("merge_mm_kwargs"):
             mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
                 cache,
-                mm_hashes=mm_cache_keys,
-                mm_needs_processing=mm_needs_processing,
+                mm_hashes=mm_hashes,
+                mm_is_cached=mm_is_cached,
                 mm_missing_kwargs=mm_missing_kwargs,
                 mm_missing_prompt_updates=mm_missing_prompt_updates,
             )

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import hashlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, ItemsView, Iterable, Mapping, Sequence
@@ -1296,29 +1297,125 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         return prompt_ids, mm_processed_data, False
 
+    def _get_mm_cache_coupled_groups(
+        self,
+        mm_data_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Sequence[Sequence[tuple[str, int]]]:
+        """Groups of ``(modality, item_idx)`` whose HF processing is
+        indivisible: the processed result of one member (including its
+        prompt-update placeholder layout) depends on the *raw* data of the
+        other members in the same request.
+
+        The default is no coupling — every item is processed and cached
+        independently, which is what the per-modality processor cache assumes.
+
+        The motivating case is Qwen-Omni with ``use_audio_in_video=True``: the
+        audio track is interleaved into the video by the HF processor, so the
+        video's interleaved placeholder layout is a function of the paired
+        audio (and vice versa). Coupling is enforced two ways that work
+        together: group-aware cache keys (see
+        :meth:`_apply_coupled_mm_cache_keys`) stop a member from being reused
+        for a *different* pairing, and group-miss expansion (see
+        :meth:`_get_cache_missing_items`) reprocesses the whole group whenever
+        any member is missing — including when LRU eviction drops one member
+        but not the other. Without both, the per-item processor cache can serve
+        one member while the other misses, producing either a ``StopIteration``
+        in the HF processor (video re-run without its paired audio) or a stale
+        interleaved layout. See
+        https://github.com/vllm-project/vllm/issues/44538.
+        """
+        return ()
+
+    def _apply_coupled_mm_cache_keys(
+        self,
+        mm_hashes: MultiModalHashes,
+        coupled_groups: Sequence[Sequence[tuple[str, int]]],
+    ) -> MultiModalHashes:
+        """Derive the *processor-cache* keys from the semantic ``mm_hashes``.
+
+        Returns ``mm_hashes`` unchanged when there is no coupling. For each
+        coupled group, every member's cache key is rewritten to incorporate
+        the content hash of *every* member, so a member is never reused for a
+        different pairing (which would give a stale interleaved layout). This
+        keeps any cached ``(kwargs, prompt_updates)`` valid even though
+        ``prompt_updates`` depend on the whole group. It does **not** by itself
+        keep a group atomically resident — LRU eviction can still drop one
+        member but not the other; that partial-residency case is handled by
+        group-miss expansion in :meth:`_get_cache_missing_items`.
+
+        These keys are used **only** for processor-cache membership and
+        storage. The semantic ``mm_hashes`` (which become
+        ``MultiModalFeatureSpec.identifier`` and feed the encoder-output and
+        prefix caches) are left untouched, so cached and uncached runs produce
+        identical downstream identities.
+        """
+        if not coupled_groups:
+            return mm_hashes
+
+        mm_cache_keys = {
+            modality: list(hashes) for modality, hashes in mm_hashes.items()
+        }
+        for group in coupled_groups:
+            members = [
+                (modality, idx)
+                for modality, idx in group
+                if 0 <= idx < len(mm_cache_keys.get(modality, ()))
+            ]
+            if len(members) < 2:
+                # A group of fewer than two present items needs no coupling.
+                continue
+            group_token = hashlib.sha256(
+                "\0".join(
+                    f"{modality}:{mm_hashes[modality][idx]}"
+                    for modality, idx in sorted(members)
+                ).encode("utf-8")
+            ).hexdigest()[:16]
+            for modality, idx in members:
+                mm_cache_keys[modality][idx] = (
+                    f"{mm_hashes[modality][idx]}-aiv-{group_token}"
+                )
+        return mm_cache_keys
+
     def _get_cache_missing_items(
         self,
         cache: BaseMultiModalProcessorCache,
         mm_data_items: MultiModalDataItems,
-        mm_hashes: MultiModalHashes,
+        mm_cache_keys: MultiModalHashes,
+        coupled_groups: Sequence[Sequence[tuple[str, int]]],
     ) -> tuple[MultiModalIsCached, MultiModalDataItems]:
         mm_is_cached = {
-            modality: cache.is_cached(hashes) for modality, hashes in mm_hashes.items()
+            modality: cache.is_cached(keys) for modality, keys in mm_cache_keys.items()
         }
 
-        mm_missing_idxs = {
-            modality: [
-                idx
-                for idx, item_is_cached in enumerate(items_is_cached)
-                if not item_is_cached
-            ]
+        # An item needs (re)processing if it is not cached. Expand that miss
+        # state over coupling groups: if any member of a group needs
+        # processing, every member does. This handles a group becoming
+        # partially resident — not only when members are missed for different
+        # content (group-aware keys already prevent cross-pairing reuse) but
+        # also when LRU eviction drops one member while another survives. The
+        # HF processor is then always given the whole coupled group, so it
+        # never runs on, say, a video without its paired audio.
+        mm_needs_processing = {
+            modality: list(not c for c in items_is_cached)
             for modality, items_is_cached in mm_is_cached.items()
         }
+        for group in coupled_groups:
+            members = [
+                (modality, idx)
+                for modality, idx in group
+                if 0 <= idx < len(mm_needs_processing.get(modality, ()))
+            ]
+            if any(mm_needs_processing[m][i] for m, i in members):
+                for m, i in members:
+                    mm_needs_processing[m][i] = True
 
         mm_missing_data = {}
-        for modality, idxs in mm_missing_idxs.items():
+        for modality, needs in mm_needs_processing.items():
             missing_modality_data = []
-            for idx in idxs:
+            for idx, item_needs_processing in enumerate(needs):
+                if not item_needs_processing:
+                    continue
                 data = mm_data_items[modality][idx]
                 if data is None:
                     raise ValueError(
@@ -1331,7 +1428,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         mm_missing_items = self.info.parse_mm_data(mm_missing_data, validate=False)
 
-        return mm_is_cached, mm_missing_items
+        return mm_needs_processing, mm_missing_items
 
     def _recompute_cached_prompt_update(
         self,
@@ -1347,15 +1444,15 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
     def _merge_mm_kwargs(
         self,
         cache: BaseMultiModalProcessorCache,
-        mm_hashes: MultiModalHashes,
-        mm_is_cached: MultiModalIsCached,
+        mm_cache_keys: MultiModalHashes,
+        mm_needs_processing: MultiModalIsCached,
         mm_missing_kwargs: MultiModalKwargsItems,
         mm_missing_prompt_updates: MultiModalPromptUpdates,
     ) -> tuple[MultiModalKwargsOptionalItems, MultiModalPromptUpdates]:
-        # Need to touch all mm hashes before update to avoid hash in updated
-        # list evict during update
-        for hashes in mm_hashes.values():
-            for item_hash in hashes:
+        # Need to touch all cache keys before update to avoid a key in the
+        # updated list being evicted during update
+        for keys in mm_cache_keys.values():
+            for item_hash in keys:
                 cache.touch_sender_cache_item(item_hash)
 
         mm_missing_next_idx = defaultdict[str, int](lambda: 0)
@@ -1364,12 +1461,20 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         merged_prompt_updates = defaultdict[str, list[Sequence[ResolvedPromptUpdate]]](
             list
         )
-        for modality, hashes in mm_hashes.items():
+        for modality, keys in mm_cache_keys.items():
             missing_kwargs = mm_missing_kwargs.get(modality, [])
             missing_prompt_updates = mm_missing_prompt_updates.get(modality, [])
 
-            for item_idx, item_hash in enumerate(hashes):
-                if not mm_is_cached[modality][item_idx]:
+            for item_idx, item_hash in enumerate(keys):
+                # Every item the HF processor reprocessed (``needs_processing``)
+                # has a freshly computed output; pass it to the cache. For a
+                # genuinely-missing item this stores the new entry; for a
+                # coupling-induced reprocess of a still-resident member the
+                # cache returns the existing entry unchanged (the group-aware
+                # key pins the exact pairing, so the resident value is
+                # equivalent). Items that did not need processing are served
+                # straight from the cache.
+                if mm_needs_processing[modality][item_idx]:
                     missing_next_idx = mm_missing_next_idx[modality]
                     missing_kwargs_item = missing_kwargs[missing_next_idx]
                     missing_updates_item = missing_prompt_updates[missing_next_idx]
@@ -1456,11 +1561,22 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         with timing_ctx.record("get_mm_hashes"):
             mm_hashes = inputs.get_mm_hashes(self.info.model_id)
 
+        # Derive the processor-cache keys from the semantic hashes. These are
+        # identical to ``mm_hashes`` unless the model couples items (e.g.
+        # Qwen-Omni use_audio_in_video), in which case coupled members share a
+        # group-aware key so the cache never serves a partial group. The
+        # semantic ``mm_hashes`` are kept unchanged for ``mm_info`` below.
+        coupled_groups = self._get_mm_cache_coupled_groups(
+            inputs.mm_data_items, inputs.hf_processor_mm_kwargs
+        )
+        mm_cache_keys = self._apply_coupled_mm_cache_keys(mm_hashes, coupled_groups)
+
         with timing_ctx.record("get_cache_missing_items"):
-            mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
+            mm_needs_processing, mm_missing_data_items = self._get_cache_missing_items(
                 cache=cache,
                 mm_data_items=inputs.mm_data_items,
-                mm_hashes=mm_hashes,
+                mm_cache_keys=mm_cache_keys,
+                coupled_groups=coupled_groups,
             )
 
         # NOTE: `prompt` does not correspond to `mm_missing_data_items`,
@@ -1495,8 +1611,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         with timing_ctx.record("merge_mm_kwargs"):
             mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
                 cache,
-                mm_hashes=mm_hashes,
-                mm_is_cached=mm_is_cached,
+                mm_cache_keys=mm_cache_keys,
+                mm_needs_processing=mm_needs_processing,
                 mm_missing_kwargs=mm_missing_kwargs,
                 mm_missing_prompt_updates=mm_missing_prompt_updates,
             )

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1381,11 +1381,11 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         self,
         cache: BaseMultiModalProcessorCache,
         mm_data_items: MultiModalDataItems,
-        mm_cache_keys: MultiModalHashes,
+        mm_hashes: MultiModalHashes,
         coupled_groups: Sequence[Sequence[tuple[str, int]]],
     ) -> tuple[MultiModalIsCached, MultiModalDataItems]:
         mm_is_cached = {
-            modality: cache.is_cached(keys) for modality, keys in mm_cache_keys.items()
+            modality: cache.is_cached(hashes) for modality, hashes in mm_hashes.items()
         }
 
         # An item needs (re)processing if it is not cached. Expand that miss
@@ -1444,15 +1444,15 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
     def _merge_mm_kwargs(
         self,
         cache: BaseMultiModalProcessorCache,
-        mm_cache_keys: MultiModalHashes,
+        mm_hashes: MultiModalHashes,
         mm_needs_processing: MultiModalIsCached,
         mm_missing_kwargs: MultiModalKwargsItems,
         mm_missing_prompt_updates: MultiModalPromptUpdates,
     ) -> tuple[MultiModalKwargsOptionalItems, MultiModalPromptUpdates]:
-        # Need to touch all cache keys before update to avoid a key in the
-        # updated list being evicted during update
-        for keys in mm_cache_keys.values():
-            for item_hash in keys:
+        # Need to touch all mm hashes before update to avoid hash in updated
+        # list evict during update
+        for hashes in mm_hashes.values():
+            for item_hash in hashes:
                 cache.touch_sender_cache_item(item_hash)
 
         mm_missing_next_idx = defaultdict[str, int](lambda: 0)
@@ -1461,11 +1461,11 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         merged_prompt_updates = defaultdict[str, list[Sequence[ResolvedPromptUpdate]]](
             list
         )
-        for modality, keys in mm_cache_keys.items():
+        for modality, hashes in mm_hashes.items():
             missing_kwargs = mm_missing_kwargs.get(modality, [])
             missing_prompt_updates = mm_missing_prompt_updates.get(modality, [])
 
-            for item_idx, item_hash in enumerate(keys):
+            for item_idx, item_hash in enumerate(hashes):
                 # Every item the HF processor reprocessed (``needs_processing``)
                 # has a freshly computed output; pass it to the cache. For a
                 # genuinely-missing item this stores the new entry; for a
@@ -1575,7 +1575,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_needs_processing, mm_missing_data_items = self._get_cache_missing_items(
                 cache=cache,
                 mm_data_items=inputs.mm_data_items,
-                mm_cache_keys=mm_cache_keys,
+                mm_hashes=mm_cache_keys,
                 coupled_groups=coupled_groups,
             )
 
@@ -1611,7 +1611,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         with timing_ctx.record("merge_mm_kwargs"):
             mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
                 cache,
-                mm_cache_keys=mm_cache_keys,
+                mm_hashes=mm_cache_keys,
                 mm_needs_processing=mm_needs_processing,
                 mm_missing_kwargs=mm_missing_kwargs,
                 mm_missing_prompt_updates=mm_missing_prompt_updates,


### PR DESCRIPTION
## Purpose

Fixes #44538.

With `use_audio_in_video=True` (Qwen2.5-Omni / Qwen3-Omni), the entrypoint extracts the audio track from a video into a **separate** multimodal item that the processor cache hashes by content. The HF processor interleaves that audio into the video, so the video and its paired audio form **one indivisible processing unit** — but the per-modality processor cache treats them independently.

This produces two failures across requests:

- **Different video, byte-identical audio** (the reported case): the second request's video misses the cache while the audio hits, so the HF processor is run on the video alone, receives no audio, and raises `StopIteration` → HTTP 400.
- **Same video, different audio** (reverse polarity): the video hits and reuses a *stale* interleaved layout sized for the previous audio.

`--mm-processor-cache-gb 0` (no cache) avoids both, confirming the bug is purely the cache decoupling a coupled unit.

## Fix

A generic, opt-in hook so the fix is not hard-coded into the cache:

`BaseMultiModalProcessor._get_mm_cache_coupled_groups(mm_data_items, hf_processor_mm_kwargs)` — returns groups of `(modality, item_idx)` that must be processed together. Default: no coupling (every model keeps current behavior). `Qwen2_5OmniThinkerMultiModalProcessor` overrides it to couple `video[i]` with `audio[i]` when `use_audio_in_video` is set; `Qwen3OmniMoeThinkerMultiModalProcessor` inherits it.

Two mechanisms work together:

1. **Group-aware cache keys** (`_apply_coupled_mm_cache_keys`): a coupled member's *processor-cache key* incorporates every member's content hash, so a member is never reused for a different pairing (fixes the stale layout). These keys are used **only** for processor-cache membership/storage; the semantic `mm_hashes` that become `MultiModalFeatureSpec.identifier` and feed the encoder-output / prefix caches are left unchanged, so cached and uncached runs keep identical downstream identity.

2. **Group-miss expansion** (`_get_cache_missing_items`): if any member of a coupling group needs processing, all members are reprocessed together. This covers both a different-pairing miss and LRU eviction dropping one member while the other survives, so the HF processor is never given a video without its paired audio.

Non-coupling models return no groups → `mm_cache_keys is mm_hashes` and behavior is byte-identical to before.

## Test Plan

New CPU-only tests in `tests/models/multimodal/processing/test_audio_in_video.py` (no GPU / model weights; they build the real Qwen processor via `MULTIMODAL_REGISTRY.create_processor` and small `random_video`/`random_audio`, following the existing `test_audio_in_video_cache_correctness` harness):

- `test_audio_in_video_same_audio_different_video` — the reported collision (video miss / audio hit); fails with `StopIteration` / wrong tokens without the fix.
- `test_audio_in_video_same_video_different_audio` — reverse polarity (video hit / audio miss); guards against the stale interleaved layout.
- `test_audio_in_video_cache_keys_do_not_change_semantic_hashes` — `mm_info.hashes` identical between cached and uncached paths.
- `test_audio_in_video_partial_residency_reprocesses_whole_group` — drives `_get_cache_missing_items` with a fake cache (audio resident / video evicted) to deterministically cover the LRU partial-residency branch without depending on eviction order.

`ruff check` and `ruff format --check` pass on the changed files.

## Related (distinct) work

Not a duplicate of the open use_audio_in_video PRs, which address different scopes: #37122 (profiling crash), #36431 (deployment config), #43595 (LRU order-key staleness in `utils/cache.py`). None touch the processor-cache coupling in `multimodal/processing/processor.py`. The issue also references #33865 / #43941 / #42995 as same-subsystem but different symptoms.