### PR TITLE
Add H20-3e FP8 fused-MoE tuned config for E=256,N=512 (Qwen3.6 A3B)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_H20-3e,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_H20-3e,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,153 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Purpose

Add a tuned Triton fused-MoE config for H20-3e at `E=256, N=512, dtype=fp8_w8a8, block_shape=[128,128]`.

This shape covers `Qwen/Qwen3.6-35B-A3B-FP8` on a single H20-3e (TP=1). No tuned config currently exists for it, so vLLM falls back to the generic default kernel parameters. The new config improves decode-side throughput at the small/medium `M` range while leaving accuracy unchanged.

## Test Plan

Single H20-3e, TP=1, model `Qwen/Qwen3.6-35B-A3B-FP8`. Same host and GPU, sequential A/B with the config file present (restored) vs absent (hidden).

- JSON validity: `python3 -m json.tool <config>.json`
- Throughput: `vllm bench serve` on ShareGPT (80 prompts, request-rate `inf`, seed 303), both native lengths and forced 1000-token output with `--ignore-eos`.
- Accuracy: full `lm_eval` GSM8K + MMLU, 5-shot, temperature 0, no `--limit`.

Server args: `--max-model-len 9000 --gpu-memory-utilization 0.90 --gdn-prefill-backend triton --enable-chunked-prefill --max-num-batched-tokens 65536 --max-num-seqs 96`.

## Test Result

Throughput (`vllm bench serve` ShareGPT, restored vs hidden):

| Mode | Output tok/s | Total tok/s | Req/s | p50 TPOT |
| --- | ---: | ---: | ---: | ---: |
| Native lengths | +7.43% | +8.20% | +8.88% | -5.86% |
| Forced 1000 out (ignore EOS) | +23.75% | +23.75% | +23.75% | -19.73% |

The forced-output lane emitted exactly 80,000 output tokens in both legs, so it is the cleanest decode-heavy comparison.

Accuracy (full GSM8K + MMLU, restored vs hidden):

| Metric | Hidden | Restored | Delta |
| --- | ---: | ---: | ---: |
| MMLU `acc,none` | 0.831719 ± 0.003036 | 0.831719 ± 0.003036 | +0.000000 |
| GSM8K `exact_match,flexible` | 0.369219 ± 0.013293 | 0.370735 ± 0.013304 | +0.001516 |
| GSM8K `exact_match,strict` | 0.352540 ± 0.013160 | 0.351782 ± 0.013153 | -0.000758 |

Accuracy is effectively unchanged; GSM8K deltas are well within stderr.

Note: a random long-prefill summarization workload showed a small p50 TTFT regression (~+7.6%) even though throughput and TPOT improved; ShareGPT p50 TTFT improved in both modes. Fully eliminating that prefill tradeoff would require runtime stage-aware tile selection, which is out of scope for this config-only change.

---

Full benchmark writeup (extended tables, setup details, default-workload A/B, and artifacts): https://github.com/haosdent/vllm/pull/1
