### PR TITLE
[MegaMoE] Support external DP load balancing with DeepGEMM MegaMoE

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -155,6 +155,20 @@ class MultiprocExecutor(Executor):
                 connect_ip=mq_connect_ip,
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()
+        # MegaMoE symmetric memory needs all GPUs visible with distinct
+        # device indices. Pop CVD here (before fork/CUDA init) and save
+        # the GPU ID so init_device can use it.
+        if (
+            self.vllm_config.kernel_config is not None
+            and getattr(self.vllm_config.kernel_config, "moe_backend", None)
+            == "deep_gemm_mega_moe"
+        ):
+            cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+            gpu_ids = [int(x) for x in cvd.split(",") if x.strip()] if cvd else []
+            if len(gpu_ids) == 1:
+                os.environ["_VLLM_MEGAMOE_GPU_ID"] = str(gpu_ids[0])
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
         # Create workers
         context = get_mp_context()
         shared_worker_lock = context.Lock()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -238,11 +238,19 @@ class Worker(WorkerBase):
     @instrument(span_name="Init device")
     def init_device(self):
         if self.device_config.device_type == "cuda":
+            # MegaMoE symmetric memory needs all GPUs visible with
+            # distinct physical device indices. The launcher passes
+            # the physical GPU ID via _VLLM_MEGAMOE_GPU_ID.
+            megamoe_gpu = os.environ.get("_VLLM_MEGAMOE_GPU_ID")
+            if megamoe_gpu is not None:
+                self.local_rank = int(megamoe_gpu)
+
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
             parallel_config = self.parallel_config
             if (
-                parallel_config.distributed_executor_backend
+                megamoe_gpu is None
+                and parallel_config.distributed_executor_backend
                 not in ("ray", "external_launcher")
                 and parallel_config.data_parallel_backend != "ray"
                 and parallel_config.nnodes_within_dp == 1


### PR DESCRIPTION
When the launcher masks CUDA_VISIBLE_DEVICES to a single GPU per process (e.g. when using external external DP load balancing), every rank reports device index 0. The CUDA symmetric memory allocator rejects the rendezvous as "overlapping devices from different ranks."

Before fork/CUDA init in the multiproc executor, detect this case when moe_backend is deep_gemm_mega_moe, expand device visibility to all GPUs, and pass the physical GPU ID to workers via _VLLM_MEGAMOE_GPU_ID. Workers read this env var to pin to the correct device instead of relying on CVD masking.


This PR is a very ugly hack :-(
Fixes https://github.com/vllm-project/vllm/issues/44556