### PR TITLE
[DSV4] Move more ops out of eager breakpoint

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -330,10 +330,35 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             device=hidden_states.device,
         )
 
+        # Metadata-independent input GEMMs + RMSNorm stay in the captured
+        # graph; the metadata-dependent rest (q up-proj + kv-insert, indexer,
+        # compressor, MLA attention) runs in the eager break.
+        qr_kv, kv_score, indexer_kv_score, indexer_weights = (
+            self.attn_gemm_parallel_execute(hidden_states)
+        )
+        qr, kv = qr_kv.split([self.q_lora_rank, self.head_dim], dim=-1)
+        qr, kv = fused_q_kv_rmsnorm(
+            qr,
+            kv,
+            self.q_norm.weight.data,
+            self.kv_norm.weight.data,
+            self.eps,
+        )
+
         # attention_impl is wrapped with @eager_break_during_capture: this is
         # where the breakable cudagraph capture breaks (the attention op runs
-        # eagerly between captured graph segments).
-        self.attention_impl(hidden_states, positions, o_padded)
+        # eagerly between captured graph segments). Tensors are passed as args
+        # so the wrapper weak-refs them for replay.
+        self.attention_impl(
+            hidden_states,
+            qr,
+            kv,
+            kv_score,
+            indexer_kv_score,
+            indexer_weights,
+            positions,
+            o_padded,
+        )
         o = o_padded[:, : self.n_local_heads, :]
 
         # Inverse-RoPE + wo_a + wo_b output projection (platform-specific).
@@ -403,24 +428,19 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
     def attention_impl(
         self,
         hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        kv: torch.Tensor,
+        kv_score: torch.Tensor,
+        indexer_kv_score: torch.Tensor,
+        indexer_weights: torch.Tensor,
         positions: torch.Tensor,
         out: torch.Tensor,  # [num_tokens, padded_heads, head_dim], written in place
     ) -> None:
+        # qr/kv (post-RMSNorm) and the input-GEMM scores are computed in the
+        # captured forward; everything from here is metadata-dependent and runs
+        # in this eager break (re-executed every replay with live metadata).
         forward_context = get_forward_context()
         attn_metadata = forward_context.attn_metadata
-
-        qr_kv, kv_score, indexer_kv_score, indexer_weights = (
-            self.attn_gemm_parallel_execute(hidden_states)
-        )
-
-        qr, kv = qr_kv.split([self.q_lora_rank, self.head_dim], dim=-1)
-        qr, kv = fused_q_kv_rmsnorm(
-            qr,
-            kv,
-            self.q_norm.weight.data,
-            self.kv_norm.weight.data,
-            self.eps,
-        )
 
         # wq_b + kv_insert (+ MLA compressor when an indexer is present) ride
         # on the default stream so q stays on its consumer stream (forward_mqa

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -347,8 +347,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         # attention_impl is wrapped with @eager_break_during_capture: this is
         # where the breakable cudagraph capture breaks (the attention op runs
-        # eagerly between captured graph segments). Tensors are passed as args
-        # so the wrapper weak-refs them for replay.
+        # eagerly between captured graph segments).
         self.attention_impl(
             hidden_states,
             qr,
@@ -436,9 +435,6 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         positions: torch.Tensor,
         out: torch.Tensor,  # [num_tokens, padded_heads, head_dim], written in place
     ) -> None:
-        # qr/kv (post-RMSNorm) and the input-GEMM scores are computed in the
-        # captured forward; everything from here is metadata-dependent and runs
-        # in this eager break (re-executed every replay with live metadata).
         forward_context = get_forward_context()
         attn_metadata = forward_context.attn_metadata
 


### PR DESCRIPTION
Same config each run (MTP-3, 8192-in/1024-out, low_entropy), 3 full sweeps per version, mean±std (population stdev):
```
  ┌─────────────┬───────────────┬───────────────┬───────────────┬─────────────────┐
  │ Concurrency │    Metric     │     main      │   refactor    │ Δ (ref vs main) │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │ 1           │ Output tok/s  │ 259.3 ± 4.7   │ 258.6 ± 2.3   │ −0.3%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │             │ P50 TPOT (ms) │ 3.56 ± 0.04   │ 3.53 ± 0.05   │ −0.9%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │             │ P50 TTFT (ms) │ 257.3 ± 0.9   │ 256.8 ± 0.6   │ −0.2%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │ 2           │ Output tok/s  │ 441.9 ± 5.0   │ 442.8 ± 10.9  │ +0.2%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │             │ P50 TPOT (ms) │ 3.90 ± 0.04   │ 3.85 ± 0.07   │ −1.3%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │ 1024        │ Output tok/s  │ 9366 ± 75     │ 9460 ± 85     │ +1.0%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │             │ Total tok/s   │ 147,470 ± 460 │ 148,243 ± 634 │ +0.5%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │             │ P50 TPOT (ms) │ 71.36 ± 0.16  │ 71.33 ± 0.42  │ −0.0%           │
  ├─────────────┼───────────────┼───────────────┼───────────────┼─────────────────┤
  │             │ P50 TTFT (ms) │ 18,863 ± 256  │ 18,525 ± 160  │ −1.8%           │
  └─────────────┴───────────────┴───────────────┴───────────────┴─────────────────┘
```