### PR TITLE
[KV Cache Quantization] SQuat: Subspace-orthogonal KV Cache Quantization

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -107,6 +107,7 @@ Priority is **1 = highest** (tried first).
 | 3 | `TRITON_ATTN` |
 | 4 | `FLEX_ATTENTION` |
 | 5 | `TURBOQUANT` |
+| 6 | `SQUAT` |
 
 **Ampere/Hopper (SM 8.x-9.x):**
 
@@ -117,6 +118,7 @@ Priority is **1 = highest** (tried first).
 | 3 | `TRITON_ATTN` |
 | 4 | `FLEX_ATTENTION` |
 | 5 | `TURBOQUANT` |
+| 6 | `SQUAT` |
 
 ### MLA Attention (DeepSeek-style)
 
@@ -180,6 +182,7 @@ Priority is **1 = highest** (tried first).
 | `ROCM_AITER_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32 | 64, 128, 256 | ✅ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ❌ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ✅ | ❌ | Decoder, Encoder, Encoder Only | N/A |
+| `SQUAT` | | fp16, bf16 | `squat` | Any | Any | ❌ | ❌ | ❌ | ❌ | Decoder | Any |
 | `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2`, `int8_per_token_head`, `fp8_per_token_head` | %16 | Any | ✅ | ✅ | ✅ | ❌ | All | Any |
 | `TRITON_ATTN_DIFFKV` | | fp16, bf16 | `auto`, `bfloat16` | Any | Any | ❌ | ❌ | ❌ | ❌ | Decoder | Any |
 | `TURBOQUANT` | | fp16, bf16 | `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc` | 16, 32, 64, 128 | Any | ❌ | ❌ | ❌ | ❌ | Decoder | Any |

--- a/tools/calibrate_squat.py
+++ b/tools/calibrate_squat.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Precompute SQuat calibration matrices for a given model.
+
+Outputs a .pt file containing per-layer M_update correction matrices
+used by the SQuat attention backend (--kv-cache-dtype squat).
+
+Reference: Wang et al., "SQuat: Subspace-orthogonal KV Cache Quantization",
+COLM 2025; preprint arXiv:2503.24358.
+
+Usage:
+    python tools/calibrate_squat.py \\
+        --model Qwen/Qwen3-30B-A3B-Instruct-2507 \\
+        --subspace-dim 60 --lamb 0.001 \\
+        --output rotations/model.pt
+"""
+
+import argparse
+import math
+import os
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+
+def build_hadamard(d: int) -> torch.Tensor:
+    """Orthonormal Hadamard matrix (Sylvester construction)."""
+    H = torch.tensor([[1.0]], dtype=torch.float64)
+    while H.shape[0] < d:
+        H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
+    return H / math.sqrt(d)
+
+
+def generate_At_inv(
+    quant_group_size: int,
+    Q_hat: torch.Tensor,
+    lamb: float = 0.001,
+    tol: float = 1e-7,
+) -> tuple[list[torch.Tensor], torch.Tensor]:
+    """Generate correction matrices for block-wise SQuat quantization."""
+    num_kv_heads, subspace_dim, head_dim = Q_hat.shape
+    T = (head_dim + quant_group_size - 1) // quant_group_size
+    device = Q_hat.device
+    dtype = Q_hat.dtype
+
+    eye = torch.eye(head_dim, device=device, dtype=dtype)
+    A_T = eye.unsqueeze(0).expand(num_kv_heads, -1, -1) + lamb * torch.matmul(
+        Q_hat.transpose(-1, -2), Q_hat
+    )
+
+    matrices = [None] * T
+    matrices[T - 1] = A_T.clone()
+
+    for t in range(T - 1, 0, -1):
+        current_dim = t * quant_group_size
+        M_t1 = A_T[:, :current_dim, :current_dim]
+        N_t1 = A_T[:, current_dim : current_dim + quant_group_size, :current_dim]
+        O_t1 = A_T[
+            :,
+            current_dim : current_dim + quant_group_size,
+            current_dim : current_dim + quant_group_size,
+        ]
+
+        I_mat = torch.eye(quant_group_size, device=device, dtype=dtype)
+        O_t1_inv = torch.inverse(
+            O_t1 + tol * I_mat.unsqueeze(0).expand(num_kv_heads, -1, -1)
+        )
+        A_t = M_t1 - torch.matmul(N_t1.transpose(-1, -2), torch.matmul(O_t1_inv, N_t1))
+        matrices[t - 1] = A_t[:, :, -quant_group_size:]
+        A_T = A_t
+
+    P_inv = torch.inverse(matrices[-1])
+    return matrices, P_inv
+
+
+def calibrate(
+    model_name: str,
+    subspace_dim: int = 60,
+    lamb: float = 0.001,
+    quant_group_size: int = 64,
+    device: str = "cuda",
+) -> dict:
+    """Compute per-layer SQuat calibration matrices."""
+    config = AutoConfig.from_pretrained(
+        model_name, token=os.environ.get("HF_TOKEN"), trust_remote_code=True
+    )
+    num_layers = config.num_hidden_layers
+    num_kv_heads = config.num_key_value_heads
+    num_q_heads = config.num_attention_heads
+    head_dim = getattr(config, "head_dim", config.hidden_size // num_q_heads)
+    hidden_size = config.hidden_size
+
+    print(f"Model: {model_name}")
+    print(
+        f"  layers={num_layers}, kv_heads={num_kv_heads}, "
+        f"q_heads={num_q_heads}, head_dim={head_dim}"
+    )
+    print(
+        f"  subspace_dim={subspace_dim}, lambda={lamb}, "
+        f"quant_group_size={quant_group_size}"
+    )
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        dtype=torch.float32,
+        token=os.environ.get("HF_TOKEN"),
+        trust_remote_code=True,
+    )
+
+    H = build_hadamard(head_dim).to(device)
+    rotations = {}
+    heads_per_kv = num_q_heads // num_kv_heads
+
+    for layer_idx in range(num_layers):
+        layer = model.model.layers[layer_idx]
+        W_q = layer.self_attn.q_proj.weight.data.float().to(device)
+        W_q_heads = W_q.view(num_q_heads, head_dim, hidden_size)
+
+        Q_hat_all = []
+        for kv_idx in range(num_kv_heads):
+            start = kv_idx * heads_per_kv
+            W_group = W_q_heads[start : start + heads_per_kv]
+
+            cov = torch.zeros(head_dim, head_dim, dtype=torch.float64, device=device)
+            for h in range(heads_per_kv):
+                W_h = W_group[h].double()
+                cov += W_h @ W_h.T
+
+            eigenvalues, eigenvectors = torch.linalg.eigh(cov)
+            r = min(subspace_dim, head_dim)
+            top_eigenvalues = eigenvalues[-r:]
+            top_eigenvectors = eigenvectors[:, -r:]
+
+            Q_hat_kv = (
+                top_eigenvalues.sqrt().unsqueeze(-1) * top_eigenvectors.T
+            ) @ H.double()
+
+            Q_hat_all.append(Q_hat_kv)
+
+        Q_hat_stacked = torch.stack(Q_hat_all, dim=0)
+        Ainv_t, P_inv = generate_At_inv(quant_group_size, Q_hat_stacked, lamb=lamb)
+
+        g = quant_group_size
+        T = (head_dim + g - 1) // g
+        M_update = None
+        if T == 2:
+            H_t = Ainv_t[0]
+            B_t = P_inv[:, g:, :g]
+            M_update = torch.matmul(H_t.transpose(-2, -1), B_t.transpose(-2, -1))
+
+        rotations[f"layer_{layer_idx}"] = {
+            **({"M_update": M_update.float().cpu()} if M_update is not None else {}),
+        }
+
+        if (layer_idx + 1) % 8 == 0 or layer_idx == num_layers - 1:
+            print(f"  Calibrated {layer_idx + 1}/{num_layers} layers")
+
+    del model
+    torch.accelerator.empty_cache()
+    return rotations
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calibrate SQuat rotation matrices")
+    parser.add_argument("--model", required=True, help="HuggingFace model name")
+    parser.add_argument("--subspace-dim", type=int, default=60)
+    parser.add_argument("--lamb", type=float, default=0.001)
+    parser.add_argument("--quant-group-size", type=int, default=64)
+    parser.add_argument("--output", required=True, help="Output .pt file")
+    args = parser.parse_args()
+
+    rotations = calibrate(
+        model_name=args.model,
+        subspace_dim=args.subspace_dim,
+        lamb=args.lamb,
+        quant_group_size=args.quant_group_size,
+    )
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    torch.save(rotations, args.output)
+    print(f"Saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -32,6 +32,7 @@ CacheDType = Literal[
     "int8_per_token_head",
     "fp8_per_token_head",
     "nvfp4",
+    "squat",
 ]
 MambaDType = Literal["auto", "float32", "float16", "bfloat16"]
 MambaCacheMode = Literal["all", "align", "none"]

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1794,7 +1794,10 @@ class EngineArgs:
             kv_offloading_backend=self.kv_offloading_backend,
         )
 
-        if resolved_cache_dtype.startswith("turboquant_"):
+        if (
+            resolved_cache_dtype.startswith("turboquant_")
+            or resolved_cache_dtype == "squat"
+        ):
             from vllm.model_executor.layers.quantization.turboquant.config import (
                 TurboQuantConfig,
             )
@@ -2127,12 +2130,15 @@ class EngineArgs:
 
         # TurboQuant requires FlashAttention 2 — FA3 boundary layers assert
         # FlashAttentionImpl which fails with TurboQuantAttentionImpl.
-        if resolved_cache_dtype.startswith("turboquant_") and (
+        if (
+            resolved_cache_dtype.startswith("turboquant_")
+            or resolved_cache_dtype == "squat"
+        ) and (
             attention_config.flash_attn_version is None
             or attention_config.flash_attn_version >= 3
         ):
             logger.warning(
-                "TurboQuant is not yet compatible with FlashAttention >= 3. "
+                "TurboQuant/SQuat is not compatible with FlashAttention >= 3. "
                 "Overriding flash_attn_version to 2. To silence this "
                 "warning, pass --attention-config.flash_attn_version=2"
             )

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -278,6 +278,12 @@ class Attention(nn.Module, AttentionLayerBase):
         )
         self.kv_cache_dtype = kv_cache_dtype
         self.calculate_kv_scales = calculate_kv_scales
+
+        if kv_cache_dtype == "squat":
+            from vllm.model_executor.models.utils import extract_layer_index
+
+            self._squat_layer_idx = extract_layer_index(prefix)
+
         if num_kv_heads is None:
             num_kv_heads = num_heads
         assert num_heads % num_kv_heads == 0, (
@@ -582,15 +588,21 @@ class Attention(nn.Module, AttentionLayerBase):
                 kv_quant_mode=quant_mode,
                 sliding_window=self.sliding_window,
             )
-        elif self.kv_cache_dtype.startswith("turboquant_"):
+        elif (
+            self.kv_cache_dtype.startswith("turboquant_")
+            or self.kv_cache_dtype == "squat"
+        ):
             from vllm.model_executor.layers.quantization.turboquant.config import (
                 TurboQuantConfig,
             )
             from vllm.v1.kv_cache_interface import TQFullAttentionSpec
 
-            tq_config = TurboQuantConfig.from_cache_dtype(
-                self.kv_cache_dtype, self.head_size
+            tq_preset = (
+                "turboquant_4bit_nc"
+                if self.kv_cache_dtype == "squat"
+                else self.kv_cache_dtype
             )
+            tq_config = TurboQuantConfig.from_cache_dtype(tq_preset, self.head_size)
             return TQFullAttentionSpec(
                 block_size=block_size,
                 num_kv_heads=self.num_kv_heads,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -136,6 +136,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.TRITON_ATTN,
                 AttentionBackendEnum.FLEX_ATTENTION,
                 AttentionBackendEnum.TURBOQUANT,
+                AttentionBackendEnum.SQUAT,
             ]
         else:
             return [
@@ -144,6 +145,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.TRITON_ATTN,
                 AttentionBackendEnum.FLEX_ATTENTION,
                 AttentionBackendEnum.TURBOQUANT,
+                AttentionBackendEnum.SQUAT,
             ]
 
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -570,8 +570,11 @@ class Platform:
                 dtype=kv_cache_dtype,
                 kv_quant_mode=kv_quant_mode,
             ).page_size_bytes
-        elif cache_config.cache_dtype.startswith("turboquant_"):
-            # TQ has a packed K|V layout; the standard FullAttentionSpec
+        elif (
+            cache_config.cache_dtype.startswith("turboquant_")
+            or cache_config.cache_dtype == "squat"
+        ):
+            # TQ/SQuat has a packed K|V layout; the standard FullAttentionSpec
             # formula over-sizes it and trips unify_kv_cache_spec_page_size
             # when all attention layers are TQ. With mixed skip+TQ the skip
             # layers still use the standard layout — take max so mamba
@@ -581,8 +584,13 @@ class Platform:
             )
             from vllm.v1.kv_cache_interface import TQFullAttentionSpec
 
+            tq_dtype = (
+                "turboquant_4bit_nc"
+                if cache_config.cache_dtype == "squat"
+                else cache_config.cache_dtype
+            )
             tq_cfg = TurboQuantConfig.from_cache_dtype(
-                cache_config.cache_dtype, model_config.get_head_size()
+                tq_dtype, model_config.get_head_size()
             )
             tq_page = TQFullAttentionSpec(
                 block_size=1,

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -48,6 +48,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "turboquant_k3v4_nc": torch.uint8,
     "turboquant_3bit_nc": torch.uint8,
     "nvfp4": torch.uint8,
+    "squat": torch.uint8,
 }
 
 TORCH_DTYPE_TO_NUMPY_DTYPE = {

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -99,6 +99,7 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     )
     CPU_ATTN = "vllm.v1.attention.backends.cpu_attn.CPUAttentionBackend"
     TURBOQUANT = "vllm.v1.attention.backends.turboquant_attn.TurboQuantAttentionBackend"
+    SQUAT = "vllm.v1.attention.backends.squat_attn.SQuatAttentionBackend"
     # Placeholder for third-party/custom backends - must be registered before use
     # set to None to avoid alias with other backend, whose value is an empty string
     CUSTOM = None

--- a/vllm/v1/attention/backends/squat_attn.py
+++ b/vllm/v1/attention/backends/squat_attn.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SQuat (Subspace-orthogonal KV Cache Quantization) attention backend.
+
+Extends TurboQuant 4bit-nc quantization with a learned correction that
+keeps quantization errors orthogonal to the query subspace. Uses the same
+packed cache layout and decode kernels as turboquant_4bit_nc.
+
+Reference: "SQuat: Subspace-orthogonal KV Cache Quantization"
+(Wang et al., COLM 2025; preprint arXiv:2503.24358)
+
+Usage:
+    SQUAT_ROTATION_PATH=rotations/model.pt \\
+    vllm serve model --kv-cache-dtype squat
+"""
+
+import functools
+import math
+import os
+from typing import Any, ClassVar
+
+import torch
+
+from vllm.config.cache import CacheDType
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.v1.attention.backends.turboquant_attn import (
+    TurboQuantAttentionBackend,
+    TurboQuantAttentionImpl,
+    TurboQuantMetadataBuilder,
+)
+
+_SQUAT_TQ_PRESET = "turboquant_4bit_nc"
+
+
+@functools.cache
+def _load_rotation_file(path: str) -> dict:
+    return torch.load(path, map_location="cpu", weights_only=True)
+
+
+@functools.cache
+def _build_hadamard(d: int, device_str: str) -> torch.Tensor:
+    H = torch.tensor([[1.0]])
+    while H.shape[0] < d:
+        H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
+    return (H / math.sqrt(d)).to(torch.device(device_str))
+
+
+def _get_layer_index(layer: torch.nn.Module) -> int | None:
+    return getattr(layer, "_squat_layer_idx", None)
+
+
+class SQuatAttentionBackend(TurboQuantAttentionBackend):
+    """Attention backend using SQuat KV-cache compression."""
+
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["squat"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "SQUAT"
+
+    @staticmethod
+    def get_impl_cls() -> type["SQuatAttentionImpl"]:
+        return SQuatAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[TurboQuantMetadataBuilder]:
+        return TurboQuantMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "squat",
+    ) -> tuple[int, ...]:
+        return TurboQuantAttentionBackend.get_kv_cache_shape(
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
+            cache_dtype_str=_SQUAT_TQ_PRESET,
+        )
+
+    @classmethod
+    def supports_kv_cache_dtype(
+        cls,
+        kv_cache_dtype: CacheDType | None,
+    ) -> bool:
+        return kv_cache_dtype == "squat"
+
+
+class SQuatAttentionImpl(TurboQuantAttentionImpl):
+    """SQuat attention with precomputed subspace correction matrices."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int | None = None,
+        alibi_slopes: list[float] | None = None,
+        sliding_window: int | None = None,
+        kv_cache_dtype: str = "squat",
+        logits_soft_cap: float | None = None,
+        attn_type: str = "decoder",
+        kv_sharing_target_layer_name: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=alibi_slopes,
+            sliding_window=sliding_window,
+            kv_cache_dtype=_SQUAT_TQ_PRESET,
+            logits_soft_cap=logits_soft_cap,
+            attn_type=attn_type,
+            kv_sharing_target_layer_name=kv_sharing_target_layer_name,
+            **kwargs,
+        )
+        self._rotation_path = os.environ.get("SQUAT_ROTATION_PATH")
+        self._rotations_loaded: dict | None = None
+
+    def _get_rotations(self) -> dict | None:
+        if self._rotations_loaded is not None:
+            return self._rotations_loaded
+        if self._rotation_path and os.path.exists(self._rotation_path):
+            self._rotations_loaded = _load_rotation_file(self._rotation_path)
+            return self._rotations_loaded
+        return None
+
+    def _ensure_on_device(self, layer: Any, device: torch.device) -> None:
+        if hasattr(layer, "_tq_cached"):
+            return
+
+        D = self.head_size
+        H = _build_hadamard(D, str(device))
+        layer._tq_PiT = H
+        layer._tq_Pi = H
+        layer._squat_M_update = None
+
+        rotations = self._get_rotations()
+        if rotations is not None:
+            layer_idx = _get_layer_index(layer)
+            if layer_idx is not None:
+                layer_key = f"layer_{layer_idx}"
+                if layer_key in rotations and "M_update" in rotations[layer_key]:
+                    M = rotations[layer_key]["M_update"]
+                    total_kv_heads = M.shape[0]
+                    local_kv_heads = self.num_kv_heads
+                    if total_kv_heads > local_kv_heads:
+                        tp_rank = device.index if device.index is not None else 0
+                        start_h = tp_rank * local_kv_heads
+                        M = M[start_h : start_h + local_kv_heads]
+                    layer._squat_M_update = M.to(device=device, dtype=torch.float32)
+
+        layer._tq_centroids = get_centroids(
+            D,
+            self.tq_config.centroid_bits,
+        ).to(device=device, dtype=torch.float32)
+        layer._tq_Pi_half = layer._tq_Pi.to(torch.float16)
+        c_sorted, _ = layer._tq_centroids.sort()
+        layer._tq_midpoints = (c_sorted[:-1] + c_sorted[1:]) / 2
+        layer._tq_centroids_sorted = c_sorted
+        layer._tq_cached = True
+
+    def _store_kv(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        layer: Any,
+    ) -> None:
+        from vllm.v1.attention.ops.triton_squat_store import (
+            squat_triton_store_mse,
+        )
+
+        correction_scale = float(os.environ.get("SQUAT_CORRECTION_SCALE", "1.0"))
+
+        squat_triton_store_mse(
+            key,
+            value,
+            kv_cache,
+            slot_mapping,
+            layer._tq_PiT,
+            layer._tq_midpoints,
+            layer._tq_centroids_sorted,
+            layer._squat_M_update,
+            mse_bits=self.tq_config.key_mse_bits,
+            key_packed_size=self.tq_config.key_packed_size,
+            value_quant_bits=self.tq_config.effective_value_quant_bits,
+            correction_scale=correction_scale,
+        )

--- a/vllm/v1/attention/ops/triton_squat_store.py
+++ b/vllm/v1/attention/ops/triton_squat_store.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused Triton kernel for SQuat KV store (4-bit MSE quantization).
+
+Extends TurboQuant 4bit-nc MSE store with block-wise SQuat correction:
+  1. Binary-search bucketize first half of rotated key to 4-bit centroids
+  2. Compute quantization error, apply M_update correction to second half
+  3. Binary-search bucketize the corrected second half
+  4. Pack 4-bit MSE indices + store norm + 4-bit value quantize
+
+Reference: Wang et al., "SQuat: Subspace-orthogonal KV Cache Quantization",
+COLM 2025; preprint arXiv:2503.24358.
+"""
+
+import math
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.ops.triton_turboquant_store import _store_quantized_value
+
+
+@triton.jit
+def _squat_fused_store_mse(
+    Y_ptr,  # [NH, D] float32 — rotated normalized keys
+    Norms_ptr,  # [NH] float32 — key vector norms
+    Value_ptr,  # [NH, D] float32 — raw values
+    Midpoints_ptr,  # [n_centroids-1] float32
+    Centroids_ptr,  # [n_centroids] float32 — sorted centroids
+    M_update_ptr,  # [H, HALF_D, HALF_D] float32 — correction matrices
+    KV_cache_ptr,  # [total_bytes] uint8 (flattened view)
+    Slot_mapping_ptr,  # [N] int32
+    stride_cache_block: tl.constexpr,
+    stride_cache_pos: tl.constexpr,
+    stride_cache_head: tl.constexpr,
+    stride_m_head: tl.constexpr,
+    stride_m_row: tl.constexpr,
+    D: tl.constexpr,
+    H: tl.constexpr,
+    HALF_D: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KPS: tl.constexpr,
+    VQB: tl.constexpr,
+    VAL_DATA_BYTES: tl.constexpr,
+    BLOCK_VAL: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    BLOCK_GRP: tl.constexpr = 16,
+    HAS_SQUAT: tl.constexpr = 1,
+    CORRECTION_SCALE: tl.constexpr = 1.0,
+):
+    """Fused SQuat correction + MSE quantize + pack + store."""
+    pid = tl.program_id(0)
+    token_idx = pid // H
+    head_idx = pid % H
+
+    slot = tl.load(Slot_mapping_ptr + token_idx)
+    if slot < 0:
+        return
+    blk = (slot // BLOCK_SIZE).to(tl.int64)
+    off = (slot % BLOCK_SIZE).to(tl.int64)
+    head_idx_i64 = tl.cast(head_idx, tl.int64)
+    slot_base = (
+        blk * stride_cache_block
+        + off * stride_cache_pos
+        + head_idx_i64 * stride_cache_head
+    )
+
+    base = pid * D
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+
+    if HAS_SQUAT:
+        # ── SQUAT PATH ──
+        y_vec = tl.load(Y_ptr + base + d_offs, mask=d_mask, other=0.0)
+        first_offs = tl.arange(0, HALF_D)
+        y_first = tl.load(Y_ptr + base + first_offs)
+
+        # Bucketize first half
+        lo1 = tl.zeros([HALF_D], dtype=tl.int32)
+        hi1 = tl.full([HALF_D], N_CENTROIDS - 1, dtype=tl.int32)
+        for _ in range(MSE_BITS):
+            mid1 = (lo1 + hi1) >> 1
+            safe_mid1 = tl.minimum(mid1, N_CENTROIDS - 2)
+            mid_val1 = tl.load(Midpoints_ptr + safe_mid1)
+            lo1 = tl.where(y_first >= mid_val1, mid1 + 1, lo1)
+            hi1 = tl.where(y_first >= mid_val1, hi1, mid1)
+        idx_first = tl.minimum(lo1, N_CENTROIDS - 1)
+
+        # Correction: error @ M_update
+        first_quant = tl.load(Centroids_ptr + idx_first)
+        error = first_quant - y_first
+        m_base = head_idx * stride_m_head
+        row_offs = tl.arange(0, HALF_D)
+        col_offs = tl.arange(0, HALF_D)
+        m_offs = row_offs[:, None] * stride_m_row + col_offs[None, :]
+        m_block = tl.load(M_update_ptr + m_base + m_offs)
+        error_2d = tl.reshape(error, [1, HALF_D])
+        correction_2d = tl.dot(error_2d, m_block)
+        correction = tl.reshape(correction_2d, [HALF_D]) * CORRECTION_SCALE
+
+        # Apply correction to second half, then bucketize full vector
+        second_offs = tl.arange(0, HALF_D) + HALF_D
+        y_second = tl.load(Y_ptr + base + second_offs)
+        tl.store(Y_ptr + base + second_offs, y_second + correction)
+        y_corrected = tl.load(Y_ptr + base + d_offs, mask=d_mask, other=0.0)
+
+        lo = tl.zeros([BLOCK_D], dtype=tl.int32)
+        hi = tl.full([BLOCK_D], N_CENTROIDS - 1, dtype=tl.int32)
+        for _ in range(MSE_BITS):
+            mid = (lo + hi) >> 1
+            safe_mid = tl.minimum(mid, N_CENTROIDS - 2)
+            mid_val = tl.load(Midpoints_ptr + safe_mid, mask=d_mask, other=0.0)
+            lo = tl.where(y_corrected >= mid_val, mid + 1, lo)
+            hi = tl.where(y_corrected >= mid_val, hi, mid)
+        idx = tl.minimum(lo, N_CENTROIDS - 1)
+    else:
+        # ── PLAIN TQ PATH ──
+        y_vec = tl.load(Y_ptr + base + d_offs, mask=d_mask, other=0.0)
+        lo = tl.zeros([BLOCK_D], dtype=tl.int32)
+        hi = tl.full([BLOCK_D], N_CENTROIDS - 1, dtype=tl.int32)
+        for _ in range(MSE_BITS):
+            mid = (lo + hi) >> 1
+            safe_mid = tl.minimum(mid, N_CENTROIDS - 2)
+            mid_val = tl.load(Midpoints_ptr + safe_mid, mask=d_mask, other=0.0)
+            lo = tl.where(y_vec >= mid_val, mid + 1, lo)
+            hi = tl.where(y_vec >= mid_val, hi, mid)
+        idx = tl.minimum(lo, N_CENTROIDS - 1)
+
+    # Pack 4-bit MSE indices (two per byte)
+    idx_pairs = tl.reshape(idx, [BLOCK_D // 2, 2])
+    shifts_4 = tl.arange(0, 2) * 4
+    packed = tl.sum((idx_pairs & 0xF) << shifts_4[None, :], axis=1).to(tl.uint8)
+    mse_offs = tl.arange(0, BLOCK_D // 2)
+    mse_mask = mse_offs < MSE_BYTES
+    tl.store(KV_cache_ptr + slot_base + mse_offs, packed, mask=mse_mask)
+
+    # Store norm
+    norm_offset = MSE_BYTES
+    vn_f16 = tl.load(Norms_ptr + pid).to(tl.float16)
+    vn_u16 = vn_f16.to(tl.uint16, bitcast=True)
+    tl.store(KV_cache_ptr + slot_base + norm_offset, (vn_u16 & 0xFF).to(tl.uint8))
+    tl.store(
+        KV_cache_ptr + slot_base + norm_offset + 1, ((vn_u16 >> 8) & 0xFF).to(tl.uint8)
+    )
+
+    # Value quantize + pack
+    _store_quantized_value(
+        Value_ptr,
+        KV_cache_ptr,
+        base,
+        slot_base,
+        d_offs,
+        d_mask,
+        D=D,
+        KPS=KPS,
+        VQB=VQB,
+        VAL_DATA_BYTES=VAL_DATA_BYTES,
+        BLOCK_D=BLOCK_D,
+        BLOCK_VAL=BLOCK_VAL,
+        BLOCK_GRP=BLOCK_GRP,
+    )
+
+
+def squat_triton_store_mse(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    PiT: torch.Tensor,
+    midpoints: torch.Tensor,
+    centroids_sorted: torch.Tensor,
+    M_update: torch.Tensor | None,
+    mse_bits: int,
+    key_packed_size: int,
+    value_quant_bits: int,
+    correction_scale: float = 1.0,
+):
+    """Launch fused SQuat MSE store kernel."""
+    N, H, D = key.shape
+    NH = N * H
+    HALF_D = D // 2
+    block_size = kv_cache.shape[1]
+    BLOCK_D = triton.next_power_of_2(D)
+    mse_bytes = math.ceil(D * mse_bits / 8)
+    n_centroids = 2**mse_bits
+    val_data_bytes = math.ceil(D * value_quant_bits / 8)
+    BLOCK_VAL = triton.next_power_of_2(val_data_bytes)
+    block_grp = triton.next_power_of_2(D // 8) if D >= 8 else 1
+
+    stride_block = kv_cache.stride(0)
+    stride_pos = kv_cache.stride(1)
+    stride_head = kv_cache.stride(2)
+
+    k_flat = key.float().reshape(NH, D)
+    norms = k_flat.norm(dim=1, keepdim=True)
+    y = (k_flat / (norms + 1e-8)) @ PiT
+    v_flat = value.float().reshape(NH, D)
+
+    m_flat = (
+        M_update.to(device=key.device, dtype=torch.float32).contiguous()
+        if M_update is not None
+        else torch.empty(1, device=key.device, dtype=torch.float32)
+    )
+    has_squat = M_update is not None
+
+    grid = (NH,)
+    _squat_fused_store_mse[grid](
+        y,
+        norms.squeeze(1),
+        v_flat,
+        midpoints,
+        centroids_sorted,
+        m_flat,
+        kv_cache.view(-1),
+        slot_mapping,
+        stride_cache_block=stride_block,
+        stride_cache_pos=stride_pos,
+        stride_cache_head=stride_head,
+        stride_m_head=HALF_D * HALF_D,
+        stride_m_row=HALF_D,
+        D=D,
+        H=H,
+        HALF_D=HALF_D,
+        BLOCK_SIZE=block_size,
+        BLOCK_D=BLOCK_D,
+        MSE_BYTES=mse_bytes,
+        KPS=key_packed_size,
+        VQB=value_quant_bits,
+        VAL_DATA_BYTES=val_data_bytes,
+        BLOCK_VAL=BLOCK_VAL,
+        MSE_BITS=mse_bits,
+        N_CENTROIDS=n_centroids,
+        BLOCK_GRP=block_grp,
+        HAS_SQUAT=1 if has_squat else 0,
+        CORRECTION_SCALE=correction_scale,
+        num_warps=4,
+        num_stages=1,
+    )


### PR DESCRIPTION
## Summary

Implements SQuat (Subspace-orthogonal KV Cache Quantization), extending TurboQuant 4bit-nc with learned per-layer correction matrices that steer quantization errors away from important query directions.

Paper: [SQuat: Subspace-orthogonal KV Cache Quantization](https://arxiv.org/abs/2503.24358) (COLM 2025)

**Key properties:**
- Same KV cache format and capacity as TurboQuant 4bit-nc (~3× over BF16)
- Nearly identical latency and throughput to TurboQuant (correction adds <1% overhead)
- Improves accuracy over TurboQuant, with the largest gains on MATH500 (+1.0–3.4pp)
- Architecture-agnostic: SQuat can be combined with any KV cache quantization method. Currently built on TurboQuant 4bit-nc, but can be adapted to other quantization backends as they are integrated into vLLM

## Accuracy

| Model | Benchmark | TQ 4bit-nc | SQuat | SQuat vs TQ |
|-------|-----------|------------|-------|-------------|
| Llama-3.1-8B-Instruct | MATH500 | 41.8 | **45.2** | **+3.4pp** |
| Llama-3.1-8B-Instruct | HumanEval | 62.2 | **62.8** | +0.6pp |
| Llama-3.1-8B-Instruct | GSM8K | 78.2 | 77.8 | -0.4pp |
| Qwen2.5-7B-Instruct | MATH500 | 70.8 | **71.8** | **+1.0pp** |
| Qwen2.5-7B-Instruct | HumanEval | 62.8 | **64.0** | **+1.2pp** |
| Qwen2.5-7B-Instruct | GSM8K | 77.5 | **77.8** | +0.3pp |
| Qwen3-30B-A3B-Thinking | MATH500 | 92.0 | **92.6** | +0.6pp |
| Qwen3-30B-A3B-Thinking | GPQA Diamond | 71.2 | **72.9** | **+1.7pp** |
| Qwen3-30B-A3B-Thinking | AIME25 | 77.8 | **78.9** | +1.1pp |

## Latency, throughput, and memory

SQuat and TurboQuant have nearly identical latency and throughput. Both use the same 4bit-nc cache format. All benchmarks on H100 80GB.

### Latency (input=1024, output=256, 10 warmup + 30 measured iterations)

**Llama-3.1-8B-Instruct (TP=1):**

| Batch Size | TQ (s) | SQuat (s) |
|------------|--------|-----------|
| 1 | 2.258 | 2.335 |
| 8 | 2.419 | 2.508 |
| 32 | 4.186 | 4.222 |
| 64 | 6.570 | 6.651 |

**Qwen2.5-7B-Instruct (TP=1):**

| Batch Size | TQ (s) | SQuat (s) |
|------------|--------|-----------|
| 1 | 1.779 | 1.826 |
| 8 | 2.188 | 2.249 |
| 32 | 3.571 | 3.631 |
| 64 | 5.464 | 5.514 |

**Qwen3-30B-A3B-Thinking (TP=2):**

| Batch Size | TQ (s) | SQuat (s) |
|------------|--------|-----------|
| 1 | 2.027 | 2.140 |
| 8 | 3.009 | 3.151 |
| 32 | 4.308 | 4.403 |
| 64 | 6.328 | 6.369 |

### Throughput (200 prompts, offline)

**Llama-3.1-8B-Instruct (TP=1):**

| Input/Output | TQ (tok/s) | SQuat (tok/s) |
|--------------|-----------|--------------|
| 256/256 | 20,678 | 20,387 |
| 1024/512 | 21,186 | 20,868 |
| 4096/256 | 21,185 | 20,830 |

**Qwen2.5-7B-Instruct (TP=1):**

| Input/Output | TQ (tok/s) | SQuat (tok/s) |
|--------------|-----------|--------------|
| 256/256 | 25,065 | 24,572 |
| 1024/512 | 25,516 | 25,266 |
| 4096/256 | 25,455 | 25,239 |

**Qwen3-30B-A3B-Thinking (TP=2):**

| Input/Output | TQ (tok/s) | SQuat (tok/s) |
|--------------|-----------|--------------|
| 256/256 | 28,914 | 27,089 |
| 1024/512 | 29,267 | 28,919 |
| 4096/256 | 29,186 | 28,860 |

### KV Cache Capacity

| Model | BF16 (tokens) | TQ/SQuat (tokens) | Ratio |
|-------|--------------|-------------------|-------|
| Llama-3.1-8B (TP=1) | 438,928 | 1,238,560 | 2.82× |
| Qwen2.5-7B (TP=1) | 1,011,568 | 2,756,816 | 2.73× |
| Qwen3-30B (TP=2) | 846,800 | 2,614,304 | 3.09× |

SQuat uses the same TQ 4bit-nc storage format, so KV cache capacity is identical to TQ.

## Changes

**New files (3):**
- `vllm/v1/attention/backends/squat_attn.py` — SQuat attention backend extending TurboQuant
- `vllm/v1/attention/ops/triton_squat_store.py` — Fused Triton kernel for SQuat KV store
- `tools/calibrate_squat.py` — Offline calibration tool

**Modified files (7):**
- `vllm/config/cache.py` — Add `"squat"` to `CacheDType`
- `vllm/engine/arg_utils.py` — Handle squat in TQ config and FA version check
- `vllm/model_executor/layers/attention/attention.py` — Add squat layer index extraction and attention spec
- `vllm/platforms/cuda.py` — Add SQUAT to backend priorities
- `vllm/platforms/interface.py` — Add squat to page size calculation
- `vllm/utils/torch_utils.py` — Map `"squat"` to `torch.uint8`
- `vllm/v1/attention/backends/registry.py` — Register SQUAT backend

## Usage

```bash
# 1. Calibrate (offline, once per model, ~2 min for 8B model)
python tools/calibrate_squat.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --subspace-dim 60 --lamb 0.001 \
    --output rotations/llama-8b.pt

# 2. Serve
VLLM_USE_V2_MODEL_RUNNER=0 \
SQUAT_ROTATION_PATH=rotations/llama-8b.pt \
vllm serve meta-llama/Llama-3.1-8B-Instruct \
    --kv-cache-dtype squat --max-model-len 32768 \
    --gpu-memory-utilization 0.90
```

> **Note on hyperparameters:** Different models require different lambda values for best results (e.g., 0.001 for Llama-3.1-8B, 0.01 for Qwen2.5-7B, 0.005 for Qwen3-30B). When applying SQuat to a new model, we recommend running a hyperparameter sweep over lambda on a small evaluation set before deployment.

> **Note on MRV2 compatibility:** `VLLM_USE_V2_MODEL_RUNNER=0` is required for Llama/Mistral models because Model Runner V2 does not yet support TurboQuant-based KV cache quantization (this also affects plain `turboquant_4bit_nc`). Models not using MRV2 are unaffected.

## Reproducing accuracy benchmarks

### Step 0: Environment setup

```bash
cd /path/to/vllm

# Create venv and install vLLM
uv venv --python 3.12
source .venv/bin/activate
VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto

# Install eval dependencies
uv pip install lm-eval[api] transformers
```

### Step 1: Calibrate SQuat rotation

Each model uses a different lambda (selected via hyperparameter sweep on MATH500):

```bash
# Llama-3.1-8B-Instruct (lambda=0.001)
python tools/calibrate_squat.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --subspace-dim 60 --lamb 0.001 --quant-group-size 64 \
    --output rotations/llama-3.1-8b-instruct.pt

# Qwen2.5-7B-Instruct (lambda=0.01)
python tools/calibrate_squat.py \
    --model Qwen/Qwen2.5-7B-Instruct \
    --subspace-dim 60 --lamb 0.01 --quant-group-size 64 \
    --output rotations/qwen2.5-7b-instruct.pt

# Qwen3-30B-A3B-Thinking (lambda=0.005)
python tools/calibrate_squat.py \
    --model Qwen/Qwen3-30B-A3B-Thinking-2507 \
    --subspace-dim 60 --lamb 0.005 --quant-group-size 64 \
    --output rotations/qwen3-30b-thinking.pt
```

### Step 2: Reproduce Llama-3.1-8B-Instruct MATH500

Open **Terminal 1** — start the server:

```bash
# === TurboQuant (expected: 41.8%) ===
VLLM_USE_V2_MODEL_RUNNER=0 \
vllm serve meta-llama/Llama-3.1-8B-Instruct \
    --trust-remote-code --port 8000 \
    --gpu-memory-utilization 0.90 --max-model-len 32768 \
    --kv-cache-dtype turboquant_4bit_nc

# === SQuat (expected: 45.2%) ===
VLLM_USE_V2_MODEL_RUNNER=0 \
SQUAT_ROTATION_PATH=rotations/llama-3.1-8b-instruct.pt \
vllm serve meta-llama/Llama-3.1-8B-Instruct \
    --trust-remote-code --port 8000 \
    --gpu-memory-utilization 0.90 --max-model-len 32768 \
    --kv-cache-dtype squat
```

Open **Terminal 2** — wait for server, then run eval:

```bash
# Wait for server to be ready
until curl -s http://localhost:8000/health > /dev/null; do sleep 1; done
echo "Server ready"

# Run MATH500 (500 questions, temperature=0.7)
python scripts/eval_math500.py \
    --base-url http://localhost:8000/v1/chat/completions \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --temperature 0.7 --max-tokens 4096 \
    --output results/math500.json

# Check result
python -c "import json; d=json.load(open('results/math500.json')); print(f'{d[\"accuracy\"]*100:.1f}% ({d[\"num_correct\"]}/{d[\"num_total\"]})')"
```

### Step 3: Reproduce GSM8K and HumanEval

With the same server running from Step 2:

```bash
# GSM8K (1319 questions, 5-shot, greedy)
lm_eval --model local-chat-completions \
    --model_args "model=meta-llama/Llama-3.1-8B-Instruct,base_url=http://localhost:8000/v1/chat/completions,num_concurrent=1,tokenized_requests=False" \
    --tasks gsm8k --num_fewshot 5 --batch_size 1 --apply_chat_template \
    --output_path results/gsm8k --log_samples

# HumanEval (164 questions, 0-shot, greedy, uses /v1/completions endpoint)
HF_ALLOW_CODE_EVAL=1 lm_eval --model local-completions \
    --model_args "model=meta-llama/Llama-3.1-8B-Instruct,base_url=http://localhost:8000/v1/completions,num_concurrent=1,tokenized_requests=False" \
    --tasks humaneval --num_fewshot 0 --batch_size 1 --confirm_run_unsafe_code \
    --output_path results/humaneval --log_samples
```

### Step 4: Reproduce latency benchmark

No server needed — runs directly:

```bash
# Run for each batch size: 1, 8, 32, 64

# TurboQuant:
VLLM_USE_V2_MODEL_RUNNER=0 \
vllm bench latency --model meta-llama/Llama-3.1-8B-Instruct \
    --tensor-parallel-size 1 --trust-remote-code \
    --input-len 1024 --output-len 256 --batch-size BATCH \
    --num-iters 30 --num-iters-warmup 10 --gpu-memory-utilization 0.90 \
    --kv-cache-dtype turboquant_4bit_nc

# SQuat:
VLLM_USE_V2_MODEL_RUNNER=0 \
SQUAT_ROTATION_PATH=rotations/llama-3.1-8b-instruct.pt \
vllm bench latency --model meta-llama/Llama-3.1-8B-Instruct \
    --tensor-parallel-size 1 --trust-remote-code \
    --input-len 1024 --output-len 256 --batch-size BATCH \
    --num-iters 30 --num-iters-warmup 10 --gpu-memory-utilization 0.90 \
    --kv-cache-dtype squat
```

### Other models

For Qwen2.5-7B-Instruct: same steps as above, replacing:
- Model: `Qwen/Qwen2.5-7B-Instruct`, lambda: `0.01`
- Rotation file: `rotations/qwen2.5-7b-instruct.pt`
- `VLLM_USE_V2_MODEL_RUNNER=0` is optional (Qwen2.5 doesn't use MRV2)

For Qwen3-30B-A3B-Thinking: same steps, replacing:
- Model: `Qwen/Qwen3-30B-A3B-Thinking-2507`, lambda: `0.005`
- Rotation file: `rotations/qwen3-30b-thinking.pt`
- TP=2: add `--tensor-parallel-size 2`
- `--max-model-len 65536`, `--max-tokens 65000`

All benchmarks tested on NVIDIA H100 80GB.

## Duplicate check

```bash
gh pr list --repo vllm-project/vllm --state open --search "squat OR SQuat OR subspace quantiz"
# No existing PRs
```

## Test plan

- [x] Existing TurboQuant tests pass: `pytest tests/quantization/test_turboquant.py -v` (121/121 passed)
- [x] SQuat server starts with `--kv-cache-dtype squat` and serves requests
- [x] SQuat falls back gracefully when `SQUAT_ROTATION_PATH` is unset (behaves as TurboQuant)
- [x] Pre-commit hooks pass

AI assistance was used in developing and benchmarking this feature.
