### PR TITLE
[Rust Frontend] Forward request trace headers to the engine

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -190,6 +190,7 @@ impl ChatLlm {
             add_special_tokens: request.add_special_tokens,
             data_parallel_rank: request.data_parallel_rank,
             lora_request: request.lora_request,
+            trace_headers: request.trace_headers,
         };
         let decoded_stream = self.text.generate(text_request).await?.map_err(Error::from).boxed();
 

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use llm_multimodal::ImageDetail;
 use serde::{Deserialize, Serialize};
@@ -430,6 +430,10 @@ pub struct ChatRequest {
     /// LoRA adapter selected for this request.
     #[serde(default)]
     pub lora_request: Option<LoraRequest>,
+    /// W3C trace-context headers to forward to the engine for distributed
+    /// tracing. `Some` (possibly empty) when the engine has tracing enabled.
+    #[serde(default)]
+    pub trace_headers: Option<BTreeMap<String, String>>,
 }
 
 impl ChatRequest {
@@ -450,6 +454,7 @@ impl ChatRequest {
             add_special_tokens: false,
             data_parallel_rank: None,
             lora_request: None,
+            trace_headers: None,
         }
     }
 

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -390,6 +390,18 @@ impl EngineCoreClient {
             .as_str()
     }
 
+    /// Return whether OpenTelemetry tracing is enabled on the engine.
+    ///
+    /// The frontend forwards request trace headers only when this is true.
+    /// Engines that do not report the field are treated as tracing-disabled.
+    pub fn tracing_enabled(&self) -> bool {
+        self.engines
+            .first()
+            .expect("engine core client requires at least one engine")
+            .ready_response
+            .tracing_enabled
+    }
+
     /// Return the total number of GPU blocks summed across all connected
     /// engines.
     pub fn total_num_gpu_blocks(&self) -> u64 {

--- a/rust/src/engine-core-client/src/mock_engine.rs
+++ b/rust/src/engine-core-client/src/mock_engine.rs
@@ -49,6 +49,7 @@ pub fn default_ready_response() -> EngineCoreReadyResponse {
         dp_stats_address: None,
         dtype: ModelDtype::Float32,
         vllm_version: "test-vllm-version".to_string(),
+        tracing_enabled: false,
     }
 }
 

--- a/rust/src/engine-core-client/src/protocol/handshake.rs
+++ b/rust/src/engine-core-client/src/protocol/handshake.rs
@@ -42,6 +42,9 @@ pub struct EngineCoreReadyResponse {
     pub dtype: ModelDtype,
     /// Python vLLM version reported by the engine process.
     pub vllm_version: String,
+    /// Whether the engine has tracing enabled; gates trace-header forwarding.
+    #[serde(default)]
+    pub tracing_enabled: bool,
 }
 
 /// Frontend-owned ZMQ addresses that are sent to the engine during startup

--- a/rust/src/engine-core-client/src/test_utils.rs
+++ b/rust/src/engine-core-client/src/test_utils.rs
@@ -68,7 +68,19 @@ pub async fn setup_mock_engine_sockets(
     engine_handshake: String,
     engine_id: impl Into<EngineId>,
 ) -> MockEngineSockets {
-    connect_to_frontend(engine_handshake, engine_id, test_mock_engine_config())
+    setup_mock_engine_sockets_with_config(engine_handshake, engine_id, test_mock_engine_config())
+        .await
+}
+
+/// Like [`setup_mock_engine_sockets`], but advertises a custom
+/// [`MockEngineConfig`] during handshake (e.g. a different engine-ready
+/// response).
+async fn setup_mock_engine_sockets_with_config(
+    engine_handshake: String,
+    engine_id: impl Into<EngineId>,
+    config: MockEngineConfig,
+) -> MockEngineSockets {
+    connect_to_frontend(engine_handshake, engine_id, config)
         .await
         .expect("connect mock engine")
 }
@@ -107,16 +119,38 @@ pub async fn setup_mock_engine_with_init(
     (init, dealer, push)
 }
 
-/// Complete the engine-core handshake and connect mock input/output sockets.
+/// Spawn a mock engine task using a custom [`MockEngineConfig`], keeping its
+/// sockets alive until the returned shutdown sender is triggered.
 ///
-/// This returns the `DealerSocket` used to receive client requests and the
-/// `PushSocket` used to send engine outputs back to the client.
-pub async fn setup_mock_engine(
+/// Shared core behind the public spawn helpers; they differ only in the config
+/// they advertise during handshake.
+fn spawn_mock_engine_task_with_config<F>(
     engine_handshake: String,
     engine_id: impl Into<EngineId>,
-) -> (DealerSocket, PushSocket) {
-    let (_, dealer, push) = setup_mock_engine_with_init(engine_handshake, engine_id).await;
-    (dealer, push)
+    config: MockEngineConfig,
+    run: F,
+) -> (oneshot::Sender<()>, tokio::task::JoinHandle<()>)
+where
+    F: for<'a> FnOnce(
+            &'a mut DealerSocket,
+            &'a mut PushSocket,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>
+        + Send
+        + 'static,
+{
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let engine_id = engine_id.into();
+    let engine_task = tokio::spawn(async move {
+        let MockEngineSockets { data_sockets, .. } =
+            setup_mock_engine_sockets_with_config(engine_handshake, engine_id, config).await;
+        let MockEngineDataSockets {
+            mut dealer,
+            mut push,
+        } = data_sockets.into_iter().next().expect("mock engine data socket");
+        run(&mut dealer, &mut push).await;
+        let _ = shutdown_rx.await;
+    });
+    (shutdown_tx, engine_task)
 }
 
 /// Spawn a mock engine task and keep its sockets alive until the returned
@@ -138,12 +172,26 @@ where
         + Send
         + 'static,
 {
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let engine_id = engine_id.into();
-    let engine_task = tokio::spawn(async move {
-        let (mut dealer, mut push) = setup_mock_engine(engine_handshake, engine_id).await;
-        run(&mut dealer, &mut push).await;
-        let _ = shutdown_rx.await;
-    });
-    (shutdown_tx, engine_task)
+    spawn_mock_engine_task_with_config(engine_handshake, engine_id, test_mock_engine_config(), run)
+}
+
+/// Like [`spawn_mock_engine_task`], but lets the test choose whether the engine
+/// advertises OpenTelemetry tracing as enabled in its handshake ready response.
+pub fn spawn_mock_engine_task_with_tracing<F>(
+    engine_handshake: String,
+    engine_id: impl Into<EngineId>,
+    tracing_enabled: bool,
+    run: F,
+) -> (oneshot::Sender<()>, tokio::task::JoinHandle<()>)
+where
+    F: for<'a> FnOnce(
+            &'a mut DealerSocket,
+            &'a mut PushSocket,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>
+        + Send
+        + 'static,
+{
+    let mut config = test_mock_engine_config();
+    config.ready_response.tracing_enabled = tracing_enabled;
+    spawn_mock_engine_task_with_config(engine_handshake, engine_id, config, run)
 }

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -92,6 +92,10 @@ pub fn to_text_request(
         add_special_tokens: true,
         data_parallel_rank: None,
         lora_request: None,
+        // TODO: forward distributed-tracing context from gRPC request metadata
+        // once the gRPC path supports tracing (HTTP routes forward W3C trace
+        // headers via `resolve_request_context`).
+        trace_headers: None,
     })
 }
 

--- a/rust/src/server/src/routes/inference/generate.rs
+++ b/rust/src/server/src/routes/inference/generate.rs
@@ -41,7 +41,11 @@ pub async fn generate(
     headers: HeaderMap,
     ValidatedJson(body): ValidatedJson<GenerateRequest>,
 ) -> Response {
-    let request_context = resolve_request_context(&headers, body.request_id.as_deref());
+    let request_context = resolve_request_context(
+        &headers,
+        body.request_id.as_deref(),
+        state.engine_core_client().tracing_enabled(),
+    );
     let lora_resolution = state.resolve_model_with_loras(body.model.as_deref()).await;
     let prepared = match prepare_generate_request(body, &lora_resolution, request_context) {
         Ok(prepared) => prepared,

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -59,6 +59,7 @@ pub fn prepare_generate_request(
         add_special_tokens: false,
         data_parallel_rank: ctx.data_parallel_rank,
         lora_request: lora_resolution.lora_request.clone(),
+        trace_headers: ctx.trace_headers,
     };
 
     Ok(PreparedRequest {

--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -48,7 +48,11 @@ pub async fn chat_completions(
     ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
 ) -> Response {
     let stream = body.stream;
-    let request_context = resolve_request_context(&headers, body.request_id.as_deref());
+    let request_context = resolve_request_context(
+        &headers,
+        body.request_id.as_deref(),
+        state.engine_core_client().tracing_enabled(),
+    );
     let lora_resolution = state.resolve_model_with_loras(Some(&body.model)).await;
 
     let prepared = match prepare_chat_request(body, &lora_resolution, request_context) {

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -138,6 +138,7 @@ pub(crate) fn prepare_chat_request(
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
         lora_request: lora_resolution.lora_request.clone(),
+        trace_headers: ctx.trace_headers,
     };
 
     Ok(PreparedRequest {
@@ -370,7 +371,7 @@ mod tests {
     use crate::utils::{ResolvedRequestContext, resolve_request_context};
 
     fn request_context(headers: &HeaderMap, request_id: Option<&str>) -> ResolvedRequestContext {
-        resolve_request_context(headers, request_id)
+        resolve_request_context(headers, request_id, false)
     }
 
     fn served(names: &[&str]) -> LoraModelResolution {

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -43,7 +43,11 @@ pub async fn completions(
 ) -> Response {
     let stream = body.stream;
     let logprobs = body.logprobs;
-    let request_context = resolve_request_context(&headers, body.request_id.as_deref());
+    let request_context = resolve_request_context(
+        &headers,
+        body.request_id.as_deref(),
+        state.engine_core_client().tracing_enabled(),
+    );
     let lora_resolution = state.resolve_model_with_loras(Some(&body.model)).await;
 
     let prepared = match prepare_completion_request(body, &lora_resolution, request_context) {

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -111,6 +111,7 @@ pub(crate) fn prepare_completion_request(
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
         lora_request: lora_resolution.lora_request.clone(),
+        trace_headers: ctx.trace_headers,
     };
 
     Ok(PreparedRequest {
@@ -136,7 +137,7 @@ mod tests {
     use crate::utils::{ResolvedRequestContext, resolve_request_context};
 
     fn request_context(headers: &HeaderMap, request_id: Option<&str>) -> ResolvedRequestContext {
-        resolve_request_context(headers, request_id)
+        resolve_request_context(headers, request_id, false)
     }
 
     fn served(names: &[&str]) -> LoraModelResolution {

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -32,7 +32,9 @@ use vllm_engine_core_client::protocol::{
     EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, EngineCoreRequest, StopReason,
     decode_value,
 };
-use vllm_engine_core_client::test_utils::{IpcNamespace, spawn_mock_engine_task};
+use vllm_engine_core_client::test_utils::{
+    IpcNamespace, spawn_mock_engine_task, spawn_mock_engine_task_with_tracing,
+};
 use vllm_engine_core_client::{
     ENGINE_CORE_DEAD_SENTINEL, EngineCoreClient, EngineCoreClientConfig, EngineId,
 };
@@ -888,6 +890,7 @@ async fn test_app_with_backend_and_stream_output_specs(
 
 async fn test_app_with_backend_and_engine_request_check<F>(
     backend: Arc<dyn ChatTextBackend>,
+    tracing_enabled: bool,
     check_request: F,
 ) -> (axum::Router, MockEngineTask)
 where
@@ -897,9 +900,10 @@ where
     let handshake_address = ipc.handshake_endpoint();
     let engine_id = b"engine-openai-check-request".to_vec();
 
-    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task_with_tracing(
         handshake_address.clone(),
         engine_id.clone(),
+        tracing_enabled,
         move |dealer, push| {
             boxed_test_future(async move {
                 let add = recv_engine_message(dealer).await;
@@ -1647,6 +1651,7 @@ async fn non_stream_chat_image_url_reaches_engine_mm_features() {
         Arc::new(FakeChatBackend::with_multimodal_model_info(
             qwen_multimodal_model_info(),
         )),
+        false,
         |request| {
             let prompt_token_ids = request.prompt_token_ids.as_ref().expect("prompt token ids");
             assert!(prompt_token_ids.contains(&151655));
@@ -1704,6 +1709,101 @@ async fn non_stream_chat_image_url_reaches_engine_mm_features() {
 
     assert_eq!(json["object"], "chat.completion");
     assert_eq!(json["choices"][0]["message"]["content"], "hi");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn trace_headers_forwarded_to_engine_when_tracing_enabled() {
+    let (app, engine_task) = test_app_with_backend_and_engine_request_check(
+        Arc::new(FakeChatBackend::new()),
+        true,
+        |request| {
+            let trace_headers = request.trace_headers.as_ref().expect("trace headers forwarded");
+            assert_eq!(
+                trace_headers.get("traceparent").map(String::as_str),
+                Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            );
+            assert_eq!(
+                trace_headers.get("tracestate").map(String::as_str),
+                Some("rojo=00f067aa0ba902b7"),
+            );
+            assert_eq!(trace_headers.len(), 2);
+        },
+    )
+    .await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                )
+                .header("tracestate", "rojo=00f067aa0ba902b7")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hi"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn trace_headers_suppressed_when_tracing_disabled() {
+    let (app, engine_task) = test_app_with_backend_and_engine_request_check(
+        Arc::new(FakeChatBackend::new()),
+        false,
+        |request| {
+            assert!(
+                request.trace_headers.is_none(),
+                "trace headers must not be forwarded when tracing is disabled",
+            );
+        },
+    )
+    .await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header(
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                )
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hi"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -1,17 +1,24 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Once;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::http::HeaderMap;
 use serde_json::Value;
 use thiserror_ext::AsReport;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::error::ApiError;
+
+const TRACE_HEADERS: [&str; 2] = ["traceparent", "tracestate"];
+
+static TRACING_DISABLED_WARNING: Once = Once::new();
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ResolvedRequestContext {
     pub request_id: String,
     pub data_parallel_rank: Option<u32>,
+    pub trace_headers: Option<BTreeMap<String, String>>,
 }
 
 /// Return the current Unix timestamp in seconds for OpenAI response objects.
@@ -70,11 +77,48 @@ pub fn convert_logit_bias(
         .transpose()
 }
 
-/// Extract common request metadata from HTTP headers: the external request ID
-/// and the optional data-parallel rank used for engine routing.
+fn contains_trace_headers(headers: &HeaderMap) -> bool {
+    TRACE_HEADERS.iter().any(|name| headers.contains_key(*name))
+}
+
+/// Extract the W3C trace-context headers (`traceparent`/`tracestate`) into a
+/// lowercase-keyed map. Mirrors Python `vllm.tracing.utils.extract_trace_headers`.
+fn extract_trace_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    TRACE_HEADERS
+        .iter()
+        .filter_map(|name| {
+            headers
+                .get(*name)
+                .and_then(|value| value.to_str().ok())
+                .map(|value| ((*name).to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+/// Resolve the trace headers to forward to the engine, gated on whether the
+/// engine has tracing enabled. Mirrors Python `_get_trace_headers`.
+fn resolve_trace_headers(
+    headers: &HeaderMap,
+    tracing_enabled: bool,
+) -> Option<BTreeMap<String, String>> {
+    if tracing_enabled {
+        return Some(extract_trace_headers(headers));
+    }
+    if contains_trace_headers(headers) {
+        TRACING_DISABLED_WARNING.call_once(|| {
+            warn!("Received a request with trace context but tracing is disabled");
+        });
+    }
+    None
+}
+
+/// Extract common request metadata from HTTP headers: the external request ID,
+/// the optional data-parallel rank used for engine routing, and the trace
+/// headers to forward to the engine when tracing is enabled.
 pub fn resolve_request_context(
     headers: &HeaderMap,
     request_id: Option<&str>,
+    tracing_enabled: bool,
 ) -> ResolvedRequestContext {
     // `None` when the header is absent or cannot be parsed as a `u32`.
     let data_parallel_rank = headers
@@ -86,9 +130,12 @@ pub fn resolve_request_context(
     let request_id_header = headers.get("X-Request-Id").and_then(|value| value.to_str().ok());
     let request_id = resolve_base_request_id(request_id_header, request_id);
 
+    let trace_headers = resolve_trace_headers(headers, tracing_enabled);
+
     ResolvedRequestContext {
         request_id,
         data_parallel_rank,
+        trace_headers,
     }
 }
 
@@ -103,4 +150,67 @@ pub fn resolve_base_request_id(
         id.truncate(8);
         id
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+
+    use super::*;
+
+    fn headers_from(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (name, value) in pairs {
+            headers.insert(
+                HeaderName::from_bytes(name.as_bytes()).expect("valid header name"),
+                HeaderValue::from_str(value).expect("valid header value"),
+            );
+        }
+        headers
+    }
+
+    #[test]
+    fn forwards_w3c_trace_headers_when_tracing_enabled() {
+        let headers = headers_from(&[("traceparent", "abc"), ("tracestate", "k=v")]);
+        let ctx = resolve_request_context(&headers, Some("req"), true);
+        let trace = ctx.trace_headers.expect("trace headers forwarded");
+        assert_eq!(trace.get("traceparent").map(String::as_str), Some("abc"));
+        assert_eq!(trace.get("tracestate").map(String::as_str), Some("k=v"));
+        assert_eq!(trace.len(), 2);
+    }
+
+    #[test]
+    fn forwards_empty_map_when_enabled_without_trace_headers() {
+        let ctx = resolve_request_context(&HeaderMap::new(), Some("req"), true);
+        let trace = ctx.trace_headers.expect("Some empty map mirrors Python");
+        assert!(trace.is_empty());
+    }
+
+    #[test]
+    fn forwards_only_w3c_trace_headers() {
+        let headers = headers_from(&[
+            ("traceparent", "abc"),
+            ("x-request-id", "not-forwarded"),
+            ("baggage", "not-forwarded"),
+        ]);
+        let ctx = resolve_request_context(&headers, Some("req"), true);
+        let trace = ctx.trace_headers.expect("trace headers forwarded");
+        assert_eq!(trace.len(), 1);
+        assert_eq!(trace.get("traceparent").map(String::as_str), Some("abc"));
+    }
+
+    #[test]
+    fn normalizes_trace_header_names_to_lowercase() {
+        let headers = headers_from(&[("TraceParent", "abc")]);
+        let ctx = resolve_request_context(&headers, Some("req"), true);
+        let trace = ctx.trace_headers.expect("trace headers forwarded");
+        assert_eq!(trace.get("traceparent").map(String::as_str), Some("abc"));
+    }
+
+    #[test]
+    fn suppresses_trace_headers_when_tracing_disabled() {
+        let headers = headers_from(&[("traceparent", "abc")]);
+        let ctx = resolve_request_context(&headers, Some("req"), false);
+        assert!(ctx.trace_headers.is_none());
+    }
 }

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -41,9 +41,9 @@ pub fn lower_text_request(
         priority: request.priority,
         data_parallel_rank: request.data_parallel_rank,
         lora_request: request.lora_request.clone(),
+        trace_headers: request.trace_headers.clone(),
         // Fields below are currently placeholders.
         arrival_time: None,
-        trace_headers: None,
         reasoning_ended: None,
     };
 

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
@@ -170,6 +170,10 @@ pub struct TextRequest {
     /// LoRA adapter selected for this request.
     #[serde(default)]
     pub lora_request: Option<LoraRequest>,
+    /// W3C trace-context headers to forward to the engine for distributed
+    /// tracing. `Some` (possibly empty) when the engine has tracing enabled.
+    #[serde(default)]
+    pub trace_headers: Option<BTreeMap<String, String>>,
 }
 
 impl TextRequest {
@@ -187,6 +191,7 @@ impl TextRequest {
             add_special_tokens: false,
             data_parallel_rank: None,
             lora_request: None,
+            trace_headers: None,
         }
     }
 

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -255,6 +255,7 @@ def test_apply_ready_response_syncs_block_size():
             dp_stats_address=None,
             dtype="bfloat16",
             vllm_version="test",
+            tracing_enabled=False,
         )
     )
     client._apply_ready_response(payload)

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -78,6 +78,7 @@ class EngineCoreReadyResponse:
     dp_stats_address: str | None
     dtype: str
     vllm_version: str
+    tracing_enabled: bool
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1468,6 +1468,10 @@ class EngineCoreProc(EngineCore):
                 dp_stats_address=self.frontend_stats_publish_address,
                 dtype=str(self.vllm_config.model_config.dtype).removeprefix("torch."),
                 vllm_version=VLLM_VERSION,
+                tracing_enabled=(
+                    self.vllm_config.observability_config.otlp_traces_endpoint
+                    is not None
+                ),
             )
             ready_payload = msgspec.msgpack.encode(ready_response)
             for input_socket in input_sockets:


### PR DESCRIPTION
  ### Summary

  - Part of the feature-parity roadmap (#44280).
  - Mirrors the Python flow: `_get_trace_headers` -> `is_tracing_enabled()` -> `vllm.tracing.utils` -> `EngineCoreRequest.trace_headers`.
- Python only forwards headers when tracing is enabled, but the Rust frontend is out-of-process and can't read that config. So the engine now reports `tracing_enabled` in its handshake, and the frontend gates on it: forward when enabled, otherwise drop and warn once.

### Test Plan

- Rust gates (workspace, `--all-features --locked`): `cargo fmt --check`, `cargo sort --check`, `cargo clippy ... -D warnings`, `cargo nextest run`.
- New unit tests covering the extraction/gate decision matrix (enabled/disabled, allowlist, lowercase normalization).
- New end-to-end route tests asserting the engine actually receives `trace_headers` when tracing is enabled and `None` when disabled.

### Notes

- Backward compatible: the new handshake field is optional (`#[serde(default)]`) and the engine always emits it; engines that omit it are treated as tracing-disabled.
- gRPC out of scope: trace context propagates via gRPC metadata rather than HTTP headers, so the gRPC request path is left as a documented `TODO` and not wired up here.