### PR TITLE
Preserve layout-changing clones

### DIFF
--- a/tests/compile/passes/ir/test_clone_cleanup.py
+++ b/tests/compile/passes/ir/test_clone_cleanup.py
@@ -132,6 +132,25 @@ class TestCloneCleanup:
         assert count_clones(graph_module.graph) == 0
         torch.testing.assert_close(actual, expected)
 
+    def test_keep_clone_that_changes_layout(self, clone_cleanup_pass):
+        """Clone must be kept when it materializes a compact slice layout."""
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            return x[:, :3].contiguous()
+
+        inp = torch.randn(4, 5)
+        graph_module = make_fx(f)(inp)
+        assert count_clones(graph_module.graph) == 1
+
+        expected = graph_module(inp)
+        clone_cleanup_pass(graph_module.graph)
+        graph_module.recompile()
+        actual = graph_module(inp)
+
+        assert count_clones(graph_module.graph) == 1
+        assert actual.stride() == expected.stride() == (3, 1)
+        torch.testing.assert_close(actual, expected)
+
     def test_multiple_clones_of_same_input(self, clone_cleanup_pass):
         """Test multiple independent clones of the same input."""
 

--- a/vllm/compilation/passes/ir/clone_elimination.py
+++ b/vllm/compilation/passes/ir/clone_elimination.py
@@ -16,6 +16,26 @@ from ..vllm_inductor_pass import VllmInductorPass
 logger = init_logger(__name__)
 
 
+def clone_preserves_layout(node: fx.Node, original_node: fx.Node) -> bool:
+    node_val = node.meta.get("val")
+    original_val = original_node.meta.get("val")
+    if node_val is None or original_val is None:
+        return True
+
+    try:
+        node_stride = tuple(node_val.stride())
+        original_stride = tuple(original_val.stride())
+        node_storage_offset = node_val.storage_offset()
+        original_storage_offset = original_val.storage_offset()
+    except (AttributeError, RuntimeError):
+        return True
+
+    return (
+        node_stride == original_stride
+        and node_storage_offset == original_storage_offset
+    )
+
+
 def user_writes_to_node(user: fx.Node, node: fx.Node) -> bool:
     if user.op == "output":
         return False
@@ -78,6 +98,15 @@ class UnsafeCloneEliminationPass(VllmInductorPass):
 
             original_node = node.args[0]
             assert isinstance(original_node, fx.Node)
+
+            if not clone_preserves_layout(node, original_node):
+                logger.debug(
+                    "Clone removal not possible, clone changes layout: "
+                    "original_node=%s node=%s",
+                    original_node,
+                    node,
+                )
+                continue
 
             # Clone needs to be preserved if node is getting written to and
             # the old value is used again.


### PR DESCRIPTION


  ## Purpose

  Preserve layout-changing `aten.clone` operations in the unsafe Inductor clone-
  elimination pass.

  The pass should still eliminate redundant clones, but it must not remove
  clones that materialize a different stride or storage offset from the input.
  This fixes the Mamba padded/sliced output case where `.contiguous()` is
  required to produce the compact layout expected by downstream custom ops.

  ## Test Plan

  Validated on Ampere with Nemotron Super NVFP4 `vllm_serve_sanity`.

  Representative `vllm serve` invocation shape used by the sanity path:

  ```bash
  vllm serve <NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4> \
    --tokenizer <NVIDIA-Nemotron-3-Super-120B-A12B-BF16> \
    --served-model-name nemo3super-nvfp4-sanity \
    --tensor-parallel-size 8 \
    --kv-cache-dtype fp8 \
    --trust-remote-code \
    --max-model-len 262144 \
    --max-num-batched-tokens 2560 \
    --max-num-seqs 1 \
    --gpu-memory-utilization 0.85 \
    --dtype auto \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --mamba-ssm-cache-dtype float32 \
    --moe-backend marlin \
    --disable-custom-all-reduce

  Additional MTP sanity was also run for Super.

  ## Test Result

  Ampere Super validation passed on the clone-layout-guard image:

  - Base Super: Slurm job 10035614, COMPLETED 0:0
      - capital_japan: Tokyo
      - math: 42

  - Super + MTP: Slurm job 10035615, COMPLETED 0:0
      - capital_japan: Tokyo
      - math: 42

  No documentation update is required; this is an internal compiler pass
  correctness fix.

  ———
  <details>
  <summary> Essential Elements of an Effective PR Description Checklist </
  summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues
    this PR will resolve)".

  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and
    after, or e2e results

  - [x] (Optional) The necessary documentation update, such as updating
    supported_models.md and examples for a new model.
  </details>
