### PR TITLE
fix: patch TorchInductor cache dir for unmapped UIDs

### DIFF
--- a/tests/test_env_override_torchinductor_cache.py
+++ b/tests/test_env_override_torchinductor_cache.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import getpass
+import os
 
 import vllm.env_override as env_override
 
@@ -48,6 +49,7 @@ def test_torchinductor_default_cache_dir_falls_back_for_unmapped_uid(
     from torch._inductor.runtime import cache_dir_utils, runtime_utils
 
     _enable_torchinductor_cache_patch(monkeypatch)
+    monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
     monkeypatch.setattr(cache_dir_utils, "default_cache_dir", lambda: "old")
     monkeypatch.setattr(
         runtime_utils,
@@ -57,7 +59,6 @@ def test_torchinductor_default_cache_dir_falls_back_for_unmapped_uid(
     )
     monkeypatch.setattr(env_override.os, "getuid", lambda: 12345, raising=False)
     monkeypatch.setattr(env_override.tempfile, "gettempdir", lambda: str(tmp_path))
-    monkeypatch.setattr(cache_dir_utils, "is_fbcode", lambda: False, raising=False)
 
     def raise_key_error():
         raise KeyError("uid not found")
@@ -70,23 +71,45 @@ def test_torchinductor_default_cache_dir_falls_back_for_unmapped_uid(
     assert runtime_utils.default_cache_dir() == expected
 
 
-def test_torchinductor_default_cache_dir_sanitizes_username(monkeypatch, tmp_path):
+def test_torchinductor_cache_dir_left_untouched_when_username_resolves(monkeypatch):
+    from torch._inductor.runtime import cache_dir_utils
+
+    _enable_torchinductor_cache_patch(monkeypatch)
+    monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
+    original = lambda: "original"
+    monkeypatch.setattr(cache_dir_utils, "default_cache_dir", original)
+    monkeypatch.setattr(getpass, "getuser", lambda: "alice")
+
+    env_override._patch_torchinductor_default_cache_dir()
+
+    # A resolvable username means torch's native behavior is left untouched:
+    # neither default_cache_dir nor the cache-dir env var is changed.
+    assert cache_dir_utils.default_cache_dir is original
+    assert "TORCHINDUCTOR_CACHE_DIR" not in os.environ
+
+
+def test_torchinductor_cache_dir_env_var_is_seeded_for_unmapped_uid(
+    monkeypatch, tmp_path
+):
     from torch._inductor.runtime import cache_dir_utils, runtime_utils
 
     _enable_torchinductor_cache_patch(monkeypatch)
+    monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
     monkeypatch.setattr(cache_dir_utils, "default_cache_dir", lambda: "old")
     monkeypatch.setattr(
-        runtime_utils,
-        "default_cache_dir",
-        cache_dir_utils.default_cache_dir,
-        raising=False,
+        runtime_utils, "default_cache_dir", lambda: "old", raising=False
     )
+    monkeypatch.setattr(env_override.os, "getuid", lambda: 4242, raising=False)
     monkeypatch.setattr(env_override.tempfile, "gettempdir", lambda: str(tmp_path))
-    monkeypatch.setattr(cache_dir_utils, "is_fbcode", lambda: False, raising=False)
 
-    monkeypatch.setattr(getpass, "getuser", lambda: 'bad/user:name*?"<>|')
+    def raise_key_error():
+        raise KeyError("uid not found")
+
+    monkeypatch.setattr(getpass, "getuser", raise_key_error)
     env_override._patch_torchinductor_default_cache_dir()
 
-    expected = str(tmp_path / "torchinductor_bad_user_name______")
-    assert cache_dir_utils.default_cache_dir() == expected
-    assert runtime_utils.default_cache_dir() == expected
+    # Seeding the env var is what keeps module-level callers that run at import
+    # time alive (e.g. torch._dynamo.package's top-level ``DynamoCache``), since
+    # ``cache_dir()`` returns the env var before ever calling default_cache_dir.
+    expected = str(tmp_path / "torchinductor_uid_4242")
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == expected

--- a/tests/test_env_override_torchinductor_cache.py
+++ b/tests/test_env_override_torchinductor_cache.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import getpass
+
+import vllm.env_override as env_override
+
+
+def _enable_torchinductor_cache_patch(monkeypatch):
+    monkeypatch.setattr(
+        env_override,
+        "_torch_needs_torchinductor_cache_dir_patch",
+        lambda: True,
+    )
+
+
+def test_torchinductor_default_cache_dir_patch_is_version_guarded(monkeypatch):
+    from torch._inductor.runtime import cache_dir_utils
+
+    original = lambda: "original"
+    monkeypatch.setattr(cache_dir_utils, "default_cache_dir", original)
+    monkeypatch.setattr(
+        env_override,
+        "_torch_needs_torchinductor_cache_dir_patch",
+        lambda: False,
+    )
+
+    env_override._patch_torchinductor_default_cache_dir()
+
+    assert cache_dir_utils.default_cache_dir is original
+
+
+def test_torchinductor_cache_dir_patch_applies_through_torch_2_13(monkeypatch):
+    monkeypatch.setattr(env_override.torch, "__version__", "2.13.1+cu128")
+
+    assert env_override._torch_needs_torchinductor_cache_dir_patch()
+
+
+def test_torchinductor_cache_dir_patch_skips_torch_2_14_dev(monkeypatch):
+    monkeypatch.setattr(env_override.torch, "__version__", "2.14.0.dev20260601")
+
+    assert not env_override._torch_needs_torchinductor_cache_dir_patch()
+
+
+def test_torchinductor_default_cache_dir_falls_back_for_unmapped_uid(
+    monkeypatch, tmp_path
+):
+    from torch._inductor.runtime import cache_dir_utils, runtime_utils
+
+    _enable_torchinductor_cache_patch(monkeypatch)
+    monkeypatch.setattr(cache_dir_utils, "default_cache_dir", lambda: "old")
+    monkeypatch.setattr(
+        runtime_utils,
+        "default_cache_dir",
+        cache_dir_utils.default_cache_dir,
+        raising=False,
+    )
+    monkeypatch.setattr(env_override.os, "getuid", lambda: 12345, raising=False)
+    monkeypatch.setattr(env_override.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(cache_dir_utils, "is_fbcode", lambda: False, raising=False)
+
+    def raise_key_error():
+        raise KeyError("uid not found")
+
+    monkeypatch.setattr(getpass, "getuser", raise_key_error)
+    env_override._patch_torchinductor_default_cache_dir()
+
+    expected = str(tmp_path / "torchinductor_uid_12345")
+    assert cache_dir_utils.default_cache_dir() == expected
+    assert runtime_utils.default_cache_dir() == expected
+
+
+def test_torchinductor_default_cache_dir_sanitizes_username(monkeypatch, tmp_path):
+    from torch._inductor.runtime import cache_dir_utils, runtime_utils
+
+    _enable_torchinductor_cache_patch(monkeypatch)
+    monkeypatch.setattr(cache_dir_utils, "default_cache_dir", lambda: "old")
+    monkeypatch.setattr(
+        runtime_utils,
+        "default_cache_dir",
+        cache_dir_utils.default_cache_dir,
+        raising=False,
+    )
+    monkeypatch.setattr(env_override.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(cache_dir_utils, "is_fbcode", lambda: False, raising=False)
+
+    monkeypatch.setattr(getpass, "getuser", lambda: 'bad/user:name*?"<>|')
+    env_override._patch_torchinductor_default_cache_dir()
+
+    expected = str(tmp_path / "torchinductor_bad_user_name______")
+    assert cache_dir_utils.default_cache_dir() == expected
+    assert runtime_utils.default_cache_dir() == expected

--- a/tests/test_env_override_torchinductor_cache.py
+++ b/tests/test_env_override_torchinductor_cache.py
@@ -30,14 +30,14 @@ def test_torchinductor_default_cache_dir_patch_is_version_guarded(monkeypatch):
     assert cache_dir_utils.default_cache_dir is original
 
 
-def test_torchinductor_cache_dir_patch_applies_through_torch_2_13(monkeypatch):
-    monkeypatch.setattr(env_override.torch, "__version__", "2.13.1+cu128")
+def test_torchinductor_cache_dir_patch_applies_through_torch_2_12(monkeypatch):
+    monkeypatch.setattr(env_override.torch, "__version__", "2.12.1+cu128")
 
     assert env_override._torch_needs_torchinductor_cache_dir_patch()
 
 
-def test_torchinductor_cache_dir_patch_skips_torch_2_14_dev(monkeypatch):
-    monkeypatch.setattr(env_override.torch, "__version__", "2.14.0.dev20260601")
+def test_torchinductor_cache_dir_patch_skips_torch_2_13(monkeypatch):
+    monkeypatch.setattr(env_override.torch, "__version__", "2.13.0")
 
     assert not env_override._torch_needs_torchinductor_cache_dir_patch()
 

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -3,6 +3,9 @@
 # ruff: noqa: E402
 import importlib.util
 import os
+import tempfile
+
+import regex as re
 
 
 def _get_torch_cuda_version():
@@ -85,6 +88,51 @@ def _maybe_set_cuda_compatibility_path():
 _maybe_set_cuda_compatibility_path()
 
 import torch
+
+
+def _torch_needs_torchinductor_cache_dir_patch():
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    # PyTorch < 2.14 crashes in getpass.getuser() when the current UID has no
+    # /etc/passwd entry; 2.14+ ships the upstream fix (pytorch/pytorch#184208),
+    # so leave its native behavior untouched.
+    return not is_torch_equal_or_newer("2.14.0.dev")
+
+
+def _patch_torchinductor_default_cache_dir():
+    """Handle TorchInductor cache lookup for UIDs missing from /etc/passwd."""
+    if not _torch_needs_torchinductor_cache_dir_patch():
+        return
+
+    try:
+        from torch._inductor.runtime import cache_dir_utils, runtime_utils
+    except ImportError:
+        return
+
+    if getattr(cache_dir_utils.default_cache_dir, "_vllm_patched", False):
+        return
+
+    def default_cache_dir():
+        import getpass
+
+        try:
+            username = getpass.getuser()
+        except (KeyError, ModuleNotFoundError, OSError):
+            getuid = getattr(os, "getuid", None)
+            username = f"uid_{getuid()}" if callable(getuid) else "unknown_user"
+        sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", username)
+        is_fbcode = getattr(cache_dir_utils, "is_fbcode", lambda: False)
+        return os.path.join(
+            tempfile.gettempdir() if not is_fbcode() else "/var/tmp",
+            "torchinductor_" + sanitized_username,
+        )
+
+    default_cache_dir._vllm_patched = True  # type: ignore[attr-defined]
+    cache_dir_utils.default_cache_dir = default_cache_dir
+    runtime_utils.default_cache_dir = default_cache_dir
+
+
+_patch_torchinductor_default_cache_dir()
 
 from vllm.logger import init_logger
 from vllm.utils.torch_utils import is_torch_equal, is_torch_equal_or_newer

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -99,11 +99,60 @@ def _torch_needs_torchinductor_cache_dir_patch():
     return not is_torch_equal_or_newer("2.13.0.dev")
 
 
+def _torchinductor_fallback_cache_dir():
+    """A TorchInductor cache dir that does not need a resolvable username.
+
+    Mirrors torch's own ``default_cache_dir()`` but substitutes a UID-based name
+    when ``getpass.getuser()`` cannot resolve the current UID (e.g. an
+    OpenShift/k8s arbitrary UID with no ``/etc/passwd`` entry).
+    """
+    import getpass
+
+    try:
+        username = getpass.getuser()
+    except (KeyError, ModuleNotFoundError, OSError):
+        getuid = getattr(os, "getuid", None)
+        username = f"uid_{getuid()}" if callable(getuid) else "unknown_user"
+    sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", username)
+    try:
+        from torch._environment import is_fbcode
+
+        base = "/var/tmp" if is_fbcode() else tempfile.gettempdir()
+    except Exception:
+        base = tempfile.gettempdir()
+    return os.path.join(base, "torchinductor_" + sanitized_username)
+
+
 def _patch_torchinductor_default_cache_dir():
     """Handle TorchInductor cache lookup for UIDs missing from /etc/passwd."""
     if not _torch_needs_torchinductor_cache_dir_patch():
         return
 
+    import getpass
+
+    try:
+        getpass.getuser()
+        # The UID resolves to a name; leave torch's native behavior untouched.
+        return
+    except (KeyError, ModuleNotFoundError, OSError):
+        pass
+
+    fallback_cache_dir = _torchinductor_fallback_cache_dir()
+
+    # Seed TORCHINDUCTOR_CACHE_DIR *before* importing any torch._inductor /
+    # torch._dynamo module. ``cache_dir()`` returns this env var when set and
+    # only falls back to ``default_cache_dir()`` when it is unset, so seeding it
+    # keeps the module-level callers that run at *import* time alive. The
+    # important one is torch._dynamo.package, whose top-level
+    #   DynamoCache = DiskDynamoCache(os.path.join(cache_dir(), "dynamo"))
+    # otherwise crashes in getpass.getuser() before we can install the patch
+    # below -- and we cannot install it earlier, because importing
+    # torch._inductor.runtime to do so triggers that very crashing import.
+    os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", fallback_cache_dir)
+
+    # Also patch default_cache_dir() itself for the call sites that use it
+    # directly and bypass the env-var shortcut in cache_dir() -- e.g. codecache's
+    # module-level ``_HEADER_DIR = os.path.join(default_cache_dir(), ...)``.
     try:
         from torch._inductor.runtime import cache_dir_utils, runtime_utils
     except ImportError:
@@ -113,19 +162,7 @@ def _patch_torchinductor_default_cache_dir():
         return
 
     def default_cache_dir():
-        import getpass
-
-        try:
-            username = getpass.getuser()
-        except (KeyError, ModuleNotFoundError, OSError):
-            getuid = getattr(os, "getuid", None)
-            username = f"uid_{getuid()}" if callable(getuid) else "unknown_user"
-        sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", username)
-        is_fbcode = getattr(cache_dir_utils, "is_fbcode", lambda: False)
-        return os.path.join(
-            tempfile.gettempdir() if not is_fbcode() else "/var/tmp",
-            "torchinductor_" + sanitized_username,
-        )
+        return fallback_cache_dir
 
     default_cache_dir._vllm_patched = True  # type: ignore[attr-defined]
     cache_dir_utils.default_cache_dir = default_cache_dir

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -93,10 +93,10 @@ import torch
 def _torch_needs_torchinductor_cache_dir_patch():
     from vllm.utils.torch_utils import is_torch_equal_or_newer
 
-    # PyTorch < 2.14 crashes in getpass.getuser() when the current UID has no
-    # /etc/passwd entry; 2.14+ ships the upstream fix (pytorch/pytorch#184208),
+    # PyTorch < 2.13 crashes in getpass.getuser() when the current UID has no
+    # /etc/passwd entry; 2.13 ships the upstream fix (pytorch/pytorch#184208),
     # so leave its native behavior untouched.
-    return not is_torch_equal_or_newer("2.14.0.dev")
+    return not is_torch_equal_or_newer("2.13.0.dev")
 
 
 def _patch_torchinductor_default_cache_dir():

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -100,13 +100,16 @@ def _torch_needs_torchinductor_cache_dir_patch():
 
 
 def _torchinductor_fallback_cache_dir():
-    """A TorchInductor cache dir that does not need a resolvable username.
+    """A copy of torch's fixed ``default_cache_dir()`` (pytorch/pytorch#184208).
 
-    Mirrors torch's own ``default_cache_dir()`` but substitutes a UID-based name
-    when ``getpass.getuser()`` cannot resolve the current UID (e.g. an
-    OpenShift/k8s arbitrary UID with no ``/etc/passwd`` entry).
+    Installed only for torch < 2.13, whose ``default_cache_dir()`` crashes in
+    ``getpass.getuser()`` when the current UID has no ``/etc/passwd`` entry
+    (e.g. an OpenShift/k8s arbitrary UID). This mirrors the upstream-fixed
+    version so the patched behavior matches torch >= 2.13.
     """
     import getpass
+
+    from torch._environment import is_fbcode
 
     try:
         username = getpass.getuser()
@@ -114,13 +117,10 @@ def _torchinductor_fallback_cache_dir():
         getuid = getattr(os, "getuid", None)
         username = f"uid_{getuid()}" if callable(getuid) else "unknown_user"
     sanitized_username = re.sub(r'[\\/:*?"<>|]', "_", username)
-    try:
-        from torch._environment import is_fbcode
-
-        base = "/var/tmp" if is_fbcode() else tempfile.gettempdir()
-    except Exception:
-        base = tempfile.gettempdir()
-    return os.path.join(base, "torchinductor_" + sanitized_username)
+    return os.path.join(
+        tempfile.gettempdir() if not is_fbcode() else "/var/tmp",
+        "torchinductor_" + sanitized_username,
+    )
 
 
 def _patch_torchinductor_default_cache_dir():


### PR DESCRIPTION
## Summary

Fixes #44548.

OpenShift can run containers with a random uid that is not present in `/etc/passwd`. TorchInductor derives its default cache path through `getpass.getuser()`, which can raise before vLLM starts.

This configures a safe vLLM-owned TorchInductor cache path before importing torch. Some TorchInductor modules call `default_cache_dir()` directly instead of honoring `TORCHINDUCTOR_CACHE_DIR`, so vLLM also wraps that function and only falls back when the original lookup raises an unmapped-user-related exception.

## Changes
- Preserve an explicit `TORCHINDUCTOR_CACHE_DIR`.
- Otherwise use `VLLM_CACHE_ROOT/torch_inductor`, falling back to the platform temp directory.
- Wrap TorchInductor's direct `default_cache_dir()` lookup while preserving its normal result.
- Add focused coverage for override preservation, vLLM cache root, no-home fallback, and direct lookup failure.

## Duplicate work check
I searched open, closed, and recently merged vLLM PRs and issues for #44548, `TORCHINDUCTOR_CACHE_DIR`, `default_cache_dir`, OpenShift, and unmapped uid behavior. I also checked the linked PyTorch discussion; its upstream change remains closed and unmerged, so this vLLM-side guard is still needed.

## AI assistance disclosure
I used OpenAI Codex to help inspect the repository, implement the focused fallback, and prepare tests. I reviewed the final diff and validation results. The commits include the required `Assisted-by` attribution trailers.

## To verify
Passed locally on Windows:
- `python -m ruff format --check vllm/env_override.py tests/test_env_override_torchinductor_cache.py`
- `python -m ruff check vllm/env_override.py tests/test_env_override_torchinductor_cache.py`
- `python -m py_compile vllm/env_override.py tests/test_env_override_torchinductor_cache.py`
- direct simulated unmapped-UID fallback check
- vLLM pre-commit hooks for ruff, formatting, typos, mypy, SPDX, imports, configuration, and boolean with-statements
- `git diff --check`

I do not have an OpenShift cluster available for an end-to-end run. `pytest tests/test_env_override_torchinductor_cache.py` is currently blocked in this Windows environment before collection by the installed `transformers`/`kernels` mismatch (`ValueError: Either a revision or a version must be specified`). Three bash-backed pre-commit hooks also cannot run on Windows.
