### PR TITLE
[Refactor][Mistral] Extract non-streaming parser logic into MistralParser

### DIFF
--- a/tests/parser/test_mistral.py
+++ b/tests/parser/test_mistral.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.parser.mistral import MistralParser
+from vllm.reasoning.mistral_reasoning_parser import MistralReasoningParser
+from vllm.tokenizers import get_tokenizer
+from vllm.tool_parsers.mistral_tool_parser import MistralToolCall, MistralToolParser
+
+PLAIN_TEXT = "The weather in Dallas is sunny."
+
+# Pre-v11: content[TOOL_CALLS] [{"name": ..., "arguments": ...}]
+PRE_V11_MODEL_OUTPUT = (
+    "[THINK]let me think[/THINK]"
+    "Here is the result"
+    '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Dallas"}}]'
+)
+
+# v11+: content[TOOL_CALLS]name{args}
+V11_MODEL_OUTPUT = (
+    "[THINK]let me think[/THINK]"
+    "Here is the result"
+    '[TOOL_CALLS]get_weather{"city": "Dallas"}'
+)
+
+NAMED_TOOL_ARGS = '{"city": "Dallas"}'
+REQUIRED_TOOL_OUTPUT = (
+    '[{"name": "get_weather", "parameters": {"city": "Dallas"}},'
+    ' {"name": "get_time", "parameters": {"timezone": "UTC"}}]'
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_time",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+def make_request(grammar, **overrides):
+    base = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    req = ChatCompletionRequest.model_validate(base)
+    if grammar:
+        req._grammar_from_tool_parser = True
+    return req
+
+
+@pytest.fixture(scope="module")
+def pre_v11_tokenizer():
+    return get_tokenizer("mistralai/Mistral-7B-Instruct-v0.3")
+
+
+@pytest.fixture(scope="module")
+def v11_tokenizer():
+    return get_tokenizer(
+        "mistralai/Magistral-Small-2509",
+        tokenizer_mode="mistral",
+    )
+
+
+def make_parser(tokenizer, reasoning_parser):
+    class _Parser(MistralParser):
+        reasoning_parser_cls = MistralReasoningParser if reasoning_parser else None
+        tool_parser_cls = MistralToolParser
+
+    return _Parser(tokenizer)
+
+
+def assert_mistral_id(tool_call):
+    assert tool_call.id is not None
+    assert len(tool_call.id) == 9
+    assert tool_call.id.isalnum()
+
+
+class TestParse:
+    # -- Non-grammar path (pre-v11) --
+
+    def test_plain_text(self, pre_v11_tokenizer):
+        parser = make_parser(pre_v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=False)
+        reasoning, content, tool_calls = parser.parse(PLAIN_TEXT, request)
+
+        assert reasoning is None
+        assert content == PLAIN_TEXT
+        assert tool_calls is not None
+        assert len(tool_calls) == 0
+
+    def test_no_reasoning_parser_think_tags_in_content(self, pre_v11_tokenizer):
+        parser = make_parser(pre_v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=False, tools=TOOLS)
+        reasoning, content, tool_calls = parser.parse(
+            PRE_V11_MODEL_OUTPUT, request, enable_auto_tools=True
+        )
+
+        assert reasoning is None
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert_mistral_id(tool_calls[0])
+        # Without reasoning parser, [THINK] tags remain in content
+        assert content is not None
+        assert "[THINK]" in content
+
+    def test_with_reasoning_backfills_ids(self, v11_tokenizer):
+        parser = make_parser(v11_tokenizer, reasoning_parser=True)
+        request = make_request(grammar=False, tools=TOOLS)
+        reasoning, content, tool_calls = parser.parse(
+            V11_MODEL_OUTPUT, request, enable_auto_tools=True
+        )
+
+        assert reasoning == "let me think"
+        assert content is not None
+        assert "Here is the result" in content
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_weather"
+        assert_mistral_id(tool_calls[0])
+
+    def test_auto_tool_choice(self, pre_v11_tokenizer):
+        parser = make_parser(pre_v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=False, tools=TOOLS)
+        reasoning, content, tool_calls = parser.parse(
+            PRE_V11_MODEL_OUTPUT, request, enable_auto_tools=True
+        )
+
+        assert reasoning is None
+        assert content is not None
+        assert "[THINK]" in content
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_weather"
+        assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+        assert_mistral_id(tool_calls[0])
+
+    def test_named_tool_choice(self, pre_v11_tokenizer):
+        parser = make_parser(pre_v11_tokenizer, reasoning_parser=False)
+        request = make_request(
+            grammar=False,
+            tools=TOOLS,
+            tool_choice={
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        )
+        reasoning, content, tool_calls = parser.parse(
+            NAMED_TOOL_ARGS, request, enable_auto_tools=True
+        )
+
+        assert reasoning is None
+        assert content is None
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_weather"
+        assert tool_calls[0].arguments == NAMED_TOOL_ARGS
+        assert_mistral_id(tool_calls[0])
+
+    def test_required_tool_choice(self, pre_v11_tokenizer):
+        parser = make_parser(pre_v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=False, tools=TOOLS, tool_choice="required")
+        reasoning, content, tool_calls = parser.parse(
+            REQUIRED_TOOL_OUTPUT, request, enable_auto_tools=True
+        )
+
+        assert reasoning is None
+        assert content is None
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        assert tool_calls[0].name == "get_weather"
+        assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+        assert tool_calls[1].name == "get_time"
+        assert json.loads(tool_calls[1].arguments) == {"timezone": "UTC"}
+        for tc in tool_calls:
+            assert_mistral_id(tc)
+
+    # -- Grammar path (v11+) --
+
+    def test_grammar_tool_calls(self, v11_tokenizer):
+        parser = make_parser(v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=True, tools=TOOLS)
+        reasoning, content, tool_calls = parser.parse(V11_MODEL_OUTPUT, request)
+
+        assert reasoning is None
+        assert content is not None
+        assert "[THINK]" in content
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_weather"
+        assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+        assert MistralToolCall.is_valid_id(tool_calls[0].id)
+
+    def test_grammar_with_reasoning(self, v11_tokenizer):
+        parser = make_parser(v11_tokenizer, reasoning_parser=True)
+        request = make_request(grammar=True, tools=TOOLS)
+        reasoning, content, tool_calls = parser.parse(V11_MODEL_OUTPUT, request)
+
+        assert reasoning == "let me think"
+        assert content is not None
+        assert "Here is the result" in content
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_weather"
+        assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+
+    def test_grammar_no_tool_calls(self, v11_tokenizer):
+        parser = make_parser(v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=True)
+        reasoning, content, tool_calls = parser.parse(PLAIN_TEXT, request)
+
+        assert reasoning is None
+        assert content == PLAIN_TEXT
+        assert tool_calls is None
+
+    def test_grammar_content_with_tools(self, v11_tokenizer):
+        parser = make_parser(v11_tokenizer, reasoning_parser=False)
+        request = make_request(grammar=True, tools=TOOLS)
+        reasoning, content, tool_calls = parser.parse(V11_MODEL_OUTPUT, request)
+
+        assert reasoning is None
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        # Content before [TOOL_CALLS] is preserved (includes [THINK] tags
+        # since no reasoning parser is active).
+        assert content is not None
+        assert "[THINK]" in content
+        assert "Here is the result" in content

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -35,7 +35,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     ExtractedToolCallInformation,
     StructuralTagResponseFormat,
 )
-from vllm.entrypoints.openai.engine.protocol import FunctionCall as VllmFunctionCall
 from vllm.reasoning.mistral_reasoning_parser import MistralReasoningParser
 from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike, get_tokenizer
@@ -44,7 +43,6 @@ from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers.mistral_tool_parser import (
     _DEFAULT_JSON_SCHEMA,
     MistralStreamingResult,
-    MistralToolCall,
     MistralToolParser,
 )
 
@@ -1578,48 +1576,6 @@ def test_grammar_from_tool_parser_set_by_adjust_request(
     request = _make_request()
     result = mistral_tool_parser.adjust_request(request)
     assert result._grammar_from_tool_parser is True
-
-
-@pytest.mark.parametrize(
-    "tool_calls, expected_len",
-    [
-        (None, 0),
-        ([], 0),
-        ([VllmFunctionCall(id="abc123xyz", name="f", arguments="{}")], 1),
-        ([VllmFunctionCall(name="f", arguments="{}")], 1),
-        (
-            [
-                VllmFunctionCall(id="fixed1234", name="a", arguments='{"x": 1}'),
-                VllmFunctionCall(name="b", arguments='{"y": 2}'),
-            ],
-            2,
-        ),
-    ],
-    ids=["none", "empty", "with_id", "without_id", "mixed"],
-)
-def test_build_non_streaming_tool_calls(
-    tool_calls: list[VllmFunctionCall] | None,
-    expected_len: int,
-) -> None:
-    result = MistralToolParser.build_non_streaming_tool_calls(tool_calls)
-    assert len(result) == expected_len
-
-    if tool_calls is None:
-        return
-
-    for i, tc in enumerate(result):
-        assert isinstance(tc, MistralToolCall)
-        assert tc.type == "function"
-
-        input_tc = tool_calls[i]
-        if input_tc.id:
-            assert tc.id == input_tc.id
-        else:
-            assert len(tc.id) == 9
-            assert tc.id.isalnum()
-
-        assert tc.function.name == input_tc.name
-        assert tc.function.arguments == input_tc.arguments
 
 
 class TestExtractMaybeReasoningAndToolStreaming:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -70,7 +70,7 @@ from vllm.renderers import ChatParams
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.collection_utils import as_list
-from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
+from vllm.utils.mistral import is_mistral_tool_parser
 
 if TYPE_CHECKING:
     from vllm.entrypoints.serve.render.serving import OpenAIServingRender
@@ -1065,32 +1065,8 @@ class OpenAIServingChat(OpenAIServing):
                 tool_calls = []
 
             auto_tools_called = False
-            if is_mistral_tokenizer(tokenizer):
-                from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
 
-                tool_call_class: type[ToolCall] = MistralToolCall
-            else:
-                tool_call_class = ToolCall
-
-            use_mistral_tool_parser = request._grammar_from_tool_parser
-            if use_mistral_tool_parser:
-                from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
-
-                tool_call_items = MistralToolParser.build_non_streaming_tool_calls(
-                    tool_calls
-                )
-                if tool_call_items:
-                    auto_tools_called = (
-                        request.tool_choice is None or request.tool_choice == "auto"
-                    )
-                message = ChatMessage(
-                    role=role,
-                    reasoning=reasoning,
-                    content=content,
-                    tool_calls=tool_call_items,
-                )
-
-            elif (not self.enable_auto_tools or not self.tool_parser) and (
+            if (not self.enable_auto_tools or not self.tool_parser) and (
                 not isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
                 and request.tool_choice != "required"
             ):
@@ -1100,70 +1076,42 @@ class OpenAIServingChat(OpenAIServing):
                 request.tool_choice
                 and type(request.tool_choice) is ChatCompletionNamedToolChoiceParam
             ):
-                tool_call_class_items = []
+                tool_call_items = []
                 tool_calls = tool_calls or []
-                for idx, tc in enumerate(tool_calls):
-                    # Use native ID if available (e.g., Kimi K2),
-                    # otherwise generate ID with correct id_type
-                    if tc.id:
-                        tool_call_class_items.append(
-                            tool_call_class(id=tc.id, function=tc)
+                for tc in tool_calls:
+                    if not tc.id:
+                        tc.id = make_tool_call_id(
+                            id_type=self.tool_call_id_type,
+                            func_name=tc.name,
+                            idx=history_tool_call_cnt,
                         )
-                    else:
-                        # Generate ID using the correct format (kimi_k2 or random),
-                        # but leave it to the class if it's Mistral to preserve
-                        # 9-char IDs
-                        if is_mistral_tokenizer(tokenizer):
-                            tool_call_class_items.append(tool_call_class(function=tc))
-                        else:
-                            generated_id = make_tool_call_id(
-                                id_type=self.tool_call_id_type,
-                                func_name=tc.name,
-                                idx=history_tool_call_cnt,
-                            )
-                            tool_call_class_items.append(
-                                tool_call_class(id=generated_id, function=tc)
-                            )
+                    tool_call_items.append(ToolCall(id=tc.id, function=tc))
                     history_tool_call_cnt += 1
                 message = ChatMessage(
                     role=role,
                     reasoning=reasoning,
-                    content="",
-                    tool_calls=tool_call_class_items,
+                    content=content or "",
+                    tool_calls=tool_call_items,
                 )
 
             elif request.tool_choice and request.tool_choice == "required":
-                tool_call_class_items = []
+                tool_call_items = []
                 tool_calls = tool_calls or []
-                for idx, tool_call in enumerate(tool_calls):
-                    # Use native ID if available,
-                    # otherwise generate ID with correct id_type
-                    if tool_call.id:
-                        tool_call_class_items.append(
-                            tool_call_class(id=tool_call.id, function=tool_call)
+                for tool_call in tool_calls:
+                    if not tool_call.id:
+                        tool_call.id = make_tool_call_id(
+                            id_type=self.tool_call_id_type,
+                            func_name=tool_call.name,
+                            idx=history_tool_call_cnt,
                         )
-                    else:
-                        # Generate ID using the correct format (kimi_k2 or random),
-                        # but leave it to the class if it's Mistral to preserve
-                        # 9-char IDs
-                        if is_mistral_tokenizer(tokenizer):
-                            tool_call_class_items.append(
-                                tool_call_class(function=tool_call)
-                            )
-                        else:
-                            generated_id = make_tool_call_id(
-                                id_type=self.tool_call_id_type,
-                                func_name=tool_call.name,
-                                idx=history_tool_call_cnt,
-                            )
-                            tool_call_class_items.append(
-                                tool_call_class(id=generated_id, function=tool_call)
-                            )
+                    tool_call_items.append(
+                        ToolCall(id=tool_call.id, function=tool_call)
+                    )
                     history_tool_call_cnt += 1
                 message = ChatMessage(
                     role=role,
-                    content="",
-                    tool_calls=tool_call_class_items,
+                    content=content or "",
+                    tool_calls=tool_call_items,
                     reasoning=reasoning,
                 )
 
@@ -1179,34 +1127,17 @@ class OpenAIServingChat(OpenAIServing):
                 and self.enable_auto_tools
                 and self.tool_parser
             ):
-                # In the OpenAI API the finish_reason is "tools_called"
-                # if the tool choice is auto and the model produced a tool
-                # call. The same is not true for named function calls
                 auto_tools_called = tool_calls is not None and len(tool_calls) > 0
                 if tool_calls:
                     tool_call_items = []
-                    for idx, tc in enumerate(tool_calls):
-                        # Use native ID if available (e.g., Kimi K2),
-                        # otherwise generate ID with correct id_type
-                        if tc.id:
-                            tool_call_items.append(
-                                tool_call_class(id=tc.id, function=tc)
+                    for tc in tool_calls:
+                        if not tc.id:
+                            tc.id = make_tool_call_id(
+                                id_type=self.tool_call_id_type,
+                                func_name=tc.name,
+                                idx=history_tool_call_cnt,
                             )
-                        else:
-                            # Generate ID using the correct format (kimi_k2 or random),
-                            # but leave it to the class if it's Mistral to preserve
-                            # 9-char IDs
-                            if is_mistral_tokenizer(tokenizer):
-                                tool_call_items.append(tool_call_class(function=tc))
-                            else:
-                                generated_id = make_tool_call_id(
-                                    id_type=self.tool_call_id_type,
-                                    func_name=tc.name,
-                                    idx=history_tool_call_cnt,
-                                )
-                                tool_call_items.append(
-                                    tool_call_class(id=generated_id, function=tc)
-                                )
+                        tool_call_items.append(ToolCall(id=tc.id, function=tc))
                         history_tool_call_cnt += 1
                     message = ChatMessage(
                         role=role,
@@ -1216,18 +1147,10 @@ class OpenAIServingChat(OpenAIServing):
                     )
 
                 else:
-                    # FOR NOW make it a chat message; we will have to detect
-                    # the type to make it later.
-                    ret_content = content
-
-                    # try to use content return from tool parser first,
-                    # tool parser may do some modify for the content.
-                    if content and len(content) > 0:
-                        ret_content = content
                     message = ChatMessage(
                         role=role,
                         reasoning=reasoning,
-                        content=ret_content,
+                        content=content,
                     )
 
             # undetermined case that is still important to handle

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -43,7 +43,6 @@ from vllm.tool_parsers.streaming import (
     extract_required_tool_call_streaming,
 )
 from vllm.utils import random_uuid
-from vllm.utils.mistral import is_mistral_tool_parser
 
 logger = init_logger(__name__)
 
@@ -546,14 +545,6 @@ class DelegatingParser(Parser):
         if tool_parser is None:
             return [], content
 
-        # When the Mistral grammar factory injected structured outputs,
-        # let the parser handle the output.
-        use_mistral_tool_parser = (
-            is_mistral_tool_parser(type(tool_parser))
-            and isinstance(request, ChatCompletionRequest)
-            and request._grammar_from_tool_parser
-        )
-
         supports_required_and_named = tool_parser.supports_required_and_named
         is_named_tool_choice = request.tool_choice and isinstance(
             request.tool_choice,
@@ -570,11 +561,7 @@ class DelegatingParser(Parser):
         )
 
         tool_calls = list[FunctionCall]()
-        if (
-            is_named_tool_choice
-            and supports_required_and_named
-            and not use_mistral_tool_parser
-        ):
+        if is_named_tool_choice and supports_required_and_named:
             if content is None:
                 return [], None
             tool_calls.append(
@@ -584,11 +571,7 @@ class DelegatingParser(Parser):
                 )
             )
             content = None
-        elif (
-            is_required_tool_choice
-            and supports_required_and_named
-            and not use_mistral_tool_parser
-        ):
+        elif is_required_tool_choice and supports_required_and_named:
             # "required" with standard JSON-based parsing
             parsed_calls = []
             with contextlib.suppress(ValidationError):
@@ -604,7 +587,7 @@ class DelegatingParser(Parser):
                     )
                 )
             content = None
-        elif is_auto_tool_choice or use_mistral_tool_parser:
+        elif is_auto_tool_choice:
             # Automatic Tool Call Parsing (also used as fallback for
             # required/named when supports_required_and_named=False)
             tool_call_info = tool_parser.extract_tool_calls(

--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.engine.protocol import FunctionCall
+from vllm.parser.abstract_parser import DelegatingParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import (
+        ChatCompletionRequest,
+    )
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+class MistralParser(DelegatingParser):
+    def __init__(self, tokenizer, tools=None, *args, **kwargs):
+        super().__init__(tokenizer, tools, *args, **kwargs)
+        from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+
+        if not isinstance(self._tool_parser, MistralToolParser):
+            raise ValueError(
+                "MistralParser requires --tool-call-parser mistral, "
+                f"got {self._tool_parser.__class__.__name__}."
+            )
+
+    def parse(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool = False,
+    ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        content: str | None = model_output
+        reasoning, tool_calls = None, None
+
+        # No grammar (pre-v11): delegate to base class for tool choice
+        # parsing (named/required/auto).
+        if not getattr(request, "_grammar_from_tool_parser", False):
+            reasoning, content, tool_calls = super().parse(
+                model_output, request, enable_auto_tools
+            )
+            if tool_calls:
+                from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+
+                # Named/required tool_choice builds FunctionCalls without
+                # ID, backfill with Mistral-format IDs.
+                for tc in tool_calls:
+                    if not tc.id:
+                        tc.id = MistralToolCall.generate_random_id()
+
+        # Grammar (v11+): output is already structured, use
+        # MistralToolParser.extract_tool_calls directly.
+        else:
+            if self._reasoning_parser is not None:
+                reasoning, content = self._reasoning_parser.extract_reasoning(
+                    model_output, request
+                )
+
+            assert self._tool_parser is not None
+            tool_call_info = self._tool_parser.extract_tool_calls(
+                content if content is not None else "",
+                request=request,  # type: ignore[arg-type]
+            )
+            if tool_call_info.tools_called:
+                tool_calls = [
+                    FunctionCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    )
+                    for tc in tool_call_info.tool_calls
+                ]
+                content = tool_call_info.content
+
+        return reasoning, content, tool_calls

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -106,6 +106,15 @@ class ParserManager:
         if reasoning_parser_cls is None and tool_parser_cls is None:
             return None
 
+        from vllm.utils.mistral import is_mistral_tool_parser
+
+        if is_mistral_tool_parser(tool_parser_cls):
+            from vllm.parser.mistral import MistralParser
+
+            MistralParser.reasoning_parser_cls = reasoning_parser_cls
+            MistralParser.tool_parser_cls = tool_parser_cls
+            return MistralParser
+
         from vllm.parser.abstract_parser import DelegatingParser
 
         r_cls = reasoning_parser_cls

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -408,21 +408,6 @@ class MistralToolParser(ToolParser):
             current_token_ids=current_token_ids,
         )
 
-    @staticmethod
-    def build_non_streaming_tool_calls(
-        tool_calls: list[FunctionCall] | None,
-    ) -> list[ToolCall]:
-        r"""Build `MistralToolCall` items for non-streaming responses."""
-        if not tool_calls:
-            return []
-
-        return [
-            MistralToolCall(id=tc.id, function=tc)
-            if tc.id
-            else MistralToolCall(function=tc)
-            for tc in tool_calls
-        ]
-
     def extract_tool_calls(
         self,
         model_output: str,
@@ -536,7 +521,7 @@ class MistralToolParser(ToolParser):
         return ExtractedToolCallInformation(
             tools_called=True,
             tool_calls=mistral_tool_calls,
-            content=content if len(content) > 0 else None,
+            content=content if content.strip() else None,
         )
 
     def extract_tool_calls_streaming(


### PR DESCRIPTION
## Purpose
Mistral models require special handling for non-streaming tool calls: 9-char alphanumeric IDs, a grammar-based extraction path for v11+ tokenizers, and `[TOOL_CALLS]` parsing for pre-v11. When this logic was originally added, the
unified parser interface (`DelegatingParser`) didn't exist yet, so the natural place for it was `serving.py` and `abstract_parser.py`. Now that the parser abstraction is in place, we can migrate the Mistral-specific behavior into its
own parser subclass, keeping the generic paths clean.

### This PR
- Introduces `MistralParser`, a `DelegatingParser` subclass that centralizes Mistral-specific non-streaming tool call handling (ID backfill, grammar-path extraction) in one place.
- Removes scattered `is_mistral_tokenizer` / `use_mistral_tool_parser` checks from `serving.py` and `abstract_parser.py`.
- Removes `MistralToolParser.build_non_streaming_tool_calls` (logic now lives in `MistralParser.parse()`).
- `parser_manager.py` routes to `MistralParser` when a Mistral tool parser is detected.

### How it works
- **Non-grammar (pre-v11):** delegates to `DelegatingParser.parse()` for  named/required/auto tool_choice handling, then backfills Mistral 9-char IDs on any tool calls missing an ID.
- **Grammar (v11+):** extracts reasoning (if enabled), then calls `MistralToolParser.extract_tool_calls` directly, converting the result back to `FunctionCall` objects.

## Test Plan
E2E test:
- Post v11
```
vllm serve mistralai/Magistral-Small-2509 \
     --tokenizer-mode mistral \
     --tool-call-parser mistral \
     --reasoning-parser mistral \
     --enable-auto-tool-choice

curl -s http://localhost:8001/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistralai/Magistral-Small-2509",
    "messages": [{"role": "user", "content": "What is the weather in Dallas?"}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the current weather in a given location", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": "auto" / "required" / {"type": "function", "function": {"name": "get_weather"}}
  }'
```

- Pre v11
```
vllm serve mistralai/Mistral-7B-Instruct-v0.3 \
  --enable-auto-tool-choice \
  --tool-call-parser mistral 

curl -s http://localhost:8002/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistralai/Mistral-7B-Instruct-v0.3",
    "messages": [{"role": "user", "content": "What is the weather in Dallas?"}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the current weather in a given location", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": "auto" / "required" / {"type": "function", "function": {"name": "get_weather"}}
  }'
```

Unit test:
```
tests/parser/test_mistral.py
```