### PR TITLE
[Kernel][Perf] Triton unified attention: window-align the KV-tile iteration for sliding-window / chunked attention

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -647,3 +647,144 @@ def test_triton_unified_attn_use_td_tile_clamp(
         soft_cap=None,
         seq_threshold_3D=0,
     )
+
+
+@pytest.mark.parametrize("num_heads", [(4, 1)])
+@pytest.mark.parametrize("head_size", [64])
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("sliding_window", [10, 17])
+@pytest.mark.parametrize("seq_threshold_3D", [0])
+@torch.inference_mode()
+def test_triton_unified_attn_sw_tile_base_bit_exact(
+    num_heads: tuple[int, int],
+    head_size: int,
+    block_size: int,
+    sliding_window: int,
+    seq_threshold_3D: int,
+) -> None:
+    """The kernel must produce bit-exact output for two SW invocations whose
+    sliding window covers the same logical (Q, K, V) values, even when the
+    SW window of one run fits in a single KV tile while the other run's
+    window straddles a tile boundary (so the two runs iterate a different
+    number of tiles and online softmax merges through the running
+    accumulator a different number of times).
+
+    Before the tile-base-shift fix, ``tile_start = first_allowed_key //
+    TILE_SIZE`` floor-rounded the iteration start. When the SW window
+    straddles a tile boundary, the second run iterates one extra tile and
+    online softmax merges across that boundary via the running-max +
+    correction pattern; bf16 ``acc_new = acc_old * exp(m_old - m_new) +
+    sum_of_tile_p`` is order-sensitive, so the same logical Q×K window
+    accumulates differently and the output drifts at ULP scale.
+
+    With the fix, the iteration begins exactly at ``first_allowed_key`` →
+    the run whose window straddled a tile boundary now iterates one tile
+    starting at the window's first key → both runs do a single-tile reduce
+    over the same set of real values → bit-exact.
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_query_heads, num_kv_heads = num_heads
+    assert num_query_heads % num_kv_heads == 0
+    dtype = torch.bfloat16
+    scale = head_size**-0.5
+    window_size = (sliding_window - 1, 0)
+    sw = sliding_window
+    num_blocks = 2048
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+
+    # Prefill TILE_SIZE is 32. Pick query positions so run 1's SW window fits
+    # in tile 0 while run 2's straddles tiles 0-1, with identical window content
+    # and query. Without the base-shift fix, run 2's two-tile merge drifts by
+    # bf16 ULPs vs run 1's single-tile reduce.
+    kv_len_1 = sw + 5
+    kv_len_2 = sw + 31
+    # Sanity: run 1's window must fit in a single tile, run 2's must straddle.
+    assert (sw + 4) // 32 == 5 // 32, "run 1 should be single-tile"
+    assert (sw + 30) // 32 != 31 // 32, "run 2 should straddle tile boundary"
+
+    # Single decode step per sequence (query_len=1).
+    query_lens = [1]
+    max_query_len = 1
+
+    # Shared per-token tensors that go inside the SW window in both runs.
+    q_token = torch.randn(num_query_heads, head_size, dtype=dtype)
+    shared_k = torch.randn(sw, num_kv_heads, head_size, dtype=dtype)
+    shared_v = torch.randn(sw, num_kv_heads, head_size, dtype=dtype)
+
+    def _run(kv_len: int) -> torch.Tensor:
+        # Block layout: enough blocks to cover the longest run.
+        max_num_blocks_per_seq = (kv_len + block_size - 1) // block_size
+        key_cache = torch.randn(
+            num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+        )
+        value_cache = torch.randn_like(key_cache)
+        # Pick a fixed block_table mapping (deterministic) so two runs writing
+        # the SW-window slots access the same physical block layout structure.
+        block_table = torch.arange(
+            1, 1 + max_num_blocks_per_seq, dtype=torch.int32
+        ).view(1, max_num_blocks_per_seq)
+        # The query sits at logical position kv_len - 1; its SW window covers
+        # keys at logical positions [kv_len - sw .. kv_len - 1].
+        # Write shared_k / shared_v into those slots via the block_table.
+        for i, pos in enumerate(range(kv_len - sw, kv_len)):
+            blk = int(block_table[0, pos // block_size].item())
+            slot = pos % block_size
+            key_cache[blk, slot] = shared_k[i]
+            value_cache[blk, slot] = shared_v[i]
+
+        query = q_token[None, :, :].clone()  # (1, num_q_heads, head_size)
+        cu_query_lens = torch.tensor([0, 1], dtype=torch.int32)
+        kv_lens = torch.tensor([kv_len], dtype=torch.int32)
+        output = torch.empty_like(query)
+
+        softmax_segm_output = torch.empty(
+            (seq_threshold_3D, num_query_heads,
+             num_par_softmax_segments, head_size_padded),
+            dtype=torch.float32,
+        )
+        softmax_segm_max = torch.empty(
+            (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+            dtype=torch.float32,
+        )
+        softmax_segm_expsum = torch.empty(
+            (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+            dtype=torch.float32,
+        )
+
+        unified_attention(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            out=output,
+            cu_seqlens_q=cu_query_lens,
+            seqused_k=kv_lens,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=int(kv_len),
+            softmax_scale=scale,
+            causal=True,
+            window_size=window_size,
+            block_table=block_table,
+            softcap=0,
+            q_descale=None,
+            k_descale=None,
+            v_descale=None,
+            seq_threshold_3D=seq_threshold_3D,
+            num_par_softmax_segments=num_par_softmax_segments,
+            softmax_segm_output=softmax_segm_output,
+            softmax_segm_max=softmax_segm_max,
+            softmax_segm_expsum=softmax_segm_expsum,
+            kv_quant_mode=KVQuantMode.NONE,
+        )
+        return output
+
+    out1 = _run(kv_len_1)
+    out2 = _run(kv_len_2)
+    assert torch.equal(out1, out2), (
+        f"SW attention output drifted across two invocations whose windows "
+        f"cover the same logical (Q, K, V) values but land at different "
+        f"slot positions within the KV tile. max abs diff = "
+        f"{(out1 - out2).abs().max().item()}"
+    )

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -164,16 +164,22 @@ def compute_tile_loop_bounds(
 
     ``tile_base`` is the absolute KV position the loop starts from
     (``seq_offset = tile_base + j * TILE_SIZE + offs_t``); it is 0 on every
-    non-shifted path. The 2D pointer SWA path shifts it to the exact window
-    lower bound instead of the floor-rounded tile boundary, so the window's
-    keys occupy the minimal ``ceil(W / TILE_SIZE)`` tiles; the floor-rounded
-    start, by contrast, lets the masked leading slots (positions before the
-    window in the first tile) push the window across up to one extra tile.
-    (It also makes the online-softmax reduction order independent of the window
-    offset mod ``TILE_SIZE``, so output is byte-identical across batch shapes.)
-    The 3D and ``USE_TD`` paths keep ``tile_base = 0``: the former
-    segments in absolute tile coordinates, and the latter's tensor-descriptor
-    load assumes each tile lies within a single KV block.
+    non-shifted path. The 2D pointer and 3D-segmented SWA paths both shift it
+    to the exact window lower bound instead of the floor-rounded tile boundary,
+    so the window's keys occupy the minimal ``ceil(W / TILE_SIZE)`` tiles; the
+    floor-rounded start, by contrast, lets the masked leading slots (positions
+    before the window in the first tile) push the window across up to one extra
+    tile. (It also makes the online-softmax reduction order independent of the
+    window offset mod ``TILE_SIZE``, so output is byte-identical across batch
+    shapes - now on the 3D path as well.)
+
+    Only the ``USE_TD`` tensor-descriptor path keeps ``tile_base = 0``: its load
+    fetches a whole tile from one physical block (relying on
+    ``BLOCK_SIZE % TILE_SIZE == 0``), which an arbitrary base would violate. On
+    the 3D path the per-segment slice below runs in window-tile coordinates
+    while ``tiles_per_segment`` stays ``seq_len``-derived, so the segments that
+    do work remain a subset of those ``reduce_segments`` treats as valid and the
+    extra high-index segments are harmlessly empty (``M = -inf``).
     """
     # compute the length of the longest sequence prefix spanned by any
     # query token in the current q_block (q_block_local_idx)
@@ -213,15 +219,20 @@ def compute_tile_loop_bounds(
         else:
             first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
-        if IS_3D or USE_TD:
-            # Keep the floor-rounded, TILE_SIZE-aligned iteration here:
-            # 3D segmenting reasons in absolute tile coordinates, and the
-            # tensor-descriptor KV load assumes each tile lies in one block
-            # (which an arbitrary base offset would violate).
+        if USE_TD:
+            # Tensor-descriptor KV load fetches a whole tile from one physical
+            # block (relies on BLOCK_SIZE % TILE_SIZE == 0); an arbitrary base
+            # would straddle a block boundary, so keep the floor-rounded,
+            # TILE_SIZE-aligned iteration.
             tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
             tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
         else:
-            # 2D pointer path: base-shift to the exact lower bound (see docstring).
+            # 2D pointer and 3D-segmented paths: base-shift to the exact window
+            # lower bound (see docstring). Each slot resolves its own physical
+            # block, so a base-shifted tile straddling two KV blocks is fine; for
+            # 3D the segment slice below runs in window-tile coordinates while
+            # tiles_per_segment stays seq_len-derived, keeping the active
+            # segments a subset of reduce_segments' valid range.
             tile_base = tl.maximum(0, first_allowed_key)
             tile_start = 0
             tile_end = cdiv_fn(

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -155,21 +155,25 @@ def compute_tile_loop_bounds(
     IS_3D: tl.constexpr,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    USE_TD: tl.constexpr = False,
 ):
-    """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
-    derived ``max_seq_prefix_len`` used for per-tile masking.
+    """Compute ``(loop_lo, loop_hi, max_seq_prefix_len, tile_base)`` for the
+    KV-tile loop, folding in: (1) the longest prefix any query in this q-block
+    spans (clamped to ``seq_len``, or extended to it under mm_prefix);
+    (2) sliding-window / chunked pruning; (3) 3D segment scoping when ``IS_3D``.
 
-    Combines three concerns into one helper:
-
-    1. Longest prefix spanned by any query token in this q-block.
-       Clamped to ``seq_len`` (causal) or extended to it when
-       mm_prefix is active (bidirectional ranges can reach past the
-       causal prefix).
-    2. Sliding-window pruning: narrows ``[tile_start, tile_end)`` to
-       only tiles that can contain an allowed key under SWA.
-    3. 3D scoping: when ``IS_3D`` is True, further narrows to the
-       segment's slice via ``(segm_idx * tiles_per_segment,
-       (segm_idx + 1) * tiles_per_segment)``.
+    ``tile_base`` is the absolute KV position the loop starts from
+    (``seq_offset = tile_base + j * TILE_SIZE + offs_t``); it is 0 on every
+    non-shifted path. The 2D pointer SWA path shifts it to the exact window
+    lower bound instead of the floor-rounded tile boundary, so the window's
+    keys occupy the minimal ``ceil(W / TILE_SIZE)`` tiles; the floor-rounded
+    start, by contrast, lets the masked leading slots (positions before the
+    window in the first tile) push the window across up to one extra tile.
+    (It also makes the online-softmax reduction order independent of the window
+    offset mod ``TILE_SIZE``, so output is byte-identical across batch shapes.)
+    The 3D and ``USE_TD`` paths keep ``tile_base = 0``: the former
+    segments in absolute tile coordinates, and the latter's tensor-descriptor
+    load assumes each tile lies within a single KV block.
     """
     # compute the length of the longest sequence prefix spanned by any
     # query token in the current q_block (q_block_local_idx)
@@ -188,34 +192,41 @@ def compute_tile_loop_bounds(
 
     num_tiles = cdiv_fn(max_seq_prefix_len, TILE_SIZE)
 
-    # ---- Sliding-window tile pruning --------------------
-    # Default: keep previous global behavior
+    # Default: iterate from absolute origin, all tiles.
+    tile_base: tl.int32 = 0
     tile_start = 0
     tile_end = num_tiles
     # TODO(Isotr0py): sliding window pruning with image bidirectional mask
     if SLIDING_WINDOW > 0 and not USE_MM_PREFIX:
-        # Query rows covered by this Q-block
+        # Query rows covered by this Q-block.
         qpos_lo = q_block_local_idx * BLOCK_Q
         qpos_hi = tl.minimum(
             qpos_lo + (BLOCK_M - 1) // num_queries_per_kv,
             cur_batch_query_len - 1,
         )
-        # For sliding window, each query position q can only attend to
-        # keys in the range [q_abs - SLIDING_WINDOW + 1, q_abs]
-        # where q_abs = context_len + q
-        # The union of allowed key positions for this Q-block is:
-        # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
+        # Allowed keys for this Q-block: [first_allowed_key, last_allowed_key],
+        # where each query q attends [q_abs - SLIDING_WINDOW + 1, q_abs].
         q_abs = context_len + qpos_lo
         if CHUNK_LOOKBACK > -1:
-            # Chunked attention: align lower bound to the start of the
-            # lookback'th previous chunk.
+            # Chunked attention: lower bound is the lookback'th prior chunk.
             first_allowed_key = ((q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK) * CHUNK_SIZE
         else:
             first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
-        # Convert to tile indices and clamp
-        tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
-        tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
+        if IS_3D or USE_TD:
+            # Keep the floor-rounded, TILE_SIZE-aligned iteration here:
+            # 3D segmenting reasons in absolute tile coordinates, and the
+            # tensor-descriptor KV load assumes each tile lies in one block
+            # (which an arbitrary base offset would violate).
+            tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
+            tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
+        else:
+            # 2D pointer path: base-shift to the exact lower bound (see docstring).
+            tile_base = tl.maximum(0, first_allowed_key)
+            tile_start = 0
+            tile_end = cdiv_fn(
+                tl.maximum(0, last_allowed_key + 1 - tile_base), TILE_SIZE
+            )
 
     if IS_3D:
         loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
@@ -224,7 +235,7 @@ def compute_tile_loop_bounds(
         loop_lo = tile_start
         loop_hi = tile_end
 
-    return loop_lo, loop_hi, max_seq_prefix_len
+    return loop_lo, loop_hi, max_seq_prefix_len, tile_base
 
 
 @triton.jit

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -375,7 +375,7 @@ def kernel_unified_attention(
     if USE_QQ_BIAS:
         qq_bias_row_ptrs = qq_bias_ptr + query_pos[:, None] * qq_bias_stride_0
 
-    loop_lo, loop_hi, max_seq_prefix_len = compute_tile_loop_bounds(
+    loop_lo, loop_hi, max_seq_prefix_len, tile_base = compute_tile_loop_bounds(
         context_len,
         seq_len,
         cur_batch_query_len,
@@ -391,11 +391,13 @@ def kernel_unified_attention(
         IS_3D,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        USE_TD,
     )
 
-    # iterate through tiles (now limited to the sliding window range)
+    # iterate through tiles; seq_offset is base-shifted by tile_base
+    # (0 unless the 2D SWA path shifted it; see compute_tile_loop_bounds).
     for j in range(loop_lo, loop_hi):
-        seq_offset = j * TILE_SIZE + offs_t
+        seq_offset = tile_base + j * TILE_SIZE + offs_t
         tile_mask = seq_offset < max_seq_prefix_len
 
         physical_block_idx = tl.load(


### PR DESCRIPTION
Fixes #44575.

## Summary

The sliding-window / chunked-attention KV-tile loop starts at a floor-rounded tile boundary, so the window's keys can occupy one more `TILE_SIZE` tile than necessary - an extra tile of KV load + MMA + softmax-merge work per Q-block, every step, on every SW / chunked layer. This aligns the iteration base to the window's first allowed key, so the window occupies the minimal number of tiles.

## Performance

For a window of `W = last_allowed_key - first_allowed_key + 1` keys at residue `r = first_allowed_key % TILE_SIZE`:

| iteration start | tiles iterated |
| --- | --- |
| floor-rounded (current) | `ceil((r + W) / TILE_SIZE)` |
| window-aligned (this PR) | `ceil(W / TILE_SIZE)` |

i.e. one fewer tile whenever `r` pushes the window across a boundary, and the eliminated tile is almost entirely masked-out work. Example (`TILE_SIZE = 32`, window `[31, 46]`, `W = 16`, `r = 31`): 2 tiles -> 1. This applies per Q-block per step on every sliding-window / chunked-attention layer (e.g. Gemma-3 / Gemma-4 block-local layers).

## Change

`compute_tile_loop_bounds` returns a `tile_base`; the loop iterates `seq_offset = tile_base + j * TILE_SIZE + offs_t`, starting at `first_allowed_key` on the 2D pointer path. `tile_base = 0` (behavior unchanged) on every other path:

- **2D pointer + SW / chunked**: base shifts to `first_allowed_key`. Each slot resolves its own physical block (`block_table[seq_offset // BLOCK_SIZE]`, `seq_offset % BLOCK_SIZE`), so a base-shifted tile straddling two KV blocks is handled correctly.
- **`USE_TD` (tensor-descriptor) path**: its KV load fetches a whole tile from one physical block (relying on `BLOCK_SIZE % TILE_SIZE == 0`); an arbitrary base could straddle a block boundary, so the shift is disabled and this path is byte-for-byte identical to before.
- **3D-segmented SW**: reasons in absolute tile indices.
- **Non-SW**: unaffected.

No change to the `unified_attention` entrypoint.

## Secondary effect

Removing the leading masked slots also makes the online-softmax reduction order independent of `r`, so the same Q against the same `(K, V)` window is byte-identical across batch shapes (previously off by bf16 ULPs).

## Test

`test_triton_unified_attn_sw_tile_base_bit_exact` runs the kernel for two sequence lengths whose windows land at different residues mod `TILE_SIZE` (one fits a single tile, the other straddles a boundary under the old start) and asserts identical output. `USE_TD` coverage is unaffected since that path is unchanged.

```
pytest tests/kernels/attention/test_triton_unified_attention.py -k tile_base
```

