### PR TITLE
Add global cache scope for ngram prompt lookup

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1443,6 +1443,50 @@ def test_draft_sample_method_gumbel_is_rejected():
         )
 
 
+def test_ngram_prompt_lookup_global_scope_is_accepted():
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+        prompt_lookup_cache_scope="global",
+    )
+
+    assert speculative_config.prompt_lookup_cache_scope == "global"
+    assert speculative_config.prompt_lookup_global_branch_length == 6
+    assert speculative_config.prompt_lookup_global_max_entries == 100000
+
+
+def test_ngram_prompt_lookup_cache_scope_defaults_to_local():
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+    )
+
+    assert speculative_config.prompt_lookup_cache_scope == "local"
+    assert speculative_config.prompt_lookup_global_branch_length is None
+    assert speculative_config.prompt_lookup_global_max_entries is None
+
+
+def test_prompt_lookup_cache_scope_requires_ngram():
+    with pytest.raises(ValidationError, match="prompt_lookup_cache_scope"):
+        SpeculativeConfig(
+            method="ngram_gpu",
+            num_speculative_tokens=1,
+            prompt_lookup_cache_scope="global",
+        )
+    with pytest.raises(ValidationError, match="prompt_lookup_global"):
+        SpeculativeConfig(
+            method="ngram_gpu",
+            num_speculative_tokens=1,
+            prompt_lookup_global_max_entries=100,
+        )
+    with pytest.raises(ValidationError, match="prompt_lookup_cache_scope"):
+        SpeculativeConfig(
+            method="ngram",
+            num_speculative_tokens=1,
+            prompt_lookup_global_max_entries=100,
+        )
+
+
 def test_ir_op_priority_default():
     """Test that IR op priority defaults are set correctly."""
     from vllm.config.kernel import IrOpPriorityConfig

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2221,6 +2221,50 @@ def test_qwen3_omni_dspark_allows_smaller_input_vocabulary():
     _validate_qwen3_omni_dspark(target_config, draft_config, 7)
 
 
+def test_ngram_prompt_lookup_global_scope_is_accepted():
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+        prompt_lookup_cache_scope="global",
+    )
+
+    assert speculative_config.prompt_lookup_cache_scope == "global"
+    assert speculative_config.prompt_lookup_global_branch_length == 6
+    assert speculative_config.prompt_lookup_global_max_entries == 100000
+
+
+def test_ngram_prompt_lookup_cache_scope_defaults_to_local():
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+    )
+
+    assert speculative_config.prompt_lookup_cache_scope == "local"
+    assert speculative_config.prompt_lookup_global_branch_length is None
+    assert speculative_config.prompt_lookup_global_max_entries is None
+
+
+def test_prompt_lookup_cache_scope_requires_ngram():
+    with pytest.raises(ValidationError, match="prompt_lookup_cache_scope"):
+        SpeculativeConfig(
+            method="ngram_gpu",
+            num_speculative_tokens=1,
+            prompt_lookup_cache_scope="global",
+        )
+    with pytest.raises(ValidationError, match="prompt_lookup_global"):
+        SpeculativeConfig(
+            method="ngram_gpu",
+            num_speculative_tokens=1,
+            prompt_lookup_global_max_entries=100,
+        )
+    with pytest.raises(ValidationError, match="prompt_lookup_cache_scope"):
+        SpeculativeConfig(
+            method="ngram",
+            num_speculative_tokens=1,
+            prompt_lookup_global_max_entries=100,
+        )
+
+
 def test_ir_op_priority_default():
     """Test that IR op priority defaults are set correctly."""
     from vllm.config.kernel import IrOpPriorityConfig

--- a/tests/v1/spec_decode/test_ngram.py
+++ b/tests/v1/spec_decode/test_ngram.py
@@ -202,3 +202,210 @@ def test_ngram_proposer():
     assert len(result[0]) == 2
     assert np.array_equal(result[0], np.array([middle_integer + 2, middle_integer + 3]))
     assert np.array_equal(result[1], np.array([]))
+
+
+def test_ngram_global_cache_proposer():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=6,
+                num_speculative_tokens=3,
+                method="ngram",
+            ),
+        )
+    )
+
+    first_request_tokens = np.array([[1, 2, 3, 4, 5, 6]], dtype=np.int32)
+    proposer.propose(
+        sampled_token_ids=[[6]],
+        num_tokens_no_spec=np.array([first_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=first_request_tokens,
+        req_ids=["req-0"],
+    )
+
+    second_request_tokens = np.array([[9, 8, 3, 4]], dtype=np.int32)
+    result = proposer.propose(
+        sampled_token_ids=[[4]],
+        num_tokens_no_spec=np.array([second_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=second_request_tokens,
+        req_ids=["req-1"],
+    )
+
+    assert result == [[5, 6]]
+
+
+def test_ngram_global_cache_respects_max_model_len():
+    model_config = ModelConfig(model="facebook/opt-125m", max_model_len=6)
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=6,
+                num_speculative_tokens=3,
+                method="ngram",
+            ),
+        )
+    )
+
+    first_request_tokens = np.array([[1, 2, 3, 4, 5]], dtype=np.int32)
+    proposer.propose(
+        sampled_token_ids=[[5]],
+        num_tokens_no_spec=np.array([first_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=first_request_tokens,
+        req_ids=["req-0"],
+    )
+
+    second_request_tokens = np.array([[9, 8, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([second_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=second_request_tokens,
+        req_ids=["req-1"],
+    )
+
+    assert result == [[3, 4]]
+
+
+def test_ngram_global_cache_evicts_old_entries():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=1,
+                prompt_lookup_max=1,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                prompt_lookup_global_max_entries=1,
+                num_speculative_tokens=1,
+                method="ngram",
+            ),
+        )
+    )
+
+    proposer.propose(
+        sampled_token_ids=[[3]],
+        num_tokens_no_spec=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.array([[1, 2, 3]], dtype=np.int32),
+        req_ids=["req-0"],
+    )
+    proposer.propose(
+        sampled_token_ids=[[6]],
+        num_tokens_no_spec=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.array([[4, 5, 6]], dtype=np.int32),
+        req_ids=["req-1"],
+    )
+
+    result = proposer.propose(
+        sampled_token_ids=[[1]],
+        num_tokens_no_spec=np.array([1], dtype=np.int32),
+        token_ids_cpu=np.array([[1]], dtype=np.int32),
+        req_ids=["req-2"],
+    )
+
+    assert result == [[]]
+
+
+def test_ngram_global_cache_does_not_fallback_to_local():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                num_speculative_tokens=2,
+                method="ngram",
+            ),
+        )
+    )
+
+    token_ids_cpu = np.array([[0, 0, 0]], dtype=np.int32)
+    proposer.propose(
+        sampled_token_ids=[[0]],
+        num_tokens_no_spec=np.array([3], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    # Local ngram would find the earlier [1, 2] in the complete context and
+    # propose [3, 4]. Global mode only indexes the configured suffix window
+    # after the first full-context insert, so this remains a cache miss.
+    token_ids_cpu = np.array([[0, 0, 0, 1, 2, 3, 4, 5, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([10], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    assert result == [[]]
+
+
+def test_ngram_global_cache_indexes_full_context_once():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                num_speculative_tokens=2,
+                method="ngram",
+            ),
+        )
+    )
+
+    # The earlier [1, 2] is outside the configured suffix window of length 3.
+    # The first time a request is indexed, global mode still inserts the full
+    # visible context so prompt-local matches can be reused without a local
+    # fallback scan.
+    token_ids_cpu = np.array([[1, 2, 3, 4, 5, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([7], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    assert result == [[3, 4]]
+
+
+def test_ngram_global_cache_skips_full_context_when_cache_is_small():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                prompt_lookup_global_max_entries=1,
+                num_speculative_tokens=2,
+                method="ngram",
+            ),
+        )
+    )
+
+    token_ids_cpu = np.array([[1, 2, 3, 4, 5, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([7], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    assert result == [[]]

--- a/tests/v1/spec_decode/test_ngram.py
+++ b/tests/v1/spec_decode/test_ngram.py
@@ -212,3 +212,221 @@ def test_ngram_proposer():
     assert len(result[0]) == 2
     assert np.array_equal(result[0], np.array([middle_integer + 2, middle_integer + 3]))
     assert np.array_equal(result[1], np.array([]))
+
+
+def test_ngram_global_cache_proposer():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=6,
+                num_speculative_tokens=3,
+                method="ngram",
+            ),
+        )
+    )
+
+    first_request_tokens = np.array([[1, 2, 3, 4, 5, 6]], dtype=np.int32)
+    proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[6]],
+        num_tokens_no_spec=np.array([first_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=first_request_tokens,
+        req_ids=["req-0"],
+    )
+
+    second_request_tokens = np.array([[9, 8, 3, 4]], dtype=np.int32)
+    result = proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[4]],
+        num_tokens_no_spec=np.array([second_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=second_request_tokens,
+        req_ids=["req-1"],
+    )
+
+    assert result == [[5, 6]]
+
+
+def test_ngram_global_cache_respects_max_model_len():
+    model_config = ModelConfig(model="facebook/opt-125m", max_model_len=6)
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=6,
+                num_speculative_tokens=3,
+                method="ngram",
+            ),
+        )
+    )
+
+    first_request_tokens = np.array([[1, 2, 3, 4, 5]], dtype=np.int32)
+    proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[5]],
+        num_tokens_no_spec=np.array([first_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=first_request_tokens,
+        req_ids=["req-0"],
+    )
+
+    second_request_tokens = np.array([[9, 8, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([second_request_tokens.shape[1]], dtype=np.int32),
+        token_ids_cpu=second_request_tokens,
+        req_ids=["req-1"],
+    )
+
+    assert result == [[3, 4]]
+
+
+def test_ngram_global_cache_evicts_old_entries():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=1,
+                prompt_lookup_max=1,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                prompt_lookup_global_max_entries=1,
+                num_speculative_tokens=1,
+                method="ngram",
+            ),
+        )
+    )
+
+    proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[3]],
+        num_tokens_no_spec=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.array([[1, 2, 3]], dtype=np.int32),
+        req_ids=["req-0"],
+    )
+    proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[6]],
+        num_tokens_no_spec=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.array([[4, 5, 6]], dtype=np.int32),
+        req_ids=["req-1"],
+    )
+
+    result = proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[1]],
+        num_tokens_no_spec=np.array([1], dtype=np.int32),
+        token_ids_cpu=np.array([[1]], dtype=np.int32),
+        req_ids=["req-2"],
+    )
+
+    assert result == [[]]
+
+
+def test_ngram_global_cache_does_not_fallback_to_local():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                num_speculative_tokens=2,
+                method="ngram",
+            ),
+        )
+    )
+
+    token_ids_cpu = np.array([[0, 0, 0]], dtype=np.int32)
+    proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[0]],
+        num_tokens_no_spec=np.array([3], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    # Local ngram would find the earlier [1, 2] in the complete context and
+    # propose [3, 4]. Global mode only indexes the configured suffix window
+    # after the first full-context insert, so this remains a cache miss.
+    token_ids_cpu = np.array([[0, 0, 0, 1, 2, 3, 4, 5, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([10], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    assert result == [[]]
+
+
+def test_ngram_global_cache_indexes_full_context_once():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                num_speculative_tokens=2,
+                method="ngram",
+            ),
+        )
+    )
+
+    # The earlier [1, 2] is outside the configured suffix window of length 3.
+    # The first time a request is indexed, global mode still inserts the full
+    # visible context so prompt-local matches can be reused without a local
+    # fallback scan.
+    token_ids_cpu = np.array([[1, 2, 3, 4, 5, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([7], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    assert result == [[3, 4]]
+
+
+def test_ngram_global_cache_skips_full_context_when_cache_is_small():
+    model_config = ModelConfig(model="facebook/opt-125m")
+    proposer = NgramProposer(
+        vllm_config=VllmConfig(
+            model_config=model_config,
+            speculative_config=SpeculativeConfig(
+                prompt_lookup_min=2,
+                prompt_lookup_max=2,
+                prompt_lookup_cache_scope="global",
+                prompt_lookup_global_branch_length=3,
+                prompt_lookup_global_max_entries=1,
+                num_speculative_tokens=2,
+                method="ngram",
+            ),
+        )
+    )
+
+    token_ids_cpu = np.array([[1, 2, 3, 4, 5, 1, 2]], dtype=np.int32)
+    result = proposer.propose(
+        num_speculative_tokens=proposer.k,
+        sampled_token_ids=[[2]],
+        num_tokens_no_spec=np.array([7], dtype=np.int32),
+        token_ids_cpu=token_ids_cpu,
+        req_ids=["req-0"],
+    )
+
+    assert result == [[]]

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -143,6 +143,12 @@ class SpeculativeConfig:
     prompt_lookup_min: int | None = Field(default=None, ge=1)
     """Minimum size of ngram token window when using Ngram proposer, if
     provided. Defaults to 1."""
+    prompt_lookup_cache_scope: Literal["local", "global"] = "local"
+    """Cache scope used by the ngram proposer."""
+    prompt_lookup_global_branch_length: int | None = Field(default=None, ge=1)
+    """Maximum visible suffix length inserted into the global ngram cache."""
+    prompt_lookup_global_max_entries: int | None = Field(default=None, ge=1)
+    """Maximum number of ngram keys retained by the global prompt lookup cache."""
 
     # Alternative drafting strategies
     parallel_drafting: bool = False
@@ -618,6 +624,18 @@ class SpeculativeConfig:
                     f"prompt_lookup_min={self.prompt_lookup_min} must "
                     f"be <= prompt_lookup_max={self.prompt_lookup_max}"
                 )
+            if (
+                self.prompt_lookup_cache_scope == "global"
+                and self.prompt_lookup_global_branch_length is None
+            ):
+                self.prompt_lookup_global_branch_length = (
+                    self.prompt_lookup_max + self.num_speculative_tokens
+                )
+            if (
+                self.prompt_lookup_cache_scope == "global"
+                and self.prompt_lookup_global_max_entries is None
+            ):
+                self.prompt_lookup_global_max_entries = 100000
 
             # TODO: current we still need extract vocab_size from target model
             # config, in future, we may try refactor it out, and set
@@ -1008,6 +1026,33 @@ class SpeculativeConfig:
             raise ValueError(
                 "synthetic_acceptance_rates / synthetic_acceptance_length "
                 "are only valid with rejection_sample_method='synthetic'."
+            )
+
+        if self.prompt_lookup_cache_scope != "local" and self.method != "ngram":
+            raise ValueError(
+                "prompt_lookup_cache_scope is only supported with method='ngram'."
+            )
+        if (
+            self.prompt_lookup_global_branch_length is not None
+            and self.method != "ngram"
+        ):
+            raise ValueError(
+                "prompt_lookup_global_branch_length is only supported with "
+                "method='ngram'."
+            )
+        if self.prompt_lookup_global_max_entries is not None and self.method != "ngram":
+            raise ValueError(
+                "prompt_lookup_global_max_entries is only supported with "
+                "method='ngram'."
+            )
+        if self.prompt_lookup_cache_scope != "global" and (
+            self.prompt_lookup_global_branch_length is not None
+            or self.prompt_lookup_global_max_entries is not None
+        ):
+            raise ValueError(
+                "prompt_lookup_global_branch_length and "
+                "prompt_lookup_global_max_entries require "
+                "prompt_lookup_cache_scope='global'."
             )
 
         if self.draft_model_config:

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -450,6 +450,12 @@ class SpeculativeConfig:
     prompt_lookup_min: int | None = Field(default=None, ge=1)
     """Minimum size of ngram token window when using Ngram proposer, if
     provided. Defaults to 1."""
+    prompt_lookup_cache_scope: Literal["local", "global"] = "local"
+    """Cache scope used by the ngram proposer."""
+    prompt_lookup_global_branch_length: int | None = Field(default=None, ge=1)
+    """Maximum visible suffix length inserted into the global ngram cache."""
+    prompt_lookup_global_max_entries: int | None = Field(default=None, ge=1)
+    """Maximum number of ngram keys retained by the global prompt lookup cache."""
 
     # Alternative drafting strategies
     parallel_drafting: bool = False
@@ -1126,6 +1132,18 @@ class SpeculativeConfig:
                     f"prompt_lookup_min={self.prompt_lookup_min} must "
                     f"be <= prompt_lookup_max={self.prompt_lookup_max}"
                 )
+            if (
+                self.prompt_lookup_cache_scope == "global"
+                and self.prompt_lookup_global_branch_length is None
+            ):
+                self.prompt_lookup_global_branch_length = (
+                    self.prompt_lookup_max + self.num_speculative_tokens
+                )
+            if (
+                self.prompt_lookup_cache_scope == "global"
+                and self.prompt_lookup_global_max_entries is None
+            ):
+                self.prompt_lookup_global_max_entries = 100000
 
             # TODO: current we still need extract vocab_size from target model
             # config, in future, we may try refactor it out, and set
@@ -1692,6 +1710,33 @@ class SpeculativeConfig:
             raise ValueError(
                 "synthetic_acceptance_rates / synthetic_acceptance_length "
                 "are only valid with rejection_sample_method='synthetic'."
+            )
+
+        if self.prompt_lookup_cache_scope != "local" and self.method != "ngram":
+            raise ValueError(
+                "prompt_lookup_cache_scope is only supported with method='ngram'."
+            )
+        if (
+            self.prompt_lookup_global_branch_length is not None
+            and self.method != "ngram"
+        ):
+            raise ValueError(
+                "prompt_lookup_global_branch_length is only supported with "
+                "method='ngram'."
+            )
+        if self.prompt_lookup_global_max_entries is not None and self.method != "ngram":
+            raise ValueError(
+                "prompt_lookup_global_max_entries is only supported with "
+                "method='ngram'."
+            )
+        if self.prompt_lookup_cache_scope != "global" and (
+            self.prompt_lookup_global_branch_length is not None
+            or self.prompt_lookup_global_max_entries is not None
+        ):
+            raise ValueError(
+                "prompt_lookup_global_branch_length and "
+                "prompt_lookup_global_max_entries require "
+                "prompt_lookup_cache_scope='global'."
             )
 
         if self.draft_model_config:

--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -1,12 +1,85 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
+from collections import OrderedDict
 
 import numpy as np
 import torch
 from numba import get_num_threads, jit, njit, prange, set_num_threads
 
 from vllm.config import VllmConfig
+
+
+class _GlobalNgramCache:
+    def __init__(
+        self,
+        min_n: int,
+        max_n: int,
+        k: int,
+        branch_length: int,
+        max_entries: int,
+        max_continuations_per_key: int = 8,
+    ) -> None:
+        self.min_n = min_n
+        self.max_n = max_n
+        self.k = k
+        self.branch_length = branch_length
+        self.max_entries = max_entries
+        self.max_continuations_per_key = max_continuations_per_key
+        self._continuations: OrderedDict[tuple[int, ...], list[tuple[int, ...]]] = (
+            OrderedDict()
+        )
+
+    def put(self, token_ids: np.ndarray, branch_length: int | None = None) -> None:
+        if token_ids.shape[0] <= self.min_n:
+            return
+        branch_length = branch_length or self.branch_length
+        tokens = token_ids[-branch_length:].tolist()
+        num_tokens = len(tokens)
+        min_n = self.min_n
+        max_n_limit = self.max_n
+        k = self.k
+        put_one = self._put_one
+        for start in range(num_tokens):
+            max_n = min(max_n_limit, num_tokens - start - 1)
+            for ngram_len in range(min_n, max_n + 1):
+                continuation_start = start + ngram_len
+                put_one(
+                    tuple(tokens[start:continuation_start]),
+                    tuple(tokens[continuation_start : continuation_start + k]),
+                )
+
+    def _put_one(self, key: tuple[int, ...], continuation: tuple[int, ...]) -> None:
+        if not continuation:
+            return
+        continuations = self._continuations
+        values = continuations.get(key)
+        if values is None:
+            values = []
+            continuations[key] = values
+        elif continuation in values:
+            values.remove(continuation)
+        values.insert(0, continuation)
+        if len(values) > self.max_continuations_per_key:
+            del values[self.max_continuations_per_key :]
+        continuations.move_to_end(key)
+        if len(continuations) > self.max_entries:
+            continuations.popitem(last=False)
+
+    def get(self, token_ids: np.ndarray) -> list[int]:
+        total_tokens = token_ids.shape[0]
+        if total_tokens < self.min_n:
+            return []
+        max_n = min(self.max_n, total_tokens)
+        tokens = token_ids[-max_n:].tolist()
+        continuations = self._continuations
+        for ngram_len in range(max_n, self.min_n - 1, -1):
+            key = tuple(tokens[-ngram_len:])
+            values = continuations.get(key)
+            if values:
+                continuations.move_to_end(key)
+                return list(values[0])
+        return []
 
 
 class NgramProposer:
@@ -25,6 +98,25 @@ class NgramProposer:
         self.k = vllm_config.speculative_config.num_speculative_tokens
         # Maximum length of the model.
         self.max_model_len = vllm_config.model_config.max_model_len
+        self.prompt_lookup_cache_scope = (
+            vllm_config.speculative_config.prompt_lookup_cache_scope
+        )
+        branch_length = (
+            vllm_config.speculative_config.prompt_lookup_global_branch_length
+        )
+        max_entries = vllm_config.speculative_config.prompt_lookup_global_max_entries
+        self.global_ngram_cache: _GlobalNgramCache | None = None
+        if self.prompt_lookup_cache_scope == "global":
+            assert branch_length is not None
+            assert max_entries is not None
+            self.global_ngram_cache = _GlobalNgramCache(
+                self.min_n,
+                self.max_n,
+                self.k,
+                branch_length,
+                max_entries,
+            )
+        self.global_ngram_last_put_lens: dict[str, int] = {}
 
         # Pre-allocate buffers for numba batch propose.
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
@@ -133,6 +225,7 @@ class NgramProposer:
         sampled_token_ids: list[list[int]],
         num_tokens_no_spec: np.ndarray,
         token_ids_cpu: np.ndarray,
+        req_ids: list[str] | None = None,
         slot_mappings: dict[str, torch.Tensor]
         | list[dict[str, torch.Tensor]]
         | None = None,  # unused
@@ -152,12 +245,79 @@ class NgramProposer:
 
             valid_ngram_requests.append(i)
 
+        if self.global_ngram_cache is not None:
+            return self.batch_propose_global(
+                len(sampled_token_ids),
+                valid_ngram_requests,
+                num_tokens_no_spec,
+                token_ids_cpu,
+                req_ids,
+            )
+
         draft_token_ids = self.batch_propose(
             len(sampled_token_ids),
             valid_ngram_requests,
             num_tokens_no_spec,
             token_ids_cpu,
         )
+
+        return draft_token_ids
+
+    def _global_initial_branch_length(self, num_tokens: int) -> int | None:
+        cache = self.global_ngram_cache
+        assert cache is not None
+        ngram_range = self.max_n - self.min_n + 1
+        max_full_context_tokens = cache.branch_length
+        if ngram_range > 0:
+            # Avoid full-context inserts that would churn the global LRU cache.
+            max_full_context_tokens = max(
+                max_full_context_tokens,
+                2 * (cache.max_entries // ngram_range),
+            )
+        if num_tokens <= max_full_context_tokens:
+            return num_tokens
+        return None
+
+    def batch_propose_global(
+        self,
+        num_requests: int,
+        valid_ngram_requests: list,
+        num_tokens_no_spec: np.ndarray,
+        token_ids_cpu: np.ndarray,
+        req_ids: list[str] | None,
+    ) -> list[list[int]]:
+        cache = self.global_ngram_cache
+        assert cache is not None
+
+        draft_token_ids = [[] for _ in range(num_requests)]
+        active_req_ids = (
+            set(req_ids)
+            if req_ids is not None
+            else {str(i) for i in range(num_requests)}
+        )
+        for req_id in list(self.global_ngram_last_put_lens):
+            if req_id not in active_req_ids:
+                self.global_ngram_last_put_lens.pop(req_id, None)
+
+        for i in valid_ngram_requests:
+            num_tokens = int(num_tokens_no_spec[i])
+            req_id = req_ids[i] if req_ids is not None else str(i)
+            last_put_len = self.global_ngram_last_put_lens.get(req_id, 0)
+            if num_tokens < last_put_len:
+                last_put_len = 0
+            if num_tokens > last_put_len:
+                branch_length = (
+                    self._global_initial_branch_length(num_tokens)
+                    if last_put_len == 0
+                    else None
+                )
+                cache.put(token_ids_cpu[i, :num_tokens], branch_length)
+                self.global_ngram_last_put_lens[req_id] = num_tokens
+
+            draft = cache.get(token_ids_cpu[i, :num_tokens])
+            if draft:
+                max_draft_tokens = self.max_model_len - num_tokens
+                draft_token_ids[i] = draft[:max_draft_tokens]
 
         return draft_token_ids
 

--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -289,7 +289,7 @@ class NgramProposer:
         cache = self.global_ngram_cache
         assert cache is not None
 
-        draft_token_ids = [[] for _ in range(num_requests)]
+        draft_token_ids: list[list[int]] = [[] for _ in range(num_requests)]
         active_req_ids = (
             set(req_ids)
             if req_ids is not None

--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -1,12 +1,85 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
+from collections import OrderedDict
 
 import numpy as np
 import torch
 from numba import get_num_threads, jit, njit, prange, set_num_threads
 
 from vllm.config import VllmConfig
+
+
+class _GlobalNgramCache:
+    def __init__(
+        self,
+        min_n: int,
+        max_n: int,
+        k: int,
+        branch_length: int,
+        max_entries: int,
+        max_continuations_per_key: int = 8,
+    ) -> None:
+        self.min_n = min_n
+        self.max_n = max_n
+        self.k = k
+        self.branch_length = branch_length
+        self.max_entries = max_entries
+        self.max_continuations_per_key = max_continuations_per_key
+        self._continuations: OrderedDict[tuple[int, ...], list[tuple[int, ...]]] = (
+            OrderedDict()
+        )
+
+    def put(self, token_ids: np.ndarray, branch_length: int | None = None) -> None:
+        if token_ids.shape[0] <= self.min_n:
+            return
+        branch_length = branch_length or self.branch_length
+        tokens = token_ids[-branch_length:].tolist()
+        num_tokens = len(tokens)
+        min_n = self.min_n
+        max_n_limit = self.max_n
+        k = self.k
+        put_one = self._put_one
+        for start in range(num_tokens):
+            max_n = min(max_n_limit, num_tokens - start - 1)
+            for ngram_len in range(min_n, max_n + 1):
+                continuation_start = start + ngram_len
+                put_one(
+                    tuple(tokens[start:continuation_start]),
+                    tuple(tokens[continuation_start : continuation_start + k]),
+                )
+
+    def _put_one(self, key: tuple[int, ...], continuation: tuple[int, ...]) -> None:
+        if not continuation:
+            return
+        continuations = self._continuations
+        values = continuations.get(key)
+        if values is None:
+            values = []
+            continuations[key] = values
+        elif continuation in values:
+            values.remove(continuation)
+        values.insert(0, continuation)
+        if len(values) > self.max_continuations_per_key:
+            del values[self.max_continuations_per_key :]
+        continuations.move_to_end(key)
+        if len(continuations) > self.max_entries:
+            continuations.popitem(last=False)
+
+    def get(self, token_ids: np.ndarray) -> list[int]:
+        total_tokens = token_ids.shape[0]
+        if total_tokens < self.min_n:
+            return []
+        max_n = min(self.max_n, total_tokens)
+        tokens = token_ids[-max_n:].tolist()
+        continuations = self._continuations
+        for ngram_len in range(max_n, self.min_n - 1, -1):
+            key = tuple(tokens[-ngram_len:])
+            values = continuations.get(key)
+            if values:
+                continuations.move_to_end(key)
+                return list(values[0])
+        return []
 
 
 class NgramProposer:
@@ -25,6 +98,25 @@ class NgramProposer:
         self.k = vllm_config.speculative_config.num_speculative_tokens
         # Maximum length of the model.
         self.max_model_len = vllm_config.model_config.max_model_len
+        self.prompt_lookup_cache_scope = (
+            vllm_config.speculative_config.prompt_lookup_cache_scope
+        )
+        branch_length = (
+            vllm_config.speculative_config.prompt_lookup_global_branch_length
+        )
+        max_entries = vllm_config.speculative_config.prompt_lookup_global_max_entries
+        self.global_ngram_cache: _GlobalNgramCache | None = None
+        if self.prompt_lookup_cache_scope == "global":
+            assert branch_length is not None
+            assert max_entries is not None
+            self.global_ngram_cache = _GlobalNgramCache(
+                self.min_n,
+                self.max_n,
+                self.k,
+                branch_length,
+                max_entries,
+            )
+        self.global_ngram_last_put_lens: dict[str, int] = {}
 
         # Pre-allocate buffers for numba batch propose.
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
@@ -138,6 +230,7 @@ class NgramProposer:
         sampled_token_ids: list[list[int]],
         num_tokens_no_spec: np.ndarray,
         token_ids_cpu: np.ndarray,
+        req_ids: list[str] | None = None,
         slot_mappings: dict[str, torch.Tensor]
         | list[dict[str, torch.Tensor]]
         | None = None,  # unused
@@ -159,6 +252,15 @@ class NgramProposer:
 
             valid_ngram_requests.append(i)
 
+        if self.global_ngram_cache is not None:
+            return self.batch_propose_global(
+                len(sampled_token_ids),
+                valid_ngram_requests,
+                num_tokens_no_spec,
+                token_ids_cpu,
+                req_ids,
+            )
+
         draft_token_ids = self.batch_propose(
             len(sampled_token_ids),
             valid_ngram_requests,
@@ -166,6 +268,64 @@ class NgramProposer:
             token_ids_cpu,
             num_speculative_tokens,
         )
+
+        return draft_token_ids
+
+    def _global_initial_branch_length(self, num_tokens: int) -> int | None:
+        cache = self.global_ngram_cache
+        assert cache is not None
+        ngram_range = self.max_n - self.min_n + 1
+        max_full_context_tokens = cache.branch_length
+        if ngram_range > 0:
+            # Avoid full-context inserts that would churn the global LRU cache.
+            max_full_context_tokens = max(
+                max_full_context_tokens,
+                2 * (cache.max_entries // ngram_range),
+            )
+        if num_tokens <= max_full_context_tokens:
+            return num_tokens
+        return None
+
+    def batch_propose_global(
+        self,
+        num_requests: int,
+        valid_ngram_requests: list,
+        num_tokens_no_spec: np.ndarray,
+        token_ids_cpu: np.ndarray,
+        req_ids: list[str] | None,
+    ) -> list[list[int]]:
+        cache = self.global_ngram_cache
+        assert cache is not None
+
+        draft_token_ids: list[list[int]] = [[] for _ in range(num_requests)]
+        active_req_ids = (
+            set(req_ids)
+            if req_ids is not None
+            else {str(i) for i in range(num_requests)}
+        )
+        for req_id in list(self.global_ngram_last_put_lens):
+            if req_id not in active_req_ids:
+                self.global_ngram_last_put_lens.pop(req_id, None)
+
+        for i in valid_ngram_requests:
+            num_tokens = int(num_tokens_no_spec[i])
+            req_id = req_ids[i] if req_ids is not None else str(i)
+            last_put_len = self.global_ngram_last_put_lens.get(req_id, 0)
+            if num_tokens < last_put_len:
+                last_put_len = 0
+            if num_tokens > last_put_len:
+                branch_length = (
+                    self._global_initial_branch_length(num_tokens)
+                    if last_put_len == 0
+                    else None
+                )
+                cache.put(token_ids_cpu[i, :num_tokens], branch_length)
+                self.global_ngram_last_put_lens[req_id] = num_tokens
+
+            draft = cache.get(token_ids_cpu[i, :num_tokens])
+            if draft:
+                max_draft_tokens = self.max_model_len - num_tokens
+                draft_token_ids[i] = draft[:max_draft_tokens]
 
         return draft_token_ids
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4823,6 +4823,7 @@ class GPUModelRunner(
                 sampled_token_ids,
                 self.input_batch.num_tokens_no_spec,
                 self.input_batch.token_ids_cpu,
+                req_ids=self.input_batch.req_ids,
                 slot_mappings=slot_mappings,
             )
         elif spec_config.method == "custom_class":

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5143,6 +5143,7 @@ class GPUModelRunner(
                 sampled_token_ids,
                 self.input_batch.num_tokens_no_spec,
                 self.input_batch.token_ids_cpu,
+                req_ids=self.input_batch.req_ids,
                 slot_mappings=slot_mappings,
             )
         elif spec_config.method == "custom_class":


### PR DESCRIPTION


## Purpose

This PR adds an opt-in global cache scope for ngram prompt-lookup speculative decoding.

The existing ngram proposer only scans the current request context. With `prompt_lookup_cache_scope="global"`, the proposer records prompt ngram continuations in a bounded process-local cache and can reuse them across requests. The default remains `local`, so existing behavior is unchanged unless the new global scope is explicitly selected.

This PR:

- adds `prompt_lookup_cache_scope`, `prompt_lookup_global_branch_length`, and `prompt_lookup_global_max_entries`
- keeps `prompt_lookup_cache_scope="local"` as the default
- wires request IDs into the V1 ngram proposer so global cache state is tracked per active request
- implements a bounded LRU global ngram continuation cache
- indexes short initial prompts fully when the cache budget can hold them, and otherwise indexes the configured suffix window
- uses a default global cache capacity of `100000` entries when global mode is selected

## Test Plan

```bash
HF_HUB_OFFLINE=1 PYTHONPATH=. python -m pytest \
  tests/v1/spec_decode/test_ngram.py \
  tests/test_config.py::test_ngram_prompt_lookup_global_scope_is_accepted \
  tests/test_config.py::test_ngram_prompt_lookup_cache_scope_defaults_to_local \
  tests/test_config.py::test_prompt_lookup_cache_scope_requires_ngram -q

PYTHONPATH=. python -m py_compile \
  vllm/config/speculative.py \
  vllm/v1/spec_decode/ngram_proposer.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/spec_decode/test_ngram.py \
  tests/test_config.py

python -m ruff check \
  vllm/config/speculative.py \
  vllm/v1/spec_decode/ngram_proposer.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/spec_decode/test_ngram.py \
  tests/test_config.py

python -m ruff format --check \
  vllm/config/speculative.py \
  vllm/v1/spec_decode/ngram_proposer.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/spec_decode/test_ngram.py \
  tests/test_config.py

git diff --check
```

Benchmark setup:

- Model: Qwen3-8B
- GPU: single NVIDIA A100-SXM4-80GB
- Batch size: 1 (`max_num_seqs=1`)
- Sampling: greedy, `temperature=0`, `top_p=1.0`, `max_tokens=128`
- Speculative config: ngram, `num_speculative_tokens=12`, `prompt_lookup_min=1`, `prompt_lookup_max=12`
- Global config: `prompt_lookup_cache_scope="global"`, `prompt_lookup_global_branch_length=24`, default `prompt_lookup_global_max_entries=100000`
- Exact-match baseline: `vanilla_noasync` output token IDs from the same final-code matrix

## Test Result

```text
11 passed
py_compile: passed
ruff check: all checks passed
ruff format --check: all checked files already formatted
git diff --check: passed
```

Performance-focused benchmark on API/agent traces:

| dataset | method | tok/s | speedup vs vanilla noasync | exact match | accepted draft tokens/draft |
|---|---|---:|---:|---:|---:|
| apibank_level-1-api, 20 reqs | vanilla_default | 80.03 | 1.03x | 20/20 | - |
| apibank_level-1-api, 20 reqs | vanilla_noasync | 77.75 | 1.00x | 20/20 | - |
| apibank_level-1-api, 20 reqs | local_ngram | 149.52 | 1.92x | 20/20 | 1.40 |
| apibank_level-1-api, 20 reqs | global_ngram_b24_default100k | 188.80 | 2.43x | 20/20 | 2.43 |
| apibank_level-1-api, 128 reqs | vanilla_default | 80.85 | 1.03x | 128/128 | - |
| apibank_level-1-api, 128 reqs | vanilla_noasync | 78.64 | 1.00x | 128/128 | - |
| apibank_level-1-api, 128 reqs | local_ngram | 145.40 | 1.85x | 128/128 | 1.26 |
| apibank_level-1-api, 128 reqs | global_ngram_b24_default100k | 221.87 | 2.82x | 128/128 | 3.06 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
