### PR TITLE
Fix empty DP model step coordination

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4050,17 +4050,13 @@ class GPUModelRunner(
                     return make_empty_encoder_model_runner_output(scheduler_output)
 
             if not num_scheduled_tokens:
-                if (
-                    self.parallel_config.distributed_executor_backend
-                    == "external_launcher"
-                    and self.parallel_config.data_parallel_size > 1
-                ):
-                    # this is a corner case when both external launcher
-                    # and DP are enabled, num_scheduled_tokens could be
-                    # 0, and has_unfinished_requests in the outer loop
-                    # returns True. before returning early here we call
-                    # dummy run to ensure coordinate_batch_across_dp
-                    # is called into to avoid out of sync issues.
+                if self.parallel_config.data_parallel_size > 1:
+                    # This is a corner case when DP is enabled,
+                    # num_scheduled_tokens could be 0, and
+                    # has_unfinished_requests in the outer loop returns True.
+                    # Before returning early here, call dummy run to ensure
+                    # coordinate_batch_across_dp is called to avoid out of sync
+                    # issues.
                     self._dummy_run(1)
                 if not has_kv_transfer_group():
                     # Return empty ModelRunnerOutput if no work to do.


### PR DESCRIPTION
## Summary
- Run the dummy model step for every DP backend when a scheduled step has zero tokens.
- Keep `coordinate_batch_across_dp` participation aligned before returning an empty model runner output.

Fixes #43547.

## Why this is useful
Issue #43547 reports a reproducible multi-node DP/NCCL deadlock where a zero-token-scheduled DP rank can return before participating in the per-step DP coordination collective. The existing code already uses `_dummy_run(1)` for this case, but only when `distributed_executor_backend == "external_launcher"`. This change broadens that existing synchronization path to all DP backends by gating only on `data_parallel_size > 1`.

## Duplicate check
- Checked #43547 and its comments.
- Checked open PRs with `43547 in:body`; only this PR matched.
- Checked open PRs with `coordinate_batch_across_dp empty DP`; this PR matched, plus an unrelated DeepSeek/SM120 PR.

## Testing
- `git diff --check`

Not run locally:
- Full vLLM test environment, because this checkout has no local `uv` environment configured.
- Multi-node NCCL/MoE reproduction, because it requires a distributed GPU setup.

## AI assistance disclosure
This PR was prepared with AI assistance. The submitting human should review and understand the changed lines and the linked issue before requesting maintainer review.