### PR TITLE
[Rust Frontend] Forward `VLLM_ENGINE_READY_TIMEOUT_S` via `--args-json`

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -365,19 +365,23 @@ class RustFrontendProcessManager:
             cmd.extend(["--coordinator-address", stats_update_address])
         from vllm.entrypoints.serve.utils.api_utils import jsonify_non_default_args
 
-        args_json = json.dumps(
-            jsonify_non_default_args(
-                args,
-                exclude={
-                    "api_server_count",
-                    # Python passes the bootstrapped engine range explicitly.
-                    "data_parallel_rank",
-                    "data_parallel_external_lb",
-                    "data_parallel_hybrid_lb",
-                },
-            ),
-            sort_keys=True,
+        args_dict = jsonify_non_default_args(
+            args,
+            exclude={
+                "api_server_count",
+                # Python passes the bootstrapped engine range explicitly.
+                "data_parallel_rank",
+                "data_parallel_external_lb",
+                "data_parallel_hybrid_lb",
+            },
         )
+        # The Rust `frontend` subcommand parses --args-json via serde_json,
+        # which bypasses clap and therefore ignores any `#[arg(env = ...)]`
+        # declarations on SharedRuntimeArgs fields. Forward the env-driven
+        # ready timeout explicitly so VLLM_ENGINE_READY_TIMEOUT_S behaves the
+        # same on both Python and Rust frontends.
+        args_dict["engine_ready_timeout_secs"] = envs.VLLM_ENGINE_READY_TIMEOUT_S
+        args_json = json.dumps(args_dict, sort_keys=True)
         cmd.extend(["--args-json", args_json])
 
         logger.info("Launching Rust frontend: %s", " ".join(cmd))


### PR DESCRIPTION
## Motivation

When using the Rust frontend, setting export VLLM_ENGINE_READY_TIMEOUT_S=1800 has no effect. Models that require extended JIT compilation during startup (e.g., DeepSeek with DeepGEMM) can easily exceed the default 600 s engine-ready timeout window — even when the user has explicitly raised the limit via VLLM_ENGINE_READY_TIMEOUT_S. 

The Rust frontend silently ignores this env var, causing the server to be killed prematurely with no actionable error message. Example command affected:

```
export VLLM_USE_RUST_FRONTEND=1
export VLLM_ENGINE_READY_TIMEOUT_S=1800

MODEL_PATH=/path/to/deepseek_v32

vllm serve $MODEL \
  --trust-remote-code \
  --enable-expert-parallel \
  --tensor-parallel-size 8 \
  --moe-backend deep_gemm
```

Note for others hitting the same issue: If you see the Rust frontend killing the server during model loading despite setting VLLM_ENGINE_READY_TIMEOUT_S. The env var is only read by the Python side and was never forwarded to the Rust subprocess. This workaround fix ensures this value is propagated correctly.

## Changes
vllm/v1/utils.py: Inject envs.VLLM_ENGINE_READY_TIMEOUT_S into the args dict before passing it as --args-json to the Rust frontend subprocess.
