### PR TITLE
Fix `LLM.wait_for_completion` output type docstring

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -556,7 +556,8 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         and returns their outputs. Use after enqueue() to get results.
 
         Args:
-            output_type: The expected output type, defaults to RequestOutput.
+            output_type: The expected output type(s). If not provided, accepts
+                both RequestOutput and PoolingRequestOutput.
             use_tqdm: If True, shows a tqdm progress bar.
 
         Returns:


### PR DESCRIPTION
## Purpose

Fixes #44616.

`LLM.wait_for_completion()` currently writes `output_type` as defaulting to `RequestOutput`, but the implementation accepts both `RequestOutput` and `PoolingRequestOutput` when `output_type` doesn't provided:

```python
if output_type is None:
    output_type = (RequestOutput, PoolingRequestOutput)
```

This PR updates the public API docstring so it matches the actual behavior.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>