### PR TITLE
[Bugfix][KV Connector] Gracefully fall back when LMCacheConnectorV1 is degraded

### DIFF
--- a/tests/v1/kv_connector/unit/test_lmcache_connector.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_connector.py
@@ -3,8 +3,10 @@
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from vllm.distributed.kv_events import BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
     LMCacheConnectorV1,
     LMCacheKVEvents,
@@ -52,8 +54,19 @@ def mock_connector():
     connector = MagicMock(spec=LMCacheConnectorV1)
     connector._kv_cache_events = None
     connector._lmcache_engine = MagicMock()
+    connector._logged_lmcache_degraded = False
 
     # Make the methods use the real implementation
+    connector._lmcache_engine_unavailable = (
+        LMCacheConnectorV1._lmcache_engine_unavailable.__get__(
+            connector, LMCacheConnectorV1
+        )
+    )
+    connector._skip_when_lmcache_degraded = (
+        LMCacheConnectorV1._skip_when_lmcache_degraded.__get__(
+            connector, LMCacheConnectorV1
+        )
+    )
     connector.get_kv_connector_kv_cache_events = (
         LMCacheConnectorV1.get_kv_connector_kv_cache_events.__get__(
             connector, LMCacheConnectorV1
@@ -69,6 +82,214 @@ def mock_connector():
     )
 
     return connector
+
+
+def make_connector_with_adapter(adapter: MagicMock) -> LMCacheConnectorV1:
+    connector = object.__new__(LMCacheConnectorV1)
+    connector._lmcache_engine = adapter
+    connector._kv_cache_events = None
+    connector._logged_lmcache_degraded = False
+    return connector
+
+
+def bind_lmcache_metadata(connector: LMCacheConnectorV1) -> None:
+    metadata = MagicMock()
+    metadata.requests = []
+    connector.bind_connector_metadata(metadata)
+
+
+class TestDegradedLMCacheFallback:
+    """Worker-side hooks should no-op when LMCache is in degraded mode."""
+
+    @pytest.fixture()
+    def degraded_connector(self):
+        adapter = MagicMock()
+        adapter.lmcache_engine = None
+        return make_connector_with_adapter(adapter), adapter
+
+    def test_start_load_kv_noops_when_lmcache_engine_is_none(self, degraded_connector):
+        connector, adapter = degraded_connector
+        forward_context = MagicMock()
+
+        connector.start_load_kv(forward_context, extra_arg="x")
+
+        adapter.start_load_kv.assert_not_called()
+
+    def test_register_kv_caches_noops_when_lmcache_engine_is_none(
+        self, degraded_connector
+    ):
+        connector, adapter = degraded_connector
+        kv_caches = {"layer.0": torch.zeros(1)}
+
+        connector.register_kv_caches(kv_caches)
+
+        adapter.register_kv_caches.assert_not_called()
+
+    def test_wait_for_layer_load_noops_when_lmcache_engine_is_none(
+        self, degraded_connector
+    ):
+        connector, adapter = degraded_connector
+
+        connector.wait_for_layer_load("layer.0")
+
+        adapter.wait_for_layer_load.assert_not_called()
+
+    def test_save_kv_layer_noops_when_lmcache_engine_is_none(self, degraded_connector):
+        connector, adapter = degraded_connector
+        kv_layer = torch.zeros(1)
+        attn_metadata = MagicMock()
+
+        connector.save_kv_layer("layer.0", kv_layer, attn_metadata, extra_arg="x")
+
+        adapter.save_kv_layer.assert_not_called()
+
+    def test_wait_for_save_noops_when_lmcache_engine_is_none(self, degraded_connector):
+        connector, adapter = degraded_connector
+
+        connector.wait_for_save()
+
+        adapter.wait_for_save.assert_not_called()
+
+    def test_get_finished_noops_when_lmcache_engine_is_none(self, degraded_connector):
+        connector, adapter = degraded_connector
+
+        assert connector.get_finished({"req-1"}) == (None, None)
+        adapter.get_finished.assert_not_called()
+
+    def test_get_block_ids_with_load_errors_is_empty_in_degraded_mode(
+        self, degraded_connector
+    ):
+        connector, adapter = degraded_connector
+
+        assert connector.get_block_ids_with_load_errors() == set()
+        adapter.get_block_ids_with_load_errors.assert_not_called()
+
+    def test_get_kv_cache_events_is_none_in_degraded_mode(self, degraded_connector):
+        connector, adapter = degraded_connector
+
+        assert connector.get_kv_connector_kv_cache_events() is None
+        adapter.get_kv_events.assert_not_called()
+
+    def test_start_load_kv_delegates_when_lmcache_engine_exists(self):
+        adapter = MagicMock()
+        adapter.lmcache_engine = object()
+        connector = make_connector_with_adapter(adapter)
+        bind_lmcache_metadata(connector)
+        forward_context = MagicMock()
+
+        connector.start_load_kv(forward_context, extra_arg="x")
+
+        adapter.start_load_kv.assert_called_once_with(forward_context, extra_arg="x")
+
+
+class TestDegradedSchedulerSide:
+    """Scheduler-side hooks must no-op when the LMCache lookup client is
+    unavailable (degraded init), instead of asserting and killing EngineCore."""
+
+    @pytest.fixture()
+    def degraded_connector(self):
+        adapter = MagicMock()
+        adapter.lookup_client = None
+        return make_connector_with_adapter(adapter), adapter
+
+    def test_get_num_new_matched_tokens_noops_when_lookup_unavailable(
+        self, degraded_connector
+    ):
+        connector, adapter = degraded_connector
+
+        assert connector.get_num_new_matched_tokens(MagicMock(), 0) == (0, False)
+        adapter.get_num_new_matched_tokens.assert_not_called()
+
+    def test_update_state_after_alloc_noops_when_lookup_unavailable(
+        self, degraded_connector
+    ):
+        connector, adapter = degraded_connector
+
+        connector.update_state_after_alloc(MagicMock(), MagicMock(), 0)
+        adapter.update_state_after_alloc.assert_not_called()
+
+    def test_build_connector_meta_returns_empty_when_lookup_unavailable(
+        self, degraded_connector
+    ):
+        connector, adapter = degraded_connector
+
+        meta = connector.build_connector_meta(MagicMock())
+        assert isinstance(meta, KVConnectorMetadata)
+        adapter.build_connector_meta.assert_not_called()
+
+    def test_request_finished_noops_when_lookup_unavailable(self, degraded_connector):
+        connector, adapter = degraded_connector
+
+        assert connector.request_finished(MagicMock(), [1, 2]) == (False, None)
+        adapter.request_finished.assert_not_called()
+
+    def test_scheduler_methods_delegate_when_lookup_available(self):
+        adapter = MagicMock()
+        adapter.lookup_client = object()
+        adapter.get_num_new_matched_tokens.return_value = 7
+        connector = make_connector_with_adapter(adapter)
+        request = MagicMock()
+
+        assert connector.get_num_new_matched_tokens(request, 3) == (7, False)
+        adapter.get_num_new_matched_tokens.assert_called_once_with(request, 3)
+
+        connector.update_state_after_alloc(request, MagicMock(), 7)
+        adapter.update_state_after_alloc.assert_called_once_with(request, 7)
+
+        connector.build_connector_meta(MagicMock())
+        adapter.build_connector_meta.assert_called_once()
+
+        connector.request_finished(request, [1, 2])
+        adapter.request_finished.assert_called_once_with(request, [1, 2])
+
+
+class TestDegradedSchedulerMetadataFallback:
+    """Worker-side hooks must no-op if the scheduler fell back to generic
+    metadata instead of LMCache metadata."""
+
+    @pytest.fixture()
+    def connector_with_generic_metadata(self):
+        adapter = MagicMock()
+        adapter.lmcache_engine = object()
+        connector = make_connector_with_adapter(adapter)
+        connector.bind_connector_metadata(KVConnectorMetadata())
+        return connector, adapter
+
+    def test_start_load_kv_noops_without_lmcache_metadata(
+        self, connector_with_generic_metadata
+    ):
+        connector, adapter = connector_with_generic_metadata
+
+        connector.start_load_kv(MagicMock(), extra_arg="x")
+
+        adapter.start_load_kv.assert_not_called()
+
+    def test_wait_for_layer_load_noops_without_lmcache_metadata(
+        self, connector_with_generic_metadata
+    ):
+        connector, adapter = connector_with_generic_metadata
+
+        connector.wait_for_layer_load("layer.0")
+
+        adapter.wait_for_layer_load.assert_not_called()
+
+    def test_save_kv_layer_noops_without_lmcache_metadata(
+        self, connector_with_generic_metadata
+    ):
+        connector, adapter = connector_with_generic_metadata
+
+        connector.save_kv_layer("layer.0", torch.zeros(1), MagicMock())
+
+        adapter.save_kv_layer.assert_not_called()
+
+    def test_wait_for_save_noops_without_lmcache_metadata(
+        self, connector_with_generic_metadata
+    ):
+        connector, adapter = connector_with_generic_metadata
+
+        connector.wait_for_save()
+
+        adapter.wait_for_save.assert_not_called()
 
 
 class TestGetKVConnectorKVCacheEvents:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -113,6 +113,60 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         self._lmcache_engine = cls(vllm_config, role, self)
 
         self._kv_cache_events: LMCacheKVEvents | None = None
+        self._logged_lmcache_degraded = False
+
+    def _warn_degraded_once(self, message: str) -> None:
+        if not self._logged_lmcache_degraded:
+            logger.warning(message)
+            self._logged_lmcache_degraded = True
+
+    def _lmcache_engine_unavailable(self) -> bool:
+        # Degraded init leaves the adapter in place with inner lmcache_engine
+        # set to None; older adapters that lack the attribute count as available.
+        inner_engine = getattr(
+            self._lmcache_engine, "lmcache_engine", self._lmcache_engine
+        )
+        return inner_engine is None
+
+    def _skip_when_lmcache_degraded(self, method_name: str) -> bool:
+        if not self._lmcache_engine_unavailable():
+            return False
+        self._warn_degraded_once(
+            "LMCache engine is unavailable. Skipping LMCache load/store worker "
+            "hooks and falling back to local recomputation."
+        )
+        logger.debug(
+            "Skipping LMCacheConnectorV1.%s because LMCache is degraded",
+            method_name,
+        )
+        return True
+
+    def _skip_when_lmcache_metadata_unavailable(self, method_name: str) -> bool:
+        # Degraded scheduler returns base KVConnectorMetadata (no "requests");
+        # forwarding it to the adapter would trip the adapter's type assertion.
+        if hasattr(self._get_connector_metadata(), "requests"):
+            return False
+        self._warn_degraded_once(
+            "LMCache connector metadata is unavailable. Skipping LMCache "
+            "load/store worker hooks and falling back to local recomputation."
+        )
+        logger.debug(
+            "Skipping LMCacheConnectorV1.%s because LMCache metadata is unavailable",
+            method_name,
+        )
+        return True
+
+    def _lmcache_lookup_unavailable(self) -> bool:
+        # Scheduler degraded signal: a failed init leaves lookup_client == None
+        # (worker role lacks the attr; the sentinel keeps it counted as available).
+        sentinel = object()
+        if getattr(self._lmcache_engine, "lookup_client", sentinel) is None:
+            self._warn_degraded_once(
+                "LMCache lookup client is unavailable. Skipping LMCache "
+                "scheduler hooks and falling back to local recomputation."
+            )
+            return True
+        return False
 
     # ==============================
     # Worker-side methods
@@ -125,6 +179,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         Args:
             kv_caches: dictionary of layer names, kv cache
         """
+        if self._skip_when_lmcache_degraded("register_kv_caches"):
+            return
         if hasattr(self._lmcache_engine, "register_kv_caches"):
             self._lmcache_engine.register_kv_caches(kv_caches)
         else:
@@ -148,6 +204,10 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             the same.
 
         """
+        if self._skip_when_lmcache_degraded("start_load_kv"):
+            return
+        if self._skip_when_lmcache_metadata_unavailable("start_load_kv"):
+            return
         self._lmcache_engine.start_load_kv(forward_context, **kwargs)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -161,6 +221,10 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         Args:
             layer_name: the name of that layer
         """
+        if self._skip_when_lmcache_degraded("wait_for_layer_load"):
+            return
+        if self._skip_when_lmcache_metadata_unavailable("wait_for_layer_load"):
+            return
         self._lmcache_engine.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
@@ -182,6 +246,10 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             attn_metadata (AttentionMetadata): the attention metadata.
             **kwargs: additional arguments for the save operation.
         """
+        if self._skip_when_lmcache_degraded("save_kv_layer"):
+            return
+        if self._skip_when_lmcache_metadata_unavailable("save_kv_layer"):
+            return
         self._lmcache_engine.save_kv_layer(
             layer_name, kv_layer, attn_metadata, **kwargs
         )
@@ -194,6 +262,10 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
 
         This prevents overwrites of paged KV buffer before saving done.
         """
+        if self._skip_when_lmcache_degraded("wait_for_save"):
+            return
+        if self._skip_when_lmcache_metadata_unavailable("wait_for_save"):
+            return
         self._lmcache_engine.wait_for_save()
 
     def get_finished(
@@ -210,6 +282,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             The finished saves/sends req ids must belong to a set provided in a
             call to this method (this call or a prior one).
         """
+        if self._skip_when_lmcache_degraded("get_finished"):
+            return None, None
         return self._lmcache_engine.get_finished(finished_req_ids)
 
     def get_block_ids_with_load_errors(self) -> set[int]:
@@ -220,6 +294,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             Set of block IDs that encountered load errors.
             Empty set if no load errors occurred.
         """
+        if self._skip_when_lmcache_degraded("get_block_ids_with_load_errors"):
+            return set()
         method = getattr(self._lmcache_engine, "get_block_ids_with_load_errors", None)
         if callable(method):
             return method()
@@ -231,6 +307,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         """
         Get the KV connector kv cache events collected during the last interval.
         """
+        if self._skip_when_lmcache_degraded("get_kv_connector_kv_cache_events"):
+            return None
 
         events = self._lmcache_engine.get_kv_events()  # type: ignore [attr-defined]
         if not events:
@@ -274,6 +352,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             the number of tokens that can be loaded from the
             external KV cache beyond what is already computed.
         """
+        if self._lmcache_lookup_unavailable():
+            return 0, False
         return self._lmcache_engine.get_num_new_matched_tokens(
             request, num_computed_tokens
         ), False
@@ -284,6 +364,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         """
         Update KVConnector state after block allocation.
         """
+        if self._lmcache_lookup_unavailable():
+            return
         self._lmcache_engine.update_state_after_alloc(request, num_external_tokens)
 
     def build_connector_meta(
@@ -298,6 +380,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         Args:
             scheduler_output (SchedulerOutput): the scheduler output object.
         """
+        if self._lmcache_lookup_unavailable():
+            return KVConnectorMetadata()
         return self._lmcache_engine.build_connector_meta(scheduler_output)
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
@@ -337,6 +421,8 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             Optional KVTransferParams to be included in the request outputs
             returned by the engine.
         """
+        if self._lmcache_lookup_unavailable():
+            return False, None
         return self._lmcache_engine.request_finished(request, block_ids)
 
     def take_events(self) -> Iterable["KVCacheEvent"]:


### PR DESCRIPTION

Fixes #44249.

This updates the legacy/in-process `LMCacheConnectorV1` wrapper to honor LMCache's degraded recompute mode instead of forwarding into adapter assertions after LMCache initialization partially fails.

Context: after #42865, the default `--kv-offloading-backend=lmcache` path maps to `LMCacheMPConnector`. This PR is for explicit `LMCacheConnectorV1` users, including the reproduction style in LMCache/LMCache#2854.

Changes:

- skip worker-side LMCache load/store hooks when the adapter exists but its internal `lmcache_engine` is unavailable
- skip scheduler-side LMCache hooks when the adapter exists but its `lookup_client` is unavailable
- skip worker-side load/store hooks when the degraded scheduler sends generic `KVConnectorMetadata()` instead of LMCache metadata
- add unit coverage for the worker degraded path, scheduler degraded path, and generic-metadata worker fallback

This overlaps with the worker-side part of #44317, but also covers the scheduler-side failure mode where `lookup_client` is `None` and the worker receives non-LMCache metadata.

## Alternative considered

A clean fail-fast design would also be reasonable: if a deployment treats LMCache as a required dependency, vLLM should reject startup with a clear initialization error.

That is not the current behavior, though. LMCache catches initialization failures, leaves the manager in degraded mode, and logs that the system will operate in recompute mode. vLLM then starts successfully and can pass health checks, but the first request later hits an adapter assertion and kills EngineCore. That is neither clean fail-fast nor graceful fallback.

This PR chooses to honor the degraded recompute contract that LMCache already advertises. If maintainers prefer required-dependency semantics for this connector, the alternative would be to make LMCache initialization errors fatal before the server becomes healthy, rather than keeping the current first-request assertion failure.

## Testing

Unit:

```text
pytest tests/v1/kv_connector/unit/test_lmcache_connector.py
41 passed

pytest tests/distributed/test_kvlayout.py::test_get_kv_connector_cache_layout_with_lmcache_connector
1 passed
```

`ruff check`, `ruff format --check`, and `pre-commit run --files` on the changed files all pass.

Real `vllm serve` E2E with the explicit connector config:

```text
--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.local_cpu":true,"lmcache.max_local_cpu_size":4.0}}'
```

Without this PR, with injected LMCache init failures:

```text
healthy:            HTTP 200
worker degraded:    HTTP 500, assert self.lmcache_engine is not None
scheduler degraded: HTTP 500, assert self.lookup_client is not None
both degraded:      HTTP 500, assert self.lookup_client is not None
```

With this PR, same scenarios:

```text
healthy:            HTTP 200
worker degraded:    HTTP 200
scheduler degraded: HTTP 200
both degraded:      HTTP 200
```

<details>
<summary>End-to-end reproduction (degraded-state injection, server, client, before/after output)</summary>

The E2E uses a real `vllm serve` process with explicit `LMCacheConnectorV1`. The injected state matches the LMCache degraded signals this PR guards: worker-side `lmcache_engine is None`, scheduler-side `lookup_client is None`, and both together. The server starts normally, then the first request exercises the degraded hook.

Create the injection package:

```bash
mkdir -p /tmp/lmcache_degraded_inject
cat >/tmp/lmcache_degraded_inject/sitecustomize.py <<'PY'
import importlib
import os

MODE = os.environ.get("LMCACHE_DEGRADE_MODE", "")
if MODE:
    adapter = None
    last_exc = None
    for module_name in (
        "lmcache.integration.vllm.vllm_v1_adapter",
        "vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration.vllm_v1_adapter",
    ):
        try:
            adapter = importlib.import_module(module_name)
            print(f"PATCHED LMCache adapter: {module_name}", flush=True)
            break
        except Exception as exc:
            last_exc = exc
    if adapter is None:
        raise RuntimeError("Could not import an LMCache vLLM adapter") from last_exc

    orig_init = adapter.LMCacheConnectorV1Impl.__init__

    def injected_init(self, vllm_config, role, parent):
        orig_init(self, vllm_config, role, parent)
        is_scheduler = role == adapter.KVConnectorRole.SCHEDULER
        if MODE in {"worker", "both"} and not is_scheduler:
            self.lmcache_engine = None
            print("INJECT worker degraded: lmcache_engine=None", flush=True)
        if MODE in {"scheduler", "both"} and is_scheduler:
            self.lookup_client = None
            print("INJECT scheduler degraded: lookup_client=None", flush=True)

    adapter.LMCacheConnectorV1Impl.__init__ = injected_init
PY
```

Run the four scenarios:

```bash
cd /path/to/vllm
export PYTHONPATH="$PWD"
export CUDA_VISIBLE_DEVICES=0
export MODEL=${MODEL:-facebook/opt-125m}
export PORT=${PORT:-8025}
export KV_CFG='{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.local_cpu":true,"lmcache.max_local_cpu_size":4.0}}'

cat >/tmp/lmcache_degraded_client.py <<'PY'
import json
import os
import urllib.error
import urllib.request

port = os.environ.get("PORT", "8025")
payload = {
    "model": "lmcache-test",
    "prompt": "This request should keep serving even if LMCache is degraded.",
    "max_tokens": 8,
    "temperature": 0,
}
req = urllib.request.Request(
    f"http://127.0.0.1:{port}/v1/completions",
    data=json.dumps(payload).encode(),
    headers={"Content-Type": "application/json"},
    method="POST",
)
try:
    with urllib.request.urlopen(req, timeout=120) as resp:
        body = resp.read().decode(errors="replace")
        print("HTTP", resp.status)
        print(body[:500])
except urllib.error.HTTPError as exc:
    print("HTTP", exc.code)
    print(exc.read().decode(errors="replace")[:1000])
PY

for mode in healthy worker scheduler both; do
  echo "=== $mode ==="
  pkill -f "vllm.entrypoints.openai.api_server" || true
  rm -f /tmp/lmcache_${mode}.log
  if [ "$mode" = healthy ]; then
    env PYTHONPATH="$PWD" \
      python -m vllm.entrypoints.openai.api_server \
        --model "$MODEL" --served-model-name lmcache-test \
        --host 127.0.0.1 --port "$PORT" \
        --kv-transfer-config "$KV_CFG" \
        --enforce-eager --max-model-len 1024 --gpu-memory-utilization 0.30 \
        >/tmp/lmcache_${mode}.log 2>&1 &
  else
    env PYTHONPATH="/tmp/lmcache_degraded_inject:$PWD" LMCACHE_DEGRADE_MODE="$mode" \
      python -m vllm.entrypoints.openai.api_server \
        --model "$MODEL" --served-model-name lmcache-test \
        --host 127.0.0.1 --port "$PORT" \
        --kv-transfer-config "$KV_CFG" \
        --enforce-eager --max-model-len 1024 --gpu-memory-utilization 0.30 \
        >/tmp/lmcache_${mode}.log 2>&1 &
  fi
  pid=$!
  for _ in $(seq 1 120); do
    curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1 && break
    sleep 1
  done
  PORT="$PORT" python /tmp/lmcache_degraded_client.py
  kill "$pid" 2>/dev/null || true
  wait "$pid" 2>/dev/null || true
  grep -E "INJECT|AssertionError|lmcache_engine is not None|lookup_client is not None|EngineDeadError|fallback|HTTP" /tmp/lmcache_${mode}.log || true
done
```

Observed results:

```text
# stock main
healthy:            HTTP 200
worker degraded:    HTTP 500, AssertionError: assert self.lmcache_engine is not None
scheduler degraded: HTTP 500, AssertionError: assert self.lookup_client is not None
both degraded:      HTTP 500, AssertionError: assert self.lookup_client is not None

# with this PR
healthy:            HTTP 200
worker degraded:    HTTP 200
scheduler degraded: HTTP 200
both degraded:      HTTP 200
```

</details>

AI assistance was used to prepare this PR.

cc @ApostaC @orozery
