### PR TITLE
[Bugfix] Don't crash engine on malformed output-socket frame (#44486)

### DIFF
--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -612,3 +612,63 @@ def test_dp_coordinator_drops_undecodable_frame():
         with contextlib.suppress(Exception):
             ctx.destroy(linger=0)
         thread.join(timeout=5)
+
+
+def test_try_decode_frame_passes_through_valid():
+    """A well-formed frame decodes normally and is returned unchanged."""
+    from vllm.v1.serial_utils import DROP_FRAME, try_decode_frame
+
+    buf = msgspec.msgpack.encode(["a", 1, 2])
+    assert try_decode_frame(msgspec.msgpack.decode, buf, "test") == ["a", 1, 2]
+    assert try_decode_frame(msgspec.msgpack.decode, buf, "test", expected_len=3) == [
+        "a",
+        1,
+        2,
+    ]
+    assert try_decode_frame(msgspec.msgpack.decode, buf, "test") is not DROP_FRAME
+
+
+def test_try_decode_frame_drops_undecodable():
+    """Garbage bytes and typed-schema mismatches yield DROP_FRAME, not a raise.
+
+    Covers the core #44486 crash: an ``int`` where an array is expected raises
+    ``msgspec.ValidationError`` under a typed decoder; the helper must swallow it.
+    """
+    from vllm.v1.engine import EngineCoreOutputs
+    from vllm.v1.serial_utils import DROP_FRAME, try_decode_frame
+
+    # Raw junk bytes -> DecodeError.
+    assert try_decode_frame(msgspec.msgpack.decode, b"\xc1\xff\xff", "test") is (
+        DROP_FRAME
+    )
+
+    # Type mismatch against a typed decoder -> ValidationError
+    # ("Expected array, got int"), the exact error from the issue.
+    typed = MsgpackDecoder(EngineCoreOutputs)
+    junk = bytes(MsgpackEncoder().encode(123)[0])
+    assert try_decode_frame(typed.decode, junk, "test") is DROP_FRAME
+
+
+def test_try_decode_frame_drops_wrong_shape():
+    """A well-formed-but-misshapen untyped frame is dropped before the unpack.
+
+    This is the second class of #44486 bug: ``msgspec.msgpack.decode`` succeeds
+    on any valid msgpack, so a wrong-arity sequence (e.g. from a crafted frame)
+    would crash the caller's fixed-arity tuple-unpack. ``expected_len`` turns
+    that into a dropped frame instead.
+    """
+    from vllm.v1.serial_utils import DROP_FRAME, try_decode_frame
+
+    # Right type, wrong length.
+    buf = msgspec.msgpack.encode([1, 2])
+    assert (
+        try_decode_frame(msgspec.msgpack.decode, buf, "test", expected_len=3)
+        is DROP_FRAME
+    )
+
+    # Decodes fine, but not a sequence at all.
+    buf = msgspec.msgpack.encode(5)
+    assert (
+        try_decode_frame(msgspec.msgpack.decode, buf, "test", expected_len=2)
+        is DROP_FRAME
+    )

--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import contextlib
+import time
 from collections import UserDict
 from dataclasses import dataclass
 
@@ -509,3 +510,105 @@ def test_output_socket_drops_undecodable_frame():
     assert not isinstance(received, Exception), received
     assert isinstance(received, EngineCoreOutputs)
     assert received.engine_index == 7
+
+
+def test_dp_coordinator_drops_undecodable_frame():
+    """A malformed frame on the DP coordinator's sockets must not crash it.
+
+    Regression test for issue #44486: the DP coordinator decodes engine
+    messages with ``decoder.decode(buffer)`` (and a raw ``msgspec.msgpack``
+    decode on the front-end socket). ``run_coordinator`` only catches
+    ``KeyboardInterrupt``, so a ``ValidationError`` from a garbage frame
+    propagated uncaught and killed the coordinator process.
+
+    This drives the real ``DPCoordinatorProc.process_input_socket`` loop. A fake
+    engine subscribes so the coordinator reaches its steady-state poll loop;
+    then a garbage frame (an ``int`` where ``EngineCoreOutputs`` is expected,
+    reproducing "Expected array, got int") is pushed to the engine output
+    socket, followed by a valid stats update. The coordinator must drop the bad
+    frame and still publish the valid stats to the front-end.
+    """
+    import threading
+
+    from vllm.utils.network_utils import get_open_zmq_ipc_path
+    from vllm.v1.engine import EngineCoreOutputs
+    from vllm.v1.engine.coordinator import DPCoordinatorProc
+    from vllm.v1.metrics.stats import SchedulerStats
+
+    front_addr = get_open_zmq_ipc_path()
+    back_output_addr = get_open_zmq_ipc_path()
+    back_publish_addr = get_open_zmq_ipc_path()
+
+    coord = DPCoordinatorProc(engine_count=1, enable_wave_coordination=True)
+    captured: dict = {}
+
+    def run():
+        try:
+            # Mirrors run_coordinator(), which only catches KeyboardInterrupt;
+            # any other exception would crash the coordinator process.
+            coord.process_input_socket(
+                front_addr, back_output_addr, back_publish_addr, None
+            )
+        except KeyboardInterrupt:
+            captured["exc"] = "KeyboardInterrupt"
+        except BaseException as e:  # noqa: BLE001
+            captured["exc"] = f"{type(e).__name__}: {e}"
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+
+    ctx = coord.ctx
+    encoder = MsgpackEncoder()
+    try:
+        # Act as the single engine subscribing, so the coordinator finishes
+        # startup and enters its steady-state poll loop.
+        sub_back = ctx.socket(zmq.SUB)
+        sub_back.setsockopt(zmq.SUBSCRIBE, b"")
+        sub_back.connect(back_publish_addr)
+        sub_back.RCVTIMEO = 5000
+        assert sub_back.recv() == b"READY"
+
+        # Subscribe to the front-end stats stream to observe liveness.
+        sub_front = ctx.socket(zmq.SUB)
+        sub_front.setsockopt(zmq.SUBSCRIBE, b"")
+        sub_front.connect(front_addr)
+        sub_front.RCVTIMEO = 8000
+        time.sleep(0.2)  # let the SUB subscription propagate to the XPUB
+
+        push = ctx.socket(zmq.PUSH)
+        push.connect(back_output_addr)
+
+        # 1) garbage frame (int where an EngineCoreOutputs array is expected).
+        push.send(bytes(encoder.encode(123)[0]))
+        # 2) a valid stats update from the engine.
+        valid = EngineCoreOutputs(
+            engine_index=0,
+            scheduler_stats=SchedulerStats(num_waiting_reqs=5, num_running_reqs=3),
+        )
+        push.send(bytes(encoder.encode(valid)[0]))
+
+        # The coordinator must survive the garbage frame and publish the stats
+        # from the valid one ([waiting, running] == [5, 3]) to the front-end.
+        seen = None
+        deadline = time.monotonic() + 8.0
+        while time.monotonic() < deadline:
+            try:
+                decoded = msgspec.msgpack.decode(sub_front.recv())
+            except zmq.Again:
+                break
+            if decoded[0] == [[5, 3]]:
+                seen = decoded[0]
+                break
+
+        assert "exc" not in captured, f"coordinator crashed: {captured.get('exc')}"
+        assert thread.is_alive(), "coordinator loop exited unexpectedly"
+        assert seen == [[5, 3]], (
+            "coordinator did not publish stats from the valid frame "
+            f"(captured={captured})"
+        )
+    finally:
+        # The loop only exits on KeyboardInterrupt; destroying the context
+        # force-closes its sockets so the thread unwinds cleanly.
+        with contextlib.suppress(Exception):
+            ctx.destroy(linger=0)
+        thread.join(timeout=5)

--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+import contextlib
 from collections import UserDict
 from dataclasses import dataclass
 
@@ -7,6 +9,8 @@ import msgspec
 import numpy as np
 import pytest
 import torch
+import zmq
+import zmq.asyncio
 
 from vllm.multimodal.inputs import (
     MultiModalBatchedField,
@@ -423,3 +427,85 @@ def test_multiple_senders_single_receiver_ipc():
         assert torch.allclose(decoded.prompt_embeds, original_tensor), (
             f"Value mismatch for sender {sender_idx} msg {msg_idx}"
         )
+
+
+def test_output_socket_drops_undecodable_frame():
+    """A malformed frame on the engine output socket must not crash the engine.
+
+    Regression test for issue #44486: an external port scanner injected junk
+    bytes onto the engine->client output socket, msgspec raised a
+    ``ValidationError`` ("Expected array, got int"), and that exception was
+    forwarded to ``outputs_queue`` and re-raised, killing the engine.
+
+    This drives the real ``AsyncMPClient._ensure_output_queue_task`` loop with a
+    lightweight fake ``self`` and an in-process ZMQ socket pair. A garbage frame
+    (an ``int`` where ``EngineCoreOutputs`` is expected, reproducing the exact
+    error from the issue) is sent first, followed by a valid
+    ``EngineCoreOutputs``. The loop must drop the bad frame and still deliver the
+    valid one.
+    """
+    from vllm.v1.engine import EngineCoreOutputs
+    from vllm.v1.engine.core_client import AsyncMPClient
+    from vllm.v1.metrics.stats import SchedulerStats
+
+    class _FakeResources:
+        def __init__(self, output_socket):
+            self.output_queue_task = None
+            self.output_socket = output_socket
+
+        def validate_alive(self, frames):
+            # The real implementation only raises on the single-frame
+            # ENGINE_CORE_DEAD sentinel; an arbitrary junk frame cannot
+            # masquerade as it, so a no-op faithfully models that here.
+            pass
+
+    class _FakeClient:
+        # Deliberately has no ``process_engine_outputs`` /
+        # ``eep_process_engine_core_notification`` attributes, so the loop
+        # takes the plain "enqueue outputs" path.
+        def __init__(self, output_socket):
+            self.resources = _FakeResources(output_socket)
+            self.decoder = MsgpackDecoder(EngineCoreOutputs)
+            self.utility_results: dict = {}
+            self.outputs_queue: asyncio.Queue = asyncio.Queue()
+
+    async def _run():
+        ctx = zmq.asyncio.Context()
+        addr = "inproc://test-44486-output"
+        recv_socket = ctx.socket(zmq.PULL)
+        recv_socket.bind(addr)
+        send_socket = ctx.socket(zmq.PUSH)
+        send_socket.connect(addr)
+
+        fake = _FakeClient(recv_socket)
+
+        encoder = MsgpackEncoder()
+
+        try:
+            # Start the real output-handling loop under test.
+            AsyncMPClient._ensure_output_queue_task(fake)
+
+            # 1) garbage frame (int where an array is expected), then
+            # 2) a valid EngineCoreOutputs.
+            await send_socket.send_multipart(list(encoder.encode(123)))
+            valid = EngineCoreOutputs(engine_index=7, scheduler_stats=SchedulerStats())
+            await send_socket.send_multipart(list(encoder.encode(valid)))
+
+            return await asyncio.wait_for(fake.outputs_queue.get(), timeout=5.0)
+        finally:
+            task = fake.resources.output_queue_task
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+            recv_socket.close(linger=0)
+            send_socket.close(linger=0)
+            ctx.term()
+
+    received = asyncio.run(_run())
+
+    # Without the fix, the queue's first item would be the forwarded
+    # ValidationError instead of our valid output.
+    assert not isinstance(received, Exception), received
+    assert isinstance(received, EngineCoreOutputs)
+    assert received.engine_index == 7

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.utils.system_utils import get_mp_context, set_process_title
 from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequestType
-from vllm.v1.serial_utils import MsgpackDecoder
+from vllm.v1.serial_utils import DROP_FRAME, MsgpackDecoder, try_decode_frame
 from vllm.v1.utils import get_engine_client_zmq_addr, shutdown
 
 logger = init_logger(__name__)
@@ -303,24 +303,19 @@ class DPCoordinatorProc:
                         # Ignore subscription messages.
                         continue
 
-                    try:
-                        decoded = msgspec.msgpack.decode(buffer)
-                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
-                        # A malformed/garbage frame (e.g. injected by a port
-                        # scanner probing a bound endpoint) must not take down
-                        # the DP coordinator. Drop it and keep serving. See
-                        # issue #44486.
-                        logger.warning(
-                            "DP Coordinator discarding undecodable message on "
-                            "front-end socket: %s",
-                            e,
-                        )
+                    # Front-end messages are 2-tuples (SCALE_ELASTIC_EP or a
+                    # new-request wave notification). expected_len guards the
+                    # unpack below against malformed/misshapen frames. See
+                    # issue #44486.
+                    decoded = try_decode_frame(
+                        msgspec.msgpack.decode,
+                        buffer,
+                        "DP coordinator front-end socket",
+                        expected_len=2,
+                    )
+                    if decoded is DROP_FRAME:
                         continue
-                    if (
-                        isinstance(decoded, (list, tuple))
-                        and len(decoded) == 2
-                        and decoded[0] == "SCALE_ELASTIC_EP"
-                    ):
+                    if decoded[0] == "SCALE_ELASTIC_EP":
                         # Handle scale up notification
                         new_engine_count = decoded[1]
                         current_count = len(self.engines)
@@ -375,19 +370,14 @@ class DPCoordinatorProc:
                     # We received a message from one of the engines.
 
                     buffer = output_back.recv()
-                    try:
-                        outputs: EngineCoreOutputs = decoder.decode(buffer)
-                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
-                        # A malformed/garbage frame (e.g. injected by a port
-                        # scanner probing a bound TCP endpoint) must not take
-                        # down the DP coordinator. Drop it and keep serving.
-                        # See issue #44486.
-                        logger.warning(
-                            "DP Coordinator discarding undecodable message on "
-                            "engine output socket: %s",
-                            e,
-                        )
+                    decoded = try_decode_frame(
+                        decoder.decode,
+                        buffer,
+                        "DP coordinator engine output socket",
+                    )
+                    if decoded is DROP_FRAME:
                         continue
+                    outputs: EngineCoreOutputs = decoded
 
                     assert not outputs.outputs
                     assert outputs.utility_output is None

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -303,7 +303,19 @@ class DPCoordinatorProc:
                         # Ignore subscription messages.
                         continue
 
-                    decoded = msgspec.msgpack.decode(buffer)
+                    try:
+                        decoded = msgspec.msgpack.decode(buffer)
+                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
+                        # A malformed/garbage frame (e.g. injected by a port
+                        # scanner probing a bound endpoint) must not take down
+                        # the DP coordinator. Drop it and keep serving. See
+                        # issue #44486.
+                        logger.warning(
+                            "DP Coordinator discarding undecodable message on "
+                            "front-end socket: %s",
+                            e,
+                        )
+                        continue
                     if (
                         isinstance(decoded, (list, tuple))
                         and len(decoded) == 2
@@ -363,7 +375,19 @@ class DPCoordinatorProc:
                     # We received a message from one of the engines.
 
                     buffer = output_back.recv()
-                    outputs: EngineCoreOutputs = decoder.decode(buffer)
+                    try:
+                        outputs: EngineCoreOutputs = decoder.decode(buffer)
+                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
+                        # A malformed/garbage frame (e.g. injected by a port
+                        # scanner probing a bound TCP endpoint) must not take
+                        # down the DP coordinator. Drop it and keep serving.
+                        # See issue #44486.
+                        logger.warning(
+                            "DP Coordinator discarding undecodable message on "
+                            "engine output socket: %s",
+                            e,
+                        )
+                        continue
 
                     assert not outputs.outputs
                     assert outputs.utility_output is None

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -57,7 +57,13 @@ from vllm.v1.engine.utils import (
 )
 from vllm.v1.executor import Executor
 from vllm.v1.pool.late_interaction import get_late_interaction_engine_index
-from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
+from vllm.v1.serial_utils import (
+    DROP_FRAME,
+    MsgpackDecoder,
+    MsgpackEncoder,
+    bytestr,
+    try_decode_frame,
+)
 
 logger = init_logger(__name__)
 
@@ -823,18 +829,12 @@ class SyncMPClient(MPClient):
 
                     frames = out_socket.recv_multipart(copy=False)
                     resources.validate_alive(frames)
-                    try:
-                        outputs: EngineCoreOutputs = decoder.decode(frames)
-                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
-                        # A malformed/garbage frame on the output socket (e.g.
-                        # injected by a port scanner probing a bound TCP
-                        # endpoint) must not take down the engine. Drop it and
-                        # keep serving. See issue #44486.
-                        logger.warning(
-                            "Discarding undecodable frame on engine output socket: %s",
-                            e,
-                        )
+                    decoded = try_decode_frame(
+                        decoder.decode, frames, "engine output socket"
+                    )
+                    if decoded is DROP_FRAME:
                         continue
+                    outputs: EngineCoreOutputs = decoded
                     if outputs.utility_output:
                         _process_utility_output(outputs.utility_output, utility_results)
                     else:
@@ -1018,18 +1018,12 @@ class AsyncMPClient(MPClient):
                 while True:
                     frames = await output_socket.recv_multipart(copy=False)
                     resources.validate_alive(frames)
-                    try:
-                        outputs: EngineCoreOutputs = decoder.decode(frames)
-                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
-                        # A malformed/garbage frame on the output socket (e.g.
-                        # injected by a port scanner probing a bound TCP
-                        # endpoint) must not take down the engine. Drop it and
-                        # keep serving. See issue #44486.
-                        logger.warning(
-                            "Discarding undecodable frame on engine output socket: %s",
-                            e,
-                        )
+                    decoded = try_decode_frame(
+                        decoder.decode, frames, "engine output socket"
+                    )
+                    if decoded is DROP_FRAME:
                         continue
+                    outputs: EngineCoreOutputs = decoded
                     if outputs.utility_output:
                         if (
                             outputs.utility_output.call_id == EEP_NOTIFICATION_CALL_ID
@@ -1358,8 +1352,19 @@ class DPAsyncMPClient(AsyncMPClient):
                     if buf is None:
                         continue
 
-                    # Update local load-balancing state.
-                    counts, wave, running = msgspec.msgpack.decode(buf)
+                    # Update local load-balancing state. This XSUB socket is
+                    # bound to a routable TCP endpoint in multi-node DP, so a
+                    # malformed/garbage frame must drop rather than kill the
+                    # stats task (which would freeze load balancing). See #44486.
+                    decoded = try_decode_frame(
+                        msgspec.msgpack.decode,
+                        buf,
+                        "DP stats-update socket",
+                        expected_len=3,
+                    )
+                    if decoded is DROP_FRAME:
+                        continue
+                    counts, wave, running = decoded
                     self.current_wave = wave
                     self.engines_running = running
                     if counts is not None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -823,7 +823,18 @@ class SyncMPClient(MPClient):
 
                     frames = out_socket.recv_multipart(copy=False)
                     resources.validate_alive(frames)
-                    outputs: EngineCoreOutputs = decoder.decode(frames)
+                    try:
+                        outputs: EngineCoreOutputs = decoder.decode(frames)
+                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
+                        # A malformed/garbage frame on the output socket (e.g.
+                        # injected by a port scanner probing a bound TCP
+                        # endpoint) must not take down the engine. Drop it and
+                        # keep serving. See issue #44486.
+                        logger.warning(
+                            "Discarding undecodable frame on engine output socket: %s",
+                            e,
+                        )
+                        continue
                     if outputs.utility_output:
                         _process_utility_output(outputs.utility_output, utility_results)
                     else:
@@ -1007,7 +1018,18 @@ class AsyncMPClient(MPClient):
                 while True:
                     frames = await output_socket.recv_multipart(copy=False)
                     resources.validate_alive(frames)
-                    outputs: EngineCoreOutputs = decoder.decode(frames)
+                    try:
+                        outputs: EngineCoreOutputs = decoder.decode(frames)
+                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
+                        # A malformed/garbage frame on the output socket (e.g.
+                        # injected by a port scanner probing a bound TCP
+                        # endpoint) must not take down the engine. Drop it and
+                        # keep serving. See issue #44486.
+                        logger.warning(
+                            "Discarding undecodable frame on engine output socket: %s",
+                            e,
+                        )
+                        continue
                     if outputs.utility_output:
                         if (
                             outputs.utility_output.call_id == EEP_NOTIFICATION_CALL_ID

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -82,6 +82,71 @@ def _log_insecure_serialization_warning():
     )
 
 
+# Sentinel returned by ``try_decode_frame`` when a frame cannot be decoded
+# or does not match the expected shape.
+DROP_FRAME: Any = object()
+
+
+def _warn_dropped_frame(source: str) -> None:
+    logger.warning_once(
+        "Discarding malformed frame(s) on %s (likely garbage input, e.g. from "
+        "a port scanner probing a bound endpoint); further such warnings for "
+        "this socket are suppressed.",
+        source,
+    )
+
+
+def try_decode_frame(
+    decode_fn: Callable[[Any], Any],
+    buf: Any,
+    source: str,
+    *,
+    expected_len: int | None = None,
+) -> Any:
+    """Decode a msgpack frame, dropping malformed or misshapen input.
+
+    Internal ZMQ sockets are meant to carry only trusted, well-formed
+    ``msgspec`` frames, but a socket bound to a routable TCP endpoint can still
+    receive junk (e.g. a security scanner probing the port). A single bad frame
+    must not take down the engine or the DP coordinator: on a ``msgspec``
+    ``ValidationError``/``DecodeError`` -- or, for untyped decodes, a shape
+    mismatch against ``expected_len`` -- this logs (throttled per ``source``)
+    and returns ``DROP_FRAME`` so the caller can skip the frame and keep
+    serving. Genuine internal protocol bugs are not swallowed. See #44486.
+
+    Args:
+        decode_fn: Callable performing the actual decode, invoked as
+            ``decode_fn(buf)`` (e.g. a ``MsgpackDecoder.decode`` bound method
+            or ``msgspec.msgpack.decode``).
+        buf: The raw frame to decode.
+        source: Short socket name, used for the warning and to throttle it
+            (one warning per distinct source).
+        expected_len: If set, require the decoded value to be a list/tuple of
+            this length; used for untyped decodes whose callers immediately
+            unpack a fixed-arity sequence. Typed decodes leave this ``None``
+            and rely on ``msgspec`` validation.
+
+    Returns:
+        The decoded object, or ``DROP_FRAME`` if it was undecodable or
+        misshapen.
+    """
+    try:
+        decoded = decode_fn(buf)
+    except (msgspec.ValidationError, msgspec.DecodeError) as e:
+        _warn_dropped_frame(source)
+        logger.debug("Undecodable frame on %s: %s", source, e)
+        return DROP_FRAME
+
+    if expected_len is not None and not (
+        isinstance(decoded, (list, tuple)) and len(decoded) == expected_len
+    ):
+        _warn_dropped_frame(source)
+        logger.debug("Misshapen frame on %s: %r", source, decoded)
+        return DROP_FRAME
+
+    return decoded
+
+
 def _typestr(val: Any) -> tuple[str, str] | None:
     if val is None:
         return None


### PR DESCRIPTION
## Purpose

Fixes #44486. Also addresses #42398 (same root cause, reported as a feature request).

An external enterprise security scanner periodically probes the server's ports with junk/attack traffic. Two internal ZMQ decode sites treat such a frame as fatal:

1. **Engine output socket** (`core_client.py`) — a garbage frame makes `msgspec` raise a `ValidationError` (`Expected array, got int`) inside `process_outputs_socket`. It's caught by the broad `except Exception` and forwarded to `outputs_queue`, where `get_output[_async]` re-raises it, bubbling up to `AsyncLLM.output_handler` and **killing the engine**.
2. **DP coordinator** (`coordinator.py`) — `process_input_socket` decodes engine messages with `decoder.decode(buffer)` (and a raw `msgspec.msgpack.decode` on the front-end socket). `run_coordinator` only catches `KeyboardInterrupt`, so a `ValidationError`/`DecodeError` from a malformed frame propagates uncaught and **kills the DP coordinator process** (relevant when DP spans nodes and these sockets are TCP-bound).

This PR hardens both decode boundaries: a deserialization failure on these sockets is treated as a *drop-this-frame* event, not a fatal one.

### Changes

- **`core_client.py`** — guard the `decoder.decode(frames)` call in both the sync (`SyncMPClient`) and async (`AsyncMPClient`) `process_outputs_socket` loops.
- **`coordinator.py`** — guard both decode sites in `process_input_socket` (the engine `output_back` socket and the front-end socket).
- In all cases: catch `(msgspec.ValidationError, msgspec.DecodeError)`, log a warning, and drop the frame. The catch is deliberately narrow (`ValidationError` is a subclass of `DecodeError`) so a genuine internal protocol bug still surfaces. The coordinator uses `continue`, matching the loop's existing convention.

Note: the coordinator's `validate_alive`/sentinel-byte path (`coordinator.py:295`) was already non-fatal (logs and continues) and is unrelated to the crash.

## Not a duplicate

- `gh pr list --search "44486 in:body"` / `"42398 in:body"` → none
- `gh pr list --search "process_outputs_socket decode"` → none
- `gh pr list --search "engine output socket malformed"` → only unrelated PRs

Issues #44486 and #42398 are open with no assignee and no linked PR.

## Test

Two **GPU-free** regression tests in `tests/v1/test_serial_utils.py`, each driving the real loop over in-process ZMQ sockets:

- `test_output_socket_drops_undecodable_frame` — drives `AsyncMPClient._ensure_output_queue_task`; sends a garbage frame (an `int`, reproducing `Expected array, got int`) then a valid `EngineCoreOutputs`, and asserts the valid one is delivered.
- `test_dp_coordinator_drops_undecodable_frame` — drives `DPCoordinatorProc.process_input_socket`; a fake engine subscribes, a garbage frame is pushed to the engine output socket, then a valid stats frame, and asserts the coordinator survives and publishes the valid stats to the front-end.

Verified each fails without its fix and passes with it:

```
# core_client, WITHOUT fix
FAILED test_output_socket_drops_undecodable_frame
  AssertionError: ValidationError('Expected `array`, got `int`')

# coordinator, WITHOUT fix
FAILED test_dp_coordinator_drops_undecodable_frame
  AssertionError: coordinator crashed: ValidationError: Expected `array`, got `int`

# WITH both fixes
12 passed
```

Full file + lint:

```
$ python -m pytest tests/v1/test_serial_utils.py -q
12 passed

$ pre-commit run --files vllm/v1/engine/core_client.py vllm/v1/engine/coordinator.py tests/v1/test_serial_utils.py
ruff check ... Passed
ruff format ... Passed
Run mypy locally for lowest supported Python version ... Passed
```

## AI assistance

AI assistance (Claude) was used for the analysis and implementation of this change. The submitter has reviewed every changed line and run the tests above.
