### PR TITLE
[PD][Bugfix] Fix KV Cache sharing with HMA

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
@@ -35,6 +35,8 @@ sw_attn_configs=(
   "GPU_MEMORY_UTILIZATION=0.8 MODEL_NAMES=google/gemma-3-4b-it VLLM_SERVE_EXTRA_ARGS=--max-model-len,8192" # SW model
   "GPU_MEMORY_UTILIZATION=0.8 MODEL_NAMES=google/gemma-3-4b-it PREFILLER_TP_SIZE=1 DECODER_TP_SIZE=2 VLLM_SERVE_EXTRA_ARGS=--max-model-len,8192"
   "GPU_MEMORY_UTILIZATION=0.8 MODEL_NAMES=google/gemma-3-4b-it PREFILLER_TP_SIZE=2 DECODER_TP_SIZE=1 VLLM_SERVE_EXTRA_ARGS=--max-model-len,8192"
+  # Gemma4: SW + cross-layer KV sharing
+  "GPU_MEMORY_UTILIZATION=0.8 MODEL_NAMES=google/gemma-4-E2B-it VLLM_SERVE_EXTRA_ARGS=--max-model-len,8192"
 )
 
 # Select config array based on DP_EP env var

--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -24,6 +24,7 @@ EXPECTED_VALUES = {
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": 0.84,
     "ibm-granite/granite-4.0-h-tiny": 0.77,
     "Qwen/Qwen3.5-0.8B": 0.33,
+    "google/gemma-4-E2B-it": 0.485,
 }
 
 SIMPLE_PROMPT = (
@@ -49,17 +50,33 @@ def test_accuracy():
     """Run the end to end accuracy test."""
     run_simple_prompt()
 
-    model_args = (
-        f"model={MODEL_NAME},"
-        f"base_url={BASE_URL}/completions,"
-        f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False"
-    )
-
-    results = lm_eval.simple_evaluate(
-        model="local-completions",
-        model_args=model_args,
-        tasks=TASK,
-    )
+    if "gemma-4" in MODEL_NAME:
+        # Gemma4 is quite sensible to having a chat template applied, so we evaluate
+        # on chat completions.
+        model_args = (
+            f"model={MODEL_NAME},"
+            f"base_url={BASE_URL}/chat/completions,"
+            f"num_concurrent={NUM_CONCURRENT},"
+            "tokenizer_backend=huggingface"
+        )
+        results = lm_eval.simple_evaluate(
+            model="local-chat-completions",
+            model_args=model_args,
+            tasks=TASK,
+            num_fewshot=5,
+            apply_chat_template=True,
+        )
+    else:
+        model_args = (
+            f"model={MODEL_NAME},"
+            f"base_url={BASE_URL}/completions,"
+            f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False"
+        )
+        results = lm_eval.simple_evaluate(
+            model="local-completions",
+            model_args=model_args,
+            tasks=TASK,
+        )
 
     measured_value = results["results"][TASK][FILTER]
     expected_value = EXPECTED_VALUES.get(MODEL_NAME)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -850,7 +850,11 @@ class NixlConnectorWorker:
             # However, physical page_size may differ when kernel requires a specific
             # block size. This leads to SSM and FA layers having different num_blocks.
             # `_physical_blocks_per_logical_kv_block` ratio is used to adjust for this.
-            layer_spec = self._layer_specs[layer_name]
+            layer_spec = self._layer_specs.get(layer_name)
+            if layer_spec is None:
+                logger.debug(f"Skipping layer {layer_name} as no KVCache spec is \
+                present. This is likely because the layer is sharing its KV cache")
+                continue
             if isinstance(layer_spec, UniformTypeKVCacheSpecs):
                 # MLA DSv32 Indexer case: UniformTypeKVCacheSpecs merges kv_cache_specs
                 layer_spec = layer_spec.kv_cache_specs[layer_name]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -852,8 +852,11 @@ class NixlConnectorWorker:
             # `_physical_blocks_per_logical_kv_block` ratio is used to adjust for this.
             layer_spec = self._layer_specs.get(layer_name)
             if layer_spec is None:
-                logger.debug(f"Skipping layer {layer_name} as no KVCache spec is \
-                present. This is likely because the layer is sharing its KV cache")
+                logger.debug(
+                    "Skipping layer %s as no KVCache spec is present. "
+                    "This is likely because the layer is sharing its KV cache",
+                    layer_name,
+                )
                 continue
             if isinstance(layer_spec, UniformTypeKVCacheSpecs):
                 # MLA DSv32 Indexer case: UniformTypeKVCacheSpecs merges kv_cache_specs


### PR DESCRIPTION
HMA is now the default way to serve models even when a connector is provided as of https://github.com/vllm-project/vllm/pull/41847.

Unfortunately we missed covering an important feature that is layers that share the same KV cache tensor, which currently crashes on main when attempting to fetch the corresponding `layer_spec`.
The fix is straightforward, as we ensure that layers that do not need a kv cache are not present in the kv_cache_spec at setup time
https://github.com/vllm-project/vllm/blob/3da29aa4a5509b068d378bd8aedbe4837cecf6a6/vllm/v1/worker/gpu_model_runner.py#L7441-L7459 

All we have to do in the PD connector is skip registration for those layers, like we did before supporting HMA.

Tested with a `google/gemma-4-E2B-it` PD deployment
```
local-chat-completions ({'model': 'google/gemma-4-E2B-it', 'base_url': 'http://127.0.0.1:25068/v1/chat/completions', 'tokenizer_backend': 'huggingface', 'max_concurrency': 100}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6573|±  |0.0131|
|     |       |strict-match    |     5|exact_match|↑  |0.4860|±  |0.0138|
```
and added test case to our eval suite
