### PR TITLE
[XPU] Fix in-place transpose of weight_scale_inv corrupting MLA dequant in FP8 block GEMM

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -54,6 +54,32 @@ steps:
       pytest -v -s v1/test_request.py &&
       pytest -v -s v1/test_outputs.py'
 
+- label: Basic Models Tests (Initialization)
+  timeout_in_minutes: 60
+  device: intel_gpu
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+    - vllm/
+    - tests/models/test_initialization.py
+    - tests/models/registry.py
+  commands:
+    - >-
+      bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+      'export VLLM_XPU_FUSED_MOE_USE_REF=1 && 
+      cd tests &&
+      pytest -v -s models/test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel]
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[DeepseekV3ForCausalLM]
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[NemotronParseForConditionalGeneration]
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[DeepseekV32ForCausalLM]
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[EagleDeepSeekMTPModel]
+      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[MiniMaxM2ForCausalLM]'
+
+
 - label: XPU CPU Offload
   timeout_in_minutes: 60
   device: intel_gpu

--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -71,13 +71,13 @@ steps:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'export VLLM_XPU_FUSED_MOE_USE_REF=1 && 
-      cd tests &&
-      pytest -v -s models/test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel]
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[DeepseekV3ForCausalLM]
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[NemotronParseForConditionalGeneration]
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[DeepseekV32ForCausalLM]
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[EagleDeepSeekMTPModel]
-      pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[MiniMaxM2ForCausalLM]'
+      cd tests/models &&
+      pytest -v -s test_initialization.py::test_can_initialize_small_subset[DeepSeekMTPModel] && 
+      pytest -v -s test_initialization.py::test_can_initialize_large_subset[DeepseekV3ForCausalLM] && 
+      pytest -v -s test_initialization.py::test_can_initialize_large_subset[NemotronParseForConditionalGeneration] &&
+      pytest -v -s test_initialization.py::test_can_initialize_large_subset[DeepseekV32ForCausalLM] &&
+      pytest -v -s test_initialization.py::test_can_initialize_large_subset[EagleDeepSeekMTPModel] &&
+      pytest -v -s test_initialization.py::test_can_initialize_large_subset[MiniMaxM2ForCausalLM]'
 
 
 - label: XPU CPU Offload

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
-from .BlockScaledMMLinearKernel import Fp8BlockScaledMMLinearKernel
+from .BlockScaledMMLinearKernel import FP8BlockParams, Fp8BlockScaledMMLinearKernel
 from .ScaledMMLinearKernel import FP8ScaledMMLinearKernel, FP8ScaledMMLinearLayerConfig
 
 
@@ -115,7 +115,22 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         # actual group_size derived from scale tensor shapes.
         if scale.dtype == torch.float8_e8m0fnu:
             scale = scale.to(torch.float32)
-        replace_parameter(layer, scale_attr, scale.data.t().contiguous())
+        layer._xpu_scale = scale.t().contiguous()
+
+    def _get_layer_params(self, layer: torch.nn.Module) -> FP8BlockParams:
+        params = super()._get_layer_params(layer)
+        # _xpu_scale is set at end of process_weights_after_loading.
+        # Guard here because base-class process_weights calls self._get_layer_params
+        # (Python dynamic dispatch) before _xpu_scale exists.
+        if not hasattr(layer, "_xpu_scale"):
+            return params
+        # Use transposed scale [K//bs, N//bs].
+        # layer.weight_scale_inv is left untouched for MLA dequant.
+        if params.weight_scale_inv is not None:
+            params.weight_scale_inv = layer._xpu_scale
+        else:
+            params.weight_scale = layer._xpu_scale
+        return params
 
     def apply_block_scaled_mm(
         self,

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -117,8 +117,8 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             scale = scale.to(torch.float32)
         layer._xpu_scale = scale.t().contiguous()
 
-    def _get_layer_params(self, layer: torch.nn.Module) -> FP8BlockParams:
-        params = super()._get_layer_params(layer)
+    def _get_layer_params(self, layer: torch.nn.Module, **kwargs) -> FP8BlockParams:
+        params = super()._get_layer_params(layer, **kwargs)
         # _xpu_scale is set at end of process_weights_after_loading.
         # Guard here because base-class process_weights calls self._get_layer_params
         # (Python dynamic dispatch) before _xpu_scale exists.


### PR DESCRIPTION
Fix `XPUFp8BlockScaledMMKernel` which was transposing `weight_scale_inv` in-place, corrupting the original tensor needed by MLA dequant. Store the transposed scale as `layer._xpu_scale` and inject it only during forward pass via `_get_layer_params`.

This PR depends on the next release of [vllm-xpu-kernels](https://github.com/vllm-project/vllm-xpu-kernels/pull/372) which adds `fp8_gemm_w8a8` kernel support for FP8 block quantization.

Accuracy on Qwen/Qwen3-4B-Instruct-2507-FP8 (Intel Arc Pro B60, `--enforce-eager`):
- GSM8K 5-shot (1319 questions): **0.857**
- Reference L20 vllm v0.20.2: 0.849

Depends on :#397