### PR TITLE
[SpecDecode] Skip embedding sharing when target/draft hidden dims differ

### DIFF
--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1332,6 +1332,28 @@ class SpecDecodeBaseProposer:
                 )
 
             if share_embeddings:
+                # Only share if embedding output dim matches the draft's
+                # hidden size. When they differ (e.g. EAGLE3-LLaMA3.1 draft
+                # with a MiniMax-M2 target), sharing would corrupt the
+                # concat(embeds, hidden_states) in the first decoder layer.
+                target_embed_dim = target_embed_tokens.weight.shape[1]
+                draft_hidden = getattr(self.model.model, "embed_tokens", None)
+                draft_embed_dim = (
+                    draft_hidden.weight.shape[1]
+                    if draft_hidden is not None
+                    else self.hidden_size
+                )
+                if target_embed_dim != draft_embed_dim:
+                    share_embeddings = False
+                    logger.info(
+                        "Skipping embedding sharing: target embedding dim "
+                        "(%d) != draft hidden size (%d). "
+                        "Draft model keeps its own embedding weights.",
+                        target_embed_dim,
+                        draft_embed_dim,
+                    )
+
+            if share_embeddings:
                 if hasattr(self.model.model, "embed_tokens"):
                     del self.model.model.embed_tokens
                 self.model.model.embed_tokens = target_embed_tokens


### PR DESCRIPTION
Fix `_maybe_share_embeddings` in `SpecDecodeBaseProposer`: when a draft checkpoint has no own `embed_tokens` (e.g. `yuhuili/EAGLE3-LLaMA3.1-Instruct-8B`), the target embedding was blindly shared to the draft model even if their hidden dimensions differ. With an EAGLE3-LLaMA3.1-8B draft (hidden_size=4096) paired with a MiniMax-M2 target (hidden_size=3072), the first decoder layer does `cat([embed(tokens), hidden_states])` expecting dim 8192 but receives 7168, triggering a `torch._assert` failure during `torch.compile` tracing and crashing engine initialization.

Add a dimension guard before sharing; skip and log a warning when dims differ.

**Test**

```bash
pytest -sv tests/models/test_initialization.py::test_can_initialize_large_subset[Eagle3MiniMaxM2ForCausalLM]
```

Without this fix the test fails with `RuntimeError: Engine core initialization failed` (root cause: shape mismatch in `cat` during compile). With this fix the test passes.