### PR TITLE
fix(humming): bias parameter accepted but never applied — GEMM output missing additive bias term

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/humming.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/humming.py
@@ -58,4 +58,6 @@ class HummingLinearKernel(MPLinearKernel):
             inputs=flatten_inputs,
             compute_config=layer.compute_config,
         )
+        if bias is not None:
+            output.add_(bias)
         return output.view(*x.shape[:-1], output.size(-1))


### PR DESCRIPTION


## Purpose

Expected Behavior
HummingLinearKernel.apply_weights is required to add the bias tensor to the GEMM output prior to returning, in accordance with the MPLinearKernel abstract interface contract. All peer implementations — Machete, Exllama, Conch, Cutlass, and Marlin — consistently apply this operation.

Root Cause
HummingLinearKernel.apply_weights declares bias as a formal parameter but contains no code path that applies it. The implementation invokes HummingMethod.forward_layer and reshapes the result, unconditionally discarding the bias tensor on every forward pass.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

