### PR TITLE
Move DP sync to a dedicated CUDA stream

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1002,11 +1002,6 @@ class VllmConfig:
         )
 
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
-            # The DP coordination all_reduce runs on a dedicated stream (see
-            # vllm/v1/worker/dp_utils.py), so reading its result back no longer
-            # forces a GPU sync on the default stream. NCCL can therefore be
-            # used for DP synchronization even under async scheduling without
-            # introducing a bubble, so we no longer fall back to Gloo there.
             self.parallel_config.disable_nccl_for_dp_synchronization = False
 
         if (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1002,17 +1002,12 @@ class VllmConfig:
         )
 
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
-            if self.scheduler_config.async_scheduling:
-                if self.parallel_config.data_parallel_size > 1 and (
-                    self.model_config is None or self.model_config.is_moe
-                ):
-                    logger.info_once(
-                        "Disabling NCCL for DP synchronization "
-                        "when using async scheduling.",
-                    )
-                self.parallel_config.disable_nccl_for_dp_synchronization = True
-            else:
-                self.parallel_config.disable_nccl_for_dp_synchronization = False
+            # The DP coordination all_reduce runs on a dedicated stream (see
+            # vllm/v1/worker/dp_utils.py), so reading its result back no longer
+            # forces a GPU sync on the default stream. NCCL can therefore be
+            # used for DP synchronization even under async scheduling without
+            # introducing a bubble, so we no longer fall back to Gloo there.
+            self.parallel_config.disable_nccl_for_dp_synchronization = False
 
         if (
             self.speculative_config is not None

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import contextlib
+from functools import cache
+
 import torch
 import torch.distributed as dist
 
@@ -13,6 +16,33 @@ from vllm.v1.worker.ubatch_utils import (
 )
 
 logger = init_logger(__name__)
+
+
+@cache
+def _get_dp_sync_stream() -> torch.cuda.Stream:
+    return torch.cuda.Stream()
+
+
+def _dp_sync_stream_context(
+    parallel_config: ParallelConfig,
+) -> contextlib.AbstractContextManager:
+    # Run the NCCL DP coordination all_reduce on a dedicated stream so that
+    # reading the result back drains only this stream, not the default stream
+    # which has async-scheduled forward kernels. When NCCL DP sync is disabled
+    # the all_reduce is a blocking CPU collective, so there is nothing to
+    # overlap and we stay on the default stream.
+    if parallel_config.disable_nccl_for_dp_synchronization:
+        return contextlib.nullcontext()
+    return torch.cuda.stream(_get_dp_sync_stream())
+
+
+@cache
+def _get_dp_coord_buffer(device: torch.device | str, dp_size: int) -> torch.Tensor:
+    # Persistent all_reduce buffer, allocated once per (device, dp_size). A
+    # per-step allocation on the dedicated stream can be freed and handed by the
+    # caching allocator to a default-stream forward kernel while the all_reduce
+    # is still in flight, corrupting the collective.
+    return torch.zeros(4, dp_size, device=device, dtype=torch.int32)
 
 
 def _get_device_and_group(parallel_config: ParallelConfig):
@@ -49,7 +79,8 @@ def _run_ar(
     tensor_cpu[1][dp_rank] = padded_num_tokens_per_ubatch
     tensor_cpu[2][dp_rank] = 1 if should_ubatch else 0
     tensor_cpu[3][dp_rank] = cudagraph_mode
-    tensor = tensor_cpu.to(device, non_blocking=True)
+    tensor = _get_dp_coord_buffer(device, dp_size)
+    tensor.copy_(tensor_cpu, non_blocking=True)
     dist.all_reduce(tensor, group=group)
     return tensor
 
@@ -127,14 +158,18 @@ def _synchronize_dp_ranks(
 
     # Coordinate between the DP ranks via an All Reduce
     # to determine the total number of tokens that each rank
-    # will run and if we are using ubatching or not.
-    tensor = _run_ar(
-        should_ubatch=should_attempt_ubatching,
-        orig_num_tokens_per_ubatch=num_tokens_unpadded,
-        padded_num_tokens_per_ubatch=num_tokens_padded,
-        cudagraph_mode=cudagraph_mode,
-        parallel_config=parallel_config,
-    )
+    # will run and if we are using ubatching or not. Read the result back to
+    # CPU inside the stream context so the subsequent .item() calls drain only
+    # the dedicated stream, not the default stream's async-scheduled forward
+    # kernels.
+    with _dp_sync_stream_context(parallel_config):
+        tensor = _run_ar(
+            should_ubatch=should_attempt_ubatching,
+            orig_num_tokens_per_ubatch=num_tokens_unpadded,
+            padded_num_tokens_per_ubatch=num_tokens_padded,
+            cudagraph_mode=cudagraph_mode,
+            parallel_config=parallel_config,
+        ).cpu()
 
     # Synchronize cudagraph_mode across ranks first (take min).
     # This is needed before DP padding decision since we use the synced


### PR DESCRIPTION
Async scheduling + (multi-node) DP + spec dec has bubbles caused by the DP synchronization steps because of the Gloo comms (NCCL falls back to Gloo for DP synchronization with async to avoid a GPU sync). This fix keeps NCCL comms but moves then onto a dedicated stream to avoid a gpu sync.

As far as I can tell, this affects all `async_scheduling` + DP configs, but is aggravated by:
- multi-node / high rank DP
- speculative decoding (more DP syncs)

This is why the regression only showed up on certain models, in the other cases the advantages from async were masking it. This fix improves performance across the board

Results:
MS4 (DP8) ISL=4096
| bsz | current TTFT(ms) | fix TTFT(ms) | delta TTFT      | current decode TPS | fix decode TPS | delta TPS      |
| --: | -----------: | -----------: | ---------: | -----------: | -----------: | ---------: |
| 1   | 434.0        | 386.9        | −10.9% | 216.9        | 269.8        | +24.4% |
| 2   | 941.7        | 818.8        | −13.1%     | 174.1        | 240.4        | +38.1%     |
| 4   | 1851.8       | 1423.9       | −23.1%     | 214.3        | 234.5        | +9.4%      |
| 8   | 3532.0       | 2871.2       | −18.7%     | 208.1        | 220.5        | +6.0%      |
| 16  | 7158.4       | 5618.7       | −21.5%     | 211.9        | 202.8        | −4.3%      |
| 32  | 14169.3      | 11370.4      | −19.8%     | 175.3        | 178.8        | +2.0%      |
| 64  | 28510.2      | 22422.6      | −21.4%     | 121.2        | 126.5        | +4.3%      |

ML3 (DP32) ISL=4096
| bsz | current TTFT(ms) | fix TTFT(ms) | delta TTFT     | current decode TPS | fix decode TPS | delta TPS      |
| --: | -----------: | -----------: | --------: | -----------: | -----------: | ---------: |
| 1   | 1347.3       | 1242.7       | −7.8% | 73.2         | 103.2        | +41.0% |
| 2   | 2713.0       | 2550.8       | −6.0%     | 70.8         | 99.5         | +40.4%     |
| 4   | 5368.6       | 5071.1       | −5.5%     | 74.8         | 92.8         | +24.1%     |
| 8   | 10880.0      | 10295.0      | −5.4%     | 75.7         | 76.0         | +0.5%      |
| 16  | 21699.0      | 20628.2      | −4.9%     | 62.6         | 55.1         | −12.0%     |
| 32  | 43062.0      | 40946.3      | −4.9%     | 45.0         | 42.4         | −5.6%      |
| 64  | 73615.7      | 69112.0      | −6.1%     | 26.3         | 26.7         | +1.5%      |

Traces:
ms4 sync w/ 1.5ms bubble
<img width="2128" height="293" alt="image" src="https://github.com/user-attachments/assets/9f93ab7c-3eaf-4d3a-8dee-8d266024735e" />

ms4 async w/ 5.1ms bubble
<img width="1998" height="293" alt="image" src="https://github.com/user-attachments/assets/0916b2f8-c57d-41bb-a5f1-522795f544ba" />

ms4 fix w/ 1.5ms bubble
<img width="2433" height="376" alt="image" src="https://github.com/user-attachments/assets/f27e69aa-6385-4461-ab45-67b5515de7b4" />

ml3 sync w/ 3ms bubble
<img width="2069" height="293" alt="image" src="https://github.com/user-attachments/assets/abeee54e-543a-4828-9b20-44e6277bd9bb" />

ml3 async w/ 15ms bubble
<img width="1599" height="293" alt="image" src="https://github.com/user-attachments/assets/45021aac-0ab0-4b14-b041-2f85de18de17" />

ml3 fix w/ 0ms bubble
<img width="2130" height="413" alt="image" src="https://github.com/user-attachments/assets/f364b2c2-ac62-4522-b051-6ac073cd4622" />