### PR TITLE
[CI/Build] Fix stable cuda_view build with ROCm torch 2.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1071,12 +1071,17 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     USE_SABI 3
     WITH_SOABI)
 
+  if(Torch_VERSION VERSION_LESS "2.11.0")
+    set(VLLM_STABLE_TORCH_TARGET_VERSION 0x020A000000000000ULL)
+  else()
+    set(VLLM_STABLE_TORCH_TARGET_VERSION 0x020B000000000000ULL)
+  endif()
+
   # Set TORCH_TARGET_VERSION for stable ABI compatibility.
-  # This ensures we only use C-shim APIs available in PyTorch 2.11.
-  # _C_stable_libtorch is abi compatible with PyTorch >= TORCH_TARGET_VERSION
-  # which is currently set to 2.11.
+  # This ensures we only use C-shim APIs available in the build PyTorch.
+  # _C_stable_libtorch is abi compatible with PyTorch >= TORCH_TARGET_VERSION.
   target_compile_definitions(_C_stable_libtorch PRIVATE
-    TORCH_TARGET_VERSION=0x020B000000000000ULL)
+    TORCH_TARGET_VERSION=${VLLM_STABLE_TORCH_TARGET_VERSION})
 
   # Needed to use cuda/hip APIs from C-shim
   if(VLLM_GPU_LANG STREQUAL "CUDA")

--- a/csrc/libtorch_stable/cuda_view.cu
+++ b/csrc/libtorch_stable/cuda_view.cu
@@ -4,7 +4,6 @@
 #include <torch/headeronly/core/ScalarType.h>
 #include <torch/csrc/stable/device.h>
 #include <torch/csrc/stable/c/shim.h>
-#include <torch/headeronly/version.h>
 #include <cuda_runtime.h>
 
 #include <array>
@@ -17,14 +16,16 @@ torch::stable::Tensor get_cuda_view_from_cpu_tensor(
   STD_TORCH_CHECK(cpu_tensor.device().is_cpu(), "Input tensor must be on CPU");
 
   const auto dtype = cpu_tensor.scalar_type();
-  const auto layout = cpu_tensor.layout();
   const torch::stable::Device cuda_dev(torch::headeronly::DeviceType::CUDA);
 
   // handle empty tensor
   if (cpu_tensor.numel() == 0) {
-    return torch::stable::empty(cpu_tensor.sizes(), dtype, layout, cuda_dev);
+    return torch::stable::empty(cpu_tensor.sizes(), dtype, std::nullopt,
+                                cuda_dev);
   }
 
+#if defined(TORCH_VERSION_2_11_0) && \
+    TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0
   std::array<StableIValue, 2> is_pinned_stack{
       torch::stable::detail::from(cpu_tensor),
       torch::stable::detail::from(std::nullopt)};
@@ -73,4 +74,10 @@ torch::stable::Tensor get_cuda_view_from_cpu_tensor(
   return torch::stable::from_blob(device_ptr, contiguous_cpu.sizes(),
                                   contiguous_cpu.strides(), cuda_dev,
                                   contiguous_cpu.scalar_type(), deleter);
+#else
+  // PyTorch 2.10 stable ABI can create a tensor from a blob, but it cannot
+  // attach a deleter or lifetime anchor to that storage. Returning a copied
+  // accelerator tensor is the safe fallback for older release images.
+  return torch::stable::to(cpu_tensor, cuda_dev, false, true);
+#endif
 }


### PR DESCRIPTION
## Summary

PR #44334 moved `get_cuda_view_from_cpu_tensor` into `_C_stable_libtorch`, which broke the `buildkite/release-v2` pipeline. The failing path is specifically the ROCm wheel build, which still uses PyTorch 2.10.

The failure happens because `cuda_view.cu` used PyTorch 2.11 stable ABI APIs (`Tensor::layout()` and `from_blob` with a lambda deleter), but the ROCm wheel build is compiling against PyTorch 2.10 stable ABI.

This patch makes `TORCH_TARGET_VERSION` match the build PyTorch version and keeps the owning UVA `from_blob` path only for PyTorch 2.11+. For PyTorch 2.10 stable ABI, it uses a safe copied accelerator tensor fallback.