### PR TITLE
fix: spurious 'System message must be at the beginning' on valid Qwen3.5/6 conversations

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 
 from vllm.config import ModelConfig
@@ -10,6 +12,7 @@ from vllm.renderers.hf import (
     _consolidate_system_messages,
     _convert_developer_to_system,
     _detect_developer_role_support,
+    _detect_qwen_system_first_template,
     _get_hf_base_chat_template_params,
     _try_extract_ast,
     resolve_chat_template,
@@ -704,6 +707,14 @@ class TestDetectDeveloperRoleSupport:
         assert _detect_developer_role_support(STRICT_ROLE_TEMPLATE) is False
 
 
+class TestDetectQwenSystemFirstTemplate:
+    def test_detects_qwen_system_first_template(self):
+        assert _detect_qwen_system_first_template(SYSTEM_FIRST_TEMPLATE) is True
+
+    def test_absent_in_chatml(self):
+        assert _detect_qwen_system_first_template(CHATML_TEMPLATE) is False
+
+
 class TestSafeApplyChatTemplateDeveloperRole:
     @pytest.fixture
     def model_config(self):
@@ -846,6 +857,60 @@ SYSTEM_FIRST_TEMPLATE = (
     "{{ '<|im_start|>assistant\\n' }}"
     "{% endif %}"
 )
+
+
+class _FakeModelConfig:
+    def __init__(self):
+        self.trust_remote_code = False
+        self.hf_config = SimpleNamespace(model_type="qwen3_5")
+
+
+class _FakeTokenizer:
+    name_or_path = "Qwen/Qwen3.5-27B"
+
+    def get_chat_template(self, chat_template=None, tools=None):
+        return chat_template
+
+    def apply_chat_template(
+        self,
+        conversation,
+        tools=None,
+        chat_template=None,
+        tokenize=True,
+        add_generation_prompt=False,
+        return_dict=False,
+    ):
+        prompt = ""
+        for i, message in enumerate(conversation):
+            role = message["role"]
+            if role == "system" and i > 0:
+                raise ValueError("System message must be at the beginning.")
+            prompt += f"<|im_start|>{role}\n{message.get('content', '')}<|im_end|>\n"
+        if add_generation_prompt:
+            prompt += "<|im_start|>assistant\n"
+        return prompt
+
+
+class TestSafeApplyChatTemplateQwenSystemRole:
+    def test_qwen_template_consolidates_non_initial_system(self):
+        conversation = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "system", "content": "Summarize the conversation."},
+            {"role": "user", "content": "Please summarize."},
+        ]
+        result = safe_apply_chat_template(
+            _FakeModelConfig(),
+            _FakeTokenizer(),
+            conversation,
+            chat_template=SYSTEM_FIRST_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert result.count("<|im_start|>system") == 1
+        assert "You are helpful.\n\nSummarize the conversation." in result
+        assert "Please summarize." in result
 
 
 class TestConsolidateSystemMessages:

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -455,6 +455,19 @@ def _detect_developer_role_support(chat_template: str) -> bool:
     return '"developer"' in chat_template or "'developer'" in chat_template
 
 
+@lru_cache(maxsize=32)
+def _detect_qwen_system_first_template(chat_template: str) -> bool:
+    # FIXME (chauncey): This is a heuristic for detecting Qwen 3.5/6's
+    # system-first template, which is currently the only known template
+    # that requires the system message to be at the very beginning.
+    # We should replace this with a more robust mechanism
+    # if more templates with this requirement are introduced.
+    return (
+        "System message must be at the beginning" in chat_template
+        and "<|im_start|>system" in chat_template
+    )
+
+
 def _convert_developer_to_system(
     conversation: list[ConversationMessage],
 ) -> list[ConversationMessage]:
@@ -717,11 +730,12 @@ def safe_apply_chat_template(
         msg["role"] == "developer" for msg in conversation
     ) and not _detect_developer_role_support(chat_template):
         conversation = _convert_developer_to_system(conversation)
-        conversation = _consolidate_system_messages(conversation)
         logger.info_once(
             "Chat template does not support the 'developer' message role. "
             "Converting developer messages to 'system' role.",
         )
+    if _detect_qwen_system_first_template(chat_template):
+        conversation = _consolidate_system_messages(conversation)
     resolved_kwargs = resolve_chat_template_kwargs(
         tokenizer=tokenizer,
         chat_template=chat_template,


### PR DESCRIPTION



## Purpose
fix: spurious 'System message must be at the beginning' on valid Qwen3.5/6 conversations
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

