### PR TITLE
fix(logging): restore missing logs in multi API server deployments with internal DP load balancing

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import MagicMock, patch
+
 from vllm.v1.engine import FinishReason
+from vllm.v1.metrics.loggers import (
+    AggregatedLoggingStatLogger,
+    LoggingStatLogger,
+    StatLoggerManager,
+)
 from vllm.v1.metrics.stats import (
     IterationStats,
     PrefillStats,
@@ -244,3 +251,53 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.external_kv_transfer == 999
     assert stats.cached_tokens == 999
     assert stats.total == 1000
+
+
+# ---------------------------------------------------------------------------
+# StatLoggerManager multi-API-server logging tests (no GPU required)
+# ---------------------------------------------------------------------------
+
+_LOGGERS_MODULE = "vllm.v1.metrics.loggers"
+
+
+def _logging_factory_was_used(client_count: int, client_index: int) -> bool:
+    """Return True if LoggingStatLogger was registered as a factory.
+    Patches out PrometheusStatLogger (needs real config) and
+    LoggingStatLogger (needs real config) so the test runs without GPU.
+    Checks whether the patched LoggingStatLogger mock was called as a
+    factory — which only happens when logging is enabled for this server.
+    """
+    mock_config = MagicMock()
+    with (
+        patch(f"{_LOGGERS_MODULE}.PrometheusStatLogger"),
+        patch(f"{_LOGGERS_MODULE}.LoggingStatLogger") as mock_logging_cls,
+    ):
+        StatLoggerManager(
+            vllm_config=mock_config,
+            enable_default_loggers=True,
+            client_count=client_count,
+            client_index=client_index,
+        )
+    return mock_logging_cls.called
+
+
+def test_stat_logger_manager_single_server():
+    """With api_server_count=1 the default logging factory must be active."""
+    assert _logging_factory_was_used(client_count=1, client_index=0), (
+        "LoggingStatLogger should be active for a single API server"
+    )
+
+
+def test_stat_logger_manager_multi_server_primary():
+    """With api_server_count>1 the primary server (index 0) must log."""
+    assert _logging_factory_was_used(client_count=4, client_index=0), (
+        "LoggingStatLogger should be active on the primary API server (index 0)"
+    )
+
+
+def test_stat_logger_manager_multi_server_non_primary():
+    """With api_server_count>1 non-primary servers must NOT log."""
+    for idx in range(1, 4):
+        assert not _logging_factory_was_used(client_count=4, client_index=idx), (
+            f"LoggingStatLogger should be silent on server index {idx}"
+        )

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from vllm.v1.engine import FinishReason
 from vllm.v1.metrics.loggers import (
-    AggregatedLoggingStatLogger,
-    LoggingStatLogger,
     StatLoggerManager,
 )
 from vllm.v1.metrics.stats import (
@@ -260,12 +258,10 @@ def test_prompt_token_stats_full_external_transfer_recompute():
 _LOGGERS_MODULE = "vllm.v1.metrics.loggers"
 
 
-def _logging_factory_was_used(client_count: int, client_index: int) -> bool:
+def _logging_factory_was_used(client_count: int) -> bool:
     """Return True if LoggingStatLogger was registered as a factory.
     Patches out PrometheusStatLogger (needs real config) and
     LoggingStatLogger (needs real config) so the test runs without GPU.
-    Checks whether the patched LoggingStatLogger mock was called as a
-    factory — which only happens when logging is enabled for this server.
     """
     mock_config = MagicMock()
     with (
@@ -276,28 +272,19 @@ def _logging_factory_was_used(client_count: int, client_index: int) -> bool:
             vllm_config=mock_config,
             enable_default_loggers=True,
             client_count=client_count,
-            client_index=client_index,
         )
     return mock_logging_cls.called
 
 
 def test_stat_logger_manager_single_server():
     """With api_server_count=1 the default logging factory must be active."""
-    assert _logging_factory_was_used(client_count=1, client_index=0), (
+    assert _logging_factory_was_used(client_count=1), (
         "LoggingStatLogger should be active for a single API server"
     )
 
 
-def test_stat_logger_manager_multi_server_primary():
-    """With api_server_count>1 the primary server (index 0) must log."""
-    assert _logging_factory_was_used(client_count=4, client_index=0), (
-        "LoggingStatLogger should be active on the primary API server (index 0)"
+def test_stat_logger_manager_multi_server():
+    """With api_server_count>1 logging must be disabled on all servers."""
+    assert not _logging_factory_was_used(client_count=4), (
+        "LoggingStatLogger should be disabled when api_server_count > 1"
     )
-
-
-def test_stat_logger_manager_multi_server_non_primary():
-    """With api_server_count>1 non-primary servers must NOT log."""
-    for idx in range(1, 4):
-        assert not _logging_factory_was_used(client_count=4, client_index=idx), (
-            f"LoggingStatLogger should be silent on server index {idx}"
-        )

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -161,6 +161,7 @@ class AsyncLLM(EngineClient):
                 custom_stat_loggers=custom_stat_loggers,
                 enable_default_loggers=log_stats,
                 client_count=client_count,
+                client_index=client_index,
                 aggregate_engine_logging=aggregate_engine_logging,
             )
             self.logger_manager.log_engine_initialized()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -161,7 +161,6 @@ class AsyncLLM(EngineClient):
                 custom_stat_loggers=custom_stat_loggers,
                 enable_default_loggers=log_stats,
                 client_count=client_count,
-                client_index=client_index,
                 aggregate_engine_logging=aggregate_engine_logging,
             )
             self.logger_manager.log_engine_initialized()

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1287,6 +1287,7 @@ class StatLoggerManager:
         enable_default_loggers: bool = True,
         aggregate_engine_logging: bool = False,
         client_count: int = 1,
+        client_index: int = 0,
     ):
         self.engine_indexes = engine_idxs if engine_idxs else [0]
         self.stat_loggers: list[AggregateStatLoggerBase] = []
@@ -1294,12 +1295,18 @@ class StatLoggerManager:
         if custom_stat_loggers is not None:
             stat_logger_factories.extend(custom_stat_loggers)
         if enable_default_loggers and logger.isEnabledFor(logging.INFO):
-            if client_count > 1:
-                logger.warning(
-                    "AsyncLLM created with api_server_count more than 1; "
-                    "disabling stats logging to avoid incomplete stats."
-                )
+            if client_count > 1 and client_index > 0:
+                # Non-primary servers stay silent to avoid duplicate output.
+                pass
             else:
+                if client_count > 1:
+                    logger.info(
+                        "Multiple API servers detected (api_server_count=%d); "
+                        "stats logging is enabled on server 0 only. "
+                        "Reported stats reflect approximately 1/%d of total traffic.",
+                        client_count,
+                        client_count,
+                    )
                 default_logger_factory = (
                     AggregatedLoggingStatLogger
                     if aggregate_engine_logging

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1287,7 +1287,6 @@ class StatLoggerManager:
         enable_default_loggers: bool = True,
         aggregate_engine_logging: bool = False,
         client_count: int = 1,
-        client_index: int = 0,
     ):
         self.engine_indexes = engine_idxs if engine_idxs else [0]
         self.stat_loggers: list[AggregateStatLoggerBase] = []
@@ -1295,18 +1294,16 @@ class StatLoggerManager:
         if custom_stat_loggers is not None:
             stat_logger_factories.extend(custom_stat_loggers)
         if enable_default_loggers and logger.isEnabledFor(logging.INFO):
-            if client_count > 1 and client_index > 0:
-                # Non-primary servers stay silent to avoid duplicate output.
-                pass
+            if client_count > 1:
+                logger.warning(
+                    "AsyncLLM created with api_server_count=%d > 1; "
+                    "disabling stats logging to avoid incomplete or misleading "
+                    "stats (each server only sees a subset of traffic). "
+                    "Use Prometheus metrics for accurate aggregated stats, or "
+                    "set VLLM_USE_RUST_FRONTEND=1 to avoid this limitation.",
+                    client_count,
+                )
             else:
-                if client_count > 1:
-                    logger.info(
-                        "Multiple API servers detected (api_server_count=%d); "
-                        "stats logging is enabled on server 0 only. "
-                        "Reported stats reflect approximately 1/%d of total traffic.",
-                        client_count,
-                        client_count,
-                    )
                 default_logger_factory = (
                     AggregatedLoggingStatLogger
                     if aggregate_engine_logging


### PR DESCRIPTION
Fixes #44632 

## Summary
  - When `--api-server-count > 1` with internal DP load balancing, `StatLoggerManager`
    was silently disabling **all** stats logging across every API server process to
    "avoid incomplete stats." This left operators with zero visibility into throughput,
    SpecDecoding metrics, and other engine stats in multi-server deployments (#44632).
  - Fix: introduce a `client_index` parameter to `StatLoggerManager`. Only the primary
    server (`client_index == 0`) registers the `LoggingStatLogger` factory; non-primary
    servers stay silent to avoid duplicate output. An info message on the primary server
    clarifies that reported stats reflect ~1/N of total traffic.
  - Pass the already-available `client_index` from `AsyncLLM.__init__` through to
    `StatLoggerManager` (it was received but never forwarded).
 
 ## Root cause
 
  - `StatLoggerManager.__init__` (`vllm/v1/metrics/loggers.py`) checked `if client_count > 1`
  and skipped adding `LoggingStatLogger` to the factory list for **all** processes.
  - `client_index` was never passed to `StatLoggerManager`, so there was no way to
  distinguish the primary server from the rest.