### PR TITLE
[fix] Enable parallel tool calls for Harmony (gpt-oss) models

### DIFF
--- a/tests/test_excluded_eos_token_ids.py
+++ b/tests/test_excluded_eos_token_ids.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for SamplingParams.excluded_eos_token_ids.
+
+When tool calling is active on Harmony models, the <|call|> token (200012)
+is a delimiter between parallel tool calls, not an end-of-turn signal.
+It must be excluded from stop_token_ids so the model can generate past it
+and emit multiple tool calls in a single turn.
+"""
+
+from vllm.sampling_params import SamplingParams
+
+CALL_TOKEN = 200012
+RETURN_TOKEN = 200002
+PAD_TOKEN = 199999
+PRIMARY_EOS = 100257
+
+
+def _make_generation_config(*eos_ids: int) -> dict:
+    return {"eos_token_id": list(eos_ids)}
+
+
+class TestExcludedEosTokenIds:
+    def test_no_exclusion_adds_all_eos_ids(self):
+        """Without exclusion, all eos_token_ids from generation_config
+        are added to stop_token_ids."""
+        sp = SamplingParams.from_optional()
+        sp.update_from_generation_config(
+            _make_generation_config(CALL_TOKEN, RETURN_TOKEN, PAD_TOKEN),
+            eos_token_id=PRIMARY_EOS,
+        )
+        assert CALL_TOKEN in sp.stop_token_ids
+        assert RETURN_TOKEN in sp.stop_token_ids
+        assert PAD_TOKEN in sp.stop_token_ids
+
+    def test_exclusion_removes_call_token(self):
+        """With excluded_eos_token_ids={CALL_TOKEN}, the <|call|> token
+        should NOT appear in stop_token_ids after update."""
+        sp = SamplingParams.from_optional()
+        sp.excluded_eos_token_ids = {CALL_TOKEN}
+        sp.update_from_generation_config(
+            _make_generation_config(CALL_TOKEN, RETURN_TOKEN, PAD_TOKEN),
+            eos_token_id=PRIMARY_EOS,
+        )
+        assert CALL_TOKEN not in sp.stop_token_ids
+        assert RETURN_TOKEN in sp.stop_token_ids
+        assert PAD_TOKEN in sp.stop_token_ids
+
+    def test_exclusion_does_not_remove_primary_eos(self):
+        """The primary eos_token_id is handled separately and should not
+        be affected by excluded_eos_token_ids."""
+        sp = SamplingParams.from_optional()
+        sp.excluded_eos_token_ids = {PRIMARY_EOS}
+        sp.update_from_generation_config(
+            _make_generation_config(PRIMARY_EOS, RETURN_TOKEN),
+            eos_token_id=PRIMARY_EOS,
+        )
+        assert sp.eos_token_id == PRIMARY_EOS
+
+    def test_exclusion_with_preexisting_stop_tokens(self):
+        """Per-request stop_token_ids should be preserved; only the
+        excluded eos tokens from generation_config are dropped."""
+        user_stop_token = 42
+        sp = SamplingParams.from_optional(stop_token_ids=[user_stop_token])
+        sp.excluded_eos_token_ids = {CALL_TOKEN}
+        sp.update_from_generation_config(
+            _make_generation_config(CALL_TOKEN, RETURN_TOKEN),
+            eos_token_id=PRIMARY_EOS,
+        )
+        assert user_stop_token in sp.stop_token_ids
+        assert CALL_TOKEN not in sp.stop_token_ids
+        assert RETURN_TOKEN in sp.stop_token_ids
+
+    def test_no_exclusion_field_is_backward_compatible(self):
+        """When excluded_eos_token_ids is None (default), behavior is
+        unchanged from before this feature was added."""
+        sp = SamplingParams.from_optional()
+        assert sp.excluded_eos_token_ids is None
+        sp.update_from_generation_config(
+            _make_generation_config(CALL_TOKEN, RETURN_TOKEN),
+            eos_token_id=PRIMARY_EOS,
+        )
+        assert CALL_TOKEN in sp.stop_token_ids
+        assert RETURN_TOKEN in sp.stop_token_ids
+
+    def test_empty_exclusion_set_is_noop(self):
+        """An empty exclusion set should behave the same as None."""
+        sp = SamplingParams.from_optional()
+        sp.excluded_eos_token_ids = set()
+        sp.update_from_generation_config(
+            _make_generation_config(CALL_TOKEN, RETURN_TOKEN),
+            eos_token_id=PRIMARY_EOS,
+        )
+        assert CALL_TOKEN in sp.stop_token_ids
+        assert RETURN_TOKEN in sp.stop_token_ids

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -53,6 +53,7 @@ from vllm.entrypoints.openai.engine.serving import (
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
+    get_parallel_tool_call_excluded_token_ids,
     get_streamable_parser_for_assistant,
     parse_chat_output,
 )
@@ -300,6 +301,15 @@ class OpenAIServingChat(OpenAIServing):
                 sampling_params = request.to_sampling_params(
                     max_tokens,
                     self.default_sampling_params,
+                )
+
+            if (
+                self.use_harmony
+                and request.tools
+                and isinstance(sampling_params, SamplingParams)
+            ):
+                sampling_params.excluded_eos_token_ids = (
+                    get_parallel_tool_call_excluded_token_ids()
                 )
 
             self._log_inputs(

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -458,6 +458,18 @@ def get_streamable_parser_for_assistant() -> StreamableParser:
     return StreamableParser(get_encoding(), role=Role.ASSISTANT)
 
 
+# Harmony protocol token IDs.  <|call|> is the delimiter between
+# parallel tool calls within a single turn.  It is NOT an end-of-turn
+# signal and should not stop generation when tool calling is active.
+HARMONY_CALL_TOKEN_ID = 200012
+
+
+def get_parallel_tool_call_excluded_token_ids() -> set[int]:
+    """Token IDs to exclude from eos/stop when parallel tool calls
+    are expected.  Currently only <|call|> (200012)."""
+    return {HARMONY_CALL_TOKEN_ID}
+
+
 def parse_output_into_messages(token_ids: Iterable[int]) -> StreamableParser:
     parser = get_streamable_parser_for_assistant()
     for token_id in token_ids:

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -46,6 +46,7 @@ from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
     build_harmony_preamble,
     extract_instructions_from_messages,
+    get_parallel_tool_call_excluded_token_ids,
     get_user_message,
     has_custom_tools,
     render_for_completion,
@@ -435,6 +436,11 @@ class OpenAIServingResponses(OpenAIServing):
             sampling_params = request.to_sampling_params(
                 default_max_tokens, self.default_sampling_params
             )
+
+            if self.use_harmony and request.tools:
+                sampling_params.excluded_eos_token_ids = (
+                    get_parallel_tool_call_excluded_token_ids()
+                )
 
             trace_headers = (
                 None

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -305,6 +305,13 @@ class SamplingParams(
     is guaranteed to be dedicated to a single request and won't be modified
     in ways that would affect other uses."""
 
+    # Token IDs that should NOT cause generation to stop even if they
+    # appear in the model's eos_token_id list (generation_config.json).
+    # Set by the serving layer to allow the model to generate past
+    # within-turn delimiters (e.g. Harmony <|call|> between parallel
+    # tool calls).
+    excluded_eos_token_ids: set[int] | None = None
+
     # The below fields are not supposed to be used as an input.
     # They are set in post_init.
     output_text_buffer_length: int = 0
@@ -610,6 +617,8 @@ class SamplingParams(
                 # stop_token_ids since it's handled separately for stopping
                 # purposes.
                 eos_ids.discard(eos_token_id)
+            if self.excluded_eos_token_ids:
+                eos_ids -= self.excluded_eos_token_ids
             if eos_ids:
                 self._all_stop_token_ids.update(eos_ids)
                 if not self.ignore_eos:


### PR DESCRIPTION
## Context

When a gpt-oss model is asked to make multiple tool calls in a single turn (e.g. "What is the weather in London and Paris?" with a `get_weather` tool), vLLM only returns the first call. The model's reasoning explicitly plans both calls, but generation stops at the first `<|call|>` token (200012) because vLLM treats it as an eos/stop token.

## Summary

Token 200012 (`<|call|>`) is a delimiter between parallel tool calls in the Harmony protocol, not an end-of-turn signal. It ends up in `stop_token_ids` via `SamplingParams.update_from_generation_config()`, which reads the model's `generation_config.json` `eos_token_id` list and adds all entries unconditionally. This PR adds an `excluded_eos_token_ids` field to `SamplingParams` that the serving layer sets when gpt-oss tool calling is active. `update_from_generation_config()` subtracts excluded tokens before adding eos IDs to `stop_token_ids`, so the model can generate past `<|call|>` and emit multiple tool calls. Generation still stops at `<|return|>` (200002), the true end-of-turn token.

Both the Chat Completions and Responses API paths are fixed.

## Architecture

The fix touches four files:

- `vllm/sampling_params.py` — new `excluded_eos_token_ids: set[int] | None` field; `update_from_generation_config()` subtracts excluded tokens from the eos set before adding to `stop_token_ids`
- `vllm/entrypoints/openai/parser/harmony_utils.py` — `HARMONY_CALL_TOKEN_ID` constant and `get_parallel_tool_call_excluded_token_ids()` helper
- `vllm/entrypoints/openai/chat_completion/serving.py` — sets `excluded_eos_token_ids` when Harmony + tools
- `vllm/entrypoints/openai/responses/serving.py` — same

## Decisions / Mitigations

- `excluded_eos_token_ids` is applied only in `update_from_generation_config`, not in `__post_init__`. On `main`, both serving paths start with `stop_token_ids=[]`, so this is sufficient.
- The `<|call|>` token ID (200012) is hardcoded as a protocol constant. This is stable across Harmony encodings and matches the value in `generation_config.json`.
- `_all_stop_token_ids` may still contain 200012 — this only affects `min_tokens` enforcement (suppressing stop tokens before minimum output length) and does not cause generation to halt.