### PR TITLE
[Rust Frontend] Add Cohere command reasoning parser aliases

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -219,6 +219,16 @@ mod tests {
             &ParserSelection::Explicit(names::QWEN3.to_string()),
         )
         .unwrap();
+        validate_parser_overrides(
+            &ParserSelection::Explicit("llama3_json".to_string()),
+            &ParserSelection::Explicit(names::COHERE_COMMAND3.to_string()),
+        )
+        .unwrap();
+        validate_parser_overrides(
+            &ParserSelection::Explicit("llama3_json".to_string()),
+            &ParserSelection::Explicit(names::COHERE_COMMAND4.to_string()),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -245,6 +255,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, kimi, kimi_k2, minimax_m2, nemotron_v3, qwen3, step3)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, cohere_command3, cohere_command4, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, kimi, kimi_k2, minimax_m2, nemotron_v3, qwen3, step3)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -15,6 +15,8 @@ use crate::parser::ParserFactory;
 /// Canonical public names for registered reasoning parsers.
 pub mod names {
     pub const COHERE_CMD: &str = "cohere_cmd";
+    pub const COHERE_COMMAND3: &str = "cohere_command3";
+    pub const COHERE_COMMAND4: &str = "cohere_command4";
     pub const DEEPSEEK_R1: &str = "deepseek_r1";
     pub const DEEPSEEK_V3: &str = "deepseek_v3";
     pub const DEEPSEEK_V4: &str = "deepseek_v4";
@@ -51,6 +53,8 @@ impl ReasoningParserFactory {
 
         factory
             .register_parser::<CohereCmdReasoningParser>(names::COHERE_CMD)
+            .register_parser::<CohereCmdReasoningParser>(names::COHERE_COMMAND3)
+            .register_parser::<CohereCmdReasoningParser>(names::COHERE_COMMAND4)
             .register_parser::<DeepSeekR1ReasoningParser>(names::DEEPSEEK_R1)
             .register_parser::<DeepSeekV3ReasoningParser>(names::DEEPSEEK_V3)
             .register_parser::<DeepSeekV4ReasoningParser>(names::DEEPSEEK_V4)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -22,18 +22,35 @@ impl Tokenizer for FakeTokenizer {
             .collect())
     }
 
-    fn token_to_id(&self, _token: &str) -> Option<u32> {
-        None
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        match token {
+            "<|START_THINKING|>" => Some(1),
+            "<|END_THINKING|>" => Some(2),
+            _ => None,
+        }
     }
 }
 
 #[test]
 fn factory_contains_and_lists_registered_parsers() {
     let factory = ReasoningParserFactory::new();
+    assert!(factory.contains(names::COHERE_COMMAND3));
+    assert!(factory.contains(names::COHERE_COMMAND4));
     assert!(factory.contains(names::QWEN3));
     assert!(factory.contains(names::DEEPSEEK_V4));
+    assert!(factory.list().contains(&names::COHERE_COMMAND3.to_string()));
+    assert!(factory.list().contains(&names::COHERE_COMMAND4.to_string()));
     assert!(factory.list().contains(&names::QWEN3.to_string()));
     assert!(factory.list().contains(&names::DEEPSEEK_V4.to_string()));
+}
+
+#[test]
+fn factory_creates_cohere_command_aliases() {
+    let tokenizer = Arc::new(FakeTokenizer);
+    let factory = ReasoningParserFactory::new();
+
+    factory.create(names::COHERE_COMMAND3, tokenizer.clone()).unwrap();
+    factory.create(names::COHERE_COMMAND4, tokenizer).unwrap();
 }
 
 #[test]


### PR DESCRIPTION



## Purpose

  Add Rust frontend reasoning parser exact-name aliases for `cohere_command3`
  and `cohere_command4`.

  Both names reuse the existing `CohereCmdReasoningParser`; this improves
  parser-name compatibility with Python/vLLM parser names without changing parser
  behavior.

  Related #44280.

## Test Plan

```
  cargo test -p vllm-chat parser::reasoning --all-features -- --nocapture
  cargo test -p vllm-chat validate_parser_overrides --all-features -- --nocapture
  cargo test -p vllm-chat --all-features
  cargo clippy -p vllm-chat --all-targets --all-features -- -D warnings
  cargo fmt --all -- --check
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

