### PR TITLE
Add ModelOpt W4A16 lm_head regression tests

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -76,3 +76,51 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
         MockLMHead.assert_called_once()
         call_kwargs = MockLMHead.call_args.kwargs
         assert call_kwargs["quant_config"] is mock_quant_config
+
+
+def test_qwen3_moe_lm_head_receives_quant_config():
+    from vllm.model_executor.models.qwen3_moe import (
+        Qwen3MoeDecoderLayer,
+        Qwen3MoeForCausalLM,
+        Qwen3MoeSparseMoeBlock,
+    )
+
+    mock_quant_config = Mock()
+
+    mock_hf_config = Mock()
+    mock_hf_config.tie_word_embeddings = False
+    mock_hf_config.vocab_size = 128
+    mock_hf_config.hidden_size = 64
+
+    mock_vllm_config = Mock()
+    mock_vllm_config.model_config.hf_text_config = mock_hf_config
+    mock_vllm_config.quant_config = mock_quant_config
+
+    # Build just enough of a Qwen3-MoE layer to satisfy the metadata scan in
+    # Qwen3MoeForCausalLM.__init__ without constructing the full model.
+    fake_layer = object.__new__(Qwen3MoeDecoderLayer)
+    fake_mlp = object.__new__(Qwen3MoeSparseMoeBlock)
+    for attr, value in {
+        "experts": Mock(),
+        "n_logical_experts": 2,
+        "n_physical_experts": 2,
+        "n_local_physical_experts": 2,
+        "n_routed_experts": 2,
+        "n_redundant_experts": 0,
+    }.items():
+        object.__setattr__(fake_mlp, attr, value)
+    object.__setattr__(fake_layer, "mlp", fake_mlp)
+
+    with (
+        patch("vllm.model_executor.models.qwen3_moe.Qwen3MoeModel") as MockModel,
+        patch("vllm.model_executor.models.qwen3_moe.ParallelLMHead") as MockLMHead,
+        patch("vllm.model_executor.models.qwen3_moe.LogitsProcessor"),
+    ):
+        MockModel.return_value.make_empty_intermediate_tensors = Mock()
+        MockModel.return_value.layers = [fake_layer]
+
+        Qwen3MoeForCausalLM(vllm_config=mock_vllm_config)
+
+        MockLMHead.assert_called_once()
+        call_kwargs = MockLMHead.call_args.kwargs
+        assert call_kwargs["quant_config"] is mock_quant_config

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
+    ModelOptNvFp4W4A16LinearMethod,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -206,6 +207,22 @@ def test_modelopt_mixed_precision_does_not_infer_missing_sibling_linear(
     method = config.get_quant_method(fake_layer, missing_prefix)
 
     assert isinstance(method, UnquantizedLinearMethod)
+
+
+@pytest.mark.parametrize("prefix", ["lm_head", "model.lm_head"])
+def test_modelopt_mixed_precision_quantizes_w4a16_parallel_lm_head(prefix):
+    """Official ModelOpt mixed-precision NVFP4 checkpoints may quantize
+    ``lm_head`` as W4A16_NVFP4 instead of leaving it BF16. Keep this covered
+    separately from generic linear layers because LM heads are implemented by
+    ``ParallelLMHead`` rather than ``LinearBase``.
+    """
+    config = _mixed_precision_config(
+        {"lm_head": {"quant_algo": "W4A16_NVFP4", "group_size": 16}}
+    )
+
+    method = config.get_quant_method(_mock_lm_head(), prefix=prefix)
+
+    assert isinstance(method, ModelOptNvFp4W4A16LinearMethod)
 
 
 def test_vocab_parallel_embedding_weight_loader_accepts_scalar_scale():


### PR DESCRIPTION

Summary

Add regression coverage for ModelOpt mixed-precision checkpoints that quantize
lm_head as W4A16_NVFP4.

Why

Some official ModelOpt NVFP4 MoE checkpoints include lm_head in
hf_quant_config.json with quant_algo = "W4A16_NVFP4". The LM head is a
ParallelLMHead, not a regular LinearBase, so it is useful to keep coverage
for this path separate from the generic W4A16 linear-layer tests.

This also adds Qwen3-MoE constructor coverage to ensure the model passes
quant_config into ParallelLMHead.

This PR is regression coverage only. It does not claim an end-to-end official
checkpoint load fix.

Duplicate-work check

Searched open PRs for ModelOpt W4A16 lm_head. Related but not duplicate:

- #43342 covers Nemotron-H quantized LM head / MTP compressed-tensors handling.

This PR is scoped to ModelOpt mixed-precision W4A16_NVFP4 dispatch for
ParallelLMHead and Qwen3-MoE constructor coverage.

Validation

- uv run --no-sync --python 3.12 python -m py_compile tests/quantization/test_modelopt.py tests/model_executor/test_qwen3_5_quantization.py
- git diff --check

Targeted pytest was not run locally because this macOS checkout does not have
the vLLM test environment (pytest/torch) installed.

AI assistance was used to prepare this patch.