### PR TITLE
Fix Harmony tool descriptions for optional fields

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -2,11 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+from openai.types.responses import FunctionTool
 from openai_harmony import DeveloperContent, Message, Role
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
 from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
+    create_tool_definition,
     extract_function_from_recipient,
     get_encoding,
     get_system_message,
@@ -19,6 +22,58 @@ from vllm.entrypoints.openai.responses.harmony import (
     response_input_to_harmony,
     response_previous_input_to_harmony,
 )
+
+_TOOL_PARAMETERS = {
+    "type": "object",
+    "properties": {"status": {"type": "string"}},
+    "required": ["status"],
+    "additionalProperties": False,
+}
+
+
+class TestCreateToolDefinition:
+    def test_chat_completion_omitted_description_defaults_to_empty_string(self):
+        tool = ChatCompletionToolsParam(
+            function={
+                "name": "report_status",
+                "parameters": _TOOL_PARAMETERS,
+            }
+        )
+
+        tool_definition = create_tool_definition(tool)
+
+        assert tool_definition.name == "report_status"
+        assert tool_definition.description == ""
+        assert tool_definition.parameters == _TOOL_PARAMETERS
+
+    def test_chat_completion_none_description_defaults_to_empty_string(self):
+        tool = ChatCompletionToolsParam(
+            function={
+                "name": "report_status",
+                "description": None,
+                "parameters": _TOOL_PARAMETERS,
+            }
+        )
+
+        tool_definition = create_tool_definition(tool)
+
+        assert tool_definition.name == "report_status"
+        assert tool_definition.description == ""
+        assert tool_definition.parameters == _TOOL_PARAMETERS
+
+    def test_response_tool_none_description_defaults_to_empty_string(self):
+        tool = FunctionTool(
+            name="report_status",
+            description=None,
+            parameters=_TOOL_PARAMETERS,
+            type="function",
+        )
+
+        tool_definition = create_tool_definition(tool)
+
+        assert tool_definition.name == "report_status"
+        assert tool_definition.description == ""
+        assert tool_definition.parameters == _TOOL_PARAMETERS
 
 
 class TestIsFunctionRecipient:

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -150,12 +150,12 @@ def create_tool_definition(tool: ChatCompletionToolsParam | Tool):
     if isinstance(tool, ChatCompletionToolsParam):
         return ToolDescription.new(
             name=tool.function.name,
-            description=tool.function.description,
+            description=tool.function.description or "",
             parameters=tool.function.parameters,
         )
     return ToolDescription.new(
         name=tool.name,
-        description=tool.description,
+        description=tool.description or "",
         parameters=tool.parameters,
     )
 


### PR DESCRIPTION
## Summary

Normalize missing Harmony function tool descriptions to an empty string.

OpenAI-compatible Chat Completions and Responses tool schemas allow function
tool descriptions to be omitted or null, but `openai_harmony.ToolDescription`
requires a string. This keeps vLLM's OpenAI-facing schema permissive while
adapting to Harmony's stricter constructor.

## Duplicate-work check

No issue number was provided, so issue-specific checks were not applicable.

Checked open PRs in `vllm-project/vllm` with:

- `harmony tool description`
- `ToolDescription description`
- `optional function description`
- `openai_harmony ToolDescription`

The broad Harmony/tool searches returned unrelated parser, streaming, metrics,
and tool-choice PRs. No open PR was found that normalizes missing function tool
descriptions before constructing Harmony `ToolDescription` objects.

## Tests

- `uv run python -m pytest tests/entrypoints/openai/parser/test_harmony_utils.py -q`

```
{
  "model": "gpt-oss-120b",
  "messages": [
    {
      "role": "user",
      "content": "Call the report_status tool with status ready and count 1. Do not answer in plain text."
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "report_status",
        "parameters": {
          "type": "object",
          "properties": {
            "status": { "type": "string" },
            "count": { "type": "integer" }
          },
          "required": ["status", "count"],
          "additionalProperties": false
        }
      }
    }
  ],
  "tool_choice": "auto",
  "temperature": 0,
  "max_tokens": 128
}
```

### Before

```

(APIServer pid=863) INFO:     127.0.0.1:41980 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
(APIServer pid=863) ERROR:    Exception in ASGI application
(APIServer pid=863) Traceback (most recent call last):
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/uvicorn/protocols/http/httptools_impl.py", line 421, in run_asgi
(APIServer pid=863)     result = await app(  # type: ignore[func-returns-value]
(APIServer pid=863)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/uvicorn/middleware/proxy_headers.py", line 63, in __call__
(APIServer pid=863)     return await self.app(scope, receive, send)
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/fastapi/applications.py", line 1159, in __call__
(APIServer pid=863)     await super().__call__(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/applications.py", line 107, in __call__
(APIServer pid=863)     await self.middleware_stack(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 186, in __call__
(APIServer pid=863)     raise exc
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 164, in __call__
(APIServer pid=863)     await self.app(scope, receive, _send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/cors.py", line 87, in __call__
(APIServer pid=863)     await self.app(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/prometheus_fastapi_instrumentator/middleware.py", line 177, in __call__
(APIServer pid=863)     raise exc
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/prometheus_fastapi_instrumentator/middleware.py", line 175, in __call__
(APIServer pid=863)     await self.app(scope, receive, send_wrapper)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/exceptions.py", line 63, in __call__
(APIServer pid=863)     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
(APIServer pid=863)     raise exc
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
(APIServer pid=863)     await app(scope, receive, sender)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
(APIServer pid=863)     await self.app(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 716, in __call__
(APIServer pid=863)     await self.middleware_stack(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 736, in app
(APIServer pid=863)     await route.handle(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 290, in handle
(APIServer pid=863)     await self.app(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 134, in app
(APIServer pid=863)     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
(APIServer pid=863)     raise exc
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
(APIServer pid=863)     await app(scope, receive, sender)
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 120, in app
(APIServer pid=863)     response = await f(request)
(APIServer pid=863)                ^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 674, in app
(APIServer pid=863)     raw_response = await run_endpoint_function(
(APIServer pid=863)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 328, in run_endpoint_function
(APIServer pid=863)     return await dependant.call(**values)
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/utils.py", line 96, in wrapper
(APIServer pid=863)     return handler_task.result()
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/utils.py", line 117, in wrapper
(APIServer pid=863)     return await func(*args, **kwargs)
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/chat_completion/api_router.py", line 61, in create_chat_completion
(APIServer pid=863)     generator = await handler.create_chat_completion(request, raw_request)
(APIServer pid=863)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/chat_completion/serving.py", line 240, in create_chat_completion
(APIServer pid=863)     return await self._with_kv_transfer_rejection_cleanup(
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/engine/serving.py", line 431, in _with_kv_transfer_rejection_cleanup
(APIServer pid=863)     return await awaitable
(APIServer pid=863)            ^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/chat_completion/serving.py", line 259, in _create_chat_completion
(APIServer pid=863)     result = await self.render_chat_request(request)
(APIServer pid=863)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/chat_completion/serving.py", line 226, in render_chat_request
(APIServer pid=863)     return await self.openai_serving_render.render_chat(request)
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/serve/render/serving.py", line 264, in render_chat
(APIServer pid=863)     conversation, engine_inputs = self._make_request_with_harmony(
(APIServer pid=863)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/serve/render/serving.py", line 427, in _make_request_with_harmony
(APIServer pid=863)     dev_msg = get_developer_message(
(APIServer pid=863)               ^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/parser/harmony_utils.py", line 185, in get_developer_message
(APIServer pid=863)     create_tool_definition(tool) for tool in function_tools
(APIServer pid=863)     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/parser/harmony_utils.py", line 150, in create_tool_definition
(APIServer pid=863)     return ToolDescription.new(
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/openai_harmony/__init__.py", line 139, in new
(APIServer pid=863)     return cls(name=name, description=description, parameters=parameters)
(APIServer pid=863)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863)   File "/usr/local/lib/python3.12/dist-packages/pydantic/main.py", line 263, in __init__
(APIServer pid=863)     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
(APIServer pid=863)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=863) pydantic_core._pydantic_core.ValidationError: 1 validation error for ToolDescription
(APIServer pid=863) description
(APIServer pid=863)   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
(APIServer pid=863)     For further information visit https://errors.pydantic.dev/2.13/v/string_type

```


### After:

```
{
  "id": "chatcmpl-b305ad2e158d8047",
  "object": "chat.completion",
  "created": 1780691405,
  "prompt_routed_experts": null,
  "model": "gpt-oss-120b",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": null,
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [
          {
            "id": "chatcmpl-tool-b8ab910d8bb3b647",
            "type": "function",
            "function": {
              "name": "report_status",
              "arguments": "{\"status\": \"ready\", \"count\": 1}"
            }
          }
        ],
        "reasoning": "The user wants to call the tool report_status with status ready and count 1. And they say \"Do not answer in plain text.\" So we should just call the tool. Use the function call."
      },
      "logprobs": null,
      "finish_reason": "tool_calls",
      "stop_reason": 200012,
      "token_ids": null,
      "routed_experts": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": "vllm-0.22.2rc1.dev140+g4140faa4a-tp2-da2044b4",
  "usage": {
    "prompt_tokens": 137,
    "total_tokens": 213,
    "completion_tokens": 76,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": null
}
```

## AI assistance

AI assistance was used to prepare this change and test plan. The submitting
human should review every changed line and the test evidence before merge.
