### PR TITLE
Fix #44676: Treat <tool_call> as implicit reasoning end in ThinkingBudgetStateHolder

### DIFF
--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -16,6 +16,12 @@ from vllm.v1.sample.logits_processor.interface import (
 if TYPE_CHECKING:
     from vllm.config.reasoning import ReasoningConfig
 
+# Constants for Tool-Call/Reasoning Handover
+TOOL_CALL_TOKEN_ID = 77093
+# Lookback window to catch the tool-call token even if it appears slightly
+# after the reasoning tokens finish.
+TOOL_CALL_LOOKBACK_TOKENS = 5
+
 
 def maybe_create_thinking_budget_state_holder(
     reasoning_config: "ReasoningConfig | None",
@@ -246,6 +252,19 @@ class ThinkingBudgetStateHolder:
                 state.get("output_tok_ids", []), self.think_start_token_ids
             )
             state["start_thinking"] = start_thinking
+
+        # Check for tool-call signature to implicitly end reasoning early
+        if (
+            state.get("in_think", False)
+            and TOOL_CALL_TOKEN_ID
+            in state.get("output_tok_ids", [])[-TOOL_CALL_LOOKBACK_TOKENS:]
+        ):
+            state["in_think"] = False
+            state["think_count"] = 0
+            # Explicitly reset end_thinking as we are exiting the thinking state
+            state["end_thinking"] = -1
+            return
+
         if state["end_thinking"] == -1:
             end_thinking = self._find_last_sequence_index(
                 state.get("output_tok_ids", []), self.think_end_token_ids


### PR DESCRIPTION
Fixes #44676.

The `ThinkingBudgetStateHolder` currently tracks reasoning budget via token count, which leads to JSON corruption when the model begins a tool call because the system force-injects `reasoning_end` tokens mid-stream.

This patch explicitly identifies the `<tool_call>` token (ID 77093) and treats it as an implicit end-of-reasoning signal. This short-circuits the budget tracker logic, preventing it from corrupting the tool-call arguments when the model pivots from reasoning to tool execution.

Verified against Qwen3.6-35B tokenizer mapping.