### PR TITLE
[Bugfix] Fix Qwen3.5-FP8 nightly fail. Guard fused_add_rms_norm input/weight dtype mismatch in RMSNorm + quant fusion

### DIFF
--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -39,6 +39,7 @@ FP4_DTYPE = torch.uint8
 
 
 _RMS_NORM_OP = torch.ops.vllm_ir.rms_norm.default
+_FUSED_ADD_RMS_NORM_OP = torch.ops.vllm_ir.fused_add_rms_norm.default
 
 
 # TODO: extend rmsnorm quant kernels to support mixed input/weight dtypes,
@@ -49,8 +50,13 @@ def _rms_input_weight_dtype_match(match: pm.Match) -> bool:
         if node.target == _RMS_NORM_OP:
             # rms_norm(x, weight, epsilon, variance_size)
             x, weight = node.args[0], node.args[1]
-            if isinstance(x, fx.Node) and isinstance(weight, fx.Node):
-                return x.meta["val"].dtype == weight.meta["val"].dtype
+        elif node.target == _FUSED_ADD_RMS_NORM_OP:
+            # fused_add_rms_norm(x, residual, weight, epsilon, variance_size)
+            x, weight = node.args[0], node.args[2]
+        else:
+            continue
+        if isinstance(x, fx.Node) and isinstance(weight, fx.Node):
+            return x.meta["val"].dtype == weight.meta["val"].dtype
     return True
 
 


### PR DESCRIPTION
## Summary

The nightly [LM Eval Qwen3.5 Models (B200) — ci build #70074](https://buildkite.com/vllm/ci/builds/70074#019e9470-dfa7-479f-b6aa-b78bcddcd4c7) job started failing on `main`, a regression introduced by #42646 "[perf] Add gemma RMS AR fusion". The RMSNorm + quant fusion's dtype guard only inspected `rms_norm` nodes, not `fused_add_rms_norm` nodes, so a `GemmaRMSNorm` (used by Qwen3.5 / Qwen3-Next) producing a bf16 input with an fp32 weight got fused into `rms_norm_per_block_quant`, which aborts with `weight.scalar_type() == input.scalar_type()`. This crashes Qwen3.5-FP8 (block-FP8) at engine startup. This PR extends the guard to also cover `fused_add_rms_norm`.

## Root cause

`#42646` changed `GemmaRMSNorm.forward_native` to emit `ir.ops.fused_add_rms_norm(x, residual, weight, eps)` for the residual path, where `weight = self.weight.float() + 1.0` is fp32 while `x`/`residual` are bf16. The fusion's `_rms_input_weight_dtype_match` extra-check only looked at `vllm_ir.rms_norm` nodes and returned `True` for `fused_add_rms_norm` matches, so the fused-add patterns fused despite the dtype mismatch and emitted a `weight=fp32 / input=bf16` call into the strict block-FP8 kernel.

## Fix

Extend `_rms_input_weight_dtype_match` to also handle `fused_add_rms_norm` nodes (input is `args[0]`, weight is `args[2]`), so a dtype mismatch now correctly skips the fusion and falls back to the unfused path — consistent with the existing behavior for plain `rms_norm`.

## Test plan

- `pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-qwen35-blackwell.txt -k Qwen3.5-35B-A3B-FP8-DEP2` passed