### PR TITLE
[Test][Quantization] Restrict test_machete_mm gate to Hopper family

### DIFF
--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -33,12 +33,13 @@ CUDA_DEVICES = [
     f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
 ]
 
-# TODO: in future PR refactor this and `is_quant_method_supported` in the kernel
-#  unit tests to a common utility function. Currently the use of
-#  `is_quant_method_supported` conflates kernels with quantization methods
-#  an assumption which is breaking down as quantizations methods can have
-#  have kernels and some kernels support multiple quantization methods.
-IS_SUPPORTED_BY_GPU = current_platform.get_device_capability()[0] >= 9
+# Machete kernels are Hopper-only by design — see CMakeLists.txt
+# (MACHETE_ARCHS = "9.0a" + "the machete kernels only work on hopper"
+# comment). `is_device_capability_family(90)` matches Hopper family only.
+# Prior gates (`>= 9` here, `has_device_capability(90)` below) caught
+# SM_10x (Blackwell, etc.) because 100 >= 90 — but machete has no
+# SM_10x kernel image, so dispatch failed with cudaErrorNoKernelImage.
+IS_SUPPORTED_BY_GPU = current_platform.is_device_capability_family(90)
 
 MNK_SHAPES = [
     (1, 128, 128),
@@ -130,13 +131,6 @@ TEST_TYPES = [
     #              token_scale_type=torch.float)
     #   for group_scale_type in [None, torch.float16]),
 ]
-
-# TODO: in future PR refactor this and `is_quant_method_supported` in the kernel
-#  unit tests to a common utility function. Currently the use of
-#  `is_quant_method_supported` conflates kernels with quantization methods
-#  an assumption which is breaking down as quantizations methods can have
-#  have kernels and some kernels support multiple quantization methods.
-IS_SUPPORTED_BY_GPU = current_platform.has_device_capability(90)
 
 
 def rand_data(shape, dtype=torch.float16, scale=1, offset=0):


### PR DESCRIPTION
## Summary

`tests/kernels/quantization/test_machete_mm.py` has `IS_SUPPORTED_BY_GPU` defined twice at module level — looks like a copy-paste from an earlier machete W4A8 PR. The later definition wins in Python, so the effective gate is `current_platform.has_device_capability(90)`. Both definitions ("`>= 9`" upper / "`has_device_capability(90)`" lower) evaluate True on SM_10x devices (Blackwell, etc.) because `100 >= 90`.

But machete kernels are explicitly Hopper-only by design — `CMakeLists.txt:565-567`:

```
# The machete kernels only work on hopper and require CUDA 12.0 or later.
cuda_archs_loose_intersection(MACHETE_ARCHS "9.0a" "${CUDA_ARCHS}")
```

On any SM_10x device, the test passes the gate, dispatches into machete ops via opcheck, and tests fail with `cudaErrorNoKernelImageForDevice` (no SM_10x kernel image is built per MACHETE_ARCHS).

## Why this hasn't surfaced

The "Kernels Quantization Test" buildkite step (`.buildkite/test_areas/kernels.yaml`) runs `kernels/quantization/` on the default L4 device (SM_8.9), where the gate evaluates False and machete skips cleanly. The "Kernels (B200)" step (`device: b200`) is curated to specific files and excludes `test_machete_mm.py`. So no lane in the current CI matrix invokes machete tests on SM_10x.

The existing TODO comment above the gate ("`conflates kernels with quantization methods... breaking down as ... some kernels support multiple quantization methods`") explicitly flagged that this gate was an approximation.

## Changes

- Tighten the gate to `current_platform.is_device_capability_family(90)` — Hopper family only, matching `CMakeLists.txt` `MACHETE_ARCHS = "9.0a"`.
- Remove the duplicate dead `IS_SUPPORTED_BY_GPU` + TODO block at lines 134-139 (the upper one becomes the only module-level definition).

Uses the same `is_device_capability_family` helper that's already in use in `test_cutlass_mla_decode.py`, `test_flashinfer_trtllm_attention.py`, etc.

## Test plan

- [x] On SM_10x: test now skips cleanly (instead of dispatching and failing with no-kernel-image).
- [x] On SM_9.x (Hopper): test runs as before — `is_device_capability_family(90)` is True.
- [x] On SM_8.x or below: test skips, same as before — `is_device_capability_family(90)` is False.

DCO signed off.