### PR TITLE
[Bugfix][Security] Exclude VLLM_API_KEY from torch.compile cache factors

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -36,6 +36,17 @@ def test_nixl_side_channel_host_is_not_compile_factor(
     assert "VLLM_NIXL_SIDE_CHANNEL_HOST" not in envs.compile_factors()
 
 
+def test_vllm_api_key_is_not_compile_factor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # VLLM_API_KEY is a server bearer-token secret. compile_factors() is
+    # written to cache_key_factors.json on disk and logged at DEBUG level,
+    # so the raw value must not be included.
+    monkeypatch.setenv("VLLM_API_KEY", "sk-test-secret-do-not-leak")
+
+    assert "VLLM_API_KEY" not in envs.compile_factors()
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2112,6 +2112,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_MODEL_REDIRECT_PATH",
         "VLLM_HOST_IP",
         "VLLM_FORCE_AOT_LOAD",
+        "VLLM_API_KEY",
         "S3_ACCESS_KEY_ID",
         "S3_SECRET_ACCESS_KEY",
         "S3_ENDPOINT_URL",


### PR DESCRIPTION
## Summary

`VLLM_API_KEY` is the bearer token used to authenticate clients to the
OpenAI-compatible API server (see
[`vllm/entrypoints/openai/api_server.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/api_server.py) — used to construct the `AuthenticationMiddleware` token list).

It is registered in `environment_variables` but was **missing** from the
`ignored_factors` set in `compile_factors()` (`vllm/envs.py`). Because
the result of `compile_factors()` is consumed by the torch.compile cache
machinery in `vllm/compilation/backends.py`, the raw value was leaking
through two paths:

1. **Plaintext on disk** — written to `cache_key_factors.json` under the
   torch compile cache directory (around L1118).
2. **DEBUG logs** — emitted via `pprint.pformat` of the raw factors
   (around L1112), which is visible if the user runs at DEBUG.

This is sibling to `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, and
`S3_ENDPOINT_URL`, which are already correctly excluded; this PR treats
`VLLM_API_KEY` consistently.

## Reproduction (before this PR, on `main`)

```bash
VLLM_API_KEY=sk-test-12345 python -c "
import vllm.envs as e
print('VLLM_API_KEY' in e.compile_factors())
print(e.compile_factors().get('VLLM_API_KEY'))
"
# True
# 'sk-test-12345'
```

(Cross-confirmed by the example `cache_key_factors.json` posted in the
description of #40246, which contains the literal entry `"VLLM_API_KEY": "null"`.)

After this PR: `'VLLM_API_KEY' in compile_factors()` is `False`.

## Duplicate-work check

Per `AGENTS.md`:

```
gh pr list --repo vllm-project/vllm --state open --search "VLLM_API_KEY ignored_factors"
gh pr list --repo vllm-project/vllm --state open --search "compile_factors api key"
gh issue list --repo vllm-project/vllm --state open --search "VLLM_API_KEY plaintext compile"
```

The closest open PRs (#40246, #43527) refactor `compile_factors()`'s
hashing/normalization but do not add `VLLM_API_KEY` to `ignored_factors`
— in fact the validation block in #40246 explicitly shows the leak. No
issue or PR currently addresses this specific omission.

## Test plan

- [x] New unit test `tests/test_envs.py::test_vllm_api_key_is_not_compile_factor`,
  mirroring the existing `test_nixl_side_channel_host_is_not_compile_factor`.
- [x] `pytest tests/test_envs.py::test_vllm_api_key_is_not_compile_factor tests/test_envs.py::test_nixl_side_channel_host_is_not_compile_factor -v` — both pass locally.
- [x] `pre-commit run --files vllm/envs.py tests/test_envs.py` (ruff/format/mypy) — all pass.
- [ ] CI green.

## AI assistance disclosure

Per `AGENTS.md` §1: AI assistance (Claude) was used to identify the
omission, draft the fix, and write the regression test. Every changed
line was reviewed end-to-end by the human submitter, and the duplicate
checks and tests above were run locally before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)