### PR TITLE
[Spec][PP] Support MTP speculative decoding under pipeline parallelism (PP>1)

### DIFF
--- a/tests/v1/spec_decode/test_draft_embed_quant_integration.py
+++ b/tests/v1/spec_decode/test_draft_embed_quant_integration.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Integration of the low-bit draft vocab embedding (A1c) into the spec config.
+
+The numerical core (QuantizedVocabEmbedding) is covered by
+test_quantized_draft_embedding.py. Here we test the SpeculativeConfig knob that
+selects the draft embedding bit-width. The actual swap happens at draft model
+*construction* (qwen3_5_mtp.py builds a QuantizedVocabEmbedding when the knob is
+set) so the fp16 table never materializes on the GPU — that wiring is validated
+end-to-end on real hardware (RUN-A and follow-ups), since it needs a built model.
+
+CPU-only: config plumbing, no download / distributed init.
+"""
+
+import pytest
+
+from vllm.config.speculative import SpeculativeConfig
+
+
+def test_verify_draft_embed_quant_bits_defaults_none():
+    """Unset -> None (no quantization, full-precision draft embed)."""
+    assert SpeculativeConfig._verify_draft_embed_quant_bits(None) is None
+
+
+def test_verify_draft_embed_quant_bits_allows_8_and_4():
+    assert SpeculativeConfig._verify_draft_embed_quant_bits(8) == 8
+    assert SpeculativeConfig._verify_draft_embed_quant_bits(4) == 4
+
+
+def test_verify_draft_embed_quant_bits_rejects_other_values():
+    """Only 4 or 8 (or None) are supported bit-widths."""
+    with pytest.raises(ValueError):
+        SpeculativeConfig._verify_draft_embed_quant_bits(3)
+    with pytest.raises(ValueError):
+        SpeculativeConfig._verify_draft_embed_quant_bits(16)

--- a/tests/v1/spec_decode/test_pp_draft_config.py
+++ b/tests/v1/spec_decode/test_pp_draft_config.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for decoupling the draft model's pipeline-parallel size from the
+target model's, so that PP>1 + speculative decoding (MTP) can place the draft
+on a single stage (draft_pp=1) without tripping the SupportsPP guard.
+
+Spike E1 for docs/superpowers/specs/2026-06-04-pp-mtp-spike-plan.md.
+CPU-only: exercises config plumbing, no model download, no distributed init.
+"""
+
+import pytest
+
+from vllm.config import ParallelConfig
+from vllm.config.speculative import SpeculativeConfig
+
+
+def _target_pp2() -> ParallelConfig:
+    """A target ParallelConfig with pp=2 that constructs on a single-GPU host
+    (mp backend + nnodes=2 bypasses the world-size>=num-GPUs validation)."""
+    return ParallelConfig(
+        pipeline_parallel_size=2,
+        tensor_parallel_size=1,
+        distributed_executor_backend="mp",
+        nnodes=2,
+    )
+
+
+def test_create_draft_parallel_config_decouples_pp():
+    """With draft_pp=1 the draft ParallelConfig must report pp=1 even when the
+    target runs pp=2. This is the mechanism that bypasses the
+    `pipeline_parallel_size > 1` SupportsPP guard for the draft model."""
+    draft = SpeculativeConfig.create_draft_parallel_config(
+        target_parallel_config=_target_pp2(),
+        speculative_draft_tensor_parallel_size=1,
+        speculative_draft_pipeline_parallel_size=1,
+    )
+
+    assert draft.pipeline_parallel_size == 1
+    assert draft.tensor_parallel_size == 1
+
+
+def test_verify_and_get_draft_pp_defaults_to_one():
+    """Unset draft_pp defaults to 1 (draft on a single stage)."""
+    assert SpeculativeConfig._verify_and_get_draft_pp(_target_pp2(), None) == 1
+
+
+def test_verify_and_get_draft_pp_allows_one_or_target():
+    target = _target_pp2()
+    assert SpeculativeConfig._verify_and_get_draft_pp(target, 1) == 1
+    assert SpeculativeConfig._verify_and_get_draft_pp(target, 2) == 2
+
+
+def test_verify_and_get_draft_pp_rejects_other_values():
+    """Only 1 or the target pp size are valid, mirroring draft_tp."""
+    with pytest.raises(ValueError):
+        SpeculativeConfig._verify_and_get_draft_pp(_target_pp2(), 3)
+
+
+# --- Spike E3 step 1: the Qwen3.5 MTP draft must declare SupportsPP so that,
+# under Design B (draft_pp == target_pp), it passes the model.py guard, which
+# reads `model_cls.supports_pp` via registry.is_pp_supported_model.
+
+
+def test_qwen3_5_mtp_declares_supports_pp():
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MoeMTP, Qwen3_5MTP
+
+    assert Qwen3_5MTP.supports_pp is True
+    assert Qwen3_5MoeMTP.supports_pp is True

--- a/tests/v1/spec_decode/test_pp_spec_broadcast.py
+++ b/tests/v1/spec_decode/test_pp_spec_broadcast.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the PP sampled-token broadcast under speculative decoding.
+
+Under PP+async scheduling the last rank broadcasts its sampled token ids to the
+other ranks so they can advance positions / build the next input. Without spec,
+the broadcast carries shape ``[num_reqs, 1]``. With MTP/EAGLE spec the sampler
+emits ``[num_reqs, num_spec + 1]`` (accepted drafts + bonus, ``-1``-padded), so
+the transport must carry the full width and the receiver must advance each
+request by its per-request *valid* count, not by 1.
+
+These tests pin that contract WITHOUT a GPUModelRunner: the pure per-request
+count is tested directly, and the variable-width transport is tested over a real
+2-rank gloo group on CPU (no CUDA).
+"""
+
+import os
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.utils.network_utils import get_open_port
+
+# The sampled-token grid the last rank "produces": req0 has 3 valid tokens
+# (2 accepted drafts + bonus), req1 has 2, req2 has 1. -1 pads the rejected tail.
+_SAMPLED = [[10, 11, 12], [20, 21, -1], [30, -1, -1]]
+_EXPECTED_VALID = [3, 2, 1]
+
+
+def test_count_valid_sampled_tokens_per_req_counts_non_sentinel():
+    from vllm.v1.worker.pp_spec_broadcast import count_valid_sampled_tokens_per_req
+
+    t = torch.tensor(_SAMPLED, dtype=torch.int32)
+    assert count_valid_sampled_tokens_per_req(t).tolist() == _EXPECTED_VALID
+
+
+def test_count_valid_sampled_tokens_per_req_non_spec_width_one():
+    from vllm.v1.worker.pp_spec_broadcast import count_valid_sampled_tokens_per_req
+
+    # Non-spec: width 1, every row a real token -> each advances by 1.
+    t = torch.tensor([[10], [20], [30]], dtype=torch.int32)
+    assert count_valid_sampled_tokens_per_req(t).tolist() == [1, 1, 1]
+
+
+# C4: the non-last rank must feed the REAL latest sampled token as its next input,
+# never the -1 placeholder. The latest valid token for a request that advanced by
+# v positions is the last valid column recv[i, v-1] (reject v=1 -> col 0; accept +
+# bonus v=2 -> col 1). This is the value-back-write the receiver must persist.
+def test_select_latest_sampled_token_per_req_picks_last_valid_column():
+    from vllm.v1.worker.pp_spec_broadcast import select_latest_sampled_token_per_req
+
+    # _SAMPLED: req0 valid=3 -> col2=12; req1 valid=2 -> col1=21; req2 valid=1 -> col0.
+    t = torch.tensor(_SAMPLED, dtype=torch.int32)
+    assert select_latest_sampled_token_per_req(t).tolist() == [12, 21, 30]
+
+
+def test_select_latest_sampled_token_per_req_non_spec_width_one():
+    from vllm.v1.worker.pp_spec_broadcast import select_latest_sampled_token_per_req
+
+    # Non-spec width-1: the single column is the latest token.
+    t = torch.tensor([[10], [20], [30]], dtype=torch.int32)
+    assert select_latest_sampled_token_per_req(t).tolist() == [10, 20, 30]
+
+
+def test_select_latest_sampled_token_per_req_never_returns_sentinel():
+    from vllm.v1.worker.pp_spec_broadcast import select_latest_sampled_token_per_req
+
+    # Every confirmed request has >=1 valid token, so the result is never -1 even
+    # when the rejected tail is -1-padded (this is exactly what break #2 needs).
+    t = torch.tensor([[42, -1, -1], [7, 8, -1]], dtype=torch.int32)
+    out = select_latest_sampled_token_per_req(t).tolist()
+    assert out == [42, 8]
+    assert -1 not in out
+
+
+# Holistic C4: select_latest only persists the single LATEST token, but under
+# MTP the non-last rank must backfill ALL v confirmed tokens (accepted drafts +
+# bonus) into its token_ids_cpu so the next step's input read (indexed by
+# num_computed_tokens, which includes the spec tokens) finds real ids at EVERY
+# position, not just the last one. recv[i, 0:v] is exactly that ordered run.
+def test_gather_valid_sampled_tokens_per_req_returns_all_valid_in_order():
+    from vllm.v1.worker.pp_spec_broadcast import gather_valid_sampled_tokens_per_req
+
+    # _SAMPLED: req0 valid=3 -> [10,11,12]; req1 valid=2 -> [20,21]; req2 valid=1 [30].
+    t = torch.tensor(_SAMPLED, dtype=torch.int32)
+    assert gather_valid_sampled_tokens_per_req(t) == [[10, 11, 12], [20, 21], [30]]
+
+
+def test_gather_valid_sampled_tokens_per_req_non_spec_width_one():
+    from vllm.v1.worker.pp_spec_broadcast import gather_valid_sampled_tokens_per_req
+
+    # Non-spec width-1: each request advances by exactly one real token.
+    t = torch.tensor([[10], [20], [30]], dtype=torch.int32)
+    assert gather_valid_sampled_tokens_per_req(t) == [[10], [20], [30]]
+
+
+def test_gather_valid_sampled_tokens_per_req_all_rejected_row_is_empty():
+    from vllm.v1.worker.pp_spec_broadcast import gather_valid_sampled_tokens_per_req
+
+    # A fully -1-padded row (no valid token, e.g. a discarded/chunked req) yields
+    # an empty list so the receiver writes nothing and advances the cursor by 0.
+    t = torch.tensor([[5, 6, -1], [-1, -1, -1]], dtype=torch.int32)
+    assert gather_valid_sampled_tokens_per_req(t) == [[5, 6], []]
+
+
+def test_gather_valid_sampled_tokens_per_req_never_contains_sentinel():
+    from vllm.v1.worker.pp_spec_broadcast import gather_valid_sampled_tokens_per_req
+
+    # Whatever the padding, the gathered runs never carry a -1 (break #2 needs
+    # every backfilled position to be a real embedding index).
+    t = torch.tensor(_SAMPLED, dtype=torch.int32)
+    flat = [tok for row in gather_valid_sampled_tokens_per_req(t) for tok in row]
+    assert -1 not in flat
+
+
+def test_num_computed_tokens_drift_correction_reject_subtracts_one():
+    from vllm.v1.worker.pp_spec_broadcast import (
+        num_computed_tokens_drift_correction,
+    )
+
+    # 1 draft proposed, draft rejected -> only the bonus is valid (v=1). The
+    # optimistic advance counted the draft as accepted, so subtract 1.
+    assert num_computed_tokens_drift_correction(1, 1) == 1
+
+
+def test_num_computed_tokens_drift_correction_accept_subtracts_zero():
+    from vllm.v1.worker.pp_spec_broadcast import (
+        num_computed_tokens_drift_correction,
+    )
+
+    # 1 draft proposed, draft accepted -> draft + bonus valid (v=2). The optimistic
+    # advance was right, so no correction.
+    assert num_computed_tokens_drift_correction(1, 2) == 0
+
+
+def test_num_computed_tokens_drift_correction_no_drafts_is_zero():
+    from vllm.v1.worker.pp_spec_broadcast import (
+        num_computed_tokens_drift_correction,
+    )
+
+    # First decode after prefill: no drafts last step (prev_num_draft_len=0), the
+    # single bonus is valid (v=1). Nothing optimistic was counted -> 0.
+    assert num_computed_tokens_drift_correction(0, 1) == 0
+
+
+def test_num_computed_tokens_drift_correction_partial_accept():
+    from vllm.v1.worker.pp_spec_broadcast import (
+        num_computed_tokens_drift_correction,
+    )
+
+    # 3 drafts proposed, 1 accepted + bonus valid (v=2) -> 2 drafts rejected.
+    assert num_computed_tokens_drift_correction(3, 2) == 2
+    # all 3 accepted + bonus (v=4) -> no correction.
+    assert num_computed_tokens_drift_correction(3, 4) == 0
+
+
+def _broadcast_worker(rank: int, world_size: int, port: int, width: int):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    try:
+        from vllm.v1.worker.pp_spec_broadcast import (
+            broadcast_sampled_token_ids,
+            count_valid_sampled_tokens_per_req,
+            receive_sampled_token_ids,
+        )
+
+        src = world_size - 1  # the last rank is the sender
+        num_reqs = len(_SAMPLED)
+        if rank == src:
+            sampled = torch.tensor(_SAMPLED, dtype=torch.int32)
+            broadcast_sampled_token_ids(sampled, dist.group.WORLD, src)
+        else:
+            recv = receive_sampled_token_ids(
+                num_reqs, width, dist.group.WORLD, src, device="cpu"
+            )
+            expected = torch.tensor(_SAMPLED, dtype=torch.int32)
+            assert torch.equal(recv, expected), f"recv mismatch: {recv}"
+            counts = count_valid_sampled_tokens_per_req(recv)
+            assert counts.tolist() == _EXPECTED_VALID, f"counts: {counts}"
+    finally:
+        dist.destroy_process_group()
+
+
+def test_variable_width_broadcast_roundtrip():
+    """Last rank broadcasts [num_reqs, num_spec+1]; non-last receives same width.
+
+    The current code hardcodes a [num_reqs, 1] receive buffer, which cannot carry
+    the spec width. This pins the variable-width transport over a real gloo group.
+    """
+    port = get_open_port()
+    width = len(_SAMPLED[0])  # num_spec + 1 == 3
+    mp.spawn(_broadcast_worker, args=(2, port, width), nprocs=2, join=True)

--- a/tests/v1/spec_decode/test_quantized_draft_embedding.py
+++ b/tests/v1/spec_decode/test_quantized_draft_embedding.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the low-bit draft vocab embedding (A1c memory fix).
+
+The MTP draft loads its own full-precision copy of a huge vocab embedding on the
+last PP rank (Qwen3.5: vocab 248320 x hidden 5120 = 2.37 GiB fp16), which is what
+pushes 27B+draft over 2x16 GiB. Because the draft is only a speculative proposer
+(rejection sampling guarantees the final output equals target greedy regardless of
+draft quality), a *lossy* low-bit draft embedding is correctness-safe: it only
+lowers acceptance, never changes the output.
+
+Crucially (RUN-A finding), the int storage must be allocated *at construction* and
+the fp16 checkpoint weight quantized *as it loads* — so the full fp16 [V, H] tensor
+never materializes on the GPU. Hence the primary constructor takes a shape, and
+`load_full_weight` quantizes an fp16 weight into the pre-allocated int storage.
+`from_weight` is a convenience (tests / post-load) that does both at once.
+
+Pure-torch (CPU), no GPU / PP / model needed.
+"""
+
+import torch
+
+from vllm.model_executor.layers.quantized_draft_embedding import (
+    QuantizedVocabEmbedding,
+)
+
+
+def test_int8_lookup_matches_fp16_within_quant_error():
+    """int8 per-row symmetric: lookup ~= fp16 lookup within one quant step."""
+    torch.manual_seed(0)
+    vocab, hidden = 1000, 64
+    weight = torch.randn(vocab, hidden, dtype=torch.float16)
+
+    qemb = QuantizedVocabEmbedding.from_weight(weight, bits=8)
+
+    ids = torch.tensor([0, 5, 42, 999, 500], dtype=torch.long)
+    ref = torch.nn.functional.embedding(ids, weight)
+    out = qemb(ids)
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.float16
+    max_err = (out.float() - ref.float()).abs().max().item()
+    assert max_err < 0.03, f"int8 lookup error too large: {max_err}"
+
+
+def test_int8_stores_one_byte_per_weight():
+    """The win: int8 weight storage is half of fp16, plus a tiny per-row scale."""
+    torch.manual_seed(0)
+    vocab, hidden = 1000, 64
+    weight = torch.randn(vocab, hidden, dtype=torch.float16)
+
+    qemb = QuantizedVocabEmbedding.from_weight(weight, bits=8)
+
+    assert qemb.qweight.dtype == torch.int8
+    assert qemb.qweight.numel() == vocab * hidden
+    assert qemb.scale.numel() == vocab
+
+
+def test_int4_lookup_matches_fp16_within_quant_error():
+    """int4 is coarser than int8 but still tracks the fp16 lookup."""
+    torch.manual_seed(0)
+    vocab, hidden = 1000, 64
+    weight = torch.randn(vocab, hidden, dtype=torch.float16)
+
+    qemb = QuantizedVocabEmbedding.from_weight(weight, bits=4)
+
+    ids = torch.tensor([0, 5, 42, 999, 500], dtype=torch.long)
+    ref = torch.nn.functional.embedding(ids, weight)
+    out = qemb(ids)
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.float16
+    max_err = (out.float() - ref.float()).abs().max().item()
+    assert max_err < 0.5, f"int4 lookup error too large: {max_err}"
+    assert max_err > 0.03, f"int4 unexpectedly precise: {max_err}"
+
+
+def test_int4_packs_two_weights_per_byte():
+    """The bigger win: int4 stores half a byte per weight (2 nibbles/byte)."""
+    torch.manual_seed(0)
+    vocab, hidden = 1000, 64
+    weight = torch.randn(vocab, hidden, dtype=torch.float16)
+
+    qemb = QuantizedVocabEmbedding.from_weight(weight, bits=4)
+
+    assert qemb.qweight.dtype == torch.uint8
+    assert qemb.qweight.numel() == vocab * hidden // 2
+    assert qemb.scale.numel() == vocab
+
+
+# --- Load-time construction (RUN-A: never materialize fp16 [V, H] on GPU) ------
+
+
+def test_construct_allocates_int_storage_without_full_fp16():
+    """Constructing from a shape pre-allocates int storage (no fp16 [V, H]).
+
+    The `weight` entry-point for the checkpoint loader must NOT be a full
+    fp16 [V, H] parameter (that is the OOM peak); it is an empty placeholder.
+    """
+    vocab, hidden = 200, 32
+    qemb = QuantizedVocabEmbedding(vocab, hidden, bits=4)
+
+    assert qemb.qweight.dtype == torch.uint8
+    assert qemb.qweight.numel() == vocab * hidden // 2
+    assert qemb.scale.numel() == vocab
+    # The loader placeholder must not hold a full fp16 table.
+    assert qemb.weight.numel() < vocab * hidden
+
+
+def test_load_full_weight_quantizes_into_preallocated_storage():
+    """load_full_weight fills the pre-allocated int storage from an fp16 table."""
+    torch.manual_seed(0)
+    vocab, hidden = 200, 32
+    qemb = QuantizedVocabEmbedding(vocab, hidden, bits=4)
+
+    weight = torch.randn(vocab, hidden, dtype=torch.float16)
+    qemb.load_full_weight(weight)
+
+    ids = torch.tensor([0, 7, 199], dtype=torch.long)
+    ref = torch.nn.functional.embedding(ids, weight)
+    out = qemb(ids)
+    assert (out.float() - ref.float()).abs().max().item() < 0.5
+
+
+def test_weight_loader_attr_routes_to_quantization():
+    """The `weight` placeholder carries a weight_loader that quantizes the
+    incoming fp16 checkpoint tensor (the AutoWeightsLoader entry point)."""
+    torch.manual_seed(0)
+    vocab, hidden = 200, 32
+    qemb = QuantizedVocabEmbedding(vocab, hidden, bits=8)
+
+    loader = qemb.weight.weight_loader
+    weight = torch.randn(vocab, hidden, dtype=torch.float16)
+    loader(qemb.weight, weight)
+
+    ids = torch.tensor([1, 50, 150], dtype=torch.long)
+    ref = torch.nn.functional.embedding(ids, weight)
+    out = qemb(ids)
+    assert (out.float() - ref.float()).abs().max().item() < 0.03

--- a/tests/v1/spec_decode/test_qwen3_5_mtp_standalone.py
+++ b/tests/v1/spec_decode/test_qwen3_5_mtp_standalone.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Design C: the Qwen3.5 MTP draft must run as a standalone (first==last) draft.
+
+Under target PP>1 the drafter executes on the *last* global PP rank, where
+`get_pp_group().is_first_rank == False`. Without a standalone flag the MTP
+forward takes the `else` branch and demands `intermediate_tensors` that the
+proposer never supplies (brick 60). With `draft_pipeline_parallel_size == 1`
+(Design C) the forward must behave as first==last: embed -> fc -> layer -> norm,
+never reading/returning IntermediateTensors.
+
+CPU-only: stubs the submodules and mocks the PP group to exercise the branch
+routing without constructing the full model (validated end-to-end at E3).
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MultiTokenPredictor
+
+HIDDEN = 4
+
+
+def _stub_predictor(standalone: bool) -> Qwen3_5MultiTokenPredictor:
+    """A minimally-stubbed predictor that exercises forward()'s branch routing
+    without the heavy real submodules (attention backends, weights, etc.)."""
+    m = object.__new__(Qwen3_5MultiTokenPredictor)
+    torch.nn.Module.__init__(m)
+    m.standalone_draft = standalone
+    m.num_mtp_layers = 1
+    m.embed_tokens = lambda ids: torch.zeros(ids.shape[0], HIDDEN)
+    m.pre_fc_norm_embedding = lambda x: x
+    m.pre_fc_norm_hidden = lambda x: x
+    # real fc maps [2*hidden] -> [hidden]; emulate by halving the last dim.
+    m.fc = lambda x: x[..., :HIDDEN]
+    m.layers = [lambda positions, hidden_states, residual: (hidden_states, residual)]
+    m.norm = lambda h, r: (h, None)
+    return m
+
+
+def _last_rank_of_pp2():
+    """Mock the global PP group as the last rank of a pp=2 group."""
+    grp = type("G", (), {"is_first_rank": False, "is_last_rank": True})()
+    return patch(
+        "vllm.model_executor.models.qwen3_5_mtp.get_pp_group", lambda: grp
+    )
+
+
+def test_standalone_draft_uses_embed_path_on_last_rank():
+    """Design C: with the standalone flag, the last-rank draft embeds its own
+    input and returns a hidden-state tensor — no intermediate_tensors needed."""
+    m = _stub_predictor(standalone=True)
+    n = 3
+    input_ids = torch.zeros(n, dtype=torch.long)
+    positions = torch.zeros(n, dtype=torch.long)
+    hidden_states = torch.zeros(n, HIDDEN)
+
+    with _last_rank_of_pp2():
+        out = m.forward(input_ids, positions, hidden_states)
+
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (n, HIDDEN)
+
+
+def test_non_standalone_last_rank_still_requires_intermediate_tensors():
+    """Control: without the flag, the last rank of pp=2 (is_first_rank=False)
+    takes the else branch and asserts on the missing intermediate_tensors —
+    i.e. exactly the broken Design-B-shaped behavior the flag fixes."""
+    m = _stub_predictor(standalone=False)
+    n = 3
+    input_ids = torch.zeros(n, dtype=torch.long)
+    positions = torch.zeros(n, dtype=torch.long)
+    hidden_states = torch.zeros(n, HIDDEN)
+
+    with _last_rank_of_pp2(), pytest.raises(AssertionError):
+        m.forward(input_ids, positions, hidden_states)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -836,6 +836,16 @@ class SpeculativeConfig:
                         self.draft_pipeline_parallel_size,
                     )
                 )
+
+        if (
+            self.method == "mtp"
+            and self.target_parallel_config is not None
+            and self.target_parallel_config.pipeline_parallel_size > 1
+        ):
+            logger.warning_once(
+                "MTP speculative decoding with pipeline parallelism "
+                "(pipeline_parallel_size > 1) is experimental."
+            )
         return self
 
     def _validate_suffix_decoding(self):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -94,6 +94,21 @@ class SpeculativeConfig:
     draft_tensor_parallel_size: int | None = Field(default=None, ge=1)
     """The degree of the tensor parallelism for the draft model. Can only be 1
     or the same as the target model's tensor parallel size."""
+    draft_pipeline_parallel_size: int | None = Field(default=None, ge=1)
+    """The degree of the pipeline parallelism for the draft model. Can only be 1
+    or the same as the target model's pipeline parallel size. Defaults to 1 so
+    that a small draft (e.g. a single-layer MTP module) runs on one pipeline
+    stage while the target uses PP>1, which is what enables PP + speculative
+    decoding without the draft tripping the SupportsPP guard."""
+    draft_embed_quant_bits: int | None = None
+    """Optional low-bit quantization for the draft model's vocab embedding (4 or
+    8; None = full precision). A speculative draft loads its own copy of the
+    target's (often huge) vocab embedding on the last PP rank; quantizing it
+    saves VRAM there. Because rejection sampling makes the final output
+    independent of draft quality, this is correctness-safe: it only affects the
+    draft acceptance rate, never the emitted tokens. Applied only on the PP
+    separate-load path (draft has its own embedding); ignored when the draft
+    shares the target's embedding (no PP)."""
     tensor_parallel_size: int | None = None
     """Users should pass "draft_tensor_parallel_size". This parameter's purpose is to
     warn users when they mistakenly provide the wrong argument."""
@@ -793,6 +808,19 @@ class SpeculativeConfig:
                     )
                 )
 
+                self.draft_pipeline_parallel_size = (
+                    SpeculativeConfig._verify_and_get_draft_pp(
+                        self.target_parallel_config,
+                        self.draft_pipeline_parallel_size,
+                    )
+                )
+
+                self.draft_embed_quant_bits = (
+                    SpeculativeConfig._verify_draft_embed_quant_bits(
+                        self.draft_embed_quant_bits,
+                    )
+                )
+
                 self.draft_model_config.max_model_len = (
                     SpeculativeConfig._maybe_override_draft_max_model_len(
                         self.max_model_len,
@@ -803,7 +831,9 @@ class SpeculativeConfig:
 
                 self.draft_parallel_config = (
                     SpeculativeConfig.create_draft_parallel_config(
-                        self.target_parallel_config, self.draft_tensor_parallel_size
+                        self.target_parallel_config,
+                        self.draft_tensor_parallel_size,
+                        self.draft_pipeline_parallel_size,
                     )
                 )
         return self
@@ -943,16 +973,66 @@ class SpeculativeConfig:
         self.draft_model_config._architecture = arch
 
     @staticmethod
+    def _verify_and_get_draft_pp(
+        target_parallel_config: ParallelConfig,
+        speculative_draft_pipeline_parallel_size: int | None,
+    ) -> int:
+        """Verify and normalize the draft model's pipeline-parallel size.
+
+        The draft (e.g. a single-layer MTP module) is small, so by default it
+        runs on a single pipeline stage (draft_pp=1) regardless of the target's
+        pipeline_parallel_size. Placing the draft on one stage is what lets a
+        PP>1 target use speculative decoding without the draft tripping the
+        ``SupportsPP`` guard. Only 1 or the target's pp size are permitted,
+        mirroring ``_verify_and_get_draft_tp``.
+        """
+        if speculative_draft_pipeline_parallel_size is None:
+            speculative_draft_pipeline_parallel_size = 1
+        elif speculative_draft_pipeline_parallel_size not in (
+            1,
+            target_parallel_config.pipeline_parallel_size,
+        ):
+            raise ValueError(
+                f"{speculative_draft_pipeline_parallel_size=} cannot be "
+                f"other value than 1 or target model pipeline_parallel_size"
+            )
+        return speculative_draft_pipeline_parallel_size
+
+    @staticmethod
+    def _verify_draft_embed_quant_bits(bits: int | None) -> int | None:
+        """Validate the draft vocab-embedding quantization bit-width.
+
+        ``None`` keeps the draft embedding at full precision; ``8`` and ``4``
+        select int8 / int4 (per-row symmetric). Any other value is rejected.
+        """
+        if bits is None:
+            return None
+        if bits not in (4, 8):
+            raise ValueError(
+                f"draft_embed_quant_bits={bits} is not supported; "
+                "use 4, 8, or None (full precision)."
+            )
+        return bits
+
+    @staticmethod
     def create_draft_parallel_config(
         target_parallel_config: ParallelConfig,
         speculative_draft_tensor_parallel_size: int,
+        speculative_draft_pipeline_parallel_size: int | None = None,
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
-        This is mostly a copy of the target parallel config, except the tp_size.
+        This is mostly a copy of the target parallel config, except the tp_size
+        and (optionally) the pp_size. When
+        ``speculative_draft_pipeline_parallel_size`` is None the draft inherits
+        the target's pipeline_parallel_size (legacy behavior).
         """
+        if speculative_draft_pipeline_parallel_size is None:
+            speculative_draft_pipeline_parallel_size = (
+                target_parallel_config.pipeline_parallel_size
+            )
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.pipeline_parallel_size,
+            pipeline_parallel_size=speculative_draft_pipeline_parallel_size,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,

--- a/vllm/model_executor/layers/quantized_draft_embedding.py
+++ b/vllm/model_executor/layers/quantized_draft_embedding.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Low-bit vocab embedding for speculative-decode draft models (A1c).
+
+The MTP draft loads its own full-precision copy of a huge vocab embedding on the
+last PP rank, which is what pushes 27B+draft over 2x16 GiB. Because the draft is
+only a speculative proposer (rejection sampling guarantees the final output equals
+target greedy regardless of draft quality), a *lossy* low-bit draft embedding is
+correctness-safe: it only lowers acceptance, never changes the output.
+
+Critically (RUN-A on the real 27B): the int storage is allocated **at
+construction** and the fp16 checkpoint weight is quantized **as it loads**, so the
+full fp16 [vocab, hidden] table never materializes on the GPU (a post-load swap
+OOMs at the load peak before it can free anything). The checkpoint's
+``embed_tokens.weight`` is routed through ``weight`` — an empty placeholder
+Parameter carrying a ``weight_loader`` that quantizes the incoming fp16 tensor
+(which lives on CPU during loading) into the pre-allocated GPU int storage.
+
+Targets TP=1 (the draft runs single-rank), so the lookup is a plain gather with
+no all-reduce. Bit-widths: 8 (int8, 1 byte/weight) and 4 (int4 packed 2
+nibbles/byte, 0.5 byte/weight; requires an even hidden dimension).
+"""
+
+import torch
+from torch import nn
+
+
+def _quantize_per_row(
+    weight: torch.Tensor, bits: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-row symmetric quantization. Returns (qweight, scale).
+
+    qweight is int8 [V, H] for bits=8, or uint8 [V, H//2] (two packed signed
+    nibbles per byte) for bits=4. scale is fp32 [V].
+    """
+    qmax = 2 ** (bits - 1) - 1  # 127 (int8) / 7 (int4)
+    row_absmax = weight.abs().amax(dim=1).clamp_min(1e-12)
+    scale = (row_absmax / qmax).to(torch.float32)
+    q = (weight.to(torch.float32) / scale.unsqueeze(1)).round().clamp_(-qmax, qmax)
+    if bits == 8:
+        return q.to(torch.int8), scale
+    # bits == 4: pack two signed nibbles per uint8 byte.
+    u = (q + 8).to(torch.uint8)  # [-7, 7] -> [1, 15], fits 4 bits
+    qweight = (u[:, 0::2] | (u[:, 1::2] << 4)).contiguous()
+    return qweight, scale
+
+
+class QuantizedVocabEmbedding(nn.Module):
+    """Per-row symmetric low-bit vocab embedding (lookup + dequant).
+
+    Args:
+        num_embeddings: vocabulary size (V).
+        embedding_dim: hidden size (H).
+        bits: quantization bit-width (8 or 4).
+        params_dtype: dtype the lookup returns (matches the model's dtype).
+    """
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        *,
+        bits: int = 8,
+        params_dtype: torch.dtype = torch.float16,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        if bits not in (4, 8):
+            raise NotImplementedError(f"bits={bits} not yet supported")
+        if bits == 4 and embedding_dim % 2 != 0:
+            raise ValueError("int4 packing requires an even hidden size")
+        self.bits = bits
+        self.out_dtype = params_dtype
+        self.num_embeddings = num_embeddings
+        self.hidden_size = embedding_dim
+
+        packed_cols = embedding_dim if bits == 8 else embedding_dim // 2
+        qdtype = torch.int8 if bits == 8 else torch.uint8
+        self.register_buffer(
+            "qweight",
+            torch.zeros((num_embeddings, packed_cols), dtype=qdtype, device=device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "scale",
+            torch.zeros(num_embeddings, dtype=torch.float32, device=device),
+            persistent=False,
+        )
+        # Entry point for the checkpoint loader: an EMPTY placeholder (never a
+        # full fp16 [V, H] table — that is the OOM peak we are avoiding). The
+        # AutoWeightsLoader matches the checkpoint's ``embed_tokens.weight`` to
+        # this param and calls its ``weight_loader``, which quantizes on the fly.
+        self.weight = nn.Parameter(
+            torch.empty(0, dtype=params_dtype, device=device), requires_grad=False
+        )
+        self.weight.weight_loader = self._weight_loader
+
+    @classmethod
+    def from_weight(
+        cls, weight: torch.Tensor, *, bits: int = 8
+    ) -> "QuantizedVocabEmbedding":
+        """Build and quantize from a full fp16 weight (tests / post-load)."""
+        m = cls(
+            weight.shape[0],
+            weight.shape[1],
+            bits=bits,
+            params_dtype=weight.dtype,
+            device=weight.device,
+        )
+        m.load_full_weight(weight)
+        return m
+
+    def load_full_weight(self, weight: torch.Tensor) -> None:
+        """Quantize a full fp16 [V, H] table into the pre-allocated int storage."""
+        qweight, scale = _quantize_per_row(weight, self.bits)
+        self.qweight.copy_(qweight)
+        self.scale.copy_(scale)
+
+    def _weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        # ``param`` is the empty placeholder; quantize the incoming fp16 tensor
+        # (on CPU during loading) straight into the GPU int storage.
+        self.load_full_weight(loaded_weight)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        rows = self.qweight[input_ids]
+        if self.bits == 8:
+            deq = rows.to(torch.float32)
+        else:  # unpack nibbles back to signed int4 values
+            low = (rows & 0x0F).to(torch.int16) - 8
+            high = ((rows >> 4) & 0x0F).to(torch.int16) - 8
+            deq = torch.stack([low, high], dim=-1)
+            deq = deq.reshape(*rows.shape[:-1], self.hidden_size).to(torch.float32)
+        out = deq * self.scale[input_ids].unsqueeze(-1)
+        return out.to(self.out_dtype)

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.fused_moe import (
 )
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantized_draft_embedding import (
+    QuantizedVocabEmbedding,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -32,6 +35,7 @@ from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
 from .interfaces import (
     MultiModalEmbeddings,
     SupportsMultiModal,
+    SupportsPP,
     _require_is_multimodal,
 )
 from .utils import (
@@ -68,15 +72,46 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         self.config = config
 
+        # Design C (standalone draft): when the draft runs with its own
+        # pipeline_parallel_size == 1 (decoupled from a target PP>1), it executes
+        # only on the last global PP rank. There `get_pp_group().is_first_rank`
+        # is False, so the forward would wrongly take the inter-stage path and
+        # demand intermediate_tensors the proposer never supplies. This flag makes
+        # the forward behave as first==last (embed -> fc -> layer -> norm). The
+        # draft's embed_tokens is already weight-loaded on the last rank and the
+        # target hidden state is resident there, so no cross-stage traffic is
+        # needed.
+        spec_config = vllm_config.speculative_config
+        self.standalone_draft = (
+            spec_config is not None and spec_config.draft_pipeline_parallel_size == 1
+        )
+
         self.vocab_size = config.vocab_size
 
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
 
-        self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size,
-            config.hidden_size,
+        quant_bits = (
+            spec_config.draft_embed_quant_bits if spec_config is not None else None
         )
+        if quant_bits is not None:
+            # A1c: under PP the draft holds its own copy of the (huge) vocab
+            # embedding on the last rank. Quantize it at LOAD time (int storage
+            # allocated here; the checkpoint fp16 weight is quantized as it loads)
+            # so the full fp16 [vocab, hidden] table never materializes on the GPU
+            # — a post-load swap OOMs at the load peak. Correctness is unaffected
+            # (rejection sampling); only the acceptance rate may drop.
+            self.embed_tokens = QuantizedVocabEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+                bits=quant_bits,
+                params_dtype=torch.get_default_dtype(),
+            )
+        else:
+            self.embed_tokens = VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
         # missing from hf_quant_config.json exclude_modules. Force unquantized.
@@ -130,7 +165,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
-        if get_pp_group().is_first_rank:
+        if self.standalone_draft or get_pp_group().is_first_rank:
             if inputs_embeds is None:
                 inputs_embeds = self.embed_input_ids(input_ids)
             assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
@@ -151,7 +186,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             residual=residual,
         )
 
-        if not get_pp_group().is_last_rank:
+        if not (self.standalone_draft or get_pp_group().is_last_rank):
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
@@ -354,7 +389,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         "hidden_states": 0,
     }
 )
-class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
+class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal, SupportsPP):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -381,10 +416,27 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
         self.model = Qwen3_5MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
+        # Expose the inner predictor's PP intermediate-tensor factory so this
+        # wrapper satisfies the SupportsPP interface (Design B: the draft is
+        # sharded across the same PP stages as the target).
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
 
+        spec_config = vllm_config.speculative_config
+        skip_lm_head_alloc = (
+            spec_config is not None and spec_config.draft_embed_quant_bits is not None
+        )
         if get_pp_group().is_last_rank:
             if config.tie_word_embeddings:
                 self.lm_head = self.model.embed_tokens
+            elif skip_lm_head_alloc:
+                # A1c memory mode: the MTP draft's lm_head is always shared with
+                # the target's (same last rank) by the proposer's
+                # _maybe_share_lm_head. Materializing a full fp16 ParallelLMHead
+                # (e.g. 2.37 GiB for Qwen3.5) here only to discard it OOMs at the
+                # load peak — use a placeholder; sharing fills it.
+                self.lm_head = PPMissingLayer()
             else:
                 self.lm_head = ParallelLMHead(
                     config.vocab_size,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -205,6 +205,13 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.worker.pp_spec_broadcast import (
+    broadcast_sampled_token_ids,
+    gather_valid_sampled_tokens_per_req,
+    num_computed_tokens_drift_correction,
+    receive_sampled_token_ids,
+    select_latest_sampled_token_per_req,
+)
 from vllm.v1.worker.ubatch_utils import (
     UBatchSlices,
     check_ubatch_thresholds,
@@ -618,6 +625,12 @@ class GPUModelRunner(
             self.rejection_sampler = RejectionSampler(
                 self.sampler, self.speculative_config, self.device
             )
+        else:
+            # Under PP>1 the draft lives only on the last rank; on every other
+            # rank `drafter` must still exist (as None) so the many
+            # `isinstance(self.drafter, ...)` checks in the hot path don't trip
+            # over a missing attribute.
+            self.drafter = None
 
         self.num_spec_tokens = 0
         self.valid_sampled_token_count_gpu: torch.Tensor | None = None
@@ -1782,8 +1795,15 @@ class GPUModelRunner(
             # and no reordering happened.
             # The indices are both the same permutation of 0..N-1 so
             # we can copy directly using a single slice.
+            # Use the per-request LATEST valid sampled token, not column 0: with
+            # spec decode prev_sampled_token_ids is [accepted drafts..., bonus],
+            # so after a multi-token accept column 0 is the FIRST accepted draft,
+            # not the latest committed token the next step must continue from.
+            # (Mirrors C4's select_latest on the cpu/non-common path.)
             self.input_ids.gpu[:num_common_tokens].copy_(
-                self.input_batch.prev_sampled_token_ids[:num_common_tokens, 0],
+                select_latest_sampled_token_per_req(
+                    self.input_batch.prev_sampled_token_ids[:num_common_tokens]
+                ),
                 non_blocking=True,
             )
             return
@@ -1794,12 +1814,16 @@ class GPUModelRunner(
         prev_common_req_indices_tensor = torch.tensor(
             prev_indices, dtype=torch.int64, pin_memory=self.pin_memory
         ).to(self.device, non_blocking=True)
+        # Per-request LATEST valid sampled token (not column 0) — see the
+        # common-case branch above; column 0 is the first accepted draft after a
+        # multi-token accept, not the latest committed token.
+        latest_sampled_per_req = select_latest_sampled_token_per_req(
+            self.input_batch.prev_sampled_token_ids
+        )
         self.input_ids.gpu.scatter_(
             dim=0,
             index=sampled_tokens_index_tensor,
-            src=self.input_batch.prev_sampled_token_ids[
-                prev_common_req_indices_tensor, 0
-            ],
+            src=latest_sampled_per_req[prev_common_req_indices_tensor],
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
@@ -4549,6 +4573,20 @@ class GPUModelRunner(
             # tokens on the CPU, so they are run after bookkeeping.
             propose_draft_token_ids(valid_sampled_token_ids)
 
+        # PP + async spec: broadcast the freshly-proposed drafts to the non-last
+        # ranks (paired 1:1 with the sampled-token broadcast above) so they can
+        # scatter the real draft tokens into the spec positions next step instead
+        # of the -1 placeholder. Without this the non-last verification-forward
+        # embeds garbage at the spec positions -> non-greedy output.
+        if (
+            self.use_async_scheduling
+            and self.num_spec_tokens
+            and not self.broadcast_pp_output
+        ):
+            pp = get_pp_group()
+            if pp.world_size > 1 and pp.is_last_rank:
+                self._pp_broadcast_draft_token_ids()
+
         # Finalize KV connector (wait_for_save + clear metadata) after
         # draft model runs. Deferred from target model forward to allow
         # draft model to also save its KV cache.
@@ -4640,30 +4678,108 @@ class GPUModelRunner(
     def _pp_broadcast_prev_sampled_token_ids(
         self, sampled_token_ids: torch.Tensor
     ) -> None:
-        """Broadcast sampled token ids (GPU) from last PP stage"""
+        """Broadcast sampled token ids (GPU) from last PP stage.
+
+        Without spec the grid is ``[num_reqs, 1]``; with MTP/EAGLE spec it is
+        ``[num_reqs, num_spec + 1]`` (accepted drafts + bonus, ``-1``-padded). The
+        transport is width-agnostic; the receiver allocates the matching width.
+        """
         pp = get_pp_group()
         assert pp.is_last_rank
-        # `prev_sampled_token_ids` is expected to have shape [num_reqs, 1].
-        assert sampled_token_ids.dim() == 2 and sampled_token_ids.shape[-1] == 1, (
-            "PP+async expects sampled_token_ids to have shape [num_reqs, 1]"
-        )
         # Skip for chunked prefill: sampled tokens are dummy
         # and will be discarded, no need to broadcast.
         if not self._is_all_reqs_chunked_prefill():
-            torch.distributed.broadcast(
-                sampled_token_ids, src=pp.rank, group=pp.device_group
+            # The sampler emits a width-1 grid on steps with no scheduled spec
+            # tokens (e.g. the first decode after prefill), but the receiver always
+            # reads num_spec+1 columns. Pad the missing columns with -1 so the
+            # broadcast shapes match on both ranks; otherwise the receiver reads
+            # uninitialized buffer garbage in the extra column and commits it as a
+            # real token, corrupting the sequence (breaks greedy-equivalence).
+            width = self.num_spec_tokens + 1
+            if sampled_token_ids.shape[-1] < width:
+                pad = sampled_token_ids.new_full(
+                    (sampled_token_ids.shape[0], width - sampled_token_ids.shape[-1]),
+                    -1,
+                )
+                sampled_token_ids = torch.cat([sampled_token_ids, pad], dim=-1)
+            broadcast_sampled_token_ids(sampled_token_ids, pp.device_group, pp.rank)
+
+    def _pp_broadcast_draft_token_ids(self) -> None:
+        """Broadcast the proposed draft token ids from the last PP stage.
+
+        The drafter runs only on the last rank (`is_last_rank` gate), so
+        ``_draft_token_ids`` is ``None`` on the non-last ranks. Without this, the
+        non-last ranks embed the ``-1`` scheduler placeholder at the spec
+        positions in ``_prepare_input_ids`` (the GPU draft scatter is skipped when
+        ``_draft_token_ids is None``) -> wrong verification-forward hidden states
+        -> non-greedy output. Broadcasting the drafts (paired 1:1 with the sampled
+        broadcast each step) lets every rank scatter the REAL draft tokens, so the
+        verification matches the single-GPU path. Width is fixed at ``num_spec``
+        and ``-1``-padded; a None/absent draft broadcasts an all-``-1`` grid so the
+        non-last receive never blocks.
+        """
+        pp = get_pp_group()
+        assert pp.is_last_rank
+        if self._is_all_reqs_chunked_prefill():
+            return
+        num_reqs = self.input_batch.num_reqs
+        width = self.num_spec_tokens
+        dt = self._draft_token_ids
+        if torch.is_tensor(dt):
+            dt = dt.to(dtype=torch.int32)
+            if dt.shape[-1] < width:
+                pad = dt.new_full((dt.shape[0], width - dt.shape[-1]), -1)
+                dt = torch.cat([dt, pad], dim=-1)
+            dt = dt[:num_reqs, :width].contiguous()
+        else:
+            dt = torch.full(
+                (num_reqs, width), -1, dtype=torch.int32, device=self.device
             )
+        broadcast_sampled_token_ids(dt, pp.device_group, pp.rank)
 
     def _pp_receive_prev_sampled_token_ids_to_input_batch(self) -> None:
         """Receive sampled token ids broadcast from last PP stage"""
         pp = get_pp_group()
         assert not pp.is_last_rank
         num_reqs = self.input_batch.num_reqs
-        # `prev_sampled_token_ids` is expected to have shape [num_reqs, 1].
-        recv = torch.empty((num_reqs, 1), dtype=torch.int32, device=self.device)
-        # skip for chunked prefill.
+        # Without spec the grid is [num_reqs, 1]; with spec it is
+        # [num_reqs, num_spec + 1] (accepted drafts + bonus, -1 padded). Allocate
+        # the matching width so the broadcast from the last rank lines up.
+        width = self.num_spec_tokens + 1
         if not self._is_all_reqs_chunked_prefill():
-            torch.distributed.broadcast(recv, src=pp.last_rank, group=pp.device_group)
+            recv = receive_sampled_token_ids(
+                num_reqs, width, pp.device_group, pp.last_rank, self.device
+            )
+            # C4 (holistic): the non-last rank never runs the sampler, so it must
+            # persist the REAL sampled tokens per request (never -1) into its local
+            # buffers. A single-position write is insufficient: when a draft is
+            # accepted, num_computed_tokens advances by v = (accepted drafts + bonus)
+            # while only one slot was written, leaving the in-between (accepted-draft)
+            # positions as -1. The next step reads token_ids_cpu[num_computed_tokens]
+            # (which includes the spec tokens) and embeds a -1 -> indexSelectSmallIndex
+            # (break #2). Empirically num_computed_tokens grows by exactly the previous
+            # step's v, so writing all v values recv[i, 0:v] and advancing the cursor by
+            # v keeps token_ids_cpu (and num_tokens_no_spec) in lockstep with the read.
+            gathered = gather_valid_sampled_tokens_per_req(recv)
+            # Receive the broadcast draft tokens (paired 1:1 with the sampled
+            # broadcast on the last rank) so this rank's _prepare_input_ids draft
+            # scatter places the REAL drafts at the spec positions instead of the
+            # -1 placeholder (its local drafter never ran -> _draft_token_ids would
+            # be None and the scatter would be skipped -> non-greedy verification).
+            if self.num_spec_tokens:
+                self._draft_token_ids = receive_sampled_token_ids(
+                    num_reqs,
+                    self.num_spec_tokens,
+                    pp.device_group,
+                    pp.last_rank,
+                    self.device,
+                )
+        else:
+            # All-chunked-prefill: nothing was broadcast (recv is uninitialized) and
+            # these requests take their next input from the prompt, not a sampled
+            # token. Keep the original placeholder behaviour for them.
+            recv = torch.empty((num_reqs, width), dtype=torch.int32, device=self.device)
+            gathered = None
         self.input_batch.prev_sampled_token_ids = recv
 
         # construct `prev_req_id_to_index` here so `_prepare_input_ids`
@@ -4675,13 +4791,61 @@ class GPUModelRunner(
             if i in discard_req_indices_set:
                 continue
             prev_req_id_to_index[req_id] = i
-            # PP+async scheduling: advance per-request local cached output length by
-            # appending a placeholder (-1) token id.
-            if (req_state := self.requests.get(req_id)) is not None:
-                req_state.output_token_ids.append(-1)
             pos = self.input_batch.num_tokens_no_spec[i]
-            self.input_batch.is_token_ids[i, pos] = True
-            self.input_batch.num_tokens_no_spec[i] = pos + 1
+            req_state = self.requests.get(req_id)
+            if gathered is None:
+                # All-chunked-prefill: keep the -1 placeholder, advance by one.
+                if req_state is not None:
+                    req_state.output_token_ids.append(-1)
+                self.input_batch.is_token_ids[i, pos] = True
+                self.input_batch.num_tokens_no_spec[i] = pos + 1
+                continue
+            # Holistic C4: persist ALL v real tokens recv[i, 0:v] (accepted drafts +
+            # bonus, in sequence order) into the v positions [pos : pos + v] and
+            # advance the token_ids_cpu cursor by v, so the next step's read at
+            # num_computed_tokens (which includes the spec tokens) never lands on an
+            # un-backfilled -1. Empirically num_computed_tokens grows by exactly the
+            # previous step's v, so this keeps the write cursor in lockstep with the
+            # read. output_token_ids is deliberately NOT grown by v here: it drives
+            # num_tokens, which the discard mask compares against the (one-step-lagging)
+            # num_computed_tokens + num_scheduled; advancing it ahead of nct mis-marks
+            # the request as chunked-prefill and suppresses the broadcast. Keep the
+            # original single-token append (the latest/bonus) so num_tokens tracks nct.
+            values = gathered[i]
+            v = len(values)
+            end = pos + v
+            self.input_batch.token_ids_cpu[i, pos:end] = values
+            self.input_batch.is_token_ids[i, pos:end] = True
+            self.input_batch.num_tokens_no_spec[i] = end
+            if req_state is not None:
+                # (B) count reconciliation — the non-last-rank analogue of
+                # correct_spec_decode_token_counts (which runs only on the sampler
+                # rank). The optimistic-extend (:1319) appended prev_num_draft_len -1
+                # placeholders for THIS step's drafts; replace them with the v real
+                # committed tokens. Without this the rejected-draft placeholders
+                # (prev_num_draft_len - (v-1) of them) are never corrected on the
+                # non-last rank, so num_tokens inflates and discard_request_mask
+                # (:2045) eventually mis-fires -> request mis-marked all-chunked ->
+                # broadcast suppressed -> a -1 is written -> break #2.
+                optimistic = req_state.prev_num_draft_len
+                if optimistic:
+                    del req_state.output_token_ids[-optimistic:]
+                req_state.output_token_ids.extend(values)
+                # (B, positions arm) num_computed_tokens drift correction — the
+                # non-last-rank analogue of the GPU kernel
+                # update_num_computed_tokens_for_batch_change (:2138), which runs
+                # only on the sampler rank (gated on valid_sampled_token_count_gpu).
+                # The scheduler advanced num_computed_tokens optimistically by
+                # 1 + prev_num_draft_len (all drafts assumed accepted); the true
+                # advance is v. Subtract the rejected drafts here so the else-branch
+                # copy (:2147) feeds self.positions (:2160) the right rope/KV
+                # positions. Without this, every draft rejection leaves the non-last
+                # rank's positions over-advanced by one -> rope off-by-one -> wrong
+                # verification -> non-greedy output.
+                correction = num_computed_tokens_drift_correction(optimistic, v)
+                if correction:
+                    self.input_batch.num_computed_tokens_cpu[i] -= correction
+                    req_state.num_computed_tokens -= correction
         self.input_batch.prev_req_id_to_index = prev_req_id_to_index
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
@@ -5893,10 +6057,16 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if self.speculative_config and (
-                self.speculative_config.use_eagle()
-                or self.speculative_config.uses_draft_model()
-                or self.speculative_config.uses_extract_hidden_states()
+            if (
+                self.speculative_config
+                # The drafter only exists on the last PP rank (see __init__);
+                # under PP>1 the non-last ranks have no draft to dummy-run.
+                and get_pp_group().is_last_rank
+                and (
+                    self.speculative_config.use_eagle()
+                    or self.speculative_config.uses_draft_model()
+                    or self.speculative_config.uses_extract_hidden_states()
+                )
             ):
                 assert isinstance(
                     self.drafter,
@@ -6800,9 +6970,14 @@ class GPUModelRunner(
         self.calculate_reorder_batch_threshold()
 
         # Initialize drafter attention backend
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
+        # The drafter only exists on the last PP rank (see __init__).
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -6853,9 +7028,14 @@ class GPUModelRunner(
         )
 
         # Initialize drafter's cudagraph dispatcher if using spec decode.
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_extract_hidden_states()
+        # The drafter only exists on the last PP rank (see __init__).
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_extract_hidden_states()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -7277,6 +7457,7 @@ class GPUModelRunner(
 
         if (
             self.speculative_config
+            and get_pp_group().is_last_rank
             and self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(self.drafter, ExtractHiddenStatesProposer)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -845,6 +845,10 @@ class GPUModelRunner(
         # Cached outputs.
         self._draft_token_ids: list[list[int]] | torch.Tensor | None = None
         self._draft_probs: torch.Tensor | None = None
+        # Per-request broadcast valid-sampled-token count from the last receiver
+        # call (non-last PP rank), consumed by _update_states to correct the
+        # optimistic num_computed_tokens drift. Keyed by req_id.
+        self._pp_prev_valid_sampled_count: dict[str, int] = {}
         self._draft_prob_req_ids: list[str] | None = None
         # N-gram GPU path: async D2H buffer/event for per-request valid draft counts.
         self._num_valid_draft_tokens: torch.Tensor | None = None
@@ -1322,6 +1326,23 @@ class GPUModelRunner(
                     # scheduling. Corrected on GPU in _prepare_inputs.
                     optimistic_num_accepted = req_state.prev_num_draft_len
                     req_state.output_token_ids.extend([-1] * optimistic_num_accepted)
+
+                    # Non-last PP rank: the GPU kernel that corrects the optimistic
+                    # num_computed_tokens (update_num_computed_tokens_for_batch_change,
+                    # in _prepare_inputs) only runs on the sampler/last rank (gated on
+                    # valid_sampled_token_count_gpu). Reconstruct the same correction
+                    # here from the broadcast valid count the receiver stashed, BEFORE
+                    # num_computed_tokens is written to req_state / the cpu buffer
+                    # below — the scheduler advanced it optimistically (all drafts
+                    # accepted); subtract the rejected drafts so rope/KV positions
+                    # (built from num_computed_tokens) are not off-by-one after a
+                    # rejection. (The last rank keeps the kernel + deferred path.)
+                    if not is_last_rank:
+                        prev_valid = self._pp_prev_valid_sampled_count.get(req_id)
+                        if prev_valid is not None:
+                            num_computed_tokens -= num_computed_tokens_drift_correction(
+                                optimistic_num_accepted, prev_valid
+                            )
 
                     deferred_spec_decode_corrections.append(
                         (req_id, optimistic_num_accepted, req_state)
@@ -4787,6 +4808,7 @@ class GPUModelRunner(
         discard_req_indices = np.nonzero(self.discard_request_mask.np[:num_reqs])[0]
         discard_req_indices_set = set(discard_req_indices)
         prev_req_id_to_index: dict[str, int] = {}
+        self._pp_prev_valid_sampled_count = {}
         for i, req_id in enumerate(self.input_batch.req_ids):
             if i in discard_req_indices_set:
                 continue
@@ -4831,21 +4853,12 @@ class GPUModelRunner(
                 if optimistic:
                     del req_state.output_token_ids[-optimistic:]
                 req_state.output_token_ids.extend(values)
-                # (B, positions arm) num_computed_tokens drift correction — the
-                # non-last-rank analogue of the GPU kernel
-                # update_num_computed_tokens_for_batch_change (:2138), which runs
-                # only on the sampler rank (gated on valid_sampled_token_count_gpu).
-                # The scheduler advanced num_computed_tokens optimistically by
-                # 1 + prev_num_draft_len (all drafts assumed accepted); the true
-                # advance is v. Subtract the rejected drafts here so the else-branch
-                # copy (:2147) feeds self.positions (:2160) the right rope/KV
-                # positions. Without this, every draft rejection leaves the non-last
-                # rank's positions over-advanced by one -> rope off-by-one -> wrong
-                # verification -> non-greedy output.
-                correction = num_computed_tokens_drift_correction(optimistic, v)
-                if correction:
-                    self.input_batch.num_computed_tokens_cpu[i] -= correction
-                    req_state.num_computed_tokens -= correction
+            # Stash this request's broadcast valid count so _update_states can apply
+            # the num_computed_tokens drift correction AFTER the scheduler's
+            # optimistic value is set (here in the receiver it would be overwritten
+            # by _update_states :1408). v = accepted drafts + bonus; the next step's
+            # optimistic advance assumed all drafts accepted.
+            self._pp_prev_valid_sampled_count[req_id] = v
         self.input_batch.prev_req_id_to_index = prev_req_id_to_index
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4795,6 +4795,26 @@ class GPUModelRunner(
                     pp.last_rank,
                     self.device,
                 )
+            # Hybrid (mamba/GDN linear-attention) models: the GDN forward rolls
+            # back its conv1d/SSM recurrent state using attn_metadata.num_accepted
+            # _tokens, which _update_states_after_model_execute sets ONLY on the
+            # sampler/last rank (this rank returns early in sample_tokens, so it
+            # never runs). Source the same per-request accepted count from the
+            # broadcast (recv: accepted drafts + bonus, -1 padded) so the non-last
+            # rank's GDN layers roll back state identically. Without this its
+            # num_accepted_tokens is stale -> accept-steps corrupt the recurrent
+            # state -> wrong verification -> non-greedy (pure-attention models are
+            # unaffected; this is the hybrid analogue of the s9 num_computed_tokens
+            # drift fix). Mirrors the last rank's gpu->cpu copy at :1567.
+            if (
+                self.model_config.is_hybrid
+                and self.num_accepted_tokens_event is not None
+            ):
+                num_accepted = (recv != -1).sum(dim=1)
+                self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+                    num_accepted, non_blocking=True
+                )
+                self.num_accepted_tokens_event.record()
         else:
             # All-chunked-prefill: nothing was broadcast (recv is uninitialized) and
             # these requests take their next input from the prompt, not a sampled

--- a/vllm/v1/worker/pp_spec_broadcast.py
+++ b/vllm/v1/worker/pp_spec_broadcast.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PP sampled-token broadcast helpers for speculative decoding.
+
+Under PP + async scheduling the last rank broadcasts its sampled token ids to the
+other ranks (which never run the sampler) so they can advance positions and build
+the next input batch. Without spec the broadcast carries shape ``[num_reqs, 1]``;
+with MTP/EAGLE spec the sampler emits ``[num_reqs, num_spec + 1]`` (accepted
+drafts + bonus, ``-1``-padded). These helpers keep the transport width-agnostic so
+both cases share one path, and expose the per-request valid count the receiver
+uses to advance each request by the right number of tokens (not always 1).
+
+Kept in a CUDA-free module so the shape/transport logic is unit-testable over a
+plain gloo CPU group.
+"""
+
+import torch
+import torch.distributed as dist
+
+
+def count_valid_sampled_tokens_per_req(sampled_token_ids: torch.Tensor) -> torch.Tensor:
+    """Per-request count of valid sampled tokens in a ``[num_reqs, width]`` grid.
+
+    Valid tokens are the non-``-1`` entries (rejected/padded positions are ``-1``);
+    this mirrors the accepted-count idiom used elsewhere in the runner
+    (``(sampled_token_ids != -1).sum(dim=1)``). For the non-spec width-1 case every
+    row holds one real token, so the count is 1 per request.
+    """
+    return (sampled_token_ids != -1).sum(dim=1)
+
+
+def select_latest_sampled_token_per_req(
+    sampled_token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Per-request latest *valid* sampled token from a ``[num_reqs, width]`` grid.
+
+    Rejected/padded positions are ``-1``; a request that advanced by ``v`` valid
+    tokens has its latest token in the last valid column ``recv[i, v - 1]`` (reject
+    ``v=1`` -> col 0; accept + bonus ``v=2`` -> col 1). This is the real value the
+    non-last rank must persist as its next input instead of a ``-1`` placeholder
+    (the C4 value-back-write that fixes the ``indexSelectSmallIndex`` break: every
+    confirmed request has ``v >= 1`` so the result is never ``-1``).
+    """
+    counts = count_valid_sampled_tokens_per_req(sampled_token_ids)
+    last_idx = (counts - 1).clamp(min=0)
+    return sampled_token_ids.gather(1, last_idx.unsqueeze(1)).squeeze(1)
+
+
+def gather_valid_sampled_tokens_per_req(
+    sampled_token_ids: torch.Tensor,
+) -> list[list[int]]:
+    """Per-request list of ALL valid sampled tokens ``recv[i, 0:v]``, in order.
+
+    ``select_latest_sampled_token_per_req`` keeps only the single latest token;
+    the holistic C4 back-write needs every confirmed token (accepted drafts +
+    bonus) so the non-last rank can fill the ``v`` ``token_ids_cpu`` positions the
+    next step will read (indexed by ``num_computed_tokens``, which includes the
+    spec tokens) — not just one slot. Valid entries are the leading non-``-1``
+    columns; a fully padded row yields ``[]`` (advance the cursor by 0).
+    """
+    counts = count_valid_sampled_tokens_per_req(sampled_token_ids).tolist()
+    rows = sampled_token_ids.tolist()
+    return [row[:v] for row, v in zip(rows, counts)]
+
+
+def num_computed_tokens_drift_correction(
+    prev_num_draft_len: int, valid_sampled_count: int
+) -> int:
+    """Amount to subtract from the optimistic ``num_computed_tokens`` on a non-last
+    rank to undo async spec-decode drift after a (partial) draft rejection.
+
+    Async spec decode advances ``num_computed_tokens`` optimistically by
+    ``1 (bonus) + prev_num_draft_len (drafts assumed accepted)``; the true advance is
+    the broadcast ``valid_sampled_count`` (accepted drafts + the bonus). The
+    difference is the number of optimistically-counted drafts that were actually
+    rejected. On the last rank this correction is applied by the GPU kernel
+    ``update_num_computed_tokens_for_batch_change`` from the sampler's valid count;
+    the non-last rank never runs the sampler, so it reconstructs the same correction
+    from the broadcast valid count instead — keeping rope/KV positions identical on
+    every rank (the invariant: advance ``num_computed_tokens`` by the valid count).
+    Non-negative (you cannot accept more drafts than were proposed); ``0`` when every
+    draft was accepted or none were proposed.
+    """
+    return (1 + prev_num_draft_len) - valid_sampled_count
+
+
+def broadcast_sampled_token_ids(
+    sampled_token_ids: torch.Tensor, group, src: int
+) -> None:
+    """Broadcast the (possibly multi-column) sampled token ids from ``src``."""
+    assert sampled_token_ids.dim() == 2, (
+        f"expected 2-D [num_reqs, width], got {tuple(sampled_token_ids.shape)}"
+    )
+    dist.broadcast(sampled_token_ids, src=src, group=group)
+
+
+def receive_sampled_token_ids(
+    num_reqs: int,
+    width: int,
+    group,
+    src: int,
+    device,
+    dtype: torch.dtype = torch.int32,
+) -> torch.Tensor:
+    """Receive a ``[num_reqs, width]`` sampled-token grid broadcast from ``src``."""
+    recv = torch.empty((num_reqs, width), dtype=dtype, device=device)
+    dist.broadcast(recv, src=src, group=group)
+    return recv


### PR DESCRIPTION
## Purpose

Enable MTP speculative decoding under pipeline parallelism (PP > 1), greedy-equivalent to the no-spec baseline. This path used to crash or silently diverge: the speculative-decode token accounting is computed on the last PP rank (where the sampler lives) and never reached the non-last ranks, so they ran on stale, optimistic state.

I validated it on current `main`: greedy-equivalent across MiMo (pure attention) and Qwen3.5-27B (hybrid GDN) at `num_speculative_tokens` 1-3, including `mamba_cache_mode=align` and fp8 KV cache, at 1.68-1.89x. Implements the design in #44697; closes #36643, closes #36872.

## Root cause

Spec decode advances `num_computed_tokens` optimistically (assuming all drafts are accepted) and corrects it after the forward via the GPU kernel `update_num_computed_tokens_for_batch_change` (`gpu_model_runner.py:2115`), gated on `valid_sampled_token_count_gpu` (`:2107`). That tensor is only produced by the sampler, i.e. the last PP rank. On non-last ranks it's `None`, so the correction is skipped, positions over-advance by the rejected-draft count after every rejection, rope/KV goes off by one, and verification produces non-greedy output.

Two more pieces have the same shape: hybrid (GDN/mamba) models roll back conv1d/SSM state by `num_accepted_tokens` (set in `_update_states_after_model_execute` `:1529`, last-rank only), and the sampled-token / draft values the non-last ranks need to embed the next input are also only resident on the last rank. One invariant fixes all three: the non-last rank applies the sampler's broadcast per-request valid/accepted count to its own accounting.

## Why this isn't a duplicate

- #40768 fixes the scheduler placeholder crash; it doesn't fix non-last-rank correctness or PP greedy-equivalence. It's complementary, not a dependency: I checked by reverting it and greedy-equivalence still holds, including at batch=16. I don't re-implement it here.
- #39704 / #38104 are earlier PP+MTP attempts, both untested and currently conflicting. This adds verified greedy-equivalence, hybrid (GDN/mamba) support, the draft-memory enablement, and a full test + benchmark suite.

## Changes (6 commits)

1. Experimental gate: a one-time `logger.warning_once` when MTP runs with PP > 1, so users know the path is new while V2 catches up.
2. Draft memory enablement: int4 draft-embed load-time quant + skipping the draft `lm_head`, so the draft fits on the last PP rank for large models. Draft-only, so it can't change output; int4 measured == int8.
3. Width-agnostic broadcast (`vllm/v1/worker/pp_spec_broadcast.py`): typed transport of the sampler's per-request tokens/counts to the non-last ranks (gloo-tested).
4. Non-last-rank input reconstruction: write the real broadcast values into `token_ids_cpu` (never leaving `-1`), scatter draft tokens into spec positions, pad the sender width. Fixes the crash.
5. `num_computed_tokens` drift correction: reconstruct the skipped correction on the non-last rank from the broadcast valid count, in `_update_states`.
6. `num_accepted_tokens` for GDN/mamba: source the accepted count from the broadcast so non-last GDN layers roll back state identically. Gated on `is_hybrid`.

## Test Plan

```bash
# Unit (CPU, no GPU):
.venv/bin/python -m pytest \
  tests/v1/spec_decode/test_pp_spec_broadcast.py \
  tests/v1/spec_decode/test_quantized_draft_embedding.py \
  tests/v1/spec_decode/test_pp_draft_config.py \
  tests/v1/spec_decode/test_qwen3_5_mtp_standalone.py \
  tests/v1/spec_decode/test_draft_embed_quant_integration.py -q
pre-commit run --all-files

# Integration (2 GPU): spec output token-identical to the same-config no-spec baseline,
# on MiMo (pure attention) and Qwen3.5-27B-AWQ (hybrid GDN, cpu_offload_gb=3, int4 draft).
```

## Test Result

- Unit: 31 passed (CPU; includes the 2-rank gloo broadcast round-trip and int4 draft-embed quant). `ruff check` and `ruff format` pass on all changed files.
- Integration (current `main`, 2x 16 GB GPUs): greedy-equivalent on every config I tried, 1.68-1.89x, ~94% acceptance on 27B.

<details>
<summary>Full validation matrix</summary>

- MiMo PP=2 + MTP: 5/5 token-identical at k = 1, 2, 3 (so the fix generalizes past k=1); 1.68x at k=1 (38.16 vs 22.75 tok/s).
- Qwen3.5-27B-AWQ PP=2 + MTP (hybrid GDN): 5/5 at k = 1, 2, 3; 1.89x at k=1 (offload-bound absolute tok/s, the ratio is the signal). Also 5/5 with `mamba_cache_mode=align` and 5/5 with fp8 KV cache (the production-gateway regime).
- Sampling: temperature 0.8 with a fixed seed is deterministic (two runs identical) and exact length, so there's no race under stochastic rejection sampling.
- Chunked prefill: greedy-equivalent (long prompt, `max_num_batched_tokens=64`).
- Acceptance: 27B 94.7% per-position (mean accept length 1.95 / 2.58 / 3.22 at k=1/2/3); MiMo 82.5% at k=1, per-position falls off fast (k=3: 0.81 / 0.14 / 0.01), so length saturates around 2 and k=2 is the sweet spot.
- 256-token runs (3-way): PP=2 has 3/5 sequences identical to 256, 2/5 diverge late (@109, @176). A single-GPU MTP run of the same prompts also diverges late, on a comparable set (seq0@25, seq4@161), so PP isn't systematically worse (it's perfect on the sequence where single-GPU diverges earliest), and both share the same near-tie (seq1@176). The residual is the floating-point near-tie floor of MTP spec decode, not something PP-specific.
- Concurrency (batch=16, no scheduler change): no crash, and exactly the requested length on all 20 sequences. Near-tie divergences are comparable to single-GPU (PP 7/20 seqs vs single-GPU 8/20). This is the regime where #40768's placeholder discipline would matter if it were load-bearing here, and it isn't, which is why this complements #40768 without depending on it.

</details>

<details>
<summary>Relationship to MRV2 (V2 model runner)</summary>

V2 is the longer-term home for spec-under-PP (#42538, #43732). I checked it directly: with `VLLM_USE_V2_MODEL_RUNNER=1`, MiMo PP=2 + MTP loads both ranks and sizes the KV cache but then deadlocks during engine construction (EngineCore `shm_broadcast` stuck, `Worker_PP1` in `futex_wait`, never reaches generate). So V2 doesn't cover this config yet, and #36643 / #36872 have no working path today without this V1 fix. The invariant here is small and should port cleanly to V2's `PPHandler`, and I'm happy to align with whatever V2 prefers.

</details>

## Notes

- AI assistance was used in diagnosing, implementing, and drafting this PR. I reviewed every changed line and ran the tests above myself.
- Out of scope: `mamba_cache_mode=all` (`none` and `align` are verified); draft PP > 1 (the draft stays on one stage); EOS-triggered early stop (the validation base model emits no EOS, so only the `ignore_eos` exact-length path is exercised).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

