### PR TITLE
[Bugfix][Metrics]: do not push humongous metric labels

### DIFF
--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1051,7 +1051,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             labelnames=metrics_info.keys(),
         )
         for engine_index in self.engine_indexes:
-            metrics_info = config_obj.metrics_info()
+            metrics_info = {
+                k: v if len(v) < 10240 else ""
+                for k, v in config_obj.metrics_info().items()
+            }
             metrics_info["engine"] = str(engine_index)
             info_gauge.labels(**metrics_info).set(1)
 


### PR DESCRIPTION
## Purpose

Limit the maximum size of Prometheus metric label length. There is one metric that emits model and vllm configuration settings. The problem is that some models, such as https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 have a humongous 7MB [config.json](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4/blob/main/config.json). That model results in a 22MB `/metrics` payload, which breaks Prometheus.

This change drops any metric labels that are large. It allows Nemotron Ultra NVFP4 metrics to work normally, and will also guard against any future accidental huge outputs.

Fixes https://github.com/vllm-project/vllm/issues/44691
