### PR TITLE
[CI] Add opt-in statistically-calibrated lm-eval accuracy gate (Wilson lower bound)

### DIFF
--- a/.buildkite/lm-eval-harness/accuracy_gate.py
+++ b/.buildkite/lm-eval-harness/accuracy_gate.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Statistically-calibrated pass/fail gating for lm-eval accuracy metrics.
+
+The default accuracy gate compares a measured metric against a baseline with a
+fixed relative tolerance ``rtol`` (``measured >= ground_truth * (1 - rtol)``).
+That threshold ignores how many samples produced ``measured``: with a small
+``limit`` the measurement is noisy, so a fixed ``rtol`` both lets real
+regressions through (false pass) and, at the tails, flags noise (false fail).
+
+This module adds an *opt-in* alternative that accounts for sampling noise via a
+one-sided **Wilson score** lower confidence bound on the (binomial) accuracy. It
+is pure stdlib (``math`` + ``statistics.NormalDist``) so it can be unit-tested on
+CPU without running ``lm_eval`` or a GPU.
+
+It is intentionally backward compatible: callers select the CI gate explicitly
+(``gate="ci"``); the default ``gate="rtol"`` path reproduces the existing
+decision exactly.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from statistics import NormalDist
+
+
+def wilson_lower_bound(p_hat: float, n: int, confidence: float = 0.95) -> float:
+    """One-sided lower confidence bound for a binomial proportion (Wilson score).
+
+    For an observed proportion ``p_hat`` from ``n`` independent Bernoulli trials,
+    returns the lower end of the one-sided ``confidence``-level Wilson interval::
+
+        z      = Phi^-1(confidence)            # one-sided normal quantile
+        center = (p_hat + z^2/(2n)) / (1 + z^2/n)
+        half   = (z / (1 + z^2/n)) * sqrt( p_hat*(1-p_hat)/n + z^2/(4 n^2) )
+        lower  = center - half
+
+    The Wilson interval is preferred over the normal (Wald) approximation because
+    it stays inside ``[0, 1]`` and remains well-behaved at the tails (e.g. it
+    yields a sensible bound when ``p_hat`` is exactly 0 or 1, where Wald collapses
+    to zero width). The result is clamped to ``[0.0, 1.0]``.
+
+    Args:
+        p_hat: Observed proportion, in ``[0, 1]``.
+        n: Number of trials (the eval sample count); must be a positive integer.
+        confidence: One-sided confidence level, in ``(0, 1)`` (default ``0.95``).
+
+    Returns:
+        The lower confidence bound, in ``[0, 1]``.
+
+    Raises:
+        ValueError: If ``p_hat`` is outside ``[0, 1]``, ``n`` is not a positive
+            integer, or ``confidence`` is outside ``(0, 1)``.
+    """
+    if not 0.0 <= p_hat <= 1.0:
+        raise ValueError(f"p_hat must be in [0, 1], got {p_hat}")
+    if not isinstance(n, int) or n <= 0:
+        raise ValueError(f"n must be a positive integer, got {n!r}")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError(f"confidence must be in (0, 1), got {confidence}")
+
+    z = NormalDist().inv_cdf(confidence)
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = (p_hat + z2 / (2 * n)) / denom
+    half = (z / denom) * math.sqrt(p_hat * (1.0 - p_hat) / n + z2 / (4 * n * n))
+    return min(1.0, max(0.0, center - half))
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Outcome of a single metric gate check."""
+
+    passed: bool
+    detail: str
+
+
+def _is_proportion(x: float) -> bool:
+    return 0.0 <= x <= 1.0
+
+
+def evaluate_metric_gate(
+    measured_value: float,
+    ground_truth: float,
+    *,
+    gate: str = "rtol",
+    n: int | None = None,
+    confidence: float = 0.95,
+    rtol: float = 0.08,
+) -> GateResult:
+    """Decide whether a measured metric passes its baseline gate.
+
+    Two modes:
+
+    * ``gate="rtol"`` (default, unchanged behaviour): pass iff
+      ``measured_value >= ground_truth * (1 - rtol)``.
+    * ``gate="ci"``: pass iff the one-sided Wilson lower bound of
+      ``measured_value`` at ``n`` samples and ``confidence`` is at least the same
+      baseline threshold ``ground_truth * (1 - rtol)``. Because the lower bound is
+      never above ``measured_value``, passing the CI gate implies passing the
+      rtol gate — the CI gate only *adds* strictness, requiring the result to
+      clear the bar with statistical confidence given the sample count. Set
+      ``rtol=0`` to require confidence that the model is at least the baseline.
+
+    The CI gate applies only to proportion-like metrics (accuracies in
+    ``[0, 1]`` such as ``exact_match`` / ``acc``); it raises for non-proportion
+    metrics (e.g. perplexity) and for a missing/invalid sample count.
+
+    Args:
+        measured_value: The metric value produced by the run.
+        ground_truth: The baseline metric value from the config.
+        gate: ``"rtol"`` (default) or ``"ci"``.
+        n: Sample count for the CI gate (the eval ``limit``). Required when
+            ``gate="ci"``.
+        confidence: One-sided confidence level for the CI gate.
+        rtol: Relative tolerance applied to the baseline (default ``0.08``).
+
+    Returns:
+        A :class:`GateResult` with the boolean outcome and a printable detail.
+
+    Raises:
+        ValueError: For an unknown ``gate``, or, in CI mode, for a non-proportion
+            metric or a missing/invalid ``n``.
+    """
+    threshold = ground_truth * (1.0 - rtol)
+
+    if gate == "rtol":
+        passed = measured_value >= threshold
+        detail = (
+            f"gate=rtol | measured={measured_value:.4f} "
+            f">= threshold={threshold:.4f} (ground_truth={ground_truth:.4f}, "
+            f"rtol={rtol}) -> {'PASS' if passed else 'FAIL'}"
+        )
+        return GateResult(passed=passed, detail=detail)
+
+    if gate == "ci":
+        if not _is_proportion(measured_value) or not _is_proportion(ground_truth):
+            raise ValueError(
+                "gate='ci' only applies to proportion metrics in [0, 1] "
+                f"(got measured={measured_value}, ground_truth={ground_truth}); "
+                "use gate='rtol' for non-proportion metrics such as perplexity"
+            )
+        if not isinstance(n, int) or n <= 0:
+            raise ValueError(
+                "gate='ci' requires a positive integer sample count n "
+                f"(set an integer 'limit' in the config); got n={n!r}"
+            )
+        lower = wilson_lower_bound(measured_value, n, confidence)
+        passed = lower >= threshold
+        detail = (
+            f"gate=ci | measured={measured_value:.4f} "
+            f"wilson_lower({int(confidence * 100)}%, n={n})={lower:.4f} "
+            f">= threshold={threshold:.4f} (ground_truth={ground_truth:.4f}, "
+            f"rtol={rtol}) -> {'PASS' if passed else 'FAIL'}"
+        )
+        return GateResult(passed=passed, detail=detail)
+
+    raise ValueError(f"unknown gate {gate!r}; expected 'rtol' or 'ci'")

--- a/.buildkite/lm-eval-harness/test_accuracy_gate.py
+++ b/.buildkite/lm-eval-harness/test_accuracy_gate.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the statistically-calibrated accuracy gate.
+
+These are pure-CPU tests: they exercise ``accuracy_gate`` only and do not import
+``lm_eval`` or launch a server, so they run anywhere. Run them with
+``pytest .buildkite/lm-eval-harness/test_accuracy_gate.py``.
+"""
+
+import math
+
+import pytest
+from accuracy_gate import evaluate_metric_gate, wilson_lower_bound
+
+# --- Wilson lower bound: cross-check against known references ----------------
+
+
+def test_wilson_matches_textbook_two_sided_95():
+    # The one-sided 97.5% lower bound equals the two-sided 95% lower bound.
+    # Textbook Wilson 95% interval for 50/100 successes is [0.4038, 0.5962].
+    assert wilson_lower_bound(0.5, 100, 0.975) == pytest.approx(0.4038, abs=1e-3)
+
+
+def test_wilson_lower_never_exceeds_phat():
+    for p in (0.1, 0.5, 0.755, 0.9):
+        for n in (50, 200, 1000):
+            assert wilson_lower_bound(p, n, 0.95) <= p + 1e-12
+
+
+def test_wilson_tightens_with_n():
+    # More samples -> lower bound moves up toward p_hat (less uncertainty).
+    small = wilson_lower_bound(0.72, 100, 0.95)
+    large = wilson_lower_bound(0.72, 1000, 0.95)
+    assert small < large < 0.72
+
+
+def test_wilson_boundary_phat_one_is_below_one():
+    # The Wald approximation collapses to width 0 at p_hat=1; Wilson does not.
+    lb = wilson_lower_bound(1.0, 1000, 0.95)
+    assert 0.0 < lb < 1.0
+    assert lb == pytest.approx(0.9973, abs=1e-3)
+
+
+def test_wilson_boundary_phat_zero_is_zero():
+    assert wilson_lower_bound(0.0, 1000, 0.95) == 0.0
+
+
+def test_wilson_in_unit_interval():
+    for p in (0.0, 0.01, 0.5, 0.99, 1.0):
+        lb = wilson_lower_bound(p, 37, 0.9)
+        assert 0.0 <= lb <= 1.0 and math.isfinite(lb)
+
+
+@pytest.mark.parametrize(
+    "p,n,conf",
+    [
+        (-0.1, 100, 0.95),
+        (1.1, 100, 0.95),
+        (0.5, 0, 0.95),
+        (0.5, -5, 0.95),
+        (0.5, 100, 0.0),
+        (0.5, 100, 1.0),
+    ],
+)
+def test_wilson_invalid_inputs_raise(p, n, conf):
+    with pytest.raises(ValueError):
+        wilson_lower_bound(p, n, conf)
+
+
+# --- rtol gate: must reproduce the legacy decision exactly -------------------
+
+
+@pytest.mark.parametrize(
+    "measured,gt,rtol,expected",
+    [
+        (0.76, 0.755, 0.08, True),  # above baseline
+        (0.70, 0.755, 0.08, True),  # within 8% relative -> legacy PASS
+        (0.69, 0.755, 0.08, False),  # below 8% relative -> legacy FAIL
+        (0.755, 0.755, 0.0, True),
+    ],  # exactly baseline, rtol 0
+)
+def test_rtol_gate_matches_legacy(measured, gt, rtol, expected):
+    res = evaluate_metric_gate(measured, gt, gate="rtol", rtol=rtol)
+    assert res.passed is expected
+    # equivalent to the original inline comparison
+    assert res.passed == (measured >= gt * (1 - rtol))
+
+
+# --- the whole point: rtol passes but CI fails at small n -------------------
+
+
+def test_ci_fails_what_rtol_passes_at_small_n():
+    measured, gt, rtol = 0.72, 0.755, 0.08
+    # legacy fixed-tolerance gate is satisfied (point estimate clears the bar)
+    assert evaluate_metric_gate(measured, gt, gate="rtol", rtol=rtol).passed
+    # but with only n=100 samples the result is not statistically distinguishable
+    # from a regression -> CI gate fails
+    assert not evaluate_metric_gate(
+        measured, gt, gate="ci", n=100, confidence=0.95, rtol=rtol
+    ).passed
+    # the same measured value with n=1000 samples clears the CI gate
+    assert evaluate_metric_gate(
+        measured, gt, gate="ci", n=1000, confidence=0.95, rtol=rtol
+    ).passed
+
+
+def test_ci_clear_pass_and_clear_fail():
+    assert evaluate_metric_gate(
+        0.82, 0.755, gate="ci", n=1000, confidence=0.95, rtol=0.08
+    ).passed
+    assert not evaluate_metric_gate(
+        0.50, 0.755, gate="ci", n=1000, confidence=0.95, rtol=0.08
+    ).passed
+
+
+def test_ci_pass_implies_rtol_pass():
+    # CI gate is strictly at least as strict as the rtol gate.
+    for measured in (0.70, 0.72, 0.76, 0.80):
+        ci = evaluate_metric_gate(
+            measured, 0.755, gate="ci", n=500, confidence=0.95, rtol=0.08
+        )
+        rtol = evaluate_metric_gate(measured, 0.755, gate="rtol", rtol=0.08)
+        if ci.passed:
+            assert rtol.passed
+
+
+# --- CI gate guards: non-proportion metrics and missing/invalid n -----------
+
+
+def test_ci_rejects_non_proportion_metric():
+    with pytest.raises(ValueError):
+        evaluate_metric_gate(5.2, 4.8, gate="ci", n=1000)  # e.g. perplexity
+
+
+@pytest.mark.parametrize("n", [None, 0, -1, 1.5, "1000"])
+def test_ci_rejects_invalid_n(n):
+    with pytest.raises(ValueError):
+        evaluate_metric_gate(0.72, 0.755, gate="ci", n=n, confidence=0.95)
+
+
+def test_unknown_gate_raises():
+    with pytest.raises(ValueError):
+        evaluate_metric_gate(0.72, 0.755, gate="bogus")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -7,6 +7,14 @@ Configs are found in configs/$MODEL.yaml
 pytest -s -v test_lm_eval_correctness.py \
     --config-list-file=configs/models-small.txt \
     --tp-size=1
+
+Optional per-config keys (default behaviour is unchanged when omitted):
+    rtol: relative tolerance for the baseline (default 0.08).
+    gate: "rtol" (default) or "ci". With "ci", a proportion metric must clear
+        the baseline threshold via a one-sided Wilson lower confidence bound at
+        ``limit`` samples (accounts for sampling noise instead of trusting the
+        point estimate). See accuracy_gate.py.
+    confidence: one-sided confidence level for gate="ci" (default 0.95).
 """
 
 import os
@@ -15,10 +23,12 @@ from contextlib import contextmanager
 import lm_eval
 import pytest
 import yaml
+from accuracy_gate import evaluate_metric_gate
 
 from vllm.platforms import current_platform
 
 DEFAULT_RTOL = 0.08
+DEFAULT_CONFIDENCE = 0.95
 
 
 @contextmanager
@@ -127,19 +137,24 @@ def test_lm_eval_correctness_param(config_filename, tp_size):
     results = launch_lm_eval(eval_config, tp_size)
 
     rtol = eval_config.get("rtol", DEFAULT_RTOL)
+    gate = eval_config.get("gate", "rtol")
+    confidence = eval_config.get("confidence", DEFAULT_CONFIDENCE)
+    limit = eval_config.get("limit")
 
     success = True
     for task in eval_config["tasks"]:
         for metric in task["metrics"]:
             ground_truth = metric["value"]
             measured_value = results["results"][task["name"]][metric["name"]]
-            print(
-                f"{task['name']} | {metric['name']}: "
-                f"ground_truth={ground_truth:.3f} | "
-                f"measured={measured_value:.3f} | rtol={rtol}"
+            result = evaluate_metric_gate(
+                measured_value,
+                ground_truth,
+                gate=gate,
+                n=limit if isinstance(limit, int) else None,
+                confidence=confidence,
+                rtol=rtol,
             )
-
-            min_acceptable = ground_truth * (1 - rtol)
-            success = success and measured_value >= min_acceptable
+            print(f"{task['name']} | {metric['name']}: {result.detail}")
+            success = success and result.passed
 
     assert success


### PR DESCRIPTION
## Purpose

The lm-eval accuracy gate in `.buildkite/lm-eval-harness/test_lm_eval_correctness.py` decides pass/fail with a fixed relative tolerance:

```python
rtol = eval_config.get("rtol", DEFAULT_RTOL)  # DEFAULT_RTOL = 0.08
min_acceptable = ground_truth * (1 - rtol)
success = success and measured_value >= min_acceptable
```

That threshold ignores the eval **sample count** (`limit`, often 1000). A fixed epsilon is not noise-aware: at `gsm8k` baseline ≈0.755 with n=1000, the binomial standard error is ≈1.4pp, so the 8% relative band (≈6pp) sits ~4 SE below baseline — loose enough to let a real ~3–5pp regression pass as long as the point estimate happens to clear the bar, while at small `limit` the same fixed band can flag pure sampling noise. Today this is handled manually (e.g. #43570 stabilised a flaky gsm8k gate by switching to greedy decode, bumping N to 200, and hand-tuning `rtol`/expected values).

This is a concrete first increment toward **#34333 ("Automated baselining and degradation detection")**, which calls for statistically principled accuracy gating. It does not close that RFC — it lands the minimal, dependency-free building block.

**Change (opt-in, backward compatible):** a new pure-stdlib `accuracy_gate.py` adds a `gate: "ci"` mode. A proportion metric must clear the same baseline threshold via a **one-sided Wilson score lower confidence bound** at `limit` samples and `confidence` (default 0.95), instead of trusting the point estimate:

```
z      = NormalDist().inv_cdf(confidence)
center = (p + z^2/(2n)) / (1 + z^2/n)
half   = (z / (1 + z^2/n)) * sqrt( p(1-p)/n + z^2/(4 n^2) )
lower  = center - half          # pass iff lower >= ground_truth * (1 - rtol)
```

Wilson is used over the Wald approximation because it stays in `[0,1]` and behaves at the tails (e.g. `p=1.0` gives a sensible bound, not zero width). The CI gate is **strictly at least as strict** as the rtol gate (the lower bound never exceeds the point estimate), so it only adds protection against borderline/under-sampled passes; set `rtol: 0` for a pure "confidently ≥ baseline" gate. It applies only to proportion metrics (accuracies in `[0,1]`) and raises a clear error for non-proportion metrics (e.g. perplexity) or a missing/invalid `limit`.

**Backward compatibility:** `gate` defaults to `"rtol"`; that path reproduces the existing comparison exactly. No existing config sets `gate`, so current behaviour is unchanged.

## Test Plan

```bash
uv venv --python 3.12 .venv && uv pip install --python .venv pytest ruff
# unit tests for the new pure gating logic (CPU, no lm_eval / no GPU):
.venv/bin/python -m pytest .buildkite/lm-eval-harness/test_accuracy_gate.py -q
# lint/format (repo ruff config):
ruff check  .buildkite/lm-eval-harness/{accuracy_gate,test_accuracy_gate,test_lm_eval_correctness}.py
ruff format --check .buildkite/lm-eval-harness/{accuracy_gate,test_accuracy_gate,test_lm_eval_correctness}.py
```

## Test Result

- **Unit tests: `26 passed in 0.01s`.** Coverage includes: Wilson lower bound cross-checked against the textbook value (50/100 → 0.4038), tail/boundary behaviour (`p=1.0`→0.9973, `p=0.0`→0.0), monotonicity in n, the rtol path matching the legacy comparison exactly, the headline case (measured 0.72 vs baseline 0.755, rtol 0.08: **passes rtol but the CI gate FAILS at n=100 and PASSES at n=1000**), and input guards (non-proportion metric, invalid n, unknown gate).
- **Lint:** `ruff check` → All checks passed; `ruff format --check` → 3 files already formatted.
- **Not run locally:** the full lm-eval accuracy harness (`test_lm_eval_correctness.py`) launches a model and **requires a GPU**, so it was **not** executed here — only the new gating logic's CPU unit tests were. The integration wiring is a minimal, type-checked refactor of the existing loop; CI/maintainers with GPU should exercise it.

---

**Not a duplicate:** searched open/closed issues & PRs — no open PR touches `test_lm_eval_correctness.py` / accuracy gating / Wilson. The only related item is RFC #34333 (the parent proposal); this PR is a concrete partial step toward it, posted as a comment there for coordination, not a competing RFC.

**AI assistance disclosure (per AGENTS.md):** this change was implemented with AI assistance (Claude); the commit carries a `Co-authored-by: Claude` trailer. It is submitted by a human author who is reviewing the change and will run/defend the GPU harness path.


