### PR TITLE
[Bugfix] Fix RMSNorm quant fusion dtype guard

### DIFF
--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -16,6 +16,7 @@ from vllm.compilation.passes.fusion.rms_quant_fusion import (
     FUSED_OPS,
     FusedRMSQuantKey,
     RMSNormQuantFusionPass,
+    _rms_input_weight_dtype_match,
 )
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
 from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
@@ -57,6 +58,38 @@ from vllm.utils.deep_gemm import (
 FP8_DTYPE = current_platform.fp8_dtype()
 
 RMS_ADD_OP = torch.ops._C.fused_add_rms_norm.default
+
+
+def _fused_add_rms_norm_match(
+    x_dtype: torch.dtype,
+    residual_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+) -> SimpleNamespace:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    residual = graph.placeholder("residual")
+    weight = graph.placeholder("weight")
+    x.meta["val"] = torch.empty(1, 16, dtype=x_dtype)
+    residual.meta["val"] = torch.empty(1, 16, dtype=residual_dtype)
+    weight.meta["val"] = torch.empty(16, dtype=weight_dtype)
+    fused_add = graph.call_function(
+        torch.ops.vllm_ir.fused_add_rms_norm.default,
+        args=(x, residual, weight, 1e-6, None),
+    )
+
+    return SimpleNamespace(nodes=[fused_add])
+
+
+def test_rms_quant_fusion_rejects_mixed_dtype_fused_add_rms_norm():
+    assert not _rms_input_weight_dtype_match(
+        _fused_add_rms_norm_match(torch.bfloat16, torch.bfloat16, torch.float32)
+    )
+    assert not _rms_input_weight_dtype_match(
+        _fused_add_rms_norm_match(torch.bfloat16, torch.float32, torch.bfloat16)
+    )
+    assert _rms_input_weight_dtype_match(
+        _fused_add_rms_norm_match(torch.bfloat16, torch.bfloat16, torch.bfloat16)
+    )
 
 # Kernel and group_shape combinations: (kernel, group_shape)
 # CUDA kernels

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -39,18 +39,26 @@ FP4_DTYPE = torch.uint8
 
 
 _RMS_NORM_OP = torch.ops.vllm_ir.rms_norm.default
+_FUSED_ADD_RMS_NORM_OP = torch.ops.vllm_ir.fused_add_rms_norm.default
 
 
-# TODO: extend rmsnorm quant kernels to support mixed input/weight dtypes,
-# and remove this check.
+# TODO: extend rmsnorm quant kernels to support mixed dtypes, and remove this
+# check.
 def _rms_input_weight_dtype_match(match: pm.Match) -> bool:
-    """Prevent fusion when rms_norm input and weight dtypes differ."""
+    """Prevent fusion when rms_norm inputs have unsupported mixed dtypes."""
     for node in match.nodes:
         if node.target == _RMS_NORM_OP:
             # rms_norm(x, weight, epsilon, variance_size)
-            x, weight = node.args[0], node.args[1]
-            if isinstance(x, fx.Node) and isinstance(weight, fx.Node):
-                return x.meta["val"].dtype == weight.meta["val"].dtype
+            tensors = (node.args[0], node.args[1])
+        elif node.target == _FUSED_ADD_RMS_NORM_OP:
+            # fused_add_rms_norm(x, x_residual, weight, epsilon, variance_size)
+            tensors = (node.args[0], node.args[1], node.args[2])
+        else:
+            continue
+
+        if all(isinstance(tensor, fx.Node) for tensor in tensors):
+            dtypes = {tensor.meta["val"].dtype for tensor in tensors}
+            return len(dtypes) == 1
     return True
 
 


### PR DESCRIPTION

## Purpose

Fix invalid RMSNorm+FP8 quant fusion for `fused_add_rms_norm` with mixed input/residual/weight dtypes.

AI-assisted: OpenAI Codex helped prepare this patch.

## Test Plan

`pytest -q tests/compile/passes/test_fusion.py::test_rms_quant_fusion_rejects_mixed_dtype_fused_add_rms_norm`

## Test Result

`1 passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) Documentation update considered; not needed for this internal fusion guard.
</details>

