### PR TITLE
fix(scaled_mm): use reshape to accept non-contiguous activations

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
@@ -131,7 +131,7 @@ class FP8ScaledMMLinearKernel(
         #   If dynamic, layer.input_scale is None and x_s computed from x.
         #   If static, layer.input_scale is scalar and x_s is input_scale.
         # View input as 2D matrix for fp8 methods
-        x_2d = x.view(-1, x.shape[-1])
+        x_2d = x.reshape(-1, x.shape[-1])
         output_shape = [*x.shape[:-1], w.shape[1]]
         out_dtype = x.dtype if maybe_out_dtype is None else maybe_out_dtype
 


### PR DESCRIPTION
## What

`ScaledMMLinearKernel.apply_weights()` flattens the activation with:

```python
x_2d = x.view(-1, x.shape[-1])
```

`view()` requires the input to be view-compatible (effectively contiguous in the flattened dims). That is not part of the linear-layer input contract: `F.linear` and other quantized linear paths accept non-contiguous higher-dim activations. The `view` therefore raises `RuntimeError` on valid non-contiguous batched inputs.

This switches the flatten to `reshape(-1, x.shape[-1])`, which behaves identically to `view` when the tensor is view-compatible and only copies when a copy is actually required.

## Why

A concrete trigger is batched Qwen-Image: joint text/image attention output is sliced into two streams before the FP8 linear:

```python
joint_hidden_states = joint_hidden_states.flatten(2, 3)
txt = joint_hidden_states[:, :seq_len_txt, :]
img = joint_hidden_states[:, seq_len_txt:, :]
img = self.to_out(img)   # non-contiguous slice -> view() raises
```

For batch size > 1 each slice is a valid non-contiguous tensor whose batch stride still spans the other stream, so it cannot be `view()`-ed to `[B*S, H]` without a copy. Minimal repro:

```python
full = torch.randn(2, 8, hidden_size, device="cuda")
x = full[:, 3:, :]
assert not x.is_contiguous()
x.view(-1, hidden_size)     # RuntimeError
x.reshape(-1, hidden_size)  # OK, copies only when required
```

The output shape is computed independently from `x.shape` (`output_shape = [*x.shape[:-1], w.shape[1]]`) and reapplied in `apply_scaled_mm`, so the flatten's contiguity does not affect output reconstruction. The change is a strict superset of the previous behavior.

Fixes #44712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
