### PR TITLE
fix(tool_parsers): strip STRING_DELIM from dict keys in gemma4 parser

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -160,6 +160,30 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args(":[t:[]")
         assert isinstance(result, dict)
 
+    def test_string_quoted_dict_key(self):
+        """Dict keys wrapped in STRING_DELIM are stripped, matching value behavior.
+
+        The value parser strips <|\"|> from values, but the key parser
+        was taking keys verbatim, leaving sentinel characters embedded
+        in dict-key positions when Gemma4 emits a string-quoted key.
+        """
+        result = _parse_gemma4_args('<|"|>123<|"|>:<|"|>value<|"|>')
+        assert result == {"123": "value"}
+
+    def test_string_quoted_dict_keys_in_nested_object(self):
+        """Nested objects with string-quoted keys."""
+        result = _parse_gemma4_args(
+            'nested:{<|"|>key_1<|"|>:<|"|>val1<|"|>,<|"|>key_2<|"|>:42}'
+        )
+        assert result == {"nested": {"key_1": "val1", "key_2": 42}}
+
+    def test_mixed_quoted_and_unquoted_keys(self):
+        """Keys without delimiters are unaffected."""
+        result = _parse_gemma4_args(
+            'name:<|"|>test<|"|>,<|"|>quoted_key<|"|>:<|"|>val<|"|>'
+        )
+        assert result == {"name": "test", "quoted_key": "val"}
+
 
 class TestParseGemma4Array:
     def test_string_array(self):

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -122,6 +122,14 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
         if i >= n:
             break
         key = args_str[key_start:i].strip()
+        # Strip STRING_DELIM from dict keys — the value parser already
+        # strips it from values, but the key parser was taking keys
+        # verbatim, leaving <|"|> sentinel characters embedded in
+        # dict-key positions when Gemma4 emits a string-quoted key.
+        if key.startswith(STRING_DELIM):
+            key = key[len(STRING_DELIM) :]
+        if key.endswith(STRING_DELIM):
+            key = key[: -len(STRING_DELIM)]
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
## Description

The `_parse_gemma4_args` key parser scans raw bytes up to the next `:` and takes dict keys verbatim, without stripping the `<|"|>` sentinel characters. The value parser correctly strips them, creating an asymmetry that breaks tools with dict-typed arguments when Gemma4 emits string-quoted keys.

Fixes #44715.

## Root Cause

In `vllm/tool_parsers/gemma4_tool_parser.py`, lines 118-125, the key parser:

```python
key = args_str[key_start:i].strip()
```

takes keys verbatim. When Gemma4 emits a string-quoted dict key like `<|"|>123<|"|>`, the key becomes the literal string `<|"|>123<|"|>` instead of `123`.

The value parser at lines 141-151 correctly recognizes and strips `STRING_DELIM`. This fix adds the same stripping logic for keys.

## Changes

- **`vllm/tool_parsers/gemma4_tool_parser.py`**: Strip `STRING_DELIM` from the beginning and end of parsed dict keys
- **`tests/tool_parsers/test_gemma4_tool_parser.py`**: Add 3 test cases covering string-quoted dict keys (flat, nested, and mixed quoted/unquoted)