### PR TITLE
[Bugfix] Strip <|"|> sentinels from dict-key positions in Gemma4ToolParser

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -155,6 +155,21 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args("left:108.,right:22.8", partial=False)
         assert result == {"left": 108.0, "right": 22.8}
 
+    def test_string_delim_wrapped_key_is_stripped(self):
+        """Keys wrapped in <|"|>...<|"|> should parse to clean strings (issue #N)."""
+        result = _parse_gemma4_args('record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}')
+        assert result == {"record_map": {"3": "new text"}}
+
+    def test_string_delim_wrapped_key_nested(self):
+        """Nested dict keys with <|"|> wrappers should also be stripped."""
+        result = _parse_gemma4_args('outer:{<|"|>k1<|"|>:{<|"|>k2<|"|>:<|"|>v<|"|>}}')
+        assert result == {"outer": {"k1": {"k2": "v"}}}
+
+    def test_bare_keys_still_parse_unchanged(self):
+        """Regression guard: bare-identifier keys (the common case) unchanged."""
+        result = _parse_gemma4_args('location:<|"|>Paris<|"|>,count:42')
+        assert result == {"location": "Paris", "count": 42}
+
     @pytest.mark.timeout(5)
     def test_malformed_partial_array(self):
         result = _parse_gemma4_args(":[t:[]")

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -122,6 +122,14 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
         if i >= n:
             break
         key = args_str[key_start:i].strip()
+
+        # String value: <|"|>...<|"|>
+        if (
+            key.startswith(STRING_DELIM)
+            and key.endswith(STRING_DELIM)
+            and len(key) >= 2 * len(STRING_DELIM)
+        ):
+            key = key[len(STRING_DELIM) : -len(STRING_DELIM)]
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
Fixes #44715

`_parse_gemma4_args()` strips `<|"|>` (STRING_DELIM) from value positions but not from key positions, so any dict-keyed tool argument the model emits with quoted keys ends up with the sentinel characters leaked into the dict key string. Affects all `dict[K, V]`-typed tool args. See the linked issue for the asymmetry in the parser source, the model-side reproduction, and the end-to-end failure mode against `google/gemma-4-31B-it`.

## Test Plan

Three new unit tests added to `tests/tool_parsers/test_gemma4_tool_parser.py`:
- key-position strip (the fix)
- nested-dict key-position strip (recursive safety)
- bare-key regression guard

Run:

    pytest tests/tool_parsers/test_gemma4_tool_parser.py -s -v

## Test Result

Before: 2 new tests fail (`'<|"|>3<|"|>'` leaks into key string), 1 passes.
After:  all 3 new tests pass; existing test suite unchanged.

---

AI-assistance disclosure: Bug analysis and fix shape developed with assistance from Claude Code Opus 4.7; final code, tests, and writeup reviewed and authored by me.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

