### PR TITLE
[Bugfix] Multinode config validation

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -212,6 +212,14 @@ class SchedulerConfig:
         #   https://github.com/vllm-project/vllm/issues/29585
         factors.append(self.max_num_batched_tokens)
 
+        # max_num_seqs determines the number of request slots and therefore the
+        # size of the per-request static buffers (e.g. block tables, sampling
+        # metadata) captured in the torch.compile graph. It also shapes the
+        # dummy batch used by the startup memory-profiling forward pass, so in
+        # multi-node TP/PP it must match across ranks or the profiling
+        # collectives desync.
+        factors.append(self.max_num_seqs)
+
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -558,6 +558,51 @@ class WorkerProc:
     rpc_broadcast_mq: MessageQueue | None
     worker_response_mq: MessageQueue | None
 
+    def _validate_cross_node_config(self, vllm_config: VllmConfig) -> None:
+        """Fail fast if ranks disagree on graph-shape-affecting config.
+
+        In a multi-node TP/PP deployment each ``vllm serve --headless`` process
+        parses its own CLI args and builds its own ``VllmConfig``. If a
+        graph-shape-affecting value (e.g. ``max_num_batched_tokens``,
+        ``max_num_seqs``) is set differently across nodes, the startup
+        memory-profiling forward pass runs with mismatched shapes and the
+        collective communication deadlocks with no actionable error. Compare
+        the per-config hashes (vLLM's own definition of what affects the
+        computation graph) across the inner-DP world group and raise on
+        mismatch. On follower nodes these values are otherwise ignored at
+        runtime, but they must match for the profiling pass to stay in lockstep.
+        """
+        if vllm_config.parallel_config.nnodes_within_dp == 1:
+            # Single-node TP/PP: one CLI parse, nothing to reconcile.
+            return
+
+        local_hashes = {
+            "model_config": vllm_config.model_config.compute_hash(),
+            "parallel_config": vllm_config.parallel_config.compute_hash(),
+            "cache_config": vllm_config.cache_config.compute_hash(),
+            "compilation_config": vllm_config.compilation_config.compute_hash(),
+            "scheduler_config": vllm_config.scheduler_config.compute_hash(),
+        }
+
+        # rank 0 of the inner-DP group is the head node's first worker, whose
+        # config is the source of truth (it hosts the scheduler).
+        group = get_inner_dp_world_group()
+        head_hashes = group.broadcast_object(
+            local_hashes if group.rank_in_group == 0 else None
+        )
+        mismatched = [
+            name for name, h in local_hashes.items() if head_hashes[name] != h
+        ]
+        if mismatched:
+            raise RuntimeError(
+                "Config mismatch across multi-node TP/PP ranks for: "
+                f"{', '.join(mismatched)}. Every node in a multi-node "
+                "deployment must be launched with identical graph-shape "
+                "arguments (e.g. --max-num-batched-tokens, --max-num-seqs). "
+                "A mismatch desyncs the startup memory-profiling forward pass "
+                "and hangs the collective communication."
+            )
+
     def _init_message_queues(
         self, input_shm_handle: Handle, vllm_config: VllmConfig
     ) -> None:
@@ -628,6 +673,10 @@ class WorkerProc:
         self.setup_proc_title_and_log_prefix(
             enable_ep=vllm_config.parallel_config.enable_expert_parallel
         )
+        # init_device() has set up the distributed groups; validate that all
+        # ranks agree on the graph-shape-affecting config before doing any work
+        # that runs collectives (model load, memory profiling).
+        self._validate_cross_node_config(vllm_config)
         if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
             self.worker.elastic_ep_execute("load_model")
         else:


### PR DESCRIPTION
## Purpose

Multi-node TP/PP engines launched via `--headless` can silently hang at startup when nodes disagree on graph-shaping config. Each `vllm serve --headless` process parses its own CLI and builds its own `VllmConfig`, and every node runs the KV-cache memory-profiling forward pass, sizing its dummy batch from its *local* `SchedulerConfig`. That profiling pass is driven by the head and executed by all ranks in lockstep, so it runs the normal TP/PP collectives.

If a shape-affecting value differs across nodes (e.g. `--max-num-batched-tokens` or a follower-only `--max-num-seqs`), those collectives are issued with mismatched shapes. There's no error — just an NCCL deadlock until the watchdog fires (e.g. 30 min at `TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800`), which is painful to diagnose. Single-node (one CLI parse) and Ray (config serialized from the head) are unaffected.

## Fix

1. **Fail-fast cross-rank validation** — `WorkerProc._validate_cross_node_config` (`multiproc_executor.py`). After `init_device()` and before model load / profiling, each worker in a multi-node deployment (`nnodes_within_dp > 1`) broadcasts its config hashes over the inner-DP group from rank 0 and raises a clear `RuntimeError` naming any mismatch. Compared hashes are vLLM's own graph-affecting set: `model_config`, `parallel_config`, `cache_config`, `compilation_config`, `scheduler_config`. Note the covered args are most likely not exhaustive, but any such args can be added easily.

2. **Add `max_num_seqs` to `SchedulerConfig.compute_hash()`** (`config/scheduler.py`). It sets the request-slot count — hence per-request static buffer sizes baked into the compiled graph and the profiling dummy batch — so it belongs in the hash, and the check above now covers it.


## Test Plan

E2E — multi-node TP via `--headless` (mp executor), TP=8 over 2 nodes:

    # Head (node-rank 0), default max_num_seqs:
    vllm serve $MODEL --tensor-parallel-size 8 \
      --nnodes 2 --node-rank 0 --master-addr $HEAD_ADDR \
      --load-format dummy --enforce-eager

    # Follower (node-rank 1, --headless), mismatched scheduler arg:
    vllm serve $MODEL --tensor-parallel-size 8 \
      --nnodes 2 --node-rank 1 --master-addr $HEAD_ADDR --headless \
      --load-format dummy --enforce-eager \
      --max-num-seqs 168          # differs from head

Before: hangs in profiling until the NCCL watchdog times out. After: both nodes raise a `RuntimeError` naming `scheduler_config`. Re-run with the flags aligned and confirm normal startup + `/health` (the check is a no-op on match). `--max-num-seqs` is just one example — any of the hashed configs behaves the same.

## Test Result

Lint:

    $ ruff check vllm/config/scheduler.py vllm/v1/executor/multiproc_executor.py
    All checks passed!
    $ ruff format --check vllm/config/scheduler.py vllm/v1/executor/multiproc_executor.py
    2 files already formatted

E2E:

- Mismatched `--max-num-seqs` run: panics with RuntimeError naming scheduler_config
