### PR TITLE
[Doc] Document Qwen3.6 (dense + MoE) ViT CUDA graph support

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -134,7 +134,8 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 | `Qwen2VLForConditionalGeneration` | `Qwen2-VL` | ✅︎ | ✅︎ | ❌︎ |
 | `Qwen2_5_VLForConditionalGeneration` | `Qwen2.5-VL` | ✅︎ | ✅︎ | ❌︎ |
 | `Qwen3VLForConditionalGeneration` | `Qwen3-VL` | ✅︎ | ✅︎ | ❌︎ |
-| `Qwen3_5ForConditionalGeneration` | `Qwen3.5` | ✅︎ | ✅︎ | ❌︎ |
+| `Qwen3_5ForConditionalGeneration` | `Qwen3.5`, `Qwen3.6` | ✅︎ | ✅︎ | ❌︎ |
+| `Qwen3_5MoeForConditionalGeneration` | `Qwen3.5-MoE`, `Qwen3.6-MoE` | ✅︎ | ✅︎ | ❌︎ |
 | `Step3VLForConditionalGeneration` | `Step3-VL` | ✅︎ | ❌︎ | ❌︎ |
 
 !!! note


### PR DESCRIPTION
## Purpose

Documents that **Qwen3.6** (dense `Qwen/Qwen3.6-27B` and MoE `Qwen/Qwen3.6-35B-A3B`) is covered by the ViT-encoder CUDA-graph path.

Per review feedback (@Isotr0py, @shen-shanshan): Qwen3.6 reuses the existing Qwen3.5 architecture — its `config.json` reports `model_type: qwen3_5`, so it is served by `Qwen3_5ForConditionalGeneration` / `Qwen3_5MoeForConditionalGeneration`, which already implement `SupportsEncoderCudaGraph`. There is therefore no new model/encoder code, and no behavioral difference from Qwen3.5.

As a result this PR now contains **only a documentation update** to the multimodal CUDA-graph support table:
- The previously proposed CI test configs were dropped — dense and MoE share the same ViT encoder as Qwen3.5, so additional CI runs would only consume CI resources without exercising new code.
- The previously proposed offline examples were dropped — Qwen3.6 runs through the existing `qwen3_5` / `qwen3_5_moe` example entries.

The branch has also been rebased onto latest `main` to resolve the prior merge conflict.

## Test Plan

Documentation-only change; no code paths are modified. Encoder CUDA-graph capture/replay for the `Qwen3_5*` architectures is already exercised by the existing `tests/models/multimodal/generation/test_vit_cudagraph.py` `qwen3_5` / `qwen3_5_moe` configs.

## Test Result

`docs` build preview renders the updated support table correctly.

AI assistance (Claude) was used to prepare this change; all lines were reviewed by the submitter.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
