### PR TITLE
[Bugfix][Frontend] Fix completion `max_tokens: null` returning HTTP 500

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -78,6 +78,41 @@ async def test_single_completion(client: openai.AsyncOpenAI, model_name: str) ->
     "model_name",
     [MODEL_NAME],
 )
+async def test_completion_with_null_max_tokens(
+    client: openai.AsyncOpenAI, model_name: str
+) -> None:
+    # ``max_tokens`` is ``int | None`` in the request schema and ``None`` is a
+    # valid value: the server falls back to the model/context limit. It must
+    # generate normally rather than raise an internal server error.
+    completion = await client.completions.create(
+        model=model_name,
+        prompt="Hello, my name is",
+        temperature=0.0,
+        extra_body={"max_tokens": None},
+    )
+    assert completion.choices is not None and len(completion.choices) == 1
+    assert completion.choices[0].text is not None
+    assert completion.choices[0].finish_reason is not None
+
+    # The streaming path had its own assert and must also succeed.
+    stream = await client.completions.create(
+        model=model_name,
+        prompt="Hello, my name is",
+        temperature=0.0,
+        stream=True,
+        extra_body={"max_tokens": None},
+    )
+    streamed_text = ""
+    async for chunk in stream:
+        streamed_text += chunk.choices[0].text
+    assert streamed_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
 async def test_completion_truncation_side_controls_prompt_truncation(
     client: openai.AsyncOpenAI, model_name: str
 ) -> None:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -330,7 +330,6 @@ class OpenAIServingCompletion(OpenAIServing):
                     # with the echo implementation.
                     prompt_token_ids_to_return: list[int] | None = None
 
-                    assert request.max_tokens is not None
                     if request.echo and not has_echoed[i]:
                         assert prompt_token_ids is not None
                         if request.return_token_ids:
@@ -501,7 +500,6 @@ class OpenAIServingCompletion(OpenAIServing):
             for output in final_res.outputs:
                 self._raise_if_error(output.finish_reason, request_id)
 
-                assert request.max_tokens is not None
                 if request.echo:
                     if request.return_token_ids:
                         prompt_text = ""


### PR DESCRIPTION

## Purpose

A `/v1/completions` request with `max_tokens: null` returns HTTP 500 (`InternalServerError`, empty message) even though `null` is a valid, schema-allowed value.

`CompletionRequest.max_tokens` is `int | None = 16`, and `get_max_tokens()` explicitly accepts `None` and falls back to the model/context limit. But both response builders in `OpenAIServingCompletion` unconditionally `assert request.max_tokens is not None` (streaming and non-streaming), so after generation completes the request raises a bare `AssertionError`. The global error mapper turns `AssertionError` into HTTP 500, so a schema-valid request fails as a server error. The chat endpoint has no such assert and already handles `None` correctly.

The asserts only guarded the `request.max_tokens == 0` echo branch, and that comparison is already `None`-safe (`None == 0` is `False`), so they are removed. No behavior change for any non-null value.

## Test Plan

```bash
pytest tests/entrypoints/openai/completion/test_completion.py::test_completion_with_null_max_tokens
```

Added `test_completion_with_null_max_tokens`, covering both the non-streaming and streaming paths (the latter had its own assert). The OpenAI client drops `max_tokens=None`, so the test forces the null via `extra_body={"max_tokens": None}`.

## Test Result

Real `vllm serve` (opt-125m), before vs after:

| request | before | after |
| --- | --- | --- |
| `{"prompt":"Hello","max_tokens":null}` | **500** `InternalServerError` (empty msg) | **200**, generates |
| `{"prompt":"Hello","max_tokens":null,"stream":true}` | 200 then SSE error chunk `code:500` | **200**, clean token stream |
| `{"prompt":"Hello","max_tokens":8}` (control) | 200 | 200 (unchanged) |
| chat `{"max_completion_tokens":null}` (control) | 200 | 200 (unchanged) |
| `{"prompt":"Hello","max_tokens":0,"echo":true,"logprobs":1}` (assert-guarded branch) | 200 | 200 (unchanged) |

The new regression test passes with the fix and fails without it (the revert raises `openai.InternalServerError: 500`, server log `assert request.max_tokens is not None / AssertionError`).

<details>
<summary>repro (serve command + client battery)</summary>

```bash
vllm serve facebook/opt-125m --served-model-name m --enforce-eager --max-model-len 1024

# 500 before fix, 200 after:
curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:8000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"m","prompt":"Hello","max_tokens":null}'

# streaming: SSE error chunk before fix, clean stream after:
curl -sN -X POST localhost:8000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"m","prompt":"Hello","max_tokens":null,"stream":true}'
```

Server log on the 500 (before fix):
```
File ".../vllm/entrypoints/openai/completion/serving.py", line 504, in ...
    assert request.max_tokens is not None
AssertionError
```
</details>

cc @DarkLight1337 @chaunceyjiang
