### PR TITLE
[Bugfix] Fix shape mismatch crash and add logprob_token_ids support in RejectionSampler

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import replace
 from typing import Any
 from unittest.mock import Mock
 
@@ -1171,6 +1172,80 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
 
     mock_sampler_output(rejection_sampler, bonus_token_tensor)
+########################### Tests for logprob_token_ids + spec decode ###########
+
+
+def _make_real_rejection_sampler() -> RejectionSampler:
+    """Create a RejectionSampler with a real (non-mocked) Sampler."""
+    sampler = Sampler(logprobs_mode="raw_logprobs")
+    return RejectionSampler(sampler)
+
+
+def _create_spec_decode_metadata_with_indices(
+    spec_tokens: list[list[int]],
+    vocab_size: int = 100,
+) -> tuple[SpecDecodeMetadata, torch.Tensor]:
+    """Create SpecDecodeMetadata with properly set target/bonus logits indices.
+
+    Returns metadata and a logits tensor sized to hold all positions.
+    """
+    num_draft_tokens = [len(ids) for ids in spec_tokens]
+    num_sampled_tokens = [n + 1 for n in num_draft_tokens]
+    total_positions = sum(num_sampled_tokens)
+
+    # Build logits: [total_positions, vocab_size]
+    logits = torch.randn(total_positions, vocab_size, device=DEVICE_TYPE)
+
+    # Build target_logits_indices and bonus_logits_indices
+    # Layout: for each request, draft positions first, then bonus
+    target_indices = []
+    bonus_indices = []
+    pos = 0
+    for i, n_draft in enumerate(num_draft_tokens):
+        for j in range(n_draft):
+            target_indices.append(pos + j)
+        bonus_indices.append(pos + n_draft)
+        pos += n_draft + 1
+
+    metadata = SpecDecodeMetadata.make_dummy(spec_tokens, device=logits.device)
+    metadata.target_logits_indices = torch.tensor(
+        target_indices, dtype=torch.int64, device=logits.device
+    )
+    metadata.bonus_logits_indices = torch.tensor(
+        bonus_indices, dtype=torch.int64, device=logits.device
+    )
+
+    return metadata, logits
+
+
+def test_logprob_token_ids_with_spec_decode_no_crash():
+    """Regression test: logprob_token_ids + spec decode should not crash.
+
+    Previously this triggered a shape mismatch error in
+    _get_logprobs_tensors because the bonus sampler call returned a
+    small [batch, num_tokens+1] tensor instead of [batch, vocab_size].
+    """
+    vocab_size = 100
+    spec_tokens = [[1, 2, 3], [4, 5]]
+    batch_size = len(spec_tokens)
+
+    rejection_sampler = _make_real_rejection_sampler()
+    spec_decode_metadata, logits = _create_spec_decode_metadata_with_indices(
+        spec_tokens, vocab_size=vocab_size
+    )
+
+    # Scoring request has logprob_token_ids for specific tokens
+    logprob_token_ids = {0: [10, 20, 30], 1: [40, 50]}
+
+    temperature = torch.ones(batch_size, device=DEVICE_TYPE)
+    metadata = create_sampling_metadata(all_greedy=False, temperature=temperature)
+    # Manually set logprob_token_ids and max_num_logprobs
+    metadata = replace(
+        metadata,
+        logprob_token_ids=logprob_token_ids,
+        max_num_logprobs=3,
+    )
+
     output = rejection_sampler(
         spec_decode_metadata,
         draft_probs=None,
@@ -1183,3 +1258,94 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     assert sampled[0, 1].item() == vocab_size - 1
     recovered = sampled[0, 2].item()
     assert 0 <= recovered < vocab_size
+
+    # Should not crash and should return logprobs_tensors
+    assert output.logprobs_tensors is not None
+    # logprob_token_ids has max 3 tokens + 1 sampled = 4 columns
+    max_spec_len = max(len(t) for t in spec_tokens)
+    expected_rows = batch_size * (max_spec_len + 1)
+    assert output.logprobs_tensors.logprobs.shape[0] == expected_rows
+    assert output.logprobs_tensors.logprobs.shape[1] == 4  # 3 tokens + 1 sampled
+
+
+def test_logprob_token_ids_values_correct():
+    """Verify that logprob_token_ids returns correct logprob values."""
+    vocab_size = 50
+    spec_tokens = [[1, 2]]
+    batch_size = 1
+
+    rejection_sampler = _make_real_rejection_sampler()
+    spec_decode_metadata, logits = _create_spec_decode_metadata_with_indices(
+        spec_tokens, vocab_size=vocab_size
+    )
+
+    # Make logits deterministic for verification
+    logits.fill_(-10.0)
+    logits[0, 5] = 10.0  # draft pos 0: token 5 is very likely
+    logits[1, 6] = 10.0  # draft pos 1: token 6 is very likely
+    logits[2, 7] = 10.0  # bonus pos: token 7 is very likely
+
+    # Request logprobs for tokens [5, 6, 7]
+    logprob_token_ids = {0: [5, 6, 7]}
+
+    temperature = torch.ones(batch_size, device=DEVICE_TYPE)
+    metadata = create_sampling_metadata(all_greedy=False, temperature=temperature)
+    metadata = replace(
+        metadata,
+        logprob_token_ids=logprob_token_ids,
+        max_num_logprobs=None,
+    )
+
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    assert output.logprobs_tensors is not None
+    lp = output.logprobs_tensors.logprobs
+
+    # Row 0 (draft pos 0): token 5 should have highest logprob
+    # Column 0 is sampled token, columns 1-3 are [5, 6, 7]
+    # Token 5 logprob at row 0 should be close to 0 (it's the argmax)
+    assert lp[0, 1] > -1.0  # token 5 at position 0 has high logprob
+
+    # Row 1 (draft pos 1): token 6 should have highest logprob
+    assert lp[1, 2] > -1.0  # token 6 at position 1 has high logprob
+
+    # Row 2 (bonus pos): token 7 should have highest logprob
+    assert lp[2, 3] > -1.0  # token 7 at position 2 has high logprob
+
+
+def test_logprob_token_ids_without_max_num_logprobs():
+    """logprob_token_ids should work even when max_num_logprobs is None."""
+    vocab_size = 100
+    spec_tokens = [[1, 2]]
+    batch_size = 1
+
+    rejection_sampler = _make_real_rejection_sampler()
+    spec_decode_metadata, logits = _create_spec_decode_metadata_with_indices(
+        spec_tokens, vocab_size=vocab_size
+    )
+
+    logprob_token_ids = {0: [10, 20]}
+
+    temperature = torch.ones(batch_size, device=DEVICE_TYPE)
+    metadata = create_sampling_metadata(all_greedy=False, temperature=temperature)
+    metadata = replace(
+        metadata,
+        logprob_token_ids=logprob_token_ids,
+        max_num_logprobs=None,
+    )
+
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    # Should still return logprobs because logprob_token_ids is set
+    assert output.logprobs_tensors is not None
+    assert output.logprobs_tensors.logprobs.shape[1] == 3  # 2 tokens + 1 sampled

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -132,6 +132,7 @@ class RejectionSampler(nn.Module):
             sampling_metadata=replace(
                 sampling_metadata,
                 max_num_logprobs=-1,
+                logprob_token_ids=None,
             ),
             predict_bonus_token=True,
             # Override the logprobs mode to return logits because they are
@@ -181,7 +182,10 @@ class RejectionSampler(nn.Module):
         )
 
         logprobs_tensors = None
-        if sampling_metadata.max_num_logprobs is not None:
+        if (
+            sampling_metadata.max_num_logprobs is not None
+            or sampling_metadata.logprob_token_ids
+        ):
             logprobs_tensors = self._get_logprobs_tensors(
                 sampling_metadata.max_num_logprobs,
                 metadata,
@@ -189,6 +193,7 @@ class RejectionSampler(nn.Module):
                 target_logits if self.is_processed_logprobs_mode else raw_target_logits,
                 bonus_sampler_output.logprobs_tensors.logprobs,
                 output_token_ids,
+                logprob_token_ids=sampling_metadata.logprob_token_ids,
             )
 
         return SamplerOutput(
@@ -198,13 +203,16 @@ class RejectionSampler(nn.Module):
 
     def _get_logprobs_tensors(
         self,
-        max_num_logprobs: int,
+        max_num_logprobs: int | None,
         metadata: SpecDecodeMetadata,
         logits: torch.Tensor,
         target_logits: torch.Tensor,
         bonus_logits: torch.Tensor,
         sampled_token_ids: torch.Tensor,
+        logprob_token_ids: dict[int, list[int]] | None = None,
     ) -> LogprobsTensors:
+        from vllm.v1.sample.utils import build_logprob_token_ids_matrix
+
         cu_num_sampled_tokens = torch.zeros_like(metadata.cu_num_sampled_tokens)
         cu_num_sampled_tokens[1:] = metadata.cu_num_sampled_tokens[:-1]
 
@@ -239,11 +247,45 @@ class RejectionSampler(nn.Module):
             if self.is_logits_logprobs_mode
             else self.sampler.compute_logprobs(accepted_logits)
         )
-        return self.sampler.gather_logprobs(
-            accepted_logprobs,
-            max_num_logprobs,
-            accepted_tokens.to(torch.int64),
-        )
+
+        # Top-N gather
+        logprobs_tensors = None
+        if max_num_logprobs is not None:
+            logprobs_tensors = self.sampler.gather_logprobs(
+                accepted_logprobs,
+                max_num_logprobs,
+                accepted_tokens.to(torch.int64),
+            )
+
+        # Specific-token gather (overrides top-N if both present)
+        if logprob_token_ids:
+            rows_per_req = sampled_token_ids.shape[-1]
+            token_ids_tensor, valid_mask = build_logprob_token_ids_matrix(
+                logprob_token_ids,
+                num_rows=accepted_logprobs.shape[0],
+                sampled=accepted_tokens,
+                device=accepted_logprobs.device,
+                pin_memory=self.sampler.pin_memory,
+                rows_per_req=rows_per_req,
+            )
+            gathered_logprobs = accepted_logprobs.gather(-1, token_ids_tensor)
+            gathered_logprobs = gathered_logprobs.masked_fill(
+                ~valid_mask, float("-inf")
+            )
+
+            sampled_logprobs = accepted_logprobs.gather(
+                -1, accepted_tokens.unsqueeze(-1).to(torch.int64)
+            )
+            token_ranks = (accepted_logprobs > sampled_logprobs).sum(dim=-1)
+
+            logprobs_tensors = LogprobsTensors(
+                logprob_token_ids=token_ids_tensor.to(torch.int32),
+                logprobs=gathered_logprobs,
+                selected_token_ranks=token_ranks,
+            )
+
+        assert logprobs_tensors is not None
+        return logprobs_tensors
 
     @staticmethod
     def parse_output(

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -13,6 +13,7 @@ from vllm.v1.sample.ops.bad_words import apply_bad_words
 from vllm.v1.sample.ops.logprobs import batched_count_greater_than
 from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
+from vllm.v1.sample.utils import build_logprob_token_ids_matrix
 
 _SAMPLING_EPS = 1e-5
 
@@ -173,35 +174,13 @@ class Sampler(nn.Module):
         if not logprob_token_ids:
             return None
 
-        batch_size = logprobs.shape[0]
-        device = logprobs.device
-
-        # Find max number of tokens across all requests
-        max_num_tokens = max(len(tids) for tids in logprob_token_ids.values())
-        pin = self.pin_memory
-
-        # Build the padded token_ids and valid_mask matrices on pinned CPU,
-        # then upload non-blocking.
-        token_ids_cpu = torch.zeros(
-            batch_size, max_num_tokens + 1, dtype=torch.int64, pin_memory=pin
+        token_ids_tensor, valid_mask = build_logprob_token_ids_matrix(
+            logprob_token_ids,
+            num_rows=logprobs.shape[0],
+            sampled=sampled,
+            device=logprobs.device,
+            pin_memory=self.pin_memory,
         )
-        # Create mask for valid positions (True = valid, False = padded)
-        valid_mask_cpu = torch.zeros(
-            batch_size, max_num_tokens + 1, dtype=torch.bool, pin_memory=pin
-        )
-        valid_mask_cpu[:, 0] = True  # Sampled token is always valid
-        for req_idx, token_ids in logprob_token_ids.items():
-            num_tokens = len(token_ids)
-            token_ids_cpu[req_idx, 1 : num_tokens + 1] = torch.as_tensor(
-                token_ids, dtype=torch.int64
-            )
-            valid_mask_cpu[req_idx, 1 : num_tokens + 1] = True
-
-        token_ids_tensor = token_ids_cpu.to(device, non_blocking=True)
-        valid_mask = valid_mask_cpu.to(device, non_blocking=True)
-        # Sampled token in column 0 — fill on-device from the sampled GPU
-        # tensor so we don't need to D2H + re-upload.
-        token_ids_tensor[:, 0] = sampled
 
         # Gather logprobs at the requested token ids.
         gathered_logprobs = logprobs.gather(-1, token_ids_tensor)

--- a/vllm/v1/sample/utils.py
+++ b/vllm/v1/sample/utils.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+
+def build_logprob_token_ids_matrix(
+    logprob_token_ids: dict[int, list[int]],
+    num_rows: int,
+    sampled: torch.Tensor,
+    device: torch.device,
+    pin_memory: bool,
+    rows_per_req: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build padded token_ids matrix and valid_mask for specific-token logprobs.
+
+    Args:
+        logprob_token_ids: dict mapping req_index -> list of token IDs
+        num_rows: total number of rows in the output matrix
+        sampled: [num_rows] tensor of sampled token IDs (on GPU)
+        device: target device
+        pin_memory: whether to use pinned memory for CPU tensors
+        rows_per_req: number of rows each request occupies (1 for normal
+            sampling, max_spec_len+1 for speculative decoding)
+
+    Returns:
+        token_ids_tensor: [num_rows, max_num_tokens+1] int64 tensor on device.
+            Column 0 = sampled token, columns 1..N = logprob_token_ids (padded).
+        valid_mask: [num_rows, max_num_tokens+1] bool tensor on device.
+            True = valid position, False = padding.
+    """
+    max_num_tokens = max(len(tids) for tids in logprob_token_ids.values())
+
+    token_ids_cpu = torch.zeros(
+        num_rows, max_num_tokens + 1, dtype=torch.int64, pin_memory=pin_memory
+    )
+    valid_mask_cpu = torch.zeros(
+        num_rows, max_num_tokens + 1, dtype=torch.bool, pin_memory=pin_memory
+    )
+    valid_mask_cpu[:, 0] = True
+
+    for req_idx, token_ids in logprob_token_ids.items():
+        num_tokens = len(token_ids)
+        token_ids_t = torch.as_tensor(token_ids, dtype=torch.int64)
+        start_row = req_idx * rows_per_req
+        end_row = min(start_row + rows_per_req, num_rows)
+        token_ids_cpu[start_row:end_row, 1 : num_tokens + 1] = token_ids_t
+        valid_mask_cpu[start_row:end_row, 1 : num_tokens + 1] = True
+
+    token_ids_tensor = token_ids_cpu.to(device, non_blocking=True)
+    valid_mask = valid_mask_cpu.to(device, non_blocking=True)
+    token_ids_tensor[:, 0] = sampled
+
+    return token_ids_tensor, valid_mask


### PR DESCRIPTION
## Summary

Fixes #42592

When speculative decoding is enabled and a batch contains both chat requests (which have draft tokens) and scoring requests (which set `logprob_token_ids` via the `generative_scoring` API), the bonus sampler's `replace()` call does not clear `logprob_token_ids`. This causes the inner `Sampler` to output logprobs with a gathered shape (not full vocab_size). When `RejectionSampler._get_logprobs_tensors` subsequently integrates these into `final_logits`, the shape mismatch triggers a crash. This reliably reproduces on model services with MTP enabled that simultaneously handle chat and scoring requests (with `logprob_token_ids`).

**Root cause:**

 The bonus sampler `replace()` call passes `logprob_token_ids` through unchanged to the inner `Sampler`, which then returns logprobs of gathered shape instead of full vocab_size, incompatible with `RejectionSampler._get_logprobs_tensors`'s expectation.

 Additionally, while fixing the crash, I found that `RejectionSampler._get_logprobs_tensors` only supported top-N logprobs gathering (`max_num_logprobs`). Even after preventing the crash, the output would still be incorrect — returning top-N logprobs instead of logprobs for the specific tokens requested via `logprob_token_ids`. This correctness issue is also fixed in this PR.

## Changes

  - Clear `logprob_token_ids=None` in `RejectionSampler.forward()`'s bonus sampler `replace()` call to prevent shape mismatch
  - Expand `RejectionSampler._get_logprobs_tensors` condition to also trigger on `logprob_token_ids`
  - Extract the token ID matrix construction logic from `Sampler.gather_specific_token_logprobs` into a standalone `build_logprob_token_ids_matrix` function in `vllm/v1/sample/utils.py`, since both `Sampler` and `RejectionSampler` now need it. This function builds a padded token ID matrix and valid mask from the `logprob_token_ids` dict, enabling batch-level gather of logprobs for specific tokens.
  - Add specific-token logprobs gather in `RejectionSampler._get_logprobs_tensors` using the shared `build_logprob_token_ids_matrix`, aligned with the non-speculative `Sampler` logic
  - Add regression tests covering the crash and logprob correctness

## Test plan

  - [x] New unit tests pass (`tests/v1/sample/test_rejection_sampler.py::test_logprob_token_ids_*`)
  - [x] End-to-end verification: `generative_scoring` endpoint returns correct logprobs when spec decode is active
  - [x] Existing `test_rejection_sampler.py` tests still pass
  - [x] `ruff check` and `ruff format` clean

## Supersedes

This supersedes #42936 (original author gave permission to take over).