### PR TITLE
[Kernel] FlashInfer FP8 scaled_mm: restore N-D output shape

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
@@ -75,7 +75,7 @@ class FlashInferFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
     ) -> torch.Tensor:
         return flashinfer_scaled_fp8_mm(
             A, B, out_dtype=out_dtype, scale_a=As, scale_b=Bs, bias=bias
-        )
+        ).view(*output_shape)
 
 
 class FlashInferFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):


### PR DESCRIPTION
Ran into issues with working on https://github.com/vllm-project/vllm-omni/pull/3305

`FlashInferFP8ScaledMMLinearKernel.apply_scaled_mm` returns the raw 2-D GEMM result, while the CUTLASS and PyTorch ScaledMM kernels reshape to `output_shape`. So a 3-D activation `(B, S, D)` collapses to `(B*S, D)`, and callers that index the linear output by absolute dim (e.g. a diffusion DiT doing `qkv.unflatten(2, ...)`) fail with `IndexError: Dimension out of range`. Only shows up for >2-D inputs.

Reshape the result to `output_shape`, matching the other kernels. Verified on SM103 with a ModelOpt-FP8 video DiT (3-D activations) that previously crashed in warmup and now runs end-to-end; no-op for 2-D inputs.
