### PR TITLE
[Rust Frontend]: Add `/tokenize` API support with Completion format

### DIFF
--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -8,6 +8,7 @@ mod metrics;
 pub(crate) mod openai;
 mod server_info;
 mod sleep;
+mod tokenize;
 mod version;
 
 use std::sync::Arc;
@@ -67,6 +68,8 @@ fn build_router_with_options(
         .route("/metrics", get(metrics::scrape))
         .route("/load", get(load::load))
         .route("/version", get(version::version))
+        // Tokenization APIs
+        .route("/tokenize", post(tokenize::tokenize))
         // OpenAI-compatible endpoints
         .route("/v1/models", get(openai::list_models))
         .route("/v1/completions", post(openai::completions))

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -1096,6 +1096,253 @@ async fn version_returns_engine_vllm_version() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn tokenize_text_returns_token_ids() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"prompt": "hello"}).to_string()))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    let expected_token_ids = bytes_to_token_ids(b"hello");
+    assert_eq!(json["tokens"], json!(expected_token_ids));
+    assert_eq!(json["count"], expected_token_ids.len());
+    assert!(json["max_model_len"].as_u64().expect("max_model_len") > 0);
+    assert!(json["token_strs"].is_null());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_text_with_return_token_strs_enabled() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"prompt": "hi", "return_token_strs": true}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    let expected_token_ids = bytes_to_token_ids(b"hi");
+    assert_eq!(json["tokens"], json!(expected_token_ids));
+    assert_eq!(json["count"], expected_token_ids.len());
+    assert_eq!(json["token_strs"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_token_ids_passes_through() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"prompt": [10, 20, 30]}).to_string()))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    assert_eq!(json["tokens"], json!([10, 20, 30]));
+    assert_eq!(json["count"], 3);
+    assert!(json["token_strs"].is_null());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_token_ids_with_return_token_strs() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"prompt": [999], "return_token_strs": true}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    assert_eq!(json["tokens"], json!([999]));
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["token_strs"], json!(["<image>"]));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_wrong_model_returns_not_found() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"model": "non-existent-model", "prompt": "hello"}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["error"]["type"], "invalid_request_error");
+    assert_eq!(json["error"]["code"], "model_not_found");
+    assert_eq!(json["error"]["param"], "model");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_valid_model_name_succeeds() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"model": "Qwen/Qwen1.5-0.5B-Chat", "prompt": "hi"}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    let expected_token_ids = bytes_to_token_ids(b"hi");
+    assert_eq!(json["tokens"], json!(expected_token_ids));
+    assert_eq!(json["count"], expected_token_ids.len());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_special_token_in_text() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"prompt": "<image>hello", "return_token_strs": true}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    let expected_tokens = vec![
+        999u32,
+        b'h' as u32,
+        b'e' as u32,
+        b'l' as u32,
+        b'l' as u32,
+        b'o' as u32,
+    ];
+    assert_eq!(json["tokens"], json!(expected_tokens));
+    assert_eq!(json["count"], expected_tokens.len());
+    assert_eq!(json["token_strs"], json!(["<image>"]));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_empty_prompt_returns_empty_tokens() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"prompt": "", "return_token_strs": true}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+
+    assert_eq!(json["count"], 0);
+    assert_eq!(json["tokens"], json!([]));
+    assert_eq!(json["token_strs"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tokenize_missing_prompt_returns_json_parse_error() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/tokenize")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"model": "Qwen/Qwen1.5-0.5B-Chat"}).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["error"]["type"], "invalid_request_error");
+    assert_eq!(json["error"]["code"], "json_parse_error");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn server_info_endpoint_is_dev_mode_only() {
     let mut app = test_app().await;
     let response = app

--- a/rust/src/server/src/routes/tokenize.rs
+++ b/rust/src/server/src/routes/tokenize.rs
@@ -1,22 +1,37 @@
+use std::mem::take;
 use std::sync::Arc;
 
 use axum::{Json, extract::State};
 use serde::{Deserialize, Serialize};
-use validator::Validate;
+use thiserror_ext::AsReport;
+use vllm_text::Prompt;
 
-use crate::{
-    error::ApiError,
-    routes::{openai::utils::validated_json::ValidatedJson, tokenize::TokenizeRequest::Completion},
-    state::AppState,
-};
+use crate::error::ApiError;
+use crate::routes::tokenize::TokenizeRequest::Completion;
+use crate::state::AppState;
 
+/// Request for tokenizing text or token IDs.
+///
+/// Supports the `completion` variant which tokenizes a prompt string
+/// or a list of token IDs and optionally returns the string representation
+/// of each token.
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct TokenizeCompletionRequest {
+    /// Name of the model to use for tokenization. If omitted, the default model
+    /// is selected from `state.served_model_names()`.
     model: Option<String>,
-    prompt: String,
+
+    /// The prompt to tokenize: either a text string or pre-existing token IDs.
+    prompt: Prompt,
+
+    /// Whether to add special tokens (e.g., BOS/EOS) during encoding.
+    /// Defaults to `true`.
     #[serde(default = "default_add_special_tokens")]
     add_special_tokens: bool,
+
+    /// If `Some(true)`, the response will include `token_strs` with the
+    /// string representation of each token ID.
     return_token_strs: Option<bool>,
 }
 
@@ -24,25 +39,36 @@ const fn default_add_special_tokens() -> bool {
     true
 }
 
+/// Tokenization request, deserialized using `#[serde(untagged)]`.
+///
+/// Currently supports only the `completion` variant.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub(crate) enum TokenizeRequest {
     Completion(TokenizeCompletionRequest),
 }
 
-#[derive(Serialize)]
+/// Response body returned by the tokenize endpoint.
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TokenizeResponse {
-    count: u64,
-    max_model_len: u64,
-    tokens: Vec<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Total number of tokens returned.
+    count: usize,
+
+    /// Maximum model context length.
+    /// `state.config().max_model_len`.
+    max_model_len: u32,
+
+    /// The tokenized token IDs.
+    tokens: Vec<u32>,
+
+    /// Optional string representation of each token
     token_strs: Option<Vec<String>>,
 }
 
-/// Tokenize request
+/// Handle a tokenize request by routing to the appropriate variant handler.
 pub async fn tokenize(
     State(state): State<Arc<AppState>>,
-    ValidatedJson(body): ValidatedJson<TokenizeRequest>,
+    Json(body): Json<TokenizeRequest>,
 ) -> Result<Json<TokenizeResponse>, ApiError> {
     match body {
         Completion(req) => completion_tokenize(state, req).await,
@@ -51,7 +77,7 @@ pub async fn tokenize(
 
 async fn completion_tokenize(
     state: Arc<AppState>,
-    req: TokenizeCompletionRequest,
+    mut req: TokenizeCompletionRequest,
 ) -> Result<Json<TokenizeResponse>, ApiError> {
     if let Some(model) = &req.model
         && !state.served_model_names().iter().any(|n| n == model)
@@ -61,6 +87,66 @@ async fn completion_tokenize(
         });
     }
 
+    let tokenizer = state.chat.text().tokenizer();
+    let prompt_token_ids = match take(&mut req.prompt) {
+        Prompt::Text(text) => match tokenizer.encode(&text, req.add_special_tokens) {
+            Ok(token_ids) => token_ids,
+            Err(error) => {
+                return Err(ApiError::ServerError {
+                    message: format!(
+                        "failed to tokenize completion request: {}",
+                        error.to_report_string()
+                    ),
+                });
+            }
+        },
+        Prompt::TokenIds(token_ids) => token_ids,
+    };
 
-    todo!()
+    let token_strs = if let Some(true) = req.return_token_strs {
+        let strs = prompt_token_ids.iter().filter_map(|&id| tokenizer.id_to_token(id)).collect();
+        Some(strs)
+    } else {
+        None
+    };
+
+    Ok(Json(TokenizeResponse {
+        count: prompt_token_ids.len(),
+        max_model_len: state.chat.text().max_model_len(),
+        tokens: prompt_token_ids,
+        token_strs,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenization_request_roundtrip() {
+        let original = TokenizeCompletionRequest {
+            model: Some("test-model".into()),
+            prompt: Prompt::Text("hello world".into()),
+            add_special_tokens: false,
+            return_token_strs: Some(true),
+        };
+
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: TokenizeCompletionRequest =
+            serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(deserialized.model, original.model);
+        assert_eq!(deserialized.add_special_tokens, original.add_special_tokens);
+        assert_eq!(deserialized.return_token_strs, original.return_token_strs);
+        assert!(matches!(&deserialized.prompt, Prompt::Text(t) if t == "hello world"));
+    }
+
+    #[test]
+    fn tokenization_request_default_add_special_tokens() {
+        let json = r#"{"prompt":"hello"}"#;
+        let req: TokenizeCompletionRequest = serde_json::from_str(json).expect("deserialize");
+        assert!(req.add_special_tokens);
+        assert!(req.model.is_none());
+        assert!(req.return_token_strs.is_none());
+    }
 }

--- a/rust/src/server/src/routes/tokenize.rs
+++ b/rust/src/server/src/routes/tokenize.rs
@@ -1,7 +1,9 @@
 use std::mem::take;
 use std::sync::Arc;
 
-use axum::{Json, extract::State};
+use axum::Json;
+use axum::extract::State;
+use axum::extract::rejection::JsonRejection;
 use serde::{Deserialize, Serialize};
 use thiserror_ext::AsReport;
 use vllm_text::Prompt;
@@ -68,8 +70,9 @@ pub(crate) struct TokenizeResponse {
 /// Handle a tokenize request by routing to the appropriate variant handler.
 pub async fn tokenize(
     State(state): State<Arc<AppState>>,
-    Json(body): Json<TokenizeRequest>,
+    body: Result<Json<TokenizeRequest>, JsonRejection>,
 ) -> Result<Json<TokenizeResponse>, ApiError> {
+    let Json(body) = body.map_err(|err| ApiError::json_parse_error(err.body_text()))?;
     match body {
         Completion(req) => completion_tokenize(state, req).await,
     }

--- a/rust/src/server/src/routes/tokenize.rs
+++ b/rust/src/server/src/routes/tokenize.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+use crate::{
+    error::ApiError,
+    routes::{openai::utils::validated_json::ValidatedJson, tokenize::TokenizeRequest::Completion},
+    state::AppState,
+};
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+pub(crate) struct TokenizeCompletionRequest {
+    model: Option<String>,
+    prompt: String,
+    #[serde(default = "default_add_special_tokens")]
+    add_special_tokens: bool,
+    return_token_strs: Option<bool>,
+}
+
+const fn default_add_special_tokens() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub(crate) enum TokenizeRequest {
+    Completion(TokenizeCompletionRequest),
+}
+
+#[derive(Serialize)]
+pub(crate) struct TokenizeResponse {
+    count: u64,
+    max_model_len: u64,
+    tokens: Vec<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token_strs: Option<Vec<String>>,
+}
+
+/// Tokenize request
+pub async fn tokenize(
+    State(state): State<Arc<AppState>>,
+    ValidatedJson(body): ValidatedJson<TokenizeRequest>,
+) -> Result<Json<TokenizeResponse>, ApiError> {
+    match body {
+        Completion(req) => completion_tokenize(state, req).await,
+    }
+}
+
+async fn completion_tokenize(
+    state: Arc<AppState>,
+    req: TokenizeCompletionRequest,
+) -> Result<Json<TokenizeResponse>, ApiError> {
+    if let Some(model) = &req.model
+        && !state.served_model_names().iter().any(|n| n == model)
+    {
+        return Err(ApiError::ModelNotFound {
+            model: model.to_string(),
+        });
+    }
+
+
+    todo!()
+}

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -91,6 +91,11 @@ impl TextLlm {
         self.backend.tokenizer()
     }
 
+    /// Return the max_model_len reported by engine
+    pub fn max_model_len(&self) -> u32 {
+        self.max_model_len
+    }
+
     /// Tokenize if needed, lower to a generate request, and return the raw
     /// token stream.
     pub async fn generate_raw(&self, request: TextRequest) -> Result<GenerateOutputStream> {


### PR DESCRIPTION


## Purpose
For the purpose of feature parity of rust frontend with python. It is being tracked https://github.com/vllm-project/vllm/issues/44280

## Test Plan
- `cargo fmt --check --package vllm-text --package vllm-chat --package vllm-server --package vllm-engine-core-client --package vllm-mock-engine`
- `cargo nextest run -p vllm-text -p vllm-chat -p vllm-server -p vllm-engine-core-client -p vllm-mock-engine`

## Test Result
- `cargo fmt --check ...` : passed
- `cargo nextest run -p` : 494 passed, 1 failed, 1 skipped (unrelated  failing test `vllm-text lower::tests::lower_text_request_uses_real_qwen_generation_defaults` )

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

