### PR TITLE
fix(scheduler): eager KV cache prefetch for waiting queue requests

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -385,6 +385,39 @@ class Scheduler(SchedulerInterface):
                 num_new_tokens = num_new_tokens // block_size * block_size
         return num_new_tokens
 
+    def prefetch_waiting_requests(self) -> None:
+        """Eagerly initiate KV cache prefetch for waiting queue requests.
+
+        Called BEFORE schedule() so KV cache I/O overlaps with GPU
+        computation. Even when the running queue fills the batch and
+        schedule() skips the waiting queue, prefetch is already in flight.
+
+        This prevents GPU idle time (up to 350ms per stall observed in
+        production with LMCache) caused by deferring KV cache reads until
+        the scheduler finally picks up waiting requests.
+
+        Fixes: https://github.com/vllm-project/vllm/issues/41784
+        """
+        if not self.waiting:
+            return
+        connector = getattr(self, 'connector', None)
+        if connector is None:
+            return
+        kv_cache_manager = self.kv_cache_manager
+        for request in self.waiting:
+            if request.num_computed_tokens > 0:
+                continue
+            if getattr(request, '_prefetch_started', False):
+                continue
+            try:
+                new_computed_blocks, num_local = (
+                    kv_cache_manager.get_computed_blocks(request))
+                if num_local > 0:
+                    connector.get_num_new_matched_tokens(request, num_local)
+                request._prefetch_started = True
+            except Exception:
+                pass
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -487,7 +487,8 @@ class EngineCore:
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
             return {}, False
-        scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
+        scheduler_output = self.scheduler.prefetch_waiting_requests()
+        self.scheduler.schedule(self._should_throttle_prefills())
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
@@ -544,7 +545,8 @@ class EngineCore:
         model_executed = False
         deferred_scheduler_output = None
         if self.scheduler.has_requests():
-            scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
+            scheduler_output = self.scheduler.prefetch_waiting_requests()
+        self.scheduler.schedule(self._should_throttle_prefills())
             with self.log_error_detail(scheduler_output):
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -487,8 +487,8 @@ class EngineCore:
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
             return {}, False
-        scheduler_output = self.scheduler.prefetch_waiting_requests()
-        self.scheduler.schedule(self._should_throttle_prefills())
+        self.scheduler.prefetch_waiting_requests()
+        scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
@@ -545,8 +545,8 @@ class EngineCore:
         model_executed = False
         deferred_scheduler_output = None
         if self.scheduler.has_requests():
-            scheduler_output = self.scheduler.prefetch_waiting_requests()
-        self.scheduler.schedule(self._should_throttle_prefills())
+            self.scheduler.prefetch_waiting_requests()
+            scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
             with self.log_error_detail(scheduler_output):
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True


### PR DESCRIPTION
## Summary

Fixes #41784: When using vLLM with LMCache, the scheduler skips the waiting queue when the running queue has sufficient tokens. This prevents KV cache prefetch from being initiated, causing GPU idle (up to 350ms per stall, cumulative 32+ seconds in production).

## Root Cause

The scheduler polls queues in order: running -> skipped_waiting -> waiting. When running fills the batch, waiting is never reached, so LMCache disk reads are never triggered.

From production logs:
- Step 3749: prefetch started for 5 waiting requests
- Step 3750: waiting queue skipped -> GPU idle 349.99 ms
- Step 3751: waiting queue skipped -> GPU idle 75.41 ms
- Cumulative stall: 32.9 seconds

## Fix

Add prefetch_waiting_requests() to Scheduler, called in EngineCore step loop BEFORE schedule(). This eagerly triggers KV cache I/O so prefetch overlaps with GPU computation even when schedule() skips the waiting queue.

## Changes
- vllm/v1/core/sched/scheduler.py: Added prefetch_waiting_requests() method
- vllm/v1/engine/core.py: Call prefetch_waiting_requests() before schedule()