### PR TITLE
[Bugfix] Canonicalize FP8 weight layout to (K, N) at the source

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -75,25 +75,7 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             # Update layer with new values
             replace_parameter(layer, "weight", weight.data)
             replace_parameter(layer, "weight_scale_inv", weight_scale_inv.data)
-        else:
-            w_q, *_ = self._get_layer_params(layer)
-            # Compressed tensors transposes the weight to (K, N)
-            # for channel and tensor quant strategies.
-            # So we can skip the transpose if the layout is
-            # already (K, N).
-            # TODO: Remove this check once the layouts have been
-            # canonicalized to a standard (N, K) dimension. See issue
-            # #33314 for more details.
-            if w_q.shape != (
-                layer.input_size_per_partition,
-                layer.output_size_per_partition,
-            ):
-                # transpose the weights to (K,N)
-                replace_parameter(
-                    layer,
-                    "weight",
-                    w_q.t(),
-                )
+        # Non-block: callers must pass weight in (K, N) layout.
 
         layer.input_scale = None
         prepare_fp8_layer_for_marlin(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -137,6 +137,8 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
                     "weight_scale",
                     convert_to_channelwise(layer.weight_scale, layer.logical_widths),
                 )
+            # Canonicalize to (K, N) for the kernel.
+            replace_parameter(layer, "weight", layer.weight.t())
 
         self.linear_kernel.process_weights_after_loading(layer)
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -384,6 +384,9 @@ class Fp8LinearMethod(LinearMethodBase):
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         if self.use_marlin:
+            if not self.block_quant:
+                # Canonicalize to (K, N) for the kernel.
+                replace_parameter(layer, "weight", layer.weight.t())
             # Only Marlin kernels support `marlin_input_dtype`; guard to avoid
             # AttributeError if backend selection changes.
             if hasattr(self.fp8_linear, "marlin_input_dtype"):
@@ -537,20 +540,15 @@ class Fp8OnlineLinearMethod(Fp8LinearMethod):
         layer.input_scale = None
         qweight, weight_scale = ops.scaled_fp8_quant(layer.weight, scale=None)
 
-        # Update layer with new values.
-        replace_parameter(layer, "weight", qweight.data)
+        # Update layer with new values. Canonicalize to (K, N) for the kernel.
+        replace_parameter(layer, "weight", qweight.t().data)
         replace_parameter(layer, "weight_scale", weight_scale.data)
 
-        if self.use_marlin:
+        if self.use_marlin and hasattr(self.fp8_linear, "marlin_input_dtype"):
             # Only Marlin kernels support `marlin_input_dtype`; guard to avoid
             # AttributeError if backend selection changes.
-            if hasattr(self.fp8_linear, "marlin_input_dtype"):
-                self.fp8_linear.marlin_input_dtype = self.marlin_input_dtype
-            self.fp8_linear.process_weights_after_loading(layer)
-        else:
-            weight = qweight.t()
-            replace_parameter(layer, "weight", weight.data)
-            self.fp8_linear.process_weights_after_loading(layer)
+            self.fp8_linear.marlin_input_dtype = self.marlin_input_dtype
+        self.fp8_linear.process_weights_after_loading(layer)
 
         # Prevent duplicate processing (e.g., during weight reload)
         layer._already_called_process_weights_after_loading = True


### PR DESCRIPTION
## Summary

Fixes #44110 at the root cause, as an alternative to #44113.

`MarlinFP8ScaledMMLinearKernel.process_weights_after_loading` previously
tried to detect whether its incoming weight was `(N, K)` or `(K, N)` and
transpose accordingly. The shape-based heuristic was a no-op when
`N == K`, silently corrupting square layers. #44113 swaps the heuristic
from shape to `is_contiguous()`, but that just trades one fragile
implicit contract in the kernel for another.

The real issue is that the kernel boundary has no agreed-on layout:
- `CutlassFP8ScaledMMLinearKernel` expects `(K, N)` and does not transpose.
- `ModelOptFp8{,PcPt}LinearMethod` already pre-transposes to `(K, N)`.
- `Fp8LinearMethod` (non-marlin), `Fp8OnlineLinearMethod` (non-marlin) pre-transpose to `(K, N)`.
- `Fp8LinearMethod` (use_marlin) and `CompressedTensorsW8A16Fp8` skip the transpose and let Marlin guess.

This PR makes every FP8 linear caller canonicalize to `(K, N)` before
delegating, and removes the detection heuristic from Marlin entirely.
This is the canonicalization step that the TODO referenced in #33314
was asking for, scoped to the FP8 paths that share this kernel.

### Changes

- `Fp8LinearMethod` (use_marlin, non-block): transpose before delegating.
- `Fp8OnlineLinearMethod`: collapse the marlin/non-marlin branches into a single transpose + delegate.
- `CompressedTensorsW8A16Fp8` (non-block): transpose before delegating.
- `MarlinFP8ScaledMMLinearKernel`: drop the conditional transpose from the non-block branch.

Net diff: 3 files, +11 / -29.

### Why this is preferable to #44113

- Removes the implicit "kernel detects layout from weight metadata" contract entirely.
- Makes the FP8 callers consistent with each other and with the Cutlass kernel's existing expectation.
- The `is_contiguous()` switch in #44113 still breaks if any future caller pre-transposes and then calls `.contiguous()`, or loads a checkpoint that happens to land non-contiguous.

## Test plan

- [x] Square (N==K, 4096×4096) regression case verified end-to-end on A40 (sm_86) with `VLLM_TEST_FORCE_FP8_MARLIN=1`, both the checkpoint-layout path (CompressedTensors-style) and the pre-transposed path (ModelOpt-style). Relative error < 0.005 in all cases.
- [x] Non-square shapes (1024×4096, 4096×12800) verified for both paths.
- [x] `pre-commit run --files` on the changed files — all hooks pass (ruff, mypy, etc.).
- [ ] Existing `tests/quantization/test_fp8.py` and `tests/evals/gsm8k/test_gsm8k_correctness.py` runs in CI.

AI assistance (Claude) was used to draft the change; I (mgoin) reviewed and tested every line.

Co-authored-by: Claude <noreply@anthropic.com>