### PR TITLE
f[Bugfix] Remove erroneous squeeze(-1) from BOSEOSFilter for token_classify

### DIFF
--- a/vllm/model_executor/layers/pooler/special.py
+++ b/vllm/model_executor/layers/pooler/special.py
@@ -191,7 +191,7 @@ class BOSEOSFilter(Pooler):
                 pooled_data = pooled_data[1:]
             if int(token_ids[-1]) == self.eos_token_id:
                 pooled_data = pooled_data[:-1]
-            pooled_outputs[i] = pooled_data.squeeze(-1)
+            pooled_outputs[i] = pooled_data
 
         return pooled_outputs
 


### PR DESCRIPTION
## Summary

Fixes #33873

The `/pooling` endpoint with `task: token_classify` was returning a 400 error for any input that tokenizes to fewer than 4 tokens (e.g. `"Hi"` → `[CLS, Hi, SEP]`).

## Root Cause

`BOSEOSFilter.forward()` in `vllm/model_executor/layers/pooler/special.py` had an erroneous `.squeeze(-1)` call after stripping BOS/EOS tokens.

For BGE-M3's `token_classify` task, the model uses `sparse_linear(hidden_size, 1)`, producing a `[n_tokens, 1]` tensor per sequence. After stripping BOS/EOS from a short input like `"Hi"` (1 content token), the tensor becomes `[1, 1]`. The `.squeeze(-1)` then collapses it to `[1]`, and for a single-token input this ultimately reaches Pydantic as a scalar float — failing all three branches of the `list[list[float]] | list[float] | str` union validator.

## Fix

Remove the `.squeeze(-1)` call. `BOSEOSFilter`'s only responsibility is stripping BOS/EOS tokens along the token dimension (dim 0). It has no business modifying the label dimension.

```python
# Before
pooled_outputs[i] = pooled_data.squeeze(-1)

# After
pooled_outputs[i] = pooled_data
```

## Testing

- Short input `"Hi"` (3 tokens → 1 content token): `[1, 1]` shape preserved → `.tolist()` gives `[[0.28]]` ✅
- Normal input `"Hello world"` (4 tokens → 2 content tokens): `[2, 1]` shape preserved ✅  
- `token_embed` path unaffected (hidden_size >> 1, squeeze was always a no-op there) ✅

## Reproduction

```bash
vllm serve BAAI/bge-m3 \
  --hf-overrides '{"architectures":["BgeM3EmbeddingModel"]}' \
  --gpu-memory-utilization 0.2 \
  --trust-remote-code

curl -s http://localhost:8000/pooling \
  -H "Content-Type: application/json" \
  -d '{"model": "bge-m3", "task": "token_classify", "input": ["Hi"]}'
```