### PR TITLE
[Bugfix] Normalize non-standard message roles from Claude Code CLI >= 2.1.154

### DIFF
--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -68,6 +68,21 @@ class AnthropicMessage(BaseModel):
     role: Literal["user", "assistant", "system"]
     content: str | list[AnthropicContentBlock]
 
+    @field_validator("role", mode="before")
+    @classmethod
+    def normalize_role(cls, v: str) -> str:
+        """Normalize non-standard roles from Claude Code CLI >= 2.1.154.
+
+        Recent versions of Claude Code send roles such as 'ctx' and 'msg'
+        which are not part of the Anthropic spec. We map them to their
+        closest standard equivalent so validation does not fail.
+        """
+        _ROLE_MAP: dict[str, str] = {
+            "ctx": "user",
+            "msg": "user",
+        }
+        return _ROLE_MAP.get(v, v)
+
 
 class AnthropicTool(BaseModel):
     """Tool definition"""


### PR DESCRIPTION
## Summary

Fixes #44000

## Problem

Claude Code CLI >= 2.1.154 sends non-standard message roles (`ctx`, `msg`) inside the Anthropic Messages API messages array. vLLM's `AnthropicMessage` model validates `role` as a strict `Literal["user", "assistant", "system"]`, causing all requests from recent Claude Code versions to fail with a 422 validation error before inference even starts.

## Fix

Add a `field_validator` on `AnthropicMessage.role` that normalizes unknown roles to their closest standard equivalent before Pydantic validation runs:

| Incoming role | Normalized to |
|---|---|
| `ctx` | `user` |
| `msg` | `user` |

Unknown roles not in the map are passed through unchanged, so Pydantic's `Literal` check still catches truly invalid roles.

## Why normalize instead of expanding the Literal?

Expanding the `Literal` would accept `ctx`/`msg` as valid roles downstream, potentially breaking other parts of the codebase that expect only standard roles. Normalizing at the boundary is safer and consistent with how API shims typically handle versioning drift.

## Testing

The fix requires no GPU. To verify locally:

```python
from vllm.entrypoints.anthropic.protocol import AnthropicMessage

# Should normalize to "user"
m = AnthropicMessage(role="ctx", content="hello")
assert m.role == "user"

m = AnthropicMessage(role="msg", content="hello")
assert m.role == "user"

# Standard roles should pass through unchanged
m = AnthropicMessage(role="assistant", content="hello")
assert m.role == "assistant"
```