### PR TITLE
[Opt] Optimize rotary embedding cache length

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/__init__.py
+++ b/vllm/model_executor/layers/rotary_embedding/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Rotary Positional Embeddings."""
 
+import math
 from typing import Any
 
 import torch
@@ -28,6 +29,15 @@ from .xdrope import XDRotaryEmbedding
 from .yarn_scaling_rope import YaRNScalingRotaryEmbedding
 
 _ROPE_DICT: dict[tuple[Any, ...], RotaryEmbedding] = {}
+
+
+def _get_runtime_max_model_len() -> int | None:
+    from vllm.config import get_current_vllm_config_or_none
+
+    vllm_config = get_current_vllm_config_or_none()
+    model_config = getattr(vllm_config, "model_config", None)
+    max_model_len = getattr(model_config, "max_model_len", None)
+    return int(max_model_len) if max_model_len is not None else None
 
 
 def get_rope(
@@ -71,6 +81,35 @@ def get_rope(
             raise ValueError(f"{partial_rotary_factor=} must be between 0.0 and 1.0")
         rotary_dim = int(head_size * partial_rotary_factor)
 
+    runtime_max_model_len = _get_runtime_max_model_len()
+    cache_key_extra = None
+    deepseek_cache_max_position = None
+    # These RoPE variants do not use max_position to compute inv_freq; it only
+    # controls cache length. Variants whose scaling math depends on
+    # max_position are handled separately or left unchanged.
+    can_clamp_max_position = scaling_type in (
+        "default",
+        "proportional",
+        "llama3",
+        "ntk",
+    ) or (scaling_type == "dynamic" and "alpha" in rope_parameters)
+    if scaling_type in ("deepseek_yarn", "deepseek_llama_scaling"):
+        original_max_position = rope_parameters["original_max_position_embeddings"]
+        scaling_factor = rope_parameters["factor"]
+        full_cache_len = math.ceil(float(original_max_position) * float(scaling_factor))
+        deepseek_cache_max_position = full_cache_len
+        if runtime_max_model_len is not None:
+            deepseek_cache_max_position = min(runtime_max_model_len, full_cache_len)
+        cache_key_extra = ("cache_max_position", deepseek_cache_max_position)
+    elif (
+        runtime_max_model_len is not None
+        and dual_chunk_attention_config is None
+        and can_clamp_max_position
+        and not rope_parameters.get("use_fope", False)
+        and max_position > runtime_max_model_len
+    ):
+        max_position = runtime_max_model_len
+
     key = (
         head_size,
         rotary_dim,
@@ -79,6 +118,7 @@ def get_rope(
         rope_parameters_args,
         dual_chunk_attention_args,
         dtype,
+        cache_key_extra,
     )
     if key in _ROPE_DICT:
         return _ROPE_DICT[key]
@@ -310,6 +350,7 @@ def get_rope(
             is_neox_style,
             scaling_factor,
             dtype,
+            cache_max_position=deepseek_cache_max_position,
             **extra_kwargs,
         )
     elif scaling_type == "longrope":

--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -45,6 +45,7 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
         beta_slow: int = 1,
         mscale: float = 1,
         mscale_all_dim: float = 0,
+        cache_max_position: int | None = None,
         init_cache: bool = True,
     ) -> None:
         self.scaling_factor = scaling_factor
@@ -57,6 +58,12 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
             yarn_get_mscale(self.scaling_factor, float(mscale))
             / yarn_get_mscale(self.scaling_factor, float(mscale_all_dim))
             * attn_factor
+        )
+        full_cache_max_position = math.ceil(max_position_embeddings * scaling_factor)
+        self.cache_max_position = (
+            full_cache_max_position
+            if cache_max_position is None
+            else min(cache_max_position, full_cache_max_position)
         )
         self.use_flashinfer = (
             self.enabled()
@@ -108,10 +115,7 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         inv_freq = self._compute_inv_freq(self.scaling_factor)
-        t = torch.arange(
-            self.max_position_embeddings * self.scaling_factor,
-            dtype=torch.float32,
-        )
+        t = torch.arange(self.cache_max_position, dtype=torch.float32)
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
         cos = freqs.cos() * self.mscale
         sin = freqs.sin() * self.mscale
@@ -250,7 +254,7 @@ class DeepseekV4ScalingRotaryEmbedding(DeepseekScalingRotaryEmbedding):
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         inv_freq = self._compute_inv_freq(self.scaling_factor)
         t = torch.arange(
-            self.max_position_embeddings * self.scaling_factor,
+            self.cache_max_position,
             device=inv_freq.device,
             dtype=torch.float32,
         )


### PR DESCRIPTION
## Description

This PR reduces RoPE `sin/cos` cache memory usage when the runtime
`max_model_len` is smaller than the model config's maximum RoPE position.

when vllm server use `--max-model-len 32768`
**DeepSeek-V4 saves 248MB, Qwen3-VL saves 224MB, gemma-4 saves 336MB**

Some recent long-context models define very large `max_position_embeddings`.
Before this change, vLLM precomputed RoPE caches for the full configured length
even when users explicitly ran with a smaller `--max-model-len`. This can waste
a large amount of memory, especially on large models and mixed-attention
architectures where multiple RoPE instances may be created and their
`sin/cos` caches cannot always be reused.

This change clamps the RoPE cache length in `get_rope()` for RoPE variants
where `max_position` only controls cache size and does not affect frequency
computation. DeepSeek YaRN-style RoPE is handled separately: the original max
position is still preserved for scaling math, while only the actual cache length
is limited.

The optimized cache keeps the same valid prefix values as the original full
cache, while avoiding allocation for positions beyond the runtime
`max_model_len`.

## Testing

Ran a remote-config smoke test comparing the optimized cache prefix against the
original full cache use --max-model-len 32768:
[test_remote_rope_configs.py](https://github.com/user-attachments/files/28667583/test_remote_rope_configs.py)
``` python test_remote_rope_configs.py  --compare-prefix  # --max-model-len 32768 as default```

## Test Result
### RoPE cache memory summary

| Model | Case | RoPE type | RoPE class | Dtype | Active dim | Cache len | Memory MiB | Saved | Prefix | Max diff |
|---|---|---|---|---|---:|---:|---:|---:|---|---:|
| deepseek-ai/DeepSeek-V4-Pro | text-compress-ratio-128 | deepseek_yarn | DeepseekV4ScalingRotaryEmbedding | float32 | 64 | 1,048,576 -> 32,768 | 256.00 -> 8.00 | 248.00 (96.9%) | PASS | 0 |
| deepseek-ai/DeepSeek-V3 | text | deepseek_yarn | DeepseekScalingRotaryEmbedding | bfloat16 | 64 | 163,840 -> 32,768 | 20.00 -> 4.00 | 16.00 (80.0%) | PASS | 0 |
| Qwen/Qwen3-VL-2B-Instruct | text | default | MRotaryEmbedding | bfloat16 | 128 | 1,048,576 -> 131,072 | 256.00 -> 32.00 | 224.00 (87.5%) | PASS | 0 |
| Qwen/Qwen3-VL-2B-Instruct | vision | default | RotaryEmbedding | bfloat16 | 32 | 8,192 -> 8,192 | 0.50 -> 0.50 | 0.00 (0.0%) | PASS | 0 |
| LLM-Research/Meta-Llama-3-8B-Instruct | text | default | RotaryEmbedding | bfloat16 | 128 | 8,192 -> 8,192 | 2.00 -> 2.00 | 0.00 (0.0%) | PASS | 0 |
| ZhipuAI/GLM-4.7 | text | default | RotaryEmbedding | bfloat16 | 64 | 202,752 -> 32,768 | 24.75 -> 4.00 | 20.75 (83.8%) | PASS | 0 |
| Tencent-Hunyuan/Hunyuan-MT-7B | text | dynamic | DynamicNTKAlphaRotaryEmbedding | bfloat16 | 128 | 32,768 -> 32,768 | 8.00 -> 8.00 | 0.00 (0.0%) | PASS | 0 |
| google/gemma-4-31B-it | text-sliding_attention | default | RotaryEmbedding | bfloat16 | 256 | 262,144 -> 32,768 | 128.00 -> 16.00 | 112.00 (87.5%) | PASS | 0 |
| google/gemma-4-31B-it | text-full_attention | proportional | Gemma4RotaryEmbedding | bfloat16 | 128 | 262,144 -> 32,768 | 256.00 -> 32.00 | 224.00 (87.5%) | PASS | 0 |
| **Total** | - | - | - | - | - | - | 951.25 -> 106.50 | 844.75 (88.8%) | - | - |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

