### PR TITLE
[Bugfix][Model] GraniteMoE: load FP8_DYNAMIC expert weight_scale tensors

### DIFF
--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -56,6 +56,7 @@ steps:
   - tests/models/test_utils.py
   - tests/models/test_vision.py
   - tests/models/transformers/fusers/
+  - tests/models/test_granitemoe.py
   device: cpu-small
   commands:
-    - pytest -v -s models/test_utils.py models/test_vision.py models/transformers/fusers/
+    - pytest -v -s models/test_utils.py models/test_vision.py models/transformers/fusers/ models/test_granitemoe.py

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -134,8 +134,9 @@ steps:
   - tests/models/test_utils.py
   - tests/models/test_vision.py
   - tests/models/test_adapters.py
+  - tests/models/test_granitemoe.py
   - tests/models/test_qwen3_5_mtp_config.py
   - tests/models/transformers/fusers/
   device: cpu-small
   commands:
-    - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/test_qwen3_5_mtp_config.py models/transformers/fusers/
+    - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/test_granitemoe.py models/test_qwen3_5_mtp_config.py models/transformers/fusers/

--- a/tests/models/test_granitemoe.py
+++ b/tests/models/test_granitemoe.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+
+import pytest
+import torch
+
+from vllm.model_executor.models.granitemoe import GraniteMoeModel
+
+
+class _CapturingLoader:
+    """Captures the rewritten weights ``GraniteMoeModel.load_weights`` emits.
+
+    ``load_weights`` only uses ``self`` for the final ``self._load_weights``
+    call, so this stand-in exercises the real renaming without a full model.
+    """
+
+    def __init__(self) -> None:
+        self.captured: dict[str, torch.Tensor] = {}
+
+    def _load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        self.captured = dict(weights)
+        return set(self.captured)
+
+
+@pytest.mark.cpu_test
+def test_granitemoe_load_weights_routes_fp8_expert_scales():
+    """FP8 expert ``weight_scale`` tensors are split and renamed per expert
+    like the weights, instead of falling through as unknown ``KeyError`` keys.
+    """
+    num_experts, intermediate, hidden = 2, 4, 6
+    prefix = "model.layers.0.block_sparse_moe"
+    weights = [
+        (
+            f"{prefix}.input_linear.weight",
+            torch.zeros(num_experts, 2 * intermediate, hidden),
+        ),
+        (
+            f"{prefix}.input_linear.weight_scale",
+            torch.zeros(num_experts, 2 * intermediate, 1),
+        ),
+        (
+            f"{prefix}.output_linear.weight",
+            torch.zeros(num_experts, hidden, intermediate),
+        ),
+        (
+            f"{prefix}.output_linear.weight_scale",
+            torch.zeros(num_experts, hidden, 1),
+        ),
+    ]
+
+    stub = _CapturingLoader()
+    GraniteMoeModel.load_weights(stub, weights)
+
+    for e in range(num_experts):
+        # New behavior: scales are routed to the per-expert shard slots.
+        assert f"{prefix}.experts.{e}.w1.weight_scale" in stub.captured
+        assert f"{prefix}.experts.{e}.w3.weight_scale" in stub.captured
+        assert f"{prefix}.experts.{e}.w2.weight_scale" in stub.captured
+        # Existing behavior: the plain weights are still routed.
+        assert f"{prefix}.experts.{e}.w1.weight" in stub.captured
+        assert f"{prefix}.experts.{e}.w3.weight" in stub.captured
+        assert f"{prefix}.experts.{e}.w2.weight" in stub.captured
+
+    # The raw fused scale names must not fall through unrewritten.
+    assert f"{prefix}.input_linear.weight_scale" not in stub.captured
+    assert f"{prefix}.output_linear.weight_scale" not in stub.captured

--- a/tests/models/test_granitemoe.py
+++ b/tests/models/test_granitemoe.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the GraniteMoe checkpoint weight name mapping."""
+
+import pytest
+
+from vllm.model_executor.models.granitemoe import GraniteMoeModel
+
+PREFIX = "model.layers.0.block_sparse_moe"
+
+
+def _map(name: str) -> str:
+    return GraniteMoeModel.hf_to_vllm_mapper.apply_list([name])[0]
+
+
+@pytest.mark.cpu_test
+def test_fused_expert_weights_are_mapped():
+    """The fused expert weights keep mapping onto the FusedMoE names."""
+    assert _map(f"{PREFIX}.input_linear.weight") == f"{PREFIX}.experts.gate_up_proj"
+    assert _map(f"{PREFIX}.output_linear.weight") == f"{PREFIX}.experts.down_proj"
+
+
+@pytest.mark.cpu_test
+def test_fused_expert_weight_scales_are_mapped():
+    """FP8 checkpoints pair each fused expert weight with a ``weight_scale``.
+
+    The suffix rules match with ``str.endswith``, so a rule keyed on
+    ``.input_linear.weight`` never matches ``.input_linear.weight_scale``.
+    Without a rule of its own the scale keeps its checkpoint name, which
+    matches no FusedMoE parameter and fails to load.
+
+    ``FusedMoE`` derives the parameter from the ``experts.gate_up_proj`` /
+    ``experts.down_proj`` substring (see ``RoutedExperts.load_weights``), so
+    the ``_scale`` suffix carries through to ``w13_weight_scale`` /
+    ``w2_weight_scale``.
+    """
+    assert (
+        _map(f"{PREFIX}.input_linear.weight_scale")
+        == f"{PREFIX}.experts.gate_up_proj_scale"
+    )
+    assert (
+        _map(f"{PREFIX}.output_linear.weight_scale")
+        == f"{PREFIX}.experts.down_proj_scale"
+    )

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -434,7 +434,11 @@ class GraniteMoeModel(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         new_weights = {}
         for n, p in weights:
-            if n.endswith(".block_sparse_moe.input_linear.weight"):
+            # The renaming and parameter loading logic is the same for weight
+            # and weight_scale tensors so we can reuse them without issues.
+            if n.endswith(".block_sparse_moe.input_linear.weight") or n.endswith(
+                ".block_sparse_moe.input_linear.weight_scale"
+            ):
                 for e in range(p.size(0)):
                     w1_name = n.replace(
                         ".block_sparse_moe.input_linear.weight",
@@ -449,7 +453,9 @@ class GraniteMoeModel(nn.Module):
                     assert w3_name not in new_weights
                     new_weights[w1_name] = w1_param
                     new_weights[w3_name] = w3_param
-            elif n.endswith(".block_sparse_moe.output_linear.weight"):
+            elif n.endswith(".block_sparse_moe.output_linear.weight") or n.endswith(
+                ".block_sparse_moe.output_linear.weight_scale"
+            ):
                 for e in range(p.size(0)):
                     w2_name = n.replace(
                         ".block_sparse_moe.output_linear.weight",

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -307,6 +307,17 @@ class GraniteMoeModel(nn.Module):
             # Legacy names to new names
             "moe.input_linear.weight": "moe.experts.gate_up_proj",
             "moe.output_linear.weight": "moe.experts.down_proj",
+            # Quantized checkpoints pair each fused expert weight with a
+            # scale. The rules above match with str.endswith, so the scales
+            # need rules of their own or they keep their checkpoint names
+            # and match no FusedMoE parameter. Keep the gate_up_proj and
+            # down_proj stems: FusedMoE rewrites those to experts.w13_weight
+            # and experts.w2_weight, so the trailing _scale is what yields
+            # w13_weight_scale and w2_weight_scale. Naming these directly
+            # after the parameters instead matches no entry and is dropped
+            # without an error.
+            "moe.input_linear.weight_scale": "moe.experts.gate_up_proj_scale",
+            "moe.output_linear.weight_scale": "moe.experts.down_proj_scale",
             ".router.layer.weight": ".gate.weight",
             # Checkpoint name to vLLM name
             ".router.weight": ".gate.weight",


### PR DESCRIPTION
## Purpose

Resolves #42463.

`granitemoehybrid.py` already routes the fused expert `weight_scale` tensors into
their `FusedMoE` slots, with the comment that "the renaming and parameter loading
logic is the same for weight and weight_scale tensors". `granitemoe.py` never
picked up the same handling, so the hybrid model can load a legacy-format FP8
GraniteMoE checkpoint and the plain one still cannot.

`GraniteMoeModel` maps the fused `block_sparse_moe.input_linear` / `output_linear`
tensors onto the `FusedMoE` `gate_up_proj` / `down_proj` names, but the suffix
rules are keyed on `.weight` only:

```python
"moe.input_linear.weight": "moe.experts.gate_up_proj",
"moe.output_linear.weight": "moe.experts.down_proj",
```

`orig_to_new_suffix` matches with `str.endswith`, so `.input_linear.weight_scale`
never matches `.input_linear.weight`. The fused scales keep their checkpoint
names, match no `FusedMoE` parameter, and loading fails in `AutoWeightsLoader`:

```
ValueError: There is no module or parameter named
'model.layers.0.block_sparse_moe.input_linear' in GraniteMoeModel.
```

This adds the two matching scale rules. `RoutedExperts.load_weights` resolves the
parameter from the `experts.gate_up_proj` / `experts.down_proj` substring and
rewrites it to `experts.w13_weight` / `experts.w2_weight`, so the trailing
`_scale` carries through to `w13_weight_scale` / `w2_weight_scale`, and the fused
scale is chunked per expert alongside the weight it scales.

The `_scale` spelling is load-bearing, and I left a comment saying so. Naming the
targets `moe.experts.w13_weight_scale` directly looks equivalent but matches no
mapping entry and is dropped without an error, because the
`process_weights_after_loading` whitelist suppresses the missing-parameter guard.
That would give silently wrong numerics rather than a failure.

### Note on this PR's history

This is a pre-existing gap rather than a regression: the hand-written
`load_weights` loop this PR originally patched also matched `.weight` only, and
raised `KeyError` on the same tensors. #52706 replaced that loop with
`AutoWeightsLoader` plus `hf_to_vllm_mapper`, which changed the exception but not
the outcome, and left the original diff with nothing to apply to. This PR is
rebased onto the new code and re-targeted at the mapper, which makes it much
smaller.

### Scope

- `granitemoeshared.py` aliases both `hf_to_vllm_mapper` and `load_weights` from
  `GraniteMoeModel`, so GraniteMoeShared is fixed by the same two rules. The
  earlier version of this PR had to leave it out of scope.
- `granitemoehybrid.py` has its own hand-rolled loader that already routes these
  two names, and is untouched here.
- Scoped to weight scales, matching the issue's `FP8_DYNAMIC` scope. Static
  activation scales (`input_scale`) cannot be expressed through this mapper at
  all: no suffix `X` satisfies `w13_weight + X == w13_input_scale`. Static
  activation FP8 would need a different hook.
- Scoped to the per-channel layout, which is what `FP8_DYNAMIC` means in
  llm-compressor (static per-channel weights, dynamic per-token activations) and
  what the issue asks for. There, `w13_weight_scale` is registered `[E, 2I, 1]`,
  so it carries the expert and gate/up dimensions like the weight and rides the
  same `chunk(2, dim=1)` split. A per-tensor (`TENSOR` strategy) fused scale is
  1-D `[E]`, misses the `dim() == 3` fused branch, and would still fail to load;
  that is a separate case and not addressed here. It is not specific to this
  change either: `granitemoehybrid.py` splits the same fused tensor with
  `p[e].chunk(2, dim=0)`, which cannot unpack a single combined scale.
  Halving a fused gate/up tensor is inherently at odds with one scalar scale
  covering both halves, whichever loader does the splitting.

## Test Plan

New CPU-only regression test `tests/models/test_granitemoe.py`, wired into the
`(CPU) Basic Models Other` step:

```
pytest -v -s models/test_granitemoe.py
```

It asserts the fused expert weights still map to `experts.gate_up_proj` /
`experts.down_proj` (regression guard) and that the paired `weight_scale` tensors
map to `experts.gate_up_proj_scale` / `experts.down_proj_scale`.

## Test Result

Run against this branch's base commit (`5db652225`) with vLLM installed from
source:

- Before the fix, `test_fused_expert_weight_scales_are_mapped` fails:
  `input_linear.weight_scale` maps to itself rather than to
  `experts.gate_up_proj_scale`. The plain-weight test passes, so the failure is
  isolated to the scales.
- After the fix, both tests pass.
- Name resolution checked against the real
  `RoutedExperts.build_expert_params_mapping(..., include_fused=True)`:
  `input_linear.weight_scale` -> `experts.gate_up_proj_scale` ->
  `w13_weight_scale` (shard `w1`), and `output_linear.weight_scale` ->
  `experts.down_proj_scale` -> `w2_weight_scale` (shard `w2`).
- Checked that new-style names (`experts.gate_up_proj`,
  `experts.gate_up_proj_scale`, `experts.w13_weight`), the `router` rules, the
  `q/k/v_proj` stacking and unrelated names are all unaffected by the two new
  rules.
- `ruff check`, `ruff format --check` and `typos` clean.

I do not have a GPU that can host an FP8 GraniteMoE checkpoint, so this is
verified at the weight-name-resolution level rather than by an end-to-end
generation run. Happy to add whatever a reviewer would want to see.


## Note on AI assistance

AI assistance was used to investigate the weight-name resolution path and to draft
this change. I reviewed the analysis and every changed line myself.
