### PR TITLE
[Bugfix] Gracefully shut down GPU workers when engine-core startup times out or is interrupted (#32116)

### DIFF
--- a/tests/v1/shutdown/test_startup_timeout_cleanup.py
+++ b/tests/v1/shutdown/test_startup_timeout_cleanup.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for GH-32116: wait_for_engine_startup() startup deadline.
+
+Two failure modes are addressed by the fix:
+
+Problem A – launcher blocks forever on startup timeout
+    API server workers time out waiting for the engine ready signal
+    (VLLM_ENGINE_READY_TIMEOUT_S), die, but the launcher's
+    wait_for_engine_startup() had no matching deadline so it kept blocking
+    until warmup completed (up to 19 min in the reported case), holding all
+    GPU memory during that window.
+
+Problem B – SIGINT / exception during startup bypasses explicit cleanup
+    Any BaseException propagated through the launch_core_engines() generator
+    (Ctrl-C SystemExit, RuntimeError from engine dying mid-handshake)
+    bypassed the explicit cleanup call to local_engine_manager.shutdown(),
+    falling back to weakref.finalize() with a hardcoded 5 s grace and no
+    logging.
+
+These tests exercise wait_for_engine_startup() in isolation (no GPU, no real
+model).  Integration-level verification (full launch_core_engines() with a
+real subprocess and GPU memory check) is left to manual testing with the
+VLLM_ENGINE_READY_TIMEOUT_S environment variable.
+"""
+
+import multiprocessing as mp
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import zmq
+
+from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.v1.engine.utils import CoreEngine, EngineZmqAddresses, wait_for_engine_startup
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sleep_forever() -> None:
+    """Subprocess target: sleep until killed.
+
+    Stands in for an engine core that is still warming up and has not yet
+    sent its HELLO message on the handshake socket.
+    """
+    time.sleep(3600)
+
+
+def _make_parallel_config(*, local: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        data_parallel_size_local=local,
+        data_parallel_hybrid_lb=False,
+        data_parallel_external_lb=False,
+    )
+
+
+def _make_proc_manager(proc: mp.process.BaseProcess) -> MagicMock:
+    """Return a CoreEngineProcManager mock backed by a real process.
+
+    The real process contributes a working sentinel FD so the ZMQ poller can
+    register it for liveness detection just as production code does.
+    """
+    pm = MagicMock()
+    pm.sentinels.return_value = [proc.sentinel]
+    pm.finished_procs.return_value = {}
+    return pm
+
+
+@pytest.fixture()
+def silent_engine_proc():
+    """A real subprocess that sleeps forever and never sends HELLO."""
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(target=_sleep_forever, daemon=False)
+    proc.start()
+    yield proc
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Problem A: wait_for_engine_startup must respect VLLM_ENGINE_READY_TIMEOUT_S
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_engine_startup_raises_timeout_on_silent_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    silent_engine_proc: "mp.Process",
+) -> None:
+    """wait_for_engine_startup() must raise TimeoutError promptly when
+    VLLM_ENGINE_READY_TIMEOUT_S elapses with no HELLO from the engine.
+
+    Before the fix the function had no overall deadline and would block until
+    the engine finally sent HELLO (potentially minutes), so this test would
+    hang forever on unpatched code.
+    """
+    timeout_s = 2
+    monkeypatch.setattr(
+        "vllm.v1.engine.utils.envs.VLLM_ENGINE_READY_TIMEOUT_S",
+        timeout_s,
+    )
+
+    ipc_addr = get_open_zmq_ipc_path()
+    addresses = EngineZmqAddresses(inputs=["unused"], outputs=["unused"])
+    parallel_config = _make_parallel_config(local=1)
+    proc_manager = _make_proc_manager(silent_engine_proc)
+    engine = CoreEngine(index=0, local=True)
+
+    start = time.monotonic()
+    with (
+        zmq_socket_ctx(ipc_addr, zmq.ROUTER, bind=True) as sock,
+        pytest.raises(TimeoutError),
+    ):
+        wait_for_engine_startup(
+            sock,
+            addresses,
+            [engine],
+            parallel_config,
+            coordinated_dp=False,
+            cache_config=MagicMock(),
+            proc_manager=proc_manager,
+            coord_process=None,
+        )
+    elapsed = time.monotonic() - start
+
+    # Must fire close to the deadline:
+    #   lower bound: >= 90% of the budget (not spuriously early)
+    #   upper bound: <  3× the budget (not stuck for a whole extra poll cycle)
+    assert elapsed >= timeout_s * 0.9, (
+        f"TimeoutError fired too early: {elapsed:.2f}s "
+        f"(expected >= {timeout_s * 0.9:.2f}s)"
+    )
+    assert elapsed < timeout_s * 3, (
+        f"wait_for_engine_startup blocked for {elapsed:.2f}s; "
+        f"expected < {timeout_s * 3:.2f}s — deadline logic may be missing"
+    )
+
+
+def test_wait_for_engine_startup_timeout_message_is_informative(
+    monkeypatch: pytest.MonkeyPatch,
+    silent_engine_proc: "mp.Process",
+) -> None:
+    """The TimeoutError message must mention the env var so users know how
+    to extend the timeout for large models."""
+    monkeypatch.setattr(
+        "vllm.v1.engine.utils.envs.VLLM_ENGINE_READY_TIMEOUT_S",
+        1,
+    )
+    ipc_addr = get_open_zmq_ipc_path()
+    addresses = EngineZmqAddresses(inputs=["unused"], outputs=["unused"])
+    engine = CoreEngine(index=0, local=True)
+
+    with (
+        zmq_socket_ctx(ipc_addr, zmq.ROUTER, bind=True) as sock,
+        pytest.raises(TimeoutError, match="VLLM_ENGINE_READY_TIMEOUT_S"),
+    ):
+        wait_for_engine_startup(
+            sock,
+            addresses,
+            [engine],
+            _make_parallel_config(local=1),
+            coordinated_dp=False,
+            cache_config=MagicMock(),
+            proc_manager=_make_proc_manager(silent_engine_proc),
+            coord_process=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy path regression: fix must not break normal startup
+# ---------------------------------------------------------------------------
+
+
+def _fake_engine_handshake(ipc_addr: str, identity: bytes) -> None:
+    """Simulate the two-step HELLO/READY handshake an engine performs on the
+    launcher's ROUTER socket.  Runs in a subprocess."""
+    import msgspec
+    import zmq as _zmq
+
+    ctx = _zmq.Context.instance()
+    sock = ctx.socket(_zmq.DEALER)
+    sock.identity = identity
+    try:
+        sock.connect(ipc_addr)
+        sock.send(
+            msgspec.msgpack.encode(
+                {"status": "HELLO", "local": True, "headless": False}
+            )
+        )
+        sock.recv()  # wait for init reply from launcher
+        sock.send(
+            msgspec.msgpack.encode(
+                {"status": "READY", "local": True, "headless": False}
+            )
+        )
+        time.sleep(1)  # keep alive until launcher drains the event
+    finally:
+        sock.close(linger=0)
+        ctx.term()
+
+
+def test_wait_for_engine_startup_succeeds_on_hello_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """wait_for_engine_startup() must return normally when the engine
+    completes the HELLO/READY handshake within the timeout budget."""
+    monkeypatch.setattr(
+        "vllm.v1.engine.utils.envs.VLLM_ENGINE_READY_TIMEOUT_S",
+        10,
+    )
+
+    ipc_addr = get_open_zmq_ipc_path()
+    addresses = EngineZmqAddresses(inputs=["unused"], outputs=["unused"])
+    engine = CoreEngine(index=0, local=True)
+    identity = engine.identity
+
+    ctx_mp = mp.get_context("fork")
+    engine_proc = ctx_mp.Process(
+        target=_fake_engine_handshake,
+        args=(ipc_addr, identity),
+        daemon=True,
+    )
+    engine_proc.start()
+    try:
+        proc_manager = _make_proc_manager(engine_proc)
+        with zmq_socket_ctx(ipc_addr, zmq.ROUTER, bind=True) as sock:
+            # Must complete without raising.
+            wait_for_engine_startup(
+                sock,
+                addresses,
+                [engine],
+                _make_parallel_config(local=1),
+                coordinated_dp=False,
+                cache_config=MagicMock(),
+                proc_manager=proc_manager,
+                coord_process=None,
+            )
+    finally:
+        engine_proc.kill()
+        engine_proc.join(timeout=5)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -979,9 +979,22 @@ class EngineCoreProc(EngineCore):
             # its worker subprocesses are terminated instead of surviving as
             # orphans that keep holding GPU memory. Cleanup during the executor's
             # own construction is handled by MultiprocExecutor.__init__.
+            #
+            # We deliberately call ``model_executor.shutdown()`` directly rather
+            # than ``self.shutdown()``: the latter touches
+            # ``self.structured_output_manager`` / ``self.scheduler`` (created
+            # only AFTER the long warmup) and would raise AttributeError on a
+            # half-built engine. The executor is bound before warmup, so this is
+            # always safe and is the part that owns the GPU worker subprocesses.
             executor = getattr(self, "model_executor", None)
             if executor is not None:
-                executor.shutdown()
+                try:
+                    executor.shutdown()
+                except Exception:
+                    # Never let a teardown error mask the original interruption.
+                    logger.exception(
+                        "Error shutting down executor during startup abort"
+                    )
             raise
 
     @contextmanager

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -893,84 +893,96 @@ class EngineCoreProc(EngineCore):
             self.tensor_ipc_receiver = TensorIpcReceiver(tensor_queue)
             logger.info("Using tensor IPC queue for multimodal tensor sharing")
 
-        with self._perform_handshakes(
-            handshake_address,
-            identity,
-            local_client,
-            vllm_config,
-            client_handshake_address,
-        ) as addresses:
-            # Set up data parallel environment.
-            self.has_coordinator = addresses.coordinator_output is not None
-            self.frontend_stats_publish_address = (
-                addresses.frontend_stats_publish_address
-            )
-            logger.debug(
-                "Has DP Coordinator: %s, stats publish address: %s",
-                self.has_coordinator,
-                self.frontend_stats_publish_address,
-            )
-            internal_dp_balancing = (
-                self.has_coordinator
-                and not vllm_config.parallel_config.data_parallel_external_lb
-            )
-            # Only publish request queue stats to coordinator for "internal"
-            # and "hybrid" LB modes.
-            self.publish_dp_lb_stats = internal_dp_balancing
-
-            self.addresses = addresses
-            self.process_input_queue_block = True
-            if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
-                self._eep_send_engine_core_notification(
-                    EEPNotificationType.NEW_CORE_ENGINES_INIT_READY,
-                    vllm_config=vllm_config,
-                )
-            self._init_data_parallel(vllm_config)
-
-            super().__init__(
+        try:
+            with self._perform_handshakes(
+                handshake_address,
+                identity,
+                local_client,
                 vllm_config,
-                executor_class,
-                log_stats,
-                executor_fail_callback,
-                internal_dp_balancing,
-            )
+                client_handshake_address,
+            ) as addresses:
+                # Set up data parallel environment.
+                self.has_coordinator = addresses.coordinator_output is not None
+                self.frontend_stats_publish_address = (
+                    addresses.frontend_stats_publish_address
+                )
+                logger.debug(
+                    "Has DP Coordinator: %s, stats publish address: %s",
+                    self.has_coordinator,
+                    self.frontend_stats_publish_address,
+                )
+                internal_dp_balancing = (
+                    self.has_coordinator
+                    and not vllm_config.parallel_config.data_parallel_external_lb
+                )
+                # Only publish request queue stats to coordinator for "internal"
+                # and "hybrid" LB modes.
+                self.publish_dp_lb_stats = internal_dp_balancing
 
-            # Background Threads and Queues for IO. These enable us to
-            # overlap ZMQ socket IO with GPU since they release the GIL,
-            # and to overlap some serialization/deserialization with the
-            # model forward pass.
-            # Threads handle Socket <-> Queues and core_busy_loop uses Queue.
-            ready_event = threading.Event()
-            input_thread = threading.Thread(
-                target=self.process_input_sockets,
-                args=(
-                    addresses.inputs,
-                    addresses.coordinator_input,
-                    identity,
-                    ready_event,
-                ),
-                daemon=True,
-            )
-            input_thread.start()
+                self.addresses = addresses
+                self.process_input_queue_block = True
+                if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+                    self._eep_send_engine_core_notification(
+                        EEPNotificationType.NEW_CORE_ENGINES_INIT_READY,
+                        vllm_config=vllm_config,
+                    )
+                self._init_data_parallel(vllm_config)
 
-            self.output_thread = threading.Thread(
-                target=self.process_output_sockets,
-                args=(
-                    addresses.outputs,
-                    addresses.coordinator_output,
-                    self.engine_index,
-                ),
-                daemon=True,
-            )
-            self.output_thread.start()
+                super().__init__(
+                    vllm_config,
+                    executor_class,
+                    log_stats,
+                    executor_fail_callback,
+                    internal_dp_balancing,
+                )
 
-            # Don't complete handshake until DP coordinator ready message is
-            # received.
-            while not ready_event.wait(timeout=10):
-                if not input_thread.is_alive():
-                    raise RuntimeError("Input socket thread died during startup")
-                assert addresses.coordinator_input is not None
-                logger.info("Waiting for READY message from DP Coordinator...")
+                # Background Threads and Queues for IO. These enable us to
+                # overlap ZMQ socket IO with GPU since they release the GIL,
+                # and to overlap some serialization/deserialization with the
+                # model forward pass.
+                # Threads handle Socket <-> Queues and core_busy_loop uses Queue.
+                ready_event = threading.Event()
+                input_thread = threading.Thread(
+                    target=self.process_input_sockets,
+                    args=(
+                        addresses.inputs,
+                        addresses.coordinator_input,
+                        identity,
+                        ready_event,
+                    ),
+                    daemon=True,
+                )
+                input_thread.start()
+
+                self.output_thread = threading.Thread(
+                    target=self.process_output_sockets,
+                    args=(
+                        addresses.outputs,
+                        addresses.coordinator_output,
+                        self.engine_index,
+                    ),
+                    daemon=True,
+                )
+                self.output_thread.start()
+
+                # Don't complete handshake until DP coordinator ready message is
+                # received.
+                while not ready_event.wait(timeout=10):
+                    if not input_thread.is_alive():
+                        raise RuntimeError("Input socket thread died during startup")
+                    assert addresses.coordinator_input is not None
+                    logger.info("Waiting for READY message from DP Coordinator...")
+        except BaseException:
+            # If construction is interrupted after the executor was created --
+            # e.g. a SIGTERM during model load / warmup, which run_engine_core's
+            # signal handler turns into SystemExit -- shut the executor down so
+            # its worker subprocesses are terminated instead of surviving as
+            # orphans that keep holding GPU memory. Cleanup during the executor's
+            # own construction is handled by MultiprocExecutor.__init__.
+            executor = getattr(self, "model_executor", None)
+            if executor is not None:
+                executor.shutdown()
+            raise
 
     @contextmanager
     def _perform_handshakes(
@@ -1150,6 +1162,48 @@ class EngineCoreProc(EngineCore):
                 )
 
             parallel_config.data_parallel_index = dp_rank
+
+            # Install signal handlers BEFORE constructing the engine. If a
+            # SIGTERM/SIGINT arrives during model loading or warmup -- before
+            # the engine object and its graceful-wakeup machinery exist -- the
+            # handler raises SystemExit so that construction unwinds and the
+            # executor's worker processes are torn down (see EngineCoreProc
+            # __init__). Otherwise the process would be killed by the default
+            # signal disposition with its worker subprocesses left running and
+            # holding GPU memory as orphans.
+            #
+            # ``startup_shutdown_requested`` guards against repeated signals
+            # (e.g. Kubernetes resending SIGTERM, or impatient Ctrl-C) during
+            # the startup-abort window: a second SystemExit would otherwise
+            # interrupt the in-flight executor.shutdown() teardown and orphan
+            # workers anyway.
+            startup_shutdown_requested = False
+
+            def signal_handler(signum, frame):
+                nonlocal startup_shutdown_requested
+                signal_name = signal.Signals(signum).name
+                if engine_core is None or signal_callback is None:
+                    if startup_shutdown_requested:
+                        # Already aborting; ignore so executor.shutdown() can
+                        # complete without being reinterrupted.
+                        return
+                    startup_shutdown_requested = True
+                    logger.info(
+                        "[shutdown] EngineCore: received signal=%s during "
+                        "startup; aborting initialization.",
+                        signal_name,
+                    )
+                    raise SystemExit()
+                logger.info(
+                    "[shutdown] EngineCore: trigger received signal=%s",
+                    signal_name,
+                )
+                engine_core.shutdown_state = EngineShutdownState.REQUESTED
+                signal_callback.trigger()
+
+            signal.signal(signal.SIGTERM, signal_handler)
+            signal.signal(signal.SIGINT, signal_handler)
+
             if data_parallel and vllm_config.model_config.is_moe:
                 # Set data parallel rank for this engine process.
                 parallel_config.data_parallel_rank = dp_rank
@@ -1172,18 +1226,6 @@ class EngineCoreProc(EngineCore):
                 engine_core.input_queue.put_nowait((EngineCoreRequestType.WAKEUP, None))
 
             signal_callback = SignalCallback(wakeup_engine)
-
-            def signal_handler(signum, frame):
-                signal_name = signal.Signals(signum).name
-                logger.info(
-                    "[shutdown] EngineCore: trigger received signal=%s",
-                    signal_name,
-                )
-                engine_core.shutdown_state = EngineShutdownState.REQUESTED
-                signal_callback.trigger()
-
-            signal.signal(signal.SIGTERM, signal_handler)
-            signal.signal(signal.SIGINT, signal_handler)
 
             engine_core.run_busy_loop()
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1212,13 +1212,21 @@ def launch_core_engines(
                 "Engine core startup failed; shutting down engine "
                 "processes to release GPU memory."
             )
-            # Grace period MUST exceed MultiprocExecutor._ensure_worker_termination's
-            # worst case (4 s wait + SIGTERM + 4 s wait + SIGKILL ~= 8 s). Otherwise
-            # the launcher will SIGKILL the engine core process mid-teardown,
-            # cutting off the worker-subprocess SIGKILL step and orphaning GPU
-            # workers we are trying to reap. 15 s gives the engine core enough
-            # time to finish its escalating teardown plus modest overhead.
-            STARTUP_SHUTDOWN_GRACE_S = 15.0
+            # Generous upper bound, not a precise budget.
+            #
+            # ``shutdown(procs, timeout)`` internally calls ``proc.terminate()``
+            # followed by ``proc.join(remaining)`` and finally
+            # ``kill_process_tree()`` for any survivor. The ``join`` short-
+            # circuits the instant the engine core process actually exits, so
+            # in the common case this returns in seconds; the timeout only
+            # fires if an engine core is genuinely hung.
+            #
+            # We intentionally do NOT match this to MultiprocExecutor's
+            # current escalating-teardown durations (4 s + SIGTERM + 4 s ~=
+            # 8 s). Picking a tight margin like 15 s would silently break if
+            # those internal waits ever changed. 60 s comfortably exceeds
+            # any plausible teardown while still bounding pathological hangs.
+            STARTUP_SHUTDOWN_GRACE_S = 60.0
             if local_engine_manager is not None:
                 try:
                     local_engine_manager.shutdown(timeout=STARTUP_SHUTDOWN_GRACE_S)

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1212,14 +1212,21 @@ def launch_core_engines(
                 "Engine core startup failed; shutting down engine "
                 "processes to release GPU memory."
             )
+            # Grace period MUST exceed MultiprocExecutor._ensure_worker_termination's
+            # worst case (4 s wait + SIGTERM + 4 s wait + SIGKILL ~= 8 s). Otherwise
+            # the launcher will SIGKILL the engine core process mid-teardown,
+            # cutting off the worker-subprocess SIGKILL step and orphaning GPU
+            # workers we are trying to reap. 15 s gives the engine core enough
+            # time to finish its escalating teardown plus modest overhead.
+            STARTUP_SHUTDOWN_GRACE_S = 15.0
             if local_engine_manager is not None:
                 try:
-                    local_engine_manager.shutdown()
+                    local_engine_manager.shutdown(timeout=STARTUP_SHUTDOWN_GRACE_S)
                 except Exception:
                     logger.exception("Error while shutting down engine cores")
             if coordinator is not None:
                 try:
-                    coordinator.shutdown()
+                    coordinator.shutdown(timeout=STARTUP_SHUTDOWN_GRACE_S)
                 except Exception:
                     logger.exception("Error while shutting down DP coordinator")
             raise

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -4,6 +4,7 @@
 import contextlib
 import os
 import threading
+import time
 import weakref
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -1184,19 +1185,44 @@ def launch_core_engines(
         else:
             local_engine_manager = None
 
-        yield local_engine_manager, coordinator, addresses, tensor_queue
+        try:
+            yield local_engine_manager, coordinator, addresses, tensor_queue
 
-        # Now wait for engines to start.
-        wait_for_engine_startup(
-            handshake_socket,
-            addresses,
-            engines_to_handshake,
-            parallel_config,
-            dp_size > 1 and vllm_config.model_config.is_moe,
-            vllm_config.cache_config,
-            local_engine_manager,
-            coordinator.proc if coordinator else None,
-        )
+            # Now wait for engines to start.
+            wait_for_engine_startup(
+                handshake_socket,
+                addresses,
+                engines_to_handshake,
+                parallel_config,
+                dp_size > 1 and vllm_config.model_config.is_moe,
+                vllm_config.cache_config,
+                local_engine_manager,
+                coordinator.proc if coordinator else None,
+            )
+        except BaseException:
+            # Explicit cleanup on any failure path so the layer that
+            # created the engine cores is the one that tears them down.
+            # This covers: TimeoutError from wait_for_engine_startup,
+            # SystemExit from SIGINT/SIGTERM during startup, RuntimeError
+            # from an engine dying mid-handshake, and any exception raised
+            # inside the `with` block by the caller.
+            # Without this, cleanup falls to a weakref.finalize safety net
+            # with a hardcoded 5 s grace and no log output.
+            logger.info(
+                "Engine core startup failed; shutting down engine "
+                "processes to release GPU memory."
+            )
+            if local_engine_manager is not None:
+                try:
+                    local_engine_manager.shutdown()
+                except Exception:
+                    logger.exception("Error while shutting down engine cores")
+            if coordinator is not None:
+                try:
+                    coordinator.shutdown()
+                except Exception:
+                    logger.exception("Error while shutting down DP coordinator")
+            raise
 
 
 def wait_for_engine_startup(
@@ -1227,9 +1253,23 @@ def wait_for_engine_startup(
             poller.register(sentinel, zmq.POLLIN)
     if coord_process is not None:
         poller.register(coord_process.sentinel, zmq.POLLIN)
+
+    deadline = time.monotonic() + envs.VLLM_ENGINE_READY_TIMEOUT_S
     while any(conn_pending) or any(start_pending):
-        events = poller.poll(STARTUP_POLL_PERIOD_MS)
+        # Cap poll timeout to remaining budget so the deadline fires
+        # promptly rather than after a full STARTUP_POLL_PERIOD_MS lag.
+        remaining_ms = int((deadline - time.monotonic()) * 1000)
+        events = poller.poll(min(STARTUP_POLL_PERIOD_MS, max(remaining_ms, 0)))
         if not events:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Engine core(s) did not complete startup within "
+                    f"{envs.VLLM_ENGINE_READY_TIMEOUT_S}s "
+                    f"(VLLM_ENGINE_READY_TIMEOUT_S). This is often caused "
+                    f"by slow model weight loading or long warmup steps "
+                    f"(e.g. deep_gemm). To allow a longer startup window "
+                    f"set VLLM_ENGINE_READY_TIMEOUT_S=<seconds>."
+                )
             if any(conn_pending):
                 logger.debug(
                     "Waiting for %d local, %d remote core engine proc(s) to connect.",


### PR DESCRIPTION
Fixes #32116

## [WIP][NOT YET READY FOR REVIEW] Summary

This PR fixes **two** related problems that leave GPU memory locked when engine
core startup does not finish within `VLLM_ENGINE_READY_TIMEOUT_S`:

1. **The reported bug (#32116).** When engine-core warmup (e.g. DeepGEMM / KV
   cache init / `torch.compile`) takes longer than the API servers'
   `VLLM_ENGINE_READY_TIMEOUT_S`, the API servers raise `TimeoutError` and exit,
   but the launcher keeps blocking in `wait_for_engine_startup()` (no deadline)
   for the **entire remaining warmup**. The engine cores and their GPU worker
   subprocesses keep holding VRAM the whole time, and the user cannot restart
   vLLM because the GPUs are still locked.

2. **Orphaned GPU workers (surfaced while fixing #1).** The obvious fix —
   give the launcher its own deadline and call `shutdown()` on the engine cores —
   is **not enough on its own**: that `shutdown()` SIGTERMs the engine-core
   processes *during warmup*, before each engine core has installed its
   SIGTERM handler. The default disposition hard-kills the engine core, and its
   GPU `VLLM::Worker` subprocesses are reparented to PID 1 and **keep holding
   GPU memory as orphans**. The same orphaning happens on a manual `Ctrl-C`
   during warmup.

Both are fixed by routing the abort through vLLM's existing, tested executor
teardown instead of letting the process be hard-killed mid-warmup.

## Root cause

- `wait_for_engine_startup()` had no overall deadline, so the launcher blocked
  for the full warmup after the API servers had already died (Problem 1).
- In `run_engine_core()`, the engine core's SIGTERM/SIGINT handler is installed
  **after** `EngineCoreProc(...)` returns — i.e. *after* warmup. The whole
  warmup (`super().__init__()` → `EngineCore.__init__` → `_initialize_kv_caches`
  → `model_executor`) runs with the **default** signal disposition. A SIGTERM in
  that window hard-kills the process; no `finally`/`except` runs, so
  `model_executor.shutdown()` is never called and the worker subprocesses
  (which actually hold the GPU) orphan (Problem 2).

## The fix

Three changes, in `vllm/v1/engine/core.py` and `vllm/v1/engine/utils.py`:

1. **`wait_for_engine_startup()` deadline + cleanup** (`utils.py`): bound the
   launcher's wait by `VLLM_ENGINE_READY_TIMEOUT_S` and, on timeout, raise so the
   `launch_core_engines()` context manager tears the engine cores down instead of
   blocking for the whole warmup. (Fixes Problem 1.)

2. **Early, dual-mode signal handler** (`core.py::run_engine_core`): install the
   SIGTERM/SIGINT handler **before** constructing the engine. During startup
   (engine object not built yet) it raises `SystemExit` so construction unwinds;
   after startup it takes the existing graceful path unchanged. An idempotency
   flag (`startup_shutdown_requested`) ignores repeated signals (k8s resending
   SIGTERM, double-Ctrl-C) so an in-flight teardown is not re-interrupted.

3. **Executor teardown on interrupted construction**
   (`core.py::EngineCoreProc.__init__`): wrap the whole construction in
   `try/except BaseException` and call `model_executor.shutdown()` so the
   executor's existing escalating teardown (4 s grace → SIGTERM workers → 4 s →
   SIGKILL workers) reaps the GPU worker subprocesses. (Fixes Problem 2.)
   - We call `model_executor.shutdown()` directly (not `self.shutdown()`):
     `self.shutdown()` touches `structured_output_manager`/`scheduler`, which are
     built *after* warmup, so it would `AttributeError` on a half-built engine.
   - In `launch_core_engines()` the startup-failure `shutdown()` is given a
     generous 60 s join-cap so the launcher does not SIGKILL the engine core
     mid-teardown (the executor's worst case is ~8 s). `proc.join()` short-
     circuits the moment the engine core exits, so the common case still returns
     in seconds.

No new teardown primitive is introduced — `MultiprocExecutor.shutdown()` is the
same call used on every normal shutdown and is idempotent via its internal
`shutting_down` flag.

## Before / after evidence

Hardware: 2× NVIDIA L40S (46 GB), `Qwen/Qwen3-30B-A3B`, `--enable-expert-parallel
--data-parallel-size 2 --api-server-count 2`. Each worker loads ~30 GB of weights
in a few seconds, then warms up (compile + KV cache + CUDA-graph capture); full
warmup ≈ 70–150 s and the engine is not READY until then. To make the timeout
land *during* warmup *after* weights are loaded (the ticket's scenario — warmup
exceeds the timeout) on this fast box, the runs below use
`VLLM_ENGINE_READY_TIMEOUT_S=30`. The reported DeepGEMM case hits the same
condition against the 600 s default (19-min warmup). The orphaned workers below
hold **~40 GB each — the loaded model weights**, exactly as reported.

(Note: this particular host hangs in NCCL `world_size=2` init before loading any
weights; `NCCL_P2P_DISABLE=1 NCCL_IB_DISABLE=1 NCCL_SHM_DISABLE=1` was needed so
the workers actually load the model. That is unrelated to the bug/fix under test.)

### Problem 1 — unpatched `main`: launcher blocks holding the loaded model after the API servers die

Weights loaded ~31 GB by T=30 s; the API servers timed out and exited at **T=50 s**;
the launcher then **kept blocking in `wait_for_engine_startup()`** (no deadline),
holding **32 → 40 GB**, until warmup finished at T=110 s:
```
[T=30s] engines=2 workers=2 gpu_mib=[31253,31253]   # weights loaded
[T=50s] >>> API workers timed out (TimeoutError)
[T=50s] engines=2 workers=2 gpu_mib=[32057,32057]   # launcher keeps blocking, GPU held
[T=90s] engines=2 workers=2 gpu_mib=[40927,40929]
[T=110s] launcher EXITED
```
GPU held **60 s after the API servers were already dead** (`GPU_held_after_api_death = 60s`).
In the reported DeepGEMM case this window is ~19 min, during which the GPUs are
locked and the user cannot restart.

### Problem 2 (automatic) — deadline-only fix (`e112c1163`): no hang, but orphans ~40 GB

Adding only the deadline (`wait_for_engine_startup` timeout + `shutdown()`) fixes
the hang — the launcher self-aborts at **T=50 s** — **but hard-kills the engine
cores mid-warmup and orphans their GPU workers, each still holding ~40 GB**:
```
[T=40s] engines=2 workers=2 gpu_mib=[32173,32323]
[T=50s] launcher EXITED
log: TimeoutError: Engine core(s) did not complete startup within 30s (VLLM_ENGINE_READY_TIMEOUT_S)...
orphaned procs:
  34472  1  VLLM::Worker_DP1_EP1
  34475  1  VLLM::Worker_DP0_EP0
GPU now: 0, 40715 MiB / 1, 40717 MiB     # ~40 GB leaked by orphaned workers
```
This is why a deadline alone is insufficient and the graceful teardown is needed.

### After — this PR (`813633441`), automatic timeout: fast exit, no orphans, GPU freed

```
[T=40s] engines=2 workers=2 gpu_mib=[32511,32513]
[T=50s] >>> API workers timed out (TimeoutError)
[T=60s] launcher EXITED
orphaned procs: (none)
GPU now: 0, 0 MiB / 1, 0 MiB
log (the early handler fires DURING warmup → executor reaps the workers):
  [shutdown] EngineCore: received signal=SIGTERM during startup; aborting initialization.
  [shutdown] Executor: waiting for worker exit count=1
  [shutdown] Executor: workers still running after grace period; sending SIGTERM count=1
  [shutdown] Executor: workers still running after SIGTERM; sending SIGKILL count=1
  (the SIGKILL interrupts in-progress "Capturing CUDA graphs ..." — i.e. mid-warmup)
```

### After — this PR (`813633441`), manual Ctrl-C during warmup: no orphans, GPU freed

SIGINT sent at **T=40 s** (mid-warmup, weights loaded):
```
[T=40s] >>> sending SIGINT to launcher (simulating Ctrl-C / killer)
[T=40s] engines=2 workers=2 gpu_mib=[32323,31873]
[T=50s] launcher EXITED
orphaned procs: (none)
GPU now: 0, 0 MiB / 1, 0 MiB
log: [shutdown] EngineCore: received signal=SIGTERM during startup ... Executor: ... SIGKILL
```

### Summary table

| | blocks holding GPU after API die | orphaned workers, auto timeout | orphaned workers, Ctrl-C | GPU after exit |
|---|---|---|---|---|
| unpatched `main` | **yes (60 s here; ~19 min w/ DeepGEMM)** | n/a (blocks) | **yes** | held |
| deadline-only (`e112c1163`) | no | **yes (~40 GB)** | **yes** | **~40 GB leaked** |
| **this PR** | **no** | **no** | **no** | **0 MiB** |

## Test plan

- New unit tests in `tests/v1/shutdown/test_startup_timeout_cleanup.py` for the
  `wait_for_engine_startup()` deadline:
  ```
  .venv/bin/python -m pytest tests/v1/shutdown/test_startup_timeout_cleanup.py -v
  # 3 passed
  ```
- Linters (as CI runs them): `pre-commit run --files vllm/v1/engine/core.py
  vllm/v1/engine/utils.py tests/v1/shutdown/test_startup_timeout_cleanup.py` —
  ruff check, ruff format, and mypy all pass.
- Integration on 2× L40S (traces above): four scenarios run back-to-back —
  unpatched (Problem 1), deadline-only (Problem 2: 2 workers orphaned holding
  ~40 GB), this PR auto-timeout, this PR manual-Ctrl-C. The two "before" states
  reproduce both problems (including the **~40 GB GPU leak** by orphaned
  `VLLM::Worker` processes with PPID 1); this PR resolves both — **no orphaned
  processes and GPU back to 0 MiB** on both the automatic-timeout and the
  manual-Ctrl-C paths.
- No-regression / happy path (same 2× L40S, same config, generous
  `VLLM_ENGINE_READY_TIMEOUT_S=600` so warmup completes): the server starts
  normally with the early signal handler installed (GPU 0 → 41.7 GB, `/health`
  200 at ~T=100s), answers a real `/v1/completions` request
  (`"The capital of France is"` → `" Paris..."`), and on Ctrl-C shuts down
  cleanly — **no orphaned processes, GPU back to 0 MiB**. The new handler does
  not affect normal startup or serving.

## Non-duplication

This is the only PR addressing #32116. It started as the launcher-side deadline +
cleanup (the first commit), which fixes the hang but — as the `s2` trace above
shows — still orphans the GPU workers; the follow-up commits add the graceful
engine-core teardown that fixes that.

I also prototyped an alternative launcher-side approach that reaped orphaned
workers by capturing their child PIDs and SIGKILLing any survivors after the
engine core died. I did not pursue it: it would touch the shared `shutdown()`
used by the API-server and coordinator managers and force-kill workers from
outside their own executor. The approach here is lower-risk — it routes the abort
through the engine core's **own** `MultiprocExecutor.shutdown()` (the same
coordinated teardown used on every normal shutdown) and changes no shared code
path.

## AI assistance

This change was developed with AI assistance (Claude). I (the submitter) have
reviewed every changed line, ran the unit tests and linters, and ran the
integration reproductions on real 2×L40S hardware as shown above.
