### PR TITLE
[Bug] Fix gemma4_tool_parser not stripping STRING_DELIM from dict keys

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -155,6 +155,13 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args("left:108.,right:22.8", partial=False)
         assert result == {"left": 108.0, "right": 22.8}
 
+    def test_string_delimited_dict_keys(self):
+        """Keys wrapped in STRING_DELIM must be stripped (issue #44715)."""
+        result = _parse_gemma4_args(
+            'record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}'
+        )
+        assert result == {"record_map": {"3": "new text"}}
+
     @pytest.mark.timeout(5)
     def test_malformed_partial_array(self):
         result = _parse_gemma4_args(":[t:[]")

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -115,13 +115,17 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
         if i >= n:
             break
 
-        # Parse key (unquoted, ends at ':')
+        # Parse key (usually unquoted, ends at ':')
+        # The model may wrap keys in STRING_DELIM when the schema
+        # declares a string-keyed dict (e.g. <|"|>3<|"|>:...).
         key_start = i
         while i < n and args_str[i] != ":":
             i += 1
         if i >= n:
             break
         key = args_str[key_start:i].strip()
+        if key.startswith(STRING_DELIM) and key.endswith(STRING_DELIM):
+            key = key[len(STRING_DELIM) : -len(STRING_DELIM)]
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
## Summary

Fixes #44715.

`_parse_gemma4_args()` strips `<|"|>` delimiters from dict **values** but not from dict **keys**. When the model emits a string-keyed dict (e.g. `<|"|>3<|"|>:<|"|>new text<|"|>`), the key is returned verbatim as `<|"|>3<|"|>` instead of `3`. This breaks any tool whose schema accepts a dict-typed argument.

**Root cause**: the key parser (lines 118–125) scans raw bytes up to `:` with no delimiter awareness, unlike the value parser which explicitly recognizes and strips `STRING_DELIM`.

**Fix**: add a 2-line check after key extraction to strip `<|"|>` when the key is wrapped in it.

## Test plan

- Added a unit test reproducing the exact scenario from the issue (`record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}`)
- Verified existing tests still pass (bare keys, nested dicts, mixed types all unaffected)

## AI disclosure

This PR was developed with AI assistance (Claude). All changes have been reviewed and understood by the submitter.

## Duplicate-work check

```
gh pr list --repo vllm-project/vllm --state open --search "44715 in:body"  # no results
gh pr list --repo vllm-project/vllm --state open --search "gemma4 dict key"  # no results
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)