### PR TITLE
[Bugfix] Strip Gemma4 string delimiters from dict keys

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -108,6 +108,14 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('nested:{inner:<|"|>value<|"|>}')
         assert result == {"nested": {"inner": "value"}}
 
+    def test_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}')
+        assert result == {"record_map": {"3": "new text"}}
+
+    def test_nested_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('outer:{inner:{<|"|>3<|"|>:<|"|>new text<|"|>}}')
+        assert result == {"outer": {"inner": {"3": "new text"}}}
+
     def test_array_of_strings(self):
         result = _parse_gemma4_args('items:[<|"|>a<|"|>,<|"|>b<|"|>]')
         assert result == {"items": ["a", "b"]}

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -54,6 +54,12 @@ STRING_DELIM = '<|"|>'
 # ---------------------------------------------------------------------------
 
 
+def _normalize_gemma4_key(key: str) -> str:
+    if key.startswith(STRING_DELIM) and key.endswith(STRING_DELIM):
+        return key[len(STRING_DELIM) : -len(STRING_DELIM)]
+    return key
+
+
 def _parse_gemma4_value(value_str: str) -> object:
     """Parse a single Gemma4 value (after key:) into a Python object."""
     value_str = value_str.strip()
@@ -121,7 +127,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
         if i >= n:
             break
-        key = args_str[key_start:i].strip()
+        key = _normalize_gemma4_key(args_str[key_start:i].strip())
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
## Purpose

Fixes #44715.

Gemma 4 tool arguments can wrap string-typed dict keys in the same `<|"|>` delimiter used for string values, for example:

```text
record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}
```

The API-server parser already strips the delimiter from values, but key parsing took the raw substring before `:`. That left keys like `<|"|>3<|"|>` in parsed tool-call arguments.

This adds the same delimiter normalization for keys and covers both direct and nested dict keys.

## Test Plan

- `python -m ruff check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py`
- `python -m ruff format --check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py`
- `python -m py_compile vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py`
- `git diff --check`
- AST-only parser regression script for `_parse_gemma4_args`
- Attempted `python -m pytest tests\tool_parsers\test_gemma4_tool_parser.py -q --noconftest`

## Test Result

Passed:

```text
python -m ruff check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py
All checks passed!

python -m ruff format --check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py
2 files already formatted

python -m py_compile vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py

git diff --check

AST-only parser regression script
ok
```

The direct pytest command is blocked in this local Windows clone because importing the test module pulls in vLLM platform detection and this checkout does not have the native extension built:

```text
ModuleNotFoundError: No module named 'vllm._C'
```

The AST-only regression script executes the parser functions from `gemma4_tool_parser.py` without importing the rest of vLLM and verifies:

```python
_parse_gemma4_args('record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}')
== {'record_map': {'3': 'new text'}}

_parse_gemma4_args('outer:{inner:{<|"|>3<|"|>:<|"|>new text<|"|>}}')
== {'outer': {'inner': {'3': 'new text'}}}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
