### PR TITLE
fix: strip Gemma4 string delimiters from arg keys

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -108,6 +108,14 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('nested:{inner:<|"|>value<|"|>}')
         assert result == {"nested": {"inner": "value"}}
 
+    def test_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}')
+        assert result == {"record_map": {"3": "new text"}}
+
+    def test_string_delimited_nested_dict_key(self):
+        result = _parse_gemma4_args('outer:{inner:{<|"|>key<|"|>:<|"|>value<|"|>}}')
+        assert result == {"outer": {"inner": {"key": "value"}}}
+
     def test_array_of_strings(self):
         result = _parse_gemma4_args('items:[<|"|>a<|"|>,<|"|>b<|"|>]')
         assert result == {"items": ["a", "b"]}

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -82,6 +82,14 @@ def _parse_gemma4_value(value_str: str) -> object:
     return value_str
 
 
+def _parse_gemma4_key(key_str: str) -> str:
+    """Parse a Gemma4 key into a Python dict key string."""
+    key_str = key_str.strip()
+    if key_str.startswith(STRING_DELIM) and key_str.endswith(STRING_DELIM):
+        return key_str[len(STRING_DELIM) : -len(STRING_DELIM)]
+    return key_str
+
+
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
     """Parse Gemma4's custom key:value format into a Python dict.
 
@@ -121,7 +129,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
         if i >= n:
             break
-        key = args_str[key_start:i].strip()
+        key = _parse_gemma4_key(args_str[key_start:i])
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
Fixes #44715.

### What this PR does

Gemma4 tool-call args use `<|"|>` as the string delimiter. `_parse_gemma4_args()` already strips that delimiter from string values, but dict keys were taken verbatim after scanning up to `:`. When Gemma4 emits a string-delimited dict key such as:

```text
record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}
```

the parser produced:

```python
{"record_map": {"<|"|>3<|"|>": "new text"}}
```

This PR adds a small key parser that strips matching Gemma4 string delimiters from key positions, so the same input parses as:

```python
{"record_map": {"3": "new text"}}
```

### Tests

Added parser unit coverage for:

- string-delimited keys inside a dict-valued argument
- string-delimited keys in nested dicts

Local checks run:

```text
uvx ruff format --check vllm/tool_parsers/gemma4_tool_parser.py tests/tool_parsers/test_gemma4_tool_parser.py
uvx ruff check vllm/tool_parsers/gemma4_tool_parser.py tests/tool_parsers/test_gemma4_tool_parser.py
python3 -m py_compile vllm/tool_parsers/gemma4_tool_parser.py tests/tool_parsers/test_gemma4_tool_parser.py
```

I also ran a direct parser smoke test for the issue reproduction and nested-key case. Full pytest for `tests/tool_parsers/test_gemma4_tool_parser.py::TestParseGemma4Args` was blocked locally by vLLM test-environment dependency resolution on macOS/Python 3.13 (`torch==2.11.0+cpu` unavailable from the configured index), so I kept local verification focused on the parser code path.