### PR TITLE
fix: Pin Ray placement group bundles to allowlisted nodes during scale up

### DIFF
--- a/tests/v1/engine/test_dp_placement_node_allowlist.py
+++ b/tests/v1/engine/test_dp_placement_node_allowlist.py
@@ -117,3 +117,179 @@ def test_allowlist_too_small_raises(monkeypatch):
 
     with pytest.raises(ValueError):  # not enough placement groups created
         _run(cfg, resources)
+
+
+def _run_add(cfg, new_dp_size, resources, total_resources, nodes):
+    created = []
+
+    def fake_pg(name, strategy, bundles):
+        created.append({"name": name, "strategy": strategy, "bundles": bundles})
+        return SimpleNamespace(name=name, strategy=strategy, bundle_specs=bundles)
+
+    with (
+        patch(
+            "ray._private.state.available_resources_per_node",
+            return_value=resources,
+        ),
+        patch(
+            "ray._private.state.total_resources_per_node",
+            return_value=total_resources,
+        ),
+        patch("ray.util.state.list_nodes", return_value=nodes),
+        patch.object(utils, "current_platform", SimpleNamespace(ray_device_key="GPU")),
+        patch("ray.util.placement_group", side_effect=fake_pg),
+    ):
+        pgs, local_ranks = CoreEngineActorManager.add_dp_placement_groups(
+            cfg, new_dp_size
+        )
+    return pgs, local_ranks, created
+
+
+def test_add_allowlist_confines_dp_to_listed_nodes(monkeypatch):
+    monkeypatch.setenv("VLLM_RAY_DP_PLACEMENT_NODE_IPS", "10.0.0.1,10.0.0.3")
+
+    # 10.0.0.1 (master) and 10.0.0.3 are allowed. 10.0.0.2 is not allowed.
+    resources = {
+        "id-10.0.0.1": {"GPU": 0.0, "node:10.0.0.1": 1.0},  # all 8 GPUs used by old_dp
+        "id-10.0.0.2": {
+            "GPU": 8.0,
+            "node:10.0.0.2": 1.0,
+        },  # 8 GPUs available but not allowed!
+        "id-10.0.0.3": {
+            "GPU": 8.0,
+            "node:10.0.0.3": 1.0,
+        },  # 8 GPUs available and allowed
+    }
+    total_resources = {
+        "id-10.0.0.1": {"GPU": 8.0, "node:10.0.0.1": 1.0},
+        "id-10.0.0.2": {"GPU": 8.0, "node:10.0.0.2": 1.0},
+        "id-10.0.0.3": {"GPU": 8.0, "node:10.0.0.3": 1.0},
+    }
+
+    nodes = [
+        SimpleNamespace(node_ip="10.0.0.1", node_id="id-10.0.0.1"),
+        SimpleNamespace(node_ip="10.0.0.2", node_id="id-10.0.0.2"),
+        SimpleNamespace(node_ip="10.0.0.3", node_id="id-10.0.0.3"),
+    ]
+
+    # old dp_size=8, new dp_size=9, world_size=8 (so num_pg_to_create = 1).
+    cfg = _vllm_config(dp_size=8, dp_local=8, master_ip="10.0.0.1", world_size=8)
+
+    pgs, local_ranks, created = _run_add(
+        cfg,
+        new_dp_size=9,
+        resources=resources,
+        total_resources=total_resources,
+        nodes=nodes,
+    )
+
+    # We requested 1 new PG.
+    # Since .2 is disallowed, and .1 has 0 available GPUs,
+    # the new PG must be placed on .3.
+    assert len(pgs) == 1
+    # Check that it is constrained to 10.0.0.3
+    assert _pinned_ips(created) == {"10.0.0.3"}
+
+
+def test_add_empty_allowlist_is_noop(monkeypatch):
+    monkeypatch.delenv("VLLM_RAY_DP_PLACEMENT_NODE_IPS", raising=False)
+
+    # Both 10.0.0.1 and 10.0.0.2 are allowed (no allowlist set).
+    resources = {
+        "id-10.0.0.1": {"GPU": 0.0, "node:10.0.0.1": 1.0},
+        "id-10.0.0.2": {"GPU": 8.0, "node:10.0.0.2": 1.0},
+    }
+    total_resources = {
+        "id-10.0.0.1": {"GPU": 8.0, "node:10.0.0.1": 1.0},
+        "id-10.0.0.2": {"GPU": 8.0, "node:10.0.0.2": 1.0},
+    }
+
+    nodes = [
+        SimpleNamespace(node_ip="10.0.0.1", node_id="id-10.0.0.1"),
+        SimpleNamespace(node_ip="10.0.0.2", node_id="id-10.0.0.2"),
+    ]
+
+    cfg = _vllm_config(dp_size=8, dp_local=8, master_ip="10.0.0.1", world_size=8)
+
+    pgs, local_ranks, created = _run_add(
+        cfg,
+        new_dp_size=9,
+        resources=resources,
+        total_resources=total_resources,
+        nodes=nodes,
+    )
+
+    assert len(pgs) == 1
+    assert _pinned_ips(created) == {"10.0.0.2"}
+
+
+def test_add_master_auto_added_with_warning(monkeypatch):
+    # Allowlist omits the master; vLLM must still keep it and warn.
+    monkeypatch.setenv("VLLM_RAY_DP_PLACEMENT_NODE_IPS", "10.0.0.3")
+
+    resources = {
+        "id-10.0.0.1": {
+            "GPU": 8.0,
+            "node:10.0.0.1": 1.0,
+        },  # master node has 8 GPUs available
+        "id-10.0.0.3": {
+            "GPU": 8.0,
+            "node:10.0.0.3": 1.0,
+        },  # allowed node has 8 GPUs available
+    }
+    total_resources = resources
+
+    nodes = [
+        SimpleNamespace(node_ip="10.0.0.1", node_id="id-10.0.0.1"),
+        SimpleNamespace(node_ip="10.0.0.3", node_id="id-10.0.0.3"),
+    ]
+
+    cfg = _vllm_config(dp_size=8, dp_local=8, master_ip="10.0.0.1", world_size=8)
+
+    pgs, local_ranks, created = _run_add(
+        cfg,
+        new_dp_size=10,
+        resources=resources,
+        total_resources=total_resources,
+        nodes=nodes,
+    )
+
+    # requested 2 new engines. They should be created on both .1 and .3
+    # because master is auto-added
+    assert len(pgs) == 2
+    assert _pinned_ips(created) == {"10.0.0.1", "10.0.0.3"}
+
+
+def test_add_allowlist_too_small_raises(monkeypatch):
+    monkeypatch.setenv("VLLM_RAY_DP_PLACEMENT_NODE_IPS", "10.0.0.1")
+
+    resources = {
+        "id-10.0.0.1": {
+            "GPU": 0.0,
+            "node:10.0.0.1": 1.0,
+        },  # master node has 0 GPUs available
+        "id-10.0.0.2": {
+            "GPU": 8.0,
+            "node:10.0.0.2": 1.0,
+        },  # 8 GPUs available but not allowed
+    }
+    total_resources = {
+        "id-10.0.0.1": {"GPU": 8.0, "node:10.0.0.1": 1.0},
+        "id-10.0.0.2": {"GPU": 8.0, "node:10.0.0.2": 1.0},
+    }
+
+    nodes = [
+        SimpleNamespace(node_ip="10.0.0.1", node_id="id-10.0.0.1"),
+        SimpleNamespace(node_ip="10.0.0.2", node_id="id-10.0.0.2"),
+    ]
+
+    cfg = _vllm_config(dp_size=8, dp_local=8, master_ip="10.0.0.1", world_size=8)
+
+    with pytest.raises(ValueError):
+        _run_add(
+            cfg,
+            new_dp_size=9,
+            resources=resources,
+            total_resources=total_resources,
+            nodes=nodes,
+        )

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -11,7 +11,7 @@ from enum import Enum, auto
 from multiprocessing import Process, connection
 from multiprocessing.process import BaseProcess
 from multiprocessing.queues import Queue
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 from unittest.mock import patch
 
 import msgspec
@@ -116,6 +116,49 @@ def _node_ip_from_resources(node_resources: dict) -> str | None:
         ):
             return key.split(":", 1)[1]
     return None
+
+
+T = TypeVar("T")
+
+
+def _filter_dp_nodes_by_allowlist(
+    nodes: list[T],
+    dp_master_ip: str,
+    get_ip_fn: Callable[[T], str | None],
+) -> list[T]:
+    """Filter Ray nodes by ``VLLM_RAY_DP_PLACEMENT_NODE_IPS``.
+
+    Args:
+        nodes: Candidate nodes to filter.
+        dp_master_ip: DP master IP; always included even if omitted from
+            the allowlist.
+        get_ip_fn: Extracts node IP from each node object.
+
+    Returns:
+        Filtered node list, or the original list if the allowlist is empty.
+    """
+    requested_node_ips = {
+        ip.strip()
+        for ip in envs.VLLM_RAY_DP_PLACEMENT_NODE_IPS.split(",")
+        if ip.strip()
+    }
+    if not requested_node_ips:
+        return nodes
+
+    allowed_node_ips = set(requested_node_ips)
+    # The master node must host the local ranks, so it has to be allowed.
+    if dp_master_ip not in allowed_node_ips:
+        allowed_node_ips.add(dp_master_ip)
+
+    filtered_nodes = [node for node in nodes if get_ip_fn(node) in allowed_node_ips]
+    logger.info(
+        "VLLM_RAY_DP_PLACEMENT_NODE_IPS set; restricting DP placement "
+        "from %d to %d node(s): %s",
+        len(nodes),
+        len(filtered_nodes),
+        sorted(allowed_node_ips),
+    )
+    return filtered_nodes
 
 
 class CoreEngineProcManager:
@@ -525,29 +568,9 @@ class CoreEngineActorManager:
         )
 
         # optionally restrict DP placement to a caller-provided node set.
-        requested_node_ips = {
-            ip.strip()
-            for ip in envs.VLLM_RAY_DP_PLACEMENT_NODE_IPS.split(",")
-            if ip.strip()
-        }
-        if requested_node_ips:
-            allowed_node_ips = set(requested_node_ips)
-            # The master node must host the local ranks, so it has to be allowed.
-            if dp_master_ip not in allowed_node_ips:
-                allowed_node_ips.add(dp_master_ip)
-            filtered_nodes = [
-                node_resources
-                for node_resources in nodes
-                if _node_ip_from_resources(node_resources) in allowed_node_ips
-            ]
-            logger.info(
-                "VLLM_RAY_DP_PLACEMENT_NODE_IPS set; restricting DP placement "
-                "from %d to %d node(s): %s",
-                len(nodes),
-                len(filtered_nodes),
-                sorted(allowed_node_ips),
-            )
-            nodes = filtered_nodes
+        nodes = _filter_dp_nodes_by_allowlist(
+            nodes, dp_master_ip, _node_ip_from_resources
+        )
 
         device_str = current_platform.ray_device_key
         n_node_devices: list[int] = [
@@ -741,6 +764,11 @@ class CoreEngineActorManager:
             "There can only be one head node"
         )
 
+        # optionally restrict DP placement to a caller-provided node set.
+        nodes = _filter_dp_nodes_by_allowlist(
+            nodes, dp_master_ip, lambda node: node.node_ip
+        )
+
         available_resources = available_resources_per_node()
         total_resources = total_resources_per_node()
 
@@ -777,13 +805,9 @@ class CoreEngineActorManager:
 
                 rank = old_dp_size + num_pg_created
 
-                # Create bundles with node constraint for master node
-                if node_ip == dp_master_ip:
-                    bundles = [
-                        {device_str: 1.0, "node:" + dp_master_ip: 0.001}
-                    ] * world_size + [{"CPU": 1.0}]
-                else:
-                    bundles = [{device_str: 1.0}] * world_size + [{"CPU": 1.0}]
+                bundles = [{device_str: 1.0, "node:" + node_ip: 0.001}] * world_size + [
+                    _make_control_bundle(node_ip)
+                ]
 
                 pg = ray.util.placement_group(
                     name=f"dp_rank_{rank}",
@@ -797,6 +821,13 @@ class CoreEngineActorManager:
                 local_rank = used_engines_on_node + i
                 local_dp_ranks.append(local_rank)
                 num_pg_created += 1
+
+        if num_pg_created < num_pg_to_create:
+            raise ValueError(
+                f"Not enough resources to allocate {new_data_parallel_size} "
+                "placement groups, only created "
+                f"{old_dp_size + num_pg_created} placement groups."
+            )
 
         return placement_groups, local_dp_ranks
 


### PR DESCRIPTION
 
## Purpose

Root Cause
PR #44669 restricted placement groups to allowlisted nodes only during  initial deployment (via  create_dp_placement_groups ).
Scale-up workflow routing through utils.py ignores  VLLM_RAY_DP_PLACEMENT_NODE_IPS  environment variable. Furthermore, it creates  Ray placement group bundles without node-specific resource constraints,  allowing Ray scheduler to bypass desired layout.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

