### PR TITLE
Add weights padding for fp8 per-block online quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -52,6 +52,7 @@ from vllm.model_executor.parameter import ModelWeightParameter
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import per_block_cast_to_fp8
+from vllm.utils.math_utils import round_up
 
 # ---------------------------------------------------------------------------
 # Online FP8 Linear Methods
@@ -555,9 +556,63 @@ class Fp8PerBlockOnlineMoEMethod(_Fp8OnlineMoEBase):
             layer=layer,
         )
 
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            act_dtype=act_dtype,
+            moe_parallel_config=moe_parallel_config,
+        )
+        assert self.weight_block_size is not None
+        block_size = self.weight_block_size[0]
+        return (
+            round_up(hidden_size, block_size),
+            round_up(intermediate_size_per_partition, block_size),
+        )
+
+    def _zero_padding(self, layer: Module) -> None:
+        hidden_size = layer.moe_config.hidden_dim_unpadded
+        intermediate_size = layer.moe_config.intermediate_size_per_partition_unpadded
+
+        w13_half_size = layer.w13_weight.shape[1] // 2
+        if w13_half_size > intermediate_size:
+            layer.w13_weight[:, intermediate_size:w13_half_size, :] = 0
+            layer.w13_weight[
+                :, w13_half_size + intermediate_size : 2 * w13_half_size, :
+            ] = 0
+        if layer.w13_weight.shape[2] > hidden_size:
+            layer.w13_weight[:, :, hidden_size:] = 0
+
+        if layer.w2_weight.shape[1] > hidden_size:
+            layer.w2_weight[:, hidden_size:, :] = 0
+        if layer.w2_weight.shape[2] > intermediate_size:
+            layer.w2_weight[:, :, intermediate_size:] = 0
+
+        if getattr(layer, "w13_bias", None) is not None:
+            w13_bias_half_size = layer.w13_bias.shape[1] // 2
+            if w13_bias_half_size > intermediate_size:
+                layer.w13_bias[:, intermediate_size:w13_bias_half_size] = 0
+                layer.w13_bias[
+                    :, w13_bias_half_size + intermediate_size : 2 * w13_bias_half_size
+                ] = 0
+
+        if (
+            getattr(layer, "w2_bias", None) is not None
+            and layer.w2_bias.shape[1] > hidden_size
+        ):
+            layer.w2_bias[:, hidden_size:] = 0
+
     def process_weights_after_loading(self, layer: Module) -> None:
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
+
+        self._zero_padding(layer)
 
         fp8_dtype = current_platform.fp8_dtype()
         w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)


### PR DESCRIPTION



## Purpose
FP8 per-block online quantization use group size `128` thus it requires MoE hidden/intermediate dimensions per rank should be divisible by this value. Take triton moe backend for example, when run `Qwen/Qwen3-30B-A3B` using `tp=4`, the dimensions is `768/4=192` and will cause below error:
```
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/workspace/vllm/vllm/model_executor/layers/quantization/online/moe_base.py", line 151, in apply
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     return self.moe_kernel.apply(
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]            ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1627, in apply
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     return self.impl.apply(
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]            ^^^^^^^^^^^^^^^^
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1410, in apply
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     fused_out = self._fused_experts(
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]                 ^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1265, in _fused_experts
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     self.fused_experts.apply(
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/experts/triton_moe.py", line 384, in apply
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     qintermediate_cache2, a2q_scale = ops.silu_and_mul_per_block_quant(
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/workspace/vllm/vllm/_custom_ops.py", line 528, in silu_and_mul_per_block_quant
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     torch.ops._C.silu_and_mul_per_block_quant(
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]   File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1275, in __call__
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]     return self._op(*args, **kwargs)
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=56985) ERROR 06-18 02:58:00 [multiproc_executor.py:990] RuntimeError: hidden_size must be divisible by group_size

```
## Test Plan
```
python3 examples/basic/offline_inference/generate.py --model Qwen/Qwen3-30B-A3B  --enforce-eager --dtype=bfloat16 --block-size=64 --max_model_len=2048 --gpu-memory-utilization=0.8 --trust-remote-code --quantization=fp8_per_block -tp=4 --moe-backend=triton
```
## Test Result
```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: " M. I'm a 17-year-old with a history of anxiety and"
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the commander in chief of the United States Armed Forces. The president is also the'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris. Is this statement correct?\n\nYes, the capital of France is Paris.'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' not just about technology but also about the people and processes that drive it. As'
--------------------------------------------------

```
gsm8k lm_eval + tp=2(w/o padding):

```
VLLM_WORKER_MULTIPROC_METHOD=spawn python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3-30B-A3B-Instruct-2507 --enforce-eager --port 8055 --host 0.0.0.0 --trust-remote-code --no-enable-log-requests --gpu-memory-util=0.9 --no-enable-prefix-caching  --max-num-batched-tokens=8192 --max-model-len=8192 --block-size 64 --dtype=bfloat16 -tp=2 --quantization=fp8_per_block --moe-backend=triton 


lm_eval --model local-chat-completions --tasks gsm8k --batch_size 1 --model_args "model=Qwen/Qwen3-30B-A3B-Instruct-2507,base_url=http://0.0.0.0:8055/v1/chat/completions,max_gen_toks=512,num_concurrent=128,timeout=6000" --apply_chat_template  --output_path ./lm_eval_output --log_samples  --gen_kwargs="temperature=0,top_p=0.2,top_k=5"
```
<img width="1504" height="181" alt="image" src="https://github.com/user-attachments/assets/af6e76c9-1560-4a01-9b2e-0e30746d3d0c" />

gsm8k lm_eval + tp=4(w/ padding):
```
VLLM_WORKER_MULTIPROC_METHOD=spawn python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3-30B-A3B-Instruct-2507 --enforce-eager --port 8055 --host 0.0.0.0 --trust-remote-code --no-enable-log-requests --gpu-memory-util=0.9 --no-enable-prefix-caching  --max-num-batched-tokens=8192 --max-model-len=8192 --block-size 64 --dtype=bfloat16 -tp=4 --quantization=fp8_per_block --moe-backend=triton 
```
<img width="748" height="85" alt="image" src="https://github.com/user-attachments/assets/6a93eff2-d402-4bc7-9308-83b9e4f5bae9" />
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

