### PR TITLE
[Draft][Rust] Add video modality support for vllm-rs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -668,6 +668,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
+dependencies = [
+ "clang-sys",
+ "libc",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1182,12 @@ name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1674,6 +1700,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -2410,7 +2442,6 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "llm-multimodal"
 version = "1.5.0"
-source = "git+https://github.com/vllm-project/llm-multimodal?rev=5b558989844d1c7af3e43d0f604069ffd9c06320#5b558989844d1c7af3e43d0f604069ffd9c06320"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -2419,9 +2450,11 @@ dependencies = [
  "image",
  "ndarray 0.17.2",
  "once_cell",
+ "opencv",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -2957,6 +2990,39 @@ dependencies = [
  "tracing",
  "url",
  "validator",
+]
+
+[[package]]
+name = "opencv"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c607a407be5ff2484f55d2eb289bffd01de84f962779b8470e76f035dd3563d"
+dependencies = [
+ "cc",
+ "dunce",
+ "jobserver",
+ "libc",
+ "num-traits",
+ "opencv-binding-generator",
+ "pkg-config",
+ "semver",
+ "shlex",
+ "vcpkg",
+ "windows",
+]
+
+[[package]]
+name = "opencv-binding-generator"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833f00c6deee8dd615249af42fa35ff030c5c73ee3c13e44baf1135a4d57af86"
+dependencies = [
+ "clang",
+ "clang-sys",
+ "dunce",
+ "percent-encoding",
+ "regex",
+ "shlex",
 ]
 
 [[package]]
@@ -6146,6 +6212,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6156,6 +6243,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6185,6 +6283,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -6282,6 +6390,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,7 +46,7 @@ http-body = "1.0.1"
 indexmap = "2.13.0"
 itertools = "0.14.0"
 libc = "0.2.177"
-llm-multimodal = { git = "https://github.com/vllm-project/llm-multimodal", rev = "5b558989844d1c7af3e43d0f604069ffd9c06320" }
+llm-multimodal = { path = "../../llm-multimodal" }
 mimalloc = "0.1.52"
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }

--- a/rust/src/chat/src/backend/hf.rs
+++ b/rust/src/chat/src/backend/hf.rs
@@ -133,7 +133,8 @@ fn resolve_multimodal_render_info(
     info: Option<&MultimodalModelInfo>,
 ) -> Option<MultimodalRenderInfo> {
     info.map(|info| MultimodalRenderInfo {
-        placeholder_token: info.placeholder_token().to_string(),
+        image_placeholder_token: info.placeholder_token().to_string(),
+        video_placeholder_token: info.video_placeholder_token().to_string(),
     })
 }
 

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -115,28 +115,20 @@ impl ResolvedMultimodalSpec {
         // image
         let image_token =
             raw.placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
-        let image_marker_token_id = tokenizer
-            .token_to_id(&image_token)
-            .ok_or_else(|| {
-                multimodal!(
-                    "placeholder token `{image_token}` is not in the tokenizer vocabulary"
-                )
-            })?;
+        let image_marker_token_id = tokenizer.token_to_id(&image_token).ok_or_else(|| {
+            multimodal!("placeholder token `{image_token}` is not in the tokenizer vocabulary")
+        })?;
         let image_embed_token_id =
             raw.placeholder_token_id(&metadata).map_err(|error| multimodal!("{error}"))? as u32;
         // video
         let video_token =
             raw.video_placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
-        let video_marker_token_id = tokenizer
-            .token_to_id(&video_token)
-            .ok_or_else(|| {
-                multimodal!(
-                    "placeholder token `{video_token}` is not in the tokenizer vocabulary"
-                )
-            })?;
-        let video_embed_token_id =
-            raw.video_placeholder_token_id(&metadata)
-                .map_err(|error| multimodal!("{error}"))? as u32;
+        let video_marker_token_id = tokenizer.token_to_id(&video_token).ok_or_else(|| {
+            multimodal!("placeholder token `{video_token}` is not in the tokenizer vocabulary")
+        })?;
+        let video_embed_token_id = raw
+            .video_placeholder_token_id(&metadata)
+            .map_err(|error| multimodal!("{error}"))? as u32;
 
         Ok(Self {
             raw,
@@ -504,7 +496,17 @@ impl MultimodalModelInfo {
         &self,
         media_parts: Vec<MediaContentPart>,
     ) -> Result<Vec<FetchedMediaItem>> {
-        let mut tracker = AsyncMultiModalTracker::new(Arc::clone(&self.media_connector));
+        let preprocessor_config = self
+            .video_processor
+            .as_ref()
+            .map(|vp| &vp.config)
+            .unwrap_or(&self.image_processor.config);
+        let mut tracker = AsyncMultiModalTracker::for_model(
+            Arc::clone(&self.media_connector),
+            &self.context.metadata(),
+            preprocessor_config,
+        )
+        .map_err(|error| multimodal!("{error}"))?;
         for part in &media_parts {
             tracker.push_part(part.clone()).map_err(|error| multimodal!("{error}"))?;
         }

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -9,7 +9,7 @@
 //! Raw media stays above `vllm-text`; this module lowers it into token IDs and
 //! opaque tensor payloads before the request is handed to text generation.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
@@ -18,8 +18,8 @@ use itertools::izip;
 use llm_multimodal::{
     AsyncMultiModalTracker, FieldLayout, ImagePreProcessor, ImageProcessorRegistry, MediaConnector,
     MediaConnectorConfig, MediaContentPart, Modality, ModelMetadata, ModelProcessorSpec,
-    ModelRegistry, PreProcessorConfig, PreprocessedImages, PromptReplacement, TokenResolver,
-    TrackedMedia,
+    ModelRegistry, PreProcessorConfig, PreprocessedImages, PreprocessedVideos, PromptReplacement,
+    TokenResolver, TrackedMedia, VideoPreProcessor, VideoProcessorRegistry,
 };
 use tracing::warn;
 use vllm_engine_core_client::protocol::ModelDtype;
@@ -43,6 +43,7 @@ pub struct MultimodalModelInfo {
     context: MultimodalModelContext,
     spec: ResolvedMultimodalSpec,
     image_processor: ResolvedImageProcessor,
+    video_processor: Option<ResolvedVideoProcessor>,
     media_connector: Arc<MediaConnector>,
 }
 
@@ -80,15 +81,25 @@ impl MultimodalModelContext {
             LazyLock::new(ImageProcessorRegistry::with_defaults);
         REGISTRY.find(&self.model_id, self.model_type.as_deref())
     }
+
+    /// Resolve a static video preprocessor for one loaded model.
+    fn resolve_video_processor(&self) -> Option<&'static dyn VideoPreProcessor> {
+        static REGISTRY: LazyLock<VideoProcessorRegistry> =
+            LazyLock::new(VideoProcessorRegistry::with_defaults);
+        REGISTRY.find(&self.model_id, self.model_type.as_deref())
+    }
 }
 
 /// Static model-specific prompt and tensor-layout behavior.
 #[derive(Clone)]
 struct ResolvedMultimodalSpec {
     raw: &'static dyn ModelProcessorSpec,
-    placeholder_token: String,
-    placeholder_marker_token_id: u32,
-    placeholder_embed_token_id: u32,
+    image_placeholder_token: String,
+    image_placeholder_marker_token_id: u32,
+    image_placeholder_embed_token_id: u32,
+    video_placeholder_token: String,
+    video_placeholder_marker_token_id: u32,
+    video_placeholder_embed_token_id: u32,
     field_layouts: HashMap<String, FieldLayout>,
     keep_on_cpu_keys: HashSet<String>,
 }
@@ -96,40 +107,139 @@ struct ResolvedMultimodalSpec {
 impl ResolvedMultimodalSpec {
     fn new(raw: &'static dyn ModelProcessorSpec, context: &MultimodalModelContext) -> Result<Self> {
         let metadata = context.metadata();
-        let placeholder_token =
+        let image_placeholder_token =
             raw.placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
-        // This is the rendered prompt marker, so resolve it from the token
-        // string itself. Do not use `ModelProcessorSpec::placeholder_token_id()`:
-        // for some specs that ID is the replacement vision/patch token,
-        // not necessarily the token ID of `placeholder_token`.
-        let placeholder_marker_token_id =
-            context.tokenizer().token_to_id(&placeholder_token).ok_or_else(|| {
+        let video_placeholder_token =
+            raw.video_placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
+        let image_placeholder_marker_token_id = context
+            .tokenizer()
+            .token_to_id(&image_placeholder_token)
+            .ok_or_else(|| {
                 multimodal!(
-                    "placeholder token `{placeholder_token}` is not in the tokenizer vocabulary"
+                    "placeholder token `{image_placeholder_token}` is not in the tokenizer vocabulary"
                 )
             })?;
-        let placeholder_embed_token_id =
+        let image_placeholder_embed_token_id =
             raw.placeholder_token_id(&metadata).map_err(|error| multimodal!("{error}"))? as u32;
+        let video_placeholder_marker_token_id = context
+            .tokenizer()
+            .token_to_id(&video_placeholder_token)
+            .ok_or_else(|| {
+                multimodal!(
+                    "placeholder token `{video_placeholder_token}` is not in the tokenizer vocabulary"
+                )
+            })?;
+        let video_placeholder_embed_token_id =
+            raw.video_placeholder_token_id(&metadata)
+                .map_err(|error| multimodal!("{error}"))? as u32;
 
         Ok(Self {
             raw,
-            placeholder_token,
-            placeholder_marker_token_id,
-            placeholder_embed_token_id,
+            image_placeholder_token,
+            image_placeholder_marker_token_id,
+            image_placeholder_embed_token_id,
+            video_placeholder_token,
+            video_placeholder_marker_token_id,
+            video_placeholder_embed_token_id,
             field_layouts: raw.field_layouts(),
             keep_on_cpu_keys: raw.keep_on_cpu_keys().into_iter().collect(),
         })
     }
 
-    fn prompt_replacements(
+    fn image_prompt_replacements(
         &self,
         context: &MultimodalModelContext,
         preprocessed: &PreprocessedImages,
-    ) -> Result<Vec<PromptReplacement>> {
-        self.raw
+    ) -> Result<Vec<ResolvedPromptReplacement>> {
+        let replacements = self
+            .raw
             .prompt_replacements(&context.metadata(), preprocessed)
-            .map_err(|error| multimodal!("{error}"))
+            .map_err(|error| multimodal!("{error}"))?;
+        Ok(replacements
+            .into_iter()
+            .map(|replacement| ResolvedPromptReplacement {
+                replacement,
+                placeholder_marker_token_id: self.image_placeholder_marker_token_id,
+                placeholder_embed_token_id: self.image_placeholder_embed_token_id,
+            })
+            .collect())
     }
+
+    fn video_prompt_replacements(
+        &self,
+        context: &MultimodalModelContext,
+        preprocessed: &PreprocessedVideos,
+    ) -> Result<Vec<ResolvedPromptReplacement>> {
+        let replacements = self
+            .raw
+            .video_prompt_replacements(&context.metadata(), preprocessed)
+            .map_err(|error| multimodal!("{error}"))?;
+        Ok(replacements
+            .into_iter()
+            .map(|replacement| ResolvedPromptReplacement {
+                replacement,
+                placeholder_marker_token_id: self.video_placeholder_marker_token_id,
+                placeholder_embed_token_id: self.video_placeholder_embed_token_id,
+            })
+            .collect())
+    }
+}
+
+/// Static video preprocessor plus its loaded config.
+#[derive(Clone)]
+struct ResolvedVideoProcessor {
+    raw: &'static dyn VideoPreProcessor,
+    config: PreProcessorConfig,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedPromptReplacement {
+    replacement: PromptReplacement,
+    placeholder_marker_token_id: u32,
+    placeholder_embed_token_id: u32,
+}
+
+#[derive(Clone)]
+enum FetchedMediaItem {
+    Image {
+        frame: Arc<llm_multimodal::ImageFrame>,
+        uuid: Option<String>,
+    },
+    Video {
+        frame: Arc<llm_multimodal::VideoFrame>,
+        uuid: Option<String>,
+    },
+}
+
+impl FetchedMediaItem {
+    fn modality(&self) -> Modality {
+        match self {
+            Self::Image { .. } => Modality::Image,
+            Self::Video { .. } => Modality::Video,
+        }
+    }
+
+    fn identifier(&self) -> String {
+        match self {
+            Self::Image { frame, uuid } => uuid.clone().unwrap_or_else(|| frame.hash.clone()),
+            Self::Video { frame, uuid } => {
+                uuid.clone().unwrap_or_else(|| frame.container_hash.clone())
+            }
+        }
+    }
+
+    fn media_hash(&self) -> String {
+        match self {
+            Self::Image { frame, .. } => frame.hash.clone(),
+            Self::Video { frame, .. } => frame.container_hash.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PreparedFeatureItem {
+    data: MmKwargsItem,
+    modality: String,
 }
 
 /// Static image preprocessor plus its loaded config.
@@ -139,10 +249,67 @@ struct ResolvedImageProcessor {
     config: PreProcessorConfig,
 }
 
-/// Request-scoped fetched media, kept together with tracker UUID metadata.
-struct FetchedImageMedia {
-    frames: Vec<Arc<llm_multimodal::ImageFrame>>,
-    uuids: Vec<Option<String>>,
+fn media_part_modality(part: &MediaContentPart) -> Option<Modality> {
+    match part {
+        MediaContentPart::Text { .. } => None,
+        MediaContentPart::ImageUrl { .. }
+        | MediaContentPart::ImageData { .. }
+        | MediaContentPart::ImageEmbeds { .. } => Some(Modality::Image),
+        MediaContentPart::VideoUrl { .. } | MediaContentPart::VideoData { .. } => {
+            Some(Modality::Video)
+        }
+    }
+}
+
+fn pop_tracked_media(
+    items: &mut VecDeque<TrackedMedia>,
+    uuids: &mut VecDeque<Option<String>>,
+    modality: Modality,
+) -> Result<FetchedMediaItem> {
+    let media = items
+        .pop_front()
+        .ok_or_else(|| multimodal!("missing fetched {modality} item"))?;
+    let uuid = uuids
+        .pop_front()
+        .ok_or_else(|| multimodal!("missing fetched {modality} UUID"))?;
+
+    match (modality, media) {
+        (Modality::Image, TrackedMedia::Image(frame)) => {
+            Ok(FetchedMediaItem::Image { frame, uuid })
+        }
+        (Modality::Video, TrackedMedia::Video(frame)) => {
+            Ok(FetchedMediaItem::Video { frame, uuid })
+        }
+        (Modality::Image, _) => Err(Error::UnsupportedMultimodalContent("non-image")),
+        (Modality::Video, _) => Err(Error::UnsupportedMultimodalContent("non-video")),
+        _ => Err(multimodal!(
+            "unsupported fetched media modality `{modality}`"
+        )),
+    }
+}
+
+fn ensure_queue_drained<T>(queue: &VecDeque<T>, modality: Modality, label: &str) -> Result<()> {
+    if queue.is_empty() {
+        return Ok(());
+    }
+    bail_multimodal!("unconsumed {modality} {label} remaining after request-order rebuild")
+}
+
+fn media_parts_by_modality(
+    fetched: &[FetchedMediaItem],
+) -> (
+    Vec<Arc<llm_multimodal::ImageFrame>>,
+    Vec<Arc<llm_multimodal::VideoFrame>>,
+) {
+    let mut images = Vec::new();
+    let mut videos = Vec::new();
+    for item in fetched {
+        match item {
+            FetchedMediaItem::Image { frame, .. } => images.push(Arc::clone(frame)),
+            FetchedMediaItem::Video { frame, .. } => videos.push(Arc::clone(frame)),
+        }
+    }
+    (images, videos)
 }
 
 impl MultimodalModelInfo {
@@ -204,6 +371,10 @@ impl MultimodalModelInfo {
             );
             return Ok(None);
         };
+        let video_processor = context.resolve_video_processor().map(|raw| ResolvedVideoProcessor {
+            raw,
+            config: preprocessor_config.clone(),
+        });
 
         let media_connector = Arc::new(
             MediaConnector::new(reqwest::Client::new(), MediaConnectorConfig::default())
@@ -217,6 +388,7 @@ impl MultimodalModelInfo {
                 raw: image_processor,
                 config: preprocessor_config,
             },
+            video_processor,
             media_connector,
         }))
     }
@@ -225,16 +397,320 @@ impl MultimodalModelInfo {
     ///
     /// The HF renderer uses this token while flattening image content in string
     /// content format.
-    pub(crate) fn placeholder_token(&self) -> &str {
-        &self.spec.placeholder_token
+    pub fn placeholder_token(&self) -> &str {
+        &self.spec.image_placeholder_token
+    }
+
+    /// Return the template-visible video placeholder token for this model.
+    ///
+    /// The HF renderer uses this token while flattening video content in string
+    /// content format.
+    pub fn video_placeholder_token(&self) -> &str {
+        &self.spec.video_placeholder_token
+    }
+
+    /// Run media fetch, preprocessing, prompt expansion, and feature build.
+    ///
+    /// `prompt_token_ids` is mutated in place because placeholder expansion
+    /// changes both the final prompt and the offsets recorded in
+    /// `PlaceholderRange`.
+    async fn prepare_multimodal(
+        &self,
+        media_parts: Vec<MediaContentPart>,
+        prompt_token_ids: &mut Vec<u32>,
+        model_dtype: ModelDtype,
+    ) -> Result<MmFeatures> {
+        if media_parts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let media_parts_len = media_parts.len();
+        let fetched = self.fetch_media(media_parts).await?;
+        let (image_frames, video_frames) = media_parts_by_modality(&fetched);
+
+        let image_preprocessed = if image_frames.is_empty() {
+            None
+        } else {
+            Some(self.preprocess_images(&image_frames).await?)
+        };
+        let video_preprocessed = if video_frames.is_empty() {
+            None
+        } else {
+            Some(self.preprocess_videos(&video_frames).await?)
+        };
+
+        let mut image_replacements: VecDeque<_> =
+            if let Some(preprocessed) = image_preprocessed.as_ref() {
+                self.spec.image_prompt_replacements(&self.context, preprocessed)?
+            } else {
+                Vec::new()
+            }
+            .into();
+        let mut video_replacements: VecDeque<_> =
+            if let Some(preprocessed) = video_preprocessed.as_ref() {
+                self.spec.video_prompt_replacements(&self.context, preprocessed)?
+            } else {
+                Vec::new()
+            }
+            .into();
+        let mut ordered_replacements = Vec::with_capacity(fetched.len());
+        for item in &fetched {
+            let replacement = match item.modality() {
+                Modality::Image => image_replacements
+                    .pop_front()
+                    .ok_or_else(|| multimodal!("missing image prompt replacement"))?,
+                Modality::Video => video_replacements
+                    .pop_front()
+                    .ok_or_else(|| multimodal!("missing video prompt replacement"))?,
+                other => bail_multimodal!("unsupported prompt replacement modality `{other}`"),
+            };
+            ordered_replacements.push(replacement);
+        }
+        ensure_queue_drained(&image_replacements, Modality::Image, "prompt replacements")?;
+        ensure_queue_drained(&video_replacements, Modality::Video, "prompt replacements")?;
+
+        let ranges = self.expand_prompt_tokens(prompt_token_ids, ordered_replacements)?;
+        let image_features = if let Some(preprocessed) = image_preprocessed {
+            self.build_image_feature_items(preprocessed, image_frames.len(), model_dtype)?
+        } else {
+            VecDeque::new()
+        };
+        let video_features = if let Some(preprocessed) = video_preprocessed {
+            self.build_video_feature_items(preprocessed, video_frames.len(), model_dtype)?
+        } else {
+            VecDeque::new()
+        };
+        let features = self.build_features(fetched, image_features, video_features, ranges)?;
+        if features.len() != media_parts_len {
+            bail_multimodal!(
+                "number of built multimodal features {} does not match number of media parts {}",
+                features.len(),
+                media_parts_len
+            );
+        }
+        Ok(features)
+    }
+
+    /// Fetch all media parts and rebuild them in original request order.
+    async fn fetch_media(
+        &self,
+        media_parts: Vec<MediaContentPart>,
+    ) -> Result<Vec<FetchedMediaItem>> {
+        let mut tracker = AsyncMultiModalTracker::new(Arc::clone(&self.media_connector));
+        for part in &media_parts {
+            tracker.push_part(part.clone()).map_err(|error| multimodal!("{error}"))?;
+        }
+
+        let tracker_output = tracker.finalize().await.map_err(|error| multimodal!("{error}"))?;
+        let mut images: VecDeque<_> =
+            tracker_output.data.get(&Modality::Image).cloned().unwrap_or_default().into();
+        let mut image_uuids: VecDeque<_> =
+            tracker_output.uuids.get(&Modality::Image).cloned().unwrap_or_default().into();
+        let mut videos: VecDeque<_> =
+            tracker_output.data.get(&Modality::Video).cloned().unwrap_or_default().into();
+        let mut video_uuids: VecDeque<_> =
+            tracker_output.uuids.get(&Modality::Video).cloned().unwrap_or_default().into();
+
+        let mut fetched = Vec::with_capacity(media_parts.len());
+        for part in media_parts {
+            let Some(modality) = media_part_modality(&part) else {
+                continue;
+            };
+            let item = match modality {
+                Modality::Image => {
+                    pop_tracked_media(&mut images, &mut image_uuids, Modality::Image)?
+                }
+                Modality::Video => {
+                    pop_tracked_media(&mut videos, &mut video_uuids, Modality::Video)?
+                }
+                other => bail_multimodal!("unsupported fetched media modality `{other}`"),
+            };
+            fetched.push(item);
+        }
+
+        ensure_queue_drained(&images, Modality::Image, "media items")?;
+        ensure_queue_drained(&videos, Modality::Video, "media items")?;
+        ensure_queue_drained(&image_uuids, Modality::Image, "UUIDs")?;
+        ensure_queue_drained(&video_uuids, Modality::Video, "UUIDs")?;
+        Ok(fetched)
+    }
+
+    /// Preprocess fetched image frames with the model's resolved image
+    /// processor.
+    async fn preprocess_images(
+        &self,
+        image_frames: &[Arc<llm_multimodal::ImageFrame>],
+    ) -> Result<PreprocessedImages> {
+        let config = self.image_processor.config.clone();
+        let processor = self.image_processor.raw;
+        let images = image_frames.iter().map(|frame| frame.data().clone()).collect::<Vec<_>>();
+
+        tokio::task::spawn_blocking(move || {
+            processor.preprocess(&images, &config).map_err(|error| multimodal!("{error}"))
+        })
+        .await
+        .map_err(|error| multimodal!("image preprocessing task failed: {error}"))?
+    }
+
+    /// Preprocess fetched video frames with the model's resolved video
+    /// processor.
+    async fn preprocess_videos(
+        &self,
+        video_frames: &[Arc<llm_multimodal::VideoFrame>],
+    ) -> Result<PreprocessedVideos> {
+        let video_processor = self
+            .video_processor
+            .as_ref()
+            .ok_or(Error::UnsupportedMultimodalContent("video_url"))?;
+        let config = video_processor.config.clone();
+        let processor = video_processor.raw;
+        let videos = video_frames.iter().map(|frame| frame.frames().to_vec()).collect::<Vec<_>>();
+
+        tokio::task::spawn_blocking(move || {
+            processor.preprocess(&videos, &config).map_err(|error| multimodal!("{error}"))
+        })
+        .await
+        .map_err(|error| multimodal!("video preprocessing task failed: {error}"))?
+    }
+
+    /// Replace rendered placeholder markers with model-specific replacement
+    /// tokens.
+    fn expand_prompt_tokens(
+        &self,
+        prompt_token_ids: &mut Vec<u32>,
+        replacements: Vec<ResolvedPromptReplacement>,
+    ) -> Result<Vec<PlaceholderRange>> {
+        expand_prompt_token_ids(prompt_token_ids, replacements)
+    }
+
+    fn build_image_feature_items(
+        &self,
+        preprocessed: PreprocessedImages,
+        item_count: usize,
+        model_dtype: ModelDtype,
+    ) -> Result<VecDeque<PreparedFeatureItem>> {
+        let tensors = tensor::collect_image_tensors(preprocessed, model_dtype)?;
+        self.build_feature_items_from_tensors("image", tensors, item_count)
+    }
+
+    fn build_video_feature_items(
+        &self,
+        preprocessed: PreprocessedVideos,
+        item_count: usize,
+        model_dtype: ModelDtype,
+    ) -> Result<VecDeque<PreparedFeatureItem>> {
+        let tensors = tensor::collect_video_tensors(preprocessed, model_dtype)?;
+        self.build_feature_items_from_tensors("video", tensors, item_count)
+    }
+
+    fn build_feature_items_from_tensors(
+        &self,
+        modality: &str,
+        tensors: HashMap<String, tensor::KwargValue>,
+        item_count: usize,
+    ) -> Result<VecDeque<PreparedFeatureItem>> {
+        let mut items = VecDeque::with_capacity(item_count);
+        for index in 0..item_count {
+            let mut data = MmKwargsItem::new();
+            for (key, tensor) in &tensors {
+                let keep_on_cpu = self.spec.keep_on_cpu_keys.contains(key);
+                let (value, field) = match self.spec.field_layouts.get(key) {
+                    Some(FieldLayout::Batched) => (
+                        tensor.batched_value_at(index)?,
+                        MmField::Batched(MmBatchedField { keep_on_cpu }),
+                    ),
+                    Some(FieldLayout::Flat { sizes_key }) => {
+                        let sizes = tensors.get(sizes_key).ok_or_else(|| {
+                            multimodal!("flat tensor sizes key `{sizes_key}` is missing")
+                        })?;
+                        let (start, end) = tensor::flat_range_for_index(sizes, sizes_key, index)?;
+                        (
+                            tensor.flat_value_range(start, end)?,
+                            MmField::Flat(MmFlatField {
+                                slices: vec![MmSlice::Slice(SliceSpec {
+                                    start: Some(0),
+                                    stop: Some((end - start) as isize),
+                                    step: None,
+                                })],
+                                dim: 0,
+                                keep_on_cpu,
+                            }),
+                        )
+                    }
+                    None => (
+                        tensor.clone(),
+                        MmField::Shared(MmSharedField {
+                            batch_size: item_count,
+                            keep_on_cpu,
+                        }),
+                    ),
+                };
+
+                data.insert(
+                    key.clone(),
+                    MmFieldElem {
+                        data: Some(value.try_into()?),
+                        field,
+                    },
+                );
+            }
+
+            items.push_back(PreparedFeatureItem {
+                data,
+                modality: modality.to_string(),
+            });
+        }
+
+        Ok(items)
+    }
+
+    fn build_features(
+        &self,
+        fetched: Vec<FetchedMediaItem>,
+        image_features: VecDeque<PreparedFeatureItem>,
+        video_features: VecDeque<PreparedFeatureItem>,
+        ranges: Vec<PlaceholderRange>,
+    ) -> Result<MmFeatures> {
+        if ranges.len() != fetched.len() {
+            bail_multimodal!(
+                "number of placeholder ranges {} does not match number of fetched media items {}",
+                ranges.len(),
+                fetched.len()
+            );
+        }
+
+        let mut image_features = image_features;
+        let mut video_features = video_features;
+        let mut features = Vec::with_capacity(fetched.len());
+        for (item, range) in izip!(fetched, ranges) {
+            let feature = match item.modality() {
+                Modality::Image => image_features
+                    .pop_front()
+                    .ok_or_else(|| multimodal!("missing prepared image feature"))?,
+                Modality::Video => video_features
+                    .pop_front()
+                    .ok_or_else(|| multimodal!("missing prepared video feature"))?,
+                other => bail_multimodal!("unsupported feature modality `{other}`"),
+            };
+            features.push(MmFeatureSpec {
+                data: Some(feature.data),
+                modality: feature.modality,
+                identifier: item.identifier(),
+                mm_position: range,
+                mm_hash: Some(item.media_hash()),
+            });
+        }
+
+        ensure_queue_drained(&image_features, Modality::Image, "feature items")?;
+        ensure_queue_drained(&video_features, Modality::Video, "feature items")?;
+        Ok(features)
     }
 }
 
 /// Finalize a rendered chat prompt into text-generation input.
 ///
 /// Text-only requests pass through unchanged as `Prompt::Text`. Multimodal
-/// requests are tokenized in chat, their image placeholders are expanded, and
-/// preprocessed image features are attached for engine-core transport.
+/// requests are tokenized in chat, their media placeholders are expanded, and
+/// preprocessed media features are attached for engine-core transport.
 pub(crate) async fn finalize_rendered_prompt(
     request: &ChatRequest,
     rendered: RenderedPrompt,
@@ -260,7 +736,7 @@ pub(crate) async fn finalize_rendered_prompt(
     Ok((Prompt::TokenIds(prompt_token_ids), Some(prepared)))
 }
 
-/// Extract image media parts from chat messages in message/content order.
+/// Extract media parts from chat messages in message/content order.
 ///
 /// Assistant history is skipped because generated assistant blocks are already
 /// represented as text for prompt rendering in this crate.
@@ -301,190 +777,16 @@ fn extract_media_parts(request: &ChatRequest) -> Result<Vec<MediaContentPart>> {
     Ok(all_parts)
 }
 
-impl MultimodalModelInfo {
-    /// Run media fetch, image preprocessing, prompt expansion, and feature
-    /// build.
-    ///
-    /// `prompt_token_ids` is mutated in place because placeholder expansion
-    /// changes both the final prompt and the offsets recorded in
-    /// `PlaceholderRange`.
-    async fn prepare_multimodal(
-        &self,
-        media_parts: Vec<MediaContentPart>,
-        prompt_token_ids: &mut Vec<u32>,
-        model_dtype: ModelDtype,
-    ) -> Result<MmFeatures> {
-        if media_parts.is_empty() {
-            return Ok(Vec::new());
-        }
-        let media_parts_len = media_parts.len();
-
-        let fetched = self.fetch_images(media_parts).await?;
-        let preprocessed = self.preprocess_images(&fetched.frames).await?;
-        let replacements = self.spec.prompt_replacements(&self.context, &preprocessed)?;
-        let ranges = self.expand_prompt_tokens(prompt_token_ids, replacements)?;
-
-        let features = self.build_features(preprocessed, fetched, ranges, model_dtype)?;
-        if features.len() != media_parts_len {
-            bail_multimodal!(
-                "number of built multimodal features {} does not match number of media parts {}",
-                features.len(),
-                media_parts_len
-            );
-        }
-        Ok(features)
-    }
-
-    /// Fetch all image parts and preserve their request-order UUID metadata.
-    async fn fetch_images(&self, media_parts: Vec<MediaContentPart>) -> Result<FetchedImageMedia> {
-        let mut tracker = AsyncMultiModalTracker::new(Arc::clone(&self.media_connector));
-        for part in media_parts {
-            tracker.push_part(part).map_err(|error| multimodal!("{error}"))?;
-        }
-
-        let tracker_output = tracker.finalize().await.map_err(|error| multimodal!("{error}"))?;
-        let images = tracker_output.data.get(&Modality::Image).cloned().unwrap_or_default();
-        let uuids = tracker_output.uuids.get(&Modality::Image).cloned().unwrap_or_default();
-
-        let frames = images
-            .into_iter()
-            .map(|media| match media {
-                TrackedMedia::Image(frame) => Ok(frame),
-                _ => Err(Error::UnsupportedMultimodalContent("non-image")),
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(FetchedImageMedia { frames, uuids })
-    }
-
-    /// Preprocess fetched image frames with the model's resolved image
-    /// processor.
-    ///
-    /// The processor work is CPU-heavy relative to request wiring, so it runs
-    /// in a blocking task and returns owned tensors ready for wire
-    /// conversion.
-    async fn preprocess_images(
-        &self,
-        image_frames: &[Arc<llm_multimodal::ImageFrame>],
-    ) -> Result<PreprocessedImages> {
-        let config = self.image_processor.config.clone();
-        let processor = self.image_processor.raw;
-        let images = image_frames.iter().map(|frame| frame.data().clone()).collect::<Vec<_>>();
-
-        tokio::task::spawn_blocking(move || {
-            processor.preprocess(&images, &config).map_err(|error| multimodal!("{error}"))
-        })
-        .await
-        .map_err(|error| multimodal!("image preprocessing task failed: {error}"))?
-    }
-
-    /// Replace rendered placeholder markers with model-specific replacement
-    /// tokens.
-    ///
-    /// Replacements are consumed in order, matching the original media-part
-    /// order. The returned ranges point into the already-expanded prompt.
-    fn expand_prompt_tokens(
-        &self,
-        prompt_token_ids: &mut Vec<u32>,
-        replacements: Vec<PromptReplacement>,
-    ) -> Result<Vec<PlaceholderRange>> {
-        expand_prompt_token_ids(
-            prompt_token_ids,
-            replacements,
-            self.spec.placeholder_marker_token_id,
-            self.spec.placeholder_embed_token_id,
-            &self.spec.placeholder_token,
-        )
-    }
-
-    /// Convert preprocessed image tensors into engine-core multimodal features.
-    ///
-    /// One `MmFeatureSpec` is produced per image. Tensor fields are
-    /// sliced according to the model spec's field layout declarations.
-    fn build_features(
-        &self,
-        preprocessed: PreprocessedImages,
-        images: FetchedImageMedia,
-        ranges: Vec<PlaceholderRange>,
-        model_dtype: ModelDtype,
-    ) -> Result<MmFeatures> {
-        let len = images.frames.len();
-        let tensors = tensor::collect_tensors(preprocessed, model_dtype)?;
-
-        let mut features = Vec::with_capacity(images.frames.len());
-        for (index, (frame, uuid, range)) in izip!(images.frames, images.uuids, ranges).enumerate()
-        {
-            let mut data = MmKwargsItem::new();
-            for (key, tensor) in &tensors {
-                let keep_on_cpu = self.spec.keep_on_cpu_keys.contains(key);
-                let (value, field) = match self.spec.field_layouts.get(key) {
-                    Some(FieldLayout::Batched) => (
-                        tensor.batched_value_at(index)?,
-                        MmField::Batched(MmBatchedField { keep_on_cpu }),
-                    ),
-                    Some(FieldLayout::Flat { sizes_key }) => {
-                        let sizes = tensors.get(sizes_key).ok_or_else(|| {
-                            multimodal!("flat tensor sizes key `{sizes_key}` is missing")
-                        })?;
-                        let (start, end) = tensor::flat_range_for_index(sizes, sizes_key, index)?;
-                        (
-                            tensor.flat_value_range(start, end)?,
-                            MmField::Flat(MmFlatField {
-                                slices: vec![MmSlice::Slice(SliceSpec {
-                                    start: Some(0),
-                                    stop: Some((end - start) as isize),
-                                    step: None,
-                                })],
-                                dim: 0,
-                                keep_on_cpu,
-                            }),
-                        )
-                    }
-                    None => (
-                        tensor.clone(),
-                        MmField::Shared(MmSharedField {
-                            batch_size: len,
-                            keep_on_cpu,
-                        }),
-                    ),
-                };
-
-                data.insert(
-                    key.clone(),
-                    MmFieldElem {
-                        data: Some(value.try_into()?),
-                        field,
-                    },
-                );
-            }
-
-            let hash = frame.hash.clone();
-            features.push(MmFeatureSpec {
-                data: Some(data),
-                modality: "image".to_string(),
-                identifier: uuid.unwrap_or_else(|| hash.clone()),
-                mm_position: range,
-                mm_hash: Some(hash),
-            });
-        }
-
-        Ok(features)
-    }
-}
-
 fn expand_prompt_token_ids(
     prompt_token_ids: &mut Vec<u32>,
-    replacements: Vec<PromptReplacement>,
-    placeholder_marker_token_id: u32,
-    placeholder_embed_token_id: u32,
-    placeholder_token: &str,
+    replacements: Vec<ResolvedPromptReplacement>,
 ) -> Result<Vec<PlaceholderRange>> {
     if replacements.is_empty() {
         return Ok(Vec::new());
     }
 
     let replacement_growth = replacements.iter().fold(0usize, |total, replacement| {
-        total.saturating_add(replacement.tokens.len().saturating_sub(1))
+        total.saturating_add(replacement.replacement.tokens.len().saturating_sub(1))
     });
     let mut expanded =
         Vec::with_capacity(prompt_token_ids.len().saturating_add(replacement_growth));
@@ -492,37 +794,39 @@ fn expand_prompt_token_ids(
     let mut cursor = 0usize;
 
     for replacement in replacements {
-        if replacement.modality != Modality::Image {
+        let offset = find_next_token(
+            prompt_token_ids,
+            replacement.placeholder_marker_token_id,
+            cursor,
+        )
+        .ok_or_else(|| {
+            multimodal!(
+                "placeholder token `{}` was not found in tokenized prompt",
+                replacement.replacement.placeholder_token
+            )
+        })?;
+
+        if replacement.replacement.tokens.is_empty() {
             bail_multimodal!(
-                "unsupported prompt replacement modality `{}`",
-                replacement.modality
+                "placeholder token `{}` expanded to no tokens",
+                replacement.replacement.placeholder_token
             );
         }
 
-        let offset = find_next_token(prompt_token_ids, placeholder_marker_token_id, cursor)
-            .ok_or_else(|| {
-                multimodal!(
-                    "placeholder token `{placeholder_token}` was not found in tokenized prompt"
-                )
-            })?;
-
-        if replacement.tokens.is_empty() {
-            bail_multimodal!("placeholder token `{placeholder_token}` expanded to no tokens");
-        }
-
-        let replacement_len = replacement.tokens.len();
+        let replacement_len = replacement.replacement.tokens.len();
         let is_embed = {
             let mask = replacement
+                .replacement
                 .tokens
                 .iter()
-                .map(|&token| token as u32 == placeholder_embed_token_id)
+                .map(|&token| token as u32 == replacement.placeholder_embed_token_id)
                 .collect::<Vec<_>>();
             WireTensor::from_bool(vec![replacement_len], mask).map_err(Error::Multimodal)?
         };
 
         expanded.extend_from_slice(&prompt_token_ids[cursor..offset]);
         let expanded_offset = expanded.len();
-        expanded.extend(replacement.tokens.into_iter().map(|token| token as u32));
+        expanded.extend(replacement.replacement.tokens.into_iter().map(|token| token as u32));
         ranges.push(PlaceholderRange {
             offset: expanded_offset,
             length: replacement_len,
@@ -533,14 +837,13 @@ fn expand_prompt_token_ids(
 
     expanded.extend_from_slice(&prompt_token_ids[cursor..]);
     *prompt_token_ids = expanded;
-
     Ok(ranges)
 }
 
 /// Find `needle` in `haystack`, starting at `start`.
 ///
 /// This is intentionally order-preserving rather than a global replace: each
-/// image consumes the next placeholder occurrence.
+/// media item consumes the next placeholder occurrence.
 fn find_next_token(haystack: &[u32], needle: u32, start: usize) -> Option<usize> {
     haystack
         .get(start..)?
@@ -579,6 +882,8 @@ mod tests {
     const LLAMA4_PATCH_ID: u32 = 200092;
     const LLAMA4_TILE_X_SEPARATOR_ID: u32 = 200093;
     const LLAMA4_TILE_Y_SEPARATOR_ID: u32 = 200094;
+    const TEST_VIDEO_MARKER_ID: u32 = 200095;
+    const TEST_VIDEO_EMBED_ID: u32 = 200096;
 
     struct TestTokenizer;
 
@@ -661,6 +966,7 @@ mod tests {
                 raw: raw_image_processor,
                 config: PreProcessorConfig::default(),
             },
+            video_processor: None,
             media_connector,
         }
     }
@@ -715,11 +1021,24 @@ mod tests {
         );
     }
 
+    fn resolve_image_replacements(
+        replacements: Vec<PromptReplacement>,
+    ) -> Vec<ResolvedPromptReplacement> {
+        replacements
+            .into_iter()
+            .map(|replacement| ResolvedPromptReplacement {
+                replacement,
+                placeholder_marker_token_id: LLAMA4_IMAGE_ID,
+                placeholder_embed_token_id: LLAMA4_PATCH_ID,
+            })
+            .collect()
+    }
+
     #[test]
     fn expand_prompt_tokens_marks_only_llama4_patch_tokens_as_embed() {
         let info = llama4_info();
         let mut prompt_token_ids = vec![1, LLAMA4_IMAGE_ID, 2];
-        let replacements = vec![llama4_multi_tile_replacement()];
+        let replacements = resolve_image_replacements(vec![llama4_multi_tile_replacement()]);
 
         let ranges = info.expand_prompt_tokens(&mut prompt_token_ids, replacements).unwrap();
 
@@ -750,7 +1069,7 @@ mod tests {
     fn expand_prompt_tokens_errors_when_placeholder_missing() {
         let info = llama4_info();
         let mut prompt_token_ids = vec![1, 2, 3];
-        let replacements = vec![llama4_single_tile_replacement()];
+        let replacements = resolve_image_replacements(vec![llama4_single_tile_replacement()]);
 
         let error = info.expand_prompt_tokens(&mut prompt_token_ids, replacements).unwrap_err();
 
@@ -778,6 +1097,7 @@ mod tests {
             llama4_single_tile_replacement(),
             llama4_single_tile_replacement(),
         ];
+        let replacements = resolve_image_replacements(replacements);
 
         let error = info.expand_prompt_tokens(&mut prompt_token_ids, replacements).unwrap_err();
 
@@ -790,11 +1110,11 @@ mod tests {
         let info = llama4_info();
         let mut prompt_token_ids = vec![1, LLAMA4_IMAGE_ID, 2];
         let original_prompt_token_ids = prompt_token_ids.clone();
-        let replacements = vec![PromptReplacement::sequence(
+        let replacements = resolve_image_replacements(vec![PromptReplacement::sequence(
             Modality::Image,
             "<|image|>",
             Vec::new(),
-        )];
+        )]);
 
         let error = info.expand_prompt_tokens(&mut prompt_token_ids, replacements).unwrap_err();
 
@@ -812,6 +1132,7 @@ mod tests {
             llama4_single_tile_replacement(),
             llama4_single_tile_replacement(),
         ];
+        let replacements = resolve_image_replacements(replacements);
 
         let ranges = info.expand_prompt_tokens(&mut prompt_token_ids, replacements).unwrap();
 
@@ -839,5 +1160,56 @@ mod tests {
         assert_eq!(ranges[1].offset, 7);
         assert_eq!(ranges[1].length, 5);
         assert_bool_mask(&ranges[1], &[false, false, true, true, false]);
+    }
+
+    #[test]
+    fn expand_prompt_token_ids_supports_mixed_image_and_video_placeholders() {
+        let mut prompt_token_ids = vec![1, LLAMA4_IMAGE_ID, 2, TEST_VIDEO_MARKER_ID, 3];
+        let replacements = vec![
+            ResolvedPromptReplacement {
+                replacement: PromptReplacement::sequence(
+                    Modality::Image,
+                    "<|image|>",
+                    vec![LLAMA4_IMAGE_START_ID as TokenId, LLAMA4_PATCH_ID as TokenId],
+                ),
+                placeholder_marker_token_id: LLAMA4_IMAGE_ID,
+                placeholder_embed_token_id: LLAMA4_PATCH_ID,
+            },
+            ResolvedPromptReplacement {
+                replacement: PromptReplacement::sequence(
+                    Modality::Video,
+                    "<|video_pad|>",
+                    vec![
+                        TEST_VIDEO_MARKER_ID as TokenId,
+                        TEST_VIDEO_EMBED_ID as TokenId,
+                        TEST_VIDEO_MARKER_ID as TokenId,
+                    ],
+                ),
+                placeholder_marker_token_id: TEST_VIDEO_MARKER_ID,
+                placeholder_embed_token_id: TEST_VIDEO_EMBED_ID,
+            },
+        ];
+
+        let ranges = expand_prompt_token_ids(&mut prompt_token_ids, replacements).unwrap();
+
+        assert_eq!(
+            prompt_token_ids,
+            vec![
+                1,
+                LLAMA4_IMAGE_START_ID,
+                LLAMA4_PATCH_ID,
+                2,
+                TEST_VIDEO_MARKER_ID,
+                TEST_VIDEO_EMBED_ID,
+                TEST_VIDEO_MARKER_ID,
+                3,
+            ]
+        );
+        assert_eq!(ranges[0].offset, 1);
+        assert_eq!(ranges[0].length, 2);
+        assert_bool_mask(&ranges[0], &[false, true]);
+        assert_eq!(ranges[1].offset, 4);
+        assert_eq!(ranges[1].length, 3);
+        assert_bool_mask(&ranges[1], &[false, true, false]);
     }
 }

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -90,16 +90,20 @@ impl MultimodalModelContext {
     }
 }
 
+/// Token identity for one media-type placeholder.
+#[derive(Clone)]
+struct PlaceholderSpec {
+    token: String,
+    marker_token_id: u32,
+    embed_token_id: u32,
+}
+
 /// Static model-specific prompt and tensor-layout behavior.
 #[derive(Clone)]
 struct ResolvedMultimodalSpec {
     raw: &'static dyn ModelProcessorSpec,
-    image_placeholder_token: String,
-    image_placeholder_marker_token_id: u32,
-    image_placeholder_embed_token_id: u32,
-    video_placeholder_token: String,
-    video_placeholder_marker_token_id: u32,
-    video_placeholder_embed_token_id: u32,
+    image_placeholder: PlaceholderSpec,
+    video_placeholder: PlaceholderSpec,
     field_layouts: HashMap<String, FieldLayout>,
     keep_on_cpu_keys: HashSet<String>,
 }
@@ -107,40 +111,45 @@ struct ResolvedMultimodalSpec {
 impl ResolvedMultimodalSpec {
     fn new(raw: &'static dyn ModelProcessorSpec, context: &MultimodalModelContext) -> Result<Self> {
         let metadata = context.metadata();
-        let image_placeholder_token =
+        let tokenizer = context.tokenizer();
+        // image
+        let image_token =
             raw.placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
-        let video_placeholder_token =
-            raw.video_placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
-        let image_placeholder_marker_token_id = context
-            .tokenizer()
-            .token_to_id(&image_placeholder_token)
+        let image_marker_token_id = tokenizer
+            .token_to_id(&image_token)
             .ok_or_else(|| {
                 multimodal!(
-                    "placeholder token `{image_placeholder_token}` is not in the tokenizer vocabulary"
+                    "placeholder token `{image_token}` is not in the tokenizer vocabulary"
                 )
             })?;
-        let image_placeholder_embed_token_id =
+        let image_embed_token_id =
             raw.placeholder_token_id(&metadata).map_err(|error| multimodal!("{error}"))? as u32;
-        let video_placeholder_marker_token_id = context
-            .tokenizer()
-            .token_to_id(&video_placeholder_token)
+        // video
+        let video_token =
+            raw.video_placeholder_token(&metadata).map_err(|error| multimodal!("{error}"))?;
+        let video_marker_token_id = tokenizer
+            .token_to_id(&video_token)
             .ok_or_else(|| {
                 multimodal!(
-                    "placeholder token `{video_placeholder_token}` is not in the tokenizer vocabulary"
+                    "placeholder token `{video_token}` is not in the tokenizer vocabulary"
                 )
             })?;
-        let video_placeholder_embed_token_id =
+        let video_embed_token_id =
             raw.video_placeholder_token_id(&metadata)
                 .map_err(|error| multimodal!("{error}"))? as u32;
 
         Ok(Self {
             raw,
-            image_placeholder_token,
-            image_placeholder_marker_token_id,
-            image_placeholder_embed_token_id,
-            video_placeholder_token,
-            video_placeholder_marker_token_id,
-            video_placeholder_embed_token_id,
+            image_placeholder: PlaceholderSpec {
+                token: image_token,
+                marker_token_id: image_marker_token_id,
+                embed_token_id: image_embed_token_id,
+            },
+            video_placeholder: PlaceholderSpec {
+                token: video_token,
+                marker_token_id: video_marker_token_id,
+                embed_token_id: video_embed_token_id,
+            },
             field_layouts: raw.field_layouts(),
             keep_on_cpu_keys: raw.keep_on_cpu_keys().into_iter().collect(),
         })
@@ -159,8 +168,8 @@ impl ResolvedMultimodalSpec {
             .into_iter()
             .map(|replacement| ResolvedPromptReplacement {
                 replacement,
-                placeholder_marker_token_id: self.image_placeholder_marker_token_id,
-                placeholder_embed_token_id: self.image_placeholder_embed_token_id,
+                placeholder_marker_token_id: self.image_placeholder.marker_token_id,
+                placeholder_embed_token_id: self.image_placeholder.embed_token_id,
             })
             .collect())
     }
@@ -178,8 +187,8 @@ impl ResolvedMultimodalSpec {
             .into_iter()
             .map(|replacement| ResolvedPromptReplacement {
                 replacement,
-                placeholder_marker_token_id: self.video_placeholder_marker_token_id,
-                placeholder_embed_token_id: self.video_placeholder_embed_token_id,
+                placeholder_marker_token_id: self.video_placeholder.marker_token_id,
+                placeholder_embed_token_id: self.video_placeholder.embed_token_id,
             })
             .collect())
     }
@@ -398,7 +407,7 @@ impl MultimodalModelInfo {
     /// The HF renderer uses this token while flattening image content in string
     /// content format.
     pub fn placeholder_token(&self) -> &str {
-        &self.spec.image_placeholder_token
+        &self.spec.image_placeholder.token
     }
 
     /// Return the template-visible video placeholder token for this model.
@@ -406,7 +415,7 @@ impl MultimodalModelInfo {
     /// The HF renderer uses this token while flattening video content in string
     /// content format.
     pub fn video_placeholder_token(&self) -> &str {
-        &self.spec.video_placeholder_token
+        &self.spec.video_placeholder.token
     }
 
     /// Run media fetch, preprocessing, prompt expansion, and feature build.

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -289,6 +289,12 @@ fn extract_media_parts(request: &ChatRequest) -> Result<Vec<MediaContentPart>> {
                     detail: *detail,
                     uuid: uuid.clone(),
                 }),
+                ChatContentPart::VideoUrl { video_url, uuid } => {
+                    all_parts.push(MediaContentPart::VideoUrl {
+                        url: video_url.clone(),
+                        uuid: uuid.clone(),
+                    })
+                }
             }
         }
     }

--- a/rust/src/chat/src/multimodal/tensor.rs
+++ b/rust/src/chat/src/multimodal/tensor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use half::{bf16, f16};
-use llm_multimodal::{ModelSpecificValue, PreprocessedImages};
+use llm_multimodal::{ModelSpecificValue, PreprocessedImages, PreprocessedVideos};
 use vllm_engine_core_client::protocol::ModelDtype;
 use vllm_engine_core_client::protocol::multimodal::MmKwargValue as ProtocolKwargValue;
 use vllm_engine_core_client::protocol::tensor::{ShapeExt as _, WireTensor};
@@ -25,8 +25,8 @@ pub(super) enum KwargValue {
     Passthrough(ProtocolKwargValue),
 }
 
-/// Collect `pixel_values` and model-specific outputs into one tensor map.
-pub(super) fn collect_tensors(
+/// Collect image tensors and model-specific outputs into one tensor map.
+pub(super) fn collect_image_tensors(
     preprocessed: PreprocessedImages,
     float_dtype: ModelDtype,
 ) -> Result<HashMap<String, KwargValue>> {
@@ -42,8 +42,42 @@ pub(super) fn collect_tensors(
         KwargValue::from_f32_tensor(data, shape, float_dtype)?
     };
 
+    collect_named_tensors("pixel_values", pixel_values, model_specific, float_dtype)
+}
+
+/// Collect video tensors and model-specific outputs into one tensor map.
+pub(super) fn collect_video_tensors(
+    preprocessed: PreprocessedVideos,
+    float_dtype: ModelDtype,
+) -> Result<HashMap<String, KwargValue>> {
+    let PreprocessedVideos {
+        pixel_values,
+        model_specific,
+        ..
+    } = preprocessed;
+
+    let pixel_values = {
+        let shape = pixel_values.shape().to_vec();
+        let data = pixel_values.into_iter().collect();
+        KwargValue::from_f32_tensor(data, shape, float_dtype)?
+    };
+
+    collect_named_tensors(
+        "pixel_values_videos",
+        pixel_values,
+        model_specific,
+        float_dtype,
+    )
+}
+
+fn collect_named_tensors(
+    pixel_values_key: &str,
+    pixel_values: KwargValue,
+    model_specific: HashMap<String, ModelSpecificValue>,
+    float_dtype: ModelDtype,
+) -> Result<HashMap<String, KwargValue>> {
     let mut tensors = HashMap::new();
-    tensors.insert("pixel_values".to_string(), pixel_values);
+    tensors.insert(pixel_values_key.to_string(), pixel_values);
     for (key, value) in model_specific {
         tensors.insert(key, KwargValue::from_model_specific(value, float_dtype)?);
     }

--- a/rust/src/chat/src/renderer/hf/mod.rs
+++ b/rust/src/chat/src/renderer/hf/mod.rs
@@ -33,7 +33,8 @@ pub use self::format::ChatTemplateContentFormatOption;
 
 #[derive(Debug, Clone)]
 pub struct MultimodalRenderInfo {
-    pub placeholder_token: String,
+    pub image_placeholder_token: String,
+    pub video_placeholder_token: String,
 }
 
 /// Hugging Face chat-template renderer backed by the local Jinja chat-template
@@ -425,12 +426,12 @@ fn to_template_string_content(
                     ChatContentPart::ImageUrl { .. } => {
                         let multimodal =
                             multimodal.ok_or(Error::UnsupportedMultimodalContent("image_url"))?;
-                        out.push_str(&multimodal.placeholder_token);
+                        out.push_str(&multimodal.image_placeholder_token);
                     }
                     ChatContentPart::VideoUrl { .. } => {
                         let multimodal =
                             multimodal.ok_or(Error::UnsupportedMultimodalContent("video_url"))?;
-                        out.push_str(&multimodal.placeholder_token);
+                        out.push_str(&multimodal.video_placeholder_token);
                     }
                 }
             }
@@ -500,7 +501,8 @@ mod tests {
     ) -> Result<crate::RenderedPrompt> {
         HfChatRenderer::new(Some(template.to_string()), HashMap::new(), content_format)?
             .with_multimodal(Some(MultimodalRenderInfo {
-                placeholder_token: "<image>".to_string(),
+                image_placeholder_token: "<image>".to_string(),
+                video_placeholder_token: "<video>".to_string(),
             }))
             .render(request)
     }
@@ -509,6 +511,14 @@ mod tests {
         sample_request(vec![ChatMessage::user(vec![
             ChatContentPart::text("a"),
             ChatContentPart::image_url("data:image/png;base64,test"),
+            ChatContentPart::text("b"),
+        ])])
+    }
+
+    fn video_request() -> ChatRequest {
+        sample_request(vec![ChatMessage::user(vec![
+            ChatContentPart::text("a"),
+            ChatContentPart::video_url("https://example.com/video.mp4"),
             ChatContentPart::text("b"),
         ])])
     }
@@ -535,6 +545,18 @@ mod tests {
         .unwrap();
 
         assert_eq!(rendered.prompt, Prompt::Text("a<|image_pad|>b".to_string()));
+    }
+
+    #[test]
+    fn string_content_format_replaces_video_with_placeholder_text() {
+        let rendered = render_mm(
+            "{{ messages[0].content }}",
+            &video_request(),
+            ChatTemplateContentFormatOption::String,
+        )
+        .unwrap();
+
+        assert_eq!(rendered.prompt, Prompt::Text("a<video>b".to_string()));
     }
 
     #[test]

--- a/rust/src/chat/src/renderer/hf/mod.rs
+++ b/rust/src/chat/src/renderer/hf/mod.rs
@@ -235,6 +235,7 @@ enum TemplateContent {
 enum TemplateContentPart {
     Text { text: String },
     Image,
+    Video,
 }
 
 #[derive(Debug, Serialize)]
@@ -401,6 +402,10 @@ fn to_template_openai_content(
                     multimodal.ok_or(Error::UnsupportedMultimodalContent("image_url"))?;
                     Ok(TemplateContentPart::Image)
                 }
+                ChatContentPart::VideoUrl { .. } => {
+                    multimodal.ok_or(Error::UnsupportedMultimodalContent("video_url"))?;
+                    Ok(TemplateContentPart::Video)
+                }
             })
             .collect(),
     }
@@ -420,6 +425,11 @@ fn to_template_string_content(
                     ChatContentPart::ImageUrl { .. } => {
                         let multimodal =
                             multimodal.ok_or(Error::UnsupportedMultimodalContent("image_url"))?;
+                        out.push_str(&multimodal.placeholder_token);
+                    }
+                    ChatContentPart::VideoUrl { .. } => {
+                        let multimodal =
+                            multimodal.ok_or(Error::UnsupportedMultimodalContent("video_url"))?;
                         out.push_str(&multimodal.placeholder_token);
                     }
                 }

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -36,6 +36,11 @@ pub enum ChatContentPart {
         detail: Option<ImageDetail>,
         uuid: Option<String>,
     },
+    /// One video URL content block.
+    VideoUrl {
+        video_url: String,
+        uuid: Option<String>,
+    },
     // ImageData...
     // ImageEmbeds...
 }
@@ -55,12 +60,21 @@ impl ChatContentPart {
         }
     }
 
+    /// Construct one video URL content part with the given URL string.
+    pub fn video_url(video_url: impl Into<String>) -> Self {
+        Self::VideoUrl {
+            video_url: video_url.into(),
+            uuid: None,
+        }
+    }
+
     /// Return the text content of this part when it's a text block, or an
     /// "unsupported multimodal content" error otherwise.
     pub(crate) fn as_text(&self) -> Result<&str> {
         match self {
             Self::Text { text } => Ok(text),
             Self::ImageUrl { .. } => Err(Error::UnsupportedMultimodalContent("image_url")),
+            Self::VideoUrl { .. } => Err(Error::UnsupportedMultimodalContent("video_url")),
         }
     }
 
@@ -74,6 +88,7 @@ impl ChatContentPart {
         match self {
             Self::Text { .. } => false,
             Self::ImageUrl { .. } => true,
+            Self::VideoUrl { .. } => true,
         }
     }
 }

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -271,9 +271,6 @@ fn convert_content(content: MessageContent) -> Result<ChatContent, ApiError> {
                     video_url: video_url.url,
                     uuid,
                 }),
-                _ => bail_invalid_request!(
-                    "Only text, image_url, and video_url content parts are supported."
-                ),
             })
             .try_collect()
             .map(ChatContent::Parts),
@@ -639,28 +636,34 @@ mod tests {
     }
 
     #[test]
-    fn prepare_chat_request_rejects_video_content_parts() {
+    fn prepare_chat_request_maps_video_url_content_parts() {
         let request = ChatCompletionRequest {
             messages: vec![ChatMessage::User {
                 content: MessageContent::Parts(vec![ContentPart::VideoUrl {
                     video_url: VideoUrl {
                         url: "https://example.com/video.mp4".to_string(),
                     },
+                    uuid: None,
                 }]),
                 name: None,
             }],
             ..base_request()
         };
 
-        let error = prepare_chat_request(
+        let prepared = prepare_chat_request(
             request,
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
         )
-        .unwrap_err();
+        .expect("request is valid");
 
-        expect!["Only text and image_url content parts are supported."]
-            .assert_eq(&error.to_error_response().error.message);
+        assert_eq!(
+            prepared.chat_request.messages,
+            vec![VllmChatMessage::user(vec![ChatContentPart::VideoUrl {
+                video_url: "https://example.com/video.mp4".to_string(),
+                uuid: None,
+            }])]
+        );
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -267,7 +267,13 @@ fn convert_content(content: MessageContent) -> Result<ChatContent, ApiError> {
                     detail: image_url.detail,
                     uuid,
                 }),
-                _ => bail_invalid_request!("Only text and image_url content parts are supported."),
+                ContentPart::VideoUrl { video_url, uuid } => Ok(ChatContentPart::VideoUrl {
+                    video_url: video_url.url,
+                    uuid,
+                }),
+                _ => bail_invalid_request!(
+                    "Only text, image_url, and video_url content parts are supported."
+                ),
             })
             .try_collect()
             .map(ChatContent::Parts),

--- a/rust/src/server/src/routes/openai/utils/types.rs
+++ b/rust/src/server/src/routes/openai/utils/types.rs
@@ -90,7 +90,11 @@ pub enum ContentPart {
         uuid: Option<String>,
     },
     #[serde(rename = "video_url")]
-    VideoUrl { video_url: VideoUrl },
+    VideoUrl {
+        video_url: VideoUrl,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uuid: Option<String>,
+    },
 }
 
 #[serde_with::skip_serializing_none]

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -424,6 +424,11 @@ impl Tokenizer for FakeChatTokenizer {
                 rest = stripped;
                 continue;
             }
+            if let Some(stripped) = rest.strip_prefix("<|image_pad|>") {
+                token_ids.push(151655);
+                rest = stripped;
+                continue;
+            }
 
             let ch = rest.chars().next().expect("rest is not empty");
             let mut buf = [0; 4];
@@ -542,11 +547,16 @@ impl ChatBackend for FakeChatBackend {
 
 impl ChatRenderer for FakeChatBackend {
     fn render(&self, request: &ChatRequest) -> vllm_chat::Result<vllm_chat::RenderedPrompt> {
+        let placeholder = self
+            .multimodal_model_info
+            .as_ref()
+            .map(|info| info.placeholder_token())
+            .unwrap_or("<image>");
         let mut prompt = String::new();
         for message in &request.messages {
             prompt.push_str(message.role().as_str());
             prompt.push_str(": ");
-            prompt.push_str(&render_fake_message_content(message)?);
+            prompt.push_str(&render_fake_message_content(message, placeholder)?);
             prompt.push('\n');
         }
         if request.chat_options.add_generation_prompt() {
@@ -558,17 +568,20 @@ impl ChatRenderer for FakeChatBackend {
     }
 }
 
-fn render_fake_message_content(message: &ChatMessage) -> vllm_chat::Result<String> {
+fn render_fake_message_content(
+    message: &ChatMessage,
+    placeholder: &str,
+) -> vllm_chat::Result<String> {
     match message {
         ChatMessage::System { content }
         | ChatMessage::Developer { content, .. }
         | ChatMessage::User { content }
-        | ChatMessage::ToolResponse { content, .. } => render_fake_content(content),
+        | ChatMessage::ToolResponse { content, .. } => render_fake_content(content, placeholder),
         ChatMessage::Assistant { .. } => message.text_content(),
     }
 }
 
-fn render_fake_content(content: &ChatContent) -> vllm_chat::Result<String> {
+fn render_fake_content(content: &ChatContent, placeholder: &str) -> vllm_chat::Result<String> {
     Ok(match content {
         ChatContent::Text(text) => text.clone(),
         ChatContent::Parts(parts) => {
@@ -576,7 +589,7 @@ fn render_fake_content(content: &ChatContent) -> vllm_chat::Result<String> {
             for part in parts {
                 match part {
                     ChatContentPart::Text { text } => out.push_str(text),
-                    ChatContentPart::ImageUrl { .. } => out.push_str("<image>"),
+                    ChatContentPart::ImageUrl { .. } => out.push_str(placeholder),
                 }
             }
             out
@@ -591,7 +604,7 @@ fn qwen_multimodal_model_info() -> vllm_chat::multimodal::MultimodalModelInfo {
     ));
     fs::write(
         &config_path,
-        r#"{"model_type":"qwen2_vl","vision_token_id":151655}"#,
+        r#"{"model_type":"qwen2_vl","image_token_id":151655}"#,
     )
     .expect("write qwen test config");
     let info = vllm_chat::multimodal::MultimodalModelInfo::from_paths(

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -429,6 +429,11 @@ impl Tokenizer for FakeChatTokenizer {
                 rest = stripped;
                 continue;
             }
+            if let Some(stripped) = rest.strip_prefix("<|video_pad|>") {
+                token_ids.push(151657);
+                rest = stripped;
+                continue;
+            }
 
             let ch = rest.chars().next().expect("rest is not empty");
             let mut buf = [0; 4];
@@ -453,6 +458,7 @@ impl Tokenizer for FakeChatTokenizer {
         match token {
             "<image>" => Some(999),
             "<|image_pad|>" => Some(151655),
+            "<|video_pad|>" => Some(151657),
             "<think>" => Some(0xF001),
             "</think>" => Some(0xF002),
             "<|START_THINKING|>" => Some(0xF003),
@@ -467,6 +473,7 @@ impl Tokenizer for FakeChatTokenizer {
         match id {
             999 => Some("<image>".to_string()),
             151655 => Some("<|image_pad|>".to_string()),
+            151657 => Some("<|video_pad|>".to_string()),
             0xF001 => Some("<think>".to_string()),
             0xF002 => Some("</think>".to_string()),
             0xF003 => Some("<|START_THINKING|>".to_string()),
@@ -547,16 +554,25 @@ impl ChatBackend for FakeChatBackend {
 
 impl ChatRenderer for FakeChatBackend {
     fn render(&self, request: &ChatRequest) -> vllm_chat::Result<vllm_chat::RenderedPrompt> {
-        let placeholder = self
+        let image_placeholder = self
             .multimodal_model_info
             .as_ref()
             .map(|info| info.placeholder_token())
             .unwrap_or("<image>");
+        let video_placeholder = self
+            .multimodal_model_info
+            .as_ref()
+            .map(|info| info.video_placeholder_token())
+            .unwrap_or("<video>");
         let mut prompt = String::new();
         for message in &request.messages {
             prompt.push_str(message.role().as_str());
             prompt.push_str(": ");
-            prompt.push_str(&render_fake_message_content(message, placeholder)?);
+            prompt.push_str(&render_fake_message_content(
+                message,
+                image_placeholder,
+                video_placeholder,
+            )?);
             prompt.push('\n');
         }
         if request.chat_options.add_generation_prompt() {
@@ -570,18 +586,25 @@ impl ChatRenderer for FakeChatBackend {
 
 fn render_fake_message_content(
     message: &ChatMessage,
-    placeholder: &str,
+    image_placeholder: &str,
+    video_placeholder: &str,
 ) -> vllm_chat::Result<String> {
     match message {
         ChatMessage::System { content }
         | ChatMessage::Developer { content, .. }
         | ChatMessage::User { content }
-        | ChatMessage::ToolResponse { content, .. } => render_fake_content(content, placeholder),
+        | ChatMessage::ToolResponse { content, .. } => {
+            render_fake_content(content, image_placeholder, video_placeholder)
+        }
         ChatMessage::Assistant { .. } => message.text_content(),
     }
 }
 
-fn render_fake_content(content: &ChatContent, placeholder: &str) -> vllm_chat::Result<String> {
+fn render_fake_content(
+    content: &ChatContent,
+    image_placeholder: &str,
+    video_placeholder: &str,
+) -> vllm_chat::Result<String> {
     Ok(match content {
         ChatContent::Text(text) => text.clone(),
         ChatContent::Parts(parts) => {
@@ -589,7 +612,8 @@ fn render_fake_content(content: &ChatContent, placeholder: &str) -> vllm_chat::R
             for part in parts {
                 match part {
                     ChatContentPart::Text { text } => out.push_str(text),
-                    ChatContentPart::ImageUrl { .. } => out.push_str(placeholder),
+                    ChatContentPart::ImageUrl { .. } => out.push_str(image_placeholder),
+                    ChatContentPart::VideoUrl { .. } => out.push_str(video_placeholder),
                 }
             }
             out
@@ -604,7 +628,7 @@ fn qwen_multimodal_model_info() -> vllm_chat::multimodal::MultimodalModelInfo {
     ));
     fs::write(
         &config_path,
-        r#"{"model_type":"qwen2_vl","image_token_id":151655}"#,
+        r#"{"model_type":"qwen2_vl","image_token_id":151655,"video_token_id":151656}"#,
     )
     .expect("write qwen test config");
     let info = vllm_chat::multimodal::MultimodalModelInfo::from_paths(

--- a/rust/src/tokenizer/src/hf.rs
+++ b/rust/src/tokenizer/src/hf.rs
@@ -105,6 +105,9 @@ impl HuggingFaceTokenizer {
     /// Load from `tokenizer.json` with `fastokens`.
     pub fn new_fastokens(path: &Path) -> Result<Self> {
         info!(path = %path.display(), "loading tokenizer with fastokens");
+        // FIXME(Isotr0py): This is a temporary workaround for fastokens missing tokens in `tokenizer_config.json`,
+        // revert to FastokensTokenizer::from_file after fastokens fix it.
+        // See: https://github.com/crusoecloud/fastokens/pull/36 and https://github.com/vllm-project/vllm/pull/44683
         let tokenizer_json = Self::load_tokenizer_json_with_extra_tokens(path)?;
         let t = FastokensTokenizer::from_json(tokenizer_json)
             .map_err(|error| tokenizer_error!("failed to load tokenizer: {}", error.as_report()))?;

--- a/rust/src/tokenizer/src/hf.rs
+++ b/rust/src/tokenizer/src/hf.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -104,7 +105,8 @@ impl HuggingFaceTokenizer {
     /// Load from `tokenizer.json` with `fastokens`.
     pub fn new_fastokens(path: &Path) -> Result<Self> {
         info!(path = %path.display(), "loading tokenizer with fastokens");
-        let t = FastokensTokenizer::from_file(path)
+        let tokenizer_json = Self::load_tokenizer_json_with_extra_tokens(path)?;
+        let t = FastokensTokenizer::from_json(tokenizer_json)
             .map_err(|error| tokenizer_error!("failed to load tokenizer: {}", error.as_report()))?;
         Ok(Self::from_fastokens_backend(t))
     }
@@ -130,6 +132,76 @@ impl HuggingFaceTokenizer {
                 Self::new_hf(path)
             }
         }
+    }
+}
+
+impl HuggingFaceTokenizer {
+    /// Read `tokenizer.json`, then merge in extra added tokens from `tokenizer_config.json`                                                                                                                                                                  
+    fn load_tokenizer_json_with_extra_tokens(path: &Path) -> Result<serde_json::Value> {
+        let tokenizer_json = fs::read_to_string(path)
+            .map_err(|error| tokenizer_error!("failed to read {}: {}", path.display(), error))?;
+        let mut tokenizer_value: serde_json::Value = serde_json::from_str(&tokenizer_json)
+            .map_err(|error| tokenizer_error!("failed to parse {}: {}", path.display(), error))?;
+
+        if let Some(parent) = path.parent() {
+            let config_path = parent.join("tokenizer_config.json");
+            if config_path.exists() {
+                if let Ok(config_text) = fs::read_to_string(&config_path) {
+                    if let Ok(config_value) =
+                        serde_json::from_str::<serde_json::Value>(&config_text)
+                    {
+                        merge_added_tokens_from_config(&mut tokenizer_value, &config_value);
+                    }
+                }
+            }
+        }
+
+        Ok(tokenizer_value)
+    }
+}
+
+/// Merge added_tokens in `tokenizer.json` and `tokenizer_config.json`.                                                                               
+fn merge_added_tokens_from_config(
+    tokenizer_json: &mut serde_json::Value,
+    config_json: &serde_json::Value,
+) {
+    use std::collections::HashSet;
+
+    let existing_ids: HashSet<u32> = tokenizer_json
+        .get("added_tokens")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("id").and_then(|id| id.as_u64()).map(|id| id as u32))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let decoder = match config_json.get("added_tokens_decoder").and_then(|v| v.as_object()) {
+        Some(d) => d,
+        None => return,
+    };
+
+    let added_tokens = match tokenizer_json.get_mut("added_tokens").and_then(|v| v.as_array_mut()) {
+        Some(a) => a,
+        None => return,
+    };
+
+    for (id_str, token_value) in decoder {
+        let id: u32 = match id_str.parse() {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        if existing_ids.contains(&id) {
+            continue;
+        }
+
+        // Convert from decoder format to added_tokens array format by adding the "id" field.
+        let mut entry = token_value.clone();
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert("id".to_string(), serde_json::json!(id));
+        }
+        added_tokens.push(entry);
     }
 }
 


### PR DESCRIPTION



## Purpose
**Still drafting video processor PR at `llm-multimodal` side: https://github.com/vllm-project/llm-multimodal/pull/2**

## Test Plan
<details>
<summary>Server logs</summary>

```
$ vllm-rs serve /mnt/data0/LLM/Qwen2-VL-2B-Instruct/ --reasoning-parser none
(RustFrontend pid=2711375) INFO 06-07 15:44:36 [cmd/src/main.rs:34] capping tokio worker threads, set TOKIO_WORKER_THREADS to override available_parallelism=64 capped_worker_threads=32
(RustFrontend pid=2711375) INFO 06-07 15:44:36 [process.rs:86] starting managed Python headless engine handshake_address=tcp://127.0.0.1:41155 command="python3" "-m" "vllm.entrypoints.cli.main" "serve" "/mnt/data0/LLM/Qwen2-VL-2B-Instruct/" "--headless" "--data-parallel-address" "127.0.0.1" "--data-parallel-rpc-port" "41155" "--data-parallel-size" "1"
(RustFrontend pid=2711375) INFO 06-07 15:44:36 [hf.rs:107] loading tokenizer with fastokens path=/mnt/data0/LLM/Qwen2-VL-2B-Instruct/tokenizer.json
(RustFrontend pid=2711375) INFO 06-07 15:44:37 [hf/mod.rs:71] loaded text backend with Hugging Face model files model_id="/mnt/data0/LLM/Qwen2-VL-2B-Instruct/"
(RustFrontend pid=2711375) INFO 06-07 15:44:37 [hf/mod.rs:108] loaded dedicated chat template file, overriding tokenizer_config chat_template path=/mnt/data0/LLM/Qwen2-VL-2B-Instruct/chat_template.json
(RustFrontend pid=2711375) INFO 06-07 15:44:37 [hf.rs:62] loaded chat backend with Hugging Face model files model_id="/mnt/data0/LLM/Qwen2-VL-2B-Instruct/" model_type="qwen2_vl" renderer=hf
(RustFrontend pid=2711375) INFO 06-07 15:44:37 [server/src/lib.rs:59] resolved coordinator mode engine_count=1 model_is_moe=false coordinator_mode=None
(RustFrontend pid=2711375) INFO 06-07 15:44:37 [transport.rs:153] waiting for engines to connect engine_count=1 handshake_address="tcp://127.0.0.1:41155"
(RustFrontend pid=2711375) INFO 06-07 15:44:37 [transport.rs:168] bound local transport sockets input_address=ipc:///tmp/vllm-rs-i-b0f570bbd61c4b5ba7b0585705a017c9 output_address=ipc:///tmp/vllm-rs-o-971095c386904710904a340529a31ae0
INFO 06-07 15:44:45 [model.py:610] Resolved architecture: Qwen2VLForConditionalGeneration
INFO 06-07 15:44:45 [model.py:1744] Using max model len 32768
INFO 06-07 15:44:45 [vllm.py:999] Asynchronous scheduling is enabled.
INFO 06-07 15:44:45 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
INFO 06-07 15:44:45 [serve.py:227] Launching 1 data parallel engine(s) in headless mode, with head node address tcp://127.0.0.1:41155.
(EngineCore pid=2711700) INFO 06-07 15:44:52 [core.py:113] Initializing a V1 LLM engine (v0.21.1rc1.dev159+g9640970de) with config: model='/mnt/data0/LLM/Qwen2-VL-2B-Instruct/', speculative_config=None, tokenizer='/mnt/data0/LLM/Qwen2-VL-2B-Instruct/', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/mnt/data0/LLM/Qwen2-VL-2B-Instruct/, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
(EngineCore pid=2711700) INFO 06-07 15:44:53 [parallel_state.py:1438] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.16.98.223:41353 backend=nccl
(EngineCore pid=2711700) INFO 06-07 15:44:53 [parallel_state.py:1751] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=2711700) INFO 06-07 15:44:53 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
(EngineCore pid=2711700) The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=2711700) INFO 06-07 15:44:56 [gpu_model_runner.py:5087] Starting to load model /mnt/data0/LLM/Qwen2-VL-2B-Instruct/...
(EngineCore pid=2711700) INFO 06-07 15:44:57 [cuda.py:433] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(EngineCore pid=2711700) INFO 06-07 15:44:57 [mm_encoder_attention.py:372] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(EngineCore pid=2711700) INFO 06-07 15:44:57 [vllm.py:999] Asynchronous scheduling is enabled.
(EngineCore pid=2711700) INFO 06-07 15:44:57 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(EngineCore pid=2711700) INFO 06-07 15:44:57 [cuda.py:378] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=2711700) INFO 06-07 15:44:57 [flash_attn.py:636] Using FlashAttention version 2
(EngineCore pid=2711700) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=2711700) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(EngineCore pid=2711700) INFO 06-07 15:44:57 [weight_utils.py:922] Filesystem type for checkpoints: FUSEBLK. Checkpoint size: 4.11 GiB. Available RAM: 85.80 GiB.
(EngineCore pid=2711700) INFO 06-07 15:44:57 [weight_utils.py:945] Auto-prefetch is disabled because the filesystem (FUSEBLK) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  1.30it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  2.01it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.86it/s]
(EngineCore pid=2711700) 
(EngineCore pid=2711700) INFO 06-07 15:44:58 [default_loader.py:397] Loading weights took 1.10 seconds
(EngineCore pid=2711700) INFO 06-07 15:44:59 [gpu_model_runner.py:5182] Model loading took 4.26 GiB memory and 1.808997 seconds
(EngineCore pid=2711700) INFO 06-07 15:44:59 [gpu_model_runner.py:6191] Encoder cache will be initialized with a budget of 32768 tokens, and profiled with 1 video items of the maximum feature size.
(EngineCore pid=2711700) INFO 06-07 15:45:27 [backends.py:1089] Using cache directory: /home/mozf/.cache/vllm/torch_compile_cache/b553d06555/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=2711700) INFO 06-07 15:45:27 [backends.py:1148] Dynamo bytecode transform time: 1.60 s
(EngineCore pid=2711700) INFO 06-07 15:45:28 [backends.py:292] Directly load the compiled graph(s) for compile range (1, 2048) from the cache, took 0.701 s
(EngineCore pid=2711700) INFO 06-07 15:45:28 [decorators.py:311] Directly load AOT compilation from path /home/mozf/.cache/vllm/torch_compile_cache/torch_aot_compile/aaa00ae3469130acc46379317559d0d5afafab0c7c86ad9f69d7dc71a76800a8/rank_0_0/model
(EngineCore pid=2711700) INFO 06-07 15:45:28 [monitor.py:53] torch.compile took 2.48 s in total
(EngineCore pid=2711700) INFO 06-07 15:45:28 [monitor.py:81] Initial profiling/warmup run took 0.01 s
(EngineCore pid=2711700) INFO 06-07 15:45:29 [gpu_model_runner.py:6403] Profiling CUDA graph memory: PIECEWISE=51 (largest=512), FULL=35 (largest=256)
(EngineCore pid=2711700) INFO 06-07 15:45:30 [gpu_model_runner.py:6508] Estimated CUDA graph memory: 0.49 GiB total
(EngineCore pid=2711700) INFO 06-07 15:45:30 [gpu_worker.py:470] Available KV cache memory: 11.83 GiB
(EngineCore pid=2711700) INFO 06-07 15:45:30 [gpu_worker.py:485] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.9200 is equivalent to --gpu-memory-utilization=0.8993 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.9407. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
(EngineCore pid=2711700) INFO 06-07 15:45:30 [kv_cache_utils.py:1755] GPU KV cache size: 443,088 tokens
(EngineCore pid=2711700) INFO 06-07 15:45:30 [kv_cache_utils.py:1756] Maximum concurrency for 32,768 tokens per request: 13.52x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|█████████████████████████████████████████████████████████████████████████████████| 51/51 [00:01<00:00, 32.79it/s]
Capturing CUDA graphs (decode, FULL): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:00<00:00, 38.29it/s]
(EngineCore pid=2711700) INFO 06-07 15:45:33 [gpu_model_runner.py:6576] Graph capturing finished in 3 secs, took 0.43 GiB
(EngineCore pid=2711700) INFO 06-07 15:45:33 [gpu_worker.py:623] CUDA graph pool memory: 0.43 GiB (actual), 0.49 GiB (estimated), difference: 0.05 GiB (12.6%).
(EngineCore pid=2711700) INFO 06-07 15:45:33 [jit_monitor.py:54] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
(EngineCore pid=2711700) INFO 06-07 15:45:34 [core.py:306] init engine (profile, create kv cache, warmup model) took 34.74 s (compilation: 2.48 s)
(EngineCore pid=2711700) INFO 06-07 15:45:34 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(RustFrontend pid=2711375) INFO 06-07 15:45:34 [transport.rs:306] engines connected engine_count=1
(RustFrontend pid=2711375) INFO 06-07 15:45:34 [server/src/lib.rs:155] starting OpenAI server bind_address=127.0.0.1:8000 model=/mnt/data0/LLM/Qwen2-VL-2B-Instruct/
(RustFrontend pid=2711375) INFO 06-07 15:49:11 [default/mod.rs:133] chat_completions{request_id=chatcmpl-8567f3c0}: reasoning parsing disabled
(EngineCore pid=2711700) WARNING 06-07 15:49:12 [sampling_params.py:430] temperature 0.009999999776482582 is less than 0.01, which may cause numerical errors nan or inf in tensors. We have maxed it out to 0.01.
(EngineCore pid=2711700) WARNING 06-07 15:49:12 [jit_monitor.py:103] Triton kernel JIT compilation during inference: _compute_slot_mapping_kernel. This causes a latency spike; consider extending warmup to cover this shape/config.
(RustFrontend pid=2711375) INFO 06-07 15:49:14 [log_stats.rs:153] Avg prompt tput: 122.3 toks/s, Avg generation tput: 4.3 toks/s, Reqs Running: 0, Waiting: 0, GPU KV cache used: 0.0%, Prefix cache hit rate: 0.0%
```

</details>

```
$ python examples/generate/multimodal/openai_chat_completion_client_for_multimodal.py -c video
Chat completion output from base64 encoded video:
 The video shows a young child sitting on a bed, wearing glasses and reading a book. The child appears to be enjoying the activity and is smiling. The background includes a bed with a blanket and some furniture.
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

