### PR TITLE
[Bugfix][Frontend] pythonic tool parser: accept negative numbers / unary ops as literal arguments

### DIFF
--- a/tests/tool_parsers/test_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_pythonic_tool_parser.py
@@ -58,6 +58,34 @@ ESCAPED_STRING_FUNCTION_CALL = FunctionCall(
     name="get_weather",
     arguments='{"city": "Martha\'s Vineyard", "metric": "\\"cool units\\""}',
 )
+# Regression coverage for GitHub #19569 — pythonic tool call parsing must
+# accept unary-op literals (negative numbers, explicit +, boolean not).
+NEGATIVE_NUMBERS_FUNCTION_OUTPUT = (
+    "set_position(x=-10, y=5, z=-3.14, offset=+2)"
+)
+NEGATIVE_NUMBERS_FUNCTION_CALL = FunctionCall(
+    name="set_position",
+    arguments='{"x": -10, "y": 5, "z": -3.14, "offset": 2}',
+)
+NEGATIVE_LIST_FUNCTION_OUTPUT = "load_offsets(deltas=[-1, -2, -3])"
+NEGATIVE_LIST_FUNCTION_CALL = FunctionCall(
+    name="load_offsets",
+    arguments='{"deltas": [-1, -2, -3]}',
+)
+NEGATIVE_DICT_FUNCTION_OUTPUT = (
+    "configure(settings={'min': -100, 'max': 100})"
+)
+NEGATIVE_DICT_FUNCTION_CALL = FunctionCall(
+    name="configure",
+    arguments='{"settings": {"min": -100, "max": 100}}',
+)
+BOOLEAN_NOT_FUNCTION_OUTPUT = (
+    "toggle(active=not True, enabled=not False)"
+)
+BOOLEAN_NOT_FUNCTION_CALL = FunctionCall(
+    name="toggle",
+    arguments='{"active": false, "enabled": true}',
+)
 
 
 @pytest.mark.parametrize("streaming", [True, False])
@@ -159,6 +187,56 @@ TEST_CASES = [
         f"[{SIMPLE_FUNCTION_OUTPUT}, {MORE_TYPES_FUNCTION_OUTPUT}]",
         [SIMPLE_FUNCTION_CALL, MORE_TYPES_FUNCTION_CALL],
         id="parallel_calls_nonstreaming",
+    ),
+    # Regression coverage for #19569 — pythonic tool call parsing must accept
+    # unary-op literals (negative numbers, explicit +, boolean not).
+    pytest.param(
+        True,
+        f"[{NEGATIVE_NUMBERS_FUNCTION_OUTPUT}]",
+        [NEGATIVE_NUMBERS_FUNCTION_CALL],
+        id="negative_numbers_streaming",
+    ),
+    pytest.param(
+        False,
+        f"[{NEGATIVE_NUMBERS_FUNCTION_OUTPUT}]",
+        [NEGATIVE_NUMBERS_FUNCTION_CALL],
+        id="negative_numbers_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        f"[{NEGATIVE_LIST_FUNCTION_OUTPUT}]",
+        [NEGATIVE_LIST_FUNCTION_CALL],
+        id="negative_list_streaming",
+    ),
+    pytest.param(
+        False,
+        f"[{NEGATIVE_LIST_FUNCTION_OUTPUT}]",
+        [NEGATIVE_LIST_FUNCTION_CALL],
+        id="negative_list_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        f"[{NEGATIVE_DICT_FUNCTION_OUTPUT}]",
+        [NEGATIVE_DICT_FUNCTION_CALL],
+        id="negative_dict_streaming",
+    ),
+    pytest.param(
+        False,
+        f"[{NEGATIVE_DICT_FUNCTION_OUTPUT}]",
+        [NEGATIVE_DICT_FUNCTION_CALL],
+        id="negative_dict_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        f"[{BOOLEAN_NOT_FUNCTION_OUTPUT}]",
+        [BOOLEAN_NOT_FUNCTION_CALL],
+        id="boolean_not_streaming",
+    ),
+    pytest.param(
+        False,
+        f"[{BOOLEAN_NOT_FUNCTION_OUTPUT}]",
+        [BOOLEAN_NOT_FUNCTION_CALL],
+        id="boolean_not_nonstreaming",
     ),
 ]
 

--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -1,12 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
+
 import pytest
 
 from vllm.tool_parsers.utils import (
+    UnexpectedAstError,
     coerce_to_schema_type,
     extract_types_from_schema,
+    get_parameter_value,
 )
+
+
+def _parse_keyword_value(src: str) -> ast.expr:
+    """Parse ``func(x=<expr>)`` and return the AST node for ``<expr>``."""
+    tree = ast.parse(src, mode="eval")
+    return tree.body.keywords[0].value  # type: ignore[attr-defined]
 
 
 class TestCoerceToSchemaType:
@@ -212,3 +222,101 @@ class TestExtractTypesFromSchema:
         }
         result = set(extract_types_from_schema(schema))
         assert result == {"integer", "null", "string"}
+
+
+class TestGetParameterValue:
+    """Tests for ``get_parameter_value`` covering literals and unary ops.
+
+    Regression coverage for GitHub #19569 — pythonic tool call parsing did
+    not handle negative numeric literals because Python's AST represents
+    them as ``UnaryOp(USub, Constant)``, not as a single ``Constant``.
+    """
+
+    # --- existing supported shapes (control cases) -----------------------
+
+    def test_positive_int_constant(self):
+        val = _parse_keyword_value("f(x=5)")
+        assert get_parameter_value(val) == 5
+
+    def test_positive_float_constant(self):
+        val = _parse_keyword_value("f(x=1.5)")
+        assert get_parameter_value(val) == 1.5
+
+    def test_string_constant(self):
+        val = _parse_keyword_value("f(x='hello')")
+        assert get_parameter_value(val) == "hello"
+
+    def test_true_constant(self):
+        val = _parse_keyword_value("f(x=True)")
+        assert get_parameter_value(val) is True
+
+    def test_none_constant(self):
+        val = _parse_keyword_value("f(x=None)")
+        assert get_parameter_value(val) is None
+
+    def test_json_style_null_name(self):
+        val = _parse_keyword_value("f(x=null)")
+        assert get_parameter_value(val) is None
+
+    def test_json_style_true_name(self):
+        val = _parse_keyword_value("f(x=true)")
+        assert get_parameter_value(val) is True
+
+    def test_list_of_constants(self):
+        val = _parse_keyword_value("f(x=[1, 2, 3])")
+        assert get_parameter_value(val) == [1, 2, 3]
+
+    def test_dict_of_constants(self):
+        val = _parse_keyword_value("f(x={'a': 1, 'b': 'two'})")
+        assert get_parameter_value(val) == {"a": 1, "b": "two"}
+
+    # --- unary op coverage (new) -----------------------------------------
+
+    def test_negative_int(self):
+        val = _parse_keyword_value("f(x=-5)")
+        assert get_parameter_value(val) == -5
+
+    def test_negative_float(self):
+        val = _parse_keyword_value("f(x=-1.5)")
+        assert get_parameter_value(val) == -1.5
+
+    def test_explicit_positive_int(self):
+        val = _parse_keyword_value("f(x=+5)")
+        assert get_parameter_value(val) == 5
+
+    def test_boolean_not_true(self):
+        val = _parse_keyword_value("f(x=not True)")
+        assert get_parameter_value(val) is False
+
+    def test_boolean_not_false(self):
+        val = _parse_keyword_value("f(x=not False)")
+        assert get_parameter_value(val) is True
+
+    def test_list_with_negative_numbers(self):
+        val = _parse_keyword_value("f(x=[-1, -2, -3])")
+        assert get_parameter_value(val) == [-1, -2, -3]
+
+    def test_dict_with_negative_value(self):
+        val = _parse_keyword_value("f(x={'delta': -10})")
+        assert get_parameter_value(val) == {"delta": -10}
+
+    def test_nested_unary_double_negative(self):
+        val = _parse_keyword_value("f(x=--5)")
+        assert get_parameter_value(val) == 5
+
+    # --- unsupported shapes still raise ----------------------------------
+
+    def test_bitwise_invert_rejected(self):
+        val = _parse_keyword_value("f(x=~5)")
+        with pytest.raises(UnexpectedAstError):
+            get_parameter_value(val)
+
+    def test_call_expression_rejected(self):
+        val = _parse_keyword_value("f(x=-g())")
+        with pytest.raises(UnexpectedAstError):
+            get_parameter_value(val)
+
+    def test_name_reference_rejected(self):
+        val = _parse_keyword_value("f(x=undefined_variable)")
+        with pytest.raises(UnexpectedAstError):
+            get_parameter_value(val)

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -283,15 +283,42 @@ _JSON_NAME_LITERALS = {
 def get_parameter_value(val: ast.expr) -> Any:
     """Extract a Python literal value from an AST expression node.
 
-    Handles constants, dicts, lists, and JSON-style name literals
+    Handles constants, dicts, lists, JSON-style name literals
     (null, true, false) that some models produce instead of Python
-    literals (None, True, False).
+    literals (None, True, False), and unary operators applied to
+    literals (-5, +5, not True).
+
+    Negative and explicitly-positive numbers, and boolean negation,
+    are represented in the Python AST as ``UnaryOp(op, operand)``,
+    not as a single ``Constant`` — e.g. ``-5`` parses as
+    ``UnaryOp(USub, Constant(5))``. Without ``UnaryOp`` handling,
+    every pythonic tool call with a negative or boolean-negated
+    argument (e.g. ``set_temperature(value=-5)``) would raise
+    ``UnexpectedAstError``.
 
     Raises:
         UnexpectedAstError: If the AST node is not a supported literal type.
     """
     if isinstance(val, ast.Constant):
         return val.value
+    elif isinstance(val, ast.UnaryOp):
+        # ``-5`` -> UnaryOp(USub, Constant(5))
+        # ``+5`` -> UnaryOp(UAdd, Constant(5))
+        # ``not True`` -> UnaryOp(Not, Constant(True))
+        # ``ast.Invert`` (``~``) is intentionally not supported — bitwise
+        # ops aren't a natural fit for tool-call argument literals.
+        operand = get_parameter_value(val.operand)
+        if isinstance(val.op, ast.USub):
+            return -operand
+        if isinstance(val.op, ast.UAdd):
+            return +operand
+        if isinstance(val.op, ast.Not):
+            return not operand
+        logger.warning(
+            "Unsupported unary op in tool call arguments: %s",
+            ast.dump(val),
+        )
+        raise UnexpectedAstError("Tool call arguments must be literals")
     elif isinstance(val, ast.Dict):
         if not all(isinstance(k, ast.Constant) for k in val.keys):
             logger.warning(


### PR DESCRIPTION
## What this fixes

  `vllm/tool_parsers/utils.py:get_parameter_value` did not handle `ast.UnaryOp`, so every pythonic tool call with a **negative number**, explicit **positive sign**, or **boolean negation** crashed with `UnexpectedAstError("Tool call arguments must be
  literals")`.

  Python's AST represents these as `UnaryOp(op, operand)`, not as a single `Constant`:

  ```python
  >>> import ast
  >>> ast.dump(ast.parse("foo(x=-5)", mode="eval"))
  "Expression(body=Call(func=Name(id='foo'), args=[],
      keywords=[keyword(arg='x',
          value=UnaryOp(op=USub(), operand=Constant(value=5)))]))"
  ```
  Examples that used to fail and now work:
  ```

┌───────────────────────────────────┬────────────────────┬────────────────────────────────┐
  │             Tool call             │  Behavior on main  │     Behavior with this PR      │
  ├───────────────────────────────────┼────────────────────┼────────────────────────────────┤
  │ set_temperature(value=-5)         │ UnexpectedAstError │ {"value": -5}                  │
  ├───────────────────────────────────┼────────────────────┼────────────────────────────────┤
  │ move(x=-10, y=5, z=-3.14)         │ UnexpectedAstError │ {"x": -10, "y": 5, "z": -3.14} │
  ├───────────────────────────────────┼────────────────────┼────────────────────────────────┤
  │ set_offset(value=+5)              │ UnexpectedAstError │ {"value": 5}                   │
  └───────────────────────────────────┴────────────────────┴────────────────────────────────┘
  ```
  Three parsers share get_parameter_value and are all fixed by this change: PythonicToolParser, Llama4PythonicToolParser, Olmo3PythonicToolParser.

  Why this is not duplicating an existing open PR

  This bug was previously reported and a fix attempted, but both were auto-closed by stale-bot due to no maintainer review — they were not rejected on technical or design grounds:

  - Issue #19569 "[Bug]: pythonic tool call parsing does not handle negative numeric literals" — closed 2026-02-25 by stale-bot. Multiple users confirmed the bug (most recently on 2025-10-27 verifying on a later commit).
  - PR #15462 by @d-tiapkin — sat in @russellb's "Tool Calling" project from 2025-04-30, never made it to actual review, auto-closed 2025-08-25 by stale-bot.

  This PR re-files the fix with broader scope (USub + UAdd + Not, not just USub) and tests at the new tests/tool_parsers/test_utils.py location (get_parameter_value was refactored into shared utils after #15462 was opened). No other open PR addresses
  this — verified via:

  gh issue view 19569 --repo vllm-project/vllm --comments
  gh pr list --repo vllm-project/vllm --state open --search "get_parameter_value in:body"
  gh pr list --repo vllm-project/vllm --state open --search "pythonic tool parser negative"

  Change shape

  Single small change to vllm/tool_parsers/utils.py:get_parameter_value: adds an elif isinstance(val, ast.UnaryOp) branch handling ast.USub, ast.UAdd, and ast.Not. Recurses into the operand so nested cases like [-1, -2, -3] and {"delta": -10} also work.
   ast.Invert (~) is intentionally left unhandled because bitwise ops aren't natural literal arguments.

  Tests run + results

  - tests/tool_parsers/test_utils.py: new TestGetParameterValue class (19 tests) covering existing supported shapes (control), unary ops (USub/UAdd/Not on int/float/bool), nested unary, list/dict containing negatives, and explicit reject cases (~5,
  -g(), undefined names).
  - tests/tool_parsers/test_pythonic_tool_parser.py: 8 new parametrised cases (streaming + non-streaming) for mixed-sign positional args, list of negatives, dict with negative values, boolean not.

  Local standalone verification (extracted function exercised against 20 cases including 3 reject cases) — all pass. Full pytest verification via vLLM CI on push.

  AI assistance disclosure: this PR wasn't prepared with AI assistance, except for PR body