### PR TITLE
Gate resume_scheduler on executor.is_sleeping after partial wake_up (#44395)

### DIFF
--- a/tests/v1/engine/test_wake_up_resume_gate.py
+++ b/tests/v1/engine/test_wake_up_resume_gate.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Regression test for issue #44395 — EngineCore.wake_up() must not resume
+scheduling after a partial wake (e.g. wake_up(tags=["weights"])).
+
+Pre-fix, `wake_up` called `resume_scheduler()` unconditionally after
+`model_executor.wake_up(tags)`. With a tag set that left the executor
+still partially asleep (KV cache offloaded, weights restored), the next
+forward pass — either a DP rank's `execute_dummy_batch()` busy-loop or
+an externally-arriving request — wrote into released GPU memory and
+crashed with "CUDA illegal memory access".
+
+The fix gates `resume_scheduler()` on `not self.model_executor.is_sleeping`,
+so scheduling stays paused until the caller's follow-up full wake_up()
+(no tags) clears `is_sleeping`.
+
+These are direct mock tests on EngineCore.wake_up — no model load, no
+GPU — so they run in seconds and remain green on machines without CUDA.
+"""
+
+from unittest.mock import MagicMock
+
+from vllm.v1.engine.core import EngineCore
+
+
+def _make_core(executor_is_sleeping: bool) -> EngineCore:
+    """Build a minimal EngineCore that exercises wake_up()'s gating logic.
+
+    Skips EngineCore.__init__ (heavy: loads model, allocates KV cache, etc.) —
+    wake_up() only touches `model_executor` and `resume_scheduler`, so those
+    are the only attributes we populate.
+    """
+    core = EngineCore.__new__(EngineCore)
+    core.model_executor = MagicMock()
+    core.model_executor.is_sleeping = executor_is_sleeping
+    core.resume_scheduler = MagicMock()
+    return core
+
+
+def test_partial_wake_does_not_resume_scheduler():
+    """Partial wake — executor still asleep — resume_scheduler must NOT fire.
+
+    This is the regression catcher: pre-fix code called resume_scheduler()
+    unconditionally, and this assertion would fail.
+    """
+    core = _make_core(executor_is_sleeping=True)
+
+    core.wake_up(tags=["weights"])
+
+    core.model_executor.wake_up.assert_called_once_with(["weights"])
+    core.resume_scheduler.assert_not_called()
+
+
+def test_full_wake_resumes_scheduler():
+    """Full wake — executor reports awake — resume_scheduler fires exactly once.
+
+    Happy path; guards against an over-correction that would leave scheduling
+    permanently paused.
+    """
+    core = _make_core(executor_is_sleeping=False)
+
+    core.wake_up()
+
+    core.model_executor.wake_up.assert_called_once_with(None)
+    core.resume_scheduler.assert_called_once()
+
+
+def test_full_wake_after_partial_resumes_scheduler():
+    """The contract from the PR body: the caller follows a partial wake with
+    a full wake. After the full wake clears is_sleeping, scheduling resumes.
+    """
+    core = _make_core(executor_is_sleeping=True)
+
+    # 1) Partial wake — executor stays asleep — no resume.
+    core.wake_up(tags=["weights"])
+    assert core.resume_scheduler.call_count == 0
+
+    # 2) Caller follows up with a full wake — executor now reports awake —
+    #    resume fires.
+    core.model_executor.is_sleeping = False
+    core.wake_up()
+    assert core.resume_scheduler.call_count == 1
+
+
+def test_scheduling_only_tag_does_not_invoke_executor_wake_up():
+    """tags=["scheduling"] is a level-0 wake that intentionally bypasses the
+    executor (the `if tags is None or tags:` branch filters it out after the
+    "scheduling" entry is removed). The gating change must not regress this.
+    """
+    core = _make_core(executor_is_sleeping=False)
+
+    core.wake_up(tags=["scheduling"])
+
+    core.model_executor.wake_up.assert_not_called()
+    core.resume_scheduler.assert_called_once()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -775,8 +775,15 @@ class EngineCore:
         if tags is None or tags:
             self.model_executor.wake_up(tags)
 
-        # Resume scheduling (applies to all levels)
-        self.resume_scheduler()
+        # Only resume scheduling when the executor is fully resident.
+        # A partial wake (e.g. wake_up(tags=["weights"])) restores weights
+        # but leaves the KV cache asleep — resuming scheduling then would
+        # let a forward pass write into released GPU memory and crash with
+        # CUDA illegal memory access. See issue #44395.
+        # The caller is expected to follow a partial wake with a full one
+        # (no tags) before scheduling can resume.
+        if not self.model_executor.is_sleeping:
+            self.resume_scheduler()
 
     def is_sleeping(self) -> bool:
         """Check if engine is sleeping at any level."""


### PR DESCRIPTION
Fixes #44395.

## What

`EngineCore.wake_up` currently calls `resume_scheduler()` unconditionally after `model_executor.wake_up(tags)`. This commit gates the resume on `not self.model_executor.is_sleeping` so partial wakes don't trip CUDA illegal-memory-access errors via a forward pass into released KV cache.

## Why

Issue #44395 — after `wake_up(tags=["weights"])` (weights restored, KV still asleep), the engine resumes scheduling. Two paths can then hit released memory:

1. **Data parallelism**: idle DP ranks' `EngineCore` busy-loop runs `execute_dummy_batch()` (a forward pass) as soon as scheduling resumes — so even without an external request, a partial wake → resume → first dummy step crashes.
2. **Without DP**: an external request arriving in the brief window between a partial wake and a follow-up full wake hits the resumed scheduler and the same release-then-write fault.

`EngineCore.is_sleeping()` already composes `self.is_scheduler_paused() or self.model_executor.is_sleeping`, so the executor side is already tracked. This patch reuses that signal to gate `resume_scheduler()`.

## Behavior change

```python
# Before
self.resume_scheduler()  # always

# After
if not self.model_executor.is_sleeping:
    self.resume_scheduler()
```

After a partial wake, scheduling stays paused. The caller must do a follow-up full wake (`wake_up()` with no tags) to clear `is_sleeping` and resume scheduling.

## Validation

Carried in a downstream image (v0.22.1 + this patch + #44778) for several sleep/wake cycles on Qwen3.6-27B (TP=2 PP=2 across 4× RTX 3090) with no observed regressions. The downstream caller does only full wakes, so the gate's primary path isn't directly stressed by that workload — it acts as defense-in-depth against the bug surfaces above. The unit-level regression test in this PR exercises the partial-wake gate directly via mocked executor.

## Open questions for review

- **Is "follow up partial wakes with a full wake" the contract you want?** Alternative: track a per-tag wake state and resume scheduling once all required tags are awake. The one-liner here is the minimal fix; a richer state machine would be a bigger change.
- **Did any existing caller rely on `wake_up(tags=[...])` returning to a scheduling-resumed state for partial tags?** I didn't find one in a quick scan; a maintainer would know better.

## Test plan

- [x] Manual validation on downstream multi-model vLLM serving stack (4× RTX 3090, Qwen3.6-27B TP=2 PP=2) — no regressions
- [x] Regression test added at `tests/v1/engine/test_wake_up_resume_gate.py` — direct mock on `EngineCore.wake_up`, four cases (partial wake → no resume, full wake → resume, partial-then-full sequence, `tags=["scheduling"]` corner). No model load, no GPU; fails on pre-fix code, passes after the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
