### PR TITLE
fix: strip Gemma4 string delimiters from dict keys

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -108,6 +108,14 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('nested:{inner:<|"|>value<|"|>}')
         assert result == {"nested": {"inner": "value"}}
 
+    def test_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}')
+        assert result == {"record_map": {"3": "new text"}}
+
+    def test_nested_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('outer:{inner:{<|"|>3<|"|>:<|"|>new text<|"|>}}')
+        assert result == {"outer": {"inner": {"3": "new text"}}}
+
     def test_array_of_strings(self):
         result = _parse_gemma4_args('items:[<|"|>a<|"|>,<|"|>b<|"|>]')
         assert result == {"items": ["a", "b"]}

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -54,6 +54,12 @@ STRING_DELIM = '<|"|>'
 # ---------------------------------------------------------------------------
 
 
+def _normalize_gemma4_key(key: str) -> str:
+    if key.startswith(STRING_DELIM) and key.endswith(STRING_DELIM):
+        return key[len(STRING_DELIM) : -len(STRING_DELIM)]
+    return key
+
+
 def _parse_gemma4_value(value_str: str) -> object:
     """Parse a single Gemma4 value (after key:) into a Python object."""
     value_str = value_str.strip()
@@ -121,7 +127,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
         if i >= n:
             break
-        key = args_str[key_start:i].strip()
+        key = _normalize_gemma4_key(args_str[key_start:i].strip())
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
## Summary
- strip Gemma4 string delimiters when they wrap a parsed dict key
- keep existing bare-key and value parsing behavior unchanged
- add regression coverage for top-level nested maps and deeper nested maps

Fixes #44715.

## To verify
- python -m py_compile vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py
- python -m ruff check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py
- python -m pytest tests\tool_parsers\test_gemma4_tool_parser.py::TestParseGemma4Args::test_string_delimited_dict_key tests\tool_parsers\test_gemma4_tool_parser.py::TestParseGemma4Args::test_nested_string_delimited_dict_key -q
- isolated parser regression script for _parse_gemma4_args

The targeted pytest command currently reaches vLLM's global conftest and fails locally before collecting these tests because this Windows clone does not have the compiled vllm._C extension. The isolated parser regression script passes and exercises the same parser cases without importing vLLM runtime modules.