### PR TITLE
[Rust Frontend] Add API key authentication middleware

### DIFF
--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -102,6 +102,15 @@ pub struct SharedRuntimeArgs {
     #[serde(default = "default_engine_ready_timeout_secs")]
     pub engine_ready_timeout_secs: u64,
 
+    /// API Key for OpenAI services. If provided, this api key will overwrite the
+    /// api key obtained through environment variables. It is important to note that
+    /// this option only applies to the OpenAI-Compatible API endpoints and NOT other
+    /// endpoints that may be present in the server. See the security guide in vLLM docs
+    /// for more details.
+    #[arg(long, env = "VLLM_API_KEY", num_args=1.., value_delimiter = ' ')]
+    #[serde(default)]
+    pub api_key: Option<Vec<String>>,
+
     /// Select the tool call parser depending on the model that you're using.
     /// Use `auto` to infer from the model or `none` to disable parsing.
     #[arg(long, default_value_t)]
@@ -231,6 +240,7 @@ impl SharedRuntimeArgs {
         let shutdown_timeout = self.shutdown_timeout();
 
         Config {
+            api_key: self.api_key,
             transport_mode: TransportMode::Bootstrapped {
                 input_address,
                 output_address,
@@ -274,6 +284,7 @@ impl SharedRuntimeArgs {
         let shutdown_timeout = self.shutdown_timeout();
 
         Config {
+            api_key: self.api_key,
             transport_mode: TransportMode::HandshakeOwner {
                 handshake_address,
                 advertised_host,

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -31,6 +31,7 @@ fn serve_args_forward_python_flags_with_separator() {
                     runtime: SharedRuntimeArgs {
                         model: "Qwen/Qwen3-0.6B",
                         engine_ready_timeout_secs: 600,
+                        api_key: None,
                         tool_call_parser: Auto,
                         reasoning_parser: Auto,
                         renderer: Auto,
@@ -261,6 +262,7 @@ fn frontend_args_accept_json() {
                     runtime: SharedRuntimeArgs {
                         model: "Qwen/Qwen3-0.6B",
                         engine_ready_timeout_secs: 600,
+                        api_key: None,
                         tool_call_parser: Auto,
                         reasoning_parser: Auto,
                         renderer: Auto,
@@ -446,15 +448,15 @@ fn frontend_args_json_aggregates_multiple_unsupported_fields() {
         "--output-address",
         "ipc:///tmp/output.sock",
         "--args-json",
-        r#"{"model_tag":"Qwen/Qwen3-0.6B","allow_credentials":true,"api_key":"secret"}"#,
+        r#"{"model_tag":"Qwen/Qwen3-0.6B","allow_credentials":true,"ssl_keyfile":"/tmp/key.pem"}"#,
     ])
     .unwrap_err();
 
     expect![[r#"
-        error: invalid value '{"model_tag":"Qwen/Qwen3-0.6B","allow_credentials":true,"api_key":"secret"}' for '--args-json <JSON>': 
+        error: invalid value '{"model_tag":"Qwen/Qwen3-0.6B","allow_credentials":true,"ssl_keyfile":"/tmp/key.pem"}' for '--args-json <JSON>': 
         The following arguments are not implemented in Rust frontend yet:
         - allow_credentials
-        - api_key
+        - ssl_keyfile
 
         Remove these arguments to continue.
 
@@ -662,6 +664,7 @@ fn serve_args_accept_handshake_aliases() {
                     runtime: SharedRuntimeArgs {
                         model: "Qwen/Qwen3-0.6B",
                         engine_ready_timeout_secs: 600,
+                        api_key: None,
                         tool_call_parser: Auto,
                         reasoning_parser: Auto,
                         renderer: Auto,
@@ -765,6 +768,7 @@ fn serve_frontend_config_uses_dp_address_as_advertised_host() {
 
     expect![[r#"
         Config {
+            api_key: None,
             transport_mode: HandshakeOwner {
                 handshake_address: "tcp://10.99.48.128:29550",
                 advertised_host: "10.99.48.128",
@@ -833,6 +837,7 @@ fn serve_frontend_config_keeps_tcp_transport_for_non_local_only_topology() {
 
     expect![[r#"
         Config {
+            api_key: None,
             transport_mode: HandshakeOwner {
                 handshake_address: "tcp://10.99.48.128:29550",
                 advertised_host: "10.99.48.128",
@@ -913,6 +918,7 @@ fn frontend_config_uses_external_coordinator_when_coordinator_address_is_present
 
     expect![[r#"
         Config {
+            api_key: None,
             transport_mode: Bootstrapped {
                 input_address: "ipc:///tmp/input.sock",
                 output_address: "ipc:///tmp/output.sock",
@@ -965,5 +971,51 @@ fn serve_frontend_config_uses_unix_listener_when_uds_is_present() {
         HttpListenerMode::BindUnix {
             path: "/tmp/vllm.sock".to_string(),
         }
+    );
+}
+
+#[test]
+fn serve_passes_api_key_into_config() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--api-key",
+        "key1 key2",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    let config = args.to_frontend_config("tcp://127.0.0.1:62100".to_string());
+    assert_eq!(
+        config.api_key,
+        Some(vec!["key1".to_string(), "key2".to_string()])
+    );
+}
+
+#[test]
+fn frontend_args_json_accepts_api_key() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "frontend",
+        "--listen-fd",
+        "3",
+        "--input-address",
+        "ipc:///tmp/input.sock",
+        "--output-address",
+        "ipc:///tmp/output.sock",
+        "--args-json",
+        r#"{"model_tag":"Qwen/Qwen3-0.6B","api_key":["key1","key2"]}"#,
+    ])
+    .unwrap();
+
+    let Command::Frontend(args) = cli.command else {
+        panic!("expected frontend args");
+    };
+    assert_eq!(
+        args.runtime.api_key,
+        Some(vec!["key1".to_string(), "key2".to_string()])
     );
 }

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -564,11 +564,6 @@ pub struct ServerUnsupportedArgs {
     #[arg(long)]
     pub allowed_headers: Option<Unsupported>,
 
-    /// If provided, the server will require one of these keys to be presented
-    /// in the header.
-    #[arg(long)]
-    pub api_key: Option<Unsupported>,
-
     /// The file path to the SSL key file.
     #[arg(long)]
     pub ssl_keyfile: Option<Unsupported>,

--- a/rust/src/server/examples/external_engine_openai_qwen.rs
+++ b/rust/src/server/examples/external_engine_openai_qwen.rs
@@ -46,6 +46,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let port = unique_local_port()?;
     let config = Config {
+        api_key: None,
         transport_mode: TransportMode::HandshakeOwner {
             handshake_address: args.handshake_address,
             advertised_host: args.host,

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -35,6 +35,10 @@ pub enum CoordinatorMode {
 /// Normalized runtime configuration for the minimal OpenAI-compatible server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Config {
+    /// API keys for protecting OpenAI-compatible endpoints. When set, the
+    /// authentication middleware requires a valid `Authorization: Bearer <key>`
+    /// header on all guarded routes.
+    pub api_key: Option<Vec<String>>,
     /// Frontend-to-engine transport setup.
     pub transport_mode: TransportMode,
     /// Requested frontend-side coordinator behavior.

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     /// API keys for protecting OpenAI-compatible endpoints. When set, the
     /// authentication middleware requires a valid `Authorization: Bearer <key>`
     /// header on all guarded routes.
+    #[serde(skip)]
     pub api_key: Option<Vec<String>>,
     /// Frontend-to-engine transport setup.
     pub transport_mode: TransportMode,

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -91,6 +91,7 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
     Ok(Arc::new(
         AppState::new(served_model_names, chat)
             .with_log_requests(config.enable_log_requests)
+            .with_api_keys(config.api_key.clone())
             .with_request_id_headers(config.enable_request_id_headers)
             .with_server_info(ServerInfoSnapshot::from_config(config)),
     ))

--- a/rust/src/server/src/middleware/auth.rs
+++ b/rust/src/server/src/middleware/auth.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{MatchedPath, Request, State};
+use axum::http::StatusCode;
+use axum::http::header::AUTHORIZATION;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::state::AppState;
+
+/// Path prefixes that require a valid API key when authentication is enabled.
+///
+/// Matches the Python frontend's `GUARDED_PREFIX` in
+/// `vllm.entrypoints.serve.utils.server_utils`. Any route whose matched path
+/// starts with one of these prefixes will be checked for a valid
+/// `Authorization: Bearer <key>` header.
+const GUARDED_PREFIXES: &[&str] = &["/v1", "/v2", "/inference"];
+
+/// Reject requests to guarded endpoints that do not carry a valid
+/// `Authorization: Bearer <key>` header.
+///
+/// Requests whose matched path does not start with any of the
+/// [`GUARDED_PREFIXES`] are passed through without authentication.
+///
+/// Original Python:
+/// `vllm.entrypoints.serve.utils.server_utils.AuthenticationMiddleware`.
+pub async fn api_key_authentication(
+    State(state): State<Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let handler = req.extensions().get::<MatchedPath>().map_or("", |path| path.as_str());
+
+    let guarded = GUARDED_PREFIXES.iter().any(|prefix| handler.starts_with(prefix));
+    if !guarded {
+        return next.run(req).await;
+    }
+
+    // A matching response similar to python frontend
+    let unauthorized = (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({"error": "Unauthorized"})),
+    )
+        .into_response();
+
+    let auth_header = req.headers().get(AUTHORIZATION).and_then(|header| header.to_str().ok());
+    let Some(auth_header) = auth_header else {
+        return unauthorized;
+    };
+
+    let Some((scheme, token)) = auth_header.split_once(" ") else {
+        return unauthorized;
+    };
+
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return unauthorized;
+    }
+
+    if state.is_authorized(token) {
+        next.run(req).await
+    } else {
+        unauthorized
+    }
+}

--- a/rust/src/server/src/middleware/mod.rs
+++ b/rust/src/server/src/middleware/mod.rs
@@ -1,7 +1,9 @@
+mod auth;
 mod load;
 mod metrics;
 mod request_id;
 
+pub use auth::api_key_authentication;
 pub use load::track_server_load;
 pub use metrics::track_http_metrics;
 pub use request_id::set_request_id_header;

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -93,12 +93,25 @@ fn build_router_with_options(
             .route("/server_info", get(server_info::server_info))
     }
 
+    let enable_auth = state.api_keys.is_some();
     let enable_request_id_headers = state.enable_request_id_headers;
+
     let mut router = router
         .with_state(state.clone())
-        .layer(from_fn_with_state(state, middleware::track_server_load))
-        .layer(from_fn(middleware::track_http_metrics))
-        .layer(TraceLayer::new_for_http());
+        .layer(from_fn_with_state(
+            state.clone(),
+            middleware::track_server_load,
+        ))
+        .layer(from_fn(middleware::track_http_metrics));
+
+    if enable_auth {
+        router = router.layer(from_fn_with_state(
+            state,
+            middleware::api_key_authentication,
+        ));
+    }
+
+    router = router.layer(TraceLayer::new_for_http());
 
     if enable_request_id_headers {
         router = router.layer(from_fn(middleware::set_request_id_header));

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -4598,3 +4598,201 @@ async fn completions_empty_stop_string_returns_validation_error() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+// ========================= API key authentication tests =========================
+
+async fn test_app_with_api_keys(api_keys: Option<Vec<String>>) -> (axum::Router, MockEngineTask) {
+    let (chat, engine_task) = test_models_with_engine_outputs_and_backend(
+        b"engine-openai-auth",
+        default_stream_output_specs(),
+        Arc::new(FakeChatBackend::new()),
+    )
+    .await;
+    let state =
+        AppState::new(vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()], chat).with_api_keys(api_keys);
+    (build_router(Arc::new(state)), engine_task)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn protected_endpoint_requires_valid_bearer_token() {
+    let (app, engine_task) = test_app_with_api_keys(Some(vec!["test-key".to_string()])).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["error"], "Unauthorized");
+
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn valid_bearer_token_allows_request() {
+    let (app, engine_task) = test_app_with_api_keys(Some(vec!["test-key".to_string()])).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("Authorization", "Bearer test-key")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["object"], "chat.completion");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn invalid_bearer_token_returns_unauthorized() {
+    let (app, engine_task) = test_app_with_api_keys(Some(vec!["test-key".to_string()])).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("Authorization", "Bearer wrong-key")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn non_bearer_scheme_returns_unauthorized() {
+    let (app, engine_task) = test_app_with_api_keys(Some(vec!["test-key".to_string()])).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .header("Authorization", "Basic test-key")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn unprotected_endpoint_allows_unauthenticated_access_with_api_keys() {
+    let (app, engine_task) = test_app_with_api_keys(Some(vec!["test-key".to_string()])).await;
+
+    for uri in ["/health", "/version", "/load", "/metrics"] {
+        let response = app
+            .clone()
+            .call(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("call app");
+
+        assert_eq!(response.status(), StatusCode::OK, "expected 200 for {uri}");
+    }
+
+    engine_task.abort_and_join().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn no_api_keys_configured_disables_auth() {
+    let (app, engine_task) = test_app_with_api_keys(None).await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["object"], "chat.completion");
+}

--- a/rust/src/server/src/state.rs
+++ b/rust/src/server/src/state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -19,6 +20,10 @@ pub struct AppState {
     /// All public model IDs served by this frontend. The first entry is the
     /// primary ID used in responses; all entries are valid in requests.
     served_model_names: Vec<String>,
+    /// API keys for protecting OpenAI-compatible endpoints. When set, requests
+    /// to guarded paths must include a valid `Authorization: Bearer <key>`
+    /// header.
+    pub(crate) api_keys: Option<HashSet<String>>,
     /// Shared chat facade used by all requests.
     pub chat: ChatLlm,
     /// Whether to log a summary line for each completed request.
@@ -53,6 +58,7 @@ impl AppState {
             enable_log_requests: false,
             enable_request_id_headers: false,
             server_info: None,
+            api_keys: None,
             server_load: AtomicU64::new(0),
             lora_manager: LoraManager::new(),
         }
@@ -73,6 +79,12 @@ impl AppState {
     /// Attach the runtime server information snapshot used by `/server_info`.
     pub(crate) fn with_server_info(mut self, server_info: ServerInfoSnapshot) -> Self {
         self.server_info = Some(server_info);
+        self
+    }
+
+    /// Set the API keys used by the authentication middleware.
+    pub(crate) fn with_api_keys(mut self, tokens: Option<Vec<String>>) -> Self {
+        self.api_keys = tokens.map(|t| t.into_iter().collect());
         self
     }
 
@@ -162,6 +174,18 @@ impl AppState {
         self.server_load.fetch_sub(1, Ordering::Relaxed);
     }
 
+    /// Performs authentication against a given token and returns whether the
+    /// request is allowed. If no keys are set, this always denies the request.
+    /// The authentication middleware is only mounted when at least one key is
+    /// configured.
+    pub(crate) fn is_authorized(&self, token: &str) -> bool {
+        let Some(keys) = &self.api_keys else {
+            return false;
+        };
+
+        keys.contains(token)
+    }
+
     /// Wait until all request-owned references are dropped, then shut down the
     /// engine client.
     ///
@@ -194,5 +218,59 @@ impl AppState {
             ))
             .await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    #[test]
+    fn with_api_keys_builds_hashset_from_vec() {
+        let keys: Option<HashSet<String>> =
+            Some(vec!["alpha".to_string(), "beta".to_string()]).map(|t| t.into_iter().collect());
+        let keys = keys.unwrap();
+        assert!(keys.contains("alpha"));
+        assert!(keys.contains("beta"));
+        assert!(!keys.contains("gamma"));
+    }
+
+    #[test]
+    fn with_api_keys_none_produces_none() {
+        let keys: Option<HashSet<String>> = None::<Vec<String>>.map(|t| t.into_iter().collect());
+        assert!(keys.is_none());
+    }
+
+    #[test]
+    fn is_authorized_logic_matches_on_valid_token() {
+        let keys: Option<HashSet<String>> =
+            Some(vec!["key1".to_string(), "key2".to_string()]).map(|t| t.into_iter().collect());
+
+        // Mirrors `is_authorized` logic.
+        let check = |token: &str| -> bool {
+            let Some(keys) = &keys else {
+                return false;
+            };
+            keys.contains(token)
+        };
+
+        assert!(check("key1"));
+        assert!(check("key2"));
+        assert!(!check("wrong"));
+        assert!(!check(""));
+    }
+
+    #[test]
+    fn is_authorized_logic_denies_when_no_keys() {
+        let keys: Option<HashSet<String>> = None;
+
+        let check = |token: &str| -> bool {
+            let Some(keys) = &keys else {
+                return false;
+            };
+            keys.contains(token)
+        };
+
+        assert!(!check("anything"));
     }
 }


### PR DESCRIPTION

## Purpose
Add `--api-key` / `VLLM_API_KEY` support to the Rust frontend, matching the Python frontend's `AuthenticationMiddleware`.

When one or more API keys are configured, requests to guarded paths (`/v1/*`, `/v2/*`, `/inference/*`) must include a valid `Authorization: Bearer <key>` header. Unguarded endpoints (`/health`, `/metrics`, `/version`, `/load`) remain publicly accessible.

Changes:
- New auth middleware with prefix-based route guarding, matching Python's GUARDED_PREFIX.
- `--api-key` CLI arg (space-delimited) and `VLLM_API_KEY` env var on `SharedRuntimeArgs`, wired through Config -> AppState -> router layer.

Tracked in: https://github.com/vllm-project/vllm/issues/44280

## Test Plan
- 6 e2e route tests: missing header -> 401, valid token -> 200, wrong token -> 401, non-Bearer scheme -> 401, unguarded endpoints -> 200, no keys configured -> auth disabled.
- 2 CLI tests: --api-key flag parsing and api_key in --args-json.
- 4 unit tests for is_authorized / with_api_keys logic.
- Updated existing CLI snapshot tests for the new field.

## Test Result
- All new and existing tests in affected crates have passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
