### PR TITLE
[Frontend] Reduce multimodal preprocessing cache contention

### DIFF
--- a/benchmarks/overheads/benchmark_multimodal_preprocessing_scheduler.py
+++ b/benchmarks/overheads/benchmark_multimodal_preprocessing_scheduler.py
@@ -1,0 +1,565 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Benchmark multimodal preprocessing scheduling overhead.
+
+This benchmark isolates the API-server/frontend scheduling path around
+``BaseRenderer._process_multimodal_async`` without loading a model or touching
+live network resources.  It uses a deterministic fake multimodal processor with
+hot cached images and synthetic cold-image processing cost.
+
+The primary workload models high-concurrency PDF/VL extraction traffic where
+many requests contain the same not-yet-cached image plus already-cached images.
+The desired scheduler behavior is that requests sharing the same cold image are
+released as soon as that image is processed, instead of being serialized behind
+unrelated multimodal preprocessing work.
+"""
+
+import argparse
+import asyncio
+import statistics
+import sys
+import threading
+import time
+import types
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Literal, NamedTuple
+
+
+@dataclass(frozen=True)
+class RequestSpec:
+    idx: int
+    kind: Literal["cached", "partial_miss"]
+    images: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class RequestResult:
+    idx: int
+    kind: str
+    latency_s: float
+    completed_at_s: float
+
+
+class VllmSymbols(NamedTuple):
+    base_renderer: type[Any]
+    timing_context: type[Any]
+    make_async: Any
+    atomic_counter: type[Any]
+
+
+def load_vllm_symbols() -> VllmSymbols:
+    # The source checkout may not have compiled extension modules.  They are not
+    # needed for this renderer-only benchmark, so stub them before importing
+    # Python modules from the checkout.
+    for name in ("vllm._C", "vllm._C_stable_libtorch"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    from vllm.multimodal.processing import TimingContext
+    from vllm.renderers.base import BaseRenderer
+    from vllm.utils.async_utils import make_async
+    from vllm.utils.counter import AtomicCounter
+
+    return VllmSymbols(
+        base_renderer=BaseRenderer,
+        timing_context=TimingContext,
+        make_async=make_async,
+        atomic_counter=AtomicCounter,
+    )
+
+
+class FakeInfo:
+    model_id = "fake-mm-model"
+
+    @staticmethod
+    def parse_mm_data(mm_data: dict[str, Any]) -> dict[str, Any]:
+        return mm_data
+
+
+class FakeProcessor:
+    def __init__(
+        self,
+        *,
+        initial_cache: set[int],
+        miss_cost_s: float,
+    ) -> None:
+        self.info = FakeInfo()
+        self.cache = set(initial_cache)
+        self.lock = threading.Lock()
+        self.miss_cost_s = miss_cost_s
+        self.apply_calls = 0
+        self.try_apply_calls = 0
+        self.prefill_calls = 0
+        self.apply_cache_hits = 0
+        self.apply_cache_misses = 0
+        self.new_images_processed = 0
+
+    def try_apply_cached(
+        self,
+        inputs: Any,
+        timing_ctx: Any,
+    ) -> dict[str, object] | None:
+        self.try_apply_calls += 1
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            if not all(image in self.cache for image in images):
+                return None
+        return self._result(inputs)
+
+    def get_cache_missing_hashes(
+        self,
+        inputs: Any,
+        timing_ctx: Any,
+    ) -> list[str] | None:
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            return [
+                str(image)
+                for image in images
+                if image not in self.cache
+            ]
+
+    def try_apply_cached_or_get_missing_hashes(
+        self,
+        inputs: Any,
+        timing_ctx: Any,
+    ) -> types.SimpleNamespace:
+        mm_input = self.try_apply_cached(inputs, timing_ctx)
+        return types.SimpleNamespace(
+            mm_input=mm_input,
+            missing_hashes=(
+                [] if mm_input is not None else
+                self.get_cache_missing_hashes(inputs, timing_ctx)
+            ),
+        )
+
+    def prefill_cache_items(
+        self,
+        inputs: Any,
+        item_hashes: Sequence[str],
+        timing_ctx: Any,
+    ) -> None:
+        selected_hashes = {int(item_hash) for item_hash in item_hashes}
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            missing = [
+                image
+                for image in images
+                if image in selected_hashes and image not in self.cache
+            ]
+
+        if not missing:
+            return
+
+        self.prefill_calls += 1
+        time.sleep(self.miss_cost_s * len(missing))
+        with self.lock:
+            self.cache.update(missing)
+            self.new_images_processed += len(missing)
+
+
+    def apply(
+        self,
+        inputs: Any,
+        timing_ctx: Any,
+    ) -> dict[str, object]:
+        self.apply_calls += 1
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            missing = [image for image in images if image not in self.cache]
+
+        if missing:
+            self.apply_cache_misses += 1
+            time.sleep(self.miss_cost_s * len(missing))
+            with self.lock:
+                self.cache.update(missing)
+                self.new_images_processed += len(missing)
+        else:
+            self.apply_cache_hits += 1
+
+        return self._result(inputs)
+
+    @staticmethod
+    def _result(inputs: Any) -> dict[str, object]:
+        return {
+            "prompt_token_ids": inputs.prompt,
+            "mm_kwargs": {},
+            "mm_hashes": {},
+            "mm_placeholders": {},
+        }
+
+
+class FakeTimingRegistry:
+    def __init__(self, timing_context: type[Any]) -> None:
+        self._timing_context = timing_context
+
+    def get(self, request_id: str) -> Any:
+        return self._timing_context(enabled=False)
+
+
+def make_renderer(
+    symbols: VllmSymbols,
+    processor: FakeProcessor,
+    *,
+    max_workers: int,
+) -> tuple[Any, ThreadPoolExecutor]:
+    class TestRenderer(symbols.base_renderer):
+        def render_messages(self, messages: Any, params: Any) -> Any:
+            raise NotImplementedError
+
+    renderer = object.__new__(TestRenderer)
+    renderer.api_process_rank = 0
+    renderer._mm_req_counter = symbols.atomic_counter()
+    renderer._readonly_mm_processor = None
+    renderer.mm_processor = processor
+    renderer._mm_timing_registry = FakeTimingRegistry(symbols.timing_context)
+    renderer._process_mm_uuids = lambda *args, **kwargs: None
+    renderer.update_mm_cache_stats = lambda: None
+    renderer.config = type(
+        "Config",
+        (),
+        {
+            "cache_config": type(
+                "CacheConfig",
+                (),
+                {"enable_prefix_caching": True},
+            )()
+        },
+    )()
+    renderer.model_config = type(
+        "ModelConfig",
+        (),
+        {"multimodal_config": None},
+    )()
+    renderer.get_mm_processor = lambda: processor
+    renderer._mm_cache_inflight_futures = {}
+
+    executor = ThreadPoolExecutor(max_workers=max_workers)
+    renderer._process_multimodal_in_executor = symbols.make_async(
+        renderer._process_multimodal,
+        executor=executor,
+    )
+    renderer._prefill_multimodal_cache_in_executor = symbols.make_async(
+        renderer._prefill_multimodal_cache,
+        executor=executor,
+    )
+    return renderer, executor
+
+
+def make_duplicate_partial_miss_workload(
+    *,
+    unique_new_images: int,
+    repeats_per_new_image: int,
+    hot_images: int,
+) -> tuple[list[RequestSpec], set[int]]:
+    initial_cache = set(range(hot_images))
+    specs: list[RequestSpec] = []
+    idx = 0
+    for repeat_idx in range(repeats_per_new_image):
+        for new_idx in range(unique_new_images):
+            base = (new_idx * 3 + repeat_idx) % (hot_images - 3)
+            specs.append(
+                RequestSpec(
+                    idx=idx,
+                    kind="partial_miss",
+                    images=(
+                        base,
+                        base + 1,
+                        base + 2,
+                        hot_images + new_idx,
+                    ),
+                ))
+            idx += 1
+    return specs, initial_cache
+
+
+
+def make_mixed_inflight_new_workload(
+    *,
+    mixed_requests: int,
+    hot_images: int,
+) -> tuple[list[RequestSpec], set[int]]:
+    initial_cache = set(range(hot_images))
+    shared_cold_image = hot_images
+    specs = [
+        RequestSpec(
+            idx=0,
+            kind="partial_miss",
+            images=(0, 1, 2, shared_cold_image),
+        )
+    ]
+    for idx in range(1, mixed_requests + 1):
+        base = idx % (hot_images - 2)
+        specs.append(
+            RequestSpec(
+                idx=idx,
+                kind="partial_miss",
+                images=(
+                    base,
+                    base + 1,
+                    shared_cold_image,
+                    shared_cold_image + idx,
+                ),
+            ))
+    return specs, initial_cache
+
+
+def make_cached_hol_workload(
+    *,
+    cached_requests: int,
+    hot_images: int,
+) -> tuple[list[RequestSpec], set[int]]:
+    initial_cache = set(range(hot_images))
+    specs = [
+        RequestSpec(
+            idx=0,
+            kind="partial_miss",
+            images=(0, 1, 2, hot_images),
+        )
+    ]
+    for idx in range(1, cached_requests + 1):
+        base = idx % (hot_images - 3)
+        specs.append(
+            RequestSpec(
+                idx=idx,
+                kind="cached",
+                images=(base, base + 1, base + 2, base + 3),
+            ))
+    return specs, initial_cache
+
+
+async def call_renderer(renderer: Any, spec: RequestSpec) -> Any:
+    return await renderer._process_multimodal_async(
+        [spec.idx],
+        {"images": spec.images},
+        mm_uuids=None,
+        mm_processor_kwargs=None,
+        tokenization_kwargs=None,
+    )
+
+
+async def run_workload(
+    symbols: VllmSymbols,
+    specs: list[RequestSpec],
+    initial_cache: set[int],
+    *,
+    concurrency: int,
+    renderer_workers: int,
+    miss_cost_s: float,
+) -> tuple[list[RequestResult], FakeProcessor, float]:
+    processor = FakeProcessor(initial_cache=initial_cache, miss_cost_s=miss_cost_s)
+    renderer, executor = make_renderer(
+        symbols,
+        processor,
+        max_workers=renderer_workers,
+    )
+    queue: asyncio.Queue[RequestSpec | None] = asyncio.Queue()
+    for spec in specs:
+        queue.put_nowait(spec)
+    for _ in range(concurrency):
+        queue.put_nowait(None)
+
+    results: list[RequestResult] = []
+    start_s = time.perf_counter()
+
+    async def worker() -> None:
+        while True:
+            spec = await queue.get()
+            if spec is None:
+                return
+            request_start_s = time.perf_counter()
+            await call_renderer(renderer, spec)
+            done_s = time.perf_counter()
+            results.append(
+                RequestResult(
+                    idx=spec.idx,
+                    kind=spec.kind,
+                    latency_s=done_s - request_start_s,
+                    completed_at_s=done_s - start_s,
+                ))
+
+    try:
+        await asyncio.gather(*(worker() for _ in range(concurrency)))
+    finally:
+        executor.shutdown(wait=True)
+
+    wall_s = time.perf_counter() - start_s
+    results.sort(key=lambda result: result.idx)
+    return results, processor, wall_s
+
+
+def percentile_ms(values_s: list[float], percentile: float) -> float:
+    if not values_s:
+        return 0.0
+    ordered = sorted(values_s)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * percentile))
+    return ordered[index] * 1000.0
+
+
+def mean_ms(values_s: list[float]) -> float:
+    if not values_s:
+        return 0.0
+    return statistics.fmean(values_s) * 1000.0
+
+
+def summarize(
+    results: list[RequestResult],
+    processor: FakeProcessor,
+    wall_s: float,
+    prefix: str,
+) -> dict[str, float]:
+    all_latencies = [result.latency_s for result in results]
+    cached_latencies = [
+        result.latency_s for result in results if result.kind == "cached"
+    ]
+    partial_miss_latencies = [
+        result.latency_s for result in results if result.kind == "partial_miss"
+    ]
+
+    summary = {
+        f"{prefix}_mean_ms": mean_ms(all_latencies),
+        f"{prefix}_p50_ms": percentile_ms(all_latencies, 0.50),
+        f"{prefix}_p95_ms": percentile_ms(all_latencies, 0.95),
+        f"{prefix}_p99_ms": percentile_ms(all_latencies, 0.99),
+        f"{prefix}_cached_p95_ms": percentile_ms(cached_latencies, 0.95),
+        f"{prefix}_partial_miss_mean_ms": mean_ms(partial_miss_latencies),
+        f"{prefix}_partial_miss_p95_ms": percentile_ms(
+            partial_miss_latencies,
+            0.95,
+        ),
+        f"{prefix}_wall_ms": wall_s * 1000.0,
+        f"{prefix}_throughput_rps": len(results) / wall_s,
+        f"{prefix}_ready_50ms": float(
+            sum(1 for result in results if result.completed_at_s <= 0.05)
+        ),
+        f"{prefix}_ready_100ms": float(
+            sum(1 for result in results if result.completed_at_s <= 0.10)
+        ),
+        f"{prefix}_apply_calls": float(processor.apply_calls),
+        f"{prefix}_prefill_calls": float(processor.prefill_calls),
+        f"{prefix}_processor_work_calls": float(
+            processor.apply_calls + processor.prefill_calls
+        ),
+        f"{prefix}_try_apply_calls": float(processor.try_apply_calls),
+        f"{prefix}_apply_cache_hits": float(processor.apply_cache_hits),
+        f"{prefix}_apply_cache_misses": float(processor.apply_cache_misses),
+        f"{prefix}_new_images_processed": float(processor.new_images_processed),
+    }
+    return summary
+
+
+async def run_once(args: argparse.Namespace) -> dict[str, float]:
+    symbols = load_vllm_symbols()
+
+    duplicate_specs, duplicate_cache = make_duplicate_partial_miss_workload(
+        unique_new_images=args.unique_new_images,
+        repeats_per_new_image=args.repeats_per_new_image,
+        hot_images=args.hot_images,
+    )
+    duplicate_results, duplicate_processor, duplicate_wall_s = await run_workload(
+        symbols,
+        duplicate_specs,
+        duplicate_cache,
+        concurrency=args.concurrency,
+        renderer_workers=args.renderer_workers,
+        miss_cost_s=args.miss_cost,
+    )
+
+    cached_hol_specs, cached_hol_cache = make_cached_hol_workload(
+        cached_requests=args.cached_hol_requests,
+        hot_images=args.hot_images,
+    )
+    cached_hol_results, cached_hol_processor, cached_hol_wall_s = await run_workload(
+        symbols,
+        cached_hol_specs,
+        cached_hol_cache,
+        concurrency=args.concurrency,
+        renderer_workers=args.renderer_workers,
+        miss_cost_s=args.miss_cost,
+    )
+
+    mixed_specs, mixed_cache = make_mixed_inflight_new_workload(
+        mixed_requests=args.mixed_requests,
+        hot_images=args.hot_images,
+    )
+    mixed_results, mixed_processor, mixed_wall_s = await run_workload(
+        symbols,
+        mixed_specs,
+        mixed_cache,
+        concurrency=args.concurrency,
+        renderer_workers=args.renderer_workers,
+        miss_cost_s=args.miss_cost,
+    )
+
+    metrics = summarize(
+        duplicate_results,
+        duplicate_processor,
+        duplicate_wall_s,
+        "duplicate",
+    )
+    metrics.update(
+        summarize(
+            cached_hol_results,
+            cached_hol_processor,
+            cached_hol_wall_s,
+            "cached_hol",
+        ))
+    metrics.update(
+        summarize(
+            mixed_results,
+            mixed_processor,
+            mixed_wall_s,
+            "mixed",
+        ))
+
+
+    # Primary score: mean scheduler-ready latency for the mixed in-flight/new
+    # miss workload.  This captures whether requests can preprocess their new
+    # missing item while waiting for a different in-flight cache miss.
+    metrics["mm_preprocess_ready_mean_ms"] = metrics["mixed_mean_ms"]
+    return metrics
+
+
+def aggregate_runs(runs: list[dict[str, float]]) -> dict[str, float]:
+    keys = runs[0].keys()
+    return {
+        key: statistics.median(run[key] for run in runs)
+        for key in keys
+    }
+
+
+def print_metrics(metrics: dict[str, float]) -> None:
+    primary = "mm_preprocess_ready_mean_ms"
+    print(f"METRIC {primary}={metrics[primary]:.6f}")
+    for key in sorted(metrics):
+        if key == primary:
+            continue
+        print(f"METRIC {key}={metrics[key]:.6f}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark multimodal preprocessing scheduler readiness."
+    )
+    parser.add_argument("--concurrency", type=int, default=72)
+    parser.add_argument("--renderer-workers", type=int, default=1)
+    parser.add_argument("--miss-cost", type=float, default=0.02)
+    parser.add_argument("--hot-images", type=int, default=256)
+    parser.add_argument("--unique-new-images", type=int, default=12)
+    parser.add_argument("--repeats-per-new-image", type=int, default=6)
+    parser.add_argument("--cached-hol-requests", type=int, default=71)
+    parser.add_argument("--mixed-requests", type=int, default=71)
+    parser.add_argument("--repetitions", type=int, default=5)
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    runs = [await run_once(args) for _ in range(args.repetitions)]
+    print_metrics(aggregate_runs(runs))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/multimodal/test_cache.py
+++ b/tests/multimodal/test_cache.py
@@ -29,7 +29,7 @@ from vllm.multimodal.inputs import (
     MultiModalSharedField,
     PlaceholderRange,
 )
-from vllm.multimodal.processing import PromptInsertion
+from vllm.multimodal.processing import BaseMultiModalProcessor, PromptInsertion
 from vllm.utils.mem_constants import GiB_bytes, MiB_bytes
 
 pytestmark = pytest.mark.cpu_test
@@ -72,6 +72,58 @@ def _dummy_items(
             for modality, size_by_key in size_by_key_modality.items()
         }
     )
+
+
+class _RecordingProcessorCache:
+
+    def __init__(self, cached_hashes: set[str]) -> None:
+        self.cached_hashes = cached_hashes
+        self.touched_hashes: list[str] = []
+
+    def is_cached(self, mm_hashes: list[str]) -> list[bool]:
+        return [mm_hash in self.cached_hashes for mm_hash in mm_hashes]
+
+    def touch_sender_cache_item(self, mm_hash: str) -> None:
+        self.touched_hashes.append(mm_hash)
+
+
+class _FakeProcessorInfo:
+
+    @staticmethod
+    def parse_mm_data(mm_data, validate: bool = True):
+        del validate
+        return mm_data
+
+
+class _FakeBaseProcessor(BaseMultiModalProcessor):
+
+    def _get_mm_fields_config(self, hf_inputs, hf_processor_mm_kwargs):
+        raise NotImplementedError
+
+    def _get_prompt_updates(
+        self,
+        mm_items,
+        hf_processor_mm_kwargs,
+        out_mm_kwargs,
+    ):
+        raise NotImplementedError
+
+
+
+def test_get_cache_missing_items_touches_cached_items():
+    processor = object.__new__(_FakeBaseProcessor)
+    processor.info = _FakeProcessorInfo()
+    cache = _RecordingProcessorCache({"cached"})
+
+    mm_is_cached, mm_missing_items = processor._get_cache_missing_items(
+        cache,
+        {"image": ["cached-data", "missing-data"]},
+        {"image": ["cached", "missing"]},
+    )
+
+    assert mm_is_cached == {"image": [True, False]}
+    assert mm_missing_items == {"image": ["missing-data"]}
+    assert cache.touched_hashes == ["cached"]
 
 
 @pytest.mark.parametrize(

--- a/tests/renderers/test_multimodal_cache_fast_path.py
+++ b/tests/renderers/test_multimodal_cache_fast_path.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import threading
+import types
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from vllm.multimodal.processing import ProcessorInputs, TimingContext
+from vllm.renderers.base import BaseRenderer
+from vllm.utils.async_utils import make_async
+from vllm.utils.counter import AtomicCounter
+
+
+class _FakeInfo:
+    @staticmethod
+    def parse_mm_data(mm_data: dict[str, Any]):
+        return mm_data
+
+
+class _FakeProcessor:
+    def __init__(self, started: threading.Event, release: threading.Event) -> None:
+        self.info = _FakeInfo()
+        self.started = started
+        self.release = release
+
+    def try_apply_cached(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        if inputs.mm_data_items["kind"] != "hit":
+            return None
+
+        return {
+            "prompt_token_ids": inputs.prompt,
+            "mm_kwargs": {},
+            "mm_hashes": {},
+            "mm_placeholders": {},
+        }
+
+
+    def get_cache_missing_hashes(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        return None
+
+    def try_apply_cached_or_get_missing_hashes(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        mm_input = self.try_apply_cached(inputs, timing_ctx)
+        return types.SimpleNamespace(
+            mm_input=mm_input,
+            missing_hashes=[] if mm_input is not None else None,
+        )
+
+    def prefill_cache_items(
+        self,
+        inputs: ProcessorInputs,
+        item_hashes: list[str],
+        timing_ctx: TimingContext,
+    ) -> None:
+        self.apply(inputs, timing_ctx)
+
+    def apply(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        self.started.set()
+        assert self.release.wait(timeout=5)
+        return {
+            "prompt_token_ids": inputs.prompt,
+            "mm_kwargs": {},
+            "mm_hashes": {},
+            "mm_placeholders": {},
+        }
+
+
+class _FakeSingleFlightProcessor:
+    def __init__(
+        self,
+        first_started: threading.Event,
+        second_started: threading.Event,
+        release_first: threading.Event,
+        release_second: threading.Event,
+    ) -> None:
+        self.info = _FakeInfo()
+        self.cache = {1, 2, 3}
+        self.lock = threading.Lock()
+        self.first_started = first_started
+        self.second_started = second_started
+        self.release_first = release_first
+        self.release_second = release_second
+        self.apply_calls = 0
+
+    def try_apply_cached(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            if not all(image in self.cache for image in images):
+                return None
+
+        return {
+            "prompt_token_ids": inputs.prompt,
+            "mm_kwargs": {},
+            "mm_hashes": {},
+            "mm_placeholders": {},
+        }
+
+    def get_cache_missing_hashes(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            return [
+                str(image)
+                for image in images
+                if image not in self.cache
+            ]
+
+    def try_apply_cached_or_get_missing_hashes(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        mm_input = self.try_apply_cached(inputs, timing_ctx)
+        return types.SimpleNamespace(
+            mm_input=mm_input,
+            missing_hashes=(
+                [] if mm_input is not None else
+                self.get_cache_missing_hashes(inputs, timing_ctx)
+            ),
+        )
+
+    def prefill_cache_items(
+        self,
+        inputs: ProcessorInputs,
+        item_hashes: list[str],
+        timing_ctx: TimingContext,
+    ) -> None:
+        selected_hashes = {int(item_hash) for item_hash in item_hashes}
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            missing = [
+                image
+                for image in images
+                if image in selected_hashes and image not in self.cache
+            ]
+
+        for image in missing:
+            if image == 100:
+                self.first_started.set()
+                assert self.release_first.wait(timeout=5)
+            elif image == 101:
+                self.second_started.set()
+                assert self.release_second.wait(timeout=5)
+
+        with self.lock:
+            self.cache.update(missing)
+
+    def apply(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ):
+        self.apply_calls += 1
+        images = inputs.mm_data_items["images"]
+        with self.lock:
+            missing = [image for image in images if image not in self.cache]
+
+        for image in missing:
+            if image == 100:
+                self.first_started.set()
+                assert self.release_first.wait(timeout=5)
+            elif image == 101:
+                self.second_started.set()
+                assert self.release_second.wait(timeout=5)
+
+        with self.lock:
+            self.cache.update(missing)
+
+        return {
+            "prompt_token_ids": inputs.prompt,
+            "mm_kwargs": {},
+            "mm_hashes": {},
+            "mm_placeholders": {},
+        }
+
+
+class _FakeTimingRegistry:
+    @staticmethod
+    def get(request_id: str):
+        return TimingContext(enabled=False)
+
+
+class _TestRenderer(BaseRenderer):
+    def render_messages(self, messages, params):
+        raise NotImplementedError
+
+
+def _make_renderer(processor: _FakeProcessor, max_workers: int = 1):
+    renderer: Any = object.__new__(_TestRenderer)
+    renderer.api_process_rank = 0
+    renderer._mm_req_counter = AtomicCounter()
+    renderer._readonly_mm_processor = None
+    renderer.mm_processor = processor
+    renderer._mm_timing_registry = _FakeTimingRegistry()
+    renderer._process_mm_uuids = lambda *args, **kwargs: None
+    renderer.update_mm_cache_stats = lambda: None
+    renderer.config = type(
+        "Config",
+        (),
+        {
+            "cache_config": type(
+                "CacheConfig",
+                (),
+                {"enable_prefix_caching": True},
+            )()
+        },
+    )()
+    renderer.model_config = type(
+        "ModelConfig",
+        (),
+        {"multimodal_config": None},
+    )()
+    renderer.get_mm_processor = lambda: processor
+    renderer._mm_cache_inflight_futures = {}
+    executor = ThreadPoolExecutor(max_workers=max_workers)
+    renderer._process_multimodal_in_executor = make_async(
+        renderer._process_multimodal,
+        executor=executor,
+    )
+    renderer._prefill_multimodal_cache_in_executor = make_async(
+        renderer._prefill_multimodal_cache,
+        executor=executor,
+    )
+    renderer._test_executor = executor
+    return renderer
+
+
+@pytest.mark.asyncio
+async def test_cached_multimodal_request_bypasses_busy_executor():
+    started = threading.Event()
+    release = threading.Event()
+    renderer = _make_renderer(_FakeProcessor(started, release))
+
+    miss_task = asyncio.create_task(
+        renderer._process_multimodal_async(
+            [1],
+            {"kind": "miss"},
+            mm_uuids=None,
+            mm_processor_kwargs=None,
+            tokenization_kwargs=None,
+        )
+    )
+
+    try:
+        assert await asyncio.to_thread(started.wait, 5)
+
+        hit_result = await asyncio.wait_for(
+            renderer._process_multimodal_async(
+                [2],
+                {"kind": "hit"},
+                mm_uuids=None,
+                mm_processor_kwargs=None,
+                tokenization_kwargs=None,
+            ),
+            timeout=0.5,
+        )
+        assert hit_result["prompt_token_ids"] == [2]
+    finally:
+        release.set()
+        await miss_task
+        renderer._test_executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_cache_miss_waits_for_inflight_owner():
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+    release_second = threading.Event()
+    processor = _FakeSingleFlightProcessor(
+        first_started,
+        second_started,
+        release_first,
+        release_second,
+    )
+    renderer = _make_renderer(processor)
+
+    first_task = asyncio.create_task(
+        renderer._process_multimodal_async(
+            [1],
+            {"images": (1, 2, 3, 100)},
+            mm_uuids=None,
+            mm_processor_kwargs=None,
+            tokenization_kwargs=None,
+        )
+    )
+
+    try:
+        assert await asyncio.to_thread(first_started.wait, 5)
+
+        second_task = asyncio.create_task(
+            renderer._process_multimodal_async(
+                [2],
+                {"images": (1, 2, 3, 101)},
+                mm_uuids=None,
+                mm_processor_kwargs=None,
+                tokenization_kwargs=None,
+            )
+        )
+        assert not await asyncio.to_thread(second_started.wait, 0.05)
+
+        duplicate_task = asyncio.create_task(
+            renderer._process_multimodal_async(
+                [3],
+                {"images": (1, 2, 3, 100)},
+                mm_uuids=None,
+                mm_processor_kwargs=None,
+                tokenization_kwargs=None,
+            )
+        )
+
+        release_first.set()
+        duplicate_result = await asyncio.wait_for(duplicate_task, timeout=0.5)
+        assert duplicate_result["prompt_token_ids"] == [3]
+        assert await asyncio.to_thread(second_started.wait, 5)
+        assert not second_task.done()
+    finally:
+        release_first.set()
+        release_second.set()
+        await first_task
+        if "second_task" in locals():
+            await second_task
+        renderer._test_executor.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+async def test_mixed_miss_prefills_owned_hash_while_waiting():
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+    release_second = threading.Event()
+    processor = _FakeSingleFlightProcessor(
+        first_started,
+        second_started,
+        release_first,
+        release_second,
+    )
+    renderer = _make_renderer(processor, max_workers=2)
+
+    first_task = asyncio.create_task(
+        renderer._process_multimodal_async(
+            [1],
+            {"images": (1, 2, 3, 100)},
+            mm_uuids=None,
+            mm_processor_kwargs=None,
+            tokenization_kwargs=None,
+        )
+    )
+
+    try:
+        assert await asyncio.to_thread(first_started.wait, 5)
+
+        mixed_task = asyncio.create_task(
+            renderer._process_multimodal_async(
+                [2],
+                {"images": (1, 2, 100, 101)},
+                mm_uuids=None,
+                mm_processor_kwargs=None,
+                tokenization_kwargs=None,
+            )
+        )
+
+        assert await asyncio.to_thread(second_started.wait, 5)
+        assert not mixed_task.done()
+
+        release_second.set()
+        await asyncio.sleep(0)
+        assert not mixed_task.done()
+
+        release_first.set()
+        mixed_result = await asyncio.wait_for(mixed_task, timeout=0.5)
+        assert mixed_result["prompt_token_ids"] == [2]
+        assert processor.apply_calls == 1
+    finally:
+        release_first.set()
+        release_second.set()
+        await first_task
+        if "mixed_task" in locals():
+            await mixed_task
+        renderer._test_executor.shutdown(wait=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1384,17 +1384,16 @@ def test_needs_dp_coordination(
 
 
 def test_renderer_num_workers_with_mm_cache():
-    """Disallow renderer_num_workers > 1 when mm processor cache is enabled,
-    since neither cache type is thread-safe."""
+    """Allow renderer workers with the thread-safe MM processor cache path."""
     mm_model = "Qwen/Qwen2-VL-2B-Instruct"
 
-    # Should raise: multi-worker + cache enabled (default cache_gb=4)
-    with pytest.raises(ValueError, match="renderer-num-workers"):
-        ModelConfig(mm_model, renderer_num_workers=4)
+    # Should pass: multi-worker + cache enabled (default cache_gb=4)
+    config = ModelConfig(mm_model, renderer_num_workers=4)
+    assert config.renderer_num_workers == 4
 
-    # Should raise: multi-worker + explicit cache size
-    with pytest.raises(ValueError, match="renderer-num-workers"):
-        ModelConfig(mm_model, renderer_num_workers=2, mm_processor_cache_gb=1.0)
+    # Should pass: multi-worker + explicit cache size
+    config = ModelConfig(mm_model, renderer_num_workers=2, mm_processor_cache_gb=1.0)
+    assert config.renderer_num_workers == 2
 
     # Should pass: multi-worker + cache disabled
     config = ModelConfig(mm_model, renderer_num_workers=4, mm_processor_cache_gb=0)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -715,18 +715,6 @@ class ModelConfig:
 
             self.multimodal_config = MultiModalConfig(**mm_config_kwargs)  # type: ignore[arg-type]
 
-            if (
-                self.renderer_num_workers > 1
-                and self.multimodal_config.mm_processor_cache_gb > 0
-            ):
-                raise ValueError(
-                    "Cannot use --renderer-num-workers > 1 with the "
-                    "multimodal processor cache enabled. The cache is "
-                    "not thread-safe and does not support concurrent "
-                    "renderer workers. Please set "
-                    "--renderer-num-workers 1 (the default), or "
-                    "disable the cache with --mm-processor-cache-gb 0."
-                )
 
         # Multimodal GGUF models must use original repo for mm processing
         if is_gguf(self.tokenizer) and self.is_multimodal_model:

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, ItemsView, Iterable, Mapping, Sequence
@@ -969,6 +971,11 @@ class MultiModalProcessingInfo(NamedTuple):
     prompt_updates: MultiModalPromptUpdates
 
 
+class MultiModalCachedApplyResult(NamedTuple):
+    mm_input: MultiModalInput | None
+    missing_hashes: list[str] | None
+
+
 class BaseMultiModalProcessor(ABC, Generic[_I]):
     """
     Abstract base class to process multi-modal inputs to be used in vLLM.
@@ -988,6 +995,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         self.info = info
         self.dummy_inputs = dummy_inputs
         self.cache = cache
+        self._cache_lock = threading.Lock()
 
         self.data_parser = self.info.get_data_parser()
 
@@ -1306,6 +1314,11 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             modality: cache.is_cached(hashes) for modality, hashes in mm_hashes.items()
         }
 
+        for modality, hashes in mm_hashes.items():
+            for item_hash, item_is_cached in zip(hashes, mm_is_cached[modality]):
+                if item_is_cached:
+                    cache.touch_sender_cache_item(item_hash)
+
         mm_missing_idxs = {
             modality: [
                 idx
@@ -1332,6 +1345,286 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         mm_missing_items = self.info.parse_mm_data(mm_missing_data, validate=False)
 
         return mm_is_cached, mm_missing_items
+
+    @staticmethod
+    def _has_cache_miss(mm_is_cached: MultiModalIsCached) -> bool:
+        return any(
+            not item_is_cached
+            for modality_is_cached in mm_is_cached.values()
+            for item_is_cached in modality_is_cached
+        )
+
+    @staticmethod
+    def _record_elapsed(
+        timing_ctx: TimingContext,
+        stage: str,
+        elapsed: float,
+    ) -> None:
+        if not timing_ctx.enabled:
+            return
+
+        timing_ctx.stage_secs[stage] = timing_ctx.stage_secs.get(stage, 0.0) + elapsed
+
+    @staticmethod
+    def _get_missing_hashes(
+        mm_hashes: MultiModalHashes,
+        mm_is_cached: MultiModalIsCached,
+    ) -> list[str]:
+        return [
+            item_hash
+            for modality, hashes in mm_hashes.items()
+            for item_hash, item_is_cached in zip(
+                hashes,
+                mm_is_cached[modality],
+            )
+            if not item_is_cached
+        ]
+
+    def try_apply_cached_or_get_missing_hashes(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> MultiModalCachedApplyResult:
+        """Return cached MM input, or missing hashes for single-flight waits.
+
+        ``missing_hashes is None`` means this request cannot use the processor
+        cache fast path and must fall back to the normal processor path.
+        """
+        cache = self.cache
+
+        _, passthrough_data = self._get_hf_mm_data(inputs.mm_data_items)
+        if cache is None or passthrough_data:
+            return MultiModalCachedApplyResult(None, None)
+
+        start = time.perf_counter()
+        mm_hashes = inputs.get_mm_hashes(self.info.model_id)
+        get_mm_hashes_secs = time.perf_counter() - start
+
+        with self._cache_lock:
+            start = time.perf_counter()
+            mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
+                cache=cache,
+                mm_data_items=inputs.mm_data_items,
+                mm_hashes=mm_hashes,
+            )
+            get_cache_missing_items_secs = time.perf_counter() - start
+
+            missing_hashes = self._get_missing_hashes(mm_hashes, mm_is_cached)
+            if missing_hashes:
+                return MultiModalCachedApplyResult(None, missing_hashes)
+
+            self._record_elapsed(
+                timing_ctx,
+                "get_mm_hashes",
+                get_mm_hashes_secs,
+            )
+            self._record_elapsed(
+                timing_ctx,
+                "get_cache_missing_items",
+                get_cache_missing_items_secs,
+            )
+
+            # NOTE: `prompt` does not correspond to the cached MM items, so use
+            # the same prompt-update-disabled path as `_cached_apply_hf_processor`.
+            with timing_ctx.record("apply_hf_processor"):
+                (
+                    prompt_ids,
+                    mm_missing_processed_data,
+                    is_update_applied,
+                ) = self._apply_hf_processor_main(
+                    prompt=inputs.prompt,
+                    mm_items=mm_missing_data_items,
+                    hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
+                    tokenization_kwargs=inputs.tokenization_kwargs,
+                    enable_hf_prompt_update=False,
+                )
+
+            mm_missing_kwargs = MultiModalKwargsItems.from_hf_inputs(
+                mm_missing_processed_data,
+                self._get_mm_fields_config(
+                    mm_missing_processed_data,
+                    inputs.hf_processor_mm_kwargs,
+                ),
+            )
+
+            mm_missing_prompt_updates = self._get_mm_prompt_updates(
+                mm_missing_data_items,
+                inputs.hf_processor_mm_kwargs,
+                mm_missing_kwargs,
+            )
+
+            with timing_ctx.record("merge_mm_kwargs"):
+                mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
+                    cache,
+                    mm_hashes=mm_hashes,
+                    mm_is_cached=mm_is_cached,
+                    mm_missing_kwargs=mm_missing_kwargs,
+                    mm_missing_prompt_updates=mm_missing_prompt_updates,
+                )
+
+        mm_info = MultiModalProcessingInfo(
+            kwargs=mm_kwargs,
+            hashes=mm_hashes,
+            prompt_updates=mm_prompt_updates,
+        )
+
+        mm_input = self._build_mm_input_with_prompt_updates(
+            prompt_ids,
+            inputs,
+            mm_info,
+            is_update_applied,
+            timing_ctx,
+        )
+        return MultiModalCachedApplyResult(mm_input, [])
+
+    def get_cache_missing_hashes(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> list[str] | None:
+        return self.try_apply_cached_or_get_missing_hashes(
+            inputs,
+            timing_ctx,
+        ).missing_hashes
+
+    def try_apply_cached(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> MultiModalInput | None:
+        """Process inputs without offloading when every MM item is cached.
+
+        The async renderer uses this as a fast path so cache-hit requests do
+        not wait behind cache-miss requests that are running the expensive HF
+        processor in the renderer executor.  It only succeeds when the request
+        can be served entirely from the processor cache; miss and passthrough
+        cases fall back to the normal executor path.
+        """
+        return self.try_apply_cached_or_get_missing_hashes(
+            inputs,
+            timing_ctx,
+        ).mm_input
+
+
+    def prefill_cache_items(
+        self,
+        inputs: ProcessorInputs,
+        item_hashes: Sequence[str],
+        timing_ctx: TimingContext,
+    ) -> None:
+        """Process selected missing MM items and store them in the cache.
+
+        This is used when a request is waiting on one in-flight missing item
+        but owns another missing item.  The owned item can be preprocessed while
+        the request waits; the request then re-enters the normal cached path.
+        """
+        cache = self.cache
+        if cache is None:
+            return
+
+        selected_hashes = set(item_hashes)
+        if not selected_hashes:
+            return
+
+        with timing_ctx.record("get_mm_hashes"):
+            mm_hashes = inputs.get_mm_hashes(self.info.model_id)
+
+        selected_mm_hashes: MultiModalHashes = {}
+        selected_mm_data = dict[str, list[object]]()
+        for modality, hashes in mm_hashes.items():
+            modality_hashes: list[str] = []
+            modality_data: list[object] = []
+            for item_idx, item_hash in enumerate(hashes):
+                if item_hash not in selected_hashes:
+                    continue
+
+                data = inputs.mm_data_items[modality][item_idx]
+                if data is None:
+                    raise ValueError(
+                        f"Cache miss for {modality} at index {item_idx} "
+                        "but data is not provided."
+                    )
+
+                modality_hashes.append(item_hash)
+                modality_data.append(data)
+
+            if modality_hashes:
+                selected_mm_hashes[modality] = modality_hashes
+                selected_mm_data[modality] = modality_data
+
+        if not selected_mm_hashes:
+            return
+
+        with self._cache_lock, timing_ctx.record("get_cache_missing_items"):
+            selected_is_cached = {
+                modality: cache.is_cached(hashes)
+                for modality, hashes in selected_mm_hashes.items()
+            }
+
+        missing_hashes: MultiModalHashes = {}
+        missing_data = dict[str, list[object]]()
+        missing_is_cached: MultiModalIsCached = {}
+        for modality, hashes in selected_mm_hashes.items():
+            modality_missing_hashes: list[str] = []
+            modality_missing_data: list[object] = []
+            for item_hash, data, item_is_cached in zip(
+                hashes,
+                selected_mm_data[modality],
+                selected_is_cached[modality],
+            ):
+                if item_is_cached:
+                    continue
+
+                modality_missing_hashes.append(item_hash)
+                modality_missing_data.append(data)
+
+            if modality_missing_hashes:
+                missing_hashes[modality] = modality_missing_hashes
+                missing_data[modality] = modality_missing_data
+                missing_is_cached[modality] = [False] * len(
+                    modality_missing_hashes
+                )
+
+        if not missing_hashes:
+            return
+
+        missing_items = self.info.parse_mm_data(missing_data, validate=False)
+
+        with timing_ctx.record("apply_hf_processor"):
+            (
+                _,
+                mm_missing_processed_data,
+                _,
+            ) = self._apply_hf_processor_main(
+                prompt=inputs.prompt,
+                mm_items=missing_items,
+                hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
+                tokenization_kwargs=inputs.tokenization_kwargs,
+                enable_hf_prompt_update=False,
+            )
+
+        mm_missing_kwargs = MultiModalKwargsItems.from_hf_inputs(
+            mm_missing_processed_data,
+            self._get_mm_fields_config(
+                mm_missing_processed_data,
+                inputs.hf_processor_mm_kwargs,
+            ),
+        )
+
+        mm_missing_prompt_updates = self._get_mm_prompt_updates(
+            missing_items,
+            inputs.hf_processor_mm_kwargs,
+            mm_missing_kwargs,
+        )
+
+        with self._cache_lock, timing_ctx.record("merge_mm_kwargs"):
+            self._merge_mm_kwargs(
+                cache,
+                mm_hashes=missing_hashes,
+                mm_is_cached=missing_is_cached,
+                mm_missing_kwargs=mm_missing_kwargs,
+                mm_missing_prompt_updates=mm_missing_prompt_updates,
+            )
 
     def _recompute_cached_prompt_update(
         self,
@@ -1456,7 +1749,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         with timing_ctx.record("get_mm_hashes"):
             mm_hashes = inputs.get_mm_hashes(self.info.model_id)
 
-        with timing_ctx.record("get_cache_missing_items"):
+        with self._cache_lock, timing_ctx.record("get_cache_missing_items"):
             mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
                 cache=cache,
                 mm_data_items=inputs.mm_data_items,
@@ -1492,7 +1785,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_missing_kwargs,
         )
 
-        with timing_ctx.record("merge_mm_kwargs"):
+        with self._cache_lock, timing_ctx.record("merge_mm_kwargs"):
             mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
                 cache,
                 mm_hashes=mm_hashes,
@@ -1684,6 +1977,22 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             is_update_applied,
         ) = self._cached_apply_hf_processor(inputs, timing_ctx)
 
+        return self._build_mm_input_with_prompt_updates(
+            prompt_ids,
+            inputs,
+            mm_info,
+            is_update_applied,
+            timing_ctx,
+        )
+
+    def _build_mm_input_with_prompt_updates(
+        self,
+        prompt_ids: list[int],
+        inputs: ProcessorInputs,
+        mm_info: MultiModalProcessingInfo,
+        is_update_applied: bool,
+        timing_ctx: TimingContext,
+    ) -> MultiModalInput:
         # NOTE: tokenization_kwargs are not required to init processor
         with timing_ctx.record("apply_prompt_updates"):
             prompt_ids, mm_placeholders = self._maybe_apply_prompt_updates(

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
         ChatCompletionMessageParam,
         ConversationMessage,
     )
+    from vllm.multimodal.processing import TimingContext
 
 logger = init_logger(__name__)
 
@@ -88,10 +89,12 @@ class BaseRenderer(ABC, Generic[_T]):
         pool_workers = config.model_config.renderer_num_workers
         self._executor = ThreadPoolExecutor(max_workers=pool_workers)
 
-        # Multimodal preprocessing is always offloaded to the thread pool
-        # to keep the asyncio event loop responsive under concurrent load.
+        # Multimodal cache misses are offloaded to the thread pool to keep the
+        # asyncio event loop responsive. Cache hits use a synchronous fast path
+        # in the event loop to avoid queueing behind expensive HF processing.
         self._mm_executor: Executor = self._executor
 
+        self._mm_cache_inflight_futures: dict[str, asyncio.Future[None]] = {}
         # Lazy initialization since offline LLM doesn't use async
         self._async_tokenizer: AsyncMicrobatchTokenizer | None = None
 
@@ -101,11 +104,14 @@ class BaseRenderer(ABC, Generic[_T]):
         self._clear_mm_cache_async = make_async(
             self.clear_mm_cache, executor=self._executor
         )
-        self._process_multimodal_async = make_async(
+        self._process_multimodal_in_executor = make_async(
             self._process_multimodal, executor=self._mm_executor
         )
         self._safe_load_prompt_embeds_async = make_async(
             safe_load_prompt_embeds, executor=self._executor
+        )
+        self._prefill_multimodal_cache_in_executor = make_async(
+            self._prefill_multimodal_cache, executor=self._mm_executor
         )
         if mm_registry.supports_multimodal_inputs(config.model_config):
             mm_processor_cache = mm_registry.processor_cache_from_config(config)
@@ -177,17 +183,23 @@ class BaseRenderer(ABC, Generic[_T]):
         return mm_cache_stats
 
     def update_mm_cache_stats(self) -> None:
+        mm_processor = self.mm_processor
         mm_processor_cache = self.mm_processor_cache
         mm_cache_stats = self._mm_cache_stats
 
         if mm_processor_cache and mm_cache_stats:
-            delta = mm_processor_cache.make_stats(delta=True)
+            assert mm_processor is not None
+            with mm_processor._cache_lock:
+                delta = mm_processor_cache.make_stats(delta=True)
             mm_cache_stats.record(delta.total, delta.hits)
 
     def clear_mm_cache(self) -> None:
+        mm_processor = self.mm_processor
         mm_processor_cache = self.mm_processor_cache
         if mm_processor_cache is not None:
-            mm_processor_cache.clear_cache()
+            assert mm_processor is not None
+            with mm_processor._cache_lock:
+                mm_processor_cache.clear_cache()
 
         if self._mm_cache_stats is not None:
             self._mm_cache_stats.reset = True
@@ -201,7 +213,8 @@ class BaseRenderer(ABC, Generic[_T]):
 
         processor_cache = processor.cache
         if processor_cache is not None:
-            processor_cache.clear_cache()
+            with processor._cache_lock:
+                processor_cache.clear_cache()
 
     def _warmup_mm_processor(
         self,
@@ -273,8 +286,8 @@ class BaseRenderer(ABC, Generic[_T]):
                 self._clear_processor_cache(self._readonly_mm_processor)
 
     async def clear_mm_cache_async(self) -> None:
-        """Serialize clear_mm_cache through the shared executor to avoid
-        races with concurrent process_inputs on the mm_processor_cache."""
+        """Serialize clear_mm_cache and take the processor cache lock to avoid
+        races with concurrent multimodal preprocessing."""
         await self._clear_mm_cache_async()
 
     def shutdown(self) -> None:
@@ -722,6 +735,191 @@ class BaseRenderer(ABC, Generic[_T]):
         self.update_mm_cache_stats()
 
         return mm_inputs
+
+    def _get_mm_cache_waiters(
+        self,
+        missing_hashes: Sequence[str],
+    ) -> list[asyncio.Future[None]]:
+        waiters: list[asyncio.Future[None]] = []
+        seen: set[str] = set()
+        for item_hash in missing_hashes:
+            if item_hash in seen:
+                continue
+            seen.add(item_hash)
+
+            waiter = self._mm_cache_inflight_futures.get(item_hash)
+            if waiter is not None:
+                waiters.append(waiter)
+
+        return waiters
+
+    def _reserve_mm_cache_misses(
+        self,
+        missing_hashes: Sequence[str],
+    ) -> list[tuple[str, asyncio.Future[None]]]:
+        loop = asyncio.get_running_loop()
+        reservations: list[tuple[str, asyncio.Future[None]]] = []
+        seen: set[str] = set()
+        for item_hash in missing_hashes:
+            if item_hash in seen:
+                continue
+            seen.add(item_hash)
+
+            if item_hash in self._mm_cache_inflight_futures:
+                continue
+
+            waiter = loop.create_future()
+            self._mm_cache_inflight_futures[item_hash] = waiter
+            reservations.append((item_hash, waiter))
+
+        return reservations
+
+    def _release_mm_cache_misses(
+        self,
+        reservations: Sequence[tuple[str, asyncio.Future[None]]],
+    ) -> None:
+        for item_hash, waiter in reservations:
+            if self._mm_cache_inflight_futures.get(item_hash) is waiter:
+                del self._mm_cache_inflight_futures[item_hash]
+
+            if not waiter.done():
+                waiter.set_result(None)
+
+
+    def _get_unreserved_mm_cache_misses(
+        self,
+        missing_hashes: Sequence[str],
+    ) -> list[str]:
+        missing_without_waiters: list[str] = []
+        seen: set[str] = set()
+        for item_hash in missing_hashes:
+            if item_hash in seen:
+                continue
+            seen.add(item_hash)
+
+            if item_hash not in self._mm_cache_inflight_futures:
+                missing_without_waiters.append(item_hash)
+
+        return missing_without_waiters
+
+    def _prefill_multimodal_cache(
+        self,
+        mm_processor: "BaseMultiModalProcessor",
+        mm_processor_inputs: MMProcessorInputs,
+        item_hashes: Sequence[str],
+        mm_timing_ctx: "TimingContext",
+    ) -> None:
+        with set_default_torch_num_threads():
+            mm_processor.prefill_cache_items(
+                mm_processor_inputs,
+                item_hashes,
+                mm_timing_ctx,
+            )
+
+        self.update_mm_cache_stats()
+
+    async def _process_multimodal_async(
+        self,
+        prompt: list[int] | str,
+        mm_data: MultiModalDataDict,
+        mm_uuids: MultiModalUUIDDict | None,
+        mm_processor_kwargs: Mapping[str, object] | None,
+        tokenization_kwargs: dict[str, Any] | None,
+        *,
+        skip_mm_cache: bool = False,
+    ) -> "MultiModalInput":
+        mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
+
+        if skip_mm_cache and self._readonly_mm_processor is not None:
+            mm_processor = self._readonly_mm_processor
+        else:
+            mm_processor = self.get_mm_processor()
+
+        mm_data_items = mm_processor.info.parse_mm_data(mm_data)
+        mm_uuid_items = parse_mm_uuids(mm_uuids)
+
+        mm_uuid_items = self._process_mm_uuids(
+            mm_data, mm_data_items, mm_uuid_items, mm_req_id
+        )
+
+        mm_processor_inputs = MMProcessorInputs(
+            prompt,
+            mm_data_items,
+            mm_uuid_items,
+            hf_processor_mm_kwargs=mm_processor_kwargs or {},
+            tokenization_kwargs=tokenization_kwargs or {},
+        )
+        mm_timing_ctx = self._mm_timing_registry.get(mm_req_id)
+
+        while True:
+            with set_default_torch_num_threads():
+                cached_result = mm_processor.try_apply_cached_or_get_missing_hashes(
+                    mm_processor_inputs,
+                    mm_timing_ctx,
+                )
+
+            if cached_result.mm_input is not None:
+                self.update_mm_cache_stats()
+                return cached_result.mm_input
+
+            missing_hashes = cached_result.missing_hashes
+            if not missing_hashes:
+                reservations: list[tuple[str, asyncio.Future[None]]] = []
+                break
+            waiters = self._get_mm_cache_waiters(missing_hashes)
+            if waiters:
+                shielded_waiters = [
+                    asyncio.shield(waiter) for waiter in waiters
+                ]
+                missing_without_waiters = self._get_unreserved_mm_cache_misses(
+                    missing_hashes
+                )
+                reservations = self._reserve_mm_cache_misses(missing_without_waiters)
+                if reservations:
+                    reserved_hashes = [
+                        item_hash for item_hash, _ in reservations
+                    ]
+                    prefill_future = self._prefill_multimodal_cache_in_executor(
+                        mm_processor,
+                        mm_processor_inputs,
+                        reserved_hashes,
+                        mm_timing_ctx,
+                    )
+
+                    def release_prefill(
+                        _future: asyncio.Future[None],
+                        reservations=reservations,
+                    ) -> None:
+                        self._release_mm_cache_misses(reservations)
+
+                    prefill_future.add_done_callback(release_prefill)
+                    await asyncio.gather(
+                        *shielded_waiters,
+                        asyncio.shield(prefill_future),
+                    )
+                else:
+                    await asyncio.gather(*shielded_waiters)
+                continue
+
+            reservations = self._reserve_mm_cache_misses(missing_hashes)
+            break
+
+        mm_future = self._process_multimodal_in_executor(
+            prompt,
+            mm_data,
+            mm_processor_kwargs=mm_processor_kwargs,
+            tokenization_kwargs=tokenization_kwargs,
+            mm_uuids=mm_uuids,
+            skip_mm_cache=skip_mm_cache,
+        )
+        if not reservations:
+            return await mm_future
+
+        mm_future.add_done_callback(
+            lambda _: self._release_mm_cache_misses(reservations)
+        )
+
+        return await asyncio.shield(mm_future)
 
     def _process_tokens(
         self,


### PR DESCRIPTION
## Purpose

This PR reduces head-of-line blocking in the OpenAI renderer multimodal preprocessing path.

In high-concurrency multimodal workloads, expensive multimodal processor cache misses can occupy the renderer executor. Before this change, cache-hit requests and duplicate cache-miss requests could still wait behind unrelated expensive HF/MM preprocessing work before becoming engine-visible.

This PR changes the renderer/MM cache path so that:

- Cached multimodal requests can complete through a synchronous fast path without queueing behind executor cache misses.
- Duplicate cache misses use single-flight coordination, so one owner computes the missing cache item while duplicate waiters await the owner future.
- Mixed cache-miss requests can prefill their owned missing hashes while waiting for unrelated in-flight misses.
- Shared owner futures are shielded so waiter cancellation does not cancel the owner future.
- Cached SHM multimodal entries are touched/pinned during missing-item probing, so cache-hit items stay alive for the later merge/read path.
- `renderer_num_workers > 1` is allowed with multimodal processor cache enabled, now that this path is synchronized.

This addresses the pre-scheduler symptom where requests are accepted by the OpenAI frontend but spend a long time in renderer/MM preprocessing before they appear in `vllm:num_requests_waiting` or `vllm:num_requests_running`.

Related issue: https://github.com/vllm-project/vllm/issues/44688

Duplicate-work check: I searched open PRs for `44688 in:body`, `multimodal renderer cache contention`, and `renderer_num_workers`; I did not find an existing open PR covering this change.

AI assistance was used while preparing and validating this change. I reviewed the changed code and ran the tests listed below.

## Test Plan

```bash
python -m py_compile \
  vllm/renderers/base.py \
  vllm/multimodal/processing/processor.py \
  benchmarks/overheads/benchmark_multimodal_preprocessing_scheduler.py \
  tests/renderers/test_multimodal_cache_fast_path.py

python -m pytest tests/renderers/test_multimodal_cache_fast_path.py -q
python -m pytest tests/multimodal/test_cache.py -q -k get_cache_missing_items_touches_cached_items
python -m pytest tests/test_config.py -q -k renderer_num_workers_with_mm_cache
uvx ruff check \
  vllm/renderers/base.py \
  vllm/multimodal/processing/processor.py \
  vllm/config/model.py \
  tests/renderers/test_multimodal_cache_fast_path.py \
  tests/multimodal/test_cache.py \
  tests/test_config.py \
  benchmarks/overheads/benchmark_multimodal_preprocessing_scheduler.py
```

## Test Result

Local validation on the prepared branch:

```text
py_compile: passed
```

```text
tests/multimodal/test_cache.py -q -k get_cache_missing_items_touches_cached_items:
1 passed
```

Renderer async smoke coverage was also run directly for the new tests because this local WSL environment cannot import the CUDA flash-attention extension required by the upstream `tests/renderers/conftest.py` collection path:

```text
test_cached_multimodal_request_bypasses_busy_executor: passed
test_duplicate_cache_miss_waits_for_inflight_owner: passed
test_mixed_miss_prefills_owned_hash_while_waiting: passed
```

```text
ruff: All checks passed
```

The config test collection also hits the same local missing `vllm_flash_attn` extension in this environment; the test is included in the PR and should run in the normal vLLM CUDA CI environment.

Real workload validation was performed together with the Qwen3-VL image preprocessing optimization from the follow-up branch. Under a 72-concurrency PDF-agent workload on a single RTX PRO 6000 Blackwell, the combined changes improved scheduler admission and reduced frontend/MM queueing. These end-to-end numbers are included as evidence for the combined candidate fix, not as an isolated measurement of this PR alone:

```text
Before, 4 renderer workers baseline:
  avg generation throughput: ~413.8 output tok/s
  avg Running:               ~49.2
  avg Waiting:               ~2.0
  max Waiting:               17

After, combined changes:
  avg generation throughput: ~521.3 output tok/s
  avg Running:               ~67.3
  avg Waiting:               ~0.72
  max Waiting:               9
  vLLM error delta:          0
```

Worst-window p95 timing moved from tens of seconds of MM executor queueing to single-digit seconds in the same workload shape:

```text
mm_executor_await p95: ~31.9s -> ~5.6s
mm_async_total p95:    ~32.0s -> ~5.6s
```