### PR TITLE
[Model] Optimize Qwen3-VL image preprocessing with compact patches

### DIFF
--- a/benchmarks/overheads/benchmark_qwen3_hf_processor.py
+++ b/benchmarks/overheads/benchmark_qwen3_hf_processor.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Deterministic Qwen3-VL text+image HF processor benchmark.
+
+This isolates the image preprocessing subpath that vLLM exercises for
+tokenized Qwen3-VL chat requests containing text plus images. By the time this
+code runs in the OpenAI server, chat template rendering and text tokenization
+have already produced prompt token IDs; the HF processor is used only to turn
+image objects into ``pixel_values`` and ``image_grid_thw``. The benchmark keeps
+text tokens around the image placeholders so it models the business workload's
+text+multi-image prompt shape without loading model weights or fetching network
+resources.
+"""
+
+import argparse
+import concurrent.futures
+import statistics
+import sys
+import time
+import types
+import warnings
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from transformers import PreTrainedTokenizerFast
+from transformers.models.qwen2_vl import Qwen2VLImageProcessor
+from transformers.models.qwen3_vl import Qwen3VLProcessor, Qwen3VLVideoProcessor
+
+QWEN36_IMAGE_PROCESSOR_KWARGS: dict[str, object] = {
+    "size": {
+        "shortest_edge": 65536,
+        "longest_edge": 16777216,
+    },
+    "patch_size": 16,
+    "temporal_patch_size": 2,
+    "merge_size": 2,
+    "image_mean": [0.5, 0.5, 0.5],
+    "image_std": [0.5, 0.5, 0.5],
+}
+
+DEFAULT_PDF_PAGE_WIDTH = 1786
+DEFAULT_PDF_PAGE_HEIGHT = 2526
+
+
+
+def stub_flash_attention_modules() -> None:
+    """Allow importing Qwen3-VL model code in CPU-only benchmark envs."""
+    module = types.ModuleType("vllm.vllm_flash_attn")
+    module.flash_attn_varlen_func = lambda *args, **kwargs: None
+    module.get_scheduler_metadata = lambda *args, **kwargs: None
+    sys.modules.setdefault("vllm.vllm_flash_attn", module)
+
+
+stub_flash_attention_modules()
+
+from vllm.model_executor.models.qwen3_vl import Qwen3VLMultiModalProcessor  # noqa: E402
+from vllm.multimodal.parse import MultiModalDataParser  # noqa: E402
+from vllm.multimodal.processing.context import TimingContext  # noqa: E402
+from vllm.multimodal.processing.inputs import ProcessorInputs  # noqa: E402
+
+
+@dataclass(frozen=True)
+class RequestInputs:
+    prompt_token_ids: list[int]
+    images: list[Image.Image]
+    mm_items: Any
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    latency_s: float
+    stage_secs: dict[str, float]
+    prompt_tokens: int
+    image_placeholders: int
+
+
+class FakeProcessingContext:
+    def __init__(self, mm_config: Any) -> None:
+        self._mm_config = mm_config
+
+    def call_hf_processor(
+        self,
+        processor: Any,
+        data: dict[str, object],
+        kwargs: dict[str, object],
+    ) -> Any:
+        kwargs = dict(kwargs)
+        kwargs.setdefault("return_tensors", "pt")
+        return processor(**data, **kwargs)
+
+    def get_mm_config(self) -> Any:
+        return self._mm_config
+
+
+class FakeProcessingInfo:
+    model_id = "deterministic-qwen3vl-hf-processor-benchmark"
+
+    def __init__(self, hf_processor: Qwen3VLProcessor) -> None:
+        self._hf_processor = hf_processor
+        self.ctx = FakeProcessingContext(SimpleNamespace(video_pruning_rate=None))
+        self._hf_config = SimpleNamespace(
+            vision_config=SimpleNamespace(
+                spatial_merge_size=hf_processor.image_processor.merge_size,
+            ),
+            image_token_id=hf_processor.image_token_id,
+            video_token_id=hf_processor.video_token_id,
+            vision_start_token_id=hf_processor.vision_start_token_id,
+            vision_end_token_id=hf_processor.vision_end_token_id,
+        )
+
+    def get_data_parser(self) -> MultiModalDataParser:
+        return MultiModalDataParser()
+
+    def get_hf_processor(self, **kwargs: object) -> Qwen3VLProcessor:
+        return self._hf_processor
+
+    def get_image_processor(self, **kwargs: object) -> Qwen2VLImageProcessor:
+        return self._hf_processor.image_processor
+
+    def get_tokenizer(self) -> PreTrainedTokenizerFast:
+        return self._hf_processor.tokenizer
+
+    def get_hf_config(self) -> Any:
+        return self._hf_config
+
+
+class FakeDummyInputs:
+    def __init__(self, info: FakeProcessingInfo) -> None:
+        self.info = info
+
+    def get_dummy_text(self, mm_counts: dict[str, int]) -> str:
+        return "".join(
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            for _ in range(mm_counts.get("image", 0))
+        )
+
+
+class BenchmarkProcessor:
+    def __init__(self) -> None:
+        tokenizer = make_tokenizer()
+        hf_processor = Qwen3VLProcessor(
+            image_processor=Qwen2VLImageProcessor(**QWEN36_IMAGE_PROCESSOR_KWARGS),
+            tokenizer=tokenizer,
+            video_processor=Qwen3VLVideoProcessor(),
+        )
+        info = FakeProcessingInfo(hf_processor)
+        self.hf_processor = hf_processor
+        self.processor = Qwen3VLMultiModalProcessor(
+            info,
+            FakeDummyInputs(info),
+            cache=None,
+        )
+        self.tokenizer = tokenizer
+
+    def make_prompt_token_ids(
+        self,
+        image_count: int,
+        text_tokens: int,
+    ) -> list[int]:
+        token_ids: list[int] = []
+        text_token_id = self.tokenizer.unk_token_id
+        text_chunks = image_count + 1
+        base_chunk = text_tokens // text_chunks
+        remainder = text_tokens % text_chunks
+
+        for index in range(image_count):
+            chunk_size = base_chunk + (1 if index < remainder else 0)
+            token_ids.extend([text_token_id] * chunk_size)
+            token_ids.extend(
+                [
+                    self.tokenizer.vision_start_token_id,
+                    self.tokenizer.image_token_id,
+                    self.tokenizer.vision_end_token_id,
+                ]
+            )
+
+        tail_size = base_chunk + (1 if image_count < remainder else 0)
+        token_ids.extend([text_token_id] * tail_size)
+        return token_ids
+
+    def make_prompt_text(self, image_count: int, text_tokens: int) -> str:
+        text_chunks = image_count + 1
+        base_chunk = text_tokens // text_chunks
+        remainder = text_tokens % text_chunks
+        parts = []
+        for index in range(image_count):
+            chunk_size = base_chunk + (1 if index < remainder else 0)
+            parts.append(" ".join(["benchmark"] * chunk_size))
+            parts.append("<|vision_start|><|image_pad|><|vision_end|>")
+        tail_size = base_chunk + (1 if image_count < remainder else 0)
+        parts.append(" ".join(["benchmark"] * tail_size))
+        return " ".join(parts)
+
+
+def make_tokenizer() -> PreTrainedTokenizerFast:
+    special_tokens = [
+        "<unk>",
+        "<|vision_start|>",
+        "<|vision_end|>",
+        "<|image_pad|>",
+        "<|video_pad|>",
+    ]
+    tokenizer_impl = Tokenizer(
+        WordLevel(
+            vocab={token: index for index, token in enumerate(special_tokens)},
+            unk_token="<unk>",
+        )
+    )
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_impl,
+        unk_token="<unk>",
+    )
+    tokenizer.add_special_tokens(
+        {"additional_special_tokens": special_tokens[1:]}
+    )
+    tokenizer.image_token = "<|image_pad|>"
+    tokenizer.video_token = "<|video_pad|>"
+    tokenizer.vision_start_token = "<|vision_start|>"
+    tokenizer.vision_end_token = "<|vision_end|>"
+    tokenizer.image_token_id = tokenizer.convert_tokens_to_ids(tokenizer.image_token)
+    tokenizer.video_token_id = tokenizer.convert_tokens_to_ids(tokenizer.video_token)
+    tokenizer.vision_start_token_id = tokenizer.convert_tokens_to_ids(
+        tokenizer.vision_start_token
+    )
+    tokenizer.vision_end_token_id = tokenizer.convert_tokens_to_ids(
+        tokenizer.vision_end_token
+    )
+    return tokenizer
+
+
+def make_image(width: int, height: int, image_index: int) -> Image.Image:
+    y = np.arange(height, dtype=np.uint16)[:, None]
+    x = np.arange(width, dtype=np.uint16)[None, :]
+    base = (x * 3 + y * 5 + image_index * 17) & 0xFF
+    rgb = np.empty((height, width, 3), dtype=np.uint8)
+    rgb[:, :, 0] = base.astype(np.uint8)
+    rgb[:, :, 1] = ((base + image_index * 11) & 0xFF).astype(np.uint8)
+    rgb[:, :, 2] = ((base * 2 + 31) & 0xFF).astype(np.uint8)
+    return Image.fromarray(rgb, "RGB")
+
+
+def make_requests(
+    bench: BenchmarkProcessor,
+    *,
+    request_count: int,
+    images_per_request: int,
+    width: int,
+    height: int,
+    text_tokens: int,
+) -> list[RequestInputs]:
+    requests: list[RequestInputs] = []
+    image_index = 0
+    prompt = bench.make_prompt_token_ids(images_per_request, text_tokens)
+    for _ in range(request_count):
+        images = []
+        for _ in range(images_per_request):
+            images.append(make_image(width, height, image_index))
+            image_index += 1
+        mm_items = bench.processor.data_parser.parse_mm_data({"image": images})
+        requests.append(RequestInputs(prompt, images, mm_items))
+    return requests
+
+
+def run_vllm_apply(
+    bench: BenchmarkProcessor,
+    request: RequestInputs,
+) -> ApplyResult:
+    timing_ctx = TimingContext(enabled=True)
+    start = time.perf_counter()
+    output = bench.processor.apply(
+        ProcessorInputs(
+            request.prompt_token_ids,
+            request.mm_items,
+            hf_processor_mm_kwargs={"return_mm_token_type_ids": False},
+        ),
+        timing_ctx,
+    )
+    latency_s = time.perf_counter() - start
+    return ApplyResult(
+        latency_s=latency_s,
+        stage_secs=timing_ctx.get_stats_dict(),
+        prompt_tokens=len(output["prompt_token_ids"]),
+        image_placeholders=len(output["mm_placeholders"].get("image", [])),
+    )
+
+
+def run_full_hf_processor(
+    bench: BenchmarkProcessor,
+    request: RequestInputs,
+) -> float:
+    start = time.perf_counter()
+    bench.hf_processor(
+        text=bench.make_prompt_text(
+            len(request.images),
+            len(request.prompt_token_ids),
+        ),
+        images=request.images,
+        return_tensors="pt",
+        return_mm_token_type_ids=False,
+    )
+    return time.perf_counter() - start
+
+
+def run_direct_image_processor(
+    bench: BenchmarkProcessor,
+    request: RequestInputs,
+) -> float:
+    start = time.perf_counter()
+    bench.hf_processor.image_processor(
+        images=request.images,
+        return_tensors="pt",
+    )
+    return time.perf_counter() - start
+
+
+def verify_direct_image_parity(
+    bench: BenchmarkProcessor,
+    request: RequestInputs,
+) -> bool:
+    output = bench.processor.apply(
+        ProcessorInputs(
+            request.prompt_token_ids,
+            request.mm_items,
+            hf_processor_mm_kwargs={"return_mm_token_type_ids": False},
+        ),
+        TimingContext(enabled=False),
+    )
+    direct = bench.hf_processor.image_processor(
+        images=request.images,
+        return_tensors="pt",
+    )
+    image_items = output["mm_kwargs"]["image"]
+    vllm_pixel_values = torch.cat(
+        [item["pixel_values"].data for item in image_items],
+        dim=0,
+    )
+    vllm_grid = torch.stack(
+        [item["image_grid_thw"].data for item in image_items],
+        dim=0,
+    )
+    if vllm_pixel_values.shape != direct["pixel_values"].shape:
+        image_processor = bench.hf_processor.image_processor
+        temporal_patch_size = image_processor.temporal_patch_size
+        patch_size = image_processor.patch_size
+        if (
+            vllm_pixel_values.shape[0] == direct["pixel_values"].shape[0]
+            and vllm_pixel_values.shape[1] * temporal_patch_size
+            == direct["pixel_values"].shape[1]
+        ):
+            vllm_pixel_values = (
+                vllm_pixel_values.view(
+                    vllm_pixel_values.shape[0],
+                    3,
+                    patch_size,
+                    patch_size,
+                )
+                .unsqueeze(2)
+                .expand(-1, -1, temporal_patch_size, -1, -1)
+                .reshape_as(direct["pixel_values"])
+            )
+
+    return bool(
+        torch.equal(vllm_grid, direct["image_grid_thw"])
+        and torch.equal(vllm_pixel_values, direct["pixel_values"])
+    )
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * q))
+    return ordered[index]
+
+
+def mean_ms(values_s: list[float]) -> float:
+    if not values_s:
+        return 0.0
+    return statistics.fmean(values_s) * 1000.0
+
+
+def median_metric(runs: list[dict[str, float]]) -> dict[str, float]:
+    return {
+        key: statistics.median(run[key] for run in runs)
+        for key in runs[0]
+    }
+
+
+def run_once(args: argparse.Namespace) -> dict[str, float]:
+    bench = BenchmarkProcessor()
+    requests = make_requests(
+        bench,
+        request_count=args.requests,
+        images_per_request=args.images_per_request,
+        width=args.width,
+        height=args.height,
+        text_tokens=args.text_tokens,
+    )
+
+    for request in requests[: args.warmups]:
+        run_vllm_apply(bench, request)
+
+    start = time.perf_counter()
+    if args.workers == 1:
+        apply_results = [run_vllm_apply(bench, request) for request in requests]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.workers
+        ) as executor:
+            apply_results = list(
+                executor.map(lambda request: run_vllm_apply(bench, request), requests)
+            )
+    wall_s = time.perf_counter() - start
+
+    full_hf_times = [run_full_hf_processor(bench, request) for request in requests]
+    direct_image_times = [
+        run_direct_image_processor(bench, request) for request in requests
+    ]
+    apply_times = [result.latency_s for result in apply_results]
+    apply_hf_processor_times = [
+        result.stage_secs.get("apply_hf_processor_secs", 0.0)
+        for result in apply_results
+    ]
+    apply_prompt_updates_times = [
+        result.stage_secs.get("apply_prompt_updates_secs", 0.0)
+        for result in apply_results
+    ]
+
+    parity_ok = verify_direct_image_parity(bench, requests[0])
+    prompt_tokens = {result.prompt_tokens for result in apply_results}
+    placeholders = {result.image_placeholders for result in apply_results}
+    expected_placeholders = args.images_per_request
+    if placeholders != {expected_placeholders}:
+        raise AssertionError(
+            f"Expected {expected_placeholders} image placeholders, got {placeholders}"
+        )
+
+    return {
+        "qwen3_vllm_apply_mean_ms": mean_ms(apply_times),
+        "qwen3_vllm_apply_p50_ms": percentile(apply_times, 0.50) * 1000.0,
+        "qwen3_vllm_apply_p95_ms": percentile(apply_times, 0.95) * 1000.0,
+        "qwen3_vllm_apply_wall_ms": wall_s * 1000.0,
+        "qwen3_vllm_apply_throughput_rps": len(requests) / wall_s,
+        "qwen3_apply_hf_processor_mean_ms": mean_ms(apply_hf_processor_times),
+        "qwen3_apply_prompt_updates_mean_ms": mean_ms(
+            apply_prompt_updates_times
+        ),
+        "qwen3_full_hf_processor_mean_ms": mean_ms(full_hf_times),
+        "qwen3_direct_image_processor_mean_ms": mean_ms(direct_image_times),
+        "qwen3_direct_image_parity": 1.0 if parity_ok else 0.0,
+        "qwen3_image_pixel_count": float(args.width * args.height),
+        "qwen3_processor_longest_edge": 16777216.0,
+        "qwen3_processor_patch_size": 16.0,
+        "qwen3_processor_merge_size": 2.0,
+        "qwen3_text_token_count": float(args.text_tokens),
+        "qwen3_prompt_token_count": float(next(iter(prompt_tokens))),
+    }
+
+
+def print_metrics(metrics: dict[str, float]) -> None:
+    primary = "qwen3_vllm_apply_mean_ms"
+    print(f"METRIC {primary}={metrics[primary]:.6f}")
+    for key in sorted(metrics):
+        if key != primary:
+            print(f"METRIC {key}={metrics[key]:.6f}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark Qwen3-VL text+image vLLM processor path."
+    )
+    parser.add_argument("--requests", type=int, default=12)
+    parser.add_argument("--images-per-request", type=int, default=4)
+    parser.add_argument("--width", type=int, default=DEFAULT_PDF_PAGE_WIDTH)
+    parser.add_argument("--height", type=int, default=DEFAULT_PDF_PAGE_HEIGHT)
+    parser.add_argument("--text-tokens", type=int, default=1024)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=2)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    if args.requests <= 0:
+        raise ValueError("--requests must be positive")
+    if args.images_per_request <= 0:
+        raise ValueError("--images-per-request must be positive")
+    if args.text_tokens < 0:
+        raise ValueError("--text-tokens must be non-negative")
+    if args.workers <= 0:
+        raise ValueError("--workers must be positive")
+    runs = [run_once(args) for _ in range(args.repetitions)]
+    metrics = median_metric(runs)
+    if metrics["qwen3_direct_image_parity"] != 1.0:
+        raise AssertionError("Direct image processor parity failed")
+    print_metrics(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qwen3_hf_processor_fast_path.py
+++ b/tests/test_qwen3_hf_processor_fast_path.py
@@ -290,6 +290,19 @@ def test_qwen3_patch_embed_compact_image_matches_duplicated_temporal(
         in_channels=3,
         hidden_size=5,
     )
+    with torch.no_grad():
+        patch_embed.proj.weight.copy_(
+            torch.arange(
+                patch_embed.proj.weight.numel(),
+                dtype=torch.float32,
+            ).reshape_as(patch_embed.proj.weight)
+        )
+        patch_embed.proj.bias.copy_(
+            torch.arange(
+                patch_embed.proj.bias.numel(),
+                dtype=torch.float32,
+            )
+        )
     compact_pixel_values = torch.arange(36, dtype=torch.float32).reshape(3, 12)
     duplicated_pixel_values = (
         compact_pixel_values.view(3, 3, 2, 2)

--- a/tests/test_qwen3_hf_processor_fast_path.py
+++ b/tests/test_qwen3_hf_processor_fast_path.py
@@ -171,6 +171,31 @@ def _compact_reference_pixel_values(
     patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7).contiguous()
     return patches.reshape(batch_size * grid_h * grid_w, channel * patch_size**2)
 
+def _assert_compact_pixel_values_match_temporal_duplication(
+    processor: Qwen3VLMultiModalProcessor,
+    compact_pixel_values: torch.Tensor,
+    duplicated_pixel_values: torch.Tensor,
+) -> None:
+    patch_size = processor.info.get_image_processor().patch_size
+    temporal_patch_size = processor.info.get_image_processor().temporal_patch_size
+
+    assert compact_pixel_values.shape[0] == duplicated_pixel_values.shape[0]
+    assert compact_pixel_values.shape[1] * temporal_patch_size == (
+        duplicated_pixel_values.shape[1]
+    )
+    expanded_compact = (
+        compact_pixel_values.view(
+            compact_pixel_values.shape[0],
+            3,
+            patch_size,
+            patch_size,
+        )
+        .unsqueeze(2)
+        .expand(-1, -1, temporal_patch_size, -1, -1)
+        .reshape_as(duplicated_pixel_values)
+    )
+    assert torch.equal(expanded_compact, duplicated_pixel_values)
+
 
 def test_qwen3_fused_compact_preprocess_matches_reference() -> None:
     processor = _make_processor()
@@ -242,26 +267,76 @@ def test_qwen3_image_only_mm_only_matches_dummy_text_path() -> None:
     assert "attention_mask" not in optimized
     assert torch.equal(optimized["image_grid_thw"], baseline["image_grid_thw"])
 
-    patch_size = processor.info.get_image_processor().patch_size
-    temporal_patch_size = processor.info.get_image_processor().temporal_patch_size
-    baseline_pixel_values = baseline["pixel_values"]
-    compact_pixel_values = optimized["pixel_values"]
-    assert compact_pixel_values.shape[0] == baseline_pixel_values.shape[0]
-    assert compact_pixel_values.shape[1] * temporal_patch_size == (
-        baseline_pixel_values.shape[1]
+    _assert_compact_pixel_values_match_temporal_duplication(
+        processor,
+        optimized["pixel_values"],
+        baseline["pixel_values"],
     )
-    expanded_compact = (
-        compact_pixel_values.view(
-            compact_pixel_values.shape[0],
-            3,
-            patch_size,
-            patch_size,
-        )
-        .unsqueeze(2)
-        .expand(-1, -1, temporal_patch_size, -1, -1)
-        .reshape_as(baseline_pixel_values)
+
+
+def test_qwen3_still_image_mm_only_uses_fast_preprocess(
+    monkeypatch: Any,
+) -> None:
+    processor = _make_processor()
+    mm_items = processor.data_parser.parse_mm_data({"image": _make_images()})
+    hf_kwargs = {"return_mm_token_type_ids": False}
+    original = Qwen3VLMultiModalProcessor._fast_preprocess_batched_images
+    fast_path_called = False
+
+    def wrapped_fast_preprocess(*args: Any, **kwargs: Any) -> Any:
+        nonlocal fast_path_called
+        fast_path_called = True
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        Qwen3VLMultiModalProcessor,
+        "_fast_preprocess_batched_images",
+        staticmethod(wrapped_fast_preprocess),
     )
-    assert torch.equal(expanded_compact, baseline_pixel_values)
+
+    baseline = BaseMultiModalProcessor._apply_hf_processor_mm_only(
+        processor,
+        mm_items,
+        hf_kwargs,
+        {},
+    )
+    optimized = processor._apply_hf_processor_mm_only(mm_items, hf_kwargs, {})
+
+    assert fast_path_called
+    assert torch.equal(optimized["image_grid_thw"], baseline["image_grid_thw"])
+    _assert_compact_pixel_values_match_temporal_duplication(
+        processor,
+        optimized["pixel_values"],
+        baseline["pixel_values"],
+    )
+
+
+def test_qwen3_mm_only_processor_kwarg_falls_back_without_diverging(
+    monkeypatch: Any,
+) -> None:
+    processor = _make_processor()
+    mm_items = processor.data_parser.parse_mm_data({"image": _make_images()})
+    hf_kwargs = {"return_mm_token_type_ids": False, "do_resize": False}
+
+    def fail_fast_preprocess(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("fast path should not run with do_resize override")
+
+    monkeypatch.setattr(
+        Qwen3VLMultiModalProcessor,
+        "_fast_preprocess_batched_images",
+        staticmethod(fail_fast_preprocess),
+    )
+
+    baseline = BaseMultiModalProcessor._apply_hf_processor_mm_only(
+        processor,
+        mm_items,
+        hf_kwargs,
+        {},
+    )
+    optimized = processor._apply_hf_processor_mm_only(mm_items, hf_kwargs, {})
+
+    assert torch.equal(optimized["image_grid_thw"], baseline["image_grid_thw"])
+    assert torch.equal(optimized["pixel_values"], baseline["pixel_values"])
 
 
 def test_qwen3_mm_only_fallback_ignores_tokenization_kwargs() -> None:

--- a/tests/test_qwen3_hf_processor_fast_path.py
+++ b/tests/test_qwen3_hf_processor_fast_path.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from transformers import PreTrainedTokenizerFast
+from transformers.models.qwen2_vl import Qwen2VLImageProcessor
+from transformers.models.qwen3_vl import Qwen3VLProcessor, Qwen3VLVideoProcessor
+
+module = types.ModuleType("vllm.vllm_flash_attn")
+module.flash_attn_varlen_func = lambda *args, **kwargs: None
+module.get_scheduler_metadata = lambda *args, **kwargs: None
+sys.modules.setdefault("vllm.vllm_flash_attn", module)
+
+from vllm.model_executor.models.qwen3_vl import (  # noqa: E402
+    Qwen3_VisionPatchEmbed,
+    Qwen3VLMultiModalProcessor,
+    _qwen3_vl_fused_compact_preprocess_uint8_bchw,
+)
+from vllm.multimodal.parse import MultiModalDataParser  # noqa: E402
+from vllm.multimodal.processing import BaseMultiModalProcessor  # noqa: E402
+from vllm.multimodal.processing.context import TimingContext  # noqa: E402
+from vllm.multimodal.processing.inputs import ProcessorInputs  # noqa: E402
+
+
+def _make_tokenizer() -> PreTrainedTokenizerFast:
+    special_tokens = [
+        "<unk>",
+        "<|vision_start|>",
+        "<|vision_end|>",
+        "<|image_pad|>",
+        "<|video_pad|>",
+    ]
+    tokenizer_impl = Tokenizer(
+        WordLevel(
+            vocab={token: index for index, token in enumerate(special_tokens)},
+            unk_token="<unk>",
+        )
+    )
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_impl,
+        unk_token="<unk>",
+    )
+    tokenizer.add_special_tokens(
+        {"additional_special_tokens": special_tokens[1:]}
+    )
+    tokenizer.image_token = "<|image_pad|>"
+    tokenizer.video_token = "<|video_pad|>"
+    tokenizer.vision_start_token = "<|vision_start|>"
+    tokenizer.vision_end_token = "<|vision_end|>"
+    tokenizer.image_token_id = tokenizer.convert_tokens_to_ids(tokenizer.image_token)
+    tokenizer.video_token_id = tokenizer.convert_tokens_to_ids(tokenizer.video_token)
+    tokenizer.vision_start_token_id = tokenizer.convert_tokens_to_ids(
+        tokenizer.vision_start_token
+    )
+    tokenizer.vision_end_token_id = tokenizer.convert_tokens_to_ids(
+        tokenizer.vision_end_token
+    )
+    return tokenizer
+
+
+class _FakeProcessingContext:
+    def call_hf_processor(
+        self,
+        processor: Any,
+        data: dict[str, object],
+        kwargs: dict[str, object],
+    ) -> Any:
+        kwargs = dict(kwargs)
+        kwargs.setdefault("return_tensors", "pt")
+        return processor(**data, **kwargs)
+
+    def get_mm_config(self) -> Any:
+        return SimpleNamespace(video_pruning_rate=None)
+
+
+class _FakeProcessingInfo:
+    model_id = "qwen3-fast-path-test"
+
+    def __init__(self, hf_processor: Qwen3VLProcessor) -> None:
+        self._hf_processor = hf_processor
+        self.ctx = _FakeProcessingContext()
+        self._hf_config = SimpleNamespace(
+            vision_config=SimpleNamespace(
+                spatial_merge_size=hf_processor.image_processor.merge_size,
+            ),
+            image_token_id=hf_processor.image_token_id,
+            video_token_id=hf_processor.video_token_id,
+            vision_start_token_id=hf_processor.vision_start_token_id,
+            vision_end_token_id=hf_processor.vision_end_token_id,
+        )
+
+    def get_data_parser(self) -> MultiModalDataParser:
+        return MultiModalDataParser()
+
+    def get_hf_processor(self, **kwargs: object) -> Qwen3VLProcessor:
+        return self._hf_processor
+
+    def get_image_processor(self, **kwargs: object) -> Qwen2VLImageProcessor:
+        return self._hf_processor.image_processor
+
+    def get_tokenizer(self) -> PreTrainedTokenizerFast:
+        return self._hf_processor.tokenizer
+
+    def get_hf_config(self) -> Any:
+        return self._hf_config
+
+
+class _FakeDummyInputs:
+    def get_dummy_text(self, mm_counts: dict[str, int]) -> str:
+        return "".join(
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            for _ in range(mm_counts.get("image", 0))
+        )
+
+
+def _make_processor() -> Qwen3VLMultiModalProcessor:
+    tokenizer = _make_tokenizer()
+    hf_processor = Qwen3VLProcessor(
+        image_processor=Qwen2VLImageProcessor(),
+        tokenizer=tokenizer,
+        video_processor=Qwen3VLVideoProcessor(),
+    )
+    info = _FakeProcessingInfo(hf_processor)
+    return Qwen3VLMultiModalProcessor(info, _FakeDummyInputs(), cache=None)
+
+
+def _make_images() -> list[Image.Image]:
+    images = []
+    for index in range(2):
+        array = np.full((224, 224, 3), index * 40, dtype=np.uint8)
+        images.append(Image.fromarray(array, "RGB"))
+    return images
+
+
+def _compact_reference_pixel_values(
+    images: torch.Tensor,
+    image_processor: Qwen2VLImageProcessor,
+) -> torch.Tensor:
+    patch_size = image_processor.patch_size
+    merge_size = image_processor.merge_size
+    patches = image_processor.rescale_and_normalize(
+        images,
+        image_processor.do_rescale,
+        image_processor.rescale_factor,
+        image_processor.do_normalize,
+        image_processor.image_mean,
+        image_processor.image_std,
+    )
+    batch_size, channel, height, width = patches.shape
+    grid_h = height // patch_size
+    grid_w = width // patch_size
+    patches = patches.reshape(
+        batch_size,
+        channel,
+        grid_h // merge_size,
+        merge_size,
+        patch_size,
+        grid_w // merge_size,
+        merge_size,
+        patch_size,
+    )
+    patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7).contiguous()
+    return patches.reshape(batch_size * grid_h * grid_w, channel * patch_size**2)
+
+
+def test_qwen3_fused_compact_preprocess_matches_reference() -> None:
+    processor = _make_processor()
+    image_processor = processor.info.get_image_processor()
+    patch_size = image_processor.patch_size
+    merge_size = image_processor.merge_size
+    height = patch_size * merge_size * 2
+    width = patch_size * merge_size * 3
+    images = torch.arange(
+        2 * 3 * height * width,
+        dtype=torch.int64,
+    ).remainder(256).to(torch.uint8)
+    images = images.reshape(2, 3, height, width)
+
+    fused = _qwen3_vl_fused_compact_preprocess_uint8_bchw(
+        images,
+        image_processor.image_mean,
+        image_processor.image_std,
+        image_processor.rescale_factor,
+        patch_size,
+        merge_size,
+    )
+    reference = _compact_reference_pixel_values(images, image_processor)
+
+    torch.testing.assert_close(fused, reference)
+
+
+def test_qwen3_fast_preprocess_requires_merge_aligned_size() -> None:
+    processor = _make_processor()
+    image_processor = processor.info.get_image_processor()
+    image_processor.do_resize = False
+    patch_size = image_processor.patch_size
+    merge_size = image_processor.merge_size
+
+    patch_aligned = torch.zeros(
+        (1, 3, patch_size, patch_size),
+        dtype=torch.uint8,
+    )
+    merge_aligned = torch.zeros(
+        (1, 3, patch_size * merge_size, patch_size * merge_size),
+        dtype=torch.uint8,
+    )
+
+    assert not Qwen3VLMultiModalProcessor._can_fast_preprocess_batched_images(
+        image_processor,
+        patch_aligned,
+        {},
+    )
+    assert Qwen3VLMultiModalProcessor._can_fast_preprocess_batched_images(
+        image_processor,
+        merge_aligned,
+        {},
+    )
+    assert Qwen3VLMultiModalProcessor._can_fast_preprocess_batched_images(
+        image_processor,
+        merge_aligned,
+        {"truncation": False},
+    )
+
+
+def test_qwen3_image_only_mm_only_matches_dummy_text_path() -> None:
+    processor = _make_processor()
+    mm_items = processor.data_parser.parse_mm_data({"image": _make_images()})
+    hf_kwargs = {"return_mm_token_type_ids": False}
+
+    baseline = BaseMultiModalProcessor._apply_hf_processor_mm_only(
+        processor,
+        mm_items,
+        hf_kwargs,
+        {},
+    )
+    optimized = processor._apply_hf_processor_mm_only(mm_items, hf_kwargs, {})
+
+    assert "attention_mask" not in optimized
+    assert torch.equal(optimized["image_grid_thw"], baseline["image_grid_thw"])
+
+    patch_size = processor.info.get_image_processor().patch_size
+    temporal_patch_size = processor.info.get_image_processor().temporal_patch_size
+    baseline_pixel_values = baseline["pixel_values"]
+    compact_pixel_values = optimized["pixel_values"]
+    assert compact_pixel_values.shape[0] == baseline_pixel_values.shape[0]
+    assert compact_pixel_values.shape[1] * temporal_patch_size == (
+        baseline_pixel_values.shape[1]
+    )
+    expanded_compact = (
+        compact_pixel_values.view(
+            compact_pixel_values.shape[0],
+            3,
+            patch_size,
+            patch_size,
+        )
+        .unsqueeze(2)
+        .expand(-1, -1, temporal_patch_size, -1, -1)
+        .reshape_as(baseline_pixel_values)
+    )
+    assert torch.equal(expanded_compact, baseline_pixel_values)
+
+
+def test_qwen3_patch_embed_compact_image_matches_duplicated_temporal(
+    default_vllm_config,
+) -> None:
+    patch_embed = Qwen3_VisionPatchEmbed(
+        patch_size=2,
+        temporal_patch_size=2,
+        in_channels=3,
+        hidden_size=5,
+    )
+    compact_pixel_values = torch.arange(36, dtype=torch.float32).reshape(3, 12)
+    duplicated_pixel_values = (
+        compact_pixel_values.view(3, 3, 2, 2)
+        .unsqueeze(2)
+        .expand(-1, -1, 2, -1, -1)
+        .reshape(3, 24)
+    )
+
+    compact_embeds = patch_embed(compact_pixel_values)
+    duplicated_embeds = patch_embed(duplicated_pixel_values)
+
+    torch.testing.assert_close(compact_embeds, duplicated_embeds)
+
+
+def test_qwen3_tokenized_text_and_images_apply_keeps_placeholder_ranges() -> None:
+    processor = _make_processor()
+    tokenizer = processor.info.get_tokenizer()
+    mm_items = processor.data_parser.parse_mm_data({"image": _make_images()})
+    prompt_token_ids = [
+        tokenizer.unk_token_id,
+        tokenizer.unk_token_id,
+        tokenizer.vision_start_token_id,
+        tokenizer.image_token_id,
+        tokenizer.vision_end_token_id,
+        tokenizer.unk_token_id,
+        tokenizer.vision_start_token_id,
+        tokenizer.image_token_id,
+        tokenizer.vision_end_token_id,
+        tokenizer.unk_token_id,
+        tokenizer.unk_token_id,
+    ]
+
+    output = processor.apply(
+        ProcessorInputs(
+            prompt_token_ids,
+            mm_items,
+            hf_processor_mm_kwargs={"return_mm_token_type_ids": False},
+        ),
+        TimingContext(enabled=True),
+    )
+
+    assert len(output["mm_placeholders"]["image"]) == 2
+    assert len(output["prompt_token_ids"]) > len(prompt_token_ids)

--- a/tests/test_qwen3_hf_processor_fast_path.py
+++ b/tests/test_qwen3_hf_processor_fast_path.py
@@ -224,11 +224,6 @@ def test_qwen3_fast_preprocess_requires_merge_aligned_size() -> None:
         merge_aligned,
         {},
     )
-    assert Qwen3VLMultiModalProcessor._can_fast_preprocess_batched_images(
-        image_processor,
-        merge_aligned,
-        {"truncation": False},
-    )
 
 
 def test_qwen3_image_only_mm_only_matches_dummy_text_path() -> None:
@@ -267,6 +262,23 @@ def test_qwen3_image_only_mm_only_matches_dummy_text_path() -> None:
         .reshape_as(baseline_pixel_values)
     )
     assert torch.equal(expanded_compact, baseline_pixel_values)
+
+
+def test_qwen3_mm_only_fallback_ignores_tokenization_kwargs() -> None:
+    processor = _make_processor()
+    images = [
+        Image.fromarray(np.zeros((32, 32, 3), dtype=np.uint8), "RGB"),
+        Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8), "RGB"),
+    ]
+    mm_items = processor.data_parser.parse_mm_data({"image": images})
+
+    optimized = processor._apply_hf_processor_mm_only(
+        mm_items,
+        {"return_mm_token_type_ids": False},
+        {"truncation": False},
+    )
+
+    assert optimized["image_grid_thw"].shape[0] == 2
 
 
 def test_qwen3_patch_embed_compact_image_matches_duplicated_temporal(

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -34,7 +34,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers import BatchFeature
-from transformers.models.qwen2_vl import Qwen2VLImageProcessor
+from transformers.image_utils import SizeDict
+from transformers.models.qwen2_vl import (
+    Qwen2VLImageProcessor,
+    Qwen2VLImageProcessorFast,
+)
 from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
     smart_resize as image_smart_resize,
 )
@@ -369,8 +373,31 @@ class Qwen3_VisionPatchEmbed(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         L, C = x.shape
-        x = x.view(L, -1, self.temporal_patch_size, self.patch_size, self.patch_size)
-        x = self.proj(x).view(L, self.hidden_size)
+        compact_image_patch_size = (
+            self.proj.in_channels * self.patch_size * self.patch_size
+        )
+        full_temporal_patch_size = compact_image_patch_size * self.temporal_patch_size
+
+        if compact_image_patch_size == C:
+            weight = self.proj.weight.sum(dim=2).reshape(
+                self.hidden_size, compact_image_patch_size
+            )
+            x = F.linear(x, weight, self.proj.bias)
+        elif full_temporal_patch_size == C:
+            x = x.view(
+                L,
+                -1,
+                self.temporal_patch_size,
+                self.patch_size,
+                self.patch_size,
+            )
+            x = self.proj(x).view(L, self.hidden_size)
+        else:
+            raise ValueError(
+                "Qwen3-VL patch input has unexpected flattened size "
+                f"{C}; expected {compact_image_patch_size} for compact images "
+                f"or {full_temporal_patch_size} for temporal inputs."
+            )
         return x
 
 
@@ -1202,6 +1229,94 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
         return video_items
 
 
+_QWEN3_VL_FUSED_COMPACT_PREPROCESS_NATIVE: Callable[
+    [
+        torch.Tensor,
+        Sequence[float],
+        Sequence[float],
+        float,
+        int,
+        int,
+    ],
+    torch.Tensor,
+] | None = None
+
+
+def _qwen3_vl_fused_compact_preprocess_uint8_bchw(
+    images: torch.Tensor,
+    image_mean: Sequence[float],
+    image_std: Sequence[float],
+    rescale_factor: float,
+    patch_size: int,
+    merge_size: int,
+) -> torch.Tensor:
+    """Normalize and patchify Qwen3-VL image tensors into compact patches.
+
+    Native hook signature:
+        (uint8_bchw, image_mean, image_std, rescale_factor, patch_size,
+         merge_size) -> float32 [N, C*P*P]
+
+    The Python fallback keeps B's compact image-patch contract while avoiding
+    the full intermediate normalized BCHW tensor.
+    """
+    if _QWEN3_VL_FUSED_COMPACT_PREPROCESS_NATIVE is not None:
+        return _QWEN3_VL_FUSED_COMPACT_PREPROCESS_NATIVE(
+            images,
+            image_mean,
+            image_std,
+            rescale_factor,
+            patch_size,
+            merge_size,
+        )
+
+    batch_size, channel, height, width = images.shape
+    grid_h = height // patch_size
+    grid_w = width // patch_size
+    block_h = grid_h // merge_size
+    block_w = grid_w // merge_size
+    source = images.reshape(
+        batch_size,
+        channel,
+        block_h,
+        merge_size,
+        patch_size,
+        block_w,
+        merge_size,
+        patch_size,
+    ).permute(0, 2, 5, 3, 6, 1, 4, 7)
+
+    fused_mean = (
+        torch.as_tensor(image_mean, dtype=torch.float32, device=images.device)
+        .view(1, 1, 1, 1, 1, channel, 1, 1)
+        .mul_(1.0 / rescale_factor)
+    )
+    fused_std = (
+        torch.as_tensor(image_std, dtype=torch.float32, device=images.device)
+        .view(1, 1, 1, 1, 1, channel, 1, 1)
+        .mul_(1.0 / rescale_factor)
+    )
+    pixel_values = torch.empty(
+        (
+            batch_size,
+            block_h,
+            block_w,
+            merge_size,
+            merge_size,
+            channel,
+            patch_size,
+            patch_size,
+        ),
+        dtype=torch.float32,
+        device=images.device,
+    )
+    torch.sub(source, fused_mean, out=pixel_values)
+    pixel_values.div_(fused_std)
+    return pixel_values.reshape(
+        batch_size * grid_h * grid_w,
+        channel * patch_size * patch_size,
+    )
+
+
 def _replace_video_token_placeholders(
     prompt_ids: list[int],
     target: list[int],
@@ -1246,6 +1361,202 @@ def _replace_video_token_placeholders(
 
 
 class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo]):
+    @staticmethod
+    def _batch_same_size_rgb_pil_images(images: object) -> object:
+        from PIL import Image as PILImage
+
+        if not isinstance(images, (list, tuple)) or len(images) == 0:
+            return images
+
+        first = images[0]
+        if not isinstance(first, PILImage.Image) or first.mode != "RGB":
+            return images
+
+        width, height = first.size
+        arrays = []
+        for image in images:
+            if (
+                not isinstance(image, PILImage.Image)
+                or image.mode != "RGB"
+                or image.size != (width, height)
+            ):
+                return images
+            arrays.append(np.asarray(image, dtype=np.uint8))
+
+        return torch.from_numpy(np.stack(arrays, axis=0)).permute(0, 3, 1, 2)
+
+    @staticmethod
+    def _can_fast_preprocess_batched_images(
+        image_processor: Qwen2VLImageProcessorFast,
+        images: object,
+        processor_kwargs: Mapping[str, object],
+    ) -> bool:
+        if not isinstance(images, torch.Tensor):
+            return False
+        if images.ndim != 4 or images.dtype != torch.uint8:
+            return False
+
+        try:
+            mean_channels = len(image_processor.image_mean)
+            std_channels = len(image_processor.image_std)
+        except TypeError:
+            return False
+        if images.shape[1] != mean_channels or images.shape[1] != std_channels:
+            return False
+        if not image_processor.do_rescale or not image_processor.do_normalize:
+            return False
+
+        ignored_kwargs = {"disable_grouping", "truncation"}
+        if any(key not in ignored_kwargs for key in processor_kwargs):
+            return False
+
+        if not image_processor.do_resize:
+            height, width = images.shape[-2:]
+            factor = image_processor.patch_size * image_processor.merge_size
+            return height % factor == 0 and width % factor == 0
+
+        return True
+
+    @staticmethod
+    def _fast_preprocess_batched_images(
+        image_processor: Qwen2VLImageProcessorFast,
+        images: torch.Tensor,
+        return_tensors: str | None = None,
+        **kwargs: object,
+    ) -> BatchFeature:
+        patch_size = image_processor.patch_size
+        merge_size = image_processor.merge_size
+        if image_processor.do_resize:
+            height, width = images.shape[-2:]
+            resized_height, resized_width = image_smart_resize(
+                height,
+                width,
+                factor=patch_size * merge_size,
+                min_pixels=image_processor.size.shortest_edge,
+                max_pixels=image_processor.size.longest_edge,
+            )
+            if (resized_height, resized_width) != (height, width):
+                images = image_processor.resize(
+                    image=images,
+                    size=SizeDict(height=resized_height, width=resized_width),
+                    resample=image_processor.resample,
+                )
+
+        batch_size, channel, height, width = images.shape
+        grid_h = height // patch_size
+        grid_w = width // patch_size
+        if (
+            images.dtype == torch.uint8
+            and image_processor.do_rescale
+            and image_processor.do_normalize
+        ):
+            pixel_values = _qwen3_vl_fused_compact_preprocess_uint8_bchw(
+                images,
+                image_processor.image_mean,
+                image_processor.image_std,
+                image_processor.rescale_factor,
+                patch_size,
+                merge_size,
+            )
+        else:
+            patches = image_processor.rescale_and_normalize(
+                images,
+                image_processor.do_rescale,
+                image_processor.rescale_factor,
+                image_processor.do_normalize,
+                image_processor.image_mean,
+                image_processor.image_std,
+            )
+            batch_size, channel, height, width = patches.shape
+            grid_h = height // patch_size
+            grid_w = width // patch_size
+            patches = patches.reshape(
+                batch_size,
+                channel,
+                grid_h // merge_size,
+                merge_size,
+                patch_size,
+                grid_w // merge_size,
+                merge_size,
+                patch_size,
+            )
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7).contiguous()
+            pixel_values = patches.reshape(
+                batch_size * grid_h * grid_w,
+                channel * patch_size * patch_size,
+            )
+        image_grid_thw = torch.tensor(
+            [[1, grid_h, grid_w]] * batch_size,
+            dtype=torch.long,
+        )
+        return BatchFeature(
+            data={
+                "pixel_values": pixel_values,
+                "image_grid_thw": image_grid_thw,
+            },
+            tensor_type=return_tensors,
+        )
+
+
+    def _apply_hf_processor_mm_only(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        mm_counts = mm_items.get_all_counts()
+        if mm_counts.get("video", 0) > 0:
+            return super()._apply_hf_processor_mm_only(
+                mm_items,
+                hf_processor_mm_kwargs,
+                tokenization_kwargs,
+            )
+
+        valid_mm_items = mm_items.select(
+            {modality for modality, count in mm_counts.items() if count > 0}
+        )
+        processor_data, passthrough_data = self._get_hf_mm_data(valid_mm_items)
+        if set(processor_data) != {"images"}:
+            return super()._apply_hf_processor_mm_only(
+                mm_items,
+                hf_processor_mm_kwargs,
+                tokenization_kwargs,
+            )
+
+        batched_images = self._batch_same_size_rgb_pil_images(
+            processor_data["images"]
+        )
+        prebatched_images = batched_images is not processor_data["images"]
+        if prebatched_images:
+            processor_data = dict(processor_data)
+            processor_data["images"] = batched_images
+
+        processor_kwargs = dict(**hf_processor_mm_kwargs, **tokenization_kwargs)
+        if not prebatched_images:
+            processor_kwargs.setdefault("disable_grouping", False)
+        processor_kwargs.pop("return_mm_token_type_ids", None)
+        processor_kwargs.pop("return_token_type_ids", None)
+
+        image_processor = self.info.get_image_processor(**hf_processor_mm_kwargs)
+        if self._can_fast_preprocess_batched_images(
+            image_processor,
+            processor_data["images"],
+            processor_kwargs,
+        ):
+            processed_data = self.info.ctx.call_hf_processor(
+                partial(self._fast_preprocess_batched_images, image_processor),
+                processor_data,
+                processor_kwargs,
+            )
+        else:
+            processed_data = self.info.ctx.call_hf_processor(
+                image_processor,
+                processor_data,
+                processor_kwargs,
+            )
+        processed_data.update(passthrough_data)
+        return processed_data
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -1840,9 +2151,12 @@ class Qwen3VLForConditionalGeneration(
         # prune+append for video). The encoder CUDA graph path bypasses that
         # post-process, producing inconsistent embedding formats vs eager. So
         # disable CUDA graph for all modalities when pruning is on.
-        modalities = [] if self.is_multimodal_pruning_enabled else ["image", "video"]
+        modalities = [] if self.is_multimodal_pruning_enabled else ["video"]
 
-        # Compute max_frames_per_video for budget sizing.
+        # Compact image patches have a different per-patch width than videos.
+        # The current encoder CUDA graph manager captures one shared input
+        # buffer for image and video, so keep CUDA graph capture on the
+        # unchanged video path and route images through eager vision forward.
         max_frames = self.get_max_frames_per_video() if "video" in modalities else 1
 
         return EncoderCudaGraphConfig(

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -379,6 +379,8 @@ class Qwen3_VisionPatchEmbed(nn.Module):
         full_temporal_patch_size = compact_image_patch_size * self.temporal_patch_size
 
         if compact_image_patch_size == C:
+            # Still images duplicate the same frame across the temporal axis,
+            # so summing Conv3D weights over time is the same projection.
             weight = self.proj.weight.sum(dim=2).reshape(
                 self.hidden_size, compact_image_patch_size
             )

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1406,7 +1406,7 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         if not image_processor.do_rescale or not image_processor.do_normalize:
             return False
 
-        ignored_kwargs = {"disable_grouping", "truncation"}
+        ignored_kwargs = {"disable_grouping"}
         if any(key not in ignored_kwargs for key in processor_kwargs):
             return False
 
@@ -1531,7 +1531,11 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
             processor_data = dict(processor_data)
             processor_data["images"] = batched_images
 
-        processor_kwargs = dict(**hf_processor_mm_kwargs, **tokenization_kwargs)
+        # The direct image-processor path does not consume tokenizer kwargs.
+        # Passing tokenizer-only options such as `truncation` into
+        # Qwen2VLImageProcessor makes Transformers validate them as image
+        # kwargs and raise.
+        processor_kwargs = dict(hf_processor_mm_kwargs)
         if not prebatched_images:
             processor_kwargs.setdefault("disable_grouping", False)
         processor_kwargs.pop("return_mm_token_type_ids", None)


### PR DESCRIPTION
## Purpose

This PR optimizes the Qwen3-VL still-image preprocessing subpath used by text+image requests.

For Qwen3-VL still-image inputs, the original processor path materializes duplicated temporal image patches:

```text
pixel_values [N, C*T*P*P]
```

For still images, the temporal frames are duplicates. This PR introduces a compact image-patch representation:

```text
pixel_values [N, C*P*P]
```

`Qwen3_VisionPatchEmbed.forward()` handles this compact image representation by summing the temporal dimension of the Conv3D kernel weights:

```text
sum_t W[:, :, t, :, :] * image_patch + bias
```

This is mathematically equivalent to applying the original Conv3D to duplicated temporal image patches.

The PR also adds a fused compact preprocessing helper for the guarded fast path:

```text
uint8 BCHW
  -> fused normalize + compact patchify
  -> float32 compact patches [num_patches, C*P*P]
```

This avoids materializing the full intermediate normalized BCHW tensor before compact patchification.

The fast path is guarded to still-image preprocessing inputs and falls back for video inputs, unsupported inputs, or unsupported processor kwargs. Tokenizer-only kwargs such as `truncation=False` are not forwarded to the direct image-processor path, including fallback cases where the compact fast path is not used.

Related issue: https://github.com/vllm-project/vllm/issues/44688

Duplicate-work check: I searched open PRs for `44688 in:body` and `Qwen3 VL compact image preprocessing`; I did not find an existing open PR covering this change.

AI assistance was used while preparing and validating this change. I reviewed the changed code and ran the tests listed below.

## Test Plan

```bash
.venv/bin/python -m py_compile \
  vllm/model_executor/models/qwen3_vl.py \
  tests/test_qwen3_hf_processor_fast_path.py \
  benchmarks/overheads/benchmark_qwen3_hf_processor.py

.venv/bin/python -m pytest tests/test_qwen3_hf_processor_fast_path.py -q
uvx ruff check \
  vllm/model_executor/models/qwen3_vl.py \
  tests/test_qwen3_hf_processor_fast_path.py \
  benchmarks/overheads/benchmark_qwen3_hf_processor.py

OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
.venv/bin/python benchmarks/overheads/benchmark_qwen3_hf_processor.py \
  --requests 8 \
  --images-per-request 4 \
  --workers 4 \
  --warmups 1 \
  --repetitions 3
```

For the baseline comparison below, I ran the benchmark script from this PR against upstream `main` at `228bcc436b` with `PYTHONPATH` pointed at that checkout.

## Test Result

```text
py_compile: passed
```

```text
tests/test_qwen3_hf_processor_fast_path.py -q:
8 passed
```

The tests cover:

- compact patch embedding equals duplicated-temporal patch embedding
- the still-image MM preprocessing path used by text+image requests equals the dummy-text HF processor path
- tokenized text + images keeps placeholder ranges
- fused compact preprocessing matches reference compact preprocessing
- tokenizer-only kwargs such as `truncation=False` are not forwarded to the direct image-processor path, including fallback cases
- the common still-image path actually takes the compact preprocessing fast path
- unsupported image-processor kwargs fall back without diverging from the baseline HF processor path

```text
ruff: All checks passed
```

Benchmark framing:

```text
This is a CPU-only, weightless processor.apply benchmark for the Qwen3-VL
still-image preprocessing path. It is not an end-to-end serving throughput
benchmark.
```

Benchmark workload:

```text
8 requests, 4 images/request, 1786x2526-ish PDF page images, text_tokens=1024
workers: 4, repetitions: 3, OMP_NUM_THREADS=1, MKL_NUM_THREADS=1
```

Upstream `main` baseline used for this benchmark (`228bcc436b`):

```text
qwen3_vllm_apply_mean_ms=4898.893212
qwen3_apply_hf_processor_mean_ms=4843.806258
qwen3_vllm_apply_throughput_rps=0.764952
qwen3_direct_image_parity=1.000000
```

This PR:

```text
qwen3_vllm_apply_mean_ms=532.418262
qwen3_apply_hf_processor_mean_ms=438.576127
qwen3_vllm_apply_throughput_rps=7.039597
qwen3_direct_image_parity=1.000000
```

Comparison:

```text
qwen3_vllm_apply_mean_ms:
  4898.9 ms -> 532.4 ms
  ~89.1% lower, ~9.20x faster

qwen3_apply_hf_processor_mean_ms:
  4843.8 ms -> 438.6 ms
  ~90.9% lower, ~11.04x faster

qwen3_vllm_apply_throughput_rps:
  0.765 -> 7.040
  ~820.3% higher, ~9.20x higher
```
