### PR TITLE
[KVConnector] Add prefix-length threshold for lazy SimpleCPUOffloadConnector

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm import SamplingParams
@@ -13,9 +15,11 @@ from vllm.config import (
     CacheConfig,
     DeviceConfig,
     KVTransferConfig,
-    ModelConfig,
     SchedulerConfig,
     VllmConfig,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    _parse_lazy_offload_min_prefix_tokens,
 )
 from vllm.utils.hashing import sha256
 from vllm.v1.core.block_pool import BlockPool
@@ -43,6 +47,8 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.simple_kv_offload.manager import SimpleCPUOffloadScheduler
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadWorkerMetadata
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -102,12 +108,6 @@ def _make_kv_cache_config(
 
 def _make_vllm_config(block_size: int = BLOCK_SIZE) -> VllmConfig:
     """Minimal VllmConfig for scheduler tests (no GPU)."""
-    model_config = ModelConfig(
-        model="facebook/opt-125m",
-        trust_remote_code=True,
-        dtype="float16",
-        seed=42,
-    )
     scheduler_config = SchedulerConfig(
         max_num_seqs=16,
         max_num_batched_tokens=64,
@@ -124,13 +124,17 @@ def _make_vllm_config(block_size: int = BLOCK_SIZE) -> VllmConfig:
         kv_connector="SimpleCPUOffloadConnector",
         kv_role="kv_both",
     )
-    return VllmConfig(
+    vllm_config = VllmConfig(
         scheduler_config=scheduler_config,
-        model_config=model_config,
         cache_config=cache_config,
         kv_transfer_config=kv_transfer_config,
         device_config=DeviceConfig("cpu"),
     )
+    # Passing a SimpleNamespace as model_config to VllmConfig fails validation
+    # and constructing a real ModelConfig would resolve an HF model. The
+    # scheduler tests only need max_model_len.
+    vllm_config.model_config = SimpleNamespace(max_model_len=10000)
+    return vllm_config
 
 
 @dataclass
@@ -149,6 +153,7 @@ def make_scheduler(
     num_gpu_blocks: int = 16,
     num_groups: int = 1,
     lazy: bool = False,
+    lazy_offload_min_prefix_tokens: int = 0,
 ) -> SchedulerFixture:
     """Build a SimpleCPUOffloadScheduler with small block pools."""
     kv_cache_config = _make_kv_cache_config(num_gpu_blocks, num_groups)
@@ -162,6 +167,7 @@ def make_scheduler(
         scheduler_block_size=BLOCK_SIZE,
         hash_block_size=BLOCK_SIZE,
         lazy_offload=lazy,
+        lazy_offload_min_prefix_tokens=lazy_offload_min_prefix_tokens,
     )
 
     # Build a real GPU block pool and bind it
@@ -530,6 +536,114 @@ def test_lazy_store_and_load_roundtrip() -> None:
     meta2 = sched.build_connector_meta(sched_out2)
     assert meta2.load_event >= 0, "Expected a load event to be assigned"
     assert len(meta2.load_gpu_blocks) > 0
+
+
+def test_lazy_min_prefix_tokens_skips_short_prefix_blocks() -> None:
+    """Lazy mode should not spill blocks from prefixes below the threshold."""
+    fix = make_scheduler(
+        num_cpu_blocks=8,
+        num_gpu_blocks=8,
+        lazy=True,
+        lazy_offload_min_prefix_tokens=3 * BLOCK_SIZE,
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+
+    num_blocks = 2
+    req = make_request(num_blocks=num_blocks)
+    gpu_blocks = _allocate_gpu_blocks(gpu_pool, req, num_blocks, group_id=0)
+    kv_blocks = KVCacheBlocks(blocks=(gpu_blocks,))
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    gpu_pool.free_blocks(gpu_blocks)
+
+    fillers = _flush_old_blocks_to_lru_head(gpu_pool, num_filler_blocks=5)
+    meta = sched.build_connector_meta(make_scheduler_output({}))
+    gpu_pool.free_blocks(fillers)
+
+    assert meta.store_event < 0
+    assert meta.store_gpu_blocks == []
+    assert meta.store_cpu_blocks == []
+
+
+def test_lazy_min_prefix_tokens_allows_prefix_at_threshold() -> None:
+    """Lazy mode should spill candidate blocks once the prefix reaches threshold."""
+    fix = make_scheduler(
+        num_cpu_blocks=8,
+        num_gpu_blocks=8,
+        lazy=True,
+        lazy_offload_min_prefix_tokens=2 * BLOCK_SIZE,
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+
+    num_blocks = 2
+    req = make_request(num_blocks=num_blocks)
+    gpu_blocks = _allocate_gpu_blocks(gpu_pool, req, num_blocks, group_id=0)
+    kv_blocks = KVCacheBlocks(blocks=(gpu_blocks,))
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    gpu_pool.free_blocks(gpu_blocks)
+
+    fillers = _flush_old_blocks_to_lru_head(gpu_pool, num_filler_blocks=5)
+    meta = sched.build_connector_meta(make_scheduler_output({}))
+    gpu_pool.free_blocks(fillers)
+
+    assert meta.store_event >= 0
+    assert len(meta.store_gpu_blocks) == num_blocks
+    assert len(meta.store_cpu_blocks) == num_blocks
+
+
+def test_lazy_min_prefix_tokens_tracks_candidates_bounded() -> None:
+    """Long-prefix candidate hashes should not grow without bound."""
+    fix = make_scheduler(
+        num_cpu_blocks=8,
+        num_gpu_blocks=8,
+        lazy=True,
+        lazy_offload_min_prefix_tokens=BLOCK_SIZE,
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+
+    capacity = sched._lazy_offloadable_hash_capacity
+    for _ in range(capacity + 3):
+        req = make_request(num_blocks=1)
+        gpu_blocks = _allocate_gpu_blocks(gpu_pool, req, num_blocks=1, group_id=0)
+        kv_blocks = KVCacheBlocks(blocks=(gpu_blocks,))
+        sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+        gpu_pool.free_blocks(gpu_blocks)
+
+    assert len(sched._lazy_offloadable_hashes) <= capacity
+
+
+@pytest.mark.parametrize(
+    ("extra_config", "expected"),
+    [
+        ({}, 0),
+        ({"lazy_offload_min_prefix_tokens": 0}, 0),
+        ({"lazy_offload_min_prefix_tokens": 1024}, 1024),
+        ({"lazy_offload_min_prefix_tokens": "1024"}, 1024),
+    ],
+)
+def test_lazy_min_prefix_tokens_config_parses_valid_values(
+    extra_config: dict[str, object],
+    expected: int,
+) -> None:
+    assert _parse_lazy_offload_min_prefix_tokens(extra_config) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, -1, "-1", "abc", "1.5", 1.5],
+)
+def test_lazy_min_prefix_tokens_config_rejects_invalid_values(
+    value: object,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="lazy_offload_min_prefix_tokens.*non-negative integer",
+    ):
+        _parse_lazy_offload_min_prefix_tokens(
+            {"lazy_offload_min_prefix_tokens": value}
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -40,6 +40,32 @@ logger = init_logger(__name__)
 
 # Default CPU capacity: 8 GB
 DEFAULT_CPU_CAPACITY_BYTES = 8 * (1024**3)
+_LAZY_OFFLOAD_MIN_PREFIX_TOKENS_KEY = "lazy_offload_min_prefix_tokens"
+
+
+def _parse_lazy_offload_min_prefix_tokens(extra_config: dict[str, Any]) -> int:
+    value = extra_config.get(_LAZY_OFFLOAD_MIN_PREFIX_TOKENS_KEY, 0)
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{_LAZY_OFFLOAD_MIN_PREFIX_TOKENS_KEY} must be a non-negative "
+            "integer."
+        )
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and value.strip().lstrip("+-").isdigit():
+        parsed = int(value)
+    else:
+        raise ValueError(
+            f"{_LAZY_OFFLOAD_MIN_PREFIX_TOKENS_KEY} must be a non-negative "
+            "integer."
+        )
+
+    if parsed < 0:
+        raise ValueError(
+            f"{_LAZY_OFFLOAD_MIN_PREFIX_TOKENS_KEY} must be a non-negative "
+            "integer."
+        )
+    return parsed
 
 
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
@@ -75,6 +101,9 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
             cpu_capacity_per_rank = explicit
 
         lazy_offload = bool(extra_config.get("lazy_offload", False))
+        lazy_offload_min_prefix_tokens = _parse_lazy_offload_min_prefix_tokens(
+            extra_config
+        )
 
         self.scheduler_manager: SimpleCPUOffloadScheduler | None = None
         self.worker_handler: SimpleCPUOffloadWorker | None = None
@@ -109,6 +138,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 scheduler_block_size=scheduler_block_size,
                 hash_block_size=hash_block_size,
                 lazy_offload=lazy_offload,
+                lazy_offload_min_prefix_tokens=lazy_offload_min_prefix_tokens,
             )
         elif role == KVConnectorRole.WORKER:
             self.worker_handler = SimpleCPUOffloadWorker(

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -3,6 +3,7 @@
 """Scheduler-side manager for SimpleCPUOffloadConnector."""
 
 import contextlib
+from collections import OrderedDict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -75,6 +76,7 @@ class SimpleCPUOffloadScheduler:
         scheduler_block_size: int,
         hash_block_size: int,
         lazy_offload: bool = False,
+        lazy_offload_min_prefix_tokens: int = 0,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -149,6 +151,14 @@ class SimpleCPUOffloadScheduler:
 
         # Store metadata
         self._lazy_mode = lazy_offload
+        self._lazy_offload_min_prefix_tokens = max(
+            0, lazy_offload_min_prefix_tokens
+        )
+        self._lazy_offloadable_hashes: OrderedDict[bytes, None] = OrderedDict()
+        self._lazy_offloadable_hash_capacity = max(
+            1,
+            kv_cache_config.num_blocks * len(kv_cache_config.kv_cache_groups),
+        )
         # Lazy mode: use a cursor to track the last scanned block in the GPU free queue.
         self._cursor: KVCacheBlock | None = None
         if self._lazy_mode:
@@ -274,6 +284,8 @@ class SimpleCPUOffloadScheduler:
         req_id = request.request_id
         block_ids_by_group = blocks.get_block_ids()
         num_groups = len(block_ids_by_group)
+
+        self._record_lazy_offloadable_hashes(blocks)
 
         # Store tracking (eager mode only). Register the request;
         # block IDs are accumulated from scheduler_output in
@@ -489,6 +501,7 @@ class SimpleCPUOffloadScheduler:
             if (
                 bhash is not None
                 and not node.is_null
+                and self._is_lazy_offload_candidate(bhash)
                 and cpu_pool.cached_block_hash_to_block.get_one_block(bhash) is None
             ):
                 gpu_ids.append(node.block_id)
@@ -511,6 +524,45 @@ class SimpleCPUOffloadScheduler:
             cpu_ids = []
 
         return gpu_ids, cpu_ids, []
+
+    def _record_lazy_offloadable_hashes(self, blocks: "KVCacheBlocks") -> None:
+        if (
+            not self._lazy_mode
+            or self._lazy_offload_min_prefix_tokens <= 0
+            or self.fa_gidx >= len(blocks.blocks)
+        ):
+            return
+
+        num_fa_hashes = sum(
+            1
+            for block in blocks.blocks[self.fa_gidx]
+            if block.block_hash is not None and not block.is_null
+        )
+        prefix_tokens = num_fa_hashes * self.fa_block_size
+        if prefix_tokens < self._lazy_offload_min_prefix_tokens:
+            return
+
+        for group_blocks in blocks.blocks:
+            for block in group_blocks:
+                if block.block_hash is not None and not block.is_null:
+                    self._remember_lazy_offloadable_hash(block.block_hash)
+
+    def _remember_lazy_offloadable_hash(self, block_hash: bytes) -> None:
+        if block_hash in self._lazy_offloadable_hashes:
+            self._lazy_offloadable_hashes.move_to_end(block_hash)
+            return
+
+        while len(self._lazy_offloadable_hashes) >= (
+            self._lazy_offloadable_hash_capacity
+        ):
+            self._lazy_offloadable_hashes.popitem(last=False)
+
+        self._lazy_offloadable_hashes[block_hash] = None
+
+    def _is_lazy_offload_candidate(self, block_hash: bytes) -> bool:
+        if self._lazy_offload_min_prefix_tokens <= 0:
+            return True
+        return block_hash in self._lazy_offloadable_hashes
 
     def _prepare_eager_store_specs(
         self, scheduler_output: SchedulerOutput


### PR DESCRIPTION


## Purpose

This PR adds an optional prefix-length threshold for lazy CPU KV offload in `SimpleCPUOffloadConnector`.

This is an incremental enhancement to the existing `SimpleCPUOffloadConnector` lazy offload mode; it does not change eager offload behavior or introduce a new connector.

When `lazy_offload_min_prefix_tokens` is set in `kv_connector_extra_config`, the scheduler records block hashes from requests whose full-attention prefix length reaches the threshold. The lazy scanner then offloads only those candidate hashes. This lets lazy CPU offload prioritize blocks from longer prefixes that are more likely to be reused.

The default behavior is unchanged:

- `lazy_offload_min_prefix_tokens` defaults to `0`.
- With the default value, lazy offload scans and stores eligible hashed GPU blocks as before.
- The new filtering is only active when a positive threshold is configured.

Implementation notes:

- The threshold is token-based.
- The prefix length is computed using the full-attention KV group's block size, rather than assuming `scheduler_block_size == hash_block_size`.
- The lazy offload candidate hash set is bounded to avoid unbounded growth in long-running serving processes.
- This PR does not add JSONL stats or new metrics output.

## Test Plan

```bash
python -m pytest tests/v1/simple_kv_offload/test_scheduler.py -q

python -m ruff check --no-cache \
  vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py \
  vllm/v1/simple_kv_offload/manager.py \
  tests/v1/simple_kv_offload/test_scheduler.py

PYTHONPYCACHEPREFIX=/tmp/vllm-pycompile python -m py_compile \
  vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py \
  vllm/v1/simple_kv_offload/manager.py \
  tests/v1/simple_kv_offload/test_scheduler.py

git diff --check origin/main...HEAD
```

## Test Result

```text
tests/v1/simple_kv_offload/test_scheduler.py
29 passed

ruff check
All checks passed

py_compile
passed

git diff --check
passed
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] No documentation update is required for this internal connector configuration option.

</details>

