### PR TITLE
Added extra_repr() to pooler classes to improve debuggability

### DIFF
--- a/vllm/model_executor/layers/pooler/activations.py
+++ b/vllm/model_executor/layers/pooler/activations.py
@@ -128,6 +128,9 @@ class PoolerClassify(PoolerActivation):
 
         self.num_labels = num_labels
 
+    def extra_repr(self) -> str:
+        return f"num_labels={self.num_labels}"
+
     def forward_chunk(self, pooled_data: torch.Tensor) -> torch.Tensor:
         num_labels = self.num_labels
         if num_labels is None:
@@ -144,6 +147,12 @@ class LambdaPoolerActivation(PoolerActivation):
         super().__init__()
 
         self.fn = fn
+
+    def extra_repr(self) -> str:
+        name = getattr(self.fn, "__name__", None)
+        if name is None:
+            name = self.fn.__class__.__name__
+        return f"fn={name}"
 
     def forward_chunk(self, pooled_data: torch.Tensor) -> torch.Tensor:
         return self.fn(pooled_data)

--- a/vllm/model_executor/layers/pooler/seqwise/heads.py
+++ b/vllm/model_executor/layers/pooler/seqwise/heads.py
@@ -43,6 +43,16 @@ class EmbeddingPoolerHead(SequencePoolerHead):
         self.head_dtype = head_dtype
         self.activation = activation
 
+    def extra_repr(self) -> str:
+        attrs = []
+        if self.head_dtype is not None:
+            attrs.append(f"head_dtype={self.head_dtype}")
+        if self.projector is not None:
+            attrs.append("projector=True")
+        if self.activation is not None:
+            attrs.append(f"activation={self.activation.__class__.__name__}")
+        return ", ".join(attrs)
+
     def get_supported_tasks(self) -> Set[PoolingTask]:
         return {"embed"}
 
@@ -123,6 +133,20 @@ class ClassifierPoolerHead(SequencePoolerHead):
         self.logit_sigma = logit_sigma
         self.head_dtype = head_dtype
         self.activation = activation
+
+    def extra_repr(self) -> str:
+        attrs = []
+        if self.head_dtype is not None:
+            attrs.append(f"head_dtype={self.head_dtype}")
+        if self.classifier is not None:
+            attrs.append("classifier=True")
+        if self.logit_mean is not None:
+            attrs.append(f"logit_mean={self.logit_mean}")
+        if self.logit_sigma is not None:
+            attrs.append(f"logit_sigma={self.logit_sigma}")
+        if self.activation is not None:
+            attrs.append(f"activation={self.activation.__class__.__name__}")
+        return ", ".join(attrs)
 
     def get_supported_tasks(self) -> Set[PoolingTask]:
         return {"classify"}

--- a/vllm/model_executor/layers/pooler/seqwise/poolers.py
+++ b/vllm/model_executor/layers/pooler/seqwise/poolers.py
@@ -61,6 +61,12 @@ class SequencePooler(Pooler):
         self.pooling = pooling
         self.head = head
 
+    def extra_repr(self) -> str:
+        return (
+            f"pooling={self.pooling.__class__.__name__}, "
+            f"head={self.head.__class__.__name__}"
+        )
+
     def get_supported_tasks(self) -> Set[PoolingTask]:
         tasks = set(POOLING_TASKS)
 

--- a/vllm/model_executor/layers/pooler/special.py
+++ b/vllm/model_executor/layers/pooler/special.py
@@ -164,6 +164,9 @@ class BOSEOSFilter(Pooler):
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
 
+    def extra_repr(self) -> str:
+        return f"bos_token_id={self.bos_token_id}, eos_token_id={self.eos_token_id}"
+
     def get_supported_tasks(self) -> Set[PoolingTask]:
         return self.pooler.get_supported_tasks()
 

--- a/vllm/model_executor/layers/pooler/tokwise/heads.py
+++ b/vllm/model_executor/layers/pooler/tokwise/heads.py
@@ -58,6 +58,16 @@ class TokenEmbeddingPoolerHead(TokenPoolerHead):
         self.projector = projector
         self.activation = activation
 
+    def extra_repr(self) -> str:
+        attrs = []
+        if self.head_dtype is not None:
+            attrs.append(f"head_dtype={self.head_dtype}")
+        if self.projector is not None:
+            attrs.append("projector=True")
+        if self.activation is not None:
+            attrs.append(f"activation={self.activation.__class__.__name__}")
+        return ", ".join(attrs)
+
     def get_supported_tasks(self) -> Set[PoolingTask]:
         return {"token_embed"}
 
@@ -109,6 +119,20 @@ class TokenClassifierPoolerHead(TokenPoolerHead):
         self.logit_sigma = logit_sigma
         self.head_dtype = head_dtype
         self.activation = activation
+
+    def extra_repr(self) -> str:
+        attrs = []
+        if self.head_dtype is not None:
+            attrs.append(f"head_dtype={self.head_dtype}")
+        if self.classifier is not None:
+            attrs.append("classifier=True")
+        if self.logit_mean is not None:
+            attrs.append(f"logit_mean={self.logit_mean}")
+        if self.logit_sigma is not None:
+            attrs.append(f"logit_sigma={self.logit_sigma}")
+        if self.activation is not None:
+            attrs.append(f"activation={self.activation.__class__.__name__}")
+        return ", ".join(attrs)
 
     def get_supported_tasks(self) -> Set[PoolingTask]:
         return {"token_classify"}

--- a/vllm/model_executor/layers/pooler/tokwise/methods.py
+++ b/vllm/model_executor/layers/pooler/tokwise/methods.py
@@ -41,6 +41,9 @@ class AllPool(TokenPoolingMethod):
 
         self.enable_chunked_prefill = scheduler_config.enable_chunked_prefill
 
+    def extra_repr(self) -> str:
+        return f"enable_chunked_prefill={self.enable_chunked_prefill}"
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/vllm/model_executor/layers/pooler/tokwise/poolers.py
+++ b/vllm/model_executor/layers/pooler/tokwise/poolers.py
@@ -65,6 +65,10 @@ class TokenPooler(Pooler):
         self.pooling = pooling
         self.head = head
 
+    def extra_repr(self) -> str:
+        head_name = self.head.__class__.__name__ if self.head is not None else None
+        return f"pooling={self.pooling.__class__.__name__}, head={head_name}"
+
     def get_supported_tasks(self) -> Set[PoolingTask]:
         tasks = set(POOLING_TASKS)
 


### PR DESCRIPTION
## Purpose
Currently most pooler modules print names like `SequencePooler() ` with no visibility into their configuration. This makes debugging pooling pipelines harder. This PR adds `extra_repr() ` to pooler classes that have _meaningful state_, so `print(model.pooler)` shows configuration details instead of empty parentheses. 

## Test Plan
Run the following script to validate the extra model attributes are being printed: 
```
cat > /tmp/test_repr.py << 'EOF'
  import os
  os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
  from vllm import LLM
  llm = LLM(model='intfloat/e5-mistral-7b-instruct')
  model = llm.llm_engine.model_executor.driver_worker.worker.model_runner.model
  pooler = model.pooler
  for task, sub_pooler in pooler.poolers_by_task.items():
      print(f"Task '{task}': {sub_pooler}")
  EOF
  .venv/bin/python /tmp/test_repr.py
```

## Test Result
 `[io_processor.py:61] Loaded prompt prefixes for input_type: ['web_search_query', 'sts_query', 'summarization_query', 'bitext_query']
Task 'token_embed': TokenPooler(
  pooling=AllPool, head=TokenEmbeddingPoolerHead
  (pooling): AllPool(enable_chunked_prefill=True)
  (head): TokenEmbeddingPoolerHead(
    head_dtype=torch.float32, activation=PoolerNormalize
    (activation): PoolerNormalize()
  )
)
Task 'embed': SequencePooler(
  pooling=LastPool, head=EmbeddingPoolerHead
  (pooling): LastPool()
  (head): EmbeddingPoolerHead(
    head_dtype=torch.float32, activation=PoolerNormalize
    (activation): PoolerNormalize()
  )
)`

Prior to the changes, we would see something like `SequencePooler()` with no other configuration details.