### PR TITLE
fix: strip Gemma4 delimiters from dict keys

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -108,6 +108,14 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('nested:{inner:<|"|>value<|"|>}')
         assert result == {"nested": {"inner": "value"}}
 
+    def test_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('record_map:{<|"|>3<|"|>:<|"|>new text<|"|>}')
+        assert result == {"record_map": {"3": "new text"}}
+
+    def test_nested_string_delimited_dict_key(self):
+        result = _parse_gemma4_args('outer:{inner:{<|"|>quoted<|"|>:<|"|>value<|"|>}}')
+        assert result == {"outer": {"inner": {"quoted": "value"}}}
+
     def test_array_of_strings(self):
         result = _parse_gemma4_args('items:[<|"|>a<|"|>,<|"|>b<|"|>]')
         assert result == {"items": ["a", "b"]}

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -54,6 +54,12 @@ STRING_DELIM = '<|"|>'
 # ---------------------------------------------------------------------------
 
 
+def _normalize_gemma4_key(key: str) -> str:
+    if key.startswith(STRING_DELIM) and key.endswith(STRING_DELIM):
+        return key[len(STRING_DELIM) : -len(STRING_DELIM)]
+    return key
+
+
 def _parse_gemma4_value(value_str: str) -> object:
     """Parse a single Gemma4 value (after key:) into a Python object."""
     value_str = value_str.strip()
@@ -121,7 +127,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
         if i >= n:
             break
-        key = args_str[key_start:i].strip()
+        key = _normalize_gemma4_key(args_str[key_start:i].strip())
         i += 1  # skip ':'
 
         # Parse value


### PR DESCRIPTION
## Summary

Fixes #44715.

Gemma4's API-server parser already strips `<|"|>` string delimiters from values, but key positions were kept verbatim. When the model emits a string-delimited dict key, `_parse_gemma4_args()` produced keys such as `<|"|>3<|"|>` instead of `3`.

This patch normalizes only keys wrapped by the Gemma4 string delimiter. Bare keys and value parsing stay unchanged, and the same helper is used by nested objects because nested objects recurse through `_parse_gemma4_args()`.

## Tests

- `python -m ruff check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py`
- `python -m ruff format --check vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py`
- `python -m py_compile vllm\tool_parsers\gemma4_tool_parser.py tests\tool_parsers\test_gemma4_tool_parser.py`
- `git diff --check`
- function-level regression check for the top-level and nested delimited-key cases

I also tried `python -m pytest tests\tool_parsers\test_gemma4_tool_parser.py -q`, but this local Windows environment currently fails while loading the repository-level `tests/conftest.py`: the installed `transformers` / `kernels` combination raises `ValueError: Either a revision or a version must be specified` before the target tests are collected.
