### PR TITLE
[Bugfix] Fix layerwise reload dropping params after a composed weight loader

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -25,6 +25,10 @@ from vllm.model_executor.model_loader.reload.meta import (
 )
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
+from vllm.model_executor.model_loader.weight_utils import (
+    composed_weight_loader,
+    default_weight_loader,
+)
 from vllm.platforms import current_platform
 
 
@@ -176,6 +180,83 @@ def test_get_numel_loaded():
     num_loaded, ret = get_numel_loaded(complex_weight_loader, args)
     assert num_loaded == 6
     assert ret == "value"
+
+
+def test_get_numel_loaded_caps_at_param_size():
+    # composed_weight_loader copies into the param twice (the load and the
+    # in-place post-load transform), but only param.numel() distinct elements
+    # are loaded. get_numel_loaded must not double-count, otherwise a layer's
+    # loaded-element total can be reached early and trailing params get dropped.
+    param = torch.empty(10)
+    loaded_weight = torch.ones(10)
+    loader = composed_weight_loader(default_weight_loader, lambda x: x + 1)
+
+    args = inspect.signature(loader).bind(param, loaded_weight)
+    num_loaded, _ = get_numel_loaded(loader, args)
+    assert num_loaded == 10
+
+
+class _ComposedLoaderLayer(torch.nn.Module):
+    """Mimics a Mamba2 mixer's equal-numel direct params (A, D, dt_bias).
+
+    ``A`` uses ``composed_weight_loader`` (an extra in-place transform copy),
+    matching ``MambaMixer2`` where ``A`` is loaded as ``-exp(A_log)``.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.A = torch.nn.Parameter(torch.empty(4, dtype=torch.float32))
+        self.D = torch.nn.Parameter(torch.ones(4))
+        self.dt_bias = torch.nn.Parameter(torch.ones(4))
+        self.A.weight_loader = composed_weight_loader(
+            default_weight_loader, lambda x: -torch.exp(x.float())
+        )
+        self.D.weight_loader = default_weight_loader
+        self.dt_bias.weight_loader = default_weight_loader
+
+
+def test_layerwise_reload_composed_loader_does_not_drop_params(monkeypatch):
+    # Regression test: a composed_weight_loader param (A) used to double-count
+    # its elements, finalizing the layer before the trailing param (D) was
+    # loaded and leaving it as uninitialized materialized memory.
+    layer = _ComposedLoaderLayer()
+    model = torch.nn.Sequential(layer)
+
+    def materialize_with_sentinel(meta_tensor):
+        tensor = torch.empty_strided(
+            size=tuple(meta_tensor.size()),
+            stride=tuple(meta_tensor.stride()),
+            dtype=meta_tensor.dtype,
+            requires_grad=False,
+        )
+        tensor.fill_(float("nan"))
+        tensor.__class__ = meta_tensor.__class__
+        tensor.__dict__ = meta_tensor.__dict__.copy()
+        return tensor
+
+    monkeypatch.setattr(
+        reload_meta, "materialize_meta_tensor", materialize_with_sentinel
+    )
+
+    loaded = {
+        "A": torch.full((4,), 0.5),
+        "dt_bias": torch.full((4,), 3.0),
+        "D": torch.full((4,), 7.0),
+    }
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    # Mimic real load_weights: resolve params once, then load in checkpoint
+    # order with D last (the param that was dropped).
+    params = dict(layer.named_parameters())
+    for name in ("A", "dt_bias", "D"):
+        param = params[name]
+        param.weight_loader(param, loaded[name])
+    finalize_layerwise_reload(model, model_config=None)
+
+    assert torch.equal(layer.A, -torch.exp(loaded["A"]))
+    assert torch.equal(layer.dt_bias, loaded["dt_bias"])
+    assert torch.equal(layer.D, loaded["D"])
 
 
 def test_layerwise_reload_skips_non_persistent_parameter_alias_buffers(monkeypatch):

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -196,7 +196,7 @@ def get_numel_loaded(
     # the trailing parameter(s) (e.g. Mamba ``mixer.D``). Cap the count at the
     # destination size to keep the per-layer accounting correct.
     numel = counter.copied_numel
-    param = args.arguments.get("param")
+    param = args.arguments.get("param", None)
     if isinstance(param, torch.Tensor):
         numel = min(numel, param.numel())
     return numel, return_value

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -185,4 +185,18 @@ def get_numel_loaded(
     """
     with CopyCounter() as counter:
         return_value = weight_loader(*args.args, **args.kwargs)
-    return counter.copied_numel, return_value
+
+    # A weight loader fills a single destination parameter, so the number of
+    # loaded elements is at most that parameter's size. Some loaders copy into
+    # the parameter more than once -- e.g. ``composed_weight_loader`` runs an
+    # in-place post-load transform (``param.copy_(fn(param))``) on top of the
+    # initial copy -- which would make CopyCounter report twice the parameter
+    # size. Over-counting inflates the layer's loaded-element total and can
+    # finalize the layer before every parameter is loaded, silently dropping
+    # the trailing parameter(s) (e.g. Mamba ``mixer.D``). Cap the count at the
+    # destination size to keep the per-layer accounting correct.
+    numel = counter.copied_numel
+    param = args.arguments.get("param")
+    if isinstance(param, torch.Tensor):
+        numel = min(numel, param.numel())
+    return numel, return_value


### PR DESCRIPTION
## Purpose

Fixes a bug in the layerwise weight-reload path
(`vllm/model_executor/model_loader/reload`) that drops a trailing parameter of a
layer when an earlier parameter uses `composed_weight_loader`.

The reload path counts loaded elements per layer (`CopyCounter` inside
`get_numel_loaded`) and finalizes a layer once `load_numel >= load_numel_total`.
`composed_weight_loader` copies into its parameter **twice** — the initial load
plus an in-place post-load transform `param.copy_(fn(param))` — so `CopyCounter`
reports **2×** that parameter's size. The over-count can push `load_numel` to the
layer total before every parameter has been loaded, finalizing the layer early
and silently dropping the parameter(s) loaded afterward. The dropped parameter is
left as `materialize_meta_tensor` (`empty_strided`) memory, i.e. uninitialized
garbage.

This bites Mamba2 mixers (`MambaMixer2`, used by NemotronH and other hybrid SSM
models). The mixer's `A`, `D`, and `dt_bias` are equal-numel direct parameters,
and `A` is loaded with `composed_weight_loader` (`-exp(A_log)`). On an online
weight reload, `A` counts double, the mixer finalizes after `A` + one of the
others, and `mixer.D` (the SSD skip connection, loaded last) is dropped — leaving
NaN/inf in `D` and producing NaN logits after a weight update.

### Fix

A weight loader fills a single destination parameter, so the number of distinct
elements it loads is at most that parameter's size. Copying into the same
parameter more than once (the composed transform) is not additional loaded data.
`get_numel_loaded` now caps each loader call's counted elements at the
destination parameter's `numel()`, restoring the per-layer accounting invariant
("the total is reached only after all parameters are loaded"). One-line behavior
change in a single function; no loader or model code is touched.

## Test Plan

`tests/model_executor/model_loader/test_reload.py`:

- `test_get_numel_loaded_caps_at_param_size` — a `composed_weight_loader` reports
  `param.numel()`, not `2×`.
- `test_layerwise_reload_composed_loader_does_not_drop_params` — a minimal
  module mirroring a Mamba2 mixer (`A` composed-loaded, `D`/`dt_bias` plain,
  equal numel) goes through `record_metadata_for_reloading` →
  `initialize_layerwise_reload` → load (`D` last) → `finalize_layerwise_reload`;
  asserts all three params keep their loaded values. Materialized tensors are
  filled with NaN so a dropped param is detectable.

```
pytest tests/model_executor/model_loader/test_reload.py -k \
  "get_numel_loaded or composed_loader or alias_buffers"
```

## Test Result

- Both new tests **fail on `main`** (`D` is NaN; `get_numel_loaded` returns
  `2×numel`) and **pass with this change**.
- Existing reload unit tests (`test_get_numel_loaded`,
  `test_layerwise_reload_skips_*_alias_buffers`) continue to pass.
- `ruff check` and `ruff format --check` pass on both files.

This is not a duplicate of #40647 (which fixes the `VllmConfig` context and the
alias-buffer copy-back in the same file) — that PR does not touch the
`get_numel_loaded` element accounting that drops `mixer.D`.

---

This change was AI-assisted (Claude Code). The root cause, fix, and tests were
reviewed by the submitter, who ran the tests and linters above.
