### PR TITLE
[SpecDecode] Raise default scheduler token budget

### DIFF
--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from argparse import ArgumentError
+from types import SimpleNamespace
 
 import pytest
 
@@ -128,3 +129,64 @@ def test_mm_prefix_lm_raises_batched_tokens_floor():
         vllm_config = engine_args.create_engine_config(UsageContext.OPENAI_API_SERVER)
 
     assert vllm_config.scheduler_config.max_num_batched_tokens >= 2496
+
+
+def _get_default_max_num_batched_tokens_for_spec_decode(
+    *,
+    max_num_new_slots_for_drafting: int,
+    max_num_batched_tokens: int | None = None,
+) -> int:
+    model_config = SimpleNamespace(
+        max_model_len=32768,
+        is_multimodal_model=False,
+        is_mm_prefix_lm=False,
+    )
+    parallel_config = SimpleNamespace(use_batched_dp_moe=False)
+    speculative_config = SimpleNamespace(
+        max_num_new_slots_for_drafting=max_num_new_slots_for_drafting
+    )
+
+    engine_args = EngineArgs(
+        model="facebook/opt-125m",
+        max_model_len=32768,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_num_seqs=64,
+        enforce_eager=True,
+    )
+    engine_args.enable_chunked_prefill = True
+    engine_args._set_default_max_num_seqs_and_batched_tokens_args(
+        UsageContext.OPENAI_API_SERVER,
+        model_config,
+        parallel_config,
+        speculative_config,
+    )
+
+    return engine_args.max_num_batched_tokens
+
+
+def test_spec_decode_raises_default_batched_tokens_floor():
+    assert (
+        _get_default_max_num_batched_tokens_for_spec_decode(
+            max_num_new_slots_for_drafting=0
+        )
+        == 8192
+    )
+
+
+def test_spec_decode_includes_draft_slot_reserve_in_default_batched_tokens():
+    assert (
+        _get_default_max_num_batched_tokens_for_spec_decode(
+            max_num_new_slots_for_drafting=1
+        )
+        == 8192 + 64
+    )
+
+
+def test_spec_decode_keeps_explicit_batched_tokens():
+    assert (
+        _get_default_max_num_batched_tokens_for_spec_decode(
+            max_num_new_slots_for_drafting=1,
+            max_num_batched_tokens=2048,
+        )
+        == 2048
+    )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2018,6 +2018,7 @@ class EngineArgs:
             usage_context,
             model_config,
             parallel_config,
+            speculative_config,
         )
 
         assert self.max_num_batched_tokens is not None, (
@@ -2482,6 +2483,7 @@ class EngineArgs:
         usage_context: UsageContext | None,
         model_config: ModelConfig,
         parallel_config: ParallelConfig,
+        speculative_config: SpeculativeConfig | None = None,
     ):
         world_size = self.pipeline_parallel_size * self.tensor_parallel_size
         (
@@ -2543,6 +2545,22 @@ class EngineArgs:
                         model_config.model,
                     )
                     self.max_num_batched_tokens = mm_min
+
+            if speculative_config is not None:
+                assert self.max_num_seqs is not None, (
+                    "max_num_seqs must be set by this point"
+                )
+                # Match the speculative scheduled-token warning floor in
+                # VllmConfig after reserving any extra drafting slots.
+                min_scheduled_tokens = 8192
+                num_draft_slots = (
+                    speculative_config.max_num_new_slots_for_drafting
+                    * self.max_num_seqs
+                )
+                self.max_num_batched_tokens = max(
+                    self.max_num_batched_tokens,
+                    min_scheduled_tokens + num_draft_slots,
+                )
 
             # When using default settings,
             # Ensure max_num_batched_tokens does not exceed model limit.


### PR DESCRIPTION
## What

Raise the default `max_num_batched_tokens` used with speculative decoding so the derived scheduled-token budget starts at the existing 8192-token warning floor. The default also includes any extra draft slots reserved by the speculative method.

Explicit user-provided `max_num_batched_tokens` values are unchanged. The existing model-length cap and multimodal prefix-LM floor remain in place.

## Why

For OpenAI server usage on some GPUs, the default batch token budget can be 2048. With speculative decoding enabled, that leaves a low scheduled-token budget and triggers the existing suboptimal-performance warning in `VllmConfig`. This can make speculative decoding slower even when acceptance is healthy.

A manual serving run with a larger budget confirmed that the slowdown was scheduler-budget related rather than a target-model verification issue. This PR makes the default path avoid that under-budgeted configuration while preserving explicit user settings.

## Validation

- `python -m pytest tests/v1/engine/test_engine_args.py`
- pre-commit hooks run by `git commit` passed, including ruff, formatting, mypy, SPDX, config validation, and related repository checks

AI assistance: Codex and Claude.