### PR TITLE
[BugFix] Use served model name in gemma4 audio-tower error message

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Mapping
-from types import SimpleNamespace
 
 import pytest
 import torch
@@ -11,7 +10,6 @@ from PIL import Image as PILImage
 from vllm.model_executor.models.gemma4_mm import (
     Gemma4ForConditionalGeneration,
     Gemma4ImagePixelInputs,
-    Gemma4ProcessingInfo,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig
@@ -22,26 +20,6 @@ from ...utils import build_model_context
 
 # TODO: to be updated to "google/gemma-4-e2b-it" once the models are available
 GEMMA4_MODEL_ID = "google/gemma-4-E2B-it"
-
-
-@pytest.mark.cpu_test
-def test_gemma4_audio_tower_error_uses_served_model_name():
-    """The audio-tower error must show the served model name, not the local
-    weights path."""
-    model_config = SimpleNamespace(
-        model="/path/to/model/weights",
-        served_model_name="served-model-name",
-    )
-    info = Gemma4ProcessingInfo.__new__(Gemma4ProcessingInfo)
-    info.ctx = SimpleNamespace(model_config=model_config)
-    info.get_hf_config = lambda: SimpleNamespace(audio_config=None)
-
-    with pytest.raises(ValueError) as exc_info:
-        info.validate_num_items("audio", 1)
-
-    msg = str(exc_info.value)
-    assert "served-model-name" in msg
-    assert model_config.model not in msg
 
 
 def test_gemma4_image_schema_accepts_variable_patch_counts():

--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Mapping
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -10,6 +11,7 @@ from PIL import Image as PILImage
 from vllm.model_executor.models.gemma4_mm import (
     Gemma4ForConditionalGeneration,
     Gemma4ImagePixelInputs,
+    Gemma4ProcessingInfo,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig
@@ -20,6 +22,26 @@ from ...utils import build_model_context
 
 # TODO: to be updated to "google/gemma-4-e2b-it" once the models are available
 GEMMA4_MODEL_ID = "google/gemma-4-E2B-it"
+
+
+@pytest.mark.cpu_test
+def test_gemma4_audio_tower_error_uses_served_model_name():
+    """The audio-tower error must show the served model name, not the local
+    weights path."""
+    model_config = SimpleNamespace(
+        model="/path/to/model/weights",
+        served_model_name="served-model-name",
+    )
+    info = Gemma4ProcessingInfo.__new__(Gemma4ProcessingInfo)
+    info.ctx = SimpleNamespace(model_config=model_config)
+    info.get_hf_config = lambda: SimpleNamespace(audio_config=None)
+
+    with pytest.raises(ValueError) as exc_info:
+        info.validate_num_items("audio", 1)
+
+    msg = str(exc_info.value)
+    assert "served-model-name" in msg
+    assert model_config.model not in msg
 
 
 def test_gemma4_image_schema_accepts_variable_patch_counts():

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -34,6 +34,7 @@ from transformers.models.gemma4.configuration_gemma4 import (
 )
 
 from vllm.config import VllmConfig
+from vllm.config.model import get_served_model_name
 from vllm.config.multimodal import BaseDummyOptions, VideoDummyOptions
 from vllm.inputs import MultiModalDataDict
 from vllm.logger import init_logger
@@ -217,7 +218,10 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
             and num_items > 0
             and self.get_hf_config().audio_config is None
         ):
-            model = self.ctx.model_config.model
+            model_config = self.ctx.model_config
+            model = get_served_model_name(
+                model_config.model, model_config.served_model_name
+            )
             raise ValueError(
                 f"Audio input was provided but the model "
                 f"'{model}' does not have an audio tower. "


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix an error message for unsupported audio inputs on Gemma 4 models without `audio_config` to use `served_model_name` instead of exposing local model path.
Related PR: https://github.com/vllm-project/vllm/pull/41003

- as-is: 
"Audio input was provided but the model `'/mnt/local/model'` does not have an audio tower. Audio inference is only supported for Gemma4 models that include an audio_config (i.e., models that include an audio_config)."

- to-be:
"Audio input was provided but the model `'google/gemma-4-31B'` does not have an audio tower. Audio inference is only supported for Gemma4 models that include an audio_config (i.e., models that include an audio_config)."

## Test Plan
~`pytest tests/models/multimodal/processing/test_gemma4.py::test_gemma4_audio_tower_error_uses_served_model_name`~

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
