### PR TITLE
[Bugfix][DeepSeekV4 MTP] Pass prefix= to e_proj/h_proj in MTP draft

### DIFF
--- a/vllm/models/deepseek_v4/amd/mtp.py
+++ b/vllm/models/deepseek_v4/amd/mtp.py
@@ -86,6 +86,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             bias=False,
             return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.e_proj",
         )
         self.h_proj = ReplicatedLinear(
             config.hidden_size,
@@ -93,6 +94,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             bias=False,
             return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.h_proj",
         )
 
         self.hc_eps = config.hc_eps

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -90,6 +90,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             bias=False,
             return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.e_proj",
         )
         self.h_proj = ReplicatedLinear(
             config.hidden_size,
@@ -97,6 +98,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             bias=False,
             return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.h_proj",
         )
 
         self.hc_eps = config.hc_eps

--- a/vllm/models/deepseek_v4/xpu/mtp.py
+++ b/vllm/models/deepseek_v4/xpu/mtp.py
@@ -85,6 +85,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             bias=False,
             return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.e_proj",
         )
         self.h_proj = ReplicatedLinear(
             config.hidden_size,
@@ -92,6 +93,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             bias=False,
             return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.h_proj",
         )
 
         self.hc_eps = config.hc_eps


### PR DESCRIPTION
## Summary

In `vllm/models/deepseek_v4/{nvidia,amd,xpu}/mtp.py`, the `DeepSeekV4MultiTokenPredictorLayer.__init__` creates `e_proj` and `h_proj` (both `ReplicatedLinear`) **without an explicit `prefix=`**. The resulting modules end up with `prefix=""`, and when `compressed_tensors` is the active quant_config, `get_scheme(layer_name="")` raises:

```
ValueError: Unable to find matching target for  in the compressed-tensors config.
```

(The blank module name in the error message is the empty prefix.)

Filed as [#44817](https://github.com/vllm-project/vllm/issues/44817). Related (closed): [#43893](https://github.com/vllm-project/vllm/pull/43893) — @yangsiqt2 proposed an alternative skip-path approach. This PR takes the smaller route — propagate the prefix the parent layer already receives — which is consistent with how the rest of the main DSV4 model passes `prefix=` throughout.

## Why this is not duplicating an existing PR

- **#43893** (closed, by @yangsiqt2): proposed skipping `quant_config` when no MTP-specific quant tensors exist on disk. Reviewer feedback was to fix at the quantizer side. That artifact-side fix is necessary (we shipped it on the model repo) but is **insufficient on its own** — even with correct ignore patterns, an empty layer_name can't be matched. This PR is the complementary vLLM-side change.
- **#44817** (open): the issue this PR closes. No PR currently attached.
- A subsequent BF16-`wo_a` runtime fallback in `nvidia/ops/o_proj.py` (described by @dnhkng on a related HF discussion) is also needed for full end-to-end MTP serve on stock vLLM. That's a separate change (different file, different code path), not addressed here.

## Why this can't be fixed at the artifact

Any ignore regex that matches `""` would also match every other module in the model, including the routed experts that should remain quantized. There is no way to disambiguate from the metadata side; the model code has to pass a non-empty prefix.

## The fix — 6 lines, 3 files

```diff
         self.e_proj = ReplicatedLinear(
             config.hidden_size, config.hidden_size,
             bias=False, return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.e_proj",
         )
         self.h_proj = ReplicatedLinear(
             config.hidden_size, config.hidden_size,
             bias=False, return_bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.h_proj",
         )
```

Applied identically to `nvidia/mtp.py`, `amd/mtp.py`, and `xpu/mtp.py`.

## Tests run + results

Reproduced verbatim and patched on 2× NVIDIA DGX Spark (GB10, SM 12.1a, ARM64/CUDA 13.2), TP=2, with the [`canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP`](https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8-MTP/tree/fix-ignore-runtime-names) artifact (`fix-ignore-runtime-names` branch, an artifact-side companion fix for `shared_experts` / `attn.compressor` runtime-vs-on-disk name mismatch).

**Before this PR:**
```
ValueError: Unable to find matching target for  in the compressed-tensors config.
```

**After this PR:** module construction proceeds past `e_proj`/`h_proj` into the MTP block's `DeepseekV4DecoderLayer`. The remaining failure (a separate `wo_a` BF16 path issue at runtime, described in @dnhkng's [HF discussion #8](https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8/discussions/8) — confirmed independently on GH200 TP=2) is out of scope for this PR and will follow up.

Existing non-MTP DSV4 W4A16+FP8 serve paths are unaffected — this change only adds a `prefix=` kwarg already accepted by the parent constructor; non-MTP serve doesn't construct `DeepSeekV4MultiTokenPredictorLayer` at all.

## AI-assistance disclosure

This PR was drafted with AI assistance (Claude Code). The human submitter (@pasta-paul, Canada Quant Labs) verified the diagnosis end-to-end on hardware — including reproducing the exact `ValueError` on stock vLLM, applying the patched code, and confirming module construction progresses past the prior failure point. The fix is a 6-line mechanical change to propagate an already-received kwarg; the human submitter understands and defends the change.

## Affected artifacts

Any `DeepSeek-V4-*-MTP` checkpoint where the MTP draft tower is intended to be served via `--speculative-config '{"method":"mtp",...}'` with a compressed-tensors quantized main model. Includes the canada-quant `W4A16-FP8-MTP`, `NVFP4-FP8-MTP`, and Pro variants.

## Credit

@yangsiqt2's analysis in #43893 is what first pinned the root cause; this PR is the more surgical version of that fix. @dnhkng's independent reproduction (HF link above) confirmed it.