### PR TITLE
[Bugfix][DeepSeekV4] Add BF16 MTP O-proj fallback for unquantized draft weights

### DIFF
--- a/tests/models/deepseek_v4/test_nvidia_o_proj.py
+++ b/tests/models/deepseek_v4/test_nvidia_o_proj.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+
+def load_o_proj_module():
+    root = Path(__file__).parents[3]
+    module_path = (
+        root / "vllm" / "models" / "deepseek_v4" / "nvidia" / "ops" / "o_proj.py"
+    )
+
+    stub_names = (
+        "vllm.models.deepseek_v4.common.ops",
+        "vllm.platforms",
+        "vllm.utils.deep_gemm",
+    )
+    original_modules = {
+        name: sys.modules.get(name) for name in stub_names if name in sys.modules
+    }
+    missing_modules = {name for name in stub_names if name not in sys.modules}
+    try:
+        common_ops = types.ModuleType("vllm.models.deepseek_v4.common.ops")
+        common_ops.fused_inv_rope_fp8_quant = None
+        sys.modules["vllm.models.deepseek_v4.common.ops"] = common_ops
+
+        platforms = types.ModuleType("vllm.platforms")
+        platforms.current_platform = None
+        sys.modules["vllm.platforms"] = platforms
+
+        deep_gemm = types.ModuleType("vllm.utils.deep_gemm")
+        deep_gemm.fp8_einsum = None
+        sys.modules["vllm.utils.deep_gemm"] = deep_gemm
+
+        spec = importlib.util.spec_from_file_location("test_o_proj", module_path)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, module in original_modules.items():
+            sys.modules[name] = module
+        for name in missing_modules:
+            sys.modules.pop(name, None)
+
+
+o_proj = load_o_proj_module()
+get_fp8_weight_scale = o_proj.get_fp8_weight_scale
+inv_rope_bf16_o_proj = o_proj.inv_rope_bf16_o_proj
+deep_gemm_fp8_o_proj = o_proj.deep_gemm_fp8_o_proj
+
+
+def test_get_fp8_weight_scale_prefers_weight_scale_inv():
+    layer = nn.Module()
+    layer.weight_scale = nn.Parameter(torch.tensor([1.0]), requires_grad=False)
+    layer.weight_scale_inv = nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+
+    assert get_fp8_weight_scale(layer) is layer.weight_scale_inv
+
+
+def test_get_fp8_weight_scale_accepts_weight_scale():
+    layer = nn.Module()
+    layer.weight_scale = nn.Parameter(torch.tensor([1.0]), requires_grad=False)
+
+    assert get_fp8_weight_scale(layer) is layer.weight_scale
+
+
+def test_get_fp8_weight_scale_returns_none_without_scale():
+    assert get_fp8_weight_scale(nn.Module()) is None
+
+
+class FakeWoA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input = None
+
+    def forward(self, x):
+        self.input = x
+        return x[..., :1]
+
+
+def test_inv_rope_bf16_o_proj_uses_unquantized_linear_path():
+    wo_a = FakeWoA()
+    o = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype=torch.bfloat16)
+    cos_sin_cache = torch.tensor([[0.0, 1.0]], dtype=torch.float32)
+    out = inv_rope_bf16_o_proj(
+        o,
+        torch.tensor([0], dtype=torch.long),
+        cos_sin_cache,
+        wo_a,
+        n_groups=1,
+        heads_per_group=1,
+        nope_dim=2,
+        rope_dim=2,
+        o_lora_rank=1,
+    )
+
+    assert out.shape == (1, 1, 1)
+    assert wo_a.input is not None
+    expected = torch.tensor([[[1.0, 2.0, 4.0, -3.0]]], dtype=torch.bfloat16)
+    torch.testing.assert_close(wo_a.input, expected)
+
+
+class FakeGroupedWoA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0, 0.0],
+                    [0.0, 2.0, 0.0, 0.0],
+                ],
+                dtype=torch.bfloat16,
+            ),
+            requires_grad=False,
+        )
+
+
+class FakeSingleGroupWoA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                ],
+                dtype=torch.bfloat16,
+            ),
+            requires_grad=False,
+        )
+
+
+def test_inv_rope_bf16_o_proj_reshapes_flat_grouped_weight():
+    o = torch.tensor(
+        [[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]], dtype=torch.bfloat16
+    )
+    out = inv_rope_bf16_o_proj(
+        o,
+        torch.tensor([0], dtype=torch.long),
+        torch.tensor([[1.0, 0.0]], dtype=torch.float32),
+        FakeGroupedWoA(),
+        n_groups=2,
+        heads_per_group=1,
+        nope_dim=2,
+        rope_dim=2,
+        o_lora_rank=2,
+    )
+
+    expected = torch.tensor([[[1.0, 2.0], [10.0, 12.0]]], dtype=torch.bfloat16)
+    torch.testing.assert_close(out, expected)
+
+
+class FakeWoB(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input = None
+
+    def forward(self, x):
+        self.input = x
+        return x + 1
+
+
+def test_deep_gemm_fp8_o_proj_uses_bf16_fallback_without_scale():
+    wo_b = FakeWoB()
+    out = deep_gemm_fp8_o_proj(
+        torch.tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype=torch.bfloat16),
+        torch.tensor([0], dtype=torch.long),
+        torch.tensor([[1.0, 0.0]], dtype=torch.float32),
+        FakeSingleGroupWoA(),
+        wo_b,
+        n_groups=1,
+        heads_per_group=1,
+        nope_dim=2,
+        rope_dim=2,
+        o_lora_rank=2,
+        einsum_recipe=(1, 128, 128),
+        tma_aligned_scales=False,
+    )
+
+    assert wo_b.input is not None
+    torch.testing.assert_close(
+        wo_b.input, torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16)
+    )
+    torch.testing.assert_close(out, torch.tensor([[2.0, 3.0]], dtype=torch.bfloat16))

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -8,6 +8,88 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import fp8_einsum
 
 
+def get_fp8_weight_scale(layer: nn.Module) -> torch.Tensor | None:
+    if hasattr(layer, "weight_scale_inv"):
+        return layer.weight_scale_inv
+    if hasattr(layer, "weight_scale"):
+        return layer.weight_scale
+    return None
+
+
+def maybe_unpack_linear_output(
+    output: torch.Tensor | tuple[torch.Tensor, torch.Tensor | None],
+) -> torch.Tensor:
+    if isinstance(output, tuple):
+        return output[0]
+    return output
+
+
+def inv_rope_bf16_o_proj(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    wo_a: nn.Module,
+    *,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    o_lora_rank: int,
+) -> torch.Tensor:
+    num_tokens, num_heads, head_dim = o.shape
+    expected_heads = n_groups * heads_per_group
+    expected_head_dim = nope_dim + rope_dim
+    if num_heads != expected_heads:
+        raise ValueError(f"Expected {expected_heads} heads, got {num_heads}.")
+    if head_dim != expected_head_dim:
+        raise ValueError(
+            f"Expected head dimension {expected_head_dim}, got {head_dim}."
+        )
+    if rope_dim % 2 != 0:
+        raise ValueError(f"rope_dim must be even, got {rope_dim}.")
+
+    grouped = o.reshape(num_tokens, n_groups, heads_per_group, head_dim)
+    projected = grouped.clone()
+
+    rope = projected[..., nope_dim:]
+    rope_pairs = rope.reshape(*rope.shape[:-1], rope_dim // 2, 2)
+    cos_sin = cos_sin_cache.index_select(0, positions)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    cos = cos[:, None, None, :, None].to(dtype=rope.dtype)
+    sin = sin[:, None, None, :, None].to(dtype=rope.dtype)
+
+    x0 = rope_pairs[..., 0:1]
+    x1 = rope_pairs[..., 1:2]
+    rope_pairs.copy_(torch.cat((x0 * cos + x1 * sin, x1 * cos - x0 * sin), dim=-1))
+
+    wo_a_weight = getattr(wo_a, "weight", None)
+    wo_a_input_size = (
+        wo_a_weight.shape[-1]
+        if wo_a_weight is not None and wo_a_weight.ndim >= 2
+        else getattr(wo_a, "input_size", heads_per_group * head_dim)
+    )
+    flattened_size = num_heads * head_dim
+    if flattened_size % wo_a_input_size != 0:
+        raise ValueError(
+            "Cannot reshape O-proj input of size "
+            f"{flattened_size} into groups of size {wo_a_input_size}."
+        )
+
+    wo_a_groups = flattened_size // wo_a_input_size
+    wo_a_input = projected.reshape(num_tokens, wo_a_groups, wo_a_input_size)
+
+    if (
+        wo_a_weight is not None
+        and wo_a_weight.ndim == 2
+        and wo_a_weight.shape[0] % o_lora_rank == 0
+        and wo_a_weight.shape[0] // o_lora_rank == wo_a_groups
+    ):
+        grouped_weight = wo_a_weight.reshape(wo_a_groups, o_lora_rank, wo_a_input_size)
+        return torch.einsum("bgi,gri->bgr", wo_a_input, grouped_weight)
+
+    return maybe_unpack_linear_output(wo_a(wo_a_input))
+
+
 def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
     """fp8_einsum recipe + scale layout for the current GPU arch.
 
@@ -43,6 +125,21 @@ def deep_gemm_fp8_o_proj(
     Shared by the FlashMLA and FlashInfer CUDA backends. ``einsum_recipe`` /
     ``tma_aligned_scales`` come from ``compute_fp8_einsum_recipe``.
     """
+    weight_scale = get_fp8_weight_scale(wo_a)
+    if weight_scale is None:
+        z = inv_rope_bf16_o_proj(
+            o,
+            positions,
+            cos_sin_cache,
+            wo_a,
+            n_groups=n_groups,
+            heads_per_group=heads_per_group,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+            o_lora_rank=o_lora_rank,
+        )
+        return wo_b(z.flatten(1))
+
     o_fp8, o_scale = fused_inv_rope_fp8_quant(
         o,
         positions,
@@ -61,7 +158,7 @@ def deep_gemm_fp8_o_proj(
     fp8_einsum(
         "bhr,hdr->bhd",
         (o_fp8, o_scale),
-        (wo_a.weight, wo_a.weight_scale_inv),
+        (wo_a.weight, weight_scale),
         z,
         recipe=einsum_recipe,
     )


### PR DESCRIPTION
## Summary

This PR adds a NVIDIA DeepSeek V4 O-projection fallback for MTP draft blocks whose `wo_a` projection is BF16/unquantized while the target model is FP8/compressed.

Some compressed-tensors DeepSeek V4 artifacts keep the MTP draft tower unquantized. After the draft layer constructs successfully, the current NVIDIA O-proj path assumes `wo_a.weight_scale_inv` exists and always enters the FP8 `fp8_einsum` path. For BF16 MTP draft weights, no FP8 scale tensor is present, so execution fails before generation.

The fix keeps the existing FP8 path when scale metadata exists, and adds a BF16 fallback when it does not:

- detect `weight_scale_inv` / `weight_scale`, returning `None` when neither exists;
- apply inverse RoPE in BF16 for the unquantized fallback path;
- reshape flat grouped `wo_a.weight` into grouped form when applicable;
- run grouped BF16 matmul and continue through `wo_b`.

## Relationship to existing work

This is not intended to duplicate the MTP `prefix=` construction fix in #44837 / #44817. That PR fixes an earlier failure where MTP `e_proj` / `h_proj` are constructed with an empty prefix and compressed-tensors cannot match them.

This PR handles the next failure point after construction succeeds: executing the BF16/unquantized MTP O-proj path on NVIDIA.

Related:

- #44837
- #44817
- #43893
- HF discussion with GH200 validation and Canada-Quant artifact context: https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8/discussions/8

I searched for existing open work around `DeepSeekV4`, `MTP`, `o_proj`, `wo_a.weight_scale_inv`, and BF16 draft weights. I found the prefix/construction PR above, but not an existing PR for this O-proj execution fallback.

## Tests

```bash
/home/grace/vllm-build/vllm/.venv/bin/python -m pytest tests/models/deepseek_v4/test_nvidia_o_proj.py -q
# 6 passed, 16 warnings in 1.13s

uvx ruff check vllm/models/deepseek_v4/nvidia/ops/o_proj.py tests/models/deepseek_v4/test_nvidia_o_proj.py
# All checks passed!

uvx ruff format --check vllm/models/deepseek_v4/nvidia/ops/o_proj.py tests/models/deepseek_v4/test_nvidia_o_proj.py
# 2 files already formatted

git diff --check
# clean
```

## Hardware validation

Locally validated end-to-end on a dual GH200 system with TP=2 using the Canada-Quant `DeepSeek-V4-Flash-W4A16-FP8-MTP` artifact plus the needed artifact/prefix fixes. The BF16 fallback allowed MTP generation to run; best measured point in that setup was MTP3 at ~193 output tok/s versus ~106 output tok/s without MTP.

These benchmark numbers are included only as validation context; this PR is a compatibility bugfix, not a general performance claim.

## AI assistance

AI assistance was used to prepare this patch and PR text. The submitting human should review every changed line and validate the behavior before opening/merging, per `AGENTS.md`.
