### PR TITLE
[Bugfix] Add missing use_mha attribute to EagleMistralLarge3Model

### DIFF
--- a/tests/model_executor/test_eagle_mistral_large3.py
+++ b/tests/model_executor/test_eagle_mistral_large3.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Regression tests for EagleMistralLarge3Model.__init__.
+
+EagleMistralLarge3Model bypasses DeepseekV2Model.__init__ and must
+manually set every attribute that DeepseekV2Model.forward reads.
+This file guards against future drift.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_config(model_type="mistral", qk_nope_head_dim=128, qk_rope_head_dim=64):
+    cfg = MagicMock()
+    cfg.model_type = model_type
+    cfg.qk_nope_head_dim = qk_nope_head_dim
+    cfg.qk_rope_head_dim = qk_rope_head_dim
+    cfg.vocab_size = 32000
+    cfg.hidden_size = 256
+    cfg.num_hidden_layers = 2
+    cfg.rms_norm_eps = 1e-5
+    cfg.first_k_dense_replace = 0
+    return cfg
+
+
+def _make_vllm_config(hf_config):
+    vllm_config = MagicMock()
+    vllm_config.model_config.hf_config = hf_config
+    vllm_config.quant_config = None
+    vllm_config.parallel_config.pipeline_parallel_size = 1
+    return vllm_config
+
+
+@pytest.mark.parametrize(
+    "model_type,qk_nope_head_dim,qk_rope_head_dim,expected_use_mha",
+    [
+        # Mistral Small 4 eagle config: MLA dims set → use_mha=False
+        ("mistral", 128, 64, False),
+        # Both dims zero → treated as MHA
+        ("mistral", 0, 0, True),
+        # deepseek model_type → always MHA regardless of dims
+        ("deepseek", 128, 64, True),
+    ],
+)
+def test_eagle_mistral_large3_use_mha_is_set(
+    model_type, qk_nope_head_dim, qk_rope_head_dim, expected_use_mha
+):
+    """EagleMistralLarge3Model.__init__ must set self.use_mha.
+
+    Regression for: AttributeError: 'EagleMistralLarge3Model' object
+    has no attribute 'use_mha' when serving Mistral Small 4 with EAGLE.
+    """
+    from vllm.model_executor.models.mistral_large_3_eagle import (
+        EagleMistralLarge3Model,
+    )
+
+    hf_config = _make_config(model_type, qk_nope_head_dim, qk_rope_head_dim)
+    vllm_config = _make_vllm_config(hf_config)
+
+    with (
+        patch(
+            "vllm.model_executor.models.mistral_large_3_eagle"
+            ".VocabParallelEmbedding"
+        ),
+        patch(
+            "vllm.model_executor.models.mistral_large_3_eagle"
+            ".DeepseekV2DecoderLayer"
+        ),
+        patch(
+            "vllm.model_executor.models.mistral_large_3_eagle.RowParallelLinear"
+        ),
+        patch("vllm.model_executor.models.mistral_large_3_eagle.RMSNorm"),
+        patch(
+            "vllm.model_executor.models.mistral_large_3_eagle"
+            ".make_empty_intermediate_tensors_factory"
+        ),
+        patch(
+            "vllm.model_executor.models.mistral_large_3_eagle.get_pp_group"
+        ) as mock_pp,
+    ):
+        mock_pp.return_value.world_size = 1
+        model = EagleMistralLarge3Model(vllm_config=vllm_config, prefix="model")
+
+    assert hasattr(model, "use_mha"), (
+        "EagleMistralLarge3Model.__init__ must set self.use_mha; "
+        "DeepseekV2DecoderLayer.forward reads it and crashes if missing."
+    )
+    assert model.use_mha is expected_use_mha, (
+        f"Expected use_mha={expected_use_mha} for model_type={model_type!r}, "
+        f"qk_nope_head_dim={qk_nope_head_dim}, qk_rope_head_dim={qk_rope_head_dim}"
+    )

--- a/vllm/model_executor/models/mistral_large_3_eagle.py
+++ b/vllm/model_executor/models/mistral_large_3_eagle.py
@@ -75,6 +75,10 @@ class EagleMistralLarge3Model(DeepseekV2Model):
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.aux_hidden_state_layers: tuple[int, ...] = ()
+        self.use_mha = config.model_type == "deepseek" or all(
+            getattr(config, dim, 0) == 0
+            for dim in ("qk_nope_head_dim", "qk_rope_head_dim")
+        )
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )

--- a/vllm/model_executor/models/mistral_large_3_eagle.py
+++ b/vllm/model_executor/models/mistral_large_3_eagle.py
@@ -79,6 +79,9 @@ class EagleMistralLarge3Model(DeepseekV2Model):
             getattr(config, dim, 0) == 0
             for dim in ("qk_nope_head_dim", "qk_rope_head_dim")
         )
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts
+        )
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )


### PR DESCRIPTION
## What this PR does

Fixes #44846

`EagleMistralLarge3Model.__init__` calls `nn.Module.__init__(self)` directly, skipping `DeepseekV2Model.__init__`. As a result, `self.use_mha` is never set. When `forward()` calls `super().forward()` into `DeepseekV2Model`, it reads `self.use_mha` inside `DeepseekV2DecoderLayer.forward` and crashes with:

```
AttributeError: 'EagleMistralLarge3Model' object has no attribute 'use_mha'
```

## Fix

Added `self.use_mha` initialization in `EagleMistralLarge3Model.__init__`, using the same logic as `DeepseekV2Model.__init__`:

```python
self.use_mha = config.model_type == "deepseek" or all(
    getattr(config, dim, 0) == 0
    for dim in ("qk_nope_head_dim", "qk_rope_head_dim")
)
```

This is the same pattern already used at three other sites in `deepseek_v2.py` (lines 1114, 1275, 1632).

## Why this is not a duplicate

No existing open PR addresses this issue.

## Test

The fix is a pure attribute initialization — no GPU required to verify correctness. The attribute is set using the same formula as the parent class.
