### PR TITLE
[Bugfix] Fix NanRepr enum comparison in ScalarType.has_nans/is_ieee_754

### DIFF
--- a/vllm/scalar_type.py
+++ b/vllm/scalar_type.py
@@ -206,14 +206,14 @@ class ScalarType:
         return not self._finite_values_only
 
     def has_nans(self) -> bool:
-        return self.nan_repr != NanRepr.NONE.value
+        return self.nan_repr != NanRepr.NONE
 
     def is_ieee_754(self) -> bool:
         """
         If the type is a floating point type that follows IEEE 754
         conventions
         """
-        return self.nan_repr == NanRepr.IEEE_754.value and not self._finite_values_only
+        return self.nan_repr == NanRepr.IEEE_754 and not self._finite_values_only
 
     def __str__(self) -> str:
         """


### PR DESCRIPTION
## Description
Comparing an Enum member to its .value (int) with == always returns False, and != always returns True, for regular Enum types (non-IntEnum). This is because Python's Enum.__eq__ returns NotImplemented when comparing against non-enum types.

## Fix
Remove .value to compare enum members directly. Other methods in the same class already use the correct pattern.