### PR TITLE
[Bugfix] Fix return type annotations for get_json/async_get_json

### DIFF
--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -318,7 +318,7 @@ class HTTPConnection:
 
             return await r.text()
 
-    def get_json(self, url: str, *, timeout: float | None = None) -> str:
+    def get_json(self, url: str, *, timeout: float | None = None) -> Any:
         with self.get_response(url, timeout=timeout) as r:
             r.raise_for_status()
 
@@ -329,7 +329,7 @@ class HTTPConnection:
         url: str,
         *,
         timeout: float | None = None,
-    ) -> str:
+    ) -> Any:
         async with await self.get_async_response(url, timeout=timeout) as r:
             r.raise_for_status()
 


### PR DESCRIPTION
## Description

Both \get_json()\ and \sync_get_json()\ were annotated as returning \str\, but \.json()\ / \wait r.json()\ returns \dict\, \list\, or other JSON-deserialized types (not \str\).

Compare with \get_text()\/\sync_get_text()\ which correctly return \str\ and call \.text()\/\wait r.text()\.

## Fix

Change the return type annotation from \str\ to \Any\ to match the actual behavior.