### PR TITLE
[Bugfix] Use proper ternary in InProcessCoreClient.get_output

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -288,7 +288,7 @@ class InprocClient(EngineCoreClient):
     def get_output(self) -> EngineCoreOutputs:
         outputs, model_executed = self.engine_core.step_fn()
         self.engine_core.post_step(model_executed=model_executed)
-        return outputs and outputs.get(0) or EngineCoreOutputs()
+        return outputs.get(0) if outputs else EngineCoreOutputs()
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.engine_core.get_supported_tasks()


### PR DESCRIPTION
Replace the fragile 'a and b or c' pattern with a proper ternary expression 'b if a else c'. While currently safe because EngineCoreOutputs (msgspec.Struct) is always truthy, this pattern is error-prone and could break if the struct ever becomes falsy.