### PR TITLE
[Bugfix] Refresh forward-context tensors before FULL CUDA graph replay

### DIFF
--- a/tests/compile/test_cudagraph_context_refresh.py
+++ b/tests/compile/test_cudagraph_context_refresh.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+
+import torch
+
+from vllm.compilation.cuda_graph import (
+    _capture_forward_context_tensors,
+    _refresh_captured_forward_context_tensors,
+)
+from vllm.config import DeviceConfig, VllmConfig
+from vllm.forward_context import BatchDescriptor, set_forward_context
+
+
+@dataclass
+class NestedMetadata:
+    seq_lens: torch.Tensor
+    block_tables: torch.Tensor
+
+
+def _make_vllm_config() -> VllmConfig:
+    return VllmConfig(device_config=DeviceConfig("cpu"))
+
+
+def test_cudagraph_replay_refreshes_forward_context_tensors():
+    vllm_config = _make_vllm_config()
+    captured_metadata = {
+        "layer.0": NestedMetadata(
+            seq_lens=torch.tensor([1, 2], dtype=torch.int32),
+            block_tables=torch.tensor([[1, 0], [2, 0]], dtype=torch.int32),
+        )
+    }
+    captured_slot_mapping = {"layer.0": torch.tensor([10, 11], dtype=torch.int32)}
+    captured_descriptor = BatchDescriptor(
+        num_tokens=2,
+        num_reqs=2,
+        uniform=True,
+    )
+
+    with set_forward_context(
+        captured_metadata,
+        vllm_config,
+        slot_mapping=captured_slot_mapping,
+        batch_descriptor=captured_descriptor,
+    ):
+        captured = _capture_forward_context_tensors()
+
+    live_metadata = {
+        "layer.0": NestedMetadata(
+            seq_lens=torch.tensor([7, 8], dtype=torch.int32),
+            block_tables=torch.tensor([[3, 4], [5, 6]], dtype=torch.int32),
+        )
+    }
+    live_slot_mapping = {"layer.0": torch.tensor([20, 21], dtype=torch.int32)}
+    live_descriptor = BatchDescriptor(
+        num_tokens=2,
+        num_reqs=2,
+        uniform=True,
+    )
+
+    with set_forward_context(
+        live_metadata,
+        vllm_config,
+        slot_mapping=live_slot_mapping,
+        batch_descriptor=live_descriptor,
+    ):
+        _refresh_captured_forward_context_tensors(captured)
+
+    assert torch.equal(captured_metadata["layer.0"].seq_lens, torch.tensor([7, 8]))
+    assert torch.equal(
+        captured_metadata["layer.0"].block_tables,
+        torch.tensor([[3, 4], [5, 6]], dtype=torch.int32),
+    )
+    assert torch.equal(captured_slot_mapping["layer.0"], torch.tensor([20, 21]))

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -4,7 +4,7 @@
 import dataclasses
 import weakref
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import ExitStack
 from typing import Any, ClassVar
 from unittest.mock import patch
@@ -129,6 +129,7 @@ class CUDAGraphEntry:
     batch_descriptor: BatchDescriptor
     cudagraph: torch.cuda.CUDAGraph | None = None
     output: Any | None = None
+    captured_forward_context_tensors: Any | None = None
 
     # for cudagraph debugging, track the input addresses
     # during capture, and check if they are the same during replay
@@ -140,6 +141,89 @@ class CUDAGraphOptions:
     debug_log_enable: bool = True
     gc_disable: bool = False
     weak_ref_output: bool = True
+
+
+def _clone_tensor_tree(obj: Any, memo: dict[int, Any] | None = None) -> Any:
+    if memo is None:
+        memo = {}
+    obj_id = id(obj)
+    if obj_id in memo:
+        return memo[obj_id]
+
+    if isinstance(obj, torch.Tensor):
+        memo[obj_id] = obj
+        return obj
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        clone = {}
+        memo[obj_id] = clone
+        for field in dataclasses.fields(obj):
+            clone[field.name] = _clone_tensor_tree(getattr(obj, field.name), memo)
+        return clone
+    if isinstance(obj, Mapping):
+        clone = {}
+        memo[obj_id] = clone
+        for key, value in obj.items():
+            clone[key] = _clone_tensor_tree(value, memo)
+        return clone
+    if isinstance(obj, tuple):
+        clone = tuple(_clone_tensor_tree(value, memo) for value in obj)
+        memo[obj_id] = clone
+        return clone
+    if isinstance(obj, list):
+        clone = [_clone_tensor_tree(value, memo) for value in obj]
+        memo[obj_id] = clone
+        return clone
+    return None
+
+
+def _copy_tensor_tree(src: Any, dst: Any) -> None:
+    if dst is None:
+        return
+    if isinstance(src, torch.Tensor) and isinstance(dst, torch.Tensor):
+        dst.copy_(src)
+        return
+    if dataclasses.is_dataclass(src) and not isinstance(src, type):
+        src = {field.name: getattr(src, field.name) for field in dataclasses.fields(src)}
+    if isinstance(src, Mapping) and isinstance(dst, Mapping):
+        for key, dst_value in dst.items():
+            if key in src:
+                _copy_tensor_tree(src[key], dst_value)
+        return
+    if (
+        isinstance(src, Sequence)
+        and isinstance(dst, Sequence)
+        and not isinstance(src, (str, bytes, bytearray))
+        and not isinstance(dst, (str, bytes, bytearray))
+    ):
+        for src_value, dst_value in zip(src, dst):
+            _copy_tensor_tree(src_value, dst_value)
+
+
+def _capture_forward_context_tensors() -> dict[str, Any]:
+    forward_context = get_forward_context()
+    return {
+        "attn_metadata": _clone_tensor_tree(forward_context.attn_metadata),
+        "slot_mapping": _clone_tensor_tree(forward_context.slot_mapping),
+        "batch_descriptor": _clone_tensor_tree(forward_context.batch_descriptor),
+        "ubatch_slices": _clone_tensor_tree(forward_context.ubatch_slices),
+        "dp_metadata": _clone_tensor_tree(forward_context.dp_metadata),
+        "additional_kwargs": _clone_tensor_tree(forward_context.additional_kwargs),
+    }
+
+
+def _refresh_captured_forward_context_tensors(captured: Any) -> None:
+    if not captured:
+        return
+    forward_context = get_forward_context()
+    _copy_tensor_tree(forward_context.attn_metadata, captured.get("attn_metadata"))
+    _copy_tensor_tree(forward_context.slot_mapping, captured.get("slot_mapping"))
+    _copy_tensor_tree(forward_context.batch_descriptor, captured.get("batch_descriptor"))
+    _copy_tensor_tree(forward_context.ubatch_slices, captured.get("ubatch_slices"))
+    _copy_tensor_tree(forward_context.dp_metadata, captured.get("dp_metadata"))
+    _copy_tensor_tree(
+        forward_context.additional_kwargs,
+        captured.get("additional_kwargs"),
+    )
 
 
 class CUDAGraphWrapper:
@@ -280,6 +364,10 @@ class CUDAGraphWrapper:
                 x.data_ptr() for x in args if isinstance(x, torch.Tensor)
             ]
             entry.input_addresses = input_addresses
+            if self.runtime_mode == CUDAGraphMode.FULL:
+                entry.captured_forward_context_tensors = (
+                    _capture_forward_context_tensors()
+                )
             cudagraph = torch.cuda.CUDAGraph()
 
             with ExitStack() as stack:
@@ -357,5 +445,9 @@ class CUDAGraphWrapper:
         # Sync offloader before replay - ensures any external dependencies
         # from pre-capture prefetches are satisfied.
         get_offloader().sync_prev_onload()
+        if self.runtime_mode == CUDAGraphMode.FULL:
+            _refresh_captured_forward_context_tensors(
+                entry.captured_forward_context_tensors
+            )
         entry.cudagraph.replay()
         return entry.output


### PR DESCRIPTION
## Summary

This PR fixes stale forward-context tensor metadata during FULL CUDA graph replay.

During FULL CUDA graph capture, a graph entry can retain tensor references from the forward context, including attention metadata, slot mappings, batch descriptors, ubatch slices, DP metadata, and additional kwargs. On replay, if the live forward context has changed for the current request or decode step but the captured tensors are not refreshed, the replay can continue with stale metadata.

This patch records the forward-context tensor tree at FULL graph capture time and copies current live forward-context tensor values into the captured tensor tree before each replay.

I checked the currently open CUDA graph/spec-decode PRs and did not find an existing PR that refreshes captured forward-context tensor values before FULL CUDA graph replay. AI assistance was used to prepare this change; the diff and tests were reviewed before submission.

## Why this matters

The issue is triggered when FULL CUDA graph mode is enabled, a graph entry has already been captured for a batch descriptor, a later request or decode step reuses that graph entry, and the live forward context has different tensor metadata values from the tensors captured earlier.

For users, this may show up as a serving-quality issue rather than a startup failure. The engine can start normally and graph capture can complete, but replayed requests may produce incorrect continuations, repetitive or degenerate output under speculative decoding, output that appears to ignore part of the current prompt/context, or unstable quality after warmup/capture.

## What changed

- Add helpers to walk nested forward-context metadata and record tensor references from the captured context.
- Store captured forward-context tensor references on each FULL CUDA graph entry during capture.
- Before `entry.cudagraph.replay()`, copy tensor values from the current live forward context into the captured tensor tree.
- Apply the refresh only to FULL graph entries; PIECEWISE replay, capture sizing, graph mode selection, and attention backend dispatch are unchanged.

## Tests

Added `tests/compile/test_cudagraph_context_refresh.py`, a focused regression unit test for the CUDA graph wrapper. It models captured vs live forward-context tensor metadata and verifies that live tensor values are copied into the captured tensor tree before FULL CUDA graph replay.

Local checks run on the prepared upstream branch:

```bash
git diff --check origin/main..HEAD
.venv/bin/python -m py_compile vllm/compilation/cuda_graph.py tests/compile/test_cudagraph_context_refresh.py
.venv/bin/python -m pytest tests/compile/test_cudagraph_context_refresh.py -q
```

Result: all passed. The targeted pytest result was `1 passed`.

Additional external validation was done in the `vLLM 2080 Ti Definitive` fork on a dual RTX 2080 Ti / SM75 runtime, using Qwen3.6/Gemma speculative decoding serving routes. That route enters FULL graph replay after graph warmup/capture and exercises replay with changing forward-context metadata; after the patch, captured tensors are refreshed before replay.
