### PR TITLE
Fail closed on missing speculative draft probabilities

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -306,6 +306,21 @@ def test_sample_tokens_skips_pp_group_lookup_without_async_scheduling(
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
 
 
+@pytest.mark.skip_global_cleanup
+def test_get_spec_decode_draft_probs_fails_closed_on_missing_prob_row():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner._draft_probs = torch.ones((1, 2, 8), dtype=torch.float32)
+    runner._draft_prob_req_ids = ["req_0"]
+    runner.input_batch = SimpleNamespace(req_ids=["req_0", "req_1"])
+    metadata = SpecDecodeMetadata.make_dummy(
+        [[1], [2]],
+        device=torch.device("cpu"),
+    )
+
+    with pytest.raises(RuntimeError, match="Missing cached draft probabilities"):
+        GPUModelRunner._get_spec_decode_draft_probs(runner, metadata)
+
+
 def test_select_common_block_size_no_valid_option():
     backend_a = _make_mock_backend_for_kernel_block_size([64])
     backend_b = _make_mock_backend_for_kernel_block_size([MultipleOf(16)])

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4790,12 +4790,12 @@ class GPUModelRunner(
                 continue
             row_idx = row_by_req_id.get(req_id)
             if row_idx is None:
-                logger.warning(
-                    "Missing cached draft probabilities for request %s; "
-                    "falling back to legacy speculative rejection behavior.",
-                    req_id,
+                raise RuntimeError(
+                    f"Missing cached draft probabilities for request {req_id}; "
+                    "cannot run exact probabilistic speculative rejection "
+                    "sampling without the draft distribution for every drafted "
+                    "request."
                 )
-                return None
             draft_probs_rows.append(self._draft_probs[row_idx, :num_draft])
 
         if not draft_probs_rows:


### PR DESCRIPTION
## Summary

Fail closed when probabilistic speculative decoding is missing a cached draft-probability row for a request that produced draft tokens.

The rejection sampler needs the draft probability `q(token)` for each drafted token to compute the exact acceptance ratio against the target distribution. If a request has draft tokens but no cached draft-probability row, continuing with `draft_probs=None` silently switches away from the exact probabilistic path for that step.

This PR changes that case from warning-and-fallback to an explicit `RuntimeError`:

- requests with no drafted tokens still do not require draft probabilities
- methods that intentionally provide no draft probabilities at all still return `None` through the existing early return
- only the inconsistent partial-cache case now fails closed

## Duplicate check

I checked for overlapping open work before opening this PR.

I did not find an open issue or PR for any of these exact paths:

- `_get_spec_decode_draft_probs`
- `_draft_prob_req_ids`
- `Missing cached draft probabilities`
- missing draft-probability rows falling back during speculative rejection

AI assistance was used for this change.

## Tests

```bash
.venv/bin/ruff check   vllm/v1/worker/gpu_model_runner.py   tests/v1/worker/test_gpu_model_runner.py

.venv/bin/python -m py_compile   vllm/v1/worker/gpu_model_runner.py   tests/v1/worker/test_gpu_model_runner.py

.venv/bin/python -m pytest -q   tests/v1/worker/test_gpu_model_runner.py::test_get_spec_decode_draft_probs_fails_closed_on_missing_prob_row
```

OpenShift A100 validation: AppWrapper Succeeded, Job Complete, targeted pytest 1 passed.
