### PR TITLE
[Aiter][ROCm]  QKV-split + QK-RMSNorm + RoPE + KV-cache-write fusion

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -446,6 +446,29 @@ def _rocm_aiter_fused_topk_fake(
 # Cache whether aiter supports FP8 MLA parameters
 _AITER_MLA_SUPPORTS_FP8: bool | None = None
 _AITER_HAS_FUSED_QK_RMSNORM: bool | None = None
+_AITER_HAS_FUSED_QK_NORM_ROPE_CACHE: bool | None = None
+
+
+def check_aiter_fused_qk_norm_rope_cache() -> bool:
+    """Check if aiter provides ``fused_qkv_split_qk_norm_rope_cache``.
+
+    The kernel is required by ``fuse_qk_norm_rope_kvcache``; if it is not
+    bundled with the installed AITER, the fusion replacement crashes at
+    first invocation. Callers (e.g. ``enable_qk_norm_rope_kvcache``)
+    should disable the fusion when this returns False so that the auto-
+    enable chain stays image-aware.
+    """
+    global _AITER_HAS_FUSED_QK_NORM_ROPE_CACHE
+    if _AITER_HAS_FUSED_QK_NORM_ROPE_CACHE is None:
+        try:
+            from aiter.ops.triton.rope.fused_qkv_split_qk_norm_rope_cache import (  # noqa: F401
+                fused_qkv_split_qk_norm_rope_cache,
+            )
+
+            _AITER_HAS_FUSED_QK_NORM_ROPE_CACHE = True
+        except (ImportError, ModuleNotFoundError, AttributeError):
+            _AITER_HAS_FUSED_QK_NORM_ROPE_CACHE = False
+    return _AITER_HAS_FUSED_QK_NORM_ROPE_CACHE
 
 
 def check_aiter_fused_qk_rmsnorm() -> bool:
@@ -2437,6 +2460,52 @@ class rocm_aiter_ops:
 
         gemm_afp4wfp4(x_q, weight, x_s, weight_scale.T, out_dtype, y)
         return y
+
+    @staticmethod
+    def triton_qk_norm_rope_kvcache(
+        qkv: torch.Tensor,
+        q_weight: torch.Tensor,
+        k_weight: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        positions: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        is_neox: bool,
+        attn_output_gate: bool,
+        rms_norm_eps: float,
+        k_scale: torch.Tensor | None,
+        v_scale: torch.Tensor | None,
+        kv_cache_layout: str,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        from aiter.ops.triton.rope.fused_qkv_split_qk_norm_rope_cache import (
+            fused_qkv_split_qk_norm_rope_cache,
+        )
+
+        return fused_qkv_split_qk_norm_rope_cache(
+            qkv=qkv,
+            q_weight=q_weight,
+            k_weight=k_weight,
+            cos=cos,
+            sin=sin,
+            positions=positions,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            slot_mapping=slot_mapping,
+            qh=num_heads,
+            kvh=num_kv_heads,
+            head_dim=head_dim,
+            is_neox=is_neox,
+            attn_output_gate=attn_output_gate,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            eps=rms_norm_eps,
+            kv_cache_layout=kv_cache_layout,
+        )
 
     @staticmethod
     def triton_rope_and_cache(

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -7,11 +7,10 @@ import torch
 from torch._higher_order_ops import auto_functionalized
 from torch._ops import OpOverload
 
-from vllm import ir
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.layernorm import RMSNorm, RMSNormGated
+from vllm.model_executor.layers.layernorm import RMSNormGated
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
@@ -222,48 +221,6 @@ class MatcherRMSNormGated(MatcherCustomOp):
             group_size=self.group_size,
             norm_before_gate=self.norm_before_gate,
         )
-
-
-class MatcherRMSNorm(MatcherCustomOp):
-    """Matcher for plain RMS norm (no residual add).
-
-    Dispatches through ``vllm.ir.ops.rms_norm`` so the traced pattern
-    follows the same IR lowering path as the model's ``RMSNorm`` layer
-    (native / vllm_c / aiter / oink / ...), whichever one the current
-    ``IrOpPriorityConfig`` selects.  This keeps the pattern aligned with
-    whatever impl actually appears in the target graph at runtime; callers
-    therefore do not need to register per-backend variants.
-    """
-
-    def __init__(
-        self,
-        epsilon: float,
-        enabled: bool | None = None,
-    ) -> None:
-        if enabled is None:
-            enabled = RMSNorm.enabled()
-
-        super().__init__(enabled)
-        self.epsilon = epsilon
-
-    def inputs(self) -> list[torch.Tensor]:
-        input = self.empty(5, 16) if self.enabled else self.empty_f32(5, 16)
-        weight = self.empty(16)
-        return [input, weight]
-
-    def forward_custom(
-        self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
-    ) -> torch.Tensor:
-        return ir.ops.rms_norm(input, weight, self.epsilon)
-
-    def forward_native(
-        self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
-    ) -> torch.Tensor:
-        return ir.ops.rms_norm(input, weight, self.epsilon)
 
 
 class MatcherDeepseekScalingRotaryEmbedding(MatcherCustomOp):

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -93,6 +93,8 @@ class MatcherRotaryEmbedding(MatcherCustomOp):
         use_flashinfer: bool = False,
         match_rocm_aiter: bool | None = None,
         enabled: bool | None = None,
+        rope_dim_offset: int = 0,
+        inverse: bool = False,
     ) -> None:
         if enabled is None:
             enabled = RotaryEmbedding.enabled()
@@ -107,6 +109,8 @@ class MatcherRotaryEmbedding(MatcherCustomOp):
         self.q_size = self.num_heads * self.head_size
         self.kv_size = self.num_kv_heads * self.head_size
         self.rotary_dim = head_size
+        self.rope_dim_offset = rope_dim_offset
+        self.inverse = inverse
         if use_flashinfer:
             self.rotary_op = FLASHINFER_ROTARY_OP
         elif match_rocm_aiter:
@@ -136,6 +140,8 @@ class MatcherRotaryEmbedding(MatcherCustomOp):
             head_size=self.head_size,
             cos_sin_cache=cos_sin_cache,
             is_neox=self.is_neox,
+            rope_dim_offset=self.rope_dim_offset,
+            inverse=self.inverse,
         )
         query_out = result[1]
         key_out = result[2] if len(result) > 2 else None

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -7,10 +7,11 @@ import torch
 from torch._higher_order_ops import auto_functionalized
 from torch._ops import OpOverload
 
+from vllm import ir
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.layernorm import RMSNormGated
+from vllm.model_executor.layers.layernorm import RMSNorm, RMSNormGated
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
@@ -221,6 +222,48 @@ class MatcherRMSNormGated(MatcherCustomOp):
             group_size=self.group_size,
             norm_before_gate=self.norm_before_gate,
         )
+
+
+class MatcherRMSNorm(MatcherCustomOp):
+    """Matcher for plain RMS norm (no residual add).
+
+    Dispatches through ``vllm.ir.ops.rms_norm`` so the traced pattern
+    follows the same IR lowering path as the model's ``RMSNorm`` layer
+    (native / vllm_c / aiter / oink / ...), whichever one the current
+    ``IrOpPriorityConfig`` selects.  This keeps the pattern aligned with
+    whatever impl actually appears in the target graph at runtime; callers
+    therefore do not need to register per-backend variants.
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        enabled: bool | None = None,
+    ) -> None:
+        if enabled is None:
+            enabled = RMSNorm.enabled()
+
+        super().__init__(enabled)
+        self.epsilon = epsilon
+
+    def inputs(self) -> list[torch.Tensor]:
+        input = self.empty(5, 16) if self.enabled else self.empty_f32(5, 16)
+        weight = self.empty(16)
+        return [input, weight]
+
+    def forward_custom(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        return ir.ops.rms_norm(input, weight, self.epsilon)
+
+    def forward_native(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        return ir.ops.rms_norm(input, weight, self.epsilon)
 
 
 class MatcherDeepseekScalingRotaryEmbedding(MatcherCustomOp):

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -557,22 +557,24 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
         match_rocm_aiter_rope: bool,
         **extra_kwargs,
     ) -> None:
-        # The pattern's traced ``eps`` literal is collapsed to ``Ignored()``
-        # by ``torch._inductor.pattern_matcher.fx_to_pattern`` (it elides
-        # Python float constants on match), so a single registration matches
-        # every eps value at apply time. Iterating eps here only produces
-        # duplicate patterns that the matcher rejects. ``is_neox`` is the
-        # only axis that changes the rotary op recorded in the traced graph
-        # (different ops for is_neox True/False), so its registrations are
-        # structurally distinct.
-        for neox in [True, False]:
-            pattern_cls(
-                layer=layer,
-                eps=1e-6,
-                is_neox=neox,
-                match_rocm_aiter_rope=match_rocm_aiter_rope,
-                **extra_kwargs,
-            ).register(self.patterns)
+        # Register the common RMSNorm epsilons, mirroring the sibling
+        # ``qk_norm_rope_fusion`` and ``sequence_parallelism`` passes. On torch
+        # versions where ``fx_to_pattern`` elides Python float constants the
+        # eps slot collapses to ``Ignored()`` and the second eps is a harmless
+        # duplicate that the matcher de-duplicates; on versions that preserve
+        # the literal these explicit registrations are what let both 1e-5 and
+        # 1e-6 models match. ``is_neox`` changes the rotary op recorded in the
+        # traced graph (distinct ops for True/False), so those registrations
+        # are always structurally distinct.
+        for eps in [1e-5, 1e-6]:
+            for neox in [True, False]:
+                pattern_cls(
+                    layer=layer,
+                    eps=eps,
+                    is_neox=neox,
+                    match_rocm_aiter_rope=match_rocm_aiter_rope,
+                    **extra_kwargs,
+                ).register(self.patterns)
 
     @enable_fake_mode
     def __init__(self, config: VllmConfig) -> None:

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -83,9 +83,26 @@ def fused_triton_qk_norm_rope_kvcache_update_impl(
     rdh = cos_sin_cache.shape[-1] // 2
     # Delegate to the attention backend's KV split: ROCM_AITER_UNIFIED_ATTN
     # places K/V on dim 1 ((num_blocks, 2, ...)), older backends on dim 0.
-    # `_split_kv_cache` is the canonical accessor and is also used by the
-    # sibling rope_kvcache_fusion pass via attn_layer.impl.
-    key_cache, value_cache = attn_layer.impl._split_kv_cache(kv_cache)  # type: ignore[attr-defined]
+    # ``_split_kv_cache`` is the canonical accessor and is also used by the
+    # sibling rope_kvcache_fusion pass via ``attn_layer.impl``. The leading
+    # underscore reflects that this is currently a per-impl convention
+    # rather than a stable base-class API; we keep using it (consistent
+    # with the sibling pass) but wrap the access with an actionable error
+    # so a non-AITER impl reaching this code path produces a clear
+    # message instead of a confusing AttributeError on a private name.
+    impl = attn_layer.impl
+    split_kv_cache = getattr(impl, "_split_kv_cache", None)
+    if split_kv_cache is None:
+        raise AttributeError(
+            f"QK-Norm+RoPE+KVCache fusion: attention impl "
+            f"{type(impl).__name__} for layer {layer_name} does not "
+            f"provide a `_split_kv_cache(kv_cache)` method (expected on "
+            f"ROCm AITER unified attention). Disable the fusion via "
+            f"--compilation-config "
+            f"'pass_config:{{fuse_qk_norm_rope_kvcache:false}}', or pin "
+            f"--attention_backend=ROCM_AITER_UNIFIED_ATTN."
+        )
+    key_cache, value_cache = split_kv_cache(kv_cache)
 
     # Mirror the unfused FP8-KV path (rocm_aiter_unified_attn.do_kv_cache_update
     # via reshape_and_cache_flash): when --kv-cache-dtype fp8 is in effect, the
@@ -99,8 +116,38 @@ def fused_triton_qk_norm_rope_kvcache_update_impl(
         key_cache = key_cache.view(fp8_dtype)
         value_cache = value_cache.view(fp8_dtype)
 
-    k_scale_f = getattr(attn_layer, "_k_scale_float", 1.0)
-    v_scale_f = getattr(attn_layer, "_v_scale_float", 1.0)
+    # ``_k_scale_float`` / ``_v_scale_float`` are populated by
+    # ``Attention.__init__`` (live model load) from checkpoint scales --
+    # ``1.0`` for uncalibrated checkpoints, the loaded value otherwise.
+    # When ``kv_cache_dtype != "auto"`` (i.e. quantized KV) these are
+    # required for correctness: the AITER kernel uses them to dequantize
+    # K/V before writing to the fp8 cache. A missing attribute here
+    # would silently apply identity scaling and corrupt the stored KV;
+    # raise instead.
+    if kv_cache_dtype != "auto":
+        if not hasattr(attn_layer, "_k_scale_float") or not hasattr(
+            attn_layer, "_v_scale_float"
+        ):
+            raise AttributeError(
+                f"QK-Norm+RoPE+KVCache fusion: layer {layer_name} has "
+                f"kv_cache_dtype={kv_cache_dtype!r} but is missing "
+                f"`_k_scale_float` / `_v_scale_float`. The fused kernel "
+                f"cannot safely write quantized KV without scales."
+            )
+        k_scale_f = attn_layer._k_scale_float
+        v_scale_f = attn_layer._v_scale_float
+    else:
+        # No KV quantization in effect; ``getattr`` default of 1.0 is
+        # safe since the kernel skips scale ops on ``None`` and a 1.0
+        # scale is a no-op.
+        k_scale_f = getattr(attn_layer, "_k_scale_float", 1.0)
+        v_scale_f = getattr(attn_layer, "_v_scale_float", 1.0)
+    # Pass ``None`` for unit scale (kernel skips the scale ops); pass a
+    # tensor otherwise. Crucially, when ``kv_cache_dtype != "auto"`` and
+    # the loaded scale happens to equal 1.0 (uncalibrated checkpoint),
+    # ``None`` and ``tensor(1.0)`` are equivalent because the kernel's
+    # scale path is multiplicative -- the unfused FP8-KV path follows
+    # the same convention.
     k_scale_t = (
         None
         if k_scale_f == 1.0
@@ -622,11 +669,31 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
         finally:
             pm.fx_to_pattern = _orig_fx_to_pat
 
-        logger.info(
-            "QK-Norm+RoPE+KVCache fusion: replaced %s pattern(s) "
-            "with AITER fused_qkv_split_qk_norm_rope_cache",
-            self.matched_count,
-        )
+        if self.matched_count == 0:
+            # The pass-manager already gates on ``is_applicable_for_range``
+            # (compile ranges above ``rope_kvcache_fusion_max_token_num``),
+            # so reaching this branch with zero matches means the fusion
+            # was enabled (gate / dtype / AITER / kernel availability all
+            # passed) and at least one pattern was registered, but nothing
+            # matched the live graph. Likely causes: torch version drift in
+            # ``pm.fx_to_pattern`` (see the ``ignore_types`` relaxation
+            # above), upstream model FX-graph refactor, or an unsupported
+            # combination of compile flags (e.g. prefix caching enabled --
+            # the pattern was traced without it).
+            logger.warning_once(
+                "QK-Norm+RoPE+KVCache fusion registered patterns but matched "
+                "0 in the live graph. Fusion is enabled but inactive; falling "
+                "back to the unfused QK-norm + RoPE + KV-cache path. Possible "
+                "causes: torch._inductor.pattern_matcher API drift, upstream "
+                "model FX-graph changes, or prefix caching enabled (the "
+                "pattern was traced without it)."
+            )
+        else:
+            logger.info(
+                "QK-Norm+RoPE+KVCache fusion: replaced %s pattern(s) "
+                "with AITER fused_qkv_split_qk_norm_rope_cache",
+                self.matched_count,
+            )
 
     def is_applicable_for_range(self, compile_range: Range) -> bool:
         return compile_range.end <= self.max_token_num

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -97,7 +97,26 @@ def fused_triton_qk_norm_rope_kvcache_update_impl(
         else torch.tensor(v_scale_f, dtype=torch.float32, device=qkv.device)
     )
 
-    kv_layout = "HND" if key_cache.shape[1] == num_kv_heads else "NHD"
+    # This fusion pass is gated to ROCm + AITER + Qwen3-Next, where
+    # ``RocmAiterUnifiedAttentionBackend.get_kv_cache_shape`` returns
+    # ``(num_blocks, 2, block_size, num_kv_heads, head_size)``. After
+    # ``_split_kv_cache`` (split on dim 1), each of ``key_cache`` and
+    # ``value_cache`` has shape
+    # ``(num_blocks, block_size, num_kv_heads, head_size)`` -- i.e. NHD.
+    # Assert the invariant rather than inferring layout from a shape
+    # coincidence (the previous heuristic ``shape[1] == num_kv_heads``
+    # silently picks the wrong layout if a backend's ``block_size``
+    # happens to equal ``num_kv_heads``). If a future backend with HND
+    # storage is added to the gate, this will fail loud at first
+    # invocation and the layout-determination needs to be revisited
+    # (e.g. via a ``kv_cache_layout`` accessor on the attention impl).
+    assert key_cache.shape[-2] == num_kv_heads, (
+        f"QK-Norm+RoPE+KVCache fusion expects NHD KV layout "
+        f"(.., num_kv_heads, head_size); got shape "
+        f"{tuple(key_cache.shape)} with num_kv_heads={num_kv_heads} "
+        f"for layer {layer_name}."
+    )
+    kv_layout = "NHD"
 
     # Qwen3-Next uses GemmaRMSNorm which applies ``(1 + weight)`` to the
     # weight before the norm. The traced pattern matches the ``.float() +

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -15,7 +15,7 @@ from vllm.model_executor.layers.attention.attention import (
     Attention,
     get_attention_context,
 )
-from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
     LayerNameType,
@@ -65,7 +65,23 @@ def fused_triton_qk_norm_rope_kvcache_update_impl(
         return dummy, q, k, v, gate
 
     rdh = cos_sin_cache.shape[-1] // 2
-    key_cache, value_cache = kv_cache.unbind(0)
+    # Delegate to the attention backend's KV split: ROCM_AITER_UNIFIED_ATTN
+    # places K/V on dim 1 ((num_blocks, 2, ...)), older backends on dim 0.
+    # `_split_kv_cache` is the canonical accessor and is also used by the
+    # sibling rope_kvcache_fusion pass via attn_layer.impl.
+    key_cache, value_cache = attn_layer.impl._split_kv_cache(kv_cache)  # type: ignore[attr-defined]
+
+    # Mirror the unfused FP8-KV path (rocm_aiter_unified_attn.do_kv_cache_update
+    # via reshape_and_cache_flash): when --kv-cache-dtype fp8 is in effect, the
+    # KV cache storage dtype is torch.uint8 (raw bytes), and the AITER triton
+    # kernel's `tl.store(... k.to(key_cache_ptr.dtype.element_ty))` would
+    # truncate bf16 K/V values to uint8 instead of fp8e4m3 -- destroying KV.
+    # View-cast to the platform fp8 dtype so the kernel's element_ty is fp8.
+    kv_cache_dtype = getattr(attn_layer, "kv_cache_dtype", "auto")
+    if kv_cache_dtype != "auto" and key_cache.dtype == torch.uint8:
+        fp8_dtype = current_platform.fp8_dtype()
+        key_cache = key_cache.view(fp8_dtype)
+        value_cache = value_cache.view(fp8_dtype)
 
     k_scale_f = getattr(attn_layer, "_k_scale_float", 1.0)
     v_scale_f = getattr(attn_layer, "_v_scale_float", 1.0)
@@ -81,6 +97,12 @@ def fused_triton_qk_norm_rope_kvcache_update_impl(
     )
 
     kv_layout = "HND" if key_cache.shape[1] == num_kv_heads else "NHD"
+
+    # Qwen3-Next uses GemmaRMSNorm which applies ``(1 + weight)`` to the
+    # weight before the norm. The traced pattern matches the ``.float() +
+    # 1.0`` op so it is consumed by the match; the AITER kernel applies
+    # the same ``(1.0 + weight)`` adjustment internally, so we pass the
+    # raw weight here.
 
     q, gate, k, v = rocm_aiter_ops.triton_qk_norm_rope_kvcache(
         qkv=qkv,
@@ -142,20 +164,19 @@ direct_register_custom_op(
 
 
 class Qwen3NextQkNormRopeKvCachePattern:
-    """Extend ``QkNormRopeKvCachePattern`` for the Qwen3Next attention layout.
+    """Match QK-norm + RoPE + KV-cache-update and replace with a fused kernel.
 
-    When *attn_output_gate* is True the QKV projection emits
-    ``[q||gate, k, v]`` where the q portion is doubled.  The pattern
-    matches the gate extraction (view -> chunk -> clone) before the
-    standard QK-norm + RoPE + KV-cache sequence.  The replacement
-    delegates to the Triton-based ``fused_qkv_split_qk_norm_rope_cache``
-    kernel which handles the split, norm, RoPE, gate extraction, and KV
-    cache update in a single launch.
+    When ``attn_output_gate`` is True the QKV projection emits
+    ``[q || gate, k, v]`` (q portion doubled); the pattern matches the gate
+    extraction (view -> chunk -> contiguous) before the QK-norm + RoPE + KV
+    cache sequence. The replacement delegates to the Triton-based
+    ``fused_qkv_split_qk_norm_rope_cache`` kernel, which handles split,
+    norm, RoPE, gate extraction, and KV-cache update in a single launch.
 
-    Qwen3Next uses GemmaRMSNorm which applies ``(1 + weight)`` before the
-    norm.  The pattern includes the ``.float() + 1.0`` nodes so they are
-    consumed; the fused op receives the raw weight and applies the
-    adjustment internally.
+    Qwen3-Next uses ``GemmaRMSNorm`` which applies ``(1 + weight)`` to the
+    weight before the norm. The pattern includes the ``.float() + 1.0`` op
+    so it is consumed by the match; the fused op receives the raw weight
+    and applies the adjustment internally.
     """
 
     FUSED_OP = torch.ops.vllm.fused_triton_qk_norm_rope_kvcache_update.default
@@ -210,13 +231,24 @@ class Qwen3NextQkNormRopeKvCachePattern:
             inputs.append(_encode_layer_name(self.layer_name))
         return inputs
 
-    def _mk_pattern_with_layer_name_input(self):
-        """Pattern/replacement with layer_name as an explicit graph input.
+    # ------------------------------------------------------------------
+    # Shared pattern / replacement bodies
+    # ------------------------------------------------------------------
+    #
+    # ``layer_name`` is the only thing that differs between the two
+    # registration paths below (``_USE_LAYERNAME`` True vs False); keeping
+    # the q/k/v ops here in a single helper ensures the two paths cannot
+    # silently diverge.
 
-        Used when ``_USE_LAYERNAME`` is True (torch >= 2.11): layer names are
-        hoisted as opaque graph inputs so a single pattern matches every
-        attention layer without per-layer registration.
-        """
+    def _make_pattern_body(
+        self,
+        qkv: torch.Tensor,
+        positions: torch.Tensor,
+        q_weight: torch.Tensor,
+        k_weight: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        layer_name,
+    ):
         num_heads = self.num_heads
         num_kv_heads = self.num_kv_heads
         head_dim = self.head_size
@@ -224,111 +256,117 @@ class Qwen3NextQkNormRopeKvCachePattern:
         q_size = self.q_size
         k_size = self.k_size
         v_size = self.v_size
-        eps = self.eps
-        is_neox = self.is_neox
-        attn_output_gate = self.attn_output_gate
 
-        rmsnorm_matcher = self.rmsnorm_matcher
-        rope_matcher = self.rope_matcher
-        FUSED_OP = self.FUSED_OP
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
 
-        if attn_output_gate:
+            q_gate_3d = q_gate.view(-1, num_heads, 2 * head_dim)
+            q_3d, gate_3d = q_gate_3d.chunk(2, dim=-1)
 
-            def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name):
-                q_gate, k, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
+            # ``chunk`` produces a non-contiguous view; the model emits a
+            # ``clone(memory_format=contiguous_format)`` here. Use
+            # ``contiguous`` so the trace records the same clone op,
+            # then call rms_norm directly on the 3D tensor (no reshape
+            # round-trip and no dtype cast -- the model has neither).
+            q_3d = q_3d.contiguous()
+            q_w = q_weight.float() + 1.0
+            q_normed = self.rmsnorm_matcher(q_3d, q_w)
+            q_normed_flat = q_normed.view(-1, q_size)
 
-                q_gate_3d = q_gate.view(-1, num_heads, 2 * head_dim)
-                q_3d, gate_3d = q_gate_3d.chunk(2, dim=-1)
+            k_3d = k.view(-1, num_kv_heads, head_dim)
+            k_w = k_weight.float() + 1.0
+            k_normed = self.rmsnorm_matcher(k_3d, k_w)
+            k_flat = k_normed.view(-1, k_size)
 
-                q_3d = q_3d.contiguous()
-                q_w = q_weight.float() + 1.0
-                q_normed = rmsnorm_matcher(q_3d, q_w)
-                q_normed_flat = q_normed.view(-1, q_size)
+            q_rope, k_rope = self.rope_matcher(
+                positions, q_normed_flat, k_flat, cos_sin_cache
+            )
 
-                k_3d = k.view(-1, num_kv_heads, head_dim)
-                k_w = k_weight.float() + 1.0
-                k_normed = rmsnorm_matcher(k_3d, k_w)
-                k_flat = k_normed.view(-1, k_size)
+            k_rope_3d = k_rope.view(-1, num_kv_heads, head_dim)
+            v_3d = v.view(-1, num_kv_heads, head_dim_v)
+            dummy = torch.ops.vllm.unified_kv_cache_update(k_rope_3d, v_3d, layer_name)
+            return dummy, q_rope, k_rope_3d, v_3d, gate_3d
 
-                q_rope, k_rope = rope_matcher(
-                    positions, q_normed_flat, k_flat, cos_sin_cache
-                )
+        q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
 
-                q_rope = q_rope.view(-1, num_heads, head_dim)
-                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
-                v = v.view(-1, num_kv_heads, head_dim_v)
-                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, layer_name)
-                return dummy, q_rope, k_rope, v, gate_3d
+        q_by_head = q.view(-1, q_size // head_dim, head_dim)
+        q_w = q_weight.float() + 1.0
+        q_normed = self.rmsnorm_matcher(q_by_head, q_w)
+        q_flat = q_normed.view(-1, q_size)
 
-            def replacement(
-                qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name
-            ):
-                results = FUSED_OP(
-                    qkv=qkv,
-                    positions=positions,
-                    q_weight=q_weight,
-                    k_weight=k_weight,
-                    rms_norm_eps=eps,
-                    cos_sin_cache=cos_sin_cache,
-                    is_neox=is_neox,
-                    attn_output_gate=True,
-                    num_heads=num_heads,
-                    num_kv_heads=num_kv_heads,
-                    head_dim=head_dim,
-                    layer_name=layer_name,
-                )
+        k_by_head = k.view(-1, k_size // head_dim, head_dim)
+        k_w = k_weight.float() + 1.0
+        k_normed = self.rmsnorm_matcher(k_by_head, k_w)
+        k_flat = k_normed.view(-1, k_size)
 
-                _, _, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
-                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
+        q_rope, k_rope = self.rope_matcher(positions, q_flat, k_flat, cos_sin_cache)
 
-                return results[0], results[1], results[2], v, results[4]
+        k_rope_3d = k_rope.view(-1, num_kv_heads, head_dim)
+        v_3d = v.view(-1, num_kv_heads, head_dim_v)
+        dummy = torch.ops.vllm.unified_kv_cache_update(k_rope_3d, v_3d, layer_name)
+        return dummy, q_rope, k_rope_3d, v_3d
+
+    def _make_replacement_body(
+        self,
+        qkv: torch.Tensor,
+        positions: torch.Tensor,
+        q_weight: torch.Tensor,
+        k_weight: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        layer_name,
+    ):
+        results = self.FUSED_OP(
+            qkv=qkv,
+            positions=positions,
+            q_weight=q_weight,
+            k_weight=k_weight,
+            rms_norm_eps=self.eps,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=self.is_neox,
+            attn_output_gate=self.attn_output_gate,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_dim=self.head_size,
+            layer_name=layer_name,
+        )
+
+        if self.attn_output_gate:
+            split_sizes = [self.q_size * 2, self.k_size, self.v_size]
         else:
+            split_sizes = [self.q_size, self.k_size, self.v_size]
+        _, _, v = qkv.split(split_sizes, dim=-1)
+        v = v.view(qkv.shape[0], self.num_kv_heads, self.head_size_v)
 
-            def pattern(  # type: ignore[misc]
+        # The pattern's q_rope is 2D (post-rope, pre-reshape) so the
+        # replacement must return q in the same 2D shape; the fused op
+        # produces (T, num_heads, head_dim) so view it back to (T, q_size).
+        q_rope_2d = results[1].view(qkv.shape[0], self.q_size)
+
+        if self.attn_output_gate:
+            return results[0], q_rope_2d, results[2], v, results[4]
+        return results[0], q_rope_2d, results[2], v
+
+    # ------------------------------------------------------------------
+    # Pattern / replacement variants for the two ``_USE_LAYERNAME`` modes
+    # ------------------------------------------------------------------
+
+    def _mk_pattern_with_layer_name_input(self):
+        """Pattern/replacement with layer_name as an explicit graph input.
+
+        Used when ``_USE_LAYERNAME`` is True (torch >= 2.11): layer names
+        are hoisted as opaque graph inputs so a single pattern matches
+        every attention layer without per-layer registration.
+        """
+
+        def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name):
+            return self._make_pattern_body(
                 qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name
-            ):
-                q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
+            )
 
-                q_by_head = q.view(-1, q_size // head_dim, head_dim)
-                q_w = q_weight.float() + 1.0
-                q_normed = rmsnorm_matcher(q_by_head, q_w)
-                q_flat = q_normed.view(-1, q_size)
-
-                k_by_head = k.view(-1, k_size // head_dim, head_dim)
-                k_w = k_weight.float() + 1.0
-                k_normed = rmsnorm_matcher(k_by_head, k_w)
-                k_flat = k_normed.view(-1, k_size)
-
-                q_rope, k_rope = rope_matcher(positions, q_flat, k_flat, cos_sin_cache)
-
-                q_rope = q_rope.view(-1, num_heads, head_dim)
-                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
-                v = v.view(-1, num_kv_heads, head_dim_v)
-                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, layer_name)
-                return dummy, q_rope, k_rope, v
-
-            def replacement(  # type: ignore[misc]
+        def replacement(qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name):
+            return self._make_replacement_body(
                 qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name
-            ):
-                results = FUSED_OP(
-                    qkv=qkv,
-                    positions=positions,
-                    q_weight=q_weight,
-                    k_weight=k_weight,
-                    rms_norm_eps=eps,
-                    cos_sin_cache=cos_sin_cache,
-                    is_neox=is_neox,
-                    attn_output_gate=False,
-                    num_heads=num_heads,
-                    num_kv_heads=num_kv_heads,
-                    head_dim=head_dim,
-                    layer_name=layer_name,
-                )
-
-                _, _, v = qkv.split([q_size, k_size, v_size], dim=-1)
-                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
-
-                return results[0], results[1], results[2], v
+            )
 
         return pattern, replacement
 
@@ -339,121 +377,24 @@ class Qwen3NextQkNormRopeKvCachePattern:
         ``VLLM_USE_LAYERNAME=0``): each layer's pattern bakes its own
         ``_ln`` so per-layer registration is required.
         """
-        num_heads = self.num_heads
-        num_kv_heads = self.num_kv_heads
-        head_dim = self.head_size
-        head_dim_v = self.head_size_v
-        q_size = self.q_size
-        k_size = self.k_size
-        v_size = self.v_size
-        eps = self.eps
-        is_neox = self.is_neox
-        attn_output_gate = self.attn_output_gate
 
-        rmsnorm_matcher = self.rmsnorm_matcher
-        rope_matcher = self.rope_matcher
-        FUSED_OP = self.FUSED_OP
+        def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache):
+            return self._make_pattern_body(
+                qkv, positions, q_weight, k_weight, cos_sin_cache, _ln
+            )
 
-        if attn_output_gate:
-
-            def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache):
-                q_gate, k, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
-
-                q_gate_3d = q_gate.view(-1, num_heads, 2 * head_dim)
-                q_3d, gate_3d = q_gate_3d.chunk(2, dim=-1)
-
-                q_3d = q_3d.contiguous()
-                q_w = q_weight.float() + 1.0
-                q_normed = rmsnorm_matcher(q_3d, q_w)
-                q_normed_flat = q_normed.view(-1, q_size)
-
-                k_3d = k.view(-1, num_kv_heads, head_dim)
-                k_w = k_weight.float() + 1.0
-                k_normed = rmsnorm_matcher(k_3d, k_w)
-                k_flat = k_normed.view(-1, k_size)
-
-                q_rope, k_rope = rope_matcher(
-                    positions, q_normed_flat, k_flat, cos_sin_cache
-                )
-
-                q_rope = q_rope.view(-1, num_heads, head_dim)
-                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
-                v = v.view(-1, num_kv_heads, head_dim_v)
-                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, _ln)
-                return dummy, q_rope, k_rope, v, gate_3d
-
-            def replacement(qkv, positions, q_weight, k_weight, cos_sin_cache):
-                results = FUSED_OP(
-                    qkv=qkv,
-                    positions=positions,
-                    q_weight=q_weight,
-                    k_weight=k_weight,
-                    rms_norm_eps=eps,
-                    cos_sin_cache=cos_sin_cache,
-                    is_neox=is_neox,
-                    attn_output_gate=True,
-                    num_heads=num_heads,
-                    num_kv_heads=num_kv_heads,
-                    head_dim=head_dim,
-                    layer_name=_ln,
-                )
-
-                _, _, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
-                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
-
-                return results[0], results[1], results[2], v, results[4]
-        else:
-
-            def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache):  # type: ignore[misc]
-                q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
-
-                q_by_head = q.view(-1, q_size // head_dim, head_dim)
-                q_w = q_weight.float() + 1.0
-                q_normed = rmsnorm_matcher(q_by_head, q_w)
-                q_flat = q_normed.view(-1, q_size)
-
-                k_by_head = k.view(-1, k_size // head_dim, head_dim)
-                k_w = k_weight.float() + 1.0
-                k_normed = rmsnorm_matcher(k_by_head, k_w)
-                k_flat = k_normed.view(-1, k_size)
-
-                q_rope, k_rope = rope_matcher(positions, q_flat, k_flat, cos_sin_cache)
-
-                q_rope = q_rope.view(-1, num_heads, head_dim)
-                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
-                v = v.view(-1, num_kv_heads, head_dim_v)
-                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, _ln)
-                return dummy, q_rope, k_rope, v
-
-            def replacement(qkv, positions, q_weight, k_weight, cos_sin_cache):  # type: ignore[misc]
-                results = FUSED_OP(
-                    qkv=qkv,
-                    positions=positions,
-                    q_weight=q_weight,
-                    k_weight=k_weight,
-                    rms_norm_eps=eps,
-                    cos_sin_cache=cos_sin_cache,
-                    is_neox=is_neox,
-                    attn_output_gate=False,
-                    num_heads=num_heads,
-                    num_kv_heads=num_kv_heads,
-                    head_dim=head_dim,
-                    layer_name=_ln,
-                )
-
-                _, _, v = qkv.split([q_size, k_size, v_size], dim=-1)
-                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
-
-                return results[0], results[1], results[2], v
+        def replacement(qkv, positions, q_weight, k_weight, cos_sin_cache):
+            return self._make_replacement_body(
+                qkv, positions, q_weight, k_weight, cos_sin_cache, _ln
+            )
 
         return pattern, replacement
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
-        _ln = _encode_layer_name(self.layer_name)
-
         if _USE_LAYERNAME:
             pattern, replacement = self._mk_pattern_with_layer_name_input()
         else:
+            _ln = _encode_layer_name(self.layer_name)
             pattern, replacement = self._mk_pattern_with_layer_name_closure(_ln)
 
         def fwd_and_view_to_reshape(*args, **kwargs) -> fx.GraphModule:
@@ -479,7 +420,7 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
     """
     Fuse QK-norm + RoPE + KV cache update into a single AITER Triton kernel.
 
-    Registers Qwen3NextQkNormRopeKvCachePattern for attention layers on
+    Registers ``Qwen3NextQkNormRopeKvCachePattern`` for attention layers on
     ROCm with AITER enabled. The Triton kernel handles QKV split, QK-norm,
     RoPE, gate extraction, and KV cache update in a single launch.
     """
@@ -491,13 +432,14 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
         match_rocm_aiter_rope: bool,
         **extra_kwargs,
     ) -> None:
-        # The pattern's traced ``eps`` literal is collapsed to ``Ignored()`` by
-        # ``torch._inductor.pattern_matcher.fx_to_pattern`` (it elides Python
-        # float constants on match), so a single registration matches every
-        # eps value at apply time. Iterating eps here only produces duplicate
-        # patterns that the matcher rejects. Only ``is_neox`` is iterated --
-        # it parameterizes the actual rotary op used in the traced graph
-        # (different ops for is_neox True/False), so patterns are distinct.
+        # The pattern's traced ``eps`` literal is collapsed to ``Ignored()``
+        # by ``torch._inductor.pattern_matcher.fx_to_pattern`` (it elides
+        # Python float constants on match), so a single registration matches
+        # every eps value at apply time. Iterating eps here only produces
+        # duplicate patterns that the matcher rejects. ``is_neox`` is the
+        # only axis that changes the rotary op recorded in the traced graph
+        # (different ops for is_neox True/False), so its registrations are
+        # structurally distinct.
         for neox in [True, False]:
             pattern_cls(
                 layer=layer,
@@ -533,27 +475,15 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
 
         attn_layers = get_layers_from_vllm_config(config, Attention)
 
-        rope_custom_enabled = cc.is_custom_op_enabled("rotary_embedding")
-        rms_custom_enabled = cc.is_custom_op_enabled("rms_norm")
-        logger.debug(
-            "QkNormRopeKvCacheFusionPass init: "
-            "RotaryEmbedding.enabled()=%s, rope_custom_enabled=%s, "
-            "RMSNorm custom_op_enabled=%s",
-            RotaryEmbedding.enabled(),
-            rope_custom_enabled,
-            rms_custom_enabled,
-        )
-
-        # Register a pattern only for the rope op that will actually appear
-        # in the traced model graph at runtime. ``MatcherRotaryEmbedding``
-        # resolves the same way as the live model layer, so iterating
+        # Resolve the rope op once: ``MatcherRotaryEmbedding`` resolves
+        # ``rotary_op`` the same way as the live model layer, so iterating
         # match_rocm_aiter_rope ∈ {True, False} would generate two
         # registrations that resolve to the same rope op under
         # ``VLLM_ROCM_USE_AITER_TRITON_ROPE=1`` and trip
         # ``check_and_add_duplicate_pattern``.
         match_rocm_aiter_rope = rocm_aiter_ops.is_triton_rotary_embed_enabled()
 
-        # When _USE_LAYERNAME is enabled, layer_name is hoisted as an
+        # When ``_USE_LAYERNAME`` is enabled, layer_name is hoisted as an
         # opaque graph input so every layer produces the same pattern --
         # register once per shape and break out of the per-layer loop.
         for _, layer in attn_layers.items():
@@ -571,15 +501,18 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
-        # ``fx_to_pattern`` is called twice in torch's pattern-matcher lifecycle:
-        # once at registration (with a hard-coded
-        # ``ignore_types=(int, float, list, torch.device, torch.dtype)``) so the
-        # registered patterns have ``Ignored()`` in int-typed slots (reshape
-        # dims, split sizes, head_size, etc.), and once at apply time with the
-        # default empty ``ignore_types`` (``pattern_matcher.py:1548``). Without
-        # the wrapper below, the apply-time fingerprint preserves the model
-        # graph's concrete ``int``/``SymInt`` values and never matches the
-        # ``Ignored()`` slots in the registered patterns -- yielding 0 matches.
+        # ``torch._inductor.pattern_matcher.fx_to_pattern`` is invoked twice
+        # in the matcher lifecycle: at ``register_replacement`` time it is
+        # called with ``ignore_types=(int, float, list, torch.device,
+        # torch.dtype)`` so int constants in the registered pattern (split
+        # sizes, view dims, head_size, etc.) become ``Ignored()``. At apply
+        # time (``pattern_matcher.py:1548`` in torch 2.10) it is called with
+        # the default empty ``ignore_types``, which preserves the live FX
+        # graph's concrete ``SymInt`` values. Without this wrapper the
+        # apply-time fingerprint never matches the ``Ignored()`` slots in
+        # the registered pattern -- yielding 0 matches for every layer.
+        # Once vLLM moves to torch >= 2.11 this becomes unnecessary, but
+        # the rest of this pass already supports both modes.
         _orig_fx_to_pat = pm.fx_to_pattern
 
         def _relaxed_fx_to_pattern(*a, **kw):

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -8,7 +8,7 @@ from torch._inductor.fx_passes.post_grad import view_to_reshape
 from torch._inductor.pattern_matcher import PatternMatcherPass
 
 from vllm import ir
-from vllm._aiter_ops import rocm_aiter_ops
+from vllm._aiter_ops import check_aiter_fused_qk_norm_rope_cache, rocm_aiter_ops
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.utils import Range
 from vllm.logger import init_logger
@@ -196,6 +196,20 @@ class Qwen3NextQkNormRopeKvCachePattern:
         self.num_kv_heads = layer.num_kv_heads
         self.head_size = layer.head_size
         self.head_size_v = layer.head_size_v
+        # The fused AITER kernel takes a single ``head_dim`` argument and
+        # uses it for both K and V (see ``triton_qk_norm_rope_kvcache`` in
+        # ``vllm/_aiter_ops.py`` and the kernel's ``head_dim`` parameter).
+        # If a future model added to ``_QK_NORM_MODEL_TYPES`` has an
+        # asymmetric V head dim, the kernel would split V using the K
+        # head_dim and silently corrupt the V cache. Fail loud at
+        # registration so the gate has to be revisited rather than
+        # producing numerically-silent wrong KV writes.
+        assert self.head_size_v == self.head_size, (
+            f"fused_triton_qk_norm_rope_kvcache_update assumes "
+            f"head_size_v == head_size; got {self.head_size_v} != "
+            f"{self.head_size} for layer {self.layer_name}. The AITER "
+            f"kernel has no separate head_dim_v argument."
+        )
         self.eps = eps
         self.is_neox = is_neox
         self.rope_flashinfer = rope_flashinfer
@@ -470,6 +484,20 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
         if not rocm_aiter_ops.is_enabled():
             logger.warning_once(
                 "QK Norm+RoPE+KVCache fusion not enabled: AITER not available"
+            )
+            return
+
+        # The config-level auto-enable in ``enable_qk_norm_rope_kvcache``
+        # already calls ``check_aiter_fused_qk_norm_rope_cache``, but a user
+        # who explicitly sets ``pass_config.fuse_qk_norm_rope_kvcache=True``
+        # bypasses that callable -- without this guard we would register
+        # patterns and only crash at first invocation when the fused kernel
+        # is dispatched.
+        if not check_aiter_fused_qk_norm_rope_cache():
+            logger.warning_once(
+                "QK Norm+RoPE+KVCache fusion not enabled: bundled AITER "
+                "does not provide aiter.ops.triton.rope."
+                "fused_qkv_split_qk_norm_rope_cache"
             )
             return
 

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Callable
+
 import torch
 import torch._inductor.pattern_matcher as pm
 from torch import fx
@@ -32,6 +34,10 @@ from .rms_quant_fusion import empty_bf16, empty_fp32, empty_i64
 
 logger = init_logger(__name__)
 
+# Pattern body / replacement body return tuples of varying arity (4 or 5
+# tensors depending on ``attn_output_gate``); typed as ``tuple[Tensor, ...]``.
+_PatternFn = Callable[..., tuple[torch.Tensor, ...]]
+
 
 # ---------------------------------------------------------------------------
 # Custom op: Triton-based fused QKV split + QK-norm + RoPE + KV cache update
@@ -59,6 +65,15 @@ def fused_triton_qk_norm_rope_kvcache_update_impl(
     dummy = torch.empty(0, device=qkv.device, dtype=qkv.dtype)
 
     if layer_slot_mapping is None:
+        # Profiling / dummy-run path: there is no real KV cache to write into,
+        # so we return uninitialized output tensors that just satisfy the
+        # downstream graph's shape/dtype expectations. The values are never
+        # read (callers gate on profile mode upstream); ``empty`` is used
+        # over ``zeros`` to avoid a needless device kernel during profiling.
+        # ``gate`` is always materialized -- even when ``attn_output_gate``
+        # is False the replacement returns it as a 5-tuple element which
+        # downstream consumers ignore -- to keep the kernel signature
+        # invariant across ``Qwen3NextQkNormRopeKvCachePattern`` variants.
         q = torch.empty(T, num_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
         k = torch.empty(T, num_kv_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
         v = torch.empty(T, num_kv_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
@@ -229,6 +244,24 @@ class Qwen3NextQkNormRopeKvCachePattern:
             f"{self.head_size} for layer {self.layer_name}. The AITER "
             f"kernel has no separate head_dim_v argument."
         )
+        # The traced pattern (``MatcherRotaryEmbedding`` + the AITER fused
+        # kernel below) assumes ``rotary_dim == head_size`` -- i.e. fully
+        # rotary. A partial-rotary layer (``rotary_dim < head_size``, e.g.
+        # GLM-style models with rotary applied only to the first half of
+        # the head) would produce a different rope op that does not match
+        # the registered pattern and would also be miscomputed by the
+        # fused kernel (it has no ``rotary_dim`` parameter). Fail loud at
+        # registration so a future model added to ``_QK_NORM_MODEL_TYPES``
+        # is forced to either provide a partial-rotary variant or stay off
+        # this fusion.
+        rotary_emb = getattr(layer, "rotary_emb", None)
+        rotary_dim = getattr(rotary_emb, "rotary_dim", self.head_size)
+        assert rotary_dim == self.head_size, (
+            f"fused_triton_qk_norm_rope_kvcache_update assumes fully-rotary "
+            f"layers (rotary_dim == head_size); got rotary_dim={rotary_dim} "
+            f"!= head_size={self.head_size} for layer {self.layer_name}. The "
+            f"AITER kernel has no rotary_dim argument."
+        )
         self.eps = eps
         self.is_neox = is_neox
         self.rope_flashinfer = rope_flashinfer
@@ -247,7 +280,7 @@ class Qwen3NextQkNormRopeKvCachePattern:
             match_rocm_aiter=match_rocm_aiter_rope,
         )
 
-    def get_inputs(self) -> list:
+    def get_inputs(self) -> list[torch.Tensor]:
         T = 5
         L = 4096
         q_portion = self.q_size * 2 if self.attn_output_gate else self.q_size
@@ -259,7 +292,7 @@ class Qwen3NextQkNormRopeKvCachePattern:
             cos_sin_cache = empty_fp32(L, self.head_size)
         else:
             cos_sin_cache = empty_bf16(L, self.head_size)
-        inputs: list = [qkv, positions, q_weight, k_weight, cos_sin_cache]
+        inputs: list[torch.Tensor] = [qkv, positions, q_weight, k_weight, cos_sin_cache]
         if _USE_LAYERNAME:
             inputs.append(_encode_layer_name(self.layer_name))
         return inputs
@@ -280,8 +313,8 @@ class Qwen3NextQkNormRopeKvCachePattern:
         q_weight: torch.Tensor,
         k_weight: torch.Tensor,
         cos_sin_cache: torch.Tensor,
-        layer_name,
-    ):
+        layer_name: LayerNameType,
+    ) -> tuple[torch.Tensor, ...]:
         num_heads = self.num_heads
         num_kv_heads = self.num_kv_heads
         head_dim = self.head_size
@@ -298,9 +331,17 @@ class Qwen3NextQkNormRopeKvCachePattern:
 
             # ``chunk`` produces a non-contiguous view; the model emits a
             # ``clone(memory_format=contiguous_format)`` here. Use
-            # ``contiguous`` so the trace records the same clone op,
-            # then call rms_norm directly on the 3D tensor (no reshape
-            # round-trip and no dtype cast -- the model has neither).
+            # ``contiguous`` so the trace records the same clone op.
+            #
+            # The model uses ``GemmaRMSNorm`` whose forward path on the live
+            # graph is ``chunk -> reshape(2D) -> norm -> view(3D)``, but
+            # ``view_to_reshape`` (applied at registration via
+            # ``fwd_and_view_to_reshape``) and the inductor's reshape
+            # canonicalization rewrite both legs to the equivalent
+            # ``view``-of-3D form recorded here. Calling ``ir.ops.rms_norm``
+            # directly on the 3D tensor (no explicit ``reshape`` round-trip,
+            # no ``.float()/.bf16()`` cast pair) matches that canonical form
+            # for both NeoX and AITER rope variants.
             q_3d = q_3d.contiguous()
             q_w = q_weight.float() + 1.0
             q_normed = ir.ops.rms_norm(q_3d, q_w, self.eps)
@@ -346,8 +387,8 @@ class Qwen3NextQkNormRopeKvCachePattern:
         q_weight: torch.Tensor,
         k_weight: torch.Tensor,
         cos_sin_cache: torch.Tensor,
-        layer_name,
-    ):
+        layer_name: LayerNameType,
+    ) -> tuple[torch.Tensor, ...]:
         results = self.FUSED_OP(
             qkv=qkv,
             positions=positions,
@@ -383,7 +424,9 @@ class Qwen3NextQkNormRopeKvCachePattern:
     # Pattern / replacement variants for the two ``_USE_LAYERNAME`` modes
     # ------------------------------------------------------------------
 
-    def _mk_pattern_with_layer_name_input(self):
+    def _mk_pattern_with_layer_name_input(
+        self,
+    ) -> tuple[_PatternFn, _PatternFn]:
         """Pattern/replacement with layer_name as an explicit graph input.
 
         Used when ``_USE_LAYERNAME`` is True (torch >= 2.11): layer names
@@ -403,7 +446,9 @@ class Qwen3NextQkNormRopeKvCachePattern:
 
         return pattern, replacement
 
-    def _mk_pattern_with_layer_name_closure(self, _ln):
+    def _mk_pattern_with_layer_name_closure(
+        self, _ln: LayerNameType
+    ) -> tuple[_PatternFn, _PatternFn]:
         """Pattern/replacement with layer_name as a closure constant.
 
         Used when ``_USE_LAYERNAME`` is False (torch < 2.11 or
@@ -495,7 +540,12 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
 
         dtype = config.model_config.dtype
         if dtype not in (torch.bfloat16, torch.float16):
-            logger.warning_once(
+            # Most fp32 / int dtype configurations are intentional (e.g.
+            # debug / accuracy investigations on small CPU runs), so this
+            # is debug rather than warning -- the auto-enable callable in
+            # ``enable_qk_norm_rope_kvcache`` already considers this and
+            # will not flip the gate on for unsupported dtypes.
+            logger.debug(
                 "QK Norm+RoPE+KVCache fusion not enabled: unsupported dtype %s", dtype
             )
             return
@@ -574,7 +624,7 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
 
         logger.info(
             "QK-Norm+RoPE+KVCache fusion: replaced %s pattern(s) "
-            "with AITER fused_qk_norm_rope_cache_pts_quant_shuffle",
+            "with AITER fused_qkv_split_qk_norm_rope_cache",
             self.matched_count,
         )
 

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -7,6 +7,7 @@ from torch import fx
 from torch._inductor.fx_passes.post_grad import view_to_reshape
 from torch._inductor.pattern_matcher import PatternMatcherPass
 
+from vllm import ir
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.utils import Range
@@ -26,7 +27,7 @@ from vllm.utils.torch_utils import (
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
-from .matcher_utils import MatcherRMSNorm, MatcherRotaryEmbedding
+from .matcher_utils import MatcherRotaryEmbedding
 from .rms_quant_fusion import empty_bf16, empty_fp32, empty_i64
 
 logger = init_logger(__name__)
@@ -204,7 +205,6 @@ class Qwen3NextQkNormRopeKvCachePattern:
         self.k_size = self.num_kv_heads * self.head_size
         self.v_size = self.num_kv_heads * self.head_size_v
 
-        self.rmsnorm_matcher = MatcherRMSNorm(eps)
         self.rope_matcher = MatcherRotaryEmbedding(
             is_neox=is_neox,
             head_size=self.head_size,
@@ -270,12 +270,12 @@ class Qwen3NextQkNormRopeKvCachePattern:
             # round-trip and no dtype cast -- the model has neither).
             q_3d = q_3d.contiguous()
             q_w = q_weight.float() + 1.0
-            q_normed = self.rmsnorm_matcher(q_3d, q_w)
+            q_normed = ir.ops.rms_norm(q_3d, q_w, self.eps)
             q_normed_flat = q_normed.view(-1, q_size)
 
             k_3d = k.view(-1, num_kv_heads, head_dim)
             k_w = k_weight.float() + 1.0
-            k_normed = self.rmsnorm_matcher(k_3d, k_w)
+            k_normed = ir.ops.rms_norm(k_3d, k_w, self.eps)
             k_flat = k_normed.view(-1, k_size)
 
             q_rope, k_rope = self.rope_matcher(
@@ -291,12 +291,12 @@ class Qwen3NextQkNormRopeKvCachePattern:
 
         q_by_head = q.view(-1, q_size // head_dim, head_dim)
         q_w = q_weight.float() + 1.0
-        q_normed = self.rmsnorm_matcher(q_by_head, q_w)
+        q_normed = ir.ops.rms_norm(q_by_head, q_w, self.eps)
         q_flat = q_normed.view(-1, q_size)
 
         k_by_head = k.view(-1, k_size // head_dim, head_dim)
         k_w = k_weight.float() + 1.0
-        k_normed = self.rmsnorm_matcher(k_by_head, k_w)
+        k_normed = ir.ops.rms_norm(k_by_head, k_w, self.eps)
         k_flat = k_normed.view(-1, k_size)
 
         q_rope, k_rope = self.rope_matcher(positions, q_flat, k_flat, cos_sin_cache)

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -1,0 +1,605 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch._inductor.pattern_matcher as pm
+from torch import fx
+from torch._inductor.fx_passes.post_grad import view_to_reshape
+from torch._inductor.pattern_matcher import PatternMatcherPass
+
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config.utils import Range
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.attention import (
+    Attention,
+    get_attention_context,
+)
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+from vllm.utils.torch_utils import (
+    _USE_LAYERNAME,
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+
+from ..inductor_pass import enable_fake_mode
+from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
+from .matcher_utils import MatcherRMSNorm, MatcherRotaryEmbedding
+from .rms_quant_fusion import empty_bf16, empty_fp32, empty_i64
+
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Custom op: Triton-based fused QKV split + QK-norm + RoPE + KV cache update
+# ---------------------------------------------------------------------------
+
+
+def fused_triton_qk_norm_rope_kvcache_update_impl(
+    qkv: torch.Tensor,
+    positions: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rms_norm_eps: float,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    attn_output_gate: bool,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    layer_name: LayerNameType,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    layer_name = _resolve_layer_name(layer_name)
+    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
+
+    T = qkv.shape[0]
+    dummy = torch.empty(0, device=qkv.device, dtype=qkv.dtype)
+
+    if layer_slot_mapping is None:
+        q = torch.empty(T, num_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+        k = torch.empty(T, num_kv_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+        v = torch.empty(T, num_kv_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+        gate = torch.empty(T, num_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+        return dummy, q, k, v, gate
+
+    rdh = cos_sin_cache.shape[-1] // 2
+    key_cache, value_cache = kv_cache.unbind(0)
+
+    k_scale_f = getattr(attn_layer, "_k_scale_float", 1.0)
+    v_scale_f = getattr(attn_layer, "_v_scale_float", 1.0)
+    k_scale_t = (
+        None
+        if k_scale_f == 1.0
+        else torch.tensor(k_scale_f, dtype=torch.float32, device=qkv.device)
+    )
+    v_scale_t = (
+        None
+        if v_scale_f == 1.0
+        else torch.tensor(v_scale_f, dtype=torch.float32, device=qkv.device)
+    )
+
+    kv_layout = "HND" if key_cache.shape[1] == num_kv_heads else "NHD"
+
+    q, gate, k, v = rocm_aiter_ops.triton_qk_norm_rope_kvcache(
+        qkv=qkv,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        cos=cos_sin_cache[:, :rdh],
+        sin=cos_sin_cache[:, rdh:],
+        positions=positions,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        slot_mapping=layer_slot_mapping,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        is_neox=is_neox,
+        attn_output_gate=attn_output_gate,
+        rms_norm_eps=rms_norm_eps,
+        k_scale=k_scale_t,
+        v_scale=v_scale_t,
+        kv_cache_layout=kv_layout,
+    )
+    return dummy, q, k, v, gate
+
+
+def fused_triton_qk_norm_rope_kvcache_update_fake(
+    qkv: torch.Tensor,
+    positions: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    rms_norm_eps: float,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    attn_output_gate: bool,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    layer_name: LayerNameType,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    T = qkv.shape[0]
+    dummy = torch.empty(0, device=qkv.device, dtype=qkv.dtype)
+    q = torch.empty(T, num_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+    k = torch.empty(T, num_kv_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+    v = torch.empty(T, num_kv_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+    gate = torch.empty(T, num_heads, head_dim, device=qkv.device, dtype=qkv.dtype)
+    return dummy, q, k, v, gate
+
+
+direct_register_custom_op(
+    op_name="fused_triton_qk_norm_rope_kvcache_update",
+    op_func=fused_triton_qk_norm_rope_kvcache_update_impl,
+    mutates_args=[],
+    fake_impl=fused_triton_qk_norm_rope_kvcache_update_fake,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pattern: Qwen3Next QK-norm + RoPE + unified_kv_cache_update (with gate)
+# ---------------------------------------------------------------------------
+
+
+class Qwen3NextQkNormRopeKvCachePattern:
+    """Extend ``QkNormRopeKvCachePattern`` for the Qwen3Next attention layout.
+
+    When *attn_output_gate* is True the QKV projection emits
+    ``[q||gate, k, v]`` where the q portion is doubled.  The pattern
+    matches the gate extraction (view -> chunk -> clone) before the
+    standard QK-norm + RoPE + KV-cache sequence.  The replacement
+    delegates to the Triton-based ``fused_qkv_split_qk_norm_rope_cache``
+    kernel which handles the split, norm, RoPE, gate extraction, and KV
+    cache update in a single launch.
+
+    Qwen3Next uses GemmaRMSNorm which applies ``(1 + weight)`` before the
+    norm.  The pattern includes the ``.float() + 1.0`` nodes so they are
+    consumed; the fused op receives the raw weight and applies the
+    adjustment internally.
+    """
+
+    FUSED_OP = torch.ops.vllm.fused_triton_qk_norm_rope_kvcache_update.default
+
+    def __init__(
+        self,
+        layer: Attention,
+        eps: float,
+        is_neox: bool,
+        attn_output_gate: bool,
+        rope_flashinfer: bool = False,
+        match_rocm_aiter_rope: bool = False,
+    ) -> None:
+        self.layer_name = layer.layer_name
+        self.num_heads = layer.num_heads
+        self.num_kv_heads = layer.num_kv_heads
+        self.head_size = layer.head_size
+        self.head_size_v = layer.head_size_v
+        self.eps = eps
+        self.is_neox = is_neox
+        self.rope_flashinfer = rope_flashinfer
+        self.attn_output_gate = attn_output_gate
+
+        self.q_size = self.num_heads * self.head_size
+        self.k_size = self.num_kv_heads * self.head_size
+        self.v_size = self.num_kv_heads * self.head_size_v
+
+        self.rmsnorm_matcher = MatcherRMSNorm(eps)
+        self.rope_matcher = MatcherRotaryEmbedding(
+            is_neox=is_neox,
+            head_size=self.head_size,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            use_flashinfer=rope_flashinfer,
+            match_rocm_aiter=match_rocm_aiter_rope,
+        )
+
+    def get_inputs(self) -> list:
+        T = 5
+        L = 4096
+        q_portion = self.q_size * 2 if self.attn_output_gate else self.q_size
+        qkv = empty_bf16(T, q_portion + self.k_size + self.v_size)
+        positions = empty_i64(T)
+        q_weight = empty_bf16(self.head_size)
+        k_weight = empty_bf16(self.head_size)
+        if self.rope_flashinfer:
+            cos_sin_cache = empty_fp32(L, self.head_size)
+        else:
+            cos_sin_cache = empty_bf16(L, self.head_size)
+        inputs: list = [qkv, positions, q_weight, k_weight, cos_sin_cache]
+        if _USE_LAYERNAME:
+            inputs.append(_encode_layer_name(self.layer_name))
+        return inputs
+
+    def _mk_pattern_with_layer_name_input(self):
+        """Pattern/replacement with layer_name as an explicit graph input.
+
+        Used when ``_USE_LAYERNAME`` is True (torch >= 2.11): layer names are
+        hoisted as opaque graph inputs so a single pattern matches every
+        attention layer without per-layer registration.
+        """
+        num_heads = self.num_heads
+        num_kv_heads = self.num_kv_heads
+        head_dim = self.head_size
+        head_dim_v = self.head_size_v
+        q_size = self.q_size
+        k_size = self.k_size
+        v_size = self.v_size
+        eps = self.eps
+        is_neox = self.is_neox
+        attn_output_gate = self.attn_output_gate
+
+        rmsnorm_matcher = self.rmsnorm_matcher
+        rope_matcher = self.rope_matcher
+        FUSED_OP = self.FUSED_OP
+
+        if attn_output_gate:
+
+            def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name):
+                q_gate, k, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
+
+                q_gate_3d = q_gate.view(-1, num_heads, 2 * head_dim)
+                q_3d, gate_3d = q_gate_3d.chunk(2, dim=-1)
+
+                q_3d = q_3d.contiguous()
+                q_w = q_weight.float() + 1.0
+                q_normed = rmsnorm_matcher(q_3d, q_w)
+                q_normed_flat = q_normed.view(-1, q_size)
+
+                k_3d = k.view(-1, num_kv_heads, head_dim)
+                k_w = k_weight.float() + 1.0
+                k_normed = rmsnorm_matcher(k_3d, k_w)
+                k_flat = k_normed.view(-1, k_size)
+
+                q_rope, k_rope = rope_matcher(
+                    positions, q_normed_flat, k_flat, cos_sin_cache
+                )
+
+                q_rope = q_rope.view(-1, num_heads, head_dim)
+                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
+                v = v.view(-1, num_kv_heads, head_dim_v)
+                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, layer_name)
+                return dummy, q_rope, k_rope, v, gate_3d
+
+            def replacement(
+                qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name
+            ):
+                results = FUSED_OP(
+                    qkv=qkv,
+                    positions=positions,
+                    q_weight=q_weight,
+                    k_weight=k_weight,
+                    rms_norm_eps=eps,
+                    cos_sin_cache=cos_sin_cache,
+                    is_neox=is_neox,
+                    attn_output_gate=True,
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    layer_name=layer_name,
+                )
+
+                _, _, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
+                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
+
+                return results[0], results[1], results[2], v, results[4]
+        else:
+
+            def pattern(  # type: ignore[misc]
+                qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name
+            ):
+                q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
+
+                q_by_head = q.view(-1, q_size // head_dim, head_dim)
+                q_w = q_weight.float() + 1.0
+                q_normed = rmsnorm_matcher(q_by_head, q_w)
+                q_flat = q_normed.view(-1, q_size)
+
+                k_by_head = k.view(-1, k_size // head_dim, head_dim)
+                k_w = k_weight.float() + 1.0
+                k_normed = rmsnorm_matcher(k_by_head, k_w)
+                k_flat = k_normed.view(-1, k_size)
+
+                q_rope, k_rope = rope_matcher(positions, q_flat, k_flat, cos_sin_cache)
+
+                q_rope = q_rope.view(-1, num_heads, head_dim)
+                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
+                v = v.view(-1, num_kv_heads, head_dim_v)
+                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, layer_name)
+                return dummy, q_rope, k_rope, v
+
+            def replacement(  # type: ignore[misc]
+                qkv, positions, q_weight, k_weight, cos_sin_cache, layer_name
+            ):
+                results = FUSED_OP(
+                    qkv=qkv,
+                    positions=positions,
+                    q_weight=q_weight,
+                    k_weight=k_weight,
+                    rms_norm_eps=eps,
+                    cos_sin_cache=cos_sin_cache,
+                    is_neox=is_neox,
+                    attn_output_gate=False,
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    layer_name=layer_name,
+                )
+
+                _, _, v = qkv.split([q_size, k_size, v_size], dim=-1)
+                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
+
+                return results[0], results[1], results[2], v
+
+        return pattern, replacement
+
+    def _mk_pattern_with_layer_name_closure(self, _ln):
+        """Pattern/replacement with layer_name as a closure constant.
+
+        Used when ``_USE_LAYERNAME`` is False (torch < 2.11 or
+        ``VLLM_USE_LAYERNAME=0``): each layer's pattern bakes its own
+        ``_ln`` so per-layer registration is required.
+        """
+        num_heads = self.num_heads
+        num_kv_heads = self.num_kv_heads
+        head_dim = self.head_size
+        head_dim_v = self.head_size_v
+        q_size = self.q_size
+        k_size = self.k_size
+        v_size = self.v_size
+        eps = self.eps
+        is_neox = self.is_neox
+        attn_output_gate = self.attn_output_gate
+
+        rmsnorm_matcher = self.rmsnorm_matcher
+        rope_matcher = self.rope_matcher
+        FUSED_OP = self.FUSED_OP
+
+        if attn_output_gate:
+
+            def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache):
+                q_gate, k, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
+
+                q_gate_3d = q_gate.view(-1, num_heads, 2 * head_dim)
+                q_3d, gate_3d = q_gate_3d.chunk(2, dim=-1)
+
+                q_3d = q_3d.contiguous()
+                q_w = q_weight.float() + 1.0
+                q_normed = rmsnorm_matcher(q_3d, q_w)
+                q_normed_flat = q_normed.view(-1, q_size)
+
+                k_3d = k.view(-1, num_kv_heads, head_dim)
+                k_w = k_weight.float() + 1.0
+                k_normed = rmsnorm_matcher(k_3d, k_w)
+                k_flat = k_normed.view(-1, k_size)
+
+                q_rope, k_rope = rope_matcher(
+                    positions, q_normed_flat, k_flat, cos_sin_cache
+                )
+
+                q_rope = q_rope.view(-1, num_heads, head_dim)
+                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
+                v = v.view(-1, num_kv_heads, head_dim_v)
+                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, _ln)
+                return dummy, q_rope, k_rope, v, gate_3d
+
+            def replacement(qkv, positions, q_weight, k_weight, cos_sin_cache):
+                results = FUSED_OP(
+                    qkv=qkv,
+                    positions=positions,
+                    q_weight=q_weight,
+                    k_weight=k_weight,
+                    rms_norm_eps=eps,
+                    cos_sin_cache=cos_sin_cache,
+                    is_neox=is_neox,
+                    attn_output_gate=True,
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    layer_name=_ln,
+                )
+
+                _, _, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
+                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
+
+                return results[0], results[1], results[2], v, results[4]
+        else:
+
+            def pattern(qkv, positions, q_weight, k_weight, cos_sin_cache):  # type: ignore[misc]
+                q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
+
+                q_by_head = q.view(-1, q_size // head_dim, head_dim)
+                q_w = q_weight.float() + 1.0
+                q_normed = rmsnorm_matcher(q_by_head, q_w)
+                q_flat = q_normed.view(-1, q_size)
+
+                k_by_head = k.view(-1, k_size // head_dim, head_dim)
+                k_w = k_weight.float() + 1.0
+                k_normed = rmsnorm_matcher(k_by_head, k_w)
+                k_flat = k_normed.view(-1, k_size)
+
+                q_rope, k_rope = rope_matcher(positions, q_flat, k_flat, cos_sin_cache)
+
+                q_rope = q_rope.view(-1, num_heads, head_dim)
+                k_rope = k_rope.view(-1, num_kv_heads, head_dim)
+                v = v.view(-1, num_kv_heads, head_dim_v)
+                dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, _ln)
+                return dummy, q_rope, k_rope, v
+
+            def replacement(qkv, positions, q_weight, k_weight, cos_sin_cache):  # type: ignore[misc]
+                results = FUSED_OP(
+                    qkv=qkv,
+                    positions=positions,
+                    q_weight=q_weight,
+                    k_weight=k_weight,
+                    rms_norm_eps=eps,
+                    cos_sin_cache=cos_sin_cache,
+                    is_neox=is_neox,
+                    attn_output_gate=False,
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    layer_name=_ln,
+                )
+
+                _, _, v = qkv.split([q_size, k_size, v_size], dim=-1)
+                v = v.view(qkv.shape[0], num_kv_heads, head_dim_v)
+
+                return results[0], results[1], results[2], v
+
+        return pattern, replacement
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        _ln = _encode_layer_name(self.layer_name)
+
+        if _USE_LAYERNAME:
+            pattern, replacement = self._mk_pattern_with_layer_name_input()
+        else:
+            pattern, replacement = self._mk_pattern_with_layer_name_closure(_ln)
+
+        def fwd_and_view_to_reshape(*args, **kwargs) -> fx.GraphModule:
+            gm = pm.fwd_only(*args, **kwargs)
+            view_to_reshape(gm)
+            return gm
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            fwd_and_view_to_reshape,
+            pm_pass,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pass class
+# ---------------------------------------------------------------------------
+
+
+class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
+    """
+    Fuse QK-norm + RoPE + KV cache update into a single AITER Triton kernel.
+
+    Registers Qwen3NextQkNormRopeKvCachePattern for attention layers on
+    ROCm with AITER enabled. The Triton kernel handles QKV split, QK-norm,
+    RoPE, gate extraction, and KV cache update in a single launch.
+    """
+
+    def _register_variants(
+        self,
+        pattern_cls: type,
+        layer: Attention,
+        match_rocm_aiter_rope: bool,
+        **extra_kwargs,
+    ) -> None:
+        # The pattern's traced ``eps`` literal is collapsed to ``Ignored()`` by
+        # ``torch._inductor.pattern_matcher.fx_to_pattern`` (it elides Python
+        # float constants on match), so a single registration matches every
+        # eps value at apply time. Iterating eps here only produces duplicate
+        # patterns that the matcher rejects. Only ``is_neox`` is iterated --
+        # it parameterizes the actual rotary op used in the traced graph
+        # (different ops for is_neox True/False), so patterns are distinct.
+        for neox in [True, False]:
+            pattern_cls(
+                layer=layer,
+                eps=1e-6,
+                is_neox=neox,
+                match_rocm_aiter_rope=match_rocm_aiter_rope,
+                **extra_kwargs,
+            ).register(self.patterns)
+
+    @enable_fake_mode
+    def __init__(self, config: VllmConfig) -> None:
+        super().__init__(config)
+
+        self.patterns: PatternMatcherPass = PatternMatcherPass(
+            pass_name="qk_norm_rope_kvcache_fusion_pass"
+        )
+
+        cc = config.compilation_config
+        self.max_token_num = cc.pass_config.rope_kvcache_fusion_max_token_num
+
+        dtype = config.model_config.dtype
+        if dtype not in (torch.bfloat16, torch.float16):
+            logger.warning_once(
+                "QK Norm+RoPE+KVCache fusion not enabled: unsupported dtype %s", dtype
+            )
+            return
+
+        if not rocm_aiter_ops.is_enabled():
+            logger.warning_once(
+                "QK Norm+RoPE+KVCache fusion not enabled: AITER not available"
+            )
+            return
+
+        attn_layers = get_layers_from_vllm_config(config, Attention)
+
+        rope_custom_enabled = cc.is_custom_op_enabled("rotary_embedding")
+        rms_custom_enabled = cc.is_custom_op_enabled("rms_norm")
+        logger.debug(
+            "QkNormRopeKvCacheFusionPass init: "
+            "RotaryEmbedding.enabled()=%s, rope_custom_enabled=%s, "
+            "RMSNorm custom_op_enabled=%s",
+            RotaryEmbedding.enabled(),
+            rope_custom_enabled,
+            rms_custom_enabled,
+        )
+
+        # Register a pattern only for the rope op that will actually appear
+        # in the traced model graph at runtime. ``MatcherRotaryEmbedding``
+        # resolves the same way as the live model layer, so iterating
+        # match_rocm_aiter_rope ∈ {True, False} would generate two
+        # registrations that resolve to the same rope op under
+        # ``VLLM_ROCM_USE_AITER_TRITON_ROPE=1`` and trip
+        # ``check_and_add_duplicate_pattern``.
+        match_rocm_aiter_rope = rocm_aiter_ops.is_triton_rotary_embed_enabled()
+
+        # When _USE_LAYERNAME is enabled, layer_name is hoisted as an
+        # opaque graph input so every layer produces the same pattern --
+        # register once per shape and break out of the per-layer loop.
+        for _, layer in attn_layers.items():
+            for gate in [True, False]:
+                self._register_variants(
+                    Qwen3NextQkNormRopeKvCachePattern,
+                    layer,
+                    match_rocm_aiter_rope,
+                    attn_output_gate=gate,
+                )
+            if _USE_LAYERNAME:
+                break
+
+        self.dump_patterns(config, self.patterns)
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph) -> None:
+        # ``fx_to_pattern`` is called twice in torch's pattern-matcher lifecycle:
+        # once at registration (with a hard-coded
+        # ``ignore_types=(int, float, list, torch.device, torch.dtype)``) so the
+        # registered patterns have ``Ignored()`` in int-typed slots (reshape
+        # dims, split sizes, head_size, etc.), and once at apply time with the
+        # default empty ``ignore_types`` (``pattern_matcher.py:1548``). Without
+        # the wrapper below, the apply-time fingerprint preserves the model
+        # graph's concrete ``int``/``SymInt`` values and never matches the
+        # ``Ignored()`` slots in the registered patterns -- yielding 0 matches.
+        _orig_fx_to_pat = pm.fx_to_pattern
+
+        def _relaxed_fx_to_pattern(*a, **kw):
+            kw["ignore_types"] = (int, torch.SymInt)
+            return _orig_fx_to_pat(*a, **kw)
+
+        pm.fx_to_pattern = _relaxed_fx_to_pattern
+        try:
+            self.matched_count = self.patterns.apply(graph)
+        finally:
+            pm.fx_to_pattern = _orig_fx_to_pat
+
+        logger.info(
+            "QK-Norm+RoPE+KVCache fusion: replaced %s pattern(s) "
+            "with AITER fused_qk_norm_rope_cache_pts_quant_shuffle",
+            self.matched_count,
+        )
+
+    def is_applicable_for_range(self, compile_range: Range) -> bool:
+        return compile_range.end <= self.max_token_num
+
+    def uuid(self) -> str:
+        return VllmInductorPass.hash_source(self, Qwen3NextQkNormRopeKvCachePattern)

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -373,7 +373,7 @@ class Qwen3NextQkNormRopeKvCachePattern:
         if self.attn_output_gate:
             q_gate, k, v = qkv.split([q_size * 2, k_size, v_size], dim=-1)
 
-            q_gate_3d = q_gate.view(-1, num_heads, 2 * head_dim)
+            q_gate_3d = q_gate.view(qkv.shape[0], num_heads, -1)
             q_3d, gate_3d = q_gate_3d.chunk(2, dim=-1)
 
             # ``chunk`` produces a non-contiguous view; the model emits a
@@ -403,7 +403,7 @@ class Qwen3NextQkNormRopeKvCachePattern:
                 positions, q_normed_flat, k_flat, cos_sin_cache
             )
 
-            k_rope_3d = k_rope.view(-1, num_kv_heads, head_dim)
+            k_rope_3d = k_rope.view(qkv.shape[0], num_kv_heads, head_dim)
             v_3d = v.view(-1, num_kv_heads, head_dim_v)
             dummy = torch.ops.vllm.unified_kv_cache_update(k_rope_3d, v_3d, layer_name)
             return dummy, q_rope, k_rope_3d, v_3d, gate_3d
@@ -647,29 +647,7 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
-        # ``torch._inductor.pattern_matcher.fx_to_pattern`` is invoked twice
-        # in the matcher lifecycle: at ``register_replacement`` time it is
-        # called with ``ignore_types=(int, float, list, torch.device,
-        # torch.dtype)`` so int constants in the registered pattern (split
-        # sizes, view dims, head_size, etc.) become ``Ignored()``. At apply
-        # time (``pattern_matcher.py:1548`` in torch 2.10) it is called with
-        # the default empty ``ignore_types``, which preserves the live FX
-        # graph's concrete ``SymInt`` values. Without this wrapper the
-        # apply-time fingerprint never matches the ``Ignored()`` slots in
-        # the registered pattern -- yielding 0 matches for every layer.
-        # Once vLLM moves to torch >= 2.11 this becomes unnecessary, but
-        # the rest of this pass already supports both modes.
-        _orig_fx_to_pat = pm.fx_to_pattern
-
-        def _relaxed_fx_to_pattern(*a, **kw):
-            kw["ignore_types"] = (int, torch.SymInt)
-            return _orig_fx_to_pat(*a, **kw)
-
-        pm.fx_to_pattern = _relaxed_fx_to_pattern
-        try:
-            self.matched_count = self.patterns.apply(graph)
-        finally:
-            pm.fx_to_pattern = _orig_fx_to_pat
+        self.matched_count = self.patterns.apply(graph)
 
         if self.matched_count == 0:
             # The pass-manager already gates on ``is_applicable_for_range``
@@ -677,9 +655,8 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
             # so reaching this branch with zero matches means the fusion
             # was enabled (gate / dtype / AITER / kernel availability all
             # passed) and at least one pattern was registered, but nothing
-            # matched the live graph. Likely causes: torch version drift in
-            # ``pm.fx_to_pattern`` (see the ``ignore_types`` relaxation
-            # above), upstream model FX-graph refactor, or an unsupported
+            # matched the live graph. Likely causes: upstream model FX-graph
+            # refactor, or an unsupported
             # combination of compile flags (e.g. prefix caching enabled --
             # the pattern was traced without it).
             logger.warning_once(

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -38,6 +38,7 @@ if current_platform.is_cuda_alike():
     from .fusion.mla_attn_quant_fusion import MLAAttnQuantFusionPass
     from .fusion.mla_rope_kvcache_cat_fusion import MLARoPEKVCacheCatFusionPass
     from .fusion.qk_norm_rope_fusion import QKNormRoPEFusionPass
+    from .fusion.qk_norm_rope_kvcache_fusion import QkNormRopeKvCacheFusionPass
     from .fusion.rms_quant_fusion import RMSNormQuantFusionPass
     from .fusion.rope_kvcache_fusion import RopeKVCacheFusionPass
     from .utility.scatter_split_replace import ScatterSplitReplacementPass
@@ -170,6 +171,11 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
                 self.passes += [ActivationQuantFusionPass(config)]
                 if rocm_aiter_ops.is_enabled():
                     self.passes += [RocmAiterSiluMulFp8GroupQuantFusionPass(config)]
+
+            if self.pass_config.fuse_qk_norm_rope_kvcache:
+                self.passes += [SplitCoalescingPass(config)]
+                self.passes += [ScatterSplitReplacementPass(config)]
+                self.passes += [QkNormRopeKvCacheFusionPass(config)]
 
             if (
                 self.pass_config.fuse_mla_dual_rms_norm

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -146,10 +146,16 @@ class PassConfig:
     """Fuse paired q/kv RMS norms in MLA attention."""
     fuse_rope_kvcache: bool = None  # type: ignore[assignment]
     """Fuse the QK rope + KV cache ops."""
+    fuse_qk_norm_rope_kvcache: bool = Field(default=None)  # type: ignore[assignment]
+    """Fuse QK RMSNorm + RoPE + KV cache update into a single AITER Triton
+    kernel. Supersedes both enable_qk_norm_rope_fusion and fuse_rope_kvcache
+    for layers that support it. Auto-enabled at O1+ on ROCm for models
+    with QK-norm (e.g. Qwen3-MoE)."""
 
     rope_kvcache_fusion_max_token_num: int = 256
     """The threshold for ROCm AITER RoPE+KVCache fusion e.g. for small batch decode.
     Larger batch sizes e.g. during prefill will use the unfused kernels.
+    Also applies to the fused QK-Norm+RoPE+KVCache pass.
     """
 
     fi_allreduce_fusion_max_size_mb: float | None = None
@@ -229,6 +235,7 @@ class PassConfig:
         "fuse_mla_dual_rms_norm",
         "fuse_rope_kvcache",
         "fuse_rope_kvcache_cat_mla",
+        "fuse_qk_norm_rope_kvcache",
         mode="wrap",
     )
     @classmethod
@@ -292,6 +299,12 @@ class PassConfig:
                 "current platform is not CUDA or ROCm. The fusion will be disabled."
             )
             self.fuse_rope_kvcache_cat_mla = False
+        if self.fuse_qk_norm_rope_kvcache and not current_platform.is_rocm():
+            logger.warning_once(
+                "QK-Norm+RoPE+KVCache fusion requires ROCm with AITER. "
+                "The fusion will be disabled."
+            )
+            self.fuse_qk_norm_rope_kvcache = False
 
     def log_enabled_passes(self) -> None:
         """
@@ -951,6 +964,16 @@ class CompilationConfig:
             # TODO(Rohan138): support rope native forward match and remove this.
             # Linked issue: https://github.com/vllm-project/vllm/issues/28042
             self.custom_ops.append("+rotary_embedding")
+        if self.pass_config.fuse_qk_norm_rope_kvcache:
+            if "+rotary_embedding" not in self.custom_ops:
+                self.custom_ops.append("+rotary_embedding")
+            if not self.use_inductor_graph_partition:
+                self.use_inductor_graph_partition = True
+                logger.info(
+                    "Enabling use_inductor_graph_partition for "
+                    "fuse_qk_norm_rope_kvcache (requires "
+                    "unified_kv_cache_update in compiled graph)."
+                )
 
         if (
             is_torch_equal_or_newer("2.9.0.dev")

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -149,8 +149,11 @@ class PassConfig:
     fuse_qk_norm_rope_kvcache: bool = Field(default=None)  # type: ignore[assignment]
     """Fuse QK RMSNorm + RoPE + KV cache update into a single AITER Triton
     kernel. Supersedes both enable_qk_norm_rope_fusion and fuse_rope_kvcache
-    for layers that support it. Auto-enabled at O1+ on ROCm for models
-    with QK-norm (e.g. Qwen3-MoE)."""
+    for layers that support it. Auto-enabled at O1+ on ROCm + AITER for
+    Qwen3-Next (the only model the bundled pattern currently matches; the
+    auto-enable callable in ``vllm/config/vllm.py`` checks for the AITER
+    fused kernel and gates on ``model_type == 'qwen3_next'``). Other models
+    with QK-norm need a separate pattern registration."""
 
     rope_kvcache_fusion_max_token_num: int = 256
     """The threshold for ROCm AITER RoPE+KVCache fusion e.g. for small batch decode.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -182,6 +182,46 @@ def enable_rope_kvcache_mla_fusion(cfg: "VllmConfig") -> bool:
     )
 
 
+_QK_NORM_MODEL_TYPES = frozenset(
+    {
+        "qwen3",
+        "qwen3_moe",
+        "qwen3_next",
+    }
+)
+
+
+def enable_qk_norm_rope_kvcache(cfg: "VllmConfig") -> bool:
+    """Enable fused QK-norm + RoPE + KV cache update for models with
+    QK-norm on ROCm with AITER.
+
+    Both ``+rotary_embedding`` and ``use_inductor_graph_partition`` are
+    auto-enabled by ``CompilationConfig.__post_init__`` when this flag is
+    True (the callable runs during optimization-level default
+    application, before ``__post_init__`` can set the dependent flags),
+    so we must not gate this on either of them here -- doing so creates
+    a chicken-and-egg dead-zone where the dependent flags can never get
+    set because the callable never returns True."""
+    from vllm._aiter_ops import (
+        check_aiter_fused_qk_norm_rope_cache,
+        rocm_aiter_ops,
+    )
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return False
+    if not rocm_aiter_ops.is_enabled():
+        return False
+    if not check_aiter_fused_qk_norm_rope_cache():
+        return False
+    if cfg.model_config is None:
+        return False
+    hf_config = cfg.model_config.hf_text_config
+    has_qk_norm = getattr(hf_config, "qk_norm", False)
+    model_type = getattr(hf_config, "model_type", "")
+    return has_qk_norm or model_type in _QK_NORM_MODEL_TYPES
+
+
 def enable_norm_pad_fusion(cfg: "VllmConfig") -> bool:
     """Enable if using AITER RMSNorm and hidden size is 2880 i.e. gpt-oss."""
 
@@ -212,6 +252,7 @@ OPTIMIZATION_LEVEL_00 = {
             "fuse_mla_dual_rms_norm": False,
             "fuse_rope_kvcache": False,
             "fuse_rope_kvcache_cat_mla": False,
+            "fuse_qk_norm_rope_kvcache": False,
         },
         "cudagraph_mode": CUDAGraphMode.NONE,
         "use_inductor_graph_partition": False,
@@ -233,6 +274,7 @@ OPTIMIZATION_LEVEL_01 = {
             "fuse_mla_dual_rms_norm": enable_mla_dual_rms_norm_fusion,
             "fuse_rope_kvcache": False,
             "fuse_rope_kvcache_cat_mla": False,
+            "fuse_qk_norm_rope_kvcache": enable_qk_norm_rope_kvcache,
         },
         "cudagraph_mode": CUDAGraphMode.PIECEWISE,
         "use_inductor_graph_partition": False,
@@ -254,6 +296,7 @@ OPTIMIZATION_LEVEL_02 = {
             "fuse_mla_dual_rms_norm": enable_mla_dual_rms_norm_fusion,
             "fuse_rope_kvcache": enable_rope_kvcache_fusion,
             "fuse_rope_kvcache_cat_mla": enable_rope_kvcache_mla_fusion,
+            "fuse_qk_norm_rope_kvcache": enable_qk_norm_rope_kvcache,
         },
         "cudagraph_mode": CUDAGraphMode.FULL_AND_PIECEWISE,
         "use_inductor_graph_partition": False,
@@ -275,6 +318,7 @@ OPTIMIZATION_LEVEL_03 = {
             "fuse_mla_dual_rms_norm": enable_mla_dual_rms_norm_fusion,
             "fuse_rope_kvcache": enable_rope_kvcache_fusion,
             "fuse_rope_kvcache_cat_mla": enable_rope_kvcache_mla_fusion,
+            "fuse_qk_norm_rope_kvcache": enable_qk_norm_rope_kvcache,
         },
         "cudagraph_mode": CUDAGraphMode.FULL_AND_PIECEWISE,
         "use_inductor_graph_partition": False,
@@ -1193,6 +1237,16 @@ class VllmConfig:
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
+        if pass_config.fuse_qk_norm_rope_kvcache:
+            if "+rotary_embedding" not in self.compilation_config.custom_ops:
+                self.compilation_config.custom_ops.append("+rotary_embedding")
+            if not self.compilation_config.use_inductor_graph_partition:
+                self.compilation_config.use_inductor_graph_partition = True
+                logger.info(
+                    "Enabling use_inductor_graph_partition for "
+                    "fuse_qk_norm_rope_kvcache (requires "
+                    "unified_kv_cache_update in compiled graph)."
+                )
         if pass_config.fuse_gemm_comms:
             pass_config.enable_sp = True
         if pass_config.enable_sp:
@@ -1885,6 +1939,21 @@ class VllmConfig:
                     logger.debug(
                         "Max num batched tokens below rope+kvcache fusion threshold, "
                         "rope+kvcache fusion enabled for num_tokens <= %d.",
+                        compile_range_end,
+                    )
+
+        if compilation_config.pass_config.fuse_qk_norm_rope_kvcache:
+            max_token_num = (
+                compilation_config.pass_config.rope_kvcache_fusion_max_token_num
+            )
+            if max_token_num is not None:
+                if compile_range_end is not None and max_token_num < compile_range_end:
+                    computed_compile_ranges_endpoints.append(max_token_num)
+                else:
+                    logger.debug(
+                        "Max num batched tokens below qk_norm+rope+kvcache fusion "
+                        "threshold, qk_norm+rope+kvcache fusion enabled for "
+                        "num_tokens <= %d.",
                         compile_range_end,
                     )
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -182,18 +182,20 @@ def enable_rope_kvcache_mla_fusion(cfg: "VllmConfig") -> bool:
     )
 
 
-_QK_NORM_MODEL_TYPES = frozenset(
-    {
-        "qwen3",
-        "qwen3_moe",
-        "qwen3_next",
-    }
-)
+_QK_NORM_MODEL_TYPES = frozenset({"qwen3_next"})
 
 
 def enable_qk_norm_rope_kvcache(cfg: "VllmConfig") -> bool:
     """Enable fused QK-norm + RoPE + KV cache update for models with
     QK-norm on ROCm with AITER.
+
+    The pattern in ``Qwen3NextQkNormRopeKvCachePattern`` is currently
+    Qwen3-Next-specific (gated/ungated attention layouts as emitted by
+    ``Qwen3NextAttention``); other QK-norm architectures (qwen3,
+    qwen3_moe, ...) need their own pattern variant and should opt in by
+    being added to ``_QK_NORM_MODEL_TYPES`` only when their pattern
+    lands. We therefore gate strictly on ``model_type`` membership and
+    do not fall back to the generic ``hf_config.qk_norm`` attribute.
 
     Both ``+rotary_embedding`` and ``use_inductor_graph_partition`` are
     auto-enabled by ``CompilationConfig.__post_init__`` when this flag is
@@ -216,10 +218,8 @@ def enable_qk_norm_rope_kvcache(cfg: "VllmConfig") -> bool:
         return False
     if cfg.model_config is None:
         return False
-    hf_config = cfg.model_config.hf_text_config
-    has_qk_norm = getattr(hf_config, "qk_norm", False)
-    model_type = getattr(hf_config, "model_type", "")
-    return has_qk_norm or model_type in _QK_NORM_MODEL_TYPES
+    model_type = getattr(cfg.model_config.hf_text_config, "model_type", "")
+    return model_type in _QK_NORM_MODEL_TYPES
 
 
 def enable_norm_pad_fusion(cfg: "VllmConfig") -> bool:

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -692,7 +692,6 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         return query, key, value, z, b, a
 
-    @torch.compile(fullgraph=True)
     def prepare_gdn_attention_core_inputs(
         self,
         mixed_qkvz: torch.Tensor,


### PR DESCRIPTION
Summary

  Adds a Triton/AITER fusion pass that replaces the unfused QKV-split → QK-RMSNorm → RoPE → KV-cache-write sequence on the full-attention layers of Qwen3-Next with a single AITER kernel launch (fused_qkv_split_qk_norm_rope_cache). Auto-enabled at
  O1+ on ROCm + AITER for model_type == "qwen3_next" when the bundled AITER ships the kernel; otherwise it stays off and the model runs the correct unfused path. Fires on all 12 full-attention layers of Qwen3-Next-80B-A3B.

  vllm serve command used to exercise the feature

  VLLM_ROCM_USE_AITER=1 \
  VLLM_ROCM_USE_AITER_LINEAR=1 \
  VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
  VLLM_ROCM_USE_AITER_MHA=0 \
  VLLM_ROCM_AITER_MOE_DISPATCH_POLICY=2 \
  SAFETENSORS_FAST_GPU=1 \
  vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
    --tensor-parallel-size 1 \
    --attention-backend ROCM_AITER_UNIFIED_ATTN \
    --kv-cache-dtype fp8 \
    --no-async-scheduling \
    --no-enable-prefix-caching \
    --max-model-len 16384 \
    --max-num-seqs 256 \
    --gpu-memory-utilization 0.92 \
    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","compile_ranges_endpoints":[512],"custom_ops":["-rms_norm","-silu_and_mul","-quant_fp8","+rotary_embedding"],"pass_config":{"fuse_norm_quant":true,"fuse_qk_norm_rope_kvcache":true},"u
  se_inductor_graph_partition":true}'

  The pass_config.fuse_qk_norm_rope_kvcache flag is shown explicitly but is redundant — the pass auto-enables from the model architecture alone.
  
    ┌───────────────────┬─────────────────────────────────────────────┬────────────────┐
  │ ISL / OSL / conc  │ TPOT mean Δ                                 │ Output tok/s Δ │
  ├───────────────────┼─────────────────────────────────────────────┼────────────────┤
  │ 1000 / 100 / 4    │ −2.3%                                       │ +1.9%          │
  │ 1000 / 100 / 64   │ −8.0%                                       │ ~flat          │
  │ 5000 / 500 / 4    │ −1.7%                                       │ +1.5%          │
  │ 10000 / 1000 / 4  │ −1.5% / (−2.5% in a separate 32-prompt run) │ +1.5% (+2.5%)  │
  │ 10000 / 1000 / 64 │ −0.3%                                       │ +0.1%          │
  └───────────────────┴─────────────────────────────────────────────┴────────────────┘

 Accuracy — lm_eval, same before and after

  Command:

  lm_eval \
    --model local-completions \
    --tasks gsm8k \
    --model_args "model=Qwen/Qwen3-Next-80B-A3B-Instruct-FP8,base_url=http://localhost:${PORT}/v1/completions,num_concurrent=16,max_retries=3,tokenized_requests=False"

  Results (gsm8k, 5-shot, full 1319 questions, fusion enabled):

  ┌──────────────────┬─────────────┬─────────────────┐
  │ Filter           │ Metric      │ Value           │
  ├──────────────────┼─────────────┼─────────────────┤
  │ flexible-extract │ exact_match │ 0.8597 ± 0.0096 │
  │ strict-match     │ exact_match │ 0.8143 ± 0.0107 │
  └──────────────────┴─────────────┴─────────────────┘