### PR TITLE
fix: improve health check robustness for EngineDeadError and other exceptions (closes #42363)

### DIFF
--- a/vllm/entrypoints/serve/instrumentator/health.py
+++ b/vllm/entrypoints/serve/instrumentator/health.py
@@ -30,4 +30,8 @@ async def health(raw_request: Request) -> Response:
         await client.check_health()
         return Response(status_code=200)
     except EngineDeadError:
+        logger.warning("Engine is dead, returning 503")
+        return Response(status_code=503)
+    except Exception as e:
+        logger.error(f"Health check failed with unexpected error: {e}")
         return Response(status_code=503)


### PR DESCRIPTION
## What
The health endpoint currently only catches `EngineDeadError`, but during model loading or startup, other exceptions might be raised causing unhandled errors. Additionally, when `EngineDeadError` is raised, there is no logging to help diagnose the issue.

## Fix
Added logging for `EngineDeadError` and a catch-all for other exceptions to return 503 gracefully instead of propagating an error to the client. This improves robustness and debuggability.

Closes #42363