### PR TITLE
[Bugfix] Avoid full prompt logprobs materialization in V1

### DIFF
--- a/tests/v1/sample/test_sampler_logprobs.py
+++ b/tests/v1/sample/test_sampler_logprobs.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
+from vllm.v1.sample.sampler import Sampler
+
+DEVICE = current_platform.device_type
+
+
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton not available on this platform")
+@pytest.mark.parametrize("num_logprobs", [0, 1, 3])
+def test_compute_topk_logprobs_matches_gather_logprobs(num_logprobs: int):
+    """Top-k logprobs should match the full log_softmax + gather path."""
+    batch_size = 4
+    vocab_size = 32
+    generator = torch.Generator(device=DEVICE).manual_seed(0)
+    logits = torch.randn(
+        batch_size,
+        vocab_size,
+        device=DEVICE,
+        generator=generator,
+    )
+    token_ids = torch.randint(
+        0,
+        vocab_size,
+        (batch_size,),
+        device=DEVICE,
+        dtype=torch.int64,
+        generator=generator,
+    )
+
+    full_logprobs = Sampler.compute_logprobs(logits)
+    expected = Sampler.gather_logprobs(full_logprobs, num_logprobs, token_ids)
+    actual = Sampler.compute_topk_logprobs(logits, num_logprobs, token_ids)
+
+    torch.testing.assert_close(
+        actual.logprob_token_ids.to(expected.logprob_token_ids.dtype),
+        expected.logprob_token_ids,
+    )
+    torch.testing.assert_close(actual.logprobs, expected.logprobs)
+    torch.testing.assert_close(
+        actual.selected_token_ranks,
+        expected.selected_token_ranks,
+    )

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 from vllm.config.model import LogprobsMode
+from vllm.triton_utils import HAS_TRITON
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -13,6 +14,11 @@ from vllm.v1.sample.ops.bad_words import apply_bad_words
 from vllm.v1.sample.ops.logprobs import batched_count_greater_than
 from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
+
+if HAS_TRITON:
+    from vllm.v1.worker.gpu.sample.logprob import (
+        compute_topk_logprobs as compute_topk_logprobs_gpu,
+    )
 
 _SAMPLING_EPS = 1e-5
 
@@ -304,6 +310,16 @@ class Sampler(nn.Module):
     @staticmethod
     def compute_logprobs(logits: torch.Tensor) -> torch.Tensor:
         return logits.log_softmax(dim=-1, dtype=torch.float32)
+
+    @staticmethod
+    def compute_topk_logprobs(
+        logits: torch.Tensor,
+        num_logprobs: int,
+        token_ids: torch.Tensor,
+    ) -> LogprobsTensors:
+        if not HAS_TRITON:
+            raise RuntimeError("Triton is required to compute top-k logprobs.")
+        return compute_topk_logprobs_gpu(logits, num_logprobs, token_ids)
 
     @staticmethod
     def gather_logprobs(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -111,6 +111,7 @@ from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.tracing import instrument
+from vllm.triton_utils import HAS_TRITON
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
@@ -5473,10 +5474,18 @@ class GPUModelRunner(
             tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
 
             # Compute prompt logprobs.
-            logprobs = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
-                logprobs, num_prompt_logprobs, tgt_token_ids
-            )
+            if num_prompt_logprobs >= logits.shape[-1] or not HAS_TRITON:
+                # Full-vocab prompt logprobs are inherently memory-heavy.
+                # Keep the existing full log_softmax path for compatibility.
+                logprobs = self.sampler.compute_logprobs(logits)
+                token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
+                    logprobs, num_prompt_logprobs, tgt_token_ids
+                )
+            else:
+                # Avoid materializing full [num_logits, vocab_size] logprobs.
+                token_ids, logprobs, ranks, _ = self.sampler.compute_topk_logprobs(
+                    logits, num_prompt_logprobs, tgt_token_ids
+                )
 
             # Transfer GPU->CPU async.
             chunk_slice = slice(start_idx, start_idx + num_logits)


### PR DESCRIPTION
## Purpose

Use the existing memory-efficient top-k logprobs kernel in the V1 prompt logprobs path when full-vocab output is not requested.


## Background

I recently ran into this issue while doing RL post-training with Qwen3.6-35B-A3B. In this workflow, `prompt_logprobs` is used frequently, and I observed that it can often trigger OOM in the V1 path for long prompts.

After looking through the codebase, I noticed that vLLM already has a memory-efficient top-k logprobs implementation that avoids materializing the full `[num_prompt_tokens, vocab_size]` logprobs tensor. This PR tries to make the V1 prompt logprobs path reuse that existing implementation for non-full-vocab requests.

I also noticed the ongoing Model Runner V2 work, but V2 is not yet feature-complete and some models/deployments still depend on the V1 path today. I would appreciate feedback from maintainers on whether this direction aligns with the future optimization plan for prompt logprobs.




## Test Plan

- Run the new sampler-level equivalence test for the V1 top-k prompt logprobs path:

```bash
python -m pytest tests/v1/sample/test_sampler_logprobs.py -q
```

- Run pre-commit checks:

```bash
PRE_COMMIT_HOME=/tmp/pre-commit-cache pre-commit run
```

- Run a local OpenAI-compatible server with Qwen3.6-35B-A3B and compare prompt logprobs responses before and after this change using requests with small `prompt_logprobs` values.

## Test Result

- `python -m pytest tests/v1/sample/test_sampler_logprobs.py -q`

```text
3 skipped
```

The test is skipped in my local environment because Triton/GPU execution is not available there, but the test covers equivalence between the new `Sampler.compute_topk_logprobs` path and the previous `compute_logprobs + gather_logprobs` path when Triton is available.

- `PRE_COMMIT_HOME=/tmp/pre-commit-cache pre-commit run`

```text
Passed
```

- Local runtime comparison with Qwen3.6-35B-A3B:

```text
Compared 16 prompt_logprobs cases.
Failures: 0.
Response structure and generated text matched.
Maximum observed logprob absolute difference: ~2.03e-06.
```

The small logprob difference is expected floating-point variance between the optimized top-k path and the previous full-logprobs path.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

