### PR TITLE
[Rust Frontend] Support Kimi K2 tool call IDs

### DIFF
--- a/rust/src/chat/src/output/default/tool.rs
+++ b/rust/src/chat/src/output/default/tool.rs
@@ -121,7 +121,11 @@ impl ToolState {
                     None => true,
                 };
                 if is_new_tool {
-                    let id = generate_tool_call_id();
+                    let id = self
+                        .parser
+                        .tool_call_id(item.tool_index)
+                        .map(str::to_string)
+                        .unwrap_or_else(generate_tool_call_id);
                     self.open_call_index = Some(item.tool_index);
                     events.push(AssistantEvent::ToolCallStart { id, name });
                 }
@@ -291,6 +295,11 @@ mod tests {
         buffered: String,
     }
 
+    struct IdScriptedParser {
+        output: ToolParserOutput,
+        tool_call_id: Option<String>,
+    }
+
     impl ToolParser for FailingParser {
         fn create(_tools: &[ChatTool]) -> vllm_tool_parser::Result<Box<dyn ToolParser>>
         where
@@ -344,6 +353,35 @@ mod tests {
 
         fn finish(&mut self) -> Result<ToolParserOutput> {
             Ok(std::mem::take(&mut self.finish_output))
+        }
+
+        fn reset(&mut self) -> String {
+            String::new()
+        }
+    }
+
+    impl ToolParser for IdScriptedParser {
+        fn create(_tools: &[ChatTool]) -> vllm_tool_parser::Result<Box<dyn ToolParser>>
+        where
+            Self: Sized + 'static,
+        {
+            Ok(Box::new(Self {
+                output: ToolParserOutput::default(),
+                tool_call_id: None,
+            }))
+        }
+
+        fn tool_call_id(&self, tool_index: usize) -> Option<&str> {
+            (tool_index == 0).then_some(self.tool_call_id.as_deref()).flatten()
+        }
+
+        fn parse_into(&mut self, _chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+            output.append(std::mem::take(&mut self.output));
+            Ok(())
+        }
+
+        fn finish(&mut self) -> Result<ToolParserOutput> {
+            Ok(ToolParserOutput::default())
         }
 
         fn reset(&mut self) -> String {
@@ -503,6 +541,70 @@ mod tests {
             }
         );
         assert!(matches!(events[3], AssistantEvent::Done { .. }));
+    }
+
+    #[tokio::test]
+    async fn tool_stream_preserves_parser_provided_tool_call_id() {
+        let events = stream::iter(vec![Ok(ContentEvent::TextDelta {
+            kind: AssistantBlockKind::Text,
+            delta: "ignored".to_string(),
+        })]);
+        let parser = IdScriptedParser {
+            output: ToolParserOutput {
+                normal_text: String::new(),
+                calls: vec![crate::parser::tool::ToolCallDelta {
+                    tool_index: 0,
+                    name: Some("get_weather".to_string()),
+                    arguments: "{}".to_string(),
+                }],
+            },
+            tool_call_id: Some("functions.get_weather:0".to_string()),
+        };
+
+        let events = tool_event_stream(events, Some(Box::new(parser)))
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<crate::Result<Vec<_>>>()
+            .unwrap();
+
+        assert!(matches!(
+            &events[0],
+            AssistantEvent::ToolCallStart { id, name }
+                if id == "functions.get_weather:0" && name == "get_weather"
+        ));
+    }
+
+    #[tokio::test]
+    async fn tool_stream_generates_tool_call_id_when_parser_omits_one() {
+        let events = stream::iter(vec![Ok(ContentEvent::TextDelta {
+            kind: AssistantBlockKind::Text,
+            delta: "ignored".to_string(),
+        })]);
+        let parser = IdScriptedParser {
+            output: ToolParserOutput {
+                normal_text: String::new(),
+                calls: vec![crate::parser::tool::ToolCallDelta {
+                    tool_index: 0,
+                    name: Some("get_weather".to_string()),
+                    arguments: "{}".to_string(),
+                }],
+            },
+            tool_call_id: None,
+        };
+
+        let events = tool_event_stream(events, Some(Box::new(parser)))
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<crate::Result<Vec<_>>>()
+            .unwrap();
+
+        assert!(matches!(
+            &events[0],
+            AssistantEvent::ToolCallStart { id, name }
+                if id.starts_with("call_") && name == "get_weather"
+        ));
     }
 
     #[tokio::test]

--- a/rust/src/chat/src/output/mod.rs
+++ b/rust/src/chat/src/output/mod.rs
@@ -128,8 +128,6 @@ trait_set! {
 
 /// Generate the northbound tool-call ID using the OpenAI-style `call_<id>`
 /// format.
-// TODO: support other ID scheme like Kimi-K2's
-// `functions.{name}:{global_index}`.
 pub(crate) fn generate_tool_call_id() -> String {
     format!("call_{}", &Uuid::new_v4().simple().to_string()[..24])
 }

--- a/rust/src/chat/tests/roundtrip.rs
+++ b/rust/src/chat/tests/roundtrip.rs
@@ -170,8 +170,7 @@ roundtrip_tests! {
     glm47 => [reasoning_and_content, tool_call_mix],
 
     // Note: Kimi K2.5 strips the reasoning content in history.
-    // TODO: we don't respect model-generated tool call id now so `tool_call_mix` cannot pass.
-    // kimi_k25 => [tool_call_mix],
+    kimi_k25 => [tool_call_mix],
 }
 
 /// Run the fixed reasoning+content fixture for one model/parser case.

--- a/rust/src/tool-parser/src/kimi_k2.rs
+++ b/rust/src/tool-parser/src/kimi_k2.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use winnow::ascii::{digit1, multispace0 as ws0};
 use winnow::combinator::{alt, eof, repeat, seq};
 use winnow::prelude::*;
@@ -33,6 +35,7 @@ enum KimiK2Event {
     ToolCallsStart,
     ToolCallStart,
     ToolCallHeader {
+        tool_call_id: String,
         function_name: String,
         function_index: usize,
     },
@@ -60,6 +63,7 @@ pub struct KimiK2ToolParser {
     buffer: String,
     mode: KimiK2Mode,
     active_tool_index: Option<usize>,
+    call_ids: BTreeMap<usize, String>,
 }
 
 impl KimiK2ToolParser {
@@ -69,6 +73,7 @@ impl KimiK2ToolParser {
             buffer: String::new(),
             mode: KimiK2Mode::Text,
             active_tool_index: None,
+            call_ids: BTreeMap::new(),
         }
     }
 
@@ -81,6 +86,7 @@ impl KimiK2ToolParser {
             KimiK2Event::ToolCallsStart => self.mode = KimiK2Mode::ToolBlock,
             KimiK2Event::ToolCallStart => self.mode = KimiK2Mode::Header,
             KimiK2Event::ToolCallHeader {
+                tool_call_id,
                 function_name,
                 function_index,
             } => {
@@ -89,6 +95,7 @@ impl KimiK2ToolParser {
                 self.mode = KimiK2Mode::Arguments {
                     json_scan: JsonObjectScanState::default(),
                 };
+                self.call_ids.insert(tool_index, tool_call_id);
                 output.calls.push(ToolCallDelta {
                     tool_index,
                     name: Some(function_name),
@@ -123,6 +130,7 @@ impl KimiK2ToolParser {
     fn reset(&mut self) -> String {
         self.mode = KimiK2Mode::Text;
         self.active_tool_index = None;
+        self.call_ids.clear();
         std::mem::take(&mut self.buffer)
     }
 }
@@ -137,6 +145,10 @@ impl ToolParser for KimiK2ToolParser {
 
     fn preserve_special_tokens(&self) -> bool {
         true
+    }
+
+    fn tool_call_id(&self, tool_index: usize) -> Option<&str> {
+        self.call_ids.get(&tool_index).map(String::as_str)
     }
 
     fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
@@ -232,16 +244,18 @@ fn tool_call_end_event(input: &mut KimiK2Input<'_>) -> ModalResult<KimiK2Event> 
 
 /// Parse a Kimi K2 tool-call header before the argument marker.
 fn tool_call_header_event(input: &mut KimiK2Input<'_>) -> ModalResult<KimiK2Event> {
-    let (header, _) = (
+    let (raw_header, _) = (
         take_until(1.., TOOL_CALL_ARGUMENT_START),
         literal(TOOL_CALL_ARGUMENT_START),
     )
         .parse_next(input)?;
 
-    let mut header_input = header;
+    let tool_call_id = raw_header.trim().to_string();
+    let mut header_input = raw_header;
     let (header, _, _) = (tool_header, ws0, eof).parse_next(&mut header_input)?;
 
     Ok(KimiK2Event::ToolCallHeader {
+        tool_call_id,
         function_name: header.function_name,
         function_index: header.function_index,
     })
@@ -503,15 +517,35 @@ mod tests {
     }
 
     #[test]
+    fn kimi_k2_preserves_model_generated_tool_call_ids() {
+        let mut parser = KimiK2ToolParser::new(&test_tools());
+        let input = build_tool_section(&[
+            build_tool_call("get_weather", 0, r#"{"location":"Shanghai"}"#),
+            build_tool_call("add", 1, r#"{"x":1,"y":2}"#),
+        ]);
+
+        for chunk in split_by_chars(&input, 7) {
+            parser.parse_chunk(chunk).unwrap();
+        }
+
+        // IDs are available after parsing but before finish(), which calls reset().
+        assert_eq!(parser.tool_call_id(0), Some("functions.get_weather:0"));
+        assert_eq!(parser.tool_call_id(1), Some("functions.add:1"));
+        parser.finish().unwrap();
+        assert_eq!(parser.tool_call_id(0), None);
+    }
+
+    #[test]
     fn kimi_k2_accepts_non_functions_header_prefix() {
         let mut parser = KimiK2ToolParser::new(&test_tools());
         let input = format!(
             "{TOOL_CALLS_START}{TOOL_CALL_START}api.tools.search:42{TOOL_CALL_ARGUMENT_START}{{}}{TOOL_CALL_END}{TOOL_CALLS_END}"
         );
 
-        let output = parser.parse_complete(&input).unwrap();
+        let output = parser.parse_chunk(&input).unwrap().coalesce_calls();
 
         assert_eq!(output.calls[0].tool_index, 42);
+        assert_eq!(parser.tool_call_id(42), Some("api.tools.search:42"));
         assert_eq!(output.calls[0].name.as_deref(), Some("search"));
         assert_eq!(output.calls[0].arguments, "{}");
     }

--- a/rust/src/tool-parser/src/lib.rs
+++ b/rust/src/tool-parser/src/lib.rs
@@ -121,6 +121,12 @@ pub trait ToolParser: Send {
         false
     }
 
+    /// Return the parser-provided ID for a tool call by index, if the model
+    /// emitted one.
+    fn tool_call_id(&self, _tool_index: usize) -> Option<&str> {
+        None
+    }
+
     /// Feed one decoded text delta into the parser, appending committed output
     /// into `output`.
     ///


### PR DESCRIPTION

## Summary

Preserve Kimi K2 model-generated tool-call IDs in the Rust frontend output path , adds an optional `ToolParser::tool_call_id()` hook. Existing parsers keep the default `None` behavior and still use generated `call_<id>` values.

- Kimi K2 parser stores the raw header ID and exposes it through that hook, so streamed and final OpenAI-compatible ool calls preserve IDs like `functions.{name}:{index}`.

- This matches the Python Kimi parser behavior, which outputs the raw Kimi header as
  `ToolCall.id` / `DeltaToolCall.id`.


The Python behavior we are matching lives  in `vllm/tool_parsers/kimi_k2_tool_parser.py`


## Tests

  [x] cargo fmt --check
  [x] cargo nextest run -p vllm-tool-parser 
  - 251 tests run, 251 passed
  [x] cargo nextest run -p vllm-tool-parser -E 'test(kimi_k2)' 
  - 12 tests run, 12 passed
  [x] cargo nextest run -p vllm-chat -E 'test(tool_stream)' 
  - 6 tests run, 6 passed
  [x] cargo clippy -p vllm-tool-parser -p vllm-chat --all-targets -- -D warnings
  - clean






---

