### PR TITLE
[Bugfix] Add missing f-string prefixes in assert messages

### DIFF
--- a/vllm/model_executor/models/phi4mm_audio.py
+++ b/vllm/model_executor/models/phi4mm_audio.py
@@ -372,7 +372,7 @@ class TransformerEncoderBase(abc.ABC, nn.Module):
                 default_nemo_conv_settings.update(nemo_conv_settings)
                 for i in ["subsampling_factor", "feat_in", "feat_out"]:
                     assert i not in nemo_conv_settings, (
-                        "{i} should be specified outside of the NeMo dictionary"
+                        f"{i} should be specified outside of the NeMo dictionary"
                     )
 
             self.embed = NemoConvSubsampling(
@@ -1175,7 +1175,7 @@ class AudioEmbedding(nn.Module):
                 default_nemo_conv_settings.update(nemo_conv_settings)
                 for i in ["subsampling_factor", "feat_in", "feat_out"]:
                     assert i not in nemo_conv_settings, (
-                        "{i} should be specified outside of the NeMo dictionary"
+                        f"{i} should be specified outside of the NeMo dictionary"
                     )
 
             self.conv_ds = NemoConvSubsampling(


### PR DESCRIPTION
### Purpose

Ran into two assert messages that have `{...}` placeholders but aren't f-strings, so when the assert fires they print the literal text instead of the value. The variable is already in scope, so it's just a missing `f`.

`vllm/model_executor/models/phi4mm_audio.py` (2 places): in `TransformerEncoderBase` and `AudioEmbedding`, the NeMo conv settings check prints `{i}` rather than the key that's actually misplaced. `i` comes from the `for i in ["subsampling_factor", "feat_in", "feat_out"]` loop right above it.

These are implicitly concatenated string literals, so only the segment holding the placeholder needs the `f`. The diff is 2 lines, one character each, and nothing changes except the message now shows the right value.

(Note: an earlier version of this PR also fixed two asserts in `triton_reshape_and_cache_flash.py`, but those were removed upstream in #43914, so this is now rebased down to the phi4mm fix.)

### Test Plan

- `ruff check` on the changed file
- `ruff format --check` on the changed file
- `python -m py_compile` on the changed file
- `git diff --check` for whitespace

### Test Result

- `ruff check`: All checks passed
- `ruff format --check`: already formatted
- `python -m py_compile`: OK
- `git diff --check`: no whitespace errors