### PR TITLE
[GGUF] Add config fallback and Gemma4/Qwen3.5 mappings

### DIFF
--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -18,7 +18,10 @@ from vllm.model_executor.model_loader.weight_utils import download_gguf
 from vllm.model_executor.models.gemma4 import (
     _load_gemma4_gguf_fused_moe_qweight_type,
 )
-from vllm.model_executor.models.gemma4_mm import _gemma4_patch_embed_weight_loader
+from vllm.model_executor.models.gemma4_mm import (
+    _gemma4_patch_embed_weight_loader,
+    _set_gemma4_patch_embed_weight_loader,
+)
 from vllm.model_executor.models.qwen3_next import _maybe_reshape_gguf_weight
 
 
@@ -337,6 +340,25 @@ class TestGGUFModelLoader:
         _gemma4_patch_embed_weight_loader(param, loaded_weight)
 
         assert torch.equal(param, loaded_weight)
+
+    def test_gemma4_patch_embedder_wraps_existing_weight_loader(self):
+        param = torch.nn.Parameter(torch.empty(2, 60), requires_grad=False)
+        loaded_weight = torch.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+        seen_weights = []
+
+        def existing_weight_loader(
+            param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> None:
+            seen_weights.append(loaded_weight)
+            param.data.copy_(loaded_weight)
+
+        param.weight_loader = existing_weight_loader
+
+        _set_gemma4_patch_embed_weight_loader(param)
+        param.weight_loader(param, loaded_weight)
+
+        assert torch.equal(seen_weights[0], loaded_weight.flatten(1))
+        assert torch.equal(param, loaded_weight.flatten(1))
 
     def test_gemma4_fused_moe_gguf_qweight_type_remap(self):
         w13_type = torch.nn.Parameter(

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -11,6 +11,7 @@ from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.gguf_loader import (
     GGUFModelLoader,
     _add_gemma4_gguf_mappings,
+    _gguf_arch_model_type,
     _gguf_name_with_suffix,
 )
 from vllm.model_executor.model_loader.weight_utils import download_gguf
@@ -18,6 +19,9 @@ from vllm.model_executor.models.gemma4 import (
     _load_gemma4_gguf_fused_moe_qweight_type,
 )
 from vllm.model_executor.models.gemma4_mm import _gemma4_patch_embed_weight_loader
+from vllm.model_executor.models.qwen3_next import (
+    _maybe_reshape_gguf_shared_expert_gate,
+)
 
 
 class TestGGUFDownload:
@@ -236,6 +240,10 @@ class TestGGUFModelLoader:
         assert _gguf_name_with_suffix("blk.0.ssm_a", "") == "blk.0.ssm_a"
         assert _gguf_name_with_suffix("blk.0.attn_q", "weight") == "blk.0.attn_q.weight"
 
+    def test_gemma4_gguf_arch_alias(self):
+        assert _gguf_arch_model_type("gemma4") == "gemma3"
+        assert _gguf_arch_model_type("qwen35") == "qwen35"
+
     def test_gemma4_manual_gguf_mappings(self):
         text_config = MagicMock()
         text_config.num_hidden_layers = 2
@@ -272,6 +280,23 @@ class TestGGUFModelLoader:
         )
         assert gguf_to_hf_name_map["mm.input_projection.weight"] == (
             "model.embed_vision.embedding_projection.weight"
+        )
+
+    def test_qwen_gguf_shared_expert_gate_weight_is_2d(self):
+        loaded_weight = torch.arange(4)
+        reshaped = _maybe_reshape_gguf_shared_expert_gate(
+            "model.layers.0.mlp.shared_expert_gate.weight",
+            loaded_weight,
+        )
+
+        assert reshaped.shape == (1, 4)
+        assert torch.equal(reshaped, loaded_weight[None, :])
+        assert (
+            _maybe_reshape_gguf_shared_expert_gate(
+                "model.layers.0.mlp.gate_proj.weight",
+                loaded_weight,
+            )
+            is loaded_weight
         )
 
     def test_gemma4_patch_embedder_weight_transform(self):

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -11,8 +11,11 @@ from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.gguf_loader import (
     GGUFModelLoader,
     _add_gemma4_gguf_mappings,
+    _add_gemma4_mtp_gguf_mappings,
+    _add_qwen3_5_mtp_gguf_mappings,
     _gguf_arch_model_type,
     _gguf_name_with_suffix,
+    _use_gguf_multimodal_weights,
 )
 from vllm.model_executor.model_loader.weight_utils import download_gguf
 from vllm.model_executor.models.gemma4 import (
@@ -244,6 +247,7 @@ class TestGGUFModelLoader:
 
     def test_gemma4_gguf_arch_alias(self):
         assert _gguf_arch_model_type("gemma4") == "gemma3"
+        assert _gguf_arch_model_type("qwen3_5_mtp") == "qwen35moe"
         assert _gguf_arch_model_type("qwen35") == "qwen35"
 
     def test_gemma4_manual_gguf_mappings(self):
@@ -298,6 +302,61 @@ class TestGGUFModelLoader:
         assert gguf_to_hf_name_map["mm.input_projection.weight"] == (
             "model.embed_vision.embedding_projection.weight"
         )
+
+    def test_qwen3_5_mtp_gguf_mappings_use_appended_layer_offset(self):
+        text_config = MagicMock()
+        text_config.num_hidden_layers = 40
+        gguf_to_hf_name_map: dict[str, str] = {}
+
+        _add_qwen3_5_mtp_gguf_mappings(gguf_to_hf_name_map, text_config)
+
+        assert gguf_to_hf_name_map["token_embd.weight"] == ("model.embed_tokens.weight")
+        assert gguf_to_hf_name_map["output.weight"] == "lm_head.weight"
+        assert gguf_to_hf_name_map["blk.40.nextn.eh_proj.weight"] == "mtp.fc.weight"
+        assert gguf_to_hf_name_map["blk.40.nextn.enorm.weight"] == (
+            "mtp.pre_fc_norm_embedding.weight"
+        )
+        assert gguf_to_hf_name_map["blk.40.attn_q.weight"] == (
+            "mtp.layers.0.self_attn.q_proj.weight"
+        )
+        assert gguf_to_hf_name_map["blk.40.ffn_gate_inp_shexp.weight"] == (
+            "mtp.layers.0.mlp.shared_expert_gate.weight"
+        )
+
+    def test_gemma4_mtp_gguf_mappings_are_text_only(self):
+        text_config = MagicMock()
+        text_config.num_hidden_layers = 4
+        gguf_to_hf_name_map: dict[str, str] = {}
+
+        _add_gemma4_mtp_gguf_mappings(gguf_to_hf_name_map, text_config)
+
+        assert gguf_to_hf_name_map["nextn.pre_projection.weight"] == (
+            "pre_projection.weight"
+        )
+        assert gguf_to_hf_name_map["nextn.post_projection.weight"] == (
+            "post_projection.weight"
+        )
+        assert gguf_to_hf_name_map["output_norm.weight"] == "model.norm.weight"
+        assert gguf_to_hf_name_map["blk.3.attn_q.weight"] == (
+            "model.layers.3.self_attn.q_proj.weight"
+        )
+        assert gguf_to_hf_name_map["blk.3.ffn_down.weight"] == (
+            "model.layers.3.mlp.down_proj.weight"
+        )
+
+    def test_gguf_mtp_draft_does_not_load_multimodal_weights(self):
+        mtp_config = MagicMock()
+        mtp_config.model_type = "qwen3_5_mtp"
+        mtp_config.architectures = ["Qwen3_5MoeMTP"]
+        mtp_config.vision_config = object()
+
+        mm_config = MagicMock()
+        mm_config.model_type = "qwen3_5_moe"
+        mm_config.architectures = ["Qwen3_5MoeForConditionalGeneration"]
+        mm_config.vision_config = object()
+
+        assert not _use_gguf_multimodal_weights(mtp_config)
+        assert _use_gguf_multimodal_weights(mm_config)
 
     def test_qwen_gguf_shared_expert_gate_weight_is_2d(self):
         loaded_weight = torch.arange(4)

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -4,11 +4,20 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
-from vllm.model_executor.model_loader.gguf_loader import GGUFModelLoader
+from vllm.model_executor.model_loader.gguf_loader import (
+    GGUFModelLoader,
+    _add_gemma4_gguf_mappings,
+    _gguf_name_with_suffix,
+)
 from vllm.model_executor.model_loader.weight_utils import download_gguf
+from vllm.model_executor.models.gemma4 import (
+    _load_gemma4_gguf_fused_moe_qweight_type,
+)
+from vllm.model_executor.models.gemma4_mm import _gemma4_patch_embed_weight_loader
 
 
 class TestGGUFDownload:
@@ -222,3 +231,97 @@ class TestGGUFModelLoader:
         model_config.model = "invalid-format"
         with pytest.raises(ValueError, match="Unrecognised GGUF reference"):
             loader._prepare_weights(model_config)
+
+    def test_suffixless_gguf_name_has_no_trailing_dot(self):
+        assert _gguf_name_with_suffix("blk.0.ssm_a", "") == "blk.0.ssm_a"
+        assert _gguf_name_with_suffix("blk.0.attn_q", "weight") == "blk.0.attn_q.weight"
+
+    def test_gemma4_manual_gguf_mappings(self):
+        text_config = MagicMock()
+        text_config.num_hidden_layers = 2
+        vision_config = MagicMock()
+        vision_config.num_hidden_layers = 3
+        gguf_to_hf_name_map: dict[str, str] = {}
+
+        _add_gemma4_gguf_mappings(
+            gguf_to_hf_name_map,
+            text_config,
+            vision_config,
+        )
+
+        assert gguf_to_hf_name_map["blk.1.layer_output_scale.weight"] == (
+            "model.language_model.layers.1.layer_scalar"
+        )
+        assert gguf_to_hf_name_map["blk.1.ffn_gate_inp.scale"] == (
+            "model.language_model.layers.1.router.scale"
+        )
+        assert gguf_to_hf_name_map["blk.1.ffn_down_exps.scale"] == (
+            "model.language_model.layers.1.router.per_expert_scale"
+        )
+        assert gguf_to_hf_name_map["blk.1.ffn_gate_up_exps.weight"] == (
+            "model.language_model.layers.1.experts.gate_up_proj.weight"
+        )
+        assert gguf_to_hf_name_map["v.blk.2.attn_q.weight"] == (
+            "model.vision_tower.encoder.layers.2.self_attn.q_proj.linear.weight"
+        )
+        assert gguf_to_hf_name_map["v.blk.2.ffn_down.weight"] == (
+            "model.vision_tower.encoder.layers.2.mlp.down_proj.linear.weight"
+        )
+        assert gguf_to_hf_name_map["v.patch_embd.weight"] == (
+            "model.vision_tower.patch_embedder.input_proj.weight"
+        )
+        assert gguf_to_hf_name_map["mm.input_projection.weight"] == (
+            "model.embed_vision.embedding_projection.weight"
+        )
+
+    def test_gemma4_patch_embedder_weight_transform(self):
+        param = torch.nn.Parameter(torch.empty(2, 60), requires_grad=False)
+        loaded_weight = torch.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+
+        _gemma4_patch_embed_weight_loader(param, loaded_weight)
+
+        assert torch.equal(param, loaded_weight.flatten(1))
+
+    def test_gemma4_patch_embedder_loader_keeps_flat_weight(self):
+        param = torch.nn.Parameter(torch.empty(2, 60), requires_grad=False)
+        loaded_weight = torch.arange(2 * 60).reshape(2, 60)
+
+        _gemma4_patch_embed_weight_loader(param, loaded_weight)
+
+        assert torch.equal(param, loaded_weight)
+
+    def test_gemma4_fused_moe_gguf_qweight_type_remap(self):
+        w13_type = torch.nn.Parameter(
+            torch.empty(1, dtype=torch.uint8), requires_grad=False
+        )
+        w13_type.is_gguf_weight_type = True
+        w13_type.weight_type = 0
+        w2_type = torch.nn.Parameter(
+            torch.empty(1, dtype=torch.uint8), requires_grad=False
+        )
+        w2_type.is_gguf_weight_type = True
+        w2_type.weight_type = 0
+        params_dict = {
+            "layers.0.moe.experts.w13_qweight_type": w13_type,
+            "layers.0.moe.experts.w2_qweight_type": w2_type,
+        }
+
+        remapped = _load_gemma4_gguf_fused_moe_qweight_type(
+            "layers.0.moe.gate_up_proj.qweight_type",
+            torch.tensor(12),
+            params_dict,
+        )
+
+        assert remapped == "layers.0.moe.experts.w13_qweight_type"
+        assert w13_type.weight_type == 12
+        assert w13_type.item() == 12
+
+        remapped = _load_gemma4_gguf_fused_moe_qweight_type(
+            "layers.0.moe.down_proj.qweight_type",
+            torch.tensor(13),
+            params_dict,
+        )
+
+        assert remapped == "layers.0.moe.experts.w2_qweight_type"
+        assert w2_type.weight_type == 13
+        assert w2_type.item() == 13

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -16,6 +16,7 @@ from vllm.model_executor.model_loader.gguf_loader import (
 )
 from vllm.model_executor.model_loader.weight_utils import download_gguf
 from vllm.model_executor.models.gemma4 import (
+    _load_gemma4_gguf_fused_moe_qweight,
     _load_gemma4_gguf_fused_moe_qweight_type,
 )
 from vllm.model_executor.models.gemma4_mm import (
@@ -271,10 +272,10 @@ class TestGGUFModelLoader:
             "model.language_model.layers.1.router.per_expert_scale"
         )
         assert gguf_to_hf_name_map["blk.1.ffn_gate_up_exps.weight"] == (
-            "model.language_model.layers.1.experts.gate_up_proj"
+            "model.language_model.layers.1.experts.gate_up_proj.weight"
         )
         assert gguf_to_hf_name_map["blk.1.ffn_down_exps.weight"] == (
-            "model.language_model.layers.1.experts.down_proj"
+            "model.language_model.layers.1.experts.down_proj.weight"
         )
         assert gguf_to_hf_name_map["blk.1.post_ffw_norm_1.weight"] == (
             "model.language_model.layers.1.post_feedforward_layernorm_1.weight"
@@ -372,8 +373,8 @@ class TestGGUFModelLoader:
         w2_type.is_gguf_weight_type = True
         w2_type.weight_type = 0
         params_dict = {
-            "layers.0.moe.experts.w13_qweight_type": w13_type,
-            "layers.0.moe.experts.w2_qweight_type": w2_type,
+            "layers.0.moe.experts.routed_experts.w13_qweight_type": w13_type,
+            "layers.0.moe.experts.routed_experts.w2_qweight_type": w2_type,
         }
 
         remapped = _load_gemma4_gguf_fused_moe_qweight_type(
@@ -382,7 +383,7 @@ class TestGGUFModelLoader:
             params_dict,
         )
 
-        assert remapped == "layers.0.moe.experts.w13_qweight_type"
+        assert remapped == "layers.0.moe.experts.routed_experts.w13_qweight_type"
         assert w13_type.weight_type == 12
         assert w13_type.item() == 12
 
@@ -392,6 +393,38 @@ class TestGGUFModelLoader:
             params_dict,
         )
 
-        assert remapped == "layers.0.moe.experts.w2_qweight_type"
+        assert remapped == "layers.0.moe.experts.routed_experts.w2_qweight_type"
         assert w2_type.weight_type == 13
         assert w2_type.item() == 13
+
+    def test_gemma4_fused_moe_gguf_qweight_remap(self):
+        w13_qweight = torch.nn.parameter.UninitializedParameter(requires_grad=False)
+        w13_qweight.is_gguf_weight = True
+        w2_qweight = torch.nn.parameter.UninitializedParameter(requires_grad=False)
+        w2_qweight.is_gguf_weight = True
+        params_dict = {
+            "layers.0.moe.experts.routed_experts.w13_qweight": w13_qweight,
+            "layers.0.moe.experts.routed_experts.w2_qweight": w2_qweight,
+        }
+
+        w13_loaded = torch.arange(2 * 3 * 4, dtype=torch.uint8).reshape(2, 3, 4)
+        remapped = _load_gemma4_gguf_fused_moe_qweight(
+            "layers.0.moe.gate_up_proj.qweight",
+            w13_loaded,
+            params_dict,
+        )
+
+        assert remapped == "layers.0.moe.experts.routed_experts.w13_qweight"
+        assert tuple(w13_qweight.shape) == (2, 3, 4)
+        assert torch.equal(w13_qweight, w13_loaded)
+
+        w2_loaded = torch.arange(2 * 5 * 6, dtype=torch.uint8).reshape(2, 5, 6)
+        remapped = _load_gemma4_gguf_fused_moe_qweight(
+            "layers.0.moe.down_proj.qweight",
+            w2_loaded,
+            params_dict,
+        )
+
+        assert remapped == "layers.0.moe.experts.routed_experts.w2_qweight"
+        assert tuple(w2_qweight.shape) == (2, 5, 6)
+        assert torch.equal(w2_qweight, w2_loaded)

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -19,9 +19,7 @@ from vllm.model_executor.models.gemma4 import (
     _load_gemma4_gguf_fused_moe_qweight_type,
 )
 from vllm.model_executor.models.gemma4_mm import _gemma4_patch_embed_weight_loader
-from vllm.model_executor.models.qwen3_next import (
-    _maybe_reshape_gguf_shared_expert_gate,
-)
+from vllm.model_executor.models.qwen3_next import _maybe_reshape_gguf_weight
 
 
 class TestGGUFDownload:
@@ -284,7 +282,7 @@ class TestGGUFModelLoader:
 
     def test_qwen_gguf_shared_expert_gate_weight_is_2d(self):
         loaded_weight = torch.arange(4)
-        reshaped = _maybe_reshape_gguf_shared_expert_gate(
+        reshaped = _maybe_reshape_gguf_weight(
             "model.layers.0.mlp.shared_expert_gate.weight",
             loaded_weight,
         )
@@ -292,12 +290,22 @@ class TestGGUFModelLoader:
         assert reshaped.shape == (1, 4)
         assert torch.equal(reshaped, loaded_weight[None, :])
         assert (
-            _maybe_reshape_gguf_shared_expert_gate(
+            _maybe_reshape_gguf_weight(
                 "model.layers.0.mlp.gate_proj.weight",
                 loaded_weight,
             )
             is loaded_weight
         )
+
+    def test_qwen_gguf_linear_attn_conv1d_weight_is_3d(self):
+        loaded_weight = torch.arange(8).reshape(2, 4)
+        reshaped = _maybe_reshape_gguf_weight(
+            "model.layers.0.linear_attn.conv1d.weight",
+            loaded_weight,
+        )
+
+        assert reshaped.shape == (2, 1, 4)
+        assert torch.equal(reshaped, loaded_weight[:, None, :])
 
     def test_gemma4_patch_embedder_weight_transform(self):
         param = torch.nn.Parameter(torch.empty(2, 60), requires_grad=False)

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -261,11 +261,26 @@ class TestGGUFModelLoader:
         assert gguf_to_hf_name_map["blk.1.ffn_gate_inp.scale"] == (
             "model.language_model.layers.1.router.scale"
         )
+        assert gguf_to_hf_name_map["blk.1.ffn_gate_inp.weight"] == (
+            "model.language_model.layers.1.router.proj.weight"
+        )
         assert gguf_to_hf_name_map["blk.1.ffn_down_exps.scale"] == (
             "model.language_model.layers.1.router.per_expert_scale"
         )
         assert gguf_to_hf_name_map["blk.1.ffn_gate_up_exps.weight"] == (
-            "model.language_model.layers.1.experts.gate_up_proj.weight"
+            "model.language_model.layers.1.experts.gate_up_proj"
+        )
+        assert gguf_to_hf_name_map["blk.1.ffn_down_exps.weight"] == (
+            "model.language_model.layers.1.experts.down_proj"
+        )
+        assert gguf_to_hf_name_map["blk.1.post_ffw_norm_1.weight"] == (
+            "model.language_model.layers.1.post_feedforward_layernorm_1.weight"
+        )
+        assert gguf_to_hf_name_map["blk.1.post_ffw_norm_2.weight"] == (
+            "model.language_model.layers.1.post_feedforward_layernorm_2.weight"
+        )
+        assert gguf_to_hf_name_map["blk.1.pre_ffw_norm_2.weight"] == (
+            "model.language_model.layers.1.pre_feedforward_layernorm_2.weight"
         )
         assert gguf_to_hf_name_map["v.blk.2.attn_q.weight"] == (
             "model.vision_tower.encoder.layers.2.self_attn.q_proj.linear.weight"

--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -59,18 +59,19 @@ def test_resolve_tokenizer_args_idempotent(runner_type):
     )
 
 
-def test_resolve_tokenizer_args_remote_gguf_base_tokenizer(monkeypatch):
+def test_resolve_tokenizer_args_remote_gguf_keeps_embedded_tokenizer(monkeypatch):
     from vllm.tokenizers import registry
 
-    def fake_resolve_gguf_tokenizer_source(tokenizer_name, revision=None):
-        assert tokenizer_name == "org/model-GGUF:UD-IQ4_NL"
+    def fake_get_gguf_file_path_from_hf(tokenizer_name, quant_type, revision=None):
+        assert tokenizer_name == "org/model-GGUF"
+        assert quant_type == "UD-IQ4_NL"
         assert revision == "gguf-rev"
-        return "org/base"
+        return "model-UD-IQ4_NL.gguf"
 
     monkeypatch.setattr(
         registry,
-        "resolve_gguf_tokenizer_source",
-        fake_resolve_gguf_tokenizer_source,
+        "get_gguf_file_path_from_hf",
+        fake_get_gguf_file_path_from_hf,
     )
 
     tokenizer_mode, tokenizer_name, args, kwargs = resolve_tokenizer_args(
@@ -79,19 +80,14 @@ def test_resolve_tokenizer_args_remote_gguf_base_tokenizer(monkeypatch):
     )
 
     assert tokenizer_mode == "hf"
-    assert tokenizer_name == "org/base"
+    assert tokenizer_name == "org/model-GGUF"
     assert args == ()
-    assert "gguf_file" not in kwargs
-    assert kwargs["revision"] is None
+    assert kwargs["gguf_file"] == "model-UD-IQ4_NL.gguf"
+    assert kwargs["revision"] == "gguf-rev"
 
 
-def test_resolve_tokenizer_args_local_gguf_base_tokenizer(monkeypatch):
+def test_resolve_tokenizer_args_local_gguf_keeps_embedded_tokenizer(monkeypatch):
     from vllm.tokenizers import registry
-
-    def fake_resolve_gguf_tokenizer_source(tokenizer_name, revision=None):
-        assert tokenizer_name == "/models/qwen.gguf"
-        assert revision == "local-rev"
-        return "org/base"
 
     monkeypatch.setattr(
         registry,
@@ -103,11 +99,6 @@ def test_resolve_tokenizer_args_local_gguf_base_tokenizer(monkeypatch):
         "check_gguf_file",
         lambda tokenizer_name: tokenizer_name == "/models/qwen.gguf",
     )
-    monkeypatch.setattr(
-        registry,
-        "resolve_gguf_tokenizer_source",
-        fake_resolve_gguf_tokenizer_source,
-    )
 
     tokenizer_mode, tokenizer_name, args, kwargs = resolve_tokenizer_args(
         "/models/qwen.gguf",
@@ -115,10 +106,10 @@ def test_resolve_tokenizer_args_local_gguf_base_tokenizer(monkeypatch):
     )
 
     assert tokenizer_mode == "hf"
-    assert tokenizer_name == "org/base"
+    assert tokenizer_name == Path("/models")
     assert args == ()
-    assert "gguf_file" not in kwargs
-    assert kwargs["revision"] is None
+    assert kwargs["gguf_file"] == "qwen.gguf"
+    assert kwargs["revision"] == "local-rev"
 
 
 def test_customized_tokenizer():

--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -59,6 +59,68 @@ def test_resolve_tokenizer_args_idempotent(runner_type):
     )
 
 
+def test_resolve_tokenizer_args_remote_gguf_base_tokenizer(monkeypatch):
+    from vllm.tokenizers import registry
+
+    def fake_resolve_gguf_tokenizer_source(tokenizer_name, revision=None):
+        assert tokenizer_name == "org/model-GGUF:UD-IQ4_NL"
+        assert revision == "gguf-rev"
+        return "org/base"
+
+    monkeypatch.setattr(
+        registry,
+        "resolve_gguf_tokenizer_source",
+        fake_resolve_gguf_tokenizer_source,
+    )
+
+    tokenizer_mode, tokenizer_name, args, kwargs = resolve_tokenizer_args(
+        "org/model-GGUF:UD-IQ4_NL",
+        revision="gguf-rev",
+    )
+
+    assert tokenizer_mode == "hf"
+    assert tokenizer_name == "org/base"
+    assert args == ()
+    assert "gguf_file" not in kwargs
+    assert kwargs["revision"] is None
+
+
+def test_resolve_tokenizer_args_local_gguf_base_tokenizer(monkeypatch):
+    from vllm.tokenizers import registry
+
+    def fake_resolve_gguf_tokenizer_source(tokenizer_name, revision=None):
+        assert tokenizer_name == "/models/qwen.gguf"
+        assert revision == "local-rev"
+        return "org/base"
+
+    monkeypatch.setattr(
+        registry,
+        "is_gguf",
+        lambda tokenizer_name: tokenizer_name == "/models/qwen.gguf",
+    )
+    monkeypatch.setattr(
+        registry,
+        "check_gguf_file",
+        lambda tokenizer_name: tokenizer_name == "/models/qwen.gguf",
+    )
+    monkeypatch.setattr(
+        registry,
+        "resolve_gguf_tokenizer_source",
+        fake_resolve_gguf_tokenizer_source,
+    )
+
+    tokenizer_mode, tokenizer_name, args, kwargs = resolve_tokenizer_args(
+        "/models/qwen.gguf",
+        revision="local-rev",
+    )
+
+    assert tokenizer_mode == "hf"
+    assert tokenizer_name == "org/base"
+    assert args == ()
+    assert "gguf_file" not in kwargs
+    assert kwargs["revision"] is None
+
+
 def test_customized_tokenizer():
     TokenizerRegistry.register("test_tokenizer", __name__, TestTokenizer.__name__)
 

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -7,7 +7,38 @@ only get the `eos_token_id` from the tokenizer as defined by
 """
 
 from vllm.tokenizers import get_tokenizer
-from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.config import (
+    get_config,
+    maybe_override_with_speculators,
+    try_get_generation_config,
+)
+
+
+def _patch_config_dict(monkeypatch, config_module, config_dict):
+    calls = []
+
+    def fake_get_config_dict(model, revision=None, token=None, **kwargs):
+        calls.append((model, revision, kwargs))
+        return config_dict, {}
+
+    monkeypatch.setattr(
+        config_module.PretrainedConfig,
+        "get_config_dict",
+        fake_get_config_dict,
+    )
+    return calls
+
+
+def _patch_config_source(monkeypatch, config_module, source):
+    monkeypatch.setattr(
+        config_module, "resolve_gguf_config_source", lambda *args, **kwargs: source
+    )
+
+
+def _patch_gguf_file(monkeypatch, config_module, filename):
+    monkeypatch.setattr(
+        config_module, "get_gguf_file_path_from_hf", lambda *args, **kwargs: filename
+    )
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +61,179 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+def test_remote_gguf_speculators_uses_resolved_config_source(monkeypatch):
+    from vllm.transformers_utils import config as config_module
+
+    _patch_config_source(monkeypatch, config_module, "org/base")
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {
+            "speculators_model_type": "eagle3",
+            "transformer_layer_config": {},
+            "speculators_config": {
+                "proposal_methods": [{"speculative_tokens": 2}],
+                "verifier": {"name_or_path": "org/target"},
+            },
+        },
+    )
+
+    model, tokenizer, speculative_config = maybe_override_with_speculators(
+        "org/spec-GGUF:UD-IQ4_NL",
+        tokenizer=None,
+        trust_remote_code=False,
+        revision="gguf-rev",
+    )
+
+    assert calls == [("org/base", None, {"local_files_only": False})]
+    assert model == "org/target"
+    assert tokenizer == "org/target"
+    assert speculative_config == {
+        "method": "eagle3",
+        "num_speculative_tokens": 2,
+        "model": "org/spec-GGUF:UD-IQ4_NL",
+    }
+
+
+def test_remote_gguf_speculators_uses_gguf_parser_fallback(monkeypatch):
+    from vllm.transformers_utils import config as config_module
+
+    _patch_config_source(monkeypatch, config_module, "org/spec-GGUF")
+    _patch_gguf_file(monkeypatch, config_module, "spec-UD-IQ4_NL.gguf")
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: False,
+    )
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {"model_type": "qwen3_5_moe"},
+    )
+
+    model, tokenizer, speculative_config = maybe_override_with_speculators(
+        "org/spec-GGUF:UD-IQ4_NL",
+        tokenizer=None,
+        trust_remote_code=False,
+        revision="gguf-rev",
+    )
+
+    assert calls == [
+        (
+            "org/spec-GGUF",
+            "gguf-rev",
+            {
+                "gguf_file": "spec-UD-IQ4_NL.gguf",
+                "local_files_only": False,
+            },
+        )
+    ]
+    assert model == "org/spec-GGUF:UD-IQ4_NL"
+    assert tokenizer is None
+    assert speculative_config is None
+
+
+def test_local_gguf_speculators_uses_explicit_hf_config_path(monkeypatch):
+    from vllm.transformers_utils import config as config_module
+
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {"model_type": "qwen3_5_moe"},
+    )
+
+    model, tokenizer, speculative_config = maybe_override_with_speculators(
+        "/models/qwen.gguf",
+        tokenizer="org/base",
+        trust_remote_code=False,
+        hf_config_path="org/base",
+    )
+
+    assert calls == [("org/base", None, {"local_files_only": False})]
+    assert model == "/models/qwen.gguf"
+    assert tokenizer == "org/base"
+    assert speculative_config is None
+
+
+def test_local_gguf_speculators_uses_resolved_config_source(monkeypatch):
+    from vllm.transformers_utils import config as config_module
+
+    _patch_config_source(monkeypatch, config_module, "org/base")
+    monkeypatch.setattr(
+        config_module,
+        "check_gguf_file",
+        lambda model: model == "/models/qwen.gguf",
+    )
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {"model_type": "qwen3_5_moe"},
+    )
+
+    model, tokenizer, speculative_config = maybe_override_with_speculators(
+        "/models/qwen.gguf",
+        tokenizer=None,
+        trust_remote_code=False,
+        revision="local-rev",
+    )
+
+    assert calls == [("org/base", None, {"local_files_only": False})]
+    assert model == "/models/qwen.gguf"
+    assert tokenizer is None
+    assert speculative_config is None
+
+
+def test_remote_gguf_get_config_uses_gguf_parser_fallback(monkeypatch):
+    from transformers import PretrainedConfig
+
+    from vllm.transformers_utils import config as config_module
+
+    calls = []
+
+    class FakeParser:
+        def parse(
+            self,
+            model,
+            trust_remote_code,
+            revision=None,
+            code_revision=None,
+            hf_overrides=None,
+            **kwargs,
+        ):
+            calls.append((model, revision, kwargs))
+            return {}, PretrainedConfig(architectures=["FakeModel"])
+
+    _patch_config_source(monkeypatch, config_module, "org/model-GGUF")
+    _patch_gguf_file(monkeypatch, config_module, "model-UD-IQ4_NL.gguf")
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: False,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_mistral_model_repo",
+        lambda model_name_or_path, revision=None: False,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_config_parser",
+        lambda config_format: FakeParser(),
+    )
+
+    config = get_config(
+        "org/model-GGUF:UD-IQ4_NL",
+        trust_remote_code=False,
+        revision="gguf-rev",
+    )
+
+    assert calls == [
+        (
+            "org/model-GGUF",
+            "gguf-rev",
+            {"gguf_file": "model-UD-IQ4_NL.gguf"},
+        )
+    ]
+    assert config.architectures == ["FakeModel"]

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -41,6 +41,116 @@ def _patch_gguf_file(monkeypatch, config_module, filename):
     )
 
 
+def _patch_gguf_reader(monkeypatch, gguf_utils_module, metadata):
+    class FakeField:
+        def __init__(self, value):
+            self.value = value
+
+        def contents(self):
+            return self.value
+
+    class FakeReader:
+        def __init__(self, model):
+            self.model = model
+
+        def get_field(self, key):
+            if key not in metadata:
+                return None
+            return FakeField(metadata[key])
+
+    monkeypatch.setattr(gguf_utils_module.gguf, "GGUFReader", FakeReader)
+
+
+def test_local_gguf_mtp_metadata_patches_qwen_config(monkeypatch):
+    from transformers import PretrainedConfig
+
+    from vllm.transformers_utils import gguf_utils
+
+    gguf_utils._get_local_gguf_mtp_metadata.cache_clear()
+    _patch_gguf_reader(
+        monkeypatch,
+        gguf_utils,
+        {
+            "general.architecture": "qwen35moe",
+            "qwen35moe.nextn_predict_layers": [1],
+        },
+    )
+    monkeypatch.setattr(gguf_utils, "check_gguf_file", lambda model: True)
+
+    config = PretrainedConfig(
+        model_type="qwen3_5_moe",
+        architectures=["Qwen3_5MoeForConditionalGeneration"],
+    )
+
+    patched_config = gguf_utils.maybe_patch_mtp_config_from_gguf(
+        "/models/qwen-mtp.gguf",
+        config,
+    )
+
+    assert patched_config.mtp_num_hidden_layers == 1
+    gguf_utils._get_local_gguf_mtp_metadata.cache_clear()
+
+
+def test_local_gguf_mtp_metadata_patches_gemma_config(monkeypatch):
+    from transformers import PretrainedConfig
+
+    from vllm.transformers_utils import gguf_utils
+
+    gguf_utils._get_local_gguf_mtp_metadata.cache_clear()
+    _patch_gguf_reader(
+        monkeypatch,
+        gguf_utils,
+        {
+            "general.architecture": "gemma4-assistant",
+            "gemma4-assistant.nextn_predict_layers": [4],
+            "gemma4-assistant.embedding_length": [1024],
+            "gemma4-assistant.embedding_length_out": [2816],
+            "gemma4-assistant.feed_forward_length": [8192],
+            "gemma4-assistant.attention.head_count": [16],
+            "gemma4-assistant.attention.head_count_kv": [8, 8, 8, 2],
+            "gemma4-assistant.attention.key_length": [512],
+            "gemma4-assistant.attention.key_length_swa": [256],
+            "gemma4-assistant.attention.sliding_window": [1024],
+            "gemma4-assistant.attention.sliding_window_pattern": [
+                True,
+                True,
+                True,
+                False,
+            ],
+        },
+    )
+    monkeypatch.setattr(gguf_utils, "check_gguf_file", lambda model: True)
+
+    config = PretrainedConfig(
+        model_type="gemma4",
+        architectures=["Gemma4ForConditionalGeneration"],
+    )
+
+    patched_config = gguf_utils.maybe_patch_mtp_config_from_gguf(
+        "/models/gemma-mtp.gguf",
+        config,
+    )
+
+    assert patched_config.model_type == "gemma4_assistant"
+    assert patched_config.num_hidden_layers == 4
+    assert patched_config.hidden_size == 1024
+    assert patched_config.backbone_hidden_size == 2816
+    assert patched_config.intermediate_size == 8192
+    assert patched_config.num_attention_heads == 16
+    assert patched_config.num_key_value_heads == 8
+    assert patched_config.num_global_key_value_heads == 2
+    assert patched_config.head_dim == 256
+    assert patched_config.global_head_dim == 512
+    assert patched_config.sliding_window == 1024
+    assert patched_config.layer_types == [
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ]
+    gguf_utils._get_local_gguf_mtp_metadata.cache_clear()
+
+
 def test_get_llama3_eos_token():
     model_name = "meta-llama/Llama-3.2-1B-Instruct"
 
@@ -496,3 +606,162 @@ def test_local_gguf_get_config_disables_trust_for_metadata_base(
     )
 
     assert calls == [("org/base", False, None, {})]
+
+
+def test_local_gguf_get_config_patches_mtp_before_speculative_override(
+    monkeypatch,
+):
+    from transformers import PretrainedConfig
+
+    from vllm.config.speculative import SpeculativeConfig
+    from vllm.transformers_utils import config as config_module
+
+    class FakeParser:
+        def parse(
+            self,
+            model,
+            trust_remote_code,
+            revision=None,
+            code_revision=None,
+            hf_overrides=None,
+            **kwargs,
+        ):
+            return {}, PretrainedConfig(
+                model_type="qwen3_5_moe",
+                architectures=["Qwen3_5MoeForConditionalGeneration"],
+            )
+
+    _patch_config_source(monkeypatch, config_module, "/models")
+    monkeypatch.setattr(
+        config_module,
+        "is_gguf",
+        lambda model: model == "/models/qwen-mtp.gguf",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "check_gguf_file",
+        lambda model: model == "/models/qwen-mtp.gguf",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: (
+            model == "/models" and config_name == config_module.HF_CONFIG_NAME
+        ),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_mistral_model_repo",
+        lambda model_name_or_path, revision=None: False,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_config_parser",
+        lambda config_format: FakeParser(),
+    )
+
+    def fake_patch_mtp_config(model, config):
+        config.update({"mtp_num_hidden_layers": 1})
+        return config
+
+    monkeypatch.setattr(
+        config_module,
+        "maybe_patch_mtp_config_from_gguf",
+        fake_patch_mtp_config,
+    )
+
+    config = get_config(
+        "/models/qwen-mtp.gguf",
+        trust_remote_code=False,
+        hf_overrides_fn=SpeculativeConfig.hf_config_override,
+    )
+
+    assert config.model_type == "qwen3_5_mtp"
+    assert config.n_predict == 1
+    assert config.architectures == ["Qwen3_5MoeMTP"]
+
+
+def test_local_nested_gguf_mtp_uses_parent_config_before_speculative_override(
+    monkeypatch,
+):
+    from pathlib import Path
+
+    from transformers import PretrainedConfig
+
+    from vllm.config.speculative import SpeculativeConfig
+    from vllm.transformers_utils import config as config_module
+
+    calls = []
+
+    class FakeParser:
+        def parse(
+            self,
+            model,
+            trust_remote_code,
+            revision=None,
+            code_revision=None,
+            hf_overrides=None,
+            **kwargs,
+        ):
+            calls.append((model, trust_remote_code, revision, kwargs))
+            return {}, PretrainedConfig(
+                model_type="gemma4",
+                architectures=["Gemma4ForConditionalGeneration"],
+            )
+
+    gguf_file = "/models/gemma-gguf/MTP/gemma-mtp.gguf"
+    gguf_repo = Path("/models/gemma-gguf/MTP")
+    parent_repo = Path("/models/gemma-gguf")
+    monkeypatch.setattr(
+        config_module,
+        "resolve_gguf_config_source",
+        lambda *args, **kwargs: gguf_repo,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_gguf",
+        lambda model: model == gguf_file,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "check_gguf_file",
+        lambda model: model == gguf_file,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: (
+            Path(model) == parent_repo and config_name == config_module.HF_CONFIG_NAME
+        ),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_mistral_model_repo",
+        lambda model_name_or_path, revision=None: False,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_config_parser",
+        lambda config_format: FakeParser(),
+    )
+
+    def fake_patch_mtp_config(model, config):
+        config.model_type = "gemma4_assistant"
+        return config
+
+    monkeypatch.setattr(
+        config_module,
+        "maybe_patch_mtp_config_from_gguf",
+        fake_patch_mtp_config,
+    )
+
+    config = get_config(
+        gguf_file,
+        trust_remote_code=False,
+        hf_overrides_fn=SpeculativeConfig.hf_config_override,
+    )
+
+    assert calls == [(parent_repo, False, None, {})]
+    assert config.model_type == "gemma4_mtp"
+    assert config.n_predict == 1
+    assert config.architectures == ["Gemma4MTPModel"]

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -80,14 +80,17 @@ def test_remote_gguf_speculators_uses_resolved_config_source(monkeypatch):
         },
     )
 
-    model, tokenizer, speculative_config = maybe_override_with_speculators(
-        "org/spec-GGUF:UD-IQ4_NL",
-        tokenizer=None,
-        trust_remote_code=False,
-        revision="gguf-rev",
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "org/spec-GGUF:UD-IQ4_NL",
+            tokenizer=None,
+            trust_remote_code=True,
+            revision="gguf-rev",
+        )
     )
 
     assert calls == [("org/base", None, {"local_files_only": False})]
+    assert trust_remote_code is False
     assert model == "org/target"
     assert tokenizer == "org/target"
     assert speculative_config == {
@@ -113,11 +116,13 @@ def test_remote_gguf_speculators_uses_gguf_parser_fallback(monkeypatch):
         {"model_type": "qwen3_5_moe"},
     )
 
-    model, tokenizer, speculative_config = maybe_override_with_speculators(
-        "org/spec-GGUF:UD-IQ4_NL",
-        tokenizer=None,
-        trust_remote_code=False,
-        revision="gguf-rev",
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "org/spec-GGUF:UD-IQ4_NL",
+            tokenizer=None,
+            trust_remote_code=False,
+            revision="gguf-rev",
+        )
     )
 
     assert calls == [
@@ -130,9 +135,62 @@ def test_remote_gguf_speculators_uses_gguf_parser_fallback(monkeypatch):
             },
         )
     ]
+    assert trust_remote_code is False
     assert model == "org/spec-GGUF:UD-IQ4_NL"
     assert tokenizer is None
     assert speculative_config is None
+
+
+def test_remote_gguf_parser_speculators_disables_trust_remote_code(monkeypatch):
+    from vllm.transformers_utils import config as config_module
+
+    _patch_config_source(monkeypatch, config_module, "org/spec-GGUF")
+    _patch_gguf_file(monkeypatch, config_module, "spec-UD-IQ4_NL.gguf")
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: False,
+    )
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {
+            "speculators_model_type": "eagle3",
+            "transformer_layer_config": {},
+            "speculators_config": {
+                "proposal_methods": [{"speculative_tokens": 2}],
+                "verifier": {"name_or_path": "org/target"},
+            },
+        },
+    )
+
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "org/spec-GGUF:UD-IQ4_NL",
+            tokenizer=None,
+            trust_remote_code=True,
+            revision="gguf-rev",
+        )
+    )
+
+    assert calls == [
+        (
+            "org/spec-GGUF",
+            "gguf-rev",
+            {
+                "gguf_file": "spec-UD-IQ4_NL.gguf",
+                "local_files_only": False,
+            },
+        )
+    ]
+    assert trust_remote_code is False
+    assert model == "org/target"
+    assert tokenizer == "org/target"
+    assert speculative_config == {
+        "method": "eagle3",
+        "num_speculative_tokens": 2,
+        "model": "org/spec-GGUF:UD-IQ4_NL",
+    }
 
 
 def test_local_gguf_speculators_uses_explicit_hf_config_path(monkeypatch):
@@ -144,17 +202,58 @@ def test_local_gguf_speculators_uses_explicit_hf_config_path(monkeypatch):
         {"model_type": "qwen3_5_moe"},
     )
 
-    model, tokenizer, speculative_config = maybe_override_with_speculators(
-        "/models/qwen.gguf",
-        tokenizer="org/base",
-        trust_remote_code=False,
-        hf_config_path="org/base",
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "/models/qwen.gguf",
+            tokenizer="org/base",
+            trust_remote_code=False,
+            hf_config_path="org/base",
+        )
     )
 
     assert calls == [("org/base", None, {"local_files_only": False})]
+    assert trust_remote_code is False
     assert model == "/models/qwen.gguf"
     assert tokenizer == "org/base"
     assert speculative_config is None
+
+
+def test_local_gguf_explicit_hf_config_path_preserves_trust_remote_code(
+    monkeypatch,
+):
+    from vllm.transformers_utils import config as config_module
+
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {
+            "speculators_model_type": "eagle3",
+            "transformer_layer_config": {},
+            "speculators_config": {
+                "proposal_methods": [{"speculative_tokens": 2}],
+                "verifier": {"name_or_path": "org/target"},
+            },
+        },
+    )
+
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "/models/qwen.gguf",
+            tokenizer="org/base",
+            trust_remote_code=True,
+            hf_config_path="org/base",
+        )
+    )
+
+    assert calls == [("org/base", None, {"local_files_only": False})]
+    assert trust_remote_code is True
+    assert model == "org/target"
+    assert tokenizer == "org/target"
+    assert speculative_config == {
+        "method": "eagle3",
+        "num_speculative_tokens": 2,
+        "model": "/models/qwen.gguf",
+    }
 
 
 def test_local_gguf_speculators_uses_resolved_config_source(monkeypatch):
@@ -172,14 +271,17 @@ def test_local_gguf_speculators_uses_resolved_config_source(monkeypatch):
         {"model_type": "qwen3_5_moe"},
     )
 
-    model, tokenizer, speculative_config = maybe_override_with_speculators(
-        "/models/qwen.gguf",
-        tokenizer=None,
-        trust_remote_code=False,
-        revision="local-rev",
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "/models/qwen.gguf",
+            tokenizer=None,
+            trust_remote_code=False,
+            revision="local-rev",
+        )
     )
 
     assert calls == [("org/base", None, {"local_files_only": False})]
+    assert trust_remote_code is False
     assert model == "/models/qwen.gguf"
     assert tokenizer is None
     assert speculative_config is None

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -141,6 +141,49 @@ def test_remote_gguf_speculators_uses_gguf_parser_fallback(monkeypatch):
     assert speculative_config is None
 
 
+def test_remote_gguf_parser_fallback_without_speculators_disables_trust_remote_code(
+    monkeypatch,
+):
+    from vllm.transformers_utils import config as config_module
+
+    _patch_config_source(monkeypatch, config_module, "org/spec-GGUF")
+    _patch_gguf_file(monkeypatch, config_module, "spec-UD-IQ4_NL.gguf")
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: False,
+    )
+    calls = _patch_config_dict(
+        monkeypatch,
+        config_module,
+        {"model_type": "qwen3_5_moe"},
+    )
+
+    model, tokenizer, speculative_config, trust_remote_code = (
+        maybe_override_with_speculators(
+            "org/spec-GGUF:UD-IQ4_NL",
+            tokenizer=None,
+            trust_remote_code=True,
+            revision="gguf-rev",
+        )
+    )
+
+    assert calls == [
+        (
+            "org/spec-GGUF",
+            "gguf-rev",
+            {
+                "gguf_file": "spec-UD-IQ4_NL.gguf",
+                "local_files_only": False,
+            },
+        )
+    ]
+    assert trust_remote_code is False
+    assert model == "org/spec-GGUF:UD-IQ4_NL"
+    assert tokenizer is None
+    assert speculative_config is None
+
+
 def test_remote_gguf_parser_speculators_disables_trust_remote_code(monkeypatch):
     from vllm.transformers_utils import config as config_module
 

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -237,3 +237,117 @@ def test_remote_gguf_get_config_uses_gguf_parser_fallback(monkeypatch):
         )
     ]
     assert config.architectures == ["FakeModel"]
+
+
+def test_remote_gguf_get_config_disables_trust_for_metadata_base(
+    monkeypatch,
+):
+    from transformers import PretrainedConfig
+
+    from vllm.transformers_utils import config as config_module
+
+    calls = []
+
+    class FakeParser:
+        def parse(
+            self,
+            model,
+            trust_remote_code,
+            revision=None,
+            code_revision=None,
+            hf_overrides=None,
+            **kwargs,
+        ):
+            calls.append((model, trust_remote_code, revision, kwargs))
+            return {}, PretrainedConfig(architectures=["FakeModel"])
+
+    _patch_config_source(monkeypatch, config_module, "org/base")
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: (
+            model == "org/base"
+            and config_name == config_module.HF_CONFIG_NAME
+            and revision is None
+        ),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_mistral_model_repo",
+        lambda model_name_or_path, revision=None: False,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_config_parser",
+        lambda config_format: FakeParser(),
+    )
+
+    get_config(
+        "org/model-GGUF:UD-IQ4_NL",
+        trust_remote_code=True,
+        revision="gguf-rev",
+    )
+
+    assert calls == [("org/base", False, None, {})]
+
+
+def test_local_gguf_get_config_disables_trust_for_metadata_base(
+    monkeypatch,
+):
+    from transformers import PretrainedConfig
+
+    from vllm.transformers_utils import config as config_module
+
+    calls = []
+
+    class FakeParser:
+        def parse(
+            self,
+            model,
+            trust_remote_code,
+            revision=None,
+            code_revision=None,
+            hf_overrides=None,
+            **kwargs,
+        ):
+            calls.append((model, trust_remote_code, revision, kwargs))
+            return {}, PretrainedConfig(architectures=["FakeModel"])
+
+    _patch_config_source(monkeypatch, config_module, "org/base")
+    monkeypatch.setattr(
+        config_module,
+        "is_gguf",
+        lambda model: model == "/models/qwen.gguf",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "check_gguf_file",
+        lambda model: model == "/models/qwen.gguf",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "file_or_path_exists",
+        lambda model, config_name, revision=None: (
+            model == "org/base"
+            and config_name == config_module.HF_CONFIG_NAME
+            and revision is None
+        ),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_mistral_model_repo",
+        lambda model_name_or_path, revision=None: False,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_config_parser",
+        lambda config_format: FakeParser(),
+    )
+
+    get_config(
+        "/models/qwen.gguf",
+        trust_remote_code=True,
+        revision="local-rev",
+    )
+
+    assert calls == [("org/base", False, None, {})]

--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -291,6 +291,50 @@ class TestRemoteGGUFSourceResolution:
             == "org/base"
         )
 
+    def test_config_source_normalizes_remote_base_model_ids(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        class FakeInfo:
+            card_data = {
+                "base_model": [
+                    "/tmp/local-model",
+                    "https://huggingface.co/org/base",
+                    "org/base",
+                ]
+            }
+
+        class FakeHfApi:
+            def model_info(self, repo_id, revision=None):
+                assert repo_id == "org/model-GGUF"
+                assert revision == "gguf-rev"
+                return FakeInfo()
+
+        probed_models = []
+
+        def fake_file_or_path_exists(model, config_name, revision=None):
+            probed_models.append(model)
+            return (
+                model == "org/base"
+                and config_name == "config.json"
+                and revision is None
+            )
+
+        monkeypatch.setattr(gguf_utils, "hf_api", lambda: FakeHfApi())
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            fake_file_or_path_exists,
+        )
+
+        assert (
+            resolve_gguf_config_source(
+                "org/model-GGUF:UD-IQ4_NL",
+                revision="gguf-rev",
+            )
+            == "org/base"
+        )
+        assert "/tmp/local-model" not in probed_models
+
     def test_config_source_falls_back_to_gguf_repo_without_valid_base(
         self,
         monkeypatch,

--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -8,6 +8,8 @@ import pytest
 from vllm.transformers_utils.gguf_utils import (
     is_gguf,
     is_remote_gguf,
+    resolve_gguf_config_source,
+    resolve_gguf_tokenizer_source,
     split_remote_gguf,
 )
 from vllm.transformers_utils.utils import (
@@ -245,3 +247,184 @@ class TestIsGGUF:
         # Cloud storage
         assert not is_gguf("s3://bucket/repo/model:IQ1_S")
         assert not is_gguf("gs://bucket/repo/model:Q2_K")
+
+
+class TestRemoteGGUFSourceResolution:
+    def test_config_source_uses_first_base_model_with_config(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        class FakeInfo:
+            card_data = {"base_model": ["org/intermediate", "org/base"]}
+
+        class FakeHfApi:
+            def model_info(self, repo_id, revision=None):
+                assert repo_id == "org/model-GGUF"
+                assert revision == "gguf-rev"
+                return FakeInfo()
+
+        def fake_file_or_path_exists(model, config_name, revision=None):
+            return (
+                model == "org/base"
+                and config_name == "config.json"
+                and revision is None
+            )
+
+        monkeypatch.setattr(gguf_utils, "hf_api", lambda: FakeHfApi())
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            fake_file_or_path_exists,
+        )
+
+        assert (
+            resolve_gguf_config_source(
+                "org/model-GGUF:UD-IQ4_NL",
+                revision="gguf-rev",
+            )
+            == "org/base"
+        )
+
+    def test_config_source_falls_back_to_gguf_repo_without_valid_base(
+        self,
+        monkeypatch,
+    ):
+        from vllm.transformers_utils import gguf_utils
+
+        class FakeInfo:
+            card_data = {"base_model": ["org/intermediate"]}
+
+        class FakeHfApi:
+            def model_info(self, repo_id, revision=None):
+                return FakeInfo()
+
+        monkeypatch.setattr(gguf_utils, "hf_api", lambda: FakeHfApi())
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            lambda model, config_name, revision=None: False,
+        )
+
+        assert (
+            resolve_gguf_config_source(
+                "org/model-GGUF:UD-IQ4_NL",
+                revision="gguf-rev",
+            )
+            == "org/model-GGUF"
+        )
+
+    def test_local_config_source_uses_metadata_base_model(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        gguf_path = Path("/models/qwen.gguf")
+
+        monkeypatch.setattr(
+            gguf_utils,
+            "check_gguf_file",
+            lambda model: Path(model) == gguf_path,
+        )
+        monkeypatch.setattr(
+            gguf_utils,
+            "_get_local_gguf_base_model_ids",
+            lambda model: ("org/base",),
+        )
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            lambda model, config_name, revision=None: (
+                model == "org/base"
+                and config_name == "config.json"
+                and revision is None
+            ),
+        )
+
+        assert resolve_gguf_config_source(gguf_path, revision="local-rev") == "org/base"
+
+    def test_local_config_source_keeps_parent_when_config_exists(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        gguf_path = Path("/models/qwen.gguf")
+
+        monkeypatch.setattr(
+            gguf_utils,
+            "check_gguf_file",
+            lambda model: Path(model) == gguf_path,
+        )
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            lambda model, config_name, revision=None: (
+                model == gguf_path.parent
+                and config_name == "config.json"
+                and revision == "local-rev"
+            ),
+        )
+
+        assert (
+            resolve_gguf_config_source(gguf_path, revision="local-rev")
+            == gguf_path.parent
+        )
+
+    def test_tokenizer_source_checks_tokenizer_files_not_config(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        class FakeInfo:
+            card_data = {"base_model": "org/base"}
+
+        class FakeHfApi:
+            def model_info(self, repo_id, revision=None):
+                return FakeInfo()
+
+        def fake_file_or_path_exists(model, config_name, revision=None):
+            return (
+                model == "org/model-GGUF"
+                and config_name == "config.json"
+                and revision == "gguf-rev"
+            ) or (
+                model == "org/base"
+                and config_name == "tokenizer_config.json"
+                and revision is None
+            )
+
+        monkeypatch.setattr(gguf_utils, "hf_api", lambda: FakeHfApi())
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            fake_file_or_path_exists,
+        )
+
+        assert (
+            resolve_gguf_tokenizer_source(
+                "org/model-GGUF:UD-IQ4_NL",
+                revision="gguf-rev",
+            )
+            == "org/base"
+        )
+
+    def test_local_tokenizer_source_uses_metadata_base_model(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        gguf_path = Path("/models/qwen.gguf")
+
+        monkeypatch.setattr(
+            gguf_utils,
+            "check_gguf_file",
+            lambda model: Path(model) == gguf_path,
+        )
+        monkeypatch.setattr(
+            gguf_utils,
+            "_get_local_gguf_base_model_ids",
+            lambda model: ("org/base",),
+        )
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            lambda model, config_name, revision=None: (
+                model == "org/base"
+                and config_name == "tokenizer_config.json"
+                and revision is None
+            ),
+        )
+
+        assert (
+            resolve_gguf_tokenizer_source(gguf_path, revision="local-rev") == "org/base"
+        )

--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -250,6 +250,14 @@ class TestIsGGUF:
 
 
 class TestRemoteGGUFSourceResolution:
+    @pytest.fixture(autouse=True)
+    def clear_remote_gguf_base_model_cache(self):
+        from vllm.transformers_utils import gguf_utils
+
+        gguf_utils._get_remote_gguf_base_model_ids.cache_clear()
+        yield
+        gguf_utils._get_remote_gguf_base_model_ids.cache_clear()
+
     def test_config_source_uses_first_base_model_with_config(self, monkeypatch):
         from vllm.transformers_utils import gguf_utils
 
@@ -428,3 +436,50 @@ class TestRemoteGGUFSourceResolution:
         assert (
             resolve_gguf_tokenizer_source(gguf_path, revision="local-rev") == "org/base"
         )
+
+    def test_remote_base_model_ids_are_cached_between_resolvers(self, monkeypatch):
+        from vllm.transformers_utils import gguf_utils
+
+        class FakeInfo:
+            card_data = {"base_model": "org/base"}
+
+        class FakeHfApi:
+            call_count = 0
+
+            def model_info(self, repo_id, revision=None):
+                self.call_count += 1
+                assert repo_id == "org/model-GGUF"
+                assert revision == "gguf-rev"
+                return FakeInfo()
+
+        fake_api = FakeHfApi()
+
+        def fake_file_or_path_exists(model, filename, revision=None):
+            return (
+                model == "org/base"
+                and filename in {"config.json", "tokenizer_config.json"}
+                and revision is None
+            )
+
+        monkeypatch.setattr(gguf_utils, "hf_api", lambda: fake_api)
+        monkeypatch.setattr(
+            gguf_utils,
+            "file_or_path_exists",
+            fake_file_or_path_exists,
+        )
+
+        assert (
+            resolve_gguf_config_source(
+                "org/model-GGUF:UD-IQ4_NL",
+                revision="gguf-rev",
+            )
+            == "org/base"
+        )
+        assert (
+            resolve_gguf_tokenizer_source(
+                "org/model-GGUF:UD-IQ4_NL",
+                revision="gguf-rev",
+            )
+            == "org/base"
+        )
+        assert fake_api.call_count == 1

--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -9,7 +9,6 @@ from vllm.transformers_utils.gguf_utils import (
     is_gguf,
     is_remote_gguf,
     resolve_gguf_config_source,
-    resolve_gguf_tokenizer_source,
     split_remote_gguf,
 )
 from vllm.transformers_utils.utils import (
@@ -372,72 +371,10 @@ class TestRemoteGGUFSourceResolution:
             == gguf_path.parent
         )
 
-    def test_tokenizer_source_checks_tokenizer_files_not_config(self, monkeypatch):
-        from vllm.transformers_utils import gguf_utils
-
-        class FakeInfo:
-            card_data = {"base_model": "org/base"}
-
-        class FakeHfApi:
-            def model_info(self, repo_id, revision=None):
-                return FakeInfo()
-
-        def fake_file_or_path_exists(model, config_name, revision=None):
-            return (
-                model == "org/model-GGUF"
-                and config_name == "config.json"
-                and revision == "gguf-rev"
-            ) or (
-                model == "org/base"
-                and config_name == "tokenizer_config.json"
-                and revision is None
-            )
-
-        monkeypatch.setattr(gguf_utils, "hf_api", lambda: FakeHfApi())
-        monkeypatch.setattr(
-            gguf_utils,
-            "file_or_path_exists",
-            fake_file_or_path_exists,
-        )
-
-        assert (
-            resolve_gguf_tokenizer_source(
-                "org/model-GGUF:UD-IQ4_NL",
-                revision="gguf-rev",
-            )
-            == "org/base"
-        )
-
-    def test_local_tokenizer_source_uses_metadata_base_model(self, monkeypatch):
-        from vllm.transformers_utils import gguf_utils
-
-        gguf_path = Path("/models/qwen.gguf")
-
-        monkeypatch.setattr(
-            gguf_utils,
-            "check_gguf_file",
-            lambda model: Path(model) == gguf_path,
-        )
-        monkeypatch.setattr(
-            gguf_utils,
-            "_get_local_gguf_base_model_ids",
-            lambda model: ("org/base",),
-        )
-        monkeypatch.setattr(
-            gguf_utils,
-            "file_or_path_exists",
-            lambda model, config_name, revision=None: (
-                model == "org/base"
-                and config_name == "tokenizer_config.json"
-                and revision is None
-            ),
-        )
-
-        assert (
-            resolve_gguf_tokenizer_source(gguf_path, revision="local-rev") == "org/base"
-        )
-
-    def test_remote_base_model_ids_are_cached_between_resolvers(self, monkeypatch):
+    def test_remote_base_model_ids_are_cached_between_config_resolvers(
+        self,
+        monkeypatch,
+    ):
         from vllm.transformers_utils import gguf_utils
 
         class FakeInfo:
@@ -456,9 +393,7 @@ class TestRemoteGGUFSourceResolution:
 
         def fake_file_or_path_exists(model, filename, revision=None):
             return (
-                model == "org/base"
-                and filename in {"config.json", "tokenizer_config.json"}
-                and revision is None
+                model == "org/base" and filename == "config.json" and revision is None
             )
 
         monkeypatch.setattr(gguf_utils, "hf_api", lambda: fake_api)
@@ -476,7 +411,7 @@ class TestRemoteGGUFSourceResolution:
             == "org/base"
         )
         assert (
-            resolve_gguf_tokenizer_source(
+            resolve_gguf_config_source(
                 "org/model-GGUF:UD-IQ4_NL",
                 revision="gguf-rev",
             )

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -5,7 +5,6 @@ import warnings
 from collections.abc import Callable
 from dataclasses import InitVar, field
 from functools import cached_property
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 import torch
@@ -44,11 +43,9 @@ from vllm.transformers_utils.config import (
     uses_xdrope_dim,
 )
 from vllm.transformers_utils.gguf_utils import (
-    check_gguf_file,
     is_gguf,
     is_remote_gguf,
     maybe_patch_hf_config_from_gguf,
-    resolve_gguf_tokenizer_source,
     split_remote_gguf,
 )
 from vllm.transformers_utils.model_arch_config_convertor import (
@@ -495,29 +492,11 @@ class ModelConfig:
         )
         self.model = maybe_model_redirect(self.model)
         # The tokenizer is consistent with the model by default.
-        tokenizer_was_default = self.tokenizer is None
-        tokenizer_revision_was_default = self.tokenizer_revision is None
         if self.tokenizer is None:
             self.tokenizer = self.model
         if self.tokenizer_revision is None:
             self.tokenizer_revision = self.revision
         self.tokenizer = maybe_model_redirect(self.tokenizer)
-        if tokenizer_was_default and is_gguf(self.model):
-            gguf_source: str | Path
-            if is_remote_gguf(self.model):
-                gguf_source, _ = split_remote_gguf(self.model)
-            elif check_gguf_file(self.model):
-                gguf_source = Path(self.model).parent
-            else:
-                gguf_source = self.model
-            tokenizer_source = resolve_gguf_tokenizer_source(
-                self.model,
-                revision=self.revision,
-            )
-            if tokenizer_source != gguf_source:
-                self.tokenizer = maybe_model_redirect(str(tokenizer_source))
-                if tokenizer_revision_was_default:
-                    self.tokenizer_revision = None
 
         if isinstance(self.hf_config_path, str):
             self.hf_config_path = maybe_model_redirect(self.hf_config_path)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Callable
 from dataclasses import InitVar, field
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 import torch
@@ -43,9 +44,11 @@ from vllm.transformers_utils.config import (
     uses_xdrope_dim,
 )
 from vllm.transformers_utils.gguf_utils import (
+    check_gguf_file,
     is_gguf,
     is_remote_gguf,
     maybe_patch_hf_config_from_gguf,
+    resolve_gguf_tokenizer_source,
     split_remote_gguf,
 )
 from vllm.transformers_utils.model_arch_config_convertor import (
@@ -492,11 +495,29 @@ class ModelConfig:
         )
         self.model = maybe_model_redirect(self.model)
         # The tokenizer is consistent with the model by default.
+        tokenizer_was_default = self.tokenizer is None
+        tokenizer_revision_was_default = self.tokenizer_revision is None
         if self.tokenizer is None:
             self.tokenizer = self.model
         if self.tokenizer_revision is None:
             self.tokenizer_revision = self.revision
         self.tokenizer = maybe_model_redirect(self.tokenizer)
+        if tokenizer_was_default and is_gguf(self.model):
+            gguf_source: str | Path
+            if is_remote_gguf(self.model):
+                gguf_source, _ = split_remote_gguf(self.model)
+            elif check_gguf_file(self.model):
+                gguf_source = Path(self.model).parent
+            else:
+                gguf_source = self.model
+            tokenizer_source = resolve_gguf_tokenizer_source(
+                self.model,
+                revision=self.revision,
+            )
+            if tokenizer_source != gguf_source:
+                self.tokenizer = maybe_model_redirect(str(tokenizer_source))
+                if tokenizer_revision_was_default:
+                    self.tokenizer_revision = None
 
         if isinstance(self.hf_config_path, str):
             self.hf_config_path = maybe_model_redirect(self.hf_config_path)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1726,6 +1726,7 @@ class EngineArgs:
                     model=self.model,
                     tokenizer=self.tokenizer,
                     revision=self.revision,
+                    hf_config_path=self.hf_config_path,
                     trust_remote_code=self.trust_remote_code,
                     vllm_speculative_config=self.speculative_config,
                     hf_token=self.hf_token,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1721,16 +1721,19 @@ class EngineArgs:
         # HuggingFace cannot load configs directly from S3 URLs. S3 models can still
         # use speculators with explicit --speculative-config.
         if not is_cloud_storage(self.model):
-            (self.model, self.tokenizer, self.speculative_config) = (
-                maybe_override_with_speculators(
-                    model=self.model,
-                    tokenizer=self.tokenizer,
-                    revision=self.revision,
-                    hf_config_path=self.hf_config_path,
-                    trust_remote_code=self.trust_remote_code,
-                    vllm_speculative_config=self.speculative_config,
-                    hf_token=self.hf_token,
-                )
+            (
+                self.model,
+                self.tokenizer,
+                self.speculative_config,
+                self.trust_remote_code,
+            ) = maybe_override_with_speculators(
+                model=self.model,
+                tokenizer=self.tokenizer,
+                revision=self.revision,
+                hf_config_path=self.hf_config_path,
+                trust_remote_code=self.trust_remote_code,
+                vllm_speculative_config=self.speculative_config,
+                hf_token=self.hf_token,
             )
 
         model_config = self.create_model_config()

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -12,6 +12,7 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
+from vllm.config.utils import replace
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.utils import (
@@ -42,6 +43,8 @@ _GGUF_MODEL_TYPE_ALIASES = {
     # gguf-py does not expose a Gemma4 arch enum yet. Gemma4 GGUF uses
     # Gemma-style base tensor names, with Gemma4-specific tensors added below.
     "gemma4": "gemma3",
+    # Qwen3.5 MTP GGUF uses the same base MoE tensor naming as Qwen3.5 MoE.
+    "qwen3_5_mtp": "qwen35moe",
 }
 
 
@@ -51,6 +54,22 @@ def _gguf_name_with_suffix(gguf_name: str, suffix: str) -> str:
 
 def _gguf_arch_model_type(model_type: str) -> str:
     return _GGUF_MODEL_TYPE_ALIASES.get(model_type, model_type)
+
+
+def _is_mtp_draft_config(config) -> bool:
+    model_type = getattr(config, "model_type", "")
+    architectures = getattr(config, "architectures", None) or ()
+    return str(model_type).endswith("_mtp") or any(
+        "MTP" in str(arch) for arch in architectures
+    )
+
+
+def _use_gguf_multimodal_weights(config) -> bool:
+    return (
+        hasattr(config, "vision_config")
+        and config.vision_config is not None
+        and not _is_mtp_draft_config(config)
+    )
 
 
 def _add_gemma4_gguf_mappings(
@@ -154,6 +173,125 @@ def _add_gemma4_gguf_mappings(
         )
 
 
+def _add_qwen3_5_mtp_gguf_mappings(
+    gguf_to_hf_name_map: dict[str, str],
+    text_config,
+) -> None:
+    """Add Qwen3.5 MTP GGUF tensor names following llama.cpp nextn layout."""
+    mtp_gguf_layer_idx = text_config.num_hidden_layers
+    layer_prefix = "mtp.layers.0"
+
+    gguf_to_hf_name_map.update(
+        {
+            "token_embd.weight": "model.embed_tokens.weight",
+            "output.weight": "lm_head.weight",
+            f"blk.{mtp_gguf_layer_idx}.nextn.eh_proj.weight": "mtp.fc.weight",
+            f"blk.{mtp_gguf_layer_idx}.nextn.enorm.weight": (
+                "mtp.pre_fc_norm_embedding.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.nextn.hnorm.weight": (
+                "mtp.pre_fc_norm_hidden.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.nextn.shared_head_norm.weight": (
+                "mtp.norm.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_norm.weight": (
+                f"{layer_prefix}.input_layernorm.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.post_attention_norm.weight": (
+                f"{layer_prefix}.post_attention_layernorm.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_q.weight": (
+                f"{layer_prefix}.self_attn.q_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_k.weight": (
+                f"{layer_prefix}.self_attn.k_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_v.weight": (
+                f"{layer_prefix}.self_attn.v_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_output.weight": (
+                f"{layer_prefix}.self_attn.o_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_q_norm.weight": (
+                f"{layer_prefix}.self_attn.q_norm.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.attn_k_norm.weight": (
+                f"{layer_prefix}.self_attn.k_norm.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_gate_inp.weight": (
+                f"{layer_prefix}.mlp.gate.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_gate_exps.weight": (
+                f"{layer_prefix}.mlp.experts.0.gate_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_up_exps.weight": (
+                f"{layer_prefix}.mlp.experts.0.up_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_down_exps.weight": (
+                f"{layer_prefix}.mlp.experts.0.down_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_gate_inp_shexp.weight": (
+                f"{layer_prefix}.mlp.shared_expert_gate.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_gate_shexp.weight": (
+                f"{layer_prefix}.mlp.shared_expert.gate_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_up_shexp.weight": (
+                f"{layer_prefix}.mlp.shared_expert.up_proj.weight"
+            ),
+            f"blk.{mtp_gguf_layer_idx}.ffn_down_shexp.weight": (
+                f"{layer_prefix}.mlp.shared_expert.down_proj.weight"
+            ),
+        }
+    )
+
+
+def _add_gemma4_mtp_gguf_mappings(
+    gguf_to_hf_name_map: dict[str, str],
+    text_config,
+) -> None:
+    """Add Gemma4 MTP GGUF tensor names following llama.cpp assistant layout."""
+    gguf_to_hf_name_map.update(
+        {
+            "token_embd.weight": "model.embed_tokens.weight",
+            "output_norm.weight": "model.norm.weight",
+            "nextn.pre_projection.weight": "pre_projection.weight",
+            "nextn.post_projection.weight": "post_projection.weight",
+        }
+    )
+
+    for idx in range(text_config.num_hidden_layers):
+        layer_prefix = f"model.layers.{idx}"
+        gguf_to_hf_name_map.update(
+            {
+                f"blk.{idx}.layer_output_scale.weight": f"{layer_prefix}.layer_scalar",
+                f"blk.{idx}.attn_norm.weight": (
+                    f"{layer_prefix}.input_layernorm.weight"
+                ),
+                f"blk.{idx}.attn_q.weight": (f"{layer_prefix}.self_attn.q_proj.weight"),
+                f"blk.{idx}.attn_q_norm.weight": (
+                    f"{layer_prefix}.self_attn.q_norm.weight"
+                ),
+                f"blk.{idx}.attn_output.weight": (
+                    f"{layer_prefix}.self_attn.o_proj.weight"
+                ),
+                f"blk.{idx}.post_attention_norm.weight": (
+                    f"{layer_prefix}.post_attention_layernorm.weight"
+                ),
+                f"blk.{idx}.ffn_norm.weight": (
+                    f"{layer_prefix}.pre_feedforward_layernorm.weight"
+                ),
+                f"blk.{idx}.ffn_gate.weight": f"{layer_prefix}.mlp.gate_proj.weight",
+                f"blk.{idx}.ffn_up.weight": f"{layer_prefix}.mlp.up_proj.weight",
+                f"blk.{idx}.ffn_down.weight": f"{layer_prefix}.mlp.down_proj.weight",
+                f"blk.{idx}.post_ffw_norm.weight": (
+                    f"{layer_prefix}.post_feedforward_layernorm.weight"
+                ),
+            }
+        )
+
+
 class GGUFModelLoader(BaseModelLoader):
     """
     Model loader that can load GGUF files. This is useful for loading models
@@ -241,11 +379,15 @@ class GGUFModelLoader(BaseModelLoader):
         text_config = config.get_text_config()
         model_type = config.model_type
         orig_model_type = model_type
-        is_multimodal = (
-            hasattr(config, "vision_config") and config.vision_config is not None
-        )
-        gguf_to_hf_name_map = {}
+        is_multimodal = _use_gguf_multimodal_weights(config)
+        gguf_to_hf_name_map: dict[str, str] = {}
         sideload_params: list[re.Pattern] = []
+        if orig_model_type == "qwen3_5_mtp":
+            _add_qwen3_5_mtp_gguf_mappings(gguf_to_hf_name_map, text_config)
+            return gguf_to_hf_name_map
+        if orig_model_type == "gemma4_mtp":
+            _add_gemma4_mtp_gguf_mappings(gguf_to_hf_name_map, text_config)
+            return gguf_to_hf_name_map
         # hack: ggufs have a different name than transformers
         if model_type == "cohere":
             model_type = "command-r"
@@ -521,7 +663,7 @@ class GGUFModelLoader(BaseModelLoader):
         weight_type_map = {}
         for f in gguf_files:
             weight_type_map.update(get_gguf_weight_type_map(f, gguf_to_hf_name_map))
-        is_multimodal = hasattr(model_config.hf_config, "vision_config")
+        is_multimodal = _use_gguf_multimodal_weights(model_config.hf_config)
         if is_multimodal:
             mmproj_file = detect_gguf_multimodal(model_name_or_path)
             assert mmproj_file is not None, (
@@ -552,7 +694,7 @@ class GGUFModelLoader(BaseModelLoader):
             Tuples of (parameter_name, tensor) for all model weights
         """
         hf_config = model_config.hf_config
-        is_multimodal = hasattr(hf_config, "vision_config")
+        is_multimodal = _use_gguf_multimodal_weights(hf_config)
 
         if is_multimodal:
             # Load mm_proj (mm_encoder + projector) for multimodal weights
@@ -584,6 +726,7 @@ class GGUFModelLoader(BaseModelLoader):
     def load_model(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""
     ) -> nn.Module:
+        vllm_config = replace(vllm_config, model_config=model_config)
         device_config = vllm_config.device_config
         local_model_path = self._prepare_weights(model_config)
         gguf_weights_map = self._get_gguf_weights_map(model_config)
@@ -612,7 +755,11 @@ class GGUFModelLoader(BaseModelLoader):
         target_device = torch.device(device_config.device)
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
-                model = initialize_model(vllm_config=vllm_config, prefix=prefix)
+                model = initialize_model(
+                    vllm_config=vllm_config,
+                    model_config=model_config,
+                    prefix=prefix,
+                )
             self.load_weights(model, model_config)
 
             process_weights_after_loading(model, model_config, target_device)

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -38,10 +38,19 @@ logger = init_logger(__name__)
 _GEMMA4_PATCH_EMBEDDER_INPUT_PROJ = (
     "model.vision_tower.patch_embedder.input_proj.weight"
 )
+_GGUF_MODEL_TYPE_ALIASES = {
+    # gguf-py does not expose a Gemma4 arch enum yet. Gemma4 GGUF uses
+    # Gemma-style base tensor names, with Gemma4-specific tensors added below.
+    "gemma4": "gemma3",
+}
 
 
 def _gguf_name_with_suffix(gguf_name: str, suffix: str) -> str:
     return f"{gguf_name}.{suffix}" if suffix else gguf_name
+
+
+def _gguf_arch_model_type(model_type: str) -> str:
+    return _GGUF_MODEL_TYPE_ALIASES.get(model_type, model_type)
 
 
 def _add_gemma4_gguf_mappings(
@@ -310,6 +319,7 @@ class GGUFModelLoader(BaseModelLoader):
                 text_config,
                 config.vision_config,
             )
+        model_type = _gguf_arch_model_type(model_type)
         if model_type == "minimax_m2":
             model_type = "minimax-m2"
             # GGUF layer map assumes merged expert weights

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -529,10 +529,7 @@ class GGUFModelLoader(BaseModelLoader):
             assert mmproj_file is not None, (
                 "Could not find mm_proj file for multimodal GGUF model"
             )
-            for name, weight in gguf_quant_weights_iterator(
-                mmproj_file, gguf_to_hf_name_map
-            ):
-                yield name, weight
+            yield from gguf_quant_weights_iterator(mmproj_file, gguf_to_hf_name_map)
 
         gguf_files = self._get_all_gguf_files(model_name_or_path)
         if len(gguf_files) > 1:
@@ -541,8 +538,7 @@ class GGUFModelLoader(BaseModelLoader):
             weights = gguf_quant_weights_iterator(
                 model_name_or_path, gguf_to_hf_name_map
             )
-        for name, weight in weights:
-            yield name, weight
+        yield from weights
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config)

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -35,6 +35,104 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+_GEMMA4_PATCH_EMBEDDER_INPUT_PROJ = (
+    "model.vision_tower.patch_embedder.input_proj.weight"
+)
+
+
+def _gguf_name_with_suffix(gguf_name: str, suffix: str) -> str:
+    return f"{gguf_name}.{suffix}" if suffix else gguf_name
+
+
+def _add_gemma4_gguf_mappings(
+    gguf_to_hf_name_map: dict[str, str],
+    text_config,
+    vision_config,
+) -> None:
+    """Add Gemma4 GGUF tensor names missing from gguf-py's generic map."""
+    for idx in range(text_config.num_hidden_layers):
+        layer_prefix = f"model.language_model.layers.{idx}"
+        gguf_to_hf_name_map.update(
+            {
+                f"blk.{idx}.layer_output_scale.weight": (
+                    f"{layer_prefix}.layer_scalar"
+                ),
+                f"blk.{idx}.ffn_gate_inp.scale": f"{layer_prefix}.router.scale",
+                f"blk.{idx}.ffn_down_exps.scale": (
+                    f"{layer_prefix}.router.per_expert_scale"
+                ),
+                f"blk.{idx}.ffn_gate_up_exps.weight": (
+                    f"{layer_prefix}.experts.gate_up_proj.weight"
+                ),
+                f"blk.{idx}.ffn_down_exps.weight": (
+                    f"{layer_prefix}.experts.down_proj.weight"
+                ),
+            }
+        )
+
+    vision_num_layers = getattr(vision_config, "num_hidden_layers", None)
+    if vision_num_layers is None:
+        vision_num_layers = vision_config.depth
+
+    gguf_to_hf_name_map.update(
+        {
+            "v.std_bias": "model.vision_tower.std_bias",
+            "v.std_scale": "model.vision_tower.std_scale",
+            "v.patch_embd.weight": _GEMMA4_PATCH_EMBEDDER_INPUT_PROJ,
+            "v.position_embd.weight": (
+                "model.vision_tower.patch_embedder.position_embedding_table"
+            ),
+            "mm.input_projection.weight": (
+                "model.embed_vision.embedding_projection.weight"
+            ),
+        }
+    )
+
+    for idx in range(vision_num_layers):
+        layer_prefix = f"model.vision_tower.encoder.layers.{idx}"
+        gguf_to_hf_name_map.update(
+            {
+                f"v.blk.{idx}.attn_q.weight": (
+                    f"{layer_prefix}.self_attn.q_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.attn_k.weight": (
+                    f"{layer_prefix}.self_attn.k_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.attn_v.weight": (
+                    f"{layer_prefix}.self_attn.v_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.attn_out.weight": (
+                    f"{layer_prefix}.self_attn.o_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.attn_q_norm.weight": (
+                    f"{layer_prefix}.self_attn.q_norm.weight"
+                ),
+                f"v.blk.{idx}.attn_k_norm.weight": (
+                    f"{layer_prefix}.self_attn.k_norm.weight"
+                ),
+                f"v.blk.{idx}.ffn_gate.weight": (
+                    f"{layer_prefix}.mlp.gate_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.ffn_up.weight": (
+                    f"{layer_prefix}.mlp.up_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.ffn_down.weight": (
+                    f"{layer_prefix}.mlp.down_proj.linear.weight"
+                ),
+                f"v.blk.{idx}.ln1.weight": (f"{layer_prefix}.input_layernorm.weight"),
+                f"v.blk.{idx}.attn_post_norm.weight": (
+                    f"{layer_prefix}.post_attention_layernorm.weight"
+                ),
+                f"v.blk.{idx}.ln2.weight": (
+                    f"{layer_prefix}.pre_feedforward_layernorm.weight"
+                ),
+                f"v.blk.{idx}.ffn_post_norm.weight": (
+                    f"{layer_prefix}.post_feedforward_layernorm.weight"
+                ),
+            }
+        )
+
+
 class GGUFModelLoader(BaseModelLoader):
     """
     Model loader that can load GGUF files. This is useful for loading models
@@ -121,6 +219,7 @@ class GGUFModelLoader(BaseModelLoader):
         # models, this returns config itself.
         text_config = config.get_text_config()
         model_type = config.model_type
+        orig_model_type = model_type
         is_multimodal = (
             hasattr(config, "vision_config") and config.vision_config is not None
         )
@@ -133,6 +232,8 @@ class GGUFModelLoader(BaseModelLoader):
             # Gemma3 models use "gemma3_text" in HuggingFace but
             # "gemma3" in GGUF architecture naming
             model_type = "gemma3"
+        if model_type == "qwen3_5":
+            model_type = "qwen35"
         if model_type in ("deepseek_v3", "deepseek_v2"):
             model_type = "deepseek2"
             # GGUF layer map assumes that we will have a merged expert weights
@@ -156,26 +257,59 @@ class GGUFModelLoader(BaseModelLoader):
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
                     )
                 )
-        if model_type in ("qwen2_moe", "qwen3_moe"):
+        if model_type in ("qwen2_moe", "qwen3_moe", "qwen3_5_moe"):
             model_type = model_type.replace("_", "")
             # GGUF layer map assumes that we will have a merged expert weights
             # so we need to map them manually
-            for idx in range(config.num_hidden_layers):
+            moe_layer_prefix = (
+                "model.language_model.layers"
+                if orig_model_type == "qwen3_5_moe" and is_multimodal
+                else "model.layers"
+            )
+            escaped_moe_layer_prefix = re.escape(moe_layer_prefix)
+            for idx in range(text_config.num_hidden_layers):
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
-                    f"model.layers.{idx}.mlp.experts.0.down_proj.weight"
+                    f"{moe_layer_prefix}.{idx}.mlp.experts.0.down_proj.weight"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
-                    f"model.layers.{idx}.mlp.experts.0.gate_proj.weight"
+                    f"{moe_layer_prefix}.{idx}.mlp.experts.0.gate_proj.weight"
                 )
                 gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
-                    f"model.layers.{idx}.mlp.experts.0.up_proj.weight"
+                    f"{moe_layer_prefix}.{idx}.mlp.experts.0.up_proj.weight"
                 )
                 sideload_params.append(
                     re.compile(
-                        f"model\\.layers\\.{idx}"
+                        f"{escaped_moe_layer_prefix}\\.{idx}"
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
                     )
                 )
+        if orig_model_type in ("qwen3_5", "qwen3_5_moe"):
+            layer_prefix = (
+                "model.language_model.layers" if is_multimodal else "model.layers"
+            )
+            for idx, layer_type in enumerate(text_config.layer_types):
+                if layer_type == "linear_attention":
+                    gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.bias"] = (
+                        f"{layer_prefix}.{idx}.linear_attn.dt_bias"
+                    )
+            if is_multimodal:
+                gguf_to_hf_name_map.update(
+                    {
+                        "mm.0.weight": "model.visual.merger.linear_fc1.weight",
+                        "mm.0.bias": "model.visual.merger.linear_fc1.bias",
+                        "mm.2.weight": "model.visual.merger.linear_fc2.weight",
+                        "mm.2.bias": "model.visual.merger.linear_fc2.bias",
+                    }
+                )
+                sideload_params.append(
+                    re.compile(r"model\.visual\.merger\.norm\.(weight|bias)")
+                )
+        if orig_model_type == "gemma4" and is_multimodal:
+            _add_gemma4_gguf_mappings(
+                gguf_to_hf_name_map,
+                text_config,
+                config.vision_config,
+            )
         if model_type == "minimax_m2":
             model_type = "minimax-m2"
             # GGUF layer map assumes merged expert weights
@@ -212,7 +346,9 @@ class GGUFModelLoader(BaseModelLoader):
 
         if is_multimodal:
             mm_proj_arch = gguf.MODEL_ARCH.MMPROJ
-            vision_num_layers = config.vision_config.num_hidden_layers
+            vision_num_layers = getattr(config.vision_config, "num_hidden_layers", None)
+            if vision_num_layers is None:
+                vision_num_layers = config.vision_config.depth
             vision_name_map = gguf.get_tensor_name_map(mm_proj_arch, vision_num_layers)
         else:
             vision_name_map = None
@@ -312,7 +448,7 @@ class GGUFModelLoader(BaseModelLoader):
             if gguf_name is None:
                 return None
 
-            return gguf_name + "." + suffix
+            return _gguf_name_with_suffix(gguf_name, suffix)
 
         # Build mapping and track unmapped parameters
         unmapped_params = []
@@ -393,17 +529,20 @@ class GGUFModelLoader(BaseModelLoader):
             assert mmproj_file is not None, (
                 "Could not find mm_proj file for multimodal GGUF model"
             )
-            yield from gguf_quant_weights_iterator(mmproj_file, gguf_to_hf_name_map)
+            for name, weight in gguf_quant_weights_iterator(
+                mmproj_file, gguf_to_hf_name_map
+            ):
+                yield name, weight
 
         gguf_files = self._get_all_gguf_files(model_name_or_path)
         if len(gguf_files) > 1:
-            yield from gguf_quant_weights_iterator_multi(
-                gguf_files, gguf_to_hf_name_map
-            )
+            weights = gguf_quant_weights_iterator_multi(gguf_files, gguf_to_hf_name_map)
         else:
-            yield from gguf_quant_weights_iterator(
+            weights = gguf_quant_weights_iterator(
                 model_name_or_path, gguf_to_hf_name_map
             )
+        for name, weight in weights:
+            yield name, weight
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config)

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -74,10 +74,10 @@ def _add_gemma4_gguf_mappings(
                     f"{layer_prefix}.router.per_expert_scale"
                 ),
                 f"blk.{idx}.ffn_gate_up_exps.weight": (
-                    f"{layer_prefix}.experts.gate_up_proj"
+                    f"{layer_prefix}.experts.gate_up_proj.weight"
                 ),
                 f"blk.{idx}.ffn_down_exps.weight": (
-                    f"{layer_prefix}.experts.down_proj"
+                    f"{layer_prefix}.experts.down_proj.weight"
                 ),
                 f"blk.{idx}.post_ffw_norm_1.weight": (
                     f"{layer_prefix}.post_feedforward_layernorm_1.weight"
@@ -331,6 +331,15 @@ class GGUFModelLoader(BaseModelLoader):
                 text_config,
                 config.vision_config,
             )
+            # Gemma4 GGUF stores fused 3D expert tensors, while the HF
+            # module exposes suffixless expert placeholders.
+            for idx in range(text_config.num_hidden_layers):
+                sideload_params.append(
+                    re.compile(
+                        f"model\\.language_model\\.layers\\.{idx}"
+                        r"\.experts\.(gate_up_proj|down_proj)"
+                    )
+                )
         model_type = _gguf_arch_model_type(model_type)
         if model_type == "minimax_m2":
             model_type = "minimax-m2"

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -67,14 +67,26 @@ def _add_gemma4_gguf_mappings(
                     f"{layer_prefix}.layer_scalar"
                 ),
                 f"blk.{idx}.ffn_gate_inp.scale": f"{layer_prefix}.router.scale",
+                f"blk.{idx}.ffn_gate_inp.weight": (
+                    f"{layer_prefix}.router.proj.weight"
+                ),
                 f"blk.{idx}.ffn_down_exps.scale": (
                     f"{layer_prefix}.router.per_expert_scale"
                 ),
                 f"blk.{idx}.ffn_gate_up_exps.weight": (
-                    f"{layer_prefix}.experts.gate_up_proj.weight"
+                    f"{layer_prefix}.experts.gate_up_proj"
                 ),
                 f"blk.{idx}.ffn_down_exps.weight": (
-                    f"{layer_prefix}.experts.down_proj.weight"
+                    f"{layer_prefix}.experts.down_proj"
+                ),
+                f"blk.{idx}.post_ffw_norm_1.weight": (
+                    f"{layer_prefix}.post_feedforward_layernorm_1.weight"
+                ),
+                f"blk.{idx}.post_ffw_norm_2.weight": (
+                    f"{layer_prefix}.post_feedforward_layernorm_2.weight"
+                ),
+                f"blk.{idx}.pre_ffw_norm_2.weight": (
+                    f"{layer_prefix}.pre_feedforward_layernorm_2.weight"
                 ),
             }
         )

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -89,6 +89,33 @@ def _remap_gemma4_expert_weight_name(name: str) -> str:
     return re.sub(r"(?<!\.moe)\.experts\.(\d+)\.", r".moe.experts.\1.", name)
 
 
+def _load_gemma4_gguf_fused_moe_qweight_type(
+    name: str,
+    loaded_weight: torch.Tensor,
+    params_dict: dict[str, torch.Tensor],
+) -> str | None:
+    if name.endswith(".moe.gate_up_proj.qweight_type"):
+        param_name = name.replace(
+            ".moe.gate_up_proj.qweight_type",
+            ".moe.experts.w13_qweight_type",
+        )
+    elif name.endswith(".moe.down_proj.qweight_type"):
+        param_name = name.replace(
+            ".moe.down_proj.qweight_type",
+            ".moe.experts.w2_qweight_type",
+        )
+    else:
+        return None
+
+    param = params_dict.get(param_name)
+    if param is None or not getattr(param, "is_gguf_weight_type", False):
+        return None
+
+    param.weight_type = loaded_weight.item()
+    param.data.copy_(loaded_weight.view(param.shape))
+    return param_name
+
+
 @triton.jit
 def _gemma4_routing_kernel(
     gating_ptr,
@@ -1479,6 +1506,15 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                     loaded_params.add(moe_name)
                     break
                 else:
+                    remapped_name = _load_gemma4_gguf_fused_moe_qweight_type(
+                        name,
+                        loaded_weight,
+                        params_dict,
+                    )
+                    if remapped_name is not None:
+                        loaded_params.add(remapped_name)
+                        continue
+
                     if name.endswith(".bias") and name not in params_dict:
                         continue
                     name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -25,6 +25,7 @@ from itertools import islice
 import regex as re
 import torch
 from torch import nn
+from torch.nn.parameter import UninitializedParameter
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
@@ -89,31 +90,85 @@ def _remap_gemma4_expert_weight_name(name: str) -> str:
     return re.sub(r"(?<!\.moe)\.experts\.(\d+)\.", r".moe.experts.\1.", name)
 
 
+def _gemma4_gguf_fused_moe_param_names(
+    name: str,
+    gguf_suffix: str,
+    fused_suffix: str,
+) -> tuple[str, str]:
+    # FusedMoE stores expert parameters under routed_experts by default.
+    # Keep the suffix without routed_experts as a fallback for custom wrappers.
+    return (
+        name.replace(
+            gguf_suffix,
+            f".moe.experts.routed_experts.{fused_suffix}",
+        ),
+        name.replace(gguf_suffix, f".moe.experts.{fused_suffix}"),
+    )
+
+
 def _load_gemma4_gguf_fused_moe_qweight_type(
     name: str,
     loaded_weight: torch.Tensor,
     params_dict: dict[str, torch.Tensor],
 ) -> str | None:
     if name.endswith(".moe.gate_up_proj.qweight_type"):
-        param_name = name.replace(
+        param_names = _gemma4_gguf_fused_moe_param_names(
+            name,
             ".moe.gate_up_proj.qweight_type",
-            ".moe.experts.w13_qweight_type",
+            "w13_qweight_type",
         )
     elif name.endswith(".moe.down_proj.qweight_type"):
-        param_name = name.replace(
+        param_names = _gemma4_gguf_fused_moe_param_names(
+            name,
             ".moe.down_proj.qweight_type",
-            ".moe.experts.w2_qweight_type",
+            "w2_qweight_type",
         )
     else:
         return None
 
-    param = params_dict.get(param_name)
-    if param is None or not getattr(param, "is_gguf_weight_type", False):
+    for param_name in param_names:
+        param = params_dict.get(param_name)
+        if param is None or not getattr(param, "is_gguf_weight_type", False):
+            continue
+
+        param.weight_type = loaded_weight.item()
+        param.data.copy_(loaded_weight.view(param.shape))
+        return param_name
+
+    return None
+
+
+def _load_gemma4_gguf_fused_moe_qweight(
+    name: str,
+    loaded_weight: torch.Tensor,
+    params_dict: dict[str, torch.Tensor],
+) -> str | None:
+    if name.endswith(".moe.gate_up_proj.qweight"):
+        param_names = _gemma4_gguf_fused_moe_param_names(
+            name,
+            ".moe.gate_up_proj.qweight",
+            "w13_qweight",
+        )
+    elif name.endswith(".moe.down_proj.qweight"):
+        param_names = _gemma4_gguf_fused_moe_param_names(
+            name,
+            ".moe.down_proj.qweight",
+            "w2_qweight",
+        )
+    else:
         return None
 
-    param.weight_type = loaded_weight.item()
-    param.data.copy_(loaded_weight.view(param.shape))
-    return param_name
+    for param_name in param_names:
+        param = params_dict.get(param_name)
+        if param is None or not getattr(param, "is_gguf_weight", False):
+            continue
+
+        if isinstance(param, UninitializedParameter):
+            param.materialize(loaded_weight.shape, dtype=loaded_weight.dtype)
+        param.data.copy_(loaded_weight)
+        return param_name
+
+    return None
 
 
 @triton.jit
@@ -1506,6 +1561,15 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                     loaded_params.add(moe_name)
                     break
                 else:
+                    remapped_name = _load_gemma4_gguf_fused_moe_qweight(
+                        name,
+                        loaded_weight,
+                        params_dict,
+                    )
+                    if remapped_name is not None:
+                        loaded_params.add(remapped_name)
+                        continue
+
                     remapped_name = _load_gemma4_gguf_fused_moe_qweight_type(
                         name,
                         loaded_weight,
@@ -1707,7 +1771,14 @@ class Gemma4ForCausalLM(
                 #
                 # No transpose needed: checkpoint orientation already
                 # matches FusedMoE's expected layout.
-                if "moe.gate_up_proj" in name and weight.dim() == 3:
+                is_gguf_moe_qweight = name.endswith(
+                    (".moe.gate_up_proj.qweight", ".moe.down_proj.qweight")
+                )
+                if (
+                    "moe.gate_up_proj" in name
+                    and weight.dim() == 3
+                    and not is_gguf_moe_qweight
+                ):
                     num_experts = weight.size(0)
                     intermediate_size = weight.size(1) // 2
                     for expert_id in range(num_experts):
@@ -1718,7 +1789,11 @@ class Gemma4ForCausalLM(
                         yield base.replace("gate_up_proj", "up_proj"), up_weight
                     continue
 
-                if "moe.down_proj" in name and weight.dim() == 3:
+                if (
+                    "moe.down_proj" in name
+                    and weight.dim() == 3
+                    and not is_gguf_moe_qweight
+                ):
                     num_experts = weight.size(0)
                     for expert_id in range(num_experts):
                         expert_name = name.replace("moe.", f"moe.experts.{expert_id}.")

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -40,9 +40,11 @@ from vllm.inputs import MultiModalDataDict
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.transformers.utils import recursive_replace_linear
+from vllm.model_executor.utils import set_weight_attrs
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     MultiModalFieldConfig,
@@ -91,6 +93,21 @@ logger = init_logger(__name__)
 _SUPPORTED_SOFT_TOKENS = (70, 140, 280, 560, 1120)
 _VIDEO_MAX_SOFT_TOKENS = 70  # soft tokens per video frame (vs 280 for images)
 _VIDEO_MAX_FRAMES = 32  # max sampled frames per video
+
+
+def _gemma4_patch_embed_weight_loader(
+    param: torch.Tensor, loaded_weight: torch.Tensor
+) -> None:
+    if (
+        param.dim() == 2
+        and loaded_weight.dim() == 4
+        and param.shape[0] == loaded_weight.shape[0]
+        and param.shape[1]
+        == loaded_weight.shape[1] * loaded_weight.shape[2] * loaded_weight.shape[3]
+    ):
+        loaded_weight = loaded_weight.flatten(1)
+
+    default_weight_loader(param, loaded_weight)
 
 
 def _get_max_soft_tokens(
@@ -1049,6 +1066,10 @@ class Gemma4ForConditionalGeneration(
                 self.vision_tower,
                 tower_quant,
                 prefix=maybe_prefix(prefix, "vision_tower"),
+            )
+            set_weight_attrs(
+                self.vision_tower.patch_embedder.input_proj.weight,
+                {"weight_loader": _gemma4_patch_embed_weight_loader},
             )
 
         # ---- Audio tower (variants with audio_config) ----

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -15,7 +15,7 @@ reason about temporal order.
 """
 
 import math
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import numpy as np
@@ -95,9 +95,9 @@ _VIDEO_MAX_SOFT_TOKENS = 70  # soft tokens per video frame (vs 280 for images)
 _VIDEO_MAX_FRAMES = 32  # max sampled frames per video
 
 
-def _gemma4_patch_embed_weight_loader(
+def _flatten_gemma4_patch_embed_weight(
     param: torch.Tensor, loaded_weight: torch.Tensor
-) -> None:
+) -> torch.Tensor:
     if (
         param.dim() == 2
         and loaded_weight.dim() == 4
@@ -105,9 +105,40 @@ def _gemma4_patch_embed_weight_loader(
         and param.shape[1]
         == loaded_weight.shape[1] * loaded_weight.shape[2] * loaded_weight.shape[3]
     ):
-        loaded_weight = loaded_weight.flatten(1)
+        return loaded_weight.flatten(1)
 
-    default_weight_loader(param, loaded_weight)
+    return loaded_weight
+
+
+def _gemma4_patch_embed_weight_loader(
+    param: torch.Tensor, loaded_weight: torch.Tensor
+) -> None:
+    default_weight_loader(
+        param, _flatten_gemma4_patch_embed_weight(param, loaded_weight)
+    )
+
+
+def _set_gemma4_patch_embed_weight_loader(weight: torch.Tensor) -> None:
+    existing_weight_loader: Callable[[torch.Tensor, torch.Tensor], None] | None = (
+        getattr(weight, "weight_loader", None)
+    )
+    if existing_weight_loader is None:
+        set_weight_attrs(weight, {"weight_loader": _gemma4_patch_embed_weight_loader})
+        return
+
+    def weight_loader(
+        param: torch.Tensor,
+        loaded_weight: torch.Tensor,
+    ) -> None:
+        existing_weight_loader(
+            param,
+            _flatten_gemma4_patch_embed_weight(param, loaded_weight),
+        )
+
+    # Compose with the quantization loader installed by recursive_replace_linear().
+    # set_weight_attrs() intentionally rejects overwrites, so direct assignment is
+    # used here to preserve the existing loader while adding the GGUF shape fix.
+    weight.weight_loader = weight_loader
 
 
 def _get_max_soft_tokens(
@@ -1067,9 +1098,8 @@ class Gemma4ForConditionalGeneration(
                 tower_quant,
                 prefix=maybe_prefix(prefix, "vision_tower"),
             )
-            set_weight_attrs(
-                self.vision_tower.patch_embedder.input_proj.weight,
-                {"weight_loader": _gemma4_patch_embed_weight_loader},
+            _set_gemma4_patch_embed_weight_loader(
+                self.vision_tower.patch_embedder.input_proj.weight
             )
 
         # ---- Audio tower (variants with audio_config) ----

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -107,6 +107,47 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _load_gguf_tuple_shards(
+    param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    shard_id: tuple[int, ...],
+    weight_loader: Callable[..., object],
+) -> bool:
+    if not (
+        getattr(param, "is_gguf_weight", False)
+        or getattr(param, "is_gguf_weight_type", False)
+    ):
+        return False
+
+    if getattr(param, "is_gguf_weight_type", False):
+        for idx in shard_id:
+            weight_loader(param, loaded_weight, idx)
+        return True
+
+    output_dim = getattr(param, "output_dim", None)
+    loader = getattr(weight_loader, "__self__", None)
+    output_sizes = getattr(loader, "output_sizes", None)
+    if output_dim is None or output_sizes is None:
+        return False
+
+    shard_sizes = [output_sizes[idx] for idx in shard_id]
+    packed_dim = getattr(param, "packed_dim", None)
+    if packed_dim == output_dim:
+        packed_factor = getattr(param, "packed_factor", 1)
+        if any(size % packed_factor != 0 for size in shard_sizes):
+            return False
+        shard_sizes = [size // packed_factor for size in shard_sizes]
+
+    if loaded_weight.size(output_dim) != sum(shard_sizes):
+        return False
+
+    for idx, loaded_weight_shard in zip(
+        shard_id, torch.split(loaded_weight, shard_sizes, dim=output_dim)
+    ):
+        weight_loader(param, loaded_weight_shard, idx)
+    return True
+
+
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
         return self.ctx.get_hf_config(Qwen3_5Config)
@@ -340,7 +381,13 @@ class Qwen3_5Model(Qwen3NextModel):
                     continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
+                if not (
+                    isinstance(shard_id, tuple)
+                    and _load_gguf_tuple_shards(
+                        param, loaded_weight, shard_id, weight_loader
+                    )
+                ):
+                    weight_loader(param, loaded_weight, shard_id)
                 break
             else:
                 is_expert_weight = False

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -85,6 +85,7 @@ from .qwen3_next import (
     Qwen3NextModel,
     Qwen3NextSparseMoeBlock,
     QwenNextMixtureOfExperts,
+    _maybe_reshape_gguf_shared_expert_gate,
 )
 from .qwen3_vl import (
     Qwen3_VisionTransformer,
@@ -471,6 +472,9 @@ class Qwen3_5Model(Qwen3NextModel):
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
+                    )
+                    loaded_weight = _maybe_reshape_gguf_shared_expert_gate(
+                        name, loaded_weight
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -85,7 +85,7 @@ from .qwen3_next import (
     Qwen3NextModel,
     Qwen3NextSparseMoeBlock,
     QwenNextMixtureOfExperts,
-    _maybe_reshape_gguf_shared_expert_gate,
+    _maybe_reshape_gguf_weight,
 )
 from .qwen3_vl import (
     Qwen3_VisionTransformer,
@@ -473,9 +473,7 @@ class Qwen3_5Model(Qwen3NextModel):
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )
-                    loaded_weight = _maybe_reshape_gguf_shared_expert_gate(
-                        name, loaded_weight
-                    )
+                    loaded_weight = _maybe_reshape_gguf_weight(name, loaded_weight)
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -23,7 +23,10 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5RMSNorm
-from vllm.model_executor.models.qwen3_next import QwenNextMixtureOfExperts
+from vllm.model_executor.models.qwen3_next import (
+    QwenNextMixtureOfExperts,
+    _maybe_reshape_gguf_weight,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
 from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
@@ -446,6 +449,7 @@ class Qwen3_5MTP(nn.Module, SupportsMultiModal):
                         name = name.replace("language_model.", "")
                 else:
                     continue
+                weight = _maybe_reshape_gguf_weight(name, weight)
                 yield name, weight
 
         loader = AutoWeightsLoader(self)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -84,6 +84,17 @@ logger = init_logger(__name__)
 KVCache = tuple[torch.Tensor, torch.Tensor]
 
 
+def _maybe_reshape_gguf_shared_expert_gate(
+    name: str,
+    loaded_weight: torch.Tensor,
+) -> torch.Tensor:
+    # GGUF stores this gate as [hidden], while ReplicatedLinear expects
+    # [1, hidden].
+    if "mlp.shared_expert_gate" in name and loaded_weight.ndim == 1:
+        return loaded_weight[None, :]
+    return loaded_weight
+
+
 class Qwen3NextSparseMoeBlock(nn.Module):
     def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -656,6 +667,9 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
+                    )
+                    loaded_weight = _maybe_reshape_gguf_shared_expert_gate(
+                        name, loaded_weight
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -84,7 +84,7 @@ logger = init_logger(__name__)
 KVCache = tuple[torch.Tensor, torch.Tensor]
 
 
-def _maybe_reshape_gguf_shared_expert_gate(
+def _maybe_reshape_gguf_weight(
     name: str,
     loaded_weight: torch.Tensor,
 ) -> torch.Tensor:
@@ -92,6 +92,10 @@ def _maybe_reshape_gguf_shared_expert_gate(
     # [1, hidden].
     if "mlp.shared_expert_gate" in name and loaded_weight.ndim == 1:
         return loaded_weight[None, :]
+    # GGUF stores Qwen GDN conv1d weights as [out, kernel]. MambaMixer2
+    # keeps conv1d weights in Conv1d-compatible [out, 1, kernel] shape.
+    if "linear_attn.conv1d.weight" in name and loaded_weight.ndim == 2:
+        return loaded_weight[:, None, :]
     return loaded_weight
 
 
@@ -668,9 +672,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )
-                    loaded_weight = _maybe_reshape_gguf_shared_expert_gate(
-                        name, loaded_weight
-                    )
+                    loaded_weight = _maybe_reshape_gguf_weight(name, loaded_weight)
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -69,6 +69,7 @@ from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
+from vllm.model_executor.utils import set_weight_attrs
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.evs import (
     compute_mrope_for_media,
@@ -148,6 +149,23 @@ logger = init_logger(__name__)
 # We use 2048 dummy video frames that would generate vision embeddings
 # of the maximum size.
 DUMMY_VIDEO_NUM_FRAMES = 2048
+
+
+def _qwen3_vl_patch_embed_weight_loader(
+    param: torch.Tensor, loaded_weight: torch.Tensor
+) -> None:
+    if (
+        param.dim() == 5
+        and loaded_weight.dim() == 4
+        and param.shape[:2] == loaded_weight.shape[:2]
+        and param.shape[3:] == loaded_weight.shape[2:]
+    ):
+        temporal_patch_size = param.shape[2]
+        loaded_weight = loaded_weight.unsqueeze(2).expand(param.shape).contiguous()
+        loaded_weight = loaded_weight / temporal_patch_size
+
+    default_weight_loader(param, loaded_weight)
+
 
 # ---------------------------------------------------------------------------
 # Triton kernel: fused bilinear position-embedding interpolation
@@ -365,6 +383,10 @@ class Qwen3_VisionPatchEmbed(nn.Module):
             kernel_size=kernel_size,
             stride=kernel_size,
             bias=True,
+        )
+        set_weight_attrs(
+            self.proj.weight,
+            {"weight_loader": _qwen3_vl_patch_embed_weight_loader},
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -17,6 +17,7 @@ from vllm.transformers_utils.gguf_utils import (
     get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
+    resolve_gguf_tokenizer_source,
     split_remote_gguf,
 )
 from vllm.transformers_utils.repo_utils import (
@@ -128,17 +129,39 @@ def resolve_tokenizer_args(
     # Separate model folder from file path for GGUF models
     if is_gguf(tokenizer_name):
         if check_gguf_file(tokenizer_name):
-            kwargs["gguf_file"] = Path(tokenizer_name).name
-            tokenizer_name = Path(tokenizer_name).parent
-        elif is_remote_gguf(tokenizer_name):
-            tokenizer_name, quant_type = split_remote_gguf(tokenizer_name)
-            # Get the HuggingFace Hub path for the GGUF file
-            gguf_file = get_gguf_file_path_from_hf(
+            gguf_path = Path(tokenizer_name)
+            tokenizer_source = resolve_gguf_tokenizer_source(
                 tokenizer_name,
-                quant_type,
                 revision=revision,
             )
-            kwargs["gguf_file"] = gguf_file
+            if tokenizer_source != gguf_path.parent:
+                tokenizer_name = tokenizer_source
+                if revision is not None:
+                    kwargs["revision"] = None
+                    revision = None
+            else:
+                kwargs["gguf_file"] = gguf_path.name
+                tokenizer_name = gguf_path.parent
+        elif is_remote_gguf(tokenizer_name):
+            gguf_repo, quant_type = split_remote_gguf(tokenizer_name)
+            tokenizer_source = resolve_gguf_tokenizer_source(
+                tokenizer_name,
+                revision=revision,
+            )
+            if tokenizer_source != gguf_repo:
+                tokenizer_name = tokenizer_source
+                if revision is not None:
+                    kwargs["revision"] = None
+                    revision = None
+            else:
+                tokenizer_name = gguf_repo
+                # Get the HuggingFace Hub path for the GGUF file
+                gguf_file = get_gguf_file_path_from_hf(
+                    tokenizer_name,
+                    quant_type,
+                    revision=revision,
+                )
+                kwargs["gguf_file"] = gguf_file
 
     if "truncation_side" not in kwargs:
         if runner_type == "generate" or runner_type == "draft":

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -17,7 +17,6 @@ from vllm.transformers_utils.gguf_utils import (
     get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
-    resolve_gguf_tokenizer_source,
     split_remote_gguf,
 )
 from vllm.transformers_utils.repo_utils import (
@@ -130,38 +129,17 @@ def resolve_tokenizer_args(
     if is_gguf(tokenizer_name):
         if check_gguf_file(tokenizer_name):
             gguf_path = Path(tokenizer_name)
-            tokenizer_source = resolve_gguf_tokenizer_source(
-                tokenizer_name,
-                revision=revision,
-            )
-            if tokenizer_source != gguf_path.parent:
-                tokenizer_name = tokenizer_source
-                if revision is not None:
-                    kwargs["revision"] = None
-                    revision = None
-            else:
-                kwargs["gguf_file"] = gguf_path.name
-                tokenizer_name = gguf_path.parent
+            kwargs["gguf_file"] = gguf_path.name
+            tokenizer_name = gguf_path.parent
         elif is_remote_gguf(tokenizer_name):
             gguf_repo, quant_type = split_remote_gguf(tokenizer_name)
-            tokenizer_source = resolve_gguf_tokenizer_source(
+            tokenizer_name = gguf_repo
+            # Get the HuggingFace Hub path for the GGUF file.
+            kwargs["gguf_file"] = get_gguf_file_path_from_hf(
                 tokenizer_name,
+                quant_type,
                 revision=revision,
             )
-            if tokenizer_source != gguf_repo:
-                tokenizer_name = tokenizer_source
-                if revision is not None:
-                    kwargs["revision"] = None
-                    revision = None
-            else:
-                tokenizer_name = gguf_repo
-                # Get the HuggingFace Hub path for the GGUF file
-                gguf_file = get_gguf_file_path_from_hf(
-                    tokenizer_name,
-                    quant_type,
-                    revision=revision,
-                )
-                kwargs["gguf_file"] = gguf_file
 
     if "truncation_side" not in kwargs:
         if runner_type == "generate" or runner_type == "draft":

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -39,6 +39,7 @@ from .gguf_utils import (
     get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
+    maybe_patch_mtp_config_from_gguf,
     resolve_gguf_config_source,
     split_remote_gguf,
 )
@@ -750,6 +751,7 @@ def get_config(
 ) -> PretrainedConfig:
     # Separate model folder from file path for GGUF models
 
+    original_model = model
     _is_gguf = is_gguf(model)
     _is_remote_gguf = is_remote_gguf(model)
     if _is_gguf:
@@ -767,6 +769,16 @@ def get_config(
                 revision = None
             elif file_or_path_exists(gguf_repo, HF_CONFIG_NAME, revision=revision):
                 model = gguf_repo
+            elif hf_overrides_fn is not None and file_or_path_exists(
+                gguf_repo.parent,
+                HF_CONFIG_NAME,
+                revision=revision,
+            ):
+                # Nested GGUF draft checkpoints can store only the draft
+                # weights under a subdirectory and share the parent config.
+                # Keep the GGUF metadata patch below so the normal speculative
+                # override path still builds the draft config.
+                model = gguf_repo.parent
             else:
                 # Preserve the previous fallback for local GGUF files that rely
                 # on Transformers' GGUF metadata parser for supported arches.
@@ -918,6 +930,9 @@ def get_config(
                     ),
                     scale_fmt,
                 )
+
+    if _is_gguf and hf_overrides_fn is not None:
+        config = maybe_patch_mtp_config_from_gguf(original_model, config)
 
     if hf_overrides_kw:
         logger.debug("Overriding HF config with %s", hf_overrides_kw)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -36,8 +36,10 @@ from vllm.utils.torch_utils import common_broadcastable_dtype
 from .config_parser_base import ConfigParserBase
 from .gguf_utils import (
     check_gguf_file,
+    get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
+    resolve_gguf_config_source,
     split_remote_gguf,
 )
 from .repo_utils import (
@@ -627,6 +629,7 @@ def maybe_override_with_speculators(
     tokenizer: str | None,
     trust_remote_code: bool,
     revision: str | None = None,
+    hf_config_path: str | None = None,
     vllm_speculative_config: dict[str, Any] | None = None,
     hf_token: bool | str | None = None,
     **kwargs,
@@ -649,16 +652,46 @@ def maybe_override_with_speculators(
         Tuple of (resolved_model, resolved_tokenizer, speculative_config)
     """
     if check_gguf_file(model):
-        kwargs["gguf_file"] = Path(model).name
-        gguf_model_repo = Path(model).parent
+        if hf_config_path is None:
+            gguf_repo = Path(model).parent
+            gguf_model_repo = resolve_gguf_config_source(
+                model,
+                revision=revision,
+            )
+            if gguf_model_repo != gguf_repo:
+                # The local GGUF parent has no usable HF config.  Revisions for
+                # the local GGUF file do not apply to its metadata base model.
+                revision = None
+            elif not file_or_path_exists(
+                gguf_repo,
+                HF_CONFIG_NAME,
+                revision=revision,
+            ):
+                # Preserve the previous fallback for local GGUF files that rely
+                # on Transformers' GGUF metadata parser for supported arches.
+                kwargs["gguf_file"] = Path(model).name
+        else:
+            gguf_model_repo = Path(model).parent
     elif is_remote_gguf(model):
-        repo_id, _ = split_remote_gguf(model)
-        gguf_model_repo = Path(repo_id)
+        repo_id, quant_type = split_remote_gguf(model)
+        gguf_model_repo = resolve_gguf_config_source(model, revision=revision)
+        if gguf_model_repo != repo_id:
+            # A GGUF repo revision does not apply to the referenced base model.
+            revision = None
+        elif not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision=revision):
+            kwargs["gguf_file"] = get_gguf_file_path_from_hf(
+                repo_id,
+                quant_type,
+                revision=revision,
+            )
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
+    config_source = hf_config_path or (
+        model if gguf_model_repo is None else gguf_model_repo
+    )
     config_dict, _ = PretrainedConfig.get_config_dict(
-        model if gguf_model_repo is None else gguf_model_repo,
+        config_source,
         revision=revision,
         token=hf_token,
         **without_trust_remote_code(kwargs),
@@ -703,13 +736,39 @@ def get_config(
     if _is_gguf:
         if check_gguf_file(model):
             # Local GGUF file
-            kwargs["gguf_file"] = Path(model).name
-            model = Path(model).parent
+            gguf_path = Path(model)
+            gguf_repo = gguf_path.parent
+            model = resolve_gguf_config_source(model, revision=revision)
+            if model != gguf_repo:
+                # The local GGUF file points at a verified HF base model.  Do
+                # not pass gguf_file, or Transformers will parse the unsupported
+                # GGUF architecture instead of the base config.
+                revision = None
+            elif file_or_path_exists(gguf_repo, HF_CONFIG_NAME, revision=revision):
+                model = gguf_repo
+            else:
+                # Preserve the previous fallback for local GGUF files that rely
+                # on Transformers' GGUF metadata parser for supported arches.
+                kwargs["gguf_file"] = gguf_path.name
+                model = gguf_repo
         elif _is_remote_gguf:
             # Remote GGUF - extract repo_id from repo_id:quant_type format
             # The actual GGUF file will be downloaded later by GGUFModelLoader
-            # Keep model as repo_id:quant_type for download, but use repo_id for config
-            model, _ = split_remote_gguf(model)
+            # Keep model as repo_id:quant_type for download, but use the GGUF
+            # repo or its verified HF base model for config.
+            remote_gguf_repo, quant_type = split_remote_gguf(model)
+            model = resolve_gguf_config_source(model, revision=revision)
+            if model != remote_gguf_repo:
+                # A GGUF repo revision does not apply to the referenced base
+                # model. Use the base model's default revision unless users
+                # pass an explicit hf_config_path.
+                revision = None
+            elif not file_or_path_exists(model, HF_CONFIG_NAME, revision=revision):
+                kwargs["gguf_file"] = get_gguf_file_path_from_hf(
+                    remote_gguf_repo,
+                    quant_type,
+                    revision=revision,
+                )
 
     if config_format == "auto":
         try:
@@ -721,25 +780,10 @@ def get_config(
                 model=model, config_name=MISTRAL_CONFIG_NAME, revision=revision
             ):
                 config_format = "mistral"
-            elif (_is_gguf and not _is_remote_gguf) or file_or_path_exists(
-                model, HF_CONFIG_NAME, revision=revision
-            ):
+            elif (
+                _is_gguf and (not _is_remote_gguf or "gguf_file" in kwargs)
+            ) or file_or_path_exists(model, HF_CONFIG_NAME, revision=revision):
                 config_format = "hf"
-            # Remote GGUF models must have config.json in repo,
-            # otherwise the config can't be parsed correctly.
-            # FIXME(Isotr0py): Support remote GGUF repos without config.json
-            elif _is_remote_gguf and not file_or_path_exists(
-                model, HF_CONFIG_NAME, revision=revision
-            ):
-                err_msg = (
-                    "Could not find config.json for remote GGUF model repo. "
-                    "To load remote GGUF model through `<repo_id>:<quant_type>`, "
-                    "ensure your model has config.json (HF format) file. "
-                    "Otherwise please specify --hf-config-path <original_repo> "
-                    "in engine args to fetch config from unquantized hf model."
-                )
-                logger.error(err_msg)
-                raise ValueError(err_msg)
             else:
                 raise ValueError(
                     "Could not detect config format for no config file found. "
@@ -796,7 +840,7 @@ def get_config(
             apply_gguf_default("norm_topk_prob", True)
 
     # Special architecture mapping check for GGUF models
-    if _is_gguf:
+    if _is_gguf and not config.architectures:
         if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
         model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -742,7 +742,9 @@ def get_config(
             if model != gguf_repo:
                 # The local GGUF file points at a verified HF base model.  Do
                 # not pass gguf_file, or Transformers will parse the unsupported
-                # GGUF architecture instead of the base config.
+                # GGUF architecture instead of the base config.  Do not inherit
+                # trust_remote_code across this implicit metadata redirect.
+                trust_remote_code = False
                 revision = None
             elif file_or_path_exists(gguf_repo, HF_CONFIG_NAME, revision=revision):
                 model = gguf_repo
@@ -761,7 +763,9 @@ def get_config(
             if model != remote_gguf_repo:
                 # A GGUF repo revision does not apply to the referenced base
                 # model. Use the base model's default revision unless users
-                # pass an explicit hf_config_path.
+                # pass an explicit hf_config_path.  Do not inherit
+                # trust_remote_code across this implicit metadata redirect.
+                trust_remote_code = False
                 revision = None
             elif not file_or_path_exists(model, HF_CONFIG_NAME, revision=revision):
                 kwargs["gguf_file"] = get_gguf_file_path_from_hf(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -633,7 +633,7 @@ def maybe_override_with_speculators(
     vllm_speculative_config: dict[str, Any] | None = None,
     hf_token: bool | str | None = None,
     **kwargs,
-) -> tuple[str, str | None, dict[str, Any] | None]:
+) -> tuple[str, str | None, dict[str, Any] | None, bool]:
     """
     Resolve model configuration when speculators are detected.
 
@@ -649,8 +649,10 @@ def maybe_override_with_speculators(
         hf_token: HuggingFace token for authenticated model access
 
     Returns:
-        Tuple of (resolved_model, resolved_tokenizer, speculative_config)
+        Tuple of (resolved_model, resolved_tokenizer, speculative_config,
+        trust_remote_code)
     """
+    disable_verifier_trust_remote_code = False
     if check_gguf_file(model):
         if hf_config_path is None:
             gguf_repo = Path(model).parent
@@ -662,6 +664,7 @@ def maybe_override_with_speculators(
                 # The local GGUF parent has no usable HF config.  Revisions for
                 # the local GGUF file do not apply to its metadata base model.
                 revision = None
+                disable_verifier_trust_remote_code = True
             elif not file_or_path_exists(
                 gguf_repo,
                 HF_CONFIG_NAME,
@@ -670,6 +673,7 @@ def maybe_override_with_speculators(
                 # Preserve the previous fallback for local GGUF files that rely
                 # on Transformers' GGUF metadata parser for supported arches.
                 kwargs["gguf_file"] = Path(model).name
+                disable_verifier_trust_remote_code = True
         else:
             gguf_model_repo = Path(model).parent
     elif is_remote_gguf(model):
@@ -678,12 +682,14 @@ def maybe_override_with_speculators(
         if gguf_model_repo != repo_id:
             # A GGUF repo revision does not apply to the referenced base model.
             revision = None
+            disable_verifier_trust_remote_code = True
         elif not file_or_path_exists(repo_id, HF_CONFIG_NAME, revision=revision):
             kwargs["gguf_file"] = get_gguf_file_path_from_hf(
                 repo_id,
                 quant_type,
                 revision=revision,
             )
+            disable_verifier_trust_remote_code = True
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
@@ -700,7 +706,7 @@ def maybe_override_with_speculators(
 
     if speculators_config is None:
         # No speculators config found, return original values
-        return model, tokenizer, vllm_speculative_config
+        return model, tokenizer, vllm_speculative_config, trust_remote_code
 
     # Speculators format detected - process overrides
     from vllm.transformers_utils.configs.speculators.base import SpeculatorsConfig
@@ -715,8 +721,17 @@ def maybe_override_with_speculators(
     # Override model and tokenizer with the verifier model from config
     verifier_model = speculators_config["verifier"]["name_or_path"]
     model = tokenizer = verifier_model
+    if disable_verifier_trust_remote_code and trust_remote_code:
+        logger.warning_once(
+            "Disabling `trust_remote_code` for speculators verifier model "
+            "'%s' because it was selected from a GGUF-derived speculators "
+            "config. Pass "
+            "an explicit `--hf-config-path` to opt in for that repository.",
+            verifier_model,
+        )
+        trust_remote_code = False
 
-    return model, tokenizer, speculative_config
+    return model, tokenizer, speculative_config, trust_remote_code
 
 
 def get_config(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -653,6 +653,17 @@ def maybe_override_with_speculators(
         trust_remote_code)
     """
     disable_verifier_trust_remote_code = False
+
+    def disable_trust_remote_code_for_gguf_config() -> bool:
+        if not disable_verifier_trust_remote_code or not trust_remote_code:
+            return trust_remote_code
+        logger.warning_once(
+            "Disabling `trust_remote_code` because model config was selected "
+            "from a GGUF-derived config source. Pass an explicit "
+            "`--hf-config-path` to opt in for that repository.",
+        )
+        return False
+
     if check_gguf_file(model):
         if hf_config_path is None:
             gguf_repo = Path(model).parent
@@ -706,6 +717,7 @@ def maybe_override_with_speculators(
 
     if speculators_config is None:
         # No speculators config found, return original values
+        trust_remote_code = disable_trust_remote_code_for_gguf_config()
         return model, tokenizer, vllm_speculative_config, trust_remote_code
 
     # Speculators format detected - process overrides
@@ -721,15 +733,7 @@ def maybe_override_with_speculators(
     # Override model and tokenizer with the verifier model from config
     verifier_model = speculators_config["verifier"]["name_or_path"]
     model = tokenizer = verifier_model
-    if disable_verifier_trust_remote_code and trust_remote_code:
-        logger.warning_once(
-            "Disabling `trust_remote_code` for speculators verifier model "
-            "'%s' because it was selected from a GGUF-derived speculators "
-            "config. Pass "
-            "an explicit `--hf-config-path` to opt in for that repository.",
-            verifier_model,
-        )
-        trust_remote_code = False
+    trust_remote_code = disable_trust_remote_code_for_gguf_config()
 
     return model, tokenizer, speculative_config, trust_remote_code
 

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -5,7 +5,7 @@
 from functools import cache
 from os import PathLike
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import gguf
 import regex as re
@@ -194,6 +194,213 @@ def _gguf_field_value(field: Any) -> Any:
     except Exception as e:
         logger.debug("Failed to read GGUF metadata field: %s", e)
         return None
+
+
+def _gguf_scalar_string(value: Any) -> str | None:
+    if hasattr(value, "item"):
+        value = value.item()
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    return value if isinstance(value, str) else None
+
+
+def _gguf_first_int(value: Any) -> int | None:
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[0]
+    if hasattr(value, "item"):
+        value = value.item()
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _gguf_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _gguf_int_list(value: Any) -> tuple[int, ...]:
+    values: list[int] = []
+    for item in _gguf_list(value):
+        if hasattr(item, "item"):
+            item = item.item()
+        try:
+            values.append(int(item))
+        except (TypeError, ValueError):
+            return ()
+    return tuple(values)
+
+
+def _gguf_bool_list(value: Any) -> tuple[bool, ...]:
+    values: list[bool] = []
+    for item in _gguf_list(value):
+        if hasattr(item, "item"):
+            item = item.item()
+        if isinstance(item, str):
+            if item.lower() not in {"true", "false", "0", "1"}:
+                return ()
+            values.append(item.lower() in {"true", "1"})
+        else:
+            values.append(bool(item))
+    return tuple(values)
+
+
+class _LocalGgufMtpMetadata(NamedTuple):
+    arch: str
+    nextn_layers: int
+    embedding_length: int | None
+    embedding_length_out: int | None
+    feed_forward_length: int | None
+    head_count: int | None
+    head_count_kv: tuple[int, ...]
+    key_length: int | None
+    key_length_swa: int | None
+    sliding_window: int | None
+    sliding_window_pattern: tuple[bool, ...]
+
+
+@cache
+def _get_local_gguf_mtp_metadata(model: str | Path) -> _LocalGgufMtpMetadata | None:
+    try:
+        reader = gguf.GGUFReader(str(model))
+    except Exception as e:
+        logger.debug("Failed to inspect GGUF MTP metadata for %s: %s", model, e)
+        return None
+
+    arch_field = reader.get_field("general.architecture")
+    arch = _gguf_scalar_string(_gguf_field_value(arch_field)) if arch_field else None
+    if arch is None:
+        return None
+
+    def get_int_field(suffix: str) -> int | None:
+        field = reader.get_field(f"{arch}.{suffix}")
+        return _gguf_first_int(_gguf_field_value(field)) if field else None
+
+    def get_int_list_field(suffix: str) -> tuple[int, ...]:
+        field = reader.get_field(f"{arch}.{suffix}")
+        return _gguf_int_list(_gguf_field_value(field)) if field else ()
+
+    def get_bool_list_field(suffix: str) -> tuple[bool, ...]:
+        field = reader.get_field(f"{arch}.{suffix}")
+        return _gguf_bool_list(_gguf_field_value(field)) if field else ()
+
+    nextn_layers = get_int_field("nextn_predict_layers")
+    if nextn_layers is None:
+        return None
+
+    return _LocalGgufMtpMetadata(
+        arch=arch,
+        nextn_layers=nextn_layers,
+        embedding_length=get_int_field("embedding_length"),
+        embedding_length_out=get_int_field("embedding_length_out"),
+        feed_forward_length=get_int_field("feed_forward_length"),
+        head_count=get_int_field("attention.head_count"),
+        head_count_kv=get_int_list_field("attention.head_count_kv"),
+        key_length=get_int_field("attention.key_length"),
+        key_length_swa=get_int_field("attention.key_length_swa"),
+        sliding_window=get_int_field("attention.sliding_window"),
+        sliding_window_pattern=get_bool_list_field("attention.sliding_window_pattern"),
+    )
+
+
+def _update_config_attrs(config: Any, attrs: dict[str, Any]) -> None:
+    if hasattr(config, "update"):
+        config.update(attrs)
+        return
+    for name, value in attrs.items():
+        setattr(config, name, value)
+
+
+def maybe_patch_mtp_config_from_gguf(
+    model: str | Path,
+    hf_config: PretrainedConfig,
+) -> PretrainedConfig:
+    """Patch MTP hints from GGUF metadata before speculative HF overrides.
+
+    GGUF MTP checkpoints store their MTP layer count in
+    ``<architecture>.nextn_predict_layers``.  vLLM's speculative config path
+    already knows how to turn HF configs into MTP draft configs, so this helper
+    only restores the corresponding HF config hints.
+    """
+    if not check_gguf_file(model):
+        return hf_config
+
+    mtp_metadata = _get_local_gguf_mtp_metadata(model)
+    if mtp_metadata is None:
+        return hf_config
+
+    arch = mtp_metadata.arch
+    if arch in {"qwen35", "qwen35moe"}:
+        hf_config.update({"mtp_num_hidden_layers": mtp_metadata.nextn_layers})
+    elif arch in {"gemma4-assistant", "gemma4-unified-assistant"}:
+        hf_config.model_type = arch.replace("-", "_")
+        text_config = getattr(hf_config, "text_config", hf_config)
+        text_attrs: dict[str, Any] = {
+            "num_hidden_layers": mtp_metadata.nextn_layers,
+        }
+        if mtp_metadata.embedding_length is not None:
+            text_attrs["hidden_size"] = mtp_metadata.embedding_length
+        if mtp_metadata.feed_forward_length is not None:
+            text_attrs["intermediate_size"] = mtp_metadata.feed_forward_length
+        if mtp_metadata.head_count is not None:
+            text_attrs["num_attention_heads"] = mtp_metadata.head_count
+        if mtp_metadata.key_length_swa is not None:
+            text_attrs["head_dim"] = mtp_metadata.key_length_swa
+        if mtp_metadata.key_length is not None:
+            text_attrs["global_head_dim"] = mtp_metadata.key_length
+        if mtp_metadata.sliding_window is not None:
+            text_attrs["sliding_window"] = mtp_metadata.sliding_window
+        pattern = mtp_metadata.sliding_window_pattern[: mtp_metadata.nextn_layers]
+        if len(pattern) == mtp_metadata.nextn_layers:
+            text_attrs["layer_types"] = [
+                "sliding_attention" if is_sliding else "full_attention"
+                for is_sliding in pattern
+            ]
+            kv_heads = mtp_metadata.head_count_kv[: mtp_metadata.nextn_layers]
+            if len(kv_heads) == mtp_metadata.nextn_layers:
+                sliding_kv = next(
+                    (
+                        heads
+                        for is_sliding, heads in zip(pattern, kv_heads)
+                        if is_sliding
+                    ),
+                    None,
+                )
+                full_kv = next(
+                    (
+                        heads
+                        for is_sliding, heads in zip(pattern, kv_heads)
+                        if not is_sliding
+                    ),
+                    None,
+                )
+                if sliding_kv is not None:
+                    text_attrs["num_key_value_heads"] = sliding_kv
+                if full_kv is not None:
+                    text_attrs["num_global_key_value_heads"] = full_kv
+        elif mtp_metadata.head_count_kv:
+            text_attrs["num_key_value_heads"] = mtp_metadata.head_count_kv[0]
+        _update_config_attrs(text_config, text_attrs)
+        if mtp_metadata.embedding_length_out is not None:
+            _update_config_attrs(
+                hf_config,
+                {"backbone_hidden_size": mtp_metadata.embedding_length_out},
+            )
+
+    return hf_config
 
 
 @cache

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -150,21 +150,22 @@ def _normalize_base_model_ids(base_model: Any) -> list[str]:
     return []
 
 
+@cache
 def _get_remote_gguf_base_model_ids(
     repo_id: str,
     revision: str | None = None,
-) -> list[str]:
+) -> tuple[str, ...]:
     try:
         info = hf_api().model_info(repo_id, revision=revision)
     except Exception as e:
         logger.debug("Failed to inspect GGUF model card for %s: %s", repo_id, e)
-        return []
+        return ()
 
     card_data = getattr(info, "card_data", None)
     base_model = getattr(card_data, "base_model", None)
     if base_model is None and isinstance(card_data, dict):
         base_model = card_data.get("base_model")
-    return _normalize_base_model_ids(base_model)
+    return tuple(_normalize_base_model_ids(base_model))
 
 
 def _normalize_hf_repo_id(value: Any) -> str | None:
@@ -231,9 +232,11 @@ def _resolve_gguf_hf_source(
     if is_remote_gguf(model):
         source: str | Path
         source, _ = split_remote_gguf(model)
-        base_model_ids = _get_remote_gguf_base_model_ids(
-            source,
-            revision=revision,
+        base_model_ids = list(
+            _get_remote_gguf_base_model_ids(
+                source,
+                revision=revision,
+            )
         )
     elif check_gguf_file(model):
         source = Path(model).parent

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -5,6 +5,7 @@
 from functools import cache
 from os import PathLike
 from pathlib import Path
+from typing import Any
 
 import gguf
 import regex as re
@@ -14,7 +15,7 @@ from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 
 from vllm.logger import init_logger
 
-from .repo_utils import list_filtered_repo_files
+from .repo_utils import file_or_path_exists, hf_api, list_filtered_repo_files
 
 logger = init_logger(__name__)
 
@@ -85,6 +86,22 @@ def is_nonstandard_gguf_quant_type(quant_type: str) -> bool:
 # Common suffixes used in GGUF file naming conventions
 # e.g., Q4_K_M, Q3_K_S, Q5_K_L, Q2_K_XL
 _GGUF_QUANT_SUFFIXES = ("_M", "_S", "_L", "_XL", "_XS", "_XXS")
+_HF_CONFIG_FILES = ("config.json",)
+_HF_TOKENIZER_FILES = (
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "tokenizer.model",
+    "spiece.model",
+    "vocab.json",
+    "merges.txt",
+)
+_HF_REPO_ID_PATTERN = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+)
+_HF_REPO_URL_PATTERN = re.compile(
+    r"^https?://huggingface\.co/"
+    r"([a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*)"
+)
 
 
 def is_valid_gguf_quant_type(gguf_quant_type: str) -> bool:
@@ -121,6 +138,151 @@ def split_remote_gguf(model: str | Path) -> tuple[str, str]:
         "- Non-standard GGUF quant types also supported: "
         "dash-separated prefixes (e.g. UD-Q4_K_XL, Custom-Q8_0)",
     )
+
+
+def _normalize_base_model_ids(base_model: Any) -> list[str]:
+    if base_model is None:
+        return []
+    if isinstance(base_model, str):
+        return [base_model] if base_model else []
+    if isinstance(base_model, (list, tuple, set)):
+        return [model_id for model_id in base_model if isinstance(model_id, str)]
+    return []
+
+
+def _get_remote_gguf_base_model_ids(
+    repo_id: str,
+    revision: str | None = None,
+) -> list[str]:
+    try:
+        info = hf_api().model_info(repo_id, revision=revision)
+    except Exception as e:
+        logger.debug("Failed to inspect GGUF model card for %s: %s", repo_id, e)
+        return []
+
+    card_data = getattr(info, "card_data", None)
+    base_model = getattr(card_data, "base_model", None)
+    if base_model is None and isinstance(card_data, dict):
+        base_model = card_data.get("base_model")
+    return _normalize_base_model_ids(base_model)
+
+
+def _normalize_hf_repo_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    if value.endswith(".git"):
+        value = value[:-4]
+
+    if _HF_REPO_ID_PATTERN.fullmatch(value):
+        return value
+
+    match = _HF_REPO_URL_PATTERN.match(value)
+    if match:
+        repo_id = match.group(1)
+        if repo_id.endswith(".git"):
+            repo_id = repo_id[:-4]
+        return repo_id
+
+    return None
+
+
+def _gguf_field_value(field: Any) -> Any:
+    try:
+        return field.contents()
+    except Exception as e:
+        logger.debug("Failed to read GGUF metadata field: %s", e)
+        return None
+
+
+@cache
+def _get_local_gguf_base_model_ids(model: str | Path) -> tuple[str, ...]:
+    try:
+        reader = gguf.GGUFReader(str(model))
+    except Exception as e:
+        logger.debug("Failed to inspect GGUF metadata for %s: %s", model, e)
+        return ()
+
+    base_model_ids: list[str] = []
+    for key, field in reader.fields.items():
+        if not (key.startswith("general.base_model.") and key.endswith(".repo_url")):
+            continue
+        if repo_id := _normalize_hf_repo_id(_gguf_field_value(field)):
+            base_model_ids.append(repo_id)
+
+    # Preserve metadata order while dropping duplicates.
+    return tuple(dict.fromkeys(base_model_ids))
+
+
+def _source_has_any_file(
+    model: str | Path,
+    filenames: tuple[str, ...],
+    revision: str | None = None,
+) -> bool:
+    return any(file_or_path_exists(model, filename, revision) for filename in filenames)
+
+
+def _resolve_gguf_hf_source(
+    model: str | Path,
+    filenames: tuple[str, ...],
+    revision: str | None = None,
+) -> str | Path:
+    if is_remote_gguf(model):
+        source: str | Path
+        source, _ = split_remote_gguf(model)
+        base_model_ids = _get_remote_gguf_base_model_ids(
+            source,
+            revision=revision,
+        )
+    elif check_gguf_file(model):
+        source = Path(model).parent
+        base_model_ids = list(_get_local_gguf_base_model_ids(model))
+    else:
+        return model
+
+    if _source_has_any_file(source, filenames, revision=revision):
+        return source
+
+    for base_model in base_model_ids:
+        # GGUF repo revisions are not meaningful for the referenced HF base model.
+        if _source_has_any_file(base_model, filenames, revision=None):
+            return base_model
+
+    return source
+
+
+def resolve_gguf_config_source(
+    model: str | Path,
+    revision: str | None = None,
+) -> str | Path:
+    """Resolve where a GGUF model should load its HF config from.
+
+    Remote GGUF repos often contain only quantized weights.  If their model card
+    points to an original HF base model, use it only after verifying that the
+    candidate actually provides ``config.json``.
+    """
+    if is_gguf(model):
+        return _resolve_gguf_hf_source(
+            model,
+            _HF_CONFIG_FILES,
+            revision=revision,
+        )
+    return model
+
+
+def resolve_gguf_tokenizer_source(
+    model: str | Path,
+    revision: str | None = None,
+) -> str | Path:
+    """Resolve where a GGUF model should load tokenizer/processor files from."""
+    if is_gguf(model):
+        return _resolve_gguf_hf_source(
+            model,
+            _HF_TOKENIZER_FILES,
+            revision=revision,
+        )
+    return model
 
 
 def is_gguf(model: str | Path) -> bool:
@@ -216,6 +378,14 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
         Keys.ClipVision.Attention.LAYERNORM_EPS: ("layer_norm_eps", float),
     }
 
+    def get_scalar(field):
+        value = field.parts[-1]
+        if hasattr(value, "shape") and value.shape == (1,):
+            return value[0].item()
+        if hasattr(value, "item"):
+            return value.item()
+        return value
+
     # Extract and validate all required fields
     config_params = {}
     for gguf_key, (param_name, dtype) in VISION_CONFIG_FIELDS.items():
@@ -227,7 +397,7 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
             )
             return None
         # Extract scalar value from GGUF field and convert to target type
-        config_params[param_name] = dtype(field.parts[-1])
+        config_params[param_name] = dtype(get_scalar(field))
 
     # Apply model-specific parameters based on projector type
     if projector_type == VisionProjectorType.GEMMA3:
@@ -279,12 +449,13 @@ def maybe_patch_hf_config_from_gguf(
     # Patch multimodal config if mmproj.gguf exists
     mmproj_path = detect_gguf_multimodal(model)
     if mmproj_path is not None:
-        vision_config = extract_vision_config_from_gguf(str(mmproj_path))
-
         # Create HF config for Gemma3 multimodal
         text_config = hf_config.get_text_config()
         is_gemma3 = hf_config.model_type in ("gemma3", "gemma3_text")
-        if vision_config is not None and is_gemma3:
+        vision_config = (
+            extract_vision_config_from_gguf(str(mmproj_path)) if is_gemma3 else None
+        )
+        if vision_config is not None:
             new_hf_config = Gemma3Config(
                 text_config=text_config,
                 vision_config=vision_config,

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -157,7 +157,14 @@ def _get_remote_gguf_base_model_ids(
     base_model = getattr(card_data, "base_model", None)
     if base_model is None and isinstance(card_data, dict):
         base_model = card_data.get("base_model")
-    return tuple(_normalize_base_model_ids(base_model))
+
+    base_model_ids: list[str] = []
+    for value in _normalize_base_model_ids(base_model):
+        if normalized_repo_id := _normalize_hf_repo_id(value):
+            base_model_ids.append(normalized_repo_id)
+
+    # Preserve model card order while dropping duplicates.
+    return tuple(dict.fromkeys(base_model_ids))
 
 
 def _normalize_hf_repo_id(value: Any) -> str | None:

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -87,14 +87,6 @@ def is_nonstandard_gguf_quant_type(quant_type: str) -> bool:
 # e.g., Q4_K_M, Q3_K_S, Q5_K_L, Q2_K_XL
 _GGUF_QUANT_SUFFIXES = ("_M", "_S", "_L", "_XL", "_XS", "_XXS")
 _HF_CONFIG_FILES = ("config.json",)
-_HF_TOKENIZER_FILES = (
-    "tokenizer_config.json",
-    "tokenizer.json",
-    "tokenizer.model",
-    "spiece.model",
-    "vocab.json",
-    "merges.txt",
-)
 _HF_REPO_ID_PATTERN = re.compile(
     r"^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$"
 )
@@ -250,6 +242,14 @@ def _resolve_gguf_hf_source(
     for base_model in base_model_ids:
         # GGUF repo revisions are not meaningful for the referenced HF base model.
         if _source_has_any_file(base_model, filenames, revision=None):
+            logger.warning_once(
+                "GGUF metadata redirects HF config loading from %s to base "
+                "model '%s'. `trust_remote_code` is not inherited across "
+                "implicit GGUF base-model redirects; pass an explicit "
+                "`--hf-config-path` to opt in for that repository.",
+                model,
+                base_model,
+            )
             return base_model
 
     return source
@@ -269,20 +269,6 @@ def resolve_gguf_config_source(
         return _resolve_gguf_hf_source(
             model,
             _HF_CONFIG_FILES,
-            revision=revision,
-        )
-    return model
-
-
-def resolve_gguf_tokenizer_source(
-    model: str | Path,
-    revision: str | None = None,
-) -> str | Path:
-    """Resolve where a GGUF model should load tokenizer/processor files from."""
-    if is_gguf(model):
-        return _resolve_gguf_hf_source(
-            model,
-            _HF_TOKENIZER_FILES,
             revision=revision,
         )
     return model


### PR DESCRIPTION
## Purpose

This PR adds generic GGUF config resolution and architecture-specific tensor mappings for Gemma4 and Qwen3.5, so that GGUF quantizations of these models can be loaded without manual `--hf-config-path` workarounds.

Most GGUF repos (e.g., Unsloth quantizations) ship only quantized weights — no `config.json`, no sidecar tokenizer files. Previously, remote GGUF repos without `config.json` hit a hard `ValueError`. This PR resolves that by falling back to the original HF base model referenced in the GGUF repo's model card or local GGUF metadata for config loading, while keeping the default tokenizer on the GGUF file so Transformers can read the embedded GGUF tokenizer/vocab.

This PR has three logical sections that can be reviewed independently.

### Section 1: Generic GGUF config resolver and embedded tokenizer handling

**Files:** `gguf_utils.py`, `config.py`, `model.py`, `arg_utils.py`, `registry.py`

Adds `resolve_gguf_config_source()` which resolves where a GGUF model should load its HF config from. The fallback chain is:

1. GGUF repo / local parent directory (if it has `config.json`)
2. Verified HF base model from model card `base_model` (remote) or GGUF metadata `general.base_model.*.repo_url` (local)
3. Transformers GGUF metadata parser (for architectures Transformers supports natively)
4. Fail with a clear error

Both `get_config()` and `maybe_override_with_speculators()` now use the same fallback chain for local and remote GGUF. The previous hard `ValueError` for remote GGUF without `config.json` is removed.

For tokenizer loading, the default tokenizer remains the GGUF model path/repo. This preserves the existing Transformers `gguf_file` path and lets Transformers read the embedded GGUF tokenizer/vocab. Users can still pass an explicit `--tokenizer` when they intentionally want a sidecar or base-model tokenizer.

MTP / speculative decoding models that ship as separate GGUF files (e.g., Qwen3.6-35B-A3B-MTP) also go through `maybe_override_with_speculators()` for config detection. The `hf_config_path` is now forwarded to that function so that explicit user overrides are respected, and the same base model fallback applies when the MTP GGUF repo lacks `config.json`.

When the resolver falls back to a base model, the GGUF repo's `revision` is not forwarded to the base model lookup, since GGUF repo revisions have no meaning for the original HF model.

Implicit GGUF metadata redirects also do not inherit `trust_remote_code`. A warning is logged when the fallback is used; users who intentionally trust remote code from the base repository can pass an explicit `--hf-config-path`.

### Section 2: Gemma4 GGUF architecture adapter

**Files:** `gguf_loader.py`, `gemma4.py`, `gemma4_mm.py`

Adds Gemma4-specific GGUF tensor name mappings that `gguf-py`'s `get_tensor_name_map()` does not yet cover:

- Vision tower: `v.blk.N.*` → `model.vision_tower.encoder.layers.N.*` (13 tensor types per layer)
- Vision embeddings: `v.std_bias`, `v.std_scale`, `v.patch_embd.weight`, `v.position_embd.weight`
- MM projector: `mm.input_projection.weight` → `model.embed_vision.embedding_projection.weight`
- MoE experts: `ffn_gate_up_exps.weight`, `ffn_down_exps.weight` → fused expert loader targets
- Router/layer scalars: `ffn_gate_inp.scale`, `ffn_down_exps.scale`, `layer_output_scale.weight`

Gemma4 patch embedder weight (GGUF 4D Conv2D → vLLM 2D Linear) is handled via a model-level `weight_loader` attribute on `vision_tower.patch_embedder.input_proj.weight`, following the same pattern as Qwen3 VL's patch embed loader. No loader-level model-specific transforms.

Gemma4 fused MoE `qweight_type` for GGUF is routed to the correct expert parameter in `gemma4.py`.

### Section 3: Qwen3.5 GGUF adapter

**Files:** `gguf_loader.py`, `qwen3_5.py`, `qwen3_vl.py`

- Adds `qwen3_5_moe` to the GGUF architecture alias map (`qwen3_5_moe` → `qwen35moe`).
- Fixes MoE expert tensor prefix for multimodal Qwen3.5: `model.language_model.layers` instead of `model.layers`.
- Adds `ssm_dt.bias` → `linear_attn.dt_bias` mapping for Qwen3.5 GDN linear attention layers.
- Adds Qwen3.5 VL vision merger mappings (`mm.0/2.weight/bias`).
- Adds a generic GGUF tuple shard splitter in `qwen3_5.py` for `MergedColumnParallelLinear` layers (e.g., `in_proj_qkvz`) that receive fused GGUF tensors with tuple `shard_id`. The splitter respects `packed_factor` and falls back to the existing `weight_loader` if conditions are not met.
- Adds a patch embed `weight_loader` for Qwen3 VL that handles GGUF 4D Conv2D → HF 5D Conv3D with temporal dimension expansion.

## Test Plan

```bash
pytest tests/transformers_utils/test_config.py -k gguf -q          # config resolver
pytest tests/transformers_utils/test_utils.py -k gguf -q           # gguf_utils
pytest tests/tokenizers_/test_registry.py -k gguf -q               # tokenizer resolver
pytest tests/models/test_gguf_download.py -q                       # loader/mapping/transform
ruff check / ruff format --check on all changed files
```

## Test Result

Local GGUF config resolution verified for:
- Qwen3.6-35B-A3B GGUF (local, no config.json in GGUF, base_model metadata present)
- Qwen3.6-35B-A3B MTP GGUF (local, same pattern)
- Gemma4-26B-A4B-it GGUF (local, config.json present in GGUF repo)
- Gemma4-26B-A4B-it-qat GGUF (local, config.json present in GGUF repo)

**Notes:**
- The Gemma4 vision tower mappings will become redundant once `gguf-py` adds native Gemma4 support. They are isolated in `_add_gemma4_gguf_mappings()` for easy removal.
- Full end-to-end multimodal serving (image input) and MTP speculative serving with GGUF have not been verified in this PR. The scope is config/tokenizer resolution and weight name mapping.

AI assistance: Codex, Claude, and Gemini.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
