### PR TITLE
Fix "Dynamo bytecode transform" span start time calculation

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1151,7 +1151,7 @@ class VllmBackend:
         )
 
         # Record Dynamo time in tracing if available
-        start_time = int(torch_compile_start_time * 1e9)
+        start_time = int((time.time() - dynamo_time) * 1e9)
         attributes = {"dynamo.time_seconds": dynamo_time}
         instrument_manual("Dynamo bytecode transform", start_time, None, attributes)
 


### PR DESCRIPTION



## Purpose
Fix "Dynamo bytecode transform" span start time calculation.

Call to `instrument_manual` currently uses `torch_compile_start_time`, which is a monotonic clock value, producing erroneous start values. Change to `time.time() - dynamo_time`.

## Test Plan
Deploy vLLM server with Jaeger service available at `localhost:16686`

Run:
```
curl -s 'http://localhost:16686/api/traces?service=vllm-omni&operation=Dynamo+bytecode+transform&limit=1' | jq '[.data[].spans[] | select(.operationName == "Dynamo bytecode transform")][0] | {spanID, startTime, duration, dynamo_time: [.tags[] | select(.key == "dynamo.time_seconds") | .value][0]}'
```

## Test Result
```
{
  "spanID": "5ba91faf7a024204",
  "startTime": 1780940082949537,
  "duration": 2044845,
  "dynamo_time": 2.0444545624777675
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

