### PR TITLE
Fix tiered offload madv fallback

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -476,6 +476,35 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
         _cleanup_file(region.mmap_path)
 
 
+def test_madvise_success_selects_madvise_population(iid, monkeypatch):
+    """A successful probe should keep using MADV_POPULATE_WRITE."""
+    real_mmap = mmap.mmap
+
+    class TrackingMmap(real_mmap):
+
+        madvise_calls = []
+
+        def __new__(cls, *args, **kwargs):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj[:] = b"\xff" * len(obj)
+            return obj
+
+        def madvise(self, *args):
+            self.madvise_calls.append(args)
+
+    monkeypatch.setattr(mmap, "mmap", TrackingMmap)
+
+    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
+        assert isinstance(r.mmap_obj, TrackingMmap)
+        assert TrackingMmap.madvise_calls == [
+            (23, 0, PAGE_SIZE),
+            (23, PAGE_SIZE, PAGE_SIZE),
+            (23, 3 * PAGE_SIZE, PAGE_SIZE),
+            (23, 5 * PAGE_SIZE, PAGE_SIZE),
+        ]
+        assert r.mmap_obj[PAGE_SIZE] == 0xff
+
+
 def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
     """Only unsupported MADV_POPULATE_WRITE should use the fallback."""
     real_mmap = mmap.mmap

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -3,6 +3,7 @@
 """Unit tests for SharedOffloadRegion."""
 
 import contextlib
+import errno
 import mmap
 import os
 import threading
@@ -402,6 +403,73 @@ def test_file_has_correct_size(iid):
     """The mmap file size on disk must equal total_size_bytes."""
     with _region(iid, num_blocks=4) as r:
         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
+
+
+def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
+    """Older kernels can reject MADV_POPULATE_WRITE with EINVAL."""
+    real_mmap = mmap.mmap
+
+    class EINVALMmap(real_mmap):
+
+        madvise_calls = []
+
+        def madvise(self, *args):
+            self.madvise_calls.append(args)
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+    monkeypatch.setattr(mmap, "mmap", EINVALMmap)
+
+    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
+        assert isinstance(r.mmap_obj, EINVALMmap)
+        assert len(EINVALMmap.madvise_calls) == 3
+
+
+def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
+    """The scheduler mmap path also works when MADV_POPULATE_WRITE is absent."""
+    real_mmap = mmap.mmap
+
+    class EINVALMmap(real_mmap):
+
+        madvise_calls = []
+
+        def madvise(self, *args):
+            self.madvise_calls.append(args)
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+    monkeypatch.setattr(mmap, "mmap", EINVALMmap)
+
+    region = SharedOffloadRegion(
+        instance_id=iid,
+        num_blocks=3,
+        rank=None,
+        kv_bytes_per_block=2 * PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+    )
+    try:
+        assert isinstance(region.mmap_obj, EINVALMmap)
+        assert len(EINVALMmap.madvise_calls) == 1
+    finally:
+        region.cleanup()
+        _cleanup_file(region.mmap_path)
+
+
+def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
+    """Only unsupported MADV_POPULATE_WRITE should use the fallback."""
+    real_mmap = mmap.mmap
+
+    class FailingMmap(real_mmap):
+
+        def madvise(self, *args):
+            raise OSError(errno.EIO, "I/O error")
+
+    monkeypatch.setattr(mmap, "mmap", FailingMmap)
+    path = f"/dev/shm/vllm_offload_{iid}.mmap"
+
+    with pytest.raises(OSError) as exc_info:
+        _make_region(iid)
+
+    assert exc_info.value.errno == errno.EIO
+    _cleanup_file(path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -412,16 +412,26 @@ def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
+        written_offsets = []
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
+
+        def __setitem__(self, key, value):
+            self.written_offsets.append(key.start)
+            super().__setitem__(key, value)
 
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
     with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
         assert isinstance(r.mmap_obj, EINVALMmap)
         assert len(EINVALMmap.madvise_calls) == 3
+        assert EINVALMmap.written_offsets == [
+            PAGE_SIZE,
+            3 * PAGE_SIZE,
+            5 * PAGE_SIZE,
+        ]
 
 
 def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
@@ -431,10 +441,15 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
+        written_offsets = []
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
+
+        def __setitem__(self, key, value):
+            self.written_offsets.append(key.start)
+            super().__setitem__(key, value)
 
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
@@ -448,6 +463,9 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     try:
         assert isinstance(region.mmap_obj, EINVALMmap)
         assert len(EINVALMmap.madvise_calls) == 1
+        assert EINVALMmap.written_offsets == [
+            page * PAGE_SIZE for page in range(6)
+        ]
     finally:
         region.cleanup()
         _cleanup_file(region.mmap_path)

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -412,26 +412,29 @@ def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
-        written_offsets = []
+
+        def __new__(cls, *args, **kwargs):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj[:] = b"\xff" * len(obj)
+            return obj
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
 
-        def __setitem__(self, key, value):
-            self.written_offsets.append(key.start)
-            super().__setitem__(key, value)
-
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
     with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
         assert isinstance(r.mmap_obj, EINVALMmap)
-        assert len(EINVALMmap.madvise_calls) == 3
-        assert EINVALMmap.written_offsets == [
+        assert len(EINVALMmap.madvise_calls) == 1
+        touched_offsets = [
             PAGE_SIZE,
             3 * PAGE_SIZE,
             5 * PAGE_SIZE,
         ]
+        assert [r.mmap_obj[offset] for offset in touched_offsets] == [0, 0, 0]
+        assert r.mmap_obj[0] == 0xff
+        assert r.mmap_obj[PAGE_SIZE + 1] == 0xff
 
 
 def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
@@ -441,15 +444,15 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
-        written_offsets = []
+
+        def __new__(cls, *args, **kwargs):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj[:] = b"\xff" * len(obj)
+            return obj
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
-
-        def __setitem__(self, key, value):
-            self.written_offsets.append(key.start)
-            super().__setitem__(key, value)
 
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
@@ -463,9 +466,11 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     try:
         assert isinstance(region.mmap_obj, EINVALMmap)
         assert len(EINVALMmap.madvise_calls) == 1
-        assert EINVALMmap.written_offsets == [
+        touched_offsets = [
             page * PAGE_SIZE for page in range(6)
         ]
+        assert [region.mmap_obj[offset] for offset in touched_offsets] == [0] * 6
+        assert region.mmap_obj[1] == 0xff
     finally:
         region.cleanup()
         _cleanup_file(region.mmap_path)

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -4,7 +4,9 @@ import errno
 import mmap
 import os
 import time
+from collections.abc import Callable
 
+import numpy as np
 import torch
 
 from vllm.logger import init_logger
@@ -29,18 +31,30 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
         time.sleep(0.005)
 
 
-def _populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
-    """Pre-fault writable mmap pages, falling back for older Linux kernels."""
+def _madvise_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
+
+
+def _fallback_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    arr = np.frombuffer(mmap_obj, dtype=np.uint8)
+    arr[offset : offset + length : mmap.PAGESIZE] = 0
+
+
+def _get_populate_write_fn(
+    mmap_obj: mmap.mmap,
+) -> Callable[[mmap.mmap, int, int], None]:
+    """Select the pre-faulting method once for this mmap."""
     try:
-        mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
-        return
+        mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, mmap.PAGESIZE)
     except OSError as e:
         if e.errno != errno.EINVAL:
             raise
-
-    end = offset + length
-    for page_offset in range(offset, end, mmap.PAGESIZE):
-        mmap_obj[page_offset : page_offset + 1] = b"\0"
+        logger.warning(
+            "MADV_POPULATE_WRITE is not supported; falling back to per-page "
+            "writes for mmap pre-population. Startup may be slower."
+        )
+        return _fallback_populate_write
+    return _madvise_populate_write
 
 
 class SharedOffloadRegion:
@@ -103,6 +117,8 @@ class SharedOffloadRegion:
             prot=mmap.PROT_READ | mmap.PROT_WRITE,
         )
 
+        populate_write_fn = _get_populate_write_fn(self.mmap_obj)
+
         if rank is not None:
             # Populate only this worker's pages (one slot per block row).
             worker_offset = rank * cpu_page_size
@@ -113,7 +129,7 @@ class SharedOffloadRegion:
                 aligned_offset = (raw_offset // page_size) * page_size
                 end = raw_offset + cpu_page_size
                 aligned_length = end - aligned_offset
-                _populate_write(self.mmap_obj, aligned_offset, aligned_length)
+                populate_write_fn(self.mmap_obj, aligned_offset, aligned_length)
             logger.debug(
                 "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
                 num_blocks,
@@ -122,7 +138,7 @@ class SharedOffloadRegion:
         else:
             # No rank — populate the entire shared region in one call.
             _t0 = time.perf_counter()
-            _populate_write(self.mmap_obj, 0, self.total_size_bytes)
+            populate_write_fn(self.mmap_obj, 0, self.total_size_bytes)
             logger.debug(
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import errno
 import mmap
 import os
 import time
@@ -10,6 +11,9 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
+
+# MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
+_MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
 
 
 def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
@@ -23,6 +27,20 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
                 f"Timed out waiting for mmap file to reach {expected_size} bytes"
             )
         time.sleep(0.005)
+
+
+def _populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    """Pre-fault writable mmap pages, falling back for older Linux kernels."""
+    try:
+        mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
+        return
+    except OSError as e:
+        if e.errno != errno.EINVAL:
+            raise
+
+    end = offset + length
+    for page_offset in range(offset, end, mmap.PAGESIZE):
+        mmap_obj[page_offset : page_offset + 1] = b"\0"
 
 
 class SharedOffloadRegion:
@@ -85,8 +103,6 @@ class SharedOffloadRegion:
             prot=mmap.PROT_READ | mmap.PROT_WRITE,
         )
 
-        # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
-        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
         if rank is not None:
             # Populate only this worker's pages (one slot per block row).
             worker_offset = rank * cpu_page_size
@@ -97,9 +113,7 @@ class SharedOffloadRegion:
                 aligned_offset = (raw_offset // page_size) * page_size
                 end = raw_offset + cpu_page_size
                 aligned_length = end - aligned_offset
-                self.mmap_obj.madvise(
-                    _MADV_POPULATE_WRITE, aligned_offset, aligned_length
-                )
+                _populate_write(self.mmap_obj, aligned_offset, aligned_length)
             logger.debug(
                 "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
                 num_blocks,
@@ -108,7 +122,7 @@ class SharedOffloadRegion:
         else:
             # No rank — populate the entire shared region in one call.
             _t0 = time.perf_counter()
-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
+            _populate_write(self.mmap_obj, 0, self.total_size_bytes)
             logger.debug(
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )


### PR DESCRIPTION
Fixes #44888 - `SharedOffloadRegion` can fail on Linux kernels older than 5.14 because `MADV_POPULATE_WRITE` is unsupported and `mmap.madvise()` returns `EINVAL`.

When `MADV_POPULATE_WRITE` fails with `EINVAL`, vLLM now pre-faults the mmap region by writing a zero byte at each page start, preserving tiered offloading startup behavior without requiring kernel 5.14+.