### PR TITLE
Expose telemetry span configs in EngineCore

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -714,6 +714,8 @@ class OutputProcessor:
         engine_core_output: EngineCoreOutput,
         req_state: RequestState,
         iteration_stats: IterationStats | None,
+        extra_attributes: dict[str, Any] | None = None,
+        span_kind: Any | None = None,
     ) -> None:
         assert req_state.stats is not None
         assert iteration_stats is not None
@@ -763,12 +765,15 @@ class OutputProcessor:
         if req_state.n:
             attributes[SpanAttributes.GEN_AI_REQUEST_N] = req_state.n
 
+        if extra_attributes:
+            attributes.update(extra_attributes)
+
         instrument_manual(
             span_name="llm_request",
             start_time=arrival_time_ns,
             attributes=attributes,
             context=trace_context,
-            kind=SpanKind.SERVER,
+            kind=span_kind if span_kind is not None else SpanKind.SERVER,
         )
 
     def _update_stats_from_output(


### PR DESCRIPTION


## Purpose

Add OpenTelemetry tracing to vLLM-Omni's multi-stage pipeline. Each request produces a trace with:

- An **`omni_request`** span (SERVER) covering the full request lifecycle in the orchestrator
- Per-stage **`llm_request`** spans (INTERNAL) for each LLM engine stage, as children of `omni_request`
- A **`diffusion_request`** span (INTERNAL) for diffusion stages, as a child of `omni_request`

All spans share a single trace ID via W3C TraceContext propagation across stages.

Spans include the following attributes:

- "vllm_omni.engine.idx"
- "vllm_omni.stage.id"
- "vllm_omni.stage.name" (e.g. thinker, talker, code2wav)
- "vllm_omni.stage.replica_id"
- "vllm_omni.pipeline.timings" (fine-grained orchestrator timings)
- "vllm_omni.diffusion.preprocess_ms"
- "vllm_omni.diffusion.exec_ms"
- "vllm_omni.diffusion.postprocess_ms"

Additonally, create a span to capture init events (largely inherited from vLLM: torch compilation, model loading, etc.)

## Test Plan

Tested manually with two model types on 4x A100-40GB, traces collected by a Jaeger sidecar (`--otlp-traces-endpoint localhost:4317`).

**Qwen3-Omni** (3-stage LLM pipeline, `async_chunk: true`)

```bash
vllm-omni serve Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --omni --deploy-config /app/qwen3_omni.yaml \
  --port 8000 --otlp-traces-endpoint localhost:4317

curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-Omni-30B-A3B-Instruct","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":32}'
```

**FLUX.2-dev** (single-stage diffusion)

```bash
vllm-omni serve black-forest-labs/FLUX.2-dev \
  --omni --enforce-eager --max-num-seqs 1 --tensor-parallel-size 2 \
  --port 8000 --otlp-traces-endpoint localhost:4317

curl -s http://localhost:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{"model":"black-forest-labs/FLUX.2-dev","prompt":"a red cat sitting on a windowsill","size":"1024x1024"}'
```

**Unit tests** (no GPU required)

```bash
python -m pytest --confcutdir=tests/tracing tests/tracing/ -v
```

22 tests across 7 classes covering `@instrument` decorator, `instrument_manual`, trace context propagation, orchestrator span lifecycle, LLM request spans, and diffusion request spans. Uses an in-process gRPC `FakeTraceService` to collect and assert on exported spans.

## Test Results

### Qwen3-Omni
Init:
<img width="1591" height="515" alt="qwen3-omni-init" src="https://github.com/user-attachments/assets/0e49dbb9-f1eb-449d-8630-524633ac975a" />

Request:
<img width="1591" height="515" alt="qwen3-omni-request" src="https://github.com/user-attachments/assets/7ce8ab28-39ab-45f4-a8b7-be8b73495aca" />


### FLUX.2-dev
Init:
<img width="1591" height="515" alt="flux-2-init" src="https://github.com/user-attachments/assets/9137c77b-0bea-4a92-83b1-87b96635954e" />

Request:
<img width="1591" height="515" alt="flux-2-request" src="https://github.com/user-attachments/assets/2ef0fc12-4afa-4762-9588-ad75db2b01c9" />


### Unit tests

```
tests/tracing/test_tracing.py::TestOmniSpanAttributes::test_attribute_constants_are_namespaced PASSED
tests/tracing/test_tracing.py::TestOmniSpanAttributes::test_diffusion_attributes_are_namespaced PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_sync_function_creates_span PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_async_function_creates_span PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_nested_spans_have_parent_child_relationship PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_span_has_valid_timestamps PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_creates_span_with_explicit_timestamps PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_span_with_no_end_time_ends_immediately PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_span_respects_parent_context PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_span_kind_is_propagated PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_multiple_attributes_types PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_extract_from_traceparent_header PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_extract_from_none_returns_none PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_extract_from_empty_dict_returns_none PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_header_injection_round_trip PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_start_span_sets_omni_span PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_start_span_inherits_parent_trace PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_end_span_sets_attributes PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_end_span_without_start_is_noop PASSED
tests/tracing/test_tracing.py::TestLlmRequestSpan::test_llm_request_span_attributes PASSED
tests/tracing/test_tracing.py::TestDiffusionRequestSpan::test_diffusion_span_with_timing_attributes PASSED
tests/tracing/test_tracing.py::TestDiffusionRequestSpan::test_diffusion_span_inherits_trace_context PASSED

22 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
