### PR TITLE
[CI/Docs] Remove stale disagg prefill links

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -17,7 +17,7 @@ Two main reasons:
 
 ## Usage example
 
-Please refer to [examples/disaggregated/disaggregated_prefill.sh](../../examples/disaggregated/disaggregated_prefill.sh) for the example usage of disaggregated prefilling.
+Refer to the connector-specific examples below for disaggregated prefilling usage.
 
 Now supports 9 types of connectors:
 
@@ -48,10 +48,6 @@ Now supports 9 types of connectors:
   ```bash
   --kv-transfer-config '{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"}'
   ```
-
-## Benchmarks
-
-Please refer to [benchmarks/disagg_benchmarks](../../benchmarks/disagg_benchmarks) for disaggregated prefilling benchmarks.
 
 ## Development
 


### PR DESCRIPTION
## Summary

PR #44854 removed the old disaggregated prefill example and benchmark files, but `docs/features/disagg_prefill.md` still linked to them. This removes those stale docs references and fixes the Read the Docs failure on main.

cc @NickLucche @hmellor @youkaichao