### PR TITLE
[Mooncake] Auto-discover compatible RDMA devices for Mooncake Connector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -32,6 +32,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import rdma_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     MooncakeBootstrapServer,
     RegisterWorkerPayload,
@@ -756,13 +757,18 @@ class MooncakeConnectorWorker:
         # Tasks can await async events, so a surplus (2x is a robust heuristic)
         # prevents workers from idling.
         self.num_sender_tasks = self.num_sender_workers * 2
-        protocol = kv_transfer_config.kv_connector_extra_config.get(  # type: ignore[union-attr]
-            "mooncake_protocol", "rdma"
+        extra_config = kv_transfer_config.kv_connector_extra_config
+        protocol = extra_config.get("mooncake_protocol", "rdma")
+        device_name = rdma_utils.get_configured_worker_rnic(
+            protocol=protocol,
+            configured_device=extra_config.get("mooncake_device_name", ""),
         )
         logger.info(
             "The Mooncake Transfer Engine is using %s as its protocol.", protocol
         )
-        ret_value = self.engine.initialize(self.hostname, "P2PHANDSHAKE", protocol, "")
+        ret_value = self.engine.initialize(
+            self.hostname, "P2PHANDSHAKE", protocol, device_name
+        )
         if ret_value != 0:
             raise RuntimeError("Mooncake Transfer Engine initialization failed.")
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Mooncake requester config helpers."""
 
+import ipaddress
 import os
+from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -13,6 +15,7 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 _SYSFS_INFINIBAND_ROOT = Path("/sys/class/infiniband")
+_PROC_NET_ROUTE = Path("/proc/net/route")
 _DEFAULT_MOONCAKE_PKEY_INDEX = 0
 
 
@@ -127,6 +130,148 @@ def _is_compatible_rdma_device(device_path: Path) -> bool:
     return any(_is_compatible_port(port_path) for port_path in port_paths)
 
 
+def _ipv4_from_gid(gid: str) -> ipaddress.IPv4Address | None:
+    """Extract IPv4 from an IPv4-mapped RoCE GID."""
+    try:
+        ip = ipaddress.IPv6Address(gid)
+    except ValueError:
+        return None
+    return ip.ipv4_mapped
+
+
+def _first_netdev_name(device_path: Path) -> str | None:
+    """Return the first Linux netdev backing an RDMA device."""
+    try:
+        netdevs = sorted(path.name for path in (device_path / "device/net").iterdir())
+    except OSError:
+        return None
+    return netdevs[0] if netdevs else None
+
+
+def _first_roce_v2_ipv4_gid(device_path: Path) -> ipaddress.IPv4Address | None:
+    """Return the first non-link-local RoCE v2 IPv4 GID for an RDMA device."""
+    try:
+        port_paths = sorted(
+            path for path in (device_path / "ports").iterdir() if path.is_dir()
+        )
+    except OSError:
+        return None
+
+    for port_path in port_paths:
+        try:
+            gid_paths = sorted(
+                path
+                for path in (port_path / "gids").iterdir()
+                if path.name.isdigit()
+            )
+        except OSError:
+            continue
+        for gid_path in gid_paths:
+            gid_type = _read_sysfs_text(
+                port_path / "gid_attrs" / "types" / gid_path.name
+            )
+            if gid_type != "RoCE v2":
+                continue
+            gid_ip = _ipv4_from_gid(_read_sysfs_text(gid_path) or "")
+            if gid_ip is not None and not gid_ip.is_link_local:
+                return gid_ip
+    return None
+
+
+def _ipv4_from_proc_route_hex(value: str) -> ipaddress.IPv4Address | None:
+    """Decode /proc/net/route IPv4 hex, e.g. 000010AC -> 172.16.0.0."""
+    try:
+        return ipaddress.IPv4Address(int.from_bytes(bytes.fromhex(value), "little"))
+    except ValueError:
+        return None
+
+
+def _read_ipv4_routes() -> dict[str, list[ipaddress.IPv4Network]]:
+    """Read non-default IPv4 routes from /proc/net/route grouped by netdev."""
+    try:
+        lines = _PROC_NET_ROUTE.read_text().splitlines()
+    except OSError:
+        return {}
+
+    # Map each Linux netdev to its non-default IPv4 routes, e.g.
+    # {"spx_p1n1": [IPv4Network("172.16.0.0/13")]}.
+    routes: dict[str, list[ipaddress.IPv4Network]] = defaultdict(list)
+    for line in lines[1:]:
+        fields = line.split()
+        if len(fields) < 8:
+            continue
+        iface = fields[0]
+        dest_hex = fields[1]
+        flags_hex = fields[3]
+        mask_hex = fields[7]
+        try:
+            flags = int(flags_hex, 16)
+        except ValueError:
+            continue
+        # ensure the route is active
+        if not flags & 0x1:
+            continue
+        dest = _ipv4_from_proc_route_hex(dest_hex)
+        mask = _ipv4_from_proc_route_hex(mask_hex)
+        if dest is None or mask is None:
+            continue
+        try:
+            network = ipaddress.IPv4Network(f"{dest}/{mask}", strict=False)
+        except ValueError:
+            continue
+        if network.prefixlen == 0:
+            continue
+        routes[iface].append(network)
+    return routes
+
+
+def _route_group_for_device(
+    device_path: Path,
+    routes_by_netdev: Mapping[str, list[ipaddress.IPv4Network]],
+) -> str | None:
+    """Return the broadest route containing the device's RoCE v2 GID IP."""
+    netdev = _first_netdev_name(device_path)
+    gid_ip = _first_roce_v2_ipv4_gid(device_path)
+    if netdev is None or gid_ip is None:
+        return None
+
+    candidates = [
+        route for route in routes_by_netdev.get(netdev, []) if gid_ip in route
+    ]
+    if not candidates:
+        return None
+
+    # The least-specific non-default route captures the routed rail family. On
+    # split-rail RoCE hosts, direct host/link routes differ per NIC while the
+    # broad rail route is shared by mutually reachable NICs.
+    return str(min(candidates, key=lambda route: route.prefixlen))
+
+
+def _filter_to_largest_routable_rnic_group(
+    device_names: list[str],
+    route_groups: Mapping[str, str],
+) -> list[str]:
+    """Choose the largest routable RNIC group for RDMA device auto discovery."""
+    if not device_names:
+        return []
+
+    # Group devices by routed rail.
+    by_route_group: dict[str, list[str]] = defaultdict(list)
+    for name in device_names:
+        route_group = route_groups.get(name)
+        if route_group is not None:
+            by_route_group[route_group].append(name)
+    if not by_route_group:
+        return sorted(device_names)
+
+    # Pick the largest routable rail group, with a deterministic tie-break.
+    selected = min(
+        by_route_group.values(),
+        key=lambda names: (-len(names), sorted(names)[0]),
+    )
+    return sorted(selected)
+
+
 def _get_auto_discovered_worker_rnics() -> str:
     try:
         device_paths = sorted(
@@ -137,10 +282,17 @@ def _get_auto_discovered_worker_rnics() -> str:
     except OSError:
         return ""
 
-    device_names = [
-        path.name for path in device_paths if _is_compatible_rdma_device(path)
-    ]
-    return ",".join(device_names)
+    compatible = [path for path in device_paths if _is_compatible_rdma_device(path)]
+    device_names = [path.name for path in compatible]
+    routes_by_netdev = _read_ipv4_routes()
+    route_groups: dict[str, str] = {}
+    for path in compatible:
+        route_group = _route_group_for_device(path, routes_by_netdev)
+        if route_group is not None:
+            route_groups[path.name] = route_group
+
+    selected = _filter_to_largest_routable_rnic_group(device_names, route_groups)
+    return ",".join(selected)
 
 
 def get_configured_worker_rnic(
@@ -158,7 +310,8 @@ def get_configured_worker_rnic(
     if protocol == "rdma":
         logger.info(
             "No RDMA devices specified for Mooncake backend (protocol=%s). "
-            "Running automatic device selection."
+            "Running automatic device selection.",
+            protocol,
         )
         discovered_devices = _get_auto_discovered_worker_rnics()
         if discovered_devices:
@@ -172,7 +325,6 @@ def get_configured_worker_rnic(
         logger.warning(
             "No compatible RDMA devices were discovered in /sys/class/infiniband. "
             "Falling back to Mooncake's built-in auto-selection.",
-            protocol,
         )
         return ""
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
@@ -160,9 +160,7 @@ def _first_roce_v2_ipv4_gid(device_path: Path) -> ipaddress.IPv4Address | None:
     for port_path in port_paths:
         try:
             gid_paths = sorted(
-                path
-                for path in (port_path / "gids").iterdir()
-                if path.name.isdigit()
+                path for path in (port_path / "gids").iterdir() if path.name.isdigit()
             )
         except OSError:
             continue

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
@@ -2,13 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Mooncake requester config helpers."""
 
+import os
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+_SYSFS_INFINIBAND_ROOT = Path("/sys/class/infiniband")
+_DEFAULT_MOONCAKE_PKEY_INDEX = 0
 
 
 def normalize_string_override(value: Any) -> str | None:
@@ -44,3 +49,136 @@ def get_configured_preferred_segment(
         )
         return env_value
     return None
+
+
+def _normalize_explicit_worker_rnics(device_list: str) -> str:
+    entries = [entry.strip() for entry in device_list.split(",")]
+    if any(not entry for entry in entries):
+        raise ValueError(
+            "Mooncake worker device_name contains an empty RDMA device entry"
+        )
+    return ",".join(entries)
+
+
+def _read_sysfs_text(path: Path) -> str | None:
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def _get_mooncake_pkey_index() -> int:
+    raw_index = os.environ.get("MC_PKEY_INDEX")
+    if raw_index is None:
+        return _DEFAULT_MOONCAKE_PKEY_INDEX
+    try:
+        pkey_index = int(raw_index)
+    except ValueError:
+        return _DEFAULT_MOONCAKE_PKEY_INDEX
+    if not 0 <= pkey_index <= 65535:
+        return _DEFAULT_MOONCAKE_PKEY_INDEX
+    return pkey_index
+
+
+def _has_compatible_pkey(port_path: Path, link_layer: str) -> bool:
+    if link_layer != "InfiniBand":
+        return True
+
+    pkey = _read_sysfs_text(port_path / "pkeys" / str(_get_mooncake_pkey_index()))
+    if pkey is None:
+        return False
+    try:
+        pkey_value = int(pkey, 16)
+    except ValueError:
+        return False
+
+    # 0x7FFF: check bits 0-14 for valid partition number
+    # 0x8000: check bit 15 for membership type (full vs limited)
+    # Limited P_Keys can fail peer-to-peer transfers
+    return bool(pkey_value & 0x8000) and bool(pkey_value & 0x7FFF)
+
+
+def _is_compatible_port(port_path: Path) -> bool:
+    link_layer = _read_sysfs_text(port_path / "link_layer")
+    state = _read_sysfs_text(port_path / "state")
+
+    if link_layer not in {"InfiniBand", "Ethernet"}:
+        return False
+
+    if state != "4: ACTIVE":
+        return False
+    return _has_compatible_pkey(port_path, link_layer)
+
+
+def _is_compatible_rdma_device(device_path: Path) -> bool:
+    # node_type must be CA (Channel Adapter)
+    if _read_sysfs_text(device_path / "node_type") != "1: CA":
+        return False
+
+    # Inspect every port: a device is usable if any of its ports is ACTIVE with
+    # a compatible link layer and P_Key.
+    try:
+        port_paths = sorted(
+            path for path in (device_path / "ports").iterdir() if path.is_dir()
+        )
+    except OSError:
+        return False
+
+    return any(_is_compatible_port(port_path) for port_path in port_paths)
+
+
+def _get_auto_discovered_worker_rnics() -> str:
+    try:
+        device_paths = sorted(
+            path
+            for path in _SYSFS_INFINIBAND_ROOT.iterdir()
+            if path.is_dir() or path.is_symlink()
+        )
+    except OSError:
+        return ""
+
+    device_names = [
+        path.name for path in device_paths if _is_compatible_rdma_device(path)
+    ]
+    return ",".join(device_names)
+
+
+def get_configured_worker_rnic(
+    *,
+    protocol: str,
+    configured_device: str,
+) -> str:
+    normalized_device = normalize_string_override(configured_device)
+    if normalized_device is not None:
+        return _normalize_explicit_worker_rnics(normalized_device)
+
+    if protocol not in {"rdma", "efa"}:
+        return ""
+
+    if protocol == "rdma":
+        logger.info(
+            "No RDMA devices specified for Mooncake backend (protocol=%s). "
+            "Running automatic device selection."
+        )
+        discovered_devices = _get_auto_discovered_worker_rnics()
+        if discovered_devices:
+            logger.info(
+                "Mooncake auto-selected compatible RDMA devices for protocol=%s: %s",
+                protocol,
+                discovered_devices,
+            )
+            return discovered_devices
+
+        logger.warning(
+            "No compatible RDMA devices were discovered in /sys/class/infiniband. "
+            "Falling back to Mooncake's built-in auto-selection.",
+            protocol,
+        )
+        return ""
+
+    logger.warning(
+        "No devices specified for Mooncake backend (protocol=%s); falling back "
+        "to Mooncake's built-in auto-selection.",
+        protocol,
+    )
+    return ""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -989,6 +989,10 @@ class MooncakeStoreWorker:
             if vllm_config.kv_transfer_config
             else {}
         )
+        store_config.device_name = rdma_utils.get_configured_worker_rnic(
+            protocol=store_config.protocol,
+            configured_device=store_config.device_name,
+        )
         self.store = MooncakeDistributedStore()
         local_ip = get_ip()
         local_hostname = rdma_utils.get_requester_local_hostname(local_ip)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -120,8 +120,9 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
         for connector_id, stats_data in transfer_stats_data.items():
             if connector_id not in self._prom_metrics:
                 logger.warning_once(
-                    f"{connector_id} is not contained in the list of registered connectors "
-                    f"with Prometheus metrics support: {self._prom_metrics.keys()}"
+                    f"{connector_id} is not contained in the list of "
+                    "registered connectors with Prometheus metrics "
+                    f"support: {self._prom_metrics.keys()}"
                 )
                 continue
             self._prom_metrics[connector_id].observe(stats_data["data"], engine_idx)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -118,10 +118,12 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         for connector_id, stats_data in transfer_stats_data.items():
-            assert connector_id in self._prom_metrics, (
-                f"{connector_id} is not contained in the list of registered connectors "
-                f"with Prometheus metrics support: {self._prom_metrics.keys()}"
-            )
+            if connector_id not in self._prom_metrics:
+                logger.warning_once(
+                    f"{connector_id} is not contained in the list of registered connectors "
+                    f"with Prometheus metrics support: {self._prom_metrics.keys()}"
+                )
+                continue
             self._prom_metrics[connector_id].observe(stats_data["data"], engine_idx)
 
 


### PR DESCRIPTION
## Purpose
The PR supports auto-discovery for compatible and mutually routable RDMA devices for use by the Mooncake connectors (e.g., `MooncakeConnector`, `MooncakeStoreConnector`) when no device names are specified. The existing device selection in mooncake can use all devices in `/sys/class/infiniband` as candidates, which can lead to errors:
- devices that have `node_type=7: unspecified` and `link_layer=Unknown` are not usable
- devices with limited membership (`pkey0=0x7fff`) can cause transfer failure, despite successful startup.
- some devices are not mutually routable - leading to certain transfer to succeed while others fail

Example (B300, 16 RNICs):
```
> ls /sys/class/infiniband
mlx5_0  mlx5_1  mlx5_10  mlx5_11  mlx5_12  mlx5_13  mlx5_14  mlx5_15  mlx5_16  mlx5_17  mlx5_20  mlx5_21  mlx5_22  mlx5_23  mlx5_6  mlx5_7
```

```
HCA      ROUTE_GROUP
mlx5_0   172.16.0.0/13
mlx5_6   172.16.0.0/13
mlx5_10  172.16.0.0/13
mlx5_12  172.16.0.0/13
mlx5_14  172.16.0.0/13
mlx5_16  172.16.0.0/13
mlx5_20  172.16.0.0/13
mlx5_22  172.16.0.0/13

mlx5_1   172.24.0.0/13
mlx5_7   172.24.0.0/13
mlx5_11  172.24.0.0/13
mlx5_13  172.24.0.0/13
mlx5_15  172.24.0.0/13
mlx5_17  172.24.0.0/13
mlx5_21  172.24.0.0/13
mlx5_23  172.24.0.0/13
```

Same rail ping (success):
```
> bash -lc 'timeout 12s ibv_rc_pingpong -d mlx5_0 -g 3 -n 10 -s 4096 -p 18611 >/tmp/rc_same_server.log 2>&1 & spid=$!; sleep 1; timeout 12s ibv_rc_pingpong -d mlx5_6 -g 3 -n 10 -s 4096 -p 18611 172.20.0.20; client_rc=$?; wait $spid; server_rc=$?; echo "client_rc=$client_rc server_rc=$server_rc"; cat /tmp/rc_same_server.log'
  local address:  LID 0x0000, QPN 0x004384, PSN 0xb3adf5, GID ::ffff:172.22.0.20
  remote address: LID 0x0000, QPN 0x0046f6, PSN 0x8d5048, GID ::ffff:172.20.0.20
81920 bytes in 0.00 seconds = 3343.67 Mbit/sec
10 iters in 0.00 seconds = 19.60 usec/iter
client_rc=0 server_rc=0
  local address:  LID 0x0000, QPN 0x0046f6, PSN 0x8d5048, GID ::ffff:172.20.0.20
  remote address: LID 0x0000, QPN 0x004384, PSN 0xb3adf5, GID ::ffff:172.22.0.20
81920 bytes in 0.00 seconds = 220.36 Mbit/sec
10 iters in 0.00 seconds = 297.40 usec/iter
```

Cross-rail ping (fail):
```
> bash -lc 'timeout 12s ibv_rc_pingpong -d mlx5_0 -g 3 -n 10 -s 4096 -p 18612 >/tmp/rc_cross_server.log 2>&1 & spid=$!; sleep 1; timeout 12s ibv_rc_pingpong -d mlx5_1 -g 3 -n 10 -s 4096 -p 18612 172.20.0.20; client_rc=$?; wait $spid; server_rc=$?; echo "client_rc=$client_rc server_rc=$server_rc"; cat /tmp/rc_cross_server.log'
  local address:  LID 0x0000, QPN 0x003d55, PSN 0x146428, GID ::ffff:172.28.0.20
client read/write: No space left on device
Couldn't read/write remote address
client_rc=1 server_rc=1
Failed to modify QP to RTR
Couldn't connect to remote QP
  local address:  LID 0x0000, QPN 0x0046f7, PSN 0x04d28e, GID ::ffff:172.20.0.20
```

## Test Plan

## Test Result
- Tested with llama8b and deepseekv4 single node and multinode disagg with KV offloading:
```
  PREFILL_CFG='{
    "kv_connector": "MultiConnector",
    "kv_role": "kv_producer",
    "kv_connector_extra_config": {
      "connectors": [
        {"kv_connector": "MooncakeConnector", "kv_role": "kv_producer"},
        {"kv_connector": "MooncakeStoreConnector", "kv_role": "kv_producer"}
      ]
    }
  }'

VLLM_ENGINE_READY_TIMEOUT_S=3600 vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --block-size 256 \
  --enable-prefix-caching \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
  --attention_config.use_fp4_indexer_cache True \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --max-cudagraph-capture-size 2048 \
  --max-num-batched-tokens 2048 \
  --no-enable-flashinfer-autotune \
  --tensor-parallel-size 8 \
  --host 0.0.0.0 \
  --port 8100 \
  --kv-transfer-config "$PREFILL_CFG"

DECODE_CFG='{
    "kv_connector": "MultiConnector",
    "kv_role": "kv_consumer",
    "kv_connector_extra_config": {
      "connectors": [
        {"kv_connector": "MooncakeConnector", "kv_role": "kv_consumer"},
        {"kv_connector": "MooncakeStoreConnector", "kv_role": "kv_consumer"}
      ]
    }
  }'

VLLM_ENGINE_READY_TIMEOUT_S=3600 vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --block-size 256 \
  --enable-prefix-caching \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
  --attention_config.use_fp4_indexer_cache True \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --max-cudagraph-capture-size 2048 \
  --max-num-batched-tokens 2048 \
  --no-enable-flashinfer-autotune \
  --tensor-parallel-size 8 \
  --host 0.0.0.0 \
  --port 8200 \
  --kv-transfer-config "$DECODE_CFG"

  python examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py \
    --host 0.0.0.0 --port 8000 \
    --prefill http://$PREFILL_IP:8100 50052 \
    --decode  http://$DECODE_IP:8200
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

