### PR TITLE
[Bugfix] Fixed make_expert_params_mapping issue in pre-commit

### DIFF
--- a/vllm/models/deepseek_v4/xpu/model.py
+++ b/vllm/models/deepseek_v4/xpu/model.py
@@ -18,7 +18,11 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
-from vllm.model_executor.layers.fused_moe import FusedMoE, GateLinear
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    GateLinear,
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     fused_topk_bias,
 )
@@ -1220,7 +1224,7 @@ class DeepseekV4Model(nn.Module):
             return make_deepseek_v4_expert_params_mapping(self.config.n_routed_experts)
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        return FusedMoE.make_expert_params_mapping(
+        return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",

--- a/vllm/models/deepseek_v4/xpu/mtp.py
+++ b/vllm/models/deepseek_v4/xpu/mtp.py
@@ -25,7 +25,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -332,7 +332,7 @@ class DeepSeekV4MTP(nn.Module):
                 self.config.n_routed_experts
             )
         else:
-            expert_mapping = FusedMoE.make_expert_params_mapping(
+            expert_mapping = fused_moe_make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="w1",
                 ckpt_down_proj_name="w2",


### PR DESCRIPTION
## Purpose
Fixed mypy pre-commit failure for the DeepSeek 4:

`llm/models/deepseek_v4/xpu/model.py:1223: error: "Callable[[int, int, int, int, Any | None, bool, bool, int | None, int | None, QuantizationConfig | None, int | None, int | None, int | None, str, Callable[..., Any] | None, FusedMoERouter | None, str, float, float | None, Any | None, bool, str, bool, int, bool, bool, list[tuple[str, str, int, str]] | None, int | None, Any | None, Any | None, Any | None, Any | None, Any | None, Any | None, bool, str | None, Any | None, type[MoERunner] | None, dict[str, Any] | None, type[RoutedExperts] | None, dict[str, Any] | None], MoERunner]" has no attribute "make_expert_params_mapping"  [attr-defined]`

## Test Plan
`pre-commit run --hook-stage manual mypy-3.13 -a`

## Test Result

It should pass.