### PR TITLE
Fix mypy for vllm/model_executor/models

### DIFF
--- a/vllm/model_executor/models/ernie_mtp.py
+++ b/vllm/model_executor/models/ernie_mtp.py
@@ -228,8 +228,11 @@ class ErnieMTP(nn.Module):
                     continue
 
                 param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
+                weight_loader = getattr(param, "weight_loader", None)
+                if weight_loader is not None:
+                    weight_loader(param, loaded_weight, shard_id)
+                else:
+                    default_weight_loader(param, loaded_weight)
                 break
             else:
                 # Skip loading extra bias for GPTQ models.
@@ -249,8 +252,8 @@ class ErnieMTP(nn.Module):
                     continue
 
                 param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
+                wl = getattr(param, "weight_loader", default_weight_loader)
+                wl(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params
 

--- a/vllm/model_executor/models/glm_ocr.py
+++ b/vllm/model_executor/models/glm_ocr.py
@@ -226,7 +226,7 @@ class GlmOcrVisionBlock(Glm4vVisionBlock):
             norm_layer = partial(nn.LayerNorm, eps=1e-6)
         self.norm1 = norm_layer(dim)
         self.norm2 = norm_layer(dim)
-        self.attn = GlmOcrVisionAttention(
+        self.attn = GlmOcrVisionAttention(  # type: ignore[assignment]
             embed_dim=dim,
             num_heads=num_heads,
             projection_size=dim,

--- a/vllm/model_executor/models/gritlm.py
+++ b/vllm/model_executor/models/gritlm.py
@@ -183,11 +183,13 @@ class GritLMPooler(SequencePooler):
         pooler_config = model_config.pooler_config
         assert pooler_config is not None
 
+        seq_pooling_type = pooler_config.seq_pooling_type
+        assert seq_pooling_type is not None
         super().__init__(
             pooling=(
                 GritLMMeanPool(model_config)
-                if pooler_config.seq_pooling_type == "MEAN"
-                else get_seq_pooling_method(pooler_config.seq_pooling_type)
+                if seq_pooling_type == "MEAN"
+                else get_seq_pooling_method(seq_pooling_type)
             ),
             head=EmbeddingPoolerHead(
                 head_dtype=model_config.head_dtype,

--- a/vllm/model_executor/models/hyperclovax.py
+++ b/vllm/model_executor/models/hyperclovax.py
@@ -224,7 +224,7 @@ class HyperCLOVAXDecoderLayer(nn.Module):
         attention_bias = getattr(config, "attention_bias", False)
 
         self.self_attn = HyperCLOVAXAttention(
-            config=config,
+            config=config,  # type: ignore[arg-type]
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             num_kv_heads=getattr(

--- a/vllm/model_executor/models/mimo_v2_mtp.py
+++ b/vllm/model_executor/models/mimo_v2_mtp.py
@@ -308,8 +308,11 @@ class MiMoV2MTP(nn.Module):
                 if name_rewritten not in params_dict:
                     continue
                 param = params_dict[name_rewritten]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight, shard_id)
+                weight_loader = getattr(param, "weight_loader", None)
+                if weight_loader is not None:
+                    weight_loader(param, loaded_weight, shard_id)
+                else:
+                    default_weight_loader(param, loaded_weight)
                 loaded_params.add(name_rewritten)
                 stacked_matched = True
                 break
@@ -331,8 +334,8 @@ class MiMoV2MTP(nn.Module):
                     0, tp_rank * heads_per_rank, heads_per_rank
                 )
 
-            weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
+            wl = getattr(param, "weight_loader", default_weight_loader)
+            wl(param, loaded_weight)
             loaded_params.add(name)
 
         return loaded_params

--- a/vllm/model_executor/models/minicpm3.py
+++ b/vllm/model_executor/models/minicpm3.py
@@ -188,7 +188,7 @@ class MiniCPM3DecoderLayer(MiniCPMDecoderLayer):
         self.input_layernorm = RMSNorm(
             self.config.hidden_size, eps=self.config.rms_norm_eps
         )
-        self.self_attn = MiniCPM3Attention(
+        self.self_attn = MiniCPM3Attention(  # type: ignore[assignment]
             config=self.config,
             hidden_size=self.hidden_size,
             num_heads=self.config.num_attention_heads,

--- a/vllm/model_executor/models/terratorch.py
+++ b/vllm/model_executor/models/terratorch.py
@@ -283,7 +283,7 @@ class Terratorch(nn.Module, IsAttentionFree, SupportsMultiModal):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         params_list = []
         model_buffers = dict(self.named_buffers())
-        loaded_buffers = []
+        loaded_buffers: list[str] = []
         for key, value in weights:
             if isinstance(value, (dict, OrderedDict)):
                 if key == "state_dict":


### PR DESCRIPTION
                                                                                                                                                                        
  Fixes part of #26533        
  
Note: ernie_mtp.py and mimo_v2_mtp.py had a latent runtime bug:  default_weight_loader was used as fallback but called with shard_id, which it doesn't accept. Fixed by branching on  whether weight_loader exists.
                                                                                                                                                             
                                                                                                                                                                                           
  Fix mypy type errors in 7 model files under `vllm/model_executor/models/` that each had a single error.                                                                                  
                                                                                                                                                                                           
  **Files fixed:**                                                                                                                                                                         
  - `ernie_mtp.py` — handle missing `weight_loader` attribute with proper fallback                                                                                                         
  - `glm_ocr.py` — suppress assignment type for subclass attention override                                                                                                                
  - `gritlm.py` — assert `seq_pooling_type` is not None before passing to method                                                                                                           
  - `hyperclovax.py` — suppress arg-type for `PretrainedConfig` → `HyperCLOVAXConfig`                                                                                                      
  - `mimo_v2_mtp.py` — handle missing `weight_loader` with proper fallback                                                                                                                 
  - `minicpm3.py` — suppress assignment type for subclass attention override                                                                                                               
  - `terratorch.py` — add type annotation for `loaded_buffers` list                                                                                                                        
                                                                                                                                                                                           
  **Verification:**                                                                                                                                                                        
  ```bash                                                                                                                                                                                  
  mypy --python-version 3.10 vllm/model_executor/models/{ernie_mtp,glm_ocr,gritlm,hyperclovax,mimo_v2_mtp,minicpm3,terratorch}.py                                                          
  # Success: no issues found in 7 source files                                                                                                                                             
                                                                                                                                                                                           
  This is the first batch toward enabling full mypy checking for the vllm/model_executor/models directory (currently in EXCLUDE).                                                          
                                                                                                                                   