### PR TITLE
[Docs] Remove broken link to deleted disaggregated_prefill.sh

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -17,8 +17,6 @@ Two main reasons:
 
 ## Usage example
 
-Please refer to [examples/disaggregated/disaggregated_prefill.sh](../../examples/disaggregated/disaggregated_prefill.sh) for the example usage of disaggregated prefilling.
-
 Now supports 9 types of connectors:
 
 - **ExampleConnector**: refer to [examples/disaggregated/example_connector/run.sh](../../examples/disaggregated/example_connector/run.sh) for the example usage of ExampleConnector disaggregated prefilling.


### PR DESCRIPTION
## Purpose

`disaggregated_prefill.sh` was removed by #44854 but the reference in `docs/features/disagg_prefill.md` was not updated. This causes MkDocs to abort in `--strict` mode, breaking the RTD build for all PRs. The per-connector examples already below that line serve as usage guidance.

## Test Plan

Verified `docs/features/disagg_prefill.md` no longer references the deleted file. RTD build passes once the broken link is removed.

## Test Result

Before: RTD build fails with:
```
WARNING - Doc file 'features/disagg_prefill.md' contains a link
'../../examples/disaggregated/disaggregated_prefill.sh', but the
target is not found among documentation files.
Aborted with 1 warnings in strict mode!
```

After: broken link removed, no warning.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

