### PR TITLE
[Doc] Mention RTX 5090 in CUDA install and INT8 quantization Blackwel…

### DIFF
--- a/docs/features/quantization/llm_compressor/int8_w8a8.md
+++ b/docs/features/quantization/llm_compressor/int8_w8a8.md
@@ -9,7 +9,7 @@ Please visit the HF collection of [quantized INT8 checkpoints of popular LLMs re
     INT8 computation is supported on NVIDIA GPUs with compute capability > 7.5 (Turing, Ampere, Ada Lovelace, Hopper).
 
 !!! warning
-    **Blackwell GPU Limitation**: INT8 is not supported on compute capability >= 10.0 (e.g., RTX 6000 Blackwell).
+    **Blackwell GPU Limitation**: INT8 is not supported on compute capability >= 10.0 (e.g., B200, GB200, RTX 6000 Blackwell, RTX 5090).
     Use [FP8 quantization](fp8.md) instead, or run on Hopper/Ada/Ampere architectures.
 
 ## Prerequisites

--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -6,7 +6,7 @@ vLLM contains pre-compiled C++ and CUDA (12.9) binaries.
 --8<-- [end:installation]
 --8<-- [start:requirements]
 
-- GPU: compute capability 7.5 or higher (e.g., T4, RTX20xx, A100, L4, H100, B200, etc.)
+- GPU: compute capability 7.5 or higher (e.g., T4, RTX20xx, A100, L4, H100, B200, RTX 5090, etc.)
 
 --8<-- [end:requirements]
 --8<-- [start:set-up-using-python]
@@ -34,7 +34,7 @@ uv pip install vllm --torch-backend=auto
 We recommend leveraging `uv` to [automatically select the appropriate PyTorch index at runtime](https://docs.astral.sh/uv/guides/integration/pytorch/#automatic-backend-selection) by inspecting the installed CUDA driver version via `--torch-backend=auto` (or `UV_TORCH_BACKEND=auto`). To select a specific backend (e.g., `cu130`), set `--torch-backend=cu130` (or `UV_TORCH_BACKEND=cu130`). If this doesn't work, try running `uv self update` to update `uv` first.
 
 !!! note
-    NVIDIA Blackwell GPUs (B200, GB200) require a minimum of CUDA 12.8, so make sure you are installing PyTorch wheels with at least that version. PyTorch itself offers a [dedicated interface](https://pytorch.org/get-started/locally/) to determine the appropriate pip command to run for a given target configuration.
+    NVIDIA Blackwell GPUs (e.g., B200, GB200, RTX 5090) require a minimum of CUDA 12.8, so make sure you are installing PyTorch wheels with at least that version. PyTorch itself offers a [dedicated interface](https://pytorch.org/get-started/locally/) to determine the appropriate pip command to run for a given target configuration.
 
 As of now, vLLM's binaries are compiled with CUDA 12.9 and public PyTorch release versions by default. We also provide vLLM binaries compiled with CUDA 12.8, 13.0, and public PyTorch release versions:
 


### PR DESCRIPTION
## Purpose

  Extends two existing Blackwell-related notes in the docs to also name RTX 5090, so consumer Blackwell (RTX 50-series, sm_120) users can recognize themselves. 

  - `docs/getting_started/installation/gpu.cuda.inc.md`
    - Line 9 (GPU requirements): adds `RTX 5090` to the existing example list.
    - Line 37 (CUDA version note): extends `(B200, GB200)` to `(e.g., B200, GB200, RTX 5090)`.
  - `docs/features/quantization/llm_compressor/int8_w8a8.md`
    - Line 12 (Blackwell INT8 limitation): extends `(e.g., RTX 6000 Blackwell)` to `(e.g., B200, GB200, RTX 6000 Blackwell, RTX 5090)`.

  Fixes #38869.

  **Why this isn't duplicating an existing PR:**
  - No specific mention on RTX 5090 compatibility in docs
  - No open or closed PRs referencing #38869


  **Sources:**
  - [NVIDIA CUDA 12.8 Release Notes](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-toolkit-release-notes/) — sm_120 introduced in CUDA Toolkit 12.8.
  - [NVIDIA Blackwell Compatibility Guide](https://docs.nvidia.com/cuda/blackwell-compatibility-guide/) 
  - [PyTorch install page](https://pytorch.org/get-started/locally/) advertises cu128 stable wheels (sm_120 supported since PyTorch 2.7).
  - For the INT8 limitation, see PR #25935 ("Fix INT8 quantization error on Blackwell GPUs (SM100+)"), which added both the runtime guard at
  `csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_helper.hpp`


  ## Test Plan

  Docs-only change; no runtime tests applicable. Validation:

  1. `pre-commit run --files docs/getting_started/installation/gpu.cuda.inc.md docs/features/quantization/llm_compressor/int8_w8a8.md`
  2. `API_AUTONAV_EXCLUDE=vllm mkdocs serve` and visually inspect the two edited pages.

  ## Test Result

  1. `pre-commit run --files ...` — all applicable hooks passed (`typos`, `markdownlint-cli2`, etc.).
  2. `mkdocs serve` — visually confirmed both notes render correctly:
     - *Getting Started → Installation → GPU → NVIDIA CUDA*: "RTX 5090" appears in the GPU requirements bullet and in the Blackwell CUDA-version `!!! note` admonition.
     - *Features → Quantization → LLM Compressor → INT8 W8A8*: the `!!! warning` admonition now reads `(e.g., B200, GB200, RTX 6000 Blackwell, RTX 5090)`.
