### PR TITLE
Fix shellcheck function call in ROCm ci-bake script

### DIFF
--- a/.buildkite/scripts/ci-bake-rocm.sh
+++ b/.buildkite/scripts/ci-bake-rocm.sh
@@ -1557,8 +1557,8 @@ confirm_remote_image_push() {
         fi
 
         if [[ -z "${remote_revision}" \
-              && ${IMAGE_EXISTED_BEFORE_BUILD} -eq 0 \
-              && image_tag_is_commit_scoped ]]; then
+              && ${IMAGE_EXISTED_BEFORE_BUILD} -eq 0 ]] \
+              && image_tag_is_commit_scoped; then
             echo "Remote image exists under a commit-scoped tag; accepting push despite missing revision label."
             return 0
         fi


### PR DESCRIPTION



## Purpose

  Fix a shellcheck `SC2078` failure in `.buildkite/scripts/ci-bake-rocm.sh`.

  `image_tag_is_commit_scoped` is a Bash function, but it was inside a
  `[[ ... ]]` expression, where it is treated as a constant non-empty string
  instead of being executed. This moves the function call outside `[[ ... ]]` so
  the condition checks the function result.

  ## Test Plan

  ```bash
  pre-commit run shellcheck --files .buildkite/scripts/ci-bake-rocm.sh
  pre-commit run --files .buildkite/scripts/ci-bake-rocm.sh

  ## Test Result

  Lint shell
  scripts.......................................................Passed
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

