### PR TITLE
[PERF] Fuse multi-group block table staged writes

### DIFF
--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -41,7 +41,7 @@ def test_block_tables_apply_staged_writes_fuses_kv_groups(monkeypatch):
         overwrite=True,
     )
     block_tables.apply_staged_writes()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     assert torch.equal(
         block_tables.block_tables[0].gpu[0, :2],

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.block_table import BlockTables
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="requires CUDA",
+)
+
+
+def test_block_tables_apply_staged_writes_fuses_kv_groups(monkeypatch):
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16, 32, 8],
+        max_num_reqs=4,
+        max_num_batched_tokens=64,
+        max_num_blocks_per_group=[8, 8, 8],
+        device=device,
+        kernel_block_sizes=[16, 16, 8],
+    )
+
+    def fail_if_apply_write_called():
+        pytest.fail("multi-group writes should use the fused apply kernel")
+
+    for block_table in block_tables.block_tables:
+        monkeypatch.setattr(block_table, "apply_write", fail_if_apply_write_called)
+
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([1, 2], [10, 11], []),
+        overwrite=True,
+    )
+    block_tables.append_block_ids(
+        req_index=1,
+        new_block_ids=([3], [12], [5, 6]),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+    torch.cuda.synchronize()
+
+    assert torch.equal(
+        block_tables.block_tables[0].gpu[0, :2],
+        torch.tensor([1, 2], dtype=torch.int32, device=device),
+    )
+    # Group 1 has blocks_per_kv_block == 2, so each KV block expands to two
+    # kernel block IDs.
+    assert torch.equal(
+        block_tables.block_tables[1].gpu[0, :4],
+        torch.tensor([20, 21, 22, 23], dtype=torch.int32, device=device),
+    )
+    assert torch.equal(
+        block_tables.block_tables[0].gpu[1, :1],
+        torch.tensor([3], dtype=torch.int32, device=device),
+    )
+    assert torch.equal(
+        block_tables.block_tables[1].gpu[1, :2],
+        torch.tensor([24, 25], dtype=torch.int32, device=device),
+    )
+    assert torch.equal(
+        block_tables.block_tables[2].gpu[1, :2],
+        torch.tensor([5, 6], dtype=torch.int32, device=device),
+    )
+    assert block_tables.num_blocks.np[0, 0] == 2
+    assert block_tables.num_blocks.np[1, 0] == 4
+    assert block_tables.num_blocks.np[2, 0] == 0
+    assert block_tables.num_blocks.np[0, 1] == 1
+    assert block_tables.num_blocks.np[1, 1] == 2
+    assert block_tables.num_blocks.np[2, 1] == 2
+    assert torch.equal(
+        block_tables.num_blocks.gpu[:, :2],
+        torch.tensor([[2, 1], [4, 2], [0, 2]], dtype=torch.int32, device=device),
+    )
+
+    for block_table in block_tables.block_tables:
+        assert not block_table._staged_write_indices
+        assert not block_table._staged_write_starts
+        assert not block_table._staged_write_contents
+        assert not block_table._staged_write_cu_lens
+
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([7], [13], [8]),
+        overwrite=False,
+    )
+    block_tables.apply_staged_writes()
+    torch.accelerator.synchronize()
+
+    assert torch.equal(
+        block_tables.block_tables[0].gpu[0, :3],
+        torch.tensor([1, 2, 7], dtype=torch.int32, device=device),
+    )
+    assert torch.equal(
+        block_tables.block_tables[1].gpu[0, :6],
+        torch.tensor([20, 21, 22, 23, 26, 27], dtype=torch.int32, device=device),
+    )
+    assert torch.equal(
+        block_tables.block_tables[2].gpu[0, :1],
+        torch.tensor([8], dtype=torch.int32, device=device),
+    )
+    assert block_tables.num_blocks.np[0, 0] == 3
+    assert block_tables.num_blocks.np[1, 0] == 6
+    assert block_tables.num_blocks.np[2, 0] == 1
+
+
+def test_block_tables_apply_staged_writes_single_group():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16],
+        max_num_reqs=2,
+        max_num_batched_tokens=16,
+        max_num_blocks_per_group=[4],
+        device=device,
+        kernel_block_sizes=[16],
+    )
+
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([1, 2],),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+    torch.accelerator.synchronize()
+
+    assert torch.equal(
+        block_tables.block_tables[0].gpu[0, :2],
+        torch.tensor([1, 2], dtype=torch.int32, device=device),
+    )

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -7,10 +7,10 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.buffer_utils import (
+    FusedStagedWriter,
     StagedWriteTensor,
     UvaBackedTensor,
-    UvaBufferPool,
-    async_tensor_h2d,
+    _load_ptr,
 )
 
 
@@ -57,22 +57,12 @@ class BlockTables:
             (self.num_kv_cache_groups, self.max_num_reqs),
             dtype=torch.int32,
         )
-        self.write_group_ids = UvaBufferPool(
-            self.num_kv_cache_groups * self.max_num_reqs,
-            dtype=torch.int32,
-        )
-        self.write_indices = UvaBufferPool(
-            self.num_kv_cache_groups * self.max_num_reqs,
-            dtype=torch.int32,
-        )
-        self.write_starts = UvaBufferPool(
-            self.num_kv_cache_groups * self.max_num_reqs,
-            dtype=torch.int32,
-        )
-        self.write_cu_lens = UvaBufferPool(
-            self.num_kv_cache_groups * self.max_num_reqs,
-            dtype=torch.int32,
-        )
+        self.fused_writer: FusedStagedWriter | None = None
+        if self.num_kv_cache_groups > 1:
+            # Only the multi-group path uses the fused writer.
+            self.fused_writer = FusedStagedWriter(
+                self.device, self.num_kv_cache_groups * self.max_num_reqs
+            )
 
         # Block tables used for model's forward pass.
         # num_kv_cache_groups x [max_num_reqs, max_num_blocks]
@@ -131,54 +121,14 @@ class BlockTables:
 
     def apply_staged_writes(self) -> None:
         if self.num_kv_cache_groups == 1:
+            # Single group: write directly, skipping the per-write group lookup.
             self.block_tables[0].apply_write()
-            self.num_blocks.copy_to_uva()
-            return
-
-        write_group_ids: list[int] = []
-        write_indices: list[int] = []
-        write_starts: list[int] = []
-        write_contents: list[int] = []
-        write_cu_lens: list[int] = []
-
-        for group_id, block_table in enumerate(self.block_tables):
-            num_writes = len(block_table._staged_write_indices)
-            if num_writes == 0:
-                continue
-
-            write_group_ids.extend([group_id] * num_writes)
-            write_indices.extend(block_table._staged_write_indices)
-            write_starts.extend(block_table._staged_write_starts)
-            content_base = len(write_contents)
-            write_contents.extend(block_table._staged_write_contents)
-            write_cu_lens.extend(
-                content_base + cu_len for cu_len in block_table._staged_write_cu_lens
+        else:
+            # Multiple groups: apply all block tables with one fused kernel.
+            assert self.fused_writer is not None
+            self.fused_writer.apply(
+                self.block_tables, self.block_table_ptrs, self.block_table_strides
             )
-
-        num_writes = len(write_group_ids)
-        if num_writes == 0:
-            self.num_blocks.copy_to_uva()
-            return
-
-        group_ids_uva = self.write_group_ids.copy_to_uva(write_group_ids)
-        indices_uva = self.write_indices.copy_to_uva(write_indices)
-        starts_uva = self.write_starts.copy_to_uva(write_starts)
-        cu_lens_uva = self.write_cu_lens.copy_to_uva(write_cu_lens)
-        contents = async_tensor_h2d(write_contents, torch.int32, self.device)
-
-        _apply_block_table_writes_kernel[(num_writes,)](
-            self.block_table_ptrs,
-            self.block_table_strides,
-            group_ids_uva,
-            indices_uva,
-            starts_uva,
-            contents,
-            cu_lens_uva,
-            BLOCK_SIZE=1024,
-        )
-
-        for block_table in self.block_tables:
-            block_table.clear_staged_writes()
         self.num_blocks.copy_to_uva()
 
     def gather_block_tables(
@@ -244,40 +194,6 @@ class BlockTables:
         # with the same memory address as that used during the model's forward pass,
         # rather than allocating a new tensor.
         return self.slot_mappings[:, :num_tokens]
-
-
-@triton.jit
-def _apply_block_table_writes_kernel(
-    block_table_ptrs,  # [num_kv_cache_groups]
-    block_table_strides,  # [num_kv_cache_groups]
-    write_group_ids_ptr,
-    write_indices_ptr,
-    write_starts_ptr,
-    write_contents_ptr,
-    write_cu_lens_ptr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    group_id = tl.load(write_group_ids_ptr + pid)
-    row_idx = tl.load(write_indices_ptr + pid)
-    start_idx = tl.load(write_starts_ptr + pid)
-
-    cu_start = tl.load(write_cu_lens_ptr + pid - 1) if pid > 0 else 0
-    cu_end = tl.load(write_cu_lens_ptr + pid)
-    content_len = cu_end - cu_start
-
-    block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
-    block_table_stride = tl.load(block_table_strides + group_id)
-
-    for i in range(0, content_len, BLOCK_SIZE):
-        block = i + tl.arange(0, BLOCK_SIZE)
-        mask = block < content_len
-        block_ids = tl.load(write_contents_ptr + cu_start + block, mask=mask)
-        tl.store(
-            block_table_ptr + row_idx * block_table_stride + start_idx + block,
-            block_ids,
-            mask=mask,
-        )
 
 
 @triton.jit(do_not_specialize=["num_reqs"])
@@ -383,10 +299,3 @@ def _compute_slot_mappings_kernel(
             slot_ids = tl.where(is_local, slot_ids, PAD_ID)
 
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)
-
-
-@triton.jit
-def _load_ptr(ptr_to_ptr, elem_dtype):
-    ptr = tl.load(ptr_to_ptr)
-    ptr = tl.cast(ptr, tl.pointer_type(elem_dtype))
-    return tl.multiple_of(ptr, 16)

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -6,7 +6,12 @@ import torch
 
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+from vllm.v1.worker.gpu.buffer_utils import (
+    StagedWriteTensor,
+    UvaBackedTensor,
+    UvaBufferPool,
+    async_tensor_h2d,
+)
 
 
 class BlockTables:
@@ -50,6 +55,22 @@ class BlockTables:
 
         self.num_blocks = UvaBackedTensor(
             (self.num_kv_cache_groups, self.max_num_reqs),
+            dtype=torch.int32,
+        )
+        self.write_group_ids = UvaBufferPool(
+            self.num_kv_cache_groups * self.max_num_reqs,
+            dtype=torch.int32,
+        )
+        self.write_indices = UvaBufferPool(
+            self.num_kv_cache_groups * self.max_num_reqs,
+            dtype=torch.int32,
+        )
+        self.write_starts = UvaBufferPool(
+            self.num_kv_cache_groups * self.max_num_reqs,
+            dtype=torch.int32,
+        )
+        self.write_cu_lens = UvaBufferPool(
+            self.num_kv_cache_groups * self.max_num_reqs,
             dtype=torch.int32,
         )
 
@@ -109,10 +130,55 @@ class BlockTables:
             self.num_blocks.np[i, req_index] = start + len(block_ids)
 
     def apply_staged_writes(self) -> None:
-        # TODO(woosuk): This can be inefficient since it launches one kernel per
-        # block table. Implement a kernel to handle all block tables at once.
+        if self.num_kv_cache_groups == 1:
+            self.block_tables[0].apply_write()
+            self.num_blocks.copy_to_uva()
+            return
+
+        write_group_ids: list[int] = []
+        write_indices: list[int] = []
+        write_starts: list[int] = []
+        write_contents: list[int] = []
+        write_cu_lens: list[int] = []
+
+        for group_id, block_table in enumerate(self.block_tables):
+            num_writes = len(block_table._staged_write_indices)
+            if num_writes == 0:
+                continue
+
+            write_group_ids.extend([group_id] * num_writes)
+            write_indices.extend(block_table._staged_write_indices)
+            write_starts.extend(block_table._staged_write_starts)
+            content_base = len(write_contents)
+            write_contents.extend(block_table._staged_write_contents)
+            write_cu_lens.extend(
+                content_base + cu_len for cu_len in block_table._staged_write_cu_lens
+            )
+
+        num_writes = len(write_group_ids)
+        if num_writes == 0:
+            self.num_blocks.copy_to_uva()
+            return
+
+        group_ids_uva = self.write_group_ids.copy_to_uva(write_group_ids)
+        indices_uva = self.write_indices.copy_to_uva(write_indices)
+        starts_uva = self.write_starts.copy_to_uva(write_starts)
+        cu_lens_uva = self.write_cu_lens.copy_to_uva(write_cu_lens)
+        contents = async_tensor_h2d(write_contents, torch.int32, self.device)
+
+        _apply_block_table_writes_kernel[(num_writes,)](
+            self.block_table_ptrs,
+            self.block_table_strides,
+            group_ids_uva,
+            indices_uva,
+            starts_uva,
+            contents,
+            cu_lens_uva,
+            BLOCK_SIZE=1024,
+        )
+
         for block_table in self.block_tables:
-            block_table.apply_write()
+            block_table.clear_staged_writes()
         self.num_blocks.copy_to_uva()
 
     def gather_block_tables(
@@ -178,6 +244,40 @@ class BlockTables:
         # with the same memory address as that used during the model's forward pass,
         # rather than allocating a new tensor.
         return self.slot_mappings[:, :num_tokens]
+
+
+@triton.jit
+def _apply_block_table_writes_kernel(
+    block_table_ptrs,  # [num_kv_cache_groups]
+    block_table_strides,  # [num_kv_cache_groups]
+    write_group_ids_ptr,
+    write_indices_ptr,
+    write_starts_ptr,
+    write_contents_ptr,
+    write_cu_lens_ptr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    group_id = tl.load(write_group_ids_ptr + pid)
+    row_idx = tl.load(write_indices_ptr + pid)
+    start_idx = tl.load(write_starts_ptr + pid)
+
+    cu_start = tl.load(write_cu_lens_ptr + pid - 1) if pid > 0 else 0
+    cu_end = tl.load(write_cu_lens_ptr + pid)
+    content_len = cu_end - cu_start
+
+    block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
+    block_table_stride = tl.load(block_table_strides + group_id)
+
+    for i in range(0, content_len, BLOCK_SIZE):
+        block = i + tl.arange(0, BLOCK_SIZE)
+        mask = block < content_len
+        block_ids = tl.load(write_contents_ptr + cu_start + block, mask=mask)
+        tl.store(
+            block_table_ptr + row_idx * block_table_stride + start_idx + block,
+            block_ids,
+            mask=mask,
+        )
 
 
 @triton.jit(do_not_specialize=["num_reqs"])

--- a/vllm/v1/worker/gpu/buffer_utils.py
+++ b/vllm/v1/worker/gpu/buffer_utils.py
@@ -194,7 +194,9 @@ class StagedWriteTensor:
             starts_uva,
             write_contents,
             cu_lens_uva,
+            None,
             BLOCK_SIZE=1024,
+            MULTI_GROUP=False,
         )
         # Clear the staged writes
         self.clear_staged_writes()
@@ -206,15 +208,81 @@ class StagedWriteTensor:
         self._staged_write_cu_lens.clear()
 
 
+class FusedStagedWriter:
+    """Applies the staged writes of several `StagedWriteTensor`s at once."""
+
+    def __init__(
+        self, device: torch.device, max_writes: int, max_concurrency: int | None = None
+    ):
+        new_pool = partial(
+            UvaBufferPool, dtype=torch.int32, max_concurrency=max_concurrency
+        )
+        self.group_ids = new_pool(max_writes)
+        self.indices = new_pool(max_writes)
+        self.starts = new_pool(max_writes)
+        self.cu_lens = new_pool(max_writes)
+        self.device = device
+
+    def apply(
+        self,
+        tensors: Sequence[StagedWriteTensor],
+        output_ptrs: torch.Tensor,
+        output_strides: torch.Tensor,
+    ) -> None:
+        """Apply and clear the staged writes of `tensors` with one kernel."""
+        group_ids: list[int] = []
+        indices: list[int] = []
+        starts: list[int] = []
+        contents: list[int | float] = []
+        cu_lens: list[int] = []
+
+        for group_id, t in enumerate(tensors):
+            n = len(t._staged_write_indices)
+            if n == 0:
+                continue
+
+            group_ids.extend([group_id] * n)
+            indices.extend(t._staged_write_indices)
+            starts.extend(t._staged_write_starts)
+            content_base = len(contents)
+            contents.extend(t._staged_write_contents)
+            cu_lens.extend(content_base + cu_len for cu_len in t._staged_write_cu_lens)
+
+        if not group_ids:
+            return
+
+        group_ids_uva = self.group_ids.copy_to_uva(group_ids)
+        indices_uva = self.indices.copy_to_uva(indices)
+        starts_uva = self.starts.copy_to_uva(starts)
+        cu_lens_uva = self.cu_lens.copy_to_uva(cu_lens)
+        contents_gpu = async_tensor_h2d(contents, torch.int32, self.device)
+
+        _apply_write_kernel[(len(group_ids),)](
+            output_ptrs,
+            output_strides,
+            indices_uva,
+            starts_uva,
+            contents_gpu,
+            cu_lens_uva,
+            group_ids_uva,
+            BLOCK_SIZE=1024,
+            MULTI_GROUP=True,
+        )
+        for t in tensors:
+            t.clear_staged_writes()
+
+
 @triton.jit
 def _apply_write_kernel(
-    output_ptr,
-    output_stride,
+    output_ptr,  # MULTI_GROUP: ptr-to-ptrs [num_groups]; else: data ptr
+    output_stride,  # MULTI_GROUP: ptr-to-strides [num_groups]; else: row stride
     write_indices_ptr,
     write_starts_ptr,
     write_contents_ptr,
     write_cu_lens_ptr,
+    write_group_ids_ptr,  # [num_writes], used only when MULTI_GROUP
     BLOCK_SIZE: tl.constexpr,
+    MULTI_GROUP: tl.constexpr,
 ):
     pid = tl.program_id(0)
     row_idx = tl.load(write_indices_ptr + pid)
@@ -224,10 +292,26 @@ def _apply_write_kernel(
     cu_end = tl.load(write_cu_lens_ptr + pid)
     content_len = cu_end - cu_start
 
+    if MULTI_GROUP:
+        # Each write targets a different output tensor (KV cache group);
+        # resolve its base pointer and row stride per write.
+        group_id = tl.load(write_group_ids_ptr + pid)
+        row_ptr = _load_ptr(output_ptr + group_id, tl.int32)
+        row_stride = tl.load(output_stride + group_id)
+    else:
+        row_ptr = output_ptr
+        row_stride = output_stride
+    row_ptr += row_idx * row_stride + start_idx
+
     for i in range(0, content_len, BLOCK_SIZE):
         block = i + tl.arange(0, BLOCK_SIZE)
         mask = block < content_len
         content = tl.load(write_contents_ptr + cu_start + block, mask=mask)
-        tl.store(
-            output_ptr + row_idx * output_stride + start_idx + block, content, mask=mask
-        )
+        tl.store(row_ptr + block, content, mask=mask)
+
+
+@triton.jit
+def _load_ptr(ptr_to_ptr, elem_dtype):
+    ptr = tl.load(ptr_to_ptr)
+    ptr = tl.cast(ptr, tl.pointer_type(elem_dtype))
+    return tl.multiple_of(ptr, 16)


### PR DESCRIPTION
## Purpose
Add a fused Triton path for V2 BlockTables.apply_staged_writes so multi-KV-group updates are applied with a single kernel instead of one kernel per block table. Keep the single-group path on the existing StagedWriteTensor implementation.

Add CUDA coverage for multi-group writes, hybrid block ID expansion, num_blocks synchronization, staged-write cleanup, and the single-group fallback path.
## Test Plan
### Start server
```shell
VLLM_USE_V2_MODEL_RUNNER=1 python3 -m vllm.entrypoints.openai.api_server \
    --host 0.0.0.0 --port 8898 \
    --max_num_seqs 128 \
    --max-model-len 32768 \
    --model /nas/disk1/Qwen3.6-35B-A3B --served-model-name Qwen3.6-35B-A3B
```
### VLLM bench
```
vllm bench serve --backend openai-chat --model Qwen3.6-35B-A3B --served-model-name Qwen3.6-35B-A3B --tokenizer /nas/disk1/Qwen3.6-35B-A3B --percentile-metrics ttft,tpot,itl,e2el --dataset-name random --max-concurrency 20 --num-prompts 300 --endpoint /v1/chat/completions --base-url http://localhost:8898 --seed 20912 --ignore-eos --random-input-len 1024 --random-output-len 100 --random-range-ratio 0.5 --random-prefix-len 0
```

## Test Result
Throughput，TTFT and TPOT was tested at concurrency ranging from 20 to 50.
Blue is before,Green is After

<img width="1334" height="535" alt="image" src="https://github.com/user-attachments/assets/ae6c833b-af6e-436c-8711-c3895c374b6c" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x] The test plan, such as providing test command.
- [ x] The test results, such as pasting the results comparison before and after, or e2e results
- [ x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
