### PR TITLE
[Test] Fix one-sided MNNVL alltoall test workspace under-reservation

### DIFF
--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -742,6 +742,11 @@ def _one_sided_data_worker(rank, world_size):
         top_k=experts_per_token,
         num_experts=num_experts,
         hidden_size=hidden_size,
+        # Account for the fp8 block-scale payload (a1q_scale: hidden//16 bytes
+        # per token) that is dispatched alongside the nvfp4 hidden states.
+        # Without this the dispatch region is under-reserved and the combine
+        # payload overflows the per-rank workspace.
+        dispatch_scale_bytes_per_token=hidden_size // 16,
     )
     assert manager.initialized
     assert manager.moe_alltoall is not None


### PR DESCRIPTION
## Summary

`tests/distributed/test_mnnvl_alltoall.py::test_one_sided_dispatch_combine`
initializes the FlashInfer one-sided `MoeAlltoAll` workspace **without
declaring the fp8 block-scale payload it later dispatches**. The worker
dispatches four payloads:

- `a1q` — nvfp4 hidden states, `(tokens, hidden // 2)` → `hidden // 2` B/token
- `a1q_scale` — fp8 block scales, `(tokens, hidden // 16)` → `hidden // 16` B/token
- `topk_ids`, `topk_weights` — `top_k * 4` B/token each

but `manager.initialize(...)` is called with `dispatch_scale_bytes_per_token`
left at its default of `0`. So the reserved per-rank dispatch region is short
by `hidden // 16` bytes/token. That offset shortfall pushes the combine
payload region past the end of the per-rank workspace, and FlashInfer's
combine guard (`trtllm_moe_alltoall.cu`) trips:

```
Check failed: (combinePayloadOffset >= 0 && combinePayloadOffset + payloadBytes <= sizePerRank)
workspace insufficient for combine payload region
```

The per-rank workspace is sized as
`aux + ep_size·max_tokens·dispatch_payload_per_token + ep_size·max_tokens·combine_payload_per_token`,
so under-declaring the dispatch payload directly under-reserves the buffer.

## Fix

Pass `dispatch_scale_bytes_per_token=hidden_size // 16` to `initialize()` so
the reserved dispatch region matches the payloads the test actually
dispatches. One-line, test-only change.

## Testing

On a 2-GPU MNNVL host, run with `CAP_SYS_PTRACE` (MNNVL needs it for IPC; the
tests `@requires_ptrace`-skip otherwise):

```
pytest tests/distributed/test_mnnvl_alltoall.py -v
```

- Before: `5 passed, 1 failed` (`test_one_sided_dispatch_combine` →
  "workspace insufficient for combine payload region").
- After: **6 passed** (all manager-lifecycle, workspace-grow, args/two-sided/
  one-sided dispatch-combine tests).

## AI assistance

This change was developed with AI assistance (Claude Code). The diff has been
reviewed and the test result above was run locally.
