### PR TITLE
[Bugfix] Key multimodal encoder cache on LoRA path, not just name

### DIFF
--- a/tests/v1/engine/test_input_processor_mm_identifier.py
+++ b/tests/v1/engine/test_input_processor_mm_identifier.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``InputProcessor._get_mm_identifier``.
+
+Regression coverage for https://github.com/vllm-project/vllm/issues/44939:
+a same-name in-place LoRA reload (same ``lora_name`` / reused
+``lora_int_id``, new ``lora_path``) must produce a distinct multi-modal
+encoder-cache identifier, otherwise the request reuses the previous
+adapter's stale encoder embeddings.
+"""
+
+from types import SimpleNamespace
+
+from vllm.lora.request import LoRARequest
+from vllm.v1.engine.input_processor import InputProcessor
+
+MM_HASH = "deadbeefcafef00d"
+
+
+def _identifier(lora_request, *, enable_tower_connector_lora=True, lora_config=True):
+    """Call the unbound method with a minimal stub as ``self``.
+
+    ``_get_mm_identifier`` only reads ``self.lora_config``.
+    """
+    cfg = (
+        SimpleNamespace(enable_tower_connector_lora=enable_tower_connector_lora)
+        if lora_config
+        else None
+    )
+    stub = SimpleNamespace(lora_config=cfg)
+    return InputProcessor._get_mm_identifier(stub, MM_HASH, lora_request)
+
+
+def _lora(name, path, int_id=1):
+    return LoRARequest(lora_name=name, lora_int_id=int_id, lora_path=path)
+
+
+def test_no_lora_returns_bare_mm_hash():
+    assert _identifier(None) == MM_HASH
+
+
+def test_feature_disabled_returns_bare_mm_hash():
+    lora = _lora("tenant", "/adapters/a")
+    assert _identifier(lora, enable_tower_connector_lora=False) == MM_HASH
+
+
+def test_no_lora_config_returns_bare_mm_hash():
+    lora = _lora("tenant", "/adapters/a")
+    assert _identifier(lora, lora_config=False) == MM_HASH
+
+
+def test_identifier_includes_name_and_mm_hash():
+    lora = _lora("tenant", "/adapters/a")
+    identifier = _identifier(lora)
+    assert identifier != MM_HASH
+    assert identifier.startswith("tenant:")
+    assert identifier.endswith(f":{MM_HASH}")
+
+
+def test_same_name_different_path_differ():
+    # The #44939 regression: in-place reload keeps the name and int_id but
+    # swaps the path. The identifier must change so the encoder cache misses
+    # and recomputes with the new adapter.
+    a = _lora("tenant", "/adapters/a", int_id=1)
+    b = _lora("tenant", "/adapters/b", int_id=1)  # same name, same id, new path
+    assert _identifier(a) != _identifier(b)
+
+
+def test_same_name_same_path_match():
+    # An unchanged adapter must keep a stable identifier so cache hits work.
+    a = _lora("tenant", "/adapters/a")
+    b = _lora("tenant", "/adapters/a")
+    assert _identifier(a) == _identifier(b)
+
+
+def test_different_name_same_path_differ():
+    a = _lora("tenant", "/adapters/a")
+    b = _lora("other", "/adapters/a")
+    assert _identifier(a) != _identifier(b)

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -27,6 +27,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.tasks import GENERATION_TASKS, POOLING_TASKS, SupportedTask
 from vllm.tokenizers import TokenizerLike
 from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
+from vllm.utils.hashing import sha256_cbor
 from vllm.utils.jsontree import json_iter_leaves
 from vllm.v1.engine import EngineCoreRequest
 
@@ -171,6 +172,13 @@ class InputProcessor:
         When enable_tower_connector_lora is True, multi-modal embeddings
         vary depending on the LoRA request. Therefore, the mm_hash must be
         generated based on the LoRA request to prevent incorrect cache hits.
+
+        The identifier folds in a fingerprint of ``lora_path`` rather than
+        keying on ``lora_name`` alone: a same-name in-place reload keeps the
+        ``lora_name`` (and reuses the ``lora_int_id``) while swapping the
+        adapter weights at a new ``lora_path``. Keying on the name only would
+        reuse the previous adapter's encoder embeddings on a cache hit and
+        skip recomputing the vision encoder/projector. See issue #44939.
         """
         if (
             lora_request is None
@@ -178,7 +186,8 @@ class InputProcessor:
             or not self.lora_config.enable_tower_connector_lora
         ):
             return mm_hash
-        return f"{lora_request.lora_name}:{mm_hash}"
+        lora_fingerprint = sha256_cbor(lora_request.lora_path).hex()
+        return f"{lora_request.lora_name}:{lora_fingerprint}:{mm_hash}"
 
     def inject_into_mm_cache(
         self,

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -179,6 +179,13 @@ class InputProcessor:
         adapter weights at a new ``lora_path``. Keying on the name only would
         reuse the previous adapter's encoder embeddings on a cache hit and
         skip recomputing the vision encoder/projector. See issue #44939.
+
+        Note: the fingerprint is over the ``lora_path`` string, so
+        re-uploading different adapter weights to the *same* ``lora_path``
+        under the same ``lora_name`` is not covered (the fingerprint is
+        unchanged and the stale encoder cache is reused). Catching that would
+        require content- or mtime-based keying, which costs more per request;
+        path-keying is the chosen tradeoff.
         """
         if (
             lora_request is None

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -168,24 +168,14 @@ class InputProcessor:
         mm_hash: str,
         lora_request: LoRARequest | None,
     ) -> str:
-        """
-        When enable_tower_connector_lora is True, multi-modal embeddings
-        vary depending on the LoRA request. Therefore, the mm_hash must be
-        generated based on the LoRA request to prevent incorrect cache hits.
+        """Fold the active LoRA into the mm encoder-cache identifier.
 
-        The identifier folds in a fingerprint of ``lora_path`` rather than
-        keying on ``lora_name`` alone: a same-name in-place reload keeps the
-        ``lora_name`` (and reuses the ``lora_int_id``) while swapping the
-        adapter weights at a new ``lora_path``. Keying on the name only would
-        reuse the previous adapter's encoder embeddings on a cache hit and
-        skip recomputing the vision encoder/projector. See issue #44939.
-
-        Note: the fingerprint is over the ``lora_path`` string, so
-        re-uploading different adapter weights to the *same* ``lora_path``
-        under the same ``lora_name`` is not covered (the fingerprint is
-        unchanged and the stale encoder cache is reused). Catching that would
-        require content- or mtime-based keying, which costs more per request;
-        path-keying is the chosen tradeoff.
+        With ``enable_tower_connector_lora`` the encoder embeddings depend on
+        the LoRA, so the identifier keys on a fingerprint of ``lora_path`` (not
+        ``lora_name``): a same-name in-place reload keeps the name and reuses
+        ``lora_int_id`` while pointing at a new path, so name-only keying would
+        serve the previous adapter's cached embeddings. Re-uploads to the same
+        path are not distinguished. See issue #44939.
         """
         if (
             lora_request is None


### PR DESCRIPTION
## Purpose

Fixes #44939.

With `--enable-tower-connector-lora`, multimodal encoder embeddings depend on the active LoRA adapter, so `InputProcessor._get_mm_identifier` folds the LoRA into the multimodal encoder-cache identifier. It keyed the identifier on `lora_name` **alone**:

```python
return f"{lora_request.lora_name}:{mm_hash}"
```

But the OpenAI server's in-place LoRA reload (`load_lora_adapter`) reuses the existing `lora_int_id` for a known `lora_name` and only takes the new `lora_path`:

```python
lora_int_id = (
    self.lora_requests[lora_name].lora_int_id
    if lora_name in self.lora_requests
    else self.lora_id_counter.inc(1)
)
```

So reloading a **different** adapter under the **same** name keeps both `lora_name` and `lora_int_id` unchanged — only `lora_path` changes. The encoder-cache identifier was therefore identical across the reload, the scheduler treated the image as an encoder-cache **hit**, skipped recomputing the vision encoder/projector, and the request silently used the **previous** adapter's stale encoder embeddings. As reported, only `/reset_encoder_cache` or loading under a new `lora_name` recovered correct behavior.

## Fix

Fold a `sha256_cbor` fingerprint of `lora_path` into the identifier:

```python
lora_fingerprint = sha256_cbor(lora_request.lora_path).hex()
return f"{lora_request.lora_name}:{lora_fingerprint}:{mm_hash}"
```

A same-name reload from a new path now yields a distinct encoder-cache key (miss → recompute with the new adapter), while an unchanged adapter keeps a stable key so normal cache hits are preserved. The early-return path (feature disabled / no LoRA) is unchanged and still returns the bare `mm_hash`.

**Known limitation:** overwriting the files at the *same* `lora_path` in place with new weights and reloading will not change the fingerprint and can still serve stale embeddings. The documented/tested reload flow loads from a new path; a content hash would be needed to cover same-path mutation and is out of scope here.

## Test

Adds `tests/v1/engine/test_input_processor_mm_identifier.py` covering the early-return paths, the #44939 regression (same name + same id + new path ⇒ distinct identifier), stability for unchanged adapters, and name-based separation.
