### PR TITLE
[Bugfix] Fix Qwen3.5 MoE expert weight loading

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -298,8 +298,18 @@ class Qwen3_5Model(Qwen3NextModel):
             "base_layer." if any(".base_layer." in name for name in params_dict) else ""
         )
         fused_expert_params_mapping = [
-            (f"experts.{base_layer}w13_weight", "experts.gate_up_proj", 0, "w1"),
-            (f"experts.{base_layer}w2_weight", "experts.down_proj", 0, "w2"),
+            (
+                f"experts.routed_experts.{base_layer}w13_weight",
+                "experts.gate_up_proj",
+                0,
+                "w1",
+            ),
+            (
+                f"experts.routed_experts.{base_layer}w2_weight",
+                "experts.down_proj",
+                0,
+                "w2",
+            ),
         ]
         num_experts = (
             self.config.num_experts if hasattr(self.config, "num_experts") else 0


### PR DESCRIPTION
## Purpose

This PR fixes a Qwen3.5 MoE expert weight loading regression on current main.

The same Qwen3.5-35B-A3B checkpoint could be loaded successfully with an older
vLLM development snapshot, but after updating to the latest vLLM code, model
startup fails during weight loading.

The failure can be reproduced with:

```bash
vllm serve /root/autodl-tmp/models/Qwen3.5-35B-A3B/ \
  --max-model-len 2048 \
  --max-num-batched-tokens 256 \
  --trust-remote-code \
  --enable-expert-parallel \
  --data-parallel-size 2 \
  --speculative_config '{"method":"mtp", "num_speculative_tokens":3}' \
  --enforce-eager
```

The worker fails to start with:

```text
KeyError: 'layers.13.mlp.experts.w13_weight'
```

The traceback shows that the error happens in Qwen3.5 fused expert weight loading:

```text
File "vllm/model_executor/models/qwen3_5.py", line 361, in load_weights
  success_w1 = self.load_fused_expert_weights(...)

File "vllm/model_executor/models/qwen3_5.py", line 258, in load_fused_expert_weights
  param = params_dict[name]

KeyError: 'layers.13.mlp.experts.w13_weight'
```

The current Qwen3.5 loader maps fused expert parameters to:

```text
experts.w13_weight
experts.w2_weight
```

However, the current MoE module stores the corresponding expert parameters under:

```text
experts.routed_experts.w13_weight
experts.routed_experts.w2_weight
```

This PR updates the Qwen3.5 fused expert parameter mapping to use the current
`experts.routed_experts.*` parameter paths.

## Test Plan

- Run Python syntax check for the modified Qwen3.5 model loader.
- Manually verify Qwen3.5-35B-A3B model startup with expert parallel enabled.

## Test Result

```bash
python3 -m py_compile vllm/model_executor/models/qwen3_5.py
```

Result: passed with no output.

Manual verification: with this change, Qwen3.5-35B-A3B no longer fails during
startup with:

```text
KeyError: 'layers.13.mlp.experts.w13_weight'
```