### PR TITLE
fix: [Transformers v5] Tarsier2ForConditionalGeneration

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1392,14 +1392,6 @@ _MULTIMODAL_EXAMPLE_MODELS = {
             "architectures": ["Tarsier2ForConditionalGeneration"],
             "model_type": "tarsier2",
         },
-        max_transformers_version="5.3",
-        transformers_version_reason={
-            "vllm": (
-                "Qwen2VLConfig was split into Qwen2VLConfig + "
-                "Qwen2VLTextConfig in transformers v5, breaking "
-                "attribute access (num_attention_heads, hidden_size, etc.)"
-            )
-        },
     ),
     "VoxtralForConditionalGeneration": _HfExamplesInfo(
         "mistralai/Voxtral-Mini-3B-2507",

--- a/vllm/transformers_utils/configs/tarsier2.py
+++ b/vllm/transformers_utils/configs/tarsier2.py
@@ -1,24 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from transformers import Qwen2VLConfig
+from transformers import PretrainedConfig, Qwen2VLConfig
+from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLTextConfig
+
+
+def _resolve_text_config(
+    text_config: "PretrainedConfig | dict",
+) -> "PretrainedConfig":
+    """Unwrap a potentially nested text config to a Qwen2VLTextConfig.
+
+    Tarsier2's config.json stores a full Qwen2VLConfig as the text_config
+    field. In Transformers v5, Qwen2VLConfig was split so that text model
+    attributes (e.g. num_attention_heads) live on an inner Qwen2VLTextConfig,
+    not on Qwen2VLConfig itself. This helper digs through that nesting and
+    returns a config object that directly exposes num_attention_heads.
+    """
+    if isinstance(text_config, dict):
+        inner = text_config.get("text_config")
+        if inner is not None:
+            return _resolve_text_config(inner)
+        return Qwen2VLTextConfig(**text_config)
+
+    if isinstance(text_config, PretrainedConfig):
+        if hasattr(text_config, "num_attention_heads"):
+            return text_config
+        inner = getattr(text_config, "text_config", None)
+        if inner is not None:
+            return _resolve_text_config(inner)
+
+    return text_config
 
 
 class Tarsier2Config(Qwen2VLConfig):
     """
-    Tarsier2's config.json is written such that AutoConfig.from_pretrained will create
-    a deeply nested config consisting of:
+    Tarsier2's config.json reports ``model_type: "llava"``, which causes
+    ``AutoConfig.from_pretrained`` to instantiate ``LlavaConfig`` with a
+    ``Qwen2VLConfig`` as its text_config. In Transformers v5, ``Qwen2VLConfig``
+    was split into ``Qwen2VLConfig`` + ``Qwen2VLTextConfig``, so attributes
+    like ``num_attention_heads`` no longer exist directly on ``Qwen2VLConfig``.
 
-    - LlavaConfig
-      - Qwen2VLConfig
-        - Qwen2VLTextConfig
-        - Qwen2VLVisionConfig
-      - Qwen2VLConfig
-        - Qwen2VLTextConfig
-        - Qwen2VLVisionConfig
-
-    When it should really just be a single Qwen2VLConfig.
-
-    This class is a hack to stop AutoConfig from creating the nested config structure.
+    This class is registered under model_type ``"tarsier2"`` (and also under
+    ``"llava"`` to intercept the on-disk model_type) so that the config is
+    loaded as a plain ``Qwen2VLConfig`` equivalent. ``get_text_config`` is
+    overridden to unwrap any remaining nesting and always return a
+    ``Qwen2VLTextConfig`` with the text model attributes present.
     """
 
     model_type = "tarsier2"
+
+    def get_text_config(self, **kwargs) -> PretrainedConfig:
+        text_config = super().get_text_config(**kwargs)
+        return _resolve_text_config(text_config)


### PR DESCRIPTION
## Summary

In Transformers v5, `Qwen2VLConfig` was split into `Qwen2VLConfig` + `Qwen2VLTextConfig`. Text model attributes like `num_attention_heads` and `hidden_size` now live on the inner `Qwen2VLTextConfig`, not directly on `Qwen2VLConfig`.


## Root cause

In Transformers v5, `Qwen2VLConfig` was split into `Qwen2VLConfig` +
`Qwen2VLTextConfig`. Text model attributes like `num_attention_heads` and
`hidden_size` now live on the inner `Qwen2VLTextConfig`, not directly on
`Qwen2VLConfig`.

Tarsier2's `config.json` stores a full `Qwen2VLConfig` as its `text_config`
field. When vLLM calls `get_hf_text_config(config)`, it calls
`config.get_text_config()`, which (via `Qwen2VLConfig.get_text_config`)
returns the `Qwen2VLConfig` sub-object. Because `Qwen2VLConfig` no longer
exposes `num_attention_heads` directly in v5, the check
`hasattr(text_config, "num_attention_heads")` returns `False`, triggering the
`ValueError`.


## Issue

Fixes #38736

Issue: https://github.com/vllm-project/vllm/issues/38736


## Diffstat

```
tests/models/registry.py | 8 -----
 vllm/transformers_utils/configs/tarsier2.py | 55 ++++++++++++++++++++++-------
 2 files changed, 42 insertions(+), 21 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.