### PR TITLE
fix: [Transformers v5] Base model and LoRA used in test has incorrect `tok...

### DIFF
--- a/tests/lora/test_quant_model.py
+++ b/tests/lora/test_quant_model.py
@@ -91,8 +91,8 @@ def test_quant_model_lora(tinyllama_lora_files, model):
         ]
     elif model.quantization == "awq":
         expected_lora_output = [
-            "#f07700: A v",
-            "#f00000: A v",
+            "#f07733: A v",
+            "#f08800: A v",
         ]
     elif model.quantization == "gptq":
         expected_lora_output = [


### PR DESCRIPTION
## Summary

The `jashing/tinyllama-colorist-lora` repo (used as the tokenizer in `test_quant_model_lora`) had its `tokenizer_config.json` updated to set `tokenizer_class` to `PreTrainedTokenizerFast` (the correct value for Transformers v5 compatibility).


## Root cause

The `jashing/tinyllama-colorist-lora` repo (used as the tokenizer in `test_quant_model_lora`) had its `tokenizer_config.json` updated to set `tokenizer_class` to `PreTrainedTokenizerFast` (the correct value for Transformers v5 compatibility). Previously it had a tokenizer class that Transformers v5 handles differently. This caused the model to produce slightly different output tokens, breaking the hardcoded expected values in `tests/lora/test_quant_model.py::test_quant_model_lora[model0]`.

The AWQ expected outputs `['#f07700: A v', '#f00000: A v']` were based on the old (incorrect) tokenizer behavior. With `PreTrainedTokenizerFast` loading from the `tokenizer.json` file (as Transformers v5 does), the correct outputs are `['#f07733: A v', '#f08800: A v']`.


## What changed

`tests/lora/test_quant_model.py` - updated hardcoded `expected_lora_output` values inside `test_quant_model_lora` for the AWQ quantization branch:

- `"#f07700: A v"` changed to `"#f07733: A v"`
- `"#f00000: A v"` changed to `"#f08800: A v"`

These new values reflect the output produced by the correct `PreTrainedTokenizerFast` tokenizer loaded from `jashing/tinyllama-colorist-lora` under Transformers v5.


## Issue

Fixes #38386

Issue: https://github.com/vllm-project/vllm/issues/38386


## Diffstat

```
tests/lora/test_quant_model.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.