### PR TITLE
[BUILD] add wheel name override

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,49 @@ def load_module_from_path(module_name, path):
 
 ROOT_DIR = Path(__file__).parent
 logger = logging.getLogger(__name__)
+PYPROJECT_TOML_PATH = ROOT_DIR / "pyproject.toml"
 
 PRECOMPILED_RUST_FRONTEND_PATH = ROOT_DIR / "vllm" / "vllm-rs"
 
 # cannot import envs directly because it depends on vllm,
 #  which is not installed yet
 envs = load_module_from_path("envs", os.path.join(ROOT_DIR, "vllm", "envs.py"))
+
+
+def get_package_name() -> str:
+    if env_version := os.getenv("VLLM_OVERRIDE_WHEEL_NAME"):
+        logger.info(
+            "Using VLLM_OVERRIDE_WHEEL_NAME=%s as the package name", env_version
+        )
+        return env_version
+    return "vllm"
+
+
+def sync_pyproject_project_name(package_name: str, target_device: str) -> None:
+    pyproject_lines = PYPROJECT_TOML_PATH.read_text(encoding="utf-8").splitlines()
+    in_project_section = False
+    for index, line in enumerate(pyproject_lines):
+        stripped_line = line.strip()
+        if stripped_line == "[project]":
+            in_project_section = True
+            continue
+        if in_project_section and stripped_line.startswith("["):
+            break
+        if in_project_section and stripped_line.startswith("name = "):
+            expected_line = f'name = "{package_name}"'
+            if stripped_line != expected_line:
+                pyproject_lines[index] = expected_line
+                PYPROJECT_TOML_PATH.write_text(
+                    "\n".join(pyproject_lines) + "\n",
+                    encoding="utf-8",
+                )
+                logger.info(
+                    "Updated pyproject.toml project name to %s for %s build",
+                    package_name,
+                    target_device,
+                )
+            break
+
 
 VLLM_TARGET_DEVICE = envs.VLLM_TARGET_DEVICE
 USE_PRECOMPILED_EXTENSIONS = envs.VLLM_USE_PRECOMPILED
@@ -77,6 +114,10 @@ elif sys.platform.startswith("linux") and os.getenv("VLLM_TARGET_DEVICE") is Non
         logger.info("Auto-detected CUDA")
     else:
         VLLM_TARGET_DEVICE = "cpu"
+
+
+PACKAGE_NAME = get_package_name()
+sync_pyproject_project_name(PACKAGE_NAME, VLLM_TARGET_DEVICE)
 
 
 def is_sccache_available() -> bool:
@@ -1158,6 +1199,7 @@ rust_extensions = [
 ]
 
 setup(
+    name=PACKAGE_NAME,
     # static metadata should rather go in pyproject.toml
     version=get_vllm_version(),
     ext_modules=ext_modules,


### PR DESCRIPTION
## Purpose
add a python project renaming machinism to support custom wheel build.
for in-tree device like cpu/xpu/rocm, we can build a wheel with device info. like 
what we have in https://wheels.vllm.ai/rocm/vllm/, https://wheels.vllm.ai/0.22.1/vllm/ while this may not able to upload to pypi. 

intel would like to publish vllm xpu wheels in the near future to pypi channel(https://pypi.org/project/vllm-xpu/), pypi require uploaded wheel name should be same to pypi project name. 

this change should have no side effect to current build pipeline.

build cmd for xpu:
```
VLLM_OVERRIDE_WHEEL_NAME=vllm_xpu VLLM_TARGET_DEVICE=xpu python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
```

cc @bigPYJ1151 @AndreasKaratzas @khluu @simon-mo 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

