### PR TITLE
[Misc] Add unit test for kda_gate_fwd_kernel and chunk_gla_fwd_kernel_o

### DIFF
--- a/tests/kernels/test_kda.py
+++ b/tests/kernels/test_kda.py
@@ -16,8 +16,9 @@ from vllm.model_executor.layers.fla.ops.kda import (
     fused_kda_gate,
 )
 from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
+from vllm.platforms import current_platform
 
-DEVICE = "cuda"
+DEVICE = "xpu" if current_platform.is_xpu() else "cuda"
 
 
 def naive_recurrent_kda(


### PR DESCRIPTION
## Purpose
Enables existing upstream unit tests for `kda_gate_fwd_kernel` and `chunk_gla_fwd_kernel_o`
Triton kernels to run on Intel XPU in `tests/kernels/test_kda.py`.

The only change is a platform-aware `DEVICE` constant - previously hardcoded to `"cuda"`,
now resolved via `current_platform.is_xpu()`. No test logic was modified.

## Test Result

All 10 cases pass