### PR TITLE
Improve Intel macOS CPU extension stability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,15 @@
 /.venv
 /build
 dist
+/.deps
+/.github
+/.mypy_cache
+/.pytest_cache
+/.ruff_cache
+/.cache
+/.DS_Store
+vllm_env/
+**/__pycache__/
 vllm/*.so
 vllm/vllm-rs
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ vllm/vllm-rs
 # Distribution / packaging
 .Python
 build/
+build_py_fallback_check/
 !requirements/build/
 cmake-build-*/
 CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,16 @@ install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
 #
 set(PYTHON_SUPPORTED_VERSIONS "3.10" "3.11" "3.12" "3.13" "3.14")
 
+# In local developer environments, prefer a predictable default python from
+# .venv when available. CI remains explicit by default.
+set(_VLLM_LOCAL_PYTHON_FALLBACK_DEFAULT OFF)
+if(EXISTS "${CMAKE_SOURCE_DIR}/.venv/bin/python" AND NOT DEFINED ENV{CI})
+  set(_VLLM_LOCAL_PYTHON_FALLBACK_DEFAULT ON)
+endif()
+option(VLLM_ALLOW_LOCAL_VENV_PYTHON_FALLBACK
+  "Allow CMake to auto-select ${CMAKE_SOURCE_DIR}/.venv/bin/python when VLLM_PYTHON_EXECUTABLE is unset"
+  ${_VLLM_LOCAL_PYTHON_FALLBACK_DEFAULT})
+
 # Supported AMD GPU architectures.
 set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
 
@@ -70,9 +80,19 @@ set(TORCH_SUPPORTED_VERSION_ROCM "2.11.0")
 if (VLLM_PYTHON_EXECUTABLE)
   find_python_from_executable(${VLLM_PYTHON_EXECUTABLE} "${PYTHON_SUPPORTED_VERSIONS}")
 else()
-  message(FATAL_ERROR
-    "Please set VLLM_PYTHON_EXECUTABLE to the path of the desired python version"
-    " before running cmake configure.")
+  set(_VLLM_LOCAL_PYTHON "${CMAKE_SOURCE_DIR}/.venv/bin/python")
+  if(VLLM_ALLOW_LOCAL_VENV_PYTHON_FALLBACK AND EXISTS "${_VLLM_LOCAL_PYTHON}")
+    set(VLLM_PYTHON_EXECUTABLE "${_VLLM_LOCAL_PYTHON}")
+    message(STATUS
+      "VLLM_PYTHON_EXECUTABLE is not set. Defaulting to ${VLLM_PYTHON_EXECUTABLE}")
+    find_python_from_executable(${VLLM_PYTHON_EXECUTABLE} "${PYTHON_SUPPORTED_VERSIONS}")
+  else()
+    message(FATAL_ERROR
+      "Please set VLLM_PYTHON_EXECUTABLE to the path of the desired python version"
+      " before running cmake configure."
+      " To allow local fallback to ${_VLLM_LOCAL_PYTHON}, set"
+      " -DVLLM_ALLOW_LOCAL_VENV_PYTHON_FALLBACK=ON.")
+  endif()
 endif()
 
 #
@@ -120,6 +140,8 @@ set(SPINLOOP_COMPILE_FLAGS "")
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
   list(APPEND SPINLOOP_COMPILE_FLAGS "-mmwaitx")
 endif()
+# spinloop uses Py_buffer APIs which are unavailable when Py_LIMITED_API is set.
+list(APPEND SPINLOOP_COMPILE_FLAGS "-UPy_LIMITED_API")
 define_extension_target(
   spinloop
   DESTINATION vllm

--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -7,6 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOSX_FOUND TRUE)
+    set(ENABLE_NUMA OFF)
 endif()
 
 
@@ -18,7 +19,9 @@ set(ENABLE_ARM_BF16 $ENV{VLLM_CPU_ARM_BF16})
 
 include_directories("${CMAKE_SOURCE_DIR}/csrc")
 
-set (ENABLE_NUMA TRUE)
+if (NOT DEFINED ENABLE_NUMA)
+    set(ENABLE_NUMA TRUE)
+endif()
 
 #
 # Check the compile flags
@@ -61,15 +64,29 @@ if (NOT MACOSX_FOUND)
     endif()
 endif()
 
-
-function (find_isa CPUINFO TARGET OUT)
-    string(FIND ${CPUINFO} ${TARGET} ISA_FOUND)
-    if(NOT ISA_FOUND EQUAL -1)
-        set(${OUT} ON PARENT_SCOPE)
+# If on macOS (x86) /proc/cpuinfo is not available, populate CPUINFO
+# from sysctl so find_isa() receives a valid first argument and
+# does not fail with incorrect argument count.
+if (MACOSX_FOUND AND NOT DEFINED CPUINFO)
+    execute_process(COMMAND sysctl -a
+                    RESULT_VARIABLE SYSCTL_RET
+                    OUTPUT_VARIABLE CPUINFO
+                    ERROR_QUIET
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT SYSCTL_RET EQUAL 0)
+        # Fall back to a safe placeholder so find_isa() receives a
+        # single-token first argument instead of being empty.
+        set(CPUINFO "none")
     else()
-        set(${OUT} OFF PARENT_SCOPE)
+        # Sanitize CPUINFO to a single token to avoid argument splitting
+        # when expanded unquoted in calls like: find_isa(${CPUINFO} "Power11" ...)
+        string(REGEX REPLACE "\\s+" "_" CPUINFO "${CPUINFO}")
     endif()
-endfunction()
+endif()
+
+
+# find_isa helper removed; detection is performed inline below to avoid
+# argument-splitting issues when CPUINFO contains list separators.
 
 
 function(check_sysctl TARGET OUT)
@@ -93,14 +110,64 @@ if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     check_sysctl(hw.optional.neon ASIMD_FOUND)
     check_sysctl(hw.optional.arm.FEAT_BF16 ARM_BF16_FOUND)
 else()
-    find_isa(${CPUINFO} "Power11" POWER11_FOUND)
-    find_isa(${CPUINFO} "POWER10" POWER10_FOUND)
-    find_isa(${CPUINFO} "POWER9" POWER9_FOUND)
-    find_isa(${CPUINFO} "asimd" ASIMD_FOUND) # Check for ARM NEON support
-    find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
-    find_isa(${CPUINFO} "S390" S390_FOUND)
-    find_isa(${CPUINFO} "zvfhmin" RVV_FP16_FOUND) # Check for RISC-V Vector FP16 support
-    find_isa(${CPUINFO} "zvfbfmin" RVV_BF16_FOUND) # Check for RISC-V Vector BF16 support
+    # Detect various ISAs by searching CPUINFO directly (avoid function calls
+    # which can be sensitive to argument splitting when CPUINFO contains
+    # list-separator characters).
+    string(FIND "${CPUINFO}" "Power11" _ISA_FOUND)
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(POWER11_FOUND ON)
+    else()
+        set(POWER11_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "POWER10" _ISA_FOUND)
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(POWER10_FOUND ON)
+    else()
+        set(POWER10_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "POWER9" _ISA_FOUND)
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(POWER9_FOUND ON)
+    else()
+        set(POWER9_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "asimd" _ISA_FOUND) # Check for ARM NEON support
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(ASIMD_FOUND ON)
+    else()
+        set(ASIMD_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "bf16" _ISA_FOUND) # Check for ARM BF16 support
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(ARM_BF16_FOUND ON)
+    else()
+        set(ARM_BF16_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "S390" _ISA_FOUND)
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(S390_FOUND ON)
+    else()
+        set(S390_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "zvfhmin" _ISA_FOUND) # Check for RISC-V Vector FP16 support
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(RVV_FP16_FOUND ON)
+    else()
+        set(RVV_FP16_FOUND OFF)
+    endif()
+
+    string(FIND "${CPUINFO}" "zvfbfmin" _ISA_FOUND) # Check for RISC-V Vector BF16 support
+    if(NOT _ISA_FOUND EQUAL -1)
+        set(RVV_BF16_FOUND ON)
+    else()
+        set(RVV_BF16_FOUND OFF)
+    endif()
 
     # Support cross-compilation by allowing override via environment variables
     if (ENABLE_ARM_BF16)
@@ -111,13 +178,22 @@ endif()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64" OR ENABLE_X86_ISA)
     set(ENABLE_X86_ISA ON)
-    if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-            CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.3))
-        message(FATAL_ERROR "X86 backend requires gcc/g++ >= 12.3")
+    if (APPLE)
+        if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+                 CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+            message(FATAL_ERROR "macOS x86 backend requires Clang/AppleClang (GCC emits incompatible TLS symbols with PyTorch libc10)")
+        endif()
+    else()
+        if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+                CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.3))
+            message(FATAL_ERROR "X86 backend requires gcc/g++ >= 12.3")
+        endif()
     endif()
     list(APPEND CXX_COMPILE_FLAGS "-mf16c")
     list(APPEND CXX_COMPILE_FLAGS_AVX512 ${CXX_COMPILE_FLAGS})
     list(APPEND CXX_COMPILE_FLAGS_AVX2 ${CXX_COMPILE_FLAGS})
+    list(APPEND CXX_COMPILE_FLAGS_AVX2
+        "-mavx2")
     list(APPEND CXX_COMPILE_FLAGS_AVX512
         "-mavx512f"
         "-mavx512vl"
@@ -129,8 +205,6 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64" OR ENABLE_X86_ISA)
         "-mamx-tile"
         "-mavx512bf16"
         "-mavx512vnni")
-    list(APPEND CXX_COMPILE_FLAGS_AVX2
-        "-mavx2")
 elseif (POWER9_FOUND OR POWER10_FOUND OR POWER11_FOUND)
     message(STATUS "PowerPC detected")
     if (POWER9_FOUND)
@@ -436,20 +510,20 @@ if(USE_ONEDNN)
 endif()
 
 if (ENABLE_X86_ISA)
-    set(VLLM_EXT_SRC_SGL
-        "csrc/cpu/sgl-kernels/conv.cpp"
-        "csrc/cpu/sgl-kernels/gemm.cpp"
-        "csrc/cpu/sgl-kernels/gemm_int8.cpp"
-        "csrc/cpu/sgl-kernels/gemm_fp8.cpp"
-        "csrc/cpu/sgl-kernels/gemm_int4.cpp"
-        "csrc/cpu/sgl-kernels/moe.cpp"
-        "csrc/cpu/sgl-kernels/moe_int8.cpp"
-        "csrc/cpu/sgl-kernels/moe_int4.cpp"
-        "csrc/cpu/sgl-kernels/moe_fp8.cpp")
+    if (NOT MACOSX_FOUND)
+        set(VLLM_EXT_SRC_SGL
+            "csrc/cpu/sgl-kernels/conv.cpp"
+            "csrc/cpu/sgl-kernels/gemm.cpp"
+            "csrc/cpu/sgl-kernels/gemm_int8.cpp"
+            "csrc/cpu/sgl-kernels/gemm_fp8.cpp"
+            "csrc/cpu/sgl-kernels/gemm_int4.cpp"
+            "csrc/cpu/sgl-kernels/moe.cpp"
+            "csrc/cpu/sgl-kernels/moe_int8.cpp"
+            "csrc/cpu/sgl-kernels/moe_int4.cpp"
+            "csrc/cpu/sgl-kernels/moe_fp8.cpp")
+    endif()
 
     set(VLLM_EXT_SRC_AVX512
-        "csrc/cpu/sgl-kernels/fla.cpp"
-        "csrc/cpu/shm.cpp"
         "csrc/cpu/cpu_wna16.cpp"
         "csrc/cpu/cpu_fused_moe.cpp"
         "csrc/cpu/utils.cpp"
@@ -464,8 +538,13 @@ if (ENABLE_X86_ISA)
         "csrc/cpu/pos_encoding.cpp"
         "csrc/moe/dynamic_4bit_int_moe_cpu.cpp") 
 
+    if (NOT MACOSX_FOUND)
+        list(PREPEND VLLM_EXT_SRC_AVX512
+            "csrc/cpu/sgl-kernels/fla.cpp"
+            "csrc/cpu/shm.cpp")
+    endif()
+
     set(VLLM_EXT_SRC_AVX2
-        "csrc/cpu/sgl-kernels/fla.cpp"
         "csrc/cpu/utils.cpp"
         "csrc/cpu/spec_decode_utils.cpp"
         "csrc/cpu/cpu_attn.cpp"
@@ -478,13 +557,36 @@ if (ENABLE_X86_ISA)
         "csrc/cpu/pos_encoding.cpp"
         "csrc/moe/dynamic_4bit_int_moe_cpu.cpp") 
 
+    if (NOT MACOSX_FOUND)
+        list(PREPEND VLLM_EXT_SRC_AVX2
+            "csrc/cpu/sgl-kernels/fla.cpp")
+    endif()
+
+    # On macOS x86, importing AVX512/AMX-compiled extension modules can raise
+    # SIGILL on machines without those features during dynamic loading. Build
+    # all CPU ISA-named modules from the AVX2-safe source set/flags instead.
+    if (MACOSX_FOUND)
+        set(VLLM_EXT_SRC_AVX512 ${VLLM_EXT_SRC_AVX2})
+        set(VLLM_EXT_SRC_SGL)
+        set(CPU_EXT_FLAGS_MAIN ${CXX_COMPILE_FLAGS_AVX2})
+        set(CPU_EXT_FLAGS_AVX512 ${CXX_COMPILE_FLAGS_AVX2})
+    else()
+        set(CPU_EXT_FLAGS_MAIN ${CXX_COMPILE_FLAGS_AVX512_AMX})
+        set(CPU_EXT_FLAGS_AVX512 ${CXX_COMPILE_FLAGS_AVX512})
+    endif()
+
     message(STATUS "CPU extension (AVX512F + BF16 + VNNI + AMX) source files: ${VLLM_EXT_SRC_AVX512} ${VLLM_EXT_SRC_SGL}")
     message(STATUS "CPU extension (AVX512F) source files: ${VLLM_EXT_SRC_AVX512}")
     message(STATUS "CPU extension (AVX2) source files: ${VLLM_EXT_SRC_AVX2}")
 
-    set(_C_LIBS numa dnnl_ext)
-    set(_C_AVX512_LIBS numa dnnl_ext)
-    set(_C_AVX2_LIBS numa dnnl_ext)
+    set(_C_LIBS dnnl_ext)
+    set(_C_AVX512_LIBS dnnl_ext)
+    set(_C_AVX2_LIBS dnnl_ext)
+    if(ENABLE_NUMA)
+        list(APPEND _C_LIBS numa)
+        list(APPEND _C_AVX512_LIBS numa)
+        list(APPEND _C_AVX2_LIBS numa)
+    endif()
 
     # AMX + AVX512F + AVX512BF16 + AVX512VNNI
     define_extension_target(
@@ -493,13 +595,15 @@ if (ENABLE_X86_ISA)
         LANGUAGE CXX
         SOURCES ${VLLM_EXT_SRC_AVX512} ${VLLM_EXT_SRC_SGL}
         LIBRARIES ${_C_LIBS}
-        COMPILE_FLAGS ${CXX_COMPILE_FLAGS_AVX512_AMX}
+        COMPILE_FLAGS ${CPU_EXT_FLAGS_MAIN}
         USE_SABI 3
         WITH_SOABI
     )
 
-    # For AMX kernels
-    target_compile_definitions(_C PRIVATE "-DCPU_CAPABILITY_AMXBF16")
+    if (NOT MACOSX_FOUND)
+        # For AMX kernels
+        target_compile_definitions(_C PRIVATE "-DCPU_CAPABILITY_AMXBF16")
+    endif()
 
     # AVX512F 
     define_extension_target(
@@ -508,10 +612,11 @@ if (ENABLE_X86_ISA)
         LANGUAGE CXX
         SOURCES ${VLLM_EXT_SRC_AVX512}
         LIBRARIES ${_C_AVX512_LIBS}
-        COMPILE_FLAGS ${CXX_COMPILE_FLAGS_AVX512}
+        COMPILE_FLAGS ${CPU_EXT_FLAGS_AVX512}
         USE_SABI 3
         WITH_SOABI
     )
+    target_compile_definitions(_C_AVX512 PRIVATE VLLM_PYTHON_MODULE_NAME=_C_AVX512 VLLM_CPU_ISA_VARIANT_MODULE)
 
     # AVX2 
     define_extension_target(
@@ -524,6 +629,7 @@ if (ENABLE_X86_ISA)
         USE_SABI 3
         WITH_SOABI
     )
+    target_compile_definitions(_C_AVX2 PRIVATE VLLM_PYTHON_MODULE_NAME=_C_AVX2 VLLM_CPU_ISA_VARIANT_MODULE)
 else()
     message(STATUS "CPU extension source files: ${VLLM_EXT_SRC}")
     #

--- a/csrc/core/scalar_type.hpp
+++ b/csrc/core/scalar_type.hpp
@@ -7,7 +7,12 @@
 #include <variant>
 
 // For STD_TORCH_CHECK
-#include <torch/headeronly/util/Exception.h>
+#if __has_include(<torch/headeronly/util/Exception.h>)
+  #include <torch/headeronly/util/Exception.h>
+#else
+  #include <c10/util/Exception.h>
+  #define STD_TORCH_CHECK TORCH_CHECK
+#endif
 
 namespace vllm {
 

--- a/csrc/cpu/cpu_attn_vec.hpp
+++ b/csrc/cpu/cpu_attn_vec.hpp
@@ -102,7 +102,9 @@ class TileGemm82 {
     kv_cache_t* __restrict__ curr_b = b_tile;
 
     for (int32_t k = 0; k < dynamic_k_size; ++k) {
-      auto [fp32_b_0_reg, fp32_b_1_reg] = load_b_pair_vec(curr_b);
+      auto b_pair = load_b_pair_vec(curr_b);
+      auto fp32_b_0_reg = b_pair.first;
+      auto fp32_b_1_reg = b_pair.second;
 
       float* __restrict__ curr_m_a = curr_a;
       vec_op::unroll_loop<int32_t, M>([&](int32_t i) {

--- a/csrc/cpu/cpu_types.hpp
+++ b/csrc/cpu/cpu_types.hpp
@@ -23,6 +23,10 @@
 
 #ifdef _OPENMP
   #include <omp.h>
+#else
+inline int omp_get_max_threads() { return 1; }
+inline int omp_get_num_threads() { return 1; }
+inline int omp_get_thread_num() { return 0; }
 #endif
 
 #endif

--- a/csrc/cpu/cpu_types_x86.hpp
+++ b/csrc/cpu/cpu_types_x86.hpp
@@ -532,7 +532,8 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
             _mm512_bslli_epi128(_mm512_cvtepu16_epi32(v.reg), 2))) {}
 
   explicit FP32Vec16(const BF16Vec32& v, int upper) {
-    __m256i v_half_i = _mm512_extracti32x8_epi32(v.reg, upper);
+    __m256i v_half_i = upper ? _mm512_extracti32x8_epi32(v.reg, 1)
+                             : _mm512_extracti32x8_epi32(v.reg, 0);
     reg = _mm512_cvtph_ps(v_half_i);
   }
 

--- a/csrc/cpu/shm.cpp
+++ b/csrc/cpu/shm.cpp
@@ -348,8 +348,13 @@ class SHMManager {
                                std::to_string(errno));
     }
 
-    void* shm_ptr = mmap(nullptr, shm_size, PROT_READ | PROT_WRITE,
-                         MAP_SHARED | MAP_POPULATE, fd, 0);
+    int mmap_flags = MAP_SHARED;
+#ifdef MAP_POPULATE
+    mmap_flags |= MAP_POPULATE;
+#endif
+
+    void* shm_ptr =
+        mmap(nullptr, shm_size, PROT_READ | PROT_WRITE, mmap_flags, fd, 0);
 
     if (shm_ptr == MAP_FAILED) {
       TORCH_CHECK(false,

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -4,9 +4,17 @@
 
 #include <torch/library.h>
 
+#include <string>
+
 // Note: overwrite the external definition for sharing same name between
 // libraries use different ISAs.
 #define TORCH_EXTENSION_NAME _C
+
+// Keep ops registered under torch.ops._C for all CPU ISA variants, but allow
+// each shared library to export its own Python init symbol.
+#ifndef VLLM_PYTHON_MODULE_NAME
+  #define VLLM_PYTHON_MODULE_NAME TORCH_EXTENSION_NAME
+#endif
 
 void release_dnnl_matmul_handler(int64_t handler);
 
@@ -90,6 +98,16 @@ at::Tensor fp8_scaled_mm_cpu(at::Tensor& mat1, at::Tensor& mat2,
                              std::vector<int64_t> block_size,
                              const std::optional<at::Tensor>& bias,
                              at::ScalarType out_dtype, bool is_vnni);
+
+#if defined(__APPLE__)
+at::Tensor fp8_scaled_mm_cpu(at::Tensor& mat1, at::Tensor& mat2,
+                             at::Tensor& scales2,
+                             std::vector<int64_t> block_size,
+                             const std::optional<at::Tensor>& bias,
+                             at::ScalarType out_dtype, bool is_vnni) {
+  TORCH_CHECK(false, "fp8_scaled_mm_cpu is not available in macOS CPU builds");
+}
+#endif
 
 // Adapted from sglang: INT4 W4A8 kernels
 std::tuple<at::Tensor, at::Tensor, at::Tensor> convert_weight_packed_scale_zp(
@@ -259,364 +277,400 @@ void sample_recovered_tokens_kernel_impl(
     const int64_t vocab_size, const bool no_draft_probs);
 }  // namespace cpu_utils
 
-TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
-  // vLLM custom ops
+#if defined(VLLM_CPU_ISA_VARIANT_MODULE)
+namespace {
 
-  ops.def(
-      "dynamic_4bit_int_moe("
-      "Tensor x, Tensor topk_ids, Tensor topk_weights,"
-      "Tensor w13_packed, Tensor w2_packed, int H, int I, int I2,"
-      "int group_size, bool apply_router_weight_on_input, int activation_kind"
-      ") -> Tensor");
+bool is_duplicate_registration_error(const c10::Error& e) {
+  const std::string msg = e.what();
+  return msg.find("same name and overload name multiple times") !=
+         std::string::npos;
+}
 
-  ops.impl("dynamic_4bit_int_moe", torch::kCPU, &dynamic_4bit_int_moe_cpu);
+}  // namespace
+#endif
 
-  // Activation ops
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, ops) {
+#if defined(VLLM_CPU_ISA_VARIANT_MODULE)
+  try {
+#endif
+    // vLLM custom ops
 
-  // Activation function used in SwiGLU.
-  ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");
-  ops.impl("silu_and_mul", torch::kCPU, &silu_and_mul);
+    ops.def(
+        "dynamic_4bit_int_moe("
+        "Tensor x, Tensor topk_ids, Tensor topk_weights,"
+        "Tensor w13_packed, Tensor w2_packed, int H, int I, int I2,"
+        "int group_size, bool apply_router_weight_on_input, int activation_kind"
+        ") -> Tensor");
 
-  // Activation function used in GeGLU with `none` approximation.
-  ops.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
-  ops.impl("gelu_and_mul", torch::kCPU, &gelu_and_mul);
+    ops.impl("dynamic_4bit_int_moe", torch::kCPU, &dynamic_4bit_int_moe_cpu);
 
-  // Activation function used in GeGLU with `tanh` approximation.
-  ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
-  ops.impl("gelu_tanh_and_mul", torch::kCPU, &gelu_tanh_and_mul);
+    // Activation ops
 
-  // GELU implementation used in GPT-2.
-  ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
-  ops.impl("gelu_new", torch::kCPU, &gelu_new);
+    // Activation function used in SwiGLU.
+    ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");
+    ops.impl("silu_and_mul", torch::kCPU, &silu_and_mul);
 
-  // Approximate GELU implementation.
-  ops.def("gelu_fast(Tensor! out, Tensor input) -> ()");
-  ops.impl("gelu_fast", torch::kCPU, &gelu_fast);
+    // Activation function used in GeGLU with `none` approximation.
+    ops.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
+    ops.impl("gelu_and_mul", torch::kCPU, &gelu_and_mul);
 
-  // Quick GELU implementation.
-  ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
-  ops.impl("gelu_quick", torch::kCPU, &gelu_quick);
+    // Activation function used in GeGLU with `tanh` approximation.
+    ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
+    ops.impl("gelu_tanh_and_mul", torch::kCPU, &gelu_tanh_and_mul);
+
+    // GELU implementation used in GPT-2.
+    ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
+    ops.impl("gelu_new", torch::kCPU, &gelu_new);
+
+    // Approximate GELU implementation.
+    ops.def("gelu_fast(Tensor! out, Tensor input) -> ()");
+    ops.impl("gelu_fast", torch::kCPU, &gelu_fast);
+
+    // Quick GELU implementation.
+    ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
+    ops.impl("gelu_quick", torch::kCPU, &gelu_quick);
 
 #if (defined(__aarch64__) && !defined(__APPLE__))
 
-  ops.def(
-      "activation_lut_bf16(Tensor! out, Tensor input, str activation)"
-      " -> ()");
-  ops.impl("activation_lut_bf16", torch::kCPU, &activation_lut_bf16);
+    ops.def(
+        "activation_lut_bf16(Tensor! out, Tensor input, str activation)"
+        " -> ()");
+    ops.impl("activation_lut_bf16", torch::kCPU, &activation_lut_bf16);
 
 #endif  // (defined(__aarch64__) && !defined(__APPLE__))
 
-  // Layernorm
-  // Apply Root Mean Square (RMS) Normalization to the input tensor.
-  ops.def(
-      "rms_norm(Tensor! out, Tensor input, Tensor weight, float epsilon) -> "
-      "()");
-  ops.impl("rms_norm", torch::kCPU, &rms_norm);
+    // Layernorm
+    // Apply Root Mean Square (RMS) Normalization to the input tensor.
+    ops.def(
+        "rms_norm(Tensor! out, Tensor input, Tensor weight, float epsilon) -> "
+        "()");
+    ops.impl("rms_norm", torch::kCPU, &rms_norm);
 
-  // In-place fused Add and RMS Normalization.
-  ops.def(
-      "fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
-      "float epsilon) -> ()");
-  ops.impl("fused_add_rms_norm", torch::kCPU, &fused_add_rms_norm);
+    // In-place fused Add and RMS Normalization.
+    ops.def(
+        "fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
+        "float epsilon) -> ()");
+    ops.impl("fused_add_rms_norm", torch::kCPU, &fused_add_rms_norm);
 
-  // Rotary embedding
-  // Apply GPT-NeoX or GPT-J style rotary embedding to query and key.
-  ops.def(
-      "rotary_embedding(Tensor positions, Tensor! query,"
-      "                 Tensor!? key, int head_size,"
-      "                 Tensor cos_sin_cache, bool is_neox, int "
-      "rope_dim_offset=0, bool inverse=False) -> ()");
-  ops.impl("rotary_embedding", torch::kCPU, &rotary_embedding);
+    // Rotary embedding
+    // Apply GPT-NeoX or GPT-J style rotary embedding to query and key.
+    ops.def(
+        "rotary_embedding(Tensor positions, Tensor! query,"
+        "                 Tensor!? key, int head_size,"
+        "                 Tensor cos_sin_cache, bool is_neox, int "
+        "rope_dim_offset=0, bool inverse=False) -> ()");
+    ops.impl("rotary_embedding", torch::kCPU, &rotary_embedding);
 
-  // Quantization
+    // Quantization
 #if defined(__AVX512F__) || defined(__AVX2__) || \
     (defined(__aarch64__) && !defined(__APPLE__)) || defined(__powerpc64__)
-  // Helper function to release oneDNN handlers
-  ops.def("release_dnnl_matmul_handler(int handler) -> ()",
-          &release_dnnl_matmul_handler);
+    // Helper function to release oneDNN handlers
+    ops.def("release_dnnl_matmul_handler(int handler) -> ()",
+            &release_dnnl_matmul_handler);
 
-  // Create oneDNN GEMM handler
-  ops.def(
-      "create_onednn_mm_handler(Tensor b, int "
-      "primitive_cache_size) -> int",
-      &create_onednn_mm_handler);
+    // Create oneDNN GEMM handler
+    ops.def(
+        "create_onednn_mm_handler(Tensor b, int "
+        "primitive_cache_size) -> int",
+        &create_onednn_mm_handler);
 
-  // oneDNN GEMM
-  ops.def(
-      "onednn_mm(Tensor! c, Tensor a, Tensor? bias, "
-      "Tensor handler_tensor) -> ()");
-  ops.impl("onednn_mm", torch::kCPU, &onednn_mm);
+    // oneDNN GEMM
+    ops.def(
+        "onednn_mm(Tensor! c, Tensor a, Tensor? bias, "
+        "Tensor handler_tensor) -> ()");
+    ops.impl("onednn_mm", torch::kCPU, &onednn_mm);
 
-  // Check if oneDNN was built with ACL backend
-  ops.def("is_onednn_acl_supported() -> bool", &is_onednn_acl_supported);
+    // Check if oneDNN was built with ACL backend
+    ops.def("is_onednn_acl_supported() -> bool", &is_onednn_acl_supported);
 
-  // Create oneDNN W8A8 handler
-  ops.def(
-      "create_onednn_scaled_mm_handler(Tensor b, Tensor b_scales, ScalarType "
-      "output_type, bool dynamic_act_quant, bool use_azp, int "
-      "primitive_cache_size) -> int",
-      &create_onednn_scaled_mm_handler);
+    // Create oneDNN W8A8 handler
+    ops.def(
+        "create_onednn_scaled_mm_handler(Tensor b, Tensor b_scales, ScalarType "
+        "output_type, bool dynamic_act_quant, bool use_azp, int "
+        "primitive_cache_size) -> int",
+        &create_onednn_scaled_mm_handler);
 
-  // oneDNN scaled_mm for W8A8 with static per-tensor activation quantization
-  ops.def(
-      "onednn_scaled_mm(Tensor! c, Tensor a, Tensor a_scales, Tensor? azp, "
-      "Tensor? azp_adj, Tensor? bias, Tensor handler_tensor) -> ()");
-  ops.impl("onednn_scaled_mm", torch::kCPU, &onednn_scaled_mm);
+    // oneDNN scaled_mm for W8A8 with static per-tensor activation quantization
+    ops.def(
+        "onednn_scaled_mm(Tensor! c, Tensor a, Tensor a_scales, Tensor? azp, "
+        "Tensor? azp_adj, Tensor? bias, Tensor handler_tensor) -> ()");
+    ops.impl("onednn_scaled_mm", torch::kCPU, &onednn_scaled_mm);
 
-  // Compute int8 quantized tensor for given scaling factor.
-  ops.def(
-      "static_scaled_int8_quant(Tensor! out, Tensor input, Tensor scale,"
-      "Tensor? azp) -> ()");
-  ops.impl("static_scaled_int8_quant", torch::kCPU, &static_scaled_int8_quant);
+    // Compute int8 quantized tensor for given scaling factor.
+    ops.def(
+        "static_scaled_int8_quant(Tensor! out, Tensor input, Tensor scale,"
+        "Tensor? azp) -> ()");
+    ops.impl("static_scaled_int8_quant", torch::kCPU,
+             &static_scaled_int8_quant);
 
-  // Compute int8 quantized tensor and scaling factor
-  ops.def(
-      "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale, "
-      "Tensor!? azp) -> ()");
-  ops.impl("dynamic_scaled_int8_quant", torch::kCPU,
-           &dynamic_scaled_int8_quant);
+    // Compute int8 quantized tensor and scaling factor
+    ops.def(
+        "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale, "
+        "Tensor!? azp) -> ()");
+    ops.impl("dynamic_scaled_int8_quant", torch::kCPU,
+             &dynamic_scaled_int8_quant);
 #endif
 
 // SHM CCL
-#if defined(__AVX512F__) || (defined(__aarch64__) && !defined(__APPLE__)) || \
-    defined(__powerpc64__)
-  ops.def(
-      "init_shm_manager(str name, int group_size, int rank, int thread_num) -> "
-      "int",
-      &init_shm_manager);
-  ops.def("join_shm_manager(int handle, str name) -> str", &join_shm_manager);
-  ops.def("shm_allreduce(int handle, Tensor! data) -> ()");
-  ops.impl("shm_allreduce", torch::kCPU, &shm_allreduce);
-  ops.def(
-      "shm_gather(int handle, Tensor data, Tensor[](a!)? outputs, int dst) -> "
-      "()");
-  ops.impl("shm_gather", torch::kCPU, &shm_gather);
-  ops.def(
-      "shm_all_gather(int handle, Tensor data, Tensor! output) -> "
-      "()");
-  ops.impl("shm_all_gather", torch::kCPU, &shm_all_gather);
-  ops.def(
-      "shm_send_tensor_list(int handle, Tensor[](a) tensor_list, int dst) -> "
-      "()");
-  ops.impl("shm_send_tensor_list", torch::kCPU, &shm_send_tensor_list);
-  ops.def("shm_recv_tensor_list(int handle, int src) -> Tensor[](a)",
-          &shm_recv_tensor_list);
+#if ((defined(__AVX512F__) && !defined(__APPLE__)) || \
+     (defined(__aarch64__) && !defined(__APPLE__)) || defined(__powerpc64__))
+    ops.def(
+        "init_shm_manager(str name, int group_size, int rank, int thread_num) "
+        "-> "
+        "int",
+        &init_shm_manager);
+    ops.def("join_shm_manager(int handle, str name) -> str", &join_shm_manager);
+    ops.def("shm_allreduce(int handle, Tensor! data) -> ()");
+    ops.impl("shm_allreduce", torch::kCPU, &shm_allreduce);
+    ops.def(
+        "shm_gather(int handle, Tensor data, Tensor[](a!)? outputs, int dst) "
+        "-> "
+        "()");
+    ops.impl("shm_gather", torch::kCPU, &shm_gather);
+    ops.def(
+        "shm_all_gather(int handle, Tensor data, Tensor! output) -> "
+        "()");
+    ops.impl("shm_all_gather", torch::kCPU, &shm_all_gather);
+    ops.def(
+        "shm_send_tensor_list(int handle, Tensor[](a) tensor_list, int dst) -> "
+        "()");
+    ops.impl("shm_send_tensor_list", torch::kCPU, &shm_send_tensor_list);
+    ops.def("shm_recv_tensor_list(int handle, int src) -> Tensor[](a)",
+            &shm_recv_tensor_list);
 #endif  // #if defined(__AVX512F__) || defined(__aarch64__)
 
-  // sgl-kernels
-#if defined(__AVX512BF16__) && defined(__AVX512F__) && defined(__AVX512VNNI__)
-  ops.def(
-      "weight_packed_linear(Tensor(a0!) mat1, Tensor(a1!) mat2, Tensor(a2!)? "
-      "bias, bool is_vnni) -> Tensor");
-  ops.impl("weight_packed_linear", torch::kCPU, &weight_packed_linear);
-  ops.def("convert_weight_packed(Tensor! weight) -> Tensor");
-  ops.impl("convert_weight_packed", torch::kCPU, &convert_weight_packed);
-  ops.def("convert_scale_packed(Tensor! scale) -> Tensor");
-  ops.impl("convert_scale_packed", torch::kCPU, &convert_scale_packed);
-  ops.def(
-      "fused_experts_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor "
-      "topk_weights, Tensor topk_ids, bool "
-      "inplace, int moe_comp_method, Tensor? w1_scale, Tensor? w2_scale, "
-      "Tensor? w1_zero, Tensor? w2_zero, int[]? block_size, "
-      "Tensor? w1_bias, Tensor? w2_bias, float? alpha, float? limit, "
-      "bool is_vnni) -> "
-      "Tensor");
-  ops.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);
-  ops.def(
-      "int8_scaled_mm_with_quant(Tensor mat1, Tensor mat2, Tensor scales2, "
-      "Tensor? bias, ScalarType out_dtype, bool is_vnni) -> Tensor");
-  ops.impl("int8_scaled_mm_with_quant", torch::kCPU,
-           &int8_scaled_mm_with_quant);
+    // sgl-kernels
+#if defined(__AVX512BF16__) && defined(__AVX512F__) && \
+    defined(__AVX512VNNI__) && !defined(__APPLE__)
+    ops.def(
+        "weight_packed_linear(Tensor(a0!) mat1, Tensor(a1!) mat2, Tensor(a2!)? "
+        "bias, bool is_vnni) -> Tensor");
+    ops.impl("weight_packed_linear", torch::kCPU, &weight_packed_linear);
+    ops.def("convert_weight_packed(Tensor! weight) -> Tensor");
+    ops.impl("convert_weight_packed", torch::kCPU, &convert_weight_packed);
+    ops.def("convert_scale_packed(Tensor! scale) -> Tensor");
+    ops.impl("convert_scale_packed", torch::kCPU, &convert_scale_packed);
+    ops.def(
+        "fused_experts_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor "
+        "topk_weights, Tensor topk_ids, bool "
+        "inplace, int moe_comp_method, Tensor? w1_scale, Tensor? w2_scale, "
+        "Tensor? w1_zero, Tensor? w2_zero, int[]? block_size, "
+        "Tensor? w1_bias, Tensor? w2_bias, float? alpha, float? limit, "
+        "bool is_vnni) -> "
+        "Tensor");
+    ops.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);
+    ops.def(
+        "int8_scaled_mm_with_quant(Tensor mat1, Tensor mat2, Tensor scales2, "
+        "Tensor? bias, ScalarType out_dtype, bool is_vnni) -> Tensor");
+    ops.impl("int8_scaled_mm_with_quant", torch::kCPU,
+             &int8_scaled_mm_with_quant);
 
-  // Adapted from sglang: INT4 W4A8 kernels
-  ops.def(
-      "convert_weight_packed_scale_zp(Tensor weight, Tensor qzeros, Tensor "
-      "scales, int quant_method_4bit) -> (Tensor, "
-      "Tensor, Tensor)");
-  ops.impl("convert_weight_packed_scale_zp", torch::kCPU,
-           &convert_weight_packed_scale_zp);
+    // Adapted from sglang: INT4 W4A8 kernels
+    ops.def(
+        "convert_weight_packed_scale_zp(Tensor weight, Tensor qzeros, Tensor "
+        "scales, int quant_method_4bit) -> (Tensor, "
+        "Tensor, Tensor)");
+    ops.impl("convert_weight_packed_scale_zp", torch::kCPU,
+             &convert_weight_packed_scale_zp);
 
-  ops.def(
-      "int4_scaled_mm_cpu(Tensor(a0!) x, Tensor(a1!) w, Tensor(a2!) w_zeros, "
-      "Tensor(a3!) w_scales, Tensor? bias) -> Tensor");
-  ops.impl("int4_scaled_mm_cpu", torch::kCPU, &int4_scaled_mm_cpu);
+    ops.def(
+        "int4_scaled_mm_cpu(Tensor(a0!) x, Tensor(a1!) w, Tensor(a2!) w_zeros, "
+        "Tensor(a3!) w_scales, Tensor? bias) -> Tensor");
+    ops.impl("int4_scaled_mm_cpu", torch::kCPU, &int4_scaled_mm_cpu);
 
-  // Adapted from sglang: FP8 W8A16 kernel
-  ops.def(
-      "fp8_scaled_mm_cpu(Tensor(a0!) mat1, Tensor(a1!) mat2, Tensor(a2!) "
-      "scales2, SymInt[] block_size, Tensor? bias, ScalarType out_dtype, "
-      "bool is_vnni) -> Tensor");
-  ops.impl("fp8_scaled_mm_cpu", torch::kCPU, &fp8_scaled_mm_cpu);
+    // Adapted from sglang: FP8 W8A16 kernel
+    ops.def(
+        "fp8_scaled_mm_cpu(Tensor(a0!) mat1, Tensor(a1!) mat2, Tensor(a2!) "
+        "scales2, SymInt[] block_size, Tensor? bias, ScalarType out_dtype, "
+        "bool is_vnni) -> Tensor");
+    ops.impl("fp8_scaled_mm_cpu", torch::kCPU, &fp8_scaled_mm_cpu);
 
-  // Adapted from sglang: casual_conv1d kernels
-  ops.def("causal_conv1d_weight_pack(Tensor weight) -> Tensor");
-  ops.impl("causal_conv1d_weight_pack", torch::kCPU,
-           &causal_conv1d_weight_pack);
-  ops.def(
-      "causal_conv1d_fwd_cpu(Tensor x, Tensor weight, Tensor? bias, Tensor? "
-      "conv_states, Tensor? query_start_loc,"
-      "Tensor? cache_indices, Tensor? has_initial_state, bool silu_activation, "
-      "int pad_slot_id, bool is_vnni) -> "
-      "Tensor");
-  ops.impl("causal_conv1d_fwd_cpu", torch::kCPU, &causal_conv1d_fwd_cpu);
-  ops.def(
-      "causal_conv1d_update_cpu(Tensor x, Tensor(a!) conv_states, Tensor "
-      "weight, Tensor? bias, bool silu_activation,"
-      "Tensor? cache_seqlens, Tensor? conv_state_indices, int pad_slot_id, "
-      "bool is_vnni) -> Tensor");
-  ops.impl("causal_conv1d_update_cpu", torch::kCPU, &causal_conv1d_update_cpu);
+    // Adapted from sglang: casual_conv1d kernels
+    ops.def("causal_conv1d_weight_pack(Tensor weight) -> Tensor");
+    ops.impl("causal_conv1d_weight_pack", torch::kCPU,
+             &causal_conv1d_weight_pack);
+    ops.def(
+        "causal_conv1d_fwd_cpu(Tensor x, Tensor weight, Tensor? bias, Tensor? "
+        "conv_states, Tensor? query_start_loc,"
+        "Tensor? cache_indices, Tensor? has_initial_state, bool "
+        "silu_activation, "
+        "int pad_slot_id, bool is_vnni) -> "
+        "Tensor");
+    ops.impl("causal_conv1d_fwd_cpu", torch::kCPU, &causal_conv1d_fwd_cpu);
+    ops.def(
+        "causal_conv1d_update_cpu(Tensor x, Tensor(a!) conv_states, Tensor "
+        "weight, Tensor? bias, bool silu_activation,"
+        "Tensor? cache_seqlens, Tensor? conv_state_indices, int pad_slot_id, "
+        "bool is_vnni) -> Tensor");
+    ops.impl("causal_conv1d_update_cpu", torch::kCPU,
+             &causal_conv1d_update_cpu);
 #endif
 
-  // Adapted from sglang: GDN kernels
-  ops.def(
-      "chunk_gated_delta_rule_cpu(Tensor query, Tensor key, Tensor value, "
-      "Tensor g, Tensor beta, "
-      "Tensor initial_state, bool output_final_state, Tensor cu_seqlens, bool "
-      "head_first, "
-      "bool use_qk_l2norm_in_kernel, float eps=1e-5) -> (Tensor, Tensor)");
-  ops.impl("chunk_gated_delta_rule_cpu", torch::kCPU,
-           &chunk_gated_delta_rule_cpu);
-  ops.def(
-      "fused_sigmoid_gating_delta_rule_update_cpu(Tensor A_log, Tensor "
-      "dt_bias, Tensor q, Tensor k, Tensor v, Tensor "
-      "a, Tensor b, Tensor(a!) initial_state_source, Tensor "
-      "initial_state_indices, Tensor cu_seqlens, bool "
-      "use_qk_l2norm_in_kernel, float softplus_beta=1.0, float "
-      "softplus_threshold=20.0) -> Tensor");
-  ops.impl("fused_sigmoid_gating_delta_rule_update_cpu", torch::kCPU,
-           &fused_sigmoid_gating_delta_rule_update_cpu);
-  ops.def(
-      "fused_gdn_gating_cpu(Tensor A_log, Tensor a, Tensor b, Tensor dt_bias) "
-      "-> (Tensor, Tensor)");
-  ops.impl("fused_gdn_gating_cpu", torch::kCPU, &fused_gdn_gating_cpu);
+    // Adapted from sglang: GDN kernels
+#if !defined(__APPLE__)
+    ops.def(
+        "chunk_gated_delta_rule_cpu(Tensor query, Tensor key, Tensor value, "
+        "Tensor g, Tensor beta, "
+        "Tensor initial_state, bool output_final_state, Tensor cu_seqlens, "
+        "bool "
+        "head_first, "
+        "bool use_qk_l2norm_in_kernel, float eps=1e-5) -> (Tensor, Tensor)");
+    ops.impl("chunk_gated_delta_rule_cpu", torch::kCPU,
+             &chunk_gated_delta_rule_cpu);
+    ops.def(
+        "fused_sigmoid_gating_delta_rule_update_cpu(Tensor A_log, Tensor "
+        "dt_bias, Tensor q, Tensor k, Tensor v, Tensor "
+        "a, Tensor b, Tensor(a!) initial_state_source, Tensor "
+        "initial_state_indices, Tensor cu_seqlens, bool "
+        "use_qk_l2norm_in_kernel, float softplus_beta=1.0, float "
+        "softplus_threshold=20.0) -> Tensor");
+    ops.impl("fused_sigmoid_gating_delta_rule_update_cpu", torch::kCPU,
+             &fused_sigmoid_gating_delta_rule_update_cpu);
+    ops.def(
+        "fused_gdn_gating_cpu(Tensor A_log, Tensor a, Tensor b, Tensor "
+        "dt_bias) "
+        "-> (Tensor, Tensor)");
+    ops.impl("fused_gdn_gating_cpu", torch::kCPU, &fused_gdn_gating_cpu);
+#endif
 
-  // CPU attention kernels
-  ops.def(
-      "get_scheduler_metadata(int num_req, int num_heads_q, int num_heads_kv, "
-      "int head_dim, Tensor seq_lens, ScalarType dtype, Tensor "
-      "query_start_loc, bool casual, int window_size, str isa_hint, bool "
-      "enable_kv_split) -> Tensor",
-      &get_scheduler_metadata);
-  ops.def(
-      "cpu_attn_reshape_and_cache(Tensor key, Tensor value, Tensor(a2!) "
-      "key_cache, Tensor(a3!) value_cache, Tensor slot_mapping, str isa, "
-      "float k_scale=1.0, float v_scale=1.0, str kv_cache_dtype=\"auto\") -> "
-      "()",
-      &cpu_attn_reshape_and_cache);
-  ops.def(
-      "cpu_attention_with_kv_cache(Tensor query, Tensor key_cache, Tensor "
-      "value_cache, Tensor(a3!) output, Tensor query_start_loc, Tensor "
-      "seq_lens, float scale, bool causal, Tensor? alibi_slopes, SymInt "
-      "sliding_window_left, SymInt sliding_window_right, Tensor block_table, "
-      "float softcap, Tensor scheduler_metadata, Tensor? s_aux, "
-      "float k_scale=1.0, float v_scale=1.0, str kv_cache_dtype=\"auto\") -> "
-      "()",
-      &cpu_attention_with_kv_cache);
+    // CPU attention kernels
+    ops.def(
+        "get_scheduler_metadata(int num_req, int num_heads_q, int "
+        "num_heads_kv, "
+        "int head_dim, Tensor seq_lens, ScalarType dtype, Tensor "
+        "query_start_loc, bool casual, int window_size, str isa_hint, bool "
+        "enable_kv_split) -> Tensor",
+        &get_scheduler_metadata);
+    ops.def(
+        "cpu_attn_reshape_and_cache(Tensor key, Tensor value, Tensor(a2!) "
+        "key_cache, Tensor(a3!) value_cache, Tensor slot_mapping, str isa, "
+        "float k_scale=1.0, float v_scale=1.0, str kv_cache_dtype=\"auto\") -> "
+        "()",
+        &cpu_attn_reshape_and_cache);
+    ops.def(
+        "cpu_attention_with_kv_cache(Tensor query, Tensor key_cache, Tensor "
+        "value_cache, Tensor(a3!) output, Tensor query_start_loc, Tensor "
+        "seq_lens, float scale, bool causal, Tensor? alibi_slopes, SymInt "
+        "sliding_window_left, SymInt sliding_window_right, Tensor block_table, "
+        "float softcap, Tensor scheduler_metadata, Tensor? s_aux, "
+        "float k_scale=1.0, float v_scale=1.0, str kv_cache_dtype=\"auto\") -> "
+        "()",
+        &cpu_attention_with_kv_cache);
 
-  // placeholders
-  ops.def("static_scaled_fp8_quant() -> ()", placeholder_op);
-  ops.def("dynamic_scaled_fp8_quant() -> ()", placeholder_op);
-  ops.def("dynamic_per_token_scaled_fp8_quant() -> ()", placeholder_op);
+    // placeholders
+    ops.def("static_scaled_fp8_quant() -> ()", placeholder_op);
+    ops.def("dynamic_scaled_fp8_quant() -> ()", placeholder_op);
+    ops.def("dynamic_per_token_scaled_fp8_quant() -> ()", placeholder_op);
 
-  // WNA16
+    // WNA16
 #if defined(__AVX512F__) || defined(__riscv_v)
-  ops.def(
-      "cpu_gemm_wna16(Tensor input, Tensor q_weight, Tensor(a2!) output, "
-      "Tensor scales, Tensor? zeros, Tensor? g_idx, Tensor? bias, SymInt "
-      "pack_factor, str isa_hint) -> ()");
-  ops.impl("cpu_gemm_wna16", torch::kCPU, &cpu_gemm_wna16);
+    ops.def(
+        "cpu_gemm_wna16(Tensor input, Tensor q_weight, Tensor(a2!) output, "
+        "Tensor scales, Tensor? zeros, Tensor? g_idx, Tensor? bias, SymInt "
+        "pack_factor, str isa_hint) -> ()");
+    ops.impl("cpu_gemm_wna16", torch::kCPU, &cpu_gemm_wna16);
 #endif
 
-  // fused moe
+    // fused moe
 #if defined(__AVX512F__)
-  ops.def(
-      "prepack_moe_weight(Tensor weight, Tensor(a1!) packed_weight, str isa) "
-      "-> ()");
-  ops.impl("prepack_moe_weight", torch::kCPU, &prepack_moe_weight);
-  ops.def(
-      "cpu_fused_moe(Tensor(a0!) output, Tensor input, Tensor w13, Tensor w2, "
-      "Tensor? w13_bias, Tensor? w2_bias, Tensor topk_weights, Tensor topk_id, "
-      "bool skip_weighted, "
-      "str act, str isa) -> ()");
-  ops.impl("cpu_fused_moe", torch::kCPU, &cpu_fused_moe);
+    ops.def(
+        "prepack_moe_weight(Tensor weight, Tensor(a1!) packed_weight, str isa) "
+        "-> ()");
+    ops.impl("prepack_moe_weight", torch::kCPU, &prepack_moe_weight);
+    ops.def(
+        "cpu_fused_moe(Tensor(a0!) output, Tensor input, Tensor w13, Tensor "
+        "w2, "
+        "Tensor? w13_bias, Tensor? w2_bias, Tensor topk_weights, Tensor "
+        "topk_id, "
+        "bool skip_weighted, "
+        "str act, str isa) -> ()");
+    ops.impl("cpu_fused_moe", torch::kCPU, &cpu_fused_moe);
 #endif
-  ops.def(
-      "mla_decode_kvcache("
-      "   Tensor! out, Tensor query, Tensor kv_cache,"
-      "   float scale, Tensor block_tables, Tensor seq_lens) -> ()");
-  ops.impl("mla_decode_kvcache", torch::kCPU, &mla_decode_kvcache);
+    ops.def(
+        "mla_decode_kvcache("
+        "   Tensor! out, Tensor query, Tensor kv_cache,"
+        "   float scale, Tensor block_tables, Tensor seq_lens) -> ()");
+    ops.impl("mla_decode_kvcache", torch::kCPU, &mla_decode_kvcache);
 
-  ops.def(
-      "compute_slot_mapping_kernel_impl(Tensor query_start_loc, Tensor "
-      "positions, Tensor block_table, Tensor(a3!) slot_mapping, SymInt "
-      "block_size) -> ()",
-      &compute_slot_mapping_kernel_impl);
+    ops.def(
+        "compute_slot_mapping_kernel_impl(Tensor query_start_loc, Tensor "
+        "positions, Tensor block_table, Tensor(a3!) slot_mapping, SymInt "
+        "block_size) -> ()",
+        &compute_slot_mapping_kernel_impl);
 
-  ops.def("init_cpu_memory_env(SymInt[] node_ids) -> ()", &init_cpu_memory_env);
+    ops.def("init_cpu_memory_env(SymInt[] node_ids) -> ()",
+            &init_cpu_memory_env);
 
-  // Speculative decoding kernels
-  ops.def(
-      "eagle_prepare_inputs_padded_kernel_impl(Tensor cu_num_draft_tokens, "
-      "Tensor valid_sampled_tokens_count, Tensor query_start_loc_gpu, "
-      "Tensor(a3!) token_indices_to_sample, "
-      "Tensor(a4!) num_rejected_tokens_gpu, "
-      "SymInt num_reqs) -> ()",
-      &cpu_utils::eagle_prepare_inputs_padded_kernel_impl);
-  ops.def(
-      "eagle_prepare_next_token_padded_kernel_impl("
-      "Tensor sampled_token_ids, Tensor discard_request_mask, "
-      "Tensor backup_next_token_ids, Tensor(a3!) next_token_ids, "
-      "Tensor(a4!) valid_sampled_tokens_count, SymInt vocab_size, "
-      "SymInt num_sampled_tokens_per_req, SymInt num_reqs) -> ()",
-      &cpu_utils::eagle_prepare_next_token_padded_kernel_impl);
-  ops.def(
-      "eagle_step_slot_mapping_metadata_kernel_impl("
-      "Tensor positions, Tensor block_table, Tensor(a2!) seq_lens, "
-      "Tensor(a3!) out_clamped_positions, Tensor(a4!) out_slot_mapping, "
-      "SymInt block_size, SymInt max_model_len, SymInt PAD_ID) -> ()",
-      &cpu_utils::eagle_step_slot_mapping_metadata_kernel_impl);
-  ops.def(
-      "copy_and_expand_eagle_inputs_kernel_impl("
-      "Tensor target_token_ids, Tensor target_positions, "
-      "Tensor next_token_ids, Tensor(a3!) out_input_ids, "
-      "Tensor(a4!) out_positions, "
-      "Tensor(a5!) out_is_rejected_token_mask, "
-      "Tensor(a6!) out_is_masked_token_mask, "
-      "Tensor(a7!) out_new_token_indices, "
-      "Tensor(a8!) out_hidden_state_mapping, "
-      "Tensor query_start_loc, Tensor query_end_loc, "
-      "SymInt padding_token_id, SymInt parallel_drafting_token_id, "
-      "SymInt total_input_tokens, SymInt num_padding_slots_per_request, "
-      "bool shift_input_ids) -> ()",
-      &cpu_utils::copy_and_expand_eagle_inputs_kernel_impl);
-  ops.def(
-      "rejection_greedy_sample_kernel_impl("
-      "Tensor(a0!) output_token_ids, Tensor cu_num_draft_tokens, "
-      "Tensor draft_token_ids, Tensor target_argmax, "
-      "Tensor bonus_token_ids, Tensor? is_greedy, "
-      "SymInt max_spec_len) -> ()",
-      &cpu_utils::rejection_greedy_sample_kernel_impl);
-  ops.def(
-      "rejection_random_sample_kernel_impl("
-      "Tensor(a0!) output_token_ids, Tensor cu_num_draft_tokens, "
-      "Tensor draft_token_ids, Tensor? draft_probs, "
-      "Tensor target_probs, Tensor bonus_token_ids, "
-      "Tensor recovered_token_ids, Tensor uniform_probs, "
-      "Tensor? is_greedy, SymInt max_spec_len, SymInt vocab_size, "
-      "bool no_draft_probs) -> ()",
-      &cpu_utils::rejection_random_sample_kernel_impl);
-  ops.def(
-      "expand_kernel_impl(Tensor(a0!) output, Tensor input, "
-      "Tensor cu_num_tokens, SymInt replace_from, "
-      "SymInt replace_to) -> ()",
-      &cpu_utils::expand_kernel_impl);
-  ops.def(
-      "sample_recovered_tokens_kernel_impl("
-      "Tensor(a0!) output_token_ids, Tensor cu_num_draft_tokens, "
-      "Tensor draft_token_ids, Tensor? draft_probs, "
-      "Tensor target_probs, Tensor inv_q, SymInt vocab_size, "
-      "bool no_draft_probs) -> ()",
-      &cpu_utils::sample_recovered_tokens_kernel_impl);
+    // Speculative decoding kernels
+    ops.def(
+        "eagle_prepare_inputs_padded_kernel_impl(Tensor cu_num_draft_tokens, "
+        "Tensor valid_sampled_tokens_count, Tensor query_start_loc_gpu, "
+        "Tensor(a3!) token_indices_to_sample, "
+        "Tensor(a4!) num_rejected_tokens_gpu, "
+        "SymInt num_reqs) -> ()",
+        &cpu_utils::eagle_prepare_inputs_padded_kernel_impl);
+    ops.def(
+        "eagle_prepare_next_token_padded_kernel_impl("
+        "Tensor sampled_token_ids, Tensor discard_request_mask, "
+        "Tensor backup_next_token_ids, Tensor(a3!) next_token_ids, "
+        "Tensor(a4!) valid_sampled_tokens_count, SymInt vocab_size, "
+        "SymInt num_sampled_tokens_per_req, SymInt num_reqs) -> ()",
+        &cpu_utils::eagle_prepare_next_token_padded_kernel_impl);
+    ops.def(
+        "eagle_step_slot_mapping_metadata_kernel_impl("
+        "Tensor positions, Tensor block_table, Tensor(a2!) seq_lens, "
+        "Tensor(a3!) out_clamped_positions, Tensor(a4!) out_slot_mapping, "
+        "SymInt block_size, SymInt max_model_len, SymInt PAD_ID) -> ()",
+        &cpu_utils::eagle_step_slot_mapping_metadata_kernel_impl);
+    ops.def(
+        "copy_and_expand_eagle_inputs_kernel_impl("
+        "Tensor target_token_ids, Tensor target_positions, "
+        "Tensor next_token_ids, Tensor(a3!) out_input_ids, "
+        "Tensor(a4!) out_positions, "
+        "Tensor(a5!) out_is_rejected_token_mask, "
+        "Tensor(a6!) out_is_masked_token_mask, "
+        "Tensor(a7!) out_new_token_indices, "
+        "Tensor(a8!) out_hidden_state_mapping, "
+        "Tensor query_start_loc, Tensor query_end_loc, "
+        "SymInt padding_token_id, SymInt parallel_drafting_token_id, "
+        "SymInt total_input_tokens, SymInt num_padding_slots_per_request, "
+        "bool shift_input_ids) -> ()",
+        &cpu_utils::copy_and_expand_eagle_inputs_kernel_impl);
+    ops.def(
+        "rejection_greedy_sample_kernel_impl("
+        "Tensor(a0!) output_token_ids, Tensor cu_num_draft_tokens, "
+        "Tensor draft_token_ids, Tensor target_argmax, "
+        "Tensor bonus_token_ids, Tensor? is_greedy, "
+        "SymInt max_spec_len) -> ()",
+        &cpu_utils::rejection_greedy_sample_kernel_impl);
+    ops.def(
+        "rejection_random_sample_kernel_impl("
+        "Tensor(a0!) output_token_ids, Tensor cu_num_draft_tokens, "
+        "Tensor draft_token_ids, Tensor? draft_probs, "
+        "Tensor target_probs, Tensor bonus_token_ids, "
+        "Tensor recovered_token_ids, Tensor uniform_probs, "
+        "Tensor? is_greedy, SymInt max_spec_len, SymInt vocab_size, "
+        "bool no_draft_probs) -> ()",
+        &cpu_utils::rejection_random_sample_kernel_impl);
+    ops.def(
+        "expand_kernel_impl(Tensor(a0!) output, Tensor input, "
+        "Tensor cu_num_tokens, SymInt replace_from, "
+        "SymInt replace_to) -> ()",
+        &cpu_utils::expand_kernel_impl);
+    ops.def(
+        "sample_recovered_tokens_kernel_impl("
+        "Tensor(a0!) output_token_ids, Tensor cu_num_draft_tokens, "
+        "Tensor draft_token_ids, Tensor? draft_probs, "
+        "Tensor target_probs, Tensor inv_q, SymInt vocab_size, "
+        "bool no_draft_probs) -> ()",
+        &cpu_utils::sample_recovered_tokens_kernel_impl);
+#if defined(VLLM_CPU_ISA_VARIANT_MODULE)
+  } catch (const c10::Error& e) {
+    if (!is_duplicate_registration_error(e)) {
+      throw;
+    }
+  }
+#endif
 }
 
-REGISTER_EXTENSION(TORCH_EXTENSION_NAME)
+REGISTER_EXTENSION(VLLM_PYTHON_MODULE_NAME)

--- a/csrc/cpu/utils.hpp
+++ b/csrc/cpu/utils.hpp
@@ -2,6 +2,9 @@
 #define UTILS_HPP
 
 #include <atomic>
+#if defined(__APPLE__)
+  #include <sys/sysctl.h>
+#endif
 #include <unistd.h>
 #include <ATen/cpu/Utils.h>
 
@@ -53,21 +56,40 @@ struct Counter {
   int64_t acquire_counter() { return counter++; }
 };
 
+inline uint32_t get_l2_cache_size_fallback() {
+#if defined(__APPLE__)
+  uint64_t l2_cache_size = 0;
+  size_t size = sizeof(l2_cache_size);
+  if (sysctlbyname("hw.l2cachesize", &l2_cache_size, &size, nullptr, 0) == 0 &&
+      l2_cache_size > 0) {
+    return static_cast<uint32_t>(l2_cache_size);
+  }
+  return 0;
+#elif defined(_SC_LEVEL2_CACHE_SIZE)
+  long sys_l2 = sysconf(_SC_LEVEL2_CACHE_SIZE);
+  if (sys_l2 > 0) {
+    return static_cast<uint32_t>(sys_l2);
+  }
+  return 0;
+#else
+  return 0;
+#endif
+}
+
 inline int64_t get_available_l2_size() {
+#if defined(TORCH_VERSION_MAJOR) && defined(TORCH_VERSION_MINOR) && \
+    (TORCH_VERSION_MAJOR > 2 ||                                     \
+     (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 11))
+  auto caps = at::cpu::get_cpu_capabilities();
+  auto it = caps.find("l2_cache_size");
+  if (it != caps.end()) {
+    return static_cast<int64_t>(it->second.toInt()) >> 1;
+  }
+#endif
+
 #if defined(__s390x__) || defined(__powerpc__)
   static int64_t size = []() {
-    uint32_t l2_cache_size = 0;
-    auto caps = at::cpu::get_cpu_capabilities();
-    auto it = caps.find("l2_cache_size");
-    if (it != caps.end()) {
-      l2_cache_size = static_cast<uint32_t>(it->second.toInt());
-    }
-    if (l2_cache_size == 0) {
-      long sys_l2 = sysconf(_SC_LEVEL2_CACHE_SIZE);
-      if (sys_l2 > 0) {
-        l2_cache_size = static_cast<uint32_t>(sys_l2);
-      }
-    }
+    uint32_t l2_cache_size = get_l2_cache_size_fallback();
     if (l2_cache_size == 0) {
       l2_cache_size = 256 * 1024;
     }
@@ -76,8 +98,10 @@ inline int64_t get_available_l2_size() {
   return size;
 #else
   static int64_t size = []() {
-    auto caps = at::cpu::get_cpu_capabilities();
-    const uint32_t l2_cache_size = caps.at("l2_cache_size").toInt();
+    uint32_t l2_cache_size = get_l2_cache_size_fallback();
+    if (l2_cache_size == 0) {
+      l2_cache_size = 256 * 1024;
+    }
     return l2_cache_size >> 1;  // use 50% of L2 cache
   }();
   return size;

--- a/csrc/spinloop.cpp
+++ b/csrc/spinloop.cpp
@@ -7,7 +7,7 @@ extern "C" {
 
 #if defined(__i386__) || defined(__x86_64__)
   #include <cpuid.h>
-  #include <mwaitxintrin.h>
+  #include <x86intrin.h>
 #endif
 
 #if defined(CLOCK_MONOTONIC_RAW)

--- a/csrc/torch_utils.h
+++ b/csrc/torch_utils.h
@@ -9,7 +9,12 @@
 // Otherwise, use TORCH_CHECK via torch/all.h.
 
 #ifdef TORCH_TARGET_VERSION
-  #include <torch/headeronly/util/Exception.h>
+  #if __has_include(<torch/headeronly/util/Exception.h>)
+    #include <torch/headeronly/util/Exception.h>
+  #else
+    #include <c10/util/Exception.h>
+    #define STD_TORCH_CHECK TORCH_CHECK
+  #endif
   #define TORCH_UTILS_CHECK STD_TORCH_CHECK
 #else
   #include <torch/all.h>

--- a/docker/entrypoints/test_vllm_nonroot_entrypoint.sh
+++ b/docker/entrypoints/test_vllm_nonroot_entrypoint.sh
@@ -48,6 +48,27 @@ run_wrapper() {
 
 fail() { echo "FAIL: $*" >&2; echo "--- stdout ---" >&2; cat "$1" >&2; exit 1; }
 
+normalize_path() {
+    _p="$1"
+    if [ -d "$_p" ]; then
+        (cd "$_p" 2>/dev/null && pwd -P) || printf '%s' "$_p"
+    else
+        printf '%s' "$_p"
+    fi
+}
+
+assert_pwd_preserved() {
+    _out="$1"
+    _expected_pwd="$2"
+    _case="$3"
+    _actual_pwd="$(grep '^PWD=' "$_out" | sed 's/^PWD=//')"
+    _expected_norm="$(normalize_path "$_expected_pwd")"
+    _actual_norm="$(normalize_path "$_actual_pwd")"
+
+    [ "$_actual_norm" = "$_expected_norm" ] \
+        || fail "$_out" "$_case: cwd not preserved (got PWD=$_actual_pwd, expected=$_expected_pwd)"
+}
+
 expect_default_home() {
     _out="$1"
     _case="$2"
@@ -183,8 +204,7 @@ case8_cwd="$WORKDIR/case8-cwd"
 mkdir -p "$case8_cwd"
 out="$WORKDIR/case8.out"
 (cd "$case8_cwd" && run_wrapper "$out" "HOME=$case8_home" "USER=alice" "LOGNAME=alice" -- --model ./relpath)
-grep -q "^PWD=$case8_cwd\$" "$out" \
-    || fail "$out" "case8: writable cwd not preserved (got $(grep '^PWD=' "$out"))"
+assert_pwd_preserved "$out" "$case8_cwd" "case8"
 grep -q "^ARGV=serve --model \\./relpath\$" "$out" \
     || fail "$out" "case8: relative argv not preserved"
 echo "PASS: case8 (writable cwd preserved; relative argv still resolves from caller's cwd)"
@@ -204,8 +224,7 @@ mkdir -p "$case9_ro"
 chmod 0555 "$case9_ro"
 out="$WORKDIR/case9.out"
 (cd "$case9_ro" && run_wrapper "$out" "HOME=$case9_home" "USER=alice" "LOGNAME=alice" -- --model ./foo)
-grep -q "^PWD=$case9_ro\$" "$out" \
-    || fail "$out" "case9: read-only cwd was rewritten (got $(grep '^PWD=' "$out"))"
+assert_pwd_preserved "$out" "$case9_ro" "case9"
 grep -q "^ARGV=serve --model \\./foo\$" "$out" \
     || fail "$out" "case9: relative argv not preserved"
 chmod 0700 "$case9_ro"
@@ -232,8 +251,7 @@ else
         run_wrapper "$out" "HOME=$case10_home" "USER=alice" "LOGNAME=alice" -- --model foo
     )
     chmod 0700 "$case10_cwd"
-    grep -q "^PWD=$case10_home\$" "$out" \
-        || fail "$out" "case10: inaccessible cwd not overridden to HOME (got $(grep '^PWD=' "$out"))"
+    assert_pwd_preserved "$out" "$case10_home" "case10"
     echo "PASS: case10 (inaccessible cwd falls back to \$HOME)"
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,14 @@ def bundle_tcmalloc(build_lib: str) -> None:
 
 class CMakeExtension(Extension):
     def __init__(self, name: str, cmake_lists_dir: str = ".", **kwa) -> None:
-        super().__init__(name, sources=[], py_limited_api=not is_freethreaded(), **kwa)
+        super().__init__(
+            name,
+            sources=[],
+            # Keep setuptools' expected extension suffix aligned with CMake,
+            # which installs these modules as abi3 on supported interpreters.
+            py_limited_api=not is_freethreaded(),
+            **kwa,
+        )
         self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
 
 

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -9,7 +9,17 @@ from typing import Any, ClassVar, Literal, overload
 
 import regex as re
 import torch
-from torch.library import Library, infer_schema
+from torch.library import Library
+
+try:
+    from torch.library import infer_schema as _torch_infer_schema
+
+    _INFER_SCHEMA_SUPPORTS_MUTATES_ARGS = True
+except ImportError:
+    # Older torch versions expose infer_schema under torch._custom_op.impl
+    from torch._custom_op.impl import infer_schema as _torch_infer_schema
+
+    _INFER_SCHEMA_SUPPORTS_MUTATES_ARGS = False
 
 from vllm.ir.tolerances import DEFAULT_TOLERANCES, ToleranceSpec
 from vllm.ir.util import hash_source, weak_cache
@@ -21,6 +31,13 @@ InputGenerator = Callable[..., tuple[Any, ...]]
 vllm_ir_torch_lib = Library("vllm_ir", "FRAGMENT")  # IR op lib; monkeypatch in tests.
 
 logger = init_logger(__name__)
+
+
+def infer_schema(op_func: Callable, mutates_args: list[str] | None = None) -> str:
+    """Torch-version-compatible infer_schema wrapper."""
+    if _INFER_SCHEMA_SUPPORTS_MUTATES_ARGS:
+        return _torch_infer_schema(op_func, mutates_args=mutates_args or [])
+    return _torch_infer_schema(op_func)
 
 
 def _torch_ops_subtree(lib: Any) -> Any:

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -14,7 +14,17 @@ import numpy.typing as npt
 import torch
 from packaging import version
 from packaging.version import Version
-from torch.library import Library, infer_schema
+from torch.library import Library
+
+try:
+    from torch.library import infer_schema as _torch_infer_schema
+
+    _INFER_SCHEMA_SUPPORTS_MUTATES_ARGS = True
+except ImportError:
+    # Older torch versions expose infer_schema under torch._custom_op.impl
+    from torch._custom_op.impl import infer_schema as _torch_infer_schema
+
+    _INFER_SCHEMA_SUPPORTS_MUTATES_ARGS = False
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -27,6 +37,17 @@ else:
     IntermediateTensors = object
 
 logger = init_logger(__name__)
+
+
+def infer_schema(op_func: Callable, mutates_args: list[str] | None = None) -> str:
+    """Torch-version-compatible infer_schema wrapper.
+
+    Newer torch exposes infer_schema(op_func, mutates_args=...), while
+    older torch only supports infer_schema(op_func).
+    """
+    if _INFER_SCHEMA_SUPPORTS_MUTATES_ARGS:
+        return _torch_infer_schema(op_func, mutates_args=mutates_args or [])
+    return _torch_infer_schema(op_func)
 
 
 STR_DTYPE_TO_TORCH_DTYPE = {


### PR DESCRIPTION
Related to #44867

This PR includes AI assistance (GitHub Copilot).

## Purpose

Improve Intel macOS CPU build/import reliability and local developer ergonomics by:
- fixing CPU extension multi-ISA registration/import behavior on Intel macOS,
- hardening CMake Python selection for local development and VS Code CMake Tools,
- improving torch compatibility helpers for older local torch versions,
- making non-root entrypoint shell tests robust across macOS path canonicalization.

The scope is focused on stability and compatibility for Intel macOS CPU workflows, while keeping CI-oriented behavior explicit.

## Test Plan

Run local quality gates and smoke checks:

1. Full pre-commit

source .venv/bin/activate
pre-commit run --all-files

2. CPU extension import smoke test

source .venv/bin/activate
python - <<'PY'
import importlib
mods = ["vllm", "vllm._C", "vllm._C_AVX512", "vllm._C_AVX2"]
for m in mods:
    importlib.import_module(m)
print("import-smoke: OK")
PY

3. CMake configure validation (local, CPU target)

cmake -S . -B /tmp/vllm-cmake-check-local -DVLLM_TARGET_DEVICE=cpu

4. Representative Linux-container CPU-safe tests (existing dev container)

cd /workspace
source .venv-linux/bin/activate
.venv-linux/bin/python -m pytest \
  test_utils.py \
  test_prefix_caching.py \
  test_kv_cache_utils.py \
  test_utils.py -q

Test Result
pre-commit run --all-files: Passed.
Import smoke (vllm, _C, _C_AVX512, _C_AVX2): Passed.
cmake -S . -B /tmp/vllm-cmake-check-local -DVLLM_TARGET_DEVICE=cpu: Configure succeeded.
Container pytest sweep: 196 passed.
