### PR TITLE
[ROCm][MLA] Fuse MLA q/kv RMSNorm + FP8 per-token quant in the FP8 attention path

### DIFF
--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -30,7 +30,7 @@ or just on the low or high end.
 | [RMSNorm + Quant](#rmsnorm--quantization-fuse_norm_quant)                      | `fuse_norm_quant`            | RMSNorm (+residual add) → FP8/FP4 quant        | O1 (conditional)               | 1-4%               | No        | Always       |
 | [SiLU+Mul + Quant](#silumul--quantization-fuse_act_quant)                      | `fuse_act_quant`             | SiLU+Mul activation → FP8/FP4 quant            | O1 (conditional)               | 1-4%               | No        | Always       |
 | [RMSNorm + Padding](#rmsnorm--padding-fuse_act_padding)                        | `fuse_act_padding`           | Residual add + RMSNorm → padding               | O1 (ROCm/AITER only)           | TBD                | No        | Always       |
-| [MLA Dual RMSNorm](#mla-dual-rmsnorm-fuse_mla_dual_rms_norm)                   | `fuse_mla_dual_rms_norm`     | Paired Q + KV RMSNorm → single kernel          | O1 (ROCm/AITER only)           | ~2%                | No        | Always       |
+| [MLA Dual RMSNorm](#mla-dual-rmsnorm-fuse_mla_dual_rms_norm)                   | `fuse_mla_dual_rms_norm`     | Paired Q + KV RMSNorm (+ FP8 quant) → 1 kernel | O1 (ROCm/AITER only)           | 1-2%               | No        | Always       |
 
 ## Support Matrix
 
@@ -381,11 +381,45 @@ q_normed, kv_normed = fused_mla_dual_rms_norm(
 Requires: AMD ROCm with AITER enabled. Enabled by default at optimization level O1 and above
 when AITER is available.
 
+**FP8 attention variant (per-token quant).** When attention is FP8-quantized and
+the `q_b_proj` uses per-output-channel weights with a per-token activation scale
+(Quark / ModelOpt), only the *q* latent is FP8 per-token-quantized — it feeds the
+FP8 `q_b_proj` GEMM — while the *kv* latent is RMS-normed and consumed by
+attention as bf16 (see `vllm/model_executor/layers/mla.py` and AMD's ATOM
+reference). So `RocmAiterRMSNormQuantFusionPass` runs first and folds only the
+q-side `rms_norm → fp8 per-token quant` into a single
+`rocm_aiter_rmsnorm_fused_dynamic_quant` op (a single `(M, 1)` scale), leaving the
+kv side a plain `rms_norm`. This breaks the symmetric BF16 dual pattern above (q
+is no longer a bare `rms_norm`). To restore the dual fusion, the same pass matches
+this asymmetric pair — q's `rocm_aiter_rmsnorm_fused_dynamic_quant` plus kv's
+`rms_norm` (bracketing the splits + `k_pe` passthrough) — and lowers it to
+`fused_mla_dual_rms_norm_per_token_quant`, backed by AITER's
+`fused_qk_rmsnorm_per_token_quant` HIP kernel. That kernel does RMSNorm + FP8
+per-token quant on its `q` slot and RMSNorm only on its `k` slot, so a **single
+launch** replaces the separate q norm+quant and kv norm kernels (q scale is
+`(M, 1)` fp32, matching `rocm_aiter_rmsnorm_fused_dynamic_quant`). This variant
+fires automatically when the installed AITER provides
+`fused_qk_rmsnorm_per_token_quant` (no extra flag).
+
+```text
+# FP8, before MLA dual fusion (q norm+quant fused; kv still plain rms_norm):
+q_c, kv_lora = split(projected, [q_dim, kv_dim])
+kv_c, k_pe   = split(kv_lora,  [kv_c_dim, k_pe_dim])
+q_fp8, q_scale = rocm_aiter_rmsnorm_fused_dynamic_quant(q_c, q_weight, eps, fp8)
+kv_normed      = rms_norm(kv_c, kv_weight, eps)          # bf16
+
+# FP8, fused (single kernel launch):
+q_c, kv_lora = split(projected, [q_dim, kv_dim])
+kv_c, k_pe   = split(kv_lora,  [kv_c_dim, k_pe_dim])
+q_fp8, q_scale, kv_normed = fused_mla_dual_rms_norm_per_token_quant(
+    q_c, q_weight, kv_c, kv_weight, eps1, eps2)
+```
+
 **Code locations.**
 
-- Pass: [`vllm/compilation/passes/fusion/rocm_aiter_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rocm_aiter_fusion.py) (`MLADualRMSNormFusionPass`)
-- Custom op: [`vllm/_aiter_ops.py`](https://github.com/vllm-project/vllm/blob/main/vllm/_aiter_ops.py) (`fused_mla_dual_rms_norm`)
-- AITER kernel: [`fused_qk_rmsnorm`](https://github.com/ROCm/aiter/pull/2442)
+- Pass: [`vllm/compilation/passes/fusion/rocm_aiter_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rocm_aiter_fusion.py) (`MLADualRMSNormFusionPass`, `MLADualRMSPerTokenQuantPattern`)
+- Custom op: [`vllm/_aiter_ops.py`](https://github.com/vllm-project/vllm/blob/main/vllm/_aiter_ops.py) (`fused_mla_dual_rms_norm`, `fused_mla_dual_rms_norm_per_token_quant`)
+- AITER kernels: [`fused_qk_rmsnorm`](https://github.com/ROCm/aiter/pull/2442), `fused_qk_rmsnorm_per_token_quant`
 
 ## See Also
 

--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -381,34 +381,21 @@ q_normed, kv_normed = fused_mla_dual_rms_norm(
 Requires: AMD ROCm with AITER enabled. Enabled by default at optimization level O1 and above
 when AITER is available.
 
-**FP8 attention variant (per-token quant).** When attention is FP8-quantized and
-the `q_b_proj` uses per-output-channel weights with a per-token activation scale
-(Quark / ModelOpt), only the *q* latent is FP8 per-token-quantized — it feeds the
-FP8 `q_b_proj` GEMM — while the *kv* latent is RMS-normed and consumed by
-attention as bf16 (see `vllm/model_executor/layers/mla.py` and AMD's ATOM
-reference). So `RocmAiterRMSNormQuantFusionPass` runs first and folds only the
-q-side `rms_norm → fp8 per-token quant` into a single
-`rocm_aiter_rmsnorm_fused_dynamic_quant` op (a single `(M, 1)` scale), leaving the
-kv side a plain `rms_norm`. This breaks the symmetric BF16 dual pattern above (q
-is no longer a bare `rms_norm`). To restore the dual fusion, the same pass matches
-this asymmetric pair — q's `rocm_aiter_rmsnorm_fused_dynamic_quant` plus kv's
-`rms_norm` (bracketing the splits + `k_pe` passthrough) — and lowers it to
-`fused_mla_dual_rms_norm_per_token_quant`, backed by AITER's
-`fused_qk_rmsnorm_per_token_quant` HIP kernel. That kernel does RMSNorm + FP8
-per-token quant on its `q` slot and RMSNorm only on its `k` slot, so a **single
-launch** replaces the separate q norm+quant and kv norm kernels (q scale is
-`(M, 1)` fp32, matching `rocm_aiter_rmsnorm_fused_dynamic_quant`). This variant
-fires automatically when the installed AITER provides
-`fused_qk_rmsnorm_per_token_quant` (no extra flag).
+**FP8 attention variant (per-token quant).** With a per-token FP8 `q_b_proj`,
+only the *q* latent is FP8-quantized while *kv* stays bf16.
+`RocmAiterRMSNormQuantFusionPass` first folds the q side into
+`rocm_aiter_rmsnorm_fused_dynamic_quant`, leaving kv a plain
+`rms_norm` — breaking the symmetric pattern above. The same pass then matches
+this asymmetric pair and lowers it to `fused_mla_dual_rms_norm_per_token_quant`.
 
 ```text
-# FP8, before MLA dual fusion (q norm+quant fused; kv still plain rms_norm):
+# Unfused (q norm+quant fused; kv still plain rms_norm):
 q_c, kv_lora = split(projected, [q_dim, kv_dim])
 kv_c, k_pe   = split(kv_lora,  [kv_c_dim, k_pe_dim])
 q_fp8, q_scale = rocm_aiter_rmsnorm_fused_dynamic_quant(q_c, q_weight, eps, fp8)
 kv_normed      = rms_norm(kv_c, kv_weight, eps)          # bf16
 
-# FP8, fused (single kernel launch):
+# Fused:
 q_c, kv_lora = split(projected, [q_dim, kv_dim])
 kv_c, k_pe   = split(kv_lora,  [kv_c_dim, k_pe_dim])
 q_fp8, q_scale, kv_normed = fused_mla_dual_rms_norm_per_token_quant(

--- a/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
+++ b/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
@@ -12,7 +12,11 @@ import torch
 
 import vllm.config
 from tests.compile.backend import TestBackend
-from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
+from vllm._aiter_ops import (
+    check_aiter_fused_qk_rmsnorm_per_token_quant,
+    is_aiter_found_and_supported,
+    rocm_aiter_ops,
+)
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
 from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
 from vllm.config import (
@@ -23,12 +27,15 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.platforms import current_platform
 
 # MLA attention geometry for DeepSeek-V3 / Kimi-K2
 Q_DIM = 1536
 KV_C_DIM = 512
 K_PE_DIM = 64
 EPS = 1e-6
+
+FP8_DTYPE = current_platform.fp8_dtype()
 
 
 class MLADualRMSNormTestModel(torch.nn.Module):
@@ -139,6 +146,181 @@ def test_fuse_mla_dual_rms_norm(
         outputs_fused = model_fused(x)
 
         torch.testing.assert_close(outputs_unfused, outputs_fused, atol=1e-2, rtol=1e-2)
+
+        assert fusion_pass.matched_count == 1, (
+            f"Expected 1 fused pair, got {fusion_pass.matched_count}"
+        )
+
+        backend.check_before_ops(model.ops_in_model_before())
+        backend.check_after_ops(model.ops_in_model_after())
+
+
+class MLADualRMSNormFp8PerTokenTestModel(torch.nn.Module):
+    """
+    Minimal model reproducing the FP8 MLA attention path with *per-token* quant.
+
+    In this path only the *q* latent is FP8 per-token-quantized (it feeds the FP8
+    ``q_b_proj`` GEMM); the *kv* latent is RMS-normed and consumed by attention
+    as bf16. So ``RocmAiterRMSNormQuantFusionPass`` (which runs earlier) folds
+    only the q-side ``rms_norm -> fp8 per-token quant`` into a single
+    ``rocm_aiter_rmsnorm_fused_dynamic_quant`` op (a single ``(M, 1)`` scale) and
+    leaves the kv side a plain ``vllm_ir.rms_norm``. This model mirrors that
+    asymmetric graph:
+
+        linear -> split([q_dim, kv_dim])
+            +-- q_c (getitem 0) -> rocm_aiter_rmsnorm_fused_dynamic_quant -> dequant
+            +-- kv_lora (getitem 1) -> split([kv_c_dim, k_pe_dim])
+                    +-- kv_c (getitem 0) -> rms_norm (bf16)
+                    +-- k_pe
+
+    ``forward`` dequantizes the q fp8 output in-graph and returns it as bf16.
+    Returning the fp8 tensor directly graph-breaks dynamo (the quant op then
+    escapes to eager and the fusion never matches), so the dequant keeps the
+    quant op inside the compiled FX graph. The unfused path runs aiter's
+    ``rmsnorm2d_fwd_with_dynamicquant`` (q) plus ``vllm_ir.rms_norm`` (kv); the
+    fused path runs both through the single HIP ``fused_qk_rmsnorm_per_token_quant``
+    kernel. With identical per-token scales the dequantized q values are bit-exact
+    except on fp8 rounding ties (at most one e4m3 step), and the bf16 kv norm
+    matches to bf16 tolerance.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        q_dim: int = Q_DIM,
+        kv_c_dim: int = KV_C_DIM,
+        k_pe_dim: int = K_PE_DIM,
+        eps: float = EPS,
+    ):
+        super().__init__()
+        self.q_dim = q_dim
+        self.kv_dim = kv_c_dim + k_pe_dim
+        self.kv_c_dim = kv_c_dim
+        self.k_pe_dim = k_pe_dim
+        self.eps = eps
+
+        self.proj = torch.nn.Linear(hidden_size, q_dim + self.kv_dim, bias=False)
+        self.q_weight = torch.nn.Parameter(torch.ones(q_dim))
+        # kv latent is RMS-normed only (no quant); RMSNorm with custom_ops
+        # ["+rms_norm"] lowers to vllm_ir.rms_norm, matching the FP8 graph.
+        self.kv_norm = RMSNorm(kv_c_dim, eps=eps)
+
+    def _dequant(self, x_fp8: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+        # Per-token: a single (M, 1) scale broadcast across the row.
+        return (x_fp8.to(torch.float32) * scale).to(torch.bfloat16)
+
+    def forward(self, x: torch.Tensor):
+        # Avoid graph input being a direct arg to a matched pattern node
+        x = torch.relu(x)
+
+        projected = self.proj(x)
+
+        q_c, kv_lora = projected.split([self.q_dim, self.kv_dim], dim=-1)
+        kv_c, k_pe = kv_lora.split([self.kv_c_dim, self.k_pe_dim], dim=-1)
+
+        q_fp8, q_scale = torch.ops.vllm.rocm_aiter_rmsnorm_fused_dynamic_quant(
+            q_c, self.q_weight, self.eps, FP8_DTYPE
+        )
+        kv_normed = self.kv_norm(kv_c)
+
+        # Dequant q in-graph keeps the quant op inside the compiled graph so the
+        # fusion pass can match it (returning fp8 directly graph-breaks dynamo);
+        # kv_normed is already bf16 and is returned (and matched) directly.
+        return self._dequant(q_fp8, q_scale), kv_normed, k_pe
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.rocm_aiter_rmsnorm_fused_dynamic_quant.default,
+            torch.ops.vllm_ir.rms_norm.default,
+        ]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_mla_dual_rms_norm_per_token_quant.default]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.skipif(
+    not is_aiter_found_and_supported()
+    or not check_aiter_fused_qk_rmsnorm_per_token_quant(),
+    reason=(
+        "Only test on ROCm with AITER (incl. fused_qk_rmsnorm_per_token_quant) "
+        "installed and supported"
+    ),
+)
+def test_fuse_mla_dual_rms_norm_fp8_per_token(
+    dtype: torch.dtype,
+    hidden_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    torch._dynamo.reset()
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=dtype),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=["+rms_norm"],
+            pass_config=PassConfig(
+                fuse_mla_dual_rms_norm=True,
+                eliminate_noops=True,
+            ),
+        ),
+    )
+
+    with vllm.config.set_current_vllm_config(vllm_config), monkeypatch.context() as m:
+        from vllm.compilation.passes.fusion.rocm_aiter_fusion import (
+            MLADualRMSNormFusionPass,
+        )
+
+        torch.set_default_device("cuda")
+        torch.set_default_dtype(dtype)
+        torch.manual_seed(42)
+
+        m.setenv("VLLM_ROCM_USE_AITER", "1")
+        rocm_aiter_ops.refresh_env_variables()
+
+        fusion_pass = MLADualRMSNormFusionPass(vllm_config)
+        passes = [
+            NoOpEliminationPass(vllm_config),
+            fusion_pass,
+            PostCleanupPass(vllm_config),
+        ]
+        backend = TestBackend(*passes)
+        model = MLADualRMSNormFp8PerTokenTestModel(hidden_size)
+
+        x = torch.randn(4, hidden_size)
+        torch._dynamo.mark_dynamic(x, 0)
+
+        # Decode runs under inference_mode; the fp8 quant op has no autograd
+        # kernel, so without this AOTAutograd builds a joint forward/backward
+        # graph that graph-breaks and the fusion never fires.
+        with torch.inference_mode():
+            outputs_unfused = model(x)
+
+            model_fused = torch.compile(model, backend=backend)
+            outputs_fused = model_fused(x)
+
+        q_deq_u, kv_normed_u, k_pe_u = outputs_unfused
+        q_deq_f, kv_normed_f, k_pe_f = outputs_fused
+
+        # k_pe is a pure passthrough and must be bit-identical.
+        torch.testing.assert_close(k_pe_u, k_pe_f, atol=0, rtol=0)
+
+        # kv latent is RMS-normed (not quantized) on both paths; the Triton and
+        # HIP rms norms agree to bf16 tolerance.
+        torch.testing.assert_close(kv_normed_u, kv_normed_f, atol=1e-2, rtol=1e-2)
+
+        # With matching per-token scales the dequantized q values are bit-exact
+        # except where the unfused and fused quant kernels round an fp8 tie
+        # differently. Require the bulk to be exact (this catches scale bugs,
+        # which shift whole rows) and bound the rare ties to one e4m3 step
+        # (relative gap 2**-3 = 0.125).
+        E4M3_STEP = 0.125
+        exact_frac = (q_deq_u == q_deq_f).float().mean().item()
+        assert exact_frac > 0.99, (
+            f"q: only {exact_frac:.4f} of elements bit-exact; scales likely differ"
+        )
+        torch.testing.assert_close(q_deq_u, q_deq_f, atol=1e-2, rtol=E4M3_STEP)
 
         assert fusion_pass.matched_count == 1, (
             f"Expected 1 fused pair, got {fusion_pass.matched_count}"

--- a/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
+++ b/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
@@ -13,7 +13,6 @@ import torch
 import vllm.config
 from tests.compile.backend import TestBackend
 from vllm._aiter_ops import (
-    check_aiter_fused_qk_rmsnorm_per_token_quant,
     is_aiter_found_and_supported,
     rocm_aiter_ops,
 )
@@ -217,12 +216,8 @@ class MLADualRMSNormFp8PerTokenTestModel(torch.nn.Module):
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("hidden_size", [7168])
 @pytest.mark.skipif(
-    not is_aiter_found_and_supported()
-    or not check_aiter_fused_qk_rmsnorm_per_token_quant(),
-    reason=(
-        "Only test on ROCm with AITER (incl. fused_qk_rmsnorm_per_token_quant) "
-        "installed and supported"
-    ),
+    not is_aiter_found_and_supported(),
+    reason="Only test on ROCm with AITER installed and supported",
 )
 def test_fuse_mla_dual_rms_norm_fp8_per_token(
     dtype: torch.dtype,

--- a/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
+++ b/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
@@ -157,31 +157,12 @@ def test_fuse_mla_dual_rms_norm(
 
 class MLADualRMSNormFp8PerTokenTestModel(torch.nn.Module):
     """
-    Minimal model reproducing the FP8 MLA attention path with *per-token* quant.
-
-    In this path only the *q* latent is FP8 per-token-quantized (it feeds the FP8
-    ``q_b_proj`` GEMM); the *kv* latent is RMS-normed and consumed by attention
-    as bf16. So ``RocmAiterRMSNormQuantFusionPass`` (which runs earlier) folds
-    only the q-side ``rms_norm -> fp8 per-token quant`` into a single
-    ``rocm_aiter_rmsnorm_fused_dynamic_quant`` op (a single ``(M, 1)`` scale) and
-    leaves the kv side a plain ``vllm_ir.rms_norm``. This model mirrors that
-    asymmetric graph:
-
+    Minimal model reproducing the FP8 MLA attention path with *per-token* quant:
         linear -> split([q_dim, kv_dim])
             +-- q_c (getitem 0) -> rocm_aiter_rmsnorm_fused_dynamic_quant -> dequant
             +-- kv_lora (getitem 1) -> split([kv_c_dim, k_pe_dim])
                     +-- kv_c (getitem 0) -> rms_norm (bf16)
                     +-- k_pe
-
-    ``forward`` dequantizes the q fp8 output in-graph and returns it as bf16.
-    Returning the fp8 tensor directly graph-breaks dynamo (the quant op then
-    escapes to eager and the fusion never matches), so the dequant keeps the
-    quant op inside the compiled FX graph. The unfused path runs aiter's
-    ``rmsnorm2d_fwd_with_dynamicquant`` (q) plus ``vllm_ir.rms_norm`` (kv); the
-    fused path runs both through the single HIP ``fused_qk_rmsnorm_per_token_quant``
-    kernel. With identical per-token scales the dequantized q values are bit-exact
-    except on fp8 rounding ties (at most one e4m3 step), and the bf16 kv norm
-    matches to bf16 tolerance.
     """
 
     def __init__(
@@ -201,8 +182,6 @@ class MLADualRMSNormFp8PerTokenTestModel(torch.nn.Module):
 
         self.proj = torch.nn.Linear(hidden_size, q_dim + self.kv_dim, bias=False)
         self.q_weight = torch.nn.Parameter(torch.ones(q_dim))
-        # kv latent is RMS-normed only (no quant); RMSNorm with custom_ops
-        # ["+rms_norm"] lowers to vllm_ir.rms_norm, matching the FP8 graph.
         self.kv_norm = RMSNorm(kv_c_dim, eps=eps)
 
     def _dequant(self, x_fp8: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
@@ -223,9 +202,6 @@ class MLADualRMSNormFp8PerTokenTestModel(torch.nn.Module):
         )
         kv_normed = self.kv_norm(kv_c)
 
-        # Dequant q in-graph keeps the quant op inside the compiled graph so the
-        # fusion pass can match it (returning fp8 directly graph-breaks dynamo);
-        # kv_normed is already bf16 and is returned (and matched) directly.
         return self._dequant(q_fp8, q_scale), kv_normed, k_pe
 
     def ops_in_model_before(self):
@@ -291,9 +267,6 @@ def test_fuse_mla_dual_rms_norm_fp8_per_token(
         x = torch.randn(4, hidden_size)
         torch._dynamo.mark_dynamic(x, 0)
 
-        # Decode runs under inference_mode; the fp8 quant op has no autograd
-        # kernel, so without this AOTAutograd builds a joint forward/backward
-        # graph that graph-breaks and the fusion never fires.
         with torch.inference_mode():
             outputs_unfused = model(x)
 
@@ -303,18 +276,10 @@ def test_fuse_mla_dual_rms_norm_fp8_per_token(
         q_deq_u, kv_normed_u, k_pe_u = outputs_unfused
         q_deq_f, kv_normed_f, k_pe_f = outputs_fused
 
-        # k_pe is a pure passthrough and must be bit-identical.
         torch.testing.assert_close(k_pe_u, k_pe_f, atol=0, rtol=0)
 
-        # kv latent is RMS-normed (not quantized) on both paths; the Triton and
-        # HIP rms norms agree to bf16 tolerance.
         torch.testing.assert_close(kv_normed_u, kv_normed_f, atol=1e-2, rtol=1e-2)
 
-        # With matching per-token scales the dequantized q values are bit-exact
-        # except where the unfused and fused quant kernels round an fp8 tie
-        # differently. Require the bulk to be exact (this catches scale bugs,
-        # which shift whole rows) and bound the rare ties to one e4m3 step
-        # (relative gap 2**-3 = 0.125).
         E4M3_STEP = 0.125
         exact_frac = (q_deq_u == q_deq_f).float().mean().item()
         assert exact_frac > 0.99, (

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -458,6 +458,10 @@ def check_aiter_fused_qk_rmsnorm_per_token_quant() -> bool:
     This is the fused RMSNorm + FP8 per-token-quant HIP kernel used to fuse the
     paired q/kv RMSNorm + FP8 per-token quantization in the MLA FP8 attention
     path.
+
+    TODO(xaguilar-amd): remove this guard once the minimum supported AITER
+    version provides fused_qk_rmsnorm_per_token_quant, as with
+    check_aiter_fused_qk_rmsnorm below.
     """
     global _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT
     if _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT is None:

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -449,6 +449,27 @@ def _rocm_aiter_fused_topk_fake(
 # Cache whether aiter supports FP8 MLA parameters
 _AITER_MLA_SUPPORTS_FP8: bool | None = None
 _AITER_HAS_FUSED_QK_RMSNORM: bool | None = None
+_AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT: bool | None = None
+
+
+def check_aiter_fused_qk_rmsnorm_per_token_quant() -> bool:
+    """Check if aiter provides fused_qk_rmsnorm_per_token_quant.
+
+    This is the fused RMSNorm + FP8 per-token-quant HIP kernel used to fuse the
+    paired q/kv RMSNorm + FP8 per-token quantization in the MLA FP8 attention
+    path.
+    """
+    global _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT
+    if _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT is None:
+        try:
+            from aiter.ops.fused_qk_rmsnorm_group_quant import (  # noqa: F401
+                fused_qk_rmsnorm_per_token_quant,
+            )
+
+            _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT = True
+        except (ImportError, ModuleNotFoundError, AttributeError):
+            _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT = False
+    return _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT
 
 
 def check_aiter_fused_qk_rmsnorm() -> bool:
@@ -1355,6 +1376,70 @@ def _fused_mla_dual_rms_norm_fake(
     return (torch.empty_like(x1), torch.empty_like(x2))
 
 
+def _fused_mla_dual_rms_norm_per_token_quant_impl(
+    q: torch.Tensor,
+    q_weight: torch.Tensor,
+    kv: torch.Tensor,
+    kv_weight: torch.Tensor,
+    q_epsilon: float,
+    kv_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused MLA q/kv RMSNorm (+ FP8 per-token quant on q) via AITER.
+
+    Backs the ``fused_mla_dual_rms_norm_per_token_quant`` custom op used by the
+    MLA FP8 attention fusion when the q latent is quantized *per token* (a single
+    ``(M, 1)`` scale). Only the *q* latent is FP8 quantized (it feeds the
+    FP8 ``q_b_proj`` GEMM); the *kv* latent is RMS-normed and consumed by attention as bf16.
+    """
+    try:
+        from aiter.ops.fused_qk_rmsnorm_group_quant import (
+            fused_qk_rmsnorm_per_token_quant,
+        )
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise ImportError(
+            "fused_qk_rmsnorm_per_token_quant requires a newer AITer version "
+            "(>= ROCm/aiter PR #2958). Please upgrade aiter or disable the "
+            "fuse_mla_dual_rms_norm pass."
+        ) from exc
+
+    mq, nq = q.shape
+    q_out = torch.empty((mq, nq), dtype=FP8_DTYPE, device=q.device)
+    q_scale = torch.empty((mq, 1), dtype=torch.float32, device=q.device)
+    kv_normed = torch.empty(kv.shape, dtype=kv.dtype, device=kv.device)
+
+    # q -> RMSNorm + FP8 per-token quant (q slot); kv -> RMSNorm only (k slot).
+    # `split` views are accepted directly (unit inner stride); the kernel
+    # handles strided inputs, matching the aiter op-test usage.
+    fused_qk_rmsnorm_per_token_quant(
+        q_out_quantized=q_out,
+        q_out_scale=q_scale,
+        q=q,
+        q_weight=q_weight,
+        q_epsilon=q_epsilon,
+        k_out=kv_normed,
+        k=kv,
+        k_weight=kv_weight,
+        k_epsilon=kv_epsilon,
+        gemma_norm=False,
+    )
+    return q_out, q_scale, kv_normed
+
+
+def _fused_mla_dual_rms_norm_per_token_quant_fake(
+    q: torch.Tensor,
+    q_weight: torch.Tensor,
+    kv: torch.Tensor,
+    kv_weight: torch.Tensor,
+    q_epsilon: float,
+    kv_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    mq, nq = q.shape
+    q_out = torch.empty((mq, nq), dtype=FP8_DTYPE, device=q.device)
+    q_scale = torch.empty((mq, 1), dtype=torch.float32, device=q.device)
+    kv_normed = torch.empty(kv.shape, dtype=kv.dtype, device=kv.device)
+    return q_out, q_scale, kv_normed
+
+
 def _rocm_aiter_gemm_a8wfp4_impl(
     x: torch.Tensor,
     w: torch.Tensor,
@@ -2046,6 +2131,13 @@ class rocm_aiter_ops:
                 fake_impl=_fused_mla_dual_rms_norm_fake,
             )
 
+            direct_register_custom_op(
+                op_name="fused_mla_dual_rms_norm_per_token_quant",
+                op_func=_fused_mla_dual_rms_norm_per_token_quant_impl,
+                mutates_args=[],
+                fake_impl=_fused_mla_dual_rms_norm_per_token_quant_fake,
+            )
+
             _OPS_REGISTERED = True
 
     @staticmethod
@@ -2119,6 +2211,10 @@ class rocm_aiter_ops:
     @staticmethod
     def get_fused_mla_dual_rms_norm_op() -> OpOverload:
         return torch.ops.vllm.fused_mla_dual_rms_norm.default
+
+    @staticmethod
+    def get_fused_mla_dual_rms_norm_per_token_quant_op() -> OpOverload:
+        return torch.ops.vllm.fused_mla_dual_rms_norm_per_token_quant.default
 
     @staticmethod
     def w8a8_gemm(

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -449,31 +449,6 @@ def _rocm_aiter_fused_topk_fake(
 # Cache whether aiter supports FP8 MLA parameters
 _AITER_MLA_SUPPORTS_FP8: bool | None = None
 _AITER_HAS_FUSED_QK_RMSNORM: bool | None = None
-_AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT: bool | None = None
-
-
-def check_aiter_fused_qk_rmsnorm_per_token_quant() -> bool:
-    """Check if aiter provides fused_qk_rmsnorm_per_token_quant.
-
-    This is the fused RMSNorm + FP8 per-token-quant HIP kernel used to fuse the
-    paired q/kv RMSNorm + FP8 per-token quantization in the MLA FP8 attention
-    path.
-
-    TODO(xaguilar-amd): remove this guard once the minimum supported AITER
-    version provides fused_qk_rmsnorm_per_token_quant, as with
-    check_aiter_fused_qk_rmsnorm below.
-    """
-    global _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT
-    if _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT is None:
-        try:
-            from aiter.ops.fused_qk_rmsnorm_group_quant import (  # noqa: F401
-                fused_qk_rmsnorm_per_token_quant,
-            )
-
-            _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT = True
-        except (ImportError, ModuleNotFoundError, AttributeError):
-            _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT = False
-    return _AITER_HAS_FUSED_QK_RMSNORM_PER_TOKEN_QUANT
 
 
 def check_aiter_fused_qk_rmsnorm() -> bool:
@@ -1395,16 +1370,9 @@ def _fused_mla_dual_rms_norm_per_token_quant_impl(
     ``(M, 1)`` scale). Only the *q* latent is FP8 quantized (it feeds the
     FP8 ``q_b_proj`` GEMM); the *kv* latent is RMS-normed and consumed by attention as bf16.
     """
-    try:
-        from aiter.ops.fused_qk_rmsnorm_group_quant import (
-            fused_qk_rmsnorm_per_token_quant,
-        )
-    except (ImportError, ModuleNotFoundError) as exc:
-        raise ImportError(
-            "fused_qk_rmsnorm_per_token_quant requires a newer AITer version "
-            "(>= ROCm/aiter PR #2958). Please upgrade aiter or disable the "
-            "fuse_mla_dual_rms_norm pass."
-        ) from exc
+    from aiter.ops.fused_qk_rmsnorm_group_quant import (
+        fused_qk_rmsnorm_per_token_quant,
+    )
 
     mq, nq = q.shape
     q_out = torch.empty((mq, nq), dtype=FP8_DTYPE, device=q.device)

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -11,7 +11,10 @@ from torch._inductor.pattern_matcher import PatternMatcherPass
 
 import vllm.ir.ops
 import vllm.model_executor.layers.quantization.utils.fp8_utils  # noqa: F401
-from vllm._aiter_ops import rocm_aiter_ops
+from vllm._aiter_ops import (
+    check_aiter_fused_qk_rmsnorm_per_token_quant,
+    rocm_aiter_ops,
+)
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -922,11 +925,150 @@ class MLADualRMSNormPattern(
         return _replacement
 
 
+class MLADualRMSPerTokenQuantPattern(
+    VllmPatternReplacement[
+        ...,
+        tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ],
+    ]
+):
+    """
+    Fuse the MLA FP8 attention path -- q-latent RMSNorm + FP8 *per-token* quant
+    together with the kv-latent RMSNorm -- into AITER's
+    ``fused_qk_rmsnorm_per_token_quant`` HIP kernel in a *single* launch.
+
+    This is the form that appears when the FP8 ``q_b_proj`` uses per-output-channel
+    weights with a per-token activation scale (Quark / ModelOpt). In that case
+    ``RocmAiterRMSNormQuantFusionPass`` (which runs earlier) folds the q-side
+    ``rms_norm -> per-token fp8 quant`` into ``rocm_aiter_rmsnorm_fused_dynamic_quant``
+    (a single ``(M, 1)`` scale) and leaves the kv side a plain ``vllm_ir.rms_norm``.
+    This pattern matches that asymmetric pair.
+
+    Target FX-graph pattern (post norm+quant fusion)::
+
+        gemm -> split_with_sizes([q_dim, kv_dim])
+            +-- q_c     -> rocm_aiter_rmsnorm_fused_dynamic_quant -> (q_fp8, q_scale)
+            +-- kv_lora -> split_with_sizes([kv_c_dim, k_pe_dim])
+                            +-- kv_c -> vllm_ir.rms_norm -> kv_normed (bf16)
+                            +-- k_pe
+    """
+
+    DYNAMIC_QUANT_OP = rocm_aiter_ops.get_rmsnorm_fused_dynamic_quant_op()
+    FUSED_OP = rocm_aiter_ops.get_fused_mla_dual_rms_norm_per_token_quant_op()
+
+    def __init__(self, epsilon: float) -> None:
+        self._epsilon = epsilon
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        q_dim, kv_c_dim, k_pe_dim = 256, 128, 64
+        return [
+            self.empty_bf16(5, q_dim + kv_c_dim + k_pe_dim),
+            self.empty_bf16(q_dim),
+            self.empty_bf16(kv_c_dim),
+        ]
+
+    @property
+    def pattern(
+        self,
+    ) -> Callable[
+        ...,
+        tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ],
+    ]:
+        eps = self._epsilon
+        dynamic_quant_op = self.DYNAMIC_QUANT_OP
+
+        def _pattern(
+            projected: torch.Tensor,
+            q_weight: torch.Tensor,
+            kv_weight: torch.Tensor,
+        ) -> tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ]:
+            q_dim = q_weight.shape[0]
+            kv_dim = projected.shape[-1] - q_dim
+            kv_c_dim = kv_weight.shape[0]
+            k_pe_dim = kv_dim - kv_c_dim
+            q_c, kv_lora = projected.split([q_dim, kv_dim], dim=-1)
+            kv_c, k_pe = kv_lora.split([kv_c_dim, k_pe_dim], dim=-1)
+            q_quant = dynamic_quant_op(
+                x=q_c,
+                weight=q_weight,
+                epsilon=eps,
+                quant_dtype=FP8_DTYPE,
+            )
+            kv_normed = vllm.ir.ops.rms_norm(kv_c, kv_weight, eps)
+            return q_quant[0], q_quant[1], kv_normed, k_pe
+
+        return _pattern
+
+    @property
+    def replacement(
+        self,
+    ) -> Callable[
+        ...,
+        tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ],
+    ]:
+        eps = self._epsilon
+        fused_op = self.FUSED_OP
+
+        def _replacement(
+            projected: torch.Tensor,
+            q_weight: torch.Tensor,
+            kv_weight: torch.Tensor,
+        ) -> tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ]:
+            q_dim = q_weight.shape[0]
+            kv_dim = projected.shape[-1] - q_dim
+            kv_c_dim = kv_weight.shape[0]
+            k_pe_dim = kv_dim - kv_c_dim
+            q_c, kv_lora = projected.split([q_dim, kv_dim], dim=-1)
+            kv_c, k_pe = kv_lora.split([kv_c_dim, k_pe_dim], dim=-1)
+            at = fused_op(
+                q_c,
+                q_weight,
+                kv_c,
+                kv_weight,
+                eps,
+                eps,
+            )
+            # q_fp8, q_scale, kv_normed, k_pe
+            return at[0], at[1], at[2], k_pe
+
+        return _replacement
+
+
 class MLADualRMSNormFusionPass(VllmFusionPatternMatcherPass):
     """
     Post-grad PatternMatcher pass that fuses paired q / kv RMS norms in
     MLA attention into ``fused_mla_dual_rms_norm`` backed by aiter's
     ``fused_qk_rmsnorm`` HIP kernel.
+
+    The FP8 attention path is also handled via
+    :class:`MLADualRMSPerTokenQuantPattern`, which fuses the q-latent RMSNorm +
+    FP8 per-token quant together with the kv-latent RMSNorm into
+    ``fused_mla_dual_rms_norm_per_token_quant`` backed by aiter's
+    ``fused_qk_rmsnorm_per_token_quant`` HIP kernel.
     """
 
     def __init__(self, config: VllmConfig) -> None:
@@ -934,3 +1076,15 @@ class MLADualRMSNormFusionPass(VllmFusionPatternMatcherPass):
 
         for epsilon in [1e-5, 1e-6]:
             self.register(MLADualRMSNormPattern(epsilon))
+
+        # In the FP8 attention path the q rms_norm is already fused into
+        # rocm_aiter_rmsnorm_fused_dynamic_quant by RocmAiterRMSNormQuantFusionPass
+        # (which runs earlier), so the symmetric BF16 dual pattern above no
+        # longer fires. Restore the dual fusion by matching that asymmetric
+        # (q per-token-quant + kv rms_norm) form -- where the q rms_norm is
+        # folded into a single (M, 1) activation scale -- and fuse it into
+        # AITER's fused_qk_rmsnorm_per_token_quant kernel. Only register when
+        # the installed aiter actually provides that kernel.
+        if check_aiter_fused_qk_rmsnorm_per_token_quant():
+            for epsilon in [1e-5, 1e-6]:
+                self.register(MLADualRMSPerTokenQuantPattern(epsilon))

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -11,10 +11,7 @@ from torch._inductor.pattern_matcher import PatternMatcherPass
 
 import vllm.ir.ops
 import vllm.model_executor.layers.quantization.utils.fp8_utils  # noqa: F401
-from vllm._aiter_ops import (
-    check_aiter_fused_qk_rmsnorm_per_token_quant,
-    rocm_aiter_ops,
-)
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -1071,7 +1068,4 @@ class MLADualRMSNormFusionPass(VllmFusionPatternMatcherPass):
 
         for epsilon in [1e-5, 1e-6]:
             self.register(MLADualRMSNormPattern(epsilon))
-
-        if check_aiter_fused_qk_rmsnorm_per_token_quant():
-            for epsilon in [1e-5, 1e-6]:
-                self.register(MLADualRMSPerTokenQuantPattern(epsilon))
+            self.register(MLADualRMSPerTokenQuantPattern(epsilon))

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -938,17 +938,12 @@ class MLADualRMSPerTokenQuantPattern(
 ):
     """
     Fuse the MLA FP8 attention path -- q-latent RMSNorm + FP8 *per-token* quant
-    together with the kv-latent RMSNorm -- into AITER's
-    ``fused_qk_rmsnorm_per_token_quant`` HIP kernel in a *single* launch.
+    plus kv-latent RMSNorm -- into AITER's ``fused_qk_rmsnorm_per_token_quant``.
 
-    This is the form that appears when the FP8 ``q_b_proj`` uses per-output-channel
-    weights with a per-token activation scale (Quark / ModelOpt). In that case
-    ``RocmAiterRMSNormQuantFusionPass`` (which runs earlier) folds the q-side
-    ``rms_norm -> per-token fp8 quant`` into ``rocm_aiter_rmsnorm_fused_dynamic_quant``
-    (a single ``(M, 1)`` scale) and leaves the kv side a plain ``vllm_ir.rms_norm``.
-    This pattern matches that asymmetric pair.
-
-    Target FX-graph pattern (post norm+quant fusion)::
+    With a per-token FP8 ``q_b_proj`` (Quark / ModelOpt), the earlier
+    ``RocmAiterRMSNormQuantFusionPass`` folds the q side into
+    ``rocm_aiter_rmsnorm_fused_dynamic_quant`` and leaves the kv side a plain
+    ``vllm_ir.rms_norm``. This pattern matches that asymmetric pair::
 
         gemm -> split_with_sizes([q_dim, kv_dim])
             +-- q_c     -> rocm_aiter_rmsnorm_fused_dynamic_quant -> (q_fp8, q_scale)
@@ -1077,14 +1072,6 @@ class MLADualRMSNormFusionPass(VllmFusionPatternMatcherPass):
         for epsilon in [1e-5, 1e-6]:
             self.register(MLADualRMSNormPattern(epsilon))
 
-        # In the FP8 attention path the q rms_norm is already fused into
-        # rocm_aiter_rmsnorm_fused_dynamic_quant by RocmAiterRMSNormQuantFusionPass
-        # (which runs earlier), so the symmetric BF16 dual pattern above no
-        # longer fires. Restore the dual fusion by matching that asymmetric
-        # (q per-token-quant + kv rms_norm) form -- where the q rms_norm is
-        # folded into a single (M, 1) activation scale -- and fuse it into
-        # AITER's fused_qk_rmsnorm_per_token_quant kernel. Only register when
-        # the installed aiter actually provides that kernel.
         if check_aiter_fused_qk_rmsnorm_per_token_quant():
             for epsilon in [1e-5, 1e-6]:
                 self.register(MLADualRMSPerTokenQuantPattern(epsilon))


### PR DESCRIPTION
## Summary

The `MLADualRMSNormFusionPass` fuses the paired `q_a_layernorm` +
`kv_a_layernorm` of MLA attention into AITER's `fused_qk_rmsnorm` HIP kernel, but
that fusion silently stops firing once attention is **FP8-quantized** — the
earlier `RocmAiterRMSNormQuantFusionPass` folds the q-side
`rms_norm → fp8 per-token quant` into a single
`rocm_aiter_rmsnorm_fused_dynamic_quant` op, so the q latent is no longer a bare
`rms_norm` and the symmetric BF16 dual pattern no longer matches. This PR
enables the dual fusion for the FP8 path by matching that asymmetric pair (q
per-token-quant + kv `rms_norm`) and lowering it to a new
`fused_mla_dual_rms_norm_per_token_quant` custom op, backed by AITER's
`fused_qk_rmsnorm_per_token_quant` kernel, so a **single** kernel launch replaces
the separate q (norm + FP8 per-token quant) and kv (norm) kernels:

```text
# FP8, before this PR (q norm+quant fused; kv still a separate rms_norm):
q_fp8, q_scale = rocm_aiter_rmsnorm_fused_dynamic_quant(q_c, q_weight, eps, fp8)
kv_normed      = rms_norm(kv_c, kv_weight, eps)          # bf16

# FP8, after this PR (single fused launch):
q_fp8, q_scale, kv_normed = fused_mla_dual_rms_norm_per_token_quant(
    q_c, q_weight, kv_c, kv_weight, eps1, eps2)
```

Only the *q* latent is FP8 per-token-quantized (it feeds the FP8 `q_b_proj`
GEMM, a single `(M, 1)` scale); the *kv* latent is RMS-normed and consumed by
attention as bf16. This matches the layout produced by the upstream norm+quant
fusion.

The pattern is registered **only** when the installed AITER actually exposes
`fused_qk_rmsnorm_per_token_quant` (guarded by
`check_aiter_fused_qk_rmsnorm_per_token_quant()`), so it is a no-op on older
AITER builds and on non-ROCm platforms. No new flag — it rides on the existing
`fuse_mla_dual_rms_norm` pass config (O1+ with AITER).

## Changes

- `vllm/_aiter_ops.py`: add the `fused_mla_dual_rms_norm_per_token_quant`
  custom op (impl + fake + registration + accessor) and the
  `check_aiter_fused_qk_rmsnorm_per_token_quant()` availability guard.
- `vllm/compilation/passes/fusion/rocm_aiter_fusion.py`: add
  `MLADualRMSPerTokenQuantPattern` and register it in
  `MLADualRMSNormFusionPass` when the kernel is available.
- `tests/compile/passes/test_fuse_mla_dual_rms_norm.py`: add a test that the
  per-token fusion fires exactly once and that fused vs unfused outputs match
  (skipped when the AITER kernel is unavailable).
- `docs/design/fusions.md`: document the FP8 per-token variant.

## Correctness (accuracy)

GSM8K, `amd/Kimi-K2.5-MXFP4-AttnFP8`, TP4, fusion enabled:

| Tasks | Version | Filter           | n-shot | Metric      |   | Value |   | Stderr |
|-------|--------:|------------------|-------:|-------------|---|------:|---|-------:|
| gsm8k |       3 | flexible-extract |      5 | exact_match | ↑ | 0.931 | ± |  0.007 |
|       |         | strict-match     |      5 | exact_match | ↑ | 0.931 | ± |  0.007 |

## Performance

Perfetto trace with the kernels fused:

<img width="1992" height="339" alt="fused_rmsnorm_perquant" src="https://github.com/user-attachments/assets/f3869a2d-4445-41fb-8499-1ccf62e11f6b" />




`vllm bench serve`, `amd/Kimi-K2.5-MXFP4-AttnFP8`, TP4, random dataset,
`--ignore-eos`. Fused = this PR; Baseline = `fuse_mla_dual_rms_norm=False`.

### ISL=1024, OSL=1024

| Conc | Out tok/s (fused) | Out tok/s (base) | Δ tput | TPOT fused (ms) | TPOT base (ms) | Δ TPOT |
|-----:|------------------:|-----------------:|:------:|----------------:|---------------:|:------:|
|    4 |            360.15 |           355.57 | +1.3%  |           10.11 |          10.30 | −1.8%  |
|    8 |            635.43 |           621.88 | +2.2%  |           11.04 |          11.24 | −1.8%  |
|   16 |            928.29 |           908.95 | +2.1%  |           14.01 |          14.26 | −1.8%  |
|   32 |           1682.78 |          1663.16 | +1.2%  |           18.44 |          18.34 | ~flat  |
|   64 |           2605.34 |          2566.46 | +1.5%  |           23.59 |          24.18 | −2.4%  |

### ISL=1024, OSL=8192

| Conc | Out tok/s (fused) | Out tok/s (base) | Δ tput | TPOT fused (ms) | TPOT base (ms) | Δ TPOT |
|-----:|------------------:|-----------------:|:------:|----------------:|---------------:|:------:|
|    8 |            653.70 |           644.97 | +1.4%  |           11.44 |          11.61 | −1.5%  |
|   32 |           1546.80 |          1525.50 | +1.4%  |           19.66 |          19.89 | −1.2%  |
|   64 |           2312.84 |          2320.38 | −0.3%  |           25.81 |          25.69 | ~flat  |


## Notes

AI assistance was used in preparing this change. 