### PR TITLE
[Bugfix] Add fetch_images to MistralCommonImageProcessor (transformers>=5.10 compat)

### DIFF
--- a/tests/transformers_utils/processors/test_pixtral.py
+++ b/tests/transformers_utils/processors/test_pixtral.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``MistralCommonImageProcessor.fetch_images``.
+
+``transformers>=5.10`` adds a ``ProcessorMixin.prepare_inputs_layout`` helper
+that calls ``self.image_processor.fetch_images(...)`` unconditionally. The
+duck-typed :class:`MistralCommonImageProcessor` previously did not implement
+that method, so loading any pixtral/mistral vision model under transformers
+5.10.x raised ``AttributeError: 'MistralCommonImageProcessor' object has no
+attribute 'fetch_images'``. These tests pin the new ``fetch_images`` method to
+the same contract as
+``transformers.image_processing_base.ImageProcessingMixin.fetch_images``.
+
+``fetch_images`` does not touch any instance state, so the processor is
+constructed with a dummy encoder to keep these tests fully offline (no model
+download).
+"""
+
+import pytest
+from PIL import Image
+
+from vllm.transformers_utils.processors.pixtral import MistralCommonImageProcessor
+
+
+@pytest.fixture(scope="module")
+def image_processor() -> MistralCommonImageProcessor:
+    # fetch_images never reads ``self.mm_encoder``; a dummy keeps tests offline.
+    return MistralCommonImageProcessor(mm_encoder=None)
+
+
+def test_fetch_images_passes_through_decoded_image(
+    image_processor: MistralCommonImageProcessor,
+):
+    image = Image.new("RGB", (4, 4))
+    result = image_processor.fetch_images(image)
+    assert result is image
+
+
+def test_fetch_images_recurses_over_list(
+    image_processor: MistralCommonImageProcessor,
+):
+    a = Image.new("RGB", (4, 4))
+    b = Image.new("RGB", (8, 8))
+    result = image_processor.fetch_images([a, b])
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0] is a
+    assert result[1] is b
+
+
+def test_fetch_images_recurses_over_nested_list(
+    image_processor: MistralCommonImageProcessor,
+):
+    a = Image.new("RGB", (4, 4))
+    b = Image.new("RGB", (8, 8))
+    result = image_processor.fetch_images([[a], [b]])
+    assert result == [[a], [b]]
+
+
+def test_fetch_images_str_delegates_to_load_image(
+    monkeypatch, image_processor: MistralCommonImageProcessor
+):
+    """A str input must round-trip through ``transformers.image_utils.load_image``.
+
+    ``load_image`` is monkey-patched so the test stays offline (no real URL/path
+    fetched) and still asserts the delegation contract.
+    """
+    sentinel = Image.new("RGB", (2, 2))
+    received: dict[str, object] = {}
+
+    def fake_load_image(path):
+        received["path"] = path
+        return sentinel
+
+    import transformers.image_utils
+
+    monkeypatch.setattr(transformers.image_utils, "load_image", fake_load_image)
+
+    result = image_processor.fetch_images("/tmp/fake.png")
+    assert result is sentinel
+    assert received["path"] == "/tmp/fake.png"
+
+
+def test_fetch_images_rejects_unsupported_type(
+    image_processor: MistralCommonImageProcessor,
+):
+    with pytest.raises(TypeError, match="only a single or a list"):
+        image_processor.fetch_images(42)  # type: ignore[arg-type]

--- a/vllm/transformers_utils/processors/pixtral.py
+++ b/vllm/transformers_utils/processors/pixtral.py
@@ -46,6 +46,39 @@ class MistralCommonImageProcessor:
         ncols, nrows = self.mm_encoder._image_to_num_tokens(image)
         return ncols * nrows, nrows, ncols
 
+    def fetch_images(self, image_url_or_urls):
+        """HF-compatible duck-typed ``fetch_images``.
+
+        Mirrors :meth:`transformers.image_processing_base.ImageProcessingMixin.\
+fetch_images` so :class:`transformers.ProcessorMixin.prepare_inputs_layout`
+        (added in transformers 5.10) works on this duck-typed image processor.
+        Older transformers versions never invoke this method, so the addition
+        is a no-op there.
+
+        Accepts the same shapes as the upstream method:
+
+        * already-decoded image (``PIL.Image`` / array) -- returned as-is.
+        * ``str`` URL or path -- delegated to
+          :func:`transformers.image_utils.load_image`.
+        * ``list`` / ``tuple`` of any of the above -- recursed element-wise.
+
+        ``ProcessorMixin.prepare_inputs_layout`` always passes already-decoded
+        images, so the str branch exists only to keep the contract identical to
+        the upstream method.
+        """
+        from transformers.image_utils import is_valid_image, load_image
+
+        if isinstance(image_url_or_urls, (list, tuple)):
+            return [self.fetch_images(x) for x in image_url_or_urls]
+        if isinstance(image_url_or_urls, str):
+            return load_image(image_url_or_urls)
+        if is_valid_image(image_url_or_urls):
+            return image_url_or_urls
+        raise TypeError(
+            "only a single or a list of entries is supported but got "
+            f"type={type(image_url_or_urls)}"
+        )
+
 
 class MistralCommonPixtralProcessor(ProcessorMixin):
     attributes = ["image_processor", "tokenizer"]


### PR DESCRIPTION
## Why

`transformers>=5.10` added `ProcessorMixin.prepare_inputs_layout`, which calls
`self.image_processor.fetch_images(images)`. vLLM's duck-typed
`MistralCommonImageProcessor` never implemented it, so Pixtral/Mistral vision
models (e.g. `Devstral-Small-2-24B-Instruct-2512`) crash at startup with
`AttributeError: 'MistralCommonImageProcessor' object has no attribute 'fetch_images'`.

Fixes #44911. This is the image-path counterpart of the merged audio-path fix
#44559 (`fetch_audio`); the same transformers 5.10 change broke both.

## What

- Add `fetch_images` to `MistralCommonImageProcessor`, mirroring
  `transformers` `ImageProcessingMixin.fetch_images`: pass decoded images
  through, delegate `str` URLs/paths to `load_image`, recurse over lists. No-op
  on older transformers that never call it.
- Add offline unit tests mirroring `test_voxtral.py`.

## Testing

- `pytest tests/transformers_utils/processors/test_pixtral.py` → 5 passed (transformers 5.10.2).
- `ruff check` / `ruff format --check` clean.
- Full build not run locally (precompiled wheel is Linux-only; developed on macOS arm64), so GPU/integration suites are deferred to CI.

No open PR addresses this image-path gap (checked by issue number and `fetch_images`); #41948 fixes a different `AttributeError`.

AI assistance (Claude) was used; all lines were reviewed and tests run by the submitter.
