### PR TITLE
Fix prompt_tokens_details always null when num_cached_tokens is 0

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -881,7 +881,7 @@ class OpenAIServingChat(OpenAIServing):
                     completion_tokens=completion_tokens,
                     total_tokens=num_prompt_tokens + completion_tokens,
                 )
-                if self.enable_prompt_tokens_details and num_cached_tokens:
+                if self.enable_prompt_tokens_details and num_cached_tokens is not None:
                     final_usage.prompt_tokens_details = PromptTokenUsageInfo(
                         cached_tokens=num_cached_tokens
                     )
@@ -1305,7 +1305,7 @@ class OpenAIServingChat(OpenAIServing):
             completion_tokens=num_generated_tokens,
             total_tokens=num_prompt_tokens + num_generated_tokens,
         )
-        if self.enable_prompt_tokens_details and final_res.num_cached_tokens:
+        if self.enable_prompt_tokens_details and final_res.num_cached_tokens is not None:
             usage.prompt_tokens_details = PromptTokenUsageInfo(
                 cached_tokens=final_res.num_cached_tokens
             )

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -443,7 +443,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 total_tokens=total_prompt_tokens + total_completion_tokens,
             )
 
-            if self.enable_prompt_tokens_details and num_cached_tokens:
+            if self.enable_prompt_tokens_details and num_cached_tokens is not None:
                 final_usage_info.prompt_tokens_details = PromptTokenUsageInfo(
                     cached_tokens=num_cached_tokens
                 )


### PR DESCRIPTION
## Summary

Fixes #44961: `usage.prompt_tokens_details` was always `null` in API responses despite `--enable-prompt-tokens-details`, because `num_cached_tokens=0` (no cache hits) is falsy in Python.

PR #18149 wired `num_cached_tokens` through the engine but the serving layer condition `if num_cached_tokens` treated `0` the same as `None`, so `prompt_tokens_details` was never populated for any request.

## Fix

Change `and num_cached_tokens` → `and num_cached_tokens is not None` in three locations:

| File | Path |
|---|---|
| `chat_completion/serving.py` | streaming usage chunk (L884) |
| `chat_completion/serving.py` | non-streaming final usage (L1308) |
| `completion/serving.py` | streaming usage chunk (L446) |

## Test Plan

Logic verification:
```
num_cached_tokens | old behavior        | new behavior
None              | null (correct)      | null (correct)
0                 | null (WRONG)        | {"cached_tokens": 0}
5                 | {"cached_tokens":5} | {"cached_tokens":5}
```

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.

Co-authored-by: Claude <noreply@anthropic.com>