### PR TITLE
[Bugfix] Respect NCCL_P2P_DISABLE in custom allreduce

### DIFF
--- a/tests/distributed/test_custom_all_reduce_unit.py
+++ b/tests/distributed/test_custom_all_reduce_unit.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch.distributed as dist
+
+import vllm.distributed.device_communicators.custom_all_reduce as custom_ar
+
+
+def test_custom_allreduce_respects_nccl_p2p_disable(monkeypatch):
+    monkeypatch.setenv("NCCL_P2P_DISABLE", "1")
+    monkeypatch.setattr(custom_ar, "custom_ar", True)
+    monkeypatch.setattr(custom_ar.dist, "get_backend", lambda group: dist.Backend.GLOO)
+    monkeypatch.setattr(custom_ar.dist, "get_rank", lambda group: 0)
+    monkeypatch.setattr(custom_ar.dist, "get_world_size", lambda group: 2)
+    monkeypatch.setattr(
+        custom_ar,
+        "in_the_same_node_as",
+        lambda group, source_rank: [True, True],
+    )
+
+    def fail_can_p2p(rank, world_size):
+        pytest.fail("_can_p2p should not run when NCCL_P2P_DISABLE=1")
+
+    monkeypatch.setattr(custom_ar, "_can_p2p", fail_can_p2p)
+
+    allreduce = custom_ar.CustomAllreduce(group=object(), device=0)
+
+    assert allreduce.disabled

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -114,6 +115,10 @@ class CustomAllreduce:
         # now `device` is a `torch.device` object
         assert isinstance(device, torch.device)
         self.device = device
+        if os.getenv("NCCL_P2P_DISABLE") == "1":
+            logger.warning("Custom allreduce is disabled because NCCL_P2P_DISABLE=1.")
+            return
+
         device_capability = current_platform.get_device_capability()
         if (
             current_platform.is_cuda()

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -203,6 +204,11 @@ class CustomAllreduce:
                 "group does not have MNNVL-capable GPUs on every rank."
             )
             return
+
+        if os.getenv("NCCL_P2P_DISABLE") == "1":
+            logger.warning("Custom allreduce is disabled because NCCL_P2P_DISABLE=1.")
+            return
+
         device_capability = current_platform.get_device_capability()
         if (
             current_platform.is_cuda()


### PR DESCRIPTION
## Purpose

Refs #17676.

When users set `NCCL_P2P_DISABLE=1`, NCCL avoids GPU P2P paths, but vLLM's custom all-reduce still performed its own P2P capability probe and could continue toward the custom P2P-based path. This disables custom all-reduce early when `NCCL_P2P_DISABLE=1` is present, matching the user's explicit NCCL P2P opt-out.

This is intentionally a scoped mitigation for one #17676 subcase, not a full fix for every engine-start hang reported in that broad issue.

## Duplicate-work check

I checked the issue and open PRs before opening this:

- `gh issue view 17676 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "17676 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "engine startup hang core engine NCCL P2P custom all reduce"`

Open PR #36570 is adjacent but not duplicate: it sets `NCCL_P2P_DISABLE=1` automatically on certain non-fully-connected CUDA topologies. This PR makes custom all-reduce respect that env var when it is already present. Other search hits (#39330, #41834) are unrelated to this custom all-reduce path.

## Test Plan

- `git diff --check -- vllm/distributed/device_communicators/custom_all_reduce.py tests/distributed/test_custom_all_reduce_unit.py`
- `.venv/bin/ruff check vllm/distributed/device_communicators/custom_all_reduce.py tests/distributed/test_custom_all_reduce_unit.py`
- `.venv/bin/ruff format --check vllm/distributed/device_communicators/custom_all_reduce.py tests/distributed/test_custom_all_reduce_unit.py`
- `.venv/bin/python -m py_compile vllm/distributed/device_communicators/custom_all_reduce.py tests/distributed/test_custom_all_reduce_unit.py`
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180s .venv/bin/python -m pytest tests/distributed/test_custom_all_reduce_unit.py -q`

## Test Result

- `git diff --check`: passed
- `ruff check`: passed
- `ruff format --check`: passed
- `py_compile`: passed
- targeted pytest: `1 passed, 2 warnings`

AI assistance was used: OpenAI Codex.
