### PR TITLE
[Bugfix] Guard spec decode slot mapping padding rows

### DIFF
--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -40,10 +40,17 @@ def _reference_eagle_step_slot_mapping(
         block_numbers.long(),
     ].long()
     slot_mapping = block_ids * block_size + (clamped_positions % block_size)
+    is_padding = seq_lens == 0
+    clamped_positions = torch.where(
+        is_padding, torch.zeros_like(clamped_positions), clamped_positions
+    )
     slot_mapping = torch.where(
-        exceeds_max, torch.full_like(slot_mapping, PADDING_SLOT_ID), slot_mapping
+        exceeds_max | is_padding,
+        torch.full_like(slot_mapping, PADDING_SLOT_ID),
+        slot_mapping,
     )
     new_seq_lens = torch.where(exceeds_max, torch.ones_like(seq_lens), seq_lens + 1)
+    new_seq_lens = torch.where(is_padding, seq_lens, new_seq_lens)
     new_seq_lens = new_seq_lens.clamp(max=max_model_len)
     return clamped_positions, slot_mapping, new_seq_lens
 
@@ -176,3 +183,44 @@ def test_eagle_step_slot_mapping_kernel_cudagraph_padding():
     # Padding slots should be PADDING_SLOT_ID
     for i in range(batch_size, input_batch_size):
         assert out_slot[i].item() == PADDING_SLOT_ID
+
+
+def test_eagle_step_slot_mapping_kernel_zero_seq_len_padding_row():
+    """Rows with seq_len 0 should not read block_table[-1]."""
+    device = torch.device(DEVICE_TYPE)
+    block_size = 16
+    max_model_len = 128
+
+    positions_1d = torch.tensor([10, 20, 30], dtype=torch.int64, device=device)
+    block_table_tensor = torch.tensor(
+        [[7, 8], [-1, -1], [11, 12]], dtype=torch.int32, device=device
+    )
+    seq_lens = torch.tensor([11, 0, 31], dtype=torch.int32, device=device)
+
+    ref_clamped, ref_slot, ref_seq_lens = _reference_eagle_step_slot_mapping(
+        positions_1d.clone(),
+        block_table_tensor,
+        seq_lens.clone(),
+        block_size,
+        max_model_len,
+    )
+
+    out_clamped = torch.full_like(positions_1d, -1)
+    out_slot = torch.full((3,), -999, dtype=torch.int64, device=device)
+    seq_lens_copy = seq_lens.clone()
+    eagle_step_update_slot_mapping_and_metadata(
+        positions_1d=positions_1d,
+        block_table_tensor=block_table_tensor,
+        seq_lens=seq_lens_copy,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        out_clamped_positions=out_clamped,
+        out_slot_mapping=out_slot,
+    )
+
+    assert torch.equal(out_clamped, ref_clamped)
+    assert torch.equal(out_slot, ref_slot)
+    assert torch.equal(seq_lens_copy, ref_seq_lens)
+    assert out_clamped[1].item() == 0
+    assert out_slot[1].item() == PADDING_SLOT_ID
+    assert seq_lens_copy[1].item() == 0

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -57,6 +57,14 @@ def eagle_step_slot_mapping_metadata_kernel(
         tl.store(out_slot_mapping_ptr + req_idx, PAD_ID)
         return
 
+    # Padded rows inside the captured batch can have seq_lens == 0 and
+    # block_table entries of -1. Do not advance them into a real request.
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    if seq_len == 0:
+        tl.store(out_clamped_positions_ptr + req_idx, 0)
+        tl.store(out_slot_mapping_ptr + req_idx, PAD_ID)
+        return
+
     # Load current position and increment
     position = tl.load(positions_ptr + req_idx)
     new_position = position + 1
@@ -75,7 +83,6 @@ def eagle_step_slot_mapping_metadata_kernel(
     slot_id = tl.where(exceeds_max, PAD_ID, slot_id)
 
     # Update seq_lens: +1 normally, or 1 if exceeded
-    seq_len = tl.load(seq_lens_ptr + req_idx)
     new_seq_len = tl.where(exceeds_max, 1, seq_len + 1)
     new_seq_len = tl.minimum(new_seq_len, max_model_len)
 


### PR DESCRIPTION
## Summary

Refs #40756 and #39295.

Guard the fused EAGLE/MTP draft-step slot-mapping kernel against inactive
padding rows with `seq_lens == 0`. These rows can carry `block_table` entries of
`-1`; advancing them as real requests can produce invalid slot mappings and
surface later as CUDA illegal memory access/device-side asserts in speculative
decoding.

This change returns early for those rows, writes `PADDING_SLOT_ID`, and leaves
their sequence length at zero. It also adds a regression test that creates a
zero-length row with a `-1` block table.

## Duplicate-work check

- Checked issue #40756 and its comments.
- `gh pr list --repo vllm-project/vllm --state open --search "40756 in:body"` returned no open PRs.
- Area searches for `MTP speculative decoding illegal memory access`, `eagle_step_slot_mapping_metadata_kernel seq_lens padding`, and CUDA-graph padded-position wording found no open PR covering this guard.
- #42603 is a closed PR for #40756, but it used a stream synchronization workaround and was rejected by maintainers as not root-caused. This PR does not add synchronization.
- #43682 is a closed, unmerged PR that proposed the same kernel guard for related issues. There is currently no open PR for that fix; this PR keeps the scope narrow and includes the regression coverage and local checks below.

## Tests

```bash
.venv/bin/ruff check vllm/v1/spec_decode/utils.py tests/v1/spec_decode/test_eagle_step_kernel.py
# All checks passed

.venv/bin/ruff format --check vllm/v1/spec_decode/utils.py tests/v1/spec_decode/test_eagle_step_kernel.py
# 2 files already formatted

.venv/bin/python -m py_compile vllm/v1/spec_decode/utils.py tests/v1/spec_decode/test_eagle_step_kernel.py
# passed

git diff --check -- vllm/v1/spec_decode/utils.py tests/v1/spec_decode/test_eagle_step_kernel.py
# passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/v1/spec_decode/test_eagle_step_kernel.py -q
# 1 skipped, 16 warnings
```

The targeted pytest is a Triton GPU kernel test and was skipped locally because
CUDA/XPU is not available in this environment.

## AI assistance disclosure

This change was prepared with AI assistance from OpenAI Codex. The submitter
should review the two changed files and validate the GPU kernel test in a CUDA
environment before merge.
