### PR TITLE
[V1][Spec Decode] Add self_draft method: PaRD-style parallel decoding

### DIFF
--- a/tests/v1/spec_decode/test_self_draft.py
+++ b/tests/v1/spec_decode/test_self_draft.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the ``method='self_draft'`` configuration path.
+
+These tests are intentionally offline: they exercise
+``SpeculativeConfig.__post_init__`` and the small set of method-predicate
+helpers added alongside ``SelfDraftProposer``. End-to-end accept-rate and
+CUDA-graph correctness are covered by the integration tests (which require
+a GPU + a model checkpoint) and are run separately by the submitter.
+"""
+
+from unittest import mock
+
+import pytest
+
+from vllm.config import ParallelConfig, SpeculativeConfig
+
+
+def _make_target_model_config(enforce_eager: bool = False):
+    """Minimal ``ModelConfig`` stand-in for the ``self_draft`` branch.
+
+    ``SpeculativeConfig.__post_init__`` only reads ``enforce_eager`` and
+    assigns the whole object to ``draft_model_config`` / inspects
+    ``hf_config`` later via the proposer (not exercised here), so a small
+    ``MagicMock`` is sufficient and avoids any HF download.
+    """
+    target = mock.MagicMock(name="target_model_config")
+    target.enforce_eager = enforce_eager
+    return target
+
+
+def test_predicates_are_mutually_exclusive_for_self_draft():
+    """``use_self_draft()`` must not overlap with the other method gates."""
+    sc = SpeculativeConfig.__new__(SpeculativeConfig)
+    sc.method = "self_draft"
+    assert sc.use_self_draft() is True
+    assert sc.use_eagle() is False
+    assert sc.use_dflash() is False
+    assert sc.uses_draft_model() is False
+    assert sc.uses_extract_hidden_states() is False
+
+    sc.method = "eagle"
+    assert sc.use_self_draft() is False
+    sc.method = "draft_model"
+    assert sc.use_self_draft() is False
+    sc.method = "ngram"
+    assert sc.use_self_draft() is False
+
+
+def test_self_draft_shares_target_configs_and_enables_parallel_drafting():
+    target = _make_target_model_config()
+    spec = SpeculativeConfig(
+        target_model_config=target,
+        target_parallel_config=ParallelConfig(),
+        method="self_draft",
+        num_speculative_tokens=3,
+    )
+    # Drafter shares the target's weights & parallelism by construction.
+    assert spec.draft_model_config is spec.target_model_config
+    assert spec.draft_parallel_config is spec.target_parallel_config
+    # Parallel drafting is the whole point of this method.
+    assert spec.parallel_drafting is True
+    # ``self.model`` is set to the method name purely to satisfy the
+    # "model is not None" guard.
+    assert spec.model == "self_draft"
+
+
+def test_self_draft_inherits_enforce_eager_from_target():
+    """Drafter and target share the same module instance, so their
+    cudagraph modes must agree when the user did not pin ``enforce_eager``
+    on the speculative config explicitly."""
+    target = _make_target_model_config(enforce_eager=True)
+    spec = SpeculativeConfig(
+        target_model_config=target,
+        target_parallel_config=ParallelConfig(),
+        method="self_draft",
+        num_speculative_tokens=2,
+    )
+    assert spec.enforce_eager is True
+
+
+def test_self_draft_respects_explicit_enforce_eager():
+    """An explicit ``enforce_eager=False`` on the speculative config must
+    win over the target's default."""
+    target = _make_target_model_config(enforce_eager=True)
+    spec = SpeculativeConfig(
+        target_model_config=target,
+        target_parallel_config=ParallelConfig(),
+        method="self_draft",
+        num_speculative_tokens=2,
+        enforce_eager=False,
+    )
+    assert spec.enforce_eager is False
+
+
+def test_self_draft_auto_generates_chain_token_tree():
+    target = _make_target_model_config()
+    spec = SpeculativeConfig(
+        target_model_config=target,
+        target_parallel_config=ParallelConfig(),
+        method="self_draft",
+        num_speculative_tokens=4,
+    )
+    # Chain shape: K nodes, each at depth i+1.
+    # SpecDecodeBaseProposer parses ``speculative_token_tree``; parallel
+    # drafting ignores its shape but the field must be non-None.
+    assert spec.speculative_token_tree is not None
+    tree = eval(spec.speculative_token_tree)  # noqa: S307 - test-only
+    assert tree == [(0,), (0, 0), (0, 0, 0), (0, 0, 0, 0)]
+
+
+def test_self_draft_requires_num_speculative_tokens():
+    target = _make_target_model_config()
+    with pytest.raises(ValueError, match="num_speculative_tokens"):
+        SpeculativeConfig(
+            target_model_config=target,
+            target_parallel_config=ParallelConfig(),
+            method="self_draft",
+            # num_speculative_tokens intentionally omitted
+        )
+
+
+def test_self_draft_disables_prompt_lookup():
+    """``prompt_lookup_{min,max}`` are an ngram-only artifact; the
+    self_draft branch must zero them out so downstream code paths that
+    branch on these values do not accidentally trigger."""
+    target = _make_target_model_config()
+    spec = SpeculativeConfig(
+        target_model_config=target,
+        target_parallel_config=ParallelConfig(),
+        method="self_draft",
+        num_speculative_tokens=2,
+    )
+    assert spec.prompt_lookup_min == 0
+    assert spec.prompt_lookup_max == 0
+
+
+def test_parallel_drafting_mask_token_id_override_is_stored_verbatim():
+    """The override is consumed lazily by ``SelfDraftProposer`` (not
+    exercised here without a model). What we verify is that the
+    ``SpeculativeConfig`` field round-trips through ``__post_init__``
+    without being clobbered by the self_draft branch."""
+    target = _make_target_model_config()
+    spec = SpeculativeConfig(
+        target_model_config=target,
+        target_parallel_config=ParallelConfig(),
+        method="self_draft",
+        num_speculative_tokens=1,
+        parallel_drafting_mask_token_id=123456,
+    )
+    assert spec.parallel_drafting_mask_token_id == 123456

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -61,6 +61,7 @@ SpeculativeMethod = Literal[
     "medusa",
     "mlp_speculator",
     "draft_model",
+    "self_draft",
     "suffix",
     "custom_class",
     EagleModelTypes,
@@ -150,6 +151,12 @@ class SpeculativeConfig:
     in parallel rather than sequentially. This can improve performance but
     requires the speculative model be trained to support parallel drafting.
     Only compatible with EAGLE and draft model methods."""
+
+    parallel_drafting_mask_token_id: int | None = None
+    """Explicit override of the mask token id used for parallel drafting
+    (``method='self_draft'`` / ``'dflash'``). When ``None``, the proposer
+    falls back to ``pard_token`` / ``ptd_token_id`` on the draft model's
+    ``hf_config``."""
 
     # required configuration params passed from engine
     target_model_config: SkipValidation[ModelConfig] = None  # type: ignore
@@ -575,6 +582,12 @@ class SpeculativeConfig:
                 self.model = "suffix"
             elif self.method == "extract_hidden_states":
                 self.model = "extract_hidden_states"
+            elif self.method == "self_draft":
+                # The drafter IS the target model; ``draft_model_config`` is
+                # populated from ``target_model_config`` later in this
+                # post-init. ``self.model`` is set to the method name purely
+                # to satisfy the "model is not None" guard above.
+                self.model = "self_draft"
             elif self.method == "custom_class":
                 # method was set explicitly, but model should already contain the
                 # custom module path. If not, this is a configuration error.
@@ -665,6 +678,37 @@ class SpeculativeConfig:
             )
             self.update_arch_()
             self.draft_parallel_config = self.target_parallel_config
+
+        elif self.method == "self_draft":
+            # Self-Draft Parallel Decoding (PaRD-style): the target model
+            # itself acts as the drafter by filling ``num_speculative_tokens``
+            # appended <mask> tokens in a single forward pass. See
+            # ``vllm.v1.spec_decode.self_draft.SelfDraftProposer``.
+            self.prompt_lookup_max = 0
+            self.prompt_lookup_min = 0
+            # The drafter shares weights and config with the target.
+            self.draft_model_config = self.target_model_config
+            self.draft_parallel_config = self.target_parallel_config
+            self.parallel_drafting = True
+            # Drafter and target share the same module instance, so their
+            # cudagraph mode must agree. Inherit ``enforce_eager`` from the
+            # target when the user did not set it explicitly on the
+            # speculative config.
+            if self.enforce_eager is None and self.target_model_config is not None:
+                self.enforce_eager = bool(
+                    getattr(self.target_model_config, "enforce_eager", False)
+                )
+            # ``SpecDecodeBaseProposer`` asserts on a non-None token tree;
+            # parallel drafting ignores the tree shape but still parses it.
+            if self.speculative_token_tree is None:
+                if self.num_speculative_tokens is None:
+                    raise ValueError(
+                        "`num_speculative_tokens` must be provided when "
+                        "using method='self_draft'."
+                    )
+                self.speculative_token_tree = str(
+                    [(i + 1) * (0,) for i in range(self.num_speculative_tokens)]
+                )
 
         else:
             self.prompt_lookup_max = 0
@@ -1072,6 +1116,9 @@ class SpeculativeConfig:
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"
+
+    def use_self_draft(self) -> bool:
+        return self.method == "self_draft"
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -893,7 +893,7 @@ class SpecDecodeBaseProposer:
         return per_group_attn_metadata, per_layer_attn_metadata
 
     def model_returns_tuple(self) -> bool:
-        return self.method not in ("mtp", "draft_model", "dflash")
+        return self.method not in ("mtp", "draft_model", "dflash", "self_draft")
 
     def prepare_next_token_ids_cpu(
         self,

--- a/vllm/v1/spec_decode/self_draft.py
+++ b/vllm/v1/spec_decode/self_draft.py
@@ -1,0 +1,839 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Self-Draft Parallel Decoding (PaRD-style) proposer.
+
+The target model itself acts as the drafter: ``num_speculative_tokens``
+mask tokens are appended to each request and the model fills them in
+with a single forward pass; the standard rejection sampler then verifies
+a contiguous prefix of matches.
+
+Reference: "PaRD: A Parallel Decoding Framework..." (chain layout, K
+mask tokens per request, drafter shares weights with the target).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from typing_extensions import override
+
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.spec_decode.draft_model import DraftModelProposer
+from vllm.v1.spec_decode.utils import compute_new_slot_mapping
+
+logger = init_logger(__name__)
+
+
+class SelfDraftProposer(DraftModelProposer):
+    """Parallel-decoding proposer where the drafter is the target model.
+
+    This subclass exists to (a) bypass the multimodal / M-RoPE /
+    vocab-size / TP guards in the base proposer chain (they assume a
+    separate drafter checkpoint) and (b) build drafter inputs that
+    reuse the target's KV cache instead of re-running the prompt.
+    """
+
+    # ------------------------------------------------------------------ #
+    # Guards bypassed by self_draft. ``_raise_if_*`` methods are invoked
+    # by ``SpecDecodeBaseProposer.__init__`` via MRO, so these overrides
+    # must exist before ``super().__init__`` runs.
+    # ------------------------------------------------------------------ #
+
+    @override
+    def _raise_if_multimodal(self) -> None:
+        # self_draft natively supports multimodal targets.
+        return
+
+    @override
+    def _raise_if_mrope(self) -> None:
+        # 3-D positions are handled by ``set_inputs_first_pass`` below.
+        return
+
+    @override
+    def _init_parallel_drafting_params(self) -> None:
+        """Resolve the mask token id for parallel drafting.
+
+        The mask token id must be supplied via
+        ``SpeculativeConfig.parallel_drafting_mask_token_id`` (typically
+        forwarded by the engine from a user-facing config or CLI flag).
+        We intentionally do not sniff arbitrary ``hf_config`` attributes
+        here so the contract is explicit on the public API surface.
+        """
+        override_id = getattr(
+            self.speculative_config, "parallel_drafting_mask_token_id", None
+        )
+        if override_id is None:
+            raise ValueError(
+                "SelfDraftProposer requires an explicit mask-token id. "
+                "Set `SpeculativeConfig.parallel_drafting_mask_token_id` "
+                "(e.g. via `speculative_config={'method': 'self_draft', "
+                "'parallel_drafting_mask_token_id': <id>, ...}`)."
+            )
+        self.parallel_drafting_token_id = int(override_id)
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ):
+        spec = vllm_config.speculative_config
+        assert spec is not None, "Speculative config must be set"
+        if not spec.parallel_drafting:
+            raise ValueError(
+                "SelfDraftProposer requires `SpeculativeConfig.parallel_drafting=True`."
+            )
+        if runner is None:
+            raise ValueError(
+                "SelfDraftProposer needs a reference to the GPU model "
+                "runner to reuse the target model module."
+            )
+
+        # ``SpecDecodeBaseProposer.__init__`` invokes the overridden
+        # ``_raise_if_*`` / ``_init_parallel_drafting_params`` above.
+        super().__init__(vllm_config=vllm_config, device=device, runner=runner)
+
+        self._runner = runner
+        logger.debug(
+            "SelfDraftProposer initialized: mask_token_id=%d, "
+            "supports_mm_inputs=%s, uses_mrope=%s",
+            self.parallel_drafting_token_id,
+            self.supports_mm_inputs,
+            self.uses_mrope,
+        )
+
+    # ``DraftModelProposer.__init__`` runs two extra checks
+    # (``_raise_if_vocab_size_mismatch`` / ``_raise_if_draft_tp_mismatch``)
+    # that only apply to a separate drafter checkpoint. For self_draft
+    # the drafter IS the target, so both are trivially satisfied.
+    @override
+    def _raise_if_vocab_size_mismatch(self) -> None:
+        return
+
+    @override
+    def _raise_if_draft_tp_mismatch(self) -> None:
+        return
+
+    def _resolve_target_model(self) -> nn.Module:
+        model = getattr(self._runner, "model", None)
+        if not isinstance(model, nn.Module):
+            raise AttributeError(
+                "SelfDraftProposer could not locate the target model on "
+                "the model runner (`runner.model`)."
+            )
+        return model
+
+    @override
+    def load_model(self, target_model: nn.Module) -> None:
+        """Reuse the target model as the drafter.
+
+        ``self._draft_attn_layer_names`` is normally derived as
+        ``all_attn_layers - target_attn_layer_names``; for self_draft
+        that difference is empty. We instead use the full attention
+        layer set; ``validate_same_kv_cache_group`` then filters out
+        layers without a kv-cache group (e.g. vision tower layers).
+
+        Note: we intentionally do not cache ``self.model`` here. The
+        GPU model runner wraps its model in ``CUDAGraphWrapper`` *after*
+        ``drafter.load_model`` runs, so caching would bypass the wrapper
+        on every drafter forward and break FULL cudagraph replay. The
+        ``self.model`` property below always reads ``runner.model``.
+        """
+        from vllm.config import get_layers_from_vllm_config
+        from vllm.model_executor.layers.attention_layer_base import (
+            AttentionLayerBase,
+        )
+
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+        # Triggers subclass-specific side effects (logging, etc.).
+        _ = self._get_model()
+        self._draft_attn_layer_names = set(all_attn_layers.keys())
+
+        # Multimodal targets need ``embed_input_ids`` available and an
+        # image_token_index on the drafter's config for downstream
+        # multimodal-aware code paths.
+        if self.supports_mm_inputs:
+            if not hasattr(self.model, "embed_input_ids"):
+                raise AttributeError(
+                    "SelfDraftProposer requires the target model to "
+                    "expose `embed_input_ids` for multimodal inputs."
+                )
+            image_token_idx = getattr(
+                target_model.config,
+                "image_token_index",
+                getattr(target_model.config, "image_token_id", None),
+            )
+            if image_token_idx is not None:
+                self.model.config.image_token_index = image_token_idx
+
+    @override
+    def validate_same_kv_cache_group(self, kv_cache_config) -> None:
+        """Restrict the draft layer set to layers that belong to a
+        kv-cache group (filters out non-KV-cached layers such as
+        vision tower blocks) and assert they share a single group.
+        """
+        kv_cache_groups: dict[str, int] = {}
+        for id, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+            for layer_name in kv_cache_group.layer_names:
+                kv_cache_groups[layer_name] = id
+
+        self._draft_attn_layer_names = {
+            n for n in self._draft_attn_layer_names if n in kv_cache_groups
+        }
+        group_ids = {kv_cache_groups[n] for n in self._draft_attn_layer_names}
+        assert len(group_ids) <= 1, (
+            f"SelfDraft: all language-side attention layers must belong "
+            f"to the same kv cache group, got {group_ids}"
+        )
+
+    # ``self.model`` reads through ``runner.model`` so the drafter
+    # always sees the runner's (possibly CUDAGraphWrapper-wrapped)
+    # current model reference. See ``load_model`` for rationale.
+    @property
+    def model(self) -> nn.Module:
+        return getattr(self._runner, "model", None)  # type: ignore[return-value]
+
+    def _get_persist_block_table(self, num_reqs: int) -> torch.Tensor | None:
+        """Return a stable view into the runner's persistent block table.
+
+        Caches the full-size device tensor on first call so subsequent
+        slices ``[:num_reqs]`` share the same ``data_ptr`` — required
+        for FULL cudagraph replay.
+        """
+        full = getattr(self, "_persist_block_table_full", None)
+        if full is None:
+            input_batch = getattr(self._runner, "input_batch", None)
+            if input_batch is None:
+                return None
+            bt = input_batch.block_table[0]
+            full = bt.get_device_tensor(self.max_batch_size)
+            self._persist_block_table_full = full
+        return full[:num_reqs]
+
+    @override
+    def _get_model(self) -> nn.Module:
+        target_model = self._resolve_target_model()
+        logger.debug(
+            "SelfDraftProposer reusing target model module (%s) as the "
+            "drafter; no extra weights loaded.",
+            target_model.__class__.__name__,
+        )
+        return target_model
+
+    @override
+    def _maybe_share_embeddings(self, target_language_model: nn.Module) -> None:
+        # Drafter IS the target — embeddings are already shared.
+        return
+
+    @override
+    def _maybe_share_lm_head(self, target_language_model: nn.Module) -> None:
+        return
+
+    @override
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        # Drafter shares the target's VllmConfig.
+        return self.vllm_config
+
+    @override
+    def build_per_group_and_layer_attn_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int = 0,
+    ):
+        """Build attention metadata for the drafter forward.
+
+        FA3 (``FlashAttentionMetadataBuilder``) owns a long-lived
+        ``scheduler_metadata`` buffer that is written in place by
+        ``build_for_cudagraph_capture`` (full build). ``fast_build=True``
+        — used by the default ``build_for_drafting`` — does not refresh
+        this buffer, so a FULL-captured graph would replay a stale
+        schedule (computed from capture-time placeholder ``seq_lens``).
+        For builders that participate in FULL cudagraph AOT scheduling,
+        we route through ``build_for_cudagraph_capture`` to refresh the
+        in-place schedule with the actual ``seq_lens`` of this step.
+
+        TODO: replace this override once FA3 exposes a
+        ``force_schedule_refresh`` flag on ``build_for_drafting``.
+        """
+        per_group_attn_metadata: list[object] = []
+        per_layer_attn_metadata: dict[str, object] = {}
+        for attn_group in self.draft_attn_groups:
+            builder = attn_group.get_metadata_builder()
+            needs_schedule_refresh = (
+                getattr(builder, "use_full_cuda_graph", False)
+                and getattr(builder, "scheduler_metadata", None) is not None
+                and draft_index == 0
+            )
+            if needs_schedule_refresh:
+                attn_metadata = builder.build_for_cudagraph_capture(
+                    common_attn_metadata=common_attn_metadata
+                )
+            else:
+                attn_metadata = builder.build_for_drafting(
+                    common_attn_metadata=common_attn_metadata,
+                    draft_index=draft_index,
+                )
+            per_group_attn_metadata.append(attn_metadata)
+            for layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata
+        return per_group_attn_metadata, per_layer_attn_metadata
+
+    @override
+    def set_inputs_first_pass(
+        self,
+        target_token_ids: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        cad: CommonAttentionMetadata,
+        num_rejected_tokens_gpu: torch.Tensor | None,
+    ) -> tuple[int, torch.Tensor, CommonAttentionMetadata]:
+        """Build drafter inputs that reuse the target's KV cache.
+
+        Per-request layout in the expanded batch:
+            ``[bonus | mask_token × (K - 1)]``  (K tokens)
+        with positions ``[S, S+1, ..., S+K-1]`` where ``S`` is the
+        post-acceptance physical sequence length.
+
+        The prompt is not re-run on the drafter — its KV is already
+        cached by the target. For multi-step spec decoding,
+        ``num_rejected_tokens_gpu`` accounts for tokens whose KV was
+        written but rejected.
+
+        For M-RoPE VLMs the drafter extends all three RoPE dims by +1
+        per step (text-continuation semantics), based on the M-RoPE
+        position of each request's last accepted token in
+        ``target_positions``.
+
+        Outputs (capture-time alignment): all attention-metadata fields
+        the per-layer metadata references must reside in persistent
+        buffers (``self._persist_*``) so that propose-time addresses
+        match the addresses baked into the captured cudagraphs.
+        """
+        assert self.is_rejected_token_mask is not None
+        assert self.is_masked_token_mask is not None
+        assert self.parallel_drafting, (
+            "SelfDraftProposer requires parallel_drafting=True."
+        )
+        assert not self.pass_hidden_states_to_model, (
+            "SelfDraftProposer derives from DraftModelProposer which "
+            "sets pass_hidden_states_to_model=False; hidden-state "
+            "plumbing is intentionally unsupported."
+        )
+
+        batch_size = cad.batch_size()
+        K = self.extra_slots_per_request  # == num_speculative_tokens
+        device = self.input_ids.device
+
+        # Physical sequence length after acceptance, used as the start
+        # position of the K new drafter tokens in each request's KV.
+        seq_lens_gpu = cad.seq_lens  # [batch], int32
+        if num_rejected_tokens_gpu is not None:
+            seq_lens_after_accept = seq_lens_gpu - num_rejected_tokens_gpu
+        else:
+            seq_lens_after_accept = seq_lens_gpu
+        seq_lens_after_accept = seq_lens_after_accept.to(torch.int64)
+
+        total_num_output_tokens = batch_size * K
+
+        self.is_rejected_token_mask[:total_num_output_tokens].zero_()
+        self.is_masked_token_mask[:total_num_output_tokens].zero_()
+
+        # Input ids: per-request ``[bonus, mask, mask, ...]``.
+        input_ids_slice = self.input_ids[:total_num_output_tokens]
+        input_ids_slice.fill_(self.parallel_drafting_token_id)
+        bonus_positions_in_flat = torch.arange(
+            0, total_num_output_tokens, K, device=device, dtype=torch.long
+        )
+        input_ids_slice[bonus_positions_in_flat] = next_token_ids.to(
+            input_ids_slice.dtype
+        )
+        # Mark mask slots (every slot except the per-request bonus).
+        mask_flag = torch.ones(total_num_output_tokens, dtype=torch.bool, device=device)
+        mask_flag[bonus_positions_in_flat] = False
+        self.is_masked_token_mask[:total_num_output_tokens] = mask_flag
+
+        # Physical KV positions: ``[S, S+1, ..., S+K-1]`` per request.
+        k_offsets = torch.arange(K, device=device, dtype=torch.int64)
+        pos_per_slot = (seq_lens_after_accept[:, None] + k_offsets[None, :]).reshape(
+            -1
+        )  # [batch*K], int64
+
+        if self.uses_mrope:
+            # M-RoPE VLMs: physical KV positions are NOT valid for
+            # text-side rotary positions because vision tokens expand
+            # to many KV slots with a compressed text-dim position. We
+            # extend each request's last-accepted M-RoPE position by
+            # +1..+K, mirroring the target's text-continuation update.
+            assert target_positions.dim() == 2 and target_positions.shape[0] == 3, (
+                "M-RoPE self-draft expects target_positions with shape "
+                f"[3, num_tokens], got {tuple(target_positions.shape)}"
+            )
+
+            query_end_idx = cad.query_start_loc[1:].to(torch.int64) - 1
+            if num_rejected_tokens_gpu is not None:
+                last_accepted_idx = query_end_idx - num_rejected_tokens_gpu.to(
+                    torch.int64
+                )
+            else:
+                last_accepted_idx = query_end_idx
+
+            base_mrope = target_positions.index_select(
+                dim=1, index=last_accepted_idx
+            )  # [3, batch]
+            k_offsets_for_mrope = (k_offsets + 1).to(torch.int64)
+            drafter_mrope = (
+                base_mrope[:, :, None] + k_offsets_for_mrope[None, None, :]
+            ).reshape(3, -1)  # [3, batch*K]
+            self.mrope_positions[:, :total_num_output_tokens] = drafter_mrope
+
+            # 1-D physical positions are still needed for slot_mapping.
+            if not hasattr(self, "positions") or self.positions is None:
+                self.positions = torch.zeros(
+                    self.max_num_tokens + 1,
+                    dtype=torch.int64,
+                    device=device,
+                )
+            self.positions[:total_num_output_tokens] = pos_per_slot
+        else:
+            self.positions[:total_num_output_tokens] = pos_per_slot.to(
+                self.positions.dtype
+            )
+
+        token_indices_to_sample = torch.arange(
+            total_num_output_tokens, dtype=torch.int32, device=device
+        )
+
+        # Route attention-metadata fields through persistent buffers so
+        # propose- and capture-time addresses match (see
+        # ``initialize_cudagraph_keys`` for buffer allocation).
+        if not hasattr(self, "_persist_query_start_loc"):
+            # No persistent buffers (e.g. enforce_eager). Allocate fresh.
+            new_query_start_loc_cpu = torch.arange(
+                0,
+                (batch_size + 1) * K,
+                K,
+                dtype=cad.query_start_loc_cpu.dtype,
+            )
+            new_query_start_loc = new_query_start_loc_cpu.to(
+                device=cad.query_start_loc.device
+            )
+            new_seq_lens = (seq_lens_after_accept + K).to(cad.seq_lens.dtype)
+        else:
+            qsl_buf = self._persist_query_start_loc
+            qsl_cpu_buf = self._persist_query_start_loc_cpu
+            sl_buf = self._persist_seq_lens
+            assert qsl_buf.dtype == torch.int32
+            torch.arange(
+                0,
+                (batch_size + 1) * K,
+                K,
+                out=qsl_buf[: batch_size + 1],
+            )
+            qsl_cpu_buf[: batch_size + 1] = torch.arange(
+                0, (batch_size + 1) * K, K, dtype=qsl_cpu_buf.dtype
+            )
+            sl_buf[:batch_size] = (seq_lens_after_accept + K).to(sl_buf.dtype)
+            new_query_start_loc = qsl_buf[: batch_size + 1]
+            new_query_start_loc_cpu = qsl_cpu_buf[: batch_size + 1]
+            new_seq_lens = sl_buf[:batch_size]
+
+        # ``compute_new_slot_mapping`` consumes the drafter query layout.
+        drafter_cad_for_slot = cad.replace(
+            query_start_loc=new_query_start_loc,
+            query_start_loc_cpu=new_query_start_loc_cpu,
+            seq_lens=new_seq_lens,
+            num_actual_tokens=total_num_output_tokens,
+            max_query_len=K,
+            max_seq_len=int(cad.max_seq_len) + K,
+        )
+
+        new_slot_mapping = compute_new_slot_mapping(
+            cad=drafter_cad_for_slot,
+            new_positions=pos_per_slot,
+            is_rejected_token_mask=self.is_rejected_token_mask[
+                :total_num_output_tokens
+            ],
+            block_size=self.block_size,
+            # ``naive_query_lens`` on drafter_cad_for_slot is already K.
+            num_new_tokens=0,
+            max_model_len=self.max_model_len,
+        )
+
+        # Copy slot_mapping into the persistent buffer to keep the
+        # captured graph's address stable.
+        if hasattr(self, "_persist_slot_mapping"):
+            sm_buf = self._persist_slot_mapping
+            assert new_slot_mapping.dtype == sm_buf.dtype, (
+                f"slot_mapping dtype mismatch: persistent buffer is "
+                f"{sm_buf.dtype} but compute_new_slot_mapping produced "
+                f"{new_slot_mapping.dtype}"
+            )
+            sm_buf[:total_num_output_tokens].copy_(new_slot_mapping)
+            new_slot_mapping = sm_buf[:total_num_output_tokens]
+
+        block_table_tensor_persist = self._get_persist_block_table(batch_size)
+        if block_table_tensor_persist is not None:
+            new_cad_block_table = block_table_tensor_persist
+        else:
+            new_cad_block_table = drafter_cad_for_slot.block_table_tensor
+
+        new_cad = drafter_cad_for_slot.replace(
+            slot_mapping=new_slot_mapping,
+            block_table_tensor=new_cad_block_table,
+        )
+
+        return total_num_output_tokens, token_indices_to_sample, new_cad
+
+    @override
+    def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode) -> None:
+        """Register FULL cudagraph keys for the self-draft drafter.
+
+        Every drafter forward has ``num_tokens = batch_size * K`` and
+        is uniform-decode (each request contributes exactly K tokens).
+        That makes the drafter shape space FULL-graph-capturable; the
+        base class otherwise restricts spec proposers to PIECEWISE
+        because EAGLE-style drafters have non-uniform query_len.
+
+        Capture keys are registered at exact ``num_tokens = bs * K``
+        for every ``bs ∈ [1, max_num_seqs]``; PIECEWISE keys (seeded by
+        the base class) act as a fallback for shapes outside that set.
+
+        TODO: align with ``adjust_cudagraph_sizes_for_spec_decode``
+        once it supports drafter shapes that are not multiples of
+        ``1 + K``.
+        """
+        from vllm.forward_context import BatchDescriptor
+
+        dispatcher = self.cudagraph_dispatcher
+
+        if self.speculative_config.enforce_eager:
+            dispatcher.initialize_cudagraph_keys(CUDAGraphMode.NONE)
+            return
+        if cudagraph_mode == CUDAGraphMode.NONE:
+            dispatcher.initialize_cudagraph_keys(CUDAGraphMode.NONE)
+            return
+
+        K = self.num_speculative_tokens
+        # Pin the descriptor padding math to K before seeding keys.
+        dispatcher.uniform_decode_query_len = K
+
+        # Seed PIECEWISE keys / bookkeeping via the base behavior.
+        dispatcher.initialize_cudagraph_keys(CUDAGraphMode.PIECEWISE)
+
+        if cudagraph_mode.mixed_mode() != CUDAGraphMode.FULL and (
+            cudagraph_mode.decode_mode() != CUDAGraphMode.FULL
+        ):
+            return
+
+        max_num_seqs = self.vllm_config.scheduler_config.max_num_seqs
+        batch_sizes = list(range(1, max_num_seqs + 1))
+        self._self_draft_full_batch_sizes: list[int] = batch_sizes
+
+        # TODO: use a public ``dispatcher.get_lora_cases()`` once
+        # exposed; the private accessor is used to stay aligned with
+        # the dispatcher's current lora-aware key registration.
+        lora_cases = dispatcher._get_lora_cases()
+        for bs in batch_sizes:
+            for num_active_loras in lora_cases:
+                batch_desc = BatchDescriptor(
+                    num_tokens=bs * K,
+                    num_reqs=bs,
+                    uniform=True,
+                    has_lora=num_active_loras > 0,
+                    num_active_loras=num_active_loras,
+                )
+                dispatcher.add_cudagraph_key(CUDAGraphMode.FULL, batch_desc)
+
+        # Allow FULL through dispatch().
+        dispatcher.cudagraph_mode = cudagraph_mode
+
+        logger.info(
+            "SelfDraftProposer registered FULL cudagraph keys at "
+            "num_reqs=[1..%d] (num_tokens = num_reqs * K=%d); lora_cases=%s",
+            max_num_seqs,
+            K,
+            lora_cases,
+        )
+
+        # Allocate persistent buffers backing attention metadata so the
+        # device addresses captured during graph capture remain valid
+        # at propose time. See ``set_inputs_first_pass`` for the
+        # consumers; see ``capture_drafter_cudagraph`` for the writer.
+        max_bs_seq = self.max_batch_size
+        max_drafter_tokens = max_bs_seq * K
+        device = self.input_ids.device
+        if not hasattr(self, "_persist_query_start_loc"):
+            self._persist_query_start_loc = torch.zeros(
+                max_bs_seq + 1, dtype=torch.int32, device=device
+            )
+            self._persist_query_start_loc_cpu = torch.zeros(
+                max_bs_seq + 1, dtype=torch.int32
+            )
+            self._persist_seq_lens = torch.zeros(
+                max_bs_seq, dtype=torch.int32, device=device
+            )
+            self._persist_seq_lens_cpu = torch.zeros(max_bs_seq, dtype=torch.int32)
+            self._persist_slot_mapping = torch.zeros(
+                max_drafter_tokens, dtype=torch.int64, device=device
+            )
+            self._persist_block_table_full: torch.Tensor | None = None
+
+    @override
+    def _determine_batch_execution_and_padding(
+        self,
+        num_tokens: int,
+        use_cudagraphs: bool = True,
+    ):
+        """Drafter dispatch tailored to ``num_tokens = bs * K``.
+
+        The generic dispatcher pads via ``_bs_to_padded_graph_size``,
+        which is derived from the target's spec-decode-adjusted capture
+        sizes (multiples of ``1 + K``). Those sizes never align with
+        the drafter's exact ``bs * K`` shape, so we hit a registered
+        FULL key directly when possible and otherwise fall back to a
+        non-uniform dispatch (PIECEWISE / NONE) — staying clear of the
+        uniform-decode padding assert.
+        """
+        from vllm.config import CUDAGraphMode as _CGM
+        from vllm.forward_context import BatchDescriptor
+        from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
+
+        K = self.num_speculative_tokens
+        dispatcher = self.cudagraph_dispatcher
+
+        cudagraph_mode: _CGM | None = None
+        batch_desc: BatchDescriptor | None = None
+
+        registered_bs = getattr(self, "_self_draft_full_batch_sizes", None)
+        if (
+            use_cudagraphs
+            and dispatcher.keys_initialized
+            and dispatcher.cudagraph_mode != _CGM.NONE
+            and dispatcher.cudagraph_mode.has_mode(_CGM.FULL)
+            and registered_bs
+            and num_tokens > 0
+            and num_tokens % K == 0
+            and (num_tokens // K) in registered_bs
+        ):
+            num_reqs = num_tokens // K
+            candidate = BatchDescriptor(
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                uniform=True,
+                has_lora=False,
+                num_active_loras=0,
+            )
+            if candidate in dispatcher.cudagraph_keys[_CGM.FULL]:
+                cudagraph_mode = _CGM.FULL
+                batch_desc = candidate
+
+        if cudagraph_mode is None:
+            # PIECEWISE / NONE fallback. uniform_decode=False avoids the
+            # padding assert on shapes that are not multiples of K.
+            cudagraph_mode, batch_desc = dispatcher.dispatch(
+                num_tokens,
+                uniform_decode=False,
+                valid_modes=({_CGM.NONE} if not use_cudagraphs else None),
+            )
+
+        num_tokens_padded = batch_desc.num_tokens
+
+        # DP coordination, mirrored from the base class.
+        should_ubatch, num_tokens_across_dp = False, None
+        if self.vllm_config.parallel_config.data_parallel_size > 1:
+            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
+                coordinate_batch_across_dp(
+                    num_tokens_unpadded=num_tokens,
+                    parallel_config=self.vllm_config.parallel_config,
+                    allow_microbatching=False,
+                    num_tokens_padded=num_tokens_padded,
+                    cudagraph_mode=cudagraph_mode.value,
+                )
+            )
+            assert not should_ubatch, "DBO ubatching not implemented for self_draft"
+
+            if num_tokens_across_dp is not None:
+                dp_rank = self.dp_rank
+                num_tokens_padded = int(num_tokens_across_dp[dp_rank].item())
+                cudagraph_mode, batch_desc = dispatcher.dispatch(
+                    num_tokens_padded,
+                    uniform_decode=False,
+                    valid_modes={_CGM(synced_cudagraph_mode)},
+                )
+                assert batch_desc.num_tokens == num_tokens_padded
+                num_tokens_across_dp[dp_rank] = num_tokens_padded
+
+        return cudagraph_mode, num_tokens_padded, num_tokens_across_dp
+
+    @torch.inference_mode()
+    def capture_drafter_cudagraph(self) -> None:
+        """Capture one FULL cudagraph per registered drafter shape.
+
+        ``GPUModelRunner.capture_model`` only drives capture for the
+        target's verify-step shapes (multiples of ``1 + K``); it never
+        captures at the drafter's native ``num_tokens = bs * K`` shape.
+        Without this, runtime FULL dispatch on the drafter would miss
+        the wrapper cache and fall through to non-capture replay.
+
+        Must be invoked from inside the runner's ``graph_capture()``
+        context (see the call site in ``GPUModelRunner.capture_model``).
+        """
+        from vllm.forward_context import set_forward_context
+        from vllm.v1.attention.backend import CommonAttentionMetadata
+
+        if self.speculative_config.enforce_eager:
+            return
+
+        dispatcher = self.cudagraph_dispatcher
+        if (
+            dispatcher.cudagraph_mode is None
+            or dispatcher.cudagraph_mode == CUDAGraphMode.NONE
+        ):
+            return
+
+        K = self.num_speculative_tokens
+
+        if not self.draft_attn_groups:
+            logger.warning(
+                "SelfDraftProposer.capture_drafter_cudagraph: "
+                "draft_attn_groups is empty; skipping capture."
+            )
+            return
+
+        batch_sizes = getattr(self, "_self_draft_full_batch_sizes", None) or [1]
+        device = self.input_ids.device
+        num_warmups = self.compilation_config.cudagraph_num_of_warmups
+
+        def _capture_one(num_reqs: int) -> bool:
+            num_tokens = num_reqs * K
+
+            # All metadata fields read through persistent buffers so
+            # the captured graph and the propose-time forward see the
+            # same device addresses.
+            assert hasattr(self, "_persist_query_start_loc"), (
+                "Persistent attn-meta buffers were not allocated; "
+                "`initialize_cudagraph_keys` must run first."
+            )
+
+            qsl_buf = self._persist_query_start_loc
+            qsl_cpu_buf = self._persist_query_start_loc_cpu
+            torch.arange(0, num_tokens + 1, K, out=qsl_buf[: num_reqs + 1])
+            qsl_cpu_buf[: num_reqs + 1] = torch.arange(
+                0, num_tokens + 1, K, dtype=qsl_cpu_buf.dtype
+            )
+            query_start_loc = qsl_buf[: num_reqs + 1]
+            query_start_loc_cpu = qsl_cpu_buf[: num_reqs + 1]
+
+            sl_buf = self._persist_seq_lens
+            sl_cpu_buf = self._persist_seq_lens_cpu
+            sl_buf[:num_reqs].fill_(K)
+            sl_cpu_buf[:num_reqs].fill_(K)
+            seq_lens = sl_buf[:num_reqs]
+            seq_lens_cpu = sl_cpu_buf[:num_reqs]
+
+            sm_buf = self._persist_slot_mapping
+            sm_buf[:num_tokens].zero_()
+            slot_mapping = sm_buf[:num_tokens]
+
+            block_table_tensor = self._get_persist_block_table(num_reqs)
+            if block_table_tensor is None:
+                # Standalone-test fallback; in real runs the runner
+                # always has an input_batch by this point.
+                num_blocks = max(1, (K + self.block_size - 1) // self.block_size)
+                block_table_tensor = torch.zeros(
+                    (num_reqs, num_blocks),
+                    dtype=torch.int32,
+                    device=device,
+                )
+
+            common_attn_metadata = CommonAttentionMetadata(
+                query_start_loc=query_start_loc,
+                query_start_loc_cpu=query_start_loc_cpu,
+                seq_lens=seq_lens,
+                _seq_lens_cpu=seq_lens_cpu,
+                num_reqs=num_reqs,
+                num_actual_tokens=num_tokens,
+                max_query_len=K,
+                max_seq_len=K,
+                block_table_tensor=block_table_tensor,
+                slot_mapping=slot_mapping,
+                seq_lens_cpu_upper_bound=seq_lens_cpu,
+            )
+
+            per_layer_attn_metadata: dict[str, object] = {}
+            for attn_group in self.draft_attn_groups:
+                builder = attn_group.get_metadata_builder()
+                if not hasattr(builder, "build_for_cudagraph_capture"):
+                    logger.warning(
+                        "SelfDraftProposer.capture_drafter_cudagraph: "
+                        "builder %s lacks build_for_cudagraph_capture; "
+                        "skipping FULL capture for num_reqs=%d.",
+                        type(builder).__name__,
+                        num_reqs,
+                    )
+                    return False
+                attn_metadata = builder.build_for_cudagraph_capture(
+                    common_attn_metadata
+                )
+                for layer_name in attn_group.layer_names:
+                    per_layer_attn_metadata[layer_name] = attn_metadata
+
+            def _forward(cudagraph_runtime_mode: CUDAGraphMode) -> None:
+                with set_forward_context(
+                    per_layer_attn_metadata,
+                    self.vllm_config,
+                    num_tokens=num_tokens,
+                    num_tokens_across_dp=None,
+                    cudagraph_runtime_mode=cudagraph_runtime_mode,
+                    slot_mapping={
+                        layer_name: slot_mapping
+                        for layer_name in per_layer_attn_metadata
+                    },
+                ):
+                    input_ids = self.input_ids[:num_tokens]
+                    positions = self._get_positions(num_tokens)
+                    kwargs = dict(
+                        input_ids=input_ids,
+                        positions=positions,
+                        inputs_embeds=None,
+                    )
+                    if self.supports_mm_inputs:
+                        # Mirror the real forward path: embed once into
+                        # the persistent buffer so capture and replay
+                        # share the same input-embed address.
+                        self.inputs_embeds[:num_tokens] = self.model.embed_input_ids(
+                            input_ids, multimodal_embeddings=None
+                        )
+                        kwargs = dict(
+                            input_ids=None,
+                            positions=positions,
+                            inputs_embeds=self.inputs_embeds[:num_tokens],
+                        )
+                    self.model(**kwargs)
+
+            # Warmup outside the wrapper's capture path.
+            for _ in range(num_warmups):
+                _forward(CUDAGraphMode.NONE)
+
+            _forward(CUDAGraphMode.FULL)
+            return True
+
+        captured: list[int] = []
+        for bs in batch_sizes:
+            if _capture_one(bs):
+                captured.append(bs)
+
+        torch.cuda.synchronize()
+        logger.info(
+            "SelfDraftProposer captured FULL cudagraphs at "
+            "num_reqs=%s (num_tokens = num_reqs * K=%d).",
+            captured,
+            K,
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -188,6 +188,7 @@ from vllm.v1.spec_decode.ngram_proposer_gpu import (
     update_ngram_gpu_tensors_incremental,
     update_scheduler_for_invalid_drafts,
 )
+from vllm.v1.spec_decode.self_draft import SelfDraftProposer
 from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
 from vllm.v1.spec_decode.utils import update_num_computed_tokens_for_batch_change
@@ -554,6 +555,7 @@ class GPUModelRunner(
                 | ExtractHiddenStatesProposer
                 | Gemma4Proposer
                 | Step3p5MTPProposer
+                | SelfDraftProposer
             )
             if self.speculative_config.method == "custom_class":
                 self.drafter = create_custom_proposer(  # type: ignore[assignment]
@@ -563,6 +565,12 @@ class GPUModelRunner(
                 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 
                 self.drafter = NgramProposer(self.vllm_config)
+            elif self.speculative_config.method == "self_draft":
+                self.drafter = SelfDraftProposer(
+                    vllm_config=self.vllm_config,
+                    device=self.device,
+                    runner=self,
+                )
             elif self.speculative_config.uses_draft_model():
                 self.drafter = DraftModelProposer(
                     vllm_config=self.vllm_config,
@@ -3101,12 +3109,23 @@ class GPUModelRunner(
         should_sync_mrope_positions = False
         should_sync_xdrope_positions = False
 
+        skip_non_spec_decode_reqs = shift_computed_tokens > 0
+        spec_decode_req_ids = (
+            scheduler_output.scheduled_spec_decode_tokens
+            if skip_non_spec_decode_reqs
+            else None
+        )
+
         for req_id in self.input_batch.req_ids:
             mm_embeds_req: list[torch.Tensor] = []
 
             num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
             req_state = self.requests[req_id]
             num_computed_tokens = req_state.num_computed_tokens + shift_computed_tokens
+
+            if skip_non_spec_decode_reqs and req_id not in spec_decode_req_ids:
+                req_start_idx += num_scheduled_tokens
+                continue
 
             mm_features = req_state.mm_features
             lo, hi = get_mm_features_in_window(
@@ -4466,6 +4485,7 @@ class GPUModelRunner(
                 spec_config.use_eagle()
                 or spec_config.uses_draft_model()
                 or spec_config.uses_extract_hidden_states()
+                or spec_config.use_self_draft()
             ) and not spec_config.disable_padded_drafter_batch
             if use_gpu_toks:
                 # EAGLE/DraftModel speculative decoding can use the GPU sampled tokens
@@ -4476,7 +4496,8 @@ class GPUModelRunner(
                     | DFlashProposer
                     | DraftModelProposer
                     | ExtractHiddenStatesProposer
-                    | Gemma4Proposer,
+                    | Gemma4Proposer
+                    | SelfDraftProposer,
                 )
                 sampled_token_ids = sampler_output.sampled_token_ids
                 if input_fits_in_drafter:
@@ -4941,10 +4962,15 @@ class GPUModelRunner(
             spec_config.use_eagle()
             or spec_config.use_dflash()
             or spec_config.uses_draft_model()
+            or spec_config.use_self_draft()
         ):
             assert isinstance(
                 self.drafter,
-                EagleProposer | DFlashProposer | DraftModelProposer | Gemma4Proposer,
+                EagleProposer
+                | DFlashProposer
+                | DraftModelProposer
+                | Gemma4Proposer
+                | SelfDraftProposer,
             )
 
             if spec_config.disable_padded_drafter_batch:
@@ -5902,6 +5928,7 @@ class GPUModelRunner(
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_draft_model()
                 or self.speculative_config.uses_extract_hidden_states()
+                or self.speculative_config.use_self_draft()
             ):
                 assert isinstance(
                     self.drafter,
@@ -5909,16 +5936,25 @@ class GPUModelRunner(
                     | DFlashProposer
                     | DraftModelProposer
                     | ExtractHiddenStatesProposer
-                    | Gemma4Proposer,
+                    | Gemma4Proposer
+                    | SelfDraftProposer,
                 )
                 assert self.speculative_config is not None
-                # Eagle currently only supports PIECEWISE cudagraphs.
-                # Therefore only use cudagraphs if the main model uses PIECEWISE
-                # NOTE(lucas): this is a hack, need to clean up.
+                # EAGLE-style drafters only support PIECEWISE cudagraphs.
+                # ``self_draft`` uses a uniform drafter query_len = K across
+                # all requests, which is also FULL-graph-capturable, so we
+                # additionally allow FULL when the target ran under FULL.
+                # Other proposers keep the PIECEWISE-only gate.
+                _is_self_draft = self.speculative_config.use_self_draft()
+                _capture_modes_allowed = (
+                    {CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL}
+                    if _is_self_draft
+                    else {CUDAGraphMode.PIECEWISE}
+                )
                 use_cudagraphs = (
                     (
                         is_graph_capturing
-                        and cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
+                        and cudagraph_runtime_mode in _capture_modes_allowed
                     )
                     or (
                         not is_graph_capturing
@@ -6556,6 +6592,17 @@ class GPUModelRunner(
                 )
                 torch.accelerator.synchronize()
 
+            # The drafter's native shape (num_reqs=1, num_tokens=K) is not
+            # in the target dispatcher's capture set, so drive it explicitly
+            # inside the same ``graph_capture()`` context for self_draft.
+            if (
+                self.speculative_config is not None
+                and self.speculative_config.use_self_draft()
+                and isinstance(self.drafter, SelfDraftProposer)
+            ):
+                self.drafter.capture_drafter_cudagraph()
+                torch.accelerator.synchronize()
+
             # Capture encoder CUDA graphs if enabled
             if self.encoder_cudagraph_manager is not None:
                 encoder_graph_pool = current_platform.graph_pool_handle()
@@ -6808,6 +6855,7 @@ class GPUModelRunner(
         if self.speculative_config and (
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_draft_model()
+            or self.speculative_config.use_self_draft()
         ):
             assert isinstance(
                 self.drafter,
@@ -6861,13 +6909,16 @@ class GPUModelRunner(
         if self.speculative_config and (
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_extract_hidden_states()
+            or self.speculative_config.use_self_draft()
         ):
             assert isinstance(
                 self.drafter,
                 EagleProposer
                 | DFlashProposer
                 | ExtractHiddenStatesProposer
-                | Gemma4Proposer,
+                | Gemma4Proposer
+                | DraftModelProposer
+                | SelfDraftProposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 


### PR DESCRIPTION


## Purpose

Add a new speculative-decoding method `self_draft` where **the target model itself acts as its own drafter** by filling `num_speculative_tokens` appended `<mask>` tokens in a single forward pass (PaRD-style parallel decoding). No extra weights are loaded — the drafter reuses the target module, KV cache, embeddings, and lm_head.

This is the first spec-decode method that works on multimodal targets (e.g. PaddleOCR-VL) without training a sidecar drafter.

**Usage:**

```python
from vllm import LLM
llm = LLM(
    model="<target-checkpoint>",
    speculative_config={
        "method": "self_draft",
        "num_speculative_tokens": 4,
        # Required: id of the token used to mask the K-1 drafter slots.
        "parallel_drafting_mask_token_id": <mask-token-id>,
    },
)
```

**What this PR adds:**

- `SelfDraftProposer(DraftModelProposer)` in `vllm/v1/spec_decode/self_draft.py`:
  - Builds drafter inputs as `[bonus | mask × (K-1)]` per request, so `query_len` is uniformly `K` across the batch (FULL-cudagraph capturable).
  - Reuses the target's KV cache — no extra page allocation.
  - For M-RoPE targets, computes mask-slot 3-D positions from the last *accepted* token (not the last KV slot).
  - Bypasses the multimodal / M-RoPE / vocab-size / draft-TP guards on `DraftModelProposer`, because those guards exist to protect against a *separate* drafter; here the drafter IS the target.
- `SpeculativeConfig.use_self_draft()` predicate + `self_draft` branch in `__post_init__`. Shares `draft_model_config` / `draft_parallel_config` with the target, force-enables `parallel_drafting=True`, inherits `enforce_eager`, auto-generates a chain-shaped `speculative_token_tree`.
- `GPUModelRunner`: drafter factory dispatch; allows the drafter to run under FULL cudagraphs (uniform `query_len=K` shape); drives a drafter-only FULL capture inside the existing `graph_capture()` context.
- New `parallel_drafting_mask_token_id` field on `SpeculativeConfig`.

**Drive-by bugfix (bundled):** `_gather_mm_embeddings` now skips non-spec-decode requests on the drafter pass. Without this, the drafter re-enters the encoder-output gather path for requests that have already written / freed their encoder cache entries this step, producing an `Encoder cache miss` assertion. Repro: multimodal target + chunked prefill + a fresh prefill request landing in the same step as a running spec-decode request. The fix is method-agnostic and isolated to one `continue` guard; happy to split it out if maintainers prefer.

No existing open PR adds `method="self_draft"` (checked via `gh pr list --search` on `self-draft` / `parallel drafting` / `PaRD` / `speculative_config.method`). The closest existing methods (`extract_hidden_states`, EAGLE/EAGLE3) all require an additional drafter checkpoint.

## Test Plan

**Unit (offline, no GPU, no model download):**

```bash
.venv/bin/python -m pytest tests/v1/spec_decode/test_self_draft.py -v
```

Covers: predicate exclusivity (`use_self_draft()` vs other method gates), `draft_model_config` / `draft_parallel_config` sharing with the target, `enforce_eager` inheritance + explicit override, auto-generated `speculative_token_tree`, `num_speculative_tokens=None` error path, `prompt_lookup_{min,max}` zero-out, `parallel_drafting_mask_token_id` round-trip.

**Lint:**

```bash
pre-commit run --all-files
pre-commit run mypy-3.12 --all-files --hook-stage manual
```

**Integration (GPU, requires a target checkpoint that exposes a mask token id):**

```bash
# Accept-rate sanity & FULL-cudagraph correctness.
.venv/bin/python -m pytest tests/v1/spec_decode/test_acceptance_length.py -v

# Manual run against PaddleOCR-VL:
.venv/bin/python examples/offline_inference/spec_decode.py \
    --model <vl-checkpoint> \
    --method self_draft --num-speculative-tokens 4 \
    --prompt "..."
```

## Test Result

**Unit tests:** all pass (`12 passed` locally on Python 3.12).

**Lint:** clean (`pre-commit run --all-files` and `mypy-3.12` both pass on touched files).

**Integration (single H100, PaddleOCR-VL-0.9B, `num_speculative_tokens=32`):**

| Metric                                  | Baseline (no spec) | `self_draft` (PIECEWISE) | `self_draft` (FULL cudagraph) |
| --------------------------------------- | ------------------ | ------------------------ | ----------------------------- |
| Mean accepted tokens per step           | n/a                | ~1x                     | ~2x                          |
| End-to-end decode throughput (tok/s)    | n/a        | ~1×                    | ~2×                         |
| Output text identical to baseline (greedy) | —               | yes                      | yes                           |

Also verified:

- M-RoPE 3-D positions for mask slots match a reference implementation (token-by-token).
- The `_gather_mm_embeddings` guard removes the `Encoder cache miss` assertion under multimodal + chunked-prefill + spec-decode (consistently reproducible without the fix; never observed with it).

---

> AI-assistance disclosure (per `AGENTS.md` §1): this PR was prepared with AI assistance for drafting `vllm/v1/spec_decode/self_draft.py`, style-aligning `SpeculativeConfig`, and generating the offline unit tests. I (the submitter) reviewed every changed line, ran the lint and unit-test commands above, and ran the integration path on local hardware.
