### PR TITLE
fix: fallback to native forward for non-CUDA devices in FatreluAndMul (closes #42322)

### DIFF
--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -106,6 +106,8 @@ class FatreluAndMul(CustomOp):
         return x1 * x2
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        if x.device.type != 'cuda':
+            return self.forward_native(x)
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)


### PR DESCRIPTION
## What
`FatreluAndMul.forward_cuda` assumes the input tensor is on CUDA device and calls JIT-compiled CUDA op `torch.ops._C.fatrelu_and_mul`. However, on non-CUDA but CUDA-alike devices (e.g., XPU), the tensor is not on CUDA, causing device mismatch error.

## Fix
Add a check in `forward_cuda` to detect if the input device is not `cuda` and fall back to `forward_native`. This mirrors the pattern already used for CPU and ensures the activation works on any device type.

Closes #42322