### PR TITLE
Handle structured output grammar compilation failures

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat_error.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_error.py
@@ -326,6 +326,61 @@ async def test_chat_error_stream():
     assert chunks[-1] == "data: [DONE]\n\n"
 
 
+@pytest.mark.asyncio
+async def test_chat_error_stream_first_empty_output():
+    """First streaming output with finish_reason='error' must not emit role chunk."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    completion_output = CompletionOutput(
+        index=0,
+        text="",
+        token_ids=[],
+        cumulative_logprob=None,
+        logprobs=None,
+        finish_reason="error",
+    )
+    request_output = RequestOutput(
+        request_id="test-id",
+        prompt="Test prompt",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[completion_output],
+        finished=True,
+        metrics=None,
+        lora_request=None,
+        encoder_prompt=None,
+        encoder_prompt_token_ids=None,
+    )
+
+    async def mock_generate(*args, **kwargs):
+        yield request_output
+
+    mock_engine.generate = MagicMock(side_effect=mock_generate)
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=True,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+
+    chunks = []
+    async for chunk in response:
+        chunks.append(chunk)
+
+    assert "Internal server error" in chunks[0]
+    assert "chat.completion.chunk" not in chunks[0]
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
 @pytest.mark.parametrize(
     "image_content",
     [

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -413,6 +413,61 @@ async def test_completion_error_stream():
     assert chunks[-1] == "data: [DONE]\n\n"
 
 
+@pytest.mark.asyncio
+async def test_completion_error_stream_first_empty_output():
+    """First streaming output with finish_reason='error' must not be skipped."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_completion = _build_serving_completion(mock_engine)
+
+    completion_output = CompletionOutput(
+        index=0,
+        text="",
+        token_ids=[],
+        cumulative_logprob=None,
+        logprobs=None,
+        finish_reason="error",
+    )
+    request_output = RequestOutput(
+        request_id="test-id",
+        prompt="Test prompt",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[completion_output],
+        finished=True,
+        metrics=None,
+        lora_request=None,
+        encoder_prompt=None,
+        encoder_prompt_token_ids=None,
+    )
+
+    async def mock_generate(*args, **kwargs):
+        yield request_output
+
+    mock_engine.generate = MagicMock(side_effect=mock_generate)
+
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=10,
+        stream=True,
+    )
+
+    response = await serving_completion.create_completion(request)
+
+    chunks = []
+    async for chunk in response:
+        chunks.append(chunk)
+
+    assert "Internal server error" in chunks[0]
+    assert "text_completion" not in chunks[0]
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
 def test_json_schema_response_format_missing_schema():
     """When response_format type is 'json_schema' but the json_schema field
     is not provided, request construction should raise a validation error

--- a/tests/v1/core/test_structured_output_grammar_failure.py
+++ b/tests/v1/core/test_structured_output_grammar_failure.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from concurrent.futures import Future
+
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.engine import FinishReason
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
+from vllm.v1.request import RequestStatus
+from vllm.v1.structured_output.request import StructuredOutputRequest
+
+from .utils import create_requests, create_scheduler
+
+
+def test_structured_output_request_records_grammar_future_error():
+    structured_output_req = StructuredOutputRequest(
+        params=StructuredOutputsParams(regex="[a-z]+")
+    )
+    future: Future = Future()
+    exc = ValueError("bad grammar")
+    future.set_exception(exc)
+    structured_output_req.grammar = future
+
+    assert structured_output_req.grammar is None
+    assert structured_output_req.grammar_error is exc
+    assert structured_output_req.is_grammar_ready is True
+
+    structured_output_req.grammar = object()
+    assert structured_output_req.grammar_error is None
+
+
+def test_scheduler_skips_failed_structured_output_grammar_during_schedule():
+    scheduler = create_scheduler()
+    request = create_requests(num_requests=1)[0]
+    request.sampling_params = SamplingParams(
+        max_tokens=1,
+        structured_outputs=StructuredOutputsParams(regex="[a-z]+"),
+    )
+    request.structured_output_request = StructuredOutputRequest.from_sampling_params(
+        request.sampling_params
+    )
+    assert request.structured_output_request is not None
+    request.status = RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+    future: Future = Future()
+    future.set_exception(RuntimeError("xgrammar compile failed"))
+    request.structured_output_request.grammar = future
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.scheduled_new_reqs == []
+    assert request.status == RequestStatus.FINISHED_ERROR
+    assert request.request_id not in scheduler.requests
+    assert output.finished_req_ids == {request.request_id}
+    assert list(scheduler.waiting) == []
+    assert list(scheduler.skipped_waiting) == []
+
+    engine_core_outputs = scheduler.update_from_output(
+        output, EMPTY_MODEL_RUNNER_OUTPUT
+    )
+    client_outputs = engine_core_outputs[0].outputs
+    assert len(client_outputs) == 1
+    assert client_outputs[0].request_id == request.request_id
+    assert client_outputs[0].finish_reason == FinishReason.ERROR

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -564,6 +564,9 @@ class OpenAIServingChat(GenerateBaseServing):
 
                 for output in res.outputs:
                     i = output.index
+                    # Raise before empty chunks are skipped so clients receive the error.
+                    self._raise_if_error(output.finish_reason, request_id)
+
                     parser = parsers[i]
                     if finish_reason_sent[i]:
                         continue
@@ -685,10 +688,6 @@ class OpenAIServingChat(GenerateBaseServing):
 
                     # if the model is finished generating
                     else:
-                        # check for error finish reason and abort streaming
-                        # finish_reason='error' indicates a retryable error
-                        self._raise_if_error(output.finish_reason, request_id)
-
                         # Send the finish response for each request.n only once
                         # In OpenAI's API, when a tool is called, the
                         # finish_reason is:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -329,6 +329,8 @@ class OpenAIServingCompletion(GenerateBaseServing):
 
                 for output in res.outputs:
                     i = output.index + prompt_idx * num_choices
+                    finish_reason = output.finish_reason
+                    self._raise_if_error(finish_reason, request_id)
 
                     # Useful when request.return_token_ids is True
                     # Returning prompt token IDs shares the same logic
@@ -395,10 +397,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
 
                     previous_text_lens[i] += len(output.text)
                     previous_num_tokens[i] += len(output.token_ids)
-                    finish_reason = output.finish_reason
                     stop_reason = output.stop_reason
-
-                    self._raise_if_error(finish_reason, request_id)
 
                     chunk = CompletionStreamResponse(
                         id=request_id,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -53,7 +53,12 @@ from vllm.v1.core.sched.request_queue import (
     create_request_queue,
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
-from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
+from vllm.v1.engine import (
+    EngineCoreEventType,
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    FinishReason,
+)
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
@@ -190,6 +195,7 @@ class Scheduler(SchedulerInterface):
         # requests so that they can free the cached states for those requests.
         # This is flushed at the end of each scheduling step.
         self.finished_req_ids: set[str] = set()
+        self.finished_error_outputs: list[tuple[int, EngineCoreOutput]] = []
 
         # IDs of requests preempted since the last call to schedule().
         self.reset_preempted_req_ids: set[str] = set()
@@ -417,6 +423,9 @@ class Scheduler(SchedulerInterface):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
+        # Normally drained by update_from_output(); clear stale error outputs
+        # if a previous step failed before reaching it.
+        self.finished_error_outputs.clear()
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
         # Each request just has the num_computed_tokens and
@@ -673,17 +682,18 @@ class Scheduler(SchedulerInterface):
                 request_id = request.request_id
 
                 # try to promote blocked statuses while traversing skipped queue.
-                if self._is_blocked_waiting_status(
-                    request.status
-                ) and not self._try_promote_blocked_waiting_request(request):
-                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                        logger.debug(
-                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
-                            request_id,
-                        )
-                    request_queue.pop_request()
-                    step_skipped_waiting.prepend_request(request)
-                    continue
+                if self._is_blocked_waiting_status(request.status):
+                    if self._finish_request_on_error(request):
+                        continue
+                    if not self._try_promote_blocked_waiting_request(request):
+                        if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                            logger.debug(
+                                "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                                request_id,
+                            )
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
+                        continue
 
                 # Check that adding the request still respects the max_loras
                 # constraint.
@@ -1151,7 +1161,6 @@ class Scheduler(SchedulerInterface):
             kv_cache_block_copies=pending_kv_cache_block_copies,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
         )
-
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store
         # 2. Wrap up all the KV cache load / save ops into an opaque object
@@ -1583,6 +1592,10 @@ class Scheduler(SchedulerInterface):
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        if self.finished_error_outputs:
+            for client_index, output in self.finished_error_outputs:
+                outputs[client_index].append(output)
+            self.finished_error_outputs.clear()
         spec_decoding_stats: SpecDecodingStats | None = None
 
         failed_kv_load_req_ids = None
@@ -2535,6 +2548,43 @@ class Scheduler(SchedulerInterface):
                 request.num_computed_tokens = request.num_tokens - 1
 
         self.finished_recving_kv_req_ids.remove(request.request_id)
+
+    def _finish_request_on_error(self, request: Request) -> bool:
+        # Handles blocked async request errors; currently only grammar failures.
+        if request.status != RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
+            return False
+
+        structured_output_req = request.structured_output_request
+        if structured_output_req is None:
+            return False
+
+        # Accessing grammar polls the async compilation future and records any
+        # failure on the request.
+        _ = structured_output_req.grammar
+        grammar_error = structured_output_req.grammar_error
+        if not isinstance(grammar_error, BaseException):
+            return False
+
+        logger.error(
+            "Structured output grammar compilation failed for request %s. "
+            "Terminating request.",
+            request.request_id,
+            exc_info=grammar_error,
+        )
+        self.finished_error_outputs.append(
+            (
+                request.client_index,
+                EngineCoreOutput(
+                    request_id=request.request_id,
+                    new_token_ids=[],
+                    finish_reason=FinishReason.ERROR,
+                    events=request.take_events(),
+                    trace_headers=request.trace_headers,
+                ),
+            )
+        )
+        self.finish_requests(request.request_id, RequestStatus.FINISHED_ERROR)
+        return True
 
     def _try_promote_blocked_waiting_request(self, request: Request) -> bool:
         """

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 class StructuredOutputRequest:
     params: StructuredOutputsParams
     _grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar | None = None
+    # Set when async grammar compilation fails; cleared when grammar is reset.
+    grammar_error: BaseException | None = None
     reasoning_ended: bool | None = None
     # Absolute index into the request's all_token_ids of the last reasoning
     # token (the reasoning-end marker). Tokens at or before this index are
@@ -53,9 +55,13 @@ class StructuredOutputRequest:
             try:
                 # We will check whether the future is ready within 100 us
                 self._grammar = self._grammar.result(timeout=0.0001)
+                self.grammar_error = None
                 self.status = RequestStatus.WAITING
             except TimeoutError:
                 return False
+            except Exception as exc:
+                self._grammar = None
+                self.grammar_error = exc
         return True
 
     @property
@@ -74,6 +80,7 @@ class StructuredOutputRequest:
         self, grammar: StructuredOutputGrammar | Future[StructuredOutputGrammar]
     ) -> None:
         self._grammar = grammar
+        self.grammar_error = None
 
     @functools.cached_property
     def structured_output_key(self) -> StructuredOutputKey:


### PR DESCRIPTION
Record exceptions from asynchronous structured-output grammar compilation instead of leaving requests blocked indefinitely waiting for a grammar that will never become available.

When a grammar future fails, finish the waiting request with FINISHED_ERROR and emit a request-local EngineCoreOutput with FinishReason.ERROR so the frontend can wake the generate task and surface the existing internal generation error path instead of timing out.

Keep blocked-request promotion focused on moving ready requests back to schedulable states, and handle grammar failures in a separate scheduler path. Use explicit structured-output fakes in scheduler tests to avoid Mock-fabricated grammar_error attributes.

Check streaming outputs for error finish reasons before emitting role, empty, or token chunks so streaming chat and completion requests surface the same internal generation error instead of starting a successful response.

Add regression coverage for failed grammar futures, scheduler traversal, frontend error-output delivery, streaming first-error outputs, and parallel-sampling parent state updates.

## Purpose
This PR fixes a request hang that can happen when asynchronous structured-output
grammar compilation fails.

Before this change, a request waiting in
`WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR` could remain blocked forever if the
grammar future raised an exception. EngineCore would finish the request
internally in some paths, but the frontend was not guaranteed to receive a
request-level error output. As a result, the OpenAI serving layer could keep
waiting for a response until the client timed out.

This change records grammar compilation exceptions on `StructuredOutputRequest`
and handles them in a dedicated scheduler path. When a grammar future fails, the
scheduler finishes the request with `FINISHED_ERROR` and emits a request-local
`EngineCoreOutput` with `FinishReason.ERROR`. This reuses the existing frontend
internal generation error handling instead of introducing a new
EngineCore-to-frontend protocol.

The PR also updates streaming OpenAI chat and completion paths to check for
`finish_reason="error"` before emitting role, empty, or token chunks. This
prevents streaming requests from starting a successful-looking response before
surfacing the internal generation error.

## Test Plan
- Run formatting/diff validation:

```bash
git diff --check
```

- Run focused scheduler and output-processor tests:

```bash
uv run --no-sync pytest \
  tests/v1/core/test_structured_output_grammar_failure.py \
  tests/v1/engine/test_output_processor.py::test_output_processor_delivers_error_finish_to_queue \
  tests/v1/engine/test_output_processor.py::test_output_processor_error_finish_updates_parallel_sampling_parent \
  tests/v1/core/test_scheduler.py::test_remote_kv_promotion_keeps_fcfs_with_grammar_prefix \
  tests/v1/core/test_scheduler.py::test_fcfs_mixed_skipped_waiting_types_keep_order
```

- Run focused OpenAI streaming error tests:

```bash
uv run --no-sync pytest \
  tests/entrypoints/openai/chat_completion/test_chat_error.py::test_chat_error_stream_first_empty_output \
  tests/entrypoints/openai/chat_completion/test_chat_error.py::test_chat_error_stream \
  tests/entrypoints/openai/completion/test_completion_error.py::test_completion_error_stream_first_empty_output \
  tests/entrypoints/openai/completion/test_completion_error.py::test_completion_error_stream
```

## Test Result
passed

