### PR TITLE
[Bugfix][ROCm][FLA] Fix Triton compilation crash with num_stages=4 on AMD

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
@@ -14,9 +14,13 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .op import exp, exp2
-from .utils import FLA_CHUNK_SIZE, use_cuda_graph
+from .utils import FLA_CHUNK_SIZE, is_amd, use_cuda_graph
 
 NUM_WARPS = [2, 4, 8, 16]
+
+# num_stages=4 causes "LLVM ERROR: operation destroyed but still has uses" on
+# ROCm (e.g. MI210/gfx90a) with Triton's AMD backend. Cap at 3 on HIP.
+_num_stages = [2, 3] if is_amd else [2, 3, 4]
 
 
 @triton.heuristics(
@@ -33,7 +37,7 @@ NUM_WARPS = [2, 4, 8, 16]
     configs=[
         triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
         for BV in [32, 64]
     ],
     key=["H", "K", "V", "BT"],

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -16,10 +16,12 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_nvidia_hopper
+from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_amd, is_nvidia_hopper
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
+# num_stages=4 causes "LLVM ERROR: operation destroyed but still has uses" on ROCm.
+_num_stages = [2, 3] if is_amd else [2, 3, 4]
 
 
 @triton.heuristics(
@@ -34,7 +36,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for BK in BKV_LIST
         for BV in BKV_LIST
         for num_warps in NUM_WARPS
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
     ],
     key=["H", "K", "V", "BT"],
 )

--- a/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
@@ -14,7 +14,10 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE
+from .utils import FLA_CHUNK_SIZE, is_amd
+
+# num_stages=4 causes "LLVM ERROR: operation destroyed but still has uses" on ROCm.
+_num_stages = [2, 3] if is_amd else [2, 3, 4]
 
 
 @triton.heuristics(
@@ -28,7 +31,7 @@ from .utils import FLA_CHUNK_SIZE
         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
         for BK in [32, 64, 128]
         for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
     ],
     key=["H", "K", "BT", "IS_VARLEN"],
 )

--- a/vllm/model_executor/layers/fla/ops/kda.py
+++ b/vllm/model_executor/layers/fla/ops/kda.py
@@ -27,6 +27,8 @@ from .utils import FLA_CHUNK_SIZE, is_amd
 
 BT_LIST_AUTOTUNE = [32, 64, 128]
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]
+# num_stages=4 causes "LLVM ERROR: operation destroyed but still has uses" on ROCm.
+_num_stages = [2, 3] if is_amd else [2, 3, 4]
 
 
 def fused_recurrent_kda_fwd(
@@ -513,7 +515,7 @@ class FusedRMSNormGated(CustomOp):
         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
         for BK in [32, 64]
         for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
     ],
     key=["BC"],
 )
@@ -809,7 +811,7 @@ def chunk_kda_scaled_dot_kkt_fwd(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
     ],
     key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
 )
@@ -1011,7 +1013,7 @@ def recompute_w_u_fwd(
         for BK in [32, 64]
         for BV in [64, 128]
         for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
     ],
     key=["BT"],
 )

--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -24,13 +24,16 @@ assert FLA_TRIL_PRECISION in ALLOWED_TRIL_PRECISIONS, (
     f"FLA_TRIL_PRECISION must be one of {ALLOWED_TRIL_PRECISIONS}, but got {FLA_TRIL_PRECISION}"
 )
 
+# num_stages>=4 causes "LLVM ERROR: operation destroyed but still has uses" on ROCm.
+_num_stages = [2, 3] if is_amd else [2, 3, 4, 5]
+
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
+        for num_stages in _num_stages
     ],
     key=["BT"],
 )
@@ -105,7 +108,7 @@ def solve_tril_16x16_kernel(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
+        for num_stages in _num_stages
     ],
     key=["H", "BT", "IS_VARLEN"],
 )
@@ -230,7 +233,7 @@ def merge_16x16_to_32x32_inverse_kernel(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
+        for num_stages in _num_stages
     ],
     key=["H", "BT", "IS_VARLEN"],
 )

--- a/vllm/model_executor/layers/fla/ops/wy_fast.py
+++ b/vllm/model_executor/layers/fla/ops/wy_fast.py
@@ -14,6 +14,10 @@ import torch
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
+from .utils import is_amd
+
+# num_stages=4 causes "LLVM ERROR: operation destroyed but still has uses" on ROCm.
+_num_stages = [2, 3] if is_amd else [2, 3, 4]
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -21,7 +25,7 @@ from .index import prepare_chunk_indices
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_stages in _num_stages
     ],
     key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
 )


### PR DESCRIPTION
## Summary

Fixes #44973.

Triton's AMD/HIP LLVM backend crashes with:
```
LLVM ERROR: operation destroyed but still has uses
```
when the autotuner reaches a `num_stages=4` config on ROCm (tested on MI210/gfx90a, Triton 3.6.0+rocm7.2.2). This is a known Triton upstream issue ([triton-lang/triton#9815](https://github.com/triton-lang/triton/issues/9815)).

**This is not a duplicate** — no open PR addresses this specific fix. PR #41446 (`[Kernel][AMD] Optimize GatedDeltaNet FLA prefill kernels on MI300X`) is a kernel-tuning PR for MI300X, not a crash fix for this LLVM error.

### Fix

Added a module-level `_num_stages` variable in each affected file that caps pipeline stages at 3 on AMD:

```python
# num_stages=4 causes "LLVM ERROR: operation destroyed but still has uses" on ROCm.
_num_stages = [2, 3] if is_amd else [2, 3, 4]
```

Then replaced every `for num_stages in [2, 3, 4]` (and `[2, 3, 4, 5]` in `solve_tril.py`) in `@triton.autotune` configs with `for num_stages in _num_stages`. The `is_amd` flag already existed in `utils.py` and was already imported by most of the affected files.

**Files changed:**
- `vllm/model_executor/layers/fla/ops/chunk_delta_h.py`
- `vllm/model_executor/layers/fla/ops/chunk_o.py`
- `vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py`
- `vllm/model_executor/layers/fla/ops/kda.py`
- `vllm/model_executor/layers/fla/ops/solve_tril.py`
- `vllm/model_executor/layers/fla/ops/wy_fast.py`

## Impact

- **AMD/ROCm**: autotuner now only tries `num_stages ∈ {2, 3}`, avoiding the crash. A small number of configs are skipped but the kernels run correctly.
- **NVIDIA/CUDA**: no change — full `num_stages` range is still explored.

## Test plan

- [ ] Verified fix resolves the crash on MI210/gfx90a by filtering `num_stages=4` configs from the autotuner (consistent with the workaround confirmed working by the issue reporter)
- [ ] No behavioral change on NVIDIA hardware (CUDA path unchanged)
- [ ] AI assistance was used (Claude) to apply the fix across all affected files

> **Note:** I do not have access to AMD GPU hardware to run the full reproducer locally. The fix is mechanically equivalent to the workaround confirmed by the issue reporter (#44973), extended to cover all 6 affected FLA kernel files (the original report only identified `chunk_delta_h.py`; `kda.py` was an additional file discovered during the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)