### PR TITLE
[Bugfix][Core][Model] Voxtral realtime: fix boot-OOM / silent-hang / max-len crash on 16 GiB

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -22,6 +22,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
@@ -1342,3 +1343,49 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.request_id], internal=True)
         else:
             output_processor.abort_requests([request.external_req_id], internal=False)
+
+
+def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
+    # A terminal length cap on a streaming session must reach the client:
+    # finished=True and the request freed, else AsyncLLM.generate() hangs.
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer,
+        log_stats=False,
+    )
+
+    request = EngineCoreRequest(
+        request_id="request-int",
+        external_req_id="request",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(
+            max_tokens=16,
+            output_kind=RequestOutputKind.DELTA,
+            stop=[],
+        ),
+        pooling_params=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        resumable=True,
+    )
+
+    queue = RequestOutputCollector(RequestOutputKind.DELTA, request.request_id)
+    output_processor.add_request(request, prompt="hello", queue=queue)
+
+    output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[],
+                finish_reason=FinishReason.LENGTH,
+            )
+        ]
+    )
+
+    request_output = queue.get_nowait()
+    assert request_output is not None
+    assert request_output.finished is True
+    assert request_output.outputs[0].finish_reason == "length"
+    assert output_processor.get_num_unfinished_requests() == 0

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -1345,16 +1345,9 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.external_req_id], internal=False)
 
 
-def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
-    # A terminal length cap on a streaming session must reach the client:
-    # finished=True and the request freed, else AsyncLLM.generate() hangs.
-    output_processor = OutputProcessor(
-        dummy_test_vectors.tokenizer,
-        log_stats=False,
-    )
-
-    request = EngineCoreRequest(
-        request_id="request-int",
+def _make_streaming_request(request_id="request-int"):
+    return EngineCoreRequest(
+        request_id=request_id,
         external_req_id="request",
         prompt_token_ids=[1, 2, 3],
         mm_features=None,
@@ -1371,6 +1364,14 @@ def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
         resumable=True,
     )
 
+
+def test_streaming_input_length_finish_is_not_terminal(dummy_test_vectors):
+    # A per-step LENGTH finish is the normal chunk boundary of a streaming
+    # session, not a terminal end: the session must stay alive for the next
+    # audio chunk (a genuine max_model_len cap is delivered separately by the
+    # scheduler). Treating LENGTH as terminal ends the session after one token.
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    request = _make_streaming_request()
     queue = RequestOutputCollector(RequestOutputKind.DELTA, request.request_id)
     output_processor.add_request(request, prompt="hello", queue=queue)
 
@@ -1385,7 +1386,29 @@ def test_streaming_input_length_finish_is_terminal(dummy_test_vectors):
     )
 
     request_output = queue.get_nowait()
+    assert request_output is None or request_output.finished is False
+    assert output_processor.get_num_unfinished_requests() == 1
+
+
+def test_streaming_input_error_finish_is_terminal(dummy_test_vectors):
+    # A real ERROR/ABORT does end the streaming session: deliver finished=True
+    # and free the request, else AsyncLLM.generate() hangs.
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    request = _make_streaming_request()
+    queue = RequestOutputCollector(RequestOutputKind.DELTA, request.request_id)
+    output_processor.add_request(request, prompt="hello", queue=queue)
+
+    output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[],
+                finish_reason=FinishReason.ERROR,
+            )
+        ]
+    )
+
+    request_output = queue.get_nowait()
     assert request_output is not None
     assert request_output.finished is True
-    assert request_output.outputs[0].finish_reason == "length"
     assert output_processor.get_num_unfinished_requests() == 0

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -150,40 +150,75 @@ class TestStreamingScheduler(unittest.TestCase):
         # Again, output tokens are cleared first, so max_tokens = 0 + 10 = 10
         assert session.max_tokens == 10
 
+    @staticmethod
+    def _make_capped_session(scheduler, waiting_for_chunk=True):
+        """Session at 1020/1024 tokens plus a 10-token chunk that crosses
+        max_model_len when applied. With waiting_for_chunk the next add_request
+        commences the chunk (the guarded branch); otherwise the session stays
+        WAITING and add_request queues the chunk."""
+        session = DummyRequest(request_id="session", prompt_token_ids=list(range(1020)))
+        session.num_computed_tokens = len(session.prompt_token_ids)
+        scheduler.add_request(session)
+        if waiting_for_chunk:
+            session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
+        chunk.sampling_params = SamplingParams(max_tokens=10)
+        return session, chunk
+
     def test_add_request_session_finishes_at_max_model_len(self):
         # Guard in add_request: when a streaming chunk pushes a live session's
         # accumulated tokens to max_model_len, the session must finish as
         # FINISHED_LENGTH_CAPPED instead of crashing later in the model runner.
         scheduler = create_scheduler()  # max_model_len = 1024
-        session = DummyRequest(
-            request_id="session", prompt_token_ids=list(range(1020))
-        )
-        session.num_computed_tokens = len(session.prompt_token_ids)
-        scheduler.add_request(session)
-        # Put the session into the "waiting for next chunk" state so the next
-        # add_request commences the chunk (the guarded branch).
-        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
-
-        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
-        chunk.sampling_params = SamplingParams(max_tokens=10)
+        session, chunk = self._make_capped_session(scheduler)
         scheduler.add_request(chunk)  # 1020 + 10 = 1030 >= 1024
 
         assert session.num_tokens >= scheduler.max_model_len
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
+    def test_add_request_max_model_len_notifies_client(self):
+        # A session finished from inside add_request() (length-capped) is freed
+        # scheduler-side, but finish_requests has no `outputs` dict there, so the
+        # client must still learn it ended. The finish is buffered and emitted as
+        # an EngineCoreOutput with finish_reason=LENGTH in the next
+        # update_from_output -- without this the websocket hangs forever.
+        scheduler = create_scheduler()  # max_model_len = 1024
+        session, chunk = self._make_capped_session(scheduler)
+        client_index = session.client_index
+        scheduler.add_request(chunk)  # 1020 + 10 >= 1024 -> length-capped
+
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        # The finish is buffered for the client (not lost).
+        assert ("session", FinishReason.LENGTH) in [
+            (rid, reason) for _, rid, reason in scheduler._streaming_finish_outputs
+        ]
+
+        # The next step's update_from_output emits it to the client and drains.
+        scheduler_output = scheduler.schedule()
+        mro = ModelRunnerOutput(
+            req_ids=[],
+            req_id_to_index={},
+            sampled_token_ids=[],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        eco_dict = scheduler.update_from_output(scheduler_output, mro)
+
+        assert client_index in eco_dict
+        finish_outputs = [
+            o for o in eco_dict[client_index].outputs if o.request_id == "session"
+        ]
+        assert len(finish_outputs) == 1
+        assert finish_outputs[0].finish_reason == FinishReason.LENGTH
+        # Buffer drained (no duplicate emission on the following step).
+        assert scheduler._streaming_finish_outputs == []
+
     def test_handle_stopped_request_finishes_at_max_model_len(self):
         # Guard in _handle_stopped_request: applying a queued streaming chunk
         # that crosses max_model_len finishes the session gracefully.
         scheduler = create_scheduler()  # max_model_len = 1024
-        session = DummyRequest(
-            request_id="session", prompt_token_ids=list(range(1020))
-        )
-        session.num_computed_tokens = len(session.prompt_token_ids)
-        scheduler.add_request(session)
-        # Session still WAITING (not WAITING_FOR_STREAMING_REQ), so add_request
-        # enqueues the chunk onto the streaming queue.
-        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
-        chunk.sampling_params = SamplingParams(max_tokens=10)
+        session, chunk = self._make_capped_session(scheduler, waiting_for_chunk=False)
         scheduler.add_request(chunk)
         assert len(session.streaming_queue) == 1
 
@@ -566,7 +601,9 @@ class TestStreamingScheduler(unittest.TestCase):
         eco_cycle2 = eco_dict_cycle2[session.client_index].outputs[0]
         assert eco_cycle2.finish_reason == FinishReason.STOP
         assert session.status == RequestStatus.WAITING_FOR_STREAMING_REQ
-        assert session in scheduler.waiting
+        # Blocked-waiting statuses (incl. WAITING_FOR_STREAMING_REQ) are queued
+        # in skipped_waiting, not waiting (see _enqueue_waiting_request).
+        assert session in scheduler.skipped_waiting
         assert session._all_token_ids == [1, 2, 3, 10, STOP_TOKEN]
 
         # CRITICAL ASSERTION: Cached prompt_token_ids STILL must not have changed

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -53,6 +53,9 @@ def create_scheduler() -> Scheduler:
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
+    # MagicMock attributes are truthy by default; pin this so Scheduler.__init__
+    # does not take the encoder-decoder assertion path (added in #33900).
+    vllm_config.model_config.is_encoder_decoder = False
     vllm_config.model_config.max_model_len = 1024
     vllm_config.model_config.enable_return_routed_experts = False
     vllm_config.cache_config = MagicMock()
@@ -146,6 +149,49 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session.sampling_params.max_tokens == 10
         # Again, output tokens are cleared first, so max_tokens = 0 + 10 = 10
         assert session.max_tokens == 10
+
+    def test_add_request_session_finishes_at_max_model_len(self):
+        # Guard in add_request: when a streaming chunk pushes a live session's
+        # accumulated tokens to max_model_len, the session must finish as
+        # FINISHED_LENGTH_CAPPED instead of crashing later in the model runner.
+        scheduler = create_scheduler()  # max_model_len = 1024
+        session = DummyRequest(
+            request_id="session", prompt_token_ids=list(range(1020))
+        )
+        session.num_computed_tokens = len(session.prompt_token_ids)
+        scheduler.add_request(session)
+        # Put the session into the "waiting for next chunk" state so the next
+        # add_request commences the chunk (the guarded branch).
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
+        chunk.sampling_params = SamplingParams(max_tokens=10)
+        scheduler.add_request(chunk)  # 1020 + 10 = 1030 >= 1024
+
+        assert session.num_tokens >= scheduler.max_model_len
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+    def test_handle_stopped_request_finishes_at_max_model_len(self):
+        # Guard in _handle_stopped_request: applying a queued streaming chunk
+        # that crosses max_model_len finishes the session gracefully.
+        scheduler = create_scheduler()  # max_model_len = 1024
+        session = DummyRequest(
+            request_id="session", prompt_token_ids=list(range(1020))
+        )
+        session.num_computed_tokens = len(session.prompt_token_ids)
+        scheduler.add_request(session)
+        # Session still WAITING (not WAITING_FOR_STREAMING_REQ), so add_request
+        # enqueues the chunk onto the streaming queue.
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(10)))
+        chunk.sampling_params = SamplingParams(max_tokens=10)
+        scheduler.add_request(chunk)
+        assert len(session.streaming_queue) == 1
+
+        finished = scheduler._handle_stopped_request(session)
+
+        assert finished is True
+        assert session.num_tokens >= scheduler.max_model_len
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
     def test_update_request_as_session(self):
         scheduler = create_scheduler()

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -228,6 +228,58 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session.num_tokens >= scheduler.max_model_len
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
+    def test_update_from_output_resume_into_cap_reports_length(self):
+        # A segment stops (STOP), then _handle_stopped_request applies a queued
+        # chunk that overflows max_model_len and finishes the session
+        # LENGTH_CAPPED. update_from_output must report LENGTH, not the stale
+        # pre-update STOP, or the client keeps a freed stream open.
+        scheduler = create_scheduler()  # max_model_len = 1024
+
+        session = DummyRequest(request_id="session", prompt_token_ids=list(range(100)))
+        scheduler.add_request(session)
+        client_index = session.client_index
+
+        # Prefill + one ordinary decode token -> session RUNNING, not stopped.
+        out = scheduler.schedule()
+        scheduler.update_from_output(
+            out,
+            ModelRunnerOutput(
+                req_ids=["session"],
+                req_id_to_index={"session": 0},
+                sampled_token_ids=[[5]],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+        )
+        assert session.status == RequestStatus.RUNNING
+
+        # Queue a chunk large enough to overflow max_model_len when applied.
+        chunk = DummyRequest(request_id="session", prompt_token_ids=list(range(1024)))
+        scheduler.add_request(chunk)
+        assert len(session.streaming_queue) == 1
+
+        # Next step: the session emits a stop token, triggering the cap.
+        out = scheduler.schedule()
+        eco = scheduler.update_from_output(
+            out,
+            ModelRunnerOutput(
+                req_ids=["session"],
+                req_id_to_index={"session": 0},
+                sampled_token_ids=[[STOP_TOKEN]],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+        )
+
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        finish_outputs = [
+            o for o in eco[client_index].outputs if o.request_id == "session"
+        ]
+        assert len(finish_outputs) == 1
+        assert finish_outputs[0].finish_reason == FinishReason.LENGTH
+
     def test_full_length_non_resumable_request_not_clamped(self):
         # Regression: the streaming graceful-cap clamp in the WAITING loop must
         # apply ONLY to resumable streaming sessions. A classic (resumable=False)

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -193,6 +193,30 @@ class TestStreamingScheduler(unittest.TestCase):
         assert session.num_tokens >= scheduler.max_model_len
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
 
+    def test_full_length_non_resumable_request_not_clamped(self):
+        # Regression: the streaming graceful-cap clamp in the WAITING loop must
+        # apply ONLY to resumable streaming sessions. A classic (resumable=False)
+        # request whose prompt is exactly max_model_len must schedule ALL its
+        # tokens in one step. Without the `request.resumable` gate the clamp
+        # `min(num_new_tokens, max_model_len - 1 - num_computed)` drops the last
+        # token (schedules 1023 not 1024), so the request can never complete --
+        # the bug that hit pooling/embedding requests at prompt_len ==
+        # max_model_len (allowed for pooling; rejected for generate at
+        # validation, which is why generation tests never caught it).
+        scheduler = create_scheduler()  # max_model_len = 1024
+        req = DummyRequest(
+            request_id="classic",
+            resumable=False,
+            prompt_token_ids=list(range(1024)),  # == max_model_len
+            max_tokens=1,
+        )
+        scheduler.add_request(req)
+        output = scheduler.schedule()
+
+        # All 1024 prompt tokens scheduled this step, not clamped to 1023.
+        assert output.num_scheduled_tokens["classic"] == 1024
+        assert req.status != RequestStatus.FINISHED_LENGTH_CAPPED
+
     def test_update_request_as_session(self):
         scheduler = create_scheduler()
 

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -48,6 +48,7 @@ class RealtimeConnection:
         self.serving = serving
         self.audio_queue: asyncio.Queue[np.ndarray | None] = asyncio.Queue()
         self.generation_task: asyncio.Task | None = None
+        self.request_id: str | None = None
 
         self._is_connected = False
         self._is_model_validated = False
@@ -204,6 +205,7 @@ class RealtimeConnection:
         6. Cleans up the audio queue
         """
         request_id = f"rt-{self.connection_id}-{uuid4()}"
+        self.request_id = request_id
         full_text = ""
 
         prompt_token_ids_len: int = 0
@@ -263,7 +265,11 @@ class RealtimeConnection:
 
         except Exception as e:
             logger.exception("Error in generation: %s", e)
-            await self.send_error(sanitize_message(str(e)), "processing_error")
+            try:
+                await self.send_error(sanitize_message(str(e)), "processing_error")
+            except Exception:
+                # The socket may already be closed; nothing more we can do.
+                pass
 
     async def send(
         self, event: SessionCreated | TranscriptionDelta | TranscriptionDone
@@ -282,8 +288,28 @@ class RealtimeConnection:
         # Signal audio stream to stop
         self.audio_queue.put_nowait(None)
 
-        # Cancel generation task if running
+        # Abort the engine request. Cancelling the asyncio task alone does NOT
+        # abort the underlying engine request: a request parked in the
+        # VAD-waiting state keeps occupying a slot and generating into a now
+        # dead websocket (an orphaned request that never frees and starves
+        # other streams). Aborting also unblocks the generation task, which is
+        # otherwise stuck awaiting the next engine output.
+        if self.request_id is not None:
+            try:
+                await self.serving.engine_client.abort(self.request_id)
+            except Exception:
+                logger.exception("Failed to abort request %s", self.request_id)
+            self.request_id = None
+
+        # Cancel the generation task if still running, and await it so the
+        # cancellation (and any generator cleanup) actually completes.
         if self.generation_task and not self.generation_task.done():
             self.generation_task.cancel()
+            try:
+                await self.generation_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("Error awaiting cancelled generation task")
 
         logger.debug("Connection cleanup complete: %s", self.connection_id)

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -120,7 +120,24 @@ class VoxtralProcessingInfo(BaseProcessingInfo):
         return {"audio": self.get_max_audio_tokens()}
 
     def get_max_audio_tokens(self) -> int:
-        return self.ctx.model_config.max_model_len
+        # For sliding-window realtime models (Voxtral-Mini-Realtime lineage),
+        # audio is processed in streaming chunks bounded by the decoder's
+        # sliding window. The number of audio-derived tokens active in the
+        # model context is therefore bounded by `text_config.sliding_window`,
+        # not by `max_model_len` (which is the cumulative session lifetime,
+        # not the concurrent context size).
+        #
+        # Without this cap, `compute_mm_encoder_budget` returns a budget
+        # proportional to `max_model_len`, the encoder cache pre-allocates
+        # `max_num_seqs * max_model_len` worth of audio feature space, and the
+        # decoder KV cache is starved on 16 GB GPUs (boot crashes with
+        # "KV cache memory needed > available"). Refs vllm-project/vllm#38233.
+        max_model_len = self.ctx.model_config.max_model_len
+        text_config = getattr(self.ctx.model_config.hf_config, "text_config", None)
+        sliding_window = getattr(text_config, "sliding_window", None)
+        if sliding_window is not None:
+            return min(sliding_window, max_model_len)
+        return max_model_len
 
     def get_max_audio_array_len(self) -> int:
         feature_extractor = self.get_feature_extractor()
@@ -334,9 +351,17 @@ class VoxtralForConditionalGeneration(
         self.downsample_factor = self.config.audio_config.downsample_factor
 
         with self._mark_language_model(vllm_config):
+            # Voxtral's text_config inherits from a Mistral 7B-class model but
+            # does not itself declare `architectures`. Without an explicit
+            # override, init_vllm_registered_model falls back to the
+            # Transformers backend, which does not propagate `sliding_window`
+            # to the attention layers, so SlidingWindowSpec is never produced
+            # and the KV cache pool is sized for max_model_len. Force the
+            # Mistral dispatch. Refs vllm-project/vllm#38233.
             self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
+                architectures=["MistralForCausalLM"],
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -120,12 +120,9 @@ class VoxtralProcessingInfo(BaseProcessingInfo):
         return {"audio": self.get_max_audio_tokens()}
 
     def get_max_audio_tokens(self) -> int:
-        # Voxtral realtime decoders declare text_config.sliding_window; for those
-        # the audio tokens that live in the attention window are window-bounded,
-        # not max_model_len-bounded. Without this cap the encoder cache and the
-        # profiling dummy audio are sized at max_model_len per item and starve the
-        # decoder KV cache (boot OOM on 16 GB GPUs). Standard Voxtral ships
-        # sliding_window=None and is unaffected. Refs vllm-project/vllm#38233.
+        # Cap audio tokens by the decoder sliding window when set: the encoder
+        # cache and profiling dummy are otherwise sized at max_model_len and OOM
+        # at boot on small GPUs. Standard Voxtral has sliding_window=None. #38233
         max_model_len = self.ctx.model_config.max_model_len
         text_config = getattr(self.ctx.model_config.hf_config, "text_config", None)
         sliding_window = getattr(text_config, "sliding_window", None)

--- a/vllm/model_executor/models/voxtral.py
+++ b/vllm/model_executor/models/voxtral.py
@@ -120,18 +120,12 @@ class VoxtralProcessingInfo(BaseProcessingInfo):
         return {"audio": self.get_max_audio_tokens()}
 
     def get_max_audio_tokens(self) -> int:
-        # For sliding-window realtime models (Voxtral-Mini-Realtime lineage),
-        # audio is processed in streaming chunks bounded by the decoder's
-        # sliding window. The number of audio-derived tokens active in the
-        # model context is therefore bounded by `text_config.sliding_window`,
-        # not by `max_model_len` (which is the cumulative session lifetime,
-        # not the concurrent context size).
-        #
-        # Without this cap, `compute_mm_encoder_budget` returns a budget
-        # proportional to `max_model_len`, the encoder cache pre-allocates
-        # `max_num_seqs * max_model_len` worth of audio feature space, and the
-        # decoder KV cache is starved on 16 GB GPUs (boot crashes with
-        # "KV cache memory needed > available"). Refs vllm-project/vllm#38233.
+        # Voxtral realtime decoders declare text_config.sliding_window; for those
+        # the audio tokens that live in the attention window are window-bounded,
+        # not max_model_len-bounded. Without this cap the encoder cache and the
+        # profiling dummy audio are sized at max_model_len per item and starve the
+        # decoder KV cache (boot OOM on 16 GB GPUs). Standard Voxtral ships
+        # sliding_window=None and is unaffected. Refs vllm-project/vllm#38233.
         max_model_len = self.ctx.model_config.max_model_len
         text_config = getattr(self.ctx.model_config.hf_config, "text_config", None)
         sliding_window = getattr(text_config, "sliding_window", None)
@@ -351,17 +345,9 @@ class VoxtralForConditionalGeneration(
         self.downsample_factor = self.config.audio_config.downsample_factor
 
         with self._mark_language_model(vllm_config):
-            # Voxtral's text_config inherits from a Mistral 7B-class model but
-            # does not itself declare `architectures`. Without an explicit
-            # override, init_vllm_registered_model falls back to the
-            # Transformers backend, which does not propagate `sliding_window`
-            # to the attention layers, so SlidingWindowSpec is never produced
-            # and the KV cache pool is sized for max_model_len. Force the
-            # Mistral dispatch. Refs vllm-project/vllm#38233.
             self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
-                architectures=["MistralForCausalLM"],
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -17,7 +17,6 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.speech_to_text import SpeechToTextParams
 from vllm.engine.protocol import StreamingInput
-from vllm.envs import VLLM_ENGINE_ITERATION_TIMEOUT_S
 from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings, SupportsRealtime
@@ -265,13 +264,20 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into buffer in background
+        # Feed output tokens back into buffer in background.
+        # input_stream is a token-feedback queue fed from engine outputs, so an
+        # idle wait here is normal (gaps between tokens or between utterances /
+        # silences) and must NOT be treated as a hang. Wrapping it in
+        # asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S) raised an uncaught
+        # TimeoutError on any silence longer than the timeout, silently killing
+        # this feeder task while the websocket stayed open — the session hung
+        # with no further tokens (vllm-project/vllm#36015, #35863). A real
+        # engine failure instead makes generate() raise and aborts the request,
+        # which cancels this task via the finally block below, so this await
+        # needs no timeout.
         async def feed_tokens():
             while True:
-                all_outputs = await asyncio.wait_for(
-                    input_stream.get(),
-                    timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
-                )
+                all_outputs = await input_stream.get()
                 await buffer.append_tokens(all_outputs[-1:])
 
         audio_task = asyncio.create_task(feed_audio())

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -267,14 +267,15 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
         # Feed output tokens back into buffer in background.
         # input_stream is a token-feedback queue fed from engine outputs, so an
         # idle wait here is normal (gaps between tokens or between utterances /
-        # silences) and must NOT be treated as a hang. Wrapping it in
-        # asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S) raised an uncaught
-        # TimeoutError on any silence longer than the timeout, silently killing
-        # this feeder task while the websocket stayed open — the session hung
-        # with no further tokens (vllm-project/vllm#36015, #35863). A real
-        # engine failure instead makes generate() raise and aborts the request,
-        # which cancels this task via the finally block below, so this await
-        # needs no timeout.
+        # silences) and must NOT be treated as a hang. Previously this await was
+        # wrapped in asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S), which
+        # raised an uncaught TimeoutError on any silence past the timeout and
+        # killed this feeder task while the websocket stayed open, so the session
+        # hung with no further tokens (vllm-project/vllm#36015, #35863). The v1
+        # engine has no per-iteration timeout watchdog, and the
+        # removed local timeout never recovered a genuinely wedged stream; a real
+        # request failure ends the stream and cancels this task via the finally
+        # block below, so this await needs no timeout.
         async def feed_tokens():
             while True:
                 all_outputs = await input_stream.get()

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -264,10 +264,9 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into the buffer. input_stream is a token
-        # queue; idle gaps (silences) are normal, not a hang. The old wait_for
-        # timeout killed this feeder on any silence and hung the session.
-        # #36015, #35863
+        # Feed output tokens back into the buffer with a blocking read: idle
+        # gaps between chunks are normal during silence, so any read timeout
+        # here would kill the feeder mid-session (#36015, #35863).
         async def feed_tokens():
             while True:
                 all_outputs = await input_stream.get()

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -264,18 +264,10 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
             await buffer.append_audio(right_pad.audio_array)
             await buffer.append_audio(None)  # signal end
 
-        # Feed output tokens back into buffer in background.
-        # input_stream is a token-feedback queue fed from engine outputs, so an
-        # idle wait here is normal (gaps between tokens or between utterances /
-        # silences) and must NOT be treated as a hang. Previously this await was
-        # wrapped in asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S), which
-        # raised an uncaught TimeoutError on any silence past the timeout and
-        # killed this feeder task while the websocket stayed open, so the session
-        # hung with no further tokens (vllm-project/vllm#36015, #35863). The v1
-        # engine has no per-iteration timeout watchdog, and the
-        # removed local timeout never recovered a genuinely wedged stream; a real
-        # request failure ends the stream and cancels this task via the finally
-        # block below, so this await needs no timeout.
+        # Feed output tokens back into the buffer. input_stream is a token
+        # queue; idle gaps (silences) are normal, not a hang. The old wait_for
+        # timeout killed this feeder on any silence and hung the session.
+        # #36015, #35863
         async def feed_tokens():
             while True:
                 all_outputs = await input_stream.get()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -197,14 +197,9 @@ class Scheduler(SchedulerInterface):
         # IDs of requests preempted since the last call to schedule().
         self.reset_preempted_req_ids: set[str] = set()
 
-        # Streaming sessions finished from inside schedule()/add_request() (e.g.
-        # a resumable realtime session that reached max_model_len). finish_requests
-        # frees them scheduler-side but, outside update_from_output, has no
-        # `outputs` dict to emit an EngineCoreOutput on -- and finished_req_ids is
-        # worker-facing only, so the client would never receive a finish_reason
-        # and the websocket would hang. Buffer (client_index, req_id, reason) here
-        # and drain it in the next update_from_output, mirroring the failed-KV-load
-        # finish path. Flushed each step.
+        # Client-facing finishes for streaming sessions ended inside schedule()/
+        # add_request() (no `outputs` dict there). Drained next update_from_output
+        # so the client gets a finish_reason instead of hanging. Flushed each step.
         self._streaming_finish_outputs: list[tuple[int, str, FinishReason]] = []
 
         # Counter for requests waiting for streaming input. Used to calculate
@@ -493,12 +488,6 @@ class Scheduler(SchedulerInterface):
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
-
-            # NOTE: realtime sessions advance their position clock through the
-            # WAITING loop (each audio chunk resumes the session with WAITING
-            # status), so the unbounded-realtime re-anchor trigger lives there,
-            # not here. The re-anchor margin keeps the running-loop decode clear
-            # of max_model_len between chunks.
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -830,18 +819,10 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
-                    # Clamp to max_model_len. Mirrors the RUNNING-path guard
-                    # above, but ONLY for streaming/resumable sessions whose
-                    # accumulated token count can grow past max_model_len across
-                    # successive `_update_request_as_session` resumes (continuous
-                    # Voxtral realtime audio). Classic one-shot prefills must NOT
-                    # be clamped here: a pooling/embedding request with
-                    # prompt_len == max_model_len would otherwise lose its last
-                    # token and hang (generate rejects that length at validation,
-                    # pooling does not). They keep the upstream invariant below.
-                    # Run before spec-decode padding so a length-capped session
-                    # drops to <=0 and the padding block (gated on
-                    # num_new_tokens == 1) is naturally skipped.
+                    # Clamp resumable (streaming) sessions to max_model_len;
+                    # their token count grows across resumes. Classic prefills
+                    # stay unclamped (a pooling req at prompt_len == max_model_len
+                    # must keep its last token). Runs before spec-decode padding.
                     if request.resumable:
                         num_new_tokens = min(
                             num_new_tokens,
@@ -880,18 +861,11 @@ class Scheduler(SchedulerInterface):
 
                     num_new_tokens = min(num_new_tokens, token_budget)
                     if not request.resumable:
-                        # Classic one-shot prefill: preserve the upstream
-                        # invariant. A non-resumable request is never clamped
-                        # above, so it always has tokens to schedule here.
+                        # Non-resumable prefills are never clamped above.
                         assert num_new_tokens > 0
                     elif num_new_tokens <= 0:
-                        # Resumable streaming session has reached max_model_len
-                        # and can never make progress. Finish it gracefully
-                        # (finish_requests removes it from the waiting queues)
-                        # instead of asserting and crashing the engine, and
-                        # avoid head-of-line blocking the waiting queue. Buffer a
-                        # client-facing finish output so the websocket does not
-                        # hang waiting for a finish_reason that never arrives.
+                        # Resumable session hit max_model_len: finish gracefully
+                        # (don't crash the engine) and notify the client.
                         finished = self.finish_requests(
                             request_id, RequestStatus.FINISHED_LENGTH_CAPPED
                         )
@@ -1764,8 +1738,7 @@ class Scheduler(SchedulerInterface):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
-                    # It may have applied a queued chunk and length-capped the
-                    # session (STOP -> LENGTH); re-read the final reason.
+                    # Applying a queued chunk may have flipped STOP -> LENGTH.
                     finish_reason = request.get_finished_reason()
                     kv_transfer_params = self._free_request(request)
 
@@ -1836,11 +1809,8 @@ class Scheduler(SchedulerInterface):
                     )
                 )
 
-        # Emit client-facing finish outputs for streaming sessions finished from
-        # inside schedule()/add_request() (the request is already freed, so this
-        # is the only place the client learns it ended). Mirrors the failed-KV
-        # path above; without it the websocket hangs on a finish_reason that
-        # never comes.
+        # Drain finishes buffered by schedule()/add_request() (request already
+        # freed; only place the client learns it ended).
         if self._streaming_finish_outputs:
             for client_index, req_id, reason in self._streaming_finish_outputs:
                 outputs[client_index].append(
@@ -1962,11 +1932,8 @@ class Scheduler(SchedulerInterface):
                 # Streaming request finished.
                 return True
             self._update_request_as_session(request, update)
-            # After extending the session with new streaming input, check if
-            # the accumulated tokens (prompt + encoder + output) reached
-            # max_model_len. Without this guard a fatal assertion fires in
-            # gpu_model_runner._bookkeeping_sync once the streaming input pushes
-            # the total past the limit (continuous Voxtral realtime sessions).
+            # Streaming input pushed the session past max_model_len: finish
+            # gracefully, else a fatal assert fires later in the model runner.
             if request.num_tokens >= self.max_model_len:
                 logger.warning(
                     "Streaming session %s reached max_model_len (%d >= %d) "
@@ -2110,10 +2077,8 @@ class Scheduler(SchedulerInterface):
             elif update is not None:
                 # Commence next input chunk.
                 self._update_request_as_session(existing, update)
-                # If the session reached max_model_len after the update (e.g.
-                # continuous audio streaming accumulating encoder tokens past
-                # the limit), finish gracefully here instead of letting it
-                # crash later in the model runner.
+                # Session reached max_model_len after the update: finish
+                # gracefully + notify the client.
                 if existing.num_tokens >= self.max_model_len:
                     logger.warning(
                         "Streaming session %s reached max_model_len "
@@ -2211,11 +2176,10 @@ class Scheduler(SchedulerInterface):
         finished: list[tuple[str, int]],
         finished_status: RequestStatus,
     ) -> None:
-        """Queue client-facing finish outputs for sessions finished from inside
-        schedule()/add_request() (where there is no `outputs` dict). Drained in
-        the next update_from_output so the client receives a finish_reason
-        instead of hanging. ``finished`` is the (req_id, client_index) list
-        returned by finish_requests."""
+        """Buffer a client-facing finish for a session ended inside schedule()/
+        add_request(); drained next update_from_output so the client isn't left
+        hanging. ``finished`` is the (req_id, client_index) list from
+        finish_requests."""
         reason = RequestStatus.get_finished_reason(finished_status)
         if reason is None:
             return

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1764,6 +1764,9 @@ class Scheduler(SchedulerInterface):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
+                    # It may have applied a queued chunk and length-capped the
+                    # session (STOP -> LENGTH); re-read the final reason.
+                    finish_reason = request.get_finished_reason()
                     kv_transfer_params = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -810,16 +810,22 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
                     # Clamp to max_model_len. Mirrors the RUNNING-path guard
-                    # above for streaming/resumable requests whose accumulated
-                    # token count can grow past max_model_len across successive
-                    # `_update_request_as_session` calls (continuous Voxtral
-                    # realtime audio sessions). Run before spec-decode padding so
-                    # a length-capped session drops to <=0 and the padding block
-                    # (gated on num_new_tokens == 1) is naturally skipped.
-                    num_new_tokens = min(
-                        num_new_tokens,
-                        self.max_model_len - 1 - num_computed_tokens,
-                    )
+                    # above, but ONLY for streaming/resumable sessions whose
+                    # accumulated token count can grow past max_model_len across
+                    # successive `_update_request_as_session` resumes (continuous
+                    # Voxtral realtime audio). Classic one-shot prefills must NOT
+                    # be clamped here: a pooling/embedding request with
+                    # prompt_len == max_model_len would otherwise lose its last
+                    # token and hang (generate rejects that length at validation,
+                    # pooling does not). They keep the upstream invariant below.
+                    # Run before spec-decode padding so a length-capped session
+                    # drops to <=0 and the padding block (gated on
+                    # num_new_tokens == 1) is naturally skipped.
+                    if request.resumable:
+                        num_new_tokens = min(
+                            num_new_tokens,
+                            self.max_model_len - 1 - num_computed_tokens,
+                        )
 
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
@@ -852,8 +858,13 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
-                    if num_new_tokens <= 0:
-                        # Length-capped: the request has reached max_model_len
+                    if not request.resumable:
+                        # Classic one-shot prefill: preserve the upstream
+                        # invariant. A non-resumable request is never clamped
+                        # above, so it always has tokens to schedule here.
+                        assert num_new_tokens > 0
+                    elif num_new_tokens <= 0:
+                        # Resumable streaming session has reached max_model_len
                         # and can never make progress. Finish it gracefully
                         # (finish_requests removes it from the waiting queues)
                         # instead of asserting and crashing the engine, and

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -51,7 +51,12 @@ from vllm.v1.core.sched.request_queue import (
     create_request_queue,
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
-from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
+from vllm.v1.engine import (
+    EngineCoreEventType,
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    FinishReason,
+)
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
@@ -191,6 +196,16 @@ class Scheduler(SchedulerInterface):
 
         # IDs of requests preempted since the last call to schedule().
         self.reset_preempted_req_ids: set[str] = set()
+
+        # Streaming sessions finished from inside schedule()/add_request() (e.g.
+        # a resumable realtime session that reached max_model_len). finish_requests
+        # frees them scheduler-side but, outside update_from_output, has no
+        # `outputs` dict to emit an EngineCoreOutput on -- and finished_req_ids is
+        # worker-facing only, so the client would never receive a finish_reason
+        # and the websocket would hang. Buffer (client_index, req_id, reason) here
+        # and drain it in the next update_from_output, mirroring the failed-KV-load
+        # finish path. Flushed each step.
+        self._streaming_finish_outputs: list[tuple[int, str, FinishReason]] = []
 
         # Counter for requests waiting for streaming input. Used to calculate
         # number of unfinished requests
@@ -478,6 +493,12 @@ class Scheduler(SchedulerInterface):
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
+
+            # NOTE: realtime sessions advance their position clock through the
+            # WAITING loop (each audio chunk resumes the session with WAITING
+            # status), so the unbounded-realtime re-anchor trigger lives there,
+            # not here. The re-anchor margin keeps the running-loop decode clear
+            # of max_model_len between chunks.
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
@@ -868,9 +889,14 @@ class Scheduler(SchedulerInterface):
                         # and can never make progress. Finish it gracefully
                         # (finish_requests removes it from the waiting queues)
                         # instead of asserting and crashing the engine, and
-                        # avoid head-of-line blocking the waiting queue.
-                        self.finish_requests(
+                        # avoid head-of-line blocking the waiting queue. Buffer a
+                        # client-facing finish output so the websocket does not
+                        # hang waiting for a finish_reason that never arrives.
+                        finished = self.finish_requests(
                             request_id, RequestStatus.FINISHED_LENGTH_CAPPED
+                        )
+                        self._buffer_streaming_finish(
+                            finished, RequestStatus.FINISHED_LENGTH_CAPPED
                         )
                         continue
 
@@ -1807,6 +1833,22 @@ class Scheduler(SchedulerInterface):
                     )
                 )
 
+        # Emit client-facing finish outputs for streaming sessions finished from
+        # inside schedule()/add_request() (the request is already freed, so this
+        # is the only place the client learns it ended). Mirrors the failed-KV
+        # path above; without it the websocket hangs on a finish_reason that
+        # never comes.
+        if self._streaming_finish_outputs:
+            for client_index, req_id, reason in self._streaming_finish_outputs:
+                outputs[client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=[],
+                        finish_reason=reason,
+                    )
+                )
+            self._streaming_finish_outputs.clear()
+
         # KV Connector: update state for finished KV Transfers.
         if kv_connector_output:
             self._update_from_kv_xfer_finished(kv_connector_output)
@@ -2078,9 +2120,12 @@ class Scheduler(SchedulerInterface):
                         existing.num_tokens,
                         self.max_model_len,
                     )
-                    self.finish_requests(
+                    finished = self.finish_requests(
                         existing.request_id,
                         RequestStatus.FINISHED_LENGTH_CAPPED,
+                    )
+                    self._buffer_streaming_finish(
+                        finished, RequestStatus.FINISHED_LENGTH_CAPPED
                     )
             else:
                 # Streaming-input session finished.
@@ -2157,6 +2202,22 @@ class Scheduler(SchedulerInterface):
             self._free_request(request, delay_free_blocks=delay_free_blocks)
 
         return [(r.request_id, r.client_index) for r in valid_requests]
+
+    def _buffer_streaming_finish(
+        self,
+        finished: list[tuple[str, int]],
+        finished_status: RequestStatus,
+    ) -> None:
+        """Queue client-facing finish outputs for sessions finished from inside
+        schedule()/add_request() (where there is no `outputs` dict). Drained in
+        the next update_from_output so the client receives a finish_reason
+        instead of hanging. ``finished`` is the (req_id, client_index) list
+        returned by finish_requests."""
+        reason = RequestStatus.get_finished_reason(finished_status)
+        if reason is None:
+            return
+        for req_id, client_index in finished:
+            self._streaming_finish_outputs.append((client_index, req_id, reason))
 
     def _free_request(
         self, request: Request, delay_free_blocks: bool = False

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -809,6 +809,18 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
+                    # Clamp to max_model_len. Mirrors the RUNNING-path guard
+                    # above for streaming/resumable requests whose accumulated
+                    # token count can grow past max_model_len across successive
+                    # `_update_request_as_session` calls (continuous Voxtral
+                    # realtime audio sessions). Run before spec-decode padding so
+                    # a length-capped session drops to <=0 and the padding block
+                    # (gated on num_new_tokens == 1) is naturally skipped.
+                    num_new_tokens = min(
+                        num_new_tokens,
+                        self.max_model_len - 1 - num_computed_tokens,
+                    )
+
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
                     if (
@@ -840,7 +852,16 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
-                    assert num_new_tokens > 0
+                    if num_new_tokens <= 0:
+                        # Length-capped: the request has reached max_model_len
+                        # and can never make progress. Finish it gracefully
+                        # (finish_requests removes it from the waiting queues)
+                        # instead of asserting and crashing the engine, and
+                        # avoid head-of-line blocking the waiting queue.
+                        self.finish_requests(
+                            request_id, RequestStatus.FINISHED_LENGTH_CAPPED
+                        )
+                        continue
 
                     # Schedule encoder inputs.
                     if request.has_encoder_inputs:
@@ -1885,6 +1906,21 @@ class Scheduler(SchedulerInterface):
                 # Streaming request finished.
                 return True
             self._update_request_as_session(request, update)
+            # After extending the session with new streaming input, check if
+            # the accumulated tokens (prompt + encoder + output) reached
+            # max_model_len. Without this guard a fatal assertion fires in
+            # gpu_model_runner._bookkeeping_sync once the streaming input pushes
+            # the total past the limit (continuous Voxtral realtime sessions).
+            if request.num_tokens >= self.max_model_len:
+                logger.warning(
+                    "Streaming session %s reached max_model_len (%d >= %d) "
+                    "after session update. Finishing request gracefully.",
+                    request.request_id,
+                    request.num_tokens,
+                    self.max_model_len,
+                )
+                request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+                return True
         else:
             request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
             self.num_waiting_for_streaming_input += 1
@@ -2018,6 +2054,23 @@ class Scheduler(SchedulerInterface):
             elif update is not None:
                 # Commence next input chunk.
                 self._update_request_as_session(existing, update)
+                # If the session reached max_model_len after the update (e.g.
+                # continuous audio streaming accumulating encoder tokens past
+                # the limit), finish gracefully here instead of letting it
+                # crash later in the model runner.
+                if existing.num_tokens >= self.max_model_len:
+                    logger.warning(
+                        "Streaming session %s reached max_model_len "
+                        "(%d >= %d) after session update. Finishing request "
+                        "gracefully.",
+                        existing.request_id,
+                        existing.num_tokens,
+                        self.max_model_len,
+                    )
+                    self.finish_requests(
+                        existing.request_id,
+                        RequestStatus.FINISHED_LENGTH_CAPPED,
+                    )
             else:
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -647,6 +647,15 @@ class OutputProcessor:
                 # if required.
                 req_state.logprobs_processor.update_from_output(engine_core_output)
 
+            # A streaming session stays unfinished between chunks, but a
+            # terminal finish (length cap / error / abort) ends it: deliver
+            # finished=True and free it, else AsyncLLM.generate() hangs.
+            terminal_stream_finish = req_state.streaming_input and finish_reason in (
+                FinishReason.LENGTH,
+                FinishReason.ERROR,
+                FinishReason.ABORT,
+            )
+
             # 4) Create and handle RequestOutput objects.
             if request_output := req_state.make_request_output(
                 new_token_ids,
@@ -655,7 +664,7 @@ class OutputProcessor:
                 stop_reason,
                 kv_transfer_params,
             ):
-                if req_state.streaming_input:
+                if req_state.streaming_input and not terminal_stream_finish:
                     request_output.finished = False
 
                 if req_state.queue is not None:
@@ -667,7 +676,7 @@ class OutputProcessor:
 
             # Free completed requests.
             if finish_reason is not None:
-                if req_state.streaming_input:
+                if req_state.streaming_input and not terminal_stream_finish:
                     if req_state.input_chunk_queue:
                         update = req_state.input_chunk_queue.popleft()
                         req_state.apply_streaming_update(update)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -647,11 +647,11 @@ class OutputProcessor:
                 # if required.
                 req_state.logprobs_processor.update_from_output(engine_core_output)
 
-            # A streaming session stays unfinished between chunks, but a
-            # terminal finish (length cap / error / abort) ends it: deliver
-            # finished=True and free it, else AsyncLLM.generate() hangs.
+            # A streaming session stays unfinished between chunks. A normal
+            # per-step finish is FinishReason.LENGTH (the session resumes with
+            # the next chunk), so only ERROR/ABORT is terminal here; genuine
+            # max_model_len caps are delivered via _streaming_finish_outputs.
             terminal_stream_finish = req_state.streaming_input and finish_reason in (
-                FinishReason.LENGTH,
                 FinishReason.ERROR,
                 FinishReason.ABORT,
             )

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -647,11 +647,11 @@ class OutputProcessor:
                 # if required.
                 req_state.logprobs_processor.update_from_output(engine_core_output)
 
-            # A streaming session stays unfinished between chunks. A normal
-            # per-step finish is FinishReason.LENGTH (the session resumes with
-            # the next chunk), so only ERROR/ABORT is terminal here; genuine
-            # max_model_len caps are delivered via _streaming_finish_outputs.
-            terminal_stream_finish = req_state.streaming_input and finish_reason in (
+            # A streaming session stays unfinished between chunks: a normal
+            # per-step finish is FinishReason.LENGTH and the session resumes
+            # with the next chunk. Only ERROR/ABORT terminates it here;
+            # genuine max_model_len caps arrive via _streaming_finish_outputs.
+            stream_continues = req_state.streaming_input and finish_reason not in (
                 FinishReason.ERROR,
                 FinishReason.ABORT,
             )
@@ -664,7 +664,7 @@ class OutputProcessor:
                 stop_reason,
                 kv_transfer_params,
             ):
-                if req_state.streaming_input and not terminal_stream_finish:
+                if stream_continues:
                     request_output.finished = False
 
                 if req_state.queue is not None:
@@ -676,7 +676,7 @@ class OutputProcessor:
 
             # Free completed requests.
             if finish_reason is not None:
-                if req_state.streaming_input and not terminal_stream_finish:
+                if stream_continues:
                     if req_state.input_chunk_queue:
                         update = req_state.input_chunk_queue.popleft()
                         req_state.apply_streaming_update(update)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,6 +6281,17 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
+                        # Realtime streaming models (Voxtral realtime,
+                        # Qwen3-ASR realtime, ...) process at most one new
+                        # multimodal chunk per generation step per session,
+                        # regardless of max_num_seqs. Profiling with the
+                        # cartesian product (max_num_seqs x max audio length)
+                        # OOMs on consumer GPUs while never reflecting runtime
+                        # memory pressure. Clamp to a single item.
+                        # Refs vllm-project/vllm#38233.
+                        if supports_realtime(self.model):
+                            max_mm_items_per_batch = 1
+
                         logger.info_once(
                             "Encoder cache will be initialized with a "
                             "budget of %s tokens, and profiled with "

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,17 +6281,10 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
-                        # Realtime models submit one new mm chunk per step per
-                        # session, so the max_num_seqs x max-audio product over-
-                        # profiles and OOMs on consumer GPUs (#38233). But runtime
-                        # encoder admission is bounded by the encoder *token*
-                        # budget, not item count (_try_schedule_encoder_inputs /
-                        # EncoderCacheManager), so several concurrent sessions'
-                        # chunks -- or a multi-audio prompt -- can land in a single
-                        # embed_multimodal forward. Profile exactly that many max-
-                        # size items (encoder_budget // max-tokens-per-item): the
-                        # same bound admission enforces. Clamping to 1 under-
-                        # profiles encoder peak memory and OOMs in service.
+                        # Realtime encoder admission is bounded by the token
+                        # budget, not item count, so profile encoder_budget //
+                        # max-tokens-per-item items (the bound admission enforces);
+                        # clamping to 1 under-profiles and OOMs in service. #38233
                         if supports_realtime(self.model):
                             max_toks = mm_budget.mm_max_toks_per_item[dummy_modality]
                             max_mm_items_per_batch = max(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,10 +6281,10 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
-                        # Realtime encoder admission is bounded by the token
-                        # budget, not item count, so profile encoder_budget //
-                        # max-tokens-per-item items (the bound admission enforces);
-                        # clamping to 1 under-profiles and OOMs in service. #38233
+                        # Realtime admission is bounded by the encoder token
+                        # budget, not by item count: profile the item count
+                        # that budget admits. Profiling a single item
+                        # under-reserves and OOMs in service (#38233).
                         if supports_realtime(self.model):
                             max_toks = mm_budget.mm_max_toks_per_item[dummy_modality]
                             max_mm_items_per_batch = max(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6281,16 +6281,23 @@ class GPUModelRunner(
                             dummy_modality
                         ]
 
-                        # Realtime streaming models (Voxtral realtime,
-                        # Qwen3-ASR realtime, ...) process at most one new
-                        # multimodal chunk per generation step per session,
-                        # regardless of max_num_seqs. Profiling with the
-                        # cartesian product (max_num_seqs x max audio length)
-                        # OOMs on consumer GPUs while never reflecting runtime
-                        # memory pressure. Clamp to a single item.
-                        # Refs vllm-project/vllm#38233.
+                        # Realtime models submit one new mm chunk per step per
+                        # session, so the max_num_seqs x max-audio product over-
+                        # profiles and OOMs on consumer GPUs (#38233). But runtime
+                        # encoder admission is bounded by the encoder *token*
+                        # budget, not item count (_try_schedule_encoder_inputs /
+                        # EncoderCacheManager), so several concurrent sessions'
+                        # chunks -- or a multi-audio prompt -- can land in a single
+                        # embed_multimodal forward. Profile exactly that many max-
+                        # size items (encoder_budget // max-tokens-per-item): the
+                        # same bound admission enforces. Clamping to 1 under-
+                        # profiles encoder peak memory and OOMs in service.
                         if supports_realtime(self.model):
-                            max_mm_items_per_batch = 1
+                            max_toks = mm_budget.mm_max_toks_per_item[dummy_modality]
+                            max_mm_items_per_batch = max(
+                                1,
+                                min(max_mm_items_per_batch, encoder_budget // max_toks),
+                            )
 
                         logger.info_once(
                             "Encoder cache will be initialized with a "


### PR DESCRIPTION
## What this is

Three independent bugs break `Voxtral-Mini-4B-Realtime` self-hosting on a single 16 GiB GPU. This is the trimmed, **bug-fix-only** PR. The unbounded-duration RoPE re-anchoring (RFC, default-off) that was bundled here originally now lives in a follow-up stacked on this branch, so this PR stays small and reviewable. We run these fixes in prod at LinTO.

**Duplicate check:** no open PR covers #38233 (boot-OOM) or the `max_model_len` engine crash; the silent-hang fix overlaps #44461 (will rebase onto it if it lands first).

Nothing here changes a classic (non-streaming) request.

## Fixes

**Boot OOM on 16 GiB (#38233).** `get_max_audio_tokens` returned `max_model_len`, so the encoder audio-token budget scaled with the full context and starved decoder KV at profiling time. Now capped by `sliding_window`. One disclosed behavior change: with a narrow window a very long one-shot clip on `/v1/audio/transcriptions` is rejected with a clear 400 (`exceeds the pre-allocated encoder cache size`) instead of admitted; streaming sessions are unaffected.

**Profiling-time OOM.** Realtime profiling sized the encoder dummy batch as `max_num_seqs ×` max-size audio, which OOMs consumer GPUs at boot. Profiling now runs exactly as many max-size items as the encoder token budget admits at runtime (the same bound the scheduler enforces), gated on `supports_realtime`.

**Silent hang on long silences (#36015, #35863).** `VoxtralRealtimeGeneration.feed_tokens()` wrapped `input_stream.get()` in `asyncio.wait_for(VLLM_ENGINE_ITERATION_TIMEOUT_S)`. A silence past the timeout killed the feeder task while the WebSocket stayed open producing nothing. An idle wait on a token-feedback queue is normal, so the timeout is removed. Overlaps #44461 (happy to rebase on it once it lands).

**Engine crash at `max_model_len`.** A streaming session grows its token count monotonically; on reaching `max_model_len` a fatal assertion took down the whole engine and every concurrent session. Resumable streaming sessions now finish gracefully as `FINISHED_LENGTH_CAPPED`, and the client is told: the finish is buffered and emitted as an `EngineCoreOutput` with `finish_reason=LENGTH` on the next step (mirroring the failed-KV-load pattern), so the WebSocket doesn't wait forever. Gated on `request.resumable`; classic one-shot requests keep the upstream `assert num_new_tokens > 0` invariant (a pooling request at `prompt_len == max_model_len` would otherwise lose its last token and hang; regression test added).

The two streaming-path fixes are gated on generic predicates (`request.resumable`, `supports_realtime`), so Qwen3-ASR realtime, the only other in-tree `SupportsRealtime` model, gets them too.

## Tests

```
pytest tests/v1/streaming_input/test_scheduler_streaming.py    # 12 passed
```

Covers the graceful finish, the buffered client finish (emitted once, drained, no duplicate), and the non-resumable clamp regression. One pre-existing upstream test repaired (`test_streaming_e2e_lifecycle` asserted the session lands in `waiting`; blocked-waiting statuses moved to `skipped_waiting` since the waiting-queue split).

Developed with AI assistance; I reviewed every line and ran the tests.