### PR TITLE
[Bugfix][Rust Frontend] Return 400 for empty or over-length completion prompts

### DIFF
--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -69,10 +69,16 @@ pub async fn completions(
     {
         Ok(stream) => stream,
         Err(error) => {
-            return server_error!(
-                "failed to submit completion request: {}",
-                error.to_report_string()
-            )
+            return match &error {
+                vllm_text::Error::EmptyPromptTokenIds { .. }
+                | vllm_text::Error::PromptTooLong { .. } => {
+                    ApiError::invalid_request(error.to_report_string(), Some("prompt"))
+                }
+                _ => server_error!(
+                    "failed to submit completion request: {}",
+                    error.to_report_string()
+                ),
+            }
             .into_response();
         }
     };


### PR DESCRIPTION

## Purpose

With `VLLM_USE_RUST_FRONTEND=1`, a `/v1/completions` request with an empty token-id prompt (`[]`) or a token-id prompt longer than the model's context length returns HTTP 500, where the Python frontend returns a clean 400. The text layer already detects both conditions (`Error::EmptyPromptTokenIds`, `Error::PromptTooLong`), but the completions handler maps every generate error to a generic 500.

## Implementation

Match those two prompt errors to 400 (`ApiError::invalid_request(.., Some("prompt"))`) in the completions generate-error arm, the same inline `match error { .. }` shape `lora.rs` already uses for typed errors; every other generate error stays the existing 500. No behavior change for valid prompts.

## Test

`cargo test -p vllm-server`, `cargo clippy --release`, and `cargo fmt --check` are clean. End-to-end on Qwen3-0.6B (`VLLM_USE_RUST_FRONTEND=1`, `--max-model-len 2048`):

| request | stock Rust | this PR | Python |
|---|---|---|---|
| empty token prompt `[]` | 500 | **400** | 400 |
| token prompt longer than context | 500 | **400** | 400 |
| valid token prompt / normal text prompt | 200 | 200 | 200 |

The engine stays healthy throughout (these are per-request errors, not crashes). Stock and this PR were run against the same engine commit for a clean differential.

## Scope

Covers the two completions-prompt cases the Rust frontend uniquely returns 500 on. Other "500 instead of 400" inputs are intentionally out of scope here: a ~5000-entry `logit_bias` faults EngineCore on both the Rust and Python frontends (an engine-side robustness issue, not a frontend parity gap), and an invalid `json_schema` type needs grammar-level validation to reject up front.

AI assistance was used to investigate, reproduce, and draft this change; the author reviewed the diff and validation output.

cc @BugenZhao
