### PR TITLE
[Bugfix] Guard compressed-tensors FP8 KV cache override on SM90+

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -236,11 +236,24 @@ class Attention(nn.Module, AttentionLayerBase):
         # case anything bypassed that path.
         kv_cache_scheme = getattr(quant_config, "kv_cache_scheme", None)
         if kv_cache_scheme is not None and kv_cache_dtype == "auto":
-            kv_cache_dtype = "fp8"
-            calculate_kv_scales = False
-            if cache_config is not None:
-                cache_config.cache_dtype = "fp8"
-                cache_config.calculate_kv_scales = False
+            # FP8 KV-cache attention kernels (FlashInfer) require SM90+.
+            # On SM89 (L4, RTX 4090) the kernels are missing and the
+            # override causes illegal-memory-access crashes during MTP
+            # speculative decoding.  Skip the auto-override on those
+            # GPUs; users can still force --kv-cache-dtype fp8.
+            if current_platform.has_device_capability(90):
+                kv_cache_dtype = "fp8"
+                calculate_kv_scales = False
+                if cache_config is not None:
+                    cache_config.cache_dtype = "fp8"
+                    cache_config.calculate_kv_scales = False
+            else:
+                logger.warning(
+                    "Model specifies kv_cache_scheme (FP8 KV cache) but "
+                    "the current GPU does not support FP8 attention "
+                    "kernels. Falling back to auto KV cache dtype. "
+                    "Use --kv-cache-dtype fp8 to override."
+                )
 
         # Check if per-head quant scales are required based on kv_cache_scheme
         use_per_head_quant_scales = (

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -248,11 +248,15 @@ class Attention(nn.Module, AttentionLayerBase):
                     cache_config.cache_dtype = "fp8"
                     cache_config.calculate_kv_scales = False
             else:
+                cap = current_platform.get_device_capability()
+                cap_str = cap.as_version_str() if cap else "unknown"
                 logger.warning(
                     "Model specifies kv_cache_scheme (FP8 KV cache) but "
-                    "the current GPU does not support FP8 attention "
-                    "kernels. Falling back to auto KV cache dtype. "
-                    "Use --kv-cache-dtype fp8 to override."
+                    "the current GPU (compute capability %s) does not "
+                    "support FP8 attention kernels (SM90+ required). "
+                    "Falling back to auto KV cache dtype. "
+                    "Use --kv-cache-dtype fp8 to override.",
+                    cap_str,
                 )
 
         # Check if per-head quant scales are required based on kv_cache_scheme

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -276,9 +276,26 @@ class Attention(nn.Module, AttentionLayerBase):
         # case anything bypassed that path.
         kv_cache_scheme = getattr(quant_config, "kv_cache_scheme", None)
         if kv_cache_scheme is not None and kv_cache_dtype == "auto":
-            kv_cache_dtype = "fp8"
-            if cache_config is not None:
-                cache_config.cache_dtype = "fp8"
+            # FP8 KV-cache attention kernels (FlashInfer) require SM90+.
+            # On SM89 (L4, RTX 4090) the kernels are missing and the
+            # override causes illegal-memory-access crashes during MTP
+            # speculative decoding.  Skip the auto-override on those
+            # GPUs; users can still force --kv-cache-dtype fp8.
+            if current_platform.has_device_capability(90):
+                kv_cache_dtype = "fp8"
+                if cache_config is not None:
+                    cache_config.cache_dtype = "fp8"
+            else:
+                cap = current_platform.get_device_capability()
+                cap_str = cap.as_version_str() if cap else "unknown"
+                logger.warning(
+                    "Model specifies kv_cache_scheme (FP8 KV cache) but "
+                    "the current GPU (compute capability %s) does not "
+                    "support FP8 attention kernels (SM90+ required). "
+                    "Falling back to auto KV cache dtype. "
+                    "Use --kv-cache-dtype fp8 to override.",
+                    cap_str,
+                )
 
         # Check if per-head quant scales are required based on kv_cache_scheme
         use_per_head_quant_scales = (


### PR DESCRIPTION
## Summary

- Fix CUDA illegal-memory-access crash when serving compressed-tensors FP8 models (e.g. `numind/NuExtract3-FP8`) with MTP speculative decoding on SM89 GPUs (L4, RTX 4090)
- The `kv_cache_scheme` in the model config unconditionally overrides `kv_cache_dtype` from `auto` to `fp8`, but FlashInfer's FP8 attention kernels only exist for SM90+
- Add a `has_device_capability(90)` guard so the auto-override only fires on SM90+, with a warning on older GPUs
- Users can still force FP8 via `--kv-cache-dtype fp8` if desired

Fixes #44879

## Duplicate-work check

No existing PRs address this issue:
```
gh pr list --repo vllm-project/vllm --state open --search "44879 in:body"  # none
gh pr list --repo vllm-project/vllm --state open --search "compressed-tensors kv_cache_scheme SM89"  # none
```

## Root cause

`compressed_tensors.py` loads `kv_cache_scheme` from the model checkpoint config. In `Attention.__init__()`, when `kv_cache_scheme is not None and kv_cache_dtype == "auto"`, `kv_cache_dtype` is unconditionally set to `"fp8"` and `cache_config.cache_dtype` is mutated globally. On SM89, FlashInfer lacks FP8 attention kernels, and the MTP speculative decoding path triggers a CUDA illegal memory access.

## Test plan

- [ ] Verify on SM89 (L4/RTX 4090): serving compressed-tensors FP8 model with MTP no longer crashes
- [ ] Verify on SM90+ (H100/H200): FP8 KV cache auto-override still works
- [ ] Verify explicit `--kv-cache-dtype fp8` bypasses the guard on all hardware

Capability check verification:
- SM89 (L4, RTX 4090): `has_device_capability(90)` = False, override skipped
- SM90+ (H100, H200, GB10): True, override applied
- ROCm MI300X (gfx942): True, override applied

## AI disclosure

AI-assisted (Claude Opus 4.8). All changes manually reviewed, verified, and understood by the submitter.