### PR TITLE
[CI] Restore MiniCPMV transformers cap, scoped to HF runner only

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1119,7 +1119,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         },
         max_transformers_version="4.57",
         transformers_version_reason={
-            "vllm": (
+            "hf": (
                 "MiniCPMVBatchFeature is incompatible with its base class in "
                 "Transformers v5. See https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/discussions/78"
             )

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1124,6 +1124,14 @@ _MULTIMODAL_EXAMPLE_MODELS = {
             "4.5": "openbmb/MiniCPM-V-4_5",
         },
         trust_remote_code=True,
+        max_transformers_version="4.57",
+        transformers_version_reason={
+            "hf": (
+                "MiniCPMV.__init__ does not call self.post_init(), so "
+                "`all_tied_weights_keys` is never set; Transformers v5 requires "
+                "this attribute in _move_missing_keys_from_meta_to_device."
+            )
+        },
     ),
     "MiniCPMV4_6ForConditionalGeneration": _HfExamplesInfo(
         "openbmb/MiniCPM-V-4_6",


### PR DESCRIPTION
## Purpose

Restores the `max_transformers_version` cap on the `MiniCPMV` test registry entry, scoped to the HF runner only (`transformers_version_reason={"hf": ...}`).

This PR previously flipped an existing `"vllm"` reason to `"hf"`. Since then #48413 removed the cap outright, so it has been rewritten: the cap is re-added, with the correct reason.

## Why the cap is needed again

Nightly [build 83094](https://buildkite.com/vllm/ci/builds/83094) (`Multi-Modal Models (Extended Generation 3)`, an `optional: true` step that only runs in the scheduled full CI run) fails 9 tests, all with:

```
AttributeError: 'MiniCPMV' object has no attribute 'all_tied_weights_keys'
```

- `test_single_image_models[minicpmv_25-test_case100..102]`
- `test_single_image_models[minicpmv_26-test_case103..105]`
- `test_multi_image_models[minicpmv_26-test_case77..79]`

The failure is entirely on the HF reference side. The traceback ends in `transformers/modeling_utils.py`:

```python
for key in missing_keys - self.all_tied_weights_keys.keys()
```

`all_tied_weights_keys` is set by `PreTrainedModel.post_init()`, and MiniCPMV's remote code never calls it: `post_init` appears zero times in `modeling_minicpmv.py` for `MiniCPM-Llama3-V-2_5`, `MiniCPM-V-4` and `MiniCPM-V-4_5` (2_6 is gated on the Hub now, but fails identically). Same failure mode as `SkyworkR1VChatModel` (#42104) and the sibling `MiniCPMO` entry, both already capped.

### Why it surfaced now

The `MiniCPMV` entry used to carry `max_transformers_version="4.57"` with a `"vllm"` reason. Because `vlm_utils/core.py::run_test` calls `check_transformers_version(on_fail="skip")` with the default `check_max_version=True`, that cap gated the HF-runner tests too. #48413 fixed the vLLM-side `MiniCPMVBatchFeature` problem and removed the cap entirely, which correctly re-enabled vLLM-only coverage but also un-gated the HF comparisons and exposed this separate, still-unfixed HF-side break.

Using an `"hf"`-scoped reason keeps both halves right: HF-runner comparisons skip, vLLM-only tests (including the ones #48413 added in `tests/models/multimodal/processing/test_minicpmv.py`) keep running, because those callers pass `check_max_version=False, check_version_reason="vllm"`.

Tracks under #38379.

## Not a duplicate

This *is* the pre-existing PR for this fix, rewritten rather than superseded by a new one. Duplicate checks run:

```
gh pr list --repo vllm-project/vllm --state open --search "minicpmv"
gh pr list --repo vllm-project/vllm --state open --search "all_tied_weights_keys in:body"
gh pr list --repo vllm-project/vllm --state open --search "48413 in:body"
```

No other open PR touches the `MiniCPMV` registry entry. #43760 and #42785 are runtime/CUDA-graph changes to the model itself.

## Testing

```
pytest tests/models/test_registry.py -q
# 368 passed, 2 failed, 16 skipped
```

The two failures (`test_registry_imports[HCXVisionForCausalLM]`, `test_registry_imports[KananaVForConditionalGeneration]`) are pre-existing and unrelated: confirmed by re-running them on a stashed tree.

Behaviour of the gate itself, against `transformers==5.16.0.dev0`:

```python
for m in ["openbmb/MiniCPM-Llama3-V-2_5", "openbmb/MiniCPM-V-2_6",
          "openbmb/MiniCPM-V-4", "openbmb/MiniCPM-V-4_5"]:
    info = HF_EXAMPLE_MODELS.find_hf_info(m)
    info.check_transformers_version(on_fail="return")                    # -> skip message
    info.check_transformers_version(on_fail="return",
                                   check_max_version=False,
                                   check_version_reason="vllm")          # -> None
```

All four variants skip HF-runner tests and none skip vLLM-only tests, which is the intended split.

No model evaluation results: this is a test-gating change only, with no effect on model output, accuracy or serving.

## AI assistance

AI assistance was used for this change (investigating the Buildkite failure, bisecting the cause to #48413, and drafting the patch and this description). I have reviewed every changed line and run the tests reported above.
