### PR TITLE
[Render] Add reasoning and tool call parsing to `/derender`

### DIFF
--- a/tests/entrypoints/serve/render/test_derender.py
+++ b/tests/entrypoints/serve/render/test_derender.py
@@ -9,6 +9,417 @@ import pytest_asyncio
 
 from tests.utils import RemoteLaunchRenderServer
 
+# ---------------------------------------------------------------------------
+# Unit tests for build_chat_message (no server required)
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_request(
+    tool_choice=None,
+    tools=None,
+    include_reasoning: bool = True,
+):
+    """Create a minimal ChatCompletionRequest for unit testing."""
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+
+    kwargs = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "include_reasoning": include_reasoning,
+    }
+    if tool_choice is not None:
+        kwargs["tool_choice"] = tool_choice
+    if tools is not None:
+        kwargs["tools"] = tools
+    return ChatCompletionRequest(**kwargs)
+
+
+def _make_mock_tokenizer():
+    """Return a non-Mistral mock tokenizer."""
+    from unittest.mock import MagicMock
+
+    return MagicMock()
+
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def test_build_chat_message_no_parser_passthrough():
+    """Without a parser, output_text passes straight through as content."""
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    req = _make_chat_request()
+    msg, auto, cnt = build_chat_message(
+        output_text="hello world",
+        output_token_ids=[1, 2, 3],
+        request=req,
+        parser=None,
+        tool_parser=None,
+        use_harmony=False,
+        enable_auto_tools=False,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    assert msg.content == "hello world"
+    assert msg.role == "assistant"
+    assert msg.reasoning is None
+    assert auto is False
+    assert cnt == 0
+
+
+def test_build_chat_message_parser_include_reasoning():
+    """Parser output reasoning is preserved when include_reasoning=True."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    parser = MagicMock()
+    parser.parse.return_value = ("I am thinking...", "final answer", [])
+
+    req = _make_chat_request(include_reasoning=True)
+    msg, _, _ = build_chat_message(
+        output_text="<think>I am thinking...</think>final answer",
+        output_token_ids=[1, 2, 3],
+        request=req,
+        parser=parser,
+        tool_parser=None,
+        use_harmony=False,
+        enable_auto_tools=False,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    assert msg.content == "final answer"
+    assert msg.reasoning == "I am thinking..."
+
+
+def test_build_chat_message_parser_exclude_reasoning():
+    """Parser output reasoning is stripped when include_reasoning=False."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    parser = MagicMock()
+    parser.parse.return_value = ("I am thinking...", "final answer", [])
+
+    req = _make_chat_request(include_reasoning=False)
+    msg, _, _ = build_chat_message(
+        output_text="<think>I am thinking...</think>final answer",
+        output_token_ids=[1, 2, 3],
+        request=req,
+        parser=parser,
+        tool_parser=None,
+        use_harmony=False,
+        enable_auto_tools=False,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    assert msg.content == "final answer"
+    assert msg.reasoning is None
+
+
+def test_build_chat_message_auto_tool_calls():
+    """Auto tool choice with matching parser output populates tool_calls."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.openai.engine.protocol import FunctionCall
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    func_call = FunctionCall(name="get_weather", arguments='{"city": "London"}')
+    parser = MagicMock()
+    parser.parse.return_value = (None, None, [func_call])
+    tool_parser = MagicMock()  # truthy but not a Mistral parser
+
+    req = _make_chat_request(tool_choice="auto", tools=_TOOLS)
+    msg, auto, cnt = build_chat_message(
+        output_text='get_weather({"city": "London"})',
+        output_token_ids=[1, 2, 3],
+        request=req,
+        parser=parser,
+        tool_parser=tool_parser,
+        use_harmony=False,
+        enable_auto_tools=True,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    assert auto is True
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert cnt == 1  # history counter incremented
+
+
+def test_build_chat_message_required_tool_calls():
+    """Required tool_choice produces tool_calls. auto_tools_called stays False."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.openai.engine.protocol import FunctionCall
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    func_call = FunctionCall(name="search", arguments='{"q": "vllm"}')
+    parser = MagicMock()
+    parser.parse.return_value = (None, "", [func_call])
+    tool_parser = MagicMock()
+
+    req = _make_chat_request(tool_choice="required", tools=_TOOLS)
+    msg, auto, cnt = build_chat_message(
+        output_text='search({"q": "vllm"})',
+        output_token_ids=[1, 2],
+        request=req,
+        parser=parser,
+        tool_parser=tool_parser,
+        use_harmony=False,
+        enable_auto_tools=True,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    # auto_tools_called is False for "required". The finish_reason is set by
+    # the caller using the `required + finish_reason=="stop"` rule.
+    assert auto is False
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "search"
+    assert cnt == 1
+
+
+def test_build_chat_message_history_cnt_threads_across_calls():
+    """history_tool_call_cnt is threaded correctly across multiple outputs."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.openai.engine.protocol import FunctionCall
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    func_a = FunctionCall(name="fn_a", arguments="{}")
+    func_b = FunctionCall(name="fn_b", arguments="{}")
+    parser = MagicMock()
+    tool_parser = MagicMock()
+
+    req = _make_chat_request(tool_choice="auto", tools=_TOOLS)
+    tokenizer = _make_mock_tokenizer()
+
+    parser.parse.return_value = (None, None, [func_a])
+    _, _, cnt1 = build_chat_message(
+        output_text="fn_a({})",
+        output_token_ids=[1],
+        request=req,
+        parser=parser,
+        tool_parser=tool_parser,
+        use_harmony=False,
+        enable_auto_tools=True,
+        tokenizer=tokenizer,
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    assert cnt1 == 1
+
+    parser.parse.return_value = (None, None, [func_b])
+    _, _, cnt2 = build_chat_message(
+        output_text="fn_b({})",
+        output_token_ids=[2],
+        request=req,
+        parser=parser,
+        tool_parser=tool_parser,
+        use_harmony=False,
+        enable_auto_tools=True,
+        tokenizer=tokenizer,
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=cnt1,
+    )
+    assert cnt2 == 2
+
+
+# ---------------------------------------------------------------------------
+# Parity tests: JSON round trip of ChatCompletionRequest must not affect output
+# ---------------------------------------------------------------------------
+
+
+def test_parity_json_roundtrip_reasoning():
+    """chat path (in process request) vs derender path (JSON round tripped request)
+    produce identical build_chat_message output for a reasoning scenario."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    parser = MagicMock()
+    parser.parse.return_value = ("The reasoning trace.", "The final answer.", [])
+
+    req_live = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "What is 6 × 7?"}],
+        include_reasoning=True,
+    )
+    # Derender path: ChatCompletionRequest arrives deserialized from JSON
+    req_derender = ChatCompletionRequest.model_validate_json(req_live.model_dump_json())
+
+    common_kwargs: dict = dict(
+        output_text="<think>The reasoning trace.</think>The final answer.",
+        output_token_ids=[1, 2, 3],
+        parser=parser,
+        tool_parser=None,
+        use_harmony=False,
+        enable_auto_tools=False,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    msg_live, auto_live, cnt_live = build_chat_message(
+        request=req_live, **common_kwargs
+    )
+    msg_derender, auto_derender, cnt_derender = build_chat_message(
+        request=req_derender, **common_kwargs
+    )
+
+    assert msg_live.content == msg_derender.content
+    assert msg_live.reasoning == msg_derender.reasoning
+    assert msg_live.tool_calls == msg_derender.tool_calls
+    assert auto_live == auto_derender
+    assert cnt_live == cnt_derender
+
+
+def test_parity_json_roundtrip_tool_calls():
+    """chat path vs derender path produce identical output for auto tool calls."""
+    from unittest.mock import MagicMock
+
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.engine.protocol import FunctionCall
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+
+    func_call = FunctionCall(name="get_weather", arguments='{"city": "London"}')
+    parser = MagicMock()
+    parser.parse.return_value = (None, None, [func_call])
+    tool_parser = MagicMock()
+
+    req_live = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Weather in London?"}],
+        tools=_TOOLS,
+        tool_choice="auto",
+    )
+    req_derender = ChatCompletionRequest.model_validate_json(req_live.model_dump_json())
+
+    common_kwargs = dict(
+        output_text='<tool_call>{"name": "get_weather", "arguments": '
+        '{"city": "London"}}</tool_call>',
+        output_token_ids=[1, 2, 3],
+        parser=parser,
+        tool_parser=tool_parser,
+        use_harmony=False,
+        enable_auto_tools=True,
+        tokenizer=_make_mock_tokenizer(),
+        role="assistant",
+        tool_call_id_type="random",
+        history_tool_call_cnt=0,
+    )
+    msg_live, auto_live, cnt_live = build_chat_message(
+        request=req_live, **common_kwargs
+    )
+    msg_derender, auto_derender, cnt_derender = build_chat_message(
+        request=req_derender, **common_kwargs
+    )
+
+    assert auto_live == auto_derender
+    assert cnt_live == cnt_derender
+    live_calls = msg_live.tool_calls or []
+    derender_calls = msg_derender.tool_calls or []
+    assert len(live_calls) == len(derender_calls)
+    if live_calls:
+        assert live_calls[0].function.name == derender_calls[0].function.name
+
+
+def test_grammar_from_tool_parser_not_preserved_by_json_but_rederived():
+    """_grammar_from_tool_parser is a PrivateAttr excluded from JSON serialization.
+
+    After round trip it is always False, but build_chat_message re-derives the
+    Mistral grammar branch from is_mistral_tool_parser(tool_parser) +
+    structured_outputs.grammar so both paths produce identical output.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
+    from vllm.sampling_params import StructuredOutputsParams
+
+    # Simulate what MistralToolParser.adjust_request() does in-process:
+    #   sets _grammar_from_tool_parser = True (PrivateAttr, not serialized)
+    #   sets structured_outputs.grammar (regular field, survives round-trip)
+    req_live = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "call a tool"}],
+    )
+    req_live._grammar_from_tool_parser = True
+    req_live.structured_outputs = StructuredOutputsParams(grammar="lark-grammar-string")
+
+    # Verify the round trip behaviour that motivated the fix
+    req_derender = ChatCompletionRequest.model_validate_json(req_live.model_dump_json())
+    assert req_derender._grammar_from_tool_parser is False, (
+        "_grammar_from_tool_parser must be False after JSON round-trip (PrivateAttr)"
+    )
+    assert req_derender.structured_outputs is not None
+    assert req_derender.structured_outputs.grammar == "lark-grammar-string", (
+        "structured_outputs.grammar must survive JSON round-trip"
+    )
+
+    # build_chat_message must take the Mistral grammar branch for BOTH requests
+    parser = MagicMock()
+    parser.parse.return_value = (None, "content", [])
+    mock_tool_parser = MagicMock()
+    fake_tool_calls = [MagicMock()]
+
+    with (
+        patch(
+            "vllm.entrypoints.serve.utils.chat_message_builder.is_mistral_tool_parser",
+            return_value=True,
+        ),
+        patch(
+            "vllm.tool_parsers.mistral_tool_parser.MistralToolParser"
+            ".build_non_streaming_tool_calls",
+            return_value=fake_tool_calls,
+        ),
+    ):
+        kwargs: dict = dict(
+            output_text="content",
+            output_token_ids=[10, 20, 30],
+            parser=parser,
+            tool_parser=mock_tool_parser,
+            use_harmony=False,
+            enable_auto_tools=True,
+            tokenizer=_make_mock_tokenizer(),
+            role="assistant",
+            tool_call_id_type="random",
+            history_tool_call_cnt=0,
+        )
+        msg_live, auto_live, _ = build_chat_message(request=req_live, **kwargs)
+        msg_derender, auto_derender, _ = build_chat_message(
+            request=req_derender, **kwargs
+        )
+
+    assert msg_live.tool_calls == msg_derender.tool_calls == fake_tool_calls
+    assert msg_live.content == msg_derender.content
+    assert auto_live == auto_derender
+
+
 MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
 
 
@@ -289,6 +700,42 @@ async def test_derender_chat_null_token_ids(client):
         },
     )
     assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_with_chat_request_no_parser(client):
+    """Providing chat_request when server has no parser degrades gracefully:
+    content == Phase-1 decoded text and role is 'assistant'."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:5]
+    chat_request = {
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    r_phase1 = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(synthetic_ids),
+        },
+    )
+    assert r_phase1.status_code == 200
+
+    r_phase2 = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(synthetic_ids),
+            "chat_request": chat_request,
+        },
+    )
+    assert r_phase2.status_code == 200
+
+    msg1 = r_phase1.json()["choices"][0]["message"]
+    msg2 = r_phase2.json()["choices"][0]["message"]
+    assert msg2["content"] == msg1["content"]
+    assert msg2["role"] == "assistant"
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/serve/render/test_derender.py
+++ b/tests/entrypoints/serve/render/test_derender.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for the /derender endpoints (postprocessing counterpart to /render)."""
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from tests.utils import RemoteLaunchRenderServer
+
+MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
+
+
+@pytest.fixture(scope="module")
+def server():
+    with RemoteLaunchRenderServer(MODEL_NAME, []) as remote_server:
+        yield remote_server
+
+
+@pytest_asyncio.fixture
+async def client(server):
+    async with httpx.AsyncClient(
+        base_url=server.url_for(""), timeout=30.0
+    ) as http_client:
+        yield http_client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _render_chat(client: httpx.AsyncClient) -> dict:
+    """Render a minimal chat request and return the GenerateRequest dict."""
+    resp = await client.post(
+        "/v1/chat/completions/render",
+        json={
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def _make_generate_response(
+    token_ids: list[int] | None,
+    request_id: str = "chatcmpl-test-id",
+    finish_reason: str = "stop",
+    logprobs: dict | None = None,
+    prompt_logprobs: list | None = None,
+    kv_transfer_params: dict | None = None,
+) -> dict:
+    choice: dict = {
+        "index": 0,
+        "token_ids": token_ids,
+        "finish_reason": finish_reason,
+        "logprobs": logprobs,
+    }
+    return {
+        "request_id": request_id,
+        "choices": [choice],
+        "prompt_logprobs": prompt_logprobs,
+        "kv_transfer_params": kv_transfer_params,
+    }
+
+
+def _make_logprobs_with_placeholders(token_id: int = 1234) -> dict:
+    entry = {
+        "token": f"token_id:{token_id}",
+        "logprob": -1.0,
+        "bytes": None,
+        "top_logprobs": [
+            {"token": f"token_id:{token_id + 1}", "logprob": -2.0, "bytes": None}
+        ],
+    }
+    return {"content": [entry]}
+
+
+# ---------------------------------------------------------------------------
+# Chat derender tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_roundtrip(client):
+    """Render then derender: decoded content should be a non-empty string."""
+    gen_req = await _render_chat(client)
+    # Use the first 5 rendered token IDs as synthetic "generated" tokens.
+    synthetic_ids = gen_req["token_ids"][:5]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(synthetic_ids),
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "chat.completion"
+    assert len(data["choices"]) == 1
+    assert data["choices"][0]["message"]["content"]
+    assert data["choices"][0]["message"]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_usage(client):
+    """Supplied prompt_tokens flows through into usage correctly."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(synthetic_ids),
+            "prompt_tokens": 10,
+        },
+    )
+    assert response.status_code == 200
+    usage = response.json()["usage"]
+    assert usage["prompt_tokens"] == 10
+    assert usage["completion_tokens"] == len(synthetic_ids)
+    assert usage["total_tokens"] == 10 + len(synthetic_ids)
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_usage_default(client):
+    """Omitting prompt_tokens gives usage.prompt_tokens == 0."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(synthetic_ids),
+        },
+    )
+    assert response.status_code == 200
+    usage = response.json()["usage"]
+    assert usage["prompt_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_logprobs(client):
+    """token_id:N placeholders in content.token are resolved to real strings."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+    token_id = synthetic_ids[0]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(
+                synthetic_ids,
+                logprobs=_make_logprobs_with_placeholders(token_id),
+            ),
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    logprobs = data["choices"][0]["logprobs"]
+    assert logprobs is not None
+    content = logprobs["content"]
+    assert content is not None and len(content) == 1
+    token_str = content[0]["token"]
+    assert not token_str.startswith("token_id:"), (
+        f"Placeholder was not resolved: {token_str!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_logprobs_bytes(client):
+    """Resolved logprob entries have bytes populated as list[int]."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+    token_id = synthetic_ids[0]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(
+                synthetic_ids,
+                logprobs=_make_logprobs_with_placeholders(token_id),
+            ),
+        },
+    )
+    assert response.status_code == 200
+    content = response.json()["choices"][0]["logprobs"]["content"]
+    bytes_field = content[0]["bytes"]
+    assert isinstance(bytes_field, list)
+    assert len(bytes_field) > 0
+    assert all(isinstance(b, int) for b in bytes_field)
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_top_logprobs(client):
+    """top_logprobs entries also have their placeholders resolved."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+    token_id = synthetic_ids[0]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(
+                synthetic_ids,
+                logprobs=_make_logprobs_with_placeholders(token_id),
+            ),
+        },
+    )
+    assert response.status_code == 200
+    content = response.json()["choices"][0]["logprobs"]["content"]
+    top = content[0]["top_logprobs"]
+    assert len(top) == 1
+    assert not top[0]["token"].startswith("token_id:"), (
+        f"top_logprobs placeholder not resolved: {top[0]['token']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_prompt_logprobs_passthrough(client):
+    """prompt_logprobs on GenerateResponse passes through unchanged."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+    # prompt_logprobs is a list[dict[int, Logprob] | None]; use None entries.
+    prompt_logprobs = [None, None]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(
+                synthetic_ids, prompt_logprobs=prompt_logprobs
+            ),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["prompt_logprobs"] == prompt_logprobs
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_kv_transfer_params_passthrough(client):
+    """kv_transfer_params passes through to the ChatCompletionResponse."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+    kv = {"key": "value"}
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(
+                synthetic_ids, kv_transfer_params=kv
+            ),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["kv_transfer_params"] == kv
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_empty_token_ids(client):
+    """Empty token_ids list returns 400."""
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response([]),
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_null_token_ids(client):
+    """Null token_ids returns 400."""
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_response": _make_generate_response(None),
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_derender_chat_unknown_model(client):
+    """Unknown model returns 404."""
+    gen_req = await _render_chat(client)
+    synthetic_ids = gen_req["token_ids"][:3]
+
+    response = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": "does-not-exist",
+            "generate_response": _make_generate_response(synthetic_ids),
+        },
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Completion derender tests
+# ---------------------------------------------------------------------------
+
+
+async def _render_completion(client: httpx.AsyncClient, prompt: str) -> dict:
+    """Render a completion prompt and return the first GenerateRequest dict."""
+    resp = await client.post(
+        "/v1/completions/render",
+        json={"model": MODEL_NAME, "prompt": prompt},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list) and len(data) >= 1
+    return data[0]
+
+
+def _make_completion_generate_response(
+    token_ids: list[int],
+    request_id: str,
+    kv_transfer_params: dict | None = None,
+    logprobs: dict | None = None,
+) -> dict:
+    return {
+        "request_id": request_id,
+        "choices": [
+            {
+                "index": 0,
+                "token_ids": token_ids,
+                "finish_reason": "stop",
+                "logprobs": logprobs,
+            }
+        ],
+        "prompt_logprobs": None,
+        "kv_transfer_params": kv_transfer_params,
+    }
+
+
+@pytest.mark.asyncio
+async def test_derender_completion_roundtrip(client):
+    """Two prompts rendered, two GenerateResponses → two choices with indices 0, 1."""
+    gr1 = await _render_completion(client, "Hello world")
+    gr2 = await _render_completion(client, "Goodbye world")
+
+    ids1 = gr1["token_ids"][:4]
+    ids2 = gr2["token_ids"][:4]
+
+    response = await client.post(
+        "/v1/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_responses": [
+                _make_completion_generate_response(ids1, gr1["request_id"]),
+                _make_completion_generate_response(ids2, gr2["request_id"]),
+            ],
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "text_completion"
+    choices = data["choices"]
+    assert len(choices) == 2
+    assert choices[0]["index"] == 0
+    assert choices[1]["index"] == 1
+    assert choices[0]["text"]
+    assert choices[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_derender_completion_usage_aggregation(client):
+    """prompt_tokens=[5, 10] is aggregated correctly into usage."""
+    gr1 = await _render_completion(client, "Hello")
+    gr2 = await _render_completion(client, "World")
+
+    ids1 = gr1["token_ids"][:3]
+    ids2 = gr2["token_ids"][:4]
+
+    response = await client.post(
+        "/v1/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_responses": [
+                _make_completion_generate_response(ids1, gr1["request_id"]),
+                _make_completion_generate_response(ids2, gr2["request_id"]),
+            ],
+            "prompt_tokens": [5, 10],
+        },
+    )
+    assert response.status_code == 200
+    usage = response.json()["usage"]
+    assert usage["prompt_tokens"] == 15
+    assert usage["completion_tokens"] == len(ids1) + len(ids2)
+    assert usage["total_tokens"] == 15 + len(ids1) + len(ids2)
+
+
+@pytest.mark.asyncio
+async def test_derender_completion_prompt_tokens_length_mismatch(client):
+    """len(prompt_tokens) != len(generate_responses) returns 400."""
+    gr1 = await _render_completion(client, "Hello")
+    ids1 = gr1["token_ids"][:3]
+
+    response = await client.post(
+        "/v1/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_responses": [
+                _make_completion_generate_response(ids1, gr1["request_id"]),
+            ],
+            "prompt_tokens": [5, 10],
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_derender_completion_empty_generate_responses(client):
+    """Empty generate_responses list returns 400."""
+    response = await client.post(
+        "/v1/completions/derender",
+        json={"model": MODEL_NAME, "generate_responses": []},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_derender_completion_logprobs(client):
+    """token_id:N placeholders in logprobs are resolved; CompletionLogProbs
+    flat-list structure is returned with non-empty tokens and text_offsets."""
+    gr1 = await _render_completion(client, "Hello world")
+    ids1 = gr1["token_ids"][:3]
+    token_id = ids1[0]
+
+    response = await client.post(
+        "/v1/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_responses": [
+                _make_completion_generate_response(
+                    ids1,
+                    gr1["request_id"],
+                    logprobs=_make_logprobs_with_placeholders(token_id),
+                ),
+            ],
+        },
+    )
+    assert response.status_code == 200
+    logprobs = response.json()["choices"][0]["logprobs"]
+    assert logprobs is not None
+    tokens = logprobs["tokens"]
+    assert len(tokens) == 1
+    assert not tokens[0].startswith("token_id:"), (
+        f"Placeholder was not resolved: {tokens[0]!r}"
+    )
+    assert len(logprobs["token_logprobs"]) == 1
+    assert isinstance(logprobs["token_logprobs"][0], float)
+    assert len(logprobs["text_offset"]) == 1
+    assert logprobs["text_offset"][0] == 0
+
+
+@pytest.mark.asyncio
+async def test_derender_completion_kv_transfer_params_passthrough(client):
+    """kv_transfer_params passes through to CompletionResponse."""
+    gr1 = await _render_completion(client, "Hello")
+    ids1 = gr1["token_ids"][:3]
+    kv = {"node": "abc"}
+
+    response = await client.post(
+        "/v1/completions/derender",
+        json={
+            "model": MODEL_NAME,
+            "generate_responses": [
+                _make_completion_generate_response(
+                    ids1, gr1["request_id"], kv_transfer_params=kv
+                ),
+            ],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["kv_transfer_params"] == kv

--- a/tests/entrypoints/serve/render/test_derender.py
+++ b/tests/entrypoints/serve/render/test_derender.py
@@ -418,7 +418,7 @@ async def test_derender_completion_prompt_tokens_length_mismatch(client):
             "prompt_tokens": [5, 10],
         },
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/serve/render/test_render_derender_e2e.py
+++ b/tests/entrypoints/serve/render/test_render_derender_e2e.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""End-to-end render -> derender round trip tests.
+
+These tests exercise the full postprocessing loop of the disaggregated /
+RL serving path:
+
+    /v1/chat/completions/render   (prompt messages -> prompt token IDs)
+        -> [generation happens on a separate tier]
+    /v1/chat/completions/derender (output token IDs -> ChatCompletionResponse)
+
+The `render` tier is GPU less (`vllm launch render`): it only loads the
+tokenizer, never the model weights, so these tests run on a system with
+no accelerator. Because generation lives on a different (disaggregated) tier
+that is not present here, we synthesize the "generated" output tokens in test
+by encoding a known assistant string with the same tokenizer the server
+uses. That is exactly the contract the real caller fulfils: it already holds
+the output token IDs returned by the generate tier and hands them to
+`/derender`. Encoding known text lets us assert the true inverse property,
+that `derender` reconstructs the chat response we expect.
+
+Two test scenarios:
+
+1. `test_e2e_plain_*`: baseline round trip with no parsers configured.
+   The decoded output text passes straight through as `message.content`.
+2. `test_e2e_parsed_*`: same round trip but the render tier is launched with
+   a reasoning parser, a tool-call parser and auto-tool-choice, and the
+   `chat_request` is supplied. This drives the parsing path:
+   ``message.reasoning`` and ``message.tool_calls`` are populated
+   by vLLM's real serving parser (the single source of truth shared with the
+   coupled chat endpoint).
+
+The tokenizer/config for both models is downloaded from the Hugging Face Hub on
+first run (weights are not fetched).
+"""
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from tests.utils import RemoteLaunchRenderServer
+from vllm.tokenizers import get_tokenizer
+
+# Tiny random model, only its tokenizer is loaded by the render tier.
+PLAIN_MODEL = "hmellor/tiny-random-LlamaForCausalLM"
+
+# Small real model used purely for its tokenizer, which defines the
+# `<think>`/`</think>` reasoning tokens and the `<tool_call>` tokens the
+# parsers below operate on. Weights are NOT downloaded (render is GPU less).
+PARSER_MODEL = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode(tokenizer, text: str) -> list[int]:
+    """Encode text into the token IDs a generate tier would have emitted.
+
+    ``add_special_tokens=False`` keeps BOS/EOS out so the round trip recovers
+    exactly the supplied string.
+    """
+    return tokenizer.encode(text, add_special_tokens=False)
+
+
+def _decoded(tokenizer, token_ids: list[int]) -> str:
+    """Decode the way the derender endpoint does (skip_special_tokens=True)."""
+    return tokenizer.decode(token_ids, skip_special_tokens=True)
+
+
+def _generate_response(
+    token_ids: list[int],
+    request_id: str = "chatcmpl-e2e",
+    finish_reason: str = "stop",
+) -> dict:
+    """Build a minimal GenerateResponse body for the derender endpoint."""
+    return {
+        "request_id": request_id,
+        "choices": [
+            {
+                "index": 0,
+                "token_ids": token_ids,
+                "finish_reason": finish_reason,
+                "logprobs": None,
+            }
+        ],
+        "prompt_logprobs": None,
+        "kv_transfer_params": None,
+    }
+
+
+async def _render_chat(client: httpx.AsyncClient, model: str, messages: list) -> dict:
+    """Render a chat request. Return the GenerateRequest dict (has token_ids)."""
+    resp = await client.post(
+        "/v1/chat/completions/render",
+        json={"model": model, "messages": messages},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["token_ids"], "render produced no prompt token IDs"
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: baseline render -> derender round trip (no parsers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def plain_server():
+    with RemoteLaunchRenderServer(PLAIN_MODEL, []) as server:
+        yield server
+
+
+@pytest_asyncio.fixture
+async def plain_client(plain_server):
+    async with httpx.AsyncClient(
+        base_url=plain_server.url_for(""), timeout=60.0
+    ) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def plain_tokenizer():
+    return get_tokenizer(PLAIN_MODEL)
+
+
+@pytest.mark.asyncio
+async def test_e2e_plain_roundtrip(plain_client, plain_tokenizer):
+    """Render a prompt, then derender synthesized output tokens.
+
+    With no parser configured the decoded output text is returned verbatim as
+    ``message.content`` — i.e. derender is the exact inverse of detokenization.
+    """
+    messages = [{"role": "user", "content": "What is the capital of France?"}]
+    gen_req = await _render_chat(plain_client, PLAIN_MODEL, messages)
+    prompt_token_count = len(gen_req["token_ids"])
+
+    # Synthesize what the generate tier would have produced.
+    answer = "The capital of France is Paris."
+    output_ids = _encode(plain_tokenizer, answer)
+    expected_content = _decoded(plain_tokenizer, output_ids)
+
+    resp = await plain_client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": PLAIN_MODEL,
+            "generate_response": _generate_response(output_ids),
+            "prompt_tokens": prompt_token_count,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["object"] == "chat.completion"
+    assert len(data["choices"]) == 1
+    choice = data["choices"][0]
+    assert choice["message"]["role"] == "assistant"
+    # The inverse property: decoded output text round-trips into content.
+    assert choice["message"]["content"] == expected_content
+    assert choice["message"].get("reasoning") is None
+    assert not choice["message"].get("tool_calls")
+    assert choice["finish_reason"] == "stop"
+
+    usage = data["usage"]
+    assert usage["prompt_tokens"] == prompt_token_count
+    assert usage["completion_tokens"] == len(output_ids)
+    assert usage["total_tokens"] == prompt_token_count + len(output_ids)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: render -> derender with parsers, tools and reasoning
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def parser_server():
+    args = [
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "hermes",
+        "--reasoning-parser",
+        "deepseek_r1",
+    ]
+    with RemoteLaunchRenderServer(PARSER_MODEL, args) as server:
+        yield server
+
+
+@pytest_asyncio.fixture
+async def parser_client(parser_server):
+    async with httpx.AsyncClient(
+        base_url=parser_server.url_for(""), timeout=60.0
+    ) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def parser_tokenizer():
+    return get_tokenizer(PARSER_MODEL)
+
+
+def _require_markers_survive(tokenizer, text: str, *markers: str) -> list[int]:
+    """Encode ``text`` and guard that ``markers`` survive the server's decode.
+
+    The derender endpoint decodes with ``skip_special_tokens=True``. If a
+    tokenizer treats a marker as a stripped special token the parser could
+    never see it (a tokenize specific quirk, not a code defect), so we skip
+    rather than report a misleading failure.
+    """
+    token_ids = _encode(tokenizer, text)
+    decoded = _decoded(tokenizer, token_ids)
+    for marker in markers:
+        if marker not in decoded:
+            pytest.skip(
+                f"marker {marker!r} did not survive tokenizer round-trip for "
+                f"{PARSER_MODEL}; cannot exercise the parser path"
+            )
+    return token_ids
+
+
+@pytest.mark.asyncio
+async def test_e2e_parsed_reasoning(parser_client, parser_tokenizer):
+    """Reasoning model: derender splits ``<think>...</think>`` into reasoning.
+
+    Mirrors test 1 but the render tier runs the deepseek_r1 reasoning
+    parser and the request carries chat_request, so the path segments
+    reasoning from content.
+    """
+    messages = [{"role": "user", "content": "Add 2 and 3."}]
+    gen_req = await _render_chat(parser_client, PARSER_MODEL, messages)
+
+    reasoning_text = "The user wants 2 + 3. That is 5."
+    answer_text = "The answer is 5."
+    output_text = f"<think>{reasoning_text}</think>{answer_text}"
+    output_ids = _require_markers_survive(parser_tokenizer, output_text, "</think>")
+
+    resp = await parser_client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": PARSER_MODEL,
+            "generate_response": _generate_response(output_ids),
+            "prompt_tokens": len(gen_req["token_ids"]),
+            "chat_request": {
+                "model": PARSER_MODEL,
+                "messages": messages,
+                "include_reasoning": True,
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    message = resp.json()["choices"][0]["message"]
+
+    assert message["role"] == "assistant"
+    assert message["reasoning"] is not None
+    assert reasoning_text in message["reasoning"]
+    assert message["content"] is not None
+    assert answer_text in message["content"]
+    # Reasoning markers must not leak into the user-facing content.
+    assert "<think>" not in message["content"]
+    assert "</think>" not in message["content"]
+
+
+@pytest.mark.asyncio
+async def test_e2e_parsed_reasoning_disabled(parser_client, parser_tokenizer):
+    """include_reasoning=False drops reasoning from the derendered message."""
+    messages = [{"role": "user", "content": "Add 2 and 3."}]
+    gen_req = await _render_chat(parser_client, PARSER_MODEL, messages)
+
+    output_text = "<think>2 + 3 = 5</think>The answer is 5."
+    output_ids = _require_markers_survive(parser_tokenizer, output_text, "</think>")
+
+    resp = await parser_client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": PARSER_MODEL,
+            "generate_response": _generate_response(output_ids),
+            "prompt_tokens": len(gen_req["token_ids"]),
+            "chat_request": {
+                "model": PARSER_MODEL,
+                "messages": messages,
+                "include_reasoning": False,
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    message = resp.json()["choices"][0]["message"]
+    assert message["reasoning"] is None
+
+
+@pytest.mark.asyncio
+async def test_e2e_parsed_tool_call(parser_client, parser_tokenizer):
+    """Auto tool choice: derender extracts a hermes ``<tool_call>`` into
+    ``message.tool_calls`` and flags ``finish_reason == 'tool_calls'``."""
+    messages = [{"role": "user", "content": "What's the weather in Paris?"}]
+    gen_req = await _render_chat(parser_client, PARSER_MODEL, messages)
+
+    output_text = (
+        '<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"city": "Paris"}}\n</tool_call>'
+    )
+    output_ids = _require_markers_survive(
+        parser_tokenizer, output_text, "<tool_call>", "</tool_call>"
+    )
+
+    resp = await parser_client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": PARSER_MODEL,
+            "generate_response": _generate_response(output_ids),
+            "prompt_tokens": len(gen_req["token_ids"]),
+            "chat_request": {
+                "model": PARSER_MODEL,
+                "messages": messages,
+                "tools": _TOOLS,
+                "tool_choice": "auto",
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    choice = resp.json()["choices"][0]
+    tool_calls = choice["message"]["tool_calls"]
+
+    assert tool_calls, "expected a tool call to be extracted"
+    assert len(tool_calls) == 1
+    call = tool_calls[0]
+    assert call["function"]["name"] == "get_weather"
+    assert "Paris" in call["function"]["arguments"]
+    assert call["id"], "tool call should have a generated id"
+    assert choice["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_e2e_parsed_reasoning_and_tool_call(parser_client, parser_tokenizer):
+    """Combined: reasoning block followed by a tool call are both parsed."""
+    messages = [{"role": "user", "content": "What's the weather in Paris?"}]
+    gen_req = await _render_chat(parser_client, PARSER_MODEL, messages)
+
+    reasoning_text = "I should look up the weather for Paris."
+    output_text = (
+        f"<think>{reasoning_text}</think>"
+        '<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"city": "Paris"}}\n</tool_call>'
+    )
+    output_ids = _require_markers_survive(
+        parser_tokenizer, output_text, "</think>", "<tool_call>", "</tool_call>"
+    )
+
+    resp = await parser_client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": PARSER_MODEL,
+            "generate_response": _generate_response(output_ids),
+            "prompt_tokens": len(gen_req["token_ids"]),
+            "chat_request": {
+                "model": PARSER_MODEL,
+                "messages": messages,
+                "tools": _TOOLS,
+                "tool_choice": "auto",
+                "include_reasoning": True,
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    choice = resp.json()["choices"][0]
+    message = choice["message"]
+
+    assert message["reasoning"] is not None
+    assert reasoning_text in message["reasoning"]
+    assert message["tool_calls"], "expected a tool call alongside reasoning"
+    assert message["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert choice["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_e2e_parsed_matches_plain_when_no_markers(
+    parser_client, parser_tokenizer
+):
+    """A plain answer (no reasoning/tool markers) round trips to content even
+    on a parse enabled server which is parity with the test 1."""
+    messages = [{"role": "user", "content": "Say hello."}]
+    gen_req = await _render_chat(parser_client, PARSER_MODEL, messages)
+
+    answer = "Hello there!"
+    output_ids = _encode(parser_tokenizer, answer)
+    expected_content = _decoded(parser_tokenizer, output_ids)
+
+    resp = await parser_client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": PARSER_MODEL,
+            "generate_response": _generate_response(output_ids),
+            "prompt_tokens": len(gen_req["token_ids"]),
+            "chat_request": {"model": PARSER_MODEL, "messages": messages},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    message = resp.json()["choices"][0]["message"]
+    assert message["content"] == expected_content
+    assert message["reasoning"] is None
+    assert not message["tool_calls"]

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -19,7 +19,6 @@ from vllm.entrypoints.chat_utils import (
     ConversationMessage,
     get_history_tool_calls_cnt,
     get_tool_call_id_type,
-    make_tool_call_id,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionLogProb,
@@ -31,7 +30,6 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseChoice,
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
-    ChatMessage,
 )
 from vllm.entrypoints.openai.chat_completion.stream_harmony import (
     TokenState,
@@ -43,7 +41,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
-    ToolCall,
     UsageInfo,
 )
 from vllm.entrypoints.openai.engine.serving import (
@@ -55,9 +52,9 @@ from vllm.entrypoints.openai.engine.serving import (
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_streamable_parser_for_assistant,
-    parse_chat_output,
 )
 from vllm.entrypoints.serve.utils.api_utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.serve.utils.tool_calls_utils import (
     maybe_filter_parallel_tool_calls,
@@ -73,7 +70,7 @@ from vllm.renderers import ChatParams
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.collection_utils import as_list
-from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
+from vllm.utils.mistral import is_mistral_tool_parser
 
 if TYPE_CHECKING:
     from vllm.entrypoints.serve.render.serving import OpenAIServingRender
@@ -976,7 +973,6 @@ class OpenAIServingChat(OpenAIServing):
             self._raise_if_error(output.finish_reason, request_id)
             token_ids = output.token_ids
             out_logprobs = output.logprobs
-            tool_call_info = None
 
             if request.logprobs and request.top_logprobs is not None:
                 assert out_logprobs is not None, "Did not output logprobs"
@@ -990,266 +986,6 @@ class OpenAIServingChat(OpenAIServing):
             else:
                 logprobs = None
 
-            if self.use_harmony:
-                reasoning, content, _ = parse_chat_output(token_ids)
-                if not request.include_reasoning:
-                    reasoning = None
-
-                if self.tool_parser is not None:
-                    if tokenizer is None:
-                        raise ValueError(
-                            "Tokenizer not available when `skip_tokenizer_init=True`"
-                        )
-
-                    tool_parser = self.tool_parser(tokenizer, request.tools)
-                    # NOTE: We use token_ids for openai tool parser
-                    tool_call_info = tool_parser.extract_tool_calls(
-                        "",
-                        request=request,
-                        token_ids=token_ids,  # type: ignore
-                    )
-                    content = tool_call_info.content
-                    message = ChatMessage(
-                        role=role,
-                        reasoning=reasoning,
-                        content=content,
-                        tool_calls=tool_call_info.tool_calls,
-                    )
-                else:
-                    message = ChatMessage(
-                        role=role,
-                        reasoning=reasoning,
-                        content=content,
-                    )
-
-                # Encode routed_experts for transport. JSON can't carry raw
-                # bytes, so we write the ndarray as a ``.npy`` byte stream
-                # and base64-encode it. ``pybase64`` is ~3x faster than the
-                # stdlib ``base64`` on large payloads thanks to SIMD.
-                routed_experts_b64 = None
-                if output.routed_experts is not None:
-                    buf = io.BytesIO()
-                    np.save(buf, output.routed_experts)
-                    routed_experts_b64 = base64.b64encode(buf.getvalue()).decode(
-                        "ascii"
-                    )
-
-                choice_data = ChatCompletionResponseChoice(
-                    index=output.index,
-                    message=message,
-                    logprobs=logprobs,
-                    finish_reason=(
-                        "tool_calls"
-                        if (tool_call_info is not None and tool_call_info.tools_called)
-                        else output.finish_reason
-                        if output.finish_reason
-                        else "stop"
-                    ),
-                    stop_reason=output.stop_reason,
-                    token_ids=(
-                        as_list(output.token_ids) if request.return_token_ids else None
-                    ),
-                    routed_experts=routed_experts_b64,
-                )
-                choices.append(choice_data)
-                continue
-
-            if parser is not None:
-                reasoning, content, tool_calls = parser.parse(
-                    output.text,
-                    request,
-                    enable_auto_tools=self.enable_auto_tools,
-                )
-                if not request.include_reasoning:
-                    reasoning = None
-            else:
-                reasoning = None
-                content = output.text
-                tool_calls = []
-
-            auto_tools_called = False
-            if is_mistral_tokenizer(tokenizer):
-                from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
-
-                tool_call_class: type[ToolCall] = MistralToolCall
-            else:
-                tool_call_class = ToolCall
-
-            use_mistral_tool_parser = request._grammar_from_tool_parser
-            if use_mistral_tool_parser:
-                from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
-
-                tool_call_items = MistralToolParser.build_non_streaming_tool_calls(
-                    tool_calls
-                )
-                if tool_call_items:
-                    auto_tools_called = (
-                        request.tool_choice is None or request.tool_choice == "auto"
-                    )
-                message = ChatMessage(
-                    role=role,
-                    reasoning=reasoning,
-                    content=content,
-                    tool_calls=tool_call_items,
-                )
-
-            elif (not self.enable_auto_tools or not self.tool_parser) and (
-                not isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
-                and request.tool_choice != "required"
-            ):
-                message = ChatMessage(role=role, reasoning=reasoning, content=content)
-
-            elif (
-                request.tool_choice
-                and type(request.tool_choice) is ChatCompletionNamedToolChoiceParam
-            ):
-                tool_call_class_items = []
-                tool_calls = tool_calls or []
-                for idx, tc in enumerate(tool_calls):
-                    # Use native ID if available (e.g., Kimi K2),
-                    # otherwise generate ID with correct id_type
-                    if tc.id:
-                        tool_call_class_items.append(
-                            tool_call_class(id=tc.id, function=tc)
-                        )
-                    else:
-                        # Generate ID using the correct format (kimi_k2 or random),
-                        # but leave it to the class if it's Mistral to preserve
-                        # 9-char IDs
-                        if is_mistral_tokenizer(tokenizer):
-                            tool_call_class_items.append(tool_call_class(function=tc))
-                        else:
-                            generated_id = make_tool_call_id(
-                                id_type=self.tool_call_id_type,
-                                func_name=tc.name,
-                                idx=history_tool_call_cnt,
-                            )
-                            tool_call_class_items.append(
-                                tool_call_class(id=generated_id, function=tc)
-                            )
-                    history_tool_call_cnt += 1
-                message = ChatMessage(
-                    role=role,
-                    reasoning=reasoning,
-                    content="",
-                    tool_calls=tool_call_class_items,
-                )
-
-            elif request.tool_choice and request.tool_choice == "required":
-                tool_call_class_items = []
-                tool_calls = tool_calls or []
-                for idx, tool_call in enumerate(tool_calls):
-                    # Use native ID if available,
-                    # otherwise generate ID with correct id_type
-                    if tool_call.id:
-                        tool_call_class_items.append(
-                            tool_call_class(id=tool_call.id, function=tool_call)
-                        )
-                    else:
-                        # Generate ID using the correct format (kimi_k2 or random),
-                        # but leave it to the class if it's Mistral to preserve
-                        # 9-char IDs
-                        if is_mistral_tokenizer(tokenizer):
-                            tool_call_class_items.append(
-                                tool_call_class(function=tool_call)
-                            )
-                        else:
-                            generated_id = make_tool_call_id(
-                                id_type=self.tool_call_id_type,
-                                func_name=tool_call.name,
-                                idx=history_tool_call_cnt,
-                            )
-                            tool_call_class_items.append(
-                                tool_call_class(id=generated_id, function=tool_call)
-                            )
-                    history_tool_call_cnt += 1
-                message = ChatMessage(
-                    role=role,
-                    content="",
-                    tool_calls=tool_call_class_items,
-                    reasoning=reasoning,
-                )
-
-            # if the request doesn't use tool choice
-            # OR specifies to not use a tool
-            elif not request.tool_choice or request.tool_choice == "none":
-                message = ChatMessage(role=role, reasoning=reasoning, content=content)
-
-            # handle when there are tools and tool choice is auto
-            elif (
-                request.tools
-                and (request.tool_choice == "auto" or request.tool_choice is None)
-                and self.enable_auto_tools
-                and self.tool_parser
-            ):
-                # In the OpenAI API the finish_reason is "tools_called"
-                # if the tool choice is auto and the model produced a tool
-                # call. The same is not true for named function calls
-                auto_tools_called = tool_calls is not None and len(tool_calls) > 0
-                if tool_calls:
-                    tool_call_items = []
-                    for idx, tc in enumerate(tool_calls):
-                        # Use native ID if available (e.g., Kimi K2),
-                        # otherwise generate ID with correct id_type
-                        if tc.id:
-                            tool_call_items.append(
-                                tool_call_class(id=tc.id, function=tc)
-                            )
-                        else:
-                            # Generate ID using the correct format (kimi_k2 or random),
-                            # but leave it to the class if it's Mistral to preserve
-                            # 9-char IDs
-                            if is_mistral_tokenizer(tokenizer):
-                                tool_call_items.append(tool_call_class(function=tc))
-                            else:
-                                generated_id = make_tool_call_id(
-                                    id_type=self.tool_call_id_type,
-                                    func_name=tc.name,
-                                    idx=history_tool_call_cnt,
-                                )
-                                tool_call_items.append(
-                                    tool_call_class(id=generated_id, function=tc)
-                                )
-                        history_tool_call_cnt += 1
-                    message = ChatMessage(
-                        role=role,
-                        reasoning=reasoning,
-                        content=content,
-                        tool_calls=tool_call_items,
-                    )
-
-                else:
-                    # FOR NOW make it a chat message; we will have to detect
-                    # the type to make it later.
-                    ret_content = content
-
-                    # try to use content return from tool parser first,
-                    # tool parser may do some modify for the content.
-                    if content and len(content) > 0:
-                        ret_content = content
-                    message = ChatMessage(
-                        role=role,
-                        reasoning=reasoning,
-                        content=ret_content,
-                    )
-
-            # undetermined case that is still important to handle
-            else:
-                logger.error(
-                    "Error in chat_completion_full_generator - cannot determine"
-                    " if tools should be extracted. Returning a standard chat "
-                    "completion."
-                )
-                message = ChatMessage(role=role, reasoning=reasoning, content=content)
-            # In OpenAI's API, when a tool is called, the finish_reason is:
-            # "tool_calls" for "auto" or "required" tool calls,
-            # and "stop" for named tool calls.
-            is_finish_reason_tool_calls = auto_tools_called or (
-                request.tool_choice
-                and request.tool_choice == "required"
-                and output.finish_reason == "stop"
-            )
-
             # Encode routed_experts for transport. JSON can't carry raw
             # bytes, so we write the ndarray as a ``.npy`` byte stream
             # and base64-encode it. ``pybase64`` is ~3x faster than the
@@ -1259,6 +995,30 @@ class OpenAIServingChat(OpenAIServing):
                 buf = io.BytesIO()
                 np.save(buf, output.routed_experts)
                 routed_experts_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
+            message, auto_tools_called, history_tool_call_cnt = build_chat_message(
+                output_text=output.text,
+                output_token_ids=token_ids,
+                request=request,
+                parser=parser,
+                tool_parser=self.tool_parser,
+                use_harmony=self.use_harmony,
+                enable_auto_tools=self.enable_auto_tools,
+                tokenizer=tokenizer,
+                role=role,
+                tool_call_id_type=self.tool_call_id_type,
+                history_tool_call_cnt=history_tool_call_cnt,
+            )
+
+            # In OpenAI's API, when a tool is called, the finish_reason is:
+            # "tool_calls" for "auto" or "required" tool calls,
+            # and "stop" for named tool calls.
+            if self.use_harmony:
+                is_finish_reason_tool_calls = auto_tools_called
+            else:
+                is_finish_reason_tool_calls = auto_tools_called or (
+                    request.tool_choice == "required" and output.finish_reason == "stop"
+                )
 
             choice_data = ChatCompletionResponseChoice(
                 index=output.index,
@@ -1275,7 +1035,8 @@ class OpenAIServingChat(OpenAIServing):
                 ),
                 routed_experts=routed_experts_b64,
             )
-            choice_data = maybe_filter_parallel_tool_calls(choice_data, request)
+            if not self.use_harmony:
+                choice_data = maybe_filter_parallel_tool_calls(choice_data, request)
 
             choices.append(choice_data)
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -50,6 +50,7 @@ from vllm.entrypoints.openai.engine.serving import (
     GenerationError,
     OpenAIServing,
     clamp_prompt_logprobs,
+    format_token_id_placeholder,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
@@ -1408,7 +1409,7 @@ class OpenAIServingChat(OpenAIServing):
             step_top_logprobs = top_logprobs[i]
             if step_top_logprobs is None or step_top_logprobs.get(token_id) is None:
                 if should_return_as_token_id:
-                    token = f"token_id:{token_id}"
+                    token = format_token_id_placeholder(token_id)
                 else:
                     if tokenizer is None:
                         raise ValueError(

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.openai.engine.serving import (
     GenerationError,
     OpenAIServing,
     clamp_prompt_logprobs,
+    format_token_id_placeholder,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.utils.api_utils import get_max_tokens, should_include_usage
@@ -628,7 +629,7 @@ class OpenAIServingCompletion(OpenAIServing):
             step_top_logprobs = top_logprobs[i]
             if step_top_logprobs is None:
                 if should_return_as_token_id:
-                    token = f"token_id:{token_id}"
+                    token = format_token_id_placeholder(token_id)
                 else:
                     if tokenizer is None:
                         raise VLLMValidationError(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -452,7 +452,7 @@ class OpenAIServing(BeamSearchOnlineMixin):
         return_as_token_id: bool = False,
     ) -> str:
         if return_as_token_id:
-            return f"token_id:{token_id}"
+            return format_token_id_placeholder(token_id)
 
         if logprob.decoded_token is not None:
             return logprob.decoded_token
@@ -470,6 +470,37 @@ class OpenAIServing(BeamSearchOnlineMixin):
         if envs.VLLM_SKIP_MODEL_NAME_VALIDATION:
             return True
         return self.models.is_base_model(model_name)
+
+
+def format_token_id_placeholder(token_id: int) -> str:
+    return f"token_id:{token_id}"
+
+
+def resolve_token_id_placeholder(
+    token: str, tokenizer: TokenizerLike
+) -> tuple[str, list[int] | None]:
+    """Decode a 'token_id:N' placeholder back to a token string and UTF-8 bytes.
+
+    Returns (token, None) unchanged if token is not a placeholder.
+    This is the inverse of format_token_id_placeholder / _get_decoded_token
+    when return_as_token_id=True.
+    """
+    if not token.startswith("token_id:"):
+        return token, None
+    try:
+        token_id = int(token[len("token_id:") :])
+    except ValueError:
+        return token, None
+    token_repr = tokenizer.convert_ids_to_tokens([token_id])[0]
+    if token_repr is None:
+        logger.warning(
+            "resolve_token_id_placeholder: token_id %d has no vocab entry; "
+            "substituting empty string",
+            token_id,
+        )
+        return "", None
+    token_str = tokenizer.convert_tokens_to_string([token_repr])
+    return token_str, list(token_str.encode("utf-8", errors="replace"))
 
 
 def clamp_prompt_logprobs(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -485,10 +485,11 @@ def resolve_token_id_placeholder(
     This is the inverse of format_token_id_placeholder / _get_decoded_token
     when return_as_token_id=True.
     """
-    if not token.startswith("token_id:"):
+    suffix = token.removeprefix("token_id:")
+    if suffix == token:
         return token, None
     try:
-        token_id = int(token[len("token_id:") :])
+        token_id = int(suffix)
     except ValueError:
         return token, None
     token_repr = tokenizer.convert_ids_to_tokens([token_id])[0]

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -494,7 +494,7 @@ def resolve_token_id_placeholder(
         return token, None
     token_repr = tokenizer.convert_ids_to_tokens([token_id])[0]
     if token_repr is None:
-        logger.warning(
+        logger.warning_once(
             "resolve_token_id_placeholder: token_id %d has no vocab entry; "
             "substituting empty string",
             token_id,

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -235,11 +235,14 @@ class DerenderChatRequest(BaseModel):
     """
 
     chat_request: ChatCompletionRequest | None = None
-    """The original (post-adjust_request) ChatCompletionRequest from /render.
+    """The original (post adjust_request) ChatCompletionRequest from /render.
 
     Required by the parsing so that tool/reasoning parsers can receive the full
-    request context they expect (request.tools, request.tool_choice,
-    request._grammar_from_tool_parser, etc.).
+    request context they expect (request.tools, request.tool_choice, etc.).
+
+    Note: Pydantic PrivateAttr fields (e.g. _grammar_from_tool_parser) are
+    excluded from serialization and will not be present after JSON round trip.
+    Derender logic must re-derive any state that depends on those fields.
     """
 
 

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -209,3 +209,51 @@ class GenerateResponse(BaseModel):
         default=None,
         description="KVTransfer parameters used for disaggregated serving.",
     )
+
+
+####### Derender (postprocessing) #######
+
+
+class DerenderChatRequest(BaseModel):
+    """Request for the /v1/chat/completions/derender endpoint.
+
+    Wraps a GenerateResponse and caller-supplied metadata needed to produce
+    a fully-formed ChatCompletionResponse without a GPU.
+    """
+
+    model: str
+    generate_response: GenerateResponse
+    prompt_tokens: int | None = None
+    """Prompt token count for usage; defaults to 0 if omitted.
+
+    GenerateResponse carries only output tokens; the caller already has
+    len(GenerateRequest.token_ids) from the render step.
+    """
+
+
+class DerenderCompletionRequest(BaseModel):
+    """Request for the /v1/completions/derender endpoint.
+
+    Parallel to DerenderChatRequest but handles the multi-prompt completions
+    case: one GenerateResponse per prompt, mirroring the list[GenerateRequest]
+    returned by /v1/completions/render.
+    """
+
+    model: str
+    generate_responses: list[GenerateResponse]
+    prompt_tokens: list[int] | None = None
+    """One prompt token count per response; each defaults to 0 if omitted.
+
+    If provided, len(prompt_tokens) must equal len(generate_responses).
+    """
+
+    @model_validator(mode="after")
+    def _validate_prompt_tokens_length(self) -> "DerenderCompletionRequest":
+        if self.prompt_tokens is not None and len(self.prompt_tokens) != len(
+            self.generate_responses
+        ):
+            raise ValueError(
+                f"prompt_tokens length ({len(self.prompt_tokens)}) must equal "
+                f"generate_responses length ({len(self.generate_responses)})"
+            )
+        return self

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -11,7 +11,11 @@ from pydantic import (
 )
 
 from vllm.config import ModelConfig
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionLogProbs
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionLogProbs,
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
 from vllm.entrypoints.openai.engine.protocol import StreamOptions, UsageInfo
 from vllm.logprobs import Logprob
 from vllm.renderers import TokenizeParams
@@ -230,6 +234,14 @@ class DerenderChatRequest(BaseModel):
     len(GenerateRequest.token_ids) from the render step.
     """
 
+    chat_request: ChatCompletionRequest | None = None
+    """The original (post-adjust_request) ChatCompletionRequest from /render.
+
+    Required by the parsing so that tool/reasoning parsers can receive the full
+    request context they expect (request.tools, request.tool_choice,
+    request._grammar_from_tool_parser, etc.).
+    """
+
 
 class DerenderCompletionRequest(BaseModel):
     """Request for the /v1/completions/derender endpoint.
@@ -245,6 +257,13 @@ class DerenderCompletionRequest(BaseModel):
     """One prompt token count per response; each defaults to 0 if omitted.
 
     If provided, len(prompt_tokens) must equal len(generate_responses).
+    """
+
+    completion_request: CompletionRequest | None = None
+    """The original (post-adjust_request) CompletionRequest from /render.
+
+    Mirrors chat_request on DerenderChatRequest. Required by the parsing
+    so parsers receive the full request context.
     """
 
     @model_validator(mode="after")

--- a/vllm/entrypoints/serve/render/api_router.py
+++ b/vllm/entrypoints/serve/render/api_router.py
@@ -5,10 +5,20 @@ from http import HTTPStatus
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionRequest,
+    CompletionResponse,
+)
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.serve.disagg.protocol import GenerateRequest
+from vllm.entrypoints.serve.disagg.protocol import (
+    DerenderChatRequest,
+    DerenderCompletionRequest,
+    GenerateRequest,
+)
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 from vllm.entrypoints.serve.utils.api_utils import validate_json_request
 from vllm.logger import init_logger
@@ -69,6 +79,54 @@ async def render_completion(request: CompletionRequest, raw_request: Request):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)
 
     return JSONResponse(content=[item.model_dump() for item in result])
+
+
+@router.post(
+    "/v1/chat/completions/derender",
+    dependencies=[Depends(validate_json_request)],
+    response_model=ChatCompletionResponse,
+    responses={
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_FOUND.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+async def derender_chat_completion(request: DerenderChatRequest, raw_request: Request):
+    handler = render(raw_request)
+    if handler is None:
+        raise NotImplementedError(
+            "The model does not support Chat Completions Derender API"
+        )
+
+    result = await handler.derender_chat_response(request)
+
+    if isinstance(result, ErrorResponse):
+        return JSONResponse(content=result.model_dump(), status_code=result.error.code)
+
+    return JSONResponse(content=result.model_dump())
+
+
+@router.post(
+    "/v1/completions/derender",
+    dependencies=[Depends(validate_json_request)],
+    response_model=CompletionResponse,
+    responses={
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_FOUND.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+async def derender_completion(request: DerenderCompletionRequest, raw_request: Request):
+    handler = render(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Completions Derender API")
+
+    result = await handler.derender_completion_response(request)
+
+    if isinstance(result, ErrorResponse):
+        return JSONResponse(content=result.model_dump(), status_code=result.error.code)
+
+    return JSONResponse(content=result.model_dump())
 
 
 def attach_router(app: FastAPI) -> None:

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -88,7 +88,11 @@ def _resolve_token_placeholder(
     if m is None:
         return token, None
     token_id = int(m.group(1))
-    token_str = tokenizer.convert_ids_to_tokens([token_id])[0]
+    token_repr = tokenizer.convert_ids_to_tokens([token_id])[0]
+    if token_repr is None:
+        return token, None
+    # Decode the tokenizer internal symbols to text
+    token_str = tokenizer.convert_tokens_to_string([token_repr])
     try:
         token_bytes: list[int] | None = list(token_str.encode("utf-8"))
     except (UnicodeEncodeError, AttributeError):

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -11,6 +11,8 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
+    get_history_tool_calls_cnt,
+    get_tool_call_id_type,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionLogProbs,
@@ -48,8 +50,12 @@ from vllm.entrypoints.serve.disagg.protocol import (
     PlaceholderRangeInfo,
 )
 from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
+from vllm.entrypoints.serve.utils.chat_message_builder import build_chat_message
 from vllm.entrypoints.serve.utils.error_response import create_error_response
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.entrypoints.serve.utils.tool_calls_utils import (
+    maybe_filter_parallel_tool_calls,
+)
 from vllm.inputs import (
     EngineInput,
     MultiModalHashes,
@@ -201,6 +207,20 @@ class OpenAIServingRender:
                 reasoning_parser_name=reasoning_parser,
             )
         )
+        self.parser_cls = ParserManager.get_parser(
+            tool_parser_name=tool_parser,
+            reasoning_parser_name=reasoning_parser,
+            enable_auto_tools=enable_auto_tools,
+            model_name=model_config.model,
+        )
+        if (
+            is_mistral_tool_parser(self.tool_parser)
+            and self.reasoning_parser is not None
+        ):
+            from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+
+            MistralToolParser.model_can_reason = True
+        self.tool_call_id_type = get_tool_call_id_type(model_config)
         self.default_chat_template_kwargs: dict[str, Any] = (
             default_chat_template_kwargs or {}
         )
@@ -545,6 +565,12 @@ class OpenAIServingRender:
         This is the symmetric inverse of render_chat_request: it detokenizes
         output token IDs, resolves token_id:N logprob placeholders, and
         formats the result as an OpenAI-compatible chat completion response.
+
+        When request.chat_request is provided (the post adjust_request object
+        from the paired /render call), reasoning and tool-call parsing is
+        applied using the same parser path as the coupled chat endpoint,
+        ensuring a single source of truth. When chat_request is absent
+        plain detokenisation is preserved.
         """
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
@@ -553,10 +579,95 @@ class OpenAIServingRender:
         tokenizer = self.renderer.get_tokenizer()
         gen = request.generate_response
         choices: list[ChatCompletionResponseChoice] = []
+        chat_request = request.chat_request
 
         try:
-            for choice in gen.choices:
-                choices.append(_build_chat_choice(choice, tokenizer))
+            if chat_request is not None:
+                # Parser aware path: run the same reasoning/tool call logic as
+                # the coupled chat endpoint so both paths share one implementation.
+                parser = None
+                chat_template_kwargs: dict[str, Any] = {}
+                if self.parser_cls is not None:
+                    chat_template_kwargs = (
+                        chat_request.build_chat_params(
+                            self.chat_template,
+                            self.chat_template_content_format,
+                        )
+                        .with_defaults(self.default_chat_template_kwargs)
+                        .chat_template_kwargs
+                    )
+                    parser = self.parser_cls(
+                        tokenizer,
+                        chat_request.tools,
+                        chat_template_kwargs=chat_template_kwargs,
+                    )
+
+                if self.tool_call_id_type == "kimi_k2":
+                    # The chat path seeds this from the rendered conversation.
+                    # Here we use chat_request.messages directly.
+                    # get_history_tool_calls_cnt only reads role/tool_calls so
+                    # both work but they aren't guaranteed identical after
+                    # template normalization> Its a latent parity gap for kimi_k2 IDs.
+                    history_tool_call_cnt = get_history_tool_calls_cnt(
+                        chat_request.messages  # type: ignore[arg-type]
+                    )
+                else:
+                    history_tool_call_cnt = 0
+
+                for choice in gen.choices:
+                    if not choice.token_ids:
+                        raise ValueError(
+                            f"choice {choice.index} has empty or null token_ids"
+                        )
+                    decoded_text = tokenizer.decode(
+                        choice.token_ids, skip_special_tokens=True
+                    )
+                    resolved_logprobs = (
+                        _resolve_logprobs(choice.logprobs, tokenizer)
+                        if choice.logprobs is not None
+                        else None
+                    )
+                    message, auto_tools_called, history_tool_call_cnt = (
+                        build_chat_message(
+                            output_text=decoded_text,
+                            output_token_ids=choice.token_ids,
+                            request=chat_request,
+                            parser=parser,
+                            tool_parser=self.tool_parser,
+                            use_harmony=self.use_harmony,
+                            enable_auto_tools=self.enable_auto_tools,
+                            tokenizer=tokenizer,
+                            role="assistant",
+                            tool_call_id_type=self.tool_call_id_type,
+                            history_tool_call_cnt=history_tool_call_cnt,
+                        )
+                    )
+                    if self.use_harmony:
+                        is_finish_reason_tool_calls = auto_tools_called
+                    else:
+                        is_finish_reason_tool_calls = auto_tools_called or bool(
+                            chat_request.tool_choice == "required"
+                            and choice.finish_reason == "stop"
+                        )
+                    choice_data = ChatCompletionResponseChoice(
+                        index=choice.index,
+                        message=message,
+                        logprobs=resolved_logprobs,
+                        finish_reason="tool_calls"
+                        if is_finish_reason_tool_calls
+                        else choice.finish_reason
+                        if choice.finish_reason
+                        else "stop",
+                    )
+                    if not self.use_harmony:
+                        choice_data = maybe_filter_parallel_tool_calls(
+                            choice_data, chat_request
+                        )
+                    choices.append(choice_data)
+            else:
+                # Plain detokenisation only.
+                for choice in gen.choices:
+                    choices.append(_build_chat_choice(choice, tokenizer))
         except ValueError as exc:
             return self.create_error_response(str(exc))
 

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import re
+import time
 from collections.abc import Sequence
 from http import HTTPStatus
 from typing import Any, cast
@@ -11,10 +13,22 @@ from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
 )
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionLogProbs,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionLogProbs,
+    CompletionRequest,
+    CompletionResponse,
+    CompletionResponseChoice,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
+    UsageInfo,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIModelRegistry
 from vllm.entrypoints.openai.parser.harmony_utils import (
@@ -26,7 +40,10 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.entrypoints.serve.disagg.mm_serde import encode_mm_kwargs_item
 from vllm.entrypoints.serve.disagg.protocol import (
+    DerenderChatRequest,
+    DerenderCompletionRequest,
     GenerateRequest,
+    GenerateResponseChoice,
     MultiModalFeatures,
     PlaceholderRangeInfo,
 )
@@ -52,12 +69,115 @@ from vllm.renderers.inputs.preprocess import (
     parse_model_prompt,
     prompt_to_seq,
 )
+from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
 from vllm.utils import random_uuid
 from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
 from vllm.utils.mistral import mt as _mt
 
 logger = init_logger(__name__)
+
+_PLACEHOLDER_RE = re.compile(r"^token_id:(\d+)$")
+
+
+def _resolve_token_placeholder(
+    token: str, tokenizer: TokenizerLike
+) -> tuple[str, list[int] | None]:
+    """Resolve a token_id:N logprob placeholder to a real token string and bytes."""
+    m = _PLACEHOLDER_RE.match(token)
+    if m is None:
+        return token, None
+    token_id = int(m.group(1))
+    token_str = tokenizer.convert_ids_to_tokens([token_id])[0]
+    try:
+        token_bytes: list[int] | None = list(token_str.encode("utf-8"))
+    except (UnicodeEncodeError, AttributeError):
+        token_bytes = None
+    return token_str, token_bytes
+
+
+def _resolve_logprobs(
+    logprobs: ChatCompletionLogProbs, tokenizer: TokenizerLike
+) -> ChatCompletionLogProbs:
+    """Resolve all token_id:N placeholders in a ChatCompletionLogProbs object."""
+    if logprobs.content is None:
+        return logprobs
+    resolved_content = []
+    for entry in logprobs.content:
+        token_str, token_bytes = _resolve_token_placeholder(entry.token, tokenizer)
+        resolved_top = []
+        for top in entry.top_logprobs:
+            top_str, top_bytes = _resolve_token_placeholder(top.token, tokenizer)
+            resolved_top.append(
+                top.model_copy(update={"token": top_str, "bytes": top_bytes})
+            )
+        resolved_content.append(
+            entry.model_copy(
+                update={
+                    "token": token_str,
+                    "bytes": token_bytes,
+                    "top_logprobs": resolved_top,
+                }
+            )
+        )
+    return ChatCompletionLogProbs(content=resolved_content)
+
+
+def _convert_chat_logprobs_to_completion_logprobs(
+    logprobs: ChatCompletionLogProbs,
+) -> CompletionLogProbs:
+    """Convert ChatCompletionLogProbs (per-token objects) to CompletionLogProbs
+    (parallel flat lists) as required by the /v1/completions response schema."""
+    if logprobs.content is None:
+        return CompletionLogProbs()
+
+    tokens: list[str] = []
+    token_logprobs: list[float | None] = []
+    top_logprobs_list: list[dict[str, float] | None] = []
+    text_offset: list[int] = []
+
+    offset = 0
+    for entry in logprobs.content:
+        text_offset.append(offset)
+        tokens.append(entry.token)
+        token_logprobs.append(entry.logprob)
+        top_logprobs_list.append(
+            {t.token: t.logprob for t in entry.top_logprobs}
+            if entry.top_logprobs
+            else None
+        )
+        offset += len(entry.token)
+
+    return CompletionLogProbs(
+        text_offset=text_offset,
+        token_logprobs=token_logprobs,
+        tokens=tokens,
+        top_logprobs=top_logprobs_list,
+    )
+
+
+def _build_chat_choice(
+    choice: GenerateResponseChoice, tokenizer: TokenizerLike
+) -> ChatCompletionResponseChoice:
+    """Detokenize and resolve logprobs for a single GenerateResponseChoice.
+
+    Raises:
+        ValueError: if choice.token_ids is empty or None.
+    """
+    if not choice.token_ids:
+        raise ValueError(f"choice {choice.index} has empty or null token_ids")
+    decoded_text = tokenizer.decode(choice.token_ids, skip_special_tokens=True)
+    resolved_logprobs = (
+        _resolve_logprobs(choice.logprobs, tokenizer)
+        if choice.logprobs is not None
+        else None
+    )
+    return ChatCompletionResponseChoice(
+        index=choice.index,
+        message=ChatMessage(role="assistant", content=decoded_text),
+        logprobs=resolved_logprobs,
+        finish_reason=choice.finish_reason,
+    )
 
 
 class OpenAIServingRender:
@@ -433,6 +553,146 @@ class OpenAIServingRender:
         engine_input = tokens_input(prompt_token_ids, cache_salt=request.cache_salt)
 
         return messages, [engine_input]
+
+    async def derender_chat_response(
+        self,
+        request: DerenderChatRequest,
+    ) -> ChatCompletionResponse | ErrorResponse:
+        """Postprocess a GenerateResponse into a ChatCompletionResponse.
+
+        This is the symmetric inverse of render_chat_request: it detokenizes
+        output token IDs, resolves token_id:N logprob placeholders, and
+        formats the result as an OpenAI-compatible chat completion response.
+        """
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
+
+        tokenizer = self.renderer.get_tokenizer()
+        gen = request.generate_response
+        choices: list[ChatCompletionResponseChoice] = []
+
+        try:
+            for choice in gen.choices:
+                choices.append(_build_chat_choice(choice, tokenizer))
+        except ValueError as exc:
+            return self.create_error_response(str(exc))
+
+        prompt_tokens = (
+            request.prompt_tokens if request.prompt_tokens is not None else 0
+        )
+        completion_tokens = sum(len(ch.token_ids) for ch in gen.choices if ch.token_ids)
+        usage = UsageInfo(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+
+        logger.info(
+            "derender_chat request_id=%s model=%s choices=%d completion_tokens=%d",
+            gen.request_id,
+            request.model,
+            len(choices),
+            completion_tokens,
+        )
+        return ChatCompletionResponse(
+            id=gen.request_id,
+            model=request.model,
+            created=int(time.time()),
+            choices=choices,
+            usage=usage,
+            prompt_logprobs=gen.prompt_logprobs,
+            kv_transfer_params=gen.kv_transfer_params,
+        )
+
+    async def derender_completion_response(
+        self,
+        request: DerenderCompletionRequest,
+    ) -> CompletionResponse | ErrorResponse:
+        """Postprocess a list of GenerateResponses into a CompletionResponse.
+
+        Mirrors the multi-prompt completions case: one GenerateResponse per
+        prompt, parallel to the list[GenerateRequest] from /v1/completions/render.
+        """
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
+
+        n = len(request.generate_responses)
+        prompt_tokens_list: list[int] = (
+            request.prompt_tokens if request.prompt_tokens is not None else [0] * n
+        )
+
+        tokenizer = self.renderer.get_tokenizer()
+        choices: list[CompletionResponseChoice] = []
+        total_prompt_tokens = 0
+        total_completion_tokens = 0
+        index = 0
+
+        for gen, pt in zip(request.generate_responses, prompt_tokens_list):
+            for choice in gen.choices:
+                if not choice.token_ids:
+                    return self.create_error_response(
+                        f"choice {choice.index} in response {gen.request_id} "
+                        "has empty or null token_ids"
+                    )
+                decoded_text = tokenizer.decode(
+                    choice.token_ids, skip_special_tokens=True
+                )
+                completion_logprobs = None
+                if choice.logprobs is not None:
+                    resolved = _resolve_logprobs(choice.logprobs, tokenizer)
+                    completion_logprobs = _convert_chat_logprobs_to_completion_logprobs(
+                        resolved
+                    )
+                choices.append(
+                    CompletionResponseChoice(
+                        index=index,
+                        text=decoded_text,
+                        finish_reason=choice.finish_reason,
+                        logprobs=completion_logprobs,
+                    )
+                )
+                total_completion_tokens += len(choice.token_ids)
+                index += 1
+            total_prompt_tokens += pt
+
+        if not request.generate_responses:
+            return self.create_error_response("generate_responses must not be empty")
+
+        first = request.generate_responses[0]
+        kv_params = first.kv_transfer_params
+        if any(
+            r.kv_transfer_params != kv_params for r in request.generate_responses[1:]
+        ):
+            logger.warning(
+                "derender_completion: kv_transfer_params differ across responses; "
+                "setting to None on the aggregated response"
+            )
+            kv_params = None
+
+        usage = UsageInfo(
+            prompt_tokens=total_prompt_tokens,
+            completion_tokens=total_completion_tokens,
+            total_tokens=total_prompt_tokens + total_completion_tokens,
+        )
+
+        logger.info(
+            "derender_completion request_id=%s model=%s choices=%d"
+            " completion_tokens=%d",
+            first.request_id,
+            request.model,
+            len(choices),
+            total_completion_tokens,
+        )
+        return CompletionResponse(
+            id=first.request_id,
+            model=request.model,
+            created=int(time.time()),
+            choices=choices,
+            usage=usage,
+            kv_transfer_params=kv_params,
+        )
 
     def create_error_response(
         self,

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -570,7 +570,7 @@ class OpenAIServingRender:
             total_tokens=prompt_tokens + completion_tokens,
         )
 
-        logger.info(
+        logger.debug(
             "derender_chat request_id=%s model=%s choices=%d completion_tokens=%d",
             gen.request_id,
             request.model,
@@ -659,7 +659,7 @@ class OpenAIServingRender:
             total_tokens=total_prompt_tokens + total_completion_tokens,
         )
 
-        logger.info(
+        logger.debug(
             "derender_completion request_id=%s model=%s choices=%d"
             " completion_tokens=%d",
             first.request_id,

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import re
 import time
 from collections.abc import Sequence
 from http import HTTPStatus
@@ -30,6 +29,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
     UsageInfo,
 )
+from vllm.entrypoints.openai.engine.serving import resolve_token_id_placeholder
 from vllm.entrypoints.openai.models.serving import OpenAIModelRegistry
 from vllm.entrypoints.openai.parser.harmony_utils import (
     build_harmony_preamble,
@@ -77,28 +77,6 @@ from vllm.utils.mistral import mt as _mt
 
 logger = init_logger(__name__)
 
-_PLACEHOLDER_RE = re.compile(r"^token_id:(\d+)$")
-
-
-def _resolve_token_placeholder(
-    token: str, tokenizer: TokenizerLike
-) -> tuple[str, list[int] | None]:
-    """Resolve a token_id:N logprob placeholder to a real token string and bytes."""
-    m = _PLACEHOLDER_RE.match(token)
-    if m is None:
-        return token, None
-    token_id = int(m.group(1))
-    token_repr = tokenizer.convert_ids_to_tokens([token_id])[0]
-    if token_repr is None:
-        return token, None
-    # Decode the tokenizer internal symbols to text
-    token_str = tokenizer.convert_tokens_to_string([token_repr])
-    try:
-        token_bytes: list[int] | None = list(token_str.encode("utf-8"))
-    except (UnicodeEncodeError, AttributeError):
-        token_bytes = None
-    return token_str, token_bytes
-
 
 def _resolve_logprobs(
     logprobs: ChatCompletionLogProbs, tokenizer: TokenizerLike
@@ -108,10 +86,10 @@ def _resolve_logprobs(
         return logprobs
     resolved_content = []
     for entry in logprobs.content:
-        token_str, token_bytes = _resolve_token_placeholder(entry.token, tokenizer)
+        token_str, token_bytes = resolve_token_id_placeholder(entry.token, tokenizer)
         resolved_top = []
         for top in entry.top_logprobs:
-            top_str, top_bytes = _resolve_token_placeholder(top.token, tokenizer)
+            top_str, top_bytes = resolve_token_id_placeholder(top.token, tokenizer)
             resolved_top.append(
                 top.model_copy(update={"token": top_str, "bytes": top_bytes})
             )

--- a/vllm/entrypoints/serve/utils/chat_message_builder.py
+++ b/vllm/entrypoints/serve/utils/chat_message_builder.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionRequest,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.engine.protocol import ToolCall
+from vllm.entrypoints.openai.parser.harmony_utils import parse_chat_output
+from vllm.logger import init_logger
+from vllm.parser.abstract_parser import Parser
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers import ToolParser
+from vllm.utils.mistral import is_mistral_tokenizer, is_mistral_tool_parser
+
+logger = init_logger(__name__)
+
+
+def build_chat_message(
+    *,
+    output_text: str,
+    output_token_ids: Sequence[int],
+    request: ChatCompletionRequest,
+    parser: Parser | None,
+    tool_parser: type[ToolParser] | None,
+    use_harmony: bool,
+    enable_auto_tools: bool,
+    tokenizer: TokenizerLike,
+    role: str,
+    tool_call_id_type: str,
+    history_tool_call_cnt: int,
+) -> tuple[ChatMessage, bool, int]:
+    """Build a ChatMessage from parsed output, handling harmony and all
+    tool_choice modes.
+
+    Single source of truth for output parsing shared by both the coupled chat
+    path (chat_completion_full_generator) and /derender.
+
+    Args:
+        output_text: Decoded text of the model output.
+        output_token_ids: Token IDs of the model output.
+        request: The original (post adjust_request) ChatCompletionRequest.
+        parser: Instantiated Parser for reasoning+tool extraction (non harmony).
+        tool_parser: Tool parser class for harmony path (instantiated here).
+        use_harmony: Whether the model uses the GPT OSS harmony protocol.
+        enable_auto_tools: Whether auto tool choice is enabled server side.
+        tokenizer: Tokenizer for tool extraction and ID type detection.
+        role: Role for the output ChatMessage (usually "assistant").
+        tool_call_id_type: ID generation type ("random" or "kimi_k2").
+        history_tool_call_cnt: Running count of tool calls seen so far.
+
+    Returns:
+        Tuple of (message, auto_tools_called, updated_history_tool_call_cnt).
+        auto_tools_called is True when auto or harmony tool calls were generated,
+        signalling the finish_reason should be "tool_calls".
+    """
+    if use_harmony:
+        if tokenizer is None:
+            raise ValueError("Tokenizer not available when skip_tokenizer_init=True")
+        reasoning, content, _ = parse_chat_output(output_token_ids)
+        if not request.include_reasoning:
+            reasoning = None
+
+        auto_tools_called = False
+        if tool_parser is not None:
+            tp_instance = tool_parser(tokenizer, request.tools)
+            tool_call_info = tp_instance.extract_tool_calls(
+                "",
+                request=request,
+                token_ids=output_token_ids,  # type: ignore[call-arg]
+            )
+            content = tool_call_info.content
+            auto_tools_called = tool_call_info.tools_called
+            message = ChatMessage(
+                role=role,
+                reasoning=reasoning,
+                content=content,
+                tool_calls=tool_call_info.tool_calls,
+            )
+        else:
+            message = ChatMessage(role=role, reasoning=reasoning, content=content)
+        return message, auto_tools_called, history_tool_call_cnt
+
+    # Non-harmony path.
+    if parser is not None:
+        reasoning, content, tool_calls = parser.parse(
+            output_text,
+            request,
+            enable_auto_tools=enable_auto_tools,
+        )
+        if not request.include_reasoning:
+            reasoning = None
+    else:
+        reasoning = None
+        content = output_text
+        tool_calls = []
+
+    auto_tools_called = False
+    if is_mistral_tokenizer(tokenizer):
+        from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+
+        tool_call_class: type[ToolCall] = MistralToolCall
+    else:
+        tool_call_class = ToolCall
+
+    # Re-derive for the derender path. _grammar_from_tool_parser is a
+    # PrivateAttr and is excluded from JSON serialization, so it is always
+    # False after a round trip. Trust it when set (chat path). Fall back to
+    # checking the tool parser class and the grammar so that adjust_request
+    # sets. Both are serializable.
+    use_mistral_tool_parser = request._grammar_from_tool_parser or (
+        is_mistral_tool_parser(tool_parser)
+        and request.structured_outputs is not None
+        and request.structured_outputs.grammar is not None
+    )
+    if use_mistral_tool_parser:
+        from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+
+        tool_call_items = MistralToolParser.build_non_streaming_tool_calls(tool_calls)
+        if tool_call_items:
+            auto_tools_called = (
+                request.tool_choice is None or request.tool_choice == "auto"
+            )
+        message = ChatMessage(
+            role=role,
+            reasoning=reasoning,
+            content=content,
+            tool_calls=tool_call_items,
+        )
+
+    elif (not enable_auto_tools or not tool_parser) and (
+        not isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
+        and request.tool_choice != "required"
+    ):
+        message = ChatMessage(role=role, reasoning=reasoning, content=content)
+
+    elif (
+        request.tool_choice
+        and type(request.tool_choice) is ChatCompletionNamedToolChoiceParam
+    ):
+        tool_call_class_items = []
+        tool_calls = tool_calls or []
+        for tc in tool_calls:
+            if tc.id:
+                tool_call_class_items.append(tool_call_class(id=tc.id, function=tc))
+            else:
+                if is_mistral_tokenizer(tokenizer):
+                    tool_call_class_items.append(tool_call_class(function=tc))
+                else:
+                    generated_id = make_tool_call_id(
+                        id_type=tool_call_id_type,
+                        func_name=tc.name,
+                        idx=history_tool_call_cnt,
+                    )
+                    tool_call_class_items.append(
+                        tool_call_class(id=generated_id, function=tc)
+                    )
+            history_tool_call_cnt += 1
+        message = ChatMessage(
+            role=role,
+            reasoning=reasoning,
+            content="",
+            tool_calls=tool_call_class_items,
+        )
+
+    elif request.tool_choice and request.tool_choice == "required":
+        tool_call_class_items = []
+        tool_calls = tool_calls or []
+        for tool_call in tool_calls:
+            if tool_call.id:
+                tool_call_class_items.append(
+                    tool_call_class(id=tool_call.id, function=tool_call)
+                )
+            else:
+                if is_mistral_tokenizer(tokenizer):
+                    tool_call_class_items.append(tool_call_class(function=tool_call))
+                else:
+                    generated_id = make_tool_call_id(
+                        id_type=tool_call_id_type,
+                        func_name=tool_call.name,
+                        idx=history_tool_call_cnt,
+                    )
+                    tool_call_class_items.append(
+                        tool_call_class(id=generated_id, function=tool_call)
+                    )
+            history_tool_call_cnt += 1
+        message = ChatMessage(
+            role=role,
+            content="",
+            tool_calls=tool_call_class_items,
+            reasoning=reasoning,
+        )
+
+    elif not request.tool_choice or request.tool_choice == "none":
+        message = ChatMessage(role=role, reasoning=reasoning, content=content)
+
+    elif (
+        request.tools
+        and (request.tool_choice == "auto" or request.tool_choice is None)
+        and enable_auto_tools
+        and tool_parser
+    ):
+        auto_tools_called = tool_calls is not None and len(tool_calls) > 0
+        if tool_calls:
+            tool_call_items = []
+            for tc in tool_calls:
+                if tc.id:
+                    tool_call_items.append(tool_call_class(id=tc.id, function=tc))
+                else:
+                    if is_mistral_tokenizer(tokenizer):
+                        tool_call_items.append(tool_call_class(function=tc))
+                    else:
+                        generated_id = make_tool_call_id(
+                            id_type=tool_call_id_type,
+                            func_name=tc.name,
+                            idx=history_tool_call_cnt,
+                        )
+                        tool_call_items.append(
+                            tool_call_class(id=generated_id, function=tc)
+                        )
+                history_tool_call_cnt += 1
+            message = ChatMessage(
+                role=role,
+                reasoning=reasoning,
+                content=content,
+                tool_calls=tool_call_items,
+            )
+        else:
+            message = ChatMessage(role=role, reasoning=reasoning, content=content)
+
+    else:
+        logger.error(
+            "Error in build_chat_message. Cannot determine if tools should be "
+            "extracted. Returning a standard chat completion."
+        )
+        message = ChatMessage(role=role, reasoning=reasoning, content=content)
+
+    return message, auto_tools_called, history_tool_call_cnt


### PR DESCRIPTION
## Purpose

In disaggregated / RL serving setups, the tier that generates tokens is separate from the tier that knows the request context (tools, reasoning settings, parser config). Today those callers tend to hand roll their own output parsers which inevitably drift from vLLM's real serving parser and silently corrupt `tool_calls` and reasoning segmentation. 

This PR is to let `/derender` run vLLM's *actual* parser as the single source of truth so the post processing a caller gets out of `/derender` is byte-for-byte what the coupled `/v1/chat/completions` path would have produced for the same tokens. In other words, a disaggregated or RL caller gets back a fully formed chat response of `reasoning`, `tool_calls`, and cleaned `content`.

Partial #42729

**Note for reviewers**: This PR is built on and dependent on #43606. **DO NOT MERGE** this PR until #43606 merges.

## Changes

- **New shared helper**: `vllm/entrypoints/serve/utils/chat_message_builder.py`. The output parsing logic that used to reside in `chat_completion_full_generator` (harmony branch, the unified-parser branch, `include_reasoning` gating, and the full `tool_choice`) is moved to a single function called `build_chat_message()`. It depends only on the tokenizer and never on the engine or GPU. This move is to make sure that chat and derender share one implementation for output parsing.
- **Chat path refactored to call the helper**: `chat_completion_full_generator` now delegates message building to `build_chat_message()`. The chat only pieces (logprobs, routed experts, stop reason, token IDs) stay in the caller as before.
- **Render service wired up**: `OpenAIServingRender` now constructs the same `parser_cls` and `tool_call_id_type` that the chat service does. When a request includes `chat_request` (the post `adjust_request` object the caller already held at `/render` time), `derender_chat_response` runs the parser and returns `reasoning` / `tool_calls`, including the correct `finish_reason="tool_calls"` handling and parallel tool call filtering.

## Notes

- **Parsing on/off** When `chat_request` is omitted, `/derender` performs plain detokenized `content`. In other words, no parsing.
- **No protocol changes.** The optional `chat_request: ChatCompletionRequest` field already existed on `DerenderChatRequest` from #43606. This PR just starts using it. Its docstring is updated to document the "send the adjusted request" contract and to note that Pydantic `PrivateAttr` fields (e.g. `_grammar_from_tool_parser`) don't survive
  a JSON round trip and are re-derived.
- **`adjust_request` is not re-run.** `chat_request` is assumed to already be the adjusted object by design.
- **Parsing is chat only.** `CompletionResponseChoice` has no `reasoning`/`tool_calls` fields and the Completions API has no tools. Therefore, `derender_completion_response` is unchanged.

## Test Plan

`pytest -s -v  tests/entrypoints/serve/render/test_derender.py`
`pytest -s -v  tests/entrypoints/serve/render/test_render_derender_e2e.py`

## Test Result

Tests pass

