### PR TITLE
[WIP][Model] Enable MiMo 2.5 DFlash

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -7,6 +7,7 @@ from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
     FusedMoEConfig,
     FusedMoEMethodBase,
     FusedMoEParallelConfig,
@@ -799,3 +800,169 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             expert_map=layer.expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
         )
+
+
+class MiMoV2Mxfp4Config(Mxfp4Config):
+    """MXFP4 config for MiMo-V2's experts.
+
+    MiMo stores its MoE experts in mxfp4 (while attention stays fp8). The stock
+    ``Mxfp4MoEMethod`` prepares the TRT-LLM weights with a layout that doesn't
+    match this checkpoint (interleaved w1/w3 + nvfp4 scale interleave), so
+    dispatch ``MiMoV2Mxfp4MoEMethod``, which ports SGLang's working recipe
+    (w3w1 concat + shuffle_matrix_a/sf_a + SiLU with swiglu_limit clamp).
+    """
+
+    # SGLang's mxfp4 path asserts swiglu_limit == 10 for these FP4 experts, and
+    # MiMo's config carries no field, so it's a fixed convention.
+    SWIGLU_LIMIT = 10.0
+
+    def get_quant_method(self, layer, prefix):
+        if isinstance(layer, FusedMoE):
+            return MiMoV2Mxfp4MoEMethod(
+                layer.moe_config, swiglu_limit=self.SWIGLU_LIMIT
+            )
+        return super().get_quant_method(layer, prefix)
+
+
+class MiMoV2Mxfp4MoEMethod(Mxfp4MoEMethod):
+    """MXFP4 MoE for MiMo: TRT-LLM kernel with SGLang's weight prep + SiLU.
+
+    Reuses the base ``create_weights`` (uint8 packed w13/w2 + uint8 E8M0
+    scales) and the base ``apply`` (which dispatches to the TRT-LLM experts /
+    ``trtllm_fp4_block_scale_moe``). Only the kernel-format conversion and the
+    SwiGLU clamp are overridden to match MiMo's checkpoint.
+    """
+
+    def __init__(self, moe, swiglu_limit: float | None = None):
+        super().__init__(moe)
+        # swiglu_limit comes from the model config (see MiMoV2MoE wiring). The
+        # TRT-LLM mxfp4 kernel always applies a clamped gated activation; for
+        # plain SiLU SwiGLU we pass alpha/beta=None and only the clamp limit.
+        self._swiglu_limit = swiglu_limit
+
+        # Force the MODULAR (routed) experts. select_deepseek_v4 prefers the
+        # Monolithic variant, which re-routes INTERNALLY with
+        # routing_bias=None/n_group=None -- discarding MiMo's grouped sigmoid +
+        # noaux_tc correction-bias routing -> wrong experts -> degenerate
+        # output. The Modular variant consumes vLLM's externally computed top-k
+        # (the correct MiMo routing) via trtllm_fp4_block_scale_routed_moe,
+        # matching SGLang.
+        from vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe import (
+            TrtLlmMxfp4ExpertsModular,
+        )
+
+        self.experts_cls = TrtLlmMxfp4ExpertsModular
+
+    def process_weights_after_loading(self, layer) -> None:
+        from flashinfer.fp4_quantization import block_scale_interleave
+        from flashinfer.fused_moe.core import (
+            _maybe_get_cached_w3_w1_permute_indices,
+            get_w2_permute_indices_with_cache,
+        )
+
+        from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+            reorder_w1w3_to_w3w1,
+        )
+
+        # 1) Reorder fused [w1=gate, w3=up] -> [w3, w1] by CONCATENATION.
+        #    (Base/DeepSeek-V4 path interleaves instead -> wrong for MiMo.)
+        w13_w, w13_s = reorder_w1w3_to_w3w1(
+            layer.w13_weight.data, layer.w13_weight_scale.data, dim=-2
+        )
+
+        w2_w = layer.w2_weight.data
+        w2_s = layer.w2_weight_scale.data
+        num_experts = w13_w.shape[0]
+        epilogue_tile_m = 128
+
+        # 2) Official TRT-LLM shuffle (SGLang's default path): permute indices
+        #    + block_scale_interleave. w13 uses the w3w1 permute, w2 the w2
+        #    permute; scales use num_elts_per_sf=16.
+        cache: dict = {}
+        g1_w, g1_s, g2_w, g2_s = [], [], [], []
+        for i in range(num_experts):
+            w13_u8 = w13_w[i].view(torch.uint8)
+            w13_s_u8 = w13_s[i].view(torch.uint8)
+            w2_u8 = w2_w[i].view(torch.uint8)
+            w2_s_u8 = w2_s[i].view(torch.uint8)
+
+            perm = _maybe_get_cached_w3_w1_permute_indices(
+                cache, w13_u8, epilogue_tile_m
+            )
+            g1_w.append(w13_u8[perm.to(w13_u8.device)].contiguous())
+            perm_sf = _maybe_get_cached_w3_w1_permute_indices(
+                cache, w13_s_u8, epilogue_tile_m, num_elts_per_sf=16
+            )
+            g1_s.append(
+                block_scale_interleave(
+                    w13_s_u8[perm_sf.to(w13_s_u8.device)].contiguous()
+                )
+            )
+
+            perm = get_w2_permute_indices_with_cache(cache, w2_u8, epilogue_tile_m)
+            g2_w.append(w2_u8[perm.to(w2_u8.device)].contiguous())
+            perm_sf = get_w2_permute_indices_with_cache(
+                cache, w2_s_u8, epilogue_tile_m, num_elts_per_sf=16
+            )
+            g2_s.append(
+                block_scale_interleave(
+                    w2_s_u8[perm_sf.to(w2_s_u8.device)].contiguous()
+                )
+            )
+
+        replace_parameter(layer, "w13_weight", torch.stack(g1_w))
+        replace_parameter(layer, "w2_weight", torch.stack(g2_w))
+        # Scales are consumed as float8_e4m3fn block-scale factors by the kernel.
+        replace_parameter(
+            layer,
+            "w13_weight_scale",
+            torch.stack(g1_s).view(torch.float8_e4m3fn).reshape(
+                num_experts, w13_w.shape[1], -1
+            ),
+        )
+        replace_parameter(
+            layer,
+            "w2_weight_scale",
+            torch.stack(g2_s).view(torch.float8_e4m3fn).reshape(
+                num_experts, w2_w.shape[1], -1
+            ),
+        )
+
+        # 3) Build the TRT-LLM kernel. The base _setup_kernel re-runs the
+        #    DeepSeek-V4 converter, so DON'T call it here -- instead construct
+        #    the moe_quant_config + kernel directly with the SiLU clamp.
+        #    TODO(gpu): confirm make_mxfp4_moe_kernel picks up gemm1_clamp_limit
+        #    and that gemm1_alpha/beta default to None (plain SiLU).
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        self._build_trtllm_kernel(layer)
+
+    def get_fused_moe_quant_config(self, layer):
+        cfg = super().get_fused_moe_quant_config(layer)
+        # Inject the SwiGLU clamp limit (alpha/beta stay None -> plain SiLU).
+        if cfg is not None and self._swiglu_limit is not None:
+            cfg.gemm1_clamp_limit = self._swiglu_limit  # TODO: verify field name
+        return cfg
+
+    def _build_trtllm_kernel(self, layer) -> None:
+        # TODO(gpu): mirror Mxfp4MoEMethod._setup_kernel's tail
+        # (make_mxfp4_moe_kernel(...)) without the weight conversion, since we
+        # already shuffled above. Left as an integration point.
+        from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+            make_mxfp4_moe_kernel,
+        )
+
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+            logger.warning(
+                "[mimo-mxfp4] experts_cls=%s  kernel.is_monolithic=%s "
+                "(want Modular / False so MiMo's external top-k routing is used)",
+                self.experts_cls.__name__,
+                getattr(self.moe_kernel, "is_monolithic", "?"),
+            )

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.mxfp4 import MiMoV2Mxfp4Config
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -51,7 +52,12 @@ from vllm.v1.attention.backends.flash_attn_diffkv import (
     FlashAttentionDiffKVBackend,
 )
 
-from .interfaces import MixtureOfExperts, SupportsPP
+from .interfaces import (
+    EagleModelMixin,
+    MixtureOfExperts,
+    SupportsEagle3,
+    SupportsPP,
+)
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -164,13 +170,25 @@ class MiMoV2MoE(nn.Module):
             torch.empty(config.n_routed_experts, dtype=self.gate_dtype)
         )
 
+        # The checkpoint stores attention in fp8 (quant_method="fp8") but the
+        # MoE experts in mxfp4 (quantization_config["store_dtype"]). Fp8Config
+        # drops store_dtype, so read it from the raw hf quant config dict and
+        # route the experts to an Mxfp4Config while attention keeps fp8.
+        hf_quant_config = getattr(config, "quantization_config", None)
+        if isinstance(hf_quant_config, dict):
+            store_dtype = hf_quant_config.get("store_dtype")
+        else:
+            store_dtype = getattr(hf_quant_config, "store_dtype", None)
+        expert_quant_config = (
+            MiMoV2Mxfp4Config() if store_dtype == "mxfp4" else quant_config
+        )
         self.experts = FusedMoE(
             num_experts=self.n_routed_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,
             intermediate_size=config.moe_intermediate_size,
             renormalize=config.norm_topk_prob,
-            quant_config=quant_config,
+            quant_config=expert_quant_config,
             prefix=f"{prefix}.experts",
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
@@ -441,8 +459,94 @@ class MiMoV2FlashDecoderLayer(nn.Module):
         return self.config.hybrid_layer_pattern[self.layer_id] == 1
 
 
+# Max representable magnitude of torch.float8_e4m3fn, used when re-quantizing.
+_FP8_E4M3_MAX = 448.0
+
+
+def _requant_block_fp8(
+    w: torch.Tensor,
+    weight_dtype: torch.dtype,
+    scale_dtype: torch.dtype,
+    block: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Re-quantize a (block-aligned) float tensor to fp8 [block, block] blocks.
+
+    Returns ``(weight_fp8, weight_scale_inv)`` where the dequantized value is
+    ``weight_fp8 * weight_scale_inv`` (DeepSeek-style block scaling).
+    """
+    n, k = w.shape
+    assert n % block == 0 and k % block == 0, (n, k)
+    blocks = w.reshape(n // block, block, k // block, block)
+    absmax = blocks.abs().amax(dim=(1, 3))
+    scale = (absmax / _FP8_E4M3_MAX).clamp(min=torch.finfo(torch.float32).tiny)
+    wq = (blocks / scale[:, None, :, None]).to(weight_dtype)
+    return wq.reshape(n, k), scale.to(scale_dtype)
+
+
+def _shard_fused_qkv_pro(
+    w_full: torch.Tensor,
+    s_full: torch.Tensor,
+    *,
+    total_num_heads: int,
+    total_num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    hidden_size: int,
+    tp_size: int,
+    tp_rank: int,
+    block: int = 128,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Shard a Pro-format fused fp8 qkv_proj for ``tp_rank``.
+
+    The checkpoint stores the fused QKV as ``num_kv_heads`` contiguous KV-groups,
+    each ``[Q | K | V]`` (Q = num_heads/num_kv_heads heads * head_dim, K = 1 head
+    * head_dim, V = 1 head * v_head_dim; the scale pads V to head_dim). A plain
+    ``chunk(tp_size)`` only yields the grouped ``[Q | K | V]`` layout the forward
+    expects when each rank holds exactly one group (``tp_size == num_kv_heads``).
+
+    When a rank holds multiple groups, the per-group fp8 block scales cannot be
+    re-permuted into the grouped layout (K spans 1.5 blocks), so we dequantize
+    this rank's groups, regroup to ``[all-Q | all-K | all-V]``, and re-quantize
+    to fp8 on the now block-aligned layout. Verified bit-for-bit against the
+    one-group-per-rank (TP=8) reconstruction.
+    """
+    groups = total_num_kv_heads
+    groups_per_rank = groups // tp_size
+
+    qpg = (total_num_heads // total_num_kv_heads) * head_dim
+    kpg = head_dim
+    vpg = v_head_dim
+    group_rows = qpg + kpg + vpg
+    scale_rows_pg = s_full.shape[0] // groups
+
+    if groups_per_rank == 1:
+        # One group per rank: the slice is already [Q | K | V]; plain chunk is
+        # exact and matches the param shapes (no re-quantization needed).
+        w = w_full.chunk(tp_size, dim=0)[tp_rank].contiguous()
+        s = s_full.chunk(tp_size, dim=0)[tp_rank].contiguous()
+        return w, s
+
+    q_parts, k_parts, v_parts = [], [], []
+    for g in range(tp_rank * groups_per_rank, (tp_rank + 1) * groups_per_rank):
+        wr0 = g * group_rows
+        sr0 = g * scale_rows_pg
+        wg = w_full[wr0 : wr0 + group_rows].to(torch.float32)
+        sg = s_full[sr0 : sr0 + scale_rows_pg].to(torch.float32)
+        s_rows = sg.repeat_interleave(block, dim=0)[:group_rows]
+        s_full_g = s_rows.repeat_interleave(block, dim=1)[:, :hidden_size]
+        deq = wg * s_full_g
+        q_parts.append(deq[:qpg])
+        k_parts.append(deq[qpg : qpg + kpg])
+        v_parts.append(deq[qpg + kpg :])
+
+    grouped = torch.cat(
+        [torch.cat(q_parts), torch.cat(k_parts), torch.cat(v_parts)], dim=0
+    )
+    return _requant_block_fp8(grouped, w_full.dtype, s_full.dtype, block)
+
+
 @support_torch_compile
-class MiMoV2Model(nn.Module):
+class MiMoV2Model(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -505,10 +609,16 @@ class MiMoV2Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
+        aux_hidden_states = self._maybe_add_hidden_state(
+            [], self.start_layer, hidden_states, residual
+        )
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
+            self._maybe_add_hidden_state(
+                aux_hidden_states, idx + 1, hidden_states, residual
+            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -517,6 +627,9 @@ class MiMoV2Model(nn.Module):
 
         hidden_states, _ = self.norm(hidden_states, residual)
 
+        # Return auxiliary hidden states if collected
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
@@ -547,6 +660,10 @@ class MiMoV2Model(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
+        # Pro-format fused qkv_proj arrives as two tensors (weight +
+        # weight_scale_inv); buffer them per layer so they can be sharded
+        # together (see _load_fused_qkv).
+        qkv_fused_buf: dict[str, dict[str, torch.Tensor]] = {}
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -589,12 +706,28 @@ class MiMoV2Model(nn.Module):
 
             if expert_matched:
                 continue
-            # Support fused qkv_proj checkpoint (Pro format)
-            if "qkv_proj" in name:
-                if name in params_dict:
-                    param = params_dict[name]
-                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
-                    default_weight_loader(param, loaded_weight)
+            # Support fused qkv_proj checkpoint (Pro format). The fused QKV is
+            # stored as num_kv_heads contiguous [Q|K|V] KV-groups, which only
+            # shards cleanly with a plain chunk when one group lands per rank
+            # (tp_size == num_kv_heads). Buffer the weight + scale and shard
+            # them together once both are seen (see _load_fused_qkv).
+            qkv_kind = name.rsplit(".", 1)[-1]
+            if name.endswith("qkv_proj.weight") or name.endswith(
+                "qkv_proj.weight_scale_inv"
+            ):
+                prefix = name[: -(len(qkv_kind) + 1)]
+                if f"{prefix}.weight" in params_dict:
+                    buf = qkv_fused_buf.setdefault(prefix, {})
+                    buf[qkv_kind] = loaded_weight
+                    if "weight" in buf and "weight_scale_inv" in buf:
+                        self._load_fused_qkv(
+                            prefix,
+                            qkv_fused_buf.pop(prefix),
+                            params_dict,
+                            loaded_params,
+                            tp_size,
+                            tp_rank,
+                        )
                 continue
             stacked_matched = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -650,10 +783,68 @@ class MiMoV2Model(nn.Module):
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 
+        # Flush any fused qkv_proj that never received both tensors (e.g. an
+        # unquantized checkpoint with no weight_scale_inv): fall back to a plain
+        # per-tensor chunk so nothing is silently dropped.
+        for prefix, buf in qkv_fused_buf.items():
+            for kind, tensor in buf.items():
+                pname = f"{prefix}.{kind}"
+                if pname not in params_dict:
+                    continue
+                param = params_dict[pname]
+                shard = tensor.chunk(tp_size, dim=0)[tp_rank]
+                if shard.shape[0] > param.shape[0]:
+                    shard = shard[: param.shape[0]]
+                default_weight_loader(param, shard)
+                loaded_params.add(pname)
+
         return loaded_params
 
+    def _load_fused_qkv(
+        self,
+        prefix: str,
+        buf: dict[str, torch.Tensor],
+        params_dict: dict[str, torch.nn.Parameter],
+        loaded_params: set[str],
+        tp_size: int,
+        tp_rank: int,
+    ) -> None:
+        """Shard a buffered Pro-format fused fp8 qkv_proj into this rank's param.
 
-class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
+        See _shard_fused_qkv_pro for the layout details. Falls back to a plain
+        chunk for tp configurations that don't divide num_kv_heads cleanly.
+        """
+        attn = self.get_submodule(prefix.rsplit(".", 1)[0])
+        groups = attn.total_num_kv_heads
+        clean_split = tp_size <= groups and groups % tp_size == 0
+        if clean_split:
+            w_rank, s_rank = _shard_fused_qkv_pro(
+                buf["weight"],
+                buf["weight_scale_inv"],
+                total_num_heads=attn.total_num_heads,
+                total_num_kv_heads=groups,
+                head_dim=attn.head_dim,
+                v_head_dim=attn.v_head_dim,
+                hidden_size=buf["weight"].shape[1],
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+            )
+            sharded = {"weight": w_rank, "weight_scale_inv": s_rank}
+        else:
+            sharded = {
+                kind: tensor.chunk(tp_size, dim=0)[tp_rank]
+                for kind, tensor in buf.items()
+            }
+        for kind, tensor in sharded.items():
+            pname = f"{prefix}.{kind}"
+            param = params_dict[pname]
+            if tensor.shape[0] > param.shape[0]:
+                tensor = tensor[: param.shape[0]]
+            default_weight_loader(param, tensor)
+            loaded_params.add(pname)
+
+
+class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsEagle3):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -11,7 +11,10 @@ from transformers import Qwen3Config
 from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -64,6 +67,7 @@ class DFlashQwen3Attention(nn.Module):
         head_dim: int | None = None,
         rms_norm_eps: float = 1e-06,
         attention_bias: bool = False,
+        add_swa_attention_sink_bias: bool = False,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
@@ -109,6 +113,13 @@ class DFlashQwen3Attention(nn.Module):
             max_position=max_position,
             rope_parameters=rope_parameters,
         )
+
+        self.attention_sink_bias = (
+            torch.nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
+            if add_swa_attention_sink_bias
+            else None
+        )
+
         self.attn = Attention(
             self.num_heads,
             self.head_dim,
@@ -118,6 +129,7 @@ class DFlashQwen3Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
+            sinks=self.attention_sink_bias,
         )
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
@@ -165,6 +177,14 @@ class DFlashQwen3DecoderLayer(nn.Module):
         set_default_rope_theta(config, default_theta=1000000)
         attn_type = AttentionType.DECODER
 
+        # DFlash drafts store the sink-bias flag inside dflash_config; fall back
+        # to the top-level attribute used by other (e.g. MiMo) configs.
+        dflash_config = getattr(config, "dflash_config", None) or {}
+        add_swa_attention_sink_bias = dflash_config.get(
+            "attention_sink_bias",
+            getattr(config, "add_swa_attention_sink_bias", False),
+        )
+
         self.self_attn = DFlashQwen3Attention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
@@ -172,6 +192,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
             num_kv_heads=config.num_key_value_heads,
             rms_norm_eps=config.rms_norm_eps,
             attention_bias=getattr(config, "attention_bias", False),
+            add_swa_attention_sink_bias=add_swa_attention_sink_bias,
             head_dim=getattr(config, "head_dim", None),
             cache_config=cache_config,
             quant_config=quant_config,
@@ -466,6 +487,8 @@ class DFlashQwen3Model(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
         for name, loaded_weight in weights:
             if "midlayer." in name:
                 name = name.replace("midlayer.", "layers.0.")
@@ -473,6 +496,20 @@ class DFlashQwen3Model(nn.Module):
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue
+            if "attention_sink_bias" in name:
+                if name not in params_dict:
+                    continue
+        
+                # Sink bias is per-head; shard it across TP ranks like the
+                # attention heads themselves.
+                param = params_dict[name]
+                heads_per_rank = loaded_weight.shape[0] // tp_size
+                head_start = tp_rank * heads_per_rank
+                narrow_weight = loaded_weight.narrow(0, head_start, heads_per_rank)
+
+                param.data.copy_(narrow_weight)
+                loaded_params.add(name)
+                continue
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1035,10 +1035,19 @@ def unify_kv_cache_spec_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> dict[str, KVCacheSpec]:
     """
-    Unify the page size of the given KVCacheSpec. If the page size of all layers
-    are the same, return the original KVCacheSpec. If not same, unify the page
-    size by increasing the block size of layers with smaller page size. Raise
-    NotImplementedError if failed to unify the page size.
+    Unify the page size of the given KVCacheSpec so that every layer has the
+    same ``page_size_bytes`` (the physical memory per block, which the
+    KVCacheManager requires to be uniform across groups).
+
+    If all layers already share a page size, the spec is returned unchanged.
+    Otherwise the common page size is the least common multiple (LCM) of all
+    layers' page sizes, and each layer's ``block_size`` is scaled up by
+    ``target_page_size // page_size_bytes`` to reach it. Because the target is
+    the LCM, every scaling factor is an integer, so any combination of page
+    sizes can be unified -- e.g. a draft model whose attention ``head_size``
+    differs from the target's (page sizes 2048 vs 2560 -> LCM 10240, block
+    sizes scaled by 5x and 4x). The cost is larger blocks for layers whose
+    page size is smaller than the LCM, which coarsens KV cache paging.
 
     Args:
         kv_cache_spec: The KVCacheSpec of each attention layer in the model
@@ -1051,22 +1060,21 @@ def unify_kv_cache_spec_page_size(
         # All layers have the same page size, no need to unify.
         return kv_cache_spec
 
-    max_page_size = max(page_sizes)
+    # Unify to the LCM of all page sizes so that every layer's block_size is
+    # scaled by an integer factor. (Scaling only up to the max page size would
+    # require every page size to divide the max, which fails for e.g. 2048 vs
+    # 2560.)
+    target_page_size = math.lcm(*page_sizes)
     new_kv_cache_spec = {}
     for layer_name, layer_spec in kv_cache_spec.items():
-        if layer_spec.page_size_bytes == max_page_size:
+        layer_page_size = layer_spec.page_size_bytes
+        if layer_page_size == target_page_size:
             new_kv_cache_spec[layer_name] = layer_spec
         else:
-            layer_page_size = layer_spec.page_size_bytes
-            if max_page_size % layer_page_size != 0:
-                raise NotImplementedError(
-                    "The page size of the layer is not divisible by the "
-                    "maximum page size. Cannot unify by adjusting block_size."
-                )
-            ratio = max_page_size // layer_page_size
+            ratio = target_page_size // layer_page_size
             new_block_size = layer_spec.block_size * ratio
             new_spec = replace(layer_spec, block_size=new_block_size)
-            assert new_spec.page_size_bytes == max_page_size
+            assert new_spec.page_size_bytes == target_page_size
             new_kv_cache_spec[layer_name] = new_spec
     return new_kv_cache_spec
 


### PR DESCRIPTION
```
vllm serve XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash \
    --enforce-eager \
    --tensor-parallel-size 4 \
    --trust-remote-code \
    --gpu-memory-utilization 0.95 \
    --max-model-len auto \
    --reasoning-parser mimo \
    --tool-call-parser mimo \
    --enable-auto-tool-choice \
    --no-enable-prefix-caching \
    --generation-config vllm \
    --speculative_config '{"method":"dflash","model":"/raid/users/inf-gdelfin/hf-models/hub/models--XiaomiMiMo--MiMo-V2.5-Pro-FP4-DFlash/snapshots/b754e6c86008bdb5cc901308dda5a38173ec7276/dflash","num_speculative_tokens":8}'
```