### PR TITLE
Change from owning configs to owning config utils

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,8 +27,9 @@
 /vllm/config/cache.py @heheda12345
 
 # Config utils
-/vllm/engine/arg_utils.py @hmellor
 /vllm/config/utils.py @hmellor
+/vllm/engine/arg_utils.py @hmellor
+/vllm/utils/argparse_utils.py
 
 # Entrypoints
 /vllm/entrypoints/anthropic @mgoin @DarkLight1337

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,8 +23,12 @@
 
 # Any change to the VllmConfig changes can have a large user-facing impact,
 # so spam a lot of people
-/vllm/config @WoosukKwon @youkaichao @robertgshaw2-redhat @mgoin @tlrmchlsmth @houseroad @hmellor @yewentao256 @ProExpertProg
+/vllm/config @WoosukKwon @youkaichao @robertgshaw2-redhat @mgoin @tlrmchlsmth @houseroad @yewentao256 @ProExpertProg
 /vllm/config/cache.py @heheda12345
+
+# Config utils
+/vllm/engine/arg_utils.py @hmellor
+/vllm/config/utils.py @hmellor
 
 # Entrypoints
 /vllm/entrypoints/anthropic @mgoin @DarkLight1337


### PR DESCRIPTION
The spam has become too much, I need my GitHub notifications to be useful again.

This PR reduces the scope of my ownership of the configs to only the utils, which I have contrinuted to significantly.