### PR TITLE
[Bugfix]Fix out-of-vocabulary recovered token on all-NaN logits (root cause of empty spec-decode output)

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -906,12 +906,22 @@ def test_schedule_spec_decoding_stats(spec_tokens, output_tokens, expected):
         assert stats.num_accepted_tokens_per_pos == expected[3]
 
 
-def test_spec_decoding_stats_empty_output():
-    """Test that spec decoding stats handle empty output tokens gracefully.
+def test_spec_decoding_empty_output_asserts():
+    """An empty sampled-token row for a request that had speculative tokens
+    scheduled is an invariant violation, and the scheduler asserts it.
 
-    This is a regression test for a bug where empty sampled_token_ids
-    would cause num_accepted = len([]) - 1 = -1, leading to a
-    ValueError when incrementing a Prometheus counter with a negative value.
+    Background: #33729 made the scheduler *skip* rejection accounting whenever
+    ``generated_token_ids`` was empty, to avoid ``num_accepted = len([]) - 1 =
+    -1`` crashing a Prometheus counter. That hid the real bug instead of fixing
+    it: the recovered-token kernel could emit an out-of-vocabulary id that
+    ``RejectionSampler.parse_output`` then dropped, producing the empty row.
+    Skipping the accounting left ``num_computed_tokens`` too high, which could
+    stall the request (no schedulable work despite being unfinished).
+
+    With the recovered-token kernel fixed to always emit an in-vocab id, a
+    request that had spec tokens scheduled always commits at least one token,
+    so the scheduler enforces ``assert generated_token_ids`` rather than
+    silently tolerating the broken state.
     """
     num_spec_tokens = 3
     scheduler = create_scheduler(num_speculative_tokens=num_spec_tokens)
@@ -921,11 +931,9 @@ def test_spec_decoding_stats_empty_output():
 
     scheduler.add_request(request)
 
-    # Initial schedule (prefill)
+    # Initial schedule (prefill) and a sampled token to begin decoding.
     output = scheduler.schedule()
     assert len(output.scheduled_new_reqs) == 1
-
-    # Complete the prefill with a sampled token
     model_runner_output = ModelRunnerOutput(
         req_ids=[req_id],
         req_id_to_index={req_id: 0},
@@ -936,34 +944,26 @@ def test_spec_decoding_stats_empty_output():
     )
     scheduler.update_from_output(output, model_runner_output)
 
-    # Add draft tokens for speculation
+    # Add draft tokens and schedule them for verification.
     draft_token_ids = DraftTokenIds([req_id], [[1, 2, 3]])
     scheduler.update_draft_token_ids(draft_token_ids)
-
-    # Schedule the speculated tokens for validation
     output = scheduler.schedule()
     assert req_id in output.scheduled_spec_decode_tokens
     assert len(output.scheduled_spec_decode_tokens[req_id]) == 3
 
-    # Simulate empty output tokens (e.g., due to request abortion or error)
-    # This would previously cause num_accepted = -1 and crash
+    # An empty sampled-token row for a request that had spec tokens scheduled
+    # cannot happen once the recovered-token kernel is fixed; the scheduler
+    # enforces the invariant with an assertion.
     model_runner_output = ModelRunnerOutput(
         req_ids=[req_id],
         req_id_to_index={req_id: 0},
-        sampled_token_ids=[[]],  # Empty output tokens
+        sampled_token_ids=[[]],  # Empty output tokens.
         logprobs=None,
         prompt_logprobs_dict={},
         pooler_output=[],
     )
-
-    # This should not raise an error
-    engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
-
-    # Spec decoding stats should be None since no tokens were generated
-    scheduler_stats = (
-        engine_core_outputs[0].scheduler_stats if engine_core_outputs else None
-    )
-    assert scheduler_stats is None or scheduler_stats.spec_decoding_stats is None
+    with pytest.raises(AssertionError):
+        scheduler.update_from_output(output, model_runner_output)
 
 
 def test_no_spec_tokens_scheduled_for_prefill_chunks():

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -937,6 +937,75 @@ def test_sample_recovered_tokens(
     assert torch.equal(recovered_token_ids, ref_recovered_token_ids)
 
 
+@pytest.mark.parametrize("vocab_size", [50000, 129280])
+@pytest.mark.parametrize("no_draft_probs", [True, False])
+def test_sample_recovered_tokens_nan_target_probs_stay_in_vocab(
+    vocab_size: int, no_draft_probs: bool
+):
+    """All-NaN ``target_probs`` must not yield an out-of-vocabulary token id.
+
+    When the target model emits NaN logits, ``target_probs`` is all-NaN. For a
+    ``vocab_size`` that is not a multiple of the kernel ``BLOCK_SIZE`` (8192),
+    the final tile contains padding positions whose score is ``0.0``. Those
+    zeros used to win the NaN-propagating ``tl.max`` reduction and yield
+    ``recovered_id == vocab_size`` (out of bounds).
+    ``RejectionSampler.parse_output`` keeps only ids ``< vocab_size``, so such a
+    row collapses to an empty list, which then stalls the scheduler. The kernel
+    must instead return an in-vocab id.
+
+    ``vocab_size=129280`` matches the DeepSeek V3.2 setup where this was first
+    observed.
+    """
+    batch_size = 2
+    max_spec_len = 2
+    num_tokens = batch_size * max_spec_len
+
+    # Draft token ids are arbitrary in-vocab ids.
+    draft_token_ids = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE_TYPE)
+
+    draft_probs = None
+    if not no_draft_probs:
+        draft_probs = torch.full(
+            (num_tokens, vocab_size),
+            1.0 / vocab_size,
+            dtype=torch.float32,
+            device=DEVICE_TYPE,
+        )
+
+    # Degenerate target distribution: the model emitted NaN logits.
+    target_probs = torch.full(
+        (num_tokens, vocab_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=DEVICE_TYPE,
+    )
+
+    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
+    generators = {
+        i: torch.Generator(device=DEVICE_TYPE).manual_seed(i) for i in range(batch_size)
+    }
+    sampling_metadata = create_sampling_metadata(
+        all_greedy=False, temperature=temperature, generators=generators
+    )
+    spec_decode_metadata = create_spec_decode_metadata(
+        draft_token_ids.reshape(batch_size, max_spec_len).tolist(), target_probs
+    )
+
+    recovered_token_ids = sample_recovered_tokens(
+        max_spec_len,
+        spec_decode_metadata.num_draft_tokens,
+        spec_decode_metadata.cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        sampling_metadata,
+        device=DEVICE_TYPE,
+    )
+
+    assert torch.all(recovered_token_ids >= 0)
+    assert torch.all(recovered_token_ids < vocab_size)
+
+
 def test_sample_recovered_tokens_uses_fp64_exponential_race_when_requested():
     batch_size = 2
     vocab_size = 64

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1393,7 +1393,13 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
-            if scheduled_spec_token_ids and generated_token_ids:
+            if scheduled_spec_token_ids:
+                # A scheduled-spec request always commits at least one token,
+                # since `sample_recovered_tokens_kernel` never emits an
+                # out-of-vocab id. Assert the invariant rather than silently
+                # skipping accounting, which would leave `num_computed_tokens`
+                # too high and could stall the request.
+                assert generated_token_ids
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_accepted = len(generated_token_ids) - 1
                 num_rejected = num_draft_tokens - num_accepted

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -921,8 +921,14 @@ def sample_recovered_tokens_kernel(
             other=0.0,
         )
 
-        # Local tile reduction
+        # Local tile reduction. Mask padding (``vocab_offset >= vocab_size``,
+        # score ``0.0`` via ``other=0.0``) to ``-inf``. Otherwise, with all-NaN
+        # ``target_probs`` those zeros win the NaN-propagating ``tl.max`` and
+        # yield an out-of-vocab ``recovered_id == vocab_size``. Masking keeps
+        # ``recovered_id`` at its in-vocab init (0); healthy runs are unaffected
+        # since real scores are ``>= 0 > -inf``.
         score = prob * inv_q
+        score = tl.where(vocab_mask, score, -float("inf"))
         local_max, local_id = tl.max(score, axis=0, return_indices=True)
 
         if local_max > max_val:


### PR DESCRIPTION
## Summary

This fixes the root cause behind the "empty speculative-decode output" condition that has been worked around twice before. When the target model emits NaN logits, `sample_recovered_tokens_kernel` could return an **out-of-vocabulary** token id (`recovered_id == vocab_size`) instead of an in-vocab id. `RejectionSampler.parse_output` keeps only ids `< vocab_size`, so that row collapses to an empty list. Downstream, the scheduler sees a request that had speculative tokens scheduled but produced **no** committed token, which has caused both a Prometheus counter crash (#33729 / #26372) and a CPU-bound tail stall with DeepSeek V3.2 sync MTP (#42722).

The fix masks the kernel's padding positions to `-inf` so the reduction can never select an out-of-vocab id, and then restores the scheduler invariant that a scheduled-spec request always commits at least one token.

## The story: a symptom fixed twice, root cause never found

In #33729 ("Fix negative accepted tokens metric crash", merged Feb 2026, fixes #26372) the engine was crashing with `ValueError: Counters can only be incremented by non-negative amounts.` because a request that had speculative tokens scheduled returned no generated tokens, making `num_accepted = len([]) - 1 = -1`. The fix was defensive: skip rejection accounting entirely when `generated_token_ids` is empty (`if scheduled_spec_token_ids and generated_token_ids:`).

Crucially, the underlying condition was never pinned down. The author wrote: *"In some cases it's possible for no tokens to be generated in a step for a request which had spec decode tokens ... For now I am just not recording it, this case should happen relatively infrequently anyhow."* When asked which condition triggers it, the answer was *"I'm still not 100% sure of the conditions causing it in that case. But I think this check/fix makes sense regardless."* So #33729 silenced the symptom without finding the cause.

That defensive skip then hid a worse failure mode. #42722 found that the same empty-output condition causes a tail stall (hang) on DeepSeek V3.2 with sync MTP: skipping the accounting leaves `num_computed_tokens` too high, the request reaches `num_tokens_with_spec == num_computed_tokens` while still unfinished, and future scheduler steps schedule zero work for it forever (GPUs idle, generation throughput drops to `0.0 tokens/s`). As noted in that thread: *"#33729 did try to fix prometheus metrics negative counter. But seems didn't consider the hang that we have now."*

This PR identifies where the empty output actually comes from. With one draft token, the raw speculative sampler row for the stalled DeepSeek request was `[129280, -1]` with `vocab_size = 129280`. The first slot `129280` is exactly `vocab_size` — an out-of-vocabulary id — so `parse_output` drops it (and `-1` is the "no bonus token" placeholder), leaving `[]`. The id `129280` is not random: it is produced by `sample_recovered_tokens_kernel` when `target_probs` is all-NaN (the model emitted NaN logits) and `vocab_size` is not a multiple of the kernel's `BLOCK_SIZE` (8192). The final tile's padding positions (`vocab_offset >= vocab_size`) load with `other=0.0`, so their score is `0.0`. `tl.max` is NaN-propagating, but the contiguous run of zeros at the end of the last tile beats the NaN reduction and lands at local offset `vocab_size - v`, yielding `recovered_id == vocab_size`. That out-of-vocab id is the empty-output source that #33729 worked around and that #42722 hung on. The core reason wasn't found before — it is here.

## Testing

Environment: 8x NVIDIA B200, torch 2.11.0+cu130, editable vLLM build.

Reproduced the root cause directly: calling `sample_recovered_tokens` with all-NaN `target_probs` returned `recovered_id == vocab_size` (out of bounds) for `vocab_size in {50000, 129280}` with `no_draft_probs=True` before the fix, and `0` (in vocab) after the fix; `parse_output` correspondingly changed from `[]` to `[0]`.

Verified the new tests are genuine regression guards: with both source fixes reverted (tests kept), the two new tests fail (the `no_draft_probs=True` kernel cases produce out-of-vocab ids, and the scheduler test does not raise); with the fixes applied, they pass.

Commands run and results:

```bash
# New tests + the existing spec-decoding accounting test.
python -m pytest -q \
  tests/v1/sample/test_rejection_sampler.py::test_sample_recovered_tokens_nan_target_probs_stay_in_vocab \
  tests/v1/core/test_scheduler.py::test_spec_decoding_empty_output_asserts \
  tests/v1/core/test_scheduler.py::test_schedule_spec_decoding_stats
# -> 11 passed

# Existing kernel parity test (healthy runs unaffected, byte-for-byte argmax).
python -m pytest -q \
  tests/v1/sample/test_rejection_sampler.py::test_sample_recovered_tokens
# -> 24 passed

# Broader sweep of affected suites.
python -m pytest -q \
  tests/v1/sample/test_rejection_sampler.py \
  tests/v1/core/test_scheduler.py -k 'spec or recovered or rejection'
# -> 78 passed, 93 deselected
```

## Related

- Fixes the root cause behind #26372 and #33729 (negative-accepted-tokens crash) and #42722 (DeepSeek V3.2 sync MTP tail stall).
- Complements #33652 (which stopped scheduling draft tokens for prefill chunks); together they make the scheduler's "scheduled spec => at least one committed token" invariant hold.
