### PR TITLE
Fix gemma4 parallel tool calling with MTP enabled

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -413,6 +413,23 @@ class TestStreamingExtraction:
                         return name
         return None
 
+    def _collect_function_names_and_arguments(self, results):
+        """Extract the function names from streaming results."""
+        function_arguments = []
+        function_names = []
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                for tc in delta.tool_calls:
+                    name = getattr(tc.function, "name", None)
+                    arg = getattr(tc.function, "arguments", "") or ""
+                    if name:
+                        function_names.append(name)
+                        function_arguments.append("")
+                    if arg:
+                        function_arguments[-1] += arg
+
+        return function_names, function_arguments
+
     def test_basic_streaming_single_tool(self, parser, mock_request):
         """Simulate the exact streaming scenario from the bug report.
 
@@ -441,6 +458,45 @@ class TestStreamingExtraction:
         assert args_text, "No arguments were streamed"
         parsed_args = json.loads(args_text)
         assert parsed_args == {"location": "Paris, France"}
+
+    def test_basic_streaming_parallel_tools(self, parser, mock_request):
+        """Simulate the exact streaming scenario that breaks with the
+           introduction of MTP.
+
+        Model generates:
+        <|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>
+        <|tool_call>call:get_time{location:<|"|>France<|"|>}<tool_call|>
+
+
+        Expected: arguments should be valid JSON {"location": "Paris"}
+        """
+        chunks = [
+            "<|tool_call>",
+            "call:get_weather{",
+            'location:<|"|>Paris',
+            '<|"|>',
+            "}<tool_call|><|tool_call>call:get_time{",
+            'location:<|"|>France',
+            '<|"|>',
+            "}<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+
+        # Verify function name
+        names, args = self._collect_function_names_and_arguments(results)
+        assert names[0] == "get_weather", f"Expected 'get_weather', got '{names[0]}'"
+        assert names[1] == "get_time", f"Expected 'get_time', got '{names[1]}'"
+
+        # Verify arguments form valid JSON
+        args_text = args[0]
+        assert args_text, "No arguments were streamed"
+        parsed_args = json.loads(args_text)
+        assert parsed_args == {"location": "Paris"}
+        args_text = args[1]
+        assert args_text, "No arguments were streamed"
+        parsed_args = json.loads(args_text)
+        assert parsed_args == {"location": "France"}
 
     def test_streaming_multi_arg(self, parser, mock_request):
         """Streaming with multiple arguments."""
@@ -668,8 +724,6 @@ class TestStreamingExtraction:
             delta.content for delta, _ in results if delta is not None and delta.content
         ]
         assert "".join(content_parts) == "<div>"
-        assert captured_current_texts[-1].endswith("<tool_call|><div>")
-        assert not captured_current_texts[-1].endswith("<tool_call|><<div>")
 
     def test_streaming_html_argument_does_not_duplicate_tag_prefixes(
         self, parser, mock_request

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -497,25 +497,37 @@ class Gemma4ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        # Buffer delta text to handle multi-token special sequences
-        delta_text = self._buffer_delta_text(delta_text)
-        # Keep current_text from the upstream stream state. The buffered delta
-        # is only for emission, and must not be stitched back into the
-        # accumulated model text or normal content like "<div>" can be
-        # duplicated into "<<div>" when a tool call just ended.
-
         # If no tool call token seen yet, emit as content
-        if self.tool_call_start_token not in current_text:
+        if self.tool_call_start_token_id not in current_token_ids:
             if delta_text:
                 return DeltaMessage(content=delta_text)
             return None
 
+        # split delta text after end <tool_call|> token so that the parser
+        # only has to consider one tool call at a time
+        delta_texts = re.split(
+            f"(?<={re.escape(self.tool_call_end_token)})", delta_text
+        )
+        delta_msg = None
         try:
-            return self._extract_streaming(
-                previous_text=previous_text,
-                current_text=current_text,
-                delta_text=delta_text,
-            )
+            for text in delta_texts:
+                if len(text) > 0:
+                    latest_msg = self._extract_streaming(
+                        previous_text=previous_text,
+                        current_text=previous_text + text,
+                        delta_text=text,
+                    )
+                    previous_text += text
+                    if delta_msg is None:
+                        delta_msg = latest_msg
+                    elif latest_msg is not None:
+                        if latest_msg.content is not None:
+                            if delta_msg.content is None:
+                                delta_msg.content = ""
+                            delta_msg.content += latest_msg.content
+                        if latest_msg.tool_calls and len(latest_msg.tool_calls) >= 1:
+                            delta_msg.tool_calls.append(latest_msg.tool_calls[0])
+            return delta_msg
         except Exception:
             logger.exception("Error in Gemma4 streaming tool call extraction")
             return None


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/41967.
Fix gemma4 tool parser when the model emits end tool and start tool in the same delta due to MTP speculative decoding. Without this fix the first tool call gets prematurely abandoned with out the proper json closures. The second tool call gets emitted correctly. I've added a new test case for the exact scenario we see.

Please can someone comment on this:
This PR removes the buffering of incoming deltas for the case where a start/end tool call token gets split across deltas. Given that Gemma4 has dedicated tokens for start and end of tool call we don't believe this is necessary. Across a few 10,000 tool call's we've never seen Gemma4-31B emit anything other than the special tokens. This buffering code appears to have been in the parser from the start leading us to believe it may have been a hangover from the model that inspired this parser?

## Test Plan
Added new test case to pytest for the sequence of chunks that triggers the bug.
I had to modify test_streaming_does_not_duplicate_plain_text_after_tool_call as it was dubiously verifying the internal parser implementation rather than just the externally visible output.

## Test Result
All tests pass.

There are a few other proposed PR's for this issue, but I believe this is the smallest in terms of minimal change to the existing implementation.