### PR TITLE
fix(multimodal): support gemma4 QAT configs by adding safe num_soft_t…

### DIFF
--- a/vllm/model_executor/models/gemma4_unified.py
+++ b/vllm/model_executor/models/gemma4_unified.py
@@ -163,7 +163,9 @@ class Gemma4UnifiedProcessingInfo(Gemma4ProcessingInfo):
         config = self.get_hf_config()
         # Unified field is `num_soft_tokens`.  Tower-based parent uses
         # `default_output_length`, hence the override.
-        tokens_per_image = config.vision_config.num_soft_tokens
+        
+        # Use getattr to prevent AttributeError on compressed/QAT model configurations
+        tokens_per_image = getattr(config.vision_config, "num_soft_tokens", 280)
         merged_kwargs = self.ctx.get_merged_mm_kwargs({})
         val, _ = _get_max_soft_tokens(merged_kwargs)
         if isinstance(val, int) and val in _SUPPORTED_SOFT_TOKENS:


### PR DESCRIPTION
## Purpose

Hey everyone! I was trying to serve the official Gemma 4 quantized model (`google/gemma-4-12B-it-qat-w4a16-ct`) using vLLM on a cloud pod, but the server immediately panicked and crashed with a fatal exception: 
`AttributeError: 'Gemma4UnifiedVisionConfig' object has no attribute 'num_soft_tokens'` inside `encoder_budget.py` via `gemma4_unified.py`.

To figure out why, I dug into the code and compared the `config.json` metadata files of both the standard unquantized base model and this quantized variant. I found out that the non-quantized model explicitly contains the `num_soft_tokens` attribute inside its `vision_config` block, but the serialized QAT export completely drops it. Because vLLM currently relies on a strict dot-property lookup, the missing key instantly brings down the engine.

I noticed someone else ran into a very similar brick wall in an issue raised here: #45039.

### 🛠️ Proposed Solution
I figured a safe fallback approach would prevent this crash entirely. This PR switches out the strict dot-property lookup inside `vllm/model_executor/models/gemma4_unified.py` with a safe Python `getattr()` lookup. If the attribute is missing (like in the QAT checkpoint), it gracefully falls back to Gemma 4's architecture standard of `280` tokens. 

I'm going to keep looking at it on my end, but I thought this quick patch would be a solid way to bridge the gap for now. If there's anything else I am missing or if you'd prefer a different architecture fallback pattern, please do let me know—all learning here! 😊
