### PR TITLE
[bugfix] skip conch kernel for g_idx reordering

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/conch.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/conch.py
@@ -43,6 +43,12 @@ class ConchLinearKernel(MPLinearKernel):
             )
             return False, error_msg
 
+        if c.has_g_idx:
+            return (
+                False,
+                "Activation reordering (g_idx) is not supported by ConchLinearKernel",
+            )
+
         if find_spec("conch") is None:
             error_msg = (
                 "conch-triton-kernels is not installed, please "


### PR DESCRIPTION
Conch kernel doesn't support g_idx reordering.

The issue is **_not_** ROCm specific. CUDA fails to capture this because the kernel ordering on cuda picks Marlin kernel before conch which handles g_idx reordering. 
Kernel ordering preference for ROCm & CUDA can be referred here - [LINK](https://github.com/vllm-project/vllm/blob/d7607ad2730ff26b5cb8730354179a4d42dc45d1/vllm/model_executor/kernels/linear/__init__.py#L348-L363)

Resolves the following test: `lora/test_quant_model.py::test_quant_model_lora[model0]`. This PR will safely skip selecting the conchkernel and on rocm the next kernel (`ExllamaLinearKernel`) in the preference order will be chosen.

