### PR TITLE
[Bugfix] Fix missing sequence_lengths in EXAONE-4.5 vision encoder

### DIFF
--- a/vllm/model_executor/models/exaone4_5.py
+++ b/vllm/model_executor/models/exaone4_5.py
@@ -152,6 +152,8 @@ class EXAONE4_5_VisionAttention(nn.Module):
         rotary_pos_emb_cos: torch.Tensor,
         rotary_pos_emb_sin: torch.Tensor,
         max_seqlen: int | None = None,
+        sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         # [s, b, c] --> [s, b, head * 3 * head_dim]
         x, _ = self.qkv(x)
@@ -176,6 +178,7 @@ class EXAONE4_5_VisionAttention(nn.Module):
             value=v,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
 
         context_layer = einops.rearrange(
@@ -190,6 +193,7 @@ class EXAONE4_5_VisionAttention(nn.Module):
     dynamic_arg_dims={
         "x": 0,
         "cu_seqlens": 0,
+        "sequence_lengths": 0,
         "rotary_pos_emb_cos": 0,
         "rotary_pos_emb_sin": 0,
     },
@@ -241,6 +245,8 @@ class Exaone4_5_VisionBlock(nn.Module):
         rotary_pos_emb_sin: torch.Tensor,
         max_seqlen: int | None = None,  # Only used for Flash Attention
         seqlens: list[int] | None = None,  # Only used for xFormers
+        # Only used for FlashInfer CuDNN backend
+        sequence_lengths: torch.Tensor | None = None,
     ) -> torch.Tensor:
         x_attn = self.attn(
             self.norm1(x),
@@ -248,6 +254,7 @@ class Exaone4_5_VisionBlock(nn.Module):
             rotary_pos_emb_cos=rotary_pos_emb_cos,
             rotary_pos_emb_sin=rotary_pos_emb_sin,
             max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
         x_fused_norm, residual = self.norm2(x, residual=x_attn)
         x = residual + self.mlp(x_fused_norm)


### PR DESCRIPTION
## Purpose

PR #42787 made the Qwen2.5-VL vision backbone pass `sequence_lengths` (FlashInfer CuDNN metadata) to every vision block, but the EXAONE-4.5 overrides of the vision block and attention kept the pre-#42787 signature. Since EXAONE-4.5 inherits `Qwen2_5_VisionTransformer.forward`, any multimodal request now fails with:

    TypeError: Exaone4_5_VisionBlock.forward() got an unexpected
    keyword argument 'sequence_lengths'

Thread `sequence_lengths` through `Exaone4_5_VisionBlock` and `EXAONE4_5_VisionAttention` into `MMEncoderAttention`, and register it in the block's `dynamic_arg_dims` for torch.compile, mirroring the equivalent fix for qwen3_omni_moe_thinker in #35741.

Closes #45071 


## Test Plan

- `pre-commit run --files vllm/model_executor/models/exaone4_5.py`
  (ruff check/format, mypy, typos, SPDX)
- Deploy `vllm/vllm-openai:v0.22.0` with the patched file overlaid on
  2x A100, using the reproduce command from #45071, and confirm the
  server completes startup profiling and serves image requests

## Test Result
- pre-commit: all hooks passed
- Server startup + image inference: It worked

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

