### PR TITLE
[BugFix][Core]: pad placeholder spec tokens for new requests to match CUDA graph shapes

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -56,6 +56,7 @@ from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
+from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
@@ -745,7 +746,7 @@ class Scheduler(SchedulerInterface):
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
-                    num_new_tokens = request.num_tokens - num_computed_tokens
+                    num_new_tokens = request.num_tokens_with_spec - num_computed_tokens
                     threshold = self.scheduler_config.long_prefill_token_threshold
                     if 0 < threshold < num_new_tokens:
                         num_new_tokens = threshold
@@ -922,6 +923,23 @@ class Scheduler(SchedulerInterface):
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
                     encoder_compute_budget = new_encoder_compute_budget
+                # Speculative decode related.
+                if request.spec_token_ids:
+                    num_scheduled_spec_tokens = (
+                        num_new_tokens
+                        + request.num_computed_tokens
+                        - request.num_tokens
+                        - request.num_output_placeholders
+                    )
+                    if num_scheduled_spec_tokens > 0:
+                        # Trim spec_token_ids list to num_scheduled_spec_tokens.
+                        del request.spec_token_ids[num_scheduled_spec_tokens:]
+                        scheduled_spec_decode_tokens[request.request_id] = (
+                            request.spec_token_ids
+                        )
+                    # New spec tokens will be set in `update_draft_token_ids` before the
+                    # next step when applicable.
+                    request.spec_token_ids = []
                 # Allocate for external load encoder cache
                 if external_load_encoder_input:
                     for i in external_load_encoder_input:
@@ -1884,6 +1902,9 @@ class Scheduler(SchedulerInterface):
         else:
             if request.resumable:
                 request.streaming_queue = deque()
+            # Fill placeholder draft tokens so spec-decode requests can match
+            # CUDA graph shapes before real draft ids arrive.
+            request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.connector is not None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -56,7 +56,6 @@ from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
-from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
@@ -770,7 +769,7 @@ class Scheduler(SchedulerInterface):
                         and token_budget >= 1 + self.num_spec_tokens
                     ):
                         scheduled_spec_decode_tokens[request_id] = [
-                            PLACEHOLDER_TOKEN_ID
+                            0
                         ] * self.num_spec_tokens
                         num_new_tokens += self.num_spec_tokens
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -746,7 +746,7 @@ class Scheduler(SchedulerInterface):
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
-                    num_new_tokens = request.num_tokens_with_spec - num_computed_tokens
+                    num_new_tokens = request.num_tokens - num_computed_tokens
                     threshold = self.scheduler_config.long_prefill_token_threshold
                     if 0 < threshold < num_new_tokens:
                         num_new_tokens = threshold
@@ -760,6 +760,19 @@ class Scheduler(SchedulerInterface):
                         # If chunked_prefill is disabled,
                         # we can stop the scheduling here.
                         break
+
+                    # Pad placeholder spec tokens for the first decode step
+                    # so the batch shape matches pre-compiled CUDA graphs.
+                    if (
+                        self.num_spec_tokens > 0
+                        and num_new_tokens == 1
+                        and num_computed_tokens == request.num_tokens - 1
+                        and token_budget >= 1 + self.num_spec_tokens
+                    ):
+                        scheduled_spec_decode_tokens[request_id] = [
+                            PLACEHOLDER_TOKEN_ID
+                        ] * self.num_spec_tokens
+                        num_new_tokens += self.num_spec_tokens
 
                     num_new_tokens = min(num_new_tokens, token_budget)
                     assert num_new_tokens > 0
@@ -923,23 +936,6 @@ class Scheduler(SchedulerInterface):
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
                     encoder_compute_budget = new_encoder_compute_budget
-                # Speculative decode related.
-                if request.spec_token_ids:
-                    num_scheduled_spec_tokens = (
-                        num_new_tokens
-                        + request.num_computed_tokens
-                        - request.num_tokens
-                        - request.num_output_placeholders
-                    )
-                    if num_scheduled_spec_tokens > 0:
-                        # Trim spec_token_ids list to num_scheduled_spec_tokens.
-                        del request.spec_token_ids[num_scheduled_spec_tokens:]
-                        scheduled_spec_decode_tokens[request.request_id] = (
-                            request.spec_token_ids
-                        )
-                    # New spec tokens will be set in `update_draft_token_ids` before the
-                    # next step when applicable.
-                    request.spec_token_ids = []
                 # Allocate for external load encoder cache
                 if external_load_encoder_input:
                     for i in external_load_encoder_input:
@@ -1902,9 +1898,6 @@ class Scheduler(SchedulerInterface):
         else:
             if request.resumable:
                 request.streaming_queue = deque()
-            # Fill placeholder draft tokens so spec-decode requests can match
-            # CUDA graph shapes before real draft ids arrive.
-            request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.connector is not None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -766,6 +766,7 @@ class Scheduler(SchedulerInterface):
                         self.num_spec_tokens > 0
                         and num_new_tokens == 1
                         and num_computed_tokens == request.num_tokens - 1
+                        and num_computed_tokens > 0
                         and token_budget >= 1 + self.num_spec_tokens
                     ):
                         scheduled_spec_decode_tokens[request_id] = [

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -214,6 +214,12 @@ class Scheduler(SchedulerInterface):
             else EncoderCacheManager(cache_size=encoder_cache_size)
         )
 
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        self.is_decode_instance = (
+            kv_transfer_config is not None
+            and kv_transfer_config.kv_role == "kv_consumer"
+        )
+
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
@@ -761,12 +767,13 @@ class Scheduler(SchedulerInterface):
                         break
 
                     # Pad placeholder spec tokens for the first decode step
-                    # so the batch shape matches pre-compiled CUDA graphs.
+                    # in PD-separated decode so the batch shape matches
+                    # pre-compiled CUDA graphs.
                     if (
-                        self.num_spec_tokens > 0
+                        self.is_decode_instance
+                        and self.num_spec_tokens > 0
                         and num_new_tokens == 1
                         and num_computed_tokens == request.num_tokens - 1
-                        and num_computed_tokens > 0
                         and token_budget >= 1 + self.num_spec_tokens
                     ):
                         scheduled_spec_decode_tokens[request_id] = [

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1438,16 +1438,6 @@ class GPUModelRunner(
         for request in reqs_to_add:
             self.input_batch.add_request(request)
             self.input_batch.update_req_spec_token_ids(request, scheduled_spec_tokens)
-            # Update the request state with the number of draft tokens for async
-            # scheduling. This tracks token generation progress and maintains
-            # request state. NOTE: The spec tokens are placeholders and not
-            # added to token_ids_cpu.
-            if self.use_async_scheduling:
-                req_state = self.requests[request.req_id]
-                spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(
-                    request.req_id, []
-                )
-                req_state.prev_num_draft_len = len(spec_token_ids)
 
         # Condense the batched states if there are gaps left by removed requests
         self.input_batch.condense()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1438,6 +1438,16 @@ class GPUModelRunner(
         for request in reqs_to_add:
             self.input_batch.add_request(request)
             self.input_batch.update_req_spec_token_ids(request, scheduled_spec_tokens)
+            # Update the request state with the number of draft tokens for async
+            # scheduling. This tracks token generation progress and maintains
+            # request state. NOTE: The spec tokens are placeholders and not
+            # added to token_ids_cpu.
+            if self.use_async_scheduling:
+                req_state = self.requests[request.req_id]
+                spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(
+                    request.req_id, []
+                )
+                req_state.prev_num_draft_len = len(spec_token_ids)
 
         # Condense the batched states if there are gaps left by removed requests
         self.input_batch.condense()


### PR DESCRIPTION
## Purpose

Fix a performance regression in PD-separated (prefill-decode separation) deployment with speculative decoding enabled.

When a new request arrives at the decode node, its first forward pass has no draft tokens yet (the drafter has no output history to work with). With CUDA graphs enabled, the batch shape for this first step is just 1 token per request, which cannot match the pre-compiled CUDA graph shape of `1 + num_spec_tokens`. This causes a fallback to eager execution, resulting in significant latency degradation on the first decode step of every request.

This PR pads `num_spec_tokens` placeholder draft tokens (using `PLACEHOLDER_TOKEN_ID = -1`) when a request is added to the scheduler, so the first forward pass uses the same batch shape as all subsequent steps and consistently hits the pre-compiled CUDA graph.

## Test Plan

- Deploy DeepSeek-V4 in PD-separated mode (2-node prefill TP=4 DP=4, 2-node decode TP=1 DP=16) with speculative decoding and CUDA graph enabled.
- Run high-concurrency benchmark and measure TPOT (Time Per Output Token).
- Verify that CUDA graph is matched on the very first step (no eager fallback in logs).

## Test Result

Model: DeepSeek-V4, high-concurrency workload, PD-separated with spec decode + CUDA graph.

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| TPOT P50 (ms) | 52.2313 | 24.5685 | **-52.9%** |

The first decode step no longer falls back to eager execution, resulting in a ~2x improvement in P50 output token latency under high concurrency.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

Signed-off-by: Zheng Shoujian <zheng.shoujian@outlook.com>