### PR TITLE
[Bugfix][CI/Build] Fix Rust frontend build after chat conversion refactor

### DIFF
--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -1,4 +1,4 @@
-mod convert;
+pub(crate) mod convert;
 mod types;
 mod validate;
 


### PR DESCRIPTION
## Summary

Fix the Rust frontend build break from #44884 where `/tokenize` reused chat conversion helpers but `chat_completions::convert` remained a private module

cc @BugenZhao @njhill @simon-mo 