### PR TITLE
[Metrics] Add engine startup time gauge

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -180,6 +180,7 @@ async def test_metrics_counts(
 
 
 EXPECTED_METRICS_V1 = [
+    "vllm:engine_startup_time_seconds",
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
     "vllm:num_requests_waiting_by_reason",

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -143,6 +143,7 @@ class AsyncLLM(EngineClient):
         )
 
         # EngineCore (starts the engine in background process).
+        engine_start_time = time.perf_counter()
         self.engine_core = EngineCoreClient.make_async_mp_client(
             vllm_config=vllm_config,
             executor_class=executor_class,
@@ -151,6 +152,7 @@ class AsyncLLM(EngineClient):
             client_count=client_count,
             client_index=client_index,
         )
+        engine_startup_time = time.perf_counter() - engine_start_time
 
         # Loggers.
         self.logger_manager: StatLoggerManager | None = None
@@ -163,6 +165,7 @@ class AsyncLLM(EngineClient):
                 client_count=client_count,
                 aggregate_engine_logging=aggregate_engine_logging,
             )
+            self.logger_manager.record_engine_startup_time(engine_startup_time)
             self.logger_manager.log_engine_initialized()
 
         self._client_count = client_count

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -102,6 +102,7 @@ class LLMEngine:
         )
 
         # EngineCore (gets EngineCoreRequests and gives EngineCoreOutputs)
+        engine_start_time = time.perf_counter()
         self.engine_core = EngineCoreClient.make_client(
             multiprocess_mode=multiprocess_mode,
             asyncio_mode=False,
@@ -109,6 +110,7 @@ class LLMEngine:
             executor_class=executor_class,
             log_stats=self.log_stats,
         )
+        engine_startup_time = time.perf_counter() - engine_start_time
 
         self.logger_manager: StatLoggerManager | None = None
         if self.log_stats:
@@ -118,6 +120,7 @@ class LLMEngine:
                 enable_default_loggers=log_stats,
                 aggregate_engine_logging=aggregate_engine_logging,
             )
+            self.logger_manager.record_engine_startup_time(engine_startup_time)
             self.logger_manager.log_engine_initialized()
 
         if not multiprocess_mode:

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -67,6 +67,9 @@ class StatLoggerBase(ABC):
     def log(self):  # noqa
         pass
 
+    def record_engine_startup_time(self, startup_time: float):  # noqa
+        pass
+
     def record_sleep_state(self, is_awake: int, level: int):  # noqa
         pass
 
@@ -439,6 +442,10 @@ class PerEngineStatLoggerAdapter(AggregateStatLoggerBase):
         for per_engine_stat_logger in self.per_engine_stat_loggers.values():
             per_engine_stat_logger.log_engine_initialized()
 
+    def record_engine_startup_time(self, startup_time: float):
+        for per_engine_stat_logger in self.per_engine_stat_loggers.values():
+            per_engine_stat_logger.record_engine_startup_time(startup_time)
+
 
 class PrometheusStatLogger(AggregateStatLoggerBase):
     _gauge_cls = Gauge
@@ -486,6 +493,19 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         self.perf_metrics_prom = self._perf_metrics_cls(
             vllm_config, labelnames, per_engine_labelvalues
         )
+
+        #
+        # Engine startup
+        #
+        gauge_engine_startup_time = self._gauge_cls(
+            name="vllm:engine_startup_time_seconds",
+            documentation=(
+                "Time spent initializing the vLLM engine core until it is ready."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=["model_name"],
+        )
+        self.gauge_engine_startup_time = gauge_engine_startup_time.labels(model_name)
 
         #
         # Scheduler state
@@ -1277,6 +1297,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
             self.gauge_engine_sleep_state["awake"][engine_idx].set(awake)
 
+    def record_engine_startup_time(self, startup_time: float):
+        self.gauge_engine_startup_time.set(startup_time)
+
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
 
@@ -1396,6 +1419,10 @@ class StatLoggerManager:
     def log(self):
         for logger in self.stat_loggers:
             logger.log()
+
+    def record_engine_startup_time(self, startup_time: float):
+        for logger in self.stat_loggers:
+            logger.record_engine_startup_time(startup_time)
 
     def log_engine_initialized(self):
         for agg_logger in self.stat_loggers:


### PR DESCRIPTION

This PR adds a Prometheus gauge `vllm:engine_startup_time_seconds` that records how long the engine core takes to initialize, including model load, `torch.compile`, memory profiling, KV cache allocation, and CUDA graph capture.

## Purpose
Today similar information is only obtainable by running `vllm bench startup` offline. Exposing it as a runtime metric lets operators monitor startup time across real deployments — useful for catching regressions after config/version changes and for SLO dashboards.

## Test plan

- [x] `pytest tests/entrypoints/serve/instrumentator/test_metrics.py -v`
      (added `vllm:engine_startup_time_seconds` to `EXPECTED_METRICS_V1`)
- [x] Manual: `vllm serve facebook/opt-125m` then
      `curl -s localhost:8000/metrics | grep engine_startup_time` shows the
      gauge with a sensible value.

## Test Result
Planed tests above passed. Detailed as follows:
### `pytest` result
```console
pytest tests/entrypoints/serve/instrumentator/test_metrics.py -v
========================================== test session starts ===========================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/venvs/vllm/bin/python3
cachedir: .pytest_cache
rootdir: /home/ubuntu/vllm
configfile: pyproject.toml
plugins: anyio-4.13.0, Faker-40.22.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 19 items                                                                                       

tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[-text] PASSED          [  5%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist[-text] PASSED           [ 10%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_abort_metrics_reset[-text] PASSED     [ 15%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[-multimodal] SKIPPED                                                                                                               [ 21%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist[-multimodal] PASSED                                                                                                                 [ 26%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_abort_metrics_reset[-multimodal] PASSED                                                                                                           [ 31%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[--enable-chunked-prefill-multimodal] SKIPPED                                                                                       [ 36%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist[--enable-chunked-prefill-multimodal] PASSED                                                                                         [ 42%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_abort_metrics_reset[--enable-chunked-prefill-multimodal] PASSED                                                                                   [ 47%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[--enable-chunked-prefill-text] PASSED                                                                                              [ 52%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist[--enable-chunked-prefill-text] PASSED                                                                                               [ 57%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_abort_metrics_reset[--enable-chunked-prefill-text] PASSED                                                                                         [ 63%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[--show-hidden-metrics-for-version=0.19-multimodal] SKIPPED                                                                         [ 68%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist[--show-hidden-metrics-for-version=0.19-multimodal] PASSED                                                                           [ 73%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_abort_metrics_reset[--show-hidden-metrics-for-version=0.19-multimodal] PASSED                                                                     [ 78%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[--show-hidden-metrics-for-version=0.19-text] PASSED                                                                                [ 84%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist[--show-hidden-metrics-for-version=0.19-text] PASSED                                                                                 [ 89%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_abort_metrics_reset[--show-hidden-metrics-for-version=0.19-text] PASSED                                                                           [ 94%]
tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_exist_run_batch PASSED                                                                                                                    [100%]
```

### Manual test result
```console
$ curl -s localhost:8000/metrics | grep engine_startup_time
# HELP vllm:engine_startup_time_seconds Time spent initializing the vLLM engine core until it is ready.
# TYPE vllm:engine_startup_time_seconds gauge
vllm:engine_startup_time_seconds{model_name="facebook/opt-125m"} 25.98533135699836
```