### PR TITLE
[Bugfix] Fix INC XPU MoE quantization routing for RoutedExperts

### DIFF
--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -772,3 +772,39 @@ class TestGetLayerConfigFusedQKV:
             DummyLayer(), "model.layers.0.self_attn.qkv_proj"
         )
         assert bits == 8
+
+
+def test_inc_get_quant_method_xpu_routed_experts_uses_moe_wna16(
+    monkeypatch,
+) -> None:
+    captured = {}
+    config = make_config()
+    layer = object.__new__(RoutedExperts)
+    layer.moe_config = object()
+    sentinel = object()
+
+    class DummyMoeWNA16Config:
+        def get_quant_method(self, routed_layer, routed_prefix):
+            captured["layer"] = routed_layer
+            captured["prefix"] = routed_prefix
+            return sentinel
+
+    monkeypatch.setattr(current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(current_platform, "is_cpu", lambda: False)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.moe_wna16.MoeWNA16Config.from_config",
+        lambda cfg: captured.update({"from_config": cfg}) or DummyMoeWNA16Config(),
+    )
+
+    method = config.get_quant_method(layer, "layer")
+
+    assert method is sentinel
+    assert captured["from_config"] == {
+        "quant_method": "gptq",
+        "bits": 4,
+        "group_size": 128,
+        "sym": True,
+        "lm_head": False,
+    }
+    assert captured["layer"] is layer
+    assert captured["prefix"] == "layer"

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
@@ -87,14 +87,38 @@ class INCWna16Scheme(INCScheme):
         prefix: str,
         layer_config: "INCLayerConfig",
     ):
-        del config, prefix
-        # XPU and CPU do not support MoE quantization yet
-        if current_platform.is_xpu() or current_platform.is_cpu():
+        del config
+
+        if current_platform.is_xpu():
+            if layer_config.is_gptq and layer_config.bits == 4 and layer_config.sym:
+                from vllm.model_executor.layers.quantization.moe_wna16 import (
+                    MoeWNA16Config,
+                )
+
+                moe_config = MoeWNA16Config.from_config(
+                    {
+                        "quant_method": "gptq",
+                        "bits": layer_config.bits,
+                        "group_size": layer_config.group_size,
+                        "sym": layer_config.sym,
+                        "lm_head": False,
+                    }
+                )
+                return moe_config.get_quant_method(layer, prefix)
+
             from vllm.model_executor.layers.fused_moe import (
                 UnquantizedFusedMoEMethod,
             )
 
             return UnquantizedFusedMoEMethod(layer.moe_config)
+
+        if current_platform.is_cpu():
+            from vllm.model_executor.layers.fused_moe import (
+                UnquantizedFusedMoEMethod,
+            )
+
+            return UnquantizedFusedMoEMethod(layer.moe_config)
+
         if layer_config.is_gptq:
             return _resolve_gptq_moe(layer, layer_config)
         if layer_config.is_awq:


### PR DESCRIPTION
Validated models:
Qwen3.6-35B-A3B-int4-mixed-AutoRound

```python
python3 examples/basic/offline_inference/generate.py   --model Qwen3.6-35B-A3B-int4-mixed-AutoRound   --tensor-parallel-size 2   --enforce-eager   --max-model-len 512   --gpu-memory-utilization 0.6
```
<img width="1159" height="310" alt="image" src="https://github.com/user-attachments/assets/d3e31272-1a1e-4798-98bd-329752a26339" />
