### PR TITLE
[Multimodal] Add PixelPrune visual token pruning for Qwen3-VL

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -358,6 +358,7 @@ class ModelConfig:
     interleave_mm_strings: InitVar[bool | None] = None
     skip_mm_profiling: InitVar[bool | None] = None
     video_pruning_rate: InitVar[float | None] = None
+    pixel_prune_threshold: InitVar[float | None] = None
     mm_tensor_ipc: InitVar[MMTensorIPC] = None
 
     def compute_hash(self) -> str:
@@ -484,6 +485,7 @@ class ModelConfig:
         interleave_mm_strings: bool | None,
         skip_mm_profiling: bool | None,
         video_pruning_rate: float | None,
+        pixel_prune_threshold: float | None,
         mm_tensor_ipc: MMTensorIPC,
     ) -> None:
         # Keep set served_model_name before maybe_model_redirect(self.model)
@@ -706,6 +708,7 @@ class ModelConfig:
                 interleave_mm_strings=interleave_mm_strings,
                 skip_mm_profiling=skip_mm_profiling,
                 video_pruning_rate=video_pruning_rate,
+                pixel_prune_threshold=pixel_prune_threshold,
                 mm_tensor_ipc=mm_tensor_ipc,
             )
 

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -192,6 +192,11 @@ class MultiModalConfig:
     Value sits in range [0;1) and determines fraction of media tokens
     from each video to be pruned.
     """
+    pixel_prune_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
+    """L∞ distance between a patch and its prediction for PixelPrune
+    near-exact matching. Value sits in range [0;1); ``None`` (default)
+    disables PixelPrune. Larger values prune more aggressively.
+    """
     mm_tensor_ipc: MMTensorIPC = "direct_rpc"
     """IPC (inter-process communication) method for multimodal tensors.
     - "direct_rpc": Use msgspec serialization via RPC
@@ -336,3 +341,6 @@ class MultiModalConfig:
 
     def is_multimodal_pruning_enabled(self):
         return self.video_pruning_rate is not None and self.video_pruning_rate > 0
+
+    def is_pixel_prune_enabled(self):
+        return self.pixel_prune_threshold is not None and self.pixel_prune_threshold < 1

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -576,6 +576,7 @@ class EngineArgs:
     renderer_num_workers: int = 1
     skip_mm_profiling: bool = MultiModalConfig.skip_mm_profiling
     video_pruning_rate: float | None = MultiModalConfig.video_pruning_rate
+    pixel_prune_threshold: float | None = MultiModalConfig.pixel_prune_threshold
     mm_tensor_ipc: MMTensorIPC = MultiModalConfig.mm_tensor_ipc
     # LoRA fields
     enable_lora: bool = False
@@ -1267,6 +1268,10 @@ class EngineArgs:
             "--video-pruning-rate", **multimodal_kwargs["video_pruning_rate"]
         )
         multimodal_group.add_argument(
+            "--pixel-prune-threshold",
+            **multimodal_kwargs["pixel_prune_threshold"],
+        )
+        multimodal_group.add_argument(
             "--mm-tensor-ipc", **multimodal_kwargs["mm_tensor_ipc"]
         )
 
@@ -1621,6 +1626,7 @@ class EngineArgs:
             override_attention_dtype=self.override_attention_dtype,
             logits_processors=self.logits_processors,
             video_pruning_rate=self.video_pruning_rate,
+            pixel_prune_threshold=self.pixel_prune_threshold,
             mm_tensor_ipc=self.mm_tensor_ipc,
             io_processor_plugin=self.io_processor_plugin,
             renderer_num_workers=self.renderer_num_workers,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -33,6 +33,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from PIL import Image
 from transformers import BatchFeature
 from transformers.models.qwen2_vl import Qwen2VLImageProcessorFast
 from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
@@ -50,7 +51,11 @@ from transformers.video_utils import VideoMetadata
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
-from vllm.config.multimodal import BaseDummyOptions, VideoDummyOptions
+from vllm.config.multimodal import (
+    BaseDummyOptions,
+    ImageDummyOptions,
+    VideoDummyOptions,
+)
 from vllm.distributed import get_pp_group, parallel_state
 from vllm.inputs import MultiModalDataDict
 from vllm.logger import init_logger
@@ -790,25 +795,86 @@ class Qwen3_VisionTransformer(nn.Module):
 
         return metadata
 
+    @staticmethod
+    def _select_packed_by_indices(
+        tensor: torch.Tensor,
+        grid_thw_list: list[list[int]],
+        keep_indices: list[torch.Tensor],
+    ) -> torch.Tensor:
+        """Select patches from a packed tensor according to keep_indices."""
+        selected = []
+        offset = 0
+        for seq_idx, (t, h, w) in enumerate(grid_thw_list):
+            seq_length = int(t) * int(h) * int(w)
+            indices = keep_indices[seq_idx].to(tensor.device)
+            selected.append(tensor[offset : offset + seq_length][indices])
+            offset += seq_length
+        return torch.cat(selected)
+
     def forward(
         self,
         x: torch.Tensor,
         grid_thw: torch.Tensor | list[list[int]],
         *,
         encoder_metadata: dict[str, torch.Tensor] | None = None,
+        keep_indices: list[torch.Tensor] | None = None,
     ) -> torch.Tensor:
         hidden_states = x.to(device=self.device, dtype=self.dtype, non_blocking=True)
         hidden_states = self.patch_embed(hidden_states)
 
-        if encoder_metadata is None:
-            if isinstance(grid_thw, list):
-                grid_thw_list = grid_thw
-            else:
-                grid_thw_list = grid_thw.tolist()
-            encoder_metadata = self.prepare_encoder_metadata(grid_thw_list)
+        grid_thw_list = grid_thw if isinstance(grid_thw, list) else grid_thw.tolist()
 
-        pos_embeds = encoder_metadata["pos_embeds"]
-        hidden_states = hidden_states + pos_embeds
+        if keep_indices is not None:
+            # PixelPrune: build encoder metadata manually after pruning.
+            pos_embeds = self.fast_pos_embed_interpolate(grid_thw_list)
+            rotary_cos, rotary_sin = self.rot_pos_emb(grid_thw_list)
+
+            hidden_states = self._select_packed_by_indices(
+                hidden_states, grid_thw_list, keep_indices
+            )
+            pos_embeds = self._select_packed_by_indices(
+                pos_embeds, grid_thw_list, keep_indices
+            )
+            rotary_cos = self._select_packed_by_indices(
+                rotary_cos, grid_thw_list, keep_indices
+            )
+            rotary_sin = self._select_packed_by_indices(
+                rotary_sin, grid_thw_list, keep_indices
+            )
+            hidden_states = hidden_states + pos_embeds
+
+            per_image_kept = [len(idx) for idx in keep_indices]
+            cu_seqlens = np.array([0] + list(np.cumsum(per_image_kept)), dtype=np.int32)
+
+            sequence_lengths = MMEncoderAttention.maybe_compute_seq_lens(
+                self.attn_backend, cu_seqlens, self.device
+            )
+            max_seqlen = torch.tensor(
+                MMEncoderAttention.compute_max_seqlen(self.attn_backend, cu_seqlens),
+                dtype=torch.int32,
+            )
+            cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+                self.attn_backend,
+                cu_seqlens,
+                self.hidden_size,
+                self.tp_size,
+                self.device,
+            )
+
+            encoder_metadata = {
+                "pos_embeds": pos_embeds,
+                "rotary_pos_emb_cos": rotary_cos,
+                "rotary_pos_emb_sin": rotary_sin,
+                "cu_seqlens": cu_seqlens,
+                "max_seqlen": max_seqlen,
+                "sequence_lengths": sequence_lengths,
+            }
+        else:
+            if encoder_metadata is None:
+                encoder_metadata = self.prepare_encoder_metadata(grid_thw_list)
+            pos_embeds = encoder_metadata["pos_embeds"]
+            hidden_states = hidden_states + pos_embeds
+
         hidden_states = hidden_states.unsqueeze(1)
 
         deepstack_feature_lists = []
@@ -1168,6 +1234,37 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
             ),
         }
 
+    def _get_dummy_images(
+        self,
+        *,
+        width: int,
+        height: int,
+        num_images: int,
+        overrides: ImageDummyOptions | None = None,
+    ) -> list[Image.Image]:
+        images = super()._get_dummy_images(
+            width=width,
+            height=height,
+            num_images=num_images,
+            overrides=overrides,
+        )
+        if not images or self.info.ctx.get_mm_config().pixel_prune_threshold is None:
+            return images
+        # PixelPrune would collapse a uniform image to one token, severely
+        # under-profiling encoder memory. A checkerboard at merged-token
+        # granularity gives every adjacent pair max distance 1.0 (> any
+        # threshold in [0, 1)), so all tokens are kept.
+        vision_config = self.info.get_hf_config().vision_config
+        block_px = vision_config.patch_size * vision_config.spatial_merge_size
+        target_w, target_h = images[0].size
+        snapped_w = max(target_w // block_px, 1) * block_px
+        snapped_h = max(target_h // block_px, 1) * block_px
+        rows = np.arange(snapped_h)[:, None] // block_px
+        cols = np.arange(snapped_w)[None, :] // block_px
+        plane = (((rows + cols) % 2) * 255).astype(np.uint8)
+        rgb = np.repeat(plane[:, :, None], 3, axis=2)
+        return [Image.fromarray(rgb) for _ in range(num_images)]
+
     def _get_dummy_videos(
         self,
         *,
@@ -1335,6 +1432,69 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
             mm_kwargs=mm_kwargs,
             tok_kwargs=tok_kwargs,
         )
+
+        pixel_prune_threshold = self.info.ctx.get_mm_config().pixel_prune_threshold
+        if pixel_prune_threshold is not None:
+            pixel_values = processed_outputs.get("pixel_values")
+            image_grid_thw = processed_outputs.get("image_grid_thw")
+            if pixel_values is not None and image_grid_thw is not None:
+                from vllm.multimodal.pixelprune import (
+                    compute_pixel_prune_keep_indices,
+                )
+
+                vision_config = self.info.get_hf_config().vision_config
+                C = vision_config.in_channels
+                T = vision_config.temporal_patch_size
+                P = vision_config.patch_size
+
+                # Static images get T identical temporal copies; keep one
+                # frame to halve the PixelPrune feature dim with the same
+                # keep set.
+                frame0 = pixel_values.view(-1, C, T, P, P)[:, :, 0]
+
+                # Keep ``prepared_pv`` and ``effective_threshold`` in the
+                # same numerical space:
+                #   threshold == 0        : space doesn't matter (byte-hash)
+                #   threshold > 0, uniform std : rescale threshold by std,
+                #       skip the reverse-normalize multiply-add
+                #   threshold > 0, otherwise : reverse-normalize into pixel
+                #       space
+                if pixel_prune_threshold > 0:
+                    image_processor = self.info.get_image_processor()
+                    std = image_processor.image_std
+                    if all(s == std[0] for s in std):
+                        prepared_pv = frame0.reshape(
+                            frame0.shape[0], C * P * P
+                        ).contiguous()
+                        effective_threshold = pixel_prune_threshold / float(std[0])
+                    else:
+                        mean_t = torch.tensor(
+                            image_processor.image_mean,
+                            dtype=pixel_values.dtype,
+                        ).view(1, C, 1, 1)
+                        std_t = torch.tensor(
+                            std,
+                            dtype=pixel_values.dtype,
+                        ).view(1, C, 1, 1)
+                        prepared_pv = (
+                            (frame0 * std_t + mean_t)
+                            .reshape(frame0.shape[0], C * P * P)
+                            .contiguous()
+                        )
+                        effective_threshold = pixel_prune_threshold
+                else:
+                    prepared_pv = frame0.reshape(
+                        frame0.shape[0], C * P * P
+                    ).contiguous()
+                    effective_threshold = pixel_prune_threshold
+
+                processed_outputs["keep_indices"] = compute_pixel_prune_keep_indices(
+                    prepared_pv,
+                    image_grid_thw,
+                    vision_config.spatial_merge_size,
+                    threshold=effective_threshold,
+                )
+
         combined_outputs = dict(
             processed_outputs,
             **video_outputs,
@@ -1346,9 +1506,14 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         hf_inputs: BatchFeature,
         hf_processor_mm_kwargs: Mapping[str, object],
     ) -> Mapping[str, MultiModalFieldConfig]:
-        return _create_qwen2vl_field_factory(
+        cfg = _create_qwen2vl_field_factory(
             self.info.get_hf_config().vision_config.spatial_merge_size
         )(hf_inputs)
+        # PixelPrune: register keep_indices field when present.
+        if "keep_indices" in hf_inputs:
+            cfg = dict(cfg)
+            cfg["keep_indices"] = MultiModalFieldConfig.batched("image")
+        return cfg
 
     def _get_prompt_updates(
         self,
@@ -1369,10 +1534,15 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
 
         def get_image_replacement_qwen3vl(item_idx: int):
             out_item = out_mm_kwargs["image"][item_idx]
-            grid_thw = out_item["image_grid_thw"].data
-            assert isinstance(grid_thw, torch.Tensor)
-
-            num_tokens = int(grid_thw.prod()) // merge_length
+            # PixelPrune: if keep_indices is present, the kept token
+            # count replaces the full grid count.
+            keep_indices = out_item.get("keep_indices")
+            if keep_indices is not None:
+                num_tokens = len(keep_indices.data) // merge_length
+            else:
+                grid_thw = out_item["image_grid_thw"].data
+                assert isinstance(grid_thw, torch.Tensor)
+                num_tokens = int(grid_thw.prod()) // merge_length
             return [hf_processor.image_token_id] * num_tokens
 
         def get_video_replacement_qwen3vl(item_idx: int):
@@ -1658,6 +1828,7 @@ class Qwen3VLForConditionalGeneration(
         self.is_multimodal_pruning_enabled = (
             multimodal_config.is_multimodal_pruning_enabled()
         )
+        self.is_pixel_prune_enabled = multimodal_config.is_pixel_prune_enabled()
 
         self.use_deepstack = hasattr(config.vision_config, "deepstack_visual_indexes")
         self.deepstack_num_level = (
@@ -1772,12 +1943,15 @@ class Qwen3VLForConditionalGeneration(
             EncoderCudaGraphConfig,
         )
 
-        # When EVS pruning is enabled, embed_multimodal post-processes both
-        # image and video embeddings (mrope positions are appended for image,
-        # prune+append for video). The encoder CUDA graph path bypasses that
-        # post-process, producing inconsistent embedding formats vs eager. So
-        # disable CUDA graph for all modalities when pruning is on.
-        modalities = [] if self.is_multimodal_pruning_enabled else ["image", "video"]
+        # NOTE: For both EVS (video) and PixelPrune (image), the number of
+        # retained tokens is data-dependent and therefore cannot be captured
+        # by CUDA Graphs. We only enable CUDA Graphs for a modality when its
+        # corresponding pruning strategy is off.
+        modalities = []
+        if not self.is_pixel_prune_enabled:
+            modalities.append("image")
+        if not self.is_multimodal_pruning_enabled:
+            modalities.append("video")
 
         # Compute max_frames_per_video for budget sizing.
         max_frames = self.get_max_frames_per_video() if "video" in modalities else 1
@@ -2042,23 +2216,30 @@ class Qwen3VLForConditionalGeneration(
         pixel_values = kwargs.pop("pixel_values", None)
         image_embeds = kwargs.pop("image_embeds", None)
         image_grid_thw = kwargs.pop("image_grid_thw", None)
+        keep_indices = kwargs.pop("keep_indices", None)
 
         if pixel_values is None and image_embeds is None:
             return None
 
         if pixel_values is not None:
-            return Qwen2_5_VLImagePixelInputs(
+            result = Qwen2_5_VLImagePixelInputs(
                 type="pixel_values",
                 pixel_values=pixel_values,
                 image_grid_thw=image_grid_thw,
             )
+            if keep_indices is not None:
+                result.keep_indices = keep_indices
+            return result
 
         if image_embeds is not None:
-            return Qwen2_5_VLImageEmbeddingInputs(
+            result = Qwen2_5_VLImageEmbeddingInputs(
                 type="image_embeds",
                 image_embeds=image_embeds,
                 image_grid_thw=image_grid_thw,
             )
+            if keep_indices is not None:
+                result.keep_indices = keep_indices
+            return result
 
     def _parse_and_validate_video_input(
         self, **kwargs: object
@@ -2095,20 +2276,37 @@ class Qwen3VLForConditionalGeneration(
         grid_thw = image_input["image_grid_thw"]
         assert grid_thw.ndim == 2
 
+        keep_indices = image_input.get("keep_indices")
+
         if image_input["type"] == "image_embeds":
             image_embeds = image_input["image_embeds"].type(self.visual.dtype)
         else:
             pixel_values = image_input["pixel_values"].type(self.visual.dtype)
             if self.use_data_parallel:
+                if keep_indices is not None:
+                    raise RuntimeError(
+                        "PixelPrune (keep_indices) is not supported "
+                        "with data parallel ViT."
+                    )
                 return run_dp_sharded_mrope_vision_model(
-                    self.visual, pixel_values, grid_thw.tolist(), rope_type="rope_3d"
+                    self.visual,
+                    pixel_values,
+                    grid_thw.tolist(),
+                    rope_type="rope_3d",
                 )
-            else:
-                image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
+            image_embeds = self.visual(
+                pixel_values,
+                grid_thw=grid_thw,
+                keep_indices=keep_indices,
+            )
 
         # Split concatenated embeddings for each image item.
         merge_size = self.visual.spatial_merge_size
-        sizes = (grid_thw.prod(-1) // merge_size // merge_size).tolist()
+        merge_length = merge_size * merge_size
+        if keep_indices is None:
+            sizes = (grid_thw.prod(-1) // merge_length).tolist()
+        else:
+            sizes = [len(idx) // merge_length for idx in keep_indices]
         return image_embeds.split(sizes)
 
     def _process_video_input(
@@ -2158,13 +2356,27 @@ class Qwen3VLForConditionalGeneration(
         """
         if self.is_multimodal_pruning_enabled:
             merge_size = self.visual.spatial_merge_size
+            merge_length = merge_size * merge_size
             grid_thw = image_input["image_grid_thw"]
             grid_thw_list = grid_thw.tolist()
+            keep_indices_all = image_input.get("keep_indices")
             image_embeds_out = []
-            for emb, size in zip(image_embeds_split, grid_thw_list):
+            for i, (emb, size) in enumerate(zip(image_embeds_split, grid_thw_list)):
                 positions = compute_mrope_for_media(size, merge_size).to(
                     emb.device, non_blocking=True
                 )
+                # When PixelPrune is also active, the corresponding image
+                # embedding has been reduced to len(keep_indices)//merge_length
+                # rows. Index `positions` by the kept merged-token rows so
+                # the cat below aligns on dim 0.
+                if keep_indices_all is not None:
+                    keep_idx = keep_indices_all[i]
+                    if not isinstance(keep_idx, torch.Tensor):
+                        keep_idx = torch.as_tensor(keep_idx)
+                    merged_idx = (keep_idx[::merge_length] // merge_length).to(
+                        positions.device
+                    )
+                    positions = positions[merged_idx]
                 positions = torch.cat(
                     [
                         positions,
@@ -2461,7 +2673,15 @@ class Qwen3VLForConditionalGeneration(
                 assert t == 1, f"Image must have 1 frame, got {t}"
                 llm_grid_h = h // spatial_merge_size
                 llm_grid_w = w // spatial_merge_size
-                yield offset, llm_grid_h, llm_grid_w, llm_grid_h * llm_grid_w
+                # PixelPrune: use reduced token count when keep_indices
+                # is present.
+                merge_length = spatial_merge_size**2
+                keep_indices = mm_feature.data.get("keep_indices")
+                if keep_indices is not None:
+                    actual_num_tokens = len(keep_indices.data) // merge_length
+                else:
+                    actual_num_tokens = llm_grid_h * llm_grid_w
+                yield offset, llm_grid_h, llm_grid_w, actual_num_tokens
             elif mm_feature.modality == "video":
                 t, h, w = mm_feature.data["video_grid_thw"].data.tolist()
                 llm_grid_h = h // spatial_merge_size
@@ -2518,6 +2738,16 @@ class Qwen3VLForConditionalGeneration(
         mm_features: list[MultiModalFeatureSpec],
         config: Qwen3VLConfig,
     ):
+        spatial_merge_size = config.vision_config.spatial_merge_size
+        merge_length = spatial_merge_size**2
+
+        # Build a map from offset → mm_feature for PixelPrune lookup.
+        image_features = sorted(
+            [f for f in mm_features if f.modality == "image"],
+            key=lambda f: f.mm_position.offset,
+        )
+        mm_feature_map = {f.mm_position.offset: f for f in image_features}
+
         llm_pos_ids_list = []
         st = 0
         for (
@@ -2531,7 +2761,7 @@ class Qwen3VLForConditionalGeneration(
             video_token_id=config.video_token_id,
             vision_start_token_id=config.vision_start_token_id,
             vision_end_token_id=config.vision_end_token_id,
-            spatial_merge_size=config.vision_config.spatial_merge_size,
+            spatial_merge_size=spatial_merge_size,
         ):
             # Skip frames with 0 tokens (EVS placeholder with tokens lumped elsewhere)
             if actual_num_tokens == 0:
@@ -2543,35 +2773,59 @@ class Qwen3VLForConditionalGeneration(
                 np.broadcast_to(np.arange(text_len), (3, text_len)) + st_idx
             )
 
-            # Check if this is a "lumped placeholder" (all tokens from multiple frames
-            # assigned to the 0-th frame - see
-            # `Qwen3VLMultiModalProcessor.get_video_repl`.
             expected_tokens_per_frame = llm_grid_h * llm_grid_w
-            if actual_num_tokens > expected_tokens_per_frame:
-                # Lumped placeholder: create grid positions for all "logical" frames
-                # represented.
+
+            # PixelPrune: recover spatial coordinates from keep_indices.
+            mm_feature = mm_feature_map.get(offset)
+            keep_indices_tensor = None
+            if mm_feature is not None:
+                raw_keep = mm_feature.data.get("keep_indices")
+                if raw_keep is not None:
+                    keep_indices_tensor = raw_keep.data
+
+            if keep_indices_tensor is not None:
+                # Convert patch-level keep_indices to merged-token indices.
+                if isinstance(keep_indices_tensor, torch.Tensor):
+                    keep_indices_np = keep_indices_tensor.cpu().numpy()
+                else:
+                    keep_indices_np = np.array(keep_indices_tensor)
+                merged_token_indices = keep_indices_np[::merge_length] // merge_length
+
+                # Recover (t, h, w) spatial coordinates from the flattened
+                # merged-token index, and shift them so the image starts
+                # right after the preceding text run.
+                tokens_per_frame = llm_grid_h * llm_grid_w
+                token_t = merged_token_indices // tokens_per_frame
+                token_hw = merged_token_indices % tokens_per_frame
+                token_h = token_hw // llm_grid_w
+                token_w = token_hw % llm_grid_w
+
+                base = text_len + st_idx
+                frame_positions = np.stack(
+                    [token_t + base, token_h + base, token_w + base],
+                    axis=0,
+                )
+                llm_pos_ids_list.append(frame_positions)
+            elif actual_num_tokens > expected_tokens_per_frame:
+                # Lumped placeholder: create grid positions for all "logical"
+                # frames represented.
                 num_logical_frames = actual_num_tokens // expected_tokens_per_frame
                 remainder = actual_num_tokens % expected_tokens_per_frame
 
-                # Create positions for complete frames.
                 for _ in range(num_logical_frames):
                     grid_indices = np.indices((1, llm_grid_h, llm_grid_w)).reshape(
                         3, -1
                     )
                     llm_pos_ids_list.append(grid_indices + text_len + st_idx)
                     st_idx = llm_pos_ids_list[-1].max() + 1
-                    text_len = 0  # No text between frames within the lump
+                    text_len = 0
 
-                # Handle remainder tokens if any (partial frame).
-                # NOTE: this should never be the case. Should we have an assert?
                 if remainder > 0:
-                    # Create a partial grid - take first 'remainder' positions
                     full_grid = np.indices((1, llm_grid_h, llm_grid_w)).reshape(3, -1)
                     grid_indices = full_grid[:, :remainder]
                     llm_pos_ids_list.append(grid_indices + text_len + st_idx)
             else:
-                # Normal case: frame has exactly the expected tokens (after actual EVS
-                # pruning).
+                # Normal case: frame has exactly the expected tokens.
                 grid_indices = np.indices((1, llm_grid_h, llm_grid_w)).reshape(3, -1)
                 llm_pos_ids_list.append(grid_indices + text_len + st_idx)
 

--- a/vllm/multimodal/pixelprune.py
+++ b/vllm/multimodal/pixelprune.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PixelPrune: pre-ViT visual token pruning via 2D predictive coding.
+
+Implements the Pred-2D selector from the PixelPrune paper
+(arXiv:2604.00886): a LOCO-I-style predictor flags redundant patches on
+the merged-token grid so they can be dropped before the ViT. Patches
+are expected in *packed merge order* (``spatial_merge_size ** 2``
+consecutive patches per merged token, Qwen-VL convention).
+"""
+
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import torch
+from numba import njit
+
+
+def _patches_equal(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """True where every element along the last dim matches."""
+    return (x - y).abs().amax(dim=-1) == 0
+
+
+# ------------------------------------------------------------------
+# Pred-2D LOCO-I selector
+# ------------------------------------------------------------------
+
+
+def select_patches_pred2d(
+    tokens: torch.Tensor,
+    h: int,
+    w: int,
+    threshold: float = 0.0,
+) -> torch.Tensor:
+    """Compute sorted keep-indices for one image's merged-token grid.
+
+    LOCO-I causal neighbourhood at position ``(r, c)``::
+
+        C  B
+        A  X
+
+    Predict B on a vertical edge (C≈A, C≠B); otherwise predict A.
+    Drop X if it matches the prediction; otherwise keep it as an anchor.
+
+    ``threshold == 0`` uses a vectorised byte-hash compare; ``threshold > 0``
+    uses an anchored serial scan against reconstructed neighbours.
+    """
+    if threshold == 0.0:
+        return _select_pred2d_vectorised(tokens, h, w)
+    return _select_pred2d_anchored(tokens, h, w, threshold)
+
+
+@functools.lru_cache(maxsize=4)
+def _get_hash_weights(D_half: int) -> np.ndarray:
+    """Fixed-seed int64 weights for the byte-view polynomial hash.
+
+    Full int64 entropy (vs a 32-bit-embedded-in-int64 variant): universal
+    hashing gives collision probability ~2^-64 per comparison instead of
+    ~2^-32, at zero runtime cost — einsum is still int64 multiply-add.
+    """
+    rng = np.random.RandomState(0xC0FFEE)
+    lo = rng.randint(0, 2**32, D_half, dtype=np.uint64)
+    hi = rng.randint(0, 2**32, D_half, dtype=np.uint64)
+    return ((hi << np.uint64(32)) | lo).view(np.int64)
+
+
+def _select_pred2d_vectorised(
+    tokens: torch.Tensor,
+    h: int,
+    w: int,
+    fingerprint: bool = True,
+) -> torch.Tensor:
+    """Vectorised exact-match path (threshold == 0).
+
+    Args:
+        fingerprint: When ``True`` (default), hash each D-dim patch to one
+            int64 via byte-view polynomial hashing so the predictor compares
+            scalars instead of D-dim vectors. CPU-only. When ``False``,
+            compares full D-dim vectors — pure-torch, device-agnostic.
+    """
+    D = tokens.shape[-1]
+    device = tokens.device
+
+    keep = torch.zeros(h, w, dtype=torch.bool, device=device)
+    keep[0, 0] = True  # anchor
+
+    if fingerprint:
+        if D % 2 != 0:
+            raise ValueError(
+                f"PixelPrune fingerprint requires even D for byte-view "
+                f"reinterpret, got D={D}."
+            )
+        # fp32 → int64 byte-view (zero-copy) → numpy int einsum.
+        # numpy's int einsum outpaces torch's int sum on CPU here.
+        t_np = tokens.to(torch.float32).contiguous().cpu().numpy()
+        t_int64 = t_np.view(np.int64).reshape(t_np.shape[0], D // 2)
+        hashed = np.einsum("nd,d->n", t_int64, _get_hash_weights(D // 2))
+        g = torch.from_numpy(hashed).to(device).view(h, w)
+
+        if w > 1:
+            keep[0, 1:] = g[0, 1:] != g[0, :-1]
+        if h > 1:
+            keep[1:, 0] = g[1:, 0] != g[:-1, 0]
+        if h > 1 and w > 1:
+            X = g[1:, 1:]  # noqa: N806
+            A = g[1:, :-1]  # noqa: N806
+            B = g[:-1, 1:]  # noqa: N806
+            C = g[:-1, :-1]  # noqa: N806
+            # Predict B on a vertical edge (C==A but C!=B); else A.
+            pred = torch.where((C == A) & (C != B), B, A)
+            keep[1:, 1:] = pred != X
+    else:
+        g = tokens.view(h, w, D)
+
+        if w > 1:
+            keep[0, 1:] = ~_patches_equal(g[0:1, 1:], g[0:1, :-1])[0]
+        if h > 1:
+            keep[1:, 0] = ~_patches_equal(g[1:, 0:1], g[:-1, 0:1])[:, 0]
+        if h > 1 and w > 1:
+            X = g[1:, 1:]  # noqa: N806
+            A = g[1:, :-1]  # noqa: N806
+            B = g[:-1, 1:]  # noqa: N806
+            C = g[:-1, :-1]  # noqa: N806
+            use_b = _patches_equal(C, A) & ~_patches_equal(C, B)
+            pred = torch.where(use_b.unsqueeze(-1), B, A)
+            keep[1:, 1:] = ~_patches_equal(X, pred)
+
+    return keep.flatten().nonzero(as_tuple=False)[:, 0]
+
+
+@njit(cache=True, nogil=True, fastmath=True, boundscheck=False)
+def _anchored_inner(g: np.ndarray, threshold: float) -> np.ndarray:
+    """Numba-compiled inner loop for the anchored LOCO-I scan.
+
+    Three L∞ reductions per cell, each with **early-exit** on first
+    over-threshold dim (avoids scanning all D dims when the answer is
+    already determined):
+
+      * ``|C-A| > t``: pred is A regardless of cb, skip ``|C-B|`` entirely.
+      * ``|x-pred| > t``: cell is kept, don't bother with max scalar.
+
+    ``np.empty_like`` instead of ``g.copy()`` saves the upfront h·w·D
+    memcpy; we write ``anchor[r, c]`` once per cell explicitly.
+    ``nogil=True`` releases the GIL so multiple images can run in parallel
+    through the renderer pool. ``fastmath`` lets LLVM reorder/vectorise
+    the abs-and-compare loops freely (safe — L∞ is associative).
+    """
+    h, w, D = g.shape
+    keep = np.zeros((h, w), dtype=np.bool_)
+    keep[0, 0] = True
+    anchor = np.empty_like(g)
+    anchor[0, 0] = g[0, 0]
+
+    for r in range(h):
+        for c in range(w):
+            if r == 0 and c == 0:
+                continue
+
+            # Top row: B falls back to A; left column: C falls back to B.
+            A = anchor[r, c - 1] if c > 0 else anchor[r - 1, 0]
+            B = anchor[r - 1, c] if r > 0 else A
+
+            if r > 0 and c > 0:
+                C = anchor[r - 1, c - 1]
+                ca_violated = False
+                for d in range(D):
+                    if abs(C[d] - A[d]) > threshold:
+                        ca_violated = True
+                        break
+                if ca_violated:
+                    pred = A
+                else:
+                    # Pick B on a vertical edge (C≈A but C≠B); else A.
+                    cb_violated = False
+                    for d in range(D):
+                        if abs(C[d] - B[d]) > threshold:
+                            cb_violated = True
+                            break
+                    pred = B if cb_violated else A
+            else:
+                pred = A
+
+            x = g[r, c]
+            keep_this = False
+            for d in range(D):
+                if abs(x[d] - pred[d]) > threshold:
+                    keep_this = True
+                    break
+
+            if keep_this:
+                keep[r, c] = True
+                # Store raw x as anchor (cell becomes its own anchor).
+                for d in range(D):
+                    anchor[r, c, d] = x[d]
+            else:
+                # Store pred (not x): downstream sees what the receiver sees.
+                for d in range(D):
+                    anchor[r, c, d] = pred[d]
+
+    return keep
+
+
+def _select_pred2d_anchored(
+    tokens: torch.Tensor,
+    h: int,
+    w: int,
+    threshold: float,
+) -> torch.Tensor:
+    """Anchored serial scan (threshold > 0); compares against reconstructed
+    neighbours so per-cell error stays bounded by one threshold step."""
+    device = tokens.device
+    # numpy doesn't support bfloat16; also numba needs contiguous fp32.
+    g = (
+        tokens.to(torch.float32)
+        .contiguous()
+        .cpu()
+        .numpy()
+        .reshape(h, w, tokens.shape[-1])
+    )
+    keep = _anchored_inner(g, float(threshold))
+    kept = np.flatnonzero(keep.ravel())
+    return torch.from_numpy(kept).to(device=device, dtype=torch.long)
+
+
+# ------------------------------------------------------------------
+# Public API
+# ------------------------------------------------------------------
+
+
+def compute_pixel_prune_keep_indices(
+    pixel_values: torch.Tensor,
+    image_grid_thw: torch.Tensor,
+    spatial_merge_size: int = 2,
+    threshold: float = 0.0,
+) -> list[torch.Tensor]:
+    """Per-image patch-level keep-indices for PixelPrune.
+
+    Images only — each ``image_grid_thw`` row must have ``t == 1``. Caller
+    decides the numerical space of ``pixel_values``: ``threshold == 0`` is
+    invariant to any per-channel affine normalization (byte-hash compares
+    bit-exact); ``threshold > 0`` is an L∞ distance in the same space as
+    the tensor, so caller must keep them consistent.
+
+    Returns one int64 patch-index tensor per image.
+    """
+    block_size = spatial_merge_size**2
+    device = pixel_values.device
+
+    merged_pv = pixel_values.reshape(-1, pixel_values.shape[-1] * block_size)
+
+    keep_indices_list: list[torch.Tensor] = []
+    offset = 0
+    block_offsets = torch.arange(block_size, device=device, dtype=torch.long)
+    for t, h, w in image_grid_thw.tolist():
+        t, h, w = int(t), int(h), int(w)
+        if t != 1:
+            raise ValueError(f"PixelPrune only supports images (t == 1), got t={t}.")
+        length = h * w // block_size
+        img_merged = merged_pv[offset : offset + length]
+        merged_h = h // spatial_merge_size
+        merged_w = w // spatial_merge_size
+
+        merged_keep = select_patches_pred2d(
+            img_merged, merged_h, merged_w, threshold=threshold
+        )
+        patch_indices = (
+            merged_keep.unsqueeze(1) * block_size + block_offsets
+        ).flatten()
+        keep_indices_list.append(patch_indices)
+        offset += length
+
+    return keep_indices_list


### PR DESCRIPTION
  ## Purpose
  
  Add **PixelPrune** visual token pruning for Qwen3-VL.
  
  - Issue: https://github.com/vllm-project/vllm/issues/39708
  - Paper: https://arxiv.org/abs/2604.00886

  Enable via `pixel_prune_threshold` (default: `None`, disabled):

  ```python
  llm = LLM(
      "Qwen/Qwen3-VL-2B-Instruct",
      pixel_prune_threshold=0,   # 0 = bit-exact hash dedup; >0 = L∞-tolerant
  )   
  ```

  On LLaVA-OneVision screen2words(cauldron) subset (Qwen3-VL-2B, 500 prompts):

| threshold | input_tok | input_tok % | req/s | TTFT p50 (ms) | TTFT p99 (ms) | TPOT p50 (ms) |
|---|---|---|---|---|---|---|
| none (baseline)      | 853,323 | 100.0% | 7.92  | 27,745 | 62,702 | 575.4 |
| 0.0 (bit-exact hash) | 441,161 |  51.7% | 12.67 | 16,491 | 38,711 |  26.7 |
| 0.005                | 411,024 |  48.2% |  9.86 | 21,921 | 50,035 |   2.5 |
| 0.02                 | 361,794 |  42.4% | 10.70 | 19,629 | 45,960 |   2.5 |
| 0.05                 | 322,925 |  37.8% | 11.20 | 19,103 | 43,810 |   2.4 |
| 0.10                 | 293,955 |  34.4% | 10.11 | 20,527 | 48,661 |   2.4 |


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

