### PR TITLE
fix: update AWQ expected outputs for Transformers v5 tokenizer

### DIFF
--- a/tests/lora/test_quant_model.py
+++ b/tests/lora/test_quant_model.py
@@ -91,8 +91,8 @@ def test_quant_model_lora(tinyllama_lora_files, model):
         ]
     elif model.quantization == "awq":
         expected_lora_output = [
-            "#f07700: A v",
-            "#f00000: A v",
+            "#f07733: A v",
+            "#f08800: A v",
         ]
     elif model.quantization == "gptq":
         expected_lora_output = [


### PR DESCRIPTION
With Transformers v5, PreTrainedTokenizerFast loads directly from tokenizer.json rather than the (incorrect) tokenizer_class in tokenizer_config.json. This changes the tokenization slightly, producing different but correct model outputs for the AWQ test.

Update the hardcoded expected values in test_quant_model_lora to match the output produced under the correct tokenizer behavior.

Fixes #38386




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
