### PR TITLE
Fix misleading error for audio duration limit rejection

### DIFF
--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -172,6 +172,8 @@ class OpenAISpeechToText(OpenAIServing):
                     sr=self.asr_config.sample_rate,
                     max_duration_s=self.max_audio_decode_duration_s,
                 )
+        except ValueError:
+            raise
         except Exception as exc:
             raise ValueError("Invalid or unsupported audio file.") from exc
 

--- a/vllm/multimodal/media/audio.py
+++ b/vllm/multimodal/media/audio.py
@@ -92,8 +92,9 @@ def load_audio_pyav(
                     raise ValueError(
                         f"Audio exceeds maximum allowed duration of "
                         f"{max_duration_s}s (metadata reports "
-                        f"{metadata_duration_s:.1f}s). This limit "
-                        f"prevents decompression-bomb attacks."
+                        f"{metadata_duration_s:.1f}s). Set "
+                        f"VLLM_MAX_AUDIO_DECODE_DURATION_S to "
+                        f"increase this limit."
                     )
 
             max_samples = (
@@ -129,8 +130,9 @@ def load_audio_pyav(
                     raise ValueError(
                         f"Audio exceeds maximum allowed duration of "
                         f"{max_duration_s}s (decoded {total_samples} "
-                        f"samples at {sr}Hz). This limit prevents "
-                        f"decompression-bomb attacks."
+                        f"samples at {sr}Hz). Set "
+                        f"VLLM_MAX_AUDIO_DECODE_DURATION_S to "
+                        f"increase this limit."
                     )
     except (ValueError, ImportError):
         raise
@@ -166,8 +168,9 @@ def load_audio_soundfile(
                 raise ValueError(
                     f"Audio exceeds maximum allowed duration of "
                     f"{max_duration_s}s (file contains "
-                    f"{file_duration_s:.1f}s at {native_sr}Hz). "
-                    f"This limit prevents decompression-bomb attacks."
+                    f"{file_duration_s:.1f}s at {native_sr}Hz). Set "
+                    f"VLLM_MAX_AUDIO_DECODE_DURATION_S to "
+                    f"increase this limit."
                 )
         y = f.read(dtype="float32", always_2d=False).T
 


### PR DESCRIPTION
Let the descriptive ValueError from load_audio propagate directly instead of catching it and re-raising a generic "Invalid or unsupported audio file" message.  Also update the error messages to mention the VLLM_MAX_AUDIO_DECODE_DURATION_S env var so users know how to increase the limit.