### PR TITLE
fix: call parent init in EagleMistralLarge3Model to set use_mha

### DIFF
--- a/vllm/model_executor/models/mistral_large_3_eagle.py
+++ b/vllm/model_executor/models/mistral_large_3_eagle.py
@@ -75,6 +75,15 @@ class EagleMistralLarge3Model(DeepseekV2Model):
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.aux_hidden_state_layers: tuple[int, ...] = ()
+
+        # Set use_mha so DeepseekV2DecoderLayer.forward can read it
+        # when called via super().forward().
+        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
+        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
+        self.use_mha = config.model_type == "deepseek" or all(
+            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
+        )
+
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )


### PR DESCRIPTION
Fixes #44846

## Problem

`EagleMistralLarge3Model.__init__` calls `nn.Module.__init__(self)` directly, bypassing `DeepseekV2Model.__init__`. This means `self.use_mha` is never set, causing an `AttributeError` when the EAGLE drafter's `forward` calls `super().forward()` into `DeepseekV2DecoderLayer.forward`, which reads `self.use_mha`.

## Fix

Add the same `use_mha` computation that exists in `DeepseekV2Model.__init__` to `EagleMistralLarge3Model.__init__`, so the attribute is available when decoder layers execute their forward pass.

## Traceback

```
AttributeError: 'EagleMistralLarge3Model' object has no attribute 'use_mha'
```

in `DeepseekV2DecoderLayer.forward` at the `if not self.use_mha:` check.