### PR TITLE
fix: compensate timestamp drift in Whisper chunked transcription

### DIFF
--- a/tests/entrypoints/speech_to_text/test_speech_to_text_cancellation.py
+++ b/tests/entrypoints/speech_to_text/test_speech_to_text_cancellation.py
@@ -53,7 +53,7 @@ async def test_non_streaming_cancel_aborts_engine_requests(
     server.asr_config = SimpleNamespace(max_audio_clip_s=30)
     server._check_model = AsyncMock(return_value=None)
     server._maybe_get_adapters = Mock(return_value=None)
-    server._preprocess_speech_to_text = AsyncMock(return_value=(engine_inputs, 40.0))
+    server._preprocess_speech_to_text = AsyncMock(return_value=(engine_inputs, 40.0, [0.0]))
     server._log_inputs = Mock()
 
     request = SimpleNamespace(
@@ -122,7 +122,7 @@ async def test_non_streaming_cancel_advances_all_chunk_generators():
     server.asr_config = SimpleNamespace(max_audio_clip_s=30)
     server._check_model = AsyncMock(return_value=None)
     server._maybe_get_adapters = Mock(return_value=None)
-    server._preprocess_speech_to_text = AsyncMock(return_value=(engine_inputs, 90.0))
+    server._preprocess_speech_to_text = AsyncMock(return_value=(engine_inputs, 90.0, [0.0]))
     server._log_inputs = Mock()
 
     request = SimpleNamespace(

--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
@@ -227,7 +227,7 @@ async def test_create_transcription_non_streaming_joins_chunks_by_language():
     models.lora_requests = {}
     models.is_base_model.return_value = True
 
-    preprocess_mock = AsyncMock(return_value=([MagicMock(), MagicMock()], 1.0))
+    preprocess_mock = AsyncMock(return_value=([MagicMock(), MagicMock()], 1.0, [0.0, 0.5]))
 
     with (
         patch(

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -194,7 +194,7 @@ class OpenAISpeechToText(OpenAIServing):
         request: SpeechToTextRequest,
         audio_data: bytes,
         request_id: str,
-    ) -> tuple[list[EngineInput], float]:
+    ) -> tuple[list[EngineInput], float, list[float]]:
         # Validate request
         request.language = self.model_cls.validate_language(request.language)
         request.to_language = (
@@ -273,7 +273,18 @@ class OpenAISpeechToText(OpenAIServing):
 
         engine_inputs = await self.renderer.render_cmpl_async(parsed_prompts)
 
-        return engine_inputs, duration
+        # Compute cumulative start offsets from actual chunk lengths so that
+        # segment timestamps stay in sync even when split_audio places
+        # boundaries before the nominal chunk duration (e.g. at 29.5s instead
+        # of 30s).  Without this, each segment's timestamps drift by up to
+        # ~0.5 s per chunk.
+        chunk_start_offsets: list[float] = []
+        cumulative = 0.0
+        for chunk in chunks:
+            chunk_start_offsets.append(cumulative)
+            cumulative += get_audio_duration(y=chunk, sr=sr)
+
+        return engine_inputs, duration, chunk_start_offsets
 
     def _preprocess_verbose_prompt(self, prompt: EncoderDecoderDictPrompt):
         dec_prompt = prompt["decoder_prompt"]
@@ -434,10 +445,12 @@ class OpenAISpeechToText(OpenAIServing):
 
         lora_request = self._maybe_get_adapters(request)
 
-        engine_inputs, duration_s = await self._preprocess_speech_to_text(
-            request=request,
-            audio_data=audio_data,
-            request_id=request_id,
+        engine_inputs, duration_s, chunk_start_offsets = (
+            await self._preprocess_speech_to_text(
+                request=request,
+                audio_data=audio_data,
+                request_id=request_id,
+            )
         )
 
         # Schedule the request and get the result generator.
@@ -549,16 +562,12 @@ class OpenAISpeechToText(OpenAIServing):
                 "translate": TranslationSegment,
             }
             segment_class: type[SpeechToTextSegment] = segments_types[self.task_type]
-            chunk_size_in_s = self.asr_config.max_audio_clip_s
-            if chunk_size_in_s is None:
-                assert len(list_result_generator) == 1, (
-                    "`max_audio_clip_s` is set to None, audio cannot be chunked"
-                )
             result_generator = merge_async_iterators(*list_result_generator)
             async for idx, op in result_generator:
-                start_time = (
-                    float(idx * chunk_size_in_s) if chunk_size_in_s is not None else 0.0
-                )
+                # Use cumulative actual chunk offsets rather than
+                # idx * nominal_chunk_size to avoid timestamp drift when
+                # split_audio places boundaries before the nominal duration.
+                start_time = chunk_start_offsets[idx]
                 if request.response_format == "verbose_json":
                     assert op.outputs[0].logprobs
                     segments: list[SpeechToTextSegment] = self._get_verbose_segments(


### PR DESCRIPTION
Fixes #32588

## Problem
When transcribing audio longer than 30s, segment-level timestamps drift by ~0.5s per chunk, accumulating over long audio (e.g. 5s off after 10 segments).

The root cause:  searches a 1-second window before the nominal 30s boundary for a low-energy split point, so chunks may actually be 29.2s, 29.5s, 29.8s, etc. However, the timestamp calculation used  (i.e. ), ignoring the actual chunk boundaries.

## Fix
- Modified  to compute cumulative start offsets from actual chunk lengths and return them alongside engine inputs.
- Modified  to use these cumulative offsets () instead of the nominal .
- Updated test mocks that patched  to return the new 3-tuple.

## Files Changed
-  -- core fix
-  -- updated mock return values
-  -- updated mock return values