### PR TITLE
Fix LFM2 ShortConv quant config propagation

### DIFF
--- a/tests/model_executor/test_lfm2_quantization.py
+++ b/tests/model_executor/test_lfm2_quantization.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock, patch
+
+import torch
+from torch import nn
+
+
+def set_unspecified_platform():
+    import vllm.platforms as platforms
+    from vllm.platforms.interface import UnspecifiedPlatform
+
+    platforms._current_platform = UnspecifiedPlatform()
+
+
+def test_lfm2_short_conv_layer_receives_quant_config():
+    set_unspecified_platform()
+    from vllm.model_executor.models.lfm2 import Lfm2ShortConvDecoderLayer
+
+    mock_quant_config = Mock()
+    mock_config = Mock()
+    mock_config.conv_dim = 64
+    mock_config.hidden_size = 64
+    mock_config.block_dim = 64
+    mock_config.intermediate_size = 128
+    mock_config.block_multiple_of = 16
+    mock_config.block_auto_adjust_ff_dim = False
+    mock_config.block_ffn_dim_multiplier = None
+    mock_config.norm_eps = 1e-5
+
+    with (
+        patch("vllm.model_executor.models.lfm2.ShortConv") as mock_short_conv,
+        patch("vllm.model_executor.models.lfm2.Lfm2MLP"),
+        patch("vllm.model_executor.models.lfm2.RMSNorm"),
+    ):
+        Lfm2ShortConvDecoderLayer(
+            config=mock_config,
+            layer_idx=0,
+            quant_config=mock_quant_config,
+            prefix="model.layers.0",
+        )
+
+    mock_short_conv.assert_called_once()
+    assert mock_short_conv.call_args.kwargs["quant_config"] is mock_quant_config
+
+
+def test_lfm2_moe_short_conv_layer_receives_quant_config():
+    set_unspecified_platform()
+    from vllm.model_executor.models.lfm2_moe import Lfm2MoeShortConvDecoderLayer
+
+    mock_quant_config = Mock()
+    mock_config = Mock()
+    mock_config.hidden_size = 64
+    mock_config.num_dense_layers = 1
+    mock_config.intermediate_size = 128
+    mock_config.norm_eps = 1e-5
+
+    with (
+        patch("vllm.model_executor.models.lfm2_moe.ShortConv") as mock_short_conv,
+        patch("vllm.model_executor.models.lfm2_moe.Lfm2MoeMlp"),
+        patch("vllm.model_executor.models.lfm2_moe.RMSNorm"),
+    ):
+        Lfm2MoeShortConvDecoderLayer(
+            config=mock_config,
+            layer_idx=0,
+            quant_config=mock_quant_config,
+            prefix="model.layers.0",
+        )
+
+    mock_short_conv.assert_called_once()
+    assert mock_short_conv.call_args.kwargs["quant_config"] is mock_quant_config
+
+
+def test_short_conv_projection_linears_receive_quant_config():
+    set_unspecified_platform()
+    from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+    from vllm.model_executor.layers.mamba.short_conv import ShortConv
+
+    mock_quant_config = Mock()
+    mock_config = Mock()
+    mock_config.conv_L_cache = 3
+    mock_config.conv_bias = False
+
+    column_calls = []
+    merged_column_calls = []
+    row_calls = []
+
+    def make_fake_linear(*args, **kwargs):
+        module = nn.Module()
+        module.weight = nn.Parameter(torch.empty(1, 1))
+        module.bias = None
+        return module
+
+    def make_fake_column_linear(*args, **kwargs):
+        column_calls.append(kwargs)
+        return make_fake_linear(*args, **kwargs)
+
+    def make_fake_merged_column_linear(*args, **kwargs):
+        merged_column_calls.append(kwargs)
+        return make_fake_linear(*args, **kwargs)
+
+    def make_fake_row_linear(*args, **kwargs):
+        row_calls.append(kwargs)
+        return make_fake_linear(*args, **kwargs)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.mamba.short_conv.ColumnParallelLinear",
+            side_effect=make_fake_column_linear,
+        ),
+        patch(
+            "vllm.model_executor.layers.mamba.short_conv.MergedColumnParallelLinear",
+            side_effect=make_fake_merged_column_linear,
+        ),
+        patch(
+            "vllm.model_executor.layers.mamba.short_conv.RowParallelLinear",
+            side_effect=make_fake_row_linear,
+        ),
+        set_current_vllm_config(VllmConfig(device_config=DeviceConfig("cpu"))),
+    ):
+        ShortConv(
+            config=mock_config,
+            dim=64,
+            layer_idx=0,
+            quant_config=mock_quant_config,
+            prefix="model.layers.0.short_conv",
+        )
+
+    assert "quant_config" not in column_calls[0]
+    assert merged_column_calls[0]["quant_config"] is mock_quant_config
+    assert row_calls[0]["quant_config"] is mock_quant_config

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
@@ -41,6 +42,7 @@ class ShortConv(MambaBase, CustomOp):
         layer_idx: int,
         model_config: ModelConfig | None = None,
         cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -66,12 +68,14 @@ class ShortConv(MambaBase, CustomOp):
             input_size=dim,
             output_sizes=[dim] * 3,
             bias=self.bias,
+            quant_config=quant_config,
             prefix=f"{prefix}.in_proj",
         )
         self.out_proj = RowParallelLinear(
             input_size=dim,
             output_size=dim,
             bias=self.bias,
+            quant_config=quant_config,
             prefix=f"{prefix}.out_proj",
         )
 

--- a/vllm/model_executor/models/lfm2.py
+++ b/vllm/model_executor/models/lfm2.py
@@ -259,6 +259,7 @@ class Lfm2ShortConvDecoderLayer(nn.Module):
             layer_idx=layer_idx,
             model_config=model_config,
             cache_config=cache_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.conv",
         )
 

--- a/vllm/model_executor/models/lfm2_moe.py
+++ b/vllm/model_executor/models/lfm2_moe.py
@@ -355,6 +355,7 @@ class Lfm2MoeShortConvDecoderLayer(nn.Module):
             layer_idx=layer_idx,
             model_config=model_config,
             cache_config=cache_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.conv",
         )
 


### PR DESCRIPTION
## Summary

Propagate `quant_config` into LFM2 ShortConv projection layers so quantized LFM2 checkpoints can instantiate packed parameters for `short_conv.in_proj` and `short_conv.out_proj`.

LFM2 already passes `quant_config` through attention and MLP layers, and its loader already maps HF `.conv.` names to vLLM `.short_conv.` names. The remaining gap was that `ShortConv` constructed its projection linears without `quant_config`, so compressed-tensors checkpoints with packed short-conv projections could fail during weight loading with missing packed parameter names.

This change:
- adds an optional `quant_config` argument to `ShortConv`;
- passes it to `in_proj` and `out_proj` while keeping the depthwise conv path unchanged;
- wires the value through LFM2 and LFM2-MoE short-conv decoder layers;
- adds constructor-level regression coverage.

## Testing

```bash
PYTHONPATH=. /root/np-quantizer-v2/.venv/bin/python -m pytest --confcutdir=tests/model_executor tests/model_executor/test_lfm2_quantization.py
uv run --no-project --with ruff ruff check vllm/model_executor/layers/mamba/short_conv.py vllm/model_executor/models/lfm2.py vllm/model_executor/models/lfm2_moe.py tests/model_executor/test_lfm2_quantization.py
uv run --no-project --with ruff ruff format --check vllm/model_executor/layers/mamba/short_conv.py vllm/model_executor/models/lfm2.py vllm/model_executor/models/lfm2_moe.py tests/model_executor/test_lfm2_quantization.py
```