### PR TITLE
[Core][Perf] Cap Torch intra-op threads in UniProcExecutor to avoid CPU oversubscription

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     VLLM_TRACE_FUNCTION: int = 0
     VLLM_USE_FLASHINFER_SAMPLER: bool = True
     VLLM_PP_LAYER_PARTITION: str | None = None
+    VLLM_UNIPROC_OMP_THREADS: int | None = None
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
     VLLM_CPU_OMP_THREADS_BIND: str = "auto"
     VLLM_CPU_NUM_OF_RESERVED_CPU: int | None = None
@@ -907,6 +908,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # this path $VLLM_ASSETS_CACHE/model_streamer/$model_name
     "VLLM_ASSETS_CACHE_MODEL_CLEAN": lambda: bool(
         int(os.getenv("VLLM_ASSETS_CACHE_MODEL_CLEAN", "0"))
+    ),
+    # Cap on Torch intra-op threads for the single-process (uni) executor.
+    # None -> use the executor's conservative built-in default; 0 (or less)
+    # -> leave Torch's default untouched. An explicit OMP_NUM_THREADS always
+    # takes precedence over this value.
+    "VLLM_UNIPROC_OMP_THREADS": lambda: (
+        int(os.environ["VLLM_UNIPROC_OMP_THREADS"])
+        if "VLLM_UNIPROC_OMP_THREADS" in os.environ
+        else None
     ),
     # Timeout for fetching images when serving multimodal models
     # Default is 5 seconds

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -23,6 +23,61 @@ from vllm.v1.worker.worker_base import WorkerWrapperBase
 logger = init_logger(__name__)
 
 
+# The single-process executor runs the model in the same process that also
+# handles scheduling and the CPU-side multimodal input path (e.g. torch.concat
+# in MultiModalFlatField._reduce_data). By default PyTorch sizes its intra-op
+# thread pool to the number of physical cores, which oversubscribes the CPU for
+# these memory-bandwidth-bound ops. Under concurrency -- and especially inside
+# containers with CFS quotas -- thread oversubscription actively *slows down*
+# concat instead of speeding it up.
+#
+# Unlike MultiprocExecutor (N worker processes x 1 thread each), a single
+# process should keep a small thread pool near the memory-bandwidth "knee"
+# rather than collapsing to 1 thread (which makes concat slower) or spawning a
+# thread per core (which causes contention). Empirically the knee is well below
+# the core count, so we cap to a small default that users can override via
+# OMP_NUM_THREADS or VLLM_UNIPROC_OMP_THREADS.
+_UNIPROC_DEFAULT_OMP_THREADS = 4
+
+
+def _maybe_limit_uniproc_omp_threads() -> None:
+    """Cap Torch intra-op parallelism for the single-process executor.
+
+    Only lowers the thread count, never raises it, and always defers to an
+    explicit ``OMP_NUM_THREADS`` set in the environment. Set
+    ``VLLM_UNIPROC_OMP_THREADS=0`` to disable this behavior and leave Torch's
+    default untouched.
+    """
+    # Respect an explicit OMP_NUM_THREADS from the user/deployment.
+    if "OMP_NUM_THREADS" in os.environ:
+        return
+
+    target = envs.VLLM_UNIPROC_OMP_THREADS
+    if target is None:
+        target = _UNIPROC_DEFAULT_OMP_THREADS
+
+    # Non-positive means "leave Torch's default untouched".
+    if target <= 0:
+        return
+
+    current = torch.get_num_threads()
+    target = min(current, target)
+    if target >= current:
+        return
+
+    logger.warning(
+        "Reducing Torch intra-op parallelism from %d to %d threads to avoid "
+        "CPU oversubscription in the single-process (uni) executor. This "
+        "memory-bandwidth-bound path (e.g. multimodal torch.concat) does not "
+        "scale to all cores and contends under concurrency. Set "
+        "OMP_NUM_THREADS or VLLM_UNIPROC_OMP_THREADS to tune this value.",
+        current,
+        target,
+    )
+    os.environ["OMP_NUM_THREADS"] = str(target)
+    torch.set_num_threads(target)
+
+
 class AsyncOutputFuture(Future):
     def __init__(self, async_output: AsyncModelRunnerOutput, single_value: bool):
         self.async_output = async_output
@@ -45,6 +100,7 @@ class AsyncOutputFuture(Future):
 class UniProcExecutor(Executor):
     def _init_executor(self) -> None:
         """Initialize the worker and load the model."""
+        _maybe_limit_uniproc_omp_threads()
         self.driver_worker = WorkerWrapperBase(rpc_rank=0)
         distributed_init_method, rank, local_rank = self._distributed_args()
         kwargs = dict(


### PR DESCRIPTION
UniProcExecutor (default for single-GPU TP=1) does not cap Torch's intra-op (OpenMP/ATen) thread count, so PyTorch sizes its thread pool to the number of physical cores. This hurts the CPU-side multimodal path: torch.concat in MultiModalFlatField._reduce_data runs on the CPU before the H2D transfer and is memory-bandwidth-bound. Past a low thread count it stops scaling, and under concurrency the per-core threads contend; inside containers with CFS quotas this oversubscription actively slows concat down (EngineCore saturates all cores while concat latency grows).

MultiprocExecutor already guards against this via
set_multiprocessing_worker_envs() (OMP_NUM_THREADS=1), but that path is N processes x 1 thread. A single process should not collapse to 1 thread (which makes concat slower) -- it should sit near the memory-bandwidth knee. UniProcExecutor had no equivalent governance.

Add thread governance to UniProcExecutor._init_executor:
- Cap intra-op threads to a conservative default (4) when unset.
- Only lower the count, never raise it.
- Always defer to an explicit OMP_NUM_THREADS.
- Add VLLM_UNIPROC_OMP_THREADS to tune the cap; 0 disables governance.

Scoped to the single-process executor; mp/ray/external-launcher paths are unaffected.




## Purpose

The single-process executor (`UniProcExecutor`, the default for single-GPU
`TP=1` deployments) does not cap Torch's intra-op (OpenMP/ATen) thread count.
By default PyTorch sizes its thread pool to the number of physical cores, so the
EngineCore process spawns one thread per core.

This hurts the CPU-side multimodal input path. In `MultiModalFlatField._reduce_data`
(`vllm/multimodal/inputs.py`), `torch.concat` runs on the CPU *before* the H2D
transfer. `torch.concat` is memory-bandwidth-bound: past a low thread count it
stops scaling, and under concurrency the per-core threads contend. Inside
containers with CFS quotas this oversubscription actively *slows down* concat
rather than speeding it up. The symptom is `VLLM::EngineCore` saturating all CPU
cores while concat latency degrades.

`MultiprocExecutor` already guards against this via
`set_multiprocessing_worker_envs()` (it forces `OMP_NUM_THREADS=1`), but that
path is N processes × 1 thread. A single process should not collapse to 1 thread
(that makes concat *slower*) — it should keep a small pool near the
memory-bandwidth knee. `UniProcExecutor` had no equivalent governance, and the
latest `main` still doesn't.

This PR adds thread governance to `UniProcExecutor._init_executor`:

- Caps Torch intra-op threads to a conservative default (`4`) when nothing is
  explicitly configured.
- **Only lowers** the count, never raises it.
- **Always defers** to an explicit `OMP_NUM_THREADS` set in the environment.
- Adds a new env `VLLM_UNIPROC_OMP_THREADS` to tune the cap; set it to `0` to
  disable governance and keep Torch's default.

This is an opt-out, conservative change scoped to the single-process executor
and does not affect `MultiprocExecutor` / Ray / external-launcher paths.

## Test Plan

Microbenchmark of `torch.concat` on the multimodal `_reduce_data` shapes across
thread counts, both in isolation and under concurrent CPU contention (threads
pinned to the available cores with concurrent busy workers), to locate the
memory-bandwidth knee.

Behavioral unit checks of the new helper `_maybe_limit_uniproc_omp_threads()`
and the `VLLM_UNIPROC_OMP_THREADS` env resolution:

- default (14 cores, nothing set) → capped to 4
- `OMP_NUM_THREADS=10` set → untouched (14)
- `VLLM_UNIPROC_OMP_THREADS=0` → disabled (untouched)
- `VLLM_UNIPROC_OMP_THREADS=6` → capped to 6
- current threads (2) already below cap → never raised

## Test Result

Isolated `torch.concat` latency vs. thread count:

| Threads | Latency |
|--------:|--------:|
| 1       | 99.6 ms |
| **4**   | **31 ms** |
| 14      | ~31–35 ms (no further gain) |

Under concurrent CPU contention:

| Threads | Latency |
|--------:|--------:|
| 14      | ~275 ms |
| **4**   | **~35 ms** |

→ 14 threads is ~8–10× slower than 4 under contention, while 1 thread is ~3×
slower than 4 in isolation. The default cap of 4 sits at the knee.

Behavioral checks — all pass:

| Case | Result |
|------|--------|
| default 14 → cap 4 | threads=4  |
| `OMP_NUM_THREADS=10` → untouched | threads=14  |
| `VLLM_UNIPROC_OMP_THREADS=0` → disabled | threads=14  |
| `VLLM_UNIPROC_OMP_THREADS=6` → 6 | threads=6  |
| current=2 < cap → never raise | threads=2  |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

