### PR TITLE
[Bugfix][LoRA] Fail fast on FP8 MoE + LoRA instead of cryptic Triton crash

### DIFF
--- a/tests/lora/test_moe_lora_fp8_guard.py
+++ b/tests/lora/test_moe_lora_fp8_guard.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the MoE-LoRA fp8-activation guard (issue #45101).
+
+When an FP8 base MoE is combined with LoRA, the activations reaching the
+Triton MoE-LoRA shrink kernel are fp8, which would force an unsupported mixed
+``fp8 x bf16`` ``tl.dot`` and crash during the profiling forward with
+``AssertionError: Unsupported lhs dtype fp8e4nv``. The guard turns that cryptic
+failure into a clear, actionable error. These tests are CPU-only -- they only
+exercise the dtype check, not any kernel.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.experts.lora_experts_mixin import (
+    _assert_lora_activation_supported,
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_moe_lora_rejects_fp8_activations(dtype):
+    x = torch.empty((4, 8), dtype=dtype)
+    with pytest.raises(NotImplementedError, match="FP8-quantized activations"):
+        _assert_lora_activation_supported(x)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_moe_lora_allows_non_fp8_activations(dtype):
+    # Non-fp8 activations must pass through without raising.
+    _assert_lora_activation_supported(torch.empty((4, 8), dtype=dtype))

--- a/vllm/model_executor/layers/fused_moe/experts/lora_experts_mixin.py
+++ b/vllm/model_executor/layers/fused_moe/experts/lora_experts_mixin.py
@@ -5,6 +5,42 @@ import torch
 
 from vllm.model_executor.layers.fused_moe.experts.lora_context import MoELoRAContext
 
+# FP8 activation dtypes the Triton MoE-LoRA kernels cannot consume. The LoRA
+# shrink computes ``tl.dot(x, lora_a)`` and Triton only permits fp8 operands
+# when *both* are fp8. LoRA adapters are bf16/fp16, so an fp8 activation ``x``
+# (produced by an FP8 base MoE) forces an unsupported mixed fp8 x bf16 dot,
+# which fails with ``AssertionError: Unsupported lhs dtype fp8e4nv`` during the
+# profiling forward. See https://github.com/vllm-project/vllm/issues/45101.
+_FP8_ACTIVATION_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2fnuz,
+)
+
+
+def _assert_lora_activation_supported(x: torch.Tensor) -> None:
+    """Fail fast with a clear message if MoE-LoRA gets fp8 activations.
+
+    Args:
+        x: The activation tensor fed into the MoE-LoRA shrink kernel.
+
+    Raises:
+        NotImplementedError: If ``x`` is FP8-quantized, since the Triton
+            MoE-LoRA kernels require bf16/fp16 activations.
+    """
+    if x.dtype in _FP8_ACTIVATION_DTYPES:
+        raise NotImplementedError(
+            "MoE LoRA is not supported with FP8-quantized activations "
+            f"(the base MoE produced {x.dtype} activations). The Triton "
+            "MoE-LoRA kernels require bf16/fp16 activations because the LoRA "
+            "shrink does tl.dot(x, lora_a) and LoRA adapters are bf16/fp16, "
+            "so an fp8 activation forces an unsupported fp8 x bf16 dot. Serve "
+            "the base model in bf16/fp16 to use LoRA, or omit --enable-lora "
+            "to serve the FP8 model without LoRA. See "
+            "https://github.com/vllm-project/vllm/issues/45101."
+        )
+
 
 class LoRAExpertsMixin:
     """
@@ -52,6 +88,7 @@ class LoRAExpertsMixin:
         torch.Tensor | None,
         torch.Tensor | None,
     ]:
+        _assert_lora_activation_supported(x)
         return lora_context.punica_wrapper.add_lora_w13(
             y,
             x,
@@ -92,6 +129,7 @@ class LoRAExpertsMixin:
         top_k_num: int,
         add_inputs: bool = True,
     ) -> None:
+        _assert_lora_activation_supported(x)
         lora_context.punica_wrapper.add_lora_w2(
             y,
             x,


### PR DESCRIPTION
## Purpose

Fixes #45101. FP8-quantized MoE combined with `--enable-lora` crashes during engine-core init (the memory-profiling forward) with:

```
File ".../triton/language/semantic.py", in dot
AssertionError: Unsupported lhs dtype fp8e4nv
RuntimeError: Engine core initialization failed.
```

This makes that combination **fail fast with a clear, actionable message** instead of a cryptic Triton assertion.

### Root cause

With an FP8 base MoE, the activations reaching the experts are fp8-quantized (with a separate `a1q_scale`). `TritonExperts.apply()` passes that fp8 activation buffer straight into the MoE-LoRA path (`apply_w13_lora(x=hidden_states)` / `apply_w2_lora(x=intermediate_cache2)`). The Triton MoE-LoRA shrink kernel (`_fused_moe_lora_one_shot_kernel` / `_fused_moe_lora_small_batch_kernel`) then computes `tl.dot(x, lora_a)`.

Triton's `dot` only allows fp8 operands when **both** are fp8; LoRA adapters are bf16/fp16, so this is an unsupported mixed `fp8 x bf16` dot, which trips the assertion. A naive in-kernel `x.to(bf16)` upcast would silence the crash but be **numerically wrong** (it drops `a1q_scale`), so this PR guards instead. Full enablement (dequantizing fp8 activations for the LoRA path) is left as a follow-up.

This only triggers with **FP8 MoE + LoRA**: FP8 MoE without LoRA, and bf16 MoE + LoRA, both work fine.

### Fix

Guard in the shared `LoRAExpertsMixin` (used by the Triton, Marlin and gpt-oss expert backends), so a single check covers all of them: if the activation entering the MoE-LoRA path is fp8, raise a clear `NotImplementedError` telling the user to serve in bf16/fp16 or drop `--enable-lora`. This matches the "fail fast with a clear message" behavior requested in the issue.

## Test Plan

Hardware: NVIDIA RTX PRO 6000 Blackwell (sm_120), vLLM 0.22.x, triton 3.6.0, torch 2.11+cu130.

1. Repro (issue config + LoRA): `vllm serve Qwen/Qwen3.6-35B-A3B-FP8 --enable-lora --max-lora-rank 64 --enforce-eager --max-model-len 4096 --trust-remote-code`
2. Negative (no false positive): `allenai/OLMoE-1B-7B-0924-Instruct --enable-lora --max-lora-rank 64` (bf16 MoE + LoRA)
3. Negative (unaffected): `Qwen/Qwen3.6-35B-A3B-FP8` **without** `--enable-lora`
4. New unit test: `tests/lora/test_moe_lora_fp8_guard.py`
5. Lint: `pre-commit run ruff-check` / `ruff-format` on changed files

## Test Result

1. **before:** `AssertionError: Unsupported lhs dtype fp8e4nv` (traceback through `vllm/lora/ops/triton_ops/fused_moe_lora_op.py::_fused_moe_lora_one_shot_kernel`), engine init fails. **after:** fails fast with `NotImplementedError: MoE LoRA is not supported with FP8-quantized activations ...`.
2. Starts cleanly (`init engine ... took 4.25 s`, `Application startup complete`) — guard does not trigger on bf16.
3. Starts cleanly and serves (`2+2=` → `5`) — unaffected.
4. `tests/lora/test_moe_lora_fp8_guard.py` passes (fp8 raises, bf16/fp16/fp32 pass).
5. ruff-check + ruff-format pass.

Minimal Triton repro of the underlying restriction on sm_120 (for reference):
```
fp8e4nv x bf16    -> CRASH: Unsupported lhs dtype fp8e4nv
fp8e4nv x fp8e4nv -> OK
bf16 x bf16       -> OK
```

## Not a duplicate

No open PR references #45101. Existing sm_120/sm_121 MoE PRs (#43814 CUTLASS grouped GEMM, #43333/#43341 B12x NVFP4, #43730 Marlin-MoE `c_tmp` clamp, #36183 sm121 NVFP4 clone) address different kernels/paths; none touch the MoE-LoRA fp8 activation guard. The issue's own hypothesis (base-MoE backend selection / `VLLM_MOE_FORCE_MARLIN`) turned out to be unrelated — the crash is specifically the MoE-LoRA shrink kernel, and `VLLM_MOE_FORCE_MARLIN` is not a real vLLM env var (the documented escape hatch is `VLLM_TEST_FORCE_FP8_MARLIN`, which only affects the base MoE).

## AI assistance

This change was developed with AI assistance (Claude Code): reproduction, root-cause analysis, the fix, and the validation above were carried out on sm_120 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
