### PR TITLE
[BugFix] Fix ModelOpt NVFP4 lm_head weight loading failure

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -14,12 +14,12 @@ import torch
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm.config.model import ModelConfig
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
     ModelOptMixedPrecisionConfig,
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
+    ModelOptNvFp4UnquantizedLMHeadMethod,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -110,7 +110,7 @@ def test_modelopt_nvfp4_leaves_excluded_parallel_lm_head_unquantized():
 
     method = config.get_quant_method(_mock_lm_head(), prefix="lm_head")
 
-    assert isinstance(method, UnquantizedLinearMethod)
+    assert isinstance(method, ModelOptNvFp4UnquantizedLMHeadMethod)
 
 
 def test_modelopt_mixed_precision_quantizes_parallel_lm_head():

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1102,33 +1102,13 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
-        # Handle KV-cache quantization first (same as base class).
-        if isinstance(layer, (Attention, MLAAttention)):
-            return self.KVCacheMethodCls(self)
-
         # When lm_head is excluded but checkpoint has NVFP4 tensors,
         # use the special unquantized method that registers placeholders.
-        if self.is_layer_excluded(prefix):
-            if isinstance(layer, (LinearBase, ParallelLMHead)):
-                return ModelOptNvFp4UnquantizedLMHeadMethod(self)
-            return None
-
-        # Vision modules are never quantized.
-        if (
-            "vision_tower" in prefix
-            or "vision_model" in prefix
-            or "vit_large_projector" in prefix
+        if self.is_layer_excluded(prefix) and isinstance(
+            layer, (LinearBase, ParallelLMHead)
         ):
-            return UnquantizedLinearMethod()
-
-        # Quantized linear layers.
-        if isinstance(layer, (LinearBase, ParallelLMHead)):
-            quant_method = self.LinearMethodCls(self)
-            if getattr(quant_method, "backend", "") == "marlin":
-                quant_method.marlin_input_dtype = get_marlin_input_dtype(prefix)
-            return quant_method
-
-        return None
+            return ModelOptNvFp4UnquantizedLMHeadMethod(self)
+        return super().get_quant_method(layer, prefix)
 
 
 class ModelOptNvFp4LinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1099,6 +1099,37 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
             group_size,
         )
 
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> "QuantizeMethodBase | None":
+        # Handle KV-cache quantization first (same as base class).
+        if isinstance(layer, (Attention, MLAAttention)):
+            return self.KVCacheMethodCls(self)
+
+        # When lm_head is excluded but checkpoint has NVFP4 tensors,
+        # use the special unquantized method that registers placeholders.
+        if self.is_layer_excluded(prefix):
+            if isinstance(layer, (LinearBase, ParallelLMHead)):
+                return ModelOptNvFp4UnquantizedLMHeadMethod(self)
+            return None
+
+        # Vision modules are never quantized.
+        if (
+            "vision_tower" in prefix
+            or "vision_model" in prefix
+            or "vit_large_projector" in prefix
+        ):
+            return UnquantizedLinearMethod()
+
+        # Quantized linear layers.
+        if isinstance(layer, (LinearBase, ParallelLMHead)):
+            quant_method = self.LinearMethodCls(self)
+            if getattr(quant_method, "backend", "") == "marlin":
+                quant_method.marlin_input_dtype = get_marlin_input_dtype(prefix)
+            return quant_method
+
+        return None
+
 
 class ModelOptNvFp4LinearMethod(LinearMethodBase):
     """Linear method for Model Optimizer NVFP4.
@@ -1230,6 +1261,97 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
+
+
+class ModelOptNvFp4UnquantizedLMHeadMethod(LinearMethodBase):
+    """Handles lm_head excluded from quantization with NVFP4 checkpoint tensors.
+
+    NVIDIA ModelOpt exports lm_head as quantized (with input_scale, weight_scale,
+    weight_scale_2), but vLLM's exclude_modules typically excludes lm_head from
+    quantization. This method registers placeholder parameters so the checkpoint
+    tensors can be loaded, then discards them — lm_head runs unquantized.
+    """
+
+    def __init__(self, quant_config: ModelOptNvFp4Config) -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        del input_size, output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        # Unquantized weight (same as UnquantizedLinearMethod)
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        # Placeholder parameters for NVFP4 checkpoint tensors.
+        # These allow the weight loader to find and consume the tensors
+        # from the checkpoint; they are discarded after loading.
+        input_scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("input_scale", input_scale)
+
+        weight_scale_2 = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale_2", weight_scale_2)
+
+        # Per-block weight scale (shape matches NVFP4 structure)
+        weight_scale = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.quant_config.group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Discard the NVFP4 quantization placeholders — lm_head runs unquantized.
+        for attr in ("input_scale", "weight_scale_2", "weight_scale"):
+            if hasattr(layer, attr):
+                delattr(layer, attr)
+
+        logger.warning_once(
+            "lm_head has NVFP4 quantization tensors in the checkpoint but is "
+            "excluded from quantization (exclude_modules). Running lm_head "
+            "unquantized."
+        )
+
+        # Transpose weight for inference (same as UnquantizedLinearMethod)
+        layer.weight = Parameter(layer.weight.t(), requires_grad=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return torch.nn.functional.linear(x, layer.weight, bias)
 
 
 class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):


### PR DESCRIPTION
## Purpose

Fix `nvidia/Qwen3.6-35B-A3B-NVFP4` and similar ModelOpt NVFP4 checkpoints that fail during weight loading:

```
ValueError: There is no module or parameter named 'lm_head.input_scale'
```

Closes #44081

### Root Cause

ModelOpt NVFP4 checkpoints export `lm_head` with four quantized tensors (`weight`, `input_scale`, `weight_scale`, `weight_scale_2`), but `hf_quant_config.json` includes `"lm_head*"` in `exclude_modules`, telling vLLM to skip quantizing `lm_head`. When excluded, vLLM returns `UnquantizedLinearMethod` which only registers `weight` — the three extra scale tensors have nowhere to load.

### Approach

Honor `exclude_modules` — `lm_head` runs unquantized. Register placeholder parameters for the NVFP4 scale tensors so they load successfully, then discard them in `process_weights_after_loading` with a warning. This follows the existing pattern in `ModelOptNvFp4W4A16LinearMethod`.

> **Note on alternatives**: PR #35660 takes a different approach — making `lm_head` run quantized (honoring the weights over `exclude_modules`). Our choice prioritizes the config's explicit exclusion directive, with a warning so users know `lm_head` is running unquantized.

### Changes

- `vllm/model_executor/layers/quantization/modelopt.py`:
  - Add `ModelOptNvFp4UnquantizedLMHeadMethod` — registers placeholder params for scale tensors, discards after loading
  - Add `get_quant_method()` override to `ModelOptNvFp4Config` — intercepts excluded lm_head case, delegates all other paths to `super()` (KV-cache, vision, MoE, quantized linear)

## Test Plan

```bash
pytest tests/quantization/test_modelopt.py -v
vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4  # requires GPU
```

## Test Result

**Before:** `ValueError: There is no module or parameter named 'lm_head.input_scale'`

**After:** `9 passed, 5 skipped`
