### PR TITLE
[Bugfix][V1] Use device-aware timeout for execute_model RPC on CPU

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -371,9 +371,11 @@ class MessageQueue:
         # Default of 24MiB chosen to be large enough to accommodate grammar
         # bitmask tensors for large batches (1024 requests).
         max_chunk_bytes: int = 1024 * 1024 * 24,
-        max_chunks: int = 10,
+        max_chunks: int | None = None,
         connect_ip: str | None = None,
     ):
+        if max_chunks is None:
+            max_chunks = envs.VLLM_MQ_MAX_CHUNKS
         if local_reader_ranks is None:
             local_reader_ranks = list(range(n_local_reader))
         else:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -208,6 +208,7 @@ if TYPE_CHECKING:
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
+    VLLM_MQ_MAX_CHUNKS: int = 10
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
     VLLM_SSM_CONV_STATE_LAYOUT: Literal["SD", "DS"] | None = None
@@ -1652,6 +1653,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # processes via zmq.
     "VLLM_MQ_MAX_CHUNK_BYTES_MB": lambda: int(
         os.getenv("VLLM_MQ_MAX_CHUNK_BYTES_MB", "16")
+    ),
+    # Control the max number of chunks in the shared memory ring buffer.
+    # Larger values allow more buffering but increase shared memory usage.
+    # CPU inference benefits from larger values (default 256 when on CPU and
+    # the env var is unset; 10 otherwise).
+    "VLLM_MQ_MAX_CHUNKS": lambda: int(
+        os.getenv("VLLM_MQ_MAX_CHUNKS", "10")
     ),
     # Timeout in seconds for execute_model RPC calls in multiprocessing
     # executor (only applies when TP > 1).

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -66,6 +66,19 @@ from vllm.v1.worker.worker_base import WorkerWrapperBase
 
 logger = init_logger(__name__)
 
+# CPU needs a longer RPC timeout than the GPU default (issue #44862).
+_CPU_EXECUTE_MODEL_TIMEOUT_SECONDS = 3600
+
+
+def _get_execute_model_timeout() -> int:
+    timeout = envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+    if (
+        os.environ.get("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS") is None
+        and current_platform.is_cpu()
+    ):
+        timeout = max(timeout, _CPU_EXECUTE_MODEL_TIMEOUT_SECONDS)
+    return timeout
+
 
 class FutureWrapper(Future):
     def __init__(
@@ -312,7 +325,7 @@ class MultiprocExecutor(Executor):
             args=(scheduler_output,),
             unique_reply_rank=self.output_rank,
             non_block=non_block,
-            timeout=envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS,
+            timeout=_get_execute_model_timeout(),
             kv_output_aggregator=self.kv_output_aggregator,
         )
 
@@ -324,7 +337,7 @@ class MultiprocExecutor(Executor):
             args=(grammar_output,),
             unique_reply_rank=self.output_rank,
             non_block=non_block,
-            timeout=envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS,
+            timeout=_get_execute_model_timeout(),
             kv_output_aggregator=self.kv_output_aggregator,
         )
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -69,6 +69,11 @@ logger = init_logger(__name__)
 # CPU needs a longer RPC timeout than the GPU default (issue #44862).
 _CPU_EXECUTE_MODEL_TIMEOUT_SECONDS = 3600
 
+# Enqueue timeout — should be much shorter than the dequeue (RPC) timeout.
+# If we can't write to the ring buffer within this window, the worker is
+# likely deadlocked and waiting longer won't help.
+_ENQUEUE_TIMEOUT_SECONDS = 60
+
 
 def _get_execute_model_timeout() -> int:
     timeout = envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
@@ -78,6 +83,19 @@ def _get_execute_model_timeout() -> int:
     ):
         timeout = max(timeout, _CPU_EXECUTE_MODEL_TIMEOUT_SECONDS)
     return timeout
+
+
+def _get_mq_max_chunks() -> int:
+    """Get the max number of chunks for the shared memory ring buffer.
+
+    CPU inference benefits from a larger ring buffer because workers may
+    hold chunks for a long time during slow forward passes (issue #44862).
+    Default: 256 on CPU, 10 on GPU.  Configurable via VLLM_MQ_MAX_CHUNKS.
+    """
+    max_chunks = envs.VLLM_MQ_MAX_CHUNKS
+    if os.environ.get("VLLM_MQ_MAX_CHUNKS") is None and current_platform.is_cpu():
+        max_chunks = 256
+    return max_chunks
 
 
 class FutureWrapper(Future):
@@ -165,6 +183,7 @@ class MultiprocExecutor(Executor):
                 self.world_size,
                 self.local_world_size,
                 max_chunk_bytes=max_chunk_bytes,
+                max_chunks=_get_mq_max_chunks(),
                 connect_ip=mq_connect_ip,
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()
@@ -384,7 +403,10 @@ class MultiprocExecutor(Executor):
             send_method = method
         else:
             send_method = cloudpickle.dumps(method, protocol=pickle.HIGHEST_PROTOCOL)
-        self.rpc_broadcast_mq.enqueue((send_method, args, kwargs, output_rank))
+        self.rpc_broadcast_mq.enqueue(
+            (send_method, args, kwargs, output_rank),
+            timeout=_ENQUEUE_TIMEOUT_SECONDS,
+        )
 
         response_mqs: Sequence[MessageQueue] = self.response_mqs
         if output_rank is not None:
@@ -581,7 +603,7 @@ class WorkerProc:
             )
 
             # Initializes a message queue for sending the model output
-            self.worker_response_mq = MessageQueue(1, 1)
+            self.worker_response_mq = MessageQueue(1, 1, max_chunks=_get_mq_max_chunks())
             self.peer_response_handles = []
         else:
             # Initialize remote MessageQueue for receiving SchedulerOutput across nodes
@@ -949,7 +971,7 @@ class WorkerProc:
         else:
             result = (WorkerProc.ResponseStatus.SUCCESS, output)
         if (response_mq := self.worker_response_mq) is not None:
-            response_mq.enqueue(result)
+            response_mq.enqueue(result, timeout=_ENQUEUE_TIMEOUT_SECONDS)
 
     def handle_output(self, output: Any):
         """Handles output from the worker. If async scheduling is enabled,


### PR DESCRIPTION
## Summary

Fix `EngineDeadError` when running MoE models on CPU with large concurrent decode batches. The root cause is a **ring buffer deadlock** in vLLM's multiproc executor — the shared memory broadcast mechanism was designed for GPU latency (ms), and when applied to CPU MoE inference (where a single forward pass can take hundreds of seconds), the 10-slot ring buffer fills up instantly and both executor and worker deadlock waiting for each other.

Related: #44862

## Root Cause

The deadlock chain:
1. Executor sends `execute_model` → worker starts slow MoE forward (pure Python for-loop over experts, each doing two matrix multiplications)
2. Executor sends next `execute_model` → ring buffer 10 slots all occupied → `acquire_write(timeout=None)` spins forever
3. After 300s, executor's response dequeue times out → `TimeoutError`
4. Worker finishes computing, tries to enqueue response → response ring buffer also full → worker also hangs on `acquire_write`
5. Both sides wait forever — deadlock

Two independent bugs:
- **enqueue write has no timeout** (`shm_broadcast.py:549-586`, `acquire_write(timeout=None)`) — blocks forever when buffer is full
- **Ring buffer only 10 slots** (`shm_broadcast.py:376`) — sufficient for GPU (ms latency) but instantly exhausted on CPU (100s of seconds per forward)

## Changes

1. **Add 60s timeout to executor enqueue** (`multiproc_executor.py`)
   - `collective_rpc` now passes timeout to `rpc_broadcast_mq.enqueue()`
   - On timeout, exception propagates through `collective_rpc → execute_model` path, engine fails fast instead of hanging

2. **Add 60s timeout to worker response enqueue** (`multiproc_executor.py`)
   - Worker's `response_mq.enqueue()` now has timeout
   - On timeout, worker raises exception → detected by death pipe → executor shuts down gracefully

3. **Configurable ring buffer capacity** (`shm_broadcast.py`)
   - New env var `VLLM_MQ_MAX_CHUNKS` controls `max_chunks`
   - Default: CPU 256, GPU 10 (unchanged)
   - Users can override with `export VLLM_MQ_MAX_CHUNKS=N`

## What this does NOT fix

- **CPU MoE forward performance** — `cpu_fused_moe.py` still uses a Python for-loop over experts. This is a separate issue and will be addressed in a follow-up PR.
- This PR prevents deadlock (fail fast + more buffer headroom), but does not speed up CPU inference itself.
