### PR TITLE
  [KvConnector]  Fix cupy-cuda13x installed on CUDA 12 images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -958,6 +958,8 @@ ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 11.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 RUN --mount=type=cache,target=/opt/uv/cache \
     --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \
+    --mount=type=bind,source=requirements/kv_connectors_cu12.txt,target=/tmp/kv_connectors_cu12.txt,ro \
+    --mount=type=bind,source=requirements/kv_connectors_cu13.txt,target=/tmp/kv_connectors_cu13.txt,ro \
     CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
     CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
     CUDA_HOME=/usr/local/cuda; \
@@ -966,11 +968,16 @@ RUN --mount=type=cache,target=/opt/uv/cache \
                 libcublas-dev-${CUDA_VERSION_DASH} \
                 libcusolver-dev-${CUDA_VERSION_DASH}"; \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
+        KV_CONNECTORS_FILE="/tmp/kv_connectors_cu${CUDA_MAJOR}.txt"; \
+        if [ ! -f "$KV_CONNECTORS_FILE" ]; then \
+            echo "Warning: No kv_connectors file for CUDA ${CUDA_MAJOR}, falling back to CUDA 12"; \
+            KV_CONNECTORS_FILE="/tmp/kv_connectors_cu12.txt"; \
+        fi; \
+        uv pip install --system -r "$KV_CONNECTORS_FILE" --no-build || ( \
             # if the above fails, install from source
             apt-get update -y && \
             apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
-            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
+            uv pip install --system -r "$KV_CONNECTORS_FILE" --no-build-isolation && \
             apt-get purge -y ${BUILD_PKGS} && \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,6 +1,3 @@
 lmcache >= 0.3.9
-# CuPy 14.1.0 imports pytest from cupy.testing._random. Use <14.1.0
-# until a fixed newer release is verified for runtime images.
-cupy-cuda13x < 14.1.0
 nixl >= 1.1.0 # Required for disaggregated prefill
 mooncake-transfer-engine >= 0.3.8

--- a/requirements/kv_connectors_cu12.txt
+++ b/requirements/kv_connectors_cu12.txt
@@ -1,0 +1,4 @@
+-r kv_connectors.txt
+# CuPy 14.1.0 imports pytest from cupy.testing._random. Use <14.1.0
+# until a fixed newer release is verified for runtime images.
+cupy-cuda12x < 14.1.0

--- a/requirements/kv_connectors_cu13.txt
+++ b/requirements/kv_connectors_cu13.txt
@@ -1,0 +1,4 @@
+-r kv_connectors.txt
+# CuPy 14.1.0 imports pytest from cupy.testing._random. Use <14.1.0
+# until a fixed newer release is verified for runtime images.
+cupy-cuda13x < 14.1.0


### PR DESCRIPTION
  fix: https://github.com/vllm-project/vllm/issues/45156
  split kv_connectors.txt into CUDA-version-specific files to avoid
  installing cupy-cuda13x on CUDA 12 systems.

  - kv_connectors.txt: common dependencies only
  - kv_connectors_cu12.txt: common + cupy-cuda12x
  - kv_connectors_cu13.txt: common + cupy-cuda13x
  - Dockerfile: select the correct cupy variant based on CUDA_MAJOR
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

