### PR TITLE
[Bugfix] Clean up ModelOpt LM head state before tying weights

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -6,6 +6,7 @@ Run `pytest tests/quantization/test_modelopt.py`.
 """
 
 import os
+from types import SimpleNamespace
 from typing import Any, NoReturn
 from unittest.mock import MagicMock, Mock, patch
 
@@ -13,16 +14,20 @@ import pytest
 import torch
 
 from tests.quantization.utils import is_quant_method_supported
+from vllm.config import set_current_vllm_config
 from vllm.config.model import ModelConfig
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
+    ModelOptFp8LinearMethod,
     ModelOptMixedPrecisionConfig,
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
+    UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
 )
 
@@ -59,6 +64,68 @@ def _mock_lm_head() -> Mock:
     lm_head = Mock(spec=ParallelLMHead)
     lm_head.__class__ = ParallelLMHead
     return lm_head
+
+
+class _UnsupportedTiedWeightMethod(QuantizeMethodBase):
+    def create_weights(
+        self, layer: torch.nn.Module, *weight_args, **extra_weight_attrs
+    ):
+        raise AssertionError("create_weights should not be called")
+
+    def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
+        raise AssertionError("apply should not be called")
+
+    def tie_weight(
+        self, target_layer: torch.nn.Module, source_layer: torch.nn.Module
+    ) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support tying weights"
+        )
+
+
+def _make_modelopt_fp8_lm_head_and_embedding():
+    config = ModelOptFp8Config(
+        quant_method="FP8",
+        is_checkpoint_fp8_serialized=True,
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+    )
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16))
+
+    with (
+        patch(
+            "vllm.model_executor.layers.vocab_parallel_embedding."
+            "get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm.model_executor.layers.vocab_parallel_embedding."
+            "get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.init_fp8_linear_kernel",
+            return_value=MagicMock(),
+        ),
+        set_current_vllm_config(vllm_config),
+    ):
+        lm_head = ParallelLMHead(
+            8,
+            4,
+            quant_config=config,
+            prefix="lm_head",
+        )
+        embed_tokens = VocabParallelEmbedding(8, 4)
+
+    return lm_head, embed_tokens
 
 
 def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionConfig:
@@ -124,6 +191,43 @@ def test_modelopt_mixed_precision_quantizes_parallel_lm_head():
         method = config.get_quant_method(_mock_lm_head(), prefix="lm_head")
 
     assert isinstance(method, ModelOptNvFp4LinearMethod)
+
+
+def test_modelopt_tied_lm_head_uses_unquantized_embedding_method():
+    lm_head, embed_tokens = _make_modelopt_fp8_lm_head_and_embedding()
+
+    assert isinstance(lm_head.quant_method, ModelOptFp8LinearMethod)
+    assert "weight_scale" in lm_head._parameters
+    assert "input_scale" in lm_head._parameters
+
+    lm_head = lm_head.tie_weights(embed_tokens)
+
+    assert lm_head.weight is embed_tokens.weight
+    assert lm_head.quant_method is embed_tokens.quant_method
+    assert isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod)
+    assert "weight_scale" not in lm_head._parameters
+    assert "input_scale" not in lm_head._parameters
+
+
+def test_modelopt_cleanup_quant_state_only_supports_parallel_lm_head():
+    lm_head, _ = _make_modelopt_fp8_lm_head_and_embedding()
+
+    with pytest.raises(NotImplementedError, match="only supports cleaning"):
+        lm_head.quant_method.cleanup_quant_state(torch.nn.Linear(4, 4))
+
+
+def test_lm_head_tie_weights_fails_for_unsupported_quantized_embedding_method():
+    lm_head, embed_tokens = _make_modelopt_fp8_lm_head_and_embedding()
+    original_weight = lm_head.weight
+    embed_tokens.quant_method = _UnsupportedTiedWeightMethod()
+
+    with pytest.raises(NotImplementedError, match="does not support tying weights"):
+        lm_head.tie_weights(embed_tokens)
+
+    assert lm_head.weight is original_weight
+    assert isinstance(lm_head.quant_method, ModelOptFp8LinearMethod)
+    assert "weight_scale" not in lm_head._parameters
+    assert "input_scale" not in lm_head._parameters
 
 
 def test_vocab_parallel_embedding_weight_loader_accepts_scalar_scale():

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -47,6 +47,18 @@ class QuantizeMethodBase(ABC):
         Expects create_weights to have been called before on the layer."""
         raise NotImplementedError
 
+    def tie_weight(self, target_layer: nn.Module, source_layer: nn.Module) -> None:
+        """Tie the target layer's weight to the source layer."""
+        # Backward compatibility: keep the default equivalent to the old direct
+        # weight assignment. Quant methods with auxiliary parameters or buffers
+        # should override cleanup_quant_state or tie_weight as needed.
+        target_layer.weight = source_layer.weight
+        target_layer.quant_method = source_layer.quant_method
+
+    def cleanup_quant_state(self, layer: nn.Module) -> None:
+        """Clean up quantization state owned by this method."""
+        return
+
     def process_weights_after_loading(self, layer: nn.Module) -> None:
         """Process the weight after loading.
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -435,7 +435,24 @@ class ModelOptFp8Config(ModelOptQuantConfigBase):
         )
 
 
-class ModelOptFp8LinearMethod(LinearMethodBase):
+class ModelOptLinearMethodBase(LinearMethodBase):
+    """Base class for ModelOpt linear methods."""
+
+    def cleanup_quant_state(self, layer: torch.nn.Module) -> None:
+        if not isinstance(layer, ParallelLMHead):
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports cleaning quantization "
+                f"state for {ParallelLMHead.__name__}, got "
+                f"{type(layer).__name__}"
+            )
+        for name in tuple(layer._parameters):
+            if name not in ("weight", "bias"):
+                delattr(layer, name)
+        for name in tuple(layer._buffers):
+            delattr(layer, name)
+
+
+class ModelOptFp8LinearMethod(ModelOptLinearMethodBase):
     """Linear method for Model Optimizer static quantization.
     Supports loading FP8 checkpoints with static weight scale and
     activation scale. Future support might be added for dynamic
@@ -530,7 +547,7 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         return self.fp8_linear.apply_weights(layer, x, bias)
 
 
-class ModelOptFp8PcPtLinearMethod(LinearMethodBase):
+class ModelOptFp8PcPtLinearMethod(ModelOptLinearMethodBase):
     """Linear method for ModelOpt FP8_PER_CHANNEL_PER_TOKEN checkpoints.
 
     Expected checkpoint structure (per Linear):
@@ -611,7 +628,7 @@ class ModelOptFp8PcPtLinearMethod(LinearMethodBase):
         return self.fp8_linear.apply_weights(layer, x, bias)
 
 
-class ModelOptFp8PbWoLinearMethod(LinearMethodBase):
+class ModelOptFp8PbWoLinearMethod(ModelOptLinearMethodBase):
     """Linear method for ModelOpt FP8_PB_WO checkpoints.
 
     ModelOpt exports `weight_scale` as a 4D tensor:
@@ -1100,7 +1117,7 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         )
 
 
-class ModelOptNvFp4LinearMethod(LinearMethodBase):
+class ModelOptNvFp4LinearMethod(ModelOptLinearMethodBase):
     """Linear method for Model Optimizer NVFP4.
     Supports loading NVFP4 checkpoints with the following structure:
 
@@ -1232,7 +1249,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 
-class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
+class ModelOptNvFp4W4A16LinearMethod(ModelOptLinearMethodBase):
     """Linear method for ModelOpt NVFP4 W4A16.
 
     4-bit NVFP4 weights, fp16/bf16 activations. Loads ModelOpt-style names
@@ -1746,7 +1763,7 @@ class ModelOptMxFp8Config(ModelOptQuantConfigBase):
         )
 
 
-class ModelOptMxFp8LinearMethod(LinearMethodBase):
+class ModelOptMxFp8LinearMethod(ModelOptLinearMethodBase):
     """Linear method for ModelOpt MXFP8 quantization."""
 
     def __init__(self, quant_config: ModelOptMxFp8Config) -> None:

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -566,7 +566,8 @@ class ParallelLMHead(VocabParallelEmbedding):
         if self.quant_config and self.quant_config.get_name() == "gguf":
             return embed_tokens
         else:
-            self.weight = embed_tokens.weight
+            self.quant_method.cleanup_quant_state(self)
+            embed_tokens.quant_method.tie_weight(self, embed_tokens)
             return self
 
     def forward(self, input_):


### PR DESCRIPTION

## Purpose
Fixes a regression introduced by PR #42124 where ModelOpt-quantized ParallelLMHead layers could leave unused quantization scale tensors registered after tying LM head weights to the token embedding table. Those stale tensors could remain on the meta device during model loading and crash some models, including `nvidia/llama-nemotron-embed-vl-1b-v2-fp8`:
```
(EngineCore pid=429)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/model_loader/base_loader.py", line 80, in load_model
(EngineCore pid=429)     process_weights_after_loading(model, model_config, target_device)
(EngineCore pid=429)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/model_loader/utils.py", line 111, in process_weights_after_loading
(EngineCore pid=429)     quant_method.process_weights_after_loading(module)
(EngineCore pid=429)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/modelopt.py", line 515, in process_weights_after_loading
(EngineCore pid=429)     if not (layer.weight_scale == layer.weight_scale[0]).all():
(EngineCore pid=429)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=429)   File "/usr/local/lib/python3.12/dist-packages/torch/_meta_registrations.py", line 8086, in meta_local_scalar_dense
(EngineCore pid=429)     raise RuntimeError("Tensor.item() cannot be called on meta tensors")
(EngineCore pid=429) RuntimeError: Tensor.item() cannot be called on meta tensors
```

## Test Plan
```
pytest tests/quantization/test_modelopt.py -q -k "tied_lm_head or cleanup_quant_state or unsupported_quantized_embedding_method"

vllm serve nvidia/llama-nemotron-embed-vl-1b-v2-fp8 --trust-remote-code
```

## Test Result

