### PR TITLE
[BugFix] Reset num_output_placeholders on KV load failure recomputation

### DIFF
--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -478,3 +478,145 @@ def test_async_recompute_blocks_not_cached_when_invalid(
 
     # request should be in the running queue
     assert request in recompute_scheduler.running
+
+
+def test_update_invalid_blocks_resets_output_placeholders_branch1(
+    recompute_scheduler: Scheduler,
+):
+    """
+    Regression test for #45138 — Branch 1 (unique invalid block).
+
+    When _update_requests_with_invalid_blocks truncates num_computed_tokens
+    at the first invalid block, it must also reset num_output_placeholders to 0.
+    Stale placeholders from a prior schedule step would corrupt scheduling
+    arithmetic in subsequent steps (num_new_tokens would include the stale
+    placeholder count), permanently stranding the request in the running queue.
+    """
+    block_size = recompute_scheduler.block_size
+
+    num_prompt_blocks = 100
+    num_prompt_tokens = num_prompt_blocks * block_size
+
+    request = create_request(num_tokens=num_prompt_tokens)
+    recompute_scheduler.add_request(request=request)
+
+    scheduler_output = recompute_scheduler.schedule()
+
+    assert request.num_computed_tokens > 0
+    original_num_computed_tokens = request.num_computed_tokens
+
+    request.num_output_placeholders = 1
+
+    allocated = recompute_scheduler.kv_cache_manager.get_block_ids(
+        request.request_id
+    )
+    req_block_ids = allocated[0]
+    invalid_block_idx = 50
+    invalid_block_id = req_block_ids[invalid_block_idx]
+
+    affected, total_tokens, _ = (
+        recompute_scheduler._update_requests_with_invalid_blocks(
+            [request],
+            {invalid_block_id},
+            scheduler_output.num_scheduled_tokens,
+        )
+    )
+
+    assert request.request_id in affected, (
+        "request must be marked affected when an invalid block is detected"
+    )
+    assert request.num_output_placeholders == 0, (
+        f"num_output_placeholders should be reset to 0 after invalid-block "
+        f"recomputation, but got {request.num_output_placeholders}"
+    )
+    assert request.num_computed_tokens < original_num_computed_tokens, (
+        "num_computed_tokens must be truncated past the invalid block"
+    )
+
+    expected_truncated = invalid_block_idx * block_size
+    assert request.num_computed_tokens == expected_truncated, (
+        f"num_computed_tokens should be {expected_truncated}, "
+        f"got {request.num_computed_tokens}"
+    )
+    assert total_tokens > 0, (
+        "total_affected_tokens must be positive when tokens are lost to "
+        "an invalid block"
+    )
+
+
+def test_update_invalid_blocks_resets_output_placeholders_branch2(
+    recompute_scheduler: Scheduler,
+):
+    """
+    Regression test for #45138 — Branch 2 (shared-block fallthrough).
+
+    When two requests share the same invalid block, the second request
+    skips the first-hit truncation (marked_invalid_block remains False)
+    and instead has its num_computed_tokens adjusted backward to the
+    externally-computed-token boundary. num_output_placeholders must also
+    be reset to 0 on this path, otherwise the stale placeholder count
+    leaks through and corrupts scheduling arithmetic.
+    """
+    block_size = recompute_scheduler.block_size
+
+    request_a = create_request(
+        request_id=101, num_tokens=100 * block_size, common_prefix_len=0
+    )
+    request_b = create_request(
+        request_id=102,
+        num_tokens=100 * block_size,
+        common_prefix_len=80 * block_size,
+    )
+
+    recompute_scheduler.add_request(request_a)
+    recompute_scheduler.add_request(request_b)
+
+    recompute_scheduler.schedule()
+
+    request_a.num_output_placeholders = 1
+    request_b.num_output_placeholders = 1
+
+    blocks_a = recompute_scheduler.kv_cache_manager.get_block_ids(
+        request_a.request_id
+    )[0]
+    blocks_b = recompute_scheduler.kv_cache_manager.get_block_ids(
+        request_b.request_id
+    )[0]
+
+    shared_block_idx = 40
+    assert blocks_a[shared_block_idx] == blocks_b[shared_block_idx], (
+        "common-prefix requests must share blocks at index "
+        f"{shared_block_idx}"
+    )
+
+    invalid_block_id = blocks_a[shared_block_idx]
+
+    # Simulate both requests having externally-computed tokens.
+    external_tokens = 60 * block_size
+    request_a.num_computed_tokens = external_tokens
+    request_b.num_computed_tokens = external_tokens
+
+    affected, _, _ = recompute_scheduler._update_requests_with_invalid_blocks(
+        [request_a, request_b],
+        {invalid_block_id},
+        {},
+    )
+
+    assert request_a.request_id in affected
+    assert request_a.num_output_placeholders == 0, (
+        "request A (Branch 1): num_output_placeholders should be reset to 0, "
+        f"got {request_a.num_output_placeholders}"
+    )
+    assert request_a.num_computed_tokens == shared_block_idx * block_size, (
+        "request A: num_computed_tokens should be truncated to the invalid "
+        f"block boundary ({shared_block_idx * block_size}), "
+        f"got {request_a.num_computed_tokens}"
+    )
+
+    assert request_b.request_id in affected, (
+        "request B must be marked affected when it shares an invalid block"
+    )
+    assert request_b.num_output_placeholders == 0, (
+        "request B (Branch 2): num_output_placeholders should be reset to 0, "
+        f"got {request_b.num_output_placeholders}"
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2325,6 +2325,10 @@ class Scheduler(SchedulerInterface):
                 marked_invalid_block = True
                 # Truncate the computed tokens at the first failed block
                 request.num_computed_tokens = idx * self.block_size
+                # Reset output placeholders since recomputation restarts
+                # from the prefill phase and stale placeholders from a
+                # prior schedule would corrupt scheduling arithmetic.
+                request.num_output_placeholders = 0
                 num_affected_tokens = (
                     req_num_computed_tokens - request.num_computed_tokens
                 )
@@ -2345,6 +2349,10 @@ class Scheduler(SchedulerInterface):
                         request.num_computed_tokens - req_num_computed_tokens
                     )
                     request.num_computed_tokens = req_num_computed_tokens
+                    # Reset output placeholders since recomputation restarts
+                    # from the prefill phase and stale placeholders from a
+                    # prior schedule would corrupt scheduling arithmetic.
+                    request.num_output_placeholders = 0
 
                 affected_req_ids.add(request.request_id)
 


### PR DESCRIPTION
## Related Issue

Closes: #45138

## Description

When a request's KV blocks fail to load via the KV connector and recomputation is triggered, only `num_computed_tokens` was being reset to the longest valid prefix boundary in `_update_requests_with_invalid_blocks`. However, `num_output_placeholders`, which may have been incremented by `AsyncScheduler._update_after_schedule` before the forward pass, was left stale.

This caused the scheduling arithmetic in subsequent steps to be corrupted: `num_new_tokens` would include the stale placeholder count (`num_new_tokens = num_tokens_with_spec + num_output_placeholders - num_computed_tokens`), leading to an overflow that eventually triggers the async-scheduling stop check prematurely, permanently stranding the request in the running queue.

## Root Cause Analysis

The complete bug trigger path:

1. Request enters with all prompt tokens hitting prefix cache → `num_computed_tokens` covers full prompt
2. `is_prefill_chunk` evaluates to `False` → `AsyncScheduler._update_after_schedule` increments `num_output_placeholders += 1`
3. Model forward runs, KV connector reports load failure for the cached blocks
4. `_handle_invalid_blocks` → `_update_requests_with_invalid_blocks` correctly resets `num_computed_tokens` to the longest valid prefix, but **does not reset `num_output_placeholders`** (the bug)
5. `update_from_output` skips the request (it's in `failed_kv_load_req_ids`), so `num_output_placeholders` is never decremented
6. On next schedule: `num_new_tokens = num_tokens + 1 - 0` instead of `num_tokens - 0`, corrupting scheduling arithmetic
7. Request eventually triggers the stuck check and is permanently stranded

## Fix

Reset `request.num_output_placeholders = 0` in both branches of `_update_requests_with_invalid_blocks` where `num_computed_tokens` is adjusted downward due to invalid blocks. This is consistent with the existing preemption path in `reset_prefix_cache` (scheduler.py:1971) which also zeroes placeholders when restarting prefill from scratch.

## Testing

- Verified via code-flow analysis simulating the exact scenario from the issue
- Confirmed the fix prevents the stale-placeholder scheduling corruption
- The change is purely CPU-side scheduler logic — no GPU required