### PR TITLE
[Kernel] Fuse per-group FP8 dynamic quant into Triton attention epilogue

### DIFF
--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -30,12 +30,18 @@ from vllm.config import (
 )
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
+    kFp8Dynamic64Sym,
+    kFp8Dynamic128Sym,
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -222,8 +228,51 @@ class TestAttentionNvfp4QuantPatternModel(AttentionQuantPatternModel):
         )
 
 
+class TestAttentionFp8GroupQuantPatternModel(AttentionQuantPatternModel):
+    """Test model for AttnFp8GroupQuantPattern fusion (dynamic per-group FP8).
+
+    The forward does attention -> per_token_group_quant_fp8 -> dequant, which
+    is the pattern the fusion folds into attention(output_block_scale=scale).
+    The dequant (instead of a real block GEMM) keeps the test free of extra
+    weights while still using both quant outputs so they appear in the graph.
+    """
+
+    quant_key = kFp8Dynamic128Sym
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.group_size = self.quant_key.scale.group_shape[1]
+        # Resolve the rounding mode outside the compiled region: the wrapper
+        # would otherwise call the lru_cache'd is_deep_gemm_e8m0_used() inside
+        # forward and graph-break. This matches what real callers do.
+        self.use_ue8m0 = is_deep_gemm_e8m0_used()
+        self.w = kwargs.get("w", {})
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor):
+        attn_output = self.attn(q, k, v)
+        q_fp8, scale = per_token_group_quant_fp8(
+            attn_output, self.group_size, use_ue8m0=self.use_ue8m0
+        )
+        # Dequantize so both quant outputs are consumed by the graph.
+        num_tokens = q_fp8.shape[0]
+        deq = q_fp8.to(torch.float32).view(num_tokens, -1, self.group_size)
+        deq = (deq * scale.unsqueeze(-1)).view(q_fp8.shape)
+        return deq.to(self.dtype)
+
+
+class TestAttentionFp8Group64QuantPatternModel(TestAttentionFp8GroupQuantPatternModel):
+    """gs=64 variant (2 groups per head_size=128) of the per-group model.
+
+    Covers ``NUM_GROUPS_PER_HEAD > 1`` end-to-end so the multi-group epilogue
+    path is exercised through the fusion, not just the kernel unit tests.
+    """
+
+    quant_key = kFp8Dynamic64Sym
+
+
 PATTERN_TEST_MODELS_FP8: list[tuple[str, type]] = []
 PATTERN_TEST_MODELS_FP4: list[tuple[str, type]] = []
+PATTERN_TEST_MODELS_FP8_GROUP: list[tuple[str, type]] = []
 HEADS: list[tuple[int, int]] = []
 SPLIT_ATTENTION: list[bool] = []
 BACKENDS_FP8: list[AttentionBackendEnum] = []
@@ -242,6 +291,16 @@ if current_platform.is_cuda():
             "nvidia/Llama-3.1-8B-Instruct-NVFP4",
             TestAttentionNvfp4QuantPatternModel,
         )
+    ]
+    PATTERN_TEST_MODELS_FP8_GROUP = [
+        (
+            "RedHatAI/Meta-Llama-3.1-8B-FP8",
+            TestAttentionFp8GroupQuantPatternModel,  # gs=128, 1 group/head
+        ),
+        (
+            "RedHatAI/Meta-Llama-3.1-8B-FP8",
+            TestAttentionFp8Group64QuantPatternModel,  # gs=64, 2 groups/head
+        ),
     ]
     BACKENDS_FP8 = [AttentionBackendEnum.TRITON_ATTN, AttentionBackendEnum.FLASHINFER]
     BACKENDS_FP4 = [AttentionBackendEnum.FLASHINFER]
@@ -479,4 +538,140 @@ def test_attention_quant_pattern(
         )
 
     # Check that results are close
+    torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("num_qo_heads, num_kv_heads", HEADS)
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("batch_size", [7, 256, 533])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "backend, model_name, model_class",
+    list(
+        flat_product([AttentionBackendEnum.TRITON_ATTN], PATTERN_TEST_MODELS_FP8_GROUP)
+    ),
+)
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton per-group attn fusion is CUDA-only"
+)
+@pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
+def test_attention_fp8_group_quant_pattern(
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    batch_size: int,
+    dtype: torch.dtype,
+    model_name: str,
+    model_class: type[AttentionQuantPatternModel],
+    backend: AttentionBackendEnum,
+    dist_init,
+    monkeypatch,
+    use_fresh_inductor_cache,
+):
+    """Fuse attention + dynamic per-group FP8 quant (AttnFp8GroupQuantPattern).
+
+    Unlike the per-tensor / NVFP4 cases, the per-group scale is carried on
+    ``output_block_scale``; the standalone ``per_token_group_fp8_quant`` op
+    must be fully removed from the graph and the result must match the
+    unfused path.
+    """
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(42)
+
+    backend_cls = backend.get_class()
+    block_size = backend_cls.get_preferred_block_size(16)
+
+    model_config = ModelConfig(model=model_name, max_model_len=2048, dtype=dtype)
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=1024,
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE, custom_ops=[]
+        ),
+        cache_config=CacheConfig(cache_dtype="fp8"),
+        attention_config=AttentionConfig(backend=backend),
+    )
+
+    q = torch.randn(batch_size, num_qo_heads * head_size, dtype=dtype, device=device)
+    k = torch.randn(batch_size, num_kv_heads * head_size, dtype=dtype, device=device)
+    v = torch.randn(batch_size, num_kv_heads * head_size, dtype=dtype, device=device)
+    torch._dynamo.mark_dynamic(q, 0)
+    torch._dynamo.mark_dynamic(k, 0)
+    torch._dynamo.mark_dynamic(v, 0)
+
+    # Unfused reference (compiled for closer numerics, no fusion pass).
+    vllm_config_unfused = copy.deepcopy(vllm_config)
+    with (
+        set_current_vllm_config(vllm_config_unfused),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config_unfused),
+    ):
+        model_unfused = model_class(
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            device=device,
+            vllm_config=vllm_config_unfused,
+            block_size=block_size,
+        ).to(device)
+        get_forward_context().attn_metadata = model_unfused.build_attn_metadata(
+            batch_size
+        )
+        result_unfused = torch.compile(model_unfused, fullgraph=True)(q, k, v)
+
+    # Fused path.
+    vllm_config.compilation_config.pass_config = PassConfig(
+        fuse_attn_quant=True, eliminate_noops=True
+    )
+    with (
+        set_current_vllm_config(vllm_config),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config),
+    ):
+        model_fused = model_class(
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            device=device,
+            vllm_config=vllm_config,
+            block_size=block_size,
+        ).to(device)
+        get_forward_context().attn_metadata = model_fused.build_attn_metadata(
+            batch_size
+        )
+
+        noop_pass = NoOpEliminationPass(vllm_config)
+        attn_pass = LazyInitPass(AttnQuantFusionPass, vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+        test_backend = TestBackend(noop_pass, attn_pass, cleanup_pass)
+
+        _ = model_fused(q, k, v)  # HACK: prime, see issue #31044
+        result_fused = torch.compile(model_fused, backend=test_backend, fullgraph=True)(
+            q, k, v
+        )
+
+    quant_key = model_class.quant_key
+    attn_fusion_supported = [
+        layer.impl.fused_output_quant_supported(quant_key)
+        for layer in vllm_config.compilation_config.static_forward_context.values()
+    ]
+    assert sum(attn_fusion_supported) == len(attn_fusion_supported)
+
+    # The standalone per-group quant op must be fully fused into attention.
+    quant_op = QUANT_OPS[quant_key]
+    test_backend.check_before_ops([quant_op], fully_replaced=True)
+    assert attn_pass.pass_.matched_count == sum(attn_fusion_supported)
+
+    # Attention should carry the per-group scale on output_block_scale.
+    attn_nodes_pre = list(find_op_nodes(ATTN_OP, test_backend.graph_pre_pass))
+    attn_nodes_post = list(find_op_nodes(ATTN_OP, test_backend.graph_post_pass))
+    assert len(attn_nodes_pre) == len(attn_nodes_post) > 0
+    assert attn_nodes_pre[0].kwargs.get("output_block_scale") is None
+    assert attn_nodes_post[0].kwargs.get("output_block_scale") is not None
+
     torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -34,12 +34,18 @@ from vllm.config import (
 )
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
+    kFp8Dynamic64Sym,
+    kFp8Dynamic128Sym,
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -230,8 +236,51 @@ class TestAttentionNvfp4QuantPatternModel(AttentionQuantPatternModel):
         )
 
 
+class TestAttentionFp8GroupQuantPatternModel(AttentionQuantPatternModel):
+    """Test model for AttnFp8GroupQuantPattern fusion (dynamic per-group FP8).
+
+    The forward does attention -> per_token_group_quant_fp8 -> dequant, which
+    is the pattern the fusion folds into attention(output_block_scale=scale).
+    The dequant (instead of a real block GEMM) keeps the test free of extra
+    weights while still using both quant outputs so they appear in the graph.
+    """
+
+    quant_key = kFp8Dynamic128Sym
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.group_size = self.quant_key.scale.group_shape[1]
+        # Resolve the rounding mode outside the compiled region: the wrapper
+        # would otherwise call the lru_cache'd is_deep_gemm_e8m0_used() inside
+        # forward and graph-break. This matches what real callers do.
+        self.use_ue8m0 = is_deep_gemm_e8m0_used()
+        self.w = kwargs.get("w", {})
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor):
+        attn_output = self.attn(q, k, v)
+        q_fp8, scale = per_token_group_quant_fp8(
+            attn_output, self.group_size, use_ue8m0=self.use_ue8m0
+        )
+        # Dequantize so both quant outputs are consumed by the graph.
+        num_tokens = q_fp8.shape[0]
+        deq = q_fp8.to(torch.float32).view(num_tokens, -1, self.group_size)
+        deq = (deq * scale.unsqueeze(-1)).view(q_fp8.shape)
+        return deq.to(self.dtype)
+
+
+class TestAttentionFp8Group64QuantPatternModel(TestAttentionFp8GroupQuantPatternModel):
+    """gs=64 variant (2 groups per head_size=128) of the per-group model.
+
+    Covers ``NUM_GROUPS_PER_HEAD > 1`` end-to-end so the multi-group epilogue
+    path is exercised through the fusion, not just the kernel unit tests.
+    """
+
+    quant_key = kFp8Dynamic64Sym
+
+
 PATTERN_TEST_MODELS_FP8: list[tuple[str, type]] = []
 PATTERN_TEST_MODELS_FP4: list[tuple[str, type]] = []
+PATTERN_TEST_MODELS_FP8_GROUP: list[tuple[str, type]] = []
 HEADS: list[tuple[int, int]] = []
 SPLIT_ATTENTION: list[bool] = []
 BACKENDS_FP8: list[AttentionBackendEnum] = []
@@ -250,6 +299,16 @@ if current_platform.is_cuda():
             "nvidia/Llama-3.1-8B-Instruct-NVFP4",
             TestAttentionNvfp4QuantPatternModel,
         )
+    ]
+    PATTERN_TEST_MODELS_FP8_GROUP = [
+        (
+            "RedHatAI/Meta-Llama-3.1-8B-FP8",
+            TestAttentionFp8GroupQuantPatternModel,  # gs=128, 1 group/head
+        ),
+        (
+            "RedHatAI/Meta-Llama-3.1-8B-FP8",
+            TestAttentionFp8Group64QuantPatternModel,  # gs=64, 2 groups/head
+        ),
     ]
     BACKENDS_FP8 = [AttentionBackendEnum.TRITON_ATTN, AttentionBackendEnum.FLASHINFER]
     BACKENDS_FP4 = [AttentionBackendEnum.FLASHINFER]
@@ -487,4 +546,140 @@ def test_attention_quant_pattern(
         )
 
     # Check that results are close
+    torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("num_qo_heads, num_kv_heads", HEADS)
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("batch_size", [7, 256, 533])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "backend, model_name, model_class",
+    list(
+        flat_product([AttentionBackendEnum.TRITON_ATTN], PATTERN_TEST_MODELS_FP8_GROUP)
+    ),
+)
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton per-group attn fusion is CUDA-only"
+)
+@pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
+def test_attention_fp8_group_quant_pattern(
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    batch_size: int,
+    dtype: torch.dtype,
+    model_name: str,
+    model_class: type[AttentionQuantPatternModel],
+    backend: AttentionBackendEnum,
+    dist_init,
+    monkeypatch,
+    use_fresh_inductor_cache,
+):
+    """Fuse attention + dynamic per-group FP8 quant (AttnFp8GroupQuantPattern).
+
+    Unlike the per-tensor / NVFP4 cases, the per-group scale is carried on
+    ``output_block_scale``; the standalone ``per_token_group_fp8_quant`` op
+    must be fully removed from the graph and the result must match the
+    unfused path.
+    """
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+    device = torch.device(f"{DEVICE_TYPE}:0")
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(42)
+
+    backend_cls = backend.get_class()
+    block_size = backend_cls.get_preferred_block_size(16)
+
+    model_config = ModelConfig(model=model_name, max_model_len=2048, dtype=dtype)
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=1024,
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE, custom_ops=[]
+        ),
+        cache_config=CacheConfig(cache_dtype="fp8"),
+        attention_config=AttentionConfig(backend=backend),
+    )
+
+    q = torch.randn(batch_size, num_qo_heads * head_size, dtype=dtype, device=device)
+    k = torch.randn(batch_size, num_kv_heads * head_size, dtype=dtype, device=device)
+    v = torch.randn(batch_size, num_kv_heads * head_size, dtype=dtype, device=device)
+    torch._dynamo.mark_dynamic(q, 0)
+    torch._dynamo.mark_dynamic(k, 0)
+    torch._dynamo.mark_dynamic(v, 0)
+
+    # Unfused reference (compiled for closer numerics, no fusion pass).
+    vllm_config_unfused = copy.deepcopy(vllm_config)
+    with (
+        set_current_vllm_config(vllm_config_unfused),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config_unfused),
+    ):
+        model_unfused = model_class(
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            device=device,
+            vllm_config=vllm_config_unfused,
+            block_size=block_size,
+        ).to(device)
+        get_forward_context().attn_metadata = model_unfused.build_attn_metadata(
+            batch_size
+        )
+        result_unfused = torch.compile(model_unfused, fullgraph=True)(q, k, v)
+
+    # Fused path.
+    vllm_config.compilation_config.pass_config = PassConfig(
+        fuse_attn_quant=True, eliminate_noops=True
+    )
+    with (
+        set_current_vllm_config(vllm_config),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config),
+    ):
+        model_fused = model_class(
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            device=device,
+            vllm_config=vllm_config,
+            block_size=block_size,
+        ).to(device)
+        get_forward_context().attn_metadata = model_fused.build_attn_metadata(
+            batch_size
+        )
+
+        noop_pass = NoOpEliminationPass(vllm_config)
+        attn_pass = LazyInitPass(AttnQuantFusionPass, vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+        test_backend = TestBackend(noop_pass, attn_pass, cleanup_pass)
+
+        _ = model_fused(q, k, v)  # HACK: prime, see issue #31044
+        result_fused = torch.compile(model_fused, backend=test_backend, fullgraph=True)(
+            q, k, v
+        )
+
+    quant_key = model_class.quant_key
+    attn_fusion_supported = [
+        layer.impl.fused_output_quant_supported(quant_key)
+        for layer in vllm_config.compilation_config.static_forward_context.values()
+    ]
+    assert sum(attn_fusion_supported) == len(attn_fusion_supported)
+
+    # The standalone per-group quant op must be fully fused into attention.
+    quant_op = QUANT_OPS[quant_key]
+    test_backend.check_before_ops([quant_op], fully_replaced=True)
+    assert attn_pass.pass_.matched_count == sum(attn_fusion_supported)
+
+    # Attention should carry the per-group scale on output_block_scale.
+    attn_nodes_pre = list(find_op_nodes(ATTN_OP, test_backend.graph_pre_pass))
+    attn_nodes_post = list(find_op_nodes(ATTN_OP, test_backend.graph_post_pass))
+    assert len(attn_nodes_pre) == len(attn_nodes_post) > 0
+    assert attn_nodes_pre[0].kwargs.get("output_block_scale") is None
+    assert attn_nodes_post[0].kwargs.get("output_block_scale") is not None
+
     torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -466,6 +466,151 @@ def test_triton_unified_attn_fp16_input_fp8_output(
     )
 
 
+# Group sizes for the fused per-group FP8 output epilogue.  128 == head_size
+# is the single-group-per-head case; 64 exercises 2 groups per head.  The
+# head_size=256 multi-group case is a known follow-up (see issue #37162) and
+# is intentionally excluded here.
+GROUP_SIZES = [128, 64]
+
+
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [(129, 463), (5, 18)],
+        [(256, 256), (128, 300)],
+        [(1, 523), (1, 37), (1, 2011)],
+    ],
+)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("group_size", GROUP_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("seq_threshold_3D", SEQ_THRESHOLD_3D_VALUES)
+@torch.inference_mode()
+def test_triton_unified_attn_fp16_input_fp8_group_output(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    group_size: int,
+    block_size: int,
+    num_blocks: int,
+    seq_threshold_3D: int,
+) -> None:
+    """Fused dynamic per-group FP8 output quantization.
+
+    Runs ``unified_attention`` with ``output_group_scale`` set so the kernel
+    epilogue quantizes the attention output to FP8 and emits one scale per
+    ``group_size`` slice of ``head_size``.  The dequantized result
+    (``out_fp8 * group_scale``) is compared against the dense reference.
+    ``seq_threshold_3D`` exercises both the 2D epilogue and the 3D decode
+    path (``reduce_segments``); the decode-only ``seq_lens`` case routes
+    through 3D when the threshold allows.
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads = num_heads[0]
+    num_kv_heads = num_heads[1]
+    assert num_query_heads % num_kv_heads == 0
+    assert head_size % group_size == 0
+    num_groups_per_head = head_size // group_size
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    dtype = torch.float16
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    num_tokens = sum(query_lens)
+    output = torch.empty(num_tokens, num_query_heads, head_size, dtype=FP8_DTYPE)
+    # Scale layout: (num_tokens, num_query_heads * num_groups_per_head),
+    # row-major, indexed by [token, head * num_groups_per_head + group].
+    output_group_scale = torch.empty(
+        num_tokens, num_query_heads * num_groups_per_head, dtype=torch.float32
+    )
+
+    # 3D scratch buffers (unused when the 2D path is selected).
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+    softmax_segm_output = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+    softmax_segm_expsum = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_tensor,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        output_group_scale=output_group_scale,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+    )
+
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=block_tables,
+        scale=scale,
+    )
+
+    # Dequantize: out_fp8[t, h, g*gs:(g+1)*gs] * scale[t, h*ng + g].
+    deq = output.to(torch.float32).view(
+        num_tokens, num_query_heads, num_groups_per_head, group_size
+    )
+    gs = output_group_scale.view(num_tokens, num_query_heads, num_groups_per_head, 1)
+    deq = (deq * gs).view(num_tokens, num_query_heads, head_size).to(torch.float16)
+
+    assert torch.isfinite(output_group_scale).all()
+    assert (output_group_scale > 0).all()
+
+    atol, rtol = 2e-1, 2e-1
+    torch.testing.assert_close(deq, ref_output, atol=atol, rtol=rtol)
+
+
 # USE_TD path covers two head-size regimes:
 # - pow2 (HEAD_SIZE == HEAD_SIZE_PADDED): full TD path including Q/O.
 # - non-pow2 (96, HEAD_SIZE_PADDED=128): gates USE_TD_QO off — Q load
@@ -643,3 +788,170 @@ def test_triton_unified_attn_use_td_tile_clamp(
         soft_cap=None,
         seq_threshold_3D=0,
     )
+
+
+@pytest.mark.parametrize("group_size", GROUP_SIZES)
+@pytest.mark.parametrize("seq_threshold_3D", SEQ_THRESHOLD_3D_VALUES)
+@torch.inference_mode()
+def test_triton_unified_attn_fp8_group_all_zero_group_ue8m0(
+    group_size: int,
+    seq_threshold_3D: int,
+) -> None:
+    """Degenerate all-zeros group with UE8M0 rounding (both 2D and 3D paths).
+
+    A group whose attention output is exactly zero has ``group_max == 0``,
+    which hits the ``FP8_QUANT_EPS`` floor; with UE8M0 the scale is rounded to
+    a tiny power of two (~2^-42). This guards that:
+      1. the kernel produces no NaN/inf scales and the EPS floor keeps every
+         scale strictly positive (no divide-by-zero),
+      2. the zeroed group quantizes to exactly 0,
+      3. the result matches ``per_token_group_quant_fp8(use_ue8m0=True)`` even
+         in this degenerate case, so the fusion places no new assumption on the
+         downstream scale consumer (the extreme 2^-42 scale is exactly what the
+         standalone quant op already emits).
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_query_heads, num_kv_heads = 8, 2
+    head_size = 128
+    block_size = 16
+    num_blocks = 2048
+    assert head_size % group_size == 0
+    num_groups_per_head = head_size // group_size
+
+    # Decode-only shape so both seq_threshold_3D values route through one path
+    # (0 -> 2D epilogue, 8 -> 3D reduce_segments epilogue).
+    seq_lens = [(1, 200), (1, 132), (1, 64)]
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    dtype = torch.float16
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    # Zero the first group's value dims -> attention output group 0 is exactly
+    # zero for every (token, head), driving group_max == 0.
+    value_cache[..., :group_size] = 0.0
+
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    num_tokens = sum(query_lens)
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+
+    def _segm_buffers():
+        return (
+            torch.empty(
+                (
+                    seq_threshold_3D,
+                    num_query_heads,
+                    num_par_softmax_segments,
+                    head_size_padded,
+                ),
+                dtype=torch.float32,
+            ),
+            torch.empty(
+                (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+                dtype=torch.float32,
+            ),
+            torch.empty(
+                (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+                dtype=torch.float32,
+            ),
+        )
+
+    common = dict(
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_tensor,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+    )
+
+    # Unquantized fp16 reference output to feed the production quant op.
+    out_ref = torch.empty(num_tokens, num_query_heads, head_size, dtype=dtype)
+    so, sm, se = _segm_buffers()
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=out_ref,
+        softmax_segm_output=so,
+        softmax_segm_max=sm,
+        softmax_segm_expsum=se,
+        **common,
+    )
+    # Precondition: the zeroed group really is exactly zero pre-quant.
+    out_ref_g = out_ref.view(
+        num_tokens, num_query_heads, num_groups_per_head, group_size
+    )
+    assert (out_ref_g[:, :, 0, :] == 0).all()
+
+    # Fused per-group FP8 with UE8M0 enabled.
+    output = torch.empty(num_tokens, num_query_heads, head_size, dtype=FP8_DTYPE)
+    output_group_scale = torch.empty(
+        num_tokens, num_query_heads * num_groups_per_head, dtype=torch.float32
+    )
+    so, sm, se = _segm_buffers()
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        output_group_scale=output_group_scale,
+        output_group_ue8m0=True,
+        softmax_segm_output=so,
+        softmax_segm_max=sm,
+        softmax_segm_expsum=se,
+        **common,
+    )
+
+    # 1) EPS floor held: every scale finite and strictly positive (no NaN/inf,
+    #    no divide-by-zero from the all-zeros group).
+    assert torch.isfinite(output_group_scale).all()
+    assert (output_group_scale > 0).all()
+
+    # 2) UE8M0 invariant: every scale is an exact power of two, including the
+    #    EPS-floored zeroed group.
+    log2_scale = torch.log2(output_group_scale)
+    torch.testing.assert_close(log2_scale, log2_scale.round(), atol=0.0, rtol=0.0)
+
+    # 3) The zeroed group quantizes to exactly 0, so its dequantized value is 0
+    #    regardless of the (tiny power-of-two) scale. This is what the
+    #    downstream GEMM consumes, so the degenerate scale is functionally
+    #    inert. NOTE: we deliberately do NOT assert the raw scale equals the
+    #    CUDA `_C` quant op here. For an all-zeros group under UE8M0 the `_C`
+    #    kernel emits exp2(ceil(log2(eps))) (~2^-33) while this epilogue (and
+    #    vLLM's own Triton `_per_token_group_quant_fp8` reference) emit
+    #    exp2(ceil(log2(eps / FP8_MAX))) (~2^-42) -- the two reference quant
+    #    ops themselves disagree in this corner. The dequantized output (0) is
+    #    identical either way.
+    out_g = output.to(torch.float32).view(
+        num_tokens, num_query_heads, num_groups_per_head, group_size
+    )
+    scale_g = output_group_scale.view(num_tokens, num_query_heads, num_groups_per_head)
+    dequant_zero_group = out_g[:, :, 0, :] * scale_g[:, :, 0:1]
+    assert (dequant_zero_group == 0).all()

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -721,6 +721,151 @@ def test_triton_unified_attn_fp16_input_fp8_output(
     )
 
 
+# Group sizes for the fused per-group FP8 output epilogue.  128 == head_size
+# is the single-group-per-head case; 64 exercises 2 groups per head.  The
+# head_size=256 multi-group case is a known follow-up (see issue #37162) and
+# is intentionally excluded here.
+GROUP_SIZES = [128, 64]
+
+
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [(129, 463), (5, 18)],
+        [(256, 256), (128, 300)],
+        [(1, 523), (1, 37), (1, 2011)],
+    ],
+)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("group_size", GROUP_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("seq_threshold_3D", SEQ_THRESHOLD_3D_VALUES)
+@torch.inference_mode()
+def test_triton_unified_attn_fp16_input_fp8_group_output(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    group_size: int,
+    block_size: int,
+    num_blocks: int,
+    seq_threshold_3D: int,
+) -> None:
+    """Fused dynamic per-group FP8 output quantization.
+
+    Runs ``unified_attention`` with ``output_group_scale`` set so the kernel
+    epilogue quantizes the attention output to FP8 and emits one scale per
+    ``group_size`` slice of ``head_size``.  The dequantized result
+    (``out_fp8 * group_scale``) is compared against the dense reference.
+    ``seq_threshold_3D`` exercises both the 2D epilogue and the 3D decode
+    path (``reduce_segments``); the decode-only ``seq_lens`` case routes
+    through 3D when the threshold allows.
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads = num_heads[0]
+    num_kv_heads = num_heads[1]
+    assert num_query_heads % num_kv_heads == 0
+    assert head_size % group_size == 0
+    num_groups_per_head = head_size // group_size
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    dtype = torch.float16
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    num_tokens = sum(query_lens)
+    output = torch.empty(num_tokens, num_query_heads, head_size, dtype=FP8_DTYPE)
+    # Scale layout: (num_tokens, num_query_heads * num_groups_per_head),
+    # row-major, indexed by [token, head * num_groups_per_head + group].
+    output_group_scale = torch.empty(
+        num_tokens, num_query_heads * num_groups_per_head, dtype=torch.float32
+    )
+
+    # 3D scratch buffers (unused when the 2D path is selected).
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+    softmax_segm_output = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+    softmax_segm_expsum = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_tensor,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        output_group_scale=output_group_scale,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+    )
+
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=block_tables,
+        scale=scale,
+    )
+
+    # Dequantize: out_fp8[t, h, g*gs:(g+1)*gs] * scale[t, h*ng + g].
+    deq = output.to(torch.float32).view(
+        num_tokens, num_query_heads, num_groups_per_head, group_size
+    )
+    gs = output_group_scale.view(num_tokens, num_query_heads, num_groups_per_head, 1)
+    deq = (deq * gs).view(num_tokens, num_query_heads, head_size).to(torch.float16)
+
+    assert torch.isfinite(output_group_scale).all()
+    assert (output_group_scale > 0).all()
+
+    atol, rtol = 2e-1, 2e-1
+    torch.testing.assert_close(deq, ref_output, atol=atol, rtol=rtol)
+
+
 # USE_TD path covers two head-size regimes:
 # - pow2 (HEAD_SIZE == HEAD_SIZE_PADDED): full TD path including Q/O.
 # - non-pow2 (96, HEAD_SIZE_PADDED=128): gates USE_TD_QO off — Q load
@@ -898,3 +1043,170 @@ def test_triton_unified_attn_use_td_tile_clamp(
         soft_cap=None,
         seq_threshold_3D=0,
     )
+
+
+@pytest.mark.parametrize("group_size", GROUP_SIZES)
+@pytest.mark.parametrize("seq_threshold_3D", SEQ_THRESHOLD_3D_VALUES)
+@torch.inference_mode()
+def test_triton_unified_attn_fp8_group_all_zero_group_ue8m0(
+    group_size: int,
+    seq_threshold_3D: int,
+) -> None:
+    """Degenerate all-zeros group with UE8M0 rounding (both 2D and 3D paths).
+
+    A group whose attention output is exactly zero has ``group_max == 0``,
+    which hits the ``FP8_QUANT_EPS`` floor; with UE8M0 the scale is rounded to
+    a tiny power of two (~2^-42). This guards that:
+      1. the kernel produces no NaN/inf scales and the EPS floor keeps every
+         scale strictly positive (no divide-by-zero),
+      2. the zeroed group quantizes to exactly 0,
+      3. the result matches ``per_token_group_quant_fp8(use_ue8m0=True)`` even
+         in this degenerate case, so the fusion places no new assumption on the
+         downstream scale consumer (the extreme 2^-42 scale is exactly what the
+         standalone quant op already emits).
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_query_heads, num_kv_heads = 8, 2
+    head_size = 128
+    block_size = 16
+    num_blocks = 2048
+    assert head_size % group_size == 0
+    num_groups_per_head = head_size // group_size
+
+    # Decode-only shape so both seq_threshold_3D values route through one path
+    # (0 -> 2D epilogue, 8 -> 3D reduce_segments epilogue).
+    seq_lens = [(1, 200), (1, 132), (1, 64)]
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+
+    dtype = torch.float16
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    # Zero the first group's value dims -> attention output group 0 is exactly
+    # zero for every (token, head), driving group_max == 0.
+    value_cache[..., :group_size] = 0.0
+
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    num_tokens = sum(query_lens)
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+
+    def _segm_buffers():
+        return (
+            torch.empty(
+                (
+                    seq_threshold_3D,
+                    num_query_heads,
+                    num_par_softmax_segments,
+                    head_size_padded,
+                ),
+                dtype=torch.float32,
+            ),
+            torch.empty(
+                (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+                dtype=torch.float32,
+            ),
+            torch.empty(
+                (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+                dtype=torch.float32,
+            ),
+        )
+
+    common = dict(
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_tensor,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+    )
+
+    # Unquantized fp16 reference output to feed the production quant op.
+    out_ref = torch.empty(num_tokens, num_query_heads, head_size, dtype=dtype)
+    so, sm, se = _segm_buffers()
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=out_ref,
+        softmax_segm_output=so,
+        softmax_segm_max=sm,
+        softmax_segm_expsum=se,
+        **common,
+    )
+    # Precondition: the zeroed group really is exactly zero pre-quant.
+    out_ref_g = out_ref.view(
+        num_tokens, num_query_heads, num_groups_per_head, group_size
+    )
+    assert (out_ref_g[:, :, 0, :] == 0).all()
+
+    # Fused per-group FP8 with UE8M0 enabled.
+    output = torch.empty(num_tokens, num_query_heads, head_size, dtype=FP8_DTYPE)
+    output_group_scale = torch.empty(
+        num_tokens, num_query_heads * num_groups_per_head, dtype=torch.float32
+    )
+    so, sm, se = _segm_buffers()
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        output_group_scale=output_group_scale,
+        output_group_ue8m0=True,
+        softmax_segm_output=so,
+        softmax_segm_max=sm,
+        softmax_segm_expsum=se,
+        **common,
+    )
+
+    # 1) EPS floor held: every scale finite and strictly positive (no NaN/inf,
+    #    no divide-by-zero from the all-zeros group).
+    assert torch.isfinite(output_group_scale).all()
+    assert (output_group_scale > 0).all()
+
+    # 2) UE8M0 invariant: every scale is an exact power of two, including the
+    #    EPS-floored zeroed group.
+    log2_scale = torch.log2(output_group_scale)
+    torch.testing.assert_close(log2_scale, log2_scale.round(), atol=0.0, rtol=0.0)
+
+    # 3) The zeroed group quantizes to exactly 0, so its dequantized value is 0
+    #    regardless of the (tiny power-of-two) scale. This is what the
+    #    downstream GEMM consumes, so the degenerate scale is functionally
+    #    inert. NOTE: we deliberately do NOT assert the raw scale equals the
+    #    CUDA `_C` quant op here. For an all-zeros group under UE8M0 the `_C`
+    #    kernel emits exp2(ceil(log2(eps))) (~2^-33) while this epilogue (and
+    #    vLLM's own Triton `_per_token_group_quant_fp8` reference) emit
+    #    exp2(ceil(log2(eps / FP8_MAX))) (~2^-42) -- the two reference quant
+    #    ops themselves disagree in this corner. The dequantized output (0) is
+    #    identical either way.
+    out_g = output.to(torch.float32).view(
+        num_tokens, num_query_heads, num_groups_per_head, group_size
+    )
+    scale_g = output_group_scale.view(num_tokens, num_query_heads, num_groups_per_head)
+    dequant_zero_group = out_g[:, :, 0, :] * scale_g[:, :, 0:1]
+    assert (dequant_zero_group == 0).all()

--- a/vllm/compilation/passes/fusion/attn_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/attn_quant_fusion.py
@@ -12,10 +12,13 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
+    kFp8Dynamic64Sym,
+    kFp8Dynamic128Sym,
     kNvfp4Dynamic,
     kStaticTensorScale,
 )
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 from vllm.utils.math_utils import round_up
 from vllm.utils.torch_utils import _USE_LAYERNAME, _encode_layer_name
 
@@ -359,6 +362,182 @@ class AttnNvfp4QuantPattern(
         return inputs
 
 
+class AttnFp8GroupQuantPattern(
+    VllmPatternReplacement[..., tuple[torch.Tensor, torch.Tensor]]
+):
+    """
+    Fusion for Attention + dynamic per-group FP8 quant.
+
+    Matches ``attention -> reshape -> per_token_group_fp8_quant`` and replaces
+    it with ``attention(output_block_scale=group_scale)``.  The Triton
+    attention backend computes the per-group scale in its epilogue, so the
+    standalone quant op is removed from the graph.
+
+    Unlike the MLA per-group pattern, no quant flags are threaded through the
+    attention custom op: ``group_size`` is recovered from the scale tensor's
+    shape, the row/column-major layout from its strides, and the UE8M0
+    rounding mode from ``is_deep_gemm_e8m0_used()`` (which is also what
+    ``per_token_group_quant_fp8`` defaults to). The pattern is therefore only
+    registered for that default rounding mode and for non-TMA-aligned scales
+    (the only layouts the Triton epilogue produces).
+    """
+
+    def __init__(
+        self,
+        layer: Attention,
+        dtype: torch.dtype,
+        quant_key: QuantKey,
+        has_col_major_scales: bool,
+        is_e8m0: bool,
+    ) -> None:
+        self._layer_name = layer.layer_name
+        self._num_heads = layer.num_heads
+        self._head_size = layer.head_size
+        self._dtype = dtype
+        self._group_size = quant_key.scale.group_shape[1]
+        self._has_col_major_scales = has_col_major_scales
+        self._is_e8m0 = is_e8m0
+        self._quant_matcher = MatcherQuantFP8(
+            quant_key,
+            has_col_major_scales=has_col_major_scales,
+            is_e8m0=is_e8m0,
+        )
+
+    @property
+    def pattern(self) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
+        _ln = _encode_layer_name(self._layer_name)
+        finfo = torch.finfo(FP8_DTYPE)
+
+        def _quant(attn_out_view, scale):
+            result = torch.empty(
+                attn_out_view.shape, device=attn_out_view.device, dtype=FP8_DTYPE
+            )
+            _, result, scale = auto_functionalized(
+                self._quant_matcher.QUANT_OP,
+                input=attn_out_view,
+                output_q=result,
+                output_s=scale,
+                group_size=self._group_size,
+                eps=1e-10,
+                fp8_min=finfo.min,
+                fp8_max=finfo.max,
+                scale_ue8m0=self._is_e8m0,
+                dummy_is_scale_transposed=self._has_col_major_scales,
+                dummy_is_tma_aligned=False,
+            )
+            return result, scale
+
+        if _USE_LAYERNAME:
+
+            def _pattern_with_ln(  # type: ignore[misc]
+                q, k, v, output_attn, scale, kv_cache_dummy_dep, layer_name
+            ):
+                at1 = auto_functionalized(
+                    ATTN_OP,
+                    query=q,
+                    key=k,
+                    value=v,
+                    output=output_attn,
+                    layer_name=layer_name,
+                    output_scale=None,
+                    output_block_scale=None,
+                    kv_cache_dummy_dep=kv_cache_dummy_dep,
+                )
+                attn_out_view = RESHAPE_OP(
+                    at1[1], [q.shape[0], self._num_heads * self._head_size]
+                )
+                return _quant(attn_out_view, scale)
+
+            return _pattern_with_ln
+
+        def _pattern(q, k, v, output_attn, scale, kv_cache_dummy_dep):
+            at1 = auto_functionalized(
+                ATTN_OP,
+                query=q,
+                key=k,
+                value=v,
+                output=output_attn,
+                layer_name=_ln,
+                output_scale=None,
+                output_block_scale=None,
+                kv_cache_dummy_dep=kv_cache_dummy_dep,
+            )
+            attn_out_view = RESHAPE_OP(
+                at1[1], [q.shape[0], self._num_heads * self._head_size]
+            )
+            return _quant(attn_out_view, scale)
+
+        return _pattern
+
+    @property
+    def replacement(self) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
+        _ln = _encode_layer_name(self._layer_name)
+
+        if _USE_LAYERNAME:
+
+            def _replacement_with_ln(  # type: ignore[misc]
+                q, k, v, output_attn, scale, kv_cache_dummy_dep, layer_name
+            ):
+                output_attn = torch.empty(
+                    [q.shape[0], self._num_heads, self._head_size],
+                    dtype=FP8_DTYPE,
+                    device=q.device,
+                )
+                at1 = auto_functionalized(
+                    ATTN_OP,
+                    query=q,
+                    key=k,
+                    value=v,
+                    output=output_attn,
+                    layer_name=layer_name,
+                    output_scale=None,
+                    output_block_scale=scale,
+                    kv_cache_dummy_dep=kv_cache_dummy_dep,
+                )
+                return RESHAPE_OP(
+                    at1[1], [-1, self._num_heads * self._head_size]
+                ), scale
+
+            return _replacement_with_ln
+
+        def _replacement(q, k, v, output_attn, scale, kv_cache_dummy_dep):
+            output_attn = torch.empty(
+                [q.shape[0], self._num_heads, self._head_size],
+                dtype=FP8_DTYPE,
+                device=q.device,
+            )
+            at1 = auto_functionalized(
+                ATTN_OP,
+                query=q,
+                key=k,
+                value=v,
+                output=output_attn,
+                layer_name=_ln,
+                output_scale=None,
+                output_block_scale=scale,
+                kv_cache_dummy_dep=kv_cache_dummy_dep,
+            )
+            return RESHAPE_OP(at1[1], [-1, self._num_heads * self._head_size]), scale
+
+        return _replacement
+
+    def get_inputs(self):
+        dtype = self._dtype
+        num_heads = self._num_heads
+        head_size = self._head_size
+        inputs: list = [
+            self.empty(5, num_heads, head_size, dtype=dtype),  # q
+            self.empty(5, num_heads, head_size, dtype=dtype),  # k
+            self.empty(5, num_heads, head_size, dtype=dtype),  # v
+            self.empty(5, num_heads, head_size, dtype=dtype),  # output_attn
+            self.empty_fp32(1, 1),  # scale placeholder
+            self.empty(0, dtype=dtype),  # kv_cache_dummy_dep
+        ]
+        if _USE_LAYERNAME:
+            inputs.append(_encode_layer_name(self._layer_name))
+        return inputs
+
+
 class AttnQuantFusionPass(VllmFusionPatternMatcherPass):
     """
     This pass fuses post-attention quantization onto attention if supported.
@@ -399,5 +578,30 @@ class AttnQuantFusionPass(VllmFusionPatternMatcherPass):
                     self.register(AttnNvfp4QuantPattern(layer, dtype))
                     if _USE_LAYERNAME:
                         break
+
+        # Per-group dynamic FP8 (deep_gemm-style block quant).  The Triton
+        # epilogue only produces the platform-default UE8M0 rounding and
+        # non-TMA-aligned scales, so register only those variants (col-major
+        # is handled via the scale tensor's strides).  Other variants simply
+        # don't match and fall back to the standalone quant op.
+        if current_platform.is_cuda():
+            is_e8m0 = is_deep_gemm_e8m0_used()
+            for quant_key in [kFp8Dynamic128Sym, kFp8Dynamic64Sym]:
+                if quant_key not in QUANT_OPS:
+                    continue
+                for has_col_major in [False, True]:
+                    for layer in layers:
+                        if layer.impl.fused_output_quant_supported(quant_key):
+                            self.register(
+                                AttnFp8GroupQuantPattern(
+                                    layer,
+                                    dtype,
+                                    quant_key,
+                                    has_col_major,
+                                    is_e8m0,
+                                )
+                            )
+                            if _USE_LAYERNAME:
+                                break
 
         self.dump_patterns(config, self.pm_pass)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -43,6 +43,12 @@ logger = init_logger(__name__)
 # smallest representable float32 guarantees that.
 FP8_SCALE_SENTINEL = torch.finfo(torch.float32).min
 
+# Minimum scale epsilon for per-group FP8 quantization, used to avoid
+# division by zero when a group is all-zeros. Shared by the per-token-group
+# quant kernels here and the fused per-group epilogue in the Triton attention
+# kernel (vllm/v1/attention/ops/triton_unified_attention.py).
+FP8_QUANT_EPS: float = 1e-10
+
 
 def is_fp8(x: torch.dtype | torch.Tensor) -> bool:
     if isinstance(x, torch.Tensor):

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -38,6 +38,12 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
+# Minimum scale epsilon for per-group FP8 quantization, used to avoid
+# division by zero when a group is all-zeros. Shared by the per-token-group
+# quant kernels here and the fused per-group epilogue in the Triton attention
+# kernel (vllm/v1/attention/ops/triton_unified_attention.py).
+FP8_QUANT_EPS: float = 1e-10
+
 
 def is_fp8(x: torch.dtype | torch.Tensor) -> bool:
     if isinstance(x, torch.Tensor):

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
+from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
@@ -482,7 +483,23 @@ class TritonAttentionImpl(AttentionImpl):
         self._v_scale_cache.fill_(1.0)
 
     def fused_output_quant_supported(self, quant_key: QuantKey):
-        return quant_key == kFp8StaticTensorSym
+        if quant_key == kFp8StaticTensorSym:
+            return True
+        # Per-group dynamic FP8 quant is supported when the output dtype is
+        # FP8, the scale is dynamic per-group, and the group size evenly
+        # divides head_size (groups must align with head boundaries).
+        # Quantization happens in the attention kernel epilogue, in both the
+        # 2D (prefill) and 3D (reduce_segments / decode) paths, so it composes
+        # with the normal 2D/3D launch selection.
+        if (
+            quant_key.dtype == self.fp8_dtype
+            and quant_key.scale.group_shape.is_per_group()
+            and not quant_key.scale.static
+            and quant_key.symmetric
+        ):
+            group_size = quant_key.scale.group_shape[1]
+            return self.head_size % group_size == 0
+        return False
 
     def __init__(
         self,
@@ -601,11 +618,27 @@ class TritonAttentionImpl(AttentionImpl):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
-        if output_block_scale is not None:
+        # ``output_block_scale`` is the carrier the attention+quant fusion
+        # pass uses to request fused dynamic per-group FP8 output quant: the
+        # per-group scale tensor is produced by the kernel epilogue instead of
+        # a separate quant op.  Only layers that returned True from
+        # ``fused_output_quant_supported`` for a per-group FP8 key reach this
+        # path (NVFP4 block-scale returns False here), so a non-None value is
+        # always the per-group FP8 scale; route it to ``output_group_scale``.
+        output_group_scale = output_block_scale
+        if output_group_scale is not None and output_scale is not None:
             raise NotImplementedError(
-                "fused block_scale output quantization is not yet supported"
-                " for TritonAttentionImpl"
+                "TritonAttentionImpl cannot fuse both per-tensor and "
+                "per-group FP8 output quantization in the same call"
             )
+        # The fusion pass registers the per-group pattern only for the
+        # platform-default UE8M0 mode (``is_deep_gemm_e8m0_used()``), which is
+        # also the default ``per_token_group_quant_fp8`` would use — so derive
+        # the rounding mode here rather than threading a flag through the
+        # shared attention custom op / forward contract.  ``group_size`` and
+        # the row/column-major layout are recovered from the scale tensor's
+        # shape and strides inside ``unified_attention``.
+        output_group_ue8m0 = output_group_scale is not None and is_deep_gemm_e8m0_used()
 
         if attn_metadata is None:
             # Profiling run.
@@ -714,6 +747,8 @@ class TritonAttentionImpl(AttentionImpl):
             softmax_segm_expsum=softmax_segm_expsum,
             sinks=self.sinks,
             output_scale=output_scale,
+            output_group_scale=output_group_scale,
+            output_group_ue8m0=output_group_ue8m0,
             mm_prefix_range=mm_prefix_range_tensor,
             rswa_prefix_lens=attn_metadata.rswa_prefix_lens,
             rswa_window=attn_metadata.rswa_window,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
+from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import get_dtype_size, is_quantized_kv_cache
 from vllm.v1.attention.backend import (
@@ -443,7 +444,23 @@ class TritonAttentionImpl(AttentionImpl):
         self._v_scale_cache.fill_(1.0)
 
     def fused_output_quant_supported(self, quant_key: QuantKey):
-        return quant_key == kFp8StaticTensorSym
+        if quant_key == kFp8StaticTensorSym:
+            return True
+        # Per-group dynamic FP8 quant is supported when the output dtype is
+        # FP8, the scale is dynamic per-group, and the group size evenly
+        # divides head_size (groups must align with head boundaries).
+        # Quantization happens in the attention kernel epilogue, in both the
+        # 2D (prefill) and 3D (reduce_segments / decode) paths, so it composes
+        # with the normal 2D/3D launch selection.
+        if (
+            quant_key.dtype == self.fp8_dtype
+            and quant_key.scale.group_shape.is_per_group()
+            and not quant_key.scale.static
+            and quant_key.symmetric
+        ):
+            group_size = quant_key.scale.group_shape[1]
+            return self.head_size % group_size == 0
+        return False
 
     def __init__(
         self,
@@ -562,11 +579,27 @@ class TritonAttentionImpl(AttentionImpl):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
-        if output_block_scale is not None:
+        # ``output_block_scale`` is the carrier the attention+quant fusion
+        # pass uses to request fused dynamic per-group FP8 output quant: the
+        # per-group scale tensor is produced by the kernel epilogue instead of
+        # a separate quant op.  Only layers that returned True from
+        # ``fused_output_quant_supported`` for a per-group FP8 key reach this
+        # path (NVFP4 block-scale returns False here), so a non-None value is
+        # always the per-group FP8 scale; route it to ``output_group_scale``.
+        output_group_scale = output_block_scale
+        if output_group_scale is not None and output_scale is not None:
             raise NotImplementedError(
-                "fused block_scale output quantization is not yet supported"
-                " for TritonAttentionImpl"
+                "TritonAttentionImpl cannot fuse both per-tensor and "
+                "per-group FP8 output quantization in the same call"
             )
+        # The fusion pass registers the per-group pattern only for the
+        # platform-default UE8M0 mode (``is_deep_gemm_e8m0_used()``), which is
+        # also the default ``per_token_group_quant_fp8`` would use — so derive
+        # the rounding mode here rather than threading a flag through the
+        # shared attention custom op / forward contract.  ``group_size`` and
+        # the row/column-major layout are recovered from the scale tensor's
+        # shape and strides inside ``unified_attention``.
+        output_group_ue8m0 = output_group_scale is not None and is_deep_gemm_e8m0_used()
 
         if attn_metadata is None:
             # Profiling run.
@@ -675,6 +708,8 @@ class TritonAttentionImpl(AttentionImpl):
             softmax_segm_expsum=softmax_segm_expsum,
             sinks=self.sinks,
             output_scale=output_scale,
+            output_group_scale=output_group_scale,
+            output_group_ue8m0=output_group_ue8m0,
             mm_prefix_range=mm_prefix_range_tensor,
             rswa_prefix_lens=attn_metadata.rswa_prefix_lens,
             rswa_window=attn_metadata.rswa_window,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -13,6 +13,9 @@ import torch
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    FP8_QUANT_EPS as _FP8_QUANT_EPS,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.ops.triton_attention_helpers import (
@@ -33,6 +36,11 @@ from vllm.v1.kv_cache_interface import KVQuantMode
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
+# Must wrap in tl.constexpr: a bare module-level Python float referenced inside
+# a @triton.jit kernel is not captured as a compile-time constant by this
+# Triton version (tl.maximum(..., <python float>) fails to compile), so the
+# wrap is load-bearing, not stylistic.
+FP8_QUANT_EPS = tl.constexpr(_FP8_QUANT_EPS)
 
 
 @triton.jit
@@ -289,6 +297,21 @@ def kernel_unified_attention(
     # instead of letting them override it. Default False preserves the
     # original (causal AND SW) OR mm_prefix behavior for all other models.
     MM_PREFIX_CLAMP_SW: tl.constexpr = False,
+    # Per-group dynamic FP8 output quantization (2D / prefill path only).
+    # When enabled the epilogue computes one FP8 scale per ``GROUP_SIZE``
+    # slice of ``head_size`` and quantizes ``acc`` in-place, writing the
+    # scales to ``out_group_scale_ptr`` — fusing the quant that would
+    # otherwise be a separate HBM round-trip after attention.
+    USE_FP8_GROUP: tl.constexpr = False,  # bool
+    GROUP_SIZE: tl.constexpr = 0,  # int, must evenly divide HEAD_SIZE
+    out_group_scale_ptr=None,  # [num_tokens, num_query_heads * NUM_GROUPS_PER_HEAD]
+    out_group_scale_stride_0: tl.int64 = 0,  # stride for token dim
+    out_group_scale_stride_1: tl.constexpr = 1,  # stride for group dim
+    NUM_GROUPS_PER_HEAD: tl.constexpr = 1,  # HEAD_SIZE // GROUP_SIZE
+    # Round per-group scales to powers of 2 (UE8M0 / MXFP-style), matching
+    # ``per_token_group_quant_fp8(use_ue8m0=True)`` — required by deep_gemm
+    # block-FP8 consumers (the default when ``is_deep_gemm_e8m0_used()``).
+    USE_UE8M0: tl.constexpr = False,  # bool
 ):
     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
@@ -647,6 +670,42 @@ def kernel_unified_attention(
         if USE_FP8:
             acc = acc * tl.load(out_scale)
             acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
+        elif USE_FP8_GROUP:
+            # Per-group dynamic FP8 quantization: compute one scale per
+            # GROUP_SIZE slice of head_size and quantize ``acc`` in-place,
+            # fusing the quant into the attention epilogue.  Each group spans
+            # a disjoint slice of ``offs_d``, so quantizing group ``g`` never
+            # perturbs the abs-max of a later group — no copy of ``acc`` is
+            # needed before the loop.
+            valid_mask = query_mask_0 & query_mask_1  # [BLOCK_M]
+            for g in tl.static_range(NUM_GROUPS_PER_HEAD):
+                g_start = g * GROUP_SIZE
+                group_mask = (offs_d >= g_start) & (offs_d < g_start + GROUP_SIZE)
+                combined_mask = group_mask[None, :] & dim_mask[None, :]
+                group_abs = tl.where(combined_mask, tl.abs(acc), 0.0)
+                group_max = tl.max(group_abs, axis=1)  # [BLOCK_M]
+                # Match per_token_group_quant_fp8 exactly so this fused path is
+                # numerically a no-op vs the standalone quant op it replaces:
+                # clamp the abs-max (not the scale) by eps, and multiply by the
+                # reciprocal of FP8_MAX (division can introduce a 1-ULP error
+                # that flips FP8 quantization at representable-value boundaries).
+                group_scale = tl.maximum(group_max, FP8_QUANT_EPS) * (1.0 / FP8_MAX)
+                if USE_UE8M0:
+                    # Round up to the next power of 2.  ``group_scale`` is
+                    # already >= eps/FP8_MAX > 0, so log2 is well-defined.
+                    group_scale = tl.exp2(tl.ceil(tl.log2(group_scale)))
+                acc = tl.where(combined_mask, acc / group_scale[:, None], acc)
+                scale_offset = (
+                    query_offset_0 * out_group_scale_stride_0
+                    + (query_offset_1 * NUM_GROUPS_PER_HEAD + g)
+                    * out_group_scale_stride_1
+                )
+                tl.store(
+                    out_group_scale_ptr + scale_offset,
+                    group_scale,
+                    mask=valid_mask,
+                )
+            acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
         if USE_TD_QO:
             # 2D target: flat output[token, head, :].  Strides come
             # straight from the caller (``output_stride_0`` per token,
@@ -704,6 +763,16 @@ def reduce_segments(
     USE_FP8: tl.constexpr,  # bool
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
+    # Per-group dynamic FP8 output quantization (3D / decode path).  The 3D
+    # main kernel stores unquantized per-segment partials; quantization must
+    # happen here, on the combined result, mirroring the ``USE_FP8`` path.
+    USE_FP8_GROUP: tl.constexpr = False,  # bool
+    GROUP_SIZE: tl.constexpr = 0,  # int, must evenly divide HEAD_SIZE
+    out_group_scale_ptr=None,  # [num_tokens, num_query_heads * NUM_GROUPS_PER_HEAD]
+    out_group_scale_stride_0: tl.int64 = 0,
+    out_group_scale_stride_1: tl.constexpr = 1,
+    NUM_GROUPS_PER_HEAD: tl.constexpr = 1,  # HEAD_SIZE // GROUP_SIZE
+    USE_UE8M0: tl.constexpr = False,  # round per-group scales to powers of 2
 ):
     query_token_idx = tl.program_id(0)
     query_head_idx = tl.program_id(1)
@@ -760,6 +829,28 @@ def reduce_segments(
 
     if USE_FP8:
         acc = acc * tl.load(out_scale_inv)
+        acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
+    elif USE_FP8_GROUP:
+        # Per-group dynamic FP8 quant on the combined (1D) result.  Groups
+        # span disjoint slices of ``offs_d``, so quantizing one never
+        # perturbs another's abs-max (no copy of ``acc`` needed).
+        offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+        for g in tl.static_range(NUM_GROUPS_PER_HEAD):
+            g_start = g * GROUP_SIZE
+            group_mask = (offs_d >= g_start) & (offs_d < g_start + GROUP_SIZE)
+            combined_mask = group_mask & dim_mask
+            group_abs = tl.where(combined_mask, tl.abs(acc), 0.0)
+            group_max = tl.max(group_abs)  # scalar (acc is 1D here)
+            # Match per_token_group_quant_fp8 exactly (see 2D epilogue note).
+            group_scale = tl.maximum(group_max, FP8_QUANT_EPS) * (1.0 / FP8_MAX)
+            if USE_UE8M0:
+                group_scale = tl.exp2(tl.ceil(tl.log2(group_scale)))
+            acc = tl.where(combined_mask, acc / group_scale, acc)
+            scale_offset = (
+                query_token_idx * out_group_scale_stride_0
+                + (query_head_idx * NUM_GROUPS_PER_HEAD + g) * out_group_scale_stride_1
+            )
+            tl.store(out_group_scale_ptr + scale_offset, group_scale)
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
 
     # write result
@@ -823,6 +914,10 @@ def unified_attention(
     softmax_segm_expsum=None,
     alibi_slopes=None,
     output_scale=None,
+    output_group_scale=None,
+    # Round fused per-group scales to powers of 2 (UE8M0) — set by callers
+    # whose downstream consumer expects deep_gemm-style block-FP8 scales.
+    output_group_ue8m0=False,
     qq_bias=None,
     # Optional tensor for sinks
     sinks=None,
@@ -928,6 +1023,37 @@ def unified_attention(
     num_kv_heads = k.shape[2]
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
+
+    # Per-group dynamic FP8 output quantization setup.  Implemented in both
+    # the 2D epilogue (``kernel_unified_attention``) and the 3D finalization
+    # (``reduce_segments``), so it composes with the normal 2D/3D launch
+    # selection below — no special-casing of the path is needed.
+    use_fp8_group = output_group_scale is not None
+    if use_fp8_group:
+        assert output_scale is None, (
+            "output_scale and output_group_scale are mutually exclusive"
+        )
+        # The scale tensor is laid out as (num_tokens, num_query_heads *
+        # num_groups_per_head); it may be column-major (transposed), so use
+        # ``size()`` for the logical shape rather than trusting stride order.
+        num_total_groups = output_group_scale.size(1)
+        hidden_size = num_query_heads * head_size
+        # ``group_size`` is inferred from the scale width; validate before the
+        # division so a malformed scale tensor fails with a clear message
+        # instead of a ZeroDivisionError or a silently-truncated group size.
+        assert num_total_groups > 0 and hidden_size % num_total_groups == 0, (
+            f"output_group_scale.size(1) ({num_total_groups}) must be a "
+            f"positive divisor of num_query_heads * head_size ({hidden_size})"
+        )
+        group_size = hidden_size // num_total_groups
+        assert group_size > 0 and head_size % group_size == 0, (
+            f"head_size ({head_size}) must be divisible by group_size "
+            f"({group_size}) for fused per-group FP8 quantization"
+        )
+        num_groups_per_head = head_size // group_size
+    else:
+        group_size = 0
+        num_groups_per_head = 1
 
     BLOCK_M = (
         16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
@@ -1163,6 +1289,13 @@ def unified_attention(
         USE_TD=use_td,
         USE_TD_QO=use_td_qo,
         MM_PREFIX_CLAMP_SW=mm_prefix_clamp_sliding_window,
+        USE_FP8_GROUP=use_fp8_group,
+        GROUP_SIZE=group_size,
+        out_group_scale_ptr=output_group_scale,
+        out_group_scale_stride_0=(output_group_scale.stride(0) if use_fp8_group else 0),
+        out_group_scale_stride_1=(output_group_scale.stride(1) if use_fp8_group else 1),
+        NUM_GROUPS_PER_HEAD=num_groups_per_head,
+        USE_UE8M0=output_group_ue8m0,
         **launch_kwargs,
     )
 
@@ -1186,4 +1319,15 @@ def unified_attention(
             BLOCK_Q=BLOCK_Q,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
             USE_FP8=output_scale is not None,
+            USE_FP8_GROUP=use_fp8_group,
+            GROUP_SIZE=group_size,
+            out_group_scale_ptr=output_group_scale,
+            out_group_scale_stride_0=(
+                output_group_scale.stride(0) if use_fp8_group else 0
+            ),
+            out_group_scale_stride_1=(
+                output_group_scale.stride(1) if use_fp8_group else 1
+            ),
+            NUM_GROUPS_PER_HEAD=num_groups_per_head,
+            USE_UE8M0=output_group_ue8m0,
         )

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -13,6 +13,9 @@ import torch
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    FP8_QUANT_EPS as _FP8_QUANT_EPS,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.ops.triton_attention_helpers import (
@@ -33,6 +36,11 @@ from vllm.v1.kv_cache_interface import KVQuantMode
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
+# Must wrap in tl.constexpr: a bare module-level Python float referenced inside
+# a @triton.jit kernel is not captured as a compile-time constant by this
+# Triton version (tl.maximum(..., <python float>) fails to compile), so the
+# wrap is load-bearing, not stylistic.
+FP8_QUANT_EPS = tl.constexpr(_FP8_QUANT_EPS)
 
 
 @triton.jit
@@ -289,6 +297,21 @@ def kernel_unified_attention(
     # instead of letting them override it. Default False preserves the
     # original (causal AND SW) OR mm_prefix behavior for all other models.
     MM_PREFIX_CLAMP_SW: tl.constexpr = False,
+    # Per-group dynamic FP8 output quantization (2D / prefill path only).
+    # When enabled the epilogue computes one FP8 scale per ``GROUP_SIZE``
+    # slice of ``head_size`` and quantizes ``acc`` in-place, writing the
+    # scales to ``out_group_scale_ptr`` — fusing the quant that would
+    # otherwise be a separate HBM round-trip after attention.
+    USE_FP8_GROUP: tl.constexpr = False,  # bool
+    GROUP_SIZE: tl.constexpr = 0,  # int, must evenly divide HEAD_SIZE
+    out_group_scale_ptr=None,  # [num_tokens, num_query_heads * NUM_GROUPS_PER_HEAD]
+    out_group_scale_stride_0: tl.int64 = 0,  # stride for token dim
+    out_group_scale_stride_1: tl.constexpr = 1,  # stride for group dim
+    NUM_GROUPS_PER_HEAD: tl.constexpr = 1,  # HEAD_SIZE // GROUP_SIZE
+    # Round per-group scales to powers of 2 (UE8M0 / MXFP-style), matching
+    # ``per_token_group_quant_fp8(use_ue8m0=True)`` — required by deep_gemm
+    # block-FP8 consumers (the default when ``is_deep_gemm_e8m0_used()``).
+    USE_UE8M0: tl.constexpr = False,  # bool
 ):
     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
@@ -652,6 +675,42 @@ def kernel_unified_attention(
         if USE_FP8:
             acc = acc * tl.load(out_scale)
             acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
+        elif USE_FP8_GROUP:
+            # Per-group dynamic FP8 quantization: compute one scale per
+            # GROUP_SIZE slice of head_size and quantize ``acc`` in-place,
+            # fusing the quant into the attention epilogue.  Each group spans
+            # a disjoint slice of ``offs_d``, so quantizing group ``g`` never
+            # perturbs the abs-max of a later group — no copy of ``acc`` is
+            # needed before the loop.
+            valid_mask = query_mask_0 & query_mask_1  # [BLOCK_M]
+            for g in tl.static_range(NUM_GROUPS_PER_HEAD):
+                g_start = g * GROUP_SIZE
+                group_mask = (offs_d >= g_start) & (offs_d < g_start + GROUP_SIZE)
+                combined_mask = group_mask[None, :] & dim_mask[None, :]
+                group_abs = tl.where(combined_mask, tl.abs(acc), 0.0)
+                group_max = tl.max(group_abs, axis=1)  # [BLOCK_M]
+                # Match per_token_group_quant_fp8 exactly so this fused path is
+                # numerically a no-op vs the standalone quant op it replaces:
+                # clamp the abs-max (not the scale) by eps, and multiply by the
+                # reciprocal of FP8_MAX (division can introduce a 1-ULP error
+                # that flips FP8 quantization at representable-value boundaries).
+                group_scale = tl.maximum(group_max, FP8_QUANT_EPS) * (1.0 / FP8_MAX)
+                if USE_UE8M0:
+                    # Round up to the next power of 2.  ``group_scale`` is
+                    # already >= eps/FP8_MAX > 0, so log2 is well-defined.
+                    group_scale = tl.exp2(tl.ceil(tl.log2(group_scale)))
+                acc = tl.where(combined_mask, acc / group_scale[:, None], acc)
+                scale_offset = (
+                    query_offset_0 * out_group_scale_stride_0
+                    + (query_offset_1 * NUM_GROUPS_PER_HEAD + g)
+                    * out_group_scale_stride_1
+                )
+                tl.store(
+                    out_group_scale_ptr + scale_offset,
+                    group_scale,
+                    mask=valid_mask,
+                )
+            acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
         if USE_TD_QO:
             # 2D target: flat output[token, head, :].  Strides come
             # straight from the caller (``output_stride_0`` per token,
@@ -709,6 +768,16 @@ def reduce_segments(
     USE_FP8: tl.constexpr,  # bool
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
+    # Per-group dynamic FP8 output quantization (3D / decode path).  The 3D
+    # main kernel stores unquantized per-segment partials; quantization must
+    # happen here, on the combined result, mirroring the ``USE_FP8`` path.
+    USE_FP8_GROUP: tl.constexpr = False,  # bool
+    GROUP_SIZE: tl.constexpr = 0,  # int, must evenly divide HEAD_SIZE
+    out_group_scale_ptr=None,  # [num_tokens, num_query_heads * NUM_GROUPS_PER_HEAD]
+    out_group_scale_stride_0: tl.int64 = 0,
+    out_group_scale_stride_1: tl.constexpr = 1,
+    NUM_GROUPS_PER_HEAD: tl.constexpr = 1,  # HEAD_SIZE // GROUP_SIZE
+    USE_UE8M0: tl.constexpr = False,  # round per-group scales to powers of 2
 ):
     query_token_idx = tl.program_id(0)
     query_head_idx = tl.program_id(1)
@@ -765,6 +834,28 @@ def reduce_segments(
 
     if USE_FP8:
         acc = acc * tl.load(out_scale_inv)
+        acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
+    elif USE_FP8_GROUP:
+        # Per-group dynamic FP8 quant on the combined (1D) result.  Groups
+        # span disjoint slices of ``offs_d``, so quantizing one never
+        # perturbs another's abs-max (no copy of ``acc`` needed).
+        offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+        for g in tl.static_range(NUM_GROUPS_PER_HEAD):
+            g_start = g * GROUP_SIZE
+            group_mask = (offs_d >= g_start) & (offs_d < g_start + GROUP_SIZE)
+            combined_mask = group_mask & dim_mask
+            group_abs = tl.where(combined_mask, tl.abs(acc), 0.0)
+            group_max = tl.max(group_abs)  # scalar (acc is 1D here)
+            # Match per_token_group_quant_fp8 exactly (see 2D epilogue note).
+            group_scale = tl.maximum(group_max, FP8_QUANT_EPS) * (1.0 / FP8_MAX)
+            if USE_UE8M0:
+                group_scale = tl.exp2(tl.ceil(tl.log2(group_scale)))
+            acc = tl.where(combined_mask, acc / group_scale, acc)
+            scale_offset = (
+                query_token_idx * out_group_scale_stride_0
+                + (query_head_idx * NUM_GROUPS_PER_HEAD + g) * out_group_scale_stride_1
+            )
+            tl.store(out_group_scale_ptr + scale_offset, group_scale)
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
 
     # write result
@@ -828,6 +919,10 @@ def unified_attention(
     softmax_segm_expsum=None,
     alibi_slopes=None,
     output_scale=None,
+    output_group_scale=None,
+    # Round fused per-group scales to powers of 2 (UE8M0) — set by callers
+    # whose downstream consumer expects deep_gemm-style block-FP8 scales.
+    output_group_ue8m0=False,
     qq_bias=None,
     # Optional tensor for sinks
     sinks=None,
@@ -933,6 +1028,37 @@ def unified_attention(
     num_kv_heads = k.shape[2]
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
+
+    # Per-group dynamic FP8 output quantization setup.  Implemented in both
+    # the 2D epilogue (``kernel_unified_attention``) and the 3D finalization
+    # (``reduce_segments``), so it composes with the normal 2D/3D launch
+    # selection below — no special-casing of the path is needed.
+    use_fp8_group = output_group_scale is not None
+    if use_fp8_group:
+        assert output_scale is None, (
+            "output_scale and output_group_scale are mutually exclusive"
+        )
+        # The scale tensor is laid out as (num_tokens, num_query_heads *
+        # num_groups_per_head); it may be column-major (transposed), so use
+        # ``size()`` for the logical shape rather than trusting stride order.
+        num_total_groups = output_group_scale.size(1)
+        hidden_size = num_query_heads * head_size
+        # ``group_size`` is inferred from the scale width; validate before the
+        # division so a malformed scale tensor fails with a clear message
+        # instead of a ZeroDivisionError or a silently-truncated group size.
+        assert num_total_groups > 0 and hidden_size % num_total_groups == 0, (
+            f"output_group_scale.size(1) ({num_total_groups}) must be a "
+            f"positive divisor of num_query_heads * head_size ({hidden_size})"
+        )
+        group_size = hidden_size // num_total_groups
+        assert group_size > 0 and head_size % group_size == 0, (
+            f"head_size ({head_size}) must be divisible by group_size "
+            f"({group_size}) for fused per-group FP8 quantization"
+        )
+        num_groups_per_head = head_size // group_size
+    else:
+        group_size = 0
+        num_groups_per_head = 1
 
     BLOCK_M = (
         16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
@@ -1168,6 +1294,13 @@ def unified_attention(
         USE_TD=use_td,
         USE_TD_QO=use_td_qo,
         MM_PREFIX_CLAMP_SW=mm_prefix_clamp_sliding_window,
+        USE_FP8_GROUP=use_fp8_group,
+        GROUP_SIZE=group_size,
+        out_group_scale_ptr=output_group_scale,
+        out_group_scale_stride_0=(output_group_scale.stride(0) if use_fp8_group else 0),
+        out_group_scale_stride_1=(output_group_scale.stride(1) if use_fp8_group else 1),
+        NUM_GROUPS_PER_HEAD=num_groups_per_head,
+        USE_UE8M0=output_group_ue8m0,
         **launch_kwargs,
     )
 
@@ -1191,4 +1324,15 @@ def unified_attention(
             BLOCK_Q=BLOCK_Q,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
             USE_FP8=output_scale is not None,
+            USE_FP8_GROUP=use_fp8_group,
+            GROUP_SIZE=group_size,
+            out_group_scale_ptr=output_group_scale,
+            out_group_scale_stride_0=(
+                output_group_scale.stride(0) if use_fp8_group else 0
+            ),
+            out_group_scale_stride_1=(
+                output_group_scale.stride(1) if use_fp8_group else 1
+            ),
+            NUM_GROUPS_PER_HEAD=num_groups_per_head,
+            USE_UE8M0=output_group_ue8m0,
         )


### PR DESCRIPTION
## Purpose

Fuses per-group FP8 dynamic output quantization into the Triton attention
kernel epilogue, eliminating the HBM round-trip to the separate
`per_token_group_fp8_quant` kernel.

Continuation of #37110 (core-approved but rebase-dead after the kernel was
unified into `kernel_unified_attention`). Picked up and coordinated on #37162:
original author @Etelis handed it off there and will review. Open design
question for @ProExpertProg below (deriving `use_ue8m0` from the platform
default vs threading it through the op).

Closes #37162.

**Not a duplicate of open work:** #40930 and #43772 fuse per-group FP8 into the
MLA path (`merge_attn_state` / MLA fused kernel); this PR targets the general
(non-MLA) `unified_attention` 2D (prefill) and 3D (`reduce_segments`, decode)
epilogues, which are disjoint code paths.

## Design

- **Fuses the quant into the attention epilogue**: per-group scale is computed
  from the fp32 accumulator while it is still in registers/SRAM, and the output
  is written straight to FP8 + scales, with no intermediate bf16 write/read to
  HBM.
- **Both paths**: 2D prefill (`kernel_unified_attention`) and 3D decode
  (`reduce_segments`, after the segment merge, since quant must happen on the
  combined result rather than per-segment).
- **Numerically a no-op vs `per_token_group_quant_fp8`**: eps clamped on the
  abs-max (not the scale), multiply-by-reciprocal of `FP8_MAX` (avoids a 1-ULP
  flip at representable-value boundaries), optional UE8M0 power-of-2 rounding.
- **No new flags on the shared op contract**: `use_ue8m0` is derived in the
  backend from `is_deep_gemm_e8m0_used()` (the same default
  `per_token_group_quant_fp8` uses), `group_size` from the scale tensor shape,
  row/col-major from its strides. `unified_attention_with_output` is shared by
  ~10 backends, so threading a quant flag through it would touch all of their
  `forward` signatures, which this avoids.
- **Fusion pass** `AttnFp8GroupQuantPattern` registers for group_size {128,64}
  x col-major {F,T}, for the platform-default UE8M0 mode; other variants fall
  back to the standalone quant op.

## Test Plan

Requires an FP8-capable GPU (Hopper+) and a build with `_C` compiled.

```
# Kernel correctness (2D + 3D paths)
pytest tests/kernels/attention/test_triton_unified_attention.py -k fp8_group -v

# End-to-end fusion (op removed from graph, fused == unfused)
pytest tests/compile/passes/test_fusion_attn.py -k fp8_group_quant -v

# Regression on existing fusions
pytest tests/compile/passes/test_fusion_attn.py -k "test_attention_quant_pattern and TRITON_ATTN" -v
```

## Test Result

**Environment:** 1x H100 NVL (sm_90), PyTorch 2.11.0+cu128, Triton 3.6.0, fp16,
real build (`_C` compiled).

**Correctness:** 76/76 kernel-unit + 24/24 e2e fusion pass. Covers group_size
{128,64} (1 and 2 groups/head), 2D+3D paths, ue8m0 in {F,T}, col-major in
{F,T}, including the scale-layout combos from #38877 and an all-zeros-group +
UE8M0 edge case (group_max == 0). No regression on static-fp8 / nvfp4. mypy /
ruff clean.

- Dequantized output vs dense bf16 reference: **L2 rel ~2.6%, max-vs-group-scale
  ~3.6%** (matches #37110's ~3.5%; within FP8 e4m3 resolution).
- vs `per_token_group_quant_fp8` (the op it replaces): **< 0.5% of FP8 bytes
  differ, all by 1 ULP**. The residual is the fp16 round-trip the fusion drops,
  so the fused path is marginally *more* accurate.

**Performance, prefill (32 q-heads / 8 kv-heads, head_size 128, group 128).**
Baseline is the production CUDA `_C` `per_token_group_fp8_quant`. The fusion's
win is that the epilogue is essentially free over bare attention; the
end-to-end speedup over attention + `_C`-quant is modest:

| shape (seqs x len) | bare attn (ms) | _C quant (ms) | unfused (ms) | fused (ms) | speedup | epilogue overhead |
|---|---|---|---|---|---|---|
| 4 x 512  | 0.180 | 0.025 | 0.203 | 0.181 | 1.12x | +0.2% |
| 4 x 1024 | 0.606 | 0.044 | 0.646 | 0.603 | 1.07x | -0.6% |
| 4 x 2048 | 2.214 | 0.080 | 2.306 | 2.192 | 1.05x | -1.0% |
| 4 x 4096 | 8.479 | 0.151 | 8.631 | 8.552 | 1.01x | +0.9% |
| 1 x 8192 | 8.452 | 0.080 | 8.561 | 8.339 | 1.03x | -1.3% |

The epilogue overhead vs bare attention is within +/-1% (noise): per-group FP8
quant is effectively free on top of attention.

**Performance, decode (3D path, query_len=1).** Implementing the 3D
`reduce_segments` epilogue (rather than forcing the 2D path under group quant)
matters: forcing 2D regresses decode up to ~7x in the low-batch/long-context
regime. With the 3D epilogue, group quant composes with the fast decode path at
~1.0x of the unquantized baseline:

| seqs | ctx | 3D baseline (us) | forced-2D (us) | 3D + group (us) | group penalty |
|---|---|---|---|---|---|
| 1 | 4096  | 36.2  | 201.3 | 36.7  | 1.01x |
| 4 | 4096  | 50.9  | 207.7 | 51.2  | 1.01x |
| 1 | 16384 | 111.0 | 790.0 | 108.0 | 0.97x |
| 8 | 16384 | 267.8 | 786.0 | 267.6 | 1.00x |

## Known follow-ups
- TMA-aligned scale layout not yet supported (epilogue emits row/col-major).
- UE8M0 power-of-2 boundary: < 0.5% of elements differ by 1 exponent vs the
  unfused path (fusion drops the intermediate fp16 round-trip); within the e2e
  tolerance.
- All-zeros group under UE8M0 emits a tiny power-of-two scale that differs from
  the CUDA `_C` quant op (~2^-42 vs ~2^-33; the `_C` and Triton reference quant
  ops disagree in this degenerate corner). The quantized values are 0 so the
  dequantized output is 0 either way, i.e. functionally inert; covered by
  `test_triton_unified_attn_fp8_group_all_zero_group_ue8m0`.
- head_dim=256 multi-group not benchmarked (kernel handles it; perf is a
  follow-up).

## AI assistance

Developed with AI coding assistance