### PR TITLE
fix: use .pop() with default None to avoid KeyError in chat.py (closes #44827)

### DIFF
--- a/examples/basic/offline_inference/chat.py
+++ b/examples/basic/offline_inference/chat.py
@@ -24,12 +24,12 @@ def create_parser():
 
 
 def main(args: dict):
-    # Pop arguments not used by LLM
-    max_tokens = args.pop("max_tokens")
-    temperature = args.pop("temperature")
-    top_p = args.pop("top_p")
-    top_k = args.pop("top_k")
-    chat_template_path = args.pop("chat_template_path")
+    # Pop arguments not used by LLM (use None as default if not provided)
+    max_tokens = args.pop("max_tokens", None)
+    temperature = args.pop("temperature", None)
+    top_p = args.pop("top_p", None)
+    top_k = args.pop("top_k", None)
+    chat_template_path = args.pop("chat_template_path", None)
 
     # Create an LLM
     llm = LLM(**args)


### PR DESCRIPTION
## What
The example script `examples/basic/offline_inference/chat.py` calls `args.pop()` for sampling parameters and chat_template_path without a default value. If the user does not provide these arguments on the command line, they will be absent from the parsed arguments dictionary, causing a KeyError.

## Fix
Changed `args.pop("max_tokens")` to `args.pop("max_tokens", None)` (and similarly for temperature, top_p, top_k, chat_template_path). This ensures that if the argument is not provided, `None` is returned instead of raising an error, which aligns with the subsequent logic that checks for `None`.

Closes #44827