### PR TITLE
[Doc] Document NIXL KV connector metrics aggregation semantics (issue #41230)

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -87,6 +87,29 @@ The figure below shows how the worker connector works with the attention module 
 
 ![Disaggregated prefilling workflow](../assets/features/disagg_prefill/workflow.png)
 
+## Interpreting KV Transfer Metrics
+
+When a KV connector is configured, vLLM periodically logs transfer
+statistics via the ``observe`` → ``aggregate`` → ``reduce`` → ``log``
+pipeline (see ``KVConnectorLogging`` in
+``vllm/distributed/kv_transfer/kv_connector/v1/metrics.py``).
+
+The connector-specific stats class (e.g. ``NixlKVConnectorStats``)
+determines the exact metrics emitted.  Below is a general guide for
+interpreting the most common metrics:
+
+| Metric | Semantics | TP > 1 note |
+|--------|-----------|-------------|
+| Num successful transfers | Total number of KV transfers completed across **all** TP ranks in the group. | Each rank sends its observations to the logger process; they are merged before ``observe()`` is called, so this number reflects the **group total**, not a per-rank count. |
+| Throughput (MB/s) | Average data throughput per transfer. | For ``NixlConnector``, this is the **per-rank average** (each rank reports its own throughput; the ``reduce`` step averages across ranks).  To get aggregate system throughput, multiply by the number of TP ranks. |
+| Latency (ms) | Time from transfer initiation to completion. | Per-rank observation, averaged across ranks in the ``reduce`` step. |
+
+!!! tip
+    When running with ``TP > 1``, remember that throughput and latency
+    metrics are **per-rank averages**.  Multiply throughput by the TP
+    degree to get total system throughput; latency values are already
+    representative since all ranks transfer concurrently.
+
 ## Third-party contributions
 
 Disaggregated prefilling is highly related to infrastructure, so vLLM relies on third-party connectors for production-level disaggregated prefilling (and vLLM team will actively review and merge new PRs for third-party connectors).

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -51,6 +51,39 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """Manages periodic logging and Prometheus recording of KV transfer metrics.
+
+    Pipeline (``observe`` → ``aggregate`` → ``reduce`` → ``log``):
+
+    1. **``observe(transfer_stats_data)``** — Called periodically when a
+       connector syncs with the scheduler.  The
+       ``transfer_stats_data`` dict is already **aggregated across all
+       workers** (TP ranks) by the time it reaches this method, so each
+       call contains observations from a single connector (or
+       ``MultiConnector``) for all ranks.
+
+    2. **``aggregate``** — Multiple ``observe`` calls within a logging
+       interval are accumulated into
+       ``self.transfer_stats_accumulator``.  The connector-specific
+       ``aggregate()`` method concatenates observation lists (via
+       ``list.extend``) from successive calls.
+
+    3. **``reduce``** — At the end of the interval, ``log()`` calls
+       ``reduce()`` on the accumulator, which computes summary
+       statistics (averages, percentiles, throughput) over the combined
+       pool of observations.  See the connector-specific stats class
+       (e.g. ``NixlKVConnectorStats``) for the exact semantics of
+       each metric.
+
+    4. **``log``** — The reduced dict is formatted as a human-readable
+       log line (``"KV Transfer metrics: ..."``) and emitted via the
+       configured ``log_fn`` (defaults to ``logger.info``).
+
+    Note: Stats arrive pre-aggregated across workers because each
+    worker sends its observations to the logger process independently,
+    and they are merged before ``observe`` is called.
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:
@@ -63,6 +96,13 @@ class KVConnectorLogging:
         self.transfer_stats_accumulator: KVConnectorStats | None = None
 
     def observe(self, transfer_stats_data: dict[str, Any]):
+        """Receive and accumulate connector transfer statistics.
+
+        Called periodically when a connector syncs with the scheduler.
+        ``transfer_stats_data`` is already aggregated across all TP ranks;
+        each call reflects observations from a single connector (or
+        ``MultiConnector``) for the entire rank group.
+        """
         # Should not be called when a KVConnector is not configured.
         assert self.connector_cls is not None
         # Called periodically when connector syncs with the scheduler.
@@ -91,7 +131,12 @@ class KVConnectorLogging:
             )
 
     def log(self, log_fn=logger.info):
-        """Log transfer metrics periodically, similar to throughput logging"""
+        """Log transfer metrics periodically, similar to throughput logging.
+
+        Calls ``reduce()`` on the accumulated stats to produce a summary
+        dict for the last logging interval, formats it as a log line, and
+        resets the accumulator for the next interval.
+        """
         if (
             self.transfer_stats_accumulator
             and not self.transfer_stats_accumulator.is_empty()


### PR DESCRIPTION
## Summary

Adds documentation for the NIXL KV connector metrics aggregation pipeline, addressing issue #41230.

### Changes

1. **`vllm/distributed/kv_transfer/kv_connector/v1/metrics.py`** — Added class and method docstrings:
   - `KVConnectorLogging` class docstring documenting the `observe → aggregate → reduce → log` pipeline
   - `observe()` method docstring with TP>1 pre-aggregation semantics note
   - `log()` method docstring describing periodic logging and accumulator reset

2. **`docs/features/disagg_prefill.md`** — Added "Interpreting KV Transfer Metrics" section:
   - 3-row table (metric / semantics / TP>1 note) covering num_successful_transfers, throughput MB/s, latency ms
   - Tip: multiply per-rank throughput by TP degree to get system throughput

### Why this is not duplicating an existing PR

Previous PRs #44438 and #44439 (both closed) attempted the same change but had DCO failures. This PR starts from a fresh branch off the latest upstream `main` with correct DCO attribution.

### Test commands run

```bash
# Verified docstrings render correctly
python -c "from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorLogging; help(KVConnectorLogging)"
```

No functional code changes — only documentation (docstrings + markdown).

### AI assistance statement

This PR was written with Claude Code (Anthropic) assistance. The submitter reviewed every changed line and verified the documentation accuracy by cross-referencing the source code.

Co-authored-by: Claude
Signed-off-by: Jackie2049 <jackie2049@foxmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)