### PR TITLE
[Bugfix] Validate model_loader_extra_config values in DefaultModelLoader

### DIFF
--- a/tests/model_executor/model_loader/test_default_loader_extra_config.py
+++ b/tests/model_executor/model_loader/test_default_loader_extra_config.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for DefaultModelLoader's model_loader_extra_config validation.
+
+Regression tests for https://github.com/vllm-project/vllm/issues/45088,
+where string values (e.g. ``{"num_threads": "6"}``) were passed through
+unvalidated and crashed deep inside ThreadPoolExecutor during engine
+startup. String booleans (e.g. ``"False"``) were also silently truthy,
+enabling multithreaded loading when the user intended to disable it.
+"""
+
+import pytest
+
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        # Issue #45088: JSON string instead of boolean.
+        {"enable_multithread_load": "True"},
+        # Silently-truthy string: would have *enabled* multithread load.
+        {"enable_multithread_load": "False"},
+        {"enable_multithread_load": 1},
+        # Issue #45088: JSON string instead of integer -> TypeError in
+        # ThreadPoolExecutor(max_workers="6").
+        {"enable_multithread_load": True, "num_threads": "6"},
+        {"enable_multithread_load": True, "num_threads": 0},
+        {"enable_multithread_load": True, "num_threads": -1},
+        {"enable_multithread_load": True, "num_threads": 6.0},
+        {"enable_multithread_load": True, "num_threads": True},
+    ],
+)
+def test_extra_config_rejects_invalid_values(extra_config):
+    with pytest.raises(ValueError, match="model_loader_extra_config"):
+        DefaultModelLoader(LoadConfig(model_loader_extra_config=extra_config))
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        {},
+        {"enable_multithread_load": True},
+        {"enable_multithread_load": False},
+        {"enable_multithread_load": True, "num_threads": 6},
+        {"num_threads": 4},
+    ],
+)
+def test_extra_config_accepts_valid_values(extra_config):
+    loader = DefaultModelLoader(LoadConfig(model_loader_extra_config=extra_config))
+    assert isinstance(loader.enable_multithread_load, bool)
+    assert isinstance(loader.num_threads, int)
+    assert loader.num_threads >= 1
+
+
+def test_extra_config_defaults():
+    loader = DefaultModelLoader(LoadConfig())
+    assert loader.enable_multithread_load is False
+    assert loader.num_threads == DefaultModelLoader.DEFAULT_NUM_THREADS
+
+
+def test_extra_config_still_rejects_unexpected_keys():
+    # Pre-existing key validation must keep working alongside the new
+    # value validation.
+    with pytest.raises(ValueError, match="Unexpected extra config keys"):
+        DefaultModelLoader(
+            LoadConfig(model_loader_extra_config={"enable_multithread": True})
+        )

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -94,6 +94,32 @@ class DefaultModelLoader(BaseModelLoader):
             "enable_weights_track", None
         )
 
+        enable_multithread_load = extra_config.get("enable_multithread_load", False)
+        if not isinstance(enable_multithread_load, bool):
+            raise ValueError(
+                "model_loader_extra_config['enable_multithread_load'] must "
+                "be a JSON boolean, got "
+                f"{type(enable_multithread_load).__name__} "
+                f"({enable_multithread_load!r}). Example: "
+                "--model-loader-extra-config "
+                '\'{"enable_multithread_load": true, "num_threads": 6}\''
+            )
+        self.enable_multithread_load: bool = enable_multithread_load
+
+        num_threads = extra_config.get("num_threads", self.DEFAULT_NUM_THREADS)
+        if (
+            isinstance(num_threads, bool)
+            or not isinstance(num_threads, int)
+            or num_threads < 1
+        ):
+            raise ValueError(
+                "model_loader_extra_config['num_threads'] must be a "
+                f"positive JSON integer, got {type(num_threads).__name__} "
+                f"({num_threads!r}). Example: --model-loader-extra-config "
+                '\'{"enable_multithread_load": true, "num_threads": 6}\''
+            )
+        self.num_threads: int = num_threads
+
     def _prepare_weights(
         self,
         model_name_or_path: str,
@@ -212,7 +238,6 @@ class DefaultModelLoader(BaseModelLoader):
         self, source: "Source"
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
-        extra_config = self.load_config.model_loader_extra_config
         hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
             source.model_or_path,
             source.subfolder,
@@ -242,13 +267,11 @@ class DefaultModelLoader(BaseModelLoader):
                     self.load_config.use_tqdm_on_load,
                 )
             else:
-                if extra_config.get("enable_multithread_load"):
+                if self.enable_multithread_load:
                     weights_iterator = multi_thread_safetensors_weights_iterator(
                         hf_weights_files,
                         self.load_config.use_tqdm_on_load,
-                        max_workers=extra_config.get(
-                            "num_threads", self.DEFAULT_NUM_THREADS
-                        ),
+                        max_workers=self.num_threads,
                     )
                 else:
                     weights_iterator = safetensors_weights_iterator(
@@ -264,14 +287,12 @@ class DefaultModelLoader(BaseModelLoader):
                         ),
                     )
         else:
-            if extra_config.get("enable_multithread_load"):
+            if self.enable_multithread_load:
                 weights_iterator = multi_thread_pt_weights_iterator(
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
                     self.load_config.pt_load_map_location,
-                    max_workers=extra_config.get(
-                        "num_threads", self.DEFAULT_NUM_THREADS
-                    ),
+                    max_workers=self.num_threads,
                 )
             else:
                 weights_iterator = pt_weights_iterator(


### PR DESCRIPTION
String values from --model-loader-extra-config JSON were passed through unvalidated: a string num_threads crashed ThreadPoolExecutor deep in EngineCore startup, and a string "False" for enable_multithread_load was silently truthy. Validate both values at loader construction, matching the existing key validation, and fail fast with a clear error.

## Purpose

Fixes #45088.

`vllm serve ... --model-loader-extra-config '{"enable_multithread_load": "True", "num_threads": "6"}'` crashes during engine startup with:
TypeError: '<=' not supported between instances of 'str' and 'int'

because the string `"6"` reaches `ThreadPoolExecutor(max_workers=...)` in `multi_thread_safetensors_weights_iterator` unvalidated.

There is also a silent variant: `enable_multithread_load` is checked with a bare truthy test, so the string `"False"` *enables* multithreaded loading.

## Fix

`DefaultModelLoader.__init__` already validates extra-config **keys** (raises `ValueError` on unexpected ones). This PR extends the same pattern to **values**:

- `enable_multithread_load` must be a JSON boolean
- `num_threads` must be a positive JSON integer (explicitly excluding `bool`, which is an `int` subclass in Python)

Validation happens once at loader construction with an error message showing the correct format, instead of a `TypeError` deep inside EngineCore startup. Both usage sites in `_get_weights_iterator` now read the validated attributes. Strict rejection was chosen over coercion because there is no safe coercion for string booleans (`"False"` → ?); happy to switch to coercing numeric strings if maintainers prefer.

**Before:**

TypeError: '<=' not supported between instances of 'str' and 'int'
RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}

**After:**

ValueError: model_loader_extra_config['num_threads'] must be a positive JSON integer, got str ('6'). Example: --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 6}'

## Test Plan

New unit tests in `tests/model_executor/model_loader/test_default_loader_extra_config.py`: 8 invalid configs rejected (including both failure modes from the issue), 5 valid configs accepted, defaults verified, and pre-existing key validation confirmed intact. No GPU required.

## Test Result

plugins: anyio-4.13.0
collected 15 items

tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config0] PASSED [  6%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config1] PASSED [ 13%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config2] PASSED [ 20%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config3] PASSED [ 26%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config4] PASSED [ 33%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config5] PASSED [ 40%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config6] PASSED [ 46%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config7] PASSED [ 53%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config0] PASSED [ 60%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config1] PASSED [ 66%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config2] PASSED [ 73%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config3] PASSED [ 80%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config4] PASSED [ 86%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_defaults PASSED [ 93%]
tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_still_rejects_unexpected_keys PASSED [100%]

The new tests fail on `main` without the fix (string values pass through unvalidated).

=========================================== short test summary info ============================================
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config0] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config1] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config2] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config3] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config4] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config5] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config6] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_rejects_invalid_values[extra_config7] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config0] - AttributeError: 'DefaultModelLoader' object has no attribute 'enable_multithread_load'
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config1] - AttributeError: 'DefaultModelLoader' object has no attribute 'enable_multithread_load'
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config2] - AttributeError: 'DefaultModelLoader' object has no attribute 'enable_multithread_load'
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config3] - AttributeError: 'DefaultModelLoader' object has no attribute 'enable_multithread_load'
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_accepts_valid_values[extra_config4] - AttributeError: 'DefaultModelLoader' object has no attribute 'enable_multithread_load'
FAILED tests/model_executor/model_loader/test_default_loader_extra_config.py::test_extra_config_defaults - AttributeError: 'DefaultModelLoader' object has no attribute 'enable_multithread_load'
================================== 14 failed, 1 passed, 17 warnings in 3.72s ===================================

