### PR TITLE
[Bugfix][Tool calling] Fix Qwen3 parsing when reasoning end tag arrives in multiple batches

### DIFF
--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -373,3 +373,201 @@ def test_reasoning_thinking_disabled(
 
     assert reasoning == expected_reasoning
     assert content == expected_content
+
+
+SPLITTING_DELTAS_AND_EXPECTED = [
+    pytest.param(
+        ["This is reasoning text", "</", "think>", "This is content"],
+        "This is reasoning text",
+        "This is content",
+        id="end_tag_split_across_two_chunks",
+    ),
+    pytest.param(
+        ["This is reasoning text<", "/think", ">", "This is content"],
+        "This is reasoning text",
+        "This is content",
+        id="end_tag_split_three_ways",
+    ),
+    pytest.param(
+        # Splitting into "</t" + "hi" to circumvent typo linting rules
+        ["First reasoning", " Second reasoning", " </t" + "hi", "nk>", "content"],
+        "First reasoning Second reasoning",
+        "content",
+        id="multiple_reasoning_chunks_before_split_tag",
+    ),
+    pytest.param(
+        ["This is reasoning", "This is content without end tag"],
+        "This is reasoningThis is content without end tag",
+        None,
+        id="missing_end_tag_everything_is_reasoning",
+    ),
+    pytest.param(
+        # Splitting into "</t" + "hi" to circumvent typo linting rules
+        ["This is reasoning</t" + "hi", "nkThis is content"],
+        "This is reasoning</thinkThis is content",
+        None,
+        id="partial_tag_not_recognized",
+    ),
+    pytest.param(
+        ["This is reasoning</th", "ink>This is content"],
+        "This is reasoning",
+        "This is content",
+        id="case_3a_tag_split_reasoning_then_content",
+    ),
+    pytest.param(
+        ["This is reasoning", "</think>This is content"],
+        "This is reasoning",
+        "This is content",
+        id="case_3b_complete_tag_in_content_chunk",
+    ),
+    pytest.param(
+        ["This is", " reasoning", "</think>This is content"],
+        "This is reasoning",
+        "This is content",
+        id="case_3c_tag_with_content_after_reasoning",
+    ),
+    pytest.param(
+        ["This is reasoning", "</th", "i", "nk>", "content"],
+        "This is reasoning",
+        "content",
+        id="case_3d_tag_split_multiple_ways",
+    ),
+    pytest.param(
+        [
+            "I'll check the weather",
+            "</think><tool_call>",
+            "<function=get_weather>",
+            "<parameter=ci",
+            "ty>Tokyo</parameter>",
+            "</function></tool_call>",
+        ],
+        "I'll check the weather",
+        "<tool_call><function=get_weather><parameter=city>Tokyo</parameter></function></tool_call>",
+        id="tool_call_parameter_tag_split",
+    ),
+    pytest.param(
+        [
+            "Let me search",
+            "</think>",
+            "<tool_call><function=search>",
+            "<parameter=query>how",
+            " to cook pasta</parameter>",
+            "</function></tool_call>",
+        ],
+        "Let me search",
+        "<tool_call><function=search><parameter=query>how to cook pasta</parameter></function></tool_call>",  # noqa: E501
+        id="tool_call_parameter_value_split",
+    ),
+    pytest.param(
+        [
+            "Getting data",
+            "</think>",
+            "<tool_call>",
+            "<function=api_call>",
+            "<parameter=url>http",
+            "s://api.example.com</parameter>",
+            "<parameter=method>G",
+            "ET</parameter>",
+            "</function></tool_call>",
+        ],
+        "Getting data",
+        "<tool_call><function=api_call><parameter=url>https://api.example.com</parameter><parameter=method>GET</parameter></function></tool_call>",  # noqa: E501
+        id="multiple_parameters_split",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "deltas, expected_reasoning, expected_content", SPLITTING_DELTAS_AND_EXPECTED
+)
+def test_splitting_reasoning_tokens(
+    deltas: list[str],
+    expected_reasoning: str | None,
+    expected_content: str | None,
+    qwen3_tokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        qwen3_tokenizer
+    )
+
+    reconstructor: StreamingReasoningReconstructor = run_reasoning_extraction_streaming(
+        parser, deltas
+    )
+
+    assert reconstructor.reasoning == expected_reasoning, (
+        f"Expected reasoning '{expected_reasoning}' but got '{reconstructor.reasoning}'"
+    )
+    assert (reconstructor.other_content or None) == expected_content, (
+        f"Expected content '{expected_content}' but got '{reconstructor.other_content}'"
+    )
+
+
+@pytest.mark.parametrize(
+    "stream_interval",
+    [2, 3, 5, 10],
+    ids=["interval_2", "interval_3", "interval_5", "interval_10"],
+)
+def test_with_stream_interval(stream_interval: int, qwen3_tokenizer):
+    """
+    Test that simulates real-world MTP or large stream-interval scenarios.
+
+    This test batches tokens according to stream_interval and verifies that
+    the parser correctly handles all edge cases when tags are split across
+    batch boundaries.
+    """
+    full_output = (
+        "I need to analyze this carefully. "
+        "First, let me think about the approach. "
+        "The solution requires checking multiple factors."
+        "</think>"
+        "Based on my analysis, I'll proceed with the following action: "
+        "<tool_call>"
+        "<function=execute_query>"
+        "<parameter=database>production</parameter>"
+        "<parameter=query>SELECT * FROM users WHERE status='active'</parameter>"
+        "</function>"
+        "</tool_call>"
+    )
+
+    # Tokenize the full output
+    tokens = qwen3_tokenizer.tokenize(full_output)
+    token_strings = [
+        qwen3_tokenizer.convert_tokens_to_string([token]) for token in tokens
+    ]
+
+    # Batch tokens according to stream_interval
+    batched_deltas = []
+    for i in range(0, len(token_strings), stream_interval):
+        batch = "".join(token_strings[i : i + stream_interval])
+        batched_deltas.append(batch)
+
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        qwen3_tokenizer
+    )
+
+    reconstructor: StreamingReasoningReconstructor = run_reasoning_extraction_streaming(
+        parser, batched_deltas
+    )
+
+    # Expected results
+    expected_reasoning = (
+        "I need to analyze this carefully. "
+        "First, let me think about the approach. "
+        "The solution requires checking multiple factors."
+    )
+    expected_content = (
+        "Based on my analysis, I'll proceed with the following action: "
+        "<tool_call>"
+        "<function=execute_query>"
+        "<parameter=database>production</parameter>"
+        "<parameter=query>SELECT * FROM users WHERE status='active'</parameter>"
+        "</function>"
+        "</tool_call>"
+    )
+
+    assert reconstructor.reasoning == expected_reasoning, (
+        f"With interval {stream_interval}, reasoning was incorrect"
+    )
+    assert reconstructor.other_content == expected_content, (
+        f"With interval {stream_interval}, content was incorrect"
+    )

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -13,21 +13,16 @@ class StreamingReasoningReconstructor:
         self.other_content = None
 
     def append_delta(self, delta: DeltaMessage):
-        # content and the reasoning content should not be present
-        # at the same time
-        assert delta.content is None or delta.reasoning is None, (
-            "Both content and reasoning content are present in the delta message"
-        )
+        if delta.reasoning is not None:
+            if self.reasoning is None:
+                self.reasoning = delta.reasoning
+            else:
+                self.reasoning += delta.reasoning
         if delta.content is not None:
             if self.other_content is None:
                 self.other_content = delta.content
             else:
                 self.other_content += delta.content
-        else:
-            if self.reasoning is None:
-                self.reasoning = delta.reasoning
-            else:
-                self.reasoning += delta.reasoning
 
 
 def run_reasoning_extraction(

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -50,6 +50,10 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         self._tool_call_end_tag = "</tool_call>"
         self._tool_call_end_token_id = self.vocab.get(self._tool_call_end_tag)
 
+        # Buffer for partial tags across chunk boundaries
+        self._pending_text = ""
+        self._reasoning_ended = False
+
     @property
     def start_token(self) -> str:
         """The token that starts reasoning content."""
@@ -189,6 +193,7 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             # End token in this delta: split reasoning from content.
             end_index = delta_text.find(self.end_token)
             if end_index >= 0:
+                self._reasoning_ended = True
                 reasoning = delta_text[:end_index]
                 content = delta_text[end_index + len(self.end_token) :]
                 if not reasoning and not content:
@@ -207,8 +212,13 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         ):
             tool_index = delta_text.find(self._tool_call_tag)
             if tool_index >= 0:
-                reasoning = delta_text[:tool_index]
-                content = delta_text[tool_index:]
+                if not self._reasoning_ended:
+                    self._reasoning_ended = True
+                    reasoning = delta_text[:tool_index]
+                    content = delta_text[tool_index:]
+                else:
+                    reasoning = ""
+                    content = delta_text
                 return DeltaMessage(
                     reasoning=reasoning if reasoning else None,
                     content=content if content else None,
@@ -226,6 +236,60 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             and self._tool_call_token_id in previous_token_ids
         ):
             return DeltaMessage(content=delta_text)
+        elif self._reasoning_ended:
+            # We've already seen the end token in a previous delta: this is all content.
+            return DeltaMessage(content=delta_text)
+
+        # Check if we have partial text for tokens in the test and deal with
+        # it. Also handle previous leftover partial text.
+        # Combine pending text from previous chunk with current delta
+        combined_text = self._pending_text + delta_text
+
+        # Strip <think> from combined text if present (old template / edge case
+        # where the model generates <think> itself).
+        if self.start_token in combined_text:
+            start_idx = combined_text.find(self.start_token)
+            if start_idx >= 0:
+                combined_text = combined_text[start_idx + len(self.start_token) :]
+
+        if self.end_token in combined_text:
+            end_idx = combined_text.find(self.end_token)
+            if end_idx >= 0:
+                reasoning_part = combined_text[:end_idx].rstrip()
+                content_part = combined_text[end_idx + len(self.end_token) :]
+                self._pending_text = ""
+                self._reasoning_ended = True
+                if not reasoning_part and not content_part:
+                    return None
+                return DeltaMessage(
+                    reasoning=reasoning_part if reasoning_part else None,
+                    content=content_part if content_part else None,
+                )
+
+        max_tag_len = max(
+            len(self.end_token),
+            len(self._tool_call_tag) if self._tool_call_tag else 0,
+        )
+
+        partial_match_len = 0
+        for i in range(1, min(max_tag_len, len(combined_text)) + 1):
+            suffix = combined_text[-i:]
+            # Check if this suffix could be the start of any tag
+            if self.end_token.startswith(suffix) or (
+                self._tool_call_tag and self._tool_call_tag.startswith(suffix)
+            ):
+                partial_match_len = i
+
+        if partial_match_len > 0:
+            # Keep the potential partial tag (and any leading whitespace) in the buffer
+            safe_to_emit = combined_text[:-partial_match_len].rstrip()
+            self._pending_text = combined_text[-partial_match_len:]
         else:
-            # No end token yet: still in reasoning phase.
-            return DeltaMessage(reasoning=delta_text)
+            # No partial tag - emit everything
+            safe_to_emit = combined_text
+            self._pending_text = ""
+
+        if not safe_to_emit:
+            return None
+
+        return DeltaMessage(reasoning=safe_to_emit)


### PR DESCRIPTION
Addressing some issues raised in https://github.com/vllm-project/vllm/issues/43436.

### Testing:
Added 2 unit tests in `tests/reasoning/test_qwen3_reasoning_parser.py`: `test_splitting_reasoning_tokens` and `test_with_stream_interval`.

TODO: benchmarking