### PR TITLE
[Bugfix] Hermes tool parser: parse tool call JSON by object boundary, not literal </tool_call>

### DIFF
--- a/tests/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/tool_parsers/test_hermes_tool_parser.py
@@ -412,3 +412,55 @@ def test_hermes_streaming_content_and_tool_call_in_single_chunk(
     assert tool_parts[0].function.name == "f"
     args_str = "".join(tc.function.arguments or "" for tc in tool_parts)
     assert json.loads(args_str) == {"x": 1}
+
+
+def test_hermes_parser_non_streaming_literal_end_tag_in_string(
+    qwen_tokenizer: TokenizerLike,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    # A literal </tool_call> inside a JSON string argument must not be treated
+    # as the end tag; otherwise the whole tool call is silently dropped.
+    content = "예시 태그: </tool_call> 포함 한국어 본문"
+    call = {"name": "edit_file", "arguments": {"content": content}}
+    text = "<tool_call>\n" + json.dumps(call, ensure_ascii=False) + "\n</tool_call>"
+
+    parser = Hermes2ProToolParser(qwen_tokenizer)
+    tool_call = parser.extract_tool_calls(
+        model_output=text,
+        request=any_chat_request,
+    )
+
+    assert tool_call.tools_called
+    assert tool_call.tool_calls[0].function.name == "edit_file"
+    assert json.loads(tool_call.tool_calls[0].function.arguments) == {
+        "content": content
+    }
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<tool_call>{"name": "a", "arguments": {}} trailing prose',
+        '<tool_call>{"name": "a", "arguments": {}}'
+        '{"name": "b", "arguments": {}}</tool_call>',
+        '<tool_call>{"name": "a", "arguments": {}}'
+        '<tool_call>{"name": "b", "arguments": {}}</tool_call>',
+    ],
+)
+def test_hermes_parser_non_streaming_trailing_data_falls_back_to_content(
+    qwen_tokenizer: TokenizerLike,
+    any_chat_request: ChatCompletionRequest,
+    text: str,
+) -> None:
+    # A valid JSON object followed by junk inside the block (trailing prose or a
+    # concatenated second object) is malformed and must fall back to content,
+    # the same as the original json.loads behavior -- not silently accept only
+    # the leading object.
+    parser = Hermes2ProToolParser(qwen_tokenizer)
+    tool_call = parser.extract_tool_calls(
+        model_output=text,
+        request=any_chat_request,
+    )
+
+    assert not tool_call.tools_called
+    assert tool_call.content == text

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -79,18 +79,44 @@ class Hermes2ProToolParser(ToolParser):
 
         else:
             try:
-                # there are two possible captures - between tags, or between a
-                # tag and end-of-string so the result of
-                # findall is an array of tuples where one is a function call and
-                # the other is None
-                function_call_tuples = self.tool_call_regex.findall(model_output)
+                # Decode each tool call by JSON-parsing from just after the
+                # <tool_call> token instead of slicing to the first literal
+                # </tool_call>. JSONDecoder.raw_decode respects string escaping,
+                # so a literal </tool_call> inside a JSON string argument no
+                # longer truncates the call. The loop walks each <tool_call>
+                # block in turn.
+                decoder = json.JSONDecoder()
+                raw_function_calls = []
+                search_idx = 0
+                while (
+                    start := model_output.find(self.tool_call_start_token, search_idx)
+                ) != -1:
+                    json_start = start + len(self.tool_call_start_token)
+                    while (
+                        json_start < len(model_output)
+                        and model_output[json_start].isspace()
+                    ):
+                        json_start += 1
+                    # raw_decode raises on invalid/incomplete JSON; the outer
+                    # except then falls back to returning the raw text as
+                    # content, matching the previous behavior.
+                    obj, end = decoder.raw_decode(model_output, json_start)
+                    # The object must be followed by the end tag or
+                    # end-of-string. Anything else (concatenated objects,
+                    # trailing junk, a missing end tag between calls) was also
+                    # rejected by the old json.loads, so raise to keep that
+                    # behavior.
+                    tail = end
+                    while tail < len(model_output) and model_output[tail].isspace():
+                        tail += 1
+                    if not (
+                        tail == len(model_output)
+                        or model_output.startswith(self.tool_call_end_token, tail)
+                    ):
+                        raise ValueError("unexpected trailing data in tool call")
+                    raw_function_calls.append(obj)
+                    search_idx = end
 
-                # load the JSON, and then use it to build the Function and
-                # Tool Call
-                raw_function_calls = [
-                    json.loads(match[0] if match[0] else match[1])
-                    for match in function_call_tuples
-                ]
                 tool_calls = [
                     ToolCall(
                         type="function",


### PR DESCRIPTION
Partially addresses #45167 (non-streaming path; streaming is tracked there as a follow-up).

## Purpose

`Hermes2ProToolParser.extract_tool_calls` extracts each tool call by slicing up to the first literal `</tool_call>` (the non-greedy `tool_call_regex`). When a tool argument's JSON string value contains that literal -- which happens when arguments echo user or document content (RAG, code-editing tools) -- the slice cuts the string short, `json.loads` sees invalid JSON, and the call is silently dropped (`tools_called=False`). This reproduces after a real tokenize->detokenize round-trip on both `Qwen/Qwen2.5-0.5B` and `kakaocorp/kanana-2-30b-a3b-instruct-2601` (repro in the issue).

This PR parses each call with `json.JSONDecoder().raw_decode()` from just after `<tool_call>`, which respects JSON string escaping and stops at the object's real boundary, so an embedded `</tool_call>` is preserved. Behavior on malformed input is unchanged: if the decoded object isn't followed by the end tag or end-of-string, extraction raises and falls back to content -- the same outcome the old `json.loads` produced (concatenated objects, trailing junk, and a missing end tag between calls are all rejected as before).

Scope: non-streaming only. The streaming path has the same root cause, but a naive `raw_decode` swap there regresses at some stream intervals (`partial_tag_overlap` mistakes a literal `</tool_call` inside an unclosed JSON string for a partial end tag) -- caught by my own streaming regression test during development. It needs a JSON-aware incremental scanner, planned as a follow-up in the issue.

## Test Plan

`pytest tests/tool_parsers/test_hermes_tool_parser.py`

Adds `test_hermes_parser_non_streaming_literal_end_tag_in_string` (a literal `</tool_call>` inside a Korean JSON string argument) and `test_hermes_parser_non_streaming_trailing_data_falls_back_to_content` (trailing prose, concatenated objects, and a missing end tag between calls still fall back to content).

## Test Result

The literal-tag test fails on `main` (call dropped, `tools_called=False`) and passes with this change, recovering `{"content": "예시 태그: </tool_call> 포함 한국어 본문"}` intact. Full suite: 34 passed, 1 skipped locally -- 30 pre-existing tests unchanged plus 4 new test instances (macOS; the global-cleanup teardown fixture is skipped due to an unrelated torch/MPS `empty_cache` issue -- test bodies all run, and CI runs the full suite as-is).
