### PR TITLE
[Bugfix] [DSV4] [ROCm] Pin apache-tvm-ffi version to `0.1.10`

### DIFF
--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -23,6 +23,7 @@ timm>=1.0.17
 # To be consistent with test_quark.py
 amd-quark>=0.8.99
 tilelang==0.1.10
-
+# Required apache-tvm-ffi matching tilelang version
+apache-tvm-ffi==0.1.10 
 # Required for faster safetensors model loading
 fastsafetensors >= 0.3.2

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -44,6 +44,7 @@ anyio==4.13.0
     #   watchfiles
 apache-tvm-ffi==0.1.10
     # via
+    #   -c requirements/rocm.txt
     #   tilelang
     #   xgrammar
 arctic-inference==0.1.1


### PR DESCRIPTION



## Purpose

It will cause the following error when launching deepseekv4

```
PIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]              ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]   File "vllmmain2/vllm/model_executor/models/registry.py", line 920, in inspect_model_cls
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]     mi = _run_in_subprocess(
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]          ^^^^^^^^^^^^^^^^^^^
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]   File "vllmmain2/vllm/model_executor/models/registry.py", line 1399, in _run_in_subprocess
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]     raise RuntimeError(
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961] RuntimeError: Error raised in subprocess:
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961] <frozen runpy>:128: RuntimeWarning: 'vllm.model_executor.models.registry' found in sys.modules after import of package 'vllm.model_executor.models', but prior to execution of 'vllm.model_executor.models.registry'; this may result in unpredictable behaviour
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961] terminate called after throwing an instance of 'tvm::ffi::Error'
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961]   what():  TypeAttr `__ffi_repr__` is already registered for type index 130. To update the stored value, register a mutable container (e.g., Dict/List) once and mutate it in place on subsequent calls.
(APIServer pid=36630) ERROR 06-10 15:50:56 [registry.py:961] 
```

This is caused by the apache-tvm-ffi unintendedly updated to `0.1.12` . Pinning to the version `0.1.10` as what has been shown in the `requirements/test/rocm.txt` resolves this issue.

## Test Plan

Launch deepseekv4 successfully

```bash
export VLLM_ROCM_USE_AITER=1
vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --tensor-parallel-size 8 \
  --distributed-executor-backend mp \
  --gpu-memory-utilization 0.9 \
  --max-num-seqs 512 \
  --max-num-batched-tokens 8192 \
  --compilation-config '{"mode": 3, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --speculative_config '{"method":"mtp","num_speculative_tokens":2}'
```

## Test Result

GSM8K
```
local-completions ({'model': 'deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://0.0.0.0:8000/v1/completions', 'num_concurrent': 256, 'max_retries': 10, 'max_gen_toks': 2048, 'timeout': 60000}), gen_kwargs: ({}), limit: None, num_fewshot: 20, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9492|_  | 0.006|
|     |       |strict-match    |    20|exact_match|_  |0.9500|_  | 0.006|
```

Draft acceptance rate
```
SpecDecoding metrics: Mean acceptance length: 2.68, Accepted throughput: 184.81 tokens/s, Drafted throughput: 220.61 tokens/s, Accepted: 1848 tokens, Drafted: 2206 tokens, Per-position acceptance rate: 0.945, 0.731, Avg Draft acceptance rate: 83.8%
```


### Docker image Log

The image built is correctly pinned `apache-tvm-ffi==0.1.10`

https://buildkite.com/vllm/amd-ci/builds/9406/canvas?sid=019eb267-753d-44c3-a0fa-8be324e73089&tab=output

<img width="1160" height="1046" alt="image" src="https://github.com/user-attachments/assets/83879365-b7a5-426c-84c3-609165f84c84" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

