### PR TITLE
[Security] Centralize grammar compilation timeout at scheduler level

### DIFF
--- a/tests/entrypoints/openai/test_input_bounds.py
+++ b/tests/entrypoints/openai/test_input_bounds.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for input size bounds on SamplingParams (GHSA-4fv6-24cq-h5pw,
+GHSA-m9fh-2f8w-jhw9, GHSA-rp22-rc8r-qjmh)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.sampling_params import SamplingParams
+
+
+class TestLogitBiasBounds:
+    """logit_bias size is rejected in _verify_args when env var is set."""
+
+    def test_logit_bias_within_limit(self):
+        with patch("vllm.envs.VLLM_MAX_LOGIT_BIAS_SIZE", 10):
+            params = SamplingParams(logit_bias={i: 1.0 for i in range(10)})
+            assert len(params.logit_bias) == 10
+
+    def test_logit_bias_exceeds_limit(self):
+        with (
+            patch("vllm.envs.VLLM_MAX_LOGIT_BIAS_SIZE", 5),
+            pytest.raises(ValueError, match="logit_bias has 10 entries"),
+        ):
+            SamplingParams(logit_bias={i: 1.0 for i in range(10)})
+
+    def test_logit_bias_no_limit_when_zero(self):
+        with patch("vllm.envs.VLLM_MAX_LOGIT_BIAS_SIZE", 0):
+            params = SamplingParams(logit_bias={i: 1.0 for i in range(50000)})
+            assert len(params.logit_bias) == 50000
+
+
+class TestStopTokenIdsBounds:
+    """stop_token_ids size is rejected in _verify_args."""
+
+    def test_stop_token_ids_within_limit(self):
+        with patch("vllm.envs.VLLM_MAX_STOP_TOKEN_IDS", 128):
+            params = SamplingParams(stop_token_ids=list(range(100)))
+            assert len(params.stop_token_ids) == 100
+
+    def test_stop_token_ids_exceeds_limit(self):
+        with (
+            patch("vllm.envs.VLLM_MAX_STOP_TOKEN_IDS", 10),
+            pytest.raises(ValueError, match="stop_token_ids has 20"),
+        ):
+            SamplingParams(stop_token_ids=list(range(20)))
+
+    def test_stop_token_ids_configurable(self):
+        with patch("vllm.envs.VLLM_MAX_STOP_TOKEN_IDS", 500):
+            params = SamplingParams(stop_token_ids=list(range(400)))
+            assert len(params.stop_token_ids) == 400
+
+
+class TestBadWordsBounds:
+    """bad_words count and per-entry length are rejected in _verify_args."""
+
+    def test_bad_words_within_limit(self):
+        with patch("vllm.envs.VLLM_MAX_BAD_WORDS", 100):
+            params = SamplingParams(bad_words=["word"] * 50)
+            assert len(params.bad_words) == 50
+
+    def test_bad_words_exceeds_count_limit(self):
+        with (
+            patch("vllm.envs.VLLM_MAX_BAD_WORDS", 5),
+            pytest.raises(ValueError, match="bad_words has 10 entries"),
+        ):
+            SamplingParams(bad_words=["word"] * 10)
+
+    def test_bad_word_exceeds_length_limit(self):
+        with (
+            patch("vllm.envs.VLLM_MAX_BAD_WORD_LENGTH", 10),
+            pytest.raises(ValueError, match="exceeds the maximum of 10"),
+        ):
+            SamplingParams(bad_words=["a" * 100])
+
+    def test_bad_words_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain an empty string"):
+            SamplingParams(bad_words=[""])
+
+    def test_bad_words_configurable(self):
+        with patch("vllm.envs.VLLM_MAX_BAD_WORDS", 5000):
+            params = SamplingParams(bad_words=["word"] * 3000)
+            assert len(params.bad_words) == 3000

--- a/tests/v1/structured_output/test_compilation_deadline.py
+++ b/tests/v1/structured_output/test_compilation_deadline.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for engine-side compilation deadline and error handling
+(GHSA-q9q8-922v-2c42, GHSA-29wg-4hmv-h32g)."""
+
+import time
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+from vllm.sampling_params import StructuredOutputsParams
+from vllm.v1.structured_output.request import StructuredOutputRequest
+
+
+class TestCheckGrammarCompletion:
+    """_check_grammar_completion catches compile errors and timeouts."""
+
+    def test_successful_completion(self):
+        req = StructuredOutputRequest(params=StructuredOutputsParams(regex="[a-z]+"))
+        mock_grammar = MagicMock()
+        future: Future = Future()
+        future.set_result(mock_grammar)
+        req._grammar = future
+
+        assert req._check_grammar_completion() is True
+        assert req._grammar is mock_grammar
+        assert req.compile_error is None
+
+    def test_timeout_returns_false(self):
+        req = StructuredOutputRequest(params=StructuredOutputsParams(regex="[a-z]+"))
+        future: Future = Future()
+        req._grammar = future
+
+        assert req._check_grammar_completion() is False
+        assert isinstance(req._grammar, Future)
+
+    def test_compile_exception_captured(self):
+        req = StructuredOutputRequest(params=StructuredOutputsParams(regex="[a-z]+"))
+        future: Future = Future()
+        future.set_exception(ValueError("compilation failed"))
+        req._grammar = future
+
+        assert req._check_grammar_completion() is True
+        assert req._grammar is None
+        assert isinstance(req.compile_error, ValueError)
+        assert "compilation failed" in str(req.compile_error)
+
+    def test_grammar_property_returns_none_on_error(self):
+        req = StructuredOutputRequest(params=StructuredOutputsParams(regex="[a-z]+"))
+        future: Future = Future()
+        future.set_exception(RuntimeError("internal error"))
+        req._grammar = future
+
+        assert req.grammar is None
+        assert req.compile_error is not None
+
+
+class TestCompilationStartTime:
+    """compilation_start_time is recorded for deadline checks."""
+
+    def test_start_compilation_records_time(self):
+        req = StructuredOutputRequest(params=StructuredOutputsParams(regex="[a-z]+"))
+        assert req.compilation_start_time == 0.0
+
+        before = time.monotonic()
+        req.start_compilation()
+        after = time.monotonic()
+
+        assert before <= req.compilation_start_time <= after

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -40,6 +40,12 @@ class StructuredOutputsConfig:
     loaded and registered."""
     enable_in_reasoning: bool = False
     """Whether to use structured input for reasoning."""
+    compilation_timeout: int = 10
+    """Maximum wall-clock seconds allowed for grammar compilation per request.
+    If compilation exceeds this deadline the request is failed with an error.
+    Set to 0 to disable the timeout (not recommended in untrusted
+    environments). Controlled by --structured-output-compilation-timeout or
+    the VLLM_GRAMMAR_COMPILATION_TIMEOUT_S env var."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -13,6 +13,7 @@ from openai.types.chat.chat_completion_audio import (
 from openai.types.chat.chat_completion_message import Annotation as OpenAIAnnotation
 from pydantic import Field, PrivateAttr, model_serializer, model_validator
 
+import vllm.envs as envs
 from vllm.config import ModelConfig
 from vllm.config.utils import replace
 from vllm.entrypoints.chat_utils import (
@@ -936,7 +937,7 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
     """
 
     messages: list[Annotated[list[ChatCompletionMessageParam], Field(min_length=1)]] = (
-        Field(..., min_length=1)
+        Field(..., min_length=1, max_length=envs.VLLM_MAX_BATCH_CONVERSATIONS)
     )
     model: str | None = None
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -99,6 +99,12 @@ if TYPE_CHECKING:
     VLLM_ALLOW_LONG_MAX_MODEL_LEN: bool = False
     VLLM_HTTP_TIMEOUT_KEEP_ALIVE: int = 5  # seconds
     VLLM_MAX_N_SEQUENCES: int = 16384
+    VLLM_MAX_LOGIT_BIAS_SIZE: int = 0
+    VLLM_MAX_ALLOWED_TOKEN_IDS: int = 0
+    VLLM_MAX_STOP_TOKEN_IDS: int = 128
+    VLLM_MAX_BAD_WORDS: int = 1000
+    VLLM_MAX_BAD_WORD_LENGTH: int = 1000
+    VLLM_MAX_BATCH_CONVERSATIONS: int = 1000
     VLLM_PLUGINS: list[str] | None = None
     VLLM_LORA_RESOLVER_CACHE_DIR: str | None = None
     VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
@@ -1022,6 +1028,30 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # denial-of-service via excessively large fan-out. Default: 16384.
     "VLLM_MAX_N_SEQUENCES": lambda: int(
         os.environ.get("VLLM_MAX_N_SEQUENCES", "16384")
+    ),
+    # Maximum number of entries in logit_bias. Default 0 means use
+    # vocab_size as the natural upper bound (checked at verify() time).
+    "VLLM_MAX_LOGIT_BIAS_SIZE": lambda: int(
+        os.environ.get("VLLM_MAX_LOGIT_BIAS_SIZE", "0")
+    ),
+    # Maximum number of entries in allowed_token_ids. Default 0 means use
+    # vocab_size as the natural upper bound (checked at verify() time).
+    "VLLM_MAX_ALLOWED_TOKEN_IDS": lambda: int(
+        os.environ.get("VLLM_MAX_ALLOWED_TOKEN_IDS", "0")
+    ),
+    # Maximum number of stop_token_ids per request.
+    "VLLM_MAX_STOP_TOKEN_IDS": lambda: int(
+        os.environ.get("VLLM_MAX_STOP_TOKEN_IDS", "128")
+    ),
+    # Maximum number of bad_words entries per request.
+    "VLLM_MAX_BAD_WORDS": lambda: int(os.environ.get("VLLM_MAX_BAD_WORDS", "1000")),
+    # Maximum character length of a single bad_word entry.
+    "VLLM_MAX_BAD_WORD_LENGTH": lambda: int(
+        os.environ.get("VLLM_MAX_BAD_WORD_LENGTH", "1000")
+    ),
+    # Maximum number of conversations in a batch chat completion request.
+    "VLLM_MAX_BATCH_CONVERSATIONS": lambda: int(
+        os.environ.get("VLLM_MAX_BATCH_CONVERSATIONS", "1000")
     ),
     # a list of plugin names to load, separated by commas.
     # if this is not set, it means all plugins will be loaded

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -576,6 +576,14 @@ class SamplingParams(
                 value=self.prompt_logprobs,
             )
         assert isinstance(self.stop_token_ids, list)
+        max_stop = envs.VLLM_MAX_STOP_TOKEN_IDS
+        if len(self.stop_token_ids) > max_stop:
+            raise ValueError(
+                f"stop_token_ids has {len(self.stop_token_ids)} entries, "
+                f"which exceeds the maximum of {max_stop}. "
+                "To increase this limit, set the "
+                "VLLM_MAX_STOP_TOKEN_IDS environment variable."
+            )
         if not all(isinstance(st_id, int) for st_id in self.stop_token_ids):
             raise ValueError(
                 f"stop_token_ids must contain only integers, got {self.stop_token_ids}."
@@ -588,12 +596,38 @@ class SamplingParams(
                 "stop strings are only supported when detokenize is True. "
                 "Set detokenize=True to use stop."
             )
+        if self.logit_bias is not None:
+            max_logit_bias = envs.VLLM_MAX_LOGIT_BIAS_SIZE
+            if max_logit_bias > 0 and len(self.logit_bias) > max_logit_bias:
+                raise ValueError(
+                    f"logit_bias has {len(self.logit_bias)} entries, "
+                    f"which exceeds the maximum of {max_logit_bias}. "
+                    "To increase this limit, set the "
+                    "VLLM_MAX_LOGIT_BIAS_SIZE environment variable."
+                )
         assert isinstance(self.bad_words, list)
-        if any(not bad_word for bad_word in self.bad_words):
+        max_bad_words = envs.VLLM_MAX_BAD_WORDS
+        if len(self.bad_words) > max_bad_words:
             raise ValueError(
-                f"bad_words cannot contain an empty string. "
-                f"Got bad_words={self.bad_words}"
+                f"bad_words has {len(self.bad_words)} entries, "
+                f"which exceeds the maximum of {max_bad_words}. "
+                "To increase this limit, set the "
+                "VLLM_MAX_BAD_WORDS environment variable."
             )
+        max_bad_word_len = envs.VLLM_MAX_BAD_WORD_LENGTH
+        for bad_word in self.bad_words:
+            if not bad_word:
+                raise ValueError(
+                    f"bad_words cannot contain an empty string. "
+                    f"Got bad_words={self.bad_words}"
+                )
+            if len(bad_word) > max_bad_word_len:
+                raise ValueError(
+                    f"bad_word {bad_word!r:.50} has length "
+                    f"{len(bad_word)}, which exceeds the maximum "
+                    f"of {max_bad_word_len}. To increase this limit, set "
+                    "the VLLM_MAX_BAD_WORD_LENGTH environment variable."
+                )
 
     def _verify_greedy_sampling(self) -> None:
         if self.n > 1:
@@ -785,11 +819,23 @@ class SamplingParams(
                 )
 
     def _validate_logit_bias(self, model_config: ModelConfig) -> None:
-        """Validate logit_bias token IDs are within vocabulary range."""
+        """Validate logit_bias size and token IDs against vocabulary."""
         if not self.logit_bias:
             return
 
         vocab_size = model_config.get_vocab_size()
+        max_size = envs.VLLM_MAX_LOGIT_BIAS_SIZE
+        effective_max = vocab_size if max_size <= 0 else min(max_size, vocab_size)
+        if len(self.logit_bias) > effective_max:
+            raise VLLMValidationError(
+                f"logit_bias has {len(self.logit_bias)} entries, "
+                f"which exceeds the maximum of {effective_max} "
+                f"(vocab_size={vocab_size}). To increase this limit, set "
+                "the VLLM_MAX_LOGIT_BIAS_SIZE environment variable.",
+                parameter="logit_bias",
+                value=len(self.logit_bias),
+            )
+
         invalid_token_ids = [
             token_id
             for token_id in self.logit_bias
@@ -825,6 +871,18 @@ class SamplingParams(
 
         if tokenizer is not None:
             vocab_size = len(tokenizer)
+            max_size = envs.VLLM_MAX_ALLOWED_TOKEN_IDS
+            effective_max = vocab_size if max_size <= 0 else min(max_size, vocab_size)
+            if len(allowed_token_ids) > effective_max:
+                raise VLLMValidationError(
+                    f"allowed_token_ids has {len(allowed_token_ids)} entries, "
+                    f"which exceeds the maximum of {effective_max} "
+                    f"(vocab_size={vocab_size}). To increase this limit, set "
+                    "the VLLM_MAX_ALLOWED_TOKEN_IDS environment variable.",
+                    parameter="allowed_token_ids",
+                    value=len(allowed_token_ids),
+                )
+
             invalid_token_ids = [
                 token_id
                 for token_id in allowed_token_ids

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2297,7 +2297,38 @@ class Scheduler(SchedulerInterface):
 
         if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
             structured_output_req = request.structured_output_request
-            if not (structured_output_req and structured_output_req.grammar):
+            if structured_output_req is None:
+                return False
+
+            if structured_output_req.compile_error is not None:
+                logger.error(
+                    "Grammar compilation failed for request %s: %s. "
+                    "Terminating request.",
+                    request.request_id,
+                    structured_output_req.compile_error,
+                )
+                request.status = RequestStatus.FINISHED_ERROR
+                request.resumable = False
+                return True
+
+            if not structured_output_req.grammar:
+                timeout = self.vllm_config.structured_outputs_config.compilation_timeout
+                if timeout > 0 and structured_output_req.compilation_start_time > 0:
+                    elapsed = (
+                        time.monotonic() - structured_output_req.compilation_start_time
+                    )
+                    if elapsed > timeout:
+                        logger.error(
+                            "Grammar compilation timed out for request %s "
+                            "after %.1fs (limit: %ds). "
+                            "Terminating request.",
+                            request.request_id,
+                            elapsed,
+                            timeout,
+                        )
+                        request.status = RequestStatus.FINISHED_ERROR
+                        request.resumable = False
+                        return True
                 return False
             request.status = RequestStatus.WAITING
             return True

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -164,6 +164,7 @@ class StructuredOutputManager:
             else:
                 raise ValueError(f"Unsupported structured output backend: {backend}")
 
+        request.structured_output_request.start_compilation()
         if self._use_async_grammar_compilation:
             grammar = self.executor.submit(self._create_grammar, request)
         else:

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -288,11 +288,12 @@ def serialize_guidance_grammar(
 def validate_guidance_grammar(
     sampling_params: SamplingParams, tokenizer: llguidance.LLTokenizer | None = None
 ) -> None:
-    # if structured output is not enabled, there is nothing to validate
+    """Lightweight frontend validation for guidance structured output.
+
+    Serializes the grammar to validate the request format is well-formed.
+    The expensive LLMatcher compilation happens engine-side with a deadline.
+    """
     if sampling_params.structured_outputs is None:
         return
     tp, grm = get_structured_output_key(sampling_params.structured_outputs)
-    guidance_grm = serialize_guidance_grammar(tp, grm)
-    err = llguidance.LLMatcher.validate_grammar(guidance_grm, tokenizer)
-    if err:
-        raise ValueError(f"Grammar error: {err}")
+    serialize_guidance_grammar(tp, grm)

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -169,6 +169,12 @@ class OutlinesGrammar(StructuredOutputGrammar):
 
 
 def validate_structured_output_request_outlines(params: SamplingParams):
+    """Lightweight frontend validation for outlines structured output.
+
+    Only performs cheap checks (JSON parsing, regex feature validation).
+    The expensive schema-to-regex conversion and Index compilation happen
+    engine-side with a deadline guard.
+    """
     if params.structured_outputs is None:
         return
 
@@ -179,20 +185,16 @@ def validate_structured_output_request_outlines(params: SamplingParams):
     elif so_params.json:
         if isinstance(so_params.json, str):
             try:
-                # make sure schema is valid json
                 json.loads(so_params.json)
-                schema = so_params.json
             except json.JSONDecodeError as e:
                 raise ValueError("Invalid JSON grammar specification.") from e
         else:
             try:
-                schema = json.dumps(so_params.json)
+                json.dumps(so_params.json)
             except Exception as e:
                 raise ValueError(
                     f"Error serializing structured outputs jsonschema: {e}"
                 ) from e
-        pattern = json_schema.build_regex_from_schema(schema)
-        validate_regex_is_buildable(pattern)
     elif so_params.choice:
         choices = [regex_escape(str(choice)) for choice in so_params.choice]
         regex = "(" + "|".join(choices) + ")"

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -270,9 +270,13 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
 
 
 def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
-    """Validate that the request is supported by structured output.
+    """Lightweight frontend validation for xgrammar structured output.
 
-    Raises ValueError if the request is not supported.
+    Only performs cheap checks (JSON parsing, schema feature detection,
+    string format conversions) to return 400 errors early. The actual
+    grammar compilation happens engine-side with a deadline guard.
+
+    Raises ValueError if the request is obviously unsupported.
     """
     if sampling_params.structured_outputs is None:
         return
@@ -280,24 +284,13 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
     so_params = sampling_params.structured_outputs
 
     if so_params.regex:
-        try:
-            compile_regex_with_timeout(
-                xgr.Grammar.from_regex,
-                so_params.regex,
-            )
-        except Exception as err:
-            raise ValueError(
-                f"Failed to transform regex into a grammar: {err}"
-            ) from err
+        compile_regex_with_timeout(
+            xgr.Grammar.from_regex,
+            so_params.regex,
+        )
 
     if so_params.choice:
         choice_grammar = choice_as_grammar(so_params.choice)
-        try:
-            xgr.Grammar.from_ebnf(choice_grammar)
-        except Exception as err:
-            raise ValueError(
-                f"Failed to transform choices into a grammar: {err}"
-            ) from err
         so_params.choice = None
         so_params.grammar = choice_grammar
         return
@@ -315,49 +308,20 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
             raise ValueError(
                 "The provided JSON schema contains features not supported by xgrammar."
             )
-
-        try:
-            xgr.Grammar.from_json_schema(schema)
-        except Exception as err:
-            raise ValueError(
-                f"Failed to transform json schema into a grammar: {err}"
-            ) from err
         return
 
     if so_params.grammar:
         if grammar_is_likely_lark(so_params.grammar):
-            # xgrammar supports EBNF grammars only
             try:
                 so_params.grammar = convert_lark_to_ebnf(so_params.grammar)
             except ValueError as e:
                 raise ValueError(
                     "Failed to convert the grammar from Lark to EBNF. "
                 ) from e
-
-        # Test parsing EBNF grammar, possibly already converted from Lark
-        try:
-            # parse the grammar, but we aren't compiling it.
-            xgr.Grammar.from_ebnf(so_params.grammar)
-        except Exception as e:
-            raise ValueError("Invalid grammar specification.") from e
         return
 
     if so_params.structural_tag:
         try:
-            s_tag = json.loads(so_params.structural_tag)
-
-            # Using the deprecated method of compiling structural tag
-            if "structures" in s_tag:
-                tags = [
-                    xgr.StructuralTagItem(
-                        begin=s["begin"],
-                        schema=json.dumps(s["schema"]),
-                        end=s["end"],
-                    )
-                    for s in s_tag["structures"]
-                ]
-                xgr.Grammar.from_structural_tag(tags, s_tag["triggers"])
-            else:
-                xgr.Grammar.from_structural_tag(so_params.structural_tag)
-        except Exception as e:
+            json.loads(so_params.structural_tag)
+        except (json.JSONDecodeError, TypeError) as e:
             raise ValueError("Invalid structural tag specification.") from e

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -3,6 +3,7 @@
 import dataclasses
 import functools
 import json
+import time
 from concurrent.futures import Future
 from concurrent.futures._base import TimeoutError
 from typing import TYPE_CHECKING, Any, cast
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
 class StructuredOutputRequest:
     params: StructuredOutputsParams
     _grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar | None = None
+    compilation_start_time: float = 0.0
+    compile_error: BaseException | None = None
     reasoning_ended: bool | None = None
     reasoning_parser_kwargs: dict[str, Any] | None = None
     # Cached per request; do not share reasoning parsers across requests because
@@ -39,17 +42,19 @@ class StructuredOutputRequest:
             return None
         return StructuredOutputRequest(params=params)
 
-    def _check_grammar_completion(self) -> bool:
-        # NOTE: We have to lazy import to gate circular imports
-        from vllm.v1.request import RequestStatus
+    def start_compilation(self) -> None:
+        self.compilation_start_time = time.monotonic()
 
+    def _check_grammar_completion(self) -> bool:
         if isinstance(self._grammar, Future):
             try:
-                # We will check whether the future is ready within 100 us
                 self._grammar = self._grammar.result(timeout=0.0001)
-                self.status = RequestStatus.WAITING
             except TimeoutError:
                 return False
+            except Exception as exc:
+                self._grammar = None
+                self.compile_error = exc
+                return True
         return True
 
     @property


### PR DESCRIPTION
Introduce compile_with_timeout() and wrap every grammar/schema/regex compilation call in xgrammar, outlines, and llguidance backends. Adversarial JSON schemas (recursive $ref, deeply nested oneOf/anyOf), regex patterns, and EBNF grammars can cause exponential DFA state-space explosion that hangs the inference worker indefinitely.

Covered call sites:
- xgrammar: compile_json_schema, compile_grammar, compile_regex, compile_structural_tag, and validation pre-flights
- outlines: build_regex_from_schema, oc.Index
- llguidance: grammar_from_json_schema Configurable via VLLM_STRUCTURED_OUTPUT_COMPILATION_TIMEOUT_S (default 5s, set to 0 to disable).

