### PR TITLE
[Core] Release cached device memory under pressure on UMA GPUs during weight loading

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -30,6 +30,7 @@ from vllm.model_executor.model_loader.reload import (
 )
 from vllm.model_executor.models.interfaces import SupportsQuant
 from vllm.tracing import instrument
+from vllm.utils.mem_utils import release_device_memory_under_pressure
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
 
@@ -109,6 +110,9 @@ def process_weights_after_loading(
             # parameters onto device for processing and back off after.
             with device_loading_context(module, target_device):
                 quant_method.process_weights_after_loading(module)
+            # Repacking transients above can leave large amounts of memory in
+            # the caching allocator, which starves the OS on UMA devices.
+            release_device_memory_under_pressure(target_device)
 
     # Initialize post-load attention weights for Attention, MLA, and MM encoder.
     # NOTE: Happens after other modules so we can easily decompress weights.

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -11,9 +11,12 @@ import psutil
 import torch
 import torch.types
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 from .mem_constants import GiB_bytes, KiB_bytes, MiB_bytes
+
+logger = init_logger(__name__)
 
 
 def format_kib(b: int) -> str:
@@ -43,6 +46,41 @@ def get_max_shared_memory_bytes(gpu: int = 0) -> int:
 def get_cpu_memory() -> int:
     """Returns the total CPU memory of the node in bytes."""
     return psutil.virtual_memory().total
+
+
+_UMA_PRESSURE_THRESHOLD = 0.8
+_UMA_MIN_RELEASE_BYTES = 512 * MiB_bytes
+
+
+def release_device_memory_under_pressure(device: torch.device) -> bool:
+    """On integrated (UMA) GPUs, release caching-allocator memory back to the
+    OS when system memory pressure is high. The OS may start thrashing before
+    an allocation failure would trigger PyTorch's own cache release.
+
+    Returns:
+        True if memory was released.
+    """
+    if device.type != "cuda" or not current_platform.is_integrated_gpu(device.index):
+        return False
+
+    releasable = torch.accelerator.memory_reserved(
+        device
+    ) - torch.accelerator.memory_allocated(device)
+    if releasable < _UMA_MIN_RELEASE_BYTES:
+        return False
+
+    # cudaMemGetInfo underreports free memory on UMA, see MemorySnapshot.measure
+    mem = psutil.virtual_memory()
+    if mem.available > (1 - _UMA_PRESSURE_THRESHOLD) * mem.total:
+        return False
+
+    torch.accelerator.synchronize(device)
+    torch.accelerator.empty_cache()
+    logger.debug(
+        "Released %sGiB of cached device memory under memory pressure",
+        format_gib(releasable),
+    )
+    return True
 
 
 class DeviceMemoryProfiler:


### PR DESCRIPTION
## Purpose

Alternative to #44502. Weight repacking in `process_weights_after_loading` leaves freed checkpoint-format tensors in the caching allocator; on integrated (UMA) devices like DGX Spark the reserved cache starves the OS, which can thrash before an OOM retry would release it.

Differences from #44502:
- One call site in the loader loop covers all quant methods, not just NVFP4 Marlin
- No per-layer `gc.collect()` — `replace_parameter` already drops the last reference
- Triggers on releasable allocator memory (`memory_reserved - memory_allocated > 512MiB`), which self-rate-limits since the gap resets after each release
- Pressure check uses `psutil.virtual_memory().available` (same UMA correction as `MemorySnapshot.measure`) since `cudaMemGetInfo` underreports free memory on UMA and would over-trigger

No-op on discrete GPUs and non-CUDA platforms.

## Test Plan

- `pre-commit run` (ruff, mypy) on changed files: passed
- Smoke test: util returns `False` on CPU device and discrete CUDA device
- Needs validation on DGX Spark with NVFP4 Nemotron Ultra (cc @shaunkotek @tomeras91)

AI assistance (Claude Code) was used for this PR; all changes reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)