### PR TITLE
[Misc] Add support for passing intermediate tensors for KV cache optimization research

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -181,6 +181,10 @@ class KVConnectorBase_V1(ABC):
         """
         return False
 
+    @property
+    def transfer_intermediate_tensors(self) -> bool:
+        return False
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/model_executor/layers/attention/kv_transfer_utils.py
+++ b/vllm/model_executor/layers/attention/kv_transfer_utils.py
@@ -54,7 +54,11 @@ def maybe_transfer_kv_layer(func: Callable) -> Callable:
         result = func(*args, **kwargs)
 
         # Save KV cache layer on exit
-        connector.save_kv_layer(layer_name, kv_cache, attn_metadata)
+        kwargs = {}
+        if connector.transfer_intermediate_tensors:
+            bound_args = sig.bind_partial(*args, **kwargs)
+            kwargs = {"intermediate_tensors": bound_args.arguments}
+        connector.save_kv_layer(layer_name, kv_cache, attn_metadata, **kwargs)
 
         return result
 


### PR DESCRIPTION
## Purpose

This PR allows the KV connectors to also get intermediate tensors (such as query). This PR does not directly improve prefix caching or PD disaggregation. Instead, it serves as a pre-requisite for the KV connector to support latest research on KV cache optimizations such as token dropping.

Example: SnapKV --> by dropping tokens by 2x (compression ratio 0.5), we can achieve 1.55x decoding throughput improvement on LongBench-v2 dataset without degrading accuracy.

## Test Plan

This test shows that one can print out the query tensor on connector side. Using lmcache as an example.

1. LMCache side:
```sh
env -u VLLM_PORT -u VLLM_BATCH_INVARIANT -u VLLM_ENABLE_V1_MULTIPROCESSING \
  lmcache server \
    --l1-size-gb 140 \
    --eviction-policy LRU \
    --chunk-size 256 \
    --port 6556 \
    --http-port 8081
```
2. vLLM side:
```sh
env -u VLLM_PORT CUDA_VISIBLE_DEVICES=3 VLLM_ENABLE_V1_MULTIPROCESSING=0 VLLM_BATCH_INVARIANT=1 PYTHONHASHSEED=0 vllm serve Qwen/Qwen3-8B --port 8001 --served-model-name Qwen/Qwen3-8B --enforce-eager --gpu-memory-utilization 0.8 --no-enable-prefix-caching --kv-transfer-config '{                                                                                                                                                      
  "kv_connector": "LMCacheMPConnector",
  "kv_role": "kv_both",
  "kv_load_failure_policy": "recompute",
  "kv_connector_extra_config": {
    "lmcache.mp.host": "tcp://localhost",
    "lmcache.mp.port": 6556,
    "lmcache.mp.mq_timeout": 60,
    "transfer_intermediate_tensors": true
  }
}'
```

## Test Result

[QUERY_PRINT] tensor=tensor([-0.0435, -0.1060,  0.1777, -0.0105, -0.1221, -0.0583, -0.1250,  0.2793], dtype=torch.bfloat16)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

