### PR TITLE
enabling humming for 3567 bit CT formats

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/humming.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/humming.py
@@ -42,7 +42,9 @@ class HummingLinearKernel(MPLinearKernel):
         }
 
         convert_linear_layer_to_humming_standard(layer=layer, name_map=name_map)
-        prepare_humming_layer(layer, quant_config)
+        input_quant_config = getattr(layer, '_humming_input_quant_config', None)
+        prepare_humming_layer(layer, quant_config,
+                              input_quant_config=input_quant_config)
 
     def apply_weights(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -37,7 +37,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsMoEMethod,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
-    WNA16_SUPPORTED_BITS,
+
     CompressedTensorsScheme,
     CompressedTensorsW4A4Fp4,
     CompressedTensorsW4A4Mxfp4,
@@ -47,7 +47,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsW8A8Int8,
     CompressedTensorsW8A8Mxfp8,
     CompressedTensorsW8A16Fp8,
-    CompressedTensorsWNA8O8Int,
+    CompressedTensorsWNAMInt,
     CompressedTensorsWNA16,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.transform.linear import (  # noqa: E501
@@ -645,15 +645,18 @@ class CompressedTensorsConfig(QuantizationConfig):
         return is_channel_group and input_quant_none and is_static
 
     @staticmethod
-    def _is_wNa8o8_int(
+    def _is_wNaM_int(
         weight_quant: QuantizationArgs,
         input_quant: QuantizationArgs | None,
         output_quant: QuantizationArgs | None,
         format: str | None,
     ) -> bool:
-        """Weight N-bit INT (pack-quantized for sub-byte, int-quantized for 8-bit)
-        with static per-tensor INT8 input/output activation quant, applied as a float
-        fake-quant around a weight-only matmul."""
+        """Weight N-bit INT with any INT activation quantization.
+
+        Static per-tensor INT8 activations use a float fake-quant around a
+        weight-only matmul.  Other activation configs (e.g. dynamic int4) are
+        handled by the kernel (Humming) internally.
+        """
         is_int_pack_format = format in (
             CompressionFormat.pack_quantized.value,
             CompressionFormat.int_quantized.value,
@@ -666,28 +669,14 @@ class CompressedTensorsConfig(QuantizationConfig):
             weight_quant.type == QuantizationType.INT and not weight_quant.dynamic
         )
         is_intN_weight = is_static_int and is_channel_group and is_int_pack_format
-        is_static_int8_in = (
+        has_int_activation = (
             input_quant is not None
             and input_quant.type == QuantizationType.INT
-            and input_quant.strategy == QuantizationStrategy.TENSOR.value
-            and input_quant.num_bits == 8
-            and not input_quant.dynamic
-        )
-        is_static_int8_out = (
+        ) or (
             output_quant is not None
             and output_quant.type == QuantizationType.INT
-            and output_quant.strategy == QuantizationStrategy.TENSOR.value
-            and output_quant.num_bits == 8
-            and not output_quant.dynamic
         )
-        # Static int8-activation layers, plus sub-byte weight-only layers (e.g.
-        # 2-bit lm_head) that marlin-backed WNA16 cannot serve. Standard 4/8-bit
-        # weight-only (no activations) falls through to WNA16.
-        is_subbyte_weight_only = weight_quant.num_bits not in WNA16_SUPPORTED_BITS
-        needs_wNa8o8 = is_intN_weight and (
-            (is_static_int8_in and is_static_int8_out) or is_subbyte_weight_only
-        )
-        return needs_wNa8o8
+        return is_intN_weight and has_int_activation
 
     def _get_scheme_from_parts(
         self,
@@ -727,15 +716,15 @@ class CompressedTensorsConfig(QuantizationConfig):
                 actorder=weight_quant.actorder,
             )
 
-        # Must come before the WNA16 check; standard 4/8-bit weight-only (no
-        # output-activation scale) still falls through to WNA16.
-        if self._is_wNa8o8_int(weight_quant, input_quant, output_quant, format):
-            return CompressedTensorsWNA8O8Int(
+        # Must come before the WNA16 check; catches layers with INT
+        # activation quant (static int8 uses fake-quant, others use Humming).
+        if self._is_wNaM_int(weight_quant, input_quant, output_quant, format):
+            return CompressedTensorsWNAMInt(
                 num_bits=weight_quant.num_bits,
                 strategy=weight_quant.strategy,
                 group_size=weight_quant.group_size,
-                has_input_act=input_quant is not None,
-                has_output_act=output_quant is not None,
+                input_quant=input_quant,
+                output_quant=output_quant,
                 layer_name=layer_name,
                 quant_format=format,
             )
@@ -743,7 +732,6 @@ class CompressedTensorsConfig(QuantizationConfig):
         if (
             self._is_wNa16_group_channel(weight_quant, input_quant)
             and (format == CompressionFormat.pack_quantized.value)
-            and (weight_quant.num_bits in WNA16_SUPPORTED_BITS)
         ):
             return CompressedTensorsWNA16(
                 num_bits=weight_quant.num_bits,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -10,13 +10,13 @@ from .compressed_tensors_w8a8_fp8 import CompressedTensorsW8A8Fp8
 from .compressed_tensors_w8a8_int8 import CompressedTensorsW8A8Int8
 from .compressed_tensors_w8a8_mxfp8 import CompressedTensorsW8A8Mxfp8
 from .compressed_tensors_w8a16_fp8 import CompressedTensorsW8A16Fp8
-from .compressed_tensors_wNa8o8 import CompressedTensorsWNA8O8Int
+from .compressed_tensors_wNaM import CompressedTensorsWNAMInt
 from .compressed_tensors_wNa16 import WNA16_SUPPORTED_BITS, CompressedTensorsWNA16
 
 __all__ = [
     "CompressedTensorsScheme",
     "CompressedTensorsWNA16",
-    "CompressedTensorsWNA8O8Int",
+    "CompressedTensorsWNAMInt",
     "CompressedTensorsW8A16Fp8",
     "CompressedTensorsW8A8Int8",
     "CompressedTensorsW8A8Fp8",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from collections.abc import Callable
+from fractions import Fraction
 
 import torch
 from compressed_tensors.quantization import ActivationOrdering
@@ -32,7 +34,15 @@ from vllm.scalar_type import scalar_types
 logger = init_logger(__name__)
 
 __all__ = ["CompressedTensorsWNA16"]
-WNA16_SUPPORTED_TYPES_MAP = {4: scalar_types.uint4b8, 8: scalar_types.uint8b128}
+WNA16_SUPPORTED_TYPES_MAP = {
+    2: scalar_types.uint2b2,
+    3: scalar_types.uint3b4,
+    4: scalar_types.uint4b8,
+    5: scalar_types.uint5b16,
+    6: scalar_types.uint6b32,
+    7: scalar_types.uint7b64,
+    8: scalar_types.uint8b128,
+}
 WNA16_ZP_SUPPORTED_TYPES_MAP = {4: scalar_types.uint4, 8: scalar_types.uint8}
 WNA16_SUPPORTED_BITS = list(WNA16_SUPPORTED_TYPES_MAP.keys())
 
@@ -49,7 +59,8 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
         actorder: ActivationOrdering | None = None,
         layer_name: str | None = None,
     ):
-        self.pack_factor = 32 // num_bits
+        self.num_bits = num_bits
+        self.pack_factor = Fraction(32, num_bits)
         self.strategy = strategy
         self.symmetric = symmetric
         self.group_size = -1 if group_size is None else group_size
@@ -58,15 +69,22 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
 
         if self.group_size == -1 and self.strategy != "channel":
             raise ValueError(
-                "Marlin kernels require group quantization or "
-                "channelwise quantization, but found no group "
+                "Pack-quantized format requires group quantization "
+                "or channelwise quantization, but found no group "
                 "size and strategy is not channelwise."
             )
 
         if num_bits not in WNA16_SUPPORTED_TYPES_MAP:
             raise ValueError(
                 f"Unsupported num_bits = {num_bits}. "
-                f"Supported num_bits = {WNA16_SUPPORTED_TYPES_MAP.keys()}"
+                f"Supported num_bits = {list(WNA16_SUPPORTED_TYPES_MAP)}"
+            )
+
+        if not self.symmetric and num_bits not in WNA16_ZP_SUPPORTED_TYPES_MAP:
+            raise ValueError(
+                f"Asymmetric quantization not supported for "
+                f"num_bits = {num_bits}. Supported: "
+                f"{list(WNA16_ZP_SUPPORTED_TYPES_MAP)}"
             )
 
         self.quant_type = (
@@ -130,6 +148,9 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
             assert input_size_per_partition % group_size == 0
             scales_and_zp_size = input_size_per_partition // group_size
 
+        packed_input_dim = math.ceil(
+            input_size_per_partition * self.num_bits / 32
+        )
         weight = PackedvLLMParameter(
             input_dim=1,
             output_dim=0,
@@ -138,7 +159,7 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
             packed_dim=1,
             data=torch.empty(
                 output_size_per_partition,
-                input_size_per_partition // self.pack_factor,
+                packed_input_dim,
                 dtype=torch.int32,
             ),
         )
@@ -152,10 +173,13 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
             ),
         }
 
+        packed_output_dim = math.ceil(
+            output_size_per_partition * self.num_bits / 32
+        )
         zeros_args = {
             "weight_loader": weight_loader,
             "data": torch.zeros(
-                output_size_per_partition // self.pack_factor,
+                packed_output_dim,
                 scales_and_zp_size,
                 dtype=torch.int32,
             ),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
@@ -8,7 +8,9 @@ reproduced as a float fake-quant on the layer input and output, around a
 weight-only matmul, rather than a fused int8 GEMM.
 """
 
+import math
 from collections.abc import Callable
+from fractions import Fraction
 
 import torch
 from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
@@ -36,7 +38,11 @@ __all__ = ["CompressedTensorsWNA8O8Int", "fake_quant_static_int8"]
 
 WNA8O8_SUPPORTED_TYPES_MAP = {
     2: scalar_types.uint2b2,
+    3: scalar_types.uint3b4,
     4: scalar_types.uint4b8,
+    5: scalar_types.uint5b16,
+    6: scalar_types.uint6b32,
+    7: scalar_types.uint7b64,
     8: scalar_types.uint8b128,
 }
 
@@ -60,7 +66,7 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         quant_format: str = "pack-quantized",
     ):
         self.num_bits = num_bits
-        self.pack_factor = 32 // num_bits
+        self.pack_factor = Fraction(32, num_bits)
         self.strategy = strategy
         self.group_size = -1 if group_size is None else group_size
         self.has_input_act = has_input_act
@@ -141,6 +147,7 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                 ),
             )
         else:
+            packed_input_dim = math.ceil(input_size_per_partition * self.num_bits / 32)
             layer.register_parameter(
                 "weight_packed",
                 PackedvLLMParameter(
@@ -151,7 +158,7 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                     weight_loader=weight_loader,
                     data=torch.empty(
                         out,
-                        input_size_per_partition // self.pack_factor,
+                        packed_input_dim,
                         dtype=torch.int32,
                     ),
                 ),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNaM.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNaM.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Weight N-bit INT scheme with static INT8 input/output activation quant.
+"""Weight N-bit INT scheme with INT activation quantization.
 
-Handles compressed-tensors INT weight checkpoints that carry static per-tensor
-INT8 ``input_activations`` and/or ``output_activations``. The activation quant is
-reproduced as a float fake-quant on the layer input and output, around a
-weight-only matmul, rather than a fused int8 GEMM.
+Handles compressed-tensors INT weight checkpoints that carry INT
+``input_activations`` and/or ``output_activations``.  For legacy static
+per-tensor INT8 activations the activation quant is reproduced as a float
+fake-quant on the layer input/output.  For other activation configs (e.g.
+dynamic int4) the kernel (Humming) handles activation quant internally.
 """
 
 import math
@@ -14,6 +15,7 @@ from fractions import Fraction
 
 import torch
 from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
+from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 
 from vllm.model_executor.kernels.linear import (
     MPLinearLayerConfig,
@@ -32,11 +34,14 @@ from vllm.model_executor.parameter import (
     ModelWeightParameter,
     PackedvLLMParameter,
 )
+from vllm.logger import init_logger
 from vllm.scalar_type import scalar_types
 
-__all__ = ["CompressedTensorsWNA8O8Int", "fake_quant_static_int8"]
+logger = init_logger(__name__)
 
-WNA8O8_SUPPORTED_TYPES_MAP = {
+__all__ = ["CompressedTensorsWNAMInt", "fake_quant_static_int8"]
+
+WNAM_SUPPORTED_TYPES_MAP = {
     2: scalar_types.uint2b2,
     3: scalar_types.uint3b4,
     4: scalar_types.uint4b8,
@@ -54,14 +59,26 @@ def fake_quant_static_int8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor
     return q * scale
 
 
-class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
+def _is_static_int8(q: QuantizationArgs | None) -> bool:
+    return (
+        q is not None
+        and q.type == "int"
+        and q.strategy == QuantizationStrategy.TENSOR.value
+        and q.num_bits == 8
+        and not q.dynamic
+    )
+
+
+class CompressedTensorsWNAMInt(CompressedTensorsScheme):
+    _kernel_backends_being_used: set[str] = set()
+
     def __init__(
         self,
         num_bits: int,
         strategy: str,
         group_size: int | None = None,
-        has_input_act: bool = False,
-        has_output_act: bool = False,
+        input_quant: QuantizationArgs | None = None,
+        output_quant: QuantizationArgs | None = None,
         layer_name: str | None = None,
         quant_format: str = "pack-quantized",
     ):
@@ -69,18 +86,21 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         self.pack_factor = Fraction(32, num_bits)
         self.strategy = strategy
         self.group_size = -1 if group_size is None else group_size
-        self.has_input_act = has_input_act
-        self.has_output_act = has_output_act
         self.layer_name = layer_name
-        # "pack-quantized" (sub-byte, int32-packed) or "int-quantized" (8-bit int8).
         self.quant_format = quant_format
         self.is_int_quantized = quant_format == "int-quantized"
-        if num_bits not in WNA8O8_SUPPORTED_TYPES_MAP:
+
+        self._input_quant = input_quant
+        self._output_quant = output_quant
+        self._is_static_int8_input = _is_static_int8(input_quant)
+        self._is_static_int8_output = _is_static_int8(output_quant)
+
+        if num_bits not in WNAM_SUPPORTED_TYPES_MAP:
             raise ValueError(
-                f"Unsupported num_bits = {num_bits} for WNA8O8Int; "
-                f"supported = {sorted(WNA8O8_SUPPORTED_TYPES_MAP)}"
+                f"Unsupported num_bits = {num_bits} for WNAMInt; "
+                f"supported = {sorted(WNAM_SUPPORTED_TYPES_MAP)}"
             )
-        self.quant_type = WNA8O8_SUPPORTED_TYPES_MAP[num_bits]
+        self.quant_type = WNAM_SUPPORTED_TYPES_MAP[num_bits]
         self._input_scale: torch.Tensor | None = None
         self._output_scale: torch.Tensor | None = None
 
@@ -102,8 +122,6 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         output_size_per_partition = sum(output_partition_sizes)
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
-        # Set for kernels' weight prep; also covers ParallelLMHead, which does
-        # not set these in __init__.
         layer.output_partition_sizes = output_partition_sizes
         layer.params_dtype = params_dtype
         if not hasattr(layer, "has_bias"):
@@ -116,12 +134,19 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                 output_size_per_partition,
             ),
             weight_type=self.quant_type,
-            act_type=params_dtype,  # activation quant applied externally (SRQ)
+            act_type=params_dtype,
             group_size=self.group_size,
             zero_points=False,
             has_g_idx=False,
         )
-        self.kernel = choose_mp_linear_kernel(mp_config)(
+        kernel_type = choose_mp_linear_kernel(mp_config)
+
+        if kernel_type.__name__ not in self._kernel_backends_being_used:
+            logger.info("Using %s for CompressedTensorsWNAMInt",
+                        kernel_type.__name__)
+            self._kernel_backends_being_used.add(kernel_type.__name__)
+
+        self.kernel = kernel_type(
             mp_config,
             w_q_param_name="weight_packed",
             w_s_param_name="weight_scale",
@@ -136,7 +161,6 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
     ):
         out = layer.output_size_per_partition
         if self.is_int_quantized:
-            # Plain int8 weight; packed to the canonical int32 layout after load.
             layer.register_parameter(
                 "weight",
                 ModelWeightParameter(
@@ -170,7 +194,6 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                 ),
             )
 
-        # Scale: per-output-channel, or per group along the input dim under TP.
         group_size = self.group_size if self.group_size != -1 else input_size
         partitioned = not marlin_repeat_scales_on_all_ranks(
             False, self.group_size, input_size != input_size_per_partition
@@ -189,8 +212,8 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         layer.register_parameter("weight_scale", weight_scale)
 
         for name, present in (
-            ("input_scale", self.has_input_act),
-            ("output_scale", self.has_output_act),
+            ("input_scale", self._is_static_int8_input),
+            ("output_scale", self._is_static_int8_output),
         ):
             if present:
                 layer.register_parameter(
@@ -201,13 +224,28 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
                     ),
                 )
 
+        if (
+            self._input_quant is not None
+            and not self._is_static_int8_input
+        ):
+            layer._humming_input_quant_config = {
+                "num_bits": self._input_quant.num_bits,
+                "type": str(self._input_quant.type),
+                "strategy": str(self._input_quant.strategy),
+                "symmetric": self._input_quant.symmetric,
+                "dynamic": self._input_quant.dynamic,
+                "group_size": self._input_quant.group_size or 0,
+                "quant_method": "compressed-tensors",
+                "format": self.quant_format,
+            }
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # Lift the static activation scales off the layer (applied externally) so
-        # the kernel only sees weight tensors. Drop uncalibrated (zero) scales.
-        self._input_scale = self._take_act_scale(layer, "input_scale")
-        self._output_scale = self._take_act_scale(layer, "output_scale")
-        self.has_input_act = self._input_scale is not None
-        self.has_output_act = self._output_scale is not None
+        if self._is_static_int8_input:
+            self._input_scale = self._take_act_scale(layer, "input_scale")
+            self._is_static_int8_input = self._input_scale is not None
+        if self._is_static_int8_output:
+            self._output_scale = self._take_act_scale(layer, "output_scale")
+            self._is_static_int8_output = self._output_scale is not None
 
         if self.is_int_quantized:
             self._pack_int_quantized_weight(layer)
@@ -256,9 +294,9 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
     def apply_weights(
         self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None
     ) -> torch.Tensor:
-        if self.has_input_act:
+        if self._is_static_int8_input and self._input_scale is not None:
             x = fake_quant_static_int8(x, self._input_scale)
         out = self.kernel.apply_weights(layer, x, bias)
-        if self.has_output_act:
+        if self._is_static_int8_output and self._output_scale is not None:
             out = fake_quant_static_int8(out, self._output_scale)
         return out

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -78,9 +78,13 @@ def convert_linear_layer_to_humming_standard(
         setattr(layer, name, param)
 
 
-def prepare_humming_layer(layer: LinearBase, quant_config: dict):
+def prepare_humming_layer(layer: LinearBase, quant_config: dict,
+                          input_quant_config: dict | None = None):
     weight_schema = BaseWeightSchema.from_config(quant_config)
-    input_schema = HummingInputSchema()
+    if input_quant_config is not None:
+        input_schema = HummingInputSchema.from_config(input_quant_config)
+    else:
+        input_schema = HummingInputSchema()
 
     # ReplicatedLinear has no TP partitioning and so does not set
     # input_size_per_partition; for it that is just input_size.

--- a/vllm/scalar_type.py
+++ b/vllm/scalar_type.py
@@ -348,6 +348,9 @@ class scalar_types:
     uint2b2 = ScalarType.uint(2, 2)
     uint3b4 = ScalarType.uint(3, 4)
     uint4b8 = ScalarType.uint(4, 8)
+    uint5b16 = ScalarType.uint(5, 16)
+    uint6b32 = ScalarType.uint(6, 32)
+    uint7b64 = ScalarType.uint(7, 64)
     uint8b128 = ScalarType.uint(8, 128)
 
     # colloquial names


### PR DESCRIPTION
## Purpose

Enabling Humming + CT integration

This enables the 3/5/6/7 bit quantization in vllm and corrects the packed shapes based on the [humming CT PR](https://github.com/vllm-project/compressed-tensors/pull/732)

pertaining to https://github.com/vllm-project/compressed-tensors/issues/719

## Summary

CT packed size for all bitwidths is now defined as ceil(numel*num_bits/32), 
so this PR corrects packed_input_dim and pack_factor as well as adding the new scalar types that didnt exist before.

## Test Plan

e2e tests were run, full repro: https://github.com/vllm-project/llm-compressor/pull/2821

## Test Result

```
Model                                 bits_per_byte  byte_perplexity  word_perplexity
-------------------------------------------------------------------------------------
Meta-Llama-3-8B-Instruct-W2A16-RTN           4.2523          19.0577     7000326.4489
Meta-Llama-3-8B-Instruct-W3A16-RTN           2.2095           4.6252        3603.5295
Meta-Llama-3-8B-Instruct-W5A16-RTN           0.6349           1.5528          10.5195
Meta-Llama-3-8B-Instruct-W7A16-RTN           0.6302           1.5478          10.3378
Meta-Llama-3-8B-Instruct-W2A4-RTN            4.2524          19.0590     7002819.2446
Meta-Llama-3-8B-Instruct-W3A4-RTN            2.2095           4.6253        3604.0628
Meta-Llama-3-8B-Instruct-W5A8-RTN            0.6349           1.5528          10.5192
Meta-Llama-3-8B-Instruct-W7A8-RTN            0.6302           1.5477          10.3372
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

