### PR TITLE
[Bugfix] Reject negative config limits

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1342,6 +1342,20 @@ def test_scheduler_config_init():
         print(SchedulerConfig.default_factory().max_model_len)
 
 
+def test_scheduler_config_rejects_negative_long_prefill_threshold():
+    with pytest.raises(ValidationError):
+        SchedulerConfig(
+            long_prefill_token_threshold=-1,
+            max_model_len=4096,
+            is_encoder_decoder=False,
+        )
+
+
+def test_model_config_rejects_max_logprobs_below_unlimited_sentinel():
+    with pytest.raises(ValidationError):
+        ModelConfig(max_logprobs=-2)
+
+
 @pytest.mark.parametrize(
     (
         "model_id",

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -219,7 +219,7 @@ class ModelConfig:
     flexibility."""
     enable_return_routed_experts: bool = False
     """Whether to return routed experts."""
-    max_logprobs: int = 20
+    max_logprobs: int = Field(default=20, ge=-1)
     """Maximum number of log probabilities to return when `logprobs` is
     specified in `SamplingParams`. The default value comes the default for the
     OpenAI Chat Completions API. -1 means no cap, i.e. all (output_length *

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -77,7 +77,7 @@ class SchedulerConfig:
     this less than max_num_partial_prefills will allow shorter prompts to jump
     the queue in front of longer prompts in some cases, improving latency."""
 
-    long_prefill_token_threshold: int = 0
+    long_prefill_token_threshold: int = Field(default=0, ge=0)
     """For chunked prefill, a request is considered long if the prompt is
     longer than this number of tokens."""
 


### PR DESCRIPTION
Fixes #43985

## Summary

- Reject `ModelConfig.max_logprobs` values below the documented `-1` unlimited sentinel.
- Reject negative `SchedulerConfig.long_prefill_token_threshold` values while preserving `0` as the existing disabled/default sentinel.
- Add regression coverage for both validation paths.

Not duplicating existing work: issue #43985 is open, unassigned, has no comments, and I found no open PR referencing the issue or these config fields.

## Testing

- `.venv/bin/python -m pytest tests/test_config.py -q -k 'negative_long_prefill_threshold or max_logprobs_below_unlimited_sentinel'`
- `.venv/bin/pre-commit run --files vllm/config/model.py vllm/config/scheduler.py tests/test_config.py`

AI assistance (Claude via Cursor) was used for this change; I have reviewed every line.