### PR TITLE
[BugFix] [Build] Fix for where setup.py fails with MAX_JOBS invalid literal error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ class cmake_build_ext(build_ext):
         # `num_jobs` is either the value of the MAX_JOBS environment variable
         # (if defined) or the number of CPUs available.
         num_jobs = envs.MAX_JOBS
-        if num_jobs is not None:
+        if isinstance(num_jobs, str) and num_jobs.isnumeric():
             num_jobs = int(num_jobs)
             logger.info("Using MAX_JOBS=%d as the number of jobs.", num_jobs)
         else:


### PR DESCRIPTION

## Purpose
Currently, `setup.py` is failing with the following error
```
Traceback (most recent call last):
  File "/vllm-upstream-test/setup.py", line 1156, in <module>
    setup(
  File "/usr/local/lib/python3.12/dist-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/dist.py", line 1104, in run_command
    super().run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/develop.py", line 35, in run
    self.install_for_development()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/develop.py", line 112, in install_for_development
    self.run_command('build_ext')
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/cmd.py", line 357, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/dist.py", line 1104, in run_command
    super().run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools_rust/setuptools_ext.py", line 177, in run
    super().run()
  File "/vllm-upstream-test/setup.py", line 364, in run
    super().run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/build_ext.py", line 99, in run
    _build_ext.run(self)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/command/build_ext.py", line 368, in run
    self.build_extensions()
  File "/vllm-upstream-test/setup.py", line 321, in build_extensions
    self.configure(ext)
  File "/vllm-upstream-test/setup.py", line 274, in configure
    num_jobs, nvcc_threads = self.compute_num_jobs()
                             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm-upstream-test/setup.py", line 181, in compute_num_jobs
    num_jobs = int(num_jobs)
               ^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: ''
```
This is because the `compute_num_jobs` function is only checking for None when `num_jobs` could be the empty string.  This PR fixes the logic to check if `num_jobs` is a string first (`None `will fail this) and then checks if `num_jobs` is numeric using `is_numeric `(`'2.1'`, and `'-2'` will fail, but `'32'`) passes.
## Test Plan
`python setup.py develop`
## Test Result
Everything builds correctly.
`Finished processing dependencies for vllm==0.9.2rc2.dev10011+g5dcec1c18.d20260610.rocm723`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ X] The test plan, such as providing test command.
- [ X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

