### PR TITLE
[Attention][MLA] Enable DCP for the FlashInfer MLA backend

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -217,7 +217,7 @@ MLA decode backends are selected using the standard
 | Backend | Dtypes | KV Dtypes | Block Sizes | Head Sizes | Sink | Non-Causal | Sparse | MM Prefix | DCP | Attention Types | Compute Cap. |
 | ------- | ------ | --------- | ----------- | ---------- | ---- | ---------- | ------ | --------- | --- | --------------- | ------------ |
 | `CUTLASS_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 128 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 10.x |
-| `FLASHINFER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 10.x |
+| `FLASHINFER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 10.x |
 | `FLASHINFER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 32, 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 10.x |
 | `FLASHMLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 9.x-10.x |
 | `FLASHMLA_SPARSE` | bf16 | `auto`, `bfloat16`, `fp8_ds_mla` | 64 | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | 9.x-10.x |

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -775,19 +775,23 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
             # correct dcp attn_out with lse.
             if self.impl.dcp_world_size > 1:
+                # The decode LSE base is a property of the decode backend that
+                # produced `lse`: FlashInfer's MLA decode returns base-2, the
+                # other MLA decode backends return natural-log.
+                is_lse_base_on_e = getattr(self.impl, "lse_decode_base_on_e", True)
                 if self.dcp_a2a:
                     attn_out = dcp_a2a_lse_reduce(
                         attn_out,
                         lse,
                         get_dcp_group(),
-                        is_lse_base_on_e=True,
+                        is_lse_base_on_e=is_lse_base_on_e,
                     )
                 else:
                     attn_out = cp_lse_ag_out_rs(
                         attn_out,
                         lse,
                         get_dcp_group(),
-                        is_lse_base_on_e=True,
+                        is_lse_base_on_e=is_lse_base_on_e,
                     )
 
             # v_up projection

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -105,6 +105,9 @@ g_fi_workspace = torch.zeros(
 
 
 class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
+    can_return_lse_for_decode: bool = True
+    lse_decode_base_on_e: bool = False
+
     def __init__(
         self,
         num_heads: int,
@@ -188,7 +191,8 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
             if is_quantized_kv_cache(self.kv_cache_dtype):
                 self.bmm2_scale *= layer._k_scale_float
 
-        o = trtllm_batch_decode_with_kv_cache_mla(
+        return_lse = self.need_to_return_lse_for_decode
+        result = trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv_c_and_k_pe_cache.unsqueeze(1),
             workspace_buffer=self._workspace_buffer,
@@ -200,11 +204,15 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
             max_seq_len=attn_metadata.max_seq_len,
             bmm1_scale=self.bmm1_scale,
             bmm2_scale=self.bmm2_scale,
+            **({"return_lse": True} if return_lse else {}),
         )
 
-        # Flatten the output for consistent shape
-        o = o.view(-1, o.shape[-2], o.shape[-1])
+        if not return_lse:
+            # Flatten the output for consistent shape.
+            return result.view(-1, result.shape[-2], result.shape[-1]), None
 
-        # TODO: Return LSE pending support from Flashinfer API:
-        # https://github.com/flashinfer-ai/flashinfer/pull/1566
-        return o, None
+        # DCP path: return the (base-2) LSE; the DCP combine handles the base
+        # via `lse_decode_base_on_e` (see MLAAttention).
+        o, lse = result
+        o = o.view(-1, o.shape[-2], o.shape[-1])
+        return o, lse


### PR DESCRIPTION



## Purpose

Enable the `FLASHINFER_MLA` backend to be used with Decode Context Parallelism (DCP) by returning the decode softmax LSE.

## Test Plan

GB200 (SM100), FlashInfer 0.6.12. Serve (vary `--decode-context-parallel-size`):

```
vllm serve <model> --tensor-parallel-size 8
  --decode-context-parallel-size <1|4|8> --dcp-comm-backend a2a
  --attention-backend FLASHINFER_MLA --kv-cache-dtype bfloat16
  --no-enable-prefix-caching --trust-remote-code
```

1. `deepseek-ai/DeepSeek-V2-Lite`: compare first-token logprobs `DCP=1` vs `DCP=2`.
2. `nvidia/DeepSeek-R1-0528-NVFP4-v2`: GSM8K (full) at DCP=1/4/8, greedy.

## Test Result

1. `DCP=1` vs `DCP=2`: `MAX_TOKEN_LOGPROB_DIFF = 0.0` (DCP == non-DCP).
2. GSM8K — DCP matches the no-DCP baseline:

   | DCP | Accuracy |
   | --- | --- |
   | 1 (baseline) | 96.59% |
   | 4 | 96.59% |
   | 8 | 96.44% |

Eager, CUDA graphs, and a 1M-token (YaRN) request all pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

