### PR TITLE
[Quantization] Fix misleading NVFP4 Marlin MoE fallback warning on GPUs with native FP4

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -298,12 +298,25 @@ def prepare_nvfp4_moe_layer_for_marlin(
 ) -> tuple[
     torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
 ]:
-    logger.warning_once(
-        "Your GPU does not have native support for FP4 computation but "
-        "FP4 quantization is being used. Weight-only FP4 compression will "
-        "be used leveraging the Marlin kernel. This may degrade "
-        "performance for compute-heavy workloads."
-    )
+    if current_platform.has_device_capability(100):
+        # Native FP4 hardware (SM100+ / SM12x): MARLIN was selected for a
+        # reason other than missing hardware support, e.g. no native NvFp4
+        # MoE backend supports the model's activation or deployment
+        # configuration, or the backend was forced explicitly.
+        logger.warning_once(
+            "This GPU supports native FP4 computation, but the Marlin "
+            "(weight-only FP4) MoE backend was selected instead of a native "
+            "FP4 MoE backend (e.g. because none supports this model's "
+            "activation or deployment configuration). This may degrade "
+            "performance for compute-heavy workloads."
+        )
+    else:
+        logger.warning_once(
+            "Your GPU does not have native support for FP4 computation but "
+            "FP4 quantization is being used. Weight-only FP4 compression "
+            "will be used leveraging the Marlin kernel. This may degrade "
+            "performance for compute-heavy workloads."
+        )
 
     input_dtype = get_marlin_input_dtype(prefix="")
     if input_dtype is not None and input_dtype.itemsize == 1:


### PR DESCRIPTION
## Purpose

`prepare_nvfp4_moe_layer_for_marlin()` unconditionally logs:

> Your GPU does not have native support for FP4 computation but FP4 quantization is being used. Weight-only FP4 compression will be used leveraging the Marlin kernel. ...

Its only caller is the NvFp4 MoE backend oracle's `MARLIN` branch (`fused_moe/oracle/nvfp4.py`), which is also reached on SM100+/SM12x GPUs that **do** have native FP4 tensor cores — e.g. when no native NvFp4 MoE backend supports the model's activation (the case for `gelu_tanh` MoE models prior to #42027), or when the backend is forced explicitly. On such GPUs the message is factually wrong, and it has confused users into filing hardware-support bugs — #23497 is an RTX 6000 Pro (SM120) user quoting exactly this warning under the title "FP4 not leverage on RTX 6000 Pro (Blackwell)".

This PR branches on `current_platform.has_device_capability(100)`: GPUs without native FP4 keep the original message verbatim; native-FP4 GPUs get an accurate one pointing at backend selection rather than hardware support.

**Not a duplicate:** no open PR touches this site. The dense-linear copy of the same message (`kernels/linear/nvfp4/marlin.py`) is being reworded separately in #44672, which does not touch the MoE site — the two compose. Related hardware-enablement context: #31085.

## Test Plan

- `ruff check` / `ruff format --check` on the changed file (repo config) — pass.
- E2E on SM121 (NVIDIA DGX Spark / GB10): boot `nvidia/Gemma-4-26B-A4B-NVFP4` offline (`quantization="modelopt_fp4"`, eager) on a v0.22-based build with this change applied, where the oracle selects `MARLIN` for this model (pre-#42027 activation gate), and inspect the boot log.

## Test Result

Before (same machine, unmodified):

```
WARNING [marlin_utils_fp4.py:300] Your GPU does not have native support for FP4 computation but FP4 quantization is being used. ...
```

After:

```
INFO [nvfp4.py:326] Using 'MARLIN' NvFp4 MoE backend out of potential backends: ['FLASHINFER_TRTLLM', 'FLASHINFER_CUTEDSL', 'FLASHINFER_CUTEDSL_BATCHED', 'FLASHINFER_CUTLASS', 'VLLM_CUTLASS', 'MARLIN', 'EMULATION'].
WARNING [marlin_utils_fp4.py:301] This GPU supports native FP4 computation, but the Marlin (weight-only FP4) MoE backend was selected instead of a native FP4 MoE backend (e.g. because none supports this model's activation or deployment configuration). This may degrade performance for compute-heavy workloads.
```

Generation completes normally; the non-native branch is the original message unchanged, so pre-SM100 behavior is identical.

---

**AI disclosure:** I had Claude (Fable 5) do this work — specifically to test its capabilities analyzing an unknown-to-me area of the codebase, and to use some of my Claude-time to give back to the open source community. I've reviewed every changed line and can defend the change; the SM121 test logs above are from my own hardware.
