### PR TITLE
[CI Bug] Remove qwen test `ValueError: No example model defined for Qwen/Qwen-7B-Chat`

### DIFF
--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -152,7 +152,6 @@ TEXT_GENERATION_MODELS = {
     "microsoft/Phi-3.5-MoE-instruct": PPTestSettings.detailed(
         multi_node_only=True, load_format="dummy"
     ),
-    "Qwen/Qwen-7B-Chat": PPTestSettings.fast(),
     "Qwen/Qwen2.5-0.5B-Instruct": PPTestSettings.fast(),
     "Qwen/Qwen1.5-MoE-A2.7B-Chat": PPTestSettings.fast(),
     "stabilityai/stablelm-3b-4e1t": PPTestSettings.fast(),

--- a/tests/models/language/generation/test_common.py
+++ b/tests/models/language/generation/test_common.py
@@ -25,7 +25,6 @@ EMBED_SCALING_MODELS = {
 AITER_MODEL_LIST = [
     "meta-llama/Llama-3.2-1B-Instruct",
     "openbmb/MiniCPM3-4B",
-    "Qwen/Qwen-7B-Chat",
     "Qwen/Qwen2.5-0.5B-Instruct",
     "TitanML/tiny-mixtral",
     "Qwen/Qwen3-8B",
@@ -81,9 +80,6 @@ AITER_MODEL_LIST = [
         pytest.param(
             "microsoft/phi-2",  # phi
             marks=[pytest.mark.core_model, pytest.mark.slow_test],
-        ),
-        pytest.param(
-            "Qwen/Qwen-7B-Chat",  # qwen (text-only)
         ),
         pytest.param(
             "Qwen/Qwen2.5-0.5B-Instruct",  # qwen2


### PR DESCRIPTION
## Purpose

Fixes https://buildkite.com/vllm/ci/builds/71234#019eb2da-8fd7-4096-b373-2593fb49305b

Qwen has been removed in https://github.com/vllm-project/vllm/pull/45131, so we remove the related tests as well.
