### PR TITLE
[Bugfix] Disable VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS by default

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -279,7 +279,7 @@ if TYPE_CHECKING:
     making the server model-name agnostic. Useful for proxy/gateway scenarios."""
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
-    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -1997,9 +1997,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set to 1, enable CUDA graph memory estimation during memory profiling.
     # This profiles CUDA graph memory usage to provide more accurate KV cache
-    # memory allocation. Enabled by default as of v0.21.0
+    # memory allocation. Disabled by default due to overestimation in the linear
+    # extrapolation model.
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
-        int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
+        int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "0"))
     ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -493,13 +493,13 @@ class Worker(WorkerBase):
                     1.0,
                 )
                 logger.info(
-                    "CUDA graph memory profiling is enabled (default since "
-                    "v0.21.0). The current --gpu-memory-utilization=%.4f is "
-                    "equivalent to --gpu-memory-utilization=%.4f without "
-                    "CUDA graph memory profiling. To maintain the same "
-                    "effective KV cache size as before, increase "
-                    "--gpu-memory-utilization to %.4f. To disable, set "
-                    "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.",
+                    "CUDA graph memory profiling is enabled (opt-in via "
+                    "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1). The current "
+                    "--gpu-memory-utilization=%.4f is equivalent to "
+                    "--gpu-memory-utilization=%.4f without CUDA graph memory "
+                    "profiling. To maintain the same effective KV cache size as "
+                    "before, increase --gpu-memory-utilization to %.4f. To disable, "
+                    "set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.",
                     current_util,
                     equiv_util,
                     suggested_util,
@@ -510,13 +510,13 @@ class Worker(WorkerBase):
                     1.0,
                 )
                 logger.warning(
-                    "CUDA graph memory profiling is disabled "
-                    "(VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0). "
+                    "CUDA graph memory profiling is disabled (default). "
                     "Without it, CUDA graph memory is not accounted for "
                     "during KV cache allocation, which may require lowering "
-                    "--gpu-memory-utilization to avoid OOM. Consider "
-                    "re-enabling it (the default as of v0.21.0) and increasing "
-                    "--gpu-memory-utilization from %.4f to %.4f.",
+                    "--gpu-memory-utilization to avoid OOM. To enable it "
+                    "(which may overestimate memory), set "
+                    "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 and consider "
+                    "increasing --gpu-memory-utilization from %.4f to %.4f.",
                     current_util,
                     suggested_util,
                 )


### PR DESCRIPTION
**Purpose**

The CUDA graph memory profiler uses a flawed linear extrapolation model in `gpu_model_runner.py` (line 6461: `per_graph_estimate[mode] = per_graph * (len(descs) - 1)`). This assumes each CUDA graph independently consumes memory, but CUDA mempools are shared across all graphs and reuse freed memory blocks. The error compounds with more cudagraph_capture_sizes, leading to severe overestimation. On B200 with Minimax M2.5 NVFP4, this reduced KV cache from 769,888 tokens to 245,840 tokens (3.1x reduction), dramatically limiting concurrency from 334.2x to 106.7x.

This change disables `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS` by default to restore correct KV cache allocation. Users who want to opt in to the estimation (which may still overestimate) can explicitly set `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1`.

**Test Plan**

The fix changes default behavior in `vllm/envs.py` and updates log messages in `vllm/v1/worker/gpu_worker.py` to reflect the new default. No additional tests are needed as existing tests cover both code paths (enabled/disabled).

To verify the fix:
```bash
python -c "from vllm import envs; print(envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS)"
# Should output: False
```

**Test Result**

Before: `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS` defaulted to `True`, causing overestimation.
After: `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS` defaults to `False`, allowing proper KV cache allocation.

Fixes #45178
