### PR TITLE
[Bugfix][KVConnector][Mooncake] Close MooncakeDistributedStore on connector teardown

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -614,3 +614,66 @@ def test_lookup_key_server_reset_skips_drain_when_no_send_thread():
 
     assert call_order == ["remove_all"]
     assert sent == [protocol.RESP_OK]
+
+
+def test_shutdown_closes_worker_store():
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER, kv_cache_config
+        )
+
+    worker = mock_worker_cls.return_value
+    connector.shutdown()
+
+    worker.close.assert_called_once_with()
+
+
+def test_del_invokes_shutdown_and_closes_store():
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER, kv_cache_config
+        )
+
+    worker = mock_worker_cls.return_value
+    # __del__ is the GC backstop; it must route through shutdown() -> close().
+    connector.__del__()
+
+    worker.close.assert_called_once_with()
+
+
+def test_shutdown_scheduler_role_is_noop():
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreScheduler"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config
+        )
+
+    # Scheduler role holds no store handle, so shutdown must be a safe no-op.
+    assert connector.connector_worker is None
+    connector.shutdown()

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1558,3 +1558,34 @@ def test_lookup_records_mooncake_metrics():
     assert isinstance(stats, MooncakeStoreConnectorStats)
     assert len(stats.data["lookup_exists"]) == 1
     assert stats.data["lookup_exists"][0]["num_keys"] == 2
+
+
+def test_store_worker_close_releases_store():
+    worker = _make_bare_worker()
+    store = worker.store
+
+    worker.close()
+
+    store.close.assert_called_once_with()
+    assert worker.store is None
+
+
+def test_store_worker_close_is_idempotent():
+    worker = _make_bare_worker()
+    store = worker.store
+
+    worker.close()
+    worker.close()
+
+    # Second call short-circuits because store was already released.
+    store.close.assert_called_once_with()
+
+
+def test_store_worker_close_swallows_store_errors():
+    worker = _make_bare_worker()
+    worker.store.close.side_effect = RuntimeError("boom")
+
+    # A failure tearing down the store must not propagate out of close().
+    worker.close()
+
+    assert worker.store is None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -153,6 +153,21 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         else:
             self.connector_worker = MooncakeStoreWorker(vllm_config, kv_cache_config)
 
+    def shutdown(self):
+        """Release connector resources on teardown.
+
+        Closes the worker's MooncakeDistributedStore handle so its
+        TransferEngine and RDMA registrations are released. Invoked from the
+        engine's explicit shutdown path and as a backstop from ``__del__``;
+        a no-op on the scheduler role, which holds no store handle.
+        """
+        worker = getattr(self, "connector_worker", None)
+        if worker is not None:
+            worker.close()
+
+    def __del__(self):
+        self.shutdown()
+
     # ============================================================
     # Scheduler-side methods
     # ============================================================

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1423,6 +1423,22 @@ class MooncakeStoreWorker:
             return self.kv_send_thread.get_kv_events()
         return []
 
+    def close(self) -> None:
+        """Release the MooncakeDistributedStore handle on teardown.
+
+        Closing the store frees its TransferEngine, the registered RDMA
+        buffers, and the connection to the master server. Idempotent so it is
+        safe to call from both the explicit shutdown path and ``__del__``.
+        """
+        store = getattr(self, "store", None)
+        if store is None:
+            return
+        self.store = None
+        try:
+            store.close()
+        except Exception as e:
+            logger.warning("Error closing MooncakeDistributedStore: %s", e)
+
 
 # ============================================================
 # Lookup Key Server


### PR DESCRIPTION
## Purpose

`MooncakeStoreConnector` never overrode the base `KVConnectorBase_V1.shutdown()` hook and had no `__del__`, so the worker's `MooncakeDistributedStore` handle was **never closed** officially (we depends on `aexit` on C++ side to clean up). The store owns a `TransferEngine`, the registered RDMA buffers, and the connection to the master server — all of which leaked on every connector teardown (e.g. engine shutdown, and RL/serving workflows that recreate the connector).

This wires teardown:

- `MooncakeStoreWorker.close()` — releases the store via `store.close()`. Idempotent (nulls the handle first) and guards/logs exceptions so a failing teardown never propagates out of `__del__`.
- `MooncakeStoreConnector.shutdown()` — overrides the base hook and delegates to `connector_worker.close()`; a no-op on the scheduler role, which holds no store handle.
- `MooncakeStoreConnector.__del__()` → `shutdown()` — GC backstop, matching the existing `NixlConnectorWorker` pattern (`__del__` → `shutdown`).

`shutdown()` is already invoked on both the scheduler-role connector (`Scheduler.shutdown`) and the worker-role connector (`gpu_worker.shutdown` → `ensure_kv_transfer_shutdown`), so this fixes the explicit-shutdown path; `__del__` covers GC-only teardown.

Scope note: the worker's `LookupKeyServer` and the scheduler's `LookupKeyClient` also expose `close()` methods that hold ZMQ sockets / an IPC file. I kept this PR focused on the store handle (the heavyweight leak); wiring those into the same path is a reasonable follow-up.

## Not a duplicate

Checked open PRs touching this area — none address store/connector teardown:

```
gh pr list --repo vllm-project/vllm --state open --search "MooncakeStoreConnector"
gh pr list --repo vllm-project/vllm --state open --search "mooncake store shutdown"
```

Matches found (#43701 DummyClient, #44304 spec-decode token length, #44956 store group semantics, #44919 RDMA auto-discover, #43509 NIXL leak, #34312 original store connector) all touch unrelated functionality.

## Test Plan / Result

```
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_connector.py -q
# 78 passed
```

Added unit tests (no GPU/RDMA/Mooncake runtime required, using the existing `MagicMock` store + bare-worker patterns):
- worker: `close()` releases the store, is idempotent, and swallows store errors.
- connector: `shutdown()` closes the worker store; `__del__` routes through `shutdown()`; scheduler-role `shutdown()` is a safe no-op.

Also run: `pre-commit run ruff-check`, `ruff-format`, and `mypy` (3.10) — all pass on the changed files.

I do **not** have a multi-node Mooncake cluster (RDMA + master server) available locally, so the end-to-end store lifecycle was not exercised on hardware; that verification is left to the human submitter / CI.

## AI assistance

This change was developed with AI assistance (Claude). The submitting human has reviewed every changed line and is accountable for the change.