### PR TITLE
[Bugfix] Skip mxfp4_experts_quant on CUDA 12.8 to fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -968,8 +968,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
-      "csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu"
       "csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu")
+    if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.9)
+      list(APPEND SRCS
+        "csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu")
+    else()
+      message(STATUS "Not building mxfp4_experts_quant kernel as CUDA Compiler "
+                     "version is not >= 12.9 (have ${CMAKE_CUDA_COMPILER_VERSION}).")
+    endif()
     set_gencode_flags_for_srcs(
       SRCS "${SRCS}"
       CUDA_ARCHS "${FP4_ARCHS}")


### PR DESCRIPTION
## Purpose

`mxfp4_experts_quant.cu` defines `NVFP4_ENABLE_ELTS16` and includes
`nvfp4_utils.cuh`, which only enables the PACK16 (16-elements-per-thread)
E2M1 conversion path when `CUDA_VERSION >= 12090`. On CUDA 12.8 the guard
falls through, `CVT_FP4_ELTS_PER_THREAD` becomes `8`, and the file fails to
compile via the hard:

```cpp
static_assert(CVT_FP4_ELTS_PER_THREAD == 16,
              "MXFP4 experts quant requires PACK16 mode (CUDA >= 12.9)");
```

`CMakeLists.txt` puts this file in a list gated only by
`CMAKE_CUDA_COMPILER_VERSION >= 12.8 AND FP4_ARCHS`, so a build that
matches the FP4 arch list on the officially-supported CUDA 12.8 toolchain
(see `CUDA_SUPPORTED_ARCHS` in `CMakeLists.txt`) fails:

```
error: static assertion failed with "MXFP4 experts quant requires PACK16 mode (CUDA >= 12.9)"
```

This is distinct from #41310 / #43658 (which switch `CUDA_VERSION` →
`CUDART_VERSION` to fix a silent PACK16 disable in TUs where `<cuda.h>` is
not in the transitive include closure on CUDA 12.9+). Those PRs do not fix
the CUDA 12.8 break, because `mxfp4_experts_quant.cu` itself explicitly
`#include <cuda.h>`; the guard does evaluate, and the failure is purely
that `CUDA_VERSION == 12080 < 12090`.

The sibling source `mxfp4_blockwise_moe_kernel.cu` does not include
`nvfp4_utils.cuh`, does not define `NVFP4_ENABLE_ELTS16`, has no PACK16
dependency, and its own runtime error message advertises `"CUDA 12.8+"`
support. It compiles successfully on CUDA 12.8 (verified, see Test plan).

## Fix

Add a `CMAKE_CUDA_COMPILER_VERSION >= 12.9` guard around
`mxfp4_experts_quant.cu` only, leaving the rest of the FP4 sources
(including `mxfp4_blockwise_moe_kernel.cu` and all `nvfp4_*.cu`) on the
existing 12.8+ path. This matches the existing
`ES_MXFP8_GROUPED_MM_ARCHS` block earlier in the same file, which also
adds a per-kernel CUDA-version gate inside the same surrounding FP4-style
block.

## Scope and known limitations

This PR fixes the **build** only. The MXFP4 op schemas
(`mxfp4_experts_quant`, `silu_and_mul_mxfp4_experts_quant`) are still
defined unconditionally in `torch_bindings.cpp`; only the CUDA
`STABLE_TORCH_LIBRARY_IMPL` block lives inside `mxfp4_experts_quant.cu`.
Consequences on a CUDA 12.8 + SM100 build after this patch:

- No unresolved symbols at `.so` load time (the impl is not referenced
  from any `.cpp`); vLLM imports cleanly.
- Calling `mxfp4_experts_quant` / `silu_and_mul_mxfp4_experts_quant` at
  runtime surfaces as a normal Torch "no kernel registered" error rather
  than a crash.
- `cutlass_mxfp4_group_mm` is unchanged — its kernel still builds on
  12.8 and its CUDA impl is still registered.
- The upstream MXFP4 backend selectors are not currently
  CUDA-version-aware:
  - `CutlassExpertsMxfp4._supports_current_device()` only checks SM100.
  - `tests/kernels/moe/test_mxfp4_moe.py` only skips on non-SM100, so on
    a CUDA 12.8 + SM100 CI runner it would exercise the now-missing
    `mxfp4_experts_quant` and fail at runtime.

A Python-side CUDA-version guard (in the MXFP4 backend selector and/or
test skip predicates) would be a clean complement and is left for a
follow-up. Happy to extend this PR if a maintainer prefers to land both
together.

## Test plan

### Single-file `nvcc` (baseline reproduction on unpatched `CMakeLists.txt`)

| Source | Toolchain | Arch | Result |
| --- | --- | --- | --- |
| `mxfp4_experts_quant.cu` | CUDA 12.8.93 | `sm_100a` | FAIL — `static assertion failed with "MXFP4 experts quant requires PACK16 mode (CUDA >= 12.9)"` |
| `mxfp4_blockwise_moe_kernel.cu` | CUDA 12.8.93 | `sm_100a` | PASS — 685 KB `.o` |

### Full `_C_stable_libtorch` build with the patch applied

| Toolchain | Torch | Arch | Result |
| --- | --- | --- | --- |
| CUDA 12.8.93 | torch 2.11.0+cu128 | `sm_100a` | PASS — 50/50 ninja steps, `_C_stable_libtorch.abi3.so` 80 MB linked in 3m26s. CMake reconfigure emitted: `-- Not building mxfp4_experts_quant kernel as CUDA Compiler version is not >= 12.9 (have 12.8.93).` Object directory on disk shows `mxfp4_blockwise_moe_kernel.cu.o` present and **`mxfp4_experts_quant.cu.o` absent** (correctly skipped by this patch). |
| CUDA 13.0.88 | torch 2.10.0+cu130 | `sm_100a` | Patch is no-op for the source list (the `if(>= 12.9)` branch is taken); single-file ninja of both `mxfp4_experts_quant.cu.o` (189 KB) and `mxfp4_blockwise_moe_kernel.cu.o` (303 KB) PASS. The full `_C_stable_libtorch` link did **not** complete in this env because `csrc/libtorch_stable/cuda_view.cu` fails with `class "torch::stable::Tensor" has no member "layout"` — an unrelated upstream/torch API drift between vLLM main and torch 2.10 in this venv, not caused or exposed by this patch. The mxfp4 single-file ninjas above confirm the only code surface this patch touches still compiles on 13.0. |

### Pre-commit

- `pre-commit run --files CMakeLists.txt` (default stage): PASS (all
  applicable hooks; most skip because no Python/C++/markdown was
  touched).
- `pre-commit run --all-files --hook-stage manual`: PASS for every hook
  on the diff. One unrelated CI hook, `update-dockerfile-graph`, also
  ran across the whole repo and reported a pre-existing upstream drift
  in `docs/assets/contributing/dockerfile-stages-dependency.png` versus
  `docker/Dockerfile`; the regenerated PNG was reverted and is not part
  of this PR.
