### PR TITLE
[Docs] Add redirect for moved lmcache examples page

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -114,6 +114,7 @@ plugins:
         features/quantization/int4.md: features/quantization/llm_compressor/int4.md
         features/quantization/int8.md: features/quantization/llm_compressor/int8_w8a8.md
         serving/openai_compatible_server.md: serving/online_serving/README.md
+        examples/others/lmcache.md: examples/disaggregated/lmcache.md
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
## Purpose

Add a missing redirect for the `examples/others/lmcache` path, which was moved
to `examples/disaggregated/lmcache` in #41082 but without a corresponding
redirect entry in `mkdocs.yaml`.

This causes a broken link for users arriving from search engines: the top Google
result for "vllm lmcache" is the v0.10.1 docs page, whose "latest stable version"
banner links to `stable/examples/others/lmcache.html`, which returns 404.

Correct URL: https://docs.vllm.ai/en/stable/examples/disaggregated/lmcache/

## Test Plan

```bash
mkdocs build 2>&1 | grep -i "redirect\|lmcache\|others"
find site/examples/others -name "*.html"
cat site/examples/others/lmcache/index.html
```
 Note: tested with a simplified `mkdocs.yaml` (commented out `api-autonav`,
`mkdocstrings`, `git-revision-date-localized`, `minify`, `glightbox`, and the
`generate_argparse`/`generate_metrics` hooks) due to local environment
constraints. The `generate_examples` hook was kept active as it generates the
redirect target.

## Test Result

- No redirect warnings in build output
- `site/examples/others/lmcache/index.html` generated correctly
- Contains meta-refresh redirect to `../../disaggregated/lmcache/`