### PR TITLE
[ROCm][MoE] Route batched expert layout through flat-reshape wrapper for AITER FP8

### DIFF
--- a/tests/kernels/moe/test_aiter_batched_experts.py
+++ b/tests/kernels/moe/test_aiter_batched_experts.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E402
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_rocm():
+    pytest.skip("AITER BatchedExperts tests require ROCm.", allow_module_level=True)
+
+from vllm._aiter_ops import is_aiter_found_and_supported
+
+if not is_aiter_found_and_supported():
+    pytest.skip(
+        "AITER BatchedExperts tests require supported ROCm AITER.",
+        allow_module_level=True,
+    )
+
+import torch
+
+from vllm.model_executor.layers.fused_moe import modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.experts import rocm_aiter_moe
+from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+    AiterBatchedExpertsFp8,
+    AiterExperts,
+)
+from vllm.model_executor.layers.fused_moe.oracle import fp8 as fp8_oracle
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
+    backend_to_kernel_cls,
+    select_fp8_moe_backend,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+    kFp8DynamicTensorSym,
+    kFp8DynamicTokenSym,
+    kFp8Static128BlockSym,
+    kFp8StaticChannelSym,
+    kFp8StaticTensorSym,
+    kMxfp4Static,
+)
+
+
+def _make_moe_config(
+    num_experts: int,
+    hidden_dim: int,
+    max_num_tokens: int,
+) -> FusedMoEConfig:
+    return FusedMoEConfig(
+        num_experts=num_experts,
+        experts_per_token=1,
+        hidden_dim=hidden_dim,
+        intermediate_size=16,
+        num_local_experts=num_experts,
+        num_logical_experts=num_experts,
+        activation=MoEActivation.SILU,
+        device="cpu",
+        routing_method=RoutingMethodType.Default,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        in_dtype=torch.float32,
+        max_num_tokens=max_num_tokens,
+    )
+
+
+def _parallel_config(all2all_backend: str) -> FusedMoEParallelConfig:
+    return FusedMoEParallelConfig(
+        tp_size=1,
+        pcp_size=1,
+        dp_size=2,
+        ep_size=2,
+        tp_rank=0,
+        pcp_rank=0,
+        dp_rank=0,
+        ep_rank=0,
+        sp_size=1,
+        use_ep=True,
+        all2all_backend=all2all_backend,
+        enable_eplb=False,
+    )
+
+
+def test_activation_formats():
+    assert (
+        AiterBatchedExpertsFp8.activation_format()
+        == mk.FusedMoEActivationFormat.BatchedExperts
+    )
+    assert AiterExperts.activation_format() == mk.FusedMoEActivationFormat.Standard
+
+
+@pytest.mark.parametrize(
+    ("all2all_backend", "expected"),
+    [
+        ("deepep_low_latency", True),
+        ("nixl_ep", True),
+        ("flashinfer_nvlink_one_sided", False),
+        ("flashinfer_nvlink_two_sided", False),
+        ("mori_high_throughput", False),
+    ],
+)
+def test_supported_parallel_configs(all2all_backend: str, expected: bool):
+    parallel_config = _parallel_config(all2all_backend)
+
+    assert parallel_config.use_batched_experts_activation_format is expected
+    assert AiterBatchedExpertsFp8._supports_parallel_config(parallel_config) is expected
+
+
+@pytest.mark.parametrize(
+    ("weight_key", "activation_key", "expected"),
+    [
+        (kFp8Static128BlockSym, kFp8Dynamic128Sym, True),
+        (kFp8StaticTensorSym, kFp8StaticTensorSym, True),
+        (kFp8StaticTensorSym, kFp8DynamicTensorSym, True),
+        (kFp8StaticChannelSym, kFp8DynamicTokenSym, True),
+        (None, None, False),
+        (kMxfp4Static, None, False),
+    ],
+)
+def test_quant_scheme_scope(weight_key, activation_key, expected: bool):
+    assert (
+        AiterBatchedExpertsFp8._supports_quant_scheme(weight_key, activation_key)
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_experts", "tokens_per_expert", "hidden_dim", "scale_dim"),
+    [
+        (1, 4, 8, None),
+        (2, 3, 4, 2),
+        (3, 2, 5, 1),
+    ],
+)
+def test_apply_flattens_batched_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    num_experts: int,
+    tokens_per_expert: int,
+    hidden_dim: int,
+    scale_dim: int | None,
+):
+    hidden_states = torch.arange(
+        num_experts * tokens_per_expert * hidden_dim,
+        dtype=torch.float32,
+    ).reshape(num_experts, tokens_per_expert, hidden_dim)
+    output = torch.empty_like(hidden_states)
+    a2_scale = torch.tensor([0.5])
+    a1q_scale = None
+    expected_a1q_scale = None
+    if scale_dim is not None:
+        a1q_scale = torch.arange(
+            num_experts * tokens_per_expert * scale_dim,
+            dtype=torch.float32,
+        ).reshape(num_experts, tokens_per_expert, scale_dim)
+        expected_a1q_scale = a1q_scale.reshape(
+            num_experts * tokens_per_expert,
+            scale_dim,
+        )
+    captured = {}
+
+    def fake_rocm_aiter_fused_experts(**kwargs):
+        captured.update(kwargs)
+        routed_ids = kwargs["topk_ids"].to(dtype=kwargs["hidden_states"].dtype)
+        return kwargs["hidden_states"] + routed_ids
+
+    monkeypatch.setattr(
+        rocm_aiter_moe,
+        "rocm_aiter_fused_experts",
+        fake_rocm_aiter_fused_experts,
+    )
+    wrapper = AiterBatchedExpertsFp8(
+        _make_moe_config(num_experts, hidden_dim, tokens_per_expert),
+        FUSED_MOE_UNQUANTIZED_CONFIG,
+        max_num_tokens=tokens_per_expert,
+        num_dispatchers=1,
+    )
+
+    wrapper.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=torch.empty(num_experts, 1, 1),
+        w2=torch.empty(num_experts, 1, 1),
+        topk_weights=torch.empty(1, 1),
+        topk_ids=torch.empty(1, 1, dtype=torch.int64),
+        activation=MoEActivation.SILU,
+        global_num_experts=99,
+        expert_map=torch.arange(num_experts),
+        a1q_scale=a1q_scale,
+        a2_scale=a2_scale,
+        workspace13=torch.empty(0),
+        workspace2=torch.empty(0),
+        expert_tokens_meta=mk.ExpertTokensMetadata.make_from_list(
+            [tokens_per_expert] * num_experts,
+            "cpu",
+        ),
+        apply_router_weight_on_input=True,
+    )
+
+    expected_ids = (
+        torch.arange(num_experts, dtype=torch.int32)
+        .repeat_interleave(tokens_per_expert)
+        .unsqueeze(-1)
+    )
+    expected_hidden = hidden_states.reshape(
+        num_experts * tokens_per_expert,
+        hidden_dim,
+    )
+
+    assert torch.equal(captured["hidden_states"], expected_hidden)
+    assert torch.equal(captured["topk_ids"], expected_ids)
+    assert torch.equal(
+        captured["topk_weights"],
+        torch.ones(num_experts * tokens_per_expert, 1),
+    )
+    assert captured["moe_config"].num_experts == num_experts
+    assert captured["expert_map"] is None
+    assert captured["num_local_tokens"] is None
+    assert captured["apply_router_weight_on_input"] is False
+    if expected_a1q_scale is None:
+        assert captured["a1q_scale"] is None
+    else:
+        assert torch.equal(captured["a1q_scale"], expected_a1q_scale)
+
+    expected_output = expected_hidden + expected_ids.float()
+    assert torch.equal(
+        output,
+        expected_output.reshape(num_experts, tokens_per_expert, hidden_dim),
+    )
+
+
+def test_oracle_registers_batched_aiter_backend():
+    assert backend_to_kernel_cls(Fp8MoeBackend.BATCHED_AITER) == [
+        AiterBatchedExpertsFp8
+    ]
+
+
+def test_oracle_routes_batched_aiter_env(monkeypatch: pytest.MonkeyPatch):
+    def is_set(name: str):
+        return name in {"VLLM_ROCM_USE_AITER", "VLLM_ROCM_USE_AITER_MOE"}
+
+    def is_supported(cls, config, weight_key, activation_key, activation_format):
+        assert activation_format == mk.FusedMoEActivationFormat.BatchedExperts
+        return True, None
+
+    config = SimpleNamespace(
+        moe_backend="auto",
+        moe_parallel_config=SimpleNamespace(
+            use_batched_activation_format=True,
+            use_deepep_v2_kernels=False,
+            ep_size=1,
+        ),
+    )
+    monkeypatch.setattr(fp8_oracle.envs, "is_set", is_set)
+    monkeypatch.setattr(fp8_oracle.envs, "VLLM_ROCM_USE_AITER", True)
+    monkeypatch.setattr(fp8_oracle.envs, "VLLM_ROCM_USE_AITER_MOE", True)
+    monkeypatch.setattr(fp8_oracle.envs, "VLLM_TEST_FORCE_FP8_MARLIN", False)
+    monkeypatch.setattr(
+        AiterBatchedExpertsFp8,
+        "is_supported_config",
+        staticmethod(is_supported),
+    )
+
+    backend, experts_cls = select_fp8_moe_backend(config, None, None)
+
+    assert backend == Fp8MoeBackend.BATCHED_AITER
+    assert experts_cls is AiterBatchedExpertsFp8
+
+
+def test_oracle_routes_explicit_aiter_to_batched_backend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def is_supported(cls, config, weight_key, activation_key, activation_format):
+        assert activation_format == mk.FusedMoEActivationFormat.BatchedExperts
+        return True, None
+
+    config = SimpleNamespace(
+        moe_backend="aiter",
+        moe_parallel_config=SimpleNamespace(
+            use_batched_activation_format=True,
+            use_deepep_v2_kernels=False,
+            ep_size=1,
+        ),
+    )
+    monkeypatch.setattr(fp8_oracle.envs, "is_set", lambda name: False)
+    monkeypatch.setattr(fp8_oracle.envs, "VLLM_TEST_FORCE_FP8_MARLIN", False)
+    monkeypatch.setattr(
+        AiterBatchedExpertsFp8,
+        "is_supported_config",
+        staticmethod(is_supported),
+    )
+
+    backend, experts_cls = select_fp8_moe_backend(config, None, None)
+
+    assert backend == Fp8MoeBackend.BATCHED_AITER
+    assert experts_cls is AiterBatchedExpertsFp8

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1067,6 +1067,10 @@ class FusedMoEParallelConfig:
 
     @property
     def use_batched_activation_format(self):
+        return self.use_batched_experts_activation_format
+
+    @property
+    def use_batched_experts_activation_format(self):
         return self.use_deepep_ll_kernels or self.use_nixl_ep_kernels
 
     @property

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate,
     TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -556,3 +557,170 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             output.set_(result)
         else:
             output.copy_(result)
+
+
+class AiterBatchedExpertsFp8(mk.FusedMoEExpertsModular):
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+        max_num_tokens: int,
+        num_dispatchers: int,
+    ):
+        super().__init__(
+            moe_config=moe_config,
+            quant_config=quant_config,
+            max_num_tokens=max_num_tokens,
+            num_dispatchers=num_dispatchers,
+        )
+        self._inner = AiterExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        )
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return False
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.BatchedExperts
+
+    @staticmethod
+    def is_supported_config(
+        cls,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+        activation_format: mk.FusedMoEActivationFormat,
+    ) -> tuple[bool, str | None]:
+        is_supported, reason = super().is_supported_config(
+            cls, moe_config, weight_key, activation_key, activation_format
+        )
+        if not is_supported and not rocm_aiter_ops.is_fused_moe_enabled():
+            reason = (
+                f"{reason}. AITER MoE is not enabled - "
+                "set VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 "
+                "to enable it"
+            )
+        return is_supported, reason
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return rocm_aiter_ops.is_fused_moe_enabled()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return (weight_key, activation_key) in {
+            (kFp8Static128BlockSym, kFp8Dynamic128Sym),
+            (kFp8StaticTensorSym, kFp8StaticTensorSym),
+            (kFp8StaticTensorSym, kFp8DynamicTensorSym),
+            (kFp8StaticChannelSym, kFp8DynamicTokenSym),
+        }
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return AiterExperts._supports_activation(activation)
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        return moe_parallel_config.use_batched_experts_activation_format
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceDelegate()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        return (0,), (0,), (local_num_experts, M, K)
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        assert hidden_states.dim() == 3, (
+            "AiterBatchedExpertsFp8 expects hidden_states shaped "
+            f"(E_local, M_e, K), got {tuple(hidden_states.shape)}"
+        )
+        assert output.shape == hidden_states.shape, (
+            "AiterBatchedExpertsFp8 expects output to match hidden_states, "
+            f"got {tuple(output.shape)} and {tuple(hidden_states.shape)}"
+        )
+        assert output.is_contiguous(), (
+            "AiterBatchedExpertsFp8 expects a contiguous output buffer"
+        )
+        assert expert_tokens_meta is not None, (
+            "AiterBatchedExpertsFp8 requires BatchedExperts token metadata"
+        )
+
+        e_local, tokens_per_expert, hidden_dim = hidden_states.shape
+        assert w1.size(0) == e_local, (
+            f"w1 expert dim {w1.size(0)} != hidden_states expert dim {e_local}"
+        )
+
+        flat_hidden_states = hidden_states.reshape(
+            e_local * tokens_per_expert, hidden_dim
+        )
+        flat_output = output.view(e_local * tokens_per_expert, hidden_dim)
+        flat_topk_ids = (
+            torch.arange(e_local, device=hidden_states.device, dtype=torch.int32)
+            .repeat_interleave(tokens_per_expert)
+            .unsqueeze(-1)
+        )
+        flat_topk_weights = torch.ones(
+            (e_local * tokens_per_expert, 1),
+            device=hidden_states.device,
+            dtype=torch.float32,
+        )
+        flat_a1q_scale = a1q_scale
+        if a1q_scale is not None and a1q_scale.dim() == 3:
+            flat_a1q_scale = a1q_scale.reshape(
+                a1q_scale.size(0) * a1q_scale.size(1), a1q_scale.size(2)
+            )
+
+        self._inner.apply(
+            output=flat_output,
+            hidden_states=flat_hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=flat_topk_weights,
+            topk_ids=flat_topk_ids,
+            activation=activation,
+            global_num_experts=e_local,
+            expert_map=None,
+            a1q_scale=flat_a1q_scale,
+            a2_scale=a2_scale,
+            workspace13=workspace13,
+            workspace2=workspace2,
+            expert_tokens_meta=None,
+            apply_router_weight_on_input=False,
+        )

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -48,6 +48,7 @@ class Fp8MoeBackend(Enum):
     TRITON = "TRITON"
     BATCHED_TRITON = "BATCHED_TRITON"
     AITER = "AITER"
+    BATCHED_AITER = "BATCHED_AITER"
     VLLM_CUTLASS = "VLLM_CUTLASS"
     BATCHED_VLLM_CUTLASS = "BATCHED_VLLM_CUTLASS"
     XPU = "XPU"
@@ -83,6 +84,7 @@ def _get_priority_backends(
         Fp8MoeBackend.VLLM_CUTLASS,
         Fp8MoeBackend.TRITON,
         Fp8MoeBackend.MARLIN,
+        Fp8MoeBackend.BATCHED_AITER,
         Fp8MoeBackend.BATCHED_DEEPGEMM,
         Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
         Fp8MoeBackend.BATCHED_TRITON,
@@ -189,6 +191,13 @@ def backend_to_kernel_cls(
         )
 
         return [AiterExperts]
+
+    elif backend == Fp8MoeBackend.BATCHED_AITER:
+        from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+            AiterBatchedExpertsFp8,
+        )
+
+        return [AiterBatchedExpertsFp8]
 
     elif backend == Fp8MoeBackend.VLLM_CUTLASS:
         from vllm.model_executor.layers.fused_moe.experts.triton_cutlass_moe import (
@@ -321,6 +330,8 @@ def select_fp8_moe_backend(
                 requested_backend = Fp8MoeBackend.BATCHED_TRITON
             elif requested_backend == Fp8MoeBackend.VLLM_CUTLASS:
                 requested_backend = Fp8MoeBackend.BATCHED_VLLM_CUTLASS
+            elif requested_backend == Fp8MoeBackend.AITER:
+                requested_backend = Fp8MoeBackend.BATCHED_AITER
 
         if (
             requested_backend
@@ -364,8 +375,13 @@ def select_fp8_moe_backend(
     if envs.is_set("VLLM_ROCM_USE_AITER") or envs.is_set("VLLM_ROCM_USE_AITER_MOE"):
         if not envs.VLLM_ROCM_USE_AITER or not envs.VLLM_ROCM_USE_AITER_MOE:
             AVAILABLE_BACKENDS.remove(Fp8MoeBackend.AITER)
+            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_AITER)
         else:
-            backend = Fp8MoeBackend.AITER
+            backend = (
+                Fp8MoeBackend.AITER
+                if activation_format == mk.FusedMoEActivationFormat.Standard
+                else Fp8MoeBackend.BATCHED_AITER
+            )
             return _return_or_raise(
                 backend, config, weight_key, activation_key, activation_format
             )
@@ -423,7 +439,7 @@ def convert_to_fp8_moe_kernel_format(
             w2_scale,
             tuple(layer.weight_block_size),
         )
-    elif fp8_backend == Fp8MoeBackend.AITER:
+    elif fp8_backend in (Fp8MoeBackend.AITER, Fp8MoeBackend.BATCHED_AITER):
         w13, w2 = rocm_aiter_ops.shuffle_weights(w13, w2)
     elif fp8_backend == Fp8MoeBackend.AITER_MXFP8:
         w13, w2, w13_scale, w2_scale = rocm_aiter_ops.shuffle_mxfp8_moe_weights(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -699,8 +699,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, f"w13_{self.weight_scale_name}", w13_scale)
         replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
 
-        # AITER backend requires weights to be marked as shuffled.
-        if self.fp8_backend == Fp8MoeBackend.AITER:
+        if self.fp8_backend in (Fp8MoeBackend.AITER, Fp8MoeBackend.BATCHED_AITER):
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
 


### PR DESCRIPTION
<!-- AI-assisted rewrite; the submitter is expected to review and own every changed line. Duplicate-work check: no open PR for AITER BatchedExperts/BATCHED_AITER FP8 MoE was found other than this PR. -->

## Purpose

Enable ROCm AITER FP8 MoE when the prepare/finalize path produces `BatchedExperts` activations, such as `deepep_low_latency` and `nixl_ep`. The existing `AiterExperts` kernel only advertises `Standard` activations, so AITER could not be selected for those batched expert layouts.

## Test Plan

Primary vLLM serve shape for this path:

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 \
vllm serve <local DeepSeek-R1-FP8 checkpoint> \
  --trust-remote-code \
  --tensor-parallel-size 1 \
  --data-parallel-size 16 \
  --data-parallel-size-local 8 \
  --enable-expert-parallel \
  --all2all-backend deepep_low_latency \
  --moe-backend aiter \
  --max-model-len 1024 \
  --max-num-batched-tokens 1024
```

Targeted checks:

```bash
python3 -m py_compile \
  vllm/model_executor/layers/fused_moe/config.py \
  vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py \
  vllm/model_executor/layers/fused_moe/oracle/fp8.py \
  vllm/model_executor/layers/quantization/fp8.py \
  tests/kernels/moe/test_aiter_batched_experts.py

python3 -m pytest -q tests/kernels/moe/test_aiter_batched_experts.py
```

## Test Result

- ROCm/AITER containers on two 8-GPU nodes: `18 passed` on each node.
- Installed-package ROCm/AITER smoke on two 8-GPU nodes: `auto` and explicit `moe_backend="aiter"` both selected `BATCHED_AITER`.
- Two-node `vllm serve` smoke with the command shape above reached `Using BATCHED_AITER Fp8 MoE backend` and completed checkpoint loading. Request-level readiness was blocked by a DeepEP/rocSHMEM transport bootstrap timeout in the test environment.
